### PR TITLE
feat(foundations): new Edu nodes — SlidingWindow, VectorSimilarity, SVM, DecisionTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ and lets `cdui start` rediscover them on the next launch.
 
 | Pack | Hands-on modules | Edu nodes |
 |------|------------------|-----------|
-| `foundations` | I1 資料表示 · I2 經典 ML | Edu-ColumnStats, Edu-KNN, Edu-LinearRegression, Edu-LogisticRegression, Edu-TokenEmbedding, Edu-FFN |
+| `foundations` | I1 資料表示 · I2 經典 ML | Edu-ColumnStats, Edu-SlidingWindow, Edu-TokenEmbedding, Edu-VectorSimilarity, Edu-KNN, Edu-LinearRegression, Edu-LogisticRegression, Edu-SVM, Edu-DecisionTree, Edu-FFN |
 | `deep` | I3 視覺 · I4 序列 | Edu-CrossAttention, Edu-ResBlock, Edu-SelfAttention, Edu-MultiHeadAttention, Edu-Patchify |
 | `rl` | I5 強化學習 | Edu-PolicyGradient |
 

--- a/backend/tests/test_chapter_examples.py
+++ b/backend/tests/test_chapter_examples.py
@@ -1,9 +1,9 @@
-"""Smoke-test every chapter plugin example by actually executing its graph.
+"""Smoke-test every plugin example by actually executing its graph.
 
-Each chapter has at least one ``plugins/c{N}/examples/C{N}-{M}/<name>/graph.json``
-that the textbook references. A broken graph wastes the student's first
-attempt at running the example, so this test asserts each graph parses,
-validates, and executes end-to-end without error.
+Each direction pack ships ``plugins/<pack>/examples/**/graph.json`` files that
+the textbook references. A broken graph wastes the student's first attempt at
+running the example, so this test asserts each graph parses, validates, and
+executes end-to-end without error.
 
 Parametrised by glob so adding a new example file is enough — no test
 code changes required.
@@ -25,7 +25,9 @@ _PLUGIN_ROOT = _REPO_ROOT / "plugins"
 
 
 def _discover_chapter_graphs() -> list[Path]:
-    return sorted(_PLUGIN_ROOT.glob("c?/examples/**/graph.json"))
+    # Match every direction pack (foundations / deep / rl) — and any future
+    # pack — under plugins/<pack>/examples/.
+    return sorted(_PLUGIN_ROOT.glob("*/examples/**/graph.json"))
 
 
 _GRAPHS = _discover_chapter_graphs()

--- a/backend/tests/test_edu_decision_tree_node.py
+++ b/backend/tests/test_edu_decision_tree_node.py
@@ -1,0 +1,216 @@
+"""Tests for EduDecisionTreeNode."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+
+from cdui_plugins.foundations.nodes.edu_decision_tree_node import EduDecisionTreeNode
+
+
+class _Ctx:
+    """Minimal stand-in for ExecutionContext with a verbose flag."""
+
+    def __init__(self, verbose: bool = False) -> None:
+        self.verbose = verbose
+
+
+def _run(x_train, y_train, x_query, *, context=None, **params):
+    p = {"max_depth": 3, "min_samples_split": 2, "criterion": "gini"}
+    p.update(params)
+    return EduDecisionTreeNode().execute(
+        {"x_train": x_train, "y_train": y_train, "x_query": x_query},
+        p,
+        context=context,
+    )
+
+
+def test_node_metadata():
+    assert EduDecisionTreeNode.NODE_NAME == "Edu-DecisionTree"
+    assert EduDecisionTreeNode.CATEGORY == "Classical"
+    out_names = [p.name for p in EduDecisionTreeNode.define_outputs()]
+    assert out_names == ["predictions", "tree", "node_count"]
+
+
+def test_separable_one_feature_root_split():
+    """x < 0 -> class 0, x > 0 -> class 1: root splits feature 0 near 0."""
+    x_train = torch.tensor(
+        [[-3.0], [-2.0], [-1.0], [1.0], [2.0], [3.0]]
+    )
+    y_train = torch.tensor([0, 0, 0, 1, 1, 1])
+    x_query = torch.tensor([[-1.5], [-0.5], [0.5], [2.5]])
+    res = _run(x_train, y_train, x_query)
+
+    tree = res["tree"]
+    assert tree.get("leaf") is None  # root is internal
+    assert tree["feature"] == 0
+    # Midpoint between -1 and 1 is 0.0.
+    assert abs(tree["threshold"]) < 1.0
+    assert res["predictions"].tolist() == [0, 0, 1, 1]
+
+
+def test_two_blocks_full_train_accuracy():
+    """Two axis-aligned blocks separable with depth-2 splits -> 100% train acc."""
+    # Class 0 lower-left & lower-right, class 1 upper band — needs >=2 splits.
+    x_train = torch.tensor([
+        [0.0, 0.0],
+        [1.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [0.0, 5.0],
+        [1.0, 5.0],
+        [5.0, 0.0],
+        [5.0, 1.0],
+    ])
+    # XOR-ish: class 1 when exactly one coordinate is "large".
+    y_train = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1])
+    res = _run(x_train, y_train, x_train, max_depth=3)
+    assert res["predictions"].tolist() == y_train.tolist()
+
+
+def test_two_d_needs_depth_two_full_train_accuracy():
+    """A 2-D dataset whose boundary needs two nested axis-aligned splits.
+
+    Region rule:
+        feature 0 <= 2  -> class 0   (left band)
+        feature 0  > 2 and feature 1 <= 2 -> class 1  (lower-right)
+        feature 0  > 2 and feature 1  > 2 -> class 2  (upper-right)
+    A single split cannot separate all three classes; depth >= 2 can, and
+    a greedy tree fits it exactly because each split has positive gain.
+    """
+    x_train = torch.tensor([
+        [0.0, 0.0], [1.0, 4.0], [0.0, 5.0],   # left band -> 0
+        [4.0, 0.0], [5.0, 1.0], [4.0, 0.5],   # lower-right -> 1
+        [4.0, 5.0], [5.0, 4.0], [4.5, 5.0],   # upper-right -> 2
+    ])
+    y_train = torch.tensor([0, 0, 0, 1, 1, 1, 2, 2, 2])
+    res = _run(x_train, y_train, x_train, max_depth=2)
+    assert res["predictions"].tolist() == y_train.tolist()
+    # Tree must actually be at least depth 2 to separate three classes.
+    node = res["tree"]
+    assert node.get("leaf") is None
+    deeper = node["left"] if node["left"].get("leaf") is None else node["right"]
+    assert deeper.get("leaf") is None  # a grandchild split exists
+
+
+def test_tree_is_json_serializable_and_well_shaped():
+    x_train = torch.tensor([[-2.0], [-1.0], [1.0], [2.0]])
+    y_train = torch.tensor([0, 0, 1, 1])
+    res = _run(x_train, y_train, x_train)
+    tree = res["tree"]
+
+    # JSON round-trips cleanly.
+    dumped = json.dumps(tree)
+    assert isinstance(dumped, str)
+
+    # Internal-node shape.
+    for key in ("feature", "threshold", "impurity", "gain", "n_samples", "left", "right"):
+        assert key in tree
+    assert isinstance(tree["feature"], int)
+    assert isinstance(tree["threshold"], float)
+    assert isinstance(tree["n_samples"], int)
+
+    # Walk to a leaf and check its shape.
+    leaf = tree["left"]
+    while not leaf.get("leaf"):
+        leaf = leaf["left"]
+    assert leaf["leaf"] is True
+    assert isinstance(leaf["prediction"], int)
+    assert isinstance(leaf["n_samples"], int)
+    assert isinstance(leaf["class_counts"], dict)
+    # class_counts keys are strings (JSON-safe), values are ints.
+    for k, v in leaf["class_counts"].items():
+        assert isinstance(k, str)
+        assert isinstance(v, int)
+
+
+def test_max_depth_respected():
+    """A deep, separable dataset capped at max_depth=1 yields a single split."""
+    # 4 well-separated clusters on feature 0 -> would normally build a deep tree.
+    x_train = torch.tensor(
+        [[0.0], [1.0], [10.0], [11.0], [20.0], [21.0], [30.0], [31.0]]
+    )
+    y_train = torch.tensor([0, 0, 1, 1, 2, 2, 3, 3])
+    res = _run(x_train, y_train, x_train, max_depth=1)
+    tree = res["tree"]
+    # Root is one split; both children must be leaves (no depth beyond 1).
+    assert tree.get("leaf") is None
+    assert tree["left"].get("leaf") is True
+    assert tree["right"].get("leaf") is True
+    # node_count = root + 2 leaves = 3.
+    assert int(res["node_count"].item()) == 3
+
+
+def test_shape_mismatch_raises():
+    # x_query feature count differs from x_train.
+    with pytest.raises(ValueError):
+        _run(
+            torch.zeros(4, 2),
+            torch.tensor([0, 1, 0, 1]),
+            torch.zeros(2, 3),
+        )
+
+
+def test_label_count_mismatch_raises():
+    with pytest.raises(ValueError, match="mismatch"):
+        _run(
+            torch.zeros(4, 2),
+            torch.tensor([0, 1, 0]),
+            torch.zeros(1, 2),
+        )
+
+
+def test_empty_training_set_raises():
+    with pytest.raises(ValueError, match="empty"):
+        _run(torch.zeros(0, 2), torch.zeros(0, dtype=torch.long), torch.zeros(1, 2))
+
+
+def test_bad_params_raise():
+    with pytest.raises(ValueError, match="max_depth"):
+        _run(torch.tensor([[0.0], [1.0]]), torch.tensor([0, 1]), torch.tensor([[0.5]]), max_depth=0)
+    with pytest.raises(ValueError, match="min_samples_split"):
+        _run(
+            torch.tensor([[0.0], [1.0]]),
+            torch.tensor([0, 1]),
+            torch.tensor([[0.5]]),
+            min_samples_split=1,
+        )
+
+
+def test_entropy_criterion_also_works():
+    x_train = torch.tensor([[-2.0], [-1.0], [1.0], [2.0]])
+    y_train = torch.tensor([0, 0, 1, 1])
+    res = _run(x_train, y_train, x_train, criterion="entropy")
+    assert res["predictions"].tolist() == [0, 0, 1, 1]
+
+
+def test_verbose_emits_steps_non_verbose_does_not():
+    x_train = torch.tensor([[-2.0], [-1.0], [1.0], [2.0]])
+    y_train = torch.tensor([0, 0, 1, 1])
+
+    quiet = _run(x_train, y_train, x_train)
+    assert "__steps__" not in quiet
+
+    loud = _run(x_train, y_train, x_train, context=_Ctx(verbose=True))
+    steps = loud["__steps__"]
+    assert len(steps) >= 1
+    names = [s.name for s in steps]
+    # At least one per-split step plus the final "tree" summary.
+    assert any(n.startswith("split_d") for n in names)
+    assert names[-1] == "tree"
+    # The per-split step carries the documented scalars.
+    split_step = next(s for s in steps if s.name.startswith("split_d"))
+    for key in ("feature", "threshold", "impurity_before", "impurity_after", "gain", "n_samples"):
+        assert key in split_step.scalars
+    assert set(steps[-1].scalars) == {"node_count", "depth"}
+
+
+def test_determinism_repeated_runs_match():
+    x_train = torch.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    y_train = torch.tensor([0, 1, 1, 0])
+    a = _run(x_train, y_train, x_train, max_depth=2)
+    b = _run(x_train, y_train, x_train, max_depth=2)
+    assert a["predictions"].tolist() == b["predictions"].tolist()
+    assert json.dumps(a["tree"]) == json.dumps(b["tree"])

--- a/backend/tests/test_edu_sliding_window_node.py
+++ b/backend/tests/test_edu_sliding_window_node.py
@@ -1,0 +1,172 @@
+"""Tests for EduSlidingWindowNode (chapter pack foundations, lesson I1-2)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from cdui_plugins.foundations.nodes.edu_sliding_window_node import EduSlidingWindowNode
+
+
+class _Ctx:
+    """Minimal stand-in for ExecutionContext exposing only ``.verbose``."""
+
+    def __init__(self, verbose: bool = False) -> None:
+        self.verbose = verbose
+
+
+def _run(image, *, kernel=None, context=None, **params):
+    p = {"kernel_preset": "edge", "stride": 1, "padding": 0}
+    p.update(params)
+    inputs = {"image": image}
+    if kernel is not None:
+        inputs["kernel"] = kernel
+    return EduSlidingWindowNode().execute(inputs, p, context=context)
+
+
+def _ramp(h, w):
+    """h*w ramp image where pixel (i, j) = i*w + j."""
+    return torch.arange(h * w, dtype=torch.float32).reshape(h, w)
+
+
+def test_node_metadata():
+    assert EduSlidingWindowNode.NODE_NAME == "Edu-SlidingWindow"
+    assert EduSlidingWindowNode.CATEGORY == "Vision"
+    out_names = [p.name for p in EduSlidingWindowNode.define_outputs()]
+    assert out_names == ["feature_map", "kernel", "windows"]
+
+
+def test_identity_preset_is_center_crop():
+    # identity 3x3 with padding 0 picks the centre pixel of each window, so the
+    # valid-region output is exactly the input with its 1-pixel border removed.
+    img = _ramp(5, 5)
+    res = _run(img, kernel_preset="identity")
+    expected = img[1:-1, 1:-1]
+    assert res["feature_map"].shape == expected.shape
+    assert torch.allclose(res["feature_map"], expected, atol=1e-6)
+    # The kernel echoed out is the 3x3 identity.
+    expected_kernel = torch.zeros(3, 3)
+    expected_kernel[1, 1] = 1.0
+    assert torch.allclose(res["kernel"], expected_kernel, atol=1e-6)
+
+
+def test_blur_mean_hand_computed():
+    # 4x4 ramp, 3x3 mean (blur) kernel, padding 0, stride 1 -> 2x2 output.
+    # Hand-computed window means (see module docstring):
+    #   (0,0)=5, (0,1)=6, (1,0)=9, (1,1)=10
+    img = _ramp(4, 4)
+    res = _run(img, kernel_preset="blur")
+    fm = res["feature_map"]
+    assert fm.shape == (2, 2)
+    assert fm[0, 0].item() == pytest.approx(5.0)
+    assert fm[0, 1].item() == pytest.approx(6.0)
+    assert fm[1, 0].item() == pytest.approx(9.0)
+    assert fm[1, 1].item() == pytest.approx(10.0)
+
+
+def test_windows_shape_and_content():
+    img = _ramp(4, 4)
+    res = _run(img, kernel_preset="blur")
+    # 2x2 outputs => 4 stacked 3x3 receptive fields.
+    assert res["windows"].shape == (4, 3, 3)
+    # First window (row-major flat index 0) is the top-left 3x3 patch.
+    assert torch.allclose(res["windows"][0], img[0:3, 0:3], atol=1e-6)
+    # Last window is the bottom-right 3x3 patch.
+    assert torch.allclose(res["windows"][3], img[1:4, 1:4], atol=1e-6)
+
+
+def test_kernel_input_overrides_preset():
+    img = _ramp(4, 4)
+    # A 2x2 sum kernel of ones: each output cell = sum of a 2x2 window.
+    k = torch.ones(2, 2)
+    res = _run(img, kernel=k, kernel_preset="edge")
+    fm = res["feature_map"]
+    # 4x4, 2x2 kernel, padding 0, stride 1 -> 3x3 output.
+    assert fm.shape == (3, 3)
+    # Top-left window {0,1,4,5} sums to 10.
+    assert fm[0, 0].item() == pytest.approx(10.0)
+    # Echoed kernel is the override, not the preset.
+    assert torch.allclose(res["kernel"], k, atol=1e-6)
+
+
+def test_three_dim_image_auto_reduced_to_channel_zero():
+    # [C, H, W]: channel 0 is a 4x4 ramp, channel 1 is garbage. Only ch0 used.
+    ch0 = _ramp(4, 4)
+    ch1 = torch.full((4, 4), 999.0)
+    img = torch.stack([ch0, ch1], dim=0)  # [2, 4, 4]
+    res = _run(img, kernel_preset="blur")
+    assert res["feature_map"].shape == (2, 2)
+    assert res["feature_map"][0, 0].item() == pytest.approx(5.0)
+
+
+def test_stride_changes_output_shape():
+    img = _ramp(5, 5)
+    # 5x5, 3x3 kernel, padding 0: stride 1 -> (5-3)//1+1 = 3; stride 2 -> 2.
+    res1 = _run(img, kernel_preset="identity", stride=1)
+    res2 = _run(img, kernel_preset="identity", stride=2)
+    assert res1["feature_map"].shape == (3, 3)
+    assert res2["feature_map"].shape == (2, 2)
+
+
+def test_padding_changes_output_shape():
+    img = _ramp(5, 5)
+    # padding 0 -> 3x3; padding 1 keeps spatial size -> (5+2-3)+1 = 5x5.
+    res0 = _run(img, kernel_preset="edge", padding=0)
+    res1 = _run(img, kernel_preset="edge", padding=1)
+    assert res0["feature_map"].shape == (3, 3)
+    assert res1["feature_map"].shape == (5, 5)
+
+
+def test_rejects_one_dim_image():
+    with pytest.raises(ValueError, match="2-D"):
+        _run(torch.arange(10, dtype=torch.float32))
+
+
+def test_rejects_kernel_bigger_than_image():
+    img = _ramp(3, 3)
+    big = torch.ones(5, 5)
+    with pytest.raises(ValueError, match="does not fit"):
+        _run(img, kernel=big)
+
+
+def test_rejects_bad_stride():
+    with pytest.raises(ValueError, match="stride"):
+        _run(_ramp(5, 5), stride=0)
+
+
+def test_verbose_emits_steps():
+    img = _ramp(4, 4)
+    res = _run(img, kernel_preset="blur", context=_Ctx(verbose=True))
+    assert "__steps__" in res
+    steps = res["__steps__"]
+    assert isinstance(steps, list)
+    assert len(steps) > 0
+    names = [s.name for s in steps]
+    # First step describes the kernel, last assembles the feature map.
+    assert names[0] == "kernel"
+    assert names[-1] == "feature_map"
+    # At least one per-position step recording the receptive field + product.
+    pos_steps = [s for s in steps if s.name.startswith("pos_r")]
+    assert pos_steps
+    assert "receptive_field" in pos_steps[0].tensors
+    assert "product" in pos_steps[0].tensors
+    assert "value" in pos_steps[0].scalars
+
+
+def test_verbose_caps_position_steps():
+    # 8x8 image, 3x3 kernel, padding 0, stride 1 -> 6x6 = 36 positions, far
+    # more than the cap of 9. Per-position steps must be capped at 9.
+    img = _ramp(8, 8)
+    res = _run(img, kernel_preset="edge", context=_Ctx(verbose=True))
+    pos_steps = [s for s in res["__steps__"] if s.name.startswith("pos_r")]
+    assert len(pos_steps) == 9
+
+
+def test_non_verbose_has_no_steps():
+    img = _ramp(4, 4)
+    # Explicit non-verbose context.
+    res = _run(img, kernel_preset="blur", context=_Ctx(verbose=False))
+    assert "__steps__" not in res
+    # And no context at all.
+    res2 = _run(img, kernel_preset="blur", context=None)
+    assert "__steps__" not in res2

--- a/backend/tests/test_edu_svm_node.py
+++ b/backend/tests/test_edu_svm_node.py
@@ -1,0 +1,198 @@
+"""Tests for EduSVMNode (chapter pack I2-2: linear soft-margin SVM)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from cdui_plugins.foundations.nodes.edu_svm_node import EduSVMNode
+
+
+class _Ctx:
+    """Minimal ExecutionContext stand-in: just carries a verbose flag."""
+
+    def __init__(self, verbose: bool) -> None:
+        self.verbose = verbose
+
+
+def _run(x_train, y_train, x_query, *, context=None, **params):
+    p = {"C": 1.0, "lr": 0.01, "epochs": 100}
+    p.update(params)
+    return EduSVMNode().execute(
+        {"x_train": x_train, "y_train": y_train, "x_query": x_query},
+        p,
+        context=context,
+    )
+
+
+def _separable_blobs(seed: int = 0, label_neg=0, label_pos=1, n_per: int = 40):
+    """Two well-separated 2-D Gaussian blobs with labels {label_neg, label_pos}."""
+    torch.manual_seed(seed)
+    neg = torch.randn(n_per, 2) * 0.4 + torch.tensor([-4.0, -4.0])
+    pos = torch.randn(n_per, 2) * 0.4 + torch.tensor([4.0, 4.0])
+    x = torch.cat([neg, pos], dim=0)
+    y = torch.tensor([label_neg] * n_per + [label_pos] * n_per)
+    return x, y
+
+
+def test_node_metadata():
+    assert EduSVMNode.NODE_NAME == "Edu-SVM"
+    assert EduSVMNode.CATEGORY == "Classical"
+    out_names = [p.name for p in EduSVMNode.define_outputs()]
+    assert out_names == [
+        "predictions",
+        "weights",
+        "bias",
+        "support_vectors",
+        "decision_values",
+    ]
+
+
+def test_input_and_param_definitions():
+    in_names = [p.name for p in EduSVMNode.define_inputs()]
+    assert in_names == ["x_train", "y_train", "x_query"]
+    param_names = [p.name for p in EduSVMNode.define_params()]
+    assert param_names == ["C", "lr", "epochs"]
+
+
+def test_separable_blobs_perfectly_classified():
+    """Two far-apart blobs → held-out query points classified ~perfectly."""
+    x_train, y_train = _separable_blobs(seed=0)
+    # Held-out query points clearly on each side of the gap.
+    x_query = torch.tensor(
+        [
+            [-3.5, -3.5],
+            [-5.0, -4.0],
+            [3.5, 3.5],
+            [5.0, 4.0],
+        ]
+    )
+    expected = torch.tensor([0, 0, 1, 1])
+    res = _run(x_train, y_train, x_query, epochs=300, lr=0.05)
+
+    preds = res["predictions"]
+    acc = (preds == expected).float().mean().item()
+    assert acc >= 0.9
+    # A real separating direction was learned.
+    assert res["weights"].norm().item() > 0.0
+    # decision_values agree in sign with the predicted side.
+    assert torch.equal(res["decision_values"] >= 0, expected.bool())
+
+
+def test_train_set_accuracy_high_on_separable_data():
+    x_train, y_train = _separable_blobs(seed=1)
+    res = _run(x_train, y_train, x_train, epochs=300, lr=0.05)
+    acc = (res["predictions"] == y_train).float().mean().item()
+    assert acc >= 0.9
+
+
+def test_original_label_space_respected():
+    """Labels {3, 7} → predictions contain only 3 or 7 (never ±1 internals)."""
+    x_train, y_train = _separable_blobs(seed=2, label_neg=3, label_pos=7)
+    x_query = torch.tensor([[-4.0, -4.0], [4.0, 4.0], [-3.0, -3.5]])
+    res = _run(x_train, y_train, x_query, epochs=300, lr=0.05)
+    preds = res["predictions"]
+    unique_preds = set(preds.tolist())
+    assert unique_preds.issubset({3, 7})
+    # The lower class (3) maps to -1 side, higher (7) to +1 side.
+    assert preds[0].item() == 3
+    assert preds[1].item() == 7
+
+
+def test_support_vector_mask_shape_and_dtype():
+    x_train, y_train = _separable_blobs(seed=3)
+    res = _run(x_train, y_train, x_train, epochs=50)
+    sv = res["support_vectors"]
+    assert sv.shape == (x_train.shape[0],)
+    # Mask must be a boolean (or integer) per-sample indicator.
+    assert sv.dtype in (torch.bool, torch.int8, torch.int32, torch.int64)
+
+
+def test_output_shapes():
+    x_train, y_train = _separable_blobs(seed=4)
+    x_query = torch.randn(6, 2)
+    res = _run(x_train, y_train, x_query, epochs=20)
+    assert res["predictions"].shape == (6,)
+    assert res["weights"].shape == (2,)
+    assert res["bias"].ndim == 0  # scalar
+    assert res["decision_values"].shape == (6,)
+
+
+def test_decision_values_equal_w_dot_x_plus_b():
+    x_train, y_train = _separable_blobs(seed=5)
+    x_query = torch.randn(5, 2)
+    res = _run(x_train, y_train, x_query, epochs=30)
+    expected = x_query @ res["weights"] + res["bias"]
+    assert torch.allclose(res["decision_values"], expected, atol=1e-5)
+
+
+def test_non_binary_labels_raise():
+    x = torch.randn(9, 2)
+    y = torch.tensor([0, 0, 0, 1, 1, 1, 2, 2, 2])  # three classes
+    with pytest.raises(ValueError, match="2 distinct classes"):
+        _run(x, y, torch.randn(2, 2))
+
+
+def test_label_count_mismatch_raises():
+    with pytest.raises(ValueError, match="mismatch"):
+        _run(torch.zeros(5, 2), torch.tensor([0, 1, 0]), torch.zeros(1, 2))
+
+
+def test_feature_dim_mismatch_raises():
+    x_train = torch.zeros(6, 2)
+    y_train = torch.tensor([0, 0, 0, 1, 1, 1])
+    x_query = torch.zeros(2, 3)  # 3 features vs 2
+    with pytest.raises(ValueError, match="features"):
+        _run(x_train, y_train, x_query)
+
+
+def test_negative_C_raises():
+    x_train, y_train = _separable_blobs(seed=6)
+    with pytest.raises(ValueError, match="C"):
+        _run(x_train, y_train, x_train, C=-1.0)
+
+
+def test_zero_epochs_raises():
+    x_train, y_train = _separable_blobs(seed=7)
+    with pytest.raises(ValueError, match="epochs"):
+        _run(x_train, y_train, x_train, epochs=0)
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduSVMNode().execute(
+            {"x_train": torch.zeros(5, 2)},
+            {"C": 1.0, "lr": 0.01, "epochs": 10},
+        )
+
+
+def test_verbose_yields_steps():
+    x_train, y_train = _separable_blobs(seed=8)
+    res = _run(
+        x_train, y_train, x_train, epochs=100, context=_Ctx(verbose=True)
+    )
+    assert "__steps__" in res
+    steps = res["__steps__"]
+    assert len(steps) > 0
+    names = [s.name for s in steps]
+    # init + capped epoch snapshots + final decision step.
+    assert names[0] == "init"
+    assert names[-1] == "decision"
+    # Epoch snapshots are capped to ~8 even though we ran 100 epochs.
+    epoch_steps = [s for s in steps if s.name.startswith("epoch_")]
+    assert 0 < len(epoch_steps) <= 8
+    # Each epoch snapshot records the documented scalars and the weight tensor.
+    for s in epoch_steps:
+        assert {"epoch", "loss", "num_support_vectors"} <= set(s.scalars)
+        assert "w" in s.tensors
+
+
+def test_non_verbose_yields_no_steps():
+    x_train, y_train = _separable_blobs(seed=9)
+    res = _run(x_train, y_train, x_train, epochs=50)
+    assert "__steps__" not in res
+    # Also true when an explicit non-verbose context is supplied.
+    res2 = _run(
+        x_train, y_train, x_train, epochs=50, context=_Ctx(verbose=False)
+    )
+    assert "__steps__" not in res2

--- a/backend/tests/test_edu_vector_similarity_node.py
+++ b/backend/tests/test_edu_vector_similarity_node.py
@@ -1,0 +1,140 @@
+"""Tests for EduVectorSimilarityNode (chapter pack I1-3)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from cdui_plugins.foundations.nodes.edu_vector_similarity_node import (
+    EduVectorSimilarityNode,
+)
+
+
+class _Ctx:
+    """Minimal stand-in for ExecutionContext exposing only `verbose`."""
+
+    def __init__(self, verbose: bool = False) -> None:
+        self.verbose = verbose
+
+
+def _run(query, keys, *, context=None, **params):
+    p = {"metric": "cosine"}
+    p.update(params)
+    return EduVectorSimilarityNode().execute(
+        {"query": query, "keys": keys}, p, context=context
+    )
+
+
+def test_node_metadata():
+    assert EduVectorSimilarityNode.NODE_NAME == "Edu-VectorSimilarity"
+    assert EduVectorSimilarityNode.CATEGORY == "Data"
+    out_names = [p.name for p in EduVectorSimilarityNode.define_outputs()]
+    assert out_names == ["similarity", "query_norms", "key_norms"]
+
+
+def test_cosine_identical_unit_vectors_is_one():
+    # A unit vector compared with itself has cosine similarity 1.
+    q = torch.tensor([1.0, 0.0, 0.0])
+    keys = torch.tensor([[1.0, 0.0, 0.0]])
+    res = _run(q, keys, metric="cosine")
+    assert res["similarity"][0, 0].item() == pytest.approx(1.0, abs=1e-6)
+
+
+def test_cosine_orthogonal_vectors_is_zero():
+    # Orthogonal vectors have zero cosine similarity.
+    q = torch.tensor([1.0, 0.0])
+    keys = torch.tensor([[0.0, 1.0]])
+    res = _run(q, keys, metric="cosine")
+    assert res["similarity"][0, 0].item() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_cosine_is_scale_invariant():
+    # Cosine ignores magnitude: scaling either vector leaves it unchanged.
+    q = torch.tensor([[3.0, 4.0]])  # ||q|| = 5
+    keys = torch.tensor([[3.0, 4.0]])
+    res = _run(q, keys, metric="cosine")
+    assert res["similarity"][0, 0].item() == pytest.approx(1.0, abs=1e-6)
+
+
+def test_dot_metric_returns_raw_inner_products():
+    # Hand-computed small case:
+    #   q0·k0 = 1*1 + 2*0 = 1 ; q0·k1 = 1*3 + 2*4 = 11
+    #   q1·k0 = 0*1 + 1*0 = 0 ; q1·k1 = 0*3 + 1*4 = 4
+    q = torch.tensor([[1.0, 2.0], [0.0, 1.0]])
+    keys = torch.tensor([[1.0, 0.0], [3.0, 4.0]])
+    res = _run(q, keys, metric="dot")
+    expected = torch.tensor([[1.0, 11.0], [0.0, 4.0]])
+    assert torch.allclose(res["similarity"], expected, atol=1e-6)
+
+
+def test_one_d_query_produces_1_by_m():
+    q = torch.tensor([1.0, 0.0, 0.0])            # [D]
+    keys = torch.randn(4, 3)                       # [M=4, D=3]
+    res = _run(q, keys)
+    assert tuple(res["similarity"].shape) == (1, 4)
+    assert tuple(res["query_norms"].shape) == (1,)
+    assert tuple(res["key_norms"].shape) == (4,)
+
+
+def test_n_by_d_query_produces_n_by_m():
+    q = torch.randn(2, 3)                           # [N=2, D=3]
+    keys = torch.randn(5, 3)                        # [M=5, D=3]
+    res = _run(q, keys)
+    assert tuple(res["similarity"].shape) == (2, 5)
+    assert tuple(res["query_norms"].shape) == (2,)
+    assert tuple(res["key_norms"].shape) == (5,)
+
+
+def test_norms_returned_for_dot_metric():
+    # Even with the dot metric, the norms are surfaced for inspection.
+    q = torch.tensor([[3.0, 4.0]])
+    keys = torch.tensor([[0.0, 5.0]])
+    res = _run(q, keys, metric="dot")
+    assert res["query_norms"].item() == pytest.approx(5.0, abs=1e-6)
+    assert res["key_norms"].item() == pytest.approx(5.0, abs=1e-6)
+
+
+def test_dimension_mismatch_raises():
+    q = torch.randn(2, 4)        # D=4
+    keys = torch.randn(3, 5)     # D=5
+    with pytest.raises(ValueError, match="match"):
+        _run(q, keys)
+
+
+def test_keys_must_be_2d():
+    q = torch.randn(3)
+    with pytest.raises(ValueError, match="keys"):
+        _run(q, torch.randn(3))  # 1-D keys are invalid
+
+
+def test_query_must_be_1d_or_2d():
+    q = torch.randn(2, 2, 3)     # 3-D query is invalid
+    keys = torch.randn(4, 3)
+    with pytest.raises(ValueError, match="query"):
+        _run(q, keys)
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduVectorSimilarityNode().execute({"query": torch.randn(3)}, {})
+
+
+def test_verbose_records_steps():
+    q = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    keys = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    res = _run(q, keys, context=_Ctx(verbose=True))
+    steps = res.get("__steps__")
+    assert steps is not None and len(steps) >= 1
+    names = [s.name for s in steps]
+    assert names == ["dot_products", "norms", "similarity"]
+
+
+def test_non_verbose_has_no_steps():
+    q = torch.tensor([[1.0, 0.0]])
+    keys = torch.tensor([[1.0, 0.0]])
+    # No context → not verbose.
+    res = _run(q, keys)
+    assert "__steps__" not in res
+    # Explicit context with verbose=False → still no steps.
+    res2 = _run(q, keys, context=_Ctx(verbose=False))
+    assert "__steps__" not in res2

--- a/plugins/foundations/examples/C1-3/Sliding-Window-Kernels/graph.json
+++ b/plugins/foundations/examples/C1-3/Sliding-Window-Kernels/graph.json
@@ -1,0 +1,15 @@
+{
+  "name": "Sliding Window 101: a kernel sweeping an image",
+  "description": "The convolution prototype, fully visible. A 5x5 image (arange 0..24) is swept by a 3x3 edge-detection (Laplacian) kernel: at every position the receptive field is multiplied elementwise by the kernel and summed into one output cell, producing a 3x3 feature map. Turn on Verbose mode to scrub each window position — receptive field, elementwise product, and sum — in the Inspector Steps tab. Switch `kernel_preset` to blur / sharpen / sobel_x to feel what each kernel measures.",
+  "nodes": [
+    { "id": "start", "type": "Start",                        "position": { "x": -260, "y": 0 }, "data": { "params": {} } },
+    { "id": "img",   "type": "TensorInput",                  "position": { "x": -20,  "y": 0 }, "data": { "params": { "shape": "5,5", "dtype": "float32", "value_mode": "arange" } } },
+    { "id": "sw",    "type": "foundations:Edu-SlidingWindow", "position": { "x": 260,  "y": 0 }, "data": { "params": { "kernel_preset": "edge", "stride": 1, "padding": 0 } } },
+    { "id": "print", "type": "Print",                         "position": { "x": 560,  "y": 0 }, "data": { "params": { "label": "feature map" } } }
+  ],
+  "edges": [
+    { "id": "trig", "source": "start", "target": "img",   "sourceHandle": "trigger",     "type": "trigger" },
+    { "id": "e1",   "source": "img",   "target": "sw",    "sourceHandle": "tensor",      "targetHandle": "image" },
+    { "id": "e2",   "source": "sw",    "target": "print", "sourceHandle": "feature_map", "targetHandle": "value" }
+  ]
+}

--- a/plugins/foundations/examples/C2-3/SVM-Margin-Decision/graph.json
+++ b/plugins/foundations/examples/C2-3/SVM-Margin-Decision/graph.json
@@ -1,0 +1,21 @@
+{
+  "name": "Edu-SVM: a linear margin learned by gradient descent",
+  "description": "Two well-separated blobs (class 0 near the origin, class 1 near (5,5)) train a hand-written linear soft-margin SVM. Turn on Verbose mode to watch the hinge loss fall and the support-vector count shrink across epochs in the Inspector Steps tab; the final step exposes the weight vector, bias, the support-vector mask, and the query decision values. The two query points (0.5,0.5) and (4.5,4.5) should be classified 0 and 1.",
+  "nodes": [
+    { "id": "start", "type": "Start",                "position": { "x": -300, "y": 0 },   "data": { "params": {} } },
+    { "id": "xtr",   "type": "TensorInput",          "position": { "x": -60,  "y": -120 }, "data": { "params": { "shape": "6,2", "dtype": "float32", "value_mode": "explicit", "values": [[0, 0], [1, 0], [0, 1], [5, 5], [4, 5], [5, 4]] } } },
+    { "id": "ytr",   "type": "TensorInput",          "position": { "x": -60,  "y": 20 },   "data": { "params": { "shape": "6", "dtype": "int64", "value_mode": "explicit", "values": [0, 0, 0, 1, 1, 1] } } },
+    { "id": "xq",    "type": "TensorInput",          "position": { "x": -60,  "y": 160 },  "data": { "params": { "shape": "2,2", "dtype": "float32", "value_mode": "explicit", "values": [[0.5, 0.5], [4.5, 4.5]] } } },
+    { "id": "svm",   "type": "foundations:Edu-SVM",  "position": { "x": 280,  "y": 0 },    "data": { "params": { "C": 1.0, "lr": 0.1, "epochs": 200 } } },
+    { "id": "print", "type": "Print",                "position": { "x": 600,  "y": 0 },    "data": { "params": { "label": "predictions" } } }
+  ],
+  "edges": [
+    { "id": "trig1", "source": "start", "target": "xtr",   "sourceHandle": "trigger",     "type": "trigger" },
+    { "id": "trig2", "source": "start", "target": "ytr",   "sourceHandle": "trigger",     "type": "trigger" },
+    { "id": "trig3", "source": "start", "target": "xq",    "sourceHandle": "trigger",     "type": "trigger" },
+    { "id": "e1",    "source": "xtr",   "target": "svm",   "sourceHandle": "tensor",      "targetHandle": "x_train" },
+    { "id": "e2",    "source": "ytr",   "target": "svm",   "sourceHandle": "tensor",      "targetHandle": "y_train" },
+    { "id": "e3",    "source": "xq",    "target": "svm",   "sourceHandle": "tensor",      "targetHandle": "x_query" },
+    { "id": "e4",    "source": "svm",   "target": "print", "sourceHandle": "predictions", "targetHandle": "value" }
+  ]
+}

--- a/plugins/foundations/nodes/edu_decision_tree_node.py
+++ b/plugins/foundations/nodes/edu_decision_tree_node.py
@@ -1,0 +1,421 @@
+"""EduDecisionTreeNode — from-scratch CART classification tree.
+
+Textbook lesson **I2-2 (CART classification tree)**: instead of calling
+``sklearn.tree.DecisionTreeClassifier`` as a black box, build a binary
+decision tree by hand and expose, for *every* internal node, the choice
+that was made and *why*:
+
+    impurity(node)   = gini  : 1 − Σ_c p_c²
+                       entropy: − Σ_c p_c log2 p_c
+    gain(feature, t) = impurity(parent)
+                       − (n_left/n)·impurity(left)
+                       − (n_right/n)·impurity(right)
+
+At each node we scan every feature, try every candidate threshold (the
+midpoints between consecutive sorted unique values), and keep the
+(feature, threshold) with the largest impurity gain. Left children hold
+the samples with ``x[feature] <= threshold``. Recursion stops when the
+node hits ``max_depth``, has fewer than ``min_samples_split`` samples,
+is already pure, or no split yields positive gain — then it becomes a
+leaf predicting the majority class.
+
+Outputs:
+- ``predictions`` — predicted integer class label per query, ``[M]``.
+- ``tree`` — a JSON-serialisable nested dict describing the learned tree
+  (feature / threshold / impurity / gain / sample counts at every node).
+- ``node_count`` — scalar count of nodes in the tree (display-only).
+
+Compare with the production ``DecisionTree`` node (sklearn) — same
+interface, but this one is fully transparent and deterministic
+(stable tie-breaking: lowest feature index, then lowest threshold) so
+students can trace a split by hand and get the same answer.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Any
+
+import torch
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+
+class EduDecisionTreeNode(BaseNode):
+    NODE_NAME = "Edu-DecisionTree"
+    CATEGORY = "Classical"
+    DESCRIPTION = (
+        "Hand-written CART classification tree (binary splits, Gini or "
+        "entropy). For every internal node it exposes the chosen feature, "
+        "threshold, impurity before/after the split, and the information "
+        "gain, plus the final nested-dict tree structure. Deterministic "
+        "tie-breaking (lowest feature index, then lowest threshold)."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="x_train",
+                data_type=DataType.TENSOR,
+                description="Training features [N, D].",
+            ),
+            PortDefinition(
+                name="y_train",
+                data_type=DataType.TENSOR,
+                description="Training labels [N] (integer class labels, any number of classes).",
+            ),
+            PortDefinition(
+                name="x_query",
+                data_type=DataType.TENSOR,
+                description="Query features [M, D] to classify.",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="predictions",
+                data_type=DataType.TENSOR,
+                description="Predicted integer class label per query, [M].",
+            ),
+            PortDefinition(
+                name="tree",
+                data_type=DataType.ANY,
+                description=(
+                    "JSON-serialisable nested dict. Internal node: "
+                    "{feature, threshold, impurity, gain, n_samples, left, right}. "
+                    "Leaf: {leaf: true, prediction, n_samples, class_counts}. "
+                    "Left = samples with x[feature] <= threshold."
+                ),
+            ),
+            PortDefinition(
+                name="node_count",
+                data_type=DataType.TENSOR,
+                description="Scalar count of nodes in the tree (display-only).",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="max_depth",
+                param_type=ParamType.INT,
+                default=3,
+                min_value=1,
+                description="Maximum tree depth. The root is depth 0.",
+            ),
+            ParamDefinition(
+                name="min_samples_split",
+                param_type=ParamType.INT,
+                default=2,
+                min_value=2,
+                description="A node with fewer than this many samples becomes a leaf.",
+            ),
+            ParamDefinition(
+                name="criterion",
+                param_type=ParamType.SELECT,
+                default="gini",
+                options=["gini", "entropy"],
+                description="Impurity measure. gini = 1 − Σ p²; entropy = − Σ p log2 p.",
+            ),
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Impurity helpers
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _impurity(y: torch.Tensor, criterion: str) -> float:
+        """Gini or entropy impurity of a 1-D label tensor."""
+        n = y.shape[0]
+        if n == 0:
+            return 0.0
+        counts = torch.bincount(y)
+        probs = counts[counts > 0].float() / float(n)
+        if criterion == "entropy":
+            return float(-(probs * torch.log2(probs)).sum().item())
+        # gini
+        return float((1.0 - (probs * probs).sum()).item())
+
+    @staticmethod
+    def _majority(y: torch.Tensor) -> int:
+        """Majority class, ties broken by the lowest label (deterministic)."""
+        counts = Counter(int(v) for v in y.tolist())
+        best_count = max(counts.values())
+        return min(label for label, c in counts.items() if c == best_count)
+
+    @staticmethod
+    def _class_counts(y: torch.Tensor) -> dict[str, int]:
+        """JSON-serialisable {label: count}; string keys, sorted by label."""
+        counts = Counter(int(v) for v in y.tolist())
+        return {str(label): counts[label] for label in sorted(counts)}
+
+    def _best_split(
+        self, x: torch.Tensor, y: torch.Tensor, parent_impurity: float, criterion: str
+    ) -> tuple[int, float, float] | None:
+        """Return (feature, threshold, gain) with the largest positive gain.
+
+        Candidate thresholds are midpoints between consecutive sorted unique
+        values of each feature. Deterministic tie-breaking: iterate features
+        in ascending index, thresholds in ascending value, and only adopt a
+        candidate that *strictly* beats the current best — so the lowest
+        feature index then lowest threshold wins on ties.
+        """
+        n = x.shape[0]
+        n_features = x.shape[1]
+        best_feature: int | None = None
+        best_threshold = 0.0
+        best_gain = 0.0  # require strictly positive gain to split
+
+        for feature in range(n_features):
+            column = x[:, feature]
+            uniques = torch.unique(column, sorted=True)
+            if uniques.numel() < 2:
+                continue  # constant feature → no split possible
+            midpoints = (uniques[:-1] + uniques[1:]) / 2.0
+            for thr in midpoints.tolist():
+                left_mask = column <= thr
+                n_left = int(left_mask.sum().item())
+                n_right = n - n_left
+                if n_left == 0 or n_right == 0:
+                    continue
+                left_imp = self._impurity(y[left_mask], criterion)
+                right_imp = self._impurity(y[~left_mask], criterion)
+                weighted = (n_left / n) * left_imp + (n_right / n) * right_imp
+                gain = parent_impurity - weighted
+                if gain > best_gain:
+                    best_gain = gain
+                    best_feature = feature
+                    best_threshold = float(thr)
+
+        if best_feature is None:
+            return None
+        return best_feature, best_threshold, best_gain
+
+    # ------------------------------------------------------------------ #
+    # Tree building / prediction
+    # ------------------------------------------------------------------ #
+    def _build(
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        depth: int,
+        max_depth: int,
+        min_samples_split: int,
+        criterion: str,
+        splits: list[dict[str, float]],
+    ) -> dict[str, Any]:
+        """Recursively build a node. Records each internal split in build order."""
+        n = x.shape[0]
+        impurity = self._impurity(y, criterion)
+
+        def make_leaf() -> dict[str, Any]:
+            return {
+                "leaf": True,
+                "prediction": self._majority(y),
+                "n_samples": int(n),
+                "class_counts": self._class_counts(y),
+            }
+
+        # Stopping conditions → leaf.
+        if (
+            depth >= max_depth
+            or n < min_samples_split
+            or impurity == 0.0  # pure node
+        ):
+            return make_leaf()
+
+        split = self._best_split(x, y, impurity, criterion)
+        if split is None:  # no positive-gain split
+            return make_leaf()
+
+        feature, threshold, gain = split
+        left_mask = x[:, feature] <= threshold
+
+        # Record this internal split in build (pre-order) order.
+        splits.append(
+            {
+                "depth": float(depth),
+                "feature": float(feature),
+                "threshold": float(threshold),
+                "impurity_before": float(impurity),
+                "impurity_after": float(impurity - gain),
+                "gain": float(gain),
+                "n_samples": float(n),
+            }
+        )
+
+        left = self._build(
+            x[left_mask], y[left_mask], depth + 1, max_depth,
+            min_samples_split, criterion, splits,
+        )
+        right = self._build(
+            x[~left_mask], y[~left_mask], depth + 1, max_depth,
+            min_samples_split, criterion, splits,
+        )
+        return {
+            "feature": int(feature),
+            "threshold": float(threshold),
+            "impurity": float(impurity),
+            "gain": float(gain),
+            "n_samples": int(n),
+            "left": left,
+            "right": right,
+        }
+
+    @staticmethod
+    def _count_nodes(node: dict[str, Any]) -> int:
+        if node.get("leaf"):
+            return 1
+        return 1 + EduDecisionTreeNode._count_nodes(node["left"]) + EduDecisionTreeNode._count_nodes(node["right"])
+
+    @staticmethod
+    def _tree_depth(node: dict[str, Any]) -> int:
+        """Number of edges on the longest root-to-leaf path (a single leaf = 0)."""
+        if node.get("leaf"):
+            return 0
+        return 1 + max(
+            EduDecisionTreeNode._tree_depth(node["left"]),
+            EduDecisionTreeNode._tree_depth(node["right"]),
+        )
+
+    @staticmethod
+    def _predict_one(node: dict[str, Any], row: torch.Tensor) -> int:
+        while not node.get("leaf"):
+            if float(row[node["feature"]].item()) <= node["threshold"]:
+                node = node["left"]
+            else:
+                node = node["right"]
+        return int(node["prediction"])
+
+    # ------------------------------------------------------------------ #
+    # execute
+    # ------------------------------------------------------------------ #
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError(
+                "EduDecisionTree requires `x_train`, `y_train`, and `x_query` inputs."
+            )
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+        if not isinstance(y_train, torch.Tensor):
+            y_train = torch.as_tensor(y_train, dtype=torch.long)
+        x_train = x_train.float()
+        x_query = x_query.float()
+        y_train = y_train.long().reshape(-1)
+
+        # --- validation -------------------------------------------------
+        if x_train.ndim != 2:
+            raise ValueError(
+                f"EduDecisionTree: x_train must be 2-D [N, D]; got shape {tuple(x_train.shape)}."
+            )
+        if x_query.ndim != 2:
+            raise ValueError(
+                f"EduDecisionTree: x_query must be 2-D [M, D]; got shape {tuple(x_query.shape)}."
+            )
+        n_train, n_features = x_train.shape
+        if n_train == 0:
+            raise ValueError("EduDecisionTree: training set is empty.")
+        if y_train.shape[0] != n_train:
+            raise ValueError(
+                f"EduDecisionTree: x_train and y_train length mismatch — "
+                f"{n_train} rows vs {y_train.shape[0]} labels."
+            )
+        if x_query.shape[1] != n_features:
+            raise ValueError(
+                f"EduDecisionTree: x_query has {x_query.shape[1]} features but "
+                f"x_train has {n_features}."
+            )
+        if (y_train < 0).any():
+            raise ValueError(
+                "EduDecisionTree: y_train must contain non-negative integer class labels."
+            )
+
+        max_depth = int(params.get("max_depth", 3))
+        min_samples_split = int(params.get("min_samples_split", 2))
+        criterion = str(params.get("criterion", "gini"))
+        if max_depth < 1:
+            raise ValueError(f"EduDecisionTree: max_depth must be >= 1; got {max_depth}.")
+        if min_samples_split < 2:
+            raise ValueError(
+                f"EduDecisionTree: min_samples_split must be >= 2; got {min_samples_split}."
+            )
+        if criterion not in ("gini", "entropy"):
+            raise ValueError(
+                f"EduDecisionTree: unknown criterion {criterion!r} (expected 'gini' or 'entropy')."
+            )
+
+        # --- build ------------------------------------------------------
+        splits: list[dict[str, float]] = []
+        tree = self._build(
+            x_train, y_train, 0, max_depth, min_samples_split, criterion, splits
+        )
+
+        node_count = self._count_nodes(tree)
+        depth = self._tree_depth(tree)
+
+        # --- predict ----------------------------------------------------
+        predictions = torch.tensor(
+            [self._predict_one(tree, x_query[i]) for i in range(x_query.shape[0])],
+            dtype=torch.long,
+        )
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+        if recorder is not None:
+            # One step per internal split, in build (pre-order) order.
+            for rec in splits:
+                d = int(rec["depth"])
+                recorder.record(
+                    f"split_d{d}",
+                    (
+                        f"depth {d}: split on feature {int(rec['feature'])} "
+                        f"at x <= {rec['threshold']:.4g} "
+                        f"(gain {rec['gain']:.4g}, {criterion})."
+                    ),
+                    scalars={
+                        "feature": rec["feature"],
+                        "threshold": rec["threshold"],
+                        "impurity_before": rec["impurity_before"],
+                        "impurity_after": rec["impurity_after"],
+                        "gain": rec["gain"],
+                        "n_samples": rec["n_samples"],
+                    },
+                )
+            recorder.record(
+                "tree",
+                f"Built a {criterion} tree with {node_count} nodes, depth {depth}.",
+                scalars={"node_count": float(node_count), "depth": float(depth)},
+            )
+
+        result: dict[str, Any] = {
+            "predictions": predictions,
+            "tree": tree,
+            "node_count": torch.tensor(node_count, dtype=torch.long),
+        }
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result

--- a/plugins/foundations/nodes/edu_sliding_window_node.py
+++ b/plugins/foundations/nodes/edu_sliding_window_node.py
@@ -1,0 +1,322 @@
+"""EduSlidingWindowNode — the convolution sliding-window prototype, step by step.
+
+Supports textbook lesson **I1-2 (image sliding window)**: instead of a
+black-box ``Conv2d``, slide a small kernel across one 2-D grayscale image and,
+for every output position, expose the three things a convolution actually does:
+
+    1. receptive_field = image[r : r+kH, c : c+kW]   (the patch under the kernel)
+    2. product         = receptive_field * kernel     (elementwise)
+    3. value           = product.sum()                (one feature-map cell)
+
+The feature map is just the grid of those summed values. ``windows`` stacks
+every receptive field so the lesson can scrub through the patches; ``kernel``
+echoes the kernel actually used (preset or override) so it can be drawn.
+
+This is the hand-written sibling of the production ``Conv2d`` node — same
+maths (a valid cross-correlation), but with each intermediate patch / product /
+sum captured in verbose mode so students see how one number on the feature map
+is built from one window of the image.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+# 3x3 kernel presets. Each is a plain Python list-of-lists so the construction
+# is readable; they're turned into float tensors at execute time.
+_KERNEL_PRESETS: dict[str, list[list[float]]] = {
+    "identity": [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
+    "edge": [[0.0, -1.0, 0.0], [-1.0, 4.0, -1.0], [0.0, -1.0, 0.0]],
+    "sharpen": [[0.0, -1.0, 0.0], [-1.0, 5.0, -1.0], [0.0, -1.0, 0.0]],
+    "blur": [[1.0 / 9.0] * 3 for _ in range(3)],
+    "sobel_x": [[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0], [-1.0, 0.0, 1.0]],
+    # sobel_y is the transpose of sobel_x.
+    "sobel_y": [[-1.0, -2.0, -1.0], [0.0, 0.0, 0.0], [1.0, 2.0, 1.0]],
+}
+
+# Cap on how many per-position steps we record in verbose mode. Beyond this we
+# sample evenly so the Teaching Inspector stays scrubbable on large images.
+_MAX_POSITION_STEPS = 9
+
+
+class EduSlidingWindowNode(BaseNode):
+    NODE_NAME = "Edu-SlidingWindow"
+    CATEGORY = "Vision"
+    DESCRIPTION = (
+        "Hand-written convolution sliding window over one 2-D grayscale image. "
+        "Zero-pads, then for every output position extracts the receptive "
+        "field, multiplies elementwise by the kernel, and sums to one "
+        "feature-map cell. Verbose mode records the patch, the product, and "
+        "the summed value for each position (sampled if there are many)."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="image",
+                data_type=DataType.TENSOR,
+                description=(
+                    "2-D grayscale image [H, W]. A 3-D [1,H,W] or [C,H,W] "
+                    "tensor is auto-reduced to channel 0."
+                ),
+            ),
+            PortDefinition(
+                name="kernel",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Optional 2-D kernel [kH, kW]. If supplied it overrides "
+                    "the kernel_preset param."
+                ),
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="feature_map",
+                data_type=DataType.TENSOR,
+                description="Convolved output [Hout, Wout]; each cell is one window·kernel sum.",
+            ),
+            PortDefinition(
+                name="kernel",
+                data_type=DataType.TENSOR,
+                description="The kernel actually used (preset or input), so the lesson can display it.",
+            ),
+            PortDefinition(
+                name="windows",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Stacked receptive fields [Hout*Wout, kH, kW] in row-major "
+                    "order — display-only, for inspecting every patch."
+                ),
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="kernel_preset",
+                param_type=ParamType.SELECT,
+                default="edge",
+                options=["identity", "edge", "sharpen", "blur", "sobel_x", "sobel_y"],
+                description=(
+                    "Built-in 3x3 kernel to slide. identity copies the centre "
+                    "pixel; edge is the Laplacian; blur is a 3x3 mean; sobel_x / "
+                    "sobel_y are gradient filters. Ignored if a `kernel` input "
+                    "is connected."
+                ),
+            ),
+            ParamDefinition(
+                name="stride",
+                param_type=ParamType.INT,
+                default=1,
+                min_value=1,
+                description="Step (in pixels) between consecutive window positions.",
+            ),
+            ParamDefinition(
+                name="padding",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description="Number of zero pixels added on every side before sliding.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        image = inputs.get("image")
+        if image is None:
+            raise ValueError("EduSlidingWindow requires an `image` input.")
+
+        if not isinstance(image, torch.Tensor):
+            image = torch.as_tensor(image, dtype=torch.float32)
+        image = image.float()
+
+        # --- Reduce the image to 2-D [H, W] -------------------------------
+        reduced_note = ""
+        if image.ndim == 3:
+            # [1,H,W] or [C,H,W] -> take channel 0.
+            reduced_note = (
+                f"Reduced 3-D image {tuple(image.shape)} to 2-D by taking channel 0."
+            )
+            image = image[0]
+        if image.ndim != 2:
+            raise ValueError(
+                "EduSlidingWindow expects a 2-D image [H, W] (or 3-D [C,H,W] "
+                f"to auto-reduce); got shape {tuple(image.shape)} after reduction."
+            )
+
+        # --- Resolve the kernel (input overrides preset) ------------------
+        kernel_in = inputs.get("kernel")
+        preset_name = str(params.get("kernel_preset", "edge"))
+        if kernel_in is not None:
+            if not isinstance(kernel_in, torch.Tensor):
+                kernel_in = torch.as_tensor(kernel_in, dtype=torch.float32)
+            kernel = kernel_in.float()
+            kernel_source = "input"
+        else:
+            if preset_name not in _KERNEL_PRESETS:
+                raise ValueError(
+                    f"EduSlidingWindow: unknown kernel_preset {preset_name!r}. "
+                    f"Choose one of {sorted(_KERNEL_PRESETS)}."
+                )
+            kernel = torch.tensor(_KERNEL_PRESETS[preset_name], dtype=torch.float32)
+            kernel_source = f"preset:{preset_name}"
+
+        if kernel.ndim != 2:
+            raise ValueError(
+                "EduSlidingWindow expects a 2-D kernel [kH, kW]; got shape "
+                f"{tuple(kernel.shape)}."
+            )
+        kH, kW = kernel.shape
+        if kH < 1 or kW < 1:
+            raise ValueError(
+                f"EduSlidingWindow: kernel must be non-empty; got {kH}x{kW}."
+            )
+
+        # --- Validate stride / padding ------------------------------------
+        stride = int(params.get("stride", 1))
+        padding = int(params.get("padding", 0))
+        if stride < 1:
+            raise ValueError(f"EduSlidingWindow: stride must be >= 1; got {stride}.")
+        if padding < 0:
+            raise ValueError(f"EduSlidingWindow: padding must be >= 0; got {padding}.")
+
+        # --- Zero-pad the image -------------------------------------------
+        # F.pad pads the last dims as (left, right, top, bottom).
+        if padding > 0:
+            padded = F.pad(image, (padding, padding, padding, padding), value=0.0)
+        else:
+            padded = image
+        H_pad, W_pad = padded.shape
+
+        # Kernel must fit inside the padded image.
+        if kH > H_pad or kW > W_pad:
+            raise ValueError(
+                f"EduSlidingWindow: kernel {kH}x{kW} does not fit in the padded "
+                f"image {H_pad}x{W_pad} (original {tuple(image.shape)}, "
+                f"padding={padding}). Reduce the kernel or increase padding."
+            )
+
+        # --- Output dimensions --------------------------------------------
+        Hout = (H_pad - kH) // stride + 1
+        Wout = (W_pad - kW) // stride + 1
+        if Hout < 1 or Wout < 1:
+            raise ValueError(
+                f"EduSlidingWindow: computed output dims {Hout}x{Wout} are not "
+                f"both >= 1 (padded image {H_pad}x{W_pad}, kernel {kH}x{kW}, "
+                f"stride={stride}). Reduce stride/kernel or add padding."
+            )
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+
+        if recorder is not None:
+            recorder.record(
+                "kernel",
+                f"Kernel actually used ({kernel_source})."
+                + (f" {reduced_note}" if reduced_note else ""),
+                scalars={
+                    "preset": preset_name,
+                    "kernel_source": kernel_source,
+                    "kH": float(kH),
+                    "kW": float(kW),
+                    "stride": float(stride),
+                    "padding": float(padding),
+                },
+                kernel=kernel,
+            )
+
+        # Which flat output positions get a recorded step. If there are more
+        # than the cap, sample evenly across the whole grid (always including
+        # the first and last) and flag that in the description.
+        total_positions = Hout * Wout
+        if recorder is not None:
+            if total_positions <= _MAX_POSITION_STEPS:
+                sampled_flat = set(range(total_positions))
+                sampling_note = ""
+            else:
+                sampled_flat = {
+                    (i * (total_positions - 1)) // (_MAX_POSITION_STEPS - 1)
+                    for i in range(_MAX_POSITION_STEPS)
+                }
+                sampling_note = (
+                    f" (showing {_MAX_POSITION_STEPS} of {total_positions} "
+                    "positions, sampled evenly)"
+                )
+        else:
+            sampled_flat = set()
+            sampling_note = ""
+
+        # --- Slide the kernel ---------------------------------------------
+        feature_map = torch.empty((Hout, Wout), dtype=torch.float32)
+        windows = torch.empty((total_positions, kH, kW), dtype=torch.float32)
+
+        flat = 0
+        for out_r in range(Hout):
+            r0 = out_r * stride
+            for out_c in range(Wout):
+                c0 = out_c * stride
+                field = padded[r0 : r0 + kH, c0 : c0 + kW]
+                product = field * kernel
+                value = product.sum()
+                feature_map[out_r, out_c] = value
+                windows[flat] = field
+
+                if recorder is not None and flat in sampled_flat:
+                    recorder.record(
+                        f"pos_r{out_r}_c{out_c}",
+                        (
+                            f"Window at output ({out_r}, {out_c}) = padded image "
+                            f"rows {r0}:{r0 + kH}, cols {c0}:{c0 + kW}. "
+                            "value = sum(receptive_field * kernel)." + sampling_note
+                        ),
+                        scalars={
+                            "out_r": float(out_r),
+                            "out_c": float(out_c),
+                            "value": float(value.item()),
+                        },
+                        receptive_field=field,
+                        product=product,
+                        value=value,
+                    )
+                flat += 1
+
+        if recorder is not None:
+            recorder.record(
+                "feature_map",
+                f"Assembled feature map [{Hout} x {Wout}] from every window sum.",
+                scalars={"Hout": float(Hout), "Wout": float(Wout)},
+                feature_map=feature_map,
+            )
+
+        result: dict[str, Any] = {
+            "feature_map": feature_map,
+            "kernel": kernel,
+            "windows": windows,
+        }
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result

--- a/plugins/foundations/nodes/edu_svm_node.py
+++ b/plugins/foundations/nodes/edu_svm_node.py
@@ -1,0 +1,333 @@
+"""EduSVMNode — hand-written linear soft-margin SVM trained by gradient descent.
+
+Textbook lesson **I2-2 (linear soft-margin SVM)**: instead of handing the
+problem to ``sklearn.svm.LinearSVC``, expose every moving part of the
+sub-gradient descent that minimises the primal hinge-loss objective:
+
+    scores            = X @ w + b
+    functional_margin = y_pm1 * scores
+    hinge             = max(0, 1 - functional_margin)
+    loss              = ½‖w‖² + C · mean(hinge)
+
+A point is a **support vector** when its functional margin is < 1 (it sits on
+or inside the margin, or is misclassified) — exactly the points that
+contribute a non-zero sub-gradient. The sub-gradient of the objective is
+
+    violating = (functional_margin < 1)
+    dw        = w − C · mean(violating · y_pm1 · x)   (mean over the batch)
+    db        =     − C · mean(violating · y_pm1)
+
+and one descent step is ``w ← w − lr·dw``, ``b ← b − lr·db``.
+
+Labels are mapped to ±1 internally (the lower class value → −1, the higher
+→ +1) and predictions are mapped back to the original label space so a
+downstream node sees the same two label values it fed in.
+
+Outputs expose the learned ``weights``/``bias``, the boolean
+``support_vectors`` mask over the training set, and the raw
+``decision_values`` ``w·x_query + b`` so a visualisation can draw the
+separating hyperplane, the ±1 margins, and highlight the support vectors.
+In verbose mode the per-epoch hinge loss and weight updates are recorded
+(capped to ~8 evenly-spaced snapshots) so students can watch the margin
+tighten over training.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+# Cap the number of per-epoch snapshots recorded in verbose mode so a
+# 10k-epoch run doesn't emit 10k steps into the Teaching Inspector.
+_MAX_EPOCH_SNAPSHOTS = 8
+
+
+class EduSVMNode(BaseNode):
+    NODE_NAME = "Edu-SVM"
+    CATEGORY = "Classical"
+    DESCRIPTION = (
+        "Hand-written linear soft-margin SVM trained by sub-gradient descent on "
+        "the hinge loss ½‖w‖² + C·mean(max(0, 1 − y·(w·x+b))). Binary labels are "
+        "mapped to ±1 internally and predictions returned in the original label "
+        "space. Exposes weights, bias, the support-vector mask (margin < 1), and "
+        "the raw decision values w·x+b for visualising the hyperplane and margins."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="x_train",
+                data_type=DataType.TENSOR,
+                description="Training features [N, D].",
+            ),
+            PortDefinition(
+                name="y_train",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Training labels [N] with EXACTLY two distinct values. The "
+                    "lower value maps to −1, the higher to +1 internally."
+                ),
+            ),
+            PortDefinition(
+                name="x_query",
+                data_type=DataType.TENSOR,
+                description="Query features [M, D] to classify.",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="predictions",
+                data_type=DataType.TENSOR,
+                description="Predicted label per query [M], in the original label space.",
+            ),
+            PortDefinition(
+                name="weights",
+                data_type=DataType.TENSOR,
+                description="Learned weight vector [D].",
+            ),
+            PortDefinition(
+                name="bias",
+                data_type=DataType.TENSOR,
+                description="Learned scalar bias.",
+            ),
+            PortDefinition(
+                name="support_vectors",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Boolean mask [N]; True where the train margin y·(w·x+b) < 1 "
+                    "(support vectors). Display-only."
+                ),
+            ),
+            PortDefinition(
+                name="decision_values",
+                data_type=DataType.TENSOR,
+                description="Raw decision function w·x_query + b, shape [M]. Display-only.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="C",
+                param_type=ParamType.FLOAT,
+                default=1.0,
+                min_value=0.0,
+                description=(
+                    "Soft-margin penalty. Larger C punishes margin violations "
+                    "harder (narrower margin, fewer mistakes); smaller C tolerates "
+                    "more violations for a wider margin."
+                ),
+            ),
+            ParamDefinition(
+                name="lr",
+                param_type=ParamType.FLOAT,
+                default=0.01,
+                min_value=0.0,
+                description="Sub-gradient descent step size.",
+            ),
+            ParamDefinition(
+                name="epochs",
+                param_type=ParamType.INT,
+                default=100,
+                min_value=1,
+                description="Number of full-batch sub-gradient descent steps.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError(
+                "EduSVM requires `x_train`, `y_train`, and `x_query` inputs."
+            )
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(y_train, torch.Tensor):
+            y_train = torch.as_tensor(y_train)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+        x_train = x_train.float()
+        x_query = x_query.float()
+        y_train = y_train.flatten()
+
+        # --- Shape validation -------------------------------------------------
+        if x_train.ndim != 2:
+            raise ValueError(
+                f"EduSVM: x_train must be 2-D [N, D]; got shape {tuple(x_train.shape)}."
+            )
+        if x_query.ndim != 2:
+            raise ValueError(
+                f"EduSVM: x_query must be 2-D [M, D]; got shape {tuple(x_query.shape)}."
+            )
+        n_samples, n_features = x_train.shape
+        if y_train.shape[0] != n_samples:
+            raise ValueError(
+                f"EduSVM: x_train and y_train length mismatch — "
+                f"{n_samples} rows vs {y_train.shape[0]} labels."
+            )
+        if x_query.shape[1] != n_features:
+            raise ValueError(
+                f"EduSVM: x_query has {x_query.shape[1]} features but x_train has "
+                f"{n_features}. Feature dimensions must match."
+            )
+
+        # --- Param validation -------------------------------------------------
+        C = float(params.get("C", 1.0))
+        lr = float(params.get("lr", 0.01))
+        epochs = int(params.get("epochs", 100))
+        if C < 0:
+            raise ValueError(f"EduSVM: C must be >= 0; got {C}.")
+        if lr < 0:
+            raise ValueError(f"EduSVM: lr must be >= 0; got {lr}.")
+        if epochs < 1:
+            raise ValueError(f"EduSVM: epochs must be >= 1; got {epochs}.")
+
+        # --- Label mapping to ±1 ---------------------------------------------
+        # Exactly two distinct classes; lower value -> -1, higher value -> +1.
+        unique_classes = torch.unique(y_train)
+        if unique_classes.numel() != 2:
+            raise ValueError(
+                f"EduSVM: y_train must have exactly 2 distinct classes; got "
+                f"{unique_classes.numel()} ({unique_classes.tolist()})."
+            )
+        neg_class, pos_class = unique_classes[0], unique_classes[1]  # sorted ascending
+        # y_pm1[i] = +1 if y_train[i] == pos_class else -1
+        y_pm1 = torch.where(
+            y_train == pos_class,
+            torch.ones(n_samples),
+            -torch.ones(n_samples),
+        )
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+
+        # --- Train: full-batch sub-gradient descent on the hinge objective ----
+        w = torch.zeros(n_features)
+        b = torch.zeros(())
+
+        if recorder is not None:
+            recorder.record(
+                "init",
+                "Initialise w = 0 (shape [D]) and b = 0; objective is "
+                "½‖w‖² + C·mean(max(0, 1 − y·(w·x+b))).",
+                scalars={
+                    "C": C,
+                    "lr": lr,
+                    "epochs": float(epochs),
+                    "n_features": float(n_features),
+                    "n_samples": float(n_samples),
+                },
+                w=w,
+            )
+
+        # Pick at most _MAX_EPOCH_SNAPSHOTS evenly-spaced epoch indices to record.
+        snapshot_epochs: set[int] = set()
+        if recorder is not None:
+            n_snap = min(_MAX_EPOCH_SNAPSHOTS, epochs)
+            # Evenly spaced across [1, epochs], always including the last epoch.
+            for s in range(n_snap):
+                idx = round((s + 1) * epochs / n_snap)
+                snapshot_epochs.add(max(1, min(epochs, idx)))
+
+        for epoch in range(1, epochs + 1):
+            scores = x_train @ w + b                  # [N]
+            functional_margins = y_pm1 * scores       # [N]
+            hinge = torch.clamp(1.0 - functional_margins, min=0.0)
+            violating = functional_margins < 1.0      # [N] bool
+
+            # Sub-gradient of ½‖w‖² + C·mean(hinge):
+            #   dw = w − C · mean(violating · y_pm1 · x)   (mean over batch)
+            #   db =     − C · mean(violating · y_pm1)
+            viol_y = violating.float() * y_pm1        # [N]
+            dw = w - C * (viol_y.unsqueeze(1) * x_train).mean(dim=0)
+            db = -C * viol_y.mean()
+
+            w = w - lr * dw
+            b = b - lr * db
+
+            if progress_callback is not None:
+                try:
+                    progress_callback(epoch / epochs)
+                except Exception:
+                    pass
+
+            if recorder is not None and epoch in snapshot_epochs:
+                loss = 0.5 * (w @ w) + C * hinge.mean()
+                num_sv = int(violating.sum().item())
+                recorder.record(
+                    f"epoch_{epoch}",
+                    "Sub-gradient step: dw = w − C·mean(violating·y·x); "
+                    "db = −C·mean(violating·y); then w ← w − lr·dw, b ← b − lr·db.",
+                    scalars={
+                        "epoch": float(epoch),
+                        "loss": float(loss.item()),
+                        "num_support_vectors": float(num_sv),
+                    },
+                    w=w,
+                )
+
+        # --- Final support-vector mask over the training set ------------------
+        final_scores = x_train @ w + b
+        final_margins = y_pm1 * final_scores
+        support_vectors = final_margins < 1.0  # bool [N]
+
+        # --- Predict on the query set ----------------------------------------
+        decision_values = x_query @ w + b      # [M], display-only
+        # sign(decision) mapped back to original labels: >= 0 -> pos_class.
+        predictions = torch.where(
+            decision_values >= 0,
+            pos_class.to(decision_values.dtype),
+            neg_class.to(decision_values.dtype),
+        )
+
+        if recorder is not None:
+            recorder.record(
+                "decision",
+                "Final hyperplane: predictions = sign(w·x_query + b) mapped back "
+                "to the original labels; support vectors are train points with "
+                "margin y·(w·x+b) < 1.",
+                scalars={
+                    "bias": float(b.item()),
+                    "weight_norm": float(w.norm().item()),
+                    "num_support_vectors": float(int(support_vectors.sum().item())),
+                },
+                weights=w,
+                support_vectors=support_vectors,
+                decision_values=decision_values,
+            )
+
+        result: dict[str, Any] = {
+            "predictions": predictions,
+            "weights": w,
+            "bias": b,
+            "support_vectors": support_vectors,
+            "decision_values": decision_values,
+        }
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result

--- a/plugins/foundations/nodes/edu_vector_similarity_node.py
+++ b/plugins/foundations/nodes/edu_vector_similarity_node.py
@@ -1,0 +1,196 @@
+"""EduVectorSimilarityNode — dot-product / cosine similarity, step by step.
+
+Supports textbook lesson **I1-3 (向量相似度)**: given a query vector (or a
+batch of them) and a set of key vectors, compute the pairwise similarity that
+underpins retrieval, attention, and nearest-neighbour search.
+
+Instead of one opaque "Similarity" node, this expands the computation into the
+named pieces a student needs to see:
+
+    raw_dot[i, j]   = q_i · k_j                       # inner products
+    qn[i]           = ||q_i||                          # query L2 norms
+    kn[j]           = ||k_j||                          # key   L2 norms
+    cosine[i, j]    = raw_dot[i, j] / (qn[i] · kn[j])  # length-normalised
+    dot[i, j]       = raw_dot[i, j]                    # unnormalised
+
+The final ``similarity`` matrix is ``[N, M]`` and is ready to be rendered as a
+heatmap (compare with ``EduSelfAttention``'s ``weights`` output). A 1-D query
+``[D]`` is treated as a single row, so the result is ``[1, M]`` (i.e. N = 1).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+_EPS = 1e-12
+
+
+class EduVectorSimilarityNode(BaseNode):
+    NODE_NAME = "Edu-VectorSimilarity"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "Pairwise query/key similarity exposed as: raw dot products q·k → L2 "
+        "norms ||q|| and ||k|| → cosine = dot / (||q||·||k||) (or raw dot). "
+        "Outputs the [N, M] similarity matrix for direct heatmap visualisation, "
+        "and records each intermediate in verbose mode."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="query",
+                data_type=DataType.TENSOR,
+                description="Query vector(s), shape [D] or [N, D]. A 1-D query becomes N=1.",
+            ),
+            PortDefinition(
+                name="keys",
+                data_type=DataType.TENSOR,
+                description="Key vectors, shape [M, D]. Each row is one key to score against.",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="similarity",
+                data_type=DataType.TENSOR,
+                description="Pairwise similarity, shape [N, M] (a 1-D query yields [1, M]). Ready for a heatmap.",
+            ),
+            PortDefinition(
+                name="query_norms",
+                data_type=DataType.TENSOR,
+                description="L2 norm of each query row, shape [N]. Returned for both metrics.",
+            ),
+            PortDefinition(
+                name="key_norms",
+                data_type=DataType.TENSOR,
+                description="L2 norm of each key row, shape [M]. Returned for both metrics.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="metric",
+                param_type=ParamType.SELECT,
+                default="cosine",
+                options=["cosine", "dot"],
+                description=(
+                    "'cosine' divides the dot product by the product of the two "
+                    "vectors' lengths (scale-invariant, in [-1, 1]); 'dot' returns "
+                    "the raw inner product (grows with vector magnitude)."
+                ),
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        query = inputs.get("query")
+        keys = inputs.get("keys")
+        if query is None or keys is None:
+            raise ValueError(
+                "EduVectorSimilarity requires `query` and `keys` inputs."
+            )
+
+        if not isinstance(query, torch.Tensor):
+            query = torch.as_tensor(query, dtype=torch.float32)
+        if not isinstance(keys, torch.Tensor):
+            keys = torch.as_tensor(keys, dtype=torch.float32)
+        query = query.float()
+        keys = keys.float()
+
+        if keys.ndim != 2:
+            raise ValueError(
+                f"EduVectorSimilarity expects `keys` of shape [M, D]; got {tuple(keys.shape)}."
+            )
+
+        # Reshape query to [N, D]; a 1-D [D] query becomes a single row (N=1).
+        if query.ndim == 1:
+            query = query.unsqueeze(0)
+        elif query.ndim != 2:
+            raise ValueError(
+                f"EduVectorSimilarity expects `query` of shape [D] or [N, D]; got {tuple(query.shape)}."
+            )
+
+        n, d_q = query.shape
+        m, d_k = keys.shape
+        if d_q != d_k:
+            raise ValueError(
+                f"EduVectorSimilarity: query feature dim D={d_q} does not match keys D={d_k}."
+            )
+
+        metric = str(params.get("metric", "cosine"))
+        if metric not in ("cosine", "dot"):
+            raise ValueError(
+                f"EduVectorSimilarity: unknown metric {metric!r}; expected 'cosine' or 'dot'."
+            )
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+
+        # raw_dot[i, j] = q_i · k_j  →  [N, M]
+        raw_dot = query @ keys.transpose(0, 1)
+        if recorder is not None:
+            recorder.record(
+                "dot_products",
+                "raw_dot[i, j] = q_i · k_j (every query against every key).",
+                scalars={"N": float(n), "M": float(m), "D": float(d_q)},
+                query=query, keys=keys, raw_dot=raw_dot,
+            )
+
+        # L2 norms of each query / key row.
+        query_norms = torch.linalg.vector_norm(query, dim=-1)  # [N]
+        key_norms = torch.linalg.vector_norm(keys, dim=-1)      # [M]
+        if recorder is not None:
+            recorder.record(
+                "norms",
+                "L2 norms: query_norms[i] = ||q_i||, key_norms[j] = ||k_j||.",
+                scalars={"D": float(d_q), "N": float(n), "M": float(m)},
+                query_norms=query_norms, key_norms=key_norms,
+            )
+
+        if metric == "cosine":
+            denom = query_norms.unsqueeze(1) * key_norms.unsqueeze(0) + _EPS
+            similarity = raw_dot / denom
+        else:  # "dot"
+            similarity = raw_dot
+        if recorder is not None:
+            recorder.record(
+                "similarity",
+                (
+                    "cosine = raw_dot / (||q_i|| · ||k_j||)"
+                    if metric == "cosine"
+                    else "dot = raw_dot (unnormalised inner product)"
+                ),
+                scalars={"metric": 1.0 if metric == "cosine" else 0.0},
+                similarity=similarity,
+            )
+
+        result: dict[str, Any] = {
+            "similarity": similarity,
+            "query_norms": query_norms,
+            "key_norms": key_norms,
+        }
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result


### PR DESCRIPTION
**Stacked on #30** (base = `refactor/edu-plugins-reorg`). Review/merge #30 first.

Fills the **I1–I2** coverage gaps with four hand-written, step-traced teaching
nodes in `plugins/foundations`:

| Node | Lesson | Intermediate states it exposes |
|------|--------|--------------------------------|
| `Edu-SlidingWindow` | I1-2 | per-window receptive field → elementwise product → sum → feature map; switchable kernel presets (edge/blur/sharpen/sobel/…) |
| `Edu-VectorSimilarity` | I1-3 | dot-product matrix → L2 norms → normalized cosine similarity (shaped like attention weights → heatmap-ready) |
| `Edu-SVM` | I2-2 | per-epoch hinge loss + support-vector count + evolving `w`; final weights/bias/SV-mask/decision-values |
| `Edu-DecisionTree` | I2-2 | per-split feature / threshold / impurity-before-after / gain; full JSON tree structure |

## Visualization

Every node records its intermediate states with `StepRecorder` (verbose mode →
Inspector **Steps** tab) and emits display-only outputs (SV mask, decision
values, similarity matrix, tree). The headline "see the algorithm's internals"
experience is the per-step trace — e.g. `Edu-SVM` lets you scrub epoch-by-epoch
as the margin tightens.

## Tests & examples

- **57 new unit tests** (metadata + numerical correctness vs hand-computed
  references + input-validation + verbose-steps), all green.
- **Two executable example graphs** — `Sliding-Window-Kernels`, `SVM-Margin-Decision`
  — verified end-to-end by the example smoke test.

## Also

Re-enables the example smoke-test discovery glob, which #30's `c*`→direction
rename had silently disabled (the `c?` pattern no longer matched
`foundations`/`deep`/`rl`, collecting 0 graphs). Now `*/examples/**` → all 32
example graphs execute in CI again.

**Backend: 1190 passed, 2 skipped.** (`uv run --directory backend pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
