### PR TITLE
fix(training): AdamW + Rprop optimizer compat with PyTorch 2.11

### DIFF
--- a/backend/app/nodes/training/optimizer_node.py
+++ b/backend/app/nodes/training/optimizer_node.py
@@ -35,6 +35,7 @@ class OptimizerNode(BaseNode):
         ]
 
     def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        import inspect
         import torch.optim as optim
 
         model = inputs["model"]
@@ -58,6 +59,20 @@ class OptimizerNode(BaseNode):
         if optimizer_cls is None:
             raise ValueError(f"Unsupported optimizer type: {opt_type}")
 
-        optimizer = optimizer_cls(model.parameters(), lr=lr, weight_decay=weight_decay)
+        # Not every optimizer accepts ``weight_decay`` (e.g. Rprop). Silently
+        # drop the kwarg when the user left it at the default 0.0 — that's
+        # equivalent to "not supplied" — but raise a clear error if they
+        # intentionally set a non-zero value the optimizer can't honour.
+        accepted = set(inspect.signature(optimizer_cls.__init__).parameters)
+        kwargs: dict[str, Any] = {"lr": lr}
+        if "weight_decay" in accepted:
+            kwargs["weight_decay"] = weight_decay
+        elif weight_decay:
+            raise ValueError(
+                f"Optimizer '{opt_type}' does not accept weight_decay; "
+                f"got {weight_decay}. Set weight_decay=0 or pick a different optimizer."
+            )
+
+        optimizer = optimizer_cls(model.parameters(), **kwargs)
 
         return {"optimizer": optimizer}

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -96,8 +96,20 @@ class TrainingLoopNode(BaseNode):
         # TrainingLoop with the model still on CPU, so any optimizer created there
         # holds stale references / state. Preserving the original class + defaults
         # keeps the user's choices (Adam/SGD/..., lr, weight_decay, etc.) intact.
+        #
+        # Filter ``defaults`` to keys the constructor actually accepts. PyTorch
+        # 2.11 added ``decoupled_weight_decay`` to Adam's defaults, but AdamW
+        # (an Adam subclass) re-routes that internally and rejects it as a
+        # public kwarg — a naive ``**defaults`` round-trip raises
+        # ``AdamW.__init__() got an unexpected keyword argument 'decoupled_weight_decay'``.
+        # Filtering by signature keeps the rebind robust against future
+        # upstream churn.
+        import inspect
         optimizer_cls = type(optimizer)
-        optimizer_kwargs = dict(optimizer.defaults)
+        accepted = set(inspect.signature(optimizer_cls.__init__).parameters)
+        optimizer_kwargs = {
+            k: v for k, v in optimizer.defaults.items() if k in accepted
+        }
         optimizer = optimizer_cls(model.parameters(), **optimizer_kwargs)
 
         # If an LR scheduler was passed in, rebind it to the new optimizer using

--- a/backend/tests/test_optimizer_compat.py
+++ b/backend/tests/test_optimizer_compat.py
@@ -1,0 +1,104 @@
+"""Regression tests for OptimizerNode + TrainingLoop optimizer rebind.
+
+Covers two PyTorch 2.11+ compatibility breaks reported by users:
+
+1. OptimizerNode: Rprop does not accept ``weight_decay`` at all, so passing
+   the default-shaped kwargs (``lr=..., weight_decay=...``) blew up at
+   create time. We silently drop the kwarg when it's the default 0.0 and
+   raise a clear error when it isn't.
+
+2. TrainingLoop: Adam's defaults dict in PyTorch 2.11 contains
+   ``decoupled_weight_decay`` (used internally to switch between Adam and
+   AdamW behaviour). AdamW (an Adam subclass) rejects that key as a
+   public kwarg. The naive rebind ``optimizer_cls(model.parameters(),
+   **optimizer.defaults)`` therefore raised
+   ``AdamW.__init__() got an unexpected keyword argument 'decoupled_weight_decay'``
+   for any graph that selected AdamW (notably the Train Mini-GPT on MNIST
+   example, via the Training Pipeline preset).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+import torch
+import torch.optim as optim
+
+from app.nodes.training.optimizer_node import OptimizerNode
+
+# Mirrors OptimizerNode's SELECT options so a future addition to one side
+# without the other shows up as a test failure.
+ALL_OPTIMIZER_TYPES = [
+    "Adam", "SGD", "AdamW", "RMSprop", "Adagrad",
+    "RAdam", "NAdam", "Rprop", "ASGD",
+]
+
+
+class _TinyModel(torch.nn.Module):
+    """Smallest possible model with trainable params."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.layer = torch.nn.Linear(2, 2)
+
+
+@pytest.mark.parametrize("opt_type", ALL_OPTIMIZER_TYPES)
+def test_optimizer_node_creates_with_default_weight_decay(opt_type: str) -> None:
+    """Every optimizer the SELECT exposes must construct cleanly with the
+    default ``weight_decay=0.0`` — including Rprop, which doesn't even have
+    a ``weight_decay`` parameter (we silently drop the kwarg in that case).
+    """
+    node = OptimizerNode()
+    out = node.execute(
+        {"model": _TinyModel()},
+        {"type": opt_type, "lr": 0.001, "weight_decay": 0.0},
+    )
+    assert out["optimizer"].__class__.__name__ == opt_type
+
+
+def test_optimizer_node_rprop_rejects_nonzero_weight_decay() -> None:
+    """A clear ValueError is far better than a confusing
+    ``Rprop.__init__() got an unexpected keyword argument 'weight_decay'``.
+    """
+    node = OptimizerNode()
+    with pytest.raises(ValueError, match="weight_decay"):
+        node.execute(
+            {"model": _TinyModel()},
+            {"type": "Rprop", "lr": 0.001, "weight_decay": 0.1},
+        )
+
+
+@pytest.mark.parametrize("opt_type", ALL_OPTIMIZER_TYPES)
+def test_optimizer_defaults_round_trip(opt_type: str) -> None:
+    """Simulates the rebind in TrainingLoopNode: take ``optimizer.defaults``,
+    filter to keys the constructor accepts, re-instantiate against a
+    fresh model. Must succeed for every optimizer type — this is the
+    invariant that broke on AdamW with the unfiltered ``**defaults``.
+    """
+    node = OptimizerNode()
+    opt1 = node.execute(
+        {"model": _TinyModel()},
+        {"type": opt_type, "lr": 0.001, "weight_decay": 0.0},
+    )["optimizer"]
+
+    cls = type(opt1)
+    accepted = set(inspect.signature(cls.__init__).parameters)
+    filtered = {k: v for k, v in opt1.defaults.items() if k in accepted}
+
+    opt2 = cls(_TinyModel().parameters(), **filtered)
+    assert opt2.__class__ is cls
+
+
+def test_adamw_round_trip_via_naive_defaults_would_fail() -> None:
+    """Documents the upstream behaviour we're working around: a naive
+    ``cls(params, **defaults)`` (no signature filtering) raises on AdamW
+    in PyTorch 2.11+. If this assertion ever flips, the
+    ``decoupled_weight_decay`` workaround in TrainingLoopNode and the
+    ``inspect.signature`` filter in this test can be revisited.
+    """
+    opt1 = optim.AdamW(_TinyModel().parameters(), lr=0.001, weight_decay=0.0)
+    if "decoupled_weight_decay" not in opt1.defaults:
+        pytest.skip("PyTorch < 2.11; the workaround isn't needed here.")
+    with pytest.raises(TypeError, match="decoupled_weight_decay"):
+        optim.AdamW(_TinyModel().parameters(), **opt1.defaults)


### PR DESCRIPTION
## Bug

Reported by treeleaves30760 running the **Train Mini-GPT on MNIST** example:

\`\`\`
Node Training Pipeline error:
AdamW.__init__() got an unexpected keyword argument 'decoupled_weight_decay'
\`\`\`

Two related PyTorch 2.11+ compat issues:

### 1. Optimizer rebind explodes for AdamW

\`TrainingLoopNode\` rebinds the optimizer to the device-moved model parameters:

\`\`\`python
optimizer_cls(model.parameters(), **optimizer.defaults)
\`\`\`

PyTorch 2.11 added \`decoupled_weight_decay\` to \`Adam\`'s \`__init__\` and to its \`defaults\` dict. \`AdamW\` (an Adam subclass) re-routes that key through \`super().__init__(...)\` and **rejects it as a public kwarg**. The naive round-trip therefore explodes for any graph that picks AdamW — most notably the **Train Mini-GPT** preset, which overrides the Training Pipeline preset's default Adam → AdamW with \`weight_decay=0.1\`.

### 2. Rprop never worked at all

\`OptimizerNode\` unconditionally passes \`weight_decay=...\` to every optimizer in the SELECT. **Rprop has no \`weight_decay\` parameter**, so picking it in the UI errored out at create time with \`Rprop.__init__() got an unexpected keyword argument 'weight_decay'\`.

## Fix

Filter optimizer kwargs by \`inspect.signature(cls.__init__)\` in both places. For \`OptimizerNode\`, also **raise a clear \`ValueError\`** when the user explicitly set a non-zero \`weight_decay\` on an optimizer that doesn't support it — silent drop would be a footgun.

## Tests

20 new parameterised tests in \`tests/test_optimizer_compat.py\`:

- All 9 SELECT optimizer types construct cleanly with default kwargs (Adam, SGD, AdamW, RMSprop, Adagrad, RAdam, NAdam, **Rprop**, ASGD).
- Rprop + non-zero weight_decay → clear \`ValueError\`.
- Round-trip via filtered defaults works for all 9 optimizers.
- One regression-doc test that confirms the upstream behaviour we're working around (skips on PyTorch < 2.11).

## Test plan
- [x] \`pytest tests/\` → 276/276 passed
- [x] Audited all 20 examples — TrainGPT-Mini (AdamW), TrainCNN-MNIST (Adam), TrainResNet-CIFAR10 (SGD), DQN-Atari (Adam), PPO-Robotics (AdamW). All 9 SELECT types now exercised by parameterised tests.
- [ ] Manual: open Train Mini-GPT on MNIST, click Run → no AdamW kwargs error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)