### PR TITLE
feat(ui): replace native window.confirm/prompt with in-app dialogs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { PresetConfigModal } from './components/PresetModal/PresetConfigModal';
 import { SubgraphEditorModal } from './components/SubgraphEditor/SubgraphEditorModal';
 import { ToastContainer } from './components/shared/Toast';
 import { ShortcutsModal } from './components/shared/ShortcutsModal';
+import { DialogContainer } from './components/shared/DialogContainer';
 import { useTabStore } from './store/tabStore';
 import { useUIStore } from './store/uiStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -91,6 +92,7 @@ function App() {
       <SubgraphEditorModal />
       <ToastContainer />
       <ShortcutsModal />
+      <DialogContainer />
     </div>
   );
 }

--- a/frontend/src/components/Canvas/FlowCanvas.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.tsx
@@ -48,6 +48,7 @@ import { useTabStore } from '../../store/tabStore';
 import { useUIStore } from '../../store/uiStore';
 import { useDragAndDrop } from '../../hooks/useDragAndDrop';
 import { isValidConnection, getPortColor } from '../../utils';
+import { prompt } from '../../utils/dialog';
 import { useNodeDefStore } from '../../store/nodeDefStore';
 import { useI18n } from '../../i18n';
 import type { OutputSummary } from '../../types';
@@ -399,10 +400,13 @@ export function FlowCanvas() {
   );
 
   const handleRename = useCallback(
-    (nodeId: string) => {
+    async (nodeId: string) => {
       const node = activeTab.nodes.find((n) => n.id === nodeId);
       const currentLabel = node?.data.label ?? '';
-      const newLabel = window.prompt(t('contextMenu.rename.prompt'), currentLabel);
+      const newLabel = await prompt({
+        title: t('contextMenu.rename.prompt'),
+        defaultValue: currentLabel,
+      });
       if (newLabel !== null && newLabel.trim()) {
         renameNode(nodeId, newLabel.trim());
       }

--- a/frontend/src/components/CustomNodeManager/CustomNodeManager.tsx
+++ b/frontend/src/components/CustomNodeManager/CustomNodeManager.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { listCustomNodes, toggleCustomNode, uploadCustomNode, deleteCustomNode, type CustomNodeInfo } from '../../api/rest';
 import { useNodeDefStore } from '../../store/nodeDefStore';
 import { useI18n } from '../../i18n';
+import { confirm } from '../../utils/dialog';
 import styles from './CustomNodeManager.module.css';
 
 interface CustomNodeManagerProps {
@@ -45,7 +46,12 @@ export function CustomNodeManager({ open, onClose }: CustomNodeManagerProps) {
   }, [fetchNodes, reload]);
 
   const handleDelete = useCallback(async (filename: string) => {
-    if (!window.confirm(t('customNodes.delete.confirm', { name: filename }))) return;
+    const ok = await confirm({
+      title: t('customNodes.delete.confirm', { name: filename }),
+      confirmText: 'Delete',
+      variant: 'danger',
+    });
+    if (!ok) return;
     try {
       await deleteCustomNode(filename);
       await fetchNodes();

--- a/frontend/src/components/TabBar/TabBar.tsx
+++ b/frontend/src/components/TabBar/TabBar.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useTabStore } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
+import { confirm } from '../../utils/dialog';
 import styles from './TabBar.module.css';
 
 export function TabBar() {
@@ -28,12 +29,16 @@ export function TabBar() {
   }, [editingId, editingName, renameTab]);
 
   const handleClose = useCallback(
-    (e: React.MouseEvent, id: string) => {
+    async (e: React.MouseEvent, id: string) => {
       e.stopPropagation();
       if (tabs.length <= 1) return;
       const tab = tabs.find((t) => t.id === id);
       if (tab && tab.status === 'running') {
-        if (!window.confirm(t('tabs.closeRunning'))) return;
+        const ok = await confirm({
+          title: t('tabs.closeRunning'),
+          variant: 'danger',
+        });
+        if (!ok) return;
       }
       removeTab(id);
     },

--- a/frontend/src/components/Toolbar/SettingsPopover.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '../../i18n';
 import { resetWeights } from '../../api/rest';
 import { computeSegmentNodes } from '../../utils/segmentPath';
 import { generateId } from '../../utils';
+import { confirm } from '../../utils/dialog';
 import styles from './SettingsPopover.module.css';
 
 interface Props {
@@ -76,7 +77,12 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
 
   const handleResetWeights = async () => {
     if (!graphId) return;
-    if (!window.confirm(t('toolbar.weights.resetAllConfirm'))) return;
+    const ok = await confirm({
+      title: t('toolbar.weights.resetAllConfirm'),
+      confirmText: t('toolbar.weights.resetAll'),
+      variant: 'danger',
+    });
+    if (!ok) return;
     try {
       const r = await resetWeights(graphId);
       addToast(`${t('toolbar.weights.resetAllOk')} (${r.evicted})`, 'success');

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -7,6 +7,7 @@ import { saveGraph, loadGraph, listGraphs, createPreset, exportGraph } from '../
 import { useI18n, SUPPORTED_LOCALES } from '../../i18n';
 import type { TranslationKey } from '../../i18n';
 import { resolveSerializedNodes, resolveSerializedEdges } from '../../utils';
+import { confirm, prompt } from '../../utils/dialog';
 import { CustomNodeManager } from '../CustomNodeManager/CustomNodeManager';
 import { useToastStore } from '../../store/toastStore';
 import type { LayoutMode } from '../../utils/autoLayout';
@@ -222,7 +223,10 @@ export function Toolbar() {
   const handleStop = useCallback(() => stop(), [stop]);
 
   const handleSave = useCallback(async () => {
-    const name = window.prompt(t('toolbar.save.prompt'));
+    const name = await prompt({
+      title: t('toolbar.save.prompt'),
+      placeholder: 'graph-name',
+    });
     if (!name?.trim()) return;
     try {
       const { nodes, edges, presets } = getSerializedGraph();
@@ -233,8 +237,13 @@ export function Toolbar() {
     }
   }, [getSerializedGraph, t, addToast]);
 
-  const handleClear = useCallback(() => {
-    if (window.confirm(t('toolbar.clear.confirm'))) clear();
+  const handleClear = useCallback(async () => {
+    const ok = await confirm({
+      title: t('toolbar.clear.confirm'),
+      confirmText: t('toolbar.clear'),
+      variant: 'danger',
+    });
+    if (ok) clear();
   }, [clear, t]);
 
   const handleLoadGraph = useCallback(
@@ -326,7 +335,10 @@ export function Toolbar() {
       addToast(t('toolbar.export.empty'), 'warning');
       return;
     }
-    const name = window.prompt(t('toolbar.export.prompt'));
+    const name = await prompt({
+      title: t('toolbar.export.prompt'),
+      placeholder: 'preset-name',
+    });
     if (!name?.trim()) return;
     try {
       await createPreset({ name: name.trim(), nodes, edges });

--- a/frontend/src/components/shared/DialogContainer.module.css
+++ b/frontend/src/components/shared/DialogContainer.module.css
@@ -1,0 +1,140 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 24px;
+}
+
+.dialog {
+  background: linear-gradient(180deg, #0e1520 0%, #0a0f17 100%);
+  border: 1px solid #1f2937;
+  border-radius: 8px;
+  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.7),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  min-width: 360px;
+  max-width: min(560px, 92vw);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid #1f2937;
+  background: rgba(10, 15, 23, 0.6);
+}
+
+.title {
+  color: #e5e7eb;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.message {
+  color: #cbd5e1;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.input {
+  background: #0a0f17;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  padding: 8px 10px;
+  color: #e5e7eb;
+  font-size: 13px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  outline: none;
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+
+.input:focus {
+  border-color: #06b6d4;
+  box-shadow: 0 0 0 2px rgba(6, 182, 212, 0.15);
+}
+
+.error {
+  color: #fca5a5;
+  font-size: 11px;
+  font-style: italic;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+.cancelBtn {
+  background: transparent;
+  border: 1px solid #334155;
+  color: #cbd5e1;
+  padding: 6px 14px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.cancelBtn:hover {
+  background: #1f2937;
+  border-color: #475569;
+  color: #e5e7eb;
+}
+
+.confirmBtn {
+  background: #0e7490;
+  border: 1px solid #06b6d4;
+  color: #ffffff;
+  padding: 6px 14px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 4px 12px -4px rgba(6, 182, 212, 0.4);
+  transition: background 0.12s, box-shadow 0.12s;
+}
+
+.confirmBtn:hover {
+  background: #06b6d4;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    0 6px 14px -6px rgba(6, 182, 212, 0.55);
+}
+
+.confirmBtn:focus-visible {
+  outline: 2px solid #67e8f9;
+  outline-offset: 2px;
+}
+
+.confirmBtn.danger {
+  background: #b91c1c;
+  border-color: #ef4444;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 4px 12px -4px rgba(239, 68, 68, 0.4);
+}
+
+.confirmBtn.danger:hover {
+  background: #dc2626;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    0 6px 14px -6px rgba(239, 68, 68, 0.55);
+}

--- a/frontend/src/components/shared/DialogContainer.test.tsx
+++ b/frontend/src/components/shared/DialogContainer.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DialogContainer } from './DialogContainer';
+import { useDialogStore } from '../../store/dialogStore';
+import { confirm, prompt } from '../../utils/dialog';
+
+describe('DialogContainer', () => {
+  beforeEach(() => {
+    useDialogStore.setState({ active: null, resolve: null });
+  });
+
+  it('renders nothing when no dialog is active', () => {
+    const { container } = render(<DialogContainer />);
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('renders confirm dialog with title and message', async () => {
+    render(<DialogContainer />);
+    confirm({ title: 'Delete graph?', message: 'This cannot be undone.' });
+    expect(await screen.findByText('Delete graph?')).toBeTruthy();
+    expect(await screen.findByText('This cannot be undone.')).toBeTruthy();
+  });
+
+  it('clicking confirm button resolves true', async () => {
+    render(<DialogContainer />);
+    const p = confirm({ title: 'OK?', confirmText: 'Yes' });
+    fireEvent.click(await screen.findByText('Yes'));
+    await expect(p).resolves.toBe(true);
+  });
+
+  it('clicking cancel button resolves false', async () => {
+    render(<DialogContainer />);
+    const p = confirm({ title: 'OK?', cancelText: 'No' });
+    fireEvent.click(await screen.findByText('No'));
+    await expect(p).resolves.toBe(false);
+  });
+
+  it('clicking backdrop resolves cancel', async () => {
+    render(<DialogContainer />);
+    const p = confirm({ title: 'X' });
+    // Wait for portal to render the backdrop.
+    await screen.findByText('X');
+    const backdrop = document.querySelector('[role="dialog"]') as HTMLElement;
+    fireEvent.click(backdrop);
+    await expect(p).resolves.toBe(false);
+  });
+
+  it('Escape resolves cancel', async () => {
+    render(<DialogContainer />);
+    const p = confirm({ title: 'X' });
+    await screen.findByText('X');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await expect(p).resolves.toBe(false);
+  });
+
+  it('renders prompt with input pre-filled with defaultValue', async () => {
+    render(<DialogContainer />);
+    prompt({ title: 'Rename', defaultValue: 'untitled' });
+    const input = (await screen.findByLabelText('Dialog input')) as HTMLInputElement;
+    expect(input.value).toBe('untitled');
+  });
+
+  it('typing + clicking confirm resolves with input value', async () => {
+    render(<DialogContainer />);
+    const p = prompt({ title: 'Name?', confirmText: 'OK' });
+    const input = (await screen.findByLabelText('Dialog input')) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'alice' } });
+    fireEvent.click(screen.getByText('OK'));
+    await expect(p).resolves.toBe('alice');
+  });
+
+  it('cancelling prompt resolves null', async () => {
+    render(<DialogContainer />);
+    const p = prompt({ title: 'Name?', cancelText: 'Cancel' });
+    fireEvent.click(await screen.findByText('Cancel'));
+    await expect(p).resolves.toBeNull();
+  });
+
+  it('danger variant adds danger class to the confirm button', async () => {
+    render(<DialogContainer />);
+    confirm({ title: 'Delete?', confirmText: 'Delete', variant: 'danger' });
+    const btn = (await screen.findByText('Delete')) as HTMLButtonElement;
+    expect(btn.className).toContain('danger');
+  });
+
+  it('validate hook blocks submit and shows the error', async () => {
+    render(<DialogContainer />);
+    const p = prompt({
+      title: 'Name?',
+      validate: (v) => (v.trim() ? null : 'Required'),
+    });
+    fireEvent.click(await screen.findByText('OK'));
+    expect(await screen.findByText('Required')).toBeTruthy();
+    // Promise is not yet resolved — fix the input and retry.
+    const input = (await screen.findByLabelText('Dialog input')) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'fine' } });
+    fireEvent.click(screen.getByText('OK'));
+    await expect(p).resolves.toBe('fine');
+  });
+});

--- a/frontend/src/components/shared/DialogContainer.tsx
+++ b/frontend/src/components/shared/DialogContainer.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useDialogStore } from '../../store/dialogStore';
+import styles from './DialogContainer.module.css';
+
+/**
+ * Renders the currently-active confirm / prompt dialog (or nothing when
+ * the store is empty). Mounted once at the App root, reads from
+ * ``useDialogStore``, calls ``store.close(value)`` to resolve the
+ * pending promise.
+ *
+ * Keyboard contract:
+ * - Escape  → cancel  (close with false / null)
+ * - Enter   → confirm (close with true / current input value)
+ *
+ * Visual: matches the HeatmapModal — dark gradient surface, teal
+ * accent on the primary action, danger variant uses a warm red. Auto-
+ * focuses the input (prompt) or the primary button (confirm).
+ */
+export function DialogContainer() {
+  const active = useDialogStore((s) => s.active);
+  const close = useDialogStore((s) => s.close);
+
+  const [inputValue, setInputValue] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const confirmBtnRef = useRef<HTMLButtonElement | null>(null);
+
+  // Reset input + focus the right element each time a new dialog opens.
+  useEffect(() => {
+    if (!active) return;
+    if (active.kind === 'prompt') {
+      setInputValue(active.defaultValue ?? '');
+      setValidationError(null);
+      // Focus + select the input on next paint so the default value is
+      // overwritable in one keystroke (matches native window.prompt UX).
+      setTimeout(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }, 0);
+    } else {
+      setTimeout(() => confirmBtnRef.current?.focus(), 0);
+    }
+  }, [active]);
+
+  // ESC cancels.
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close(active.kind === 'prompt' ? null : false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [active, close]);
+
+  if (!active) return null;
+
+  const variant = active.kind === 'confirm' ? active.variant ?? 'info' : 'info';
+  const cancelText = active.cancelText ?? 'Cancel';
+  const confirmText =
+    active.confirmText ?? (active.kind === 'prompt' ? 'OK' : 'Confirm');
+
+  function handleConfirm() {
+    if (!active) return;
+    if (active.kind === 'prompt') {
+      const validate = active.validate;
+      const err = validate ? validate(inputValue) : null;
+      if (err) {
+        setValidationError(err);
+        return;
+      }
+      close(inputValue);
+    } else {
+      close(true);
+    }
+  }
+
+  function handleCancel() {
+    if (!active) return;
+    close(active.kind === 'prompt' ? null : false);
+  }
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    handleConfirm();
+  }
+
+  return createPortal(
+    <div
+      className={styles.backdrop}
+      onClick={handleCancel}
+      role="dialog"
+      aria-modal="true"
+      aria-label={active.title}
+    >
+      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <span className={styles.title}>{active.title}</span>
+        </div>
+        <form onSubmit={onSubmit} className={styles.body}>
+          {active.message && (
+            <div className={styles.message}>{active.message}</div>
+          )}
+          {active.kind === 'prompt' && (
+            <>
+              <input
+                ref={inputRef}
+                type="text"
+                className={styles.input}
+                value={inputValue}
+                onChange={(e) => {
+                  setInputValue(e.target.value);
+                  if (validationError) setValidationError(null);
+                }}
+                placeholder={active.placeholder}
+                aria-label="Dialog input"
+              />
+              {validationError && (
+                <div className={styles.error}>{validationError}</div>
+              )}
+            </>
+          )}
+          <div className={styles.footer}>
+            <button
+              type="button"
+              className={styles.cancelBtn}
+              onClick={handleCancel}
+            >
+              {cancelText}
+            </button>
+            <button
+              ref={confirmBtnRef}
+              type="submit"
+              className={`${styles.confirmBtn} ${variant === 'danger' ? styles.danger : ''}`}
+            >
+              {confirmText}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/store/dialogStore.ts
+++ b/frontend/src/store/dialogStore.ts
@@ -1,0 +1,70 @@
+import { create } from 'zustand';
+
+/**
+ * In-app replacement for the browser's native ``window.confirm`` and
+ * ``window.prompt``. The native dialogs visually clash with the
+ * Crafted-dark IDE aesthetic and (in the case of ``confirm``) silently
+ * block the entire WebSocket / Chrome-extension interaction surface
+ * until dismissed — which has caused multiple "graph won't run"
+ * incidents during dev.
+ *
+ * Only one dialog can be open at a time. Code calls ``confirm({...})``
+ * or ``prompt({...})`` (in ../utils/dialog.ts) and awaits the result;
+ * the resolver lives on the store so the UI can call it from a button
+ * click without prop-drilling.
+ */
+
+export type DialogVariant = 'info' | 'danger';
+
+export interface ConfirmRequest {
+  kind: 'confirm';
+  title: string;
+  message?: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: DialogVariant;
+}
+
+export interface PromptRequest {
+  kind: 'prompt';
+  title: string;
+  message?: string;
+  defaultValue?: string;
+  placeholder?: string;
+  confirmText?: string;
+  cancelText?: string;
+  /** Optional input validator — return a string error message to block submit, or null when valid. */
+  validate?: (value: string) => string | null;
+}
+
+export type DialogRequest = ConfirmRequest | PromptRequest;
+
+interface DialogState {
+  /** The currently-open request, or null when nothing is showing. */
+  active: DialogRequest | null;
+  /** Resolver attached when the request was opened — called with the user's choice. */
+  resolve: ((value: boolean | string | null) => void) | null;
+  open: <T extends boolean | string | null>(
+    request: DialogRequest,
+    resolve: (value: T) => void,
+  ) => void;
+  close: (value: boolean | string | null) => void;
+}
+
+export const useDialogStore = create<DialogState>((set, get) => ({
+  active: null,
+  resolve: null,
+  open: (request, resolve) => {
+    // If a dialog is already open, resolve the previous one as cancelled
+    // (false / null) before replacing — keeps callers' promises from
+    // hanging forever if the app fires two confirms back-to-back.
+    const prior = get().resolve;
+    if (prior) prior(request.kind === 'prompt' ? null : false);
+    set({ active: request, resolve: resolve as (v: boolean | string | null) => void });
+  },
+  close: (value) => {
+    const r = get().resolve;
+    set({ active: null, resolve: null });
+    if (r) r(value);
+  },
+}));

--- a/frontend/src/utils/dialog.test.ts
+++ b/frontend/src/utils/dialog.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { confirm, prompt } from './dialog';
+import { useDialogStore } from '../store/dialogStore';
+
+describe('confirm()', () => {
+  beforeEach(() => {
+    // Reset store between tests so a leaked dialog from one doesn't pollute another.
+    useDialogStore.setState({ active: null, resolve: null });
+  });
+
+  it('opens a confirm request and resolves true on close(true)', async () => {
+    const p = confirm({ title: 'Delete?' });
+    const state = useDialogStore.getState();
+    expect(state.active?.kind).toBe('confirm');
+    expect(state.active?.title).toBe('Delete?');
+    state.close(true);
+    await expect(p).resolves.toBe(true);
+  });
+
+  it('resolves false on close(false)', async () => {
+    const p = confirm({ title: 'X' });
+    useDialogStore.getState().close(false);
+    await expect(p).resolves.toBe(false);
+  });
+
+  it('resolves false on close(null)', async () => {
+    const p = confirm({ title: 'X' });
+    useDialogStore.getState().close(null);
+    await expect(p).resolves.toBe(false);
+  });
+
+  it('opening a second dialog cancels the first', async () => {
+    const first = confirm({ title: 'first' });
+    const second = confirm({ title: 'second' });
+    // First should resolve as cancelled — second is the active one now.
+    await expect(first).resolves.toBe(false);
+    expect(useDialogStore.getState().active?.title).toBe('second');
+    useDialogStore.getState().close(true);
+    await expect(second).resolves.toBe(true);
+  });
+});
+
+describe('prompt()', () => {
+  beforeEach(() => {
+    useDialogStore.setState({ active: null, resolve: null });
+  });
+
+  it('resolves with the entered string on close(value)', async () => {
+    const p = prompt({ title: 'Name?' });
+    useDialogStore.getState().close('alice');
+    await expect(p).resolves.toBe('alice');
+  });
+
+  it('resolves null on close(null)', async () => {
+    const p = prompt({ title: 'Name?' });
+    useDialogStore.getState().close(null);
+    await expect(p).resolves.toBeNull();
+  });
+
+  it('resolves null on close(false) for prompt mode', async () => {
+    // Defensive: even though the UI never calls close(false) for prompts,
+    // the helper should normalise non-string returns to null.
+    const p = prompt({ title: 'Name?' });
+    useDialogStore.getState().close(false);
+    await expect(p).resolves.toBeNull();
+  });
+
+  it('exposes the request shape on the store', () => {
+    prompt({ title: 'Save as…', defaultValue: 'untitled', placeholder: 'name' });
+    const a = useDialogStore.getState().active;
+    expect(a?.kind).toBe('prompt');
+    if (a?.kind === 'prompt') {
+      expect(a.defaultValue).toBe('untitled');
+      expect(a.placeholder).toBe('name');
+    }
+  });
+});

--- a/frontend/src/utils/dialog.ts
+++ b/frontend/src/utils/dialog.ts
@@ -1,0 +1,54 @@
+import {
+  useDialogStore,
+  type ConfirmRequest,
+  type PromptRequest,
+} from '../store/dialogStore';
+
+/**
+ * Drop-in replacement for ``window.confirm``. Resolves true on confirm,
+ * false on cancel/escape/backdrop. Only one dialog can be open at a
+ * time — opening a second one cancels the first.
+ *
+ * @example
+ *   const ok = await confirm({
+ *     title: 'Clear canvas?',
+ *     message: 'All unsaved nodes and edges will be removed.',
+ *     confirmText: 'Clear',
+ *     variant: 'danger',
+ *   });
+ *   if (!ok) return;
+ *   clearCanvas();
+ */
+export function confirm(
+  request: Omit<ConfirmRequest, 'kind'>,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    useDialogStore.getState().open(
+      { kind: 'confirm', ...request },
+      (value) => resolve(value === true),
+    );
+  });
+}
+
+/**
+ * Drop-in replacement for ``window.prompt``. Resolves with the entered
+ * string on confirm, ``null`` on cancel/escape/backdrop.
+ *
+ * @example
+ *   const name = await prompt({
+ *     title: 'Save graph as…',
+ *     defaultValue: 'untitled-graph',
+ *     placeholder: 'name',
+ *   });
+ *   if (name === null) return;
+ */
+export function prompt(
+  request: Omit<PromptRequest, 'kind'>,
+): Promise<string | null> {
+  return new Promise<string | null>((resolve) => {
+    useDialogStore.getState().open(
+      { kind: 'prompt', ...request },
+      (value) => resolve(typeof value === 'string' ? value : null),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Replace 7 \`window.confirm()\` / \`window.prompt()\` calls with a custom in-app dialog system that matches the Crafted-dark aesthetic and doesn't block the main event loop the way native dialogs do.

## Why this matters

The browser's native modal dialogs hard-stop the entire application event loop until dismissed. During dev that has caused multiple incidents where the page appeared frozen — the WebSocket and the Chrome-extension driver both queue behind the blocked main thread, so 'graph won't run' / 'extension can't see the page' was actually 'a hidden \`window.confirm\` is waiting'. They also visually clash with the dark IDE aesthetic.

## What's new

### Dialog system

- \`store/dialogStore.ts\` — Zustand store with a single active \`ConfirmRequest\` or \`PromptRequest\`, plus a resolver attached on open.
- \`utils/dialog.ts\` — drop-in helpers:
  - \`confirm({ title, message?, confirmText?, cancelText?, variant? })\` → \`Promise<boolean>\`
  - \`prompt({ title, message?, defaultValue?, placeholder?, validate? })\` → \`Promise<string | null>\`
- \`components/shared/DialogContainer.tsx\` — mounted once at App root (alongside \`ToastContainer\`). Renders via portal, supports:
  - **ESC** → cancel
  - **Enter** → confirm (form submission)
  - **Backdrop click** → cancel
  - **Auto-focus** → input on prompt, primary button on confirm
  - **\`validate()\` hook** for inline error messages on prompt
  - **\`variant: 'danger'\`** for destructive actions (red primary button)

### Migrated 7 call sites

| File | Action | Variant |
| --- | --- | --- |
| \`Toolbar.tsx\` | Clear canvas | danger |
| \`Toolbar.tsx\` | Save graph (prompt) | — |
| \`Toolbar.tsx\` | Export preset (prompt) | — |
| \`SettingsPopover.tsx\` | Reset all weights | danger |
| \`TabBar.tsx\` | Close running tab | danger |
| \`CustomNodeManager.tsx\` | Delete custom node | danger |
| \`FlowCanvas.tsx\` | Rename node (prompt) | — |

\`grep -r 'window\.\(confirm\|prompt\|alert\)(' frontend/src\` returns nothing.

## Test plan

- [x] \`pnpm vitest run\` → **109/109** passing (19 new: 9 dialog.test.ts + 10 DialogContainer.test.tsx)
- [x] \`pnpm tsc -b\` clean
- [x] Manual Chrome verification:
  - Clear canvas → red Cancel/Clear dialog appears → Cancel keeps 39 nodes intact → Clear takes 39 → 0 nodes
  - Save graph → prompt dialog with auto-focused input → ESC closes
  - Both backdrop-click and ESC paths resolve as cancel for both dialog kinds

🤖 Generated with [Claude Code](https://claude.com/claude-code)