### PR TITLE
feat: 新增一鍵安裝腳本與跨平台任務執行器

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+RUNNER := uv run python scripts/dev.py
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help:
+	@echo "CodefyUI"
+	@echo ""
+	@echo "  make install   安裝所有依賴（backend + frontend）"
+	@echo "  make dev       啟動開發伺服器（backend :8000 + frontend :5173）"
+	@echo "  make stop      停止所有服務"
+	@echo "  make test      執行 backend 測試"
+	@echo "  make clean     移除虛擬環境與 node_modules"
+	@echo ""
+	@echo "Windows 使用者（不需要 make）："
+	@echo "  uv run python scripts/dev.py <command>"
+	@echo ""
+
+.PHONY: install
+install:
+	$(RUNNER) install
+
+.PHONY: dev
+dev:
+	$(RUNNER) dev
+
+.PHONY: stop
+stop:
+	$(RUNNER) stop
+
+.PHONY: test
+test:
+	$(RUNNER) test
+
+.PHONY: clean
+clean:
+	$(RUNNER) clean

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RUNNER := uv run python scripts/dev.py
+RUNNER := python dev.py
 
 .DEFAULT_GOAL := help
 
@@ -12,8 +12,8 @@ help:
 	@echo "  make test      執行 backend 測試"
 	@echo "  make clean     移除虛擬環境與 node_modules"
 	@echo ""
-	@echo "Windows 使用者（不需要 make）："
-	@echo "  uv run python scripts/dev.py <command>"
+	@echo "或直接（全平台通用）："
+	@echo "  python dev.py <command>"
 	@echo ""
 
 .PHONY: install

--- a/README.md
+++ b/README.md
@@ -25,11 +25,16 @@ A visual, node-based deep learning pipeline builder. Design CNN, RNN, Transforme
 
 ## Quick Start
 
-只需要 **Python 3.11+** 與 **pnpm**，三個平台（macOS / Linux / Windows）指令完全相同：
+**One-liner install** (macOS / Linux):
 
 ```bash
-python dev.py install   # 安裝所有依賴（首次執行自動安裝 uv）
-python dev.py dev       # 啟動開發伺服器
+curl -fsSL https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.sh | bash
+```
+
+Automatically installs git, Python 3, Node.js, pnpm, and uv if missing. After install:
+
+```bash
+cd ~/CodefyUI && python dev.py dev
 ```
 
 Open [http://localhost:5173](http://localhost:5173). The frontend proxies API/WS requests to the backend at `:8000`.

--- a/README.md
+++ b/README.md
@@ -25,30 +25,24 @@ A visual, node-based deep learning pipeline builder. Design CNN, RNN, Transforme
 
 ## Quick Start
 
-This quick start assumes an **NVIDIA GPU with CUDA 12.4**. For CPU, Apple Silicon, AMD, or detailed troubleshooting, see the [full setup guide](./SETUP.md).
+只需要 **Python 3.11+** 與 **pnpm**，三個平台（macOS / Linux / Windows）指令完全相同：
 
 ```bash
-# ── Backend (terminal 1) ──────────────────────
-cd backend
-uv venv --python 3.11
-.venv\Scripts\activate                              # Windows
-# source .venv/bin/activate                         # macOS / Linux
-
-uv pip install -e ".[dev]"
-uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
-uv pip install gymnasium safetensors
-
-uvicorn app.main:app --reload
-
-# ── Frontend (terminal 2) ─────────────────────
-cd frontend
-pnpm install
-pnpm dev
+python dev.py install   # 安裝所有依賴（首次執行自動安裝 uv）
+python dev.py dev       # 啟動開發伺服器
 ```
 
 Open [http://localhost:5173](http://localhost:5173). The frontend proxies API/WS requests to the backend at `:8000`.
 
-> **No NVIDIA GPU?** See [SETUP.md](./SETUP.md) for CPU, Apple Silicon (MPS), and AMD instructions.
+| 指令 | 說明 |
+|------|------|
+| `python dev.py install` | 安裝 backend + frontend 依賴 |
+| `python dev.py dev` | 啟動 backend :8000 + frontend :5173 |
+| `python dev.py stop` | 停止所有服務 |
+| `python dev.py test` | 執行 backend 測試 |
+| `python dev.py clean` | 移除虛擬環境與 node_modules |
+
+> This quick start assumes an **NVIDIA GPU with CUDA 12.4**. For CPU, Apple Silicon, AMD, or detailed troubleshooting, see the [full setup guide](./SETUP.md).
 
 ### CLI Execution
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ A visual, node-based deep learning pipeline builder. Design CNN, RNN, Transforme
 
 ## Quick Start
 
-**One-liner install** (macOS / Linux):
+**One-liner install**:
 
 ```bash
+# macOS / Linux
 curl -fsSL https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.sh | bash
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.ps1 | iex
 ```
 
 Automatically installs git, Python 3, Node.js, pnpm, and uv if missing. After install:

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -25,11 +25,16 @@
 
 ## 快速開始
 
-只需要 **Python 3.11+** 與 **pnpm**，三個平台（macOS / Linux / Windows）指令完全相同：
+**一行指令安裝**（macOS / Linux）：
 
 ```bash
-python dev.py install   # 安裝所有依賴（首次執行自動安裝 uv）
-python dev.py dev       # 啟動開發伺服器
+curl -fsSL https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.sh | bash
+```
+
+自動安裝所有缺少的依賴（git、Python 3、Node.js、pnpm、uv）。安裝完成後：
+
+```bash
+cd ~/CodefyUI && python dev.py dev
 ```
 
 開啟 [http://localhost:5173](http://localhost:5173)。前端會將 API/WS 請求代理到後端的 `:8000` 埠。

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -25,30 +25,24 @@
 
 ## 快速開始
 
-以下快速開始假設使用 **NVIDIA 顯卡 + CUDA 12.4**。若使用 CPU、Apple Silicon、AMD 或需要更詳細的疑難排解，請參考[完整安裝指南](./SETUP_zh-TW.md)。
+只需要 **Python 3.11+** 與 **pnpm**，三個平台（macOS / Linux / Windows）指令完全相同：
 
 ```bash
-# ── 後端（終端機 1）──────────────────────
-cd backend
-uv venv --python 3.11
-.venv\Scripts\activate                              # Windows
-# source .venv/bin/activate                         # macOS / Linux
-
-uv pip install -e ".[dev]"
-uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
-uv pip install gymnasium safetensors
-
-uvicorn app.main:app --reload
-
-# ── 前端（終端機 2）──────────────────────
-cd frontend
-pnpm install
-pnpm dev
+python dev.py install   # 安裝所有依賴（首次執行自動安裝 uv）
+python dev.py dev       # 啟動開發伺服器
 ```
 
 開啟 [http://localhost:5173](http://localhost:5173)。前端會將 API/WS 請求代理到後端的 `:8000` 埠。
 
-> **沒有 NVIDIA 顯卡？** 請參考 [SETUP_zh-TW.md](./SETUP_zh-TW.md) 查看 CPU、Apple Silicon (MPS) 與 AMD 的安裝方式。
+| 指令 | 說明 |
+|------|------|
+| `python dev.py install` | 安裝 backend + frontend 依賴 |
+| `python dev.py dev` | 啟動 backend :8000 + frontend :5173 |
+| `python dev.py stop` | 停止所有服務 |
+| `python dev.py test` | 執行 backend 測試 |
+| `python dev.py clean` | 移除虛擬環境與 node_modules |
+
+> 以上快速開始假設使用 **NVIDIA 顯卡 + CUDA 12.4**。若使用 CPU、Apple Silicon、AMD 或需要更詳細的疑難排解，請參考[完整安裝指南](./SETUP_zh-TW.md)。
 
 ### CLI 執行
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -25,10 +25,14 @@
 
 ## 快速開始
 
-**一行指令安裝**（macOS / Linux）：
+**一行指令安裝**：
 
 ```bash
+# macOS / Linux
 curl -fsSL https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.sh | bash
+
+# Windows（PowerShell）
+irm https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.ps1 | iex
 ```
 
 自動安裝所有缺少的依賴（git、Python 3、Node.js、pnpm、uv）。安裝完成後：

--- a/dev.py
+++ b/dev.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Cross-platform task runner for CodefyUI.
+"""CodefyUI 跨平台任務執行器。
 
-Usage:
-    uv run python scripts/dev.py <command>
+用法：
+    python dev.py <command>
 
-Commands:
+指令：
     install   安裝所有依賴（backend + frontend）
     dev       啟動開發伺服器（Ctrl+C 停止）
     stop      停止所有服務
@@ -18,11 +18,33 @@ import sys
 import threading
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = Path(__file__).resolve().parent
 BACKEND_DIR = ROOT / "backend"
 FRONTEND_DIR = ROOT / "frontend"
 VENV = BACKEND_DIR / ".venv"
 VENV_BIN = VENV / ("Scripts" if sys.platform == "win32" else "bin")
+
+
+# ── Bootstrap ─────────────────────────────────────────────────────────────────
+
+def _ensure_uv() -> None:
+    if shutil.which("uv"):
+        return
+    print("=== uv 未安裝，正在自動安裝 ===")
+    if sys.platform == "win32":
+        subprocess.run(
+            ["powershell", "-c", "irm https://astral.sh/uv/install.ps1 | iex"],
+            check=True,
+        )
+    else:
+        subprocess.run(
+            "curl -LsSf https://astral.sh/uv/install.sh | sh",
+            shell=True,
+            check=True,
+        )
+    # 安裝後重新啟動自身，讓新 PATH 生效
+    import os
+    os.execv(sys.executable, [sys.executable] + sys.argv)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -61,7 +83,6 @@ def dev() -> None:
     backend_cmd = [uvicorn, "app.main:app", "--reload"]
     frontend_cmd = ["pnpm", "dev"]
 
-    # Windows 需要 shell=True 才能找到 pnpm（非 .exe 的指令）
     shell = sys.platform == "win32"
 
     print("=== 啟動 CodefyUI（Ctrl+C 停止）===")
@@ -135,4 +156,5 @@ if __name__ == "__main__":
     if len(sys.argv) < 2 or sys.argv[1] not in COMMANDS:
         print(__doc__)
         sys.exit(1)
+    _ensure_uv()
     COMMANDS[sys.argv[1]]()

--- a/install.ps1
+++ b/install.ps1
@@ -8,6 +8,15 @@ function Step { Write-Host "`n==> $args" -ForegroundColor Cyan }
 function Ok   { Write-Host "  v $args" -ForegroundColor Green }
 function Warn { Write-Host "  ! $args" -ForegroundColor Yellow }
 
+# ── 自動提升管理員權限 ────────────────────────────────────────────────
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Host "  ! 需要管理員權限，正在重新啟動..." -ForegroundColor Yellow
+    $cmd = "-NoExit -ExecutionPolicy Bypass -Command `"irm https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.ps1 | iex`""
+    Start-Process PowerShell -Verb RunAs -ArgumentList $cmd
+    exit
+}
+
 function Finish {
     Write-Host "`n按 Enter 關閉視窗..." -NoNewline
     $null = Read-Host

--- a/install.ps1
+++ b/install.ps1
@@ -1,97 +1,114 @@
 # CodefyUI Windows 安裝腳本
 # 用法：irm https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.ps1 | iex
-$ErrorActionPreference = "Stop"
 
-$REPO     = "https://github.com/latteine1217/CodefyUI.git"
-$INSTALL  = if ($env:CODEFYUI_DIR) { $env:CODEFYUI_DIR } else { "$HOME\CodefyUI" }
+$REPO    = "https://github.com/latteine1217/CodefyUI.git"
+$INSTALL = if ($env:CODEFYUI_DIR) { $env:CODEFYUI_DIR } else { "$HOME\CodefyUI" }
 
-function Step  { Write-Host "`n==> $args" -ForegroundColor Cyan }
-function Ok    { Write-Host "  v $args" -ForegroundColor Green }
-function Warn  { Write-Host "  ! $args" -ForegroundColor Yellow }
-function Die   { Write-Host "`nx $args" -ForegroundColor Red; exit 1 }
+function Step { Write-Host "`n==> $args" -ForegroundColor Cyan }
+function Ok   { Write-Host "  v $args" -ForegroundColor Green }
+function Warn { Write-Host "  ! $args" -ForegroundColor Yellow }
 
-Write-Host ""
-Write-Host "╔══════════════════════════════════════╗" -ForegroundColor White
-Write-Host "║        CodefyUI  安裝程式            ║" -ForegroundColor White
-Write-Host "╚══════════════════════════════════════╝" -ForegroundColor White
-Write-Host "  安裝目錄：$INSTALL"
+function Pause-And-Exit {
+    param([string]$msg, [int]$code = 1)
+    Write-Host "`nx 錯誤：$msg" -ForegroundColor Red
+    Write-Host "`n按 Enter 關閉視窗..." -NoNewline
+    $null = Read-Host
+    exit $code
+}
 
-# ── winget ────────────────────────────────────────────────────────────
-function Install-Winget {
-    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
-        Die "找不到 winget，請先從 Microsoft Store 安裝『應用程式安裝程式』"
+try {
+    Write-Host ""
+    Write-Host "╔══════════════════════════════════════╗" -ForegroundColor White
+    Write-Host "║        CodefyUI  安裝程式            ║" -ForegroundColor White
+    Write-Host "╚══════════════════════════════════════╝" -ForegroundColor White
+    Write-Host "  安裝目錄：$INSTALL"
+
+    # ── winget 可用性 ──────────────────────────────────────────────────
+    $hasWinget = [bool](Get-Command winget -ErrorAction SilentlyContinue)
+
+    # ── git ────────────────────────────────────────────────────────────
+    Step "git"
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Warn "未安裝，透過 winget 安裝..."
+        if (-not $hasWinget) { Pause-And-Exit "找不到 winget，請先從 Microsoft Store 安裝『應用程式安裝程式』" }
+        winget install --id Git.Git -e --source winget --accept-package-agreements --accept-source-agreements
+        $env:PATH += ";C:\Program Files\Git\cmd"
     }
-}
+    Ok "$(git --version)"
 
-# ── git ───────────────────────────────────────────────────────────────
-Step "git"
-if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Warn "未安裝，透過 winget 安裝..."
-    Install-Winget
-    winget install --id Git.Git -e --source winget --silent
-    $env:PATH += ";C:\Program Files\Git\cmd"
-}
-Ok "$(git --version)"
-
-# ── Python 3 ──────────────────────────────────────────────────────────
-Step "Python 3"
-$PYTHON = $null
-foreach ($cmd in @("python", "python3")) {
-    if (Get-Command $cmd -ErrorAction SilentlyContinue) {
-        $ver = & $cmd -c "import sys; print(sys.version_info >= (3,8))" 2>$null
-        if ($ver -eq "True") { $PYTHON = $cmd; break }
+    # ── Python 3 ───────────────────────────────────────────────────────
+    Step "Python 3"
+    $PYTHON = $null
+    foreach ($cmd in @("python", "python3", "py")) {
+        if (Get-Command $cmd -ErrorAction SilentlyContinue) {
+            $ok = & $cmd -c "import sys; print(sys.version_info >= (3,8))" 2>$null
+            if ($ok -eq "True") { $PYTHON = $cmd; break }
+        }
     }
-}
-if (-not $PYTHON) {
-    Warn "未安裝，透過 winget 安裝..."
-    Install-Winget
-    winget install --id Python.Python.3.11 -e --source winget --silent
-    $env:PATH += ";$HOME\AppData\Local\Programs\Python\Python311;$HOME\AppData\Local\Programs\Python\Python311\Scripts"
-    $PYTHON = "python"
-}
-Ok "$(& $PYTHON --version)"
+    if (-not $PYTHON) {
+        Warn "未安裝，透過 winget 安裝..."
+        if (-not $hasWinget) { Pause-And-Exit "找不到 winget，請先從 Microsoft Store 安裝『應用程式安裝程式』" }
+        winget install --id Python.Python.3.11 -e --source winget --accept-package-agreements --accept-source-agreements
+        $env:PATH += ";$HOME\AppData\Local\Programs\Python\Python311"
+        $env:PATH += ";$HOME\AppData\Local\Programs\Python\Python311\Scripts"
+        $PYTHON = "python"
+    }
+    Ok "$(& $PYTHON --version)"
 
-# ── Node.js ───────────────────────────────────────────────────────────
-Step "Node.js"
-if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
-    Warn "未安裝，透過 winget 安裝..."
-    Install-Winget
-    winget install --id OpenJS.NodeJS.LTS -e --source winget --silent
-    $env:PATH += ";C:\Program Files\nodejs"
+    # ── Node.js ────────────────────────────────────────────────────────
+    Step "Node.js"
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+        Warn "未安裝，透過 winget 安裝..."
+        if (-not $hasWinget) { Pause-And-Exit "找不到 winget，請先從 Microsoft Store 安裝『應用程式安裝程式』" }
+        winget install --id OpenJS.NodeJS.LTS -e --source winget --accept-package-agreements --accept-source-agreements
+        $env:PATH += ";C:\Program Files\nodejs"
+    }
+    Ok "Node.js $(node --version)"
+
+    # ── pnpm ───────────────────────────────────────────────────────────
+    Step "pnpm"
+    if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
+        Warn "未安裝，透過 npm 安裝..."
+        npm install -g pnpm
+    }
+    Ok "pnpm $(pnpm --version)"
+
+    # ── Clone / Update ─────────────────────────────────────────────────
+    Step "下載 CodefyUI"
+    if (Test-Path "$INSTALL\.git") {
+        Warn "目錄已存在，執行更新..."
+        git -C $INSTALL pull --ff-only
+        Ok "已更新至最新版本"
+    } else {
+        git clone --depth 1 $REPO $INSTALL
+        Ok "Clone 完成"
+    }
+
+    # ── 安裝依賴 ───────────────────────────────────────────────────────
+    Step "安裝專案依賴"
+    Set-Location $INSTALL
+    & $PYTHON dev.py install
+
+    # ── 完成 ───────────────────────────────────────────────────────────
+    Write-Host ""
+    Write-Host "╔══════════════════════════════════════╗" -ForegroundColor Green
+    Write-Host "║          安裝完成！                  ║" -ForegroundColor Green
+    Write-Host "╚══════════════════════════════════════╝" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "  啟動開發伺服器："
+    Write-Host "    cd $INSTALL" -ForegroundColor White
+    Write-Host "    python dev.py dev" -ForegroundColor White
+    Write-Host ""
+
+} catch {
+    Write-Host ""
+    Write-Host "x 安裝失敗：$($_.Exception.Message)" -ForegroundColor Red
+    Write-Host "  行數：$($_.InvocationInfo.ScriptLineNumber)" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "按 Enter 關閉視窗..." -NoNewline
+    $null = Read-Host
+    exit 1
 }
-Ok "Node.js $(node --version)"
 
-# ── pnpm ──────────────────────────────────────────────────────────────
-Step "pnpm"
-if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
-    Warn "未安裝，透過 npm 安裝..."
-    npm install -g pnpm --silent
-}
-Ok "pnpm $(pnpm --version)"
-
-# ── Clone / Update ────────────────────────────────────────────────────
-Step "下載 CodefyUI"
-if (Test-Path "$INSTALL\.git") {
-    Warn "目錄已存在，執行更新..."
-    git -C $INSTALL pull --ff-only
-    Ok "已更新至最新版本"
-} else {
-    git clone --depth 1 $REPO $INSTALL
-    Ok "Clone 完成"
-}
-
-# ── 安裝依賴 ──────────────────────────────────────────────────────────
-Step "安裝專案依賴"
-Set-Location $INSTALL
-& $PYTHON dev.py install
-
-# ── 完成 ──────────────────────────────────────────────────────────────
-Write-Host ""
-Write-Host "╔══════════════════════════════════════╗" -ForegroundColor Green
-Write-Host "║          安裝完成！                  ║" -ForegroundColor Green
-Write-Host "╚══════════════════════════════════════╝" -ForegroundColor Green
-Write-Host ""
-Write-Host "  啟動開發伺服器："
-Write-Host "    cd $INSTALL" -ForegroundColor White
-Write-Host "    python dev.py dev" -ForegroundColor White
-Write-Host ""
+Write-Host "按 Enter 關閉視窗..." -NoNewline
+$null = Read-Host

--- a/install.ps1
+++ b/install.ps1
@@ -1,9 +1,14 @@
 # CodefyUI Windows 安裝腳本
 # 用法：irm https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.ps1 | iex
 
-$REPO    = "https://github.com/latteine1217/CodefyUI.git"
-$INSTALL = if ($env:CODEFYUI_DIR) { $env:CODEFYUI_DIR } else { "$HOME\CodefyUI" }
-$TOOLS   = "$HOME\.codefyui"
+$INSTALL  = if ($env:CODEFYUI_DIR) { $env:CODEFYUI_DIR } else { "$HOME\CodefyUI" }
+$TOOLS    = "$HOME\.codefyui"
+$REPO_ZIP = "https://github.com/latteine1217/CodefyUI/archive/refs/heads/main.zip"
+$PY_URL   = "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe"
+$NODE_VER = "v22.16.0"
+$NODE_URL = "https://nodejs.org/dist/$NODE_VER/node-$NODE_VER-win-x64.zip"
+
+$ProgressPreference = "SilentlyContinue"
 
 function Step { Write-Host "`n==> $args" -ForegroundColor Cyan }
 function Ok   { Write-Host "  v $args" -ForegroundColor Green }
@@ -18,10 +23,8 @@ function Add-ToPath ([string]$dir) {
     }
 }
 function Download ([string]$url, [string]$dest) {
-    Warn "下載 $([System.IO.Path]::GetFileName($dest))..."
-    $ProgressPreference = "SilentlyContinue"
-    Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
-    $ProgressPreference = "Continue"
+    Warn "下載中..."
+    (New-Object Net.WebClient).DownloadFile($url, $dest)
 }
 
 New-Item -ItemType Directory -Force -Path $TOOLS | Out-Null
@@ -33,21 +36,6 @@ try {
     Write-Host "╚══════════════════════════════════════╝" -ForegroundColor White
     Write-Host "  安裝目錄：$INSTALL"
 
-    # ── Git ────────────────────────────────────────────────────────────
-    Step "Git"
-    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-        $headers = @{ "User-Agent" = "CodefyUI-Installer" }
-        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/git-for-windows/git/releases/latest" -Headers $headers
-        $asset   = $release.assets | Where-Object { $_.name -match "64-bit\.exe$" -and $_.name -notmatch "Portable" } | Select-Object -First 1
-        $gitExe  = "$TOOLS\git.exe"
-        Download $asset.browser_download_url $gitExe
-        Warn "安裝 Git..."
-        Start-Process $gitExe -ArgumentList "/VERYSILENT /NORESTART /NOCANCEL /SP-" -Wait
-        Add-ToPath "C:\Program Files\Git\cmd"
-        Remove-Item $gitExe -Force
-    }
-    Ok "$(git --version)"
-
     # ── Python 3 ───────────────────────────────────────────────────────
     Step "Python 3"
     $PYTHON = $null
@@ -58,35 +46,30 @@ try {
         }
     }
     if (-not $PYTHON) {
-        $pyUrl = "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe"
         $pyExe = "$TOOLS\python.exe"
-        Download $pyUrl $pyExe
+        Download $PY_URL $pyExe
         Warn "安裝 Python 3.11..."
         Start-Process $pyExe -ArgumentList "/quiet InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0" -Wait
+        Remove-Item $pyExe -Force
         Add-ToPath "$HOME\AppData\Local\Programs\Python\Python311"
         Add-ToPath "$HOME\AppData\Local\Programs\Python\Python311\Scripts"
-        Remove-Item $pyExe -Force
         $PYTHON = "python"
     }
     Ok "$(& $PYTHON --version)"
 
-    # ── Node.js (portable zip) ─────────────────────────────────────────
+    # ── Node.js (portable) ─────────────────────────────────────────────
     Step "Node.js"
+    $nodeDir = "$TOOLS\node"
     if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
-        $v      = (Invoke-RestMethod https://nodejs.org/dist/index.json | Where-Object { $_.lts } | Select-Object -First 1).version
-        $zipUrl = "https://nodejs.org/dist/$v/node-$v-win-x64.zip"
-        $zip    = "$TOOLS\node.zip"
-        $nodeDir = "$TOOLS\node"
-
-        Download $zipUrl $zip
-        Warn "解壓 Node.js $v..."
+        $zip = "$TOOLS\node.zip"
+        Download $NODE_URL $zip
+        Warn "解壓 Node.js $NODE_VER..."
         if (Test-Path $nodeDir) { Remove-Item $nodeDir -Recurse -Force }
-        $ProgressPreference = "SilentlyContinue"
         Expand-Archive $zip $TOOLS -Force
-        $ProgressPreference = "Continue"
-        Rename-Item "$TOOLS\node-$v-win-x64" $nodeDir
+        Rename-Item "$TOOLS\node-$NODE_VER-win-x64" $nodeDir
         Remove-Item $zip -Force
-
+        Add-ToPath $nodeDir
+    } else {
         Add-ToPath $nodeDir
     }
     Ok "Node.js $(node --version)"
@@ -94,22 +77,22 @@ try {
     # ── pnpm ───────────────────────────────────────────────────────────
     Step "pnpm"
     if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
-        Warn "透過 npm 安裝 pnpm..."
-        npm install -g pnpm
+        Warn "安裝 pnpm..."
+        npm install -g pnpm --silent
         Add-ToPath "$HOME\AppData\Roaming\npm"
     }
     Ok "pnpm $(pnpm --version)"
 
-    # ── Clone / Update ─────────────────────────────────────────────────
+    # ── 下載 CodefyUI ──────────────────────────────────────────────────
     Step "下載 CodefyUI"
-    if (Test-Path "$INSTALL\.git") {
-        Warn "目錄已存在，執行更新..."
-        git -C $INSTALL pull --ff-only
-        Ok "已更新至最新版本"
-    } else {
-        git clone --depth 1 $REPO $INSTALL
-        Ok "Clone 完成"
-    }
+    $zip = "$TOOLS\codefyui.zip"
+    Download $REPO_ZIP $zip
+    Warn "解壓..."
+    if (Test-Path $INSTALL) { Remove-Item $INSTALL -Recurse -Force }
+    Expand-Archive $zip $TOOLS -Force
+    Move-Item "$TOOLS\CodefyUI-main" $INSTALL
+    Remove-Item $zip -Force
+    Ok "下載完成"
 
     # ── 安裝依賴 ───────────────────────────────────────────────────────
     Step "安裝專案依賴"

--- a/install.ps1
+++ b/install.ps1
@@ -23,19 +23,31 @@ function Finish {
 }
 
 # ── 套件管理器：winget 優先，fallback 到 Chocolatey ──────────────────
+function Ensure-ChocoInPath {
+    $chocoBin = "$env:ProgramData\chocolatey\bin"
+    if ((Test-Path $chocoBin) -and ($env:PATH -notlike "*$chocoBin*")) {
+        $env:PATH += ";$chocoBin"
+    }
+}
+
 function Get-PackageManager {
     if (Get-Command winget -ErrorAction SilentlyContinue) { return "winget" }
+    Ensure-ChocoInPath
     if (Get-Command choco  -ErrorAction SilentlyContinue) { return "choco"  }
     return $null
 }
 
 function Install-Choco {
     Warn "winget 不可用，改安裝 Chocolatey..."
+    Ensure-ChocoInPath
+    if (Get-Command choco -ErrorAction SilentlyContinue) {
+        Ok "Chocolatey 已安裝（$(choco --version)）"
+        return
+    }
     Set-ExecutionPolicy Bypass -Scope Process -Force
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor 3072
     iex ((New-Object Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-    # 載入 choco 到目前 session
-    $env:PATH += ";$env:ProgramData\chocolatey\bin"
+    Ensure-ChocoInPath
 }
 
 function Pkg-Install {

--- a/install.ps1
+++ b/install.ps1
@@ -8,12 +8,35 @@ function Step { Write-Host "`n==> $args" -ForegroundColor Cyan }
 function Ok   { Write-Host "  v $args" -ForegroundColor Green }
 function Warn { Write-Host "  ! $args" -ForegroundColor Yellow }
 
-function Pause-And-Exit {
-    param([string]$msg, [int]$code = 1)
-    Write-Host "`nx 錯誤：$msg" -ForegroundColor Red
+function Finish {
     Write-Host "`n按 Enter 關閉視窗..." -NoNewline
     $null = Read-Host
-    exit $code
+}
+
+# ── 套件管理器：winget 優先，fallback 到 Chocolatey ──────────────────
+function Get-PackageManager {
+    if (Get-Command winget -ErrorAction SilentlyContinue) { return "winget" }
+    if (Get-Command choco  -ErrorAction SilentlyContinue) { return "choco"  }
+    return $null
+}
+
+function Install-Choco {
+    Warn "winget 不可用，改安裝 Chocolatey..."
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor 3072
+    iex ((New-Object Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+    # 載入 choco 到目前 session
+    $env:PATH += ";$env:ProgramData\chocolatey\bin"
+}
+
+function Pkg-Install {
+    param([string]$wingetId, [string]$chocoId)
+    $pm = Get-PackageManager
+    if (-not $pm) { Install-Choco; $pm = "choco" }
+    switch ($pm) {
+        "winget" { winget install --id $wingetId -e --source winget --accept-package-agreements --accept-source-agreements }
+        "choco"  { choco install $chocoId -y }
+    }
 }
 
 try {
@@ -23,15 +46,11 @@ try {
     Write-Host "╚══════════════════════════════════════╝" -ForegroundColor White
     Write-Host "  安裝目錄：$INSTALL"
 
-    # ── winget 可用性 ──────────────────────────────────────────────────
-    $hasWinget = [bool](Get-Command winget -ErrorAction SilentlyContinue)
-
     # ── git ────────────────────────────────────────────────────────────
     Step "git"
     if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-        Warn "未安裝，透過 winget 安裝..."
-        if (-not $hasWinget) { Pause-And-Exit "找不到 winget，請先從 Microsoft Store 安裝『應用程式安裝程式』" }
-        winget install --id Git.Git -e --source winget --accept-package-agreements --accept-source-agreements
+        Warn "未安裝，正在安裝..."
+        Pkg-Install "Git.Git" "git"
         $env:PATH += ";C:\Program Files\Git\cmd"
     }
     Ok "$(git --version)"
@@ -46,9 +65,8 @@ try {
         }
     }
     if (-not $PYTHON) {
-        Warn "未安裝，透過 winget 安裝..."
-        if (-not $hasWinget) { Pause-And-Exit "找不到 winget，請先從 Microsoft Store 安裝『應用程式安裝程式』" }
-        winget install --id Python.Python.3.11 -e --source winget --accept-package-agreements --accept-source-agreements
+        Warn "未安裝，正在安裝..."
+        Pkg-Install "Python.Python.3.11" "python311"
         $env:PATH += ";$HOME\AppData\Local\Programs\Python\Python311"
         $env:PATH += ";$HOME\AppData\Local\Programs\Python\Python311\Scripts"
         $PYTHON = "python"
@@ -58,9 +76,8 @@ try {
     # ── Node.js ────────────────────────────────────────────────────────
     Step "Node.js"
     if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
-        Warn "未安裝，透過 winget 安裝..."
-        if (-not $hasWinget) { Pause-And-Exit "找不到 winget，請先從 Microsoft Store 安裝『應用程式安裝程式』" }
-        winget install --id OpenJS.NodeJS.LTS -e --source winget --accept-package-agreements --accept-source-agreements
+        Warn "未安裝，正在安裝..."
+        Pkg-Install "OpenJS.NodeJS.LTS" "nodejs-lts"
         $env:PATH += ";C:\Program Files\nodejs"
     }
     Ok "Node.js $(node --version)"
@@ -98,17 +115,11 @@ try {
     Write-Host "  啟動開發伺服器："
     Write-Host "    cd $INSTALL" -ForegroundColor White
     Write-Host "    python dev.py dev" -ForegroundColor White
-    Write-Host ""
 
 } catch {
     Write-Host ""
     Write-Host "x 安裝失敗：$($_.Exception.Message)" -ForegroundColor Red
     Write-Host "  行數：$($_.InvocationInfo.ScriptLineNumber)" -ForegroundColor Red
-    Write-Host ""
-    Write-Host "按 Enter 關閉視窗..." -NoNewline
-    $null = Read-Host
-    exit 1
 }
 
-Write-Host "按 Enter 關閉視窗..." -NoNewline
-$null = Read-Host
+Finish

--- a/install.ps1
+++ b/install.ps1
@@ -36,7 +36,8 @@ try {
     # ── Git ────────────────────────────────────────────────────────────
     Step "Git"
     if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-        $release = Invoke-RestMethod "https://api.github.com/repos/git-for-windows/git/releases/latest"
+        $headers = @{ "User-Agent" = "CodefyUI-Installer" }
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/git-for-windows/git/releases/latest" -Headers $headers
         $asset   = $release.assets | Where-Object { $_.name -match "64-bit\.exe$" -and $_.name -notmatch "Portable" } | Select-Object -First 1
         $gitExe  = "$TOOLS\git.exe"
         Download $asset.browser_download_url $gitExe

--- a/install.ps1
+++ b/install.ps1
@@ -12,49 +12,55 @@ function Finish {
     $null = Read-Host
 }
 
-# ── 套件管理器偵測（winget > Scoop > Chocolatey）────────────────────────
-
 function Add-ToPath ([string]$dir) {
     if ((Test-Path $dir) -and $env:PATH -notlike "*$dir*") {
         $env:PATH = "$dir;$env:PATH"
     }
 }
 
-function Get-PackageManager {
-    if (Get-Command winget -ErrorAction SilentlyContinue) { return "winget" }
-
-    # Scoop（user-level，不需要 admin）
+# ── Scoop ─────────────────────────────────────────────────────────────
+function Ensure-Scoop {
     Add-ToPath "$HOME\scoop\shims"
-    if (Get-Command scoop -ErrorAction SilentlyContinue) { return "scoop" }
-
-    # Chocolatey — 直接檢查 exe 而非依賴 PATH
-    $chocoExe = "$env:ProgramData\chocolatey\bin\choco.exe"
-    if (Test-Path $chocoExe) {
-        Add-ToPath "$env:ProgramData\chocolatey\bin"
-        return "choco"
+    if (Get-Command scoop -ErrorAction SilentlyContinue) { return $true }
+    Warn "安裝 Scoop..."
+    try {
+        Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+        iwr -useb get.scoop.sh | iex
+        Add-ToPath "$HOME\scoop\shims"
+        return [bool](Get-Command scoop -ErrorAction SilentlyContinue)
+    } catch {
+        return $false
     }
-
-    return $null
 }
 
-function Install-Scoop {
-    Warn "安裝 Scoop（不需要管理員）..."
-    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-    iwr -useb get.scoop.sh | iex
-    Add-ToPath "$HOME\scoop\shims"
-}
+# ── 安裝單一工具 ──────────────────────────────────────────────────────
+function Install-Tool {
+    param(
+        [string]$name,
+        [string]$wingetId,
+        [string]$scoopId,
+        [string]$manualUrl
+    )
 
-function Pkg-Install ([string]$wingetId, [string]$scoopId, [string]$chocoId) {
-    $pm = Get-PackageManager
-    if (-not $pm) {
-        Install-Scoop
-        $pm = "scoop"
+    # winget
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        winget install --id $wingetId -e --source winget `
+            --accept-package-agreements --accept-source-agreements
+        return
     }
-    switch ($pm) {
-        "winget" { winget install --id $wingetId -e --source winget --accept-package-agreements --accept-source-agreements }
-        "scoop"  { scoop install $scoopId }
-        "choco"  { & "$env:ProgramData\chocolatey\bin\choco.exe" install $chocoId -y }
+
+    # Scoop
+    if (Ensure-Scoop) {
+        scoop install $scoopId
+        return
     }
+
+    # 手動安裝提示
+    Write-Host ""
+    Write-Host "  無法自動安裝 $name，請手動下載：" -ForegroundColor Red
+    Write-Host "  $manualUrl" -ForegroundColor Cyan
+    Finish
+    exit 1
 }
 
 # ─────────────────────────────────────────────────────────────────────
@@ -70,9 +76,10 @@ try {
     Step "git"
     if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
         Warn "未安裝，正在安裝..."
-        Pkg-Install "Git.Git" "git" "git"
+        Install-Tool "Git" "Git.Git" "git" "https://git-scm.com/download/win"
         Add-ToPath "C:\Program Files\Git\cmd"
         Add-ToPath "$HOME\scoop\apps\git\current\cmd"
+        Add-ToPath "$HOME\scoop\shims"
     }
     Ok "$(git --version)"
 
@@ -87,10 +94,10 @@ try {
     }
     if (-not $PYTHON) {
         Warn "未安裝，正在安裝..."
-        Pkg-Install "Python.Python.3.11" "python" "python311"
+        Install-Tool "Python 3.11" "Python.Python.3.11" "python" "https://www.python.org/downloads/"
         Add-ToPath "$HOME\AppData\Local\Programs\Python\Python311"
         Add-ToPath "$HOME\AppData\Local\Programs\Python\Python311\Scripts"
-        Add-ToPath "$HOME\scoop\apps\python\current"
+        Add-ToPath "$HOME\scoop\shims"
         $PYTHON = "python"
     }
     Ok "$(& $PYTHON --version)"
@@ -99,9 +106,9 @@ try {
     Step "Node.js"
     if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
         Warn "未安裝，正在安裝..."
-        Pkg-Install "OpenJS.NodeJS.LTS" "nodejs-lts" "nodejs-lts"
+        Install-Tool "Node.js LTS" "OpenJS.NodeJS.LTS" "nodejs-lts" "https://nodejs.org/en/download"
         Add-ToPath "C:\Program Files\nodejs"
-        Add-ToPath "$HOME\scoop\apps\nodejs-lts\current"
+        Add-ToPath "$HOME\scoop\shims"
     }
     Ok "Node.js $(node --version)"
 
@@ -110,6 +117,7 @@ try {
     if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
         Warn "未安裝，透過 npm 安裝..."
         npm install -g pnpm
+        Add-ToPath "$HOME\AppData\Roaming\npm"
     }
     Ok "pnpm $(pnpm --version)"
 

--- a/install.ps1
+++ b/install.ps1
@@ -3,6 +3,7 @@
 
 $REPO    = "https://github.com/latteine1217/CodefyUI.git"
 $INSTALL = if ($env:CODEFYUI_DIR) { $env:CODEFYUI_DIR } else { "$HOME\CodefyUI" }
+$TOOLS   = "$HOME\.codefyui"
 
 function Step { Write-Host "`n==> $args" -ForegroundColor Cyan }
 function Ok   { Write-Host "  v $args" -ForegroundColor Green }
@@ -11,59 +12,19 @@ function Finish {
     Write-Host "`n按 Enter 關閉視窗..." -NoNewline
     $null = Read-Host
 }
-
 function Add-ToPath ([string]$dir) {
     if ((Test-Path $dir) -and $env:PATH -notlike "*$dir*") {
         $env:PATH = "$dir;$env:PATH"
     }
 }
-
-# ── Scoop ─────────────────────────────────────────────────────────────
-function Ensure-Scoop {
-    Add-ToPath "$HOME\scoop\shims"
-    if (Get-Command scoop -ErrorAction SilentlyContinue) { return $true }
-    Warn "安裝 Scoop..."
-    try {
-        Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-        iwr -useb get.scoop.sh | iex
-        Add-ToPath "$HOME\scoop\shims"
-        return [bool](Get-Command scoop -ErrorAction SilentlyContinue)
-    } catch {
-        return $false
-    }
+function Download ([string]$url, [string]$dest) {
+    Warn "下載 $([System.IO.Path]::GetFileName($dest))..."
+    $ProgressPreference = "SilentlyContinue"
+    Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+    $ProgressPreference = "Continue"
 }
 
-# ── 安裝單一工具 ──────────────────────────────────────────────────────
-function Install-Tool {
-    param(
-        [string]$name,
-        [string]$wingetId,
-        [string]$scoopId,
-        [string]$manualUrl
-    )
-
-    # winget
-    if (Get-Command winget -ErrorAction SilentlyContinue) {
-        winget install --id $wingetId -e --source winget `
-            --accept-package-agreements --accept-source-agreements
-        return
-    }
-
-    # Scoop
-    if (Ensure-Scoop) {
-        scoop install $scoopId
-        return
-    }
-
-    # 手動安裝提示
-    Write-Host ""
-    Write-Host "  無法自動安裝 $name，請手動下載：" -ForegroundColor Red
-    Write-Host "  $manualUrl" -ForegroundColor Cyan
-    Finish
-    exit 1
-}
-
-# ─────────────────────────────────────────────────────────────────────
+New-Item -ItemType Directory -Force -Path $TOOLS | Out-Null
 
 try {
     Write-Host ""
@@ -72,14 +33,17 @@ try {
     Write-Host "╚══════════════════════════════════════╝" -ForegroundColor White
     Write-Host "  安裝目錄：$INSTALL"
 
-    # ── git ────────────────────────────────────────────────────────────
-    Step "git"
+    # ── Git ────────────────────────────────────────────────────────────
+    Step "Git"
     if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-        Warn "未安裝，正在安裝..."
-        Install-Tool "Git" "Git.Git" "git" "https://git-scm.com/download/win"
+        $release = Invoke-RestMethod "https://api.github.com/repos/git-for-windows/git/releases/latest"
+        $asset   = $release.assets | Where-Object { $_.name -match "64-bit\.exe$" -and $_.name -notmatch "Portable" } | Select-Object -First 1
+        $gitExe  = "$TOOLS\git.exe"
+        Download $asset.browser_download_url $gitExe
+        Warn "安裝 Git..."
+        Start-Process $gitExe -ArgumentList "/VERYSILENT /NORESTART /NOCANCEL /SP-" -Wait
         Add-ToPath "C:\Program Files\Git\cmd"
-        Add-ToPath "$HOME\scoop\apps\git\current\cmd"
-        Add-ToPath "$HOME\scoop\shims"
+        Remove-Item $gitExe -Force
     }
     Ok "$(git --version)"
 
@@ -93,29 +57,43 @@ try {
         }
     }
     if (-not $PYTHON) {
-        Warn "未安裝，正在安裝..."
-        Install-Tool "Python 3.11" "Python.Python.3.11" "python" "https://www.python.org/downloads/"
+        $pyUrl = "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe"
+        $pyExe = "$TOOLS\python.exe"
+        Download $pyUrl $pyExe
+        Warn "安裝 Python 3.11..."
+        Start-Process $pyExe -ArgumentList "/quiet InstallAllUsers=0 PrependPath=1 Include_test=0 Include_doc=0" -Wait
         Add-ToPath "$HOME\AppData\Local\Programs\Python\Python311"
         Add-ToPath "$HOME\AppData\Local\Programs\Python\Python311\Scripts"
-        Add-ToPath "$HOME\scoop\shims"
+        Remove-Item $pyExe -Force
         $PYTHON = "python"
     }
     Ok "$(& $PYTHON --version)"
 
-    # ── Node.js ────────────────────────────────────────────────────────
+    # ── Node.js (portable zip) ─────────────────────────────────────────
     Step "Node.js"
     if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
-        Warn "未安裝，正在安裝..."
-        Install-Tool "Node.js LTS" "OpenJS.NodeJS.LTS" "nodejs-lts" "https://nodejs.org/en/download"
-        Add-ToPath "C:\Program Files\nodejs"
-        Add-ToPath "$HOME\scoop\shims"
+        $v      = (Invoke-RestMethod https://nodejs.org/dist/index.json | Where-Object { $_.lts } | Select-Object -First 1).version
+        $zipUrl = "https://nodejs.org/dist/$v/node-$v-win-x64.zip"
+        $zip    = "$TOOLS\node.zip"
+        $nodeDir = "$TOOLS\node"
+
+        Download $zipUrl $zip
+        Warn "解壓 Node.js $v..."
+        if (Test-Path $nodeDir) { Remove-Item $nodeDir -Recurse -Force }
+        $ProgressPreference = "SilentlyContinue"
+        Expand-Archive $zip $TOOLS -Force
+        $ProgressPreference = "Continue"
+        Rename-Item "$TOOLS\node-$v-win-x64" $nodeDir
+        Remove-Item $zip -Force
+
+        Add-ToPath $nodeDir
     }
     Ok "Node.js $(node --version)"
 
     # ── pnpm ───────────────────────────────────────────────────────────
     Step "pnpm"
     if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
-        Warn "未安裝，透過 npm 安裝..."
+        Warn "透過 npm 安裝 pnpm..."
         npm install -g pnpm
         Add-ToPath "$HOME\AppData\Roaming\npm"
     }

--- a/install.ps1
+++ b/install.ps1
@@ -7,58 +7,57 @@ $INSTALL = if ($env:CODEFYUI_DIR) { $env:CODEFYUI_DIR } else { "$HOME\CodefyUI" 
 function Step { Write-Host "`n==> $args" -ForegroundColor Cyan }
 function Ok   { Write-Host "  v $args" -ForegroundColor Green }
 function Warn { Write-Host "  ! $args" -ForegroundColor Yellow }
-
-# ── 自動提升管理員權限 ────────────────────────────────────────────────
-$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-if (-not $isAdmin) {
-    Write-Host "  ! 需要管理員權限，正在重新啟動..." -ForegroundColor Yellow
-    $cmd = "-NoExit -ExecutionPolicy Bypass -Command `"irm https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.ps1 | iex`""
-    Start-Process PowerShell -Verb RunAs -ArgumentList $cmd
-    exit
-}
-
 function Finish {
     Write-Host "`n按 Enter 關閉視窗..." -NoNewline
     $null = Read-Host
 }
 
-# ── 套件管理器：winget 優先，fallback 到 Chocolatey ──────────────────
-function Ensure-ChocoInPath {
-    $chocoBin = "$env:ProgramData\chocolatey\bin"
-    if ((Test-Path $chocoBin) -and ($env:PATH -notlike "*$chocoBin*")) {
-        $env:PATH += ";$chocoBin"
+# ── 套件管理器偵測（winget > Scoop > Chocolatey）────────────────────────
+
+function Add-ToPath ([string]$dir) {
+    if ((Test-Path $dir) -and $env:PATH -notlike "*$dir*") {
+        $env:PATH = "$dir;$env:PATH"
     }
 }
 
 function Get-PackageManager {
     if (Get-Command winget -ErrorAction SilentlyContinue) { return "winget" }
-    Ensure-ChocoInPath
-    if (Get-Command choco  -ErrorAction SilentlyContinue) { return "choco"  }
+
+    # Scoop（user-level，不需要 admin）
+    Add-ToPath "$HOME\scoop\shims"
+    if (Get-Command scoop -ErrorAction SilentlyContinue) { return "scoop" }
+
+    # Chocolatey — 直接檢查 exe 而非依賴 PATH
+    $chocoExe = "$env:ProgramData\chocolatey\bin\choco.exe"
+    if (Test-Path $chocoExe) {
+        Add-ToPath "$env:ProgramData\chocolatey\bin"
+        return "choco"
+    }
+
     return $null
 }
 
-function Install-Choco {
-    Warn "winget 不可用，改安裝 Chocolatey..."
-    Ensure-ChocoInPath
-    if (Get-Command choco -ErrorAction SilentlyContinue) {
-        Ok "Chocolatey 已安裝（$(choco --version)）"
-        return
-    }
-    Set-ExecutionPolicy Bypass -Scope Process -Force
-    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor 3072
-    iex ((New-Object Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-    Ensure-ChocoInPath
+function Install-Scoop {
+    Warn "安裝 Scoop（不需要管理員）..."
+    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+    iwr -useb get.scoop.sh | iex
+    Add-ToPath "$HOME\scoop\shims"
 }
 
-function Pkg-Install {
-    param([string]$wingetId, [string]$chocoId)
+function Pkg-Install ([string]$wingetId, [string]$scoopId, [string]$chocoId) {
     $pm = Get-PackageManager
-    if (-not $pm) { Install-Choco; $pm = "choco" }
+    if (-not $pm) {
+        Install-Scoop
+        $pm = "scoop"
+    }
     switch ($pm) {
         "winget" { winget install --id $wingetId -e --source winget --accept-package-agreements --accept-source-agreements }
-        "choco"  { choco install $chocoId -y }
+        "scoop"  { scoop install $scoopId }
+        "choco"  { & "$env:ProgramData\chocolatey\bin\choco.exe" install $chocoId -y }
     }
 }
+
+# ─────────────────────────────────────────────────────────────────────
 
 try {
     Write-Host ""
@@ -71,8 +70,9 @@ try {
     Step "git"
     if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
         Warn "未安裝，正在安裝..."
-        Pkg-Install "Git.Git" "git"
-        $env:PATH += ";C:\Program Files\Git\cmd"
+        Pkg-Install "Git.Git" "git" "git"
+        Add-ToPath "C:\Program Files\Git\cmd"
+        Add-ToPath "$HOME\scoop\apps\git\current\cmd"
     }
     Ok "$(git --version)"
 
@@ -87,9 +87,10 @@ try {
     }
     if (-not $PYTHON) {
         Warn "未安裝，正在安裝..."
-        Pkg-Install "Python.Python.3.11" "python311"
-        $env:PATH += ";$HOME\AppData\Local\Programs\Python\Python311"
-        $env:PATH += ";$HOME\AppData\Local\Programs\Python\Python311\Scripts"
+        Pkg-Install "Python.Python.3.11" "python" "python311"
+        Add-ToPath "$HOME\AppData\Local\Programs\Python\Python311"
+        Add-ToPath "$HOME\AppData\Local\Programs\Python\Python311\Scripts"
+        Add-ToPath "$HOME\scoop\apps\python\current"
         $PYTHON = "python"
     }
     Ok "$(& $PYTHON --version)"
@@ -98,8 +99,9 @@ try {
     Step "Node.js"
     if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
         Warn "未安裝，正在安裝..."
-        Pkg-Install "OpenJS.NodeJS.LTS" "nodejs-lts"
-        $env:PATH += ";C:\Program Files\nodejs"
+        Pkg-Install "OpenJS.NodeJS.LTS" "nodejs-lts" "nodejs-lts"
+        Add-ToPath "C:\Program Files\nodejs"
+        Add-ToPath "$HOME\scoop\apps\nodejs-lts\current"
     }
     Ok "Node.js $(node --version)"
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,97 @@
+# CodefyUI Windows 安裝腳本
+# 用法：irm https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.ps1 | iex
+$ErrorActionPreference = "Stop"
+
+$REPO     = "https://github.com/latteine1217/CodefyUI.git"
+$INSTALL  = if ($env:CODEFYUI_DIR) { $env:CODEFYUI_DIR } else { "$HOME\CodefyUI" }
+
+function Step  { Write-Host "`n==> $args" -ForegroundColor Cyan }
+function Ok    { Write-Host "  v $args" -ForegroundColor Green }
+function Warn  { Write-Host "  ! $args" -ForegroundColor Yellow }
+function Die   { Write-Host "`nx $args" -ForegroundColor Red; exit 1 }
+
+Write-Host ""
+Write-Host "╔══════════════════════════════════════╗" -ForegroundColor White
+Write-Host "║        CodefyUI  安裝程式            ║" -ForegroundColor White
+Write-Host "╚══════════════════════════════════════╝" -ForegroundColor White
+Write-Host "  安裝目錄：$INSTALL"
+
+# ── winget ────────────────────────────────────────────────────────────
+function Install-Winget {
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        Die "找不到 winget，請先從 Microsoft Store 安裝『應用程式安裝程式』"
+    }
+}
+
+# ── git ───────────────────────────────────────────────────────────────
+Step "git"
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Warn "未安裝，透過 winget 安裝..."
+    Install-Winget
+    winget install --id Git.Git -e --source winget --silent
+    $env:PATH += ";C:\Program Files\Git\cmd"
+}
+Ok "$(git --version)"
+
+# ── Python 3 ──────────────────────────────────────────────────────────
+Step "Python 3"
+$PYTHON = $null
+foreach ($cmd in @("python", "python3")) {
+    if (Get-Command $cmd -ErrorAction SilentlyContinue) {
+        $ver = & $cmd -c "import sys; print(sys.version_info >= (3,8))" 2>$null
+        if ($ver -eq "True") { $PYTHON = $cmd; break }
+    }
+}
+if (-not $PYTHON) {
+    Warn "未安裝，透過 winget 安裝..."
+    Install-Winget
+    winget install --id Python.Python.3.11 -e --source winget --silent
+    $env:PATH += ";$HOME\AppData\Local\Programs\Python\Python311;$HOME\AppData\Local\Programs\Python\Python311\Scripts"
+    $PYTHON = "python"
+}
+Ok "$(& $PYTHON --version)"
+
+# ── Node.js ───────────────────────────────────────────────────────────
+Step "Node.js"
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+    Warn "未安裝，透過 winget 安裝..."
+    Install-Winget
+    winget install --id OpenJS.NodeJS.LTS -e --source winget --silent
+    $env:PATH += ";C:\Program Files\nodejs"
+}
+Ok "Node.js $(node --version)"
+
+# ── pnpm ──────────────────────────────────────────────────────────────
+Step "pnpm"
+if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
+    Warn "未安裝，透過 npm 安裝..."
+    npm install -g pnpm --silent
+}
+Ok "pnpm $(pnpm --version)"
+
+# ── Clone / Update ────────────────────────────────────────────────────
+Step "下載 CodefyUI"
+if (Test-Path "$INSTALL\.git") {
+    Warn "目錄已存在，執行更新..."
+    git -C $INSTALL pull --ff-only
+    Ok "已更新至最新版本"
+} else {
+    git clone --depth 1 $REPO $INSTALL
+    Ok "Clone 完成"
+}
+
+# ── 安裝依賴 ──────────────────────────────────────────────────────────
+Step "安裝專案依賴"
+Set-Location $INSTALL
+& $PYTHON dev.py install
+
+# ── 完成 ──────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "╔══════════════════════════════════════╗" -ForegroundColor Green
+Write-Host "║          安裝完成！                  ║" -ForegroundColor Green
+Write-Host "╚══════════════════════════════════════╝" -ForegroundColor Green
+Write-Host ""
+Write-Host "  啟動開發伺服器："
+Write-Host "    cd $INSTALL" -ForegroundColor White
+Write-Host "    python dev.py dev" -ForegroundColor White
+Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# CodefyUI 一鍵安裝腳本
+# 用法：curl -fsSL https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.sh | bash
+set -euo pipefail
+
+# ── 顏色 ──────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
+
+REPO="https://github.com/latteine1217/CodefyUI.git"
+INSTALL_DIR="${CODEFYUI_DIR:-$HOME/CodefyUI}"
+
+step() { echo -e "\n${BLUE}==>${NC} ${BOLD}$*${NC}"; }
+ok()   { echo -e "  ${GREEN}✓${NC} $*"; }
+warn() { echo -e "  ${YELLOW}!${NC} $*"; }
+die()  { echo -e "\n${RED}✗ 錯誤：$*${NC}" >&2; exit 1; }
+
+# root 不需要 sudo
+SUDO=""
+[[ "$(id -u)" != "0" ]] && SUDO="sudo"
+
+# ── OS 偵測 ───────────────────────────────────────────────────────────
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  OS="macos"
+elif [[ -f /etc/debian_version ]]; then
+  OS="debian"
+elif [[ -f /etc/redhat-release ]]; then
+  OS="redhat"
+else
+  OS="unknown"
+fi
+
+# ── 套件安裝 helper ───────────────────────────────────────────────────
+pkg_install() {
+  case "$OS" in
+    macos)
+      if ! command -v brew &>/dev/null; then
+        warn "安裝 Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      fi
+      brew install "$@" ;;
+    debian)
+      $SUDO apt-get update -qq
+      $SUDO apt-get install -y "$@" ;;
+    redhat)
+      $SUDO yum install -y "$@" ;;
+    *)
+      die "不支援的作業系統，請手動安裝：$*" ;;
+  esac
+}
+
+# ══════════════════════════════════════════════════════════════════════
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║        CodefyUI  安裝程式            ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════╝${NC}"
+echo -e "  安裝目錄：${BOLD}$INSTALL_DIR${NC}"
+
+# ── git ───────────────────────────────────────────────────────────────
+step "git"
+if ! command -v git &>/dev/null; then
+  warn "未安裝，正在安裝..."
+  pkg_install git
+fi
+ok "$(git --version)"
+
+# ── Python 3 ──────────────────────────────────────────────────────────
+step "Python 3"
+PYTHON=""
+for cmd in python3 python; do
+  if command -v "$cmd" &>/dev/null && "$cmd" -c "import sys; assert sys.version_info >= (3,8)" 2>/dev/null; then
+    PYTHON="$cmd"; break
+  fi
+done
+
+if [[ -z "$PYTHON" ]]; then
+  warn "未安裝，正在安裝..."
+  case "$OS" in
+    macos)   pkg_install python@3.11 ;;
+    debian)  pkg_install python3 ;;
+    redhat)  pkg_install python3 ;;
+    *)       die "請手動安裝 Python 3.8+" ;;
+  esac
+  PYTHON="python3"
+fi
+ok "$($PYTHON --version)"
+
+# ── Node.js ───────────────────────────────────────────────────────────
+step "Node.js"
+if ! command -v node &>/dev/null; then
+  warn "未安裝，透過 nvm 安裝 LTS..."
+  export NVM_DIR="$HOME/.nvm"
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+  # 在目前 shell 載入 nvm（不依賴 .bashrc）
+  [[ -s "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
+  nvm install --lts --no-progress
+  nvm use --lts
+fi
+ok "Node.js $(node --version)"
+
+# ── pnpm ──────────────────────────────────────────────────────────────
+step "pnpm"
+if ! command -v pnpm &>/dev/null; then
+  warn "未安裝，正在安裝..."
+  # 優先用 npm（已隨 Node.js 安裝）
+  if command -v npm &>/dev/null; then
+    npm install -g pnpm --silent
+  else
+    curl -fsSL https://get.pnpm.io/install.sh | sh -
+    export PNPM_HOME="$HOME/.local/share/pnpm"
+    export PATH="$PNPM_HOME:$PATH"
+  fi
+fi
+ok "pnpm $(pnpm --version)"
+
+# ── Clone / Update ────────────────────────────────────────────────────
+step "下載 CodefyUI"
+if [[ -d "$INSTALL_DIR/.git" ]]; then
+  warn "目錄已存在，執行更新..."
+  git -C "$INSTALL_DIR" pull --ff-only
+  ok "已更新至最新版本"
+else
+  git clone --depth 1 "$REPO" "$INSTALL_DIR"
+  ok "Clone 完成"
+fi
+
+# ── 安裝依賴 ──────────────────────────────────────────────────────────
+step "安裝專案依賴"
+cd "$INSTALL_DIR"
+$PYTHON dev.py install
+
+# ── 完成 ──────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}${BOLD}╔══════════════════════════════════════╗${NC}"
+echo -e "${GREEN}${BOLD}║          安裝完成！                  ║${NC}"
+echo -e "${GREEN}${BOLD}╚══════════════════════════════════════╝${NC}"
+echo ""
+echo -e "  啟動開發伺服器："
+echo -e "    ${BOLD}cd $INSTALL_DIR${NC}"
+echo -e "    ${BOLD}python dev.py dev${NC}"
+echo ""

--- a/install.sh
+++ b/install.sh
@@ -91,10 +91,12 @@ if ! command -v node &>/dev/null; then
   warn "未安裝，透過 nvm 安裝 LTS..."
   export NVM_DIR="$HOME/.nvm"
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-  # 在目前 shell 載入 nvm（不依賴 .bashrc）
+  # nvm 內部使用未定義變數，需暫時關閉 -u
+  set +u
   [[ -s "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
   nvm install --lts --no-progress
   nvm use --lts
+  set -u
 fi
 ok "Node.js $(node --version)"
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Cross-platform task runner for CodefyUI.
+
+Usage:
+    uv run python scripts/dev.py <command>
+
+Commands:
+    install   安裝所有依賴（backend + frontend）
+    dev       啟動開發伺服器（Ctrl+C 停止）
+    stop      停止所有服務
+    test      執行 backend 測試
+    clean     移除虛擬環境與 node_modules
+"""
+
+import shutil
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BACKEND_DIR = ROOT / "backend"
+FRONTEND_DIR = ROOT / "frontend"
+VENV = BACKEND_DIR / ".venv"
+VENV_BIN = VENV / ("Scripts" if sys.platform == "win32" else "bin")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def run(cmd: list, cwd: Path = ROOT) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True)
+
+
+def _stream(proc: subprocess.Popen, prefix: str) -> None:
+    assert proc.stdout is not None
+    for raw in iter(proc.stdout.readline, b""):
+        print(f"{prefix} {raw.decode(errors='replace').rstrip()}", flush=True)
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+def install() -> None:
+    print("=== Backend: 建立虛擬環境 ===")
+    run(["uv", "venv", "--python", "3.11"], cwd=BACKEND_DIR)
+
+    print("=== Backend: 安裝依賴 ===")
+    run(["uv", "pip", "install", "-e", ".[dev]"], cwd=BACKEND_DIR)
+
+    print("=== Backend: 安裝 PyTorch ===")
+    run(["uv", "pip", "install", "torch", "torchvision", "gymnasium", "safetensors"],
+        cwd=BACKEND_DIR)
+
+    print("=== Frontend: 安裝依賴 ===")
+    run(["pnpm", "install"], cwd=FRONTEND_DIR)
+
+    print("=== 安裝完成 ===")
+
+
+def dev() -> None:
+    uvicorn = str(VENV_BIN / "uvicorn")
+    backend_cmd = [uvicorn, "app.main:app", "--reload"]
+    frontend_cmd = ["pnpm", "dev"]
+
+    # Windows 需要 shell=True 才能找到 pnpm（非 .exe 的指令）
+    shell = sys.platform == "win32"
+
+    print("=== 啟動 CodefyUI（Ctrl+C 停止）===")
+    print("    backend  → http://localhost:8000")
+    print("    frontend → http://localhost:5173")
+    print("")
+
+    backend = subprocess.Popen(
+        backend_cmd,
+        cwd=BACKEND_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=shell,
+    )
+    frontend = subprocess.Popen(
+        frontend_cmd,
+        cwd=FRONTEND_DIR,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=shell,
+    )
+
+    threading.Thread(target=_stream, args=(backend, "[backend] "), daemon=True).start()
+    threading.Thread(target=_stream, args=(frontend, "[frontend]"), daemon=True).start()
+
+    try:
+        backend.wait()
+        frontend.wait()
+    except KeyboardInterrupt:
+        print("\n=== 停止服務 ===")
+        backend.terminate()
+        frontend.terminate()
+        backend.wait()
+        frontend.wait()
+
+
+def stop() -> None:
+    print("=== 停止所有服務 ===")
+    if sys.platform == "win32":
+        subprocess.run(["taskkill", "/F", "/IM", "uvicorn.exe"], capture_output=True)
+        subprocess.run(["taskkill", "/F", "/FI", "WINDOWTITLE eq vite*"], capture_output=True)
+    else:
+        subprocess.run(["pkill", "-f", "uvicorn app.main:app"], capture_output=True)
+        subprocess.run(["pkill", "-f", "vite"], capture_output=True)
+    print("=== 完成 ===")
+
+
+def test() -> None:
+    pytest = str(VENV_BIN / "pytest")
+    run([pytest], cwd=BACKEND_DIR)
+
+
+def clean() -> None:
+    print("=== 清除虛擬環境與 node_modules ===")
+    shutil.rmtree(VENV, ignore_errors=True)
+    shutil.rmtree(FRONTEND_DIR / "node_modules", ignore_errors=True)
+    print("=== 完成 ===")
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+COMMANDS = {
+    "install": install,
+    "dev": dev,
+    "stop": stop,
+    "test": test,
+    "clean": clean,
+}
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2 or sys.argv[1] not in COMMANDS:
+        print(__doc__)
+        sys.exit(1)
+    COMMANDS[sys.argv[1]]()


### PR DESCRIPTION
## Summary

- 新增 `install.sh`：一行 curl 指令完成全環境安裝（macOS / Linux）
- 新增 `dev.py`：跨平台任務執行器，取代需要 `make` 的 Makefile
- 新增 `Makefile`：薄層封裝，呼叫 `dev.py`（可選）
- 更新 README.md / README_zh-TW.md Quick Start 說明

## 安裝方式

```bash
curl -fsSL https://raw.githubusercontent.com/latteine1217/CodefyUI/main/install.sh | bash
```

自動安裝所有缺少的依賴（git、Python 3、Node.js via nvm、pnpm、uv）。

## 開發指令（全平台統一）

```bash
python dev.py install   # 安裝依賴
python dev.py dev       # 啟動開發伺服器
python dev.py stop      # 停止服務
python dev.py test      # 執行測試
python dev.py clean     # 清除環境
```

## Test plan

- [ ] macOS：執行 curl 一行指令完整安裝
- [ ] Linux（Ubuntu/Debian）：Colab 空白環境測試
- [ ] Windows：`python dev.py install` 正常執行

🤖 Generated with [Claude Code](https://claude.com/claude-code)