### PR TITLE
fix(install): friendly preflight + auto-patch user PATH on Linux/macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -211,6 +211,56 @@ STUB
 chmod +x "$LAUNCHER"
 ok "cdui → $LAUNCHER"
 
+# ── 確保 ~/.local/bin 在 PATH 上 ─────────────────────────────────────
+# Distros vary: Debian's ~/.profile auto-adds ~/.local/bin if it exists, but
+# many minimal images / non-login shells don't source ~/.profile. We append
+# an export to whichever rc file the user's shell would actually read so
+# `cdui` is on PATH after they open a new terminal. Idempotent — guarded by
+# a marker so re-running install doesn't duplicate the line.
+ensure_path_rc() {
+  local rc="$1"
+  [[ -n "$rc" ]] || return 0
+  # Already on PATH and rc already mentions ~/.local/bin → nothing to do.
+  if grep -Fq "# >>> CodefyUI PATH (cdui) >>>" "$rc" 2>/dev/null; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$rc")"
+  cat >> "$rc" <<'PATCH'
+
+# >>> CodefyUI PATH (cdui) >>>
+# Added by install.sh so the `cdui` launcher in ~/.local/bin is on PATH.
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+# <<< CodefyUI PATH (cdui) <<<
+PATCH
+  ok "已將 ~/.local/bin 加入 $rc"
+}
+
+if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+  step "把 ~/.local/bin 加入 PATH"
+  shell_name="$(basename "${SHELL:-bash}")"
+  case "$shell_name" in
+    bash)
+      # Prefer ~/.bashrc for interactive non-login (most terminals); fall back
+      # to ~/.profile so login shells also pick it up.
+      ensure_path_rc "$HOME/.bashrc"
+      [[ -f "$HOME/.profile" || ! -f "$HOME/.bash_profile" ]] && ensure_path_rc "$HOME/.profile"
+      ;;
+    zsh)
+      ensure_path_rc "${ZDOTDIR:-$HOME}/.zshrc"
+      ;;
+    fish)
+      mkdir -p "$HOME/.config/fish"
+      ensure_path_rc "$HOME/.config/fish/config.fish"
+      ;;
+    *)
+      warn "未知的 shell：$shell_name；請手動把 ~/.local/bin 加入 PATH"
+      ;;
+  esac
+fi
+
 # ── 完成 ──────────────────────────────────────────────────────────────
 echo ""
 echo -e "${GREEN}${BOLD}╔══════════════════════════════════════╗${NC}"
@@ -224,4 +274,7 @@ fi
 echo -e "    ${BOLD}cdui dev${NC}        # 開發模式（HMR；需 Node）"
 echo ""
 echo -e "  其他指令：${BOLD}cdui update | build | stop | test | clean | uninstall${NC}"
+echo ""
+echo -e "  若 ${BOLD}cdui${NC} 仍找不到（例如非互動式 shell），可暫時使用："
+echo -e "    ${BOLD}~/.local/bin/cdui start${NC}  或  ${BOLD}$INSTALL_DIR/cdui start${NC}"
 echo ""

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -192,6 +192,33 @@ def _exec_into_venv_if_available() -> None:
     os.execv(str(VENV_PY), [str(VENV_PY)] + sys.argv)
 
 
+def _require_venv_tool(tool_name: str) -> str:
+    """Resolve a venv-installed executable, or exit with a clean repair hint.
+
+    Many users land here after a partial install (network blip during
+    ``cdui install``, interrupted GPU index download, etc.). Surfacing a raw
+    ``FileNotFoundError`` from subprocess is hostile; a single sentence
+    explaining the fix is far better.
+    """
+    exe = VENV_BIN / (f"{tool_name}.exe" if sys.platform == "win32" else tool_name)
+    if exe.exists():
+        return str(exe)
+    if not VENV.exists():
+        msg = (
+            f"錯誤：找不到虛擬環境（{VENV}）。\n"
+            f"  請先安裝後再執行此指令：\n"
+            f"    cdui install\n"
+        )
+    else:
+        msg = (
+            f"錯誤：虛擬環境存在但找不到 {tool_name}（{exe}）。\n"
+            f"  上次 'cdui install' 可能未完成。建議：\n"
+            f"    cdui clean && cdui install\n"
+        )
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
 def _ensure_uv() -> None:
     if shutil.which("uv"):
         return
@@ -771,7 +798,7 @@ def start() -> None:
         )
         sys.exit(1)
     _warn_if_dist_stale()
-    uvicorn = str(VENV_BIN / "uvicorn")
+    uvicorn = _require_venv_tool("uvicorn")
     print("=== CodefyUI 啟動（Ctrl+C 停止）===")
     print("    開啟 → http://localhost:8000")
     print("")
@@ -789,7 +816,7 @@ def dev() -> None:
         sys.exit(1)
     _install_frontend_deps_if_needed()
 
-    uvicorn = str(VENV_BIN / "uvicorn")
+    uvicorn = _require_venv_tool("uvicorn")
     backend_cmd = [uvicorn, "app.main:app", "--reload"]
     frontend_cmd = ["pnpm", "dev"]
 
@@ -841,7 +868,7 @@ def stop() -> None:
 
 
 def test() -> None:
-    pytest = str(VENV_BIN / "pytest")
+    pytest = _require_venv_tool("pytest")
     run([pytest], cwd=BACKEND_DIR)
 
 


### PR DESCRIPTION
## Summary

Two install-flow issues that left users stranded after a successful-looking install.

### 1. `cdui` was unreachable on Linux/macOS without manual PATH tweaks

`install.sh` dropped the launcher into `~/.local/bin/cdui` but never added that directory to the user's shell PATH. `install.ps1` already does this on Windows; on minimal Ubuntu/Fedora and on non-login shells that don't source `~/.profile`, the launcher was simply not on PATH and \`cdui start\` failed with \`command not found\`. README:41 said "open a new terminal" — not sufficient.

**Fix:** detect the user's shell (`$SHELL` → bash/zsh/fish), append a guarded block to the relevant rc file that prepends `~/.local/bin` to PATH if not already present. Idempotent — re-running install does not duplicate the line. Marker: \`# >>> CodefyUI PATH (cdui) >>>\`. Also prints the absolute path as a fallback in case the user is in a non-interactive shell.

### 2. `cdui start/dev/test` crashed with a stack trace if the venv was incomplete

The previous code did `str(VENV_BIN / \"uvicorn\")` and ran it directly — when the venv didn't exist or was partial (interrupted `uv pip install`), `subprocess.run` raised `FileNotFoundError` with no hint to recover.

**Fix:** new `_require_venv_tool(name)` helper in `scripts/dev.py` checks for the executable, and on failure prints a single-sentence repair message (`run cdui install` if no venv, `cdui clean && cdui install` if venv exists but tool missing). \`start\`, \`dev\`, and \`test\` now route through it.

## Test plan

- [x] `bash -n install.sh` (syntax check)
- [ ] Manual: fresh Ubuntu — verify \`cdui\` is on PATH after \`source ~/.bashrc\`
- [ ] Manual: \`cdui clean && cdui start\` → friendly error, no traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)