### PR TITLE
feat: production sklearn wrappers + RLHF + MoE (8 nodes)

### DIFF
--- a/backend/app/nodes/classical/__init__.py
+++ b/backend/app/nodes/classical/__init__.py
@@ -1,9 +1,12 @@
 """Classical machine-learning teaching nodes.
 
-Edu-style hand-written implementations of foundational classifiers and
-regressors — KNN, linear regression, logistic regression. They expose
-the core math (distances, normal equation, gradient descent) directly
-so a step trace can show each computation. Production users who just
-want sklearn behaviour go through the matching ``KNN`` /
-``LinearRegression`` / ``LogisticRegression`` wrapper nodes (next PR).
+Two parallel tracks:
+
+- ``Edu*`` — hand-written implementations that expose the core math
+  (distances, normal equation, gradient descent) for step-tracing.
+  Right for ≤200-row teaching datasets.
+- production wrappers (``KNN``, ``LinearRegression``,
+  ``LogisticRegression``, ``SVMClassifier``, ``DecisionTreeClassifier``)
+  — sklearn-backed, drop-in replacements that scale and add the full
+  knob set. Right for "the textbook is done, ship it."
 """

--- a/backend/app/nodes/classical/decision_tree_classifier_node.py
+++ b/backend/app/nodes/classical/decision_tree_classifier_node.py
@@ -1,0 +1,133 @@
+"""DecisionTreeClassifierNode — CART decision tree via sklearn.
+
+Recursively splits the feature space by maximising information gain (or Gini
+purity) at each node. Outputs:
+
+- ``predictions``: per-query class label.
+- ``feature_importances``: how much each feature contributed to the splits.
+- ``tree_text``: sklearn's human-readable rule dump — the killer feature
+  for teaching (you can literally read off the rules).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class DecisionTreeClassifierNode(BaseNode):
+    NODE_NAME = "DecisionTreeClassifier"
+    CATEGORY = "Classical"
+    DESCRIPTION = (
+        "CART decision tree (sklearn). Recursively splits features to "
+        "maximise purity; the killer feature for teaching is tree_text — a "
+        "readable dump of the learned if/else rules."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="x_train", data_type=DataType.TENSOR, description="Training features [N, F]."),
+            PortDefinition(name="y_train", data_type=DataType.LIST, description="Training labels (length N)."),
+            PortDefinition(name="x_query", data_type=DataType.TENSOR, description="Query features [M, F]."),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="predictions", data_type=DataType.LIST, description="Predicted label per query."),
+            PortDefinition(name="feature_importances", data_type=DataType.TENSOR, description="Importance score per feature [F], summing to 1."),
+            PortDefinition(name="tree_text", data_type=DataType.STRING, description="Human-readable dump of the learned rules."),
+            PortDefinition(name="classes", data_type=DataType.LIST, description="Class labels in sorted order."),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="max_depth",
+                param_type=ParamType.INT,
+                default=5,
+                min_value=0,
+                description="Maximum tree depth. 0 = no limit (grow until pure).",
+            ),
+            ParamDefinition(
+                name="criterion",
+                param_type=ParamType.SELECT,
+                default="gini",
+                options=["gini", "entropy", "log_loss"],
+                description="Split quality function: gini impurity, entropy, or log loss.",
+            ),
+            ParamDefinition(
+                name="random_state",
+                param_type=ParamType.INT,
+                default=42,
+                description="Seed for tie-breaking; controls reproducibility on equal-quality splits.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        from sklearn.tree import DecisionTreeClassifier, export_text
+
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError(
+                "DecisionTreeClassifier requires `x_train`, `y_train`, and `x_query` inputs."
+            )
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+
+        x_train_np = x_train.detach().cpu().float().numpy()
+        x_query_np = x_query.detach().cpu().float().numpy()
+
+        labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
+        labels = [str(v) for v in labels]
+        if x_train_np.shape[0] != len(labels):
+            raise ValueError(
+                f"DecisionTreeClassifier: features and labels length mismatch — "
+                f"{x_train_np.shape[0]} rows vs {len(labels)} labels."
+            )
+
+        max_depth_raw = int(params.get("max_depth", 5))
+        max_depth = None if max_depth_raw <= 0 else max_depth_raw
+        criterion = str(params.get("criterion", "gini"))
+        random_state = int(params.get("random_state", 42))
+
+        clf = DecisionTreeClassifier(
+            max_depth=max_depth,
+            criterion=criterion,
+            random_state=random_state,
+        )
+        clf.fit(x_train_np, labels)
+
+        preds = clf.predict(x_query_np).tolist()
+        classes = [str(c) for c in clf.classes_.tolist()]
+        tree_text = export_text(clf)
+
+        return {
+            "predictions": [str(p) for p in preds],
+            "feature_importances": torch.from_numpy(clf.feature_importances_).float(),
+            "tree_text": tree_text,
+            "classes": classes,
+        }

--- a/backend/app/nodes/classical/knn_node.py
+++ b/backend/app/nodes/classical/knn_node.py
@@ -1,0 +1,126 @@
+"""KNNNode — production k-NN classifier wrapping ``sklearn.neighbors``.
+
+Same interface as :class:`EduKNNNode`, different implementation:
+
+- ``EduKNN``: hand-written O(N_train · N_query) brute force, three-line math,
+  exposes intermediate distances/indices for visualisation. Right for ≤ 200-row
+  teaching datasets.
+- ``KNN`` (this node): wraps ``sklearn.neighbors.KNeighborsClassifier``. Builds
+  a KD-tree / ball-tree internally, scales to 100k+ rows, supports the full
+  ``weights``/``metric`` knob set. Right for "I want to actually use this on
+  real data."
+
+The pair lets the textbook teach the algorithm with EduKNN, then swap in KNN
+without rewiring the graph — a recurring theme of the dual-track design.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class KNNNode(BaseNode):
+    NODE_NAME = "KNN"
+    CATEGORY = "Classical"
+    DESCRIPTION = (
+        "k-Nearest-Neighbours classifier (sklearn). Drop-in replacement for "
+        "EduKNN with KD-tree indexing, distance weighting, and a choice of "
+        "metrics. Use this when you want production scaling; use EduKNN when "
+        "you want to see the math."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="x_train", data_type=DataType.TENSOR, description="Training features [N, F]."),
+            PortDefinition(name="y_train", data_type=DataType.LIST, description="Training labels (length N)."),
+            PortDefinition(name="x_query", data_type=DataType.TENSOR, description="Query features [M, F] to classify."),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="predictions", data_type=DataType.LIST, description="Predicted label per query."),
+            PortDefinition(name="probabilities", data_type=DataType.TENSOR, description="Class probabilities [M, C] from the k-NN vote."),
+            PortDefinition(name="classes", data_type=DataType.LIST, description="Class labels in column order (sklearn-sorted)."),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(name="n_neighbors", param_type=ParamType.INT, default=5, min_value=1, description="Number of neighbours k."),
+            ParamDefinition(
+                name="weights",
+                param_type=ParamType.SELECT,
+                default="uniform",
+                options=["uniform", "distance"],
+                description="Vote weighting: uniform = each neighbour counts the same; distance = closer neighbours count more.",
+            ),
+            ParamDefinition(
+                name="metric",
+                param_type=ParamType.SELECT,
+                default="minkowski",
+                options=["minkowski", "euclidean", "manhattan", "chebyshev", "cosine"],
+                description="Distance metric. minkowski with default p=2 == euclidean.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        from sklearn.neighbors import KNeighborsClassifier
+
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError("KNN requires `x_train`, `y_train`, and `x_query` inputs.")
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+        x_train_np = x_train.detach().cpu().float().numpy()
+        x_query_np = x_query.detach().cpu().float().numpy()
+
+        labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
+        if x_train_np.shape[0] != len(labels):
+            raise ValueError(
+                f"KNN: features and labels length mismatch — "
+                f"{x_train_np.shape[0]} rows vs {len(labels)} labels."
+            )
+
+        n_neighbors = max(1, min(int(params.get("n_neighbors", 5)), x_train_np.shape[0]))
+        weights = str(params.get("weights", "uniform"))
+        metric = str(params.get("metric", "minkowski"))
+
+        clf = KNeighborsClassifier(
+            n_neighbors=n_neighbors,
+            weights=weights,
+            metric=metric,
+        )
+        clf.fit(x_train_np, labels)
+        preds = clf.predict(x_query_np).tolist()
+        proba = clf.predict_proba(x_query_np)
+        classes = [str(c) for c in clf.classes_.tolist()]
+
+        return {
+            "predictions": [str(p) for p in preds],
+            "probabilities": torch.from_numpy(proba).float(),
+            "classes": classes,
+        }

--- a/backend/app/nodes/classical/linear_regression_node.py
+++ b/backend/app/nodes/classical/linear_regression_node.py
@@ -1,0 +1,106 @@
+"""LinearRegressionNode — production OLS via ``sklearn.linear_model``.
+
+Closed-form ordinary least squares. The math (``β = (XᵀX)⁻¹ Xᵀy``) is one
+line; sklearn handles the numerics (SVD when ``X`` is rank-deficient, etc.).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class LinearRegressionNode(BaseNode):
+    NODE_NAME = "LinearRegression"
+    CATEGORY = "Classical"
+    DESCRIPTION = (
+        "Ordinary-least-squares linear regression (sklearn). Closed-form fit, "
+        "no iteration. Outputs coefficients, intercept, and predictions for a "
+        "query set. The first line of every regression curriculum."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="x_train", data_type=DataType.TENSOR, description="Training features [N, F]."),
+            PortDefinition(name="y_train", data_type=DataType.TENSOR, description="Training targets [N] or [N, T]."),
+            PortDefinition(name="x_query", data_type=DataType.TENSOR, description="Query features [M, F]."),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="predictions", data_type=DataType.TENSOR, description="Predicted targets for x_query."),
+            PortDefinition(name="coef", data_type=DataType.TENSOR, description="Fitted coefficients (one per feature, possibly per target)."),
+            PortDefinition(name="intercept", data_type=DataType.SCALAR, description="Fitted intercept (scalar for 1-D targets)."),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="fit_intercept",
+                param_type=ParamType.BOOL,
+                default=True,
+                description="If False, the regression line passes through the origin.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        from sklearn.linear_model import LinearRegression
+
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError("LinearRegression requires `x_train`, `y_train`, and `x_query` inputs.")
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(y_train, torch.Tensor):
+            y_train = torch.as_tensor(y_train, dtype=torch.float32)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+
+        x_train_np = x_train.detach().cpu().float().numpy()
+        x_query_np = x_query.detach().cpu().float().numpy()
+        y_train_np = y_train.detach().cpu().float().numpy()
+
+        if x_train_np.shape[0] != y_train_np.shape[0]:
+            raise ValueError(
+                f"LinearRegression: features and targets length mismatch — "
+                f"{x_train_np.shape[0]} rows vs {y_train_np.shape[0]} targets."
+            )
+
+        fit_intercept = bool(params.get("fit_intercept", True))
+        model = LinearRegression(fit_intercept=fit_intercept)
+        model.fit(x_train_np, y_train_np)
+        preds_np = model.predict(x_query_np)
+
+        intercept = model.intercept_
+        if hasattr(intercept, "shape") and intercept.shape:
+            intercept_out = torch.from_numpy(intercept).float()
+        else:
+            intercept_out = float(intercept)
+
+        return {
+            "predictions": torch.from_numpy(preds_np).float(),
+            "coef": torch.from_numpy(model.coef_).float(),
+            "intercept": intercept_out,
+        }

--- a/backend/app/nodes/classical/logistic_regression_node.py
+++ b/backend/app/nodes/classical/logistic_regression_node.py
@@ -1,0 +1,138 @@
+"""LogisticRegressionNode — production softmax classifier (sklearn).
+
+Drop-in replacement for :class:`EduLogisticRegressionNode`. Same inputs and
+outputs; sklearn's solver picks LBFGS by default and handles multinomial
+softmax automatically.
+
+Use ``EduLogisticRegression`` to teach the gradient-descent loop and the
+softmax math; switch to this node when the dataset is real.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class LogisticRegressionNode(BaseNode):
+    NODE_NAME = "LogisticRegression"
+    CATEGORY = "Classical"
+    DESCRIPTION = (
+        "Multinomial logistic regression (sklearn). Fits a softmax classifier "
+        "with L2 / L1 regularisation; same I/O shape as EduLogisticRegression "
+        "for plug-and-play swapping."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="x_train", data_type=DataType.TENSOR, description="Training features [N, F]."),
+            PortDefinition(name="y_train", data_type=DataType.LIST, description="Training labels (length N)."),
+            PortDefinition(name="x_query", data_type=DataType.TENSOR, description="Query features [M, F]."),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="predictions", data_type=DataType.LIST, description="Predicted label per query."),
+            PortDefinition(name="probabilities", data_type=DataType.TENSOR, description="Softmax probabilities [M, C]."),
+            PortDefinition(name="classes", data_type=DataType.LIST, description="Class labels in column order."),
+            PortDefinition(name="coef", data_type=DataType.TENSOR, description="Learned coefficients [C, F]."),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="C",
+                param_type=ParamType.FLOAT,
+                default=1.0,
+                description="Inverse regularisation strength (smaller = more regularised).",
+            ),
+            ParamDefinition(
+                name="max_iter",
+                param_type=ParamType.INT,
+                default=200,
+                min_value=1,
+                description="Maximum solver iterations.",
+            ),
+            ParamDefinition(
+                name="penalty",
+                param_type=ParamType.SELECT,
+                default="l2",
+                options=["l2", "l1", "none"],
+                description="Regularisation type. l1 needs the liblinear/saga solver; sklearn picks one for you.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        from sklearn.linear_model import LogisticRegression
+
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError("LogisticRegression requires `x_train`, `y_train`, and `x_query` inputs.")
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+
+        x_train_np = x_train.detach().cpu().float().numpy()
+        x_query_np = x_query.detach().cpu().float().numpy()
+
+        labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
+        labels = [str(v) for v in labels]
+        if x_train_np.shape[0] != len(labels):
+            raise ValueError(
+                f"LogisticRegression: features and labels length mismatch — "
+                f"{x_train_np.shape[0]} rows vs {len(labels)} labels."
+            )
+        if len(set(labels)) < 2:
+            raise ValueError("LogisticRegression: need at least 2 classes in y_train.")
+
+        C = float(params.get("C", 1.0))
+        max_iter = max(1, int(params.get("max_iter", 200)))
+        penalty = str(params.get("penalty", "l2"))
+        # sklearn 1.4+ accepts None instead of 'none' for the penalty string.
+        penalty_arg: str | None = None if penalty == "none" else penalty
+        # liblinear is the only solver that supports L1 + binary; saga handles
+        # L1 + multiclass. lbfgs handles L2 + multinomial. Letting sklearn pick
+        # would otherwise raise on L1.
+        solver = "saga" if penalty == "l1" else "lbfgs"
+
+        model = LogisticRegression(
+            C=C,
+            max_iter=max_iter,
+            penalty=penalty_arg,
+            solver=solver,
+        )
+        model.fit(x_train_np, labels)
+
+        preds = model.predict(x_query_np).tolist()
+        proba = model.predict_proba(x_query_np)
+        classes = [str(c) for c in model.classes_.tolist()]
+
+        return {
+            "predictions": [str(p) for p in preds],
+            "probabilities": torch.from_numpy(proba).float(),
+            "classes": classes,
+            "coef": torch.from_numpy(model.coef_).float(),
+        }

--- a/backend/app/nodes/classical/svm_classifier_node.py
+++ b/backend/app/nodes/classical/svm_classifier_node.py
@@ -1,0 +1,124 @@
+"""SVMClassifierNode — Support Vector Classifier via ``sklearn.svm.SVC``.
+
+Picks the maximum-margin hyperplane between classes; the kernel trick lets it
+draw nonlinear decision boundaries in input space (rbf, polynomial, sigmoid).
+
+Outputs the support vectors so downstream viz can highlight which training
+points actually determine the boundary — the geometric heart of SVMs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class SVMClassifierNode(BaseNode):
+    NODE_NAME = "SVMClassifier"
+    CATEGORY = "Classical"
+    DESCRIPTION = (
+        "Support Vector Classifier (sklearn). Maximum-margin hyperplane, "
+        "with kernel trick for nonlinear boundaries. Exposes support vectors "
+        "for visualisation — those are the points that define the boundary."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="x_train", data_type=DataType.TENSOR, description="Training features [N, F]."),
+            PortDefinition(name="y_train", data_type=DataType.LIST, description="Training labels (length N)."),
+            PortDefinition(name="x_query", data_type=DataType.TENSOR, description="Query features [M, F]."),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="predictions", data_type=DataType.LIST, description="Predicted label per query."),
+            PortDefinition(name="support_vectors", data_type=DataType.TENSOR, description="Training points on or near the margin [n_sv, F]."),
+            PortDefinition(name="classes", data_type=DataType.LIST, description="Class labels in sorted order."),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="C",
+                param_type=ParamType.FLOAT,
+                default=1.0,
+                description="Penalty strength; smaller C = wider margin and more violations tolerated.",
+            ),
+            ParamDefinition(
+                name="kernel",
+                param_type=ParamType.SELECT,
+                default="rbf",
+                options=["linear", "rbf", "poly", "sigmoid"],
+                description="Kernel function: linear hyperplane, gaussian RBF, polynomial, or sigmoid.",
+            ),
+            ParamDefinition(
+                name="gamma",
+                param_type=ParamType.STRING,
+                default="scale",
+                description="Kernel coefficient (rbf/poly/sigmoid). 'scale' uses 1/(F·var(X)); 'auto' uses 1/F; or pass a number as a string.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        from sklearn.svm import SVC
+
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError("SVMClassifier requires `x_train`, `y_train`, and `x_query` inputs.")
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+
+        x_train_np = x_train.detach().cpu().float().numpy()
+        x_query_np = x_query.detach().cpu().float().numpy()
+
+        labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
+        labels = [str(v) for v in labels]
+        if x_train_np.shape[0] != len(labels):
+            raise ValueError(
+                f"SVMClassifier: features and labels length mismatch — "
+                f"{x_train_np.shape[0]} rows vs {len(labels)} labels."
+            )
+
+        C = float(params.get("C", 1.0))
+        kernel = str(params.get("kernel", "rbf"))
+        gamma_raw = params.get("gamma", "scale")
+        gamma: float | str
+        try:
+            gamma = float(gamma_raw)
+        except (TypeError, ValueError):
+            gamma = str(gamma_raw)
+
+        clf = SVC(C=C, kernel=kernel, gamma=gamma, probability=False)
+        clf.fit(x_train_np, labels)
+        preds = clf.predict(x_query_np).tolist()
+        classes = [str(c) for c in clf.classes_.tolist()]
+
+        return {
+            "predictions": [str(p) for p in preds],
+            "support_vectors": torch.from_numpy(clf.support_vectors_).float(),
+            "classes": classes,
+        }

--- a/backend/app/nodes/rl/kl_divergence_node.py
+++ b/backend/app/nodes/rl/kl_divergence_node.py
@@ -1,0 +1,119 @@
+"""KLDivergenceNode — KL(p || q) for the RLHF "stay close to ref" term.
+
+In PPO-RLHF, the policy update is regularised by KL divergence against the
+reference (frozen) policy:
+
+    L = E[ r(x) − β · KL(π_policy(x) || π_ref(x)) ]
+
+This node computes that KL term given two probability (or logit) tensors
+of the same shape ``[..., V]``. ``reduction`` controls whether the output
+is per-sample or scalar (matching the PyTorch convention).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class KLDivergenceNode(BaseNode):
+    NODE_NAME = "KLDivergence"
+    CATEGORY = "RL"
+    DESCRIPTION = (
+        "KL(p || q) divergence — the regularisation term in RLHF that keeps "
+        "the policy close to the reference. Accepts probabilities or logits; "
+        "returns scalar (default) or per-sample."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="p", data_type=DataType.TENSOR, description="Policy distribution: [..., V] probs or logits."),
+            PortDefinition(name="q", data_type=DataType.TENSOR, description="Reference distribution: [..., V] probs or logits."),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="kl", data_type=DataType.TENSOR, description="KL divergence — scalar or per-sample, depending on reduction."),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="input_kind",
+                param_type=ParamType.SELECT,
+                default="probs",
+                options=["probs", "logits"],
+                description="Whether p and q are already probabilities or pre-softmax logits.",
+            ),
+            ParamDefinition(
+                name="reduction",
+                param_type=ParamType.SELECT,
+                default="batchmean",
+                options=["batchmean", "sum", "mean", "none"],
+                description="How to aggregate per-sample KL. batchmean = sum / batch_size (the RLHF default).",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        p = inputs.get("p")
+        q = inputs.get("q")
+        if p is None or q is None:
+            raise ValueError("KLDivergence requires `p` and `q` inputs.")
+
+        if not isinstance(p, torch.Tensor):
+            p = torch.as_tensor(p, dtype=torch.float32)
+        if not isinstance(q, torch.Tensor):
+            q = torch.as_tensor(q, dtype=torch.float32)
+        p = p.float()
+        q = q.float()
+
+        if p.shape != q.shape:
+            raise ValueError(
+                f"KLDivergence: `p` and `q` must have the same shape, got "
+                f"{tuple(p.shape)} vs {tuple(q.shape)}."
+            )
+
+        kind = str(params.get("input_kind", "probs"))
+        reduction = str(params.get("reduction", "batchmean"))
+
+        # F.kl_div expects target = p (probs) and input = log q.
+        if kind == "logits":
+            log_q = F.log_softmax(q, dim=-1)
+            p_probs = F.softmax(p, dim=-1)
+        else:
+            eps = 1e-12
+            log_q = torch.log(q.clamp_min(eps))
+            p_probs = p
+
+        # KL(p || q) = Σ p_i (log p_i − log q_i). F.kl_div with log_target=False
+        # computes target * (log target − input) per element.
+        if reduction == "none":
+            # Element-wise KL contribution; reduce over last dim to get per-sample.
+            kl_elem = F.kl_div(log_q, p_probs, reduction="none", log_target=False)
+            kl = kl_elem.sum(dim=-1)
+            # Flatten leading batch dims into [B] when multi-axis.
+            kl = kl.reshape(-1) if kl.dim() > 1 else kl
+        else:
+            kl = F.kl_div(log_q, p_probs, reduction=reduction, log_target=False)
+
+        return {"kl": kl}

--- a/backend/app/nodes/rl/reward_model_node.py
+++ b/backend/app/nodes/rl/reward_model_node.py
@@ -1,0 +1,111 @@
+"""RewardModelNode — the scalar-reward head used in RLHF.
+
+In Reinforcement Learning from Human Feedback, you train a small head on
+top of a frozen language model that maps a hidden state to a single scalar
+reward (how "good" the response is, per human raters). That scalar is what
+PPO maximises during the policy-update phase.
+
+This node is the head: a tiny MLP that takes the last-token hidden state
+of a sequence and returns one number per sequence. For teaching, that's
+enough — the textbook can wire it after a Transformer / LLM block and
+demonstrate Bradley-Terry pairwise loss in the preset.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class _RewardHead(nn.Module):
+    """Two-layer MLP → scalar reward."""
+
+    def __init__(self, input_dim: int, hidden_dim: int):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, h: torch.Tensor) -> torch.Tensor:
+        # h: [B, H] or [B, T, H] (we use the last token in the sequence case).
+        if h.dim() == 3:
+            h = h[:, -1, :]
+        return self.net(h).squeeze(-1)  # [B]
+
+
+class RewardModelNode(BaseNode):
+    NODE_NAME = "RewardModel"
+    CATEGORY = "RL"
+    DESCRIPTION = (
+        "RLHF reward head. Tiny MLP that scores a sequence with one scalar — "
+        "the thing you train on human preferences and then have PPO maximise. "
+        "Accepts [B, H] (one vector per item) or [B, T, H] (uses last token)."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="hidden_states",
+                data_type=DataType.TENSOR,
+                description="Hidden states from the policy model: [B, H] or [B, T, H].",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="model", data_type=DataType.MODEL, description="The reward MLP head (nn.Module)."),
+            PortDefinition(name="rewards", data_type=DataType.TENSOR, description="Scalar reward per item, shape [B]."),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(name="input_dim", param_type=ParamType.INT, default=128, min_value=1, description="Hidden-state dimension H."),
+            ParamDefinition(name="hidden_dim", param_type=ParamType.INT, default=64, min_value=1, description="MLP bottleneck width."),
+            ParamDefinition(name="seed", param_type=ParamType.INT, default=42, description="Init seed for reproducibility."),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        input_dim = int(params.get("input_dim", 128))
+        hidden_dim = int(params.get("hidden_dim", 64))
+        seed = int(params.get("seed", 42))
+
+        gen_state = torch.random.get_rng_state()
+        try:
+            torch.manual_seed(seed)
+            model = _RewardHead(input_dim, hidden_dim)
+        finally:
+            torch.random.set_rng_state(gen_state)
+
+        h = inputs.get("hidden_states")
+        if h is None:
+            rewards = torch.zeros(0)
+        else:
+            if not isinstance(h, torch.Tensor):
+                h = torch.as_tensor(h, dtype=torch.float32)
+            with torch.no_grad():
+                rewards = model(h.float())
+
+        return {"model": model, "rewards": rewards}

--- a/backend/app/nodes/transformer/moe_layer_node.py
+++ b/backend/app/nodes/transformer/moe_layer_node.py
@@ -1,0 +1,163 @@
+"""MoELayerNode — Mixture-of-Experts feed-forward layer.
+
+Replaces the FFN block in a Transformer with N expert FFNs plus a gating
+network. For each token, the gate picks the top-k experts by softmax score;
+the layer's output is the weighted sum of those k experts' outputs.
+
+This is the structure used in Switch Transformer, Mixtral, and DeepSeek-MoE.
+The teaching version here is intentionally tiny — students see the gating
+math and per-expert routing without GPU-cluster boilerplate.
+
+Outputs:
+
+- ``output``: [B, T, H], same shape as input.
+- ``routing_weights``: [B, T, k], the softmax-normalised weights over the
+  selected experts (one row per token sums to 1).
+- ``expert_indices``: [B, T, k], the integer expert indices each token
+  was routed to. Lets a viz draw "which expert handled which token."
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class _ExpertFFN(nn.Module):
+    """Single expert: SwiGLU-style 2-layer FFN."""
+
+    def __init__(self, hidden_dim: int, expert_hidden_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(hidden_dim, expert_hidden_dim)
+        self.fc2 = nn.Linear(expert_hidden_dim, hidden_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(F.silu(self.fc1(x)))
+
+
+class _MoELayer(nn.Module):
+    def __init__(self, num_experts: int, top_k: int, hidden_dim: int, expert_hidden_dim: int):
+        super().__init__()
+        self.num_experts = num_experts
+        self.top_k = max(1, min(top_k, num_experts))
+        self.gate = nn.Linear(hidden_dim, num_experts, bias=False)
+        self.experts = nn.ModuleList(
+            [_ExpertFFN(hidden_dim, expert_hidden_dim) for _ in range(num_experts)]
+        )
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        # x: [B, T, H]
+        b, t, h = x.shape
+        # Gating logits → top-k softmax. We softmax *only* over the selected
+        # experts so the routing weights sum to 1 per token (the standard
+        # Switch / Mixtral convention).
+        gate_logits = self.gate(x)  # [B, T, N]
+        topk_vals, topk_idx = torch.topk(gate_logits, k=self.top_k, dim=-1)  # both [B, T, k]
+        topk_weights = F.softmax(topk_vals, dim=-1)  # [B, T, k]
+
+        # For each (b, t, k) slot, run x[b, t] through experts[topk_idx[b, t, k]]
+        # and weight it by topk_weights[b, t, k]. We do this densely (small N
+        # for teaching), then mask + sum — clear over fast.
+        flat_x = x.reshape(b * t, h)  # [B*T, H]
+        flat_idx = topk_idx.reshape(b * t, self.top_k)  # [B*T, k]
+        flat_w = topk_weights.reshape(b * t, self.top_k)  # [B*T, k]
+
+        out = torch.zeros_like(flat_x)
+        for k in range(self.top_k):
+            expert_id_for_slot = flat_idx[:, k]  # [B*T]
+            weights_for_slot = flat_w[:, k].unsqueeze(-1)  # [B*T, 1]
+            # Group by expert and run the matching tokens through that expert.
+            for e in range(self.num_experts):
+                mask = expert_id_for_slot == e
+                if not mask.any():
+                    continue
+                tokens = flat_x[mask]
+                expert_out = self.experts[e](tokens)
+                out[mask] = out[mask] + weights_for_slot[mask] * expert_out
+
+        return out.reshape(b, t, h), topk_weights, topk_idx
+
+
+class MoELayerNode(BaseNode):
+    NODE_NAME = "MoELayer"
+    CATEGORY = "Transformer"
+    DESCRIPTION = (
+        "Mixture-of-Experts FFN. For each token, a gate picks the top-k "
+        "experts by softmax score; the layer output is the weighted sum of "
+        "those experts' outputs. The architecture used in Switch / Mixtral / "
+        "DeepSeek-MoE."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="x", data_type=DataType.TENSOR, description="Input hidden states [B, T, H]."),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="output", data_type=DataType.TENSOR, description="MoE output, same shape as input [B, T, H]."),
+            PortDefinition(name="routing_weights", data_type=DataType.TENSOR, description="Per-token softmax weights over top-k experts [B, T, k]."),
+            PortDefinition(name="expert_indices", data_type=DataType.TENSOR, description="Per-token top-k expert ids [B, T, k]."),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(name="num_experts", param_type=ParamType.INT, default=4, min_value=1, description="Number of expert FFNs."),
+            ParamDefinition(name="top_k", param_type=ParamType.INT, default=2, min_value=1, description="Experts per token (clamped to num_experts)."),
+            ParamDefinition(name="hidden_dim", param_type=ParamType.INT, default=128, min_value=1, description="Token hidden size H."),
+            ParamDefinition(name="expert_hidden_dim", param_type=ParamType.INT, default=256, min_value=1, description="Inner width of each expert FFN."),
+            ParamDefinition(name="seed", param_type=ParamType.INT, default=42, description="Init seed for reproducibility."),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x = inputs.get("x")
+        if x is None:
+            raise ValueError("MoELayer requires an `x` input tensor.")
+        if not isinstance(x, torch.Tensor):
+            x = torch.as_tensor(x, dtype=torch.float32)
+        x = x.float()
+        if x.dim() == 2:
+            x = x.unsqueeze(0)  # treat [T, H] as [1, T, H]
+
+        num_experts = max(1, int(params.get("num_experts", 4)))
+        top_k = max(1, int(params.get("top_k", 2)))
+        hidden_dim = int(params.get("hidden_dim", 128))
+        expert_hidden_dim = int(params.get("expert_hidden_dim", 256))
+        seed = int(params.get("seed", 42))
+
+        gen_state = torch.random.get_rng_state()
+        try:
+            torch.manual_seed(seed)
+            layer = _MoELayer(num_experts, top_k, hidden_dim, expert_hidden_dim)
+        finally:
+            torch.random.set_rng_state(gen_state)
+
+        with torch.no_grad():
+            out, routing_w, idx = layer(x)
+
+        return {
+            "output": out,
+            "routing_weights": routing_w,
+            "expert_indices": idx,
+        }

--- a/backend/tests/test_decision_tree_classifier_node.py
+++ b/backend/tests/test_decision_tree_classifier_node.py
@@ -1,0 +1,94 @@
+"""Tests for DecisionTreeClassifierNode (sklearn wrapper)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.classical.decision_tree_classifier_node import (
+    DecisionTreeClassifierNode,
+)
+
+
+def _run(x_train, y_train, x_query, **params):
+    p = {"max_depth": 5, "criterion": "gini", "random_state": 42}
+    p.update(params)
+    return DecisionTreeClassifierNode().execute(
+        {"x_train": x_train, "y_train": y_train, "x_query": x_query}, p
+    )
+
+
+def test_node_metadata():
+    assert DecisionTreeClassifierNode.NODE_NAME == "DecisionTreeClassifier"
+    assert DecisionTreeClassifierNode.CATEGORY == "Classical"
+    out_names = [p.name for p in DecisionTreeClassifierNode.define_outputs()]
+    assert set(out_names) >= {
+        "predictions",
+        "feature_importances",
+        "tree_text",
+        "classes",
+    }
+
+
+def test_recovers_decision_rule():
+    """A tree should perfectly fit a small dataset with a clear split."""
+    x = torch.tensor([[1.0], [2.0], [3.0], [4.0], [5.0], [6.0]])
+    y = ["a", "a", "a", "b", "b", "b"]
+    res = _run(x, y, x, max_depth=3)
+    correct = sum(1 for i, p in enumerate(res["predictions"]) if p == y[i])
+    assert correct == 6
+
+
+def test_feature_importances_shape():
+    x = torch.randn(40, 5, generator=torch.Generator().manual_seed(0))
+    y = ["a"] * 20 + ["b"] * 20
+    res = _run(x, y, x)
+    assert res["feature_importances"].shape == (5,)
+    # Importances should sum to 1 (or be all-zero for an empty tree).
+    s = float(res["feature_importances"].sum())
+    assert abs(s - 1.0) < 1e-5 or s == 0.0
+
+
+def test_dominant_feature_dominates_importance():
+    """A tree should put nearly all importance on the only useful feature."""
+    torch.manual_seed(0)
+    n = 60
+    # Feature 0 perfectly determines the label; feature 1 is noise.
+    x0 = torch.cat([torch.full((n // 2,), -1.0), torch.full((n // 2,), 1.0)]).unsqueeze(1)
+    x1 = torch.randn(n, 1)
+    x = torch.cat([x0, x1], dim=1)
+    y = ["a"] * (n // 2) + ["b"] * (n // 2)
+    res = _run(x, y, x, max_depth=3)
+    importances = res["feature_importances"].tolist()
+    assert importances[0] > importances[1]
+
+
+def test_tree_text_is_string():
+    x = torch.tensor([[0.0], [1.0], [2.0], [3.0]])
+    y = ["a", "a", "b", "b"]
+    res = _run(x, y, x)
+    assert isinstance(res["tree_text"], str)
+    # sklearn's export_text always emits a header
+    assert "feature" in res["tree_text"].lower() or "class" in res["tree_text"].lower()
+
+
+def test_label_count_mismatch_raises():
+    with pytest.raises(ValueError, match="length"):
+        _run(torch.zeros(5, 2), ["a"] * 3, torch.zeros(1, 2))
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        DecisionTreeClassifierNode().execute(
+            {"x_train": torch.zeros(5, 2)},
+            {"max_depth": 5, "criterion": "gini", "random_state": 42},
+        )
+
+
+def test_unlimited_depth_via_zero():
+    """max_depth=0 should map to None (no limit)."""
+    x = torch.randn(20, 2, generator=torch.Generator().manual_seed(0))
+    y = ["a"] * 10 + ["b"] * 10
+    # No crash and produces the right shape
+    res = _run(x, y, x, max_depth=0)
+    assert len(res["predictions"]) == 20

--- a/backend/tests/test_kl_divergence_node.py
+++ b/backend/tests/test_kl_divergence_node.py
@@ -1,0 +1,83 @@
+"""Tests for KLDivergenceNode."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from app.nodes.rl.kl_divergence_node import KLDivergenceNode
+
+
+def _run(p, q, **params):
+    pp = {"input_kind": "probs", "reduction": "batchmean"}
+    pp.update(params)
+    return KLDivergenceNode().execute({"p": p, "q": q}, pp)
+
+
+def test_node_metadata():
+    assert KLDivergenceNode.NODE_NAME == "KLDivergence"
+    assert KLDivergenceNode.CATEGORY == "RL"
+    out_names = [p.name for p in KLDivergenceNode.define_outputs()]
+    assert "kl" in out_names
+
+
+def test_identical_distributions_give_zero():
+    p = torch.tensor([[0.5, 0.5]])
+    q = torch.tensor([[0.5, 0.5]])
+    res = _run(p, q)
+    assert abs(float(res["kl"])) < 1e-6
+
+
+def test_known_value():
+    """KL([1,0] || [0.5,0.5]) = log(2) ≈ 0.693."""
+    p = torch.tensor([[1.0, 0.0]])
+    q = torch.tensor([[0.5, 0.5]])
+    res = _run(p, q)
+    assert abs(float(res["kl"]) - math.log(2.0)) < 1e-4
+
+
+def test_kl_is_nonnegative_random():
+    torch.manual_seed(0)
+    logits_p = torch.randn(8, 5)
+    logits_q = torch.randn(8, 5)
+    p = torch.softmax(logits_p, dim=-1)
+    q = torch.softmax(logits_q, dim=-1)
+    res = _run(p, q)
+    assert float(res["kl"]) >= 0.0
+
+
+def test_logits_input():
+    """Same KL value whether you pass probs or logits."""
+    logits_p = torch.tensor([[2.0, 0.0]])
+    logits_q = torch.tensor([[0.0, 2.0]])
+    p_probs = torch.softmax(logits_p, dim=-1)
+    q_probs = torch.softmax(logits_q, dim=-1)
+
+    a = _run(p_probs, q_probs, input_kind="probs")
+    b = _run(logits_p, logits_q, input_kind="logits")
+    assert abs(float(a["kl"]) - float(b["kl"])) < 1e-5
+
+
+def test_reduction_none_gives_per_sample():
+    p = torch.tensor([[1.0, 0.0], [0.5, 0.5]])
+    q = torch.tensor([[0.5, 0.5], [0.5, 0.5]])
+    res = _run(p, q, reduction="none")
+    assert res["kl"].shape == (2,)
+    # First sample: log(2). Second sample: 0.
+    assert abs(float(res["kl"][0]) - math.log(2.0)) < 1e-4
+    assert abs(float(res["kl"][1])) < 1e-5
+
+
+def test_shape_mismatch_raises():
+    with pytest.raises(ValueError, match="shape"):
+        _run(torch.zeros(3, 5), torch.zeros(3, 4))
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        KLDivergenceNode().execute(
+            {"p": torch.zeros(3, 5)},
+            {"input_kind": "probs", "reduction": "batchmean"},
+        )

--- a/backend/tests/test_knn_node.py
+++ b/backend/tests/test_knn_node.py
@@ -1,0 +1,92 @@
+"""Tests for KNNNode (sklearn wrapper)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.classical.knn_node import KNNNode
+
+
+def _run(x_train, y_train, x_query, **params):
+    p = {"n_neighbors": 3, "weights": "uniform", "metric": "minkowski"}
+    p.update(params)
+    return KNNNode().execute(
+        {"x_train": x_train, "y_train": y_train, "x_query": x_query}, p
+    )
+
+
+def test_node_metadata():
+    assert KNNNode.NODE_NAME == "KNN"
+    assert KNNNode.CATEGORY == "Classical"
+    out_names = [p.name for p in KNNNode.define_outputs()]
+    assert "predictions" in out_names
+    assert "classes" in out_names
+
+
+def test_predicts_majority_class():
+    x_train = torch.tensor(
+        [
+            [0.0, 0.0],
+            [0.1, 0.1],
+            [0.2, 0.0],
+            [10.0, 10.0],
+        ]
+    )
+    y_train = ["a", "a", "a", "b"]
+    x_query = torch.tensor([[0.05, 0.05]])
+    res = _run(x_train, y_train, x_query, n_neighbors=3)
+    assert res["predictions"] == ["a"]
+
+
+def test_returns_classes_in_sorted_order():
+    x_train = torch.tensor([[0.0], [1.0], [2.0], [3.0]])
+    y_train = ["b", "a", "a", "b"]
+    x_query = torch.tensor([[0.0]])
+    res = _run(x_train, y_train, x_query, n_neighbors=1)
+    # sklearn uses np.unique → sorted strings
+    assert res["classes"] == ["a", "b"]
+
+
+def test_distance_weighting_prefers_closest():
+    """weights='distance' makes the closer point dominate even when outvoted."""
+    # Three neighbours: index 0 close, indices 1 and 2 far
+    x_train = torch.tensor([[0.0], [10.0], [10.5]])
+    y_train = ["a", "b", "b"]
+    x_query = torch.tensor([[0.1]])
+    # Uniform: 2 b's vs 1 a → predicts b
+    res_uni = _run(x_train, y_train, x_query, n_neighbors=3, weights="uniform")
+    assert res_uni["predictions"] == ["b"]
+    # Distance: a is much closer (≈0.1) vs b (≈10) → predicts a
+    res_dist = _run(x_train, y_train, x_query, n_neighbors=3, weights="distance")
+    assert res_dist["predictions"] == ["a"]
+
+
+def test_works_with_integer_labels():
+    x_train = torch.randn(20, 4, generator=torch.Generator().manual_seed(0))
+    y_train = torch.tensor([0] * 10 + [1] * 10)
+    x_query = torch.randn(5, 4, generator=torch.Generator().manual_seed(1))
+    res = _run(x_train, y_train, x_query, n_neighbors=3)
+    assert len(res["predictions"]) == 5
+
+
+def test_label_count_mismatch_raises():
+    with pytest.raises(ValueError, match="length"):
+        _run(torch.zeros(5, 2), ["a"] * 3, torch.zeros(1, 2))
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        KNNNode().execute(
+            {"x_train": torch.zeros(5, 2)},
+            {"n_neighbors": 3, "weights": "uniform", "metric": "minkowski"},
+        )
+
+
+def test_n_neighbors_clamped_to_train_size():
+    x_train = torch.randn(3, 2, generator=torch.Generator().manual_seed(0))
+    y_train = ["a", "b", "c"]
+    x_query = torch.randn(1, 2)
+    # Should not crash even though n_neighbors > N_train
+    res = _run(x_train, y_train, x_query, n_neighbors=10)
+    assert len(res["predictions"]) == 1

--- a/backend/tests/test_linear_regression_node.py
+++ b/backend/tests/test_linear_regression_node.py
@@ -1,0 +1,74 @@
+"""Tests for LinearRegressionNode (sklearn wrapper)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.classical.linear_regression_node import LinearRegressionNode
+
+
+def _run(x_train, y_train, x_query, **params):
+    p = {"fit_intercept": True}
+    p.update(params)
+    return LinearRegressionNode().execute(
+        {"x_train": x_train, "y_train": y_train, "x_query": x_query}, p
+    )
+
+
+def test_node_metadata():
+    assert LinearRegressionNode.NODE_NAME == "LinearRegression"
+    assert LinearRegressionNode.CATEGORY == "Classical"
+    out_names = [p.name for p in LinearRegressionNode.define_outputs()]
+    assert "predictions" in out_names
+    assert "coef" in out_names
+    assert "intercept" in out_names
+
+
+def test_recovers_known_line():
+    """y = 2 x + 5 should be recovered exactly (closed-form OLS, no noise)."""
+    x = torch.arange(10, dtype=torch.float32).view(-1, 1)
+    y = 2 * x.squeeze() + 5
+    res = _run(x, y, x)
+    assert torch.allclose(res["coef"].view(-1), torch.tensor([2.0]), atol=1e-4)
+    assert abs(float(res["intercept"]) - 5.0) < 1e-4
+    assert torch.allclose(res["predictions"], y, atol=1e-4)
+
+
+def test_no_intercept_passes_through_origin():
+    x = torch.arange(10, dtype=torch.float32).view(-1, 1)
+    y = 3 * x.squeeze()
+    res = _run(x, y, x, fit_intercept=False)
+    assert abs(float(res["intercept"])) < 1e-6
+    assert torch.allclose(res["coef"].view(-1), torch.tensor([3.0]), atol=1e-4)
+
+
+def test_multivariate():
+    """y = 1*x1 + 2*x2 + 3."""
+    x = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [2.0, 0.0], [0.0, 2.0]])
+    y = x[:, 0] + 2.0 * x[:, 1] + 3.0
+    res = _run(x, y, x)
+    assert torch.allclose(res["coef"].view(-1), torch.tensor([1.0, 2.0]), atol=1e-4)
+    assert abs(float(res["intercept"]) - 3.0) < 1e-4
+
+
+def test_prediction_shape_matches_query():
+    x_train = torch.arange(10, dtype=torch.float32).view(-1, 1)
+    y_train = 2 * x_train.squeeze()
+    x_query = torch.tensor([[100.0], [200.0], [300.0]])
+    res = _run(x_train, y_train, x_query)
+    assert res["predictions"].shape == (3,)
+    assert torch.allclose(res["predictions"], torch.tensor([200.0, 400.0, 600.0]), atol=1e-3)
+
+
+def test_label_count_mismatch_raises():
+    with pytest.raises(ValueError, match="length"):
+        _run(torch.zeros(5, 2), torch.zeros(3), torch.zeros(1, 2))
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        LinearRegressionNode().execute(
+            {"x_train": torch.zeros(5, 2)},
+            {"fit_intercept": True},
+        )

--- a/backend/tests/test_logistic_regression_node.py
+++ b/backend/tests/test_logistic_regression_node.py
@@ -1,0 +1,79 @@
+"""Tests for LogisticRegressionNode (sklearn wrapper)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.classical.logistic_regression_node import LogisticRegressionNode
+
+
+def _run(x_train, y_train, x_query, **params):
+    p = {"C": 1.0, "max_iter": 200, "penalty": "l2"}
+    p.update(params)
+    return LogisticRegressionNode().execute(
+        {"x_train": x_train, "y_train": y_train, "x_query": x_query}, p
+    )
+
+
+def test_node_metadata():
+    assert LogisticRegressionNode.NODE_NAME == "LogisticRegression"
+    assert LogisticRegressionNode.CATEGORY == "Classical"
+    out_names = [p.name for p in LogisticRegressionNode.define_outputs()]
+    assert set(out_names) >= {"predictions", "probabilities", "classes", "coef"}
+
+
+def test_separates_two_clusters():
+    """Two well-separated clusters → near-perfect classification."""
+    torch.manual_seed(0)
+    a = torch.randn(50, 2) + torch.tensor([5.0, 5.0])
+    b = torch.randn(50, 2) + torch.tensor([-5.0, -5.0])
+    x = torch.cat([a, b], dim=0)
+    y = ["a"] * 50 + ["b"] * 50
+    res = _run(x, y, x)
+    correct = sum(1 for i, p in enumerate(res["predictions"]) if p == y[i])
+    assert correct >= 95
+
+
+def test_probabilities_sum_to_one():
+    torch.manual_seed(1)
+    x = torch.randn(40, 3)
+    y = ["a"] * 20 + ["b"] * 20
+    res = _run(x, y, x)
+    sums = res["probabilities"].sum(dim=1)
+    assert torch.allclose(sums, torch.ones_like(sums), atol=1e-5)
+
+
+def test_classes_match_columns():
+    torch.manual_seed(2)
+    x = torch.randn(30, 2)
+    y = ["a"] * 10 + ["b"] * 10 + ["c"] * 10
+    res = _run(x, y, x)
+    assert res["classes"] == ["a", "b", "c"]
+    assert res["probabilities"].shape == (30, 3)
+
+
+def test_works_with_integer_labels():
+    x = torch.randn(20, 2, generator=torch.Generator().manual_seed(0))
+    y = torch.tensor([0] * 10 + [1] * 10)
+    res = _run(x, y, x)
+    # Predictions get stringified for consistency
+    assert all(isinstance(p, str) for p in res["predictions"])
+
+
+def test_label_count_mismatch_raises():
+    with pytest.raises(ValueError, match="length"):
+        _run(torch.zeros(5, 2), ["a"] * 3, torch.zeros(1, 2))
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        LogisticRegressionNode().execute(
+            {"x_train": torch.zeros(5, 2)},
+            {"C": 1.0, "max_iter": 200, "penalty": "l2"},
+        )
+
+
+def test_single_class_raises():
+    with pytest.raises(ValueError, match="class"):
+        _run(torch.randn(10, 2), ["a"] * 10, torch.randn(2, 2))

--- a/backend/tests/test_moe_layer_node.py
+++ b/backend/tests/test_moe_layer_node.py
@@ -1,0 +1,93 @@
+"""Tests for MoELayerNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.transformer.moe_layer_node import MoELayerNode
+
+
+def _run(x, **params):
+    p = {
+        "num_experts": 4,
+        "top_k": 2,
+        "hidden_dim": 8,
+        "expert_hidden_dim": 16,
+        "seed": 42,
+    }
+    p.update(params)
+    return MoELayerNode().execute({"x": x}, p)
+
+
+def test_node_metadata():
+    assert MoELayerNode.NODE_NAME == "MoELayer"
+    assert MoELayerNode.CATEGORY == "Transformer"
+    out_names = [p.name for p in MoELayerNode.define_outputs()]
+    assert "output" in out_names
+    assert "routing_weights" in out_names
+    assert "expert_indices" in out_names
+
+
+def test_output_preserves_shape():
+    """[B, T, H] in → [B, T, H] out."""
+    x = torch.randn(2, 5, 8, generator=torch.Generator().manual_seed(0))
+    res = _run(x)
+    assert res["output"].shape == (2, 5, 8)
+
+
+def test_routing_weights_top_k():
+    """routing_weights should have shape [B, T, top_k] and sum to 1 per token."""
+    x = torch.randn(2, 5, 8, generator=torch.Generator().manual_seed(0))
+    res = _run(x, top_k=2)
+    rw = res["routing_weights"]
+    assert rw.shape == (2, 5, 2)
+    sums = rw.sum(dim=-1)
+    assert torch.allclose(sums, torch.ones_like(sums), atol=1e-5)
+
+
+def test_expert_indices_in_range():
+    x = torch.randn(2, 3, 8, generator=torch.Generator().manual_seed(0))
+    res = _run(x, num_experts=4, top_k=2)
+    idx = res["expert_indices"]
+    assert idx.shape == (2, 3, 2)
+    assert int(idx.min()) >= 0
+    assert int(idx.max()) < 4
+
+
+def test_top_k_one_uses_single_expert():
+    x = torch.randn(1, 4, 8, generator=torch.Generator().manual_seed(0))
+    res = _run(x, top_k=1)
+    assert res["routing_weights"].shape == (1, 4, 1)
+    # Each token should be assigned exactly one expert; weights all == 1.
+    assert torch.allclose(res["routing_weights"], torch.ones(1, 4, 1), atol=1e-5)
+
+
+def test_seed_reproducible():
+    x = torch.randn(2, 3, 8, generator=torch.Generator().manual_seed(0))
+    a = _run(x, seed=42)
+    b = _run(x, seed=42)
+    assert torch.allclose(a["output"], b["output"])
+    c = _run(x, seed=99)
+    assert not torch.allclose(a["output"], c["output"])
+
+
+def test_top_k_clamped_to_num_experts():
+    x = torch.randn(1, 2, 8, generator=torch.Generator().manual_seed(0))
+    # top_k > num_experts should be clamped — no crash
+    res = _run(x, num_experts=3, top_k=10)
+    assert res["routing_weights"].shape[-1] == 3
+
+
+def test_dim_mismatch_raises():
+    x = torch.randn(1, 2, 16)  # H=16 but hidden_dim=8
+    with pytest.raises(RuntimeError):
+        _run(x, hidden_dim=8)
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        MoELayerNode().execute(
+            {},
+            {"num_experts": 4, "top_k": 2, "hidden_dim": 8, "expert_hidden_dim": 16, "seed": 42},
+        )

--- a/backend/tests/test_reward_model_node.py
+++ b/backend/tests/test_reward_model_node.py
@@ -1,0 +1,60 @@
+"""Tests for RewardModelNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from app.nodes.rl.reward_model_node import RewardModelNode
+
+
+def _run(hidden_states=None, **params):
+    p = {"input_dim": 8, "hidden_dim": 16, "seed": 42}
+    p.update(params)
+    inputs = {}
+    if hidden_states is not None:
+        inputs["hidden_states"] = hidden_states
+    return RewardModelNode().execute(inputs, p)
+
+
+def test_node_metadata():
+    assert RewardModelNode.NODE_NAME == "RewardModel"
+    assert RewardModelNode.CATEGORY == "RL"
+    out_names = [p.name for p in RewardModelNode.define_outputs()]
+    assert "model" in out_names
+    assert "rewards" in out_names
+
+
+def test_returns_module_when_no_input():
+    res = _run()
+    assert isinstance(res["model"], nn.Module)
+
+
+def test_scores_2d_hidden_states():
+    """[B, H] → scalar reward per item, shape [B]."""
+    h = torch.randn(4, 8, generator=torch.Generator().manual_seed(0))
+    res = _run(h)
+    assert res["rewards"].shape == (4,)
+
+
+def test_uses_last_token_for_3d_input():
+    """[B, T, H] → uses the last token to score the sequence, [B]."""
+    h = torch.randn(2, 5, 8, generator=torch.Generator().manual_seed(0))
+    res = _run(h)
+    assert res["rewards"].shape == (2,)
+
+
+def test_seed_makes_init_reproducible():
+    h = torch.randn(3, 8, generator=torch.Generator().manual_seed(0))
+    a = _run(h, seed=42)
+    b = _run(h, seed=42)
+    assert torch.allclose(a["rewards"], b["rewards"])
+    c = _run(h, seed=99)
+    assert not torch.allclose(a["rewards"], c["rewards"])
+
+
+def test_dim_mismatch_raises():
+    h = torch.randn(2, 16)
+    with pytest.raises(RuntimeError):
+        _run(h, input_dim=8)

--- a/backend/tests/test_svm_classifier_node.py
+++ b/backend/tests/test_svm_classifier_node.py
@@ -1,0 +1,84 @@
+"""Tests for SVMClassifierNode (sklearn wrapper)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.classical.svm_classifier_node import SVMClassifierNode
+
+
+def _run(x_train, y_train, x_query, **params):
+    p = {"C": 1.0, "kernel": "rbf", "gamma": "scale"}
+    p.update(params)
+    return SVMClassifierNode().execute(
+        {"x_train": x_train, "y_train": y_train, "x_query": x_query}, p
+    )
+
+
+def test_node_metadata():
+    assert SVMClassifierNode.NODE_NAME == "SVMClassifier"
+    assert SVMClassifierNode.CATEGORY == "Classical"
+    out_names = [p.name for p in SVMClassifierNode.define_outputs()]
+    assert set(out_names) >= {"predictions", "support_vectors", "classes"}
+
+
+def test_separates_clean_clusters():
+    torch.manual_seed(0)
+    a = torch.randn(40, 2) + torch.tensor([3.0, 3.0])
+    b = torch.randn(40, 2) + torch.tensor([-3.0, -3.0])
+    x = torch.cat([a, b], dim=0)
+    y = ["a"] * 40 + ["b"] * 40
+    res = _run(x, y, x, kernel="linear")
+    correct = sum(1 for i, p in enumerate(res["predictions"]) if p == y[i])
+    assert correct >= 75  # near-perfect on a clearly-linearly-separable problem
+
+
+def test_rbf_handles_nonlinear():
+    """RBF should handle xor-like data better than linear."""
+    torch.manual_seed(0)
+    # Mixed quadrants → not linearly separable
+    pts = []
+    labels = []
+    for sign_a in [-1, 1]:
+        for sign_b in [-1, 1]:
+            cluster = torch.randn(20, 2) * 0.3 + torch.tensor([sign_a * 2.0, sign_b * 2.0])
+            pts.append(cluster)
+            labels += ["a" if sign_a == sign_b else "b"] * 20
+    x = torch.cat(pts, dim=0)
+    res = _run(x, labels, x, kernel="rbf")
+    correct = sum(1 for i, p in enumerate(res["predictions"]) if p == labels[i])
+    assert correct >= 70  # RBF should crush this
+
+
+def test_classes_returned():
+    x = torch.randn(20, 2, generator=torch.Generator().manual_seed(0))
+    y = ["a"] * 10 + ["b"] * 10
+    res = _run(x, y, x)
+    assert res["classes"] == ["a", "b"]
+
+
+def test_support_vectors_subset_of_train():
+    """SVs must be points from the training set."""
+    torch.manual_seed(0)
+    x = torch.randn(30, 2)
+    y = ["a"] * 15 + ["b"] * 15
+    res = _run(x, y, x, kernel="linear")
+    sv = res["support_vectors"]
+    # Each SV must equal a row in x_train
+    for sv_row in sv:
+        diffs = (x - sv_row).abs().sum(dim=1)
+        assert diffs.min().item() < 1e-4
+
+
+def test_label_count_mismatch_raises():
+    with pytest.raises(ValueError, match="length"):
+        _run(torch.zeros(5, 2), ["a"] * 3, torch.zeros(1, 2))
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        SVMClassifierNode().execute(
+            {"x_train": torch.zeros(5, 2)},
+            {"C": 1.0, "kernel": "rbf", "gamma": "scale"},
+        )

--- a/examples/Classical/Iris-Sklearn-KNN/graph.json
+++ b/examples/Classical/Iris-Sklearn-KNN/graph.json
@@ -1,0 +1,25 @@
+{
+  "name": "Iris with sklearn KNN: same graph, production scale",
+  "description": "Identical pipeline shape to KNN-from-Scratch — CSV → ColumnSelector → Normalize → TrainTestSplit — but the classifier is the production KNN node (sklearn-backed) instead of EduKNN. Both nodes share the same input/output contract, so swapping is a one-edit change in the graph; the goal of the lesson is to show that the dual-track design lets you teach the math with EduKNN and ship with KNN. Distance-weighted voting + KD-tree internally means this same graph would still run at 100k+ rows.",
+  "nodes": [
+    { "id": "start-1",   "type": "Start",          "position": { "x": -260, "y": 0 }, "data": { "params": {} } },
+    { "id": "csv",       "type": "CSVReader",      "position": { "x": -40,  "y": 0 }, "data": { "params": { "path": "data/samples/iris.csv", "target_column": "species", "include_columns": "", "skip_header": true } } },
+    { "id": "select",    "type": "ColumnSelector", "position": { "x": 220,  "y": 0 }, "data": { "params": { "indices": "2,3", "names": "" } } },
+    { "id": "norm",      "type": "Normalize",      "position": { "x": 480,  "y": 0 }, "data": { "params": { "mode": "zscore", "axis": 0 } } },
+    { "id": "split",     "type": "TrainTestSplit", "position": { "x": 740,  "y": 0 }, "data": { "params": { "test_size": 0.2, "seed": 42, "stratify": true } } },
+    { "id": "knn",       "type": "KNN",            "position": { "x": 1020, "y": 0 }, "data": { "params": { "n_neighbors": 5, "weights": "distance", "metric": "minkowski" } } },
+    { "id": "print",     "type": "Print",          "position": { "x": 1300, "y": 0 }, "data": { "params": { "label": "sklearn KNN test predictions" } } }
+  ],
+  "edges": [
+    { "id": "trig",          "source": "start-1", "target": "csv",    "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "e_csv_sel",     "source": "csv",     "target": "select", "sourceHandle": "tensor",  "targetHandle": "tensor" },
+    { "id": "e_csv_cols",    "source": "csv",     "target": "select", "sourceHandle": "columns", "targetHandle": "columns" },
+    { "id": "e_sel_norm",    "source": "select",  "target": "norm",   "sourceHandle": "tensor",  "targetHandle": "tensor" },
+    { "id": "e_norm_split",  "source": "norm",    "target": "split",  "sourceHandle": "tensor",  "targetHandle": "features" },
+    { "id": "e_csv_split",   "source": "csv",     "target": "split",  "sourceHandle": "labels",  "targetHandle": "labels" },
+    { "id": "e_xtrain",      "source": "split",   "target": "knn",    "sourceHandle": "x_train", "targetHandle": "x_train" },
+    { "id": "e_ytrain",      "source": "split",   "target": "knn",    "sourceHandle": "y_train", "targetHandle": "y_train" },
+    { "id": "e_xtest",       "source": "split",   "target": "knn",    "sourceHandle": "x_test",  "targetHandle": "x_query" },
+    { "id": "e_pred_print",  "source": "knn",     "target": "print",  "sourceHandle": "predictions", "targetHandle": "value" }
+  ]
+}

--- a/examples/RL/RLHF-Reward-and-KL/graph.json
+++ b/examples/RL/RLHF-Reward-and-KL/graph.json
@@ -1,0 +1,28 @@
+{
+  "name": "RLHF building blocks: reward + KL",
+  "description": "The two pieces that turn a pretrained LLM into an RLHF-tuned one. Top half: a fake hidden-state batch (4 sequences × 16 dim) is fed into RewardModel, which scores each sequence with one scalar — this is what you'd train on human preferences. Bottom half: a random logit tensor (the 'policy') and a zero-logit tensor (the uniform 'reference') are compared by KLDivergence — this is the regularisation term that keeps PPO from drifting too far from the reference model. The two blocks are independent here so each can be inspected in isolation; in a real RLHF run, KL-divergence × β is subtracted from the reward inside PPO.",
+  "nodes": [
+    { "id": "start-1",  "type": "Start",        "position": { "x": -260, "y": 0    }, "data": { "params": {} } },
+
+    { "id": "h",        "type": "TensorCreate", "position": { "x": -40,  "y": -120 }, "data": { "params": { "shape": "4,16", "fill": "randn", "value": 0, "requires_grad": false } } },
+    { "id": "rm",       "type": "RewardModel",  "position": { "x": 220,  "y": -120 }, "data": { "params": { "input_dim": 16, "hidden_dim": 32, "seed": 42 } } },
+    { "id": "print_r",  "type": "Print",        "position": { "x": 520,  "y": -120 }, "data": { "params": { "label": "rewards per sequence" } } },
+
+    { "id": "p",        "type": "TensorCreate", "position": { "x": -40,  "y": 100  }, "data": { "params": { "shape": "1,4", "fill": "randn", "value": 0, "requires_grad": false } } },
+    { "id": "q",        "type": "TensorCreate", "position": { "x": -40,  "y": 220  }, "data": { "params": { "shape": "1,4", "fill": "full", "value": 0.0, "requires_grad": false } } },
+    { "id": "kl",       "type": "KLDivergence", "position": { "x": 240,  "y": 160  }, "data": { "params": { "input_kind": "logits", "reduction": "batchmean" } } },
+    { "id": "print_kl", "type": "Print",        "position": { "x": 540,  "y": 160  }, "data": { "params": { "label": "KL(policy || ref)" } } }
+  ],
+  "edges": [
+    { "id": "trig_h", "source": "start-1", "target": "h",  "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "trig_p", "source": "start-1", "target": "p",  "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "trig_q", "source": "start-1", "target": "q",  "sourceHandle": "trigger", "type": "trigger" },
+
+    { "id": "e_h_rm",  "source": "h",  "target": "rm",       "sourceHandle": "tensor", "targetHandle": "hidden_states" },
+    { "id": "e_rm_pr", "source": "rm", "target": "print_r",  "sourceHandle": "rewards", "targetHandle": "value" },
+
+    { "id": "e_p_kl",  "source": "p",  "target": "kl",       "sourceHandle": "tensor", "targetHandle": "p" },
+    { "id": "e_q_kl",  "source": "q",  "target": "kl",       "sourceHandle": "tensor", "targetHandle": "q" },
+    { "id": "e_kl_pr", "source": "kl", "target": "print_kl", "sourceHandle": "kl", "targetHandle": "value" }
+  ]
+}

--- a/examples/Transformer/MoE-TopK-Routing/graph.json
+++ b/examples/Transformer/MoE-TopK-Routing/graph.json
@@ -1,0 +1,17 @@
+{
+  "name": "Mixture of Experts: top-k routing in 5 nodes",
+  "description": "What MoE actually does to a token batch. A 2 × 5 × 32 tensor (2 batches of 5 tokens, hidden dim 32) goes into MoELayer with N=4 experts and top_k=2. Each token picks its 2 best experts by softmax over a small gating network; the layer's output is the weighted sum of those 2 experts' FFN outputs. The Print on routing_weights shows the [B, T, k] tensor so students can read off which experts each token chose and how confident the gate was. Same architecture pattern as Switch Transformer, Mixtral, and DeepSeek-MoE — sized down so the routing decisions fit on one screen.",
+  "nodes": [
+    { "id": "start-1",   "type": "Start",        "position": { "x": -260, "y": 0    }, "data": { "params": {} } },
+    { "id": "x",         "type": "TensorCreate", "position": { "x": -40,  "y": 0    }, "data": { "params": { "shape": "2,5,32", "fill": "randn", "value": 0, "requires_grad": false } } },
+    { "id": "moe",       "type": "MoELayer",     "position": { "x": 240,  "y": 0    }, "data": { "params": { "num_experts": 4, "top_k": 2, "hidden_dim": 32, "expert_hidden_dim": 64, "seed": 42 } } },
+    { "id": "print_w",   "type": "Print",        "position": { "x": 540,  "y": -100 }, "data": { "params": { "label": "routing_weights [B, T, k]" } } },
+    { "id": "print_idx", "type": "Print",        "position": { "x": 540,  "y": 100  }, "data": { "params": { "label": "expert_indices [B, T, k]" } } }
+  ],
+  "edges": [
+    { "id": "trig_x",  "source": "start-1", "target": "x",         "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "e_x_moe", "source": "x",       "target": "moe",       "sourceHandle": "tensor",          "targetHandle": "x" },
+    { "id": "e_moe_w", "source": "moe",     "target": "print_w",   "sourceHandle": "routing_weights", "targetHandle": "value" },
+    { "id": "e_moe_i", "source": "moe",     "target": "print_idx", "sourceHandle": "expert_indices",  "targetHandle": "value" }
+  ]
+}


### PR DESCRIPTION
## Summary

PR 2 of 2 from the AI-Algo-Textbook coverage plan. Closes the gap between Edu* (hand-written, transparent) classifiers and what students need when they leave the textbook for production. Plus the two RLHF building blocks and the MoE FFN — three teaching gaps the textbook flagged.

**5 sklearn wrappers** (Classical category, drop-in for the existing Edu* nodes):
- `KNN` — `KNeighborsClassifier`, KD-tree internally, supports `weights="distance"` and the full metric set
- `LinearRegression` — closed-form OLS
- `LogisticRegression` — multinomial softmax with L1/L2/none, picks the right solver per penalty
- `SVMClassifier` — `SVC` with linear/rbf/poly/sigmoid kernels; outputs `support_vectors` for viz
- `DecisionTreeClassifier` — outputs `feature_importances` and the human-readable `tree_text` rules dump

**2 RLHF blocks** (RL category):
- `RewardModel` — small MLP head; accepts `[B, H]` or `[B, T, H]` (uses last token); the piece you train on human preferences
- `KLDivergence` — `KL(p || q)` with probs/logits inputs and the four standard reductions; the regulariser term in PPO-RLHF

**1 MoE block** (Transformer category):
- `MoELayer` — top-k softmax gating over N expert FFNs (Switch / Mixtral / DeepSeek pattern); outputs `routing_weights` and `expert_indices` so a viz can show which expert handled which token

**3 demo presets**:
- `Classical/Iris-Sklearn-KNN` — same shape as `KNN-from-Scratch` but with the production node, demonstrating drop-in swap
- `RL/RLHF-Reward-and-KL` — independent reward-head and KL-divergence blocks
- `Transformer/MoE-TopK-Routing` — 2×5×32 token batch through MoE(N=4, k=2)

## Test plan

- [x] Backend: 590/590 pytest (8 new test files, 53 new tests)
- [x] Frontend: 109/109 vitest (no frontend changes — all new nodes use the default `baseNode` renderer; categories already exist in palette ordering)
- [x] tsc clean
- [x] All 8 nodes appear in `/api/nodes` (101 total) under correct categories
- [x] All 3 presets validate via `/api/examples/list`
- [x] All 3 presets execute end-to-end via `/ws/execution` with no `node_status: error` events
- [x] Smoke-tested in Chrome against the running dev stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)