### PR TITLE
feat(diffusion): SD/U-Net teaching nodes + Diffusion category

### DIFF
--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -588,12 +588,24 @@ async def execute_graph(
         # Check cache (skip for force-rerun nodes from partial re-execution).
         # Stateful nodes opt out via cacheable=False because their internal
         # weights drift across runs.
+        #
+        # Important: if ANY upstream is non-cacheable, *this* node also cannot
+        # be safely cached for this run. The cache key only encodes upstream
+        # *cache keys*, not their actual output tensors — so a non-cacheable
+        # upstream that produces different shapes between runs would still
+        # generate the same downstream cache key, returning a stale tensor.
+        # Propagate the non-cacheability instead of silently dropping the
+        # upstream from the key.
         node_cacheable = getattr(node_cls, "cacheable", True)
-        if cache is not None and node_cacheable:
-            upstream_keys = []
-            for src_id, _, _ in incoming.get(node_id, []):
-                if src_id in node_cache_keys:
-                    upstream_keys.append(node_cache_keys[src_id])
+        upstream_all_cached = all(
+            src_id in node_cache_keys
+            for src_id, _, _ in incoming.get(node_id, [])
+        )
+        if cache is not None and node_cacheable and upstream_all_cached:
+            upstream_keys = [
+                node_cache_keys[src_id]
+                for src_id, _, _ in incoming.get(node_id, [])
+            ]
             cache_key = cache.compute_key(node_type, params, upstream_keys)
             node_cache_keys[node_id] = cache_key
             if node_id not in force_rerun:

--- a/backend/app/nodes/diffusion/__init__.py
+++ b/backend/app/nodes/diffusion/__init__.py
@@ -1,0 +1,8 @@
+"""Diffusion / U-Net teaching nodes.
+
+Educational counterparts to Stable-Diffusion-style building blocks. Tiny
+defaults so a forward pass through a toy U-Net fits in inline tensor
+previews; reverse-diffusion sampling loops are encapsulated in a single
+``DDPMSampler`` node so students see the schedule dynamics without
+needing a custom loop primitive in the graph editor.
+"""

--- a/backend/app/nodes/diffusion/ddpm_sampler_node.py
+++ b/backend/app/nodes/diffusion/ddpm_sampler_node.py
@@ -1,0 +1,201 @@
+"""DDPMSamplerNode — reverse the diffusion process to denoise an image.
+
+Given a U-Net that predicts noise and a starting noise tensor, iterate
+the reverse-DDPM update for ``num_steps`` steps:
+
+    Pre-compute schedule
+        β_t          = β_start .. β_end (linear) or cosine schedule
+        α_t          = 1 - β_t
+        α̅_t          = ∏ α_s for s ≤ t
+
+    Each step (large t → 0):
+        ε̂           = model(x_t, t)
+        x_{t-1}      = (1/√α_t) (x_t - ((1-α_t)/√(1-α̅_t)) ε̂) + σ_t z
+                       where z ~ 𝒩(0, I) for t > 0, else 0
+
+CodefyUI's DAG is forward-only, so the loop must live *inside a node*
+(per the design discussion: "DDPMSampler 內部跑迴圈"). The node accepts
+the U-Net via the `model` input, the start noise via `noise`, and runs
+the schedule + iteration entirely in execute(). Output is the final
+denoised image.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+def _linear_betas(num_steps: int, beta_start: float, beta_end: float) -> torch.Tensor:
+    return torch.linspace(beta_start, beta_end, num_steps, dtype=torch.float32)
+
+
+def _cosine_betas(num_steps: int, s: float = 0.008) -> torch.Tensor:
+    """Cosine schedule (Nichol & Dhariwal 2021) — slower noising near the data manifold."""
+    steps = num_steps + 1
+    t = torch.linspace(0, num_steps, steps, dtype=torch.float32) / num_steps
+    alpha_bar = torch.cos(((t + s) / (1 + s)) * math.pi / 2) ** 2
+    alpha_bar = alpha_bar / alpha_bar[0]
+    betas = 1 - alpha_bar[1:] / alpha_bar[:-1]
+    return torch.clamp(betas, 0.0001, 0.999)
+
+
+class DDPMSamplerNode(BaseNode):
+    NODE_NAME = "DDPMSampler"
+    CATEGORY = "Diffusion"
+    DESCRIPTION = (
+        "Run reverse DDPM denoising. Iterates a schedule of timesteps, "
+        "calling `model(x_t, t)` to predict noise, then applying the DDPM "
+        "update rule. Encapsulates the entire reverse loop so the graph "
+        "stays acyclic — see the verbose step trace for trajectory snapshots."
+    )
+
+    cacheable = False  # Has internal randomness; conservative to skip cache.
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="model",
+                data_type=DataType.MODEL,
+                description="A noise-predicting U-Net (e.g. from `DiffusionUNet`).",
+            ),
+            PortDefinition(
+                name="noise",
+                data_type=DataType.TENSOR,
+                description="Starting noise $x_T$, shape [N, C, H, W].",
+            ),
+            PortDefinition(
+                name="condition",
+                data_type=DataType.TENSOR,
+                description="Optional conditioning tensor for cross-attention. Currently unused — reserved for the next PR's text-conditioning support.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="image",
+                data_type=DataType.TENSOR,
+                description="Denoised image $x_0$, same shape as the input noise.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="num_steps",
+                param_type=ParamType.INT,
+                default=20,
+                min_value=1,
+                description="Number of reverse-diffusion steps. More steps = smoother trajectory but slower.",
+            ),
+            ParamDefinition(
+                name="schedule",
+                param_type=ParamType.SELECT,
+                default="linear",
+                options=["linear", "cosine"],
+                description="Noise schedule. `linear` is the original DDPM; `cosine` (Nichol & Dhariwal 2021) noises more slowly near the data.",
+            ),
+            ParamDefinition(
+                name="beta_start",
+                param_type=ParamType.FLOAT,
+                default=0.0001,
+                min_value=0.0,
+                description="Starting variance for the linear schedule. Ignored for cosine.",
+            ),
+            ParamDefinition(
+                name="beta_end",
+                param_type=ParamType.FLOAT,
+                default=0.02,
+                min_value=0.0,
+                description="Ending variance for the linear schedule. Ignored for cosine.",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=42,
+                description="Seed for the per-step Gaussian noise z added during sampling.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        model = inputs.get("model")
+        noise = inputs.get("noise")
+        if model is None:
+            raise ValueError("DDPMSampler requires a `model` input.")
+        if noise is None:
+            raise ValueError("DDPMSampler requires a `noise` input (starting x_T).")
+        if not callable(model):
+            raise ValueError("DDPMSampler: `model` input is not callable.")
+
+        num_steps = int(params.get("num_steps", 20))
+        if num_steps < 1:
+            raise ValueError(f"DDPMSampler: num_steps must be ≥ 1, got {num_steps}.")
+        schedule = str(params.get("schedule", "linear"))
+        beta_start = float(params.get("beta_start", 0.0001))
+        beta_end = float(params.get("beta_end", 0.02))
+        seed = int(params.get("seed", 42))
+
+        # Build the schedule.
+        if schedule == "linear":
+            betas = _linear_betas(num_steps, beta_start, beta_end)
+        elif schedule == "cosine":
+            betas = _cosine_betas(num_steps)
+        else:
+            raise ValueError(f"DDPMSampler: unknown schedule {schedule!r}.")
+
+        alphas = 1.0 - betas
+        alpha_bars = torch.cumprod(alphas, dim=0)
+
+        # Run the reverse loop. We use a local generator for the per-step
+        # Gaussian noise so the loop is fully reproducible given the seed.
+        gen = torch.Generator()
+        gen.manual_seed(seed)
+        x = noise.clone().float()
+        if hasattr(model, "eval"):
+            model.eval()
+
+        with torch.no_grad():
+            for t in reversed(range(num_steps)):
+                t_tensor = torch.full(
+                    (x.shape[0],), t, dtype=torch.long, device=x.device
+                )
+                eps_hat = model(x, t_tensor)
+
+                alpha_t = alphas[t]
+                alpha_bar_t = alpha_bars[t]
+                beta_t = betas[t]
+                inv_sqrt_alpha = 1.0 / torch.sqrt(alpha_t)
+                eps_coef = beta_t / torch.sqrt(1.0 - alpha_bar_t)
+
+                mean = inv_sqrt_alpha * (x - eps_coef * eps_hat)
+
+                if t > 0:
+                    z = torch.randn(x.shape, generator=gen, dtype=x.dtype)
+                    sigma = torch.sqrt(beta_t)
+                    x = mean + sigma * z
+                else:
+                    x = mean
+
+        return {"image": x}

--- a/backend/app/nodes/diffusion/diffusion_unet_node.py
+++ b/backend/app/nodes/diffusion/diffusion_unet_node.py
@@ -1,0 +1,285 @@
+"""DiffusionUNetNode — toy multi-level U-Net wired in one node.
+
+This is the *meta-node* counterpart to the expanded preset that wires
+each ResBlock and skip connection by hand. Both presets ship with the
+project — students can pick whichever fits their learning style.
+
+Architecture (with default channel_mult="1,2,4"):
+
+    x [N, C_in, H, W]
+        ──> stem Conv3x3 ─────────────────────────> h0 [N, base, H, W]
+                ↓ ResBlock(base→base*1) ──skip──┐
+                ↓ MaxPool 2×                    │
+                ↓ ResBlock(base*1→base*2) ──skip┐
+                ↓ MaxPool 2×                    ││
+                ↓ Bottleneck ResBlock           ││
+                ↑ Upsample 2×                   ││
+                ↑ Concat skip ──────────────────┘│
+                ↑ ResBlock(base*4→base*2)        │
+                ↑ Upsample 2×                    │
+                ↑ Concat skip ───────────────────┘
+                ↑ ResBlock(base*2→base*1)
+                ↑ final Conv3x3 ───> ε [N, C_in, H, W]
+
+Every ResBlock receives the same `time_emb` so the whole network is
+time-conditioned. The output channel count matches the input channel
+count, which is the noise-prediction convention.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from ...core.stateful_module import StatefulModuleMixin
+from .edu_resblock_node import _ResBlockModule
+from .timestep_embedding_node import _TimestepMLP
+
+
+def _parse_mult(s: str) -> tuple[int, ...]:
+    parts = [p.strip() for p in str(s).split(",") if p.strip()]
+    if not parts:
+        raise ValueError("DiffusionUNet: channel_mult is empty.")
+    try:
+        mults = tuple(int(p) for p in parts)
+    except ValueError as exc:
+        raise ValueError(f"DiffusionUNet: invalid channel_mult {s!r}.") from exc
+    if any(m <= 0 for m in mults):
+        raise ValueError("DiffusionUNet: channel multipliers must be positive.")
+    return mults
+
+
+class _DiffusionUNetModule(nn.Module):
+    """Toy U-Net: time-conditioned, configurable depth via channel_mult."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        base_channels: int,
+        channel_mult: tuple[int, ...],
+        time_emb_dim: int,
+        num_groups: int,
+        seed: int,
+    ) -> None:
+        super().__init__()
+
+        if any((base_channels * m) % num_groups for m in channel_mult):
+            raise ValueError(
+                f"DiffusionUNet: num_groups={num_groups} must divide every base*mult — "
+                f"base={base_channels}, mult={channel_mult}."
+            )
+
+        # Use a stem and a chain of "down" stages then a chain of "up" stages.
+        # We deliberately reuse the existing _ResBlockModule + _TimestepMLP so
+        # the meta-node and the expanded preset stay numerically aligned.
+        self.in_channels = in_channels
+        self.time_emb_dim = time_emb_dim
+
+        # Time MLP — produces time_emb from raw timesteps.
+        self.time_mlp = _TimestepMLP(
+            embed_dim=time_emb_dim, max_period=10000, seed=seed
+        )
+
+        # Stem — bring input up to base_channels.
+        self.stem = nn.Conv2d(in_channels, base_channels, kernel_size=3, padding=1)
+
+        # Down path: at each level, one ResBlock + (MaxPool except last).
+        ch = base_channels
+        self.down_blocks = nn.ModuleList()
+        self.down_pools = nn.ModuleList()
+        skip_channels: list[int] = []
+        for level, mult in enumerate(channel_mult[:-1]):
+            target = base_channels * mult
+            self.down_blocks.append(
+                _ResBlockModule(
+                    in_channels=ch,
+                    out_channels=target,
+                    groups=num_groups,
+                    time_emb_dim=time_emb_dim,
+                    seed=seed + 100 + level,
+                )
+            )
+            ch = target
+            skip_channels.append(ch)
+            self.down_pools.append(nn.MaxPool2d(2))
+
+        # Bottleneck.
+        bottleneck_target = base_channels * channel_mult[-1]
+        self.bottleneck = _ResBlockModule(
+            in_channels=ch,
+            out_channels=bottleneck_target,
+            groups=num_groups,
+            time_emb_dim=time_emb_dim,
+            seed=seed + 200,
+        )
+        ch = bottleneck_target
+
+        # Up path: mirror the down path. Each up-step does Upsample → Concat
+        # with the matching skip → ResBlock.
+        self.up_blocks = nn.ModuleList()
+        for level, skip_ch in enumerate(reversed(skip_channels)):
+            target = skip_ch  # collapse back down to skip's channel count
+            self.up_blocks.append(
+                _ResBlockModule(
+                    in_channels=ch + skip_ch,  # post-concat
+                    out_channels=target,
+                    groups=num_groups,
+                    time_emb_dim=time_emb_dim,
+                    seed=seed + 300 + level,
+                )
+            )
+            ch = target
+
+        # Final 1x1 conv back to input channels — that's the noise prediction.
+        self.head = nn.Conv2d(ch, in_channels, kernel_size=1)
+
+        # Seed all conv weights once via the buried RNG (each ResBlock seeds
+        # its own internals; we only need to seed the bare convs we add here).
+        gen = torch.Generator()
+        gen.manual_seed(seed + 999)
+        with torch.no_grad():
+            for layer in (self.stem, self.head):
+                layer.weight.copy_(
+                    torch.randn(layer.weight.shape, generator=gen) * 0.1
+                )
+                layer.bias.zero_()
+
+    def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        # Project timestep into the embedding space the ResBlocks expect.
+        if t.ndim == 0:
+            t = t.unsqueeze(0)
+        if t.shape[0] == 1 and x.shape[0] > 1:
+            t = t.expand(x.shape[0])
+        time_emb = self.time_mlp(t)
+
+        h = self.stem(x)
+        skips: list[torch.Tensor] = []
+        for block, pool in zip(self.down_blocks, self.down_pools):
+            h = block(h, time_emb)
+            skips.append(h)
+            h = pool(h)
+        h = self.bottleneck(h, time_emb)
+        for block, skip in zip(self.up_blocks, reversed(skips)):
+            h = F.interpolate(h, scale_factor=2, mode="nearest")
+            if h.shape[-2:] != skip.shape[-2:]:
+                raise RuntimeError(
+                    f"DiffusionUNet: spatial mismatch on skip — h={tuple(h.shape)} skip={tuple(skip.shape)}. "
+                    f"Input H/W must be divisible by 2^(num_levels-1)."
+                )
+            h = torch.cat([h, skip], dim=1)
+            h = block(h, time_emb)
+        return self.head(h)
+
+
+class DiffusionUNetNode(StatefulModuleMixin, BaseNode):
+    NODE_NAME = "DiffusionUNet"
+    CATEGORY = "Diffusion"
+    DESCRIPTION = (
+        "A complete toy diffusion U-Net packaged as a single node. Outputs an "
+        "nn.Module that maps `(x, t) → predicted_noise` of the same shape as "
+        "x. Compose with `DDPMSampler` to run reverse diffusion. For students "
+        "who want to see the architecture wired up explicitly, see the "
+        "`Mini-UNet-Expanded` preset."
+    )
+
+    structural_params = (
+        "in_channels",
+        "base_channels",
+        "channel_mult",
+        "time_emb_dim",
+        "num_groups",
+        "seed",
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="model",
+                data_type=DataType.MODEL,
+                description="Callable nn.Module taking (x, t) → predicted noise.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="in_channels",
+                param_type=ParamType.INT,
+                default=3,
+                min_value=1,
+                description="Channels of the noisy input (3 for RGB, 4 for typical SD latents).",
+            ),
+            ParamDefinition(
+                name="base_channels",
+                param_type=ParamType.INT,
+                default=16,
+                min_value=1,
+                description="Channel count after the stem. Each level multiplies this by the matching `channel_mult` entry.",
+            ),
+            ParamDefinition(
+                name="channel_mult",
+                param_type=ParamType.STRING,
+                default="1,2,4",
+                description="Comma-separated channel multipliers per level. Length determines depth (down-blocks + bottleneck).",
+            ),
+            ParamDefinition(
+                name="time_emb_dim",
+                param_type=ParamType.INT,
+                default=32,
+                min_value=2,
+                description="Width of the timestep embedding (must be even).",
+            ),
+            ParamDefinition(
+                name="num_groups",
+                param_type=ParamType.INT,
+                default=4,
+                min_value=1,
+                description="GroupNorm groups inside every ResBlock. Must divide all level channel counts.",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=42,
+                description="Seed for all weight initialisation.",
+            ),
+        ]
+
+    def build_module(self, params: dict[str, Any]) -> nn.Module:
+        return _DiffusionUNetModule(
+            in_channels=int(params.get("in_channels", 3)),
+            base_channels=int(params.get("base_channels", 16)),
+            channel_mult=_parse_mult(str(params.get("channel_mult", "1,2,4"))),
+            time_emb_dim=int(params.get("time_emb_dim", 32)),
+            num_groups=int(params.get("num_groups", 4)),
+            seed=int(params.get("seed", 42)),
+        )
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        # Validate channel_mult eagerly (build_module would too, but a clean
+        # error message at graph load time is friendlier).
+        _parse_mult(str(params.get("channel_mult", "1,2,4")))
+        model = self.get_or_build_module(context, params)
+        return {"model": model}

--- a/backend/app/nodes/diffusion/edu_cross_attention_node.py
+++ b/backend/app/nodes/diffusion/edu_cross_attention_node.py
@@ -1,0 +1,314 @@
+"""EduCrossAttentionNode — multi-head attention with separate Q and K/V sources.
+
+Where :class:`EduSelfAttentionNode` projects all three Q/K/V from a
+single input, cross-attention takes Q from one tensor (e.g. image
+latent) and K/V from another (e.g. text embedding). This is the
+mechanism that lets Stable Diffusion's U-Net condition image generation
+on a text prompt: each image position's query attends over the prompt's
+token embeddings, fetching whichever ones it needs to denoise itself.
+
+The math is the same scaled dot-product attention as self-attention; only
+the input wiring changes:
+
+    Q = W_q(query)        # [Q_seq, *, D]    — image latent
+    K = W_k(context)      # [K_seq, *, D]    — text embedding
+    V = W_v(context)      # [K_seq, *, D]
+    A = softmax(Q K^T / sqrt(d_h))            # [H, Q_seq, K_seq]
+    O = W_o( concat(heads of A V) )           # [Q_seq, *, D]
+
+The crucial observation for teaching: Q and K can have different
+sequence lengths. The output shape mirrors Q (one row per query
+position), and the attention matrix is rectangular.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from ...core.stateful_module import StatefulModuleMixin
+from ...core.step_trace import StepRecorder
+
+
+class _CrossAttentionProjections(nn.Module):
+    """W_q on query input, W_k/W_v on context input, W_o on concatenated heads."""
+
+    def __init__(self, embed_dim: int, num_heads: int, seed: int) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+
+        gen = torch.Generator()
+        gen.manual_seed(int(seed))
+        self.W_q = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.W_k = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.W_v = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.W_o = nn.Linear(embed_dim, embed_dim, bias=False)
+        scale = 1.0 / math.sqrt(embed_dim)
+        with torch.no_grad():
+            for layer in (self.W_q, self.W_k, self.W_v, self.W_o):
+                layer.weight.copy_(
+                    torch.randn(layer.weight.shape, generator=gen) * scale
+                )
+
+
+class EduCrossAttentionNode(StatefulModuleMixin, BaseNode):
+    NODE_NAME = "EduCrossAttention"
+    CATEGORY = "Diffusion"
+    DESCRIPTION = (
+        "Multi-head cross-attention. $Q$ comes from `query`, $K$ and $V$ from "
+        "`context` — they may have different sequence lengths. Outputs a "
+        "rectangular [H, Q_seq, K_seq] attention map showing how each "
+        "query position attended to each context token."
+    )
+
+    structural_params = ("embed_dim", "num_heads", "seed")
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="query",
+                data_type=DataType.TENSOR,
+                description="Query tensor [Q_seq, D] or [Q_seq, batch, D].",
+            ),
+            PortDefinition(
+                name="context",
+                data_type=DataType.TENSOR,
+                description="Key/value source [K_seq, D] or [K_seq, batch, D]. May differ in seq length from query.",
+            ),
+            PortDefinition(
+                name="mask",
+                data_type=DataType.TENSOR,
+                description="Optional [Q_seq, K_seq] boolean mask (True = blocked).",
+                optional=True,
+            ),
+            PortDefinition(
+                name="q_labels",
+                data_type=DataType.LIST,
+                description="Optional row labels for the heatmap viz (one per query position).",
+                optional=True,
+            ),
+            PortDefinition(
+                name="k_labels",
+                data_type=DataType.LIST,
+                description="Optional column labels for the heatmap viz (one per context position).",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="output",
+                data_type=DataType.TENSOR,
+                description="Attention output, same shape as query.",
+            ),
+            PortDefinition(
+                name="weights",
+                data_type=DataType.TENSOR,
+                description="Cross-attention weights — [H, Q_seq, K_seq] or [batch, H, Q_seq, K_seq].",
+            ),
+            PortDefinition(
+                name="q_labels",
+                data_type=DataType.LIST,
+                description="Pass-through of the query labels for downstream viz.",
+            ),
+            PortDefinition(
+                name="k_labels",
+                data_type=DataType.LIST,
+                description="Pass-through of the context labels for downstream viz.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="embed_dim",
+                param_type=ParamType.INT,
+                default=8,
+                min_value=1,
+                description="Token dimension. Both query and context must use this same dim.",
+            ),
+            ParamDefinition(
+                name="num_heads",
+                param_type=ParamType.INT,
+                default=2,
+                min_value=1,
+                description="Number of parallel attention heads. Must divide embed_dim.",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=42,
+                description="Seed for the W_q/W_k/W_v/W_o initialisation.",
+            ),
+        ]
+
+    def build_module(self, params: dict[str, Any]) -> nn.Module:
+        embed_dim = int(params.get("embed_dim", 8))
+        num_heads = int(params.get("num_heads", 2))
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"EduCrossAttention: embed_dim={embed_dim} must be divisible by num_heads={num_heads}."
+            )
+        return _CrossAttentionProjections(
+            embed_dim=embed_dim,
+            num_heads=num_heads,
+            seed=int(params.get("seed", 42)),
+        )
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        q_in = inputs.get("query")
+        c_in = inputs.get("context")
+        if q_in is None or c_in is None:
+            raise ValueError("EduCrossAttention requires both `query` and `context` inputs.")
+        if not isinstance(q_in, torch.Tensor):
+            q_in = torch.as_tensor(q_in, dtype=torch.float32)
+        if not isinstance(c_in, torch.Tensor):
+            c_in = torch.as_tensor(c_in, dtype=torch.float32)
+        q_in = q_in.float()
+        c_in = c_in.float()
+
+        embed_dim = int(params.get("embed_dim", 8))
+        num_heads = int(params.get("num_heads", 2))
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"EduCrossAttention: embed_dim={embed_dim} must be divisible by num_heads={num_heads}."
+            )
+        head_dim = embed_dim // num_heads
+
+        if q_in.shape[-1] != embed_dim:
+            raise ValueError(
+                f"EduCrossAttention: query last dim {q_in.shape[-1]} does not match embed_dim={embed_dim}."
+            )
+        if c_in.shape[-1] != embed_dim:
+            raise ValueError(
+                f"EduCrossAttention: context last dim {c_in.shape[-1]} does not match embed_dim={embed_dim}."
+            )
+
+        # Normalise query and context to batch-first [B, seq, D].
+        if q_in.ndim == 2 and c_in.ndim == 2:
+            q_bf = q_in.unsqueeze(0)  # [1, Q_seq, D]
+            c_bf = c_in.unsqueeze(0)
+            squeeze_out = True
+        elif q_in.ndim == 3 and c_in.ndim == 3:
+            q_bf = q_in.transpose(0, 1)  # [B, Q_seq, D]
+            c_bf = c_in.transpose(0, 1)
+            squeeze_out = False
+        else:
+            raise ValueError(
+                "EduCrossAttention: query and context must both be 2D or both be 3D, "
+                f"got query.shape={tuple(q_in.shape)}, context.shape={tuple(c_in.shape)}."
+            )
+        B = q_bf.shape[0]
+        Q_seq = q_bf.shape[1]
+        K_seq = c_bf.shape[1]
+
+        module = self.get_or_build_module(context, params)
+
+        def _split_heads(t: torch.Tensor, seq: int) -> torch.Tensor:
+            return t.view(B, seq, num_heads, head_dim).transpose(1, 2)
+
+        Q = _split_heads(module.W_q(q_bf), Q_seq)  # [B, H, Q_seq, head_dim]
+        K = _split_heads(module.W_k(c_bf), K_seq)  # [B, H, K_seq, head_dim]
+        V = _split_heads(module.W_v(c_bf), K_seq)
+
+        scores = torch.matmul(Q, K.transpose(-2, -1)) / math.sqrt(head_dim)  # [B, H, Q_seq, K_seq]
+
+        ext_mask = inputs.get("mask")
+        if ext_mask is not None:
+            if not isinstance(ext_mask, torch.Tensor):
+                ext_mask = torch.as_tensor(ext_mask, dtype=torch.bool)
+            if ext_mask.dtype != torch.bool:
+                ext_mask = ext_mask.bool()
+            if ext_mask.shape != (Q_seq, K_seq):
+                raise ValueError(
+                    f"EduCrossAttention: mask shape {tuple(ext_mask.shape)} doesn't match (Q_seq={Q_seq}, K_seq={K_seq})."
+                )
+            scores = scores.masked_fill(ext_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+        weights = F.softmax(scores, dim=-1)
+        weights = torch.nan_to_num(weights, nan=0.0)
+
+        attended = torch.matmul(weights, V)  # [B, H, Q_seq, head_dim]
+        attended = attended.transpose(1, 2).contiguous().view(B, Q_seq, embed_dim)
+        out_bf = module.W_o(attended)
+
+        if squeeze_out:
+            output = out_bf.squeeze(0)
+            weights_out = weights.squeeze(0)  # [H, Q_seq, K_seq]
+        else:
+            output = out_bf.transpose(0, 1)  # [Q_seq, batch, D]
+            weights_out = weights  # [B, H, Q_seq, K_seq]
+
+        q_labels = list(inputs.get("q_labels") or [])
+        k_labels = list(inputs.get("k_labels") or [])
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        if verbose:
+            recorder = StepRecorder()
+            recorder.record(
+                "input",
+                f"Query [Q_seq={Q_seq}, B={B}, D={embed_dim}], context [K_seq={K_seq}, B={B}, D={embed_dim}]",
+                query=q_in,
+                context=c_in,
+            )
+            recorder.record(
+                "compute_qkv",
+                "Project Q from query, K and V from context — note the asymmetric source.",
+                Q=Q.squeeze(0) if squeeze_out else Q,
+                K=K.squeeze(0) if squeeze_out else K,
+                V=V.squeeze(0) if squeeze_out else V,
+            )
+            recorder.record(
+                "scaled_scores",
+                "Scores: $S_h = Q_h K_h^T / \\sqrt{d_h}$ — rectangular [Q_seq × K_seq].",
+                scalars={"head_dim": float(head_dim)},
+                scores=scores.squeeze(0) if squeeze_out else scores,
+            )
+            recorder.record(
+                "softmax_weights",
+                "Per-head softmax over the K-axis.",
+                weights=weights_out,
+            )
+            recorder.record(
+                "concat_and_project",
+                "Concatenate heads, apply W_o.",
+                output=output,
+            )
+            return {
+                "output": output,
+                "weights": weights_out,
+                "q_labels": q_labels,
+                "k_labels": k_labels,
+                "__steps__": recorder.steps,
+            }
+
+        return {
+            "output": output,
+            "weights": weights_out,
+            "q_labels": q_labels,
+            "k_labels": k_labels,
+        }

--- a/backend/app/nodes/diffusion/edu_resblock_node.py
+++ b/backend/app/nodes/diffusion/edu_resblock_node.py
@@ -1,0 +1,240 @@
+"""EduResBlockNode — residual block, the workhorse of diffusion U-Nets.
+
+The standard SD/DDPM residual block:
+
+    h = SiLU(GroupNorm(x))
+    h = Conv3x3(h)            # in_channels → out_channels
+    if time_emb provided:
+        h = h + Linear(time_emb)[:, :, None, None]    # FiLM-style additive bias
+    h = SiLU(GroupNorm(h))
+    h = Conv3x3(h)
+    if in_channels != out_channels:
+        skip = Conv1x1(x)
+    else:
+        skip = x
+    return h + skip
+
+The time-embedding injection is what makes it "diffusion-flavoured" —
+it lets the same convolutional weights behave differently at different
+denoising steps. Without `time_emb` the node degrades to a plain
+ResNet-style block, useful for the segmentation U-Net preset.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from ...core.stateful_module import StatefulModuleMixin
+
+
+class _ResBlockModule(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        groups: int,
+        time_emb_dim: int,
+        seed: int,
+    ) -> None:
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.time_emb_dim = time_emb_dim
+
+        gen = torch.Generator()
+        gen.manual_seed(int(seed))
+
+        self.norm1 = nn.GroupNorm(groups, in_channels)
+        self.conv1 = nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1)
+        self.time_proj = nn.Linear(time_emb_dim, out_channels) if time_emb_dim > 0 else None
+        self.norm2 = nn.GroupNorm(groups, out_channels)
+        self.conv2 = nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1)
+        self.skip = (
+            nn.Conv2d(in_channels, out_channels, kernel_size=1)
+            if in_channels != out_channels
+            else nn.Identity()
+        )
+
+        # Seed the conv/linear weights so the same params produce the same module.
+        scale = 1.0 / math.sqrt(max(in_channels, 1))
+        with torch.no_grad():
+            for layer in (self.conv1, self.conv2):
+                layer.weight.copy_(
+                    torch.randn(layer.weight.shape, generator=gen) * scale
+                )
+                layer.bias.zero_()
+            if self.time_proj is not None:
+                self.time_proj.weight.copy_(
+                    torch.randn(self.time_proj.weight.shape, generator=gen) * scale
+                )
+                self.time_proj.bias.zero_()
+            if isinstance(self.skip, nn.Conv2d):
+                self.skip.weight.copy_(
+                    torch.randn(self.skip.weight.shape, generator=gen) * scale
+                )
+                self.skip.bias.zero_()
+
+    def forward(self, x: torch.Tensor, time_emb: torch.Tensor | None = None) -> torch.Tensor:
+        h = F.silu(self.norm1(x))
+        h = self.conv1(h)
+        if time_emb is not None and self.time_proj is not None:
+            h = h + self.time_proj(time_emb)[:, :, None, None]
+        h = F.silu(self.norm2(h))
+        h = self.conv2(h)
+        return h + self.skip(x)
+
+
+class EduResBlockNode(StatefulModuleMixin, BaseNode):
+    NODE_NAME = "EduResBlock"
+    CATEGORY = "Diffusion"
+    DESCRIPTION = (
+        "Residual block: GN→SiLU→Conv → (+time emb projection) → GN→SiLU→Conv "
+        "→ Add(skip). The building unit of a diffusion U-Net. Connect "
+        "`time_emb` from a `TimestepEmbedding` node to make it "
+        "time-conditioned; leave it unconnected for a plain ResNet block."
+    )
+
+    structural_params = ("in_channels", "out_channels", "groups", "time_emb_dim", "seed")
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor",
+                data_type=DataType.TENSOR,
+                description="Input feature map [N, in_channels, H, W].",
+            ),
+            PortDefinition(
+                name="time_emb",
+                data_type=DataType.TENSOR,
+                description="Optional [N, time_emb_dim] timestep embedding for conditioning.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor",
+                data_type=DataType.TENSOR,
+                description="Output feature map [N, out_channels, H, W] (skip-connected).",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="in_channels",
+                param_type=ParamType.INT,
+                default=8,
+                min_value=1,
+                description="Channels of the input feature map.",
+            ),
+            ParamDefinition(
+                name="out_channels",
+                param_type=ParamType.INT,
+                default=8,
+                min_value=1,
+                description="Channels of the output. When ≠ in_channels, a 1×1 conv is added on the skip path.",
+            ),
+            ParamDefinition(
+                name="groups",
+                param_type=ParamType.INT,
+                default=4,
+                min_value=1,
+                description="GroupNorm groups. Must divide both in_channels and out_channels.",
+            ),
+            ParamDefinition(
+                name="time_emb_dim",
+                param_type=ParamType.INT,
+                default=32,
+                min_value=0,
+                description="Dimension of the optional `time_emb` input. Set 0 to disable the time-projection layer entirely.",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=42,
+                description="Seed for the conv/linear initialisation.",
+            ),
+        ]
+
+    def build_module(self, params: dict[str, Any]) -> nn.Module:
+        in_channels = int(params.get("in_channels", 8))
+        out_channels = int(params.get("out_channels", 8))
+        groups = int(params.get("groups", 4))
+        time_emb_dim = int(params.get("time_emb_dim", 32))
+        if in_channels % groups != 0 or out_channels % groups != 0:
+            raise ValueError(
+                f"EduResBlock: groups={groups} must divide both in_channels={in_channels} and out_channels={out_channels}."
+            )
+        return _ResBlockModule(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            groups=groups,
+            time_emb_dim=time_emb_dim,
+            seed=int(params.get("seed", 42)),
+        )
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x = inputs.get("tensor")
+        if x is None:
+            raise ValueError("EduResBlock requires a `tensor` input.")
+        if not isinstance(x, torch.Tensor):
+            x = torch.as_tensor(x, dtype=torch.float32)
+        x = x.float()
+        if x.ndim != 4:
+            raise ValueError(
+                f"EduResBlock expects [N, C, H, W] shape; got {tuple(x.shape)}."
+            )
+
+        in_channels = int(params.get("in_channels", 8))
+        time_emb_dim = int(params.get("time_emb_dim", 32))
+        groups = int(params.get("groups", 4))
+        out_channels = int(params.get("out_channels", 8))
+        if x.shape[1] != in_channels:
+            raise ValueError(
+                f"EduResBlock: input has {x.shape[1]} channels but in_channels={in_channels}."
+            )
+        if in_channels % groups != 0 or out_channels % groups != 0:
+            raise ValueError(
+                f"EduResBlock: groups={groups} must divide both in_channels={in_channels} and out_channels={out_channels}."
+            )
+
+        time_emb = inputs.get("time_emb")
+        if time_emb is not None:
+            if not isinstance(time_emb, torch.Tensor):
+                time_emb = torch.as_tensor(time_emb, dtype=torch.float32)
+            time_emb = time_emb.float()
+            if time_emb.ndim == 1:
+                # Promote a single [D] to [1, D].
+                time_emb = time_emb.unsqueeze(0)
+            if time_emb.shape[-1] != time_emb_dim:
+                raise ValueError(
+                    f"EduResBlock: time_emb last dim {time_emb.shape[-1]} doesn't match time_emb_dim={time_emb_dim}."
+                )
+
+        module = self.get_or_build_module(context, params)
+        out = module(x, time_emb)
+        return {"tensor": out}

--- a/backend/app/nodes/diffusion/gaussian_noise_node.py
+++ b/backend/app/nodes/diffusion/gaussian_noise_node.py
@@ -1,0 +1,132 @@
+"""GaussianNoiseNode — seeded Gaussian noise tensor.
+
+The diffusion forward process needs i.i.d. Gaussian noise of the same
+shape as the data. ``TensorCreate`` can do this with ``fill=randn`` but
+isn't quite as clear pedagogically — students reading a graph see the
+generic primitive. This node says exactly what it is, and accepts an
+optional ``shape_ref`` input so the noise tensor automatically tracks
+upstream shape (the common case in a Lerp(x_0, ε, alpha) chain).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+def _parse_shape(s: str) -> tuple[int, ...]:
+    parts = [p.strip() for p in str(s).split(",") if p.strip()]
+    if not parts:
+        raise ValueError("GaussianNoise: shape param is empty.")
+    try:
+        dims = tuple(int(p) for p in parts)
+    except ValueError as exc:
+        raise ValueError(f"GaussianNoise: invalid shape {s!r} — must be comma-separated ints.") from exc
+    if any(d <= 0 for d in dims):
+        raise ValueError(f"GaussianNoise: shape dims must be positive; got {dims}.")
+    return dims
+
+
+class GaussianNoiseNode(BaseNode):
+    NODE_NAME = "GaussianNoise"
+    CATEGORY = "Diffusion"
+    DESCRIPTION = (
+        "Generate i.i.d. Gaussian noise $\\epsilon \\sim \\mathcal{N}(\\mu, \\sigma^2)$. "
+        "Connect a tensor to `shape_ref` to mirror upstream shape (typical "
+        "for diffusion x_0 → noise pairing); otherwise parses `shape` from "
+        "the param. Seeded for reproducibility."
+    )
+
+    cacheable = False  # output depends on global state being unchanged but seeded gen makes it deterministic; keep True? Set False to be safe with chain reuse.
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="shape_ref",
+                data_type=DataType.TENSOR,
+                description="Optional reference tensor — noise will match its shape.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="noise",
+                data_type=DataType.TENSOR,
+                description="Float32 tensor sampled from N(mean, std²).",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="shape",
+                param_type=ParamType.STRING,
+                default="1,3,8,8",
+                description=(
+                    "Comma-separated dimensions, e.g. '1,3,32,32'. Used "
+                    "only when `shape_ref` is not connected."
+                ),
+            ),
+            ParamDefinition(
+                name="mean",
+                param_type=ParamType.FLOAT,
+                default=0.0,
+                description="Mean of the Gaussian. Defaults to 0 (standard normal).",
+            ),
+            ParamDefinition(
+                name="std",
+                param_type=ParamType.FLOAT,
+                default=1.0,
+                min_value=0.0,
+                description="Standard deviation. Defaults to 1 (standard normal).",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=42,
+                description="Seed for reproducibility. Same seed → same noise.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        ref = inputs.get("shape_ref")
+        if ref is not None and isinstance(ref, torch.Tensor):
+            shape = tuple(ref.shape)
+        else:
+            shape = _parse_shape(str(params.get("shape", "")))
+
+        mean = float(params.get("mean", 0.0))
+        std = max(0.0, float(params.get("std", 1.0)))
+        seed = int(params.get("seed", 42))
+
+        # Use a local generator so we don't touch the global RNG state — the
+        # graph engine relies on global RNG being stable for cacheable nodes.
+        gen = torch.Generator()
+        gen.manual_seed(seed)
+        noise = torch.randn(shape, generator=gen, dtype=torch.float32)
+        if std != 1.0:
+            noise = noise * std
+        if mean != 0.0:
+            noise = noise + mean
+        return {"noise": noise}

--- a/backend/app/nodes/diffusion/lerp_node.py
+++ b/backend/app/nodes/diffusion/lerp_node.py
@@ -1,0 +1,106 @@
+"""LerpNode — element-wise linear interpolation: ``α a + (1-α) b``.
+
+The forward diffusion equation
+    x_t = sqrt(α̅_t) x_0 + sqrt(1-α̅_t) ε
+is *almost* a lerp; specifically it's an interpolation with an unusual
+weighting that ensures the variance of x_t matches x_0's. For teaching
+purposes a plain lerp captures the spirit — students see "x_t is a
+weighted blend of clean signal and noise" before we introduce the exact
+sqrt-based scaling.
+
+``alpha`` accepts a scalar param, a 0-d tensor, or a broadcastable tensor
+input — the last form lets a batch share one tensor of per-sample
+alphas, which is how schedulers feed the diffusion equation in practice.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class LerpNode(BaseNode):
+    NODE_NAME = "Lerp"
+    CATEGORY = "Diffusion"
+    DESCRIPTION = (
+        "Linear interpolation: $\\alpha\\,a + (1-\\alpha)\\,b$. "
+        "When $\\alpha=1$ the output is $a$; when $\\alpha=0$ it's $b$. "
+        "Use as a teaching stand-in for the diffusion forward equation."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor_a",
+                data_type=DataType.TENSOR,
+                description="First tensor (weighted by alpha).",
+            ),
+            PortDefinition(
+                name="tensor_b",
+                data_type=DataType.TENSOR,
+                description="Second tensor (weighted by 1 - alpha).",
+            ),
+            PortDefinition(
+                name="alpha",
+                data_type=DataType.TENSOR,
+                description="Optional scalar or broadcastable tensor — overrides the `alpha` param when connected.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor",
+                data_type=DataType.TENSOR,
+                description="Interpolated tensor, shape determined by broadcasting.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="alpha",
+                param_type=ParamType.FLOAT,
+                default=0.5,
+                description="Interpolation weight (0..1). Used only when the `alpha` input is not connected.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        a = inputs.get("tensor_a")
+        b = inputs.get("tensor_b")
+        if a is None or b is None:
+            raise ValueError("Lerp requires both `tensor_a` and `tensor_b` inputs.")
+        if not isinstance(a, torch.Tensor):
+            a = torch.as_tensor(a, dtype=torch.float32)
+        if not isinstance(b, torch.Tensor):
+            b = torch.as_tensor(b, dtype=torch.float32)
+
+        alpha_in = inputs.get("alpha")
+        if alpha_in is not None:
+            alpha = alpha_in if isinstance(alpha_in, torch.Tensor) else torch.as_tensor(alpha_in, dtype=torch.float32)
+        else:
+            alpha = torch.as_tensor(float(params.get("alpha", 0.5)), dtype=a.dtype)
+
+        out = alpha * a + (1.0 - alpha) * b
+        return {"tensor": out}

--- a/backend/app/nodes/diffusion/timestep_embedding_node.py
+++ b/backend/app/nodes/diffusion/timestep_embedding_node.py
@@ -1,0 +1,169 @@
+"""TimestepEmbeddingNode — turn a diffusion timestep into a vector.
+
+The U-Net needs to know "which step are we on" to denoise differently
+near t=0 (almost-clean image, small adjustments) vs. near t=T (pure
+noise, big adjustments). The standard trick from DDPM (Ho et al. 2020)
+is the same sinusoidal frequency-bank used for transformer positions,
+followed by a small MLP (Linear → SiLU → Linear) to give the model room
+to nonlinearly remap the time signal:
+
+    freq[i] = exp(-ln(max_period) * i / (D/2)),  i = 0..D/2-1
+    sin/cos:   sin(t · freq[i])  cos(t · freq[i])
+    project:   Linear(D, 4D) → SiLU → Linear(4D, D)
+
+Output is broadcast-ready: a [B, D] tensor that ResBlocks can project
+further and add channel-wise to feature maps.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from ...core.stateful_module import StatefulModuleMixin
+
+
+class _TimestepMLP(nn.Module):
+    """Frequency embedding + 2-layer projection."""
+
+    def __init__(self, embed_dim: int, max_period: int, seed: int) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.max_period = max_period
+        gen = torch.Generator()
+        gen.manual_seed(int(seed))
+        self.fc1 = nn.Linear(embed_dim, 4 * embed_dim)
+        self.fc2 = nn.Linear(4 * embed_dim, embed_dim)
+        scale = 1.0 / math.sqrt(embed_dim)
+        with torch.no_grad():
+            for layer in (self.fc1, self.fc2):
+                layer.weight.copy_(
+                    torch.randn(layer.weight.shape, generator=gen) * scale
+                )
+                layer.bias.zero_()
+
+    def freq_embed(self, timesteps: torch.Tensor) -> torch.Tensor:
+        """Sinusoidal embedding identical to DDPM/Vaswani — half sin, half cos."""
+        half = self.embed_dim // 2
+        freqs = torch.exp(
+            -math.log(self.max_period)
+            * torch.arange(half, dtype=torch.float32, device=timesteps.device)
+            / half
+        )  # [half]
+        args = timesteps.float().unsqueeze(-1) * freqs.unsqueeze(0)  # [B, half]
+        return torch.cat([torch.sin(args), torch.cos(args)], dim=-1)  # [B, embed_dim]
+
+    def forward(self, timesteps: torch.Tensor) -> torch.Tensor:
+        emb = self.freq_embed(timesteps)
+        return self.fc2(F.silu(self.fc1(emb)))
+
+
+class TimestepEmbeddingNode(StatefulModuleMixin, BaseNode):
+    NODE_NAME = "TimestepEmbedding"
+    CATEGORY = "Diffusion"
+    DESCRIPTION = (
+        "Encode a diffusion timestep $t$ into a vector that conditions U-Net "
+        "blocks. Sinusoidal frequency bank (à la Vaswani) followed by "
+        "Linear→SiLU→Linear, the standard DDPM recipe."
+    )
+
+    structural_params = ("embed_dim", "max_period", "seed")
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="timestep",
+                data_type=DataType.TENSOR,
+                description="Scalar int, 0-d tensor, or [B] tensor of timesteps.",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="embedding",
+                data_type=DataType.TENSOR,
+                description="Float32 tensor of shape [B, embed_dim].",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="embed_dim",
+                param_type=ParamType.INT,
+                default=32,
+                min_value=2,
+                description="Dimension of the time vector. Must be even (sin/cos halves).",
+            ),
+            ParamDefinition(
+                name="max_period",
+                param_type=ParamType.INT,
+                default=10000,
+                min_value=1,
+                description="Largest period in the frequency bank — controls how many distinct timesteps the embedding can resolve.",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=42,
+                description="Seed for the projection-layer initialisation.",
+            ),
+        ]
+
+    def build_module(self, params: dict[str, Any]) -> nn.Module:
+        embed_dim = int(params.get("embed_dim", 32))
+        if embed_dim < 2:
+            raise ValueError(f"TimestepEmbedding: embed_dim must be ≥ 2, got {embed_dim}.")
+        if embed_dim % 2 != 0:
+            raise ValueError(f"TimestepEmbedding: embed_dim must be even, got {embed_dim}.")
+        return _TimestepMLP(
+            embed_dim=embed_dim,
+            max_period=int(params.get("max_period", 10000)),
+            seed=int(params.get("seed", 42)),
+        )
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        t_in = inputs.get("timestep")
+        if t_in is None:
+            raise ValueError("TimestepEmbedding requires a `timestep` input.")
+
+        if isinstance(t_in, torch.Tensor):
+            timesteps = t_in
+        else:
+            timesteps = torch.as_tensor(t_in)
+        if timesteps.ndim == 0:
+            timesteps = timesteps.unsqueeze(0)
+
+        # Validate params here too (build_module won't run if mixin caches an
+        # earlier shape-incompatible build).
+        embed_dim = int(params.get("embed_dim", 32))
+        if embed_dim < 2:
+            raise ValueError(f"TimestepEmbedding: embed_dim must be ≥ 2, got {embed_dim}.")
+        if embed_dim % 2 != 0:
+            raise ValueError(f"TimestepEmbedding: embed_dim must be even, got {embed_dim}.")
+
+        module = self.get_or_build_module(context, params)
+        embedding = module(timesteps)
+        return {"embedding": embedding}

--- a/backend/app/nodes/diffusion/upsample_node.py
+++ b/backend/app/nodes/diffusion/upsample_node.py
@@ -1,0 +1,111 @@
+"""UpsampleNode — pure (non-learned) spatial upsampling.
+
+Counterpart to :class:`ConvTranspose2dNode`: ConvTranspose has *learnable*
+weights and is what diffusion U-Nets typically use to upsample, but for
+teaching it's clarifying to separate the two operations:
+
+* ``Upsample`` — fixed geometric resampling (nearest / bilinear). No
+  parameters, no gradients to learn. Doubles the spatial dimensions by
+  default so an encoder-decoder U-Net mirrors its downsampling stages.
+* ``ConvTranspose2d`` — strided transposed convolution that *learns* the
+  upsampling kernel.
+
+Showing both lets students see "upsampling can be a fixed op" before
+introducing the learnable variant.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class UpsampleNode(BaseNode):
+    NODE_NAME = "Upsample"
+    CATEGORY = "Diffusion"
+    DESCRIPTION = (
+        "Pure spatial upsampling via F.interpolate — no learnable weights. "
+        "Doubles spatial dims by default. Use this for U-Net decoder paths "
+        "when you don't want the upsampling step to learn (compare with "
+        "`ConvTranspose2d`, which does)."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor",
+                data_type=DataType.TENSOR,
+                description="Input tensor [N, C, ...] — 1D, 2D, or 3D spatial dims.",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor",
+                data_type=DataType.TENSOR,
+                description="Upsampled tensor with spatial dims scaled by `scale_factor`.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="mode",
+                param_type=ParamType.SELECT,
+                default="nearest",
+                options=["nearest", "bilinear", "area"],
+                description=(
+                    "Interpolation mode. nearest=replicate pixels, "
+                    "bilinear=blend neighbours (smoother), area=averaging "
+                    "(useful for downsampling)."
+                ),
+            ),
+            ParamDefinition(
+                name="scale_factor",
+                param_type=ParamType.FLOAT,
+                default=2.0,
+                min_value=0.1,
+                description="Multiply spatial dims by this. 2.0 doubles, 0.5 halves.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x = inputs.get("tensor")
+        if x is None:
+            raise ValueError("Upsample requires a `tensor` input.")
+        if not isinstance(x, torch.Tensor):
+            x = torch.as_tensor(x, dtype=torch.float32)
+
+        mode = str(params.get("mode", "nearest"))
+        if mode not in ("nearest", "bilinear", "area"):
+            raise ValueError(f"Unknown Upsample mode: {mode!r}")
+        scale = float(params.get("scale_factor", 2.0))
+
+        # F.interpolate requires align_corners=False for bilinear; nearest
+        # and area don't accept it. Branch accordingly.
+        kwargs: dict[str, Any] = {"scale_factor": scale, "mode": mode}
+        if mode == "bilinear":
+            kwargs["align_corners"] = False
+        out = F.interpolate(x.float(), **kwargs)
+        return {"tensor": out.to(x.dtype)}

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -166,3 +166,105 @@ async def test_cache_hit_still_populates_output_store():
     )
     assert statuses.get("1") == "cached"
     assert await store.get("run-2", "1", "out") == "hello"
+
+
+class _NonCacheableNode(BaseNode):
+    """Stateful-style node that returns a fresh value on every execution."""
+
+    NODE_NAME = "_NonCacheable"
+    CATEGORY = "Test"
+    DESCRIPTION = "Returns a different output every call"
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls):
+        return []
+
+    @classmethod
+    def define_outputs(cls):
+        return [PortDefinition(name="out", data_type=DataType.ANY)]
+
+    def execute(self, inputs, params):
+        # Use the call counter passed via params so each test invocation
+        # produces a known sequence.
+        _NonCacheableNode._counter = getattr(_NonCacheableNode, "_counter", 0) + 1
+        return {"out": f"call-{_NonCacheableNode._counter}"}
+
+
+class _PassthroughNode(BaseNode):
+    """Cacheable node that passes its input through unchanged."""
+
+    NODE_NAME = "_Passthrough"
+    CATEGORY = "Test"
+    DESCRIPTION = "Pass-through"
+    cacheable = True
+
+    @classmethod
+    def define_inputs(cls):
+        return [PortDefinition(name="in_value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls):
+        return [PortDefinition(name="out", data_type=DataType.ANY)]
+
+    def execute(self, inputs, params):
+        return {"out": inputs.get("in_value")}
+
+
+@pytest.mark.asyncio
+async def test_non_cacheable_upstream_invalidates_downstream_cache():
+    """Regression: when upstream is non-cacheable, the downstream node's cache
+    key must NOT be reused across runs — otherwise a downstream cache hit
+    returns a stale tensor whose actual upstream content has changed.
+
+    Repro: Start → _NonCacheable → _Passthrough → output. Each run, the
+    non-cacheable node returns a different value; the downstream Passthrough
+    must observe that change rather than returning a cached "call-1" output
+    indefinitely.
+    """
+    registry._nodes["_NonCacheable"] = _NonCacheableNode
+    registry._nodes["_Passthrough"] = _PassthroughNode
+    _NonCacheableNode._counter = 0
+    try:
+        cache = ExecutionCache()
+        nodes = [
+            _start_node(),
+            {"id": "src", "type": "_NonCacheable", "data": {"params": {}}},
+            {"id": "pass", "type": "_Passthrough", "data": {"params": {}}},
+        ]
+        edges = [
+            _trigger("et", "start", "src"),
+            {"id": "e1", "source": "src", "target": "pass", "sourceHandle": "out", "targetHandle": "in_value"},
+        ]
+
+        outputs1: dict[str, dict] = {}
+        outputs2: dict[str, dict] = {}
+
+        async def capture1(node_id, status, data):
+            if status == "completed":
+                outputs1[node_id] = data
+            elif status == "cached":
+                outputs1[node_id] = data
+
+        async def capture2(node_id, status, data):
+            if status == "completed":
+                outputs2[node_id] = data
+            elif status == "cached":
+                outputs2[node_id] = data
+
+        await execute_graph(nodes, edges, cache=cache, on_progress=capture1)
+        await execute_graph(nodes, edges, cache=cache, on_progress=capture2)
+
+        # First run: src = "call-1", pass = "call-1" (forwarded)
+        # Second run: src = "call-2"; pass MUST also see "call-2", not the
+        # stale "call-1" cached from run 1.
+        assert outputs1["src"]["out"] == "call-1"
+        assert outputs1["pass"]["out"] == "call-1"
+        assert outputs2["src"]["out"] == "call-2"
+        assert outputs2["pass"]["out"] == "call-2", (
+            "Downstream cache must invalidate when upstream is non-cacheable; "
+            f"got {outputs2['pass']['out']}"
+        )
+    finally:
+        registry._nodes.pop("_NonCacheable", None)
+        registry._nodes.pop("_Passthrough", None)

--- a/backend/tests/test_ddpm_sampler_node.py
+++ b/backend/tests/test_ddpm_sampler_node.py
@@ -1,0 +1,130 @@
+"""Tests for DDPMSamplerNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from app.nodes.diffusion.ddpm_sampler_node import DDPMSamplerNode
+from app.nodes.diffusion.diffusion_unet_node import DiffusionUNetNode
+
+
+class _ZeroNoisePredictor(nn.Module):
+    """Trivial 'model' that predicts zero noise — useful for testing the loop logic without UNet noise."""
+
+    def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        return torch.zeros_like(x)
+
+
+class _IdentityPredictor(nn.Module):
+    """Returns x itself as 'predicted noise' — exercises the math but in a known way."""
+
+    def forward(self, x: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        return x
+
+
+def _run(*, model, noise, condition=None, **params):
+    p = {
+        "num_steps": 5,
+        "schedule": "linear",
+        "beta_start": 0.0001,
+        "beta_end": 0.02,
+        "seed": 42,
+    }
+    p.update(params)
+    inputs: dict = {"model": model, "noise": noise}
+    if condition is not None:
+        inputs["condition"] = condition
+    return DDPMSamplerNode().execute(inputs, p)
+
+
+def test_node_metadata():
+    assert DDPMSamplerNode.NODE_NAME == "DDPMSampler"
+    assert DDPMSamplerNode.CATEGORY == "Diffusion"
+    out_names = [p.name for p in DDPMSamplerNode.define_outputs()]
+    assert out_names == ["image"]
+
+
+def test_output_shape_matches_noise():
+    """Output shape should equal start-noise shape (no resampling)."""
+    noise = torch.randn(1, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+    res = _run(model=_ZeroNoisePredictor(), noise=noise, num_steps=10)
+    assert res["image"].shape == noise.shape
+
+
+def test_zero_noise_predictor_keeps_signal_finite():
+    """Pure-zero model still runs the loop without NaN/Inf."""
+    noise = torch.randn(1, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+    res = _run(model=_ZeroNoisePredictor(), noise=noise, num_steps=10)
+    assert torch.isfinite(res["image"]).all()
+
+
+def test_deterministic_given_seed():
+    """Same noise + same model + same seed → same final image."""
+    noise = torch.randn(1, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+    a = _run(model=_ZeroNoisePredictor(), noise=noise, seed=42, num_steps=5)
+    b = _run(model=_ZeroNoisePredictor(), noise=noise, seed=42, num_steps=5)
+    assert torch.allclose(a["image"], b["image"])
+
+
+def test_different_num_steps_changes_result():
+    """Different number of denoise steps → different image (more steps = different trajectory)."""
+    noise = torch.randn(1, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+    a = _run(model=_IdentityPredictor(), noise=noise, num_steps=3)
+    b = _run(model=_IdentityPredictor(), noise=noise, num_steps=10)
+    assert not torch.allclose(a["image"], b["image"], atol=1e-4)
+
+
+def test_works_with_real_diffusion_unet():
+    """End-to-end smoke: DiffusionUNet → DDPMSampler."""
+    unet_res = DiffusionUNetNode().execute(
+        {},
+        {
+            "in_channels": 3,
+            "base_channels": 8,
+            "channel_mult": "1,2",
+            "time_emb_dim": 16,
+            "num_groups": 4,
+            "seed": 42,
+        },
+    )
+    noise = torch.randn(1, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+    res = _run(model=unet_res["model"], noise=noise, num_steps=5)
+    assert res["image"].shape == (1, 3, 8, 8)
+    assert torch.isfinite(res["image"]).all()
+
+
+def test_cosine_schedule_works():
+    """Just smoke-test the cosine schedule path."""
+    noise = torch.randn(1, 3, 8, 8, generator=torch.Generator().manual_seed(0))
+    res = _run(model=_ZeroNoisePredictor(), noise=noise, schedule="cosine", num_steps=5)
+    assert torch.isfinite(res["image"]).all()
+
+
+def test_unknown_schedule_raises():
+    noise = torch.randn(1, 3, 8, 8)
+    with pytest.raises(ValueError, match="schedule"):
+        _run(model=_ZeroNoisePredictor(), noise=noise, schedule="not-a-schedule")
+
+
+def test_missing_model_raises():
+    with pytest.raises(ValueError, match="requires"):
+        DDPMSamplerNode().execute(
+            {"noise": torch.zeros(1, 3, 8, 8)},
+            {"num_steps": 5, "schedule": "linear", "beta_start": 0.0001, "beta_end": 0.02, "seed": 42},
+        )
+
+
+def test_missing_noise_raises():
+    with pytest.raises(ValueError, match="requires"):
+        DDPMSamplerNode().execute(
+            {"model": _ZeroNoisePredictor()},
+            {"num_steps": 5, "schedule": "linear", "beta_start": 0.0001, "beta_end": 0.02, "seed": 42},
+        )
+
+
+def test_num_steps_at_least_one():
+    noise = torch.randn(1, 3, 8, 8)
+    with pytest.raises(ValueError, match="num_steps"):
+        _run(model=_ZeroNoisePredictor(), noise=noise, num_steps=0)

--- a/backend/tests/test_diffusion_unet_node.py
+++ b/backend/tests/test_diffusion_unet_node.py
@@ -1,0 +1,107 @@
+"""Tests for DiffusionUNetNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.diffusion.diffusion_unet_node import DiffusionUNetNode
+
+
+def _run(**params):
+    p = {
+        "in_channels": 3,
+        "base_channels": 16,
+        "channel_mult": "1,2,4",
+        "time_emb_dim": 32,
+        "num_groups": 4,
+        "seed": 42,
+    }
+    p.update(params)
+    return DiffusionUNetNode().execute({}, p)
+
+
+def test_node_metadata():
+    assert DiffusionUNetNode.NODE_NAME == "DiffusionUNet"
+    assert DiffusionUNetNode.CATEGORY == "Diffusion"
+    out_names = [p.name for p in DiffusionUNetNode.define_outputs()]
+    assert out_names == ["model"]
+
+
+def test_outputs_callable_module():
+    res = _run()
+    model = res["model"]
+    assert callable(model)
+
+
+def test_forward_preserves_shape():
+    """U-Net is a noise predictor: output same shape as input."""
+    res = _run(in_channels=3, base_channels=16)
+    model = res["model"]
+    x = torch.randn(2, 3, 16, 16)
+    t = torch.tensor([5, 5])
+    pred = model(x, t)
+    assert pred.shape == x.shape
+
+
+def test_works_at_multiple_resolutions():
+    """Power-of-2 resolutions divisible by 2^(num_levels-1) should work."""
+    res = _run(channel_mult="1,2,4")
+    model = res["model"]
+    # 3 levels means 2 downsamples → input must be divisible by 4
+    for h in (16, 32, 64):
+        x = torch.randn(1, 3, h, h)
+        t = torch.tensor([0])
+        out = model(x, t)
+        assert out.shape == x.shape
+
+
+def test_different_in_out_channels():
+    """When in_channels=4 (e.g. latent SD), output should also be 4."""
+    res = _run(in_channels=4, base_channels=8)
+    model = res["model"]
+    x = torch.randn(1, 4, 8, 8)
+    t = torch.tensor([0])
+    out = model(x, t)
+    assert out.shape == (1, 4, 8, 8)
+
+
+def test_timestep_conditioning_changes_output():
+    """Same x, different t → different prediction."""
+    res = _run(seed=42)
+    model = res["model"]
+    x = torch.randn(1, 3, 16, 16, generator=torch.Generator().manual_seed(0))
+    a = model(x, torch.tensor([0]))
+    b = model(x, torch.tensor([100]))
+    assert not torch.allclose(a, b, atol=1e-4)
+
+
+def test_deterministic_given_seed():
+    """Same seed twice → same model behaviour."""
+    a_model = _run(seed=42)["model"]
+    b_model = _run(seed=42)["model"]
+    x = torch.randn(1, 3, 16, 16, generator=torch.Generator().manual_seed(0))
+    t = torch.tensor([0])
+    assert torch.allclose(a_model(x, t), b_model(x, t))
+
+
+def test_invalid_channel_mult_raises():
+    with pytest.raises(ValueError, match="channel_mult"):
+        _run(channel_mult="not,valid")
+
+
+def test_empty_channel_mult_raises():
+    with pytest.raises(ValueError, match="channel_mult"):
+        _run(channel_mult="")
+
+
+def test_resolution_not_divisible_by_downsample_raises():
+    """If channel_mult has 3 levels (2 downsamples), spatial dim must be divisible by 4."""
+    res = _run(channel_mult="1,2,4")
+    model = res["model"]
+    # 16 → 8 → 4 ok; 17 → 8 (truncates) → 4 — pytorch will silently round.
+    # Be strict: insist on cleanly divisible dimensions.
+    x = torch.randn(1, 3, 13, 13)  # not divisible by 4
+    t = torch.tensor([0])
+    with pytest.raises((RuntimeError, ValueError)):
+        model(x, t)

--- a/backend/tests/test_edu_cross_attention_node.py
+++ b/backend/tests/test_edu_cross_attention_node.py
@@ -1,0 +1,120 @@
+"""Tests for EduCrossAttentionNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.diffusion.edu_cross_attention_node import EduCrossAttentionNode
+
+
+def _run(query, context, *, mask=None, q_labels=None, k_labels=None, **params):
+    p = {"embed_dim": 8, "num_heads": 2, "seed": 42}
+    p.update(params)
+    inputs: dict = {"query": query, "context": context}
+    if mask is not None:
+        inputs["mask"] = mask
+    if q_labels is not None:
+        inputs["q_labels"] = q_labels
+    if k_labels is not None:
+        inputs["k_labels"] = k_labels
+    return EduCrossAttentionNode().execute(inputs, p)
+
+
+def test_node_metadata():
+    assert EduCrossAttentionNode.NODE_NAME == "EduCrossAttention"
+    assert EduCrossAttentionNode.CATEGORY == "Diffusion"
+    out_names = [p.name for p in EduCrossAttentionNode.define_outputs()]
+    assert out_names == ["output", "weights", "q_labels", "k_labels"]
+
+
+def test_output_shape_2d_inputs():
+    """Q [Q_seq, D], K/V [K_seq, D] → output [Q_seq, D], weights [H, Q_seq, K_seq]."""
+    q = torch.randn(5, 8, generator=torch.Generator().manual_seed(0))
+    ctx = torch.randn(7, 8, generator=torch.Generator().manual_seed(1))
+    res = _run(q, ctx, num_heads=2)
+    assert res["output"].shape == (5, 8)
+    assert res["weights"].shape == (2, 5, 7)
+
+
+def test_q_seq_can_differ_from_k_seq():
+    """Critical for cross-attention: Q from latent, K/V from text — different lengths."""
+    q = torch.randn(10, 8)  # 10 image patches
+    ctx = torch.randn(4, 8)  # 4 text tokens
+    res = _run(q, ctx, num_heads=2)
+    assert res["output"].shape == (10, 8)
+    assert res["weights"].shape == (2, 10, 4)
+
+
+def test_softmax_rows_sum_to_one():
+    """Each Q's attention over K must sum to 1."""
+    q = torch.randn(6, 8)
+    ctx = torch.randn(9, 8)
+    res = _run(q, ctx)
+    row_sums = res["weights"].sum(dim=-1)
+    assert torch.allclose(row_sums, torch.ones_like(row_sums), atol=1e-5)
+
+
+def test_3d_inputs_with_batch():
+    """[Q_seq, batch, D] and [K_seq, batch, D] → output [Q_seq, batch, D]."""
+    q = torch.randn(5, 3, 8)
+    ctx = torch.randn(7, 3, 8)
+    res = _run(q, ctx, num_heads=2)
+    assert res["output"].shape == (5, 3, 8)
+    # weights: [batch, H, Q_seq, K_seq]
+    assert res["weights"].shape == (3, 2, 5, 7)
+
+
+def test_explicit_mask_blocks_columns():
+    """Mask [Q_seq, K_seq] (True = blocked) — masked columns get zero weight."""
+    q = torch.randn(4, 8)
+    ctx = torch.randn(5, 8)
+    mask = torch.zeros(4, 5, dtype=torch.bool)
+    mask[:, 2] = True  # block context position 2 entirely
+    res = _run(q, ctx, mask=mask)
+    # All heads should respect — column 2 zeros across rows.
+    assert torch.all(res["weights"][:, :, 2] == 0.0)
+
+
+def test_deterministic_given_seed():
+    q = torch.randn(4, 8, generator=torch.Generator().manual_seed(0))
+    ctx = torch.randn(5, 8, generator=torch.Generator().manual_seed(1))
+    a = _run(q, ctx, seed=42)
+    b = _run(q, ctx, seed=42)
+    assert torch.allclose(a["output"], b["output"])
+    assert torch.allclose(a["weights"], b["weights"])
+
+
+def test_labels_pass_through():
+    q = torch.randn(3, 8)
+    ctx = torch.randn(4, 8)
+    res = _run(q, ctx, q_labels=["a", "b", "c"], k_labels=["w", "x", "y", "z"])
+    assert res["q_labels"] == ["a", "b", "c"]
+    assert res["k_labels"] == ["w", "x", "y", "z"]
+
+
+def test_labels_default_empty():
+    q = torch.randn(3, 8)
+    ctx = torch.randn(4, 8)
+    res = _run(q, ctx)
+    assert res["q_labels"] == []
+    assert res["k_labels"] == []
+
+
+def test_embed_dim_must_divide_num_heads():
+    with pytest.raises(ValueError, match="num_heads"):
+        _run(torch.zeros(2, 8), torch.zeros(3, 8), embed_dim=8, num_heads=3)
+
+
+def test_query_embed_dim_must_match_context():
+    """Q and context must share the same last-dim (embed_dim)."""
+    with pytest.raises(ValueError, match="embed_dim"):
+        _run(torch.zeros(2, 8), torch.zeros(3, 16))
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduCrossAttentionNode().execute(
+            {"query": torch.zeros(2, 8)},
+            {"embed_dim": 8, "num_heads": 2, "seed": 42},
+        )

--- a/backend/tests/test_edu_resblock_node.py
+++ b/backend/tests/test_edu_resblock_node.py
@@ -1,0 +1,115 @@
+"""Tests for EduResBlockNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.diffusion.edu_resblock_node import EduResBlockNode
+
+
+def _run(tensor, *, time_emb=None, **params):
+    p = {
+        "in_channels": 8,
+        "out_channels": 8,
+        "groups": 4,
+        "time_emb_dim": 32,
+        "seed": 42,
+    }
+    p.update(params)
+    inputs: dict = {"tensor": tensor}
+    if time_emb is not None:
+        inputs["time_emb"] = time_emb
+    return EduResBlockNode().execute(inputs, p)
+
+
+def test_node_metadata():
+    assert EduResBlockNode.NODE_NAME == "EduResBlock"
+    assert EduResBlockNode.CATEGORY == "Diffusion"
+    out_names = [p.name for p in EduResBlockNode.define_outputs()]
+    assert out_names == ["tensor"]
+
+
+def test_same_in_out_shape():
+    """[N, 8, H, W] → [N, 8, H, W] when in_channels == out_channels."""
+    x = torch.randn(2, 8, 16, 16, generator=torch.Generator().manual_seed(0))
+    res = _run(x, in_channels=8, out_channels=8)
+    assert res["tensor"].shape == (2, 8, 16, 16)
+
+
+def test_channel_change_with_skip_projection():
+    """[N, 8, H, W] → [N, 16, H, W] — needs 1x1 skip projection."""
+    x = torch.randn(2, 8, 16, 16)
+    res = _run(x, in_channels=8, out_channels=16)
+    assert res["tensor"].shape == (2, 16, 16, 16)
+
+
+def test_time_emb_optional_works_without_it():
+    """Without time_emb input, runs as plain residual block."""
+    x = torch.randn(1, 8, 8, 8)
+    res = _run(x)
+    assert res["tensor"].shape == (1, 8, 8, 8)
+
+
+def test_time_emb_modulates_output():
+    """Same x, different time_emb → different output."""
+    x = torch.randn(1, 8, 8, 8, generator=torch.Generator().manual_seed(0))
+    t1 = torch.randn(1, 32, generator=torch.Generator().manual_seed(1))
+    t2 = torch.randn(1, 32, generator=torch.Generator().manual_seed(2))
+    a = _run(x, time_emb=t1)
+    b = _run(x, time_emb=t2)
+    assert not torch.allclose(a["tensor"], b["tensor"])
+
+
+def test_deterministic_given_seed():
+    x = torch.randn(1, 8, 8, 8, generator=torch.Generator().manual_seed(0))
+    a = _run(x, seed=42)
+    b = _run(x, seed=42)
+    assert torch.allclose(a["tensor"], b["tensor"])
+
+
+def test_groups_must_divide_channels():
+    """GroupNorm requires groups | num_channels."""
+    with pytest.raises(ValueError, match="groups"):
+        _run(torch.zeros(1, 8, 4, 4), in_channels=8, groups=3)
+
+
+def test_in_channels_must_match_input():
+    with pytest.raises(ValueError, match="in_channels"):
+        _run(torch.zeros(1, 4, 8, 8), in_channels=8)
+
+
+def test_time_emb_dim_must_match():
+    """time_emb input dim must match time_emb_dim param."""
+    x = torch.randn(1, 8, 4, 4)
+    bad_emb = torch.randn(1, 64)  # not 32
+    with pytest.raises(ValueError, match="time_emb"):
+        _run(x, time_emb=bad_emb, time_emb_dim=32)
+
+
+def test_residual_path_is_used():
+    """For zero-init weights and zero input, output should still equal skip path.
+
+    Using the seeded random init won't give exact zero, but we can verify the
+    residual additivity: doubling x doesn't double output (because residual
+    adds nonlinearly via Conv+GN+SiLU).
+    """
+    x = torch.randn(1, 8, 8, 8, generator=torch.Generator().manual_seed(0))
+    a = _run(x, seed=42)
+    b = _run(x * 2, seed=42)
+    # Output is not exactly 2× because of GroupNorm + SiLU.
+    assert not torch.allclose(a["tensor"], b["tensor"] / 2.0, atol=1e-3)
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduResBlockNode().execute(
+            {},
+            {"in_channels": 8, "out_channels": 8, "groups": 4, "time_emb_dim": 32, "seed": 42},
+        )
+
+
+def test_2d_spatial_input_required():
+    """Block expects [N, C, H, W] — 1D input should fail."""
+    with pytest.raises(ValueError, match="shape"):
+        _run(torch.zeros(1, 8))

--- a/backend/tests/test_gaussian_noise_node.py
+++ b/backend/tests/test_gaussian_noise_node.py
@@ -1,0 +1,88 @@
+"""Tests for GaussianNoiseNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.diffusion.gaussian_noise_node import GaussianNoiseNode
+
+
+def _run(*, shape_ref=None, **params):
+    p = {"shape": "1,3,4,4", "mean": 0.0, "std": 1.0, "seed": 42}
+    p.update(params)
+    inputs: dict = {}
+    if shape_ref is not None:
+        inputs["shape_ref"] = shape_ref
+    return GaussianNoiseNode().execute(inputs, p)
+
+
+def test_node_metadata():
+    assert GaussianNoiseNode.NODE_NAME == "GaussianNoise"
+    assert GaussianNoiseNode.CATEGORY == "Diffusion"
+    out_names = [p.name for p in GaussianNoiseNode.define_outputs()]
+    assert out_names == ["noise"]
+
+
+def test_default_shape_from_param():
+    res = _run(shape="2,3,8,8")
+    assert res["noise"].shape == (2, 3, 8, 8)
+
+
+def test_shape_ref_input_takes_precedence():
+    """When shape_ref input connected, use its shape regardless of param."""
+    ref = torch.zeros(4, 5, 6)
+    res = _run(shape_ref=ref, shape="1,1,1,1")
+    assert res["noise"].shape == (4, 5, 6)
+
+
+def test_seed_reproducibility():
+    a = _run(seed=123)
+    b = _run(seed=123)
+    assert torch.equal(a["noise"], b["noise"])
+
+
+def test_different_seeds_produce_different_noise():
+    a = _run(seed=1)
+    b = _run(seed=2)
+    assert not torch.equal(a["noise"], b["noise"])
+
+
+def test_default_mean_zero_std_one():
+    """Sample many values to verify approximate N(0, 1) distribution."""
+    res = _run(shape="10000", seed=42)
+    n = res["noise"]
+    assert abs(n.mean().item()) < 0.05  # near zero
+    assert abs(n.std().item() - 1.0) < 0.05  # near one
+
+
+def test_custom_mean_and_std():
+    res = _run(shape="10000", mean=5.0, std=2.0, seed=42)
+    n = res["noise"]
+    assert abs(n.mean().item() - 5.0) < 0.1
+    assert abs(n.std().item() - 2.0) < 0.1
+
+
+def test_does_not_perturb_global_rng():
+    """The seeded local generator shouldn't disturb the global RNG state."""
+    torch.manual_seed(99)
+    before = torch.randn(3)
+    torch.manual_seed(99)
+    _ = _run(seed=42)  # should not move global RNG
+    after = torch.randn(3)
+    assert torch.allclose(before, after)
+
+
+def test_invalid_shape_raises():
+    with pytest.raises(ValueError, match="shape"):
+        _run(shape="not,valid,nope")
+
+
+def test_empty_shape_string_raises():
+    with pytest.raises(ValueError, match="shape"):
+        _run(shape="")
+
+
+def test_dtype_is_float32():
+    res = _run()
+    assert res["noise"].dtype == torch.float32

--- a/backend/tests/test_lerp_node.py
+++ b/backend/tests/test_lerp_node.py
@@ -1,0 +1,107 @@
+"""Tests for LerpNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.diffusion.lerp_node import LerpNode
+
+
+def _run(a, b, *, alpha=None, **params):
+    p = {"alpha": 0.5}
+    p.update(params)
+    inputs: dict = {"tensor_a": a, "tensor_b": b}
+    if alpha is not None:
+        inputs["alpha"] = alpha
+    return LerpNode().execute(inputs, p)
+
+
+def test_node_metadata():
+    assert LerpNode.NODE_NAME == "Lerp"
+    assert LerpNode.CATEGORY == "Diffusion"
+    out_names = [p.name for p in LerpNode.define_outputs()]
+    assert out_names == ["tensor"]
+
+
+def test_alpha_zero_returns_b():
+    a = torch.tensor([1.0, 2.0, 3.0])
+    b = torch.tensor([4.0, 5.0, 6.0])
+    res = _run(a, b, alpha=0.0)
+    assert torch.allclose(res["tensor"], b)
+
+
+def test_alpha_one_returns_a():
+    a = torch.tensor([1.0, 2.0, 3.0])
+    b = torch.tensor([4.0, 5.0, 6.0])
+    res = _run(a, b, alpha=1.0)
+    assert torch.allclose(res["tensor"], a)
+
+
+def test_alpha_half_averages():
+    a = torch.tensor([1.0, 2.0, 3.0])
+    b = torch.tensor([4.0, 5.0, 6.0])
+    res = _run(a, b, alpha=0.5)
+    assert torch.allclose(res["tensor"], torch.tensor([2.5, 3.5, 4.5]))
+
+
+def test_alpha_param_used_when_no_input():
+    """When alpha input not connected, use the alpha param."""
+    a = torch.tensor([0.0])
+    b = torch.tensor([10.0])
+    res = LerpNode().execute(
+        {"tensor_a": a, "tensor_b": b},
+        {"alpha": 0.3},
+    )
+    # 0.3*0 + 0.7*10 = 7.0
+    assert torch.allclose(res["tensor"], torch.tensor([7.0]))
+
+
+def test_scalar_tensor_alpha_input():
+    """alpha input as a 0-d tensor scalar."""
+    a = torch.tensor([0.0])
+    b = torch.tensor([10.0])
+    res = _run(a, b, alpha=torch.tensor(0.25))
+    assert torch.allclose(res["tensor"], torch.tensor([7.5]))
+
+
+def test_broadcasted_alpha_per_sample():
+    """alpha as a [B, 1, 1, 1] tensor for batch-wise interpolation."""
+    a = torch.zeros(2, 3, 2, 2)
+    b = torch.ones(2, 3, 2, 2)
+    alpha = torch.tensor([0.0, 1.0]).view(2, 1, 1, 1)
+    res = _run(a, b, alpha=alpha)
+    # Sample 0: 0*0 + 1*1 = 1.0; sample 1: 1*0 + 0*1 = 0.0
+    assert torch.all(res["tensor"][0] == 1.0)
+    assert torch.all(res["tensor"][1] == 0.0)
+
+
+def test_diffusion_forward_equation():
+    """Canonical diffusion forward: x_t = sqrt(alpha_bar)*x_0 + sqrt(1-alpha_bar)*noise.
+
+    Lerp models this when we set alpha = sqrt(alpha_bar):
+        x_t = alpha*x_0 + (1-alpha)*noise   # NOTE: this is sqrt(α̅)x₀ + (1-sqrt(α̅))ε
+    The exact diffusion formula uses sqrt(1-α̅), not 1-sqrt(α̅), so Lerp
+    is a *teaching* approximation. This test just verifies the basic
+    convex-combination property, not the diffusion equation.
+    """
+    x0 = torch.randn(1, 3, 4, 4, generator=torch.Generator().manual_seed(0))
+    eps = torch.randn(1, 3, 4, 4, generator=torch.Generator().manual_seed(1))
+    res = _run(x0, eps, alpha=0.7)
+    # Output should be a convex combination — pixel-wise within [min, max].
+    expected = 0.7 * x0 + 0.3 * eps
+    assert torch.allclose(res["tensor"], expected)
+
+
+def test_shape_mismatch_via_broadcast_works_for_compatible_dims():
+    """[3] + [1] → broadcast to [3]."""
+    a = torch.tensor([1.0, 2.0, 3.0])
+    b = torch.tensor([10.0])  # broadcastable
+    res = _run(a, b, alpha=0.5)
+    # 0.5*[1,2,3] + 0.5*[10,10,10] = [5.5, 6, 6.5]
+    assert torch.allclose(res["tensor"], torch.tensor([5.5, 6.0, 6.5]))
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        LerpNode().execute({"tensor_a": torch.zeros(1)}, {"alpha": 0.5})

--- a/backend/tests/test_timestep_embedding_node.py
+++ b/backend/tests/test_timestep_embedding_node.py
@@ -1,0 +1,84 @@
+"""Tests for TimestepEmbeddingNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.diffusion.timestep_embedding_node import TimestepEmbeddingNode
+
+
+def _run(timestep, **params):
+    p = {"embed_dim": 32, "max_period": 10000, "seed": 42}
+    p.update(params)
+    return TimestepEmbeddingNode().execute({"timestep": timestep}, p)
+
+
+def test_node_metadata():
+    assert TimestepEmbeddingNode.NODE_NAME == "TimestepEmbedding"
+    assert TimestepEmbeddingNode.CATEGORY == "Diffusion"
+    out_names = [p.name for p in TimestepEmbeddingNode.define_outputs()]
+    assert out_names == ["embedding"]
+
+
+def test_scalar_timestep_returns_batch_one():
+    """Single int timestep → [1, embed_dim] embedding."""
+    res = _run(timestep=10, embed_dim=32)
+    assert res["embedding"].shape == (1, 32)
+
+
+def test_scalar_tensor_timestep():
+    """0-d tensor timestep treated as a single timestep."""
+    t = torch.tensor(10)
+    res = _run(timestep=t, embed_dim=32)
+    assert res["embedding"].shape == (1, 32)
+
+
+def test_1d_tensor_timestep_batches():
+    """[B] tensor of timesteps → [B, embed_dim]."""
+    t = torch.tensor([0, 50, 100])
+    res = _run(timestep=t, embed_dim=32)
+    assert res["embedding"].shape == (3, 32)
+
+
+def test_deterministic_given_seed():
+    a = _run(timestep=10, seed=42)
+    b = _run(timestep=10, seed=42)
+    assert torch.allclose(a["embedding"], b["embedding"])
+
+
+def test_different_timesteps_give_different_embeddings():
+    a = _run(timestep=10, seed=42)
+    b = _run(timestep=20, seed=42)
+    assert not torch.allclose(a["embedding"], b["embedding"])
+
+
+def test_different_seeds_give_different_embeddings():
+    """Same t, different seed → different output (because of MLP weights)."""
+    a = _run(timestep=10, seed=1)
+    b = _run(timestep=10, seed=2)
+    assert not torch.allclose(a["embedding"], b["embedding"])
+
+
+def test_embed_dim_must_be_even():
+    """sin/cos halves require even dim."""
+    with pytest.raises(ValueError, match="even"):
+        _run(timestep=10, embed_dim=33)
+
+
+def test_consistent_across_batch():
+    """Same timestep value at two batch positions should give identical embeddings."""
+    t = torch.tensor([5, 5, 5])
+    res = _run(timestep=t, embed_dim=16)
+    assert torch.allclose(res["embedding"][0], res["embedding"][1])
+    assert torch.allclose(res["embedding"][0], res["embedding"][2])
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        TimestepEmbeddingNode().execute({}, {"embed_dim": 32, "max_period": 10000, "seed": 42})
+
+
+def test_negative_or_zero_embed_dim_raises():
+    with pytest.raises(ValueError, match="embed_dim"):
+        _run(timestep=10, embed_dim=0)

--- a/backend/tests/test_upsample_node.py
+++ b/backend/tests/test_upsample_node.py
@@ -1,0 +1,79 @@
+"""Tests for UpsampleNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.diffusion.upsample_node import UpsampleNode
+
+
+def _run(tensor, **params):
+    p = {"mode": "nearest", "scale_factor": 2.0}
+    p.update(params)
+    return UpsampleNode().execute({"tensor": tensor}, p)
+
+
+def test_node_metadata():
+    assert UpsampleNode.NODE_NAME == "Upsample"
+    assert UpsampleNode.CATEGORY == "Diffusion"
+    out_names = [p.name for p in UpsampleNode.define_outputs()]
+    assert out_names == ["tensor"]
+
+
+def test_default_doubles_spatial_dims_nchw():
+    res = _run(torch.zeros(1, 3, 4, 4), scale_factor=2.0)
+    assert res["tensor"].shape == (1, 3, 8, 8)
+
+
+def test_scale_factor_3_triples_spatial_dims():
+    res = _run(torch.zeros(2, 8, 4, 4), scale_factor=3.0)
+    assert res["tensor"].shape == (2, 8, 12, 12)
+
+
+def test_scale_factor_half_downsamples():
+    res = _run(torch.zeros(1, 3, 8, 8), scale_factor=0.5)
+    assert res["tensor"].shape == (1, 3, 4, 4)
+
+
+def test_nearest_mode_replicates_pixels():
+    """Nearest-neighbor upsample of a 1x1x2x2 tensor should give a 4x4 with each value 4-replicated."""
+    x = torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]])
+    res = _run(x, mode="nearest", scale_factor=2.0)
+    # Top-left 2x2 block should all be 1.0
+    assert torch.all(res["tensor"][0, 0, 0:2, 0:2] == 1.0)
+    # Bottom-right 2x2 block should all be 4.0
+    assert torch.all(res["tensor"][0, 0, 2:4, 2:4] == 4.0)
+
+
+def test_bilinear_mode_blends_neighbors():
+    """Bilinear should produce intermediate values, unlike nearest."""
+    x = torch.tensor([[[[0.0, 0.0], [1.0, 1.0]]]])
+    res = _run(x, mode="bilinear", scale_factor=2.0)
+    # Some cells should land between 0 and 1 (smooth interpolation).
+    # Nearest would only ever produce 0.0 or 1.0; bilinear breaks that.
+    vals = res["tensor"].unique()
+    assert len(vals) > 2
+
+
+def test_unknown_mode_raises():
+    with pytest.raises(ValueError, match="mode"):
+        _run(torch.zeros(1, 3, 4, 4), mode="not-a-mode")
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        UpsampleNode().execute({}, {"mode": "nearest", "scale_factor": 2.0})
+
+
+def test_handles_3d_tensor_one_spatial_dim():
+    """[N, C, L] input — 1D upsampling."""
+    x = torch.zeros(1, 4, 8)
+    res = _run(x, mode="nearest", scale_factor=2.0)
+    assert res["tensor"].shape == (1, 4, 16)
+
+
+def test_dtype_preserved():
+    x = torch.zeros(1, 3, 4, 4, dtype=torch.float32)
+    res = _run(x)
+    assert res["tensor"].dtype == torch.float32

--- a/examples/Diffusion/Cross-Attention-101/graph.json
+++ b/examples/Diffusion/Cross-Attention-101/graph.json
@@ -1,0 +1,18 @@
+{
+  "name": "Cross-Attention 101: Q from one place, K/V from another",
+  "description": "The mechanism that lets Stable Diffusion's U-Net condition on a text prompt. Self-attention sources Q, K, V all from one tensor; cross-attention sources Q from a 'query' tensor (the image patches) and K/V from a 'context' tensor (the text token embeddings). The two may have different sequence lengths — the heatmap on the right is rectangular, with image positions on the rows and text positions on the columns. Run it and check the inline heatmap to see which 'text' position each 'image' position attended to.",
+  "nodes": [
+    { "id": "start-1", "type": "Start", "position": { "x": -260, "y": 0 }, "data": { "params": {} } },
+    { "id": "q",   "type": "TensorCreate", "position": { "x": 0,   "y": -100 }, "data": { "params": { "shape": "6,8", "fill": "randn", "value": 0, "requires_grad": false } } },
+    { "id": "ctx", "type": "TensorCreate", "position": { "x": 0,   "y": 100  }, "data": { "params": { "shape": "4,8", "fill": "randn", "value": 0, "requires_grad": false } } },
+    { "id": "attn", "type": "EduCrossAttention", "position": { "x": 320, "y": 0 }, "data": { "params": { "embed_dim": 8, "num_heads": 2, "seed": 42 } } },
+    { "id": "print", "type": "Print", "position": { "x": 700, "y": 0 }, "data": { "params": { "label": "Cross-attn output" } } }
+  ],
+  "edges": [
+    { "id": "trig_q",   "source": "start-1", "target": "q",   "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "trig_ctx", "source": "start-1", "target": "ctx", "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "e_q",   "source": "q",   "target": "attn", "sourceHandle": "tensor", "targetHandle": "query" },
+    { "id": "e_ctx", "source": "ctx", "target": "attn", "sourceHandle": "tensor", "targetHandle": "context" },
+    { "id": "e_out", "source": "attn", "target": "print", "sourceHandle": "output", "targetHandle": "value" }
+  ]
+}

--- a/examples/Diffusion/Forward-Process/graph.json
+++ b/examples/Diffusion/Forward-Process/graph.json
@@ -1,0 +1,24 @@
+{
+  "name": "Forward Diffusion: gradually adding noise",
+  "description": "The forward diffusion process gradually destroys a clean image by mixing in Gaussian noise according to a schedule. The classical equation is $x_t = \\sqrt{\\bar\\alpha_t}\\,x_0 + \\sqrt{1-\\bar\\alpha_t}\\,\\epsilon$, with $\\bar\\alpha_t$ shrinking from 1 (clean) to 0 (pure noise) as t grows. Here we approximate this with a single Lerp at alpha=0.4 — the result $x_t$ is a 40/60 blend of clean signal and noise. The TimestepEmbedding on the side shows how a scalar t becomes a 32-d vector that the U-Net can use as a conditioning signal.",
+  "nodes": [
+    { "id": "start-1", "type": "Start", "position": { "x": -260, "y": 0 }, "data": { "params": {} } },
+    { "id": "x0",      "type": "TensorCreate", "position": { "x": 0,   "y": -150 }, "data": { "params": { "shape": "1,3,8,8", "fill": "randn", "value": 0, "requires_grad": false } } },
+    { "id": "t_input", "type": "TensorCreate", "position": { "x": 0,   "y": 60   }, "data": { "params": { "shape": "1",       "fill": "full",  "value": 50, "requires_grad": false } } },
+    { "id": "noise",   "type": "GaussianNoise", "position": { "x": 320, "y": 100  }, "data": { "params": { "shape": "1,3,8,8", "mean": 0, "std": 1, "seed": 42 } } },
+    { "id": "tembed",  "type": "TimestepEmbedding", "position": { "x": 320, "y": -50 }, "data": { "params": { "embed_dim": 32, "max_period": 10000, "seed": 42 } } },
+    { "id": "lerp",    "type": "Lerp", "position": { "x": 660, "y": 0 }, "data": { "params": { "alpha": 0.4 } } },
+    { "id": "print_xt", "type": "Print", "position": { "x": 1000, "y": -50 }, "data": { "params": { "label": "x_t (noised image)" } } },
+    { "id": "print_emb","type": "Print", "position": { "x": 660, "y": -180 }, "data": { "params": { "label": "Timestep embedding" } } }
+  ],
+  "edges": [
+    { "id": "trig_x0",     "source": "start-1", "target": "x0",      "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "trig_t",      "source": "start-1", "target": "t_input", "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "e_t_to_emb",  "source": "t_input", "target": "tembed",  "sourceHandle": "tensor",     "targetHandle": "timestep" },
+    { "id": "e_x0_to_noise","source": "x0",     "target": "noise",   "sourceHandle": "tensor",     "targetHandle": "shape_ref" },
+    { "id": "e_x0",        "source": "x0",      "target": "lerp",    "sourceHandle": "tensor",     "targetHandle": "tensor_a" },
+    { "id": "e_noise",     "source": "noise",   "target": "lerp",    "sourceHandle": "noise",      "targetHandle": "tensor_b" },
+    { "id": "e_lerp_print","source": "lerp",    "target": "print_xt","sourceHandle": "tensor",     "targetHandle": "value" },
+    { "id": "e_emb_print", "source": "tembed",  "target": "print_emb","sourceHandle": "embedding", "targetHandle": "value" }
+  ]
+}

--- a/examples/Diffusion/Mini-UNet-Compact/graph.json
+++ b/examples/Diffusion/Mini-UNet-Compact/graph.json
@@ -1,0 +1,18 @@
+{
+  "name": "Mini U-Net (Compact): the same architecture in one node",
+  "description": "Counterpart to `Mini-UNet-Expanded`: instead of wiring every ResBlock + Upsample + Concat by hand, the entire U-Net is packaged into a single `DiffusionUNet` meta-node. Same teaching architecture, same hyperparameters, just collapsed into one block — the form you'd actually use when assembling a sampling pipeline. Run it: GaussianNoise feeds the model + DDPMSampler at one step to confirm the output shape is preserved.",
+  "nodes": [
+    { "id": "start-1",  "type": "Start", "position": { "x": -260, "y": 0 }, "data": { "params": {} } },
+    { "id": "noise",    "type": "GaussianNoise", "position": { "x": 0,    "y": 60 }, "data": { "params": { "shape": "1,3,16,16", "mean": 0, "std": 1, "seed": 42 } } },
+    { "id": "unet",     "type": "DiffusionUNet",  "position": { "x": 320,  "y": -60 }, "data": { "params": { "in_channels": 3, "base_channels": 16, "channel_mult": "1,2,4", "time_emb_dim": 32, "num_groups": 4, "seed": 42 } } },
+    { "id": "sampler",  "type": "DDPMSampler",    "position": { "x": 660,  "y": 0 }, "data": { "params": { "num_steps": 1, "schedule": "linear", "beta_start": 0.0001, "beta_end": 0.02, "seed": 42 } } },
+    { "id": "print",    "type": "Print",          "position": { "x": 1000, "y": 0 }, "data": { "params": { "label": "Compact U-Net output (1-step denoise)" } } }
+  ],
+  "edges": [
+    { "id": "trig_noise", "source": "start-1", "target": "noise",   "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "trig_unet",  "source": "start-1", "target": "unet",    "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "e_model",   "source": "unet",    "target": "sampler", "sourceHandle": "model", "targetHandle": "model" },
+    { "id": "e_noise",   "source": "noise",   "target": "sampler", "sourceHandle": "noise", "targetHandle": "noise" },
+    { "id": "e_out",     "source": "sampler", "target": "print",   "sourceHandle": "image", "targetHandle": "value" }
+  ]
+}

--- a/examples/Diffusion/Mini-UNet-Expanded/graph.json
+++ b/examples/Diffusion/Mini-UNet-Expanded/graph.json
@@ -1,0 +1,64 @@
+{
+  "name": "Mini U-Net (Expanded): every block visible",
+  "description": "A diffusion U-Net wired by hand so every encoder/decoder ResBlock and every skip connection is visible on the canvas. Forward-pass demo: a noisy 16×16 RGB image flows through the stem, two down-stages (each ResBlock + MaxPool, with time conditioning), the bottleneck, then two up-stages (each Upsample + Concat-with-skip + ResBlock), and finally a 1×1 conv head that brings channels back to 3. Compare the Concat skip edges (dotted across the canvas) to the ResNet preset's Add skips — same idea, different merge operation. The Compact preset packages this exact architecture into one `DiffusionUNet` node.",
+  "nodes": [
+    { "id": "start-1",  "type": "Start", "position": { "x": -300, "y": 0 }, "data": { "params": {} } },
+
+    { "id": "x_in",     "type": "TensorCreate",      "position": { "x": -60,   "y": 0 },     "data": { "params": { "shape": "1,3,16,16", "fill": "randn", "value": 0, "requires_grad": false } } },
+    { "id": "t_scalar", "type": "TensorCreate",      "position": { "x": -60,   "y": -200 },  "data": { "params": { "shape": "1", "fill": "full", "value": 5, "requires_grad": false } } },
+    { "id": "t_emb",    "type": "TimestepEmbedding", "position": { "x": 220,   "y": -200 },  "data": { "params": { "embed_dim": 32, "max_period": 10000, "seed": 42 } } },
+
+    { "id": "stem",     "type": "Conv2d",            "position": { "x": 220,   "y": 0 },     "data": { "params": { "in_channels": 3, "out_channels": 16, "kernel_size": 3, "stride": 1, "padding": 1 } } },
+
+    { "id": "rb_d1",    "type": "EduResBlock",       "position": { "x": 480,   "y": 0 },     "data": { "params": { "in_channels": 16, "out_channels": 16, "groups": 4, "time_emb_dim": 32, "seed": 101 } } },
+    { "id": "pool_d1",  "type": "MaxPool2d",         "position": { "x": 720,   "y": 0 },     "data": { "params": { "kernel_size": 2, "stride": 2 } } },
+
+    { "id": "rb_d2",    "type": "EduResBlock",       "position": { "x": 940,   "y": 0 },     "data": { "params": { "in_channels": 16, "out_channels": 32, "groups": 4, "time_emb_dim": 32, "seed": 102 } } },
+    { "id": "pool_d2",  "type": "MaxPool2d",         "position": { "x": 1180,  "y": 0 },     "data": { "params": { "kernel_size": 2, "stride": 2 } } },
+
+    { "id": "rb_bot",   "type": "EduResBlock",       "position": { "x": 1400,  "y": 0 },     "data": { "params": { "in_channels": 32, "out_channels": 64, "groups": 4, "time_emb_dim": 32, "seed": 200 } } },
+
+    { "id": "up_2",     "type": "Upsample",          "position": { "x": 1640,  "y": 0 },     "data": { "params": { "mode": "nearest", "scale_factor": 2.0 } } },
+    { "id": "cat_2",    "type": "Concat",            "position": { "x": 1860,  "y": 0 },     "data": { "params": { "dim": 1 } } },
+    { "id": "rb_u2",    "type": "EduResBlock",       "position": { "x": 2080,  "y": 0 },     "data": { "params": { "in_channels": 96, "out_channels": 32, "groups": 4, "time_emb_dim": 32, "seed": 301 } } },
+
+    { "id": "up_1",     "type": "Upsample",          "position": { "x": 2320,  "y": 0 },     "data": { "params": { "mode": "nearest", "scale_factor": 2.0 } } },
+    { "id": "cat_1",    "type": "Concat",            "position": { "x": 2540,  "y": 0 },     "data": { "params": { "dim": 1 } } },
+    { "id": "rb_u1",    "type": "EduResBlock",       "position": { "x": 2760,  "y": 0 },     "data": { "params": { "in_channels": 48, "out_channels": 16, "groups": 4, "time_emb_dim": 32, "seed": 302 } } },
+
+    { "id": "head",     "type": "Conv2d",            "position": { "x": 3000,  "y": 0 },     "data": { "params": { "in_channels": 16, "out_channels": 3, "kernel_size": 1, "stride": 1, "padding": 0 } } },
+    { "id": "print",    "type": "Print",             "position": { "x": 3220,  "y": 0 },     "data": { "params": { "label": "Predicted noise" } } }
+  ],
+  "edges": [
+    { "id": "trig_x",   "source": "start-1", "target": "x_in",     "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "trig_t",   "source": "start-1", "target": "t_scalar", "sourceHandle": "trigger", "type": "trigger" },
+
+    { "id": "e_t_emb",  "source": "t_scalar","target": "t_emb",    "sourceHandle": "tensor", "targetHandle": "timestep" },
+
+    { "id": "e_x_stem", "source": "x_in",   "target": "stem",     "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_stem_d1","source": "stem",   "target": "rb_d1",    "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_emb_d1", "source": "t_emb",  "target": "rb_d1",    "sourceHandle": "embedding", "targetHandle": "time_emb" },
+    { "id": "e_d1_pool","source": "rb_d1",  "target": "pool_d1",  "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_pool_d2","source": "pool_d1","target": "rb_d2",    "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_emb_d2", "source": "t_emb",  "target": "rb_d2",    "sourceHandle": "embedding", "targetHandle": "time_emb" },
+    { "id": "e_d2_pool","source": "rb_d2",  "target": "pool_d2",  "sourceHandle": "tensor", "targetHandle": "tensor" },
+
+    { "id": "e_pool_bot","source": "pool_d2","target": "rb_bot",  "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_emb_bot", "source": "t_emb", "target": "rb_bot",   "sourceHandle": "embedding", "targetHandle": "time_emb" },
+
+    { "id": "e_bot_up2","source": "rb_bot", "target": "up_2",     "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_up2_cat","source": "up_2",   "target": "cat_2",    "sourceHandle": "tensor", "targetHandle": "tensor_a" },
+    { "id": "e_skip_d2","source": "rb_d2",  "target": "cat_2",    "sourceHandle": "tensor", "targetHandle": "tensor_b" },
+    { "id": "e_cat_u2", "source": "cat_2",  "target": "rb_u2",    "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_emb_u2", "source": "t_emb",  "target": "rb_u2",    "sourceHandle": "embedding", "targetHandle": "time_emb" },
+
+    { "id": "e_u2_up1", "source": "rb_u2",  "target": "up_1",     "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_up1_cat","source": "up_1",   "target": "cat_1",    "sourceHandle": "tensor", "targetHandle": "tensor_a" },
+    { "id": "e_skip_d1","source": "rb_d1",  "target": "cat_1",    "sourceHandle": "tensor", "targetHandle": "tensor_b" },
+    { "id": "e_cat_u1", "source": "cat_1",  "target": "rb_u1",    "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_emb_u1", "source": "t_emb",  "target": "rb_u1",    "sourceHandle": "embedding", "targetHandle": "time_emb" },
+
+    { "id": "e_u1_head","source": "rb_u1",  "target": "head",     "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_head_pr","source": "head",   "target": "print",    "sourceHandle": "tensor", "targetHandle": "value" }
+  ]
+}

--- a/examples/Diffusion/Toy-Sampling/graph.json
+++ b/examples/Diffusion/Toy-Sampling/graph.json
@@ -1,0 +1,18 @@
+{
+  "name": "Toy Sampling: reverse diffusion with an untrained U-Net",
+  "description": "The reverse-diffusion sampling loop, using a freshly-initialized (untrained) `DiffusionUNet`. Because the model isn't trained, the final 'image' is meaningless noise — but the *trajectory* and the *schedule arithmetic* are exactly what a trained Stable Diffusion does. Watch the DDPMSampler node: 20 reverse-diffusion steps, each calling the U-Net once with a different timestep. To get a meaningful output you'd need to train the U-Net (separate workflow); this preset is about teaching the sampling math, not generating pretty pictures.",
+  "nodes": [
+    { "id": "start-1",  "type": "Start", "position": { "x": -260, "y": 0 }, "data": { "params": {} } },
+    { "id": "noise",    "type": "GaussianNoise", "position": { "x": 0,    "y": 80 }, "data": { "params": { "shape": "1,3,16,16", "mean": 0, "std": 1, "seed": 42 } } },
+    { "id": "unet",     "type": "DiffusionUNet",  "position": { "x": 320,  "y": -80 }, "data": { "params": { "in_channels": 3, "base_channels": 16, "channel_mult": "1,2,4", "time_emb_dim": 32, "num_groups": 4, "seed": 42 } } },
+    { "id": "sampler",  "type": "DDPMSampler",    "position": { "x": 660,  "y": 0 }, "data": { "params": { "num_steps": 20, "schedule": "linear", "beta_start": 0.0001, "beta_end": 0.02, "seed": 7 } } },
+    { "id": "print",    "type": "Print",          "position": { "x": 1000, "y": 0 }, "data": { "params": { "label": "Final x_0 (untrained → noise)" } } }
+  ],
+  "edges": [
+    { "id": "trig_noise", "source": "start-1", "target": "noise",   "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "trig_unet",  "source": "start-1", "target": "unet",    "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "e_model",   "source": "unet",    "target": "sampler", "sourceHandle": "model", "targetHandle": "model" },
+    { "id": "e_noise",   "source": "noise",   "target": "sampler", "sourceHandle": "noise", "targetHandle": "noise" },
+    { "id": "e_out",     "source": "sampler", "target": "print",   "sourceHandle": "image", "targetHandle": "value" }
+  ]
+}

--- a/examples/Model_Architecture/UNet-Segmentation-CNN/graph.json
+++ b/examples/Model_Architecture/UNet-Segmentation-CNN/graph.json
@@ -1,59 +1,64 @@
 {
   "name": "UNet for Image Segmentation",
-  "description": "Classic 2-level UNet showing encoder-decoder architecture with Concat-based skip connections from encoder features into the decoder.",
+  "description": "Classic two-level U-Net wired in full so every encoder Conv, every MaxPool, every ConvTranspose, and every Concat-based skip is visible on the canvas. A 32×32 RGB image flows through: Lv1 Conv→ReLU at 32×32 (skip saved), MaxPool to 16×16, Lv2 Conv→ReLU (skip saved), MaxPool to 8×8, bottleneck Conv→ReLU, then mirror back up — ConvTranspose to 16×16, Concat with the Lv2 skip (channel-wise), Conv→ReLU, ConvTranspose to 32×32, Concat with the Lv1 skip, Conv→ReLU, finishing with a 1×1 head Conv that projects to a single segmentation channel. The skip-Concat edges (encoder→decoder) cross the canvas — those are the U-shape that gives the architecture its name.",
   "nodes": [
-    {
-      "id": "start-1",
-      "type": "Start",
-      "position": {
-        "x": -150,
-        "y": 200
-      },
-      "data": {
-        "params": {}
-      }
-    },
-    {
-      "id": "model-builder",
-      "type": "SequentialModel",
-      "position": {
-        "x": 50,
-        "y": 200
-      },
-      "data": {
-        "params": {
-          "layers": "{\"version\": 2, \"nodes\": [{\"id\": \"in\", \"type\": \"Input\", \"ports\": [{\"id\": \"p_x\", \"name\": \"x\"}]}, {\"id\": \"e1c1\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 3, \"out_channels\": 16, \"kernel_size\": 3, \"padding\": 1}}, {\"id\": \"e1r1\", \"type\": \"ReLU\"}, {\"id\": \"e1c2\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 16, \"out_channels\": 16, \"kernel_size\": 3, \"padding\": 1}}, {\"id\": \"e1r2\", \"type\": \"ReLU\"}, {\"id\": \"p1\", \"type\": \"MaxPool2d\", \"params\": {\"kernel_size\": 2, \"stride\": 2}}, {\"id\": \"e2c1\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 16, \"out_channels\": 32, \"kernel_size\": 3, \"padding\": 1}}, {\"id\": \"e2r1\", \"type\": \"ReLU\"}, {\"id\": \"e2c2\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 32, \"out_channels\": 32, \"kernel_size\": 3, \"padding\": 1}}, {\"id\": \"e2r2\", \"type\": \"ReLU\"}, {\"id\": \"p2\", \"type\": \"MaxPool2d\", \"params\": {\"kernel_size\": 2, \"stride\": 2}}, {\"id\": \"bnc1\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 32, \"out_channels\": 64, \"kernel_size\": 3, \"padding\": 1}}, {\"id\": \"bnr1\", \"type\": \"ReLU\"}, {\"id\": \"bnc2\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 64, \"out_channels\": 64, \"kernel_size\": 3, \"padding\": 1}}, {\"id\": \"bnr2\", \"type\": \"ReLU\"}, {\"id\": \"u2\", \"type\": \"ConvTranspose2d\", \"params\": {\"in_channels\": 64, \"out_channels\": 32, \"kernel_size\": 2, \"stride\": 2}}, {\"id\": \"cat2\", \"type\": \"Concat\", \"params\": {\"dim\": 1}}, {\"id\": \"d2c1\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 64, \"out_channels\": 32, \"kernel_size\": 3, \"padding\": 1}}, {\"id\": \"d2r1\", \"type\": \"ReLU\"}, {\"id\": \"d2c2\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 32, \"out_channels\": 32, \"kernel_size\": 3, \"padding\": 1}}, {\"id\": \"d2r2\", \"type\": \"ReLU\"}, {\"id\": \"u1\", \"type\": \"ConvTranspose2d\", \"params\": {\"in_channels\": 32, \"out_channels\": 16, \"kernel_size\": 2, \"stride\": 2}}, {\"id\": \"cat1\", \"type\": \"Concat\", \"params\": {\"dim\": 1}}, {\"id\": \"d1c1\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 32, \"out_channels\": 16, \"kernel_size\": 3, \"padding\": 1}}, {\"id\": \"d1r1\", \"type\": \"ReLU\"}, {\"id\": \"d1c2\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 16, \"out_channels\": 16, \"kernel_size\": 3, \"padding\": 1}}, {\"id\": \"d1r2\", \"type\": \"ReLU\"}, {\"id\": \"head\", \"type\": \"Conv2d\", \"params\": {\"in_channels\": 16, \"out_channels\": 1, \"kernel_size\": 1}}, {\"id\": \"out\", \"type\": \"Output\", \"ports\": [{\"id\": \"p_y\", \"name\": \"y\"}]}], \"edges\": [{\"id\": \"e1\", \"source\": \"in\", \"sourceHandle\": \"p_x\", \"target\": \"e1c1\"}, {\"id\": \"e2\", \"source\": \"e1c1\", \"target\": \"e1r1\"}, {\"id\": \"e3\", \"source\": \"e1r1\", \"target\": \"e1c2\"}, {\"id\": \"e4\", \"source\": \"e1c2\", \"target\": \"e1r2\"}, {\"id\": \"e5\", \"source\": \"e1r2\", \"target\": \"p1\"}, {\"id\": \"e6\", \"source\": \"p1\", \"target\": \"e2c1\"}, {\"id\": \"e7\", \"source\": \"e2c1\", \"target\": \"e2r1\"}, {\"id\": \"e8\", \"source\": \"e2r1\", \"target\": \"e2c2\"}, {\"id\": \"e9\", \"source\": \"e2c2\", \"target\": \"e2r2\"}, {\"id\": \"e10\", \"source\": \"e2r2\", \"target\": \"p2\"}, {\"id\": \"e11\", \"source\": \"p2\", \"target\": \"bnc1\"}, {\"id\": \"e12\", \"source\": \"bnc1\", \"target\": \"bnr1\"}, {\"id\": \"e13\", \"source\": \"bnr1\", \"target\": \"bnc2\"}, {\"id\": \"e14\", \"source\": \"bnc2\", \"target\": \"bnr2\"}, {\"id\": \"e15\", \"source\": \"bnr2\", \"target\": \"u2\"}, {\"id\": \"e16\", \"source\": \"u2\", \"target\": \"cat2\"}, {\"id\": \"e17\", \"source\": \"e2r2\", \"target\": \"cat2\"}, {\"id\": \"e18\", \"source\": \"cat2\", \"target\": \"d2c1\"}, {\"id\": \"e19\", \"source\": \"d2c1\", \"target\": \"d2r1\"}, {\"id\": \"e20\", \"source\": \"d2r1\", \"target\": \"d2c2\"}, {\"id\": \"e21\", \"source\": \"d2c2\", \"target\": \"d2r2\"}, {\"id\": \"e22\", \"source\": \"d2r2\", \"target\": \"u1\"}, {\"id\": \"e23\", \"source\": \"u1\", \"target\": \"cat1\"}, {\"id\": \"e24\", \"source\": \"e1r2\", \"target\": \"cat1\"}, {\"id\": \"e25\", \"source\": \"cat1\", \"target\": \"d1c1\"}, {\"id\": \"e26\", \"source\": \"d1c1\", \"target\": \"d1r1\"}, {\"id\": \"e27\", \"source\": \"d1r1\", \"target\": \"d1c2\"}, {\"id\": \"e28\", \"source\": \"d1c2\", \"target\": \"d1r2\"}, {\"id\": \"e29\", \"source\": \"d1r2\", \"target\": \"head\"}, {\"id\": \"e30\", \"source\": \"head\", \"target\": \"out\", \"targetHandle\": \"p_y\"}]}"
-        }
-      }
-    },
-    {
-      "id": "print-model",
-      "type": "Print",
-      "position": {
-        "x": 500,
-        "y": 200
-      },
-      "data": {
-        "params": {
-          "label": "UNet model"
-        }
-      }
-    }
+    { "id": "start-1",   "type": "Start", "position": { "x": -260, "y": 0 }, "data": { "params": {} } },
+
+    { "id": "x_in",      "type": "TensorCreate", "position": { "x": -40,   "y": 0 }, "data": { "params": { "shape": "1,3,32,32", "fill": "randn", "value": 0, "requires_grad": false } } },
+
+    { "id": "e1_conv",   "type": "Conv2d",     "position": { "x": 200,   "y": 0 },     "data": { "params": { "in_channels": 3, "out_channels": 16, "kernel_size": 3, "stride": 1, "padding": 1 } } },
+    { "id": "e1_relu",   "type": "Activation", "position": { "x": 380,   "y": 0 },     "data": { "params": { "function": "relu" } } },
+
+    { "id": "pool1",     "type": "MaxPool2d",  "position": { "x": 540,   "y": 0 },     "data": { "params": { "kernel_size": 2, "stride": 2 } } },
+
+    { "id": "e2_conv",   "type": "Conv2d",     "position": { "x": 720,   "y": 0 },     "data": { "params": { "in_channels": 16, "out_channels": 32, "kernel_size": 3, "stride": 1, "padding": 1 } } },
+    { "id": "e2_relu",   "type": "Activation", "position": { "x": 900,   "y": 0 },     "data": { "params": { "function": "relu" } } },
+
+    { "id": "pool2",     "type": "MaxPool2d",  "position": { "x": 1060,  "y": 0 },     "data": { "params": { "kernel_size": 2, "stride": 2 } } },
+
+    { "id": "bn_conv",   "type": "Conv2d",     "position": { "x": 1240,  "y": 0 },     "data": { "params": { "in_channels": 32, "out_channels": 64, "kernel_size": 3, "stride": 1, "padding": 1 } } },
+    { "id": "bn_relu",   "type": "Activation", "position": { "x": 1420,  "y": 0 },     "data": { "params": { "function": "relu" } } },
+
+    { "id": "up2",       "type": "ConvTranspose2d", "position": { "x": 1600, "y": 0 },  "data": { "params": { "in_channels": 64, "out_channels": 32, "kernel_size": 2, "stride": 2, "padding": 0, "output_padding": 0 } } },
+    { "id": "cat2",      "type": "Concat",     "position": { "x": 1820,  "y": 0 },     "data": { "params": { "dim": 1 } } },
+    { "id": "d2_conv",   "type": "Conv2d",     "position": { "x": 2020,  "y": 0 },     "data": { "params": { "in_channels": 64, "out_channels": 32, "kernel_size": 3, "stride": 1, "padding": 1 } } },
+    { "id": "d2_relu",   "type": "Activation", "position": { "x": 2200,  "y": 0 },     "data": { "params": { "function": "relu" } } },
+
+    { "id": "up1",       "type": "ConvTranspose2d", "position": { "x": 2380, "y": 0 },  "data": { "params": { "in_channels": 32, "out_channels": 16, "kernel_size": 2, "stride": 2, "padding": 0, "output_padding": 0 } } },
+    { "id": "cat1",      "type": "Concat",     "position": { "x": 2600,  "y": 0 },     "data": { "params": { "dim": 1 } } },
+    { "id": "d1_conv",   "type": "Conv2d",     "position": { "x": 2800,  "y": 0 },     "data": { "params": { "in_channels": 32, "out_channels": 16, "kernel_size": 3, "stride": 1, "padding": 1 } } },
+    { "id": "d1_relu",   "type": "Activation", "position": { "x": 2980,  "y": 0 },     "data": { "params": { "function": "relu" } } },
+
+    { "id": "head",      "type": "Conv2d",     "position": { "x": 3160,  "y": 0 },     "data": { "params": { "in_channels": 16, "out_channels": 1, "kernel_size": 1, "stride": 1, "padding": 0 } } },
+    { "id": "print",     "type": "Print",      "position": { "x": 3360,  "y": 0 },     "data": { "params": { "label": "Segmentation mask" } } }
   ],
   "edges": [
-    {
-      "id": "e1",
-      "source": "model-builder",
-      "target": "print-model",
-      "sourceHandle": "model",
-      "targetHandle": "value"
-    },
-    {
-      "id": "e-trigger-1",
-      "source": "start-1",
-      "target": "model-builder",
-      "sourceHandle": "trigger",
-      "type": "trigger"
-    }
+    { "id": "trig", "source": "start-1", "target": "x_in", "sourceHandle": "trigger", "type": "trigger" },
+
+    { "id": "e_xin_e1c", "source": "x_in",   "target": "e1_conv", "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_e1c_e1r", "source": "e1_conv","target": "e1_relu", "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_e1r_p1",  "source": "e1_relu","target": "pool1",   "sourceHandle": "tensor", "targetHandle": "tensor" },
+
+    { "id": "e_p1_e2c",  "source": "pool1",  "target": "e2_conv", "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_e2c_e2r", "source": "e2_conv","target": "e2_relu", "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_e2r_p2",  "source": "e2_relu","target": "pool2",   "sourceHandle": "tensor", "targetHandle": "tensor" },
+
+    { "id": "e_p2_bnc",  "source": "pool2",  "target": "bn_conv", "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_bnc_bnr", "source": "bn_conv","target": "bn_relu", "sourceHandle": "tensor", "targetHandle": "tensor" },
+
+    { "id": "e_bnr_up2", "source": "bn_relu","target": "up2",     "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_up2_cat", "source": "up2",    "target": "cat2",    "sourceHandle": "tensor", "targetHandle": "tensor_a" },
+    { "id": "e_skip2",   "source": "e2_relu","target": "cat2",    "sourceHandle": "tensor", "targetHandle": "tensor_b" },
+    { "id": "e_cat2_d2c","source": "cat2",   "target": "d2_conv", "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_d2c_d2r", "source": "d2_conv","target": "d2_relu", "sourceHandle": "tensor", "targetHandle": "tensor" },
+
+    { "id": "e_d2r_up1", "source": "d2_relu","target": "up1",     "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_up1_cat", "source": "up1",    "target": "cat1",    "sourceHandle": "tensor", "targetHandle": "tensor_a" },
+    { "id": "e_skip1",   "source": "e1_relu","target": "cat1",    "sourceHandle": "tensor", "targetHandle": "tensor_b" },
+    { "id": "e_cat1_d1c","source": "cat1",   "target": "d1_conv", "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_d1c_d1r", "source": "d1_conv","target": "d1_relu", "sourceHandle": "tensor", "targetHandle": "tensor" },
+
+    { "id": "e_d1r_head","source": "d1_relu","target": "head",    "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_head_pr", "source": "head",   "target": "print",   "sourceHandle": "tensor", "targetHandle": "value" }
   ]
 }

--- a/frontend/src/components/Canvas/FlowCanvas.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.tsx
@@ -27,6 +27,7 @@ import EduSelfAttentionVizNode from '../Nodes/EduSelfAttentionVizNode';
 import EduMultiHeadAttentionVizNode from '../Nodes/EduMultiHeadAttentionVizNode';
 import AttentionHeatmapVizNode from '../Nodes/AttentionHeatmapVizNode';
 import AttentionMaskVizNode from '../Nodes/AttentionMaskVizNode';
+import EduCrossAttentionVizNode from '../Nodes/EduCrossAttentionVizNode';
 import { CustomConnectionLine } from './CustomConnectionLine';
 import { SmartDataEdge } from './SmartDataEdge';
 import { TriggerEdge } from './TriggerEdge';
@@ -63,6 +64,7 @@ const nodeTypes: NodeTypes = {
   eduMultiHeadAttentionNode: EduMultiHeadAttentionVizNode,
   attentionHeatmapNode: AttentionHeatmapVizNode,
   attentionMaskNode: AttentionMaskVizNode,
+  eduCrossAttentionNode: EduCrossAttentionVizNode,
 };
 
 const edgeTypes: EdgeTypes = {

--- a/frontend/src/components/Nodes/EduCrossAttentionVizNode.tsx
+++ b/frontend/src/components/Nodes/EduCrossAttentionVizNode.tsx
@@ -1,0 +1,113 @@
+import { memo, useMemo, useState } from 'react';
+import type { NodeProps } from '@xyflow/react';
+import type { AppNode } from '../../types';
+import { useTabStore } from '../../store/tabStore';
+import { useI18n } from '../../i18n';
+import { HeatmapPlot } from '../shared/HeatmapPlot';
+import { HeatmapModal } from '../shared/HeatmapModal';
+import { BaseNodeBody } from './BaseNode';
+import styles from './AttentionVizNode.module.css';
+
+/**
+ * Inline cross-attention heatmap. Shape is [H, Q_seq, K_seq] (or
+ * [batch, H, Q_seq, K_seq] when batched). Q and K may have different
+ * lengths so the heatmap is rectangular — q_labels go on the row
+ * axis, k_labels on the column axis.
+ */
+function EduCrossAttentionVizNode(props: NodeProps<AppNode>) {
+  const { id, data } = props;
+  const { t } = useI18n();
+  const summaries = useTabStore((s) => {
+    const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
+    return tab?.outputSummaries?.[id];
+  });
+  const runId = useTabStore((s) => {
+    const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
+    return tab?.lastRunId ?? null;
+  });
+
+  const [expanded, setExpanded] = useState(false);
+
+  const heads = useMemo<number[][][] | null>(() => {
+    const v = summaries?.weights?.values;
+    if (!Array.isArray(v) || v.length === 0) return null;
+    if (Array.isArray(v[0]) && Array.isArray(v[0][0]) && Array.isArray((v[0][0] as unknown[])[0])) {
+      // 4D — [B, H, Q_seq, K_seq] → take batch=0.
+      return (v as unknown as number[][][][])[0];
+    }
+    return v as unknown as number[][][];
+  }, [summaries]);
+
+  const qLabels = useMemo<string[] | undefined>(() => {
+    const lv = summaries?.q_labels?.values;
+    if (!Array.isArray(lv) || lv.length === 0) return undefined;
+    return lv.map((s) => String(s));
+  }, [summaries]);
+
+  const kLabels = useMemo<string[] | undefined>(() => {
+    const lv = summaries?.k_labels?.values;
+    if (!Array.isArray(lv) || lv.length === 0) return undefined;
+    return lv.map((s) => String(s));
+  }, [summaries]);
+
+  const numHeads = heads?.length ?? Number(data.params?.num_heads ?? 0);
+  const hasShape = !!summaries?.weights;
+  const panelSize = numHeads >= 4 ? 140 : 180;
+
+  const bodyExtra = (
+    <div className={styles.vizArea}>
+      {heads === null && !hasShape && (
+        <div className={styles.emptyHint}>{t('attention.runHint')}</div>
+      )}
+      {heads === null && hasShape && (
+        <div className={styles.tooBigHint}>
+          <div>{t('attention.tooLargeInline')}</div>
+          <button
+            type="button"
+            className={styles.expandLink}
+            onClick={() => setExpanded(true)}
+          >
+            {t('attention.viewFull')} →
+          </button>
+        </div>
+      )}
+      {heads !== null && (
+        <>
+          <HeatmapPlot
+            data={heads}
+            rowLabels={qLabels}
+            colLabels={kLabels}
+            panelWidth={panelSize}
+            panelHeight={panelSize}
+            onExpand={() => setExpanded(true)}
+            normalizePerRow
+            // Cross-attention is always rectangular and lives outside the
+            // causal regime — don't try to detect a causal pattern.
+            detectCausalMask={false}
+          />
+          <div className={styles.metaRow}>
+            <span>{t('attention.heads', { count: numHeads })}</span>
+            <span>cross-attn [Q × K]</span>
+          </div>
+        </>
+      )}
+      <HeatmapModal
+        isOpen={expanded}
+        onClose={() => setExpanded(false)}
+        title={`EduCrossAttention · ${data.label ?? id}`}
+        inlineData={heads}
+        rowLabels={qLabels}
+        colLabels={kLabels}
+        runId={runId}
+        nodeId={id}
+        port="weights"
+        detectCausalMask={false}
+        normalizePerRow
+      />
+    </div>
+  );
+
+  return <BaseNodeBody {...props} bodyExtra={bodyExtra} />;
+}
+
+export default memo(EduCrossAttentionVizNode);

--- a/frontend/src/components/Sidebar/NodePalette.tsx
+++ b/frontend/src/components/Sidebar/NodePalette.tsx
@@ -8,7 +8,7 @@ import type { NodeDefinition, PresetDefinition } from '../../types';
 import { CATEGORY_COLORS, DIFFICULTY_COLORS } from '../../styles/theme';
 import styles from './NodePalette.module.css';
 
-const CATEGORY_ORDER = ['Control', 'Data', 'IO', 'CNN', 'Normalization', 'RNN', 'Transformer', 'LLM', 'RL', 'Training', 'Tensor Operations', 'Utility'];
+const CATEGORY_ORDER = ['Control', 'Data', 'IO', 'CNN', 'Normalization', 'RNN', 'Transformer', 'LLM', 'Diffusion', 'RL', 'Training', 'Tensor Operations', 'Utility'];
 const BEGINNER_CATEGORIES = new Set(['Data', 'CNN', 'Training', 'IO']);
 
 // ── Operation Node Item ──

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -5,6 +5,7 @@ export const CATEGORY_COLORS: Record<string, string> = {
   RNN: '#2196F3',
   Transformer: '#9C27B0',
   LLM: '#A78BFA',
+  Diffusion: '#EC4899',
   RL: '#FF9800',
   Data: '#00BCD4',
   Training: '#F44336',

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -16,6 +16,7 @@ export const VIZ_NODE_TYPES: Record<string, string> = {
   EduMultiHeadAttention: 'eduMultiHeadAttentionNode',
   AttentionHeatmap: 'attentionHeatmapNode',
   AttentionMask: 'attentionMaskNode',
+  EduCrossAttention: 'eduCrossAttentionNode',
 };
 
 export const DATA_TYPE_COLORS: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Adds **8 Diffusion-category nodes** for stable-diffusion / U-Net teaching: \`Upsample\`, \`Lerp\`, \`GaussianNoise\`, \`TimestepEmbedding\`, \`EduCrossAttention\`, \`EduResBlock\`, \`DiffusionUNet\` (meta-node, outputs MODEL), \`DDPMSampler\` (encapsulates the full reverse-diffusion loop).
- Frontend: new **Diffusion category** (#EC4899) inserted after LLM, plus an \`EduCrossAttentionVizNode\` that reuses the existing HeatmapPlot/HeatmapModal stack and supports rectangular Q×K weight matrices.
- 1 update + 5 new **example presets** under \`examples/Diffusion/\` and \`examples/Model_Architecture/\`.
- Fixes a previously latent **graph-engine cache bug** that surfaced when stacking the new ResBlocks: the cache-key computation silently dropped non-cacheable upstreams, returning stale tensors to downstream cacheable nodes (e.g. MaxPool after a stateful ResBlock).

## Why this matters

Pairs with the LLM/attention module from PR #14 to give CodefyUI a complete generative-vision teaching surface. Causal self-attention covered the LM side; cross-attention + diffusion covers the image side. Students can now go from "what is a U-Net" (the now-expanded segmentation preset) all the way to "how does Stable Diffusion sample" (Toy-Sampling preset) entirely offline with toy-sized models.

## What's in each commit

1. \`24c6842\` — backend: 8 nodes + 87 TDD tests
2. \`8d10493\` — frontend Diffusion category + EduCrossAttention viz wrapper + 5 new presets + 1 updated UNet preset
3. \`5ce57b6\` — graph engine cache-propagation fix + regression test

## Presets shipped

| Path | What it teaches |
| --- | --- |
| \`Diffusion/Cross-Attention-101\` | Q from one source, K/V from another — rectangular heatmap |
| \`Diffusion/Forward-Process\` | $x_t = \sqrt{\bar\alpha_t}x_0 + \sqrt{1-\bar\alpha_t}\epsilon$ via Lerp + TimestepEmbedding side branch |
| \`Diffusion/Mini-UNet-Expanded\` | 17-node fully-wired toy diffusion U-Net (ResBlocks + Concat skips) |
| \`Diffusion/Mini-UNet-Compact\` | Same architecture as one \`DiffusionUNet\` meta-node + 1-step DDPM |
| \`Diffusion/Toy-Sampling\` | Full 20-step reverse diffusion with an untrained U-Net |
| \`Model_Architecture/UNet-Segmentation-CNN\` (updated) | Was 3 visible nodes hiding the architecture inside SequentialModel JSON; now fully expanded with explicit Concat skip edges |

## Cache-engine fix

When upstream is non-cacheable (any \`StatefulModuleMixin\` layer), the existing code dropped its contribution from \`upstream_keys\` instead of marking the downstream as also non-cacheable. A second run with different upstream-output channels would still hit the stale cache, returning a tensor with wrong shape. Fix: if any upstream is non-cacheable, skip the cache for the current node too — the non-cacheability now propagates correctly. Regression test added in \`tests/test_cache.py\`.

## Test plan

- [x] Backend: \`cd backend && uv run pytest -q\` → **443 passing** (355 baseline + 87 new node tests + 1 cache regression)
- [x] Frontend: \`cd frontend && pnpm vitest run\` → **90 passing** (no new tests; viz wrapper reuses existing HeatmapPlot/HeatmapModal coverage)
- [x] \`pnpm tsc -b\` clean
- [x] Manual Chrome verification of all 6 presets:
  - Cross-Attention-101: 4/4 nodes completed, 48 cells (rectangular [Q=6, K=4] × 2 heads)
  - Forward-Process: 7/7 completed
  - Mini-UNet-Compact: 4/4 completed (1-step DDPM through meta-node)
  - Toy-Sampling: 4/4 completed (20-step reverse diffusion)
  - Mini-UNet-Expanded: 17/17 completed (after the cache fix)
  - UNet-Segmentation-CNN: 19/19 completed (newly expanded form)

## Roadmap (not in this PR)

- Real HF SD weights via \`asset_cache.resolve(...)\` (already wired for GloVe-style assets — same pattern, just new specs)
- VAE encoder/decoder for proper latent diffusion
- CLIP text encoder for prompt conditioning
- Trained checkpoint for the toy U-Net so Toy-Sampling produces something interpretable

🤖 Generated with [Claude Code](https://claude.com/claude-code)