### PR TITLE
fix(backend): hot-reload custom node edits + restrict WordVector backends

### DIFF
--- a/backend/app/api/routes_custom_nodes.py
+++ b/backend/app/api/routes_custom_nodes.py
@@ -190,9 +190,14 @@ async def delete_custom_node(filename: str):
 
 
 def _reload_all():
-    """Re-discover all nodes and presets after a custom node change."""
+    """Re-discover all nodes and presets after a custom node change.
+
+    Built-ins are imported fresh after ``registry.clear()`` (no reload needed
+    since they don't change at runtime); custom nodes pass ``force_reload``
+    so edits to existing files actually take effect, not just adds/deletes.
+    """
     registry.clear()
     registry.discover(settings.NODES_DIR, "app.nodes")
-    registry.discover(settings.CUSTOM_NODES_DIR, "app.custom_nodes")
+    registry.discover(settings.CUSTOM_NODES_DIR, "app.custom_nodes", force_reload=True)
     preset_registry.clear()
     preset_registry.discover(settings.PRESETS_DIR, registry)

--- a/backend/app/core/node_registry.py
+++ b/backend/app/core/node_registry.py
@@ -4,6 +4,7 @@ import importlib
 import inspect
 import logging
 import pkgutil
+import sys
 from pathlib import Path
 from typing import Type
 
@@ -29,7 +30,23 @@ class NodeRegistry:
     def get(self, name: str) -> Type[BaseNode] | None:
         return self._nodes.get(name)
 
-    def discover(self, package_path: Path, package_name: str) -> int:
+    def discover(
+        self,
+        package_path: Path,
+        package_name: str,
+        *,
+        force_reload: bool = False,
+    ) -> int:
+        """Walk *package_path* and register every ``BaseNode`` subclass.
+
+        ``force_reload=True`` re-runs ``importlib.reload`` on any module that
+        is already cached in ``sys.modules`` so that edits to the file on
+        disk (typically a custom node a teacher just tweaked) actually take
+        effect when ``POST /api/nodes/reload`` is called. Default is False
+        because reloading at first-discovery time would replace already-
+        imported class objects with fresh ones, breaking ``is`` identity for
+        any caller that imported the class directly.
+        """
         count = 0
         if not package_path.exists():
             return count
@@ -37,7 +54,10 @@ class NodeRegistry:
             [str(package_path)], prefix=package_name + "."
         ):
             try:
-                module = importlib.import_module(modname)
+                if force_reload and modname in sys.modules:
+                    module = importlib.reload(sys.modules[modname])
+                else:
+                    module = importlib.import_module(modname)
             except Exception as e:
                 logger.warning("Failed to import %s: %s", modname, e)
                 continue

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -98,8 +98,13 @@ async def health():
 @app.post("/api/nodes/reload")
 async def reload_nodes():
     registry.clear()
+    # Built-ins are immutable for the server lifetime — no point in paying
+    # the reload tax. Custom nodes, however, may have been edited on disk
+    # since the last load, so we force-reload them to pick up the changes.
     count = registry.discover(settings.NODES_DIR, "app.nodes")
-    custom_count = registry.discover(settings.CUSTOM_NODES_DIR, "app.custom_nodes")
+    custom_count = registry.discover(
+        settings.CUSTOM_NODES_DIR, "app.custom_nodes", force_reload=True
+    )
     preset_registry.clear()
     preset_count = preset_registry.discover(settings.PRESETS_DIR, registry)
     return {

--- a/backend/app/nodes/llm/word_vector_node.py
+++ b/backend/app/nodes/llm/word_vector_node.py
@@ -1,21 +1,16 @@
 """WordVectorNode — look up pre-trained vectors for input words/tokens.
 
-Supports two flavours of "word embedding":
+Currently the only user-selectable backend is ``demo-16d`` — a hand-crafted
+toy vocabulary (~60 words, 16 dimensions) shipped inline so the canonical
+``king − man + woman ≈ queen`` analogy works fully offline. Constructed
+dimensions (royalty / divinity / masculinity / femininity / animal classes /
+motion / vehicles / food / weather) are deliberately interpretable.
 
-* ``demo-16d`` — a hand-crafted toy vocabulary (~60 words, 16 dimensions)
-  shipped inline so the canonical analogy demo
-  (``king − man + woman ≈ queen``) works fully offline. Constructed dimensions
-  (royalty / divinity / masculinity / femininity / animal classes / motion /
-  vehicles / food / weather) are deliberately interpretable.
-
-* ``glove-50d`` / ``glove-100d`` — real GloVe vectors over a top-10k English
-  vocabulary, lazy-downloaded from a GitHub Release asset on first use via
-  :mod:`app.core.asset_cache`. When the URL hasn't been published yet the
-  node raises a friendly error pointing the user at ``demo-16d``.
-
-A third backend (``minilm-sentence-384d`` via the optional ``llm-sentence``
-extra) is reserved for a follow-up PR — the SELECT entry exists so the UI
-plumbing is in place, but it isn't loadable from this PR.
+:func:`_load_backend` keeps stub branches for ``glove-50d`` / ``glove-100d``
+and ``minilm-sentence-384d`` so saved graphs from earlier previews surface a
+clear "asset not yet published" error instead of a stack trace. The SELECT
+options will grow back once the GloVe asset bundle and the optional
+``[llm-sentence]`` extra ship.
 """
 
 from __future__ import annotations
@@ -114,6 +109,11 @@ class WordVectorNode(BaseNode):
 
     @classmethod
     def define_params(cls) -> list[ParamDefinition]:
+        # Only the offline ``demo-16d`` backend is exposed for now. The GloVe
+        # asset bundle and the optional sentence-transformer backend are
+        # implemented in :func:`_load_backend` but their assets / extras have
+        # not been published yet — exposing them here would surface a
+        # NotImplementedError at run time. Re-add when the asset URLs land.
         return [
             ParamDefinition(
                 name="backend",
@@ -121,14 +121,13 @@ class WordVectorNode(BaseNode):
                 default="demo-16d",
                 options=[
                     "demo-16d",
-                    "glove-50d",
-                    "glove-100d",
-                    "minilm-sentence-384d",
                 ],
                 description=(
-                    "Vector source. demo-16d is a hand-crafted toy vocab that "
-                    "ships offline; glove-* downloads real GloVe vectors on "
-                    "first use; minilm-sentence-384d requires the [llm-sentence] extra."
+                    "Vector source. demo-16d is a hand-crafted toy vocab "
+                    "(~60 words, 16 dimensions) that ships offline so the "
+                    "canonical king − man + woman ≈ queen analogy works. "
+                    "GloVe and sentence-transformer backends will return in a "
+                    "follow-up release."
                 ),
             ),
             ParamDefinition(


### PR DESCRIPTION
## Summary

Two launch-blocking bugs surfaced by the pre-launch audit.

### 1. Custom-node hot-reload was silently broken

`node_registry.discover()` called `importlib.import_module(modname)`, which returns the cached module — meaning edits to an existing custom node `.py` were never picked up by `POST /api/nodes/reload` or the toolbar **Reload Nodes** button. Only adds/deletes worked. README:155 advertises hot-reload as a headline custom-node feature.

**Fix:** add `force_reload: bool = False` to `discover()`; when True and the module is already cached, call `importlib.reload()` instead. The public reload endpoints (`reload_nodes` in `main.py`, `_reload_all` in `routes_custom_nodes.py`) pass `force_reload=True` only for the custom-nodes path — built-ins are immutable for the server lifetime and force-reloading them would break the \`is\`-identity assertion in `tests/test_start_node.py`.

### 2. WordVector node exposed unimplemented backends

`WordVectorNode.define_params()` exposed `glove-50d`, `glove-100d`, and `minilm-sentence-384d` SELECT options. The first two raise `NotImplementedError` because the GloVe asset bundle is not yet published; the third needs the optional `[llm-sentence]` extra. Users picking them hit a hard error.

**Fix:** SELECT now lists only `demo-16d` (offline, ~60 word toy vocab — enough for the canonical \`king − man + woman ≈ queen\` analogy). The stub branches in `_load_backend()` are kept so saved graphs from earlier preview builds still surface a friendly error rather than a stack trace. The selectable options will return when the assets ship.

## Test plan

- [x] `pytest tests/ -q` → 253 passed
- [x] `tests/test_start_node.py::test_start_node_is_auto_discovered` still passes (the default no-reload path preserves class identity)
- [ ] Manual: edit a custom node file, click Reload Nodes in the toolbar — change is reflected without server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)