### PR TITLE
fix(pyproject): use PEP 639 SPDX license string

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,8 +3,15 @@ name = "codefyui-backend"
 version = "0.1.0"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
 requires-python = ">=3.10"
-license = { text = "AGPL-3.0-only" }
-license-files = ["../LICENSE", "../COMMERCIAL-LICENSE.md"]
+# PEP 639 SPDX license expression (bare string). The previous PEP 621
+# table form `{ text = "..." }` is rejected by setuptools >= 77 with
+# "configuration error: project.license must be string". The companion
+# `license-files` key is intentionally omitted because PEP 639 disallows
+# `..` paths and the LICENSE / COMMERCIAL-LICENSE.md files live at the
+# repo root, not inside backend/. Setuptools auto-detects LICENSE in
+# the project directory if present; for distribution metadata the SPDX
+# identifier above is the canonical statement.
+license = "AGPL-3.0-only"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",


### PR DESCRIPTION
## Summary

Hotfix: \`backend/pyproject.toml\` license field was rejected by setuptools ≥ 77.

setuptools 77+ enforces PEP 639 strict mode — \`project.license\` must be a bare SPDX expression, not the older PEP 621 table form \`{ text = \"...\" }\`. Releases \`1.0.0rc11\` and \`1.0.0\` both shipped with the table form, so:

\`\`\`
configuration error: \`project.license\` must be string
GIVEN VALUE: { \"text\": \"AGPL-3.0-only\" }
\`\`\`

Every fresh \`cdui install\` (which runs \`uv pip install -e .[dev]\`) hit this error, breaking:
- **Install Check** workflow on Linux + macOS + Windows for both 1.0.0rc11 and 1.0.0
- **Backend Tests** matrix on Python 3.10 / 3.11 / 3.12

Local dev wasn't affected because the venv was already built against an earlier setuptools that accepted the table form.

### Changes

- \`license = { text = \"AGPL-3.0-only\" }\` → \`license = \"AGPL-3.0-only\"\`
- Dropped \`license-files = [\"../LICENSE\", \"../COMMERCIAL-LICENSE.md\"]\` — PEP 639 disallows \`..\` in license-files paths, and the LICENSE files live at repo root, not inside backend/. The SPDX identifier above is the canonical license declaration; the LICENSE file at repo root is what users see in the GitHub UI.

### Verification

Locally: fresh venv + \`uv pip install -e .\` succeeds against setuptools 82.0.1 (newer than CI's 81.0.0).

Once this lands a 1.0.1 patch tag will follow with the same content as 1.0.0 plus this fix, so the installer one-liner works for all new users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)