### PR TITLE
feat(frontend): WS reconnect + persistence robustness + i18n + UI polish

### DIFF
--- a/frontend/src/api/ws.ts
+++ b/frontend/src/api/ws.ts
@@ -1,10 +1,37 @@
+import { useToastStore } from '../store/toastStore';
+import { useI18n } from '../i18n';
+
 type MessageHandler = (data: any) => void;
+
+// Reconnect tunables. Exponential backoff capped at ~30s; we stop after
+// MAX_RECONNECT_ATTEMPTS so we don't keep timers alive forever when the
+// server is permanently down.
+const INITIAL_RECONNECT_DELAY_MS = 1000;
+const MAX_RECONNECT_DELAY_MS = 30000;
+const MAX_RECONNECT_ATTEMPTS = 10;
 
 export class ExecutionWebSocket {
   private ws: WebSocket | null = null;
   private handlers: Map<string, MessageHandler[]> = new Map();
+  // Set when callers explicitly disconnect() — suppresses reconnect loops
+  // during teardown / tab close.
+  private intentionalClose = false;
+  // Set true after the first successful onopen. We only auto-reconnect if a
+  // *previously established* connection drops; first-time connect failures
+  // bubble up via the connect() Promise so callers can show their own error.
+  private hasBeenConnected = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  // Toast suppression: we only want one "Connection lost" toast per outage,
+  // not one per backoff tick.
+  private notifiedDisconnect = false;
 
   connect(): Promise<void> {
+    this.intentionalClose = false;
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     this.ws = new WebSocket(`${protocol}//${window.location.host}/ws/execution`);
 
@@ -23,13 +50,64 @@ export class ExecutionWebSocket {
     };
 
     this.ws.onclose = () => {
-      console.log('WebSocket disconnected');
+      if (this.intentionalClose) return;
+      // Don't loop on initial-connect failure — the connect() promise has
+      // already rejected and the caller is responsible for surfacing that.
+      if (!this.hasBeenConnected) return;
+      this.scheduleReconnect();
     };
 
     return new Promise<void>((resolve, reject) => {
-      this.ws!.onopen = () => resolve();
+      this.ws!.onopen = () => {
+        // If we just recovered from a dropped connection, tell the user.
+        if (this.notifiedDisconnect) {
+          useToastStore.getState().addToast(
+            useI18n.getState().t('connection.restored'),
+            'success',
+          );
+          this.notifiedDisconnect = false;
+        }
+        this.hasBeenConnected = true;
+        this.reconnectAttempt = 0;
+        resolve();
+      };
       this.ws!.onerror = () => reject(new Error('WebSocket connection failed'));
     });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
+      useToastStore.getState().addToast(
+        useI18n.getState().t('connection.failed'),
+        'error',
+      );
+      return;
+    }
+
+    // Only one disconnect toast per outage so a flapping server doesn't
+    // flood the toast stack.
+    if (!this.notifiedDisconnect) {
+      useToastStore.getState().addToast(
+        useI18n.getState().t('connection.lost'),
+        'warning',
+      );
+      this.notifiedDisconnect = true;
+    }
+
+    const delay = Math.min(
+      INITIAL_RECONNECT_DELAY_MS * 2 ** this.reconnectAttempt,
+      MAX_RECONNECT_DELAY_MS,
+    );
+    this.reconnectAttempt++;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      // connect() will reject if the server is still down; in that case
+      // the WebSocket's onclose fires (because hasBeenConnected is true)
+      // and queues the next attempt from there.
+      this.connect().catch(() => {
+        /* handled via onclose → scheduleReconnect */
+      });
+    }, delay);
   }
 
   on(type: string, handler: MessageHandler): void {
@@ -53,8 +131,16 @@ export class ExecutionWebSocket {
   }
 
   disconnect(): void {
+    this.intentionalClose = true;
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     this.ws?.close();
     this.ws = null;
+    this.hasBeenConnected = false;
+    this.reconnectAttempt = 0;
+    this.notifiedDisconnect = false;
   }
 
   get connected(): boolean {

--- a/frontend/src/components/Canvas/EmptyCanvasOverlay.tsx
+++ b/frontend/src/components/Canvas/EmptyCanvasOverlay.tsx
@@ -21,6 +21,7 @@ const SECTION_ORDER: { category: string; titleKey: 'empty.section.trainable' | '
 function renderCard(
   example: ExampleSummary,
   onClick: (e: ExampleSummary) => void,
+  t: (k: any, vars?: Record<string, string | number>) => string,
 ) {
   const catColor = EXAMPLE_CATEGORY_COLORS[example.category] ?? '#FF9800';
   const catLabel = example.category.replace(/_/g, ' ');
@@ -53,7 +54,7 @@ function renderCard(
         >
           {catLabel}
         </span>
-        <span className={styles.nodeCount}>{example.node_count} nodes</span>
+        <span className={styles.nodeCount}>{t('empty.nodeCount', { count: example.node_count })}</span>
       </div>
     </button>
   );
@@ -129,7 +130,7 @@ export function EmptyCanvasOverlay() {
           <div key={section.category} className={styles.section}>
             <div className={styles.sectionTitle}>{t(section.titleKey)}</div>
             <div className={styles.quickStartGrid}>
-              {section.items.map((example) => renderCard(example, handleClick))}
+              {section.items.map((example) => renderCard(example, handleClick, t))}
             </div>
           </div>
         ))}
@@ -137,7 +138,7 @@ export function EmptyCanvasOverlay() {
         {!loading && uncategorized.length > 0 && (
           <div className={styles.section}>
             <div className={styles.quickStartGrid}>
-              {uncategorized.map((example) => renderCard(example, handleClick))}
+              {uncategorized.map((example) => renderCard(example, handleClick, t))}
             </div>
           </div>
         )}

--- a/frontend/src/components/Canvas/QuickNodeSearch.tsx
+++ b/frontend/src/components/Canvas/QuickNodeSearch.tsx
@@ -164,7 +164,7 @@ export function QuickNodeSearch({ screenPos, flowPos, onClose }: QuickNodeSearch
               <span className={styles.dot} style={{ background: color }} />
               <div className={styles.itemContent}>
                 <span className={styles.itemName}>{name}</span>
-                {r.kind === 'preset' && <span className={styles.presetBadge}>PRESET</span>}
+                {r.kind === 'preset' && <span className={styles.presetBadge}>{t('preset.badge')}</span>}
                 {desc && <span className={styles.itemDesc}>{desc}</span>}
               </div>
               <span className={styles.itemCategory} style={{ color }}>{category}</span>

--- a/frontend/src/components/InspectorPanel/InspectorPanel.tsx
+++ b/frontend/src/components/InspectorPanel/InspectorPanel.tsx
@@ -187,7 +187,7 @@ export function InspectorPanel() {
       className={styles.collapseBtn}
       onClick={() => setCollapsed((v) => !v)}
       title={collapsed ? t('inspector.expand') : t('inspector.collapse')}
-      aria-label={collapsed ? 'Expand inspector' : 'Collapse inspector'}
+      aria-label={collapsed ? t('inspector.expand') : t('inspector.collapse')}
     >
       {collapsed ? '‹' : '›'}
     </button>

--- a/frontend/src/components/Nodes/BaseNode.tsx
+++ b/frontend/src/components/Nodes/BaseNode.tsx
@@ -91,7 +91,7 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
     try {
       await downloadModelFile(downloadablePath);
     } catch (err: any) {
-      useToastStore.getState().addToast(err.message ?? 'Download failed', 'error');
+      useToastStore.getState().addToast(err.message ?? t('download.failed'), 'error');
     } finally {
       setDownloading(false);
     }

--- a/frontend/src/components/Nodes/StartNode.tsx
+++ b/frontend/src/components/Nodes/StartNode.tsx
@@ -1,7 +1,9 @@
 import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { useI18n } from '../../i18n';
 import styles from './StartNode.module.css';
 
 export function StartNode(_: NodeProps) {
+  const { t } = useI18n();
   return (
     <div className={styles.startNode}>
       <svg className={styles.icon} viewBox="0 0 16 16" fill="none">
@@ -15,7 +17,7 @@ export function StartNode(_: NodeProps) {
           fillOpacity="0.4"
         />
       </svg>
-      <span>Start</span>
+      <span>{t('node.start.label')}</span>
       <Handle
         type="source"
         position={Position.Right}

--- a/frontend/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.tsx
@@ -236,7 +236,8 @@ export function ResultsPanel() {
           <button
             onClick={toggleCollapse}
             className={styles.collapseBtn}
-            title={collapsed ? 'Expand panel' : 'Collapse panel'}
+            title={collapsed ? t('results.expand') : t('results.collapse')}
+            aria-label={collapsed ? t('results.expand') : t('results.collapse')}
           >
             {collapsed ? '▴' : '▾'}
           </button>

--- a/frontend/src/components/Toolbar/SettingsPopover.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.tsx
@@ -120,11 +120,10 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
     <div ref={ref} className={styles.panel} role="dialog" aria-label={t('toolbar.settings')}>
       <div className={styles.head}>
         <h4>{t('toolbar.settings')}</h4>
-        <input
-          className={styles.search}
-          placeholder={t('toolbar.settings.search')}
-          aria-label={t('toolbar.settings.search')}
-        />
+        {/* Search input deferred until per-toggle filtering lands — a
+            non-functional input at the top of the popover is more confusing
+            than helpful. The i18n key `toolbar.settings.search` is kept for
+            when it returns. */}
       </div>
 
       <div className={styles.body}>

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -483,7 +483,7 @@ export function Toolbar() {
           <button
             className={styles.splitButtonCaret}
             onClick={() => setLayoutMenuOpen((v) => !v)}
-            aria-label="Layout mode"
+            aria-label={t('toolbar.layoutMode.aria')}
           >
             ▾
           </button>
@@ -579,7 +579,7 @@ export function Toolbar() {
           <button
             onClick={() => setLangMenuOpen((v) => !v)}
             className={`${styles.dropdown} ${langMenuOpen ? styles.open : ''}`}
-            aria-label="Language"
+            aria-label={t('toolbar.language.aria')}
             aria-expanded={langMenuOpen}
           >
             {SUPPORTED_LOCALES.find((l) => l.code === locale)?.label ?? locale}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -51,6 +51,11 @@ const en = {
   'status.skipped': 'Skipped',
   'status.cached': 'Cached',
 
+  // Connection (WebSocket reconnect surface)
+  'connection.lost': 'Connection lost — reconnecting…',
+  'connection.restored': 'Connection restored',
+  'connection.failed': 'Could not reconnect to the execution server',
+
   // Node Palette
   'palette.title': 'Nodes',
   'palette.search': 'Search nodes...',
@@ -359,6 +364,18 @@ const en = {
   'scatter.runHint': 'Run the graph to see the projection',
   'textInput.placeholder': 'Type text here…',
   'textInput.charCount': '{count} chars',
+
+  // Misc strings extracted to translate UI surfaces that previously had
+  // hard-coded English (results panel collapse, empty-canvas card footer,
+  // download failures, Start node label, toolbar aria, persistence quota).
+  'results.expand': 'Expand panel',
+  'results.collapse': 'Collapse panel',
+  'empty.nodeCount': '{count} nodes',
+  'node.start.label': 'Start',
+  'download.failed': 'Download failed',
+  'toolbar.layoutMode.aria': 'Layout mode',
+  'toolbar.language.aria': 'Language',
+  'persistence.quotaError': 'Could not save tabs — browser storage is full.',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -53,6 +53,11 @@ const zhTW: Record<TranslationKey, string> = {
   'status.skipped': '已跳過',
   'status.cached': '已快取',
 
+  // Connection (WebSocket reconnect surface)
+  'connection.lost': '連線中斷 — 嘗試重新連線中…',
+  'connection.restored': '已重新連線',
+  'connection.failed': '無法重新連線至執行伺服器',
+
   // Node Palette
   'palette.title': '節點',
   'palette.search': '搜尋節點...',
@@ -361,6 +366,17 @@ const zhTW: Record<TranslationKey, string> = {
   'scatter.runHint': '執行圖以查看投影結果',
   'textInput.placeholder': '在此輸入文字…',
   'textInput.charCount': '{count} 字元',
+
+  // Misc — 結果面板收合 / 空畫布節點數 / 下載錯誤 / Start 節點 /
+  // 工具列 aria / localStorage 配額不足
+  'results.expand': '展開面板',
+  'results.collapse': '收合面板',
+  'empty.nodeCount': '{count} 個節點',
+  'node.start.label': '開始',
+  'download.failed': '下載失敗',
+  'toolbar.layoutMode.aria': '排版模式',
+  'toolbar.language.aria': '語言',
+  'persistence.quotaError': '無法儲存分頁 — 瀏覽器儲存空間已滿。',
 };
 
 export default zhTW;

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -208,6 +208,11 @@ interface PersistedTab {
   autoBackward?: boolean;
 }
 
+// Throttle the user-facing quota toast so a big graph editing session
+// doesn't burst N toasts when localStorage fills up. One per minute is
+// plenty to surface "your work isn't being saved".
+let _lastQuotaWarn = 0;
+
 function saveTabs(tabs: TabState[], activeTabId: string) {
   try {
     const data: { tabs: PersistedTab[]; activeTabId: string } = {
@@ -228,7 +233,19 @@ function saveTabs(tabs: TabState[], activeTabId: string) {
     };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
   } catch {
-    // Storage full or unavailable — silently ignore
+    // QuotaExceededError / SecurityError / private mode etc. The README
+    // promises auto-save; failing silently lets the user lose work without
+    // realising. Surface once per minute at most.
+    const now = Date.now();
+    if (now - _lastQuotaWarn > 60_000) {
+      _lastQuotaWarn = now;
+      try {
+        const message = useI18n.getState().t('persistence.quotaError');
+        useToastStore.getState().addToast(message, 'error');
+      } catch {
+        /* toast/i18n not initialised yet — nothing useful to do here */
+      }
+    }
   }
 }
 
@@ -1133,6 +1150,25 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
 }));
 
 // ── Auto-save to localStorage ──
-useTabStore.subscribe((state) => {
-  saveTabs(state.tabs, state.activeTabId);
+//
+// React Flow fires a state change per pointer event during a drag, and
+// status updates from the backend stream tick it many times per run. Writing
+// (and JSON-stringifying) the whole tab tree on every tick wastes CPU and
+// can stutter visibly on large graphs. We collapse a burst of changes into
+// a single trailing-edge save; the actual `saveTabs` call reads fresh state
+// at fire time so we never persist a stale snapshot.
+const SAVE_DEBOUNCE_MS = 250;
+let _saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+function _scheduleSave() {
+  if (_saveTimer !== null) clearTimeout(_saveTimer);
+  _saveTimer = setTimeout(() => {
+    _saveTimer = null;
+    const s = useTabStore.getState();
+    saveTabs(s.tabs, s.activeTabId);
+  }, SAVE_DEBOUNCE_MS);
+}
+
+useTabStore.subscribe(() => {
+  _scheduleSave();
 });


### PR DESCRIPTION
## Summary

A bundle of pre-launch frontend polish surfaced by the audit.

### WebSocket auto-reconnect with toasts (`api/ws.ts`)

Previously \`ws.onclose\` just \`console.log\`'d \"WebSocket disconnected\". A backend restart (e.g. \`cdui update\`) silently killed every open tab and the user only noticed when **Run** stopped responding.

- Exponential backoff: 1s → 30s, capped at 10 attempts.
- First-time connect failures still bubble up via the \`connect()\` promise so the existing \`useGraphExecution\` error toast still fires; reconnect only kicks in for previously-established connections.
- Per-outage toast: one \"Connection lost — reconnecting…\" warning, then \"Connection restored\" success on recovery, or \"Could not reconnect\" error if max attempts exhausted.

### Persistence debounce + quota toast (`store/tabStore.ts`)

\`useTabStore.subscribe\` wrote to localStorage on every state change — React Flow fires one per pointer event during a drag, and node-status updates fire many times per run. Big graphs visibly stuttered. Errors (\`QuotaExceededError\`, \`SecurityError\`) were silently swallowed, so the README's \"auto-saves to localStorage\" promise broke without a peep.

- 250ms trailing-edge debounce; the timer reads fresh state at fire time so we never persist a stale snapshot.
- Quota / unavailable: surface via toast (60s throttle so a flapping storage doesn't flood).

### SettingsPopover: hide non-functional search

The search input had placeholder + aria-label but no \`value\`/\`onChange\`/filter — purely cosmetic. Confused users who expected to filter toggles. Removed the JSX; i18n key kept for when search lands.

### i18n: cover the last 8 hard-coded English strings

Visible in the zh-TW UI as English text. New keys added to both `en.ts` and `zh-TW.ts`; eight components updated to call `t()`:

| Component | Change |
|---|---|
| \`ResultsPanel\` | collapse/expand title → \`results.expand\` / \`results.collapse\` |
| \`InspectorPanel\` | aria-label now reuses existing \`inspector.expand\` / \`collapse\` |
| \`EmptyCanvasOverlay\` | \`{n} nodes\` → \`empty.nodeCount\` |
| \`QuickNodeSearch\` | \`PRESET\` badge → existing \`preset.badge\` |
| \`StartNode\` | label \"Start\" → \`node.start.label\` |
| \`BaseNode\` | download error fallback → \`download.failed\` |
| \`Toolbar\` | Layout / Language aria-labels → \`toolbar.layoutMode.aria\` / \`toolbar.language.aria\` |

## Test plan

- [x] \`pnpm tsc --noEmit\` → exit 0
- [x] \`pnpm vitest run\` → 55/55 passed
- [ ] Manual: kill backend with frontend open → toast appears, reconnect on backend restart
- [ ] Manual: switch UI to zh-TW, verify no English leaks in the listed components

🤖 Generated with [Claude Code](https://claude.com/claude-code)