### PR TITLE
docs: sync node counts to 94 / 15 categories + close zh-TW gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A visual, node-based deep learning pipeline builder. Design CNN, RNN, Transforme
 ## Features
 
 - **Visual Graph Editor** — Drag-and-drop nodes, connect ports with type-safe edges, real-time validation
-- **69 Built-in Nodes** across 13 categories (CNN, RNN, Transformer, RL, Data, Data Flow, Training, IO, Control, Utility, Normalization, Tensor Operations, LLM)
+- **94 Built-in Nodes** across 15 categories (CNN, RNN, Transformer, RL, Data, Data Flow, Training, IO, Control, Utility, Normalization, Tensor Operations, LLM, Classical, Diffusion)
 - **Teaching Inspector** — Record full per-node outputs, inspect input→output tensor diffs side-by-side, and wrap a subgraph with the **Compare Segment** bubble to focus on just head-input vs tail-output. Drop in a `TensorInput` node with an inline grid editor to feed the pipeline and watch each transformation
 - **Preset System** — Pre-built model templates for quick start; export your own subgraphs as reusable presets
 - **Multi-Tab Workspace** — Multiple independent canvases, each with its own execution context
@@ -110,10 +110,10 @@ backend/    Python 3.10+ · FastAPI · PyTorch
 | Category | Nodes | Count |
 |----------|-------|-------|
 | **CNN** | Conv2d, Conv1d, ConvTranspose2d, MaxPool2d, AvgPool2d, AdaptiveAvgPool2d, BatchNorm2d, Dropout, Activation | 9 |
-| **RNN** | LSTM, GRU | 2 |
-| **Transformer** | MultiHeadAttention, TransformerEncoder, TransformerDecoder | 3 |
-| **RL** | DQN, PPO, EnvWrapper | 3 |
-| **Data** | Dataset, DataLoader, Transform, HuggingFaceDataset, KaggleDataset, TensorInput, TextInput | 7 |
+| **RNN** | LSTM, GRU, RNNCell | 3 |
+| **Transformer** | MultiHeadAttention, TransformerEncoder, TransformerDecoder, MoELayer | 4 |
+| **RL** | DQN, PPO, EnvWrapper, RewardModel, KLDivergence | 5 |
+| **Data** | Dataset, DataLoader, Transform, HuggingFaceDataset, KaggleDataset, TensorInput, TextInput, CSVReader, ColumnSelector, Normalize, SyntheticDataset, TrainTestSplit | 12 |
 | **Data Flow** | Map, Reduce, Switch | 3 |
 | **Training** | Optimizer, Loss, TrainingLoop, LRScheduler, SequentialModel, BackwardOnce | 6 |
 | **IO** | ImageReader, ImageWriter, ImageBatchReader, FileReader, CheckpointSaver, CheckpointLoader, ModelLoader, ModelSaver, Inference | 9 |
@@ -121,7 +121,9 @@ backend/    Python 3.10+ · FastAPI · PyTorch
 | **Utility** | Print, Reshape, Concat, Flatten, Linear, Visualize, Embedding | 7 |
 | **Normalization** | BatchNorm1d, LayerNorm, GroupNorm, InstanceNorm2d | 4 |
 | **Tensor Operations** | Add, MatMul, Mean, Multiply, Permute, Softmax, Split, Squeeze, Stack, TensorCreate, Unsqueeze | 11 |
-| **LLM** | Tokenizer, WordVector, EmbeddingScatter, CosineSimilarity | 4 |
+| **LLM** | Tokenizer, WordVector, EmbeddingScatter, CosineSimilarity, AttentionMask, AttentionHeatmap, PositionalEncoding | 7 |
+| **Classical** | KNN, LinearRegression, LogisticRegression, DecisionTreeClassifier, SVMClassifier, MLPClassifier, Accuracy | 7 |
+| **Diffusion** | Upsample, TimestepEmbedding, Lerp, GaussianNoise, DDPMSampler, DiffusionUNet | 6 |
 
 ## Examples
 

--- a/docs/README_zh-TW.md
+++ b/docs/README_zh-TW.md
@@ -9,7 +9,7 @@
 ## 功能特色
 
 - **視覺化圖形編輯器** — 拖放節點、型別安全的連線、即時驗證
-- **69 個內建節點**，涵蓋 13 大類別（CNN、RNN、Transformer、RL、資料、資料流、訓練、IO、控制、工具、正規化、張量運算、LLM）
+- **94 個內建節點**，涵蓋 15 大類別（CNN、RNN、Transformer、RL、資料、資料流、訓練、IO、控制、工具、正規化、張量運算、LLM、傳統機器學習、Diffusion）
 - **教學檢視器 (Teaching Inspector)** — 記錄每個節點的完整輸出，在右側面板對照輸入與輸出張量的差異；用 **段落比較** 功能以淺橘色泡泡包住一段子圖，只比較 head 的輸入與 tail 的輸出。搭配新的 `TensorInput` 節點（可在網頁直接編輯格子）餵入資料，看資料逐節點變化
 - **預設模組系統** — 內建模型模板快速開始；可將子圖匯出為可重用的預設模組
 - **多分頁工作區** — 多個獨立畫布，各自擁有獨立的執行環境
@@ -107,10 +107,10 @@ backend/    Python 3.10+ · FastAPI · PyTorch
 | 類別 | 節點 | 數量 |
 |------|------|------|
 | **CNN** | Conv2d、Conv1d、ConvTranspose2d、MaxPool2d、AvgPool2d、AdaptiveAvgPool2d、BatchNorm2d、Dropout、Activation | 9 |
-| **RNN** | LSTM、GRU | 2 |
-| **Transformer** | MultiHeadAttention、TransformerEncoder、TransformerDecoder | 3 |
-| **RL** | DQN、PPO、EnvWrapper | 3 |
-| **資料** | Dataset、DataLoader、Transform、HuggingFaceDataset、KaggleDataset、TensorInput、TextInput | 7 |
+| **RNN** | LSTM、GRU、RNNCell | 3 |
+| **Transformer** | MultiHeadAttention、TransformerEncoder、TransformerDecoder、MoELayer | 4 |
+| **RL** | DQN、PPO、EnvWrapper、RewardModel、KLDivergence | 5 |
+| **資料** | Dataset、DataLoader、Transform、HuggingFaceDataset、KaggleDataset、TensorInput、TextInput、CSVReader、ColumnSelector、Normalize、SyntheticDataset、TrainTestSplit | 12 |
 | **資料流** | Map、Reduce、Switch | 3 |
 | **訓練** | Optimizer、Loss、TrainingLoop、LRScheduler、SequentialModel、BackwardOnce | 6 |
 | **IO** | ImageReader、ImageWriter、ImageBatchReader、FileReader、CheckpointSaver、CheckpointLoader、ModelLoader、ModelSaver、Inference | 9 |
@@ -118,7 +118,9 @@ backend/    Python 3.10+ · FastAPI · PyTorch
 | **工具** | Print、Reshape、Concat、Flatten、Linear、Visualize、Embedding | 7 |
 | **正規化** | BatchNorm1d、LayerNorm、GroupNorm、InstanceNorm2d | 4 |
 | **張量運算** | Add、MatMul、Mean、Multiply、Permute、Softmax、Split、Squeeze、Stack、TensorCreate、Unsqueeze | 11 |
-| **LLM** | Tokenizer、WordVector、EmbeddingScatter、CosineSimilarity | 4 |
+| **LLM** | Tokenizer、WordVector、EmbeddingScatter、CosineSimilarity、AttentionMask、AttentionHeatmap、PositionalEncoding | 7 |
+| **傳統機器學習 (Classical)** | KNN、LinearRegression、LogisticRegression、DecisionTreeClassifier、SVMClassifier、MLPClassifier、Accuracy | 7 |
+| **Diffusion** | Upsample、TimestepEmbedding、Lerp、GaussianNoise、DDPMSampler、DiffusionUNet | 6 |
 
 ## 範例
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -273,7 +273,7 @@ python scripts/dev.py dev
    ```bash
    curl http://127.0.0.1:8000/api/health
    ```
-   Should return `{"status":"ok","nodes_loaded":69,"presets_loaded":3}` (the exact `nodes_loaded` count grows with each release; check it's non-zero).
+   Should return `{"status":"ok","nodes_loaded":94,"presets_loaded":3}` (the exact `nodes_loaded` count grows with each release; check it's non-zero).
 
 2. Verify device detection:
    ```bash

--- a/docs/SETUP_zh-TW.md
+++ b/docs/SETUP_zh-TW.md
@@ -273,7 +273,7 @@ python scripts/dev.py dev
    ```bash
    curl http://127.0.0.1:8000/api/health
    ```
-   應回傳 `{"status":"ok","nodes_loaded":69,"presets_loaded":3}`（`nodes_loaded` 數量會隨版本增加，確認非 0 即可）。
+   應回傳 `{"status":"ok","nodes_loaded":94,"presets_loaded":3}`（`nodes_loaded` 數量會隨版本增加，確認非 0 即可）。
 
 2. 驗證裝置偵測：
    ```bash

--- a/frontend/src/components/ConfigPanel/TensorGridEditor.tsx
+++ b/frontend/src/components/ConfigPanel/TensorGridEditor.tsx
@@ -151,7 +151,7 @@ export function TensorGridEditor({ param, value, onChange, displayLabel, sibling
       {!disabled && total > MAX_INLINE_NUMEL && (
         <div className={styles.hintWarn}>
           Shape has {total} elements — too large for inline editing (max {MAX_INLINE_NUMEL}).
-          Switch value_mode to <code>random</code> or upload a file (coming soon).
+          Switch <code>value_mode</code> to <code>random</code>, <code>zeros</code>, <code>ones</code>, or <code>arange</code>.
         </div>
       )}
 

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -7,6 +7,9 @@ const zhTW: NodeTranslations = {
   },
 
   // ── Classical (sklearn) ──
+  Accuracy: {
+    description: '計算預測標籤與真實標籤的分類正確率。會輸出 [0, 1] 的小數、答對數與樣本總數三個欄位 — 讓圖表能直接落在「50%」這種一目了然的數字上。C2 章節的標準收尾節點：線性分類器在同心圓資料上失敗時，這裡就會跳出 ≈ 0.5 的證據。',
+  },
   DecisionTreeClassifier: {
     description: 'CART 決策樹（封裝 sklearn）。遞迴切分特徵以最大化純度；教學上最有價值的是 tree_text 輸出 — 直接把學到的 if/else 規則以易讀格式印出來。',
     params: {
@@ -35,6 +38,16 @@ const zhTW: NodeTranslations = {
       C: '正則化強度的倒數（值越小，正則化越強）。',
       max_iter: '求解器最大迭代次數。',
       penalty: '正則化類型。l1 需要 liblinear/saga 求解器；sklearn 會自動挑。',
+    },
+  },
+  MLPClassifier: {
+    description: '前饋神經網路分類器（封裝 sklearn MLPClassifier）。一層或多層隱藏層、ReLU/tanh 激活、Adam 優化器。I/O 介面與線性分類器完全相同，所以「同心圓線性分類失敗 → 換 MLP 救回」這個敘事只需換一個節點型別。要看內部步驟用 Edu 系列，要直接拿結果用這個。',
+    params: {
+      hidden_sizes: '逗號分隔的隱藏層大小。「16,16」代表兩層、每層 16 個神經元。',
+      activation: '隱藏層激活函數。「identity」會讓整個網路退化成線性 — 用來示範為什麼需要非線性激活。',
+      max_iter: '最大訓練迭代次數（在整個資料集上跑幾輪）。',
+      learning_rate_init: 'Adam 的初始學習率。',
+      seed: '可重現用的隨機種子。',
     },
   },
   SVMClassifier: {
@@ -272,6 +285,17 @@ const zhTW: NodeTranslations = {
       name: '要載入的資料集',
       split: '資料分割',
       data_dir: '下載/儲存資料集的目錄',
+    },
+  },
+  SyntheticDataset: {
+    description: '用 sklearn 即時生成 2D 玩具資料集（同心圓、雙月、blob 群聚或一般 make_classification）。輸出格式與 CSVReader 一致，所以 TrainTestSplit 與下游分類器可以直接接 — 範例圖不再需要綁定 CSV 檔。C2-2 ~ C2-5 的標準資料來源。',
+    params: {
+      kind: 'circles 同心圓（線性不可分）；moons 雙交錯半月；blobs 等向高斯群聚（線性可分）；classification 通用 sklearn make_classification。',
+      n_samples: '要生成的樣本總數。',
+      noise: '加在點上的高斯噪聲（僅 circles/moons/classification 用得到）。',
+      factor: 'circles 內外圈半徑比，介於 0 與 1 之間。其他 kind 會忽略。',
+      centers: 'blob 群聚的中心數（只在 kind=blobs 時使用）。',
+      seed: '可重現用的隨機種子。',
     },
   },
   HuggingFaceDataset: {

--- a/plans/analysis-report.md
+++ b/plans/analysis-report.md
@@ -499,7 +499,7 @@ ExecutionContext.backward_mode=True
 
 #### 2.7.1 Plugin 系統
 
-**Why now：** 91 個內建節點已涵蓋 CNN/RNN/Transformer/RL/Diffusion/Classical/LLM 的核心，再往下擴充會撐爆 built-in 集合的可維護性。教育場景的需求是「按章節、按課程、按學派」分離節點集——這就是 plugin 系統的核心目的。
+**Why now：** 94 個內建節點已涵蓋 CNN/RNN/Transformer/RL/Diffusion/Classical/LLM 的核心，再往下擴充會撐爆 built-in 集合的可維護性。教育場景的需求是「按章節、按課程、按學派」分離節點集——這就是 plugin 系統的核心目的。
 
 **架構：**
 ```
@@ -813,7 +813,7 @@ cdui plugin search <query>
 - ~~end users 需要裝 Node~~ — frontend-dist 發佈管線解決
 - ~~Window.confirm / prompt 體驗差~~ — PR #17 解決
 - ~~測試框架不足~~ — 0f2473c 60 個節點測試 + plugin 測試
-- ~~i18n 未完成~~ — PR #23 91 個節點完成 zh-TW
+- ~~i18n 未完成~~ — PR #23 起累積完成 94/94 個內建節點 zh-TW
 - ~~AGPL 授權未正式化~~ — PR #9 完成
 
 ### 4.4 反向觀察：CodefyUI 已建立的領先優勢（2026-05 update）


### PR DESCRIPTION
## Summary
- README and SETUP advertised 69 nodes / 13 categories, but the backend now ships **94 nodes across 15 categories**. Classical (7 nodes) and Diffusion (6 nodes) were missing entirely, and almost every other category had stale entries.
- Drop the misleading `(coming soon)` file-upload hint in `TensorGridEditor` — that mode never shipped and isn't on the roadmap. Replace with the actual fallbacks (random / zeros / ones / arange).
- Close the i18n gap referenced in `analysis-report.md`: add zh-TW translations for **Accuracy**, **MLPClassifier**, **SyntheticDataset** so zh-TW now covers all 94 built-in nodes.
- Bump the health-check example in `SETUP{,_zh-TW}.md` from `nodes_loaded:69` to `nodes_loaded:94`.
- Update `analysis-report.md`: 91 → 94 in two places.

## What was missing from README node tables
| Category | Was | Now | Added |
|---|---|---|---|
| RNN | 2 | 3 | RNNCell |
| Transformer | 3 | 4 | MoELayer |
| RL | 3 | 5 | RewardModel, KLDivergence |
| Data | 7 | 12 | CSVReader, ColumnSelector, Normalize, SyntheticDataset, TrainTestSplit |
| LLM | 4 | 7 | AttentionMask, AttentionHeatmap, PositionalEncoding |
| **Classical** | — | 7 | KNN, LinearRegression, LogisticRegression, DecisionTreeClassifier, SVMClassifier, MLPClassifier, Accuracy |
| **Diffusion** | — | 6 | Upsample, TimestepEmbedding, Lerp, GaussianNoise, DDPMSampler, DiffusionUNet |

## Test plan
- [x] Counts verified against `grep -c NODE_NAME` per category directory in `backend/app/nodes/`.
- [x] `pnpm tsc --noEmit` in `frontend/` passes (i18n object still satisfies `NodeTranslations`).
- [ ] CI: frontend-build workflow on this PR.
- [ ] Health-check string is documentation only, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)