### PR TITLE
fix(ws): same-origin allow so cdui start works without 403

### DIFF
--- a/backend/app/api/ws_execution.py
+++ b/backend/app/api/ws_execution.py
@@ -113,13 +113,26 @@ def _summarize_outputs(result: dict[str, Any]) -> dict[str, Any]:
 
 @router.websocket("/ws/execution")
 async def websocket_execution(ws: WebSocket):
-    # Validate Origin header against allowed CORS origins
+    # Origin policy:
+    # 1. Same-origin requests are always allowed. This covers `cdui start`
+    #    where the SPA is served by uvicorn at the same host:port — any
+    #    fixed CORS_ORIGINS list can't predict the user's chosen port and
+    #    rejecting same-origin would break production mode entirely.
+    # 2. Cross-origin requests (typically `cdui dev` with Vite on :5173
+    #    hitting the backend on :8000) must whitelist the origin in
+    #    settings.CORS_ORIGINS.
+    # 3. Missing Origin header (non-browser clients, e.g. the WS test
+    #    suite) is allowed — the existing CORS middleware already enforces
+    #    browser-side origin policy on regular HTTP requests.
     origin = ws.headers.get("origin")
     if origin:
-        allowed = {urlparse(o).netloc for o in settings.CORS_ORIGINS}
-        if urlparse(origin).netloc not in allowed:
-            await ws.close(code=4003, reason="Origin not allowed")
-            return
+        origin_netloc = urlparse(origin).netloc
+        request_host = ws.headers.get("host", "")
+        if origin_netloc != request_host:
+            allowed = {urlparse(o).netloc for o in settings.CORS_ORIGINS}
+            if origin_netloc not in allowed:
+                await ws.close(code=4003, reason="Origin not allowed")
+                return
 
     await ws.accept()
 

--- a/backend/tests/test_ws_execution.py
+++ b/backend/tests/test_ws_execution.py
@@ -57,3 +57,79 @@ async def test_ws_unknown_action():
             msg = json.loads(await ws.receive_text())
             assert msg["type"] == "error"
             assert "foobar" in msg["error"]
+
+
+# ── Origin policy ──────────────────────────────────────────────────────
+# Regression guards for the WS handshake's same-origin / CORS_ORIGINS gate
+# (see ws_execution.websocket_execution comment). The bug these protect
+# against: end users on `cdui start` (single uvicorn at :8000) hit
+# 403 Forbidden because the default CORS_ORIGINS only listed Vite dev
+# ports (5173 / 5174 / 3000) and rejected the same-origin connection.
+
+
+@pytest.mark.asyncio
+async def test_ws_same_origin_allowed():
+    """Same-origin connections must be accepted regardless of CORS_ORIGINS.
+
+    This is the `cdui start` case — SPA and WS share host:port so Origin
+    matches Host, and the handshake should succeed without any explicit
+    allowlist entry for the production port.
+    """
+    async with AsyncClient(
+        transport=ASGIWebSocketTransport(app=app),
+        base_url="http://test",
+    ) as client:
+        # Origin matches the synthetic Host ("test") that ASGI assigns.
+        async with aconnect_ws(
+            "/ws/execution",
+            client,
+            headers={"origin": "http://test"},
+        ) as ws:
+            await ws.send_text(json.dumps({"action": "foobar"}))
+            msg = json.loads(await ws.receive_text())
+            assert msg["type"] == "error"  # handshake succeeded
+
+
+@pytest.mark.asyncio
+async def test_ws_cross_origin_in_allowlist_allowed():
+    """Cross-origin from a CORS_ORIGINS entry must be accepted.
+
+    Covers `cdui dev` — Vite at :5173 hitting the backend at :8000.
+    """
+    async with AsyncClient(
+        transport=ASGIWebSocketTransport(app=app),
+        base_url="http://test",
+    ) as client:
+        async with aconnect_ws(
+            "/ws/execution",
+            client,
+            headers={"origin": "http://localhost:5173"},
+        ) as ws:
+            await ws.send_text(json.dumps({"action": "foobar"}))
+            msg = json.loads(await ws.receive_text())
+            assert msg["type"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_ws_cross_origin_not_in_allowlist_rejected():
+    """Cross-origin not in CORS_ORIGINS must be rejected at handshake.
+
+    The ASGI test transport surfaces a close-before-accept as
+    ``WebSocketDisconnect`` with our custom 4003 code (real browsers
+    see uvicorn translate it into an HTTP 403 response).
+    """
+    from httpx_ws import WebSocketDisconnect
+
+    async with AsyncClient(
+        transport=ASGIWebSocketTransport(app=app),
+        base_url="http://test",
+    ) as client:
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            async with aconnect_ws(
+                "/ws/execution",
+                client,
+                headers={"origin": "http://attacker.example"},
+            ) as _ws:
+                pass  # connection should fail before we get here
+        # 4003 is what ws_execution.py uses for "Origin not allowed".
+        assert exc_info.value.code == 4003


### PR DESCRIPTION
## Bug

Reported by treeleaves30760 after running `cdui start`:

\`\`\`
INFO:     127.0.0.1:51032 - \"WebSocket /ws/execution\" 403
INFO:     connection rejected (403 Forbidden)
INFO:     connection closed
\`\`\`

The SPA opens fine; clicking **Run** triggers a WS connection that the backend rejects.

## Root cause

\`ws_execution.websocket_execution\` validates the \`Origin\` header against \`settings.CORS_ORIGINS\`, which defaults to **the Vite dev ports only**:

\`\`\`python
CORS_ORIGINS: list[str] = [
    \"http://localhost:5173\",
    \"http://localhost:5174\",
    \"http://localhost:3000\",
]
\`\`\`

\`cdui start\` serves the SPA from uvicorn at :8000, so the browser sends \`Origin: http://localhost:8000\` — not in the list — and the handler closed with code 4003. Uvicorn translates close-before-accept into HTTP 403, **breaking production mode entirely**.

## Fix

Same-origin connections (\`Origin\` netloc == \`Host\` header) are always allowed; cross-origin still requires a \`CORS_ORIGINS\` entry. Covers both modes without having to predict every production port:

| Mode | Origin vs Host | Result |
|------|----------------|--------|
| \`cdui start\` (single uvicorn) | same-origin | allow |
| \`cdui dev\` (Vite :5173 → :8000) | cross-origin → check allowlist | allow (5173 is in defaults) |
| Non-browser client (no Origin header) | n/a — skipped | allow (existing behaviour) |
| Other cross-origin | check allowlist → not present | reject (4003) |

## Test plan

- [x] 3 new tests in \`test_ws_execution.py\`:
  - \`test_ws_same_origin_allowed\` — covers the bug above
  - \`test_ws_cross_origin_in_allowlist_allowed\` — covers \`cdui dev\`
  - \`test_ws_cross_origin_not_in_allowlist_rejected\` — asserts close code 4003
- [x] Full backend suite: 256/256 passed
- [ ] Manual: \`cdui start\` → click Run → WS handshake succeeds, no 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)