### PR TITLE
fix(export): use graph name for Python script header and filename

### DIFF
--- a/frontend/src/api/rest.test.ts
+++ b/frontend/src/api/rest.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { exportGraph } from './rest';
+
+const g = globalThis as unknown as { fetch: typeof fetch };
+let originalFetch: typeof fetch;
+
+function mockFetch(status: number, body: unknown) {
+  const response = {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'mock',
+    json: async () => body,
+  } as unknown as Response;
+  g.fetch = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
+  return g.fetch as unknown as ReturnType<typeof vi.fn>;
+}
+
+beforeEach(() => {
+  originalFetch = g.fetch;
+});
+
+afterEach(() => {
+  g.fetch = originalFetch;
+});
+
+describe('exportGraph', () => {
+  it('sends name when provided so the script header uses it', async () => {
+    const fetchMock = mockFetch(200, { script: '...' });
+    await exportGraph([], [], 'Train CNN on MNIST');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/graph/export');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ nodes: [], edges: [], name: 'Train CNN on MNIST' });
+  });
+
+  it('omits name when not provided so backend falls back to its default', async () => {
+    const fetchMock = mockFetch(200, { script: '...' });
+    await exportGraph([], []);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ nodes: [], edges: [] });
+  });
+
+  it('throws when the endpoint fails', async () => {
+    mockFetch(500, {});
+    await expect(exportGraph([], [], 'x')).rejects.toThrow(/Export failed/);
+  });
+});

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -46,14 +46,16 @@ export async function listGraphs() {
   return res.json();
 }
 
-export async function exportGraph(nodes: any[], edges: any[]) {
+export async function exportGraph(nodes: any[], edges: any[], name?: string) {
+  const body: { nodes: any[]; edges: any[]; name?: string } = { nodes, edges };
+  if (name) body.name = name;
   const res = await fetch(`${BASE_URL}/graph/export`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ nodes, edges }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`Export failed: ${res.statusText}`);
-  return res.json();
+  return res.json() as Promise<{ script: string }>;
 }
 
 /** A2: clear persisted layer weights kept by the backend NodeStateStore.

--- a/frontend/src/components/Canvas/EmptyCanvasOverlay.tsx
+++ b/frontend/src/components/Canvas/EmptyCanvasOverlay.tsx
@@ -63,6 +63,7 @@ function renderCard(
 export function EmptyCanvasOverlay() {
   const setNodes = useTabStore((s) => s.setNodes);
   const setEdges = useTabStore((s) => s.setEdges);
+  const renameTab = useTabStore((s) => s.renameTab);
   const { t } = useI18n();
   const addToast = useToastStore((s) => s.addToast);
 
@@ -106,6 +107,14 @@ export function EmptyCanvasOverlay() {
         setNodes(resolvedNodes);
         setEdges(resolvedEdges);
 
+        // Mirror the example name onto the active tab so saves, exports,
+        // and the script header all use a meaningful name out of the box.
+        const exampleName = typeof data.name === 'string' && data.name.trim() ? data.name.trim() : null;
+        if (exampleName) {
+          const { activeTabId } = useTabStore.getState();
+          renameTab(activeTabId, exampleName);
+        }
+
         if (importedPresets.length > 0) {
           useNodeDefStore.setState({ presets: mergedPresets });
         }
@@ -113,7 +122,7 @@ export function EmptyCanvasOverlay() {
         addToast(t('empty.loadError'), 'error');
       }
     },
-    [setNodes, setEdges, t],
+    [setNodes, setEdges, renameTab, t, addToast],
   );
 
   return (

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -355,9 +355,9 @@ export function Toolbar() {
       addToast(t('toolbar.exportPython.empty'), 'warning');
       return;
     }
+    const name = activeTab.name || 'graph';
     try {
-      const result = await exportGraph(nodes, edges);
-      const name = activeTab.name || 'graph';
+      const result = await exportGraph(nodes, edges, name);
       const blob = new Blob([result.script], { type: 'text/x-python' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');


### PR DESCRIPTION
## Summary

Follow-up to #20 from end-to-end Chrome testing. The export flow worked, but the generated script's docstring was always "Untitled" and the downloaded file was always `Tab_1.py`, because:

1. `exportGraph()` only sent `{ nodes, edges }` — the backend `GraphData.name` therefore defaulted to "Untitled".
2. Loading an example never updated the active tab's name, so the toolbar's filename source (`activeTab.name`) stayed at the default "Tab 1".

## Changes

- **`api/rest.ts`** — `exportGraph(nodes, edges, name?)`; sends `name` in the POST body when provided.
- **`Toolbar.tsx`** — passes `activeTab.name` to `exportGraph`.
- **`EmptyCanvasOverlay.tsx`** — calls `renameTab(activeTabId, data.name)` after loading an example so the tab title reflects the example name out of the box.
- **`rest.test.ts`** — new vitest covering name pass-through, no-name fallback, and failure path.

## Test plan

- [x] `npx vitest run` — 112 frontend tests pass (3 new in `rest.test.ts`).
- [x] `pytest backend/tests/test_codegen.py tests/test_api_graph.py` — 10 backend tests pass (regression check).
- [x] **End-to-end Chrome**: opened a new tab, clicked the "Train CNN on MNIST" example. Tab title automatically changed to "Train CNN on MNIST". Clicked Export → Python; `/api/graph/export` returned 200 and the downloaded script's docstring now reads "Train CNN on MNIST". Verified `activeTabName === 'Train CNN on MNIST'` and the toolbar's computed `download` attribute resolved to `Train_CNN_on_MNIST.py` via in-page JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)