### PR TITLE
feat(i18n): complete zh-TW coverage for nodes and UI strings

### DIFF
--- a/frontend/src/components/Canvas/QuickNodeSearch.tsx
+++ b/frontend/src/components/Canvas/QuickNodeSearch.tsx
@@ -26,7 +26,7 @@ export function QuickNodeSearch({ screenPos, flowPos, onClose }: QuickNodeSearch
   const presets = useNodeDefStore((s) => s.presets);
   const addNode = useTabStore((s) => s.addNode);
   const addPresetNode = useTabStore((s) => s.addPresetNode);
-  const { tn } = useI18n();
+  const { t, tn } = useI18n();
 
   // Filter results
   const results: SearchResult[] = (() => {
@@ -139,12 +139,12 @@ export function QuickNodeSearch({ screenPos, flowPos, onClose }: QuickNodeSearch
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={handleKeyDown}
         className={styles.input}
-        placeholder="Search nodes..."
+        placeholder={t('palette.search')}
         autoComplete="off"
       />
       <div ref={listRef} className={styles.list}>
         {results.length === 0 && (
-          <div className={styles.empty}>No matches</div>
+          <div className={styles.empty}>{t('palette.noMatch')}</div>
         )}
         {results.map((r, i) => {
           const name = r.kind === 'node' ? r.def.node_name : r.preset.preset_name;

--- a/frontend/src/components/InspectorPanel/InspectorPanel.tsx
+++ b/frontend/src/components/InspectorPanel/InspectorPanel.tsx
@@ -194,7 +194,7 @@ export function InspectorPanel() {
     return (
       <div className={`${styles.panel} ${styles.collapsed}`}>
         {collapseButton}
-        <div className={styles.collapsedStub}>INSPECTOR</div>
+        <div className={styles.collapsedStub}>{t('inspector.collapsedStub')}</div>
       </div>
     );
   }
@@ -235,7 +235,7 @@ export function InspectorPanel() {
       <div className={styles.panel}>
         {collapseButton}
         <div className={styles.panelHeader}>
-          <span className={styles.segmentBadge}>SEGMENT</span>
+          <span className={styles.segmentBadge}>{t('inspector.segmentBadge')}</span>
           <span className={styles.segmentNames}>
             {targets.headName} → {targets.tailName}
           </span>
@@ -299,7 +299,7 @@ export function InspectorPanel() {
         {inspectorTab === 'forward' && (
           <>
             {inputs.length === 0 && outputs.length === 0 && (
-              <div className={styles.emptyState}>This node has no ports.</div>
+              <div className={styles.emptyState}>{t('inspector.emptyPorts')}</div>
             )}
             {/* Pair input[i] with output[i] when possible */}
             {pairLists(inputs, outputs).map((row, i) => {

--- a/frontend/src/components/InspectorPanel/ValueDiff.tsx
+++ b/frontend/src/components/InspectorPanel/ValueDiff.tsx
@@ -1,3 +1,4 @@
+import { useI18n } from '../../i18n';
 import type { OutputData, TensorOutput } from '../../types';
 import { TensorGridView } from './TensorGridView';
 import styles from './InspectorPanel.module.css';
@@ -50,8 +51,9 @@ function makeHighlight(
 }
 
 export function ValueDiff({ input, output, inputLabel = 'Input', outputLabel = 'Output' }: Props) {
+  const { t } = useI18n();
   if (input === null && output === null) {
-    return <div className={styles.diffEmpty}>No values captured for this port</div>;
+    return <div className={styles.diffEmpty}>{t('inspector.valueDiff.noValues')}</div>;
   }
 
   let highlight: ((i: number, j: number) => number) | undefined;

--- a/frontend/src/components/Nodes/NoteNode.tsx
+++ b/frontend/src/components/Nodes/NoteNode.tsx
@@ -111,7 +111,7 @@ function NoteNodeInner({ id, data, selected }: NodeProps & { data: NodeData }) {
       <div className={styles.accentBar} style={{ background: noteColor }} />
 
       {/* Bind indicator */}
-      {isBound && <div className={styles.bindIcon} title="Bound to node">&#128279;</div>}
+      {isBound && <div className={styles.bindIcon} title={t('note.boundToNode')}>&#128279;</div>}
 
       {/* Text note */}
       {noteKind === 'text' && (

--- a/frontend/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.tsx
@@ -351,14 +351,14 @@ export function ResultsPanel() {
               <div className={styles.trainingColumns}>
                 {/* Loss chart */}
                 <div className={styles.trainingChartCol}>
-                  <div className={styles.sectionHeader}>Loss Curve</div>
+                  <div className={styles.sectionHeader}>{t('results.lossCurve')}</div>
                   {trainingData.epochs.length > 0 ? (
                     <LossChart
                       losses={trainingData.epochs.map((e) => e.loss)}
                       height={Math.max(80, panelHeight - 90)}
                     />
                   ) : (
-                    <div className={styles.emptyState}>Waiting for first epoch...</div>
+                    <div className={styles.emptyState}>{t('results.waitingEpoch')}</div>
                   )}
                 </div>
 
@@ -408,16 +408,16 @@ export function ResultsPanel() {
                         const last = trainingData.epochs[trainingData.epochs.length - 1];
                         return (
                           <div className={styles.sectionHeader}>
-                            Epochs ({last.epoch}/{last.total})
+                            {t('results.epochsHeader', { current: last.epoch, total: last.total })}
                           </div>
                         );
                       })()}
                       <div className={styles.epochTable}>
                         <div className={`${styles.epochRow} ${styles.epochRowHeader}`}>
                           <span>#</span>
-                          <span>Loss</span>
-                          <span>Delta</span>
-                          <span>Time</span>
+                          <span>{t('results.col.loss')}</span>
+                          <span>{t('results.col.delta')}</span>
+                          <span>{t('results.col.time')}</span>
                         </div>
                         {trainingData.epochs.map((ep, i) => {
                           const prev = i > 0 ? trainingData.epochs[i - 1].loss : null;

--- a/frontend/src/components/SubgraphEditor/LayerNode.tsx
+++ b/frontend/src/components/SubgraphEditor/LayerNode.tsx
@@ -1,9 +1,11 @@
 import { memo } from 'react';
 import { Handle, Node, Position } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
+import { useI18n } from '../../i18n';
 import type { LayerNodeData } from './graphSerialization';
 
 function LayerNodeComponent({ data, selected }: NodeProps<Node<LayerNodeData>>) {
+  const { t } = useI18n();
   const paramEntries = Object.entries(data.params);
   const hasParams = paramEntries.length > 0;
 
@@ -65,7 +67,7 @@ function LayerNodeComponent({ data, selected }: NodeProps<Node<LayerNodeData>>) 
           ))}
           {paramEntries.length > 3 && (
             <div style={{ fontSize: '0.5625rem', color: '#555', textAlign: 'center' }}>
-              +{paramEntries.length - 3} more
+              {t('subgraph.layerNode.moreParams', { count: paramEntries.length - 3 })}
             </div>
           )}
         </div>

--- a/frontend/src/components/shared/ParamField.tsx
+++ b/frontend/src/components/shared/ParamField.tsx
@@ -8,6 +8,7 @@ import {
   uploadImageFile,
   uploadModelFile,
 } from '../../api/rest';
+import { useI18n, type TranslationKey } from '../../i18n';
 import { useToastStore } from '../../store/toastStore';
 import { TensorGridEditor } from '../ConfigPanel/TensorGridEditor';
 import styles from './ParamField.module.css';
@@ -29,7 +30,7 @@ interface FileFieldBackend {
   upload: (file: File) => Promise<{ filename: string }>;
   download: (filename: string) => Promise<void>;
   accept: string;
-  uploadTitle: string;
+  uploadTitleKey: TranslationKey;
 }
 
 const MODEL_FILE_BACKEND: FileFieldBackend = {
@@ -37,7 +38,7 @@ const MODEL_FILE_BACKEND: FileFieldBackend = {
   upload: uploadModelFile,
   download: downloadModelFile,
   accept: '.pt,.pth,.safetensors,.ckpt,.bin',
-  uploadTitle: 'Upload model file',
+  uploadTitleKey: 'paramField.upload.model',
 };
 
 const IMAGE_FILE_BACKEND: FileFieldBackend = {
@@ -45,7 +46,7 @@ const IMAGE_FILE_BACKEND: FileFieldBackend = {
   upload: uploadImageFile,
   download: downloadImageFile,
   accept: '.png,.jpg,.jpeg,.bmp,.webp,.gif,.tiff',
-  uploadTitle: 'Upload image file',
+  uploadTitleKey: 'paramField.upload.image',
 };
 
 function FileField({
@@ -61,6 +62,7 @@ function FileField({
   displayLabel: string;
   backend: FileFieldBackend;
 }) {
+  const { t } = useI18n();
   const [files, setFiles] = useState<string[]>([]);
   const [uploading, setUploading] = useState(false);
   const [downloading, setDownloading] = useState(false);
@@ -83,7 +85,7 @@ function FileField({
       refresh();
       onChange(param.name, result.filename);
     } catch (err: any) {
-      useToastStore.getState().addToast(err.message ?? 'Upload failed', 'error');
+      useToastStore.getState().addToast(err.message ?? t('paramField.uploadFailed'), 'error');
     } finally {
       setUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
@@ -96,7 +98,7 @@ function FileField({
     try {
       await backend.download(String(value));
     } catch (err: any) {
-      useToastStore.getState().addToast(err.message ?? 'Download failed', 'error');
+      useToastStore.getState().addToast(err.message ?? t('paramField.downloadFailed'), 'error');
     } finally {
       setDownloading(false);
     }
@@ -112,7 +114,7 @@ function FileField({
           className={`${styles.input} ${styles.select} ${styles.modelFileSelect}`}
         >
           <option value="" style={{ background: '#222' }}>
-            -- select file --
+            {t('paramField.selectFile')}
           </option>
           {files.map((f) => (
             <option key={f} value={f} style={{ background: '#222' }}>
@@ -125,7 +127,7 @@ function FileField({
           className={styles.modelFileBtn}
           onClick={() => fileInputRef.current?.click()}
           disabled={uploading}
-          title={backend.uploadTitle}
+          title={t(backend.uploadTitleKey)}
         >
           {uploading ? '...' : '↑'}
         </button>
@@ -134,7 +136,7 @@ function FileField({
           className={styles.modelFileBtn}
           onClick={handleDownload}
           disabled={!value || downloading}
-          title="Download selected file"
+          title={t('paramField.download')}
         >
           {downloading ? '...' : '↓'}
         </button>
@@ -142,7 +144,7 @@ function FileField({
           type="button"
           className={styles.modelFileBtn}
           onClick={refresh}
-          title="Refresh file list"
+          title={t('paramField.refresh')}
         >
           ↻
         </button>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -123,6 +123,7 @@ const en = {
   'note.unbind': 'Unbind Note',
   'note.changeColor': 'Change Color',
   'note.layoutWarning': 'Unbound notes were not repositioned by auto-layout.',
+  'note.boundToNode': 'Bound to node',
 
   // Tabs
   'tabs.add': 'New tab',
@@ -162,6 +163,7 @@ const en = {
   'subgraph.port.namePlaceholder': 'port name',
   'subgraph.port.duplicate': 'Duplicate port name',
   'subgraph.port.list': 'Ports',
+  'subgraph.layerNode.moreParams': '+{count} more',
 
   // Tooltips
   'toolbar.tooltips.on': 'Tips ON',
@@ -179,6 +181,15 @@ const en = {
   'customNodes.upload': 'Upload .py',
   'toolbar.customNodes': 'Custom Nodes',
   'toolbar.customNodes.title': 'Manage custom nodes',
+
+  // ParamField (file picker for model / image params)
+  'paramField.upload.model': 'Upload model file',
+  'paramField.upload.image': 'Upload image file',
+  'paramField.download': 'Download selected file',
+  'paramField.refresh': 'Refresh file list',
+  'paramField.selectFile': '-- select file --',
+  'paramField.uploadFailed': 'Upload failed',
+  'paramField.downloadFailed': 'Download failed',
 
   // Grid Snap
   'toolbar.gridSnap.on': 'Snap ON',
@@ -214,6 +225,12 @@ const en = {
   'results.epoch': 'Epoch',
   'results.currentLoss': 'Loss',
   'results.bestLoss': 'Best',
+  'results.lossCurve': 'Loss Curve',
+  'results.waitingEpoch': 'Waiting for first epoch...',
+  'results.epochsHeader': 'Epochs ({current}/{total})',
+  'results.col.loss': 'Loss',
+  'results.col.delta': 'Delta',
+  'results.col.time': 'Time',
 
   // Beginner Mode
   'toolbar.beginnerMode.on': 'Beginner',
@@ -244,12 +261,16 @@ const en = {
   'inspector.title': 'Inspector',
   'inspector.collapse': 'Collapse inspector',
   'inspector.expand': 'Expand inspector',
+  'inspector.collapsedStub': 'INSPECTOR',
+  'inspector.segmentBadge': 'SEGMENT',
+  'inspector.emptyPorts': 'This node has no ports.',
   'inspector.empty.notRun': 'Run the graph to capture data',
   'inspector.empty.notRunHint': 'Make sure Rec is ON, then click ▶ Run',
   'inspector.empty.noSelection': 'Select a node or segment to inspect',
   'inspector.empty.noSelectionHint': 'Click any node, or shift-select two and press Compare',
   'inspector.segment.inputs': 'Segment inputs ({count})',
   'inspector.segment.outputs': 'Segment outputs ({count})',
+  'inspector.valueDiff.noValues': 'No values captured for this port',
   'segment.removeThis': 'Remove this segment',
 
   // A1 — Verbose / step-trace mode

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -125,6 +125,7 @@ const zhTW: Record<TranslationKey, string> = {
   'note.unbind': '解除綁定',
   'note.changeColor': '更改顏色',
   'note.layoutWarning': '未綁定的註記不會被自動排版重新定位。',
+  'note.boundToNode': '已綁定到節點',
 
   // Tabs
   'tabs.add': '新增分頁',
@@ -164,6 +165,7 @@ const zhTW: Record<TranslationKey, string> = {
   'subgraph.port.namePlaceholder': 'port 名稱',
   'subgraph.port.duplicate': 'port 名稱重複',
   'subgraph.port.list': 'Ports',
+  'subgraph.layerNode.moreParams': '+{count} 更多',
 
   // Tooltips
   'toolbar.tooltips.on': '提示 ON',
@@ -181,6 +183,15 @@ const zhTW: Record<TranslationKey, string> = {
   'customNodes.upload': '上傳 .py',
   'toolbar.customNodes': '自訂節點',
   'toolbar.customNodes.title': '管理自訂節點',
+
+  // ParamField（模型 / 影像檔案選擇器）
+  'paramField.upload.model': '上傳模型檔案',
+  'paramField.upload.image': '上傳影像檔案',
+  'paramField.download': '下載選取的檔案',
+  'paramField.refresh': '重新整理檔案列表',
+  'paramField.selectFile': '-- 選擇檔案 --',
+  'paramField.uploadFailed': '上傳失敗',
+  'paramField.downloadFailed': '下載失敗',
 
   // Grid Snap
   'toolbar.gridSnap.on': '吸附 ON',
@@ -216,6 +227,12 @@ const zhTW: Record<TranslationKey, string> = {
   'results.epoch': '輪次',
   'results.currentLoss': '損失',
   'results.bestLoss': '最佳',
+  'results.lossCurve': '損失曲線',
+  'results.waitingEpoch': '等待第一個 epoch...',
+  'results.epochsHeader': 'Epoch（{current}/{total}）',
+  'results.col.loss': '損失',
+  'results.col.delta': '變化量',
+  'results.col.time': '耗時',
 
   // Beginner Mode
   'toolbar.beginnerMode.on': '入門模式',
@@ -246,12 +263,16 @@ const zhTW: Record<TranslationKey, string> = {
   'inspector.title': '檢視器',
   'inspector.collapse': '收合檢視器',
   'inspector.expand': '展開檢視器',
+  'inspector.collapsedStub': '檢視器',
+  'inspector.segmentBadge': '段落',
+  'inspector.emptyPorts': '此節點沒有連接埠。',
   'inspector.empty.notRun': '執行圖以捕獲資料',
   'inspector.empty.notRunHint': '確認「錄製」已開啟，然後按下「執行」',
   'inspector.empty.noSelection': '選取節點或段落以檢視',
   'inspector.empty.noSelectionHint': '點擊任一節點，或 Shift 選兩個後按「段落比較」',
   'inspector.segment.inputs': '段落輸入（{count}）',
   'inspector.segment.outputs': '段落輸出（{count}）',
+  'inspector.valueDiff.noValues': '此連接埠沒有捕獲的值',
   'segment.removeThis': '移除此段落',
 
   // A1 — 詳細／步驟追蹤模式

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -1,6 +1,11 @@
 import type { NodeTranslations } from './types';
 
 const zhTW: NodeTranslations = {
+  // ── Control ──
+  Start: {
+    description: '標記執行的進入點。將此節點連接到要執行的腳本的第一個節點，類似於「當綠旗被點擊」積木。',
+  },
+
   // ── CNN ──
   Conv2d: {
     description: '對輸入張量套用 2D 卷積（封裝 nn.Conv2d）。$y[i,j]=\\sum_{k,l} x[i+k,j+l]\\cdot w[k,l] + b$',
@@ -177,6 +182,16 @@ const zhTW: NodeTranslations = {
   },
 
   // ── Data ──
+  TensorInput: {
+    description: '教學用進入點 — 內嵌張量編輯器，可使用明確值、隨機、零、一或 arange 模式。隨機模式可用 seed 重現。',
+    params: {
+      shape: '張量形狀，以逗號分隔的整數（例如 \'1,4,4\'）',
+      dtype: '資料型別',
+      value_mode: '張量填充方式',
+      values: '巢狀值列表（當 value_mode=explicit 時使用）',
+      seed: '可重現隨機數的種子（當 value_mode=random 時使用）',
+    },
+  },
   Dataset: {
     description: '載入標準資料集（MNIST、CIFAR10 或 FashionMNIST）',
     params: {
@@ -245,6 +260,9 @@ const zhTW: NodeTranslations = {
       grad_clip_norm: '最大梯度範數裁剪（0 = 停用）',
     },
   },
+  BackwardOnce: {
+    description: '標記張量為 autograd 反向傳播的目標，供 Backward 檢視器使用。僅在工具列啟用 Backward 模式時執行。反向傳播目標：$\\mathcal{L} = \\sum(\\text{input})$（合成純量）。',
+  },
 
   LRScheduler: {
     description: '建立學習率排程器',
@@ -295,19 +313,20 @@ const zhTW: NodeTranslations = {
   },
 
   ModelSaver: {
-    description: '將模型權重（state_dict）儲存為 .pt/.pth 檔案',
+    description: '將模型權重（state_dict）儲存為 .pt/.pth/.safetensors 檔案',
     params: {
-      path: '輸出檔案路徑（.pt 或 .pth）',
+      path: '輸出檔案路徑（.pt、.pth 或 .safetensors）',
       save_mode: '儲存模式：state_dict（推薦）或完整模型',
+      format: '檔案格式：pytorch（.pt/.pth）或 safetensors（.safetensors）',
     },
   },
   ModelLoader: {
-    description: '從 .pt/.pth 檔案載入模型權重，或載入完整的已儲存模型',
+    description: '從 .pt/.pth/.safetensors 檔案載入模型權重，或載入完整的已儲存模型',
     params: {
-      path: '權重檔案路徑（.pt 或 .pth）',
+      path: '權重檔案路徑（.pt、.pth 或 .safetensors）',
       load_mode: '載入模式：state_dict（需要模型輸入）或完整模型',
       device: '載入權重的裝置',
-      strict: '是否嚴格要求 state_dict 中的鍵值匹配',
+      strict: '是否嚴格要求 state_dict 中的鍵值匹配（僅 state_dict 模式）',
     },
   },
   CheckpointSaver: {


### PR DESCRIPTION
## Summary
- 補上缺失節點的 zh-TW 翻譯：`Start`、`BackwardOnce`、`TensorInput`，以及 `ModelSaver`/`ModelLoader` 的 `format`/`safetensors` 參數。
- 把 `InspectorPanel`、`ResultsPanel`、`QuickNodeSearch`、`ValueDiff`、`ParamField`、`NoteNode`、`LayerNode` 中硬編碼的英文字串改用 i18n key（en/zh-TW 同步加上）。
- `ParamField` 的 `FileFieldBackend.uploadTitle` 由字面字串改為 `uploadTitleKey: TranslationKey`。
- 全 `frontend/src` 已掃過，無任何簡體字殘留。

## Test plan
- [x] `pnpm exec tsc --noEmit` 通過（exit 0）
- [ ] 手動切換 EN ↔ zh-TW，確認 Inspector/Results 面板、QuickSearch、ParamField 等位置文字正確
- [ ] 確認 `Start` / `BackwardOnce` / `TensorInput` 節點 tooltip 與 ConfigPanel 顯示繁體中文

🤖 Generated with [Claude Code](https://claude.com/claude-code)