### PR TITLE
feat: 新增一鍵安裝腳本與跨平台任務執行器

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+RUNNER := uv run python scripts/dev.py
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help:
+	@echo "CodefyUI"
+	@echo ""
+	@echo "  make install   安裝所有依賴（backend + frontend）"
+	@echo "  make dev       啟動開發伺服器（backend :8000 + frontend :5173）"
+	@echo "  make stop      停止所有服務"
+	@echo "  make test      執行 backend 測試"
+	@echo "  make clean     移除虛擬環境與 node_modules"
+	@echo ""
+	@echo "Windows 使用者（不需要 make）："
+	@echo "  uv run python scripts/dev.py <command>"
+	@echo ""
+
+.PHONY: install
+install:
+	$(RUNNER) install
+
+.PHONY: dev
+dev:
+	$(RUNNER) dev
+
+.PHONY: stop
+stop:
+	$(RUNNER) stop
+
+.PHONY: test
+test:
+	$(RUNNER) test
+
+.PHONY: clean
+clean:
+	$(RUNNER) clean

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RUNNER := uv run python scripts/dev.py
+RUNNER := python dev.py
 
 .DEFAULT_GOAL := help
 
@@ -12,8 +12,8 @@ help:
 	@echo "  make test      執行 backend 測試"
 	@echo "  make clean     移除虛擬環境與 node_modules"
 	@echo ""
-	@echo "Windows 使用者（不需要 make）："
-	@echo "  uv run python scripts/dev.py <command>"
+	@echo "或直接（全平台通用）："
+	@echo "  python dev.py <command>"
 	@echo ""
 
 .PHONY: install

--- a/README.md
+++ b/README.md
@@ -25,11 +25,16 @@ A visual, node-based deep learning pipeline builder. Design CNN, RNN, Transforme
 
 ## Quick Start
 
-只需要 **Python 3.11+** 與 **pnpm**，三個平台（macOS / Linux / Windows）指令完全相同：
+**One-liner install** (macOS / Linux):
 
 ```bash
-python dev.py install   # 安裝所有依賴（首次執行自動安裝 uv）
-python dev.py dev       # 啟動開發伺服器
+curl -fsSL https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.sh | bash
+```
+
+Automatically installs git, Python 3, Node.js, pnpm, and uv if missing. After install:
+
+```bash
+cd ~/CodefyUI && python dev.py dev
 ```
 
 Open [http://localhost:5173](http://localhost:5173). The frontend proxies API/WS requests to the backend at `:8000`.

--- a/README.md
+++ b/README.md
@@ -25,30 +25,24 @@ A visual, node-based deep learning pipeline builder. Design CNN, RNN, Transforme
 
 ## Quick Start
 
-This quick start assumes an **NVIDIA GPU with CUDA 12.4**. For CPU, Apple Silicon, AMD, or detailed troubleshooting, see the [full setup guide](./SETUP.md).
+只需要 **Python 3.11+** 與 **pnpm**，三個平台（macOS / Linux / Windows）指令完全相同：
 
 ```bash
-# ── Backend (terminal 1) ──────────────────────
-cd backend
-uv venv --python 3.11
-.venv\Scripts\activate                              # Windows
-# source .venv/bin/activate                         # macOS / Linux
-
-uv pip install -e ".[dev]"
-uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
-uv pip install gymnasium safetensors
-
-uvicorn app.main:app --reload
-
-# ── Frontend (terminal 2) ─────────────────────
-cd frontend
-pnpm install
-pnpm dev
+python dev.py install   # 安裝所有依賴（首次執行自動安裝 uv）
+python dev.py dev       # 啟動開發伺服器
 ```
 
 Open [http://localhost:5173](http://localhost:5173). The frontend proxies API/WS requests to the backend at `:8000`.
 
-> **No NVIDIA GPU?** See [SETUP.md](./SETUP.md) for CPU, Apple Silicon (MPS), and AMD instructions.
+| 指令 | 說明 |
+|------|------|
+| `python dev.py install` | 安裝 backend + frontend 依賴 |
+| `python dev.py dev` | 啟動 backend :8000 + frontend :5173 |
+| `python dev.py stop` | 停止所有服務 |
+| `python dev.py test` | 執行 backend 測試 |
+| `python dev.py clean` | 移除虛擬環境與 node_modules |
+
+> This quick start assumes an **NVIDIA GPU with CUDA 12.4**. For CPU, Apple Silicon, AMD, or detailed troubleshooting, see the [full setup guide](./SETUP.md).
 
 ### CLI Execution
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -25,11 +25,16 @@
 
 ## 快速開始
 
-只需要 **Python 3.11+** 與 **pnpm**，三個平台（macOS / Linux / Windows）指令完全相同：
+**一行指令安裝**（macOS / Linux）：
 
 ```bash
-python dev.py install   # 安裝所有依賴（首次執行自動安裝 uv）
-python dev.py dev       # 啟動開發伺服器
+curl -fsSL https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.sh | bash
+```
+
+自動安裝所有缺少的依賴（git、Python 3、Node.js、pnpm、uv）。安裝完成後：
+
+```bash
+cd ~/CodefyUI && python dev.py dev
 ```
 
 開啟 [http://localhost:5173](http://localhost:5173)。前端會將 API/WS 請求代理到後端的 `:8000` 埠。

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -25,30 +25,24 @@
 
 ## 快速開始
 
-以下快速開始假設使用 **NVIDIA 顯卡 + CUDA 12.4**。若使用 CPU、Apple Silicon、AMD 或需要更詳細的疑難排解，請參考[完整安裝指南](./SETUP_zh-TW.md)。
+只需要 **Python 3.11+** 與 **pnpm**，三個平台（macOS / Linux / Windows）指令完全相同：
 
 ```bash
-# ── 後端（終端機 1）──────────────────────
-cd backend
-uv venv --python 3.11
-.venv\Scripts\activate                              # Windows
-# source .venv/bin/activate                         # macOS / Linux
-
-uv pip install -e ".[dev]"
-uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
-uv pip install gymnasium safetensors
-
-uvicorn app.main:app --reload
-
-# ── 前端（終端機 2）──────────────────────
-cd frontend
-pnpm install
-pnpm dev
+python dev.py install   # 安裝所有依賴（首次執行自動安裝 uv）
+python dev.py dev       # 啟動開發伺服器
 ```
 
 開啟 [http://localhost:5173](http://localhost:5173)。前端會將 API/WS 請求代理到後端的 `:8000` 埠。
 
-> **沒有 NVIDIA 顯卡？** 請參考 [SETUP_zh-TW.md](./SETUP_zh-TW.md) 查看 CPU、Apple Silicon (MPS) 與 AMD 的安裝方式。
+| 指令 | 說明 |
+|------|------|
+| `python dev.py install` | 安裝 backend + frontend 依賴 |
+| `python dev.py dev` | 啟動 backend :8000 + frontend :5173 |
+| `python dev.py stop` | 停止所有服務 |
+| `python dev.py test` | 執行 backend 測試 |
+| `python dev.py clean` | 移除虛擬環境與 node_modules |
+
+> 以上快速開始假設使用 **NVIDIA 顯卡 + CUDA 12.4**。若使用 CPU、Apple Silicon、AMD 或需要更詳細的疑難排解，請參考[完整安裝指南](./SETUP_zh-TW.md)。
 
 ### CLI 執行
 

--- a/dev.py
+++ b/dev.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Cross-platform task runner for CodefyUI.
+"""CodefyUI 跨平台任務執行器。
 
-Usage:
-    uv run python scripts/dev.py <command>
+用法：
+    python dev.py <command>
 
-Commands:
+指令：
     install   安裝所有依賴（backend + frontend）
     dev       啟動開發伺服器（Ctrl+C 停止）
     stop      停止所有服務
@@ -18,11 +18,33 @@ import sys
 import threading
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = Path(__file__).resolve().parent
 BACKEND_DIR = ROOT / "backend"
 FRONTEND_DIR = ROOT / "frontend"
 VENV = BACKEND_DIR / ".venv"
 VENV_BIN = VENV / ("Scripts" if sys.platform == "win32" else "bin")
+
+
+# ── Bootstrap ─────────────────────────────────────────────────────────────────
+
+def _ensure_uv() -> None:
+    if shutil.which("uv"):
+        return
+    print("=== uv 未安裝，正在自動安裝 ===")
+    if sys.platform == "win32":
+        subprocess.run(
+            ["powershell", "-c", "irm https://astral.sh/uv/install.ps1 | iex"],
+            check=True,
+        )
+    else:
+        subprocess.run(
+            "curl -LsSf https://astral.sh/uv/install.sh | sh",
+            shell=True,
+            check=True,
+        )
+    # 安裝後重新啟動自身，讓新 PATH 生效
+    import os
+    os.execv(sys.executable, [sys.executable] + sys.argv)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -61,7 +83,6 @@ def dev() -> None:
     backend_cmd = [uvicorn, "app.main:app", "--reload"]
     frontend_cmd = ["pnpm", "dev"]
 
-    # Windows 需要 shell=True 才能找到 pnpm（非 .exe 的指令）
     shell = sys.platform == "win32"
 
     print("=== 啟動 CodefyUI（Ctrl+C 停止）===")
@@ -135,4 +156,5 @@ if __name__ == "__main__":
     if len(sys.argv) < 2 or sys.argv[1] not in COMMANDS:
         print(__doc__)
         sys.exit(1)
+    _ensure_uv()
     COMMANDS[sys.argv[1]]()

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# CodefyUI 一鍵安裝腳本
+# 用法：curl -fsSL https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.sh | bash
+set -euo pipefail
+
+# ── 顏色 ──────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
+
+REPO="https://github.com/latteine1217/CodefyUI.git"
+INSTALL_DIR="${CODEFYUI_DIR:-$HOME/CodefyUI}"
+
+step() { echo -e "\n${BLUE}==>${NC} ${BOLD}$*${NC}"; }
+ok()   { echo -e "  ${GREEN}✓${NC} $*"; }
+warn() { echo -e "  ${YELLOW}!${NC} $*"; }
+die()  { echo -e "\n${RED}✗ 錯誤：$*${NC}" >&2; exit 1; }
+
+# root 不需要 sudo
+SUDO=""
+[[ "$(id -u)" != "0" ]] && SUDO="sudo"
+
+# ── OS 偵測 ───────────────────────────────────────────────────────────
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  OS="macos"
+elif [[ -f /etc/debian_version ]]; then
+  OS="debian"
+elif [[ -f /etc/redhat-release ]]; then
+  OS="redhat"
+else
+  OS="unknown"
+fi
+
+# ── 套件安裝 helper ───────────────────────────────────────────────────
+pkg_install() {
+  case "$OS" in
+    macos)
+      if ! command -v brew &>/dev/null; then
+        warn "安裝 Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      fi
+      brew install "$@" ;;
+    debian)
+      $SUDO apt-get update -qq
+      $SUDO apt-get install -y "$@" ;;
+    redhat)
+      $SUDO yum install -y "$@" ;;
+    *)
+      die "不支援的作業系統，請手動安裝：$*" ;;
+  esac
+}
+
+# ══════════════════════════════════════════════════════════════════════
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║        CodefyUI  安裝程式            ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════╝${NC}"
+echo -e "  安裝目錄：${BOLD}$INSTALL_DIR${NC}"
+
+# ── git ───────────────────────────────────────────────────────────────
+step "git"
+if ! command -v git &>/dev/null; then
+  warn "未安裝，正在安裝..."
+  pkg_install git
+fi
+ok "$(git --version)"
+
+# ── Python 3 ──────────────────────────────────────────────────────────
+step "Python 3"
+PYTHON=""
+for cmd in python3 python; do
+  if command -v "$cmd" &>/dev/null && "$cmd" -c "import sys; assert sys.version_info >= (3,8)" 2>/dev/null; then
+    PYTHON="$cmd"; break
+  fi
+done
+
+if [[ -z "$PYTHON" ]]; then
+  warn "未安裝，正在安裝..."
+  case "$OS" in
+    macos)   pkg_install python@3.11 ;;
+    debian)  pkg_install python3 ;;
+    redhat)  pkg_install python3 ;;
+    *)       die "請手動安裝 Python 3.8+" ;;
+  esac
+  PYTHON="python3"
+fi
+ok "$($PYTHON --version)"
+
+# ── Node.js ───────────────────────────────────────────────────────────
+step "Node.js"
+if ! command -v node &>/dev/null; then
+  warn "未安裝，透過 nvm 安裝 LTS..."
+  export NVM_DIR="$HOME/.nvm"
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+  # 在目前 shell 載入 nvm（不依賴 .bashrc）
+  [[ -s "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
+  nvm install --lts --no-progress
+  nvm use --lts
+fi
+ok "Node.js $(node --version)"
+
+# ── pnpm ──────────────────────────────────────────────────────────────
+step "pnpm"
+if ! command -v pnpm &>/dev/null; then
+  warn "未安裝，正在安裝..."
+  # 優先用 npm（已隨 Node.js 安裝）
+  if command -v npm &>/dev/null; then
+    npm install -g pnpm --silent
+  else
+    curl -fsSL https://get.pnpm.io/install.sh | sh -
+    export PNPM_HOME="$HOME/.local/share/pnpm"
+    export PATH="$PNPM_HOME:$PATH"
+  fi
+fi
+ok "pnpm $(pnpm --version)"
+
+# ── Clone / Update ────────────────────────────────────────────────────
+step "下載 CodefyUI"
+if [[ -d "$INSTALL_DIR/.git" ]]; then
+  warn "目錄已存在，執行更新..."
+  git -C "$INSTALL_DIR" pull --ff-only
+  ok "已更新至最新版本"
+else
+  git clone --depth 1 "$REPO" "$INSTALL_DIR"
+  ok "Clone 完成"
+fi
+
+# ── 安裝依賴 ──────────────────────────────────────────────────────────
+step "安裝專案依賴"
+cd "$INSTALL_DIR"
+$PYTHON dev.py install
+
+# ── 完成 ──────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}${BOLD}╔══════════════════════════════════════╗${NC}"
+echo -e "${GREEN}${BOLD}║          安裝完成！                  ║${NC}"
+echo -e "${GREEN}${BOLD}╚══════════════════════════════════════╝${NC}"
+echo ""
+echo -e "  啟動開發伺服器："
+echo -e "    ${BOLD}cd $INSTALL_DIR${NC}"
+echo -e "    ${BOLD}python dev.py dev${NC}"
+echo ""

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Cross-platform task runner for CodefyUI.
+
+Usage:
+    uv run python scripts/dev.py <command>
+
+Commands:
+    install   安裝所有依賴（backend + frontend）
+    dev       啟動開發伺服器（Ctrl+C 停止）
+    stop      停止所有服務
+    test      執行 backend 測試
+    clean     移除虛擬環境與 node_modules
+"""
+
+import shutil
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BACKEND_DIR = ROOT / "backend"
+FRONTEND_DIR = ROOT / "frontend"
+VENV = BACKEND_DIR / ".venv"
+VENV_BIN = VENV / ("Scripts" if sys.platform == "win32" else "bin")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def run(cmd: list, cwd: Path = ROOT) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True)
+
+
+def _stream(proc: subprocess.Popen, prefix: str) -> None:
+    assert proc.stdout is not None
+    for raw in iter(proc.stdout.readline, b""):
+        print(f"{prefix} {raw.decode(errors='replace').rstrip()}", flush=True)
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+def install() -> None:
+    print("=== Backend: 建立虛擬環境 ===")
+    run(["uv", "venv", "--python", "3.11"], cwd=BACKEND_DIR)
+
+    print("=== Backend: 安裝依賴 ===")
+    run(["uv", "pip", "install", "-e", ".[dev]"], cwd=BACKEND_DIR)
+
+    print("=== Backend: 安裝 PyTorch ===")
+    run(["uv", "pip", "install", "torch", "torchvision", "gymnasium", "safetensors"],
+        cwd=BACKEND_DIR)
+
+    print("=== Frontend: 安裝依賴 ===")
+    run(["pnpm", "install"], cwd=FRONTEND_DIR)
+
+    print("=== 安裝完成 ===")
+
+
+def dev() -> None:
+    uvicorn = str(VENV_BIN / "uvicorn")
+    backend_cmd = [uvicorn, "app.main:app", "--reload"]
+    frontend_cmd = ["pnpm", "dev"]
+
+    # Windows 需要 shell=True 才能找到 pnpm（非 .exe 的指令）
+    shell = sys.platform == "win32"
+
+    print("=== 啟動 CodefyUI（Ctrl+C 停止）===")
+    print("    backend  → http://localhost:8000")
+    print("    frontend → http://localhost:5173")
+    print("")
+
+    backend = subprocess.Popen(
+        backend_cmd,
+        cwd=BACKEND_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=shell,
+    )
+    frontend = subprocess.Popen(
+        frontend_cmd,
+        cwd=FRONTEND_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=shell,
+    )
+
+    threading.Thread(target=_stream, args=(backend, "[backend] "), daemon=True).start()
+    threading.Thread(target=_stream, args=(frontend, "[frontend]"), daemon=True).start()
+
+    try:
+        backend.wait()
+        frontend.wait()
+    except KeyboardInterrupt:
+        print("\n=== 停止服務 ===")
+        backend.terminate()
+        frontend.terminate()
+        backend.wait()
+        frontend.wait()
+
+
+def stop() -> None:
+    print("=== 停止所有服務 ===")
+    if sys.platform == "win32":
+        subprocess.run(["taskkill", "/F", "/IM", "uvicorn.exe"], capture_output=True)
+        subprocess.run(["taskkill", "/F", "/FI", "WINDOWTITLE eq vite*"], capture_output=True)
+    else:
+        subprocess.run(["pkill", "-f", "uvicorn app.main:app"], capture_output=True)
+        subprocess.run(["pkill", "-f", "vite"], capture_output=True)
+    print("=== 完成 ===")
+
+
+def test() -> None:
+    pytest = str(VENV_BIN / "pytest")
+    run([pytest], cwd=BACKEND_DIR)
+
+
+def clean() -> None:
+    print("=== 清除虛擬環境與 node_modules ===")
+    shutil.rmtree(VENV, ignore_errors=True)
+    shutil.rmtree(FRONTEND_DIR / "node_modules", ignore_errors=True)
+    print("=== 完成 ===")
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+COMMANDS = {
+    "install": install,
+    "dev": dev,
+    "stop": stop,
+    "test": test,
+    "clean": clean,
+}
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2 or sys.argv[1] not in COMMANDS:
+        print(__doc__)
+        sys.exit(1)
+    COMMANDS[sys.argv[1]]()


### PR DESCRIPTION
## Summary

- 新增 `install.sh`：macOS / Linux 一行 curl 安裝，自動安裝所有缺少的依賴（git、Python 3、Node.js via nvm、pnpm、uv）
- 新增 `install.ps1`：Windows 一行 PowerShell 安裝，直接下載 Python 3.11、Node.js portable，零套件管理器依賴
- 新增 `dev.py`（根目錄）：跨平台任務執行器，首次執行自動 bootstrap uv
- 新增 `Makefile`：薄層封裝，呼叫 `dev.py`（可選）
- 更新 README.md / README_zh-TW.md Quick Start 說明

## 安裝方式

```bash
# macOS / Linux
curl -fsSL https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.sh | bash

# Windows（PowerShell）
irm https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.ps1 | iex
```

## 開發指令（全平台統一）

```bash
python dev.py install   # 安裝依賴
python dev.py dev       # 啟動開發伺服器（backend :8000 + frontend :5173）
python dev.py stop      # 停止服務
python dev.py test      # 執行測試
python dev.py clean     # 清除環境
```

## 設計原則

- **零前置條件**：只需要 Python（Windows 也會自動安裝）
- **跨平台一致**：macOS / Linux / Windows 指令完全相同
- **無套件管理器依賴**：Windows 版直接下載 portable zip，不需要 winget / Scoop / Chocolatey

## Test plan

- [ ] macOS：`curl -fsSL .../install.sh | bash` 完整安裝
- [ ] Linux（Ubuntu / Colab 空白環境）：完整安裝
- [ ] Windows：`irm .../install.ps1 | iex` 完整安裝

🤖 Generated with [Claude Code](https://claude.com/claude-code)