### PR TITLE
Fix the mimetype import error for Windows User

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,21 @@
 import logging
+import mimetypes
 from contextlib import asynccontextmanager
 from pathlib import Path
 from urllib.parse import urlparse
+
+# Windows reads MIME types from the registry, which other installers (VS, IIS,
+# antivirus, etc.) routinely clobber — `.js` often ends up as `text/plain`,
+# which browsers refuse to execute under `<script type="module">` strict MIME
+# checks, leaving the SPA blank. Force the correct types in-process so we
+# never depend on whatever the host registry happens to say.
+mimetypes.add_type("text/javascript", ".js")
+mimetypes.add_type("text/javascript", ".mjs")
+mimetypes.add_type("text/css", ".css")
+mimetypes.add_type("application/json", ".json")
+mimetypes.add_type("image/svg+xml", ".svg")
+mimetypes.add_type("font/woff2", ".woff2")
+mimetypes.add_type("font/woff", ".woff")
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,11 +4,27 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from urllib.parse import urlparse
 
+import logging
+import mimetypes
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from urllib.parse import urlparse
+
 # Windows reads MIME types from the registry, which other installers (VS, IIS,
 # antivirus, etc.) routinely clobber — `.js` often ends up as `text/plain`,
 # which browsers refuse to execute under `<script type="module">` strict MIME
 # checks, leaving the SPA blank. Force the correct types in-process so we
 # never depend on whatever the host registry happens to say.
+if sys.platform == "win32":
+    mimetypes.add_type("text/javascript", ".js")
+    mimetypes.add_type("text/javascript", ".mjs")
+    mimetypes.add_type("text/css", ".css")
+    mimetypes.add_type("application/json", ".json")
+    mimetypes.add_type("image/svg+xml", ".svg")
+    mimetypes.add_type("font/woff2", ".woff2")
+    mimetypes.add_type("font/woff", ".woff")
+
 mimetypes.add_type("text/javascript", ".js")
 mimetypes.add_type("text/javascript", ".mjs")
 mimetypes.add_type("text/css", ".css")


### PR DESCRIPTION
## Symptom

  On Windows, after a clean install via `install.ps1` + `cdui start`, opening
  `http://localhost:8000` shows a blank page. DevTools Console:

  > Failed to load module script: Expected a JavaScript-or-Wasm module script
  > but the server responded with a MIME type of "text/plain". Strict MIME
  > type checking is enforced for module scripts per HTML spec.

  macOS / Linux are unaffected.

  ## Root cause

  Python's `mimetypes` module on Windows reads MIME types from the registry
  (`HKEY_CLASSES_ROOT\.js\Content Type`). Other installers (Visual Studio,
  IIS, some AV products) routinely clobber that key to `text/plain`.
  Starlette's `StaticFiles` uses `mimetypes.guess_type()` directly, so the JS
  bundle is served as `text/plain` and the browser refuses to execute it
  under `<script type="module">` strict MIME checks — the SPA never mounts.

  Reproduced locally:

      > python -c "import mimetypes; mimetypes.init(); print(mimetypes.guess_type('a.js'))"
      ('text/plain', None)

  ## Fix

  Register the correct MIME types in `backend/app/main.py` at import time,
  before any FastAPI / Starlette code touches the mimetypes table.
  `mimetypes.add_type` takes precedence over registry-derived values, so the
  running process always serves the right `Content-Type` regardless of host
  state.

  Covers `.js`, `.mjs`, `.css`, `.json`, `.svg`, `.woff`, `.woff2`. No-op on
  macOS / Linux (these are already the defaults there).

  ## Verification

  - Before patch on Windows: blank page, console error as above.
  - After patch: SPA loads normally, Network tab shows `Content-Type:
    text/javascript` on the bundle.
  - macOS teammate confirmed unchanged behavior.