### PR TITLE
ci: pin pnpm@9 + Python 3.10-3.12 matrix + cdui smoke + release-build draft fix

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,72 @@
+name: Backend Tests
+
+# Catch:
+#   1. Python-version regressions — `pyproject.toml` says `>=3.10` but the
+#      install scripts hardcode 3.11. Without this matrix, code that
+#      accidentally depends on 3.11+ syntax silently breaks 3.10 users.
+#   2. uv.lock drift — a PR that edits `pyproject.toml` without
+#      regenerating the lock would otherwise sail through review.
+#   3. Test failures introduced in PRs that don't touch the install path
+#      (the existing install-check workflow only fires on releases).
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-test.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-test.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: pytest (Python ${{ matrix.python }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        # Cover the supported floor (3.10 per pyproject), the install-script
+        # default (3.11), and the most recent stable Python so we surface
+        # forward-compatibility issues early.
+        python: ['3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Provision Python ${{ matrix.python }}
+        run: uv python install ${{ matrix.python }}
+
+      - name: Verify uv.lock is in sync with pyproject.toml
+        working-directory: backend
+        run: uv lock --check
+
+      - name: Create venv and install backend (with [dev] extra)
+        working-directory: backend
+        run: |
+          uv venv --python ${{ matrix.python }}
+          uv pip install -e ".[dev]"
+
+      - name: pytest
+        working-directory: backend
+        run: |
+          .venv/bin/python -m pytest tests/ -q
+
+      - name: Smoke-import backend (catches syntax errors at import time)
+        working-directory: backend
+        run: |
+          .venv/bin/python -c "from app.main import app; print('FastAPI app:', app.title)"

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -31,7 +31,10 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          # Pinned to the major matching frontend/pnpm-lock.yaml's
+          # `lockfileVersion: '9.0'`. `latest` would silently jump to a new
+          # major and break `pnpm install --frozen-lockfile`.
+          version: 9
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/install-check.yml
+++ b/.github/workflows/install-check.yml
@@ -104,6 +104,44 @@ jobs:
         shell: bash
         run: kill "$BACKEND_PID" 2>/dev/null || true
 
+      # Separately exercise the cdui launcher stub installed by install.sh.
+      # The previous step ran uvicorn directly, which would mask a broken
+      # launcher (missing PATH entry, bad `exec`, wrong INSTALL_DIR).
+      - name: Smoke-test cdui launcher
+        shell: bash
+        run: |
+          launcher="$HOME/.local/bin/cdui"
+          [[ -x "$launcher" ]] \
+            || { echo "::error::cdui launcher missing or not executable: $launcher"; ls -la "$(dirname "$launcher")" || true; exit 1; }
+          # The launcher should forward to ${INSTALL_DIR}/cdui which dispatches
+          # `start`. Run it in the background and verify health.
+          "$launcher" start > "$RUNNER_TEMP/cdui-start.log" 2>&1 &
+          launcher_pid=$!
+          echo "CDUI_PID=$launcher_pid" >> "$GITHUB_ENV"
+          launcher_ok=false
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8000/api/health > /dev/null; then
+              launcher_ok=true
+              break
+            fi
+            sleep 2
+          done
+          if [[ "$launcher_ok" != "true" ]]; then
+            echo "::error::cdui start launcher failed to bring up backend in 60s"
+            cat "$RUNNER_TEMP/cdui-start.log" || true
+            exit 1
+          fi
+          echo "✓ cdui launcher reached /api/health"
+
+      - name: Stop cdui launcher
+        if: always() && env.CDUI_PID != ''
+        shell: bash
+        run: |
+          kill "$CDUI_PID" 2>/dev/null || true
+          # The launcher exec's cdui which exec's uvicorn; clean up that PID
+          # too so the runner shuts down cleanly.
+          pkill -f "uvicorn app.main:app" 2>/dev/null || true
+
       - name: Upload backend log on failure
         if: failure()
         uses: actions/upload-artifact@v7
@@ -200,6 +238,48 @@ jobs:
         shell: pwsh
         run: |
           try { Stop-Process -Id $env:BACKEND_PID -Force -ErrorAction SilentlyContinue } catch {}
+
+      # Smoke-test the cdui.cmd launcher stub installed by install.ps1. The
+      # previous step ran uvicorn directly, which would miss a broken
+      # launcher (bad PATH patch, malformed cmd file, wrong install path).
+      - name: Smoke-test cdui launcher
+        shell: pwsh
+        run: |
+          $launcher = Join-Path $env:USERPROFILE '.local\bin\cdui.cmd'
+          if (-not (Test-Path $launcher)) {
+            Write-Host "::error::cdui.cmd launcher missing: $launcher"
+            Get-ChildItem (Split-Path $launcher) -ErrorAction SilentlyContinue
+            exit 1
+          }
+          $logPath = Join-Path $env:RUNNER_TEMP 'cdui-start.log'
+          $errPath = Join-Path $env:RUNNER_TEMP 'cdui-start.err'
+          $proc = Start-Process -FilePath $launcher `
+            -ArgumentList 'start' `
+            -NoNewWindow -PassThru -RedirectStandardOutput $logPath -RedirectStandardError $errPath
+          "CDUI_PID=$($proc.Id)" | Out-File -Append -FilePath $env:GITHUB_ENV
+          $launcherOk = $false
+          for ($i = 1; $i -le 30; $i++) {
+            try {
+              $resp = Invoke-RestMethod -Uri http://127.0.0.1:8000/api/health -TimeoutSec 5
+              if ($resp.status -eq 'ok') { $launcherOk = $true; break }
+            } catch {}
+            Start-Sleep -Seconds 2
+          }
+          if (-not $launcherOk) {
+            Write-Host "::error::cdui.cmd start failed to bring up backend in 60s"
+            if (Test-Path $logPath) { Get-Content $logPath }
+            if (Test-Path $errPath) { Get-Content $errPath }
+            exit 1
+          }
+          Write-Host "✓ cdui.cmd launcher reached /api/health"
+
+      - name: Stop cdui launcher
+        if: always() && env.CDUI_PID != ''
+        shell: pwsh
+        run: |
+          try { Stop-Process -Id $env:CDUI_PID -Force -ErrorAction SilentlyContinue } catch {}
+          # The launcher chain forks a uvicorn.exe; kill any straggler too.
+          Get-Process uvicorn -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
 
       - name: Upload backend log on failure
         if: failure()

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -92,7 +92,10 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          # Pin to the major that matches frontend/pnpm-lock.yaml. Floating to
+          # `latest` would silently break `pnpm install --frozen-lockfile`
+          # when pnpm cuts a new major.
+          version: 9
 
       - uses: actions/setup-node@v5
         with:
@@ -170,23 +173,36 @@ jobs:
 
           body="$(cat release-body.md)"
 
+          # IMPORTANT: GitHub rejects make_latest=true with HTTP 422 when the
+          # release is still a draft. We therefore only flip make_latest in
+          # the PATCH that targets an *already-published* release; for draft
+          # creates/updates we omit it and let the maintainer's "Publish
+          # release" click (or a follow-up step) do the flip.
           if [[ -n "$existing_id" ]]; then
             echo "Updating existing release $existing_id"
             if [[ "$preserve_draft" == "true" ]]; then
-              gh api -X PATCH "repos/$REPO/releases/$existing_id" \
-                -f tag_name="$TAG" \
-                -f name="$TAG" \
-                -F prerelease="$PRERELEASE" \
-                -f body="$body" \
-                -f make_latest=true
+              # UI-created release: don't change draft state. Read current
+              # draft flag so we can decide whether make_latest is allowed.
+              is_draft="$(gh api "repos/$REPO/releases/$existing_id" --jq '.draft')"
+              patch_args=( -X PATCH "repos/$REPO/releases/$existing_id"
+                           -f tag_name="$TAG"
+                           -f name="$TAG"
+                           -F prerelease="$PRERELEASE"
+                           -f body="$body" )
+              if [[ "$is_draft" == "false" ]]; then
+                patch_args+=( -f make_latest=true )
+              fi
+              gh api "${patch_args[@]}"
             else
+              # Tag-push / dispatch: always (re-)assert draft=true so the
+              # maintainer reviews notes before publishing. make_latest is
+              # invalid while draft=true and is intentionally omitted.
               gh api -X PATCH "repos/$REPO/releases/$existing_id" \
                 -f tag_name="$TAG" \
                 -f name="$TAG" \
                 -F draft=true \
                 -F prerelease="$PRERELEASE" \
-                -f body="$body" \
-                -f make_latest=true
+                -f body="$body"
             fi
           else
             echo "Creating new draft release for $TAG"
@@ -195,8 +211,7 @@ jobs:
               -f name="$TAG" \
               -F draft=true \
               -F prerelease="$PRERELEASE" \
-              -f body="$body" \
-              -f make_latest=true
+              -f body="$body"
           fi
 
       - name: Upload frontend-dist.tar.gz to release

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,8 @@
   "name": "codefyui-frontend",
   "private": true,
   "version": "0.1.0",
+  "license": "AGPL-3.0-only",
+  "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Five CI fragility issues from the pre-launch audit, plus the launch-blocking release workflow bug that would have broken \`1.0.0rc11\`.

### release-build.yml: stop sending \`make_latest=true\` while \`draft=true\`

The PATCH/POST that creates the release passed \`make_latest=true\` unconditionally. **GitHub returns HTTP 422 Validation Failed** when this combination hits a draft release, killing the asset-upload step that runs after with \`set -euo pipefail\`. This would have prevented \`1.0.0rc11\` from ever publishing \`frontend-dist.tar.gz\`.

**Fix:** the PATCH path now reads the existing release's draft state and only includes \`make_latest=true\` when \`draft=false\`. The other paths (POST new release, PATCH back to draft) drop \`make_latest\` entirely — GitHub's auto-latest behaviour kicks in once the maintainer publishes.

### pnpm pin to v9

Both workflows used \`pnpm/action-setup@v4 with version: latest\`. The pnpm v10 cut would silently break \`pnpm install --frozen-lockfile\` against the v9 lockfile. Pinned to major 9. Also added \`packageManager: pnpm@9.15.0\` to \`package.json\` so local dev sees the same version.

### New: \`backend-test.yml\` — Python matrix + \`uv lock --check\` + pytest

The existing \`install-check.yml\` only fires on releases. PRs that broke backend tests landed unobserved. Install scripts hardcode Python 3.11, so 3.10 / 3.12 regressions never surfaced.

The new workflow runs on PR + push to main with paths filter on \`backend/**\`. Matrix: Python 3.10 / 3.11 / 3.12. Steps: \`uv lock --check\` → install with \`[dev]\` → \`pytest\` → smoke-import the FastAPI app.

### \`install-check.yml\`: smoke-test the cdui launcher itself

The existing test ran \`uvicorn\` directly, bypassing the launcher stub at \`~/.local/bin/cdui\`. A broken stub (bad PATH patch, wrong INSTALL_DIR, malformed \`cdui.cmd\`) would have shipped undetected. Linux + Windows now have a **Smoke-test cdui launcher** step that backgrounds \`cdui start\`, hits \`/api/health\`, and kills the process.

## Test plan

- [x] All 4 workflow YAMLs validate (\`yaml.safe_load\`)
- [x] \`package.json\` has valid JSON with \`packageManager: pnpm@9.15.0\`
- [ ] First \`backend-test\` run on this PR exits green for all 3 Python versions
- [ ] First \`install-check\` run after release confirms cdui launcher reaches \`/api/health\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)