### PR TITLE
feat(deep): new Edu nodes — Conv2d, MaxPool2d, Resample, DenoiseStep, RNNCell, LSTMCell, LayerNorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ and lets `cdui start` rediscover them on the next launch.
 | Pack | Hands-on modules | Edu nodes |
 |------|------------------|-----------|
 | `foundations` | I1 資料表示 · I2 經典 ML | Edu-ColumnStats, Edu-SlidingWindow, Edu-TokenEmbedding, Edu-VectorSimilarity, Edu-KNN, Edu-LinearRegression, Edu-LogisticRegression, Edu-SVM, Edu-DecisionTree, Edu-FFN |
-| `deep` | I3 視覺 · I4 序列 | Edu-CrossAttention, Edu-ResBlock, Edu-SelfAttention, Edu-MultiHeadAttention, Edu-Patchify |
+| `deep` | I3 視覺 · I4 序列 | Edu-Conv2d, Edu-MaxPool2d, Edu-ResBlock, Edu-Resample, Edu-DenoiseStep, Edu-CrossAttention, Edu-Patchify, Edu-RNNCell, Edu-LSTMCell, Edu-SelfAttention, Edu-MultiHeadAttention, Edu-LayerNorm |
 | `rl` | I5 強化學習 | Edu-PolicyGradient |
 
 Each Edu node decomposes a single lesson concept into a chain of named steps

--- a/backend/tests/test_edu_conv2d_node.py
+++ b/backend/tests/test_edu_conv2d_node.py
@@ -1,0 +1,178 @@
+"""Tests for EduConv2dNode (chapter pack I3 — CNN / im2col convolution)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from cdui_plugins.deep.nodes.edu_conv2d_node import EduConv2dNode
+
+
+class _Ctx:
+    """Minimal stand-in for ExecutionContext to toggle verbose mode."""
+
+    def __init__(self, verbose: bool) -> None:
+        self.verbose = verbose
+
+
+def _run(x, weight=None, bias=None, *, context=None, **params):
+    inputs: dict = {"x": x}
+    if weight is not None:
+        inputs["weight"] = weight
+    if bias is not None:
+        inputs["bias"] = bias
+    return EduConv2dNode().execute(inputs, dict(params), context=context)
+
+
+def test_node_metadata():
+    assert EduConv2dNode.NODE_NAME == "Edu-Conv2d"
+    assert EduConv2dNode.CATEGORY == "CNN"
+    out_names = [p.name for p in EduConv2dNode.define_outputs()]
+    assert out_names == ["y", "cols", "weight"]
+
+
+def test_matches_f_conv2d_basic():
+    torch.manual_seed(0)
+    x = torch.randn(2, 3, 7, 7)
+    weight = torch.randn(4, 3, 3, 3)
+    bias = torch.randn(4)
+    res = _run(x, weight, bias, stride=1, padding=0)
+    expected = F.conv2d(x, weight, bias, stride=1, padding=0)
+    assert torch.allclose(res["y"], expected, atol=1e-5)
+
+
+def test_matches_f_conv2d_with_stride_and_padding():
+    torch.manual_seed(1)
+    x = torch.randn(2, 3, 9, 8)
+    weight = torch.randn(5, 3, 3, 3)
+    bias = torch.randn(5)
+    res = _run(x, weight, bias, stride=2, padding=1)
+    expected = F.conv2d(x, weight, bias, stride=2, padding=1)
+    assert torch.allclose(res["y"], expected, atol=1e-5)
+
+
+def test_matches_f_conv2d_no_bias_nonsquare_kernel():
+    torch.manual_seed(2)
+    x = torch.randn(1, 2, 10, 12)
+    weight = torch.randn(3, 2, 2, 4)  # kH=2, kW=4
+    res = _run(x, weight, stride=2, padding=1)
+    expected = F.conv2d(x, weight, None, stride=2, padding=1)
+    assert torch.allclose(res["y"], expected, atol=1e-5)
+
+
+def test_returned_weight_is_the_one_used():
+    torch.manual_seed(3)
+    x = torch.randn(1, 2, 5, 5)
+    weight = torch.randn(3, 2, 3, 3)
+    res = _run(x, weight)
+    assert torch.equal(res["weight"], weight)
+
+
+def test_random_weight_when_absent_uses_seed():
+    x = torch.randn(1, 3, 6, 6)
+    a = _run(x, out_channels=4, kernel_size=3, seed=7)
+    b = _run(x, out_channels=4, kernel_size=3, seed=7)
+    c = _run(x, out_channels=4, kernel_size=3, seed=8)
+    # Same seed → identical weights; the conv output is deterministic too.
+    assert torch.equal(a["weight"], b["weight"])
+    assert a["weight"].shape == (4, 3, 3, 3)
+    assert torch.allclose(a["y"], b["y"])
+    assert not torch.equal(a["weight"], c["weight"])
+
+
+def test_random_weight_path_still_matches_f_conv2d():
+    x = torch.randn(2, 3, 8, 8)
+    res = _run(x, out_channels=4, kernel_size=3, stride=1, padding=1, seed=5)
+    w = res["weight"]
+    expected = F.conv2d(x, w, None, stride=1, padding=1)
+    assert torch.allclose(res["y"], expected, atol=1e-5)
+
+
+def test_cols_shape_is_im2col_matrix():
+    x = torch.randn(2, 3, 7, 7)
+    weight = torch.randn(4, 3, 3, 3)
+    res = _run(x, weight, stride=1, padding=0)
+    # Hout = Wout = (7 - 3) + 1 = 5 → L = 25; Cin*kH*kW = 27.
+    assert res["cols"].shape == (2, 3 * 3 * 3, 25)
+
+
+def test_promotes_3d_input_to_batch_one():
+    x = torch.randn(3, 6, 6)  # [Cin, H, W]
+    weight = torch.randn(4, 3, 3, 3)
+    res = _run(x, weight)
+    assert res["y"].shape[0] == 1
+    # Equivalent to F.conv2d on the batched version.
+    expected = F.conv2d(x.unsqueeze(0), weight, None)
+    assert torch.allclose(res["y"], expected, atol=1e-5)
+
+
+def test_output_shape_formula():
+    x = torch.randn(2, 3, 16, 16)
+    weight = torch.randn(7, 3, 5, 5)
+    res = _run(x, weight, stride=3, padding=2)
+    Hout = (16 + 2 * 2 - 5) // 3 + 1
+    Wout = (16 + 2 * 2 - 5) // 3 + 1
+    assert res["y"].shape == (2, 7, Hout, Wout)
+
+
+def test_rejects_non_4d_input():
+    x = torch.randn(2, 5)  # 2-D, not promotable
+    with pytest.raises(ValueError, match="shape"):
+        _run(x, torch.randn(2, 2, 3, 3))
+
+
+def test_rejects_channel_mismatch():
+    x = torch.randn(1, 3, 6, 6)
+    weight = torch.randn(4, 2, 3, 3)  # weight Cin=2 but x Cin=3
+    with pytest.raises(ValueError, match="Cin"):
+        _run(x, weight)
+
+
+def test_rejects_kernel_larger_than_input():
+    x = torch.randn(1, 1, 3, 3)
+    weight = torch.randn(2, 1, 5, 5)  # 5 > 3, no padding → Hout < 1
+    with pytest.raises(ValueError, match=">= 1"):
+        _run(x, weight, stride=1, padding=0)
+
+
+def test_rejects_bad_bias_shape():
+    x = torch.randn(1, 2, 5, 5)
+    weight = torch.randn(3, 2, 3, 3)
+    bias = torch.randn(5)  # should be [3]
+    with pytest.raises(ValueError, match="bias"):
+        _run(x, weight, bias)
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduConv2dNode().execute({}, {})
+
+
+def test_verbose_records_steps():
+    x = torch.randn(1, 2, 6, 6)
+    weight = torch.randn(3, 2, 3, 3)
+    res = _run(x, weight, context=_Ctx(verbose=True))
+    steps = res["__steps__"]
+    assert len(steps) == 4
+    names = [s.name for s in steps]
+    assert names == ["im2col", "weight_matrix", "matmul", "feature_map"]
+    # The im2col step carries the cols tensor and shape scalars.
+    im2col = steps[0]
+    assert "cols" in im2col.tensors
+    assert im2col.scalars["Cin"] == 2.0
+    assert im2col.scalars["kH"] == 3.0
+    # The feature_map step carries y.
+    assert "y" in steps[3].tensors
+
+
+def test_non_verbose_has_no_steps():
+    x = torch.randn(1, 2, 6, 6)
+    weight = torch.randn(3, 2, 3, 3)
+    res = _run(x, weight, context=_Ctx(verbose=False))
+    assert "__steps__" not in res
+    # And no context at all behaves the same.
+    res2 = _run(x, weight)
+    assert "__steps__" not in res2

--- a/backend/tests/test_edu_denoise_step_node.py
+++ b/backend/tests/test_edu_denoise_step_node.py
@@ -1,0 +1,191 @@
+"""Tests for EduDenoiseStepNode (chapter pack I3-3, one DDIM reverse step)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from cdui_plugins.deep.nodes.edu_denoise_step_node import EduDenoiseStepNode
+
+
+def _run(x_t, noise_pred, *, context=None, **params):
+    base = {"t": 50, "num_steps": 100, "beta_start": 0.0001, "beta_end": 0.02}
+    base.update(params)
+    return EduDenoiseStepNode().execute(
+        {"x_t": x_t, "noise_pred": noise_pred}, base, context=context
+    )
+
+
+def _abars(num_steps, beta_start, beta_end, t):
+    """Reference schedule: returns (abar_t, abar_prev)."""
+    betas = torch.linspace(beta_start, beta_end, num_steps)
+    alphas_cumprod = torch.cumprod(1.0 - betas, dim=0)
+    return alphas_cumprod[t], alphas_cumprod[t - 1]
+
+
+class _VerboseCtx:
+    verbose = True
+
+
+class _QuietCtx:
+    verbose = False
+
+
+# --------------------------------------------------------------------------- #
+# Metadata
+# --------------------------------------------------------------------------- #
+def test_node_metadata():
+    assert EduDenoiseStepNode.NODE_NAME == "Edu-DenoiseStep"
+    assert EduDenoiseStepNode.CATEGORY == "Diffusion"
+    out_names = [p.name for p in EduDenoiseStepNode.define_outputs()]
+    assert out_names == ["x_prev", "pred_x0"]
+    in_names = [p.name for p in EduDenoiseStepNode.define_inputs()]
+    assert in_names == ["x_t", "noise_pred"]
+
+
+# --------------------------------------------------------------------------- #
+# Hand-computed numeric correctness
+# --------------------------------------------------------------------------- #
+def test_hand_computed_step():
+    # Small schedule we can fully recompute by the DDIM formulas.
+    num_steps, beta_start, beta_end, t = 4, 0.1, 0.4, 2
+    x_t = torch.tensor([[[[3.0]]]])
+    noise_pred = torch.tensor([[[[0.5]]]])
+
+    abar_t, abar_prev = _abars(num_steps, beta_start, beta_end, t)
+    expected_pred_x0 = (x_t - torch.sqrt(1.0 - abar_t) * noise_pred) / torch.sqrt(abar_t)
+    expected_x_prev = (
+        torch.sqrt(abar_prev) * expected_pred_x0
+        + torch.sqrt(1.0 - abar_prev) * noise_pred
+    )
+
+    res = _run(
+        x_t,
+        noise_pred,
+        t=t,
+        num_steps=num_steps,
+        beta_start=beta_start,
+        beta_end=beta_end,
+    )
+    assert torch.allclose(res["pred_x0"], expected_pred_x0, atol=1e-6)
+    assert torch.allclose(res["x_prev"], expected_x_prev, atol=1e-6)
+
+
+def test_shape_preserved():
+    x_t = torch.randn(2, 3, 5, 7)
+    noise_pred = torch.randn(2, 3, 5, 7)
+    res = _run(x_t, noise_pred, t=10, num_steps=50)
+    assert res["x_prev"].shape == x_t.shape
+    assert res["pred_x0"].shape == x_t.shape
+
+
+def test_arbitrary_shape_supported():
+    # The node operates elementwise; a flat vector must work too.
+    x_t = torch.randn(6)
+    noise_pred = torch.randn(6)
+    res = _run(x_t, noise_pred, t=3, num_steps=20)
+    assert res["x_prev"].shape == (6,)
+    assert res["pred_x0"].shape == (6,)
+
+
+def test_zero_noise_gives_scaled_x0():
+    # With eps = 0:  pred_x0 = x_t / sqrt(abar_t).
+    num_steps, beta_start, beta_end, t = 8, 0.0001, 0.02, 5
+    x_t = torch.randn(1, 2, 3, 3)
+    noise_pred = torch.zeros_like(x_t)
+
+    abar_t, _ = _abars(num_steps, beta_start, beta_end, t)
+    expected = x_t / torch.sqrt(abar_t)
+
+    res = _run(
+        x_t,
+        noise_pred,
+        t=t,
+        num_steps=num_steps,
+        beta_start=beta_start,
+        beta_end=beta_end,
+    )
+    assert torch.allclose(res["pred_x0"], expected, atol=1e-6)
+    # And with zero noise the re-noising reduces to sqrt(abar_prev) * pred_x0.
+    _, abar_prev = _abars(num_steps, beta_start, beta_end, t)
+    assert torch.allclose(
+        res["x_prev"], torch.sqrt(abar_prev) * expected, atol=1e-6
+    )
+
+
+def test_deterministic_repeated_calls():
+    x_t = torch.randn(1, 1, 4, 4)
+    noise_pred = torch.randn(1, 1, 4, 4)
+    a = _run(x_t, noise_pred, t=7, num_steps=30)
+    b = _run(x_t, noise_pred, t=7, num_steps=30)
+    assert torch.equal(a["x_prev"], b["x_prev"])
+    assert torch.equal(a["pred_x0"], b["pred_x0"])
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+def test_shape_mismatch_raises():
+    x_t = torch.randn(1, 1, 4, 4)
+    noise_pred = torch.randn(1, 1, 4, 5)
+    with pytest.raises(ValueError, match="shape"):
+        _run(x_t, noise_pred, t=5, num_steps=20)
+
+
+def test_t_too_large_raises():
+    x_t = torch.randn(1, 1, 1, 1)
+    noise_pred = torch.zeros_like(x_t)
+    # t == num_steps is out of range (valid indices are 1..num_steps-1).
+    with pytest.raises(ValueError, match="t must satisfy"):
+        _run(x_t, noise_pred, t=20, num_steps=20)
+
+
+def test_t_too_small_raises():
+    x_t = torch.randn(1, 1, 1, 1)
+    noise_pred = torch.zeros_like(x_t)
+    with pytest.raises(ValueError, match="t must satisfy"):
+        _run(x_t, noise_pred, t=0, num_steps=20)
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduDenoiseStepNode().execute({"x_t": torch.zeros(1, 1, 1, 1)}, {})
+
+
+# --------------------------------------------------------------------------- #
+# Verbose step trace
+# --------------------------------------------------------------------------- #
+def test_steps_absent_without_verbose():
+    x_t = torch.randn(1, 1, 2, 2)
+    noise_pred = torch.randn(1, 1, 2, 2)
+    # No context at all.
+    assert "__steps__" not in _run(x_t, noise_pred, t=3, num_steps=20)
+    # Context present but verbose=False.
+    assert "__steps__" not in _run(
+        x_t, noise_pred, t=3, num_steps=20, context=_QuietCtx()
+    )
+
+
+def test_steps_emitted_when_verbose():
+    x_t = torch.randn(1, 1, 2, 2)
+    noise_pred = torch.randn(1, 1, 2, 2)
+    res = _run(x_t, noise_pred, t=3, num_steps=20, context=_VerboseCtx())
+    assert "__steps__" in res
+    steps = res["__steps__"]
+    names = [s.name for s in steps]
+    assert names == ["schedule", "predict_x0", "x_prev"]
+
+    schedule = steps[0]
+    for key in ("t", "abar_t", "abar_prev", "sqrt_abar_t", "sqrt_one_minus_abar_t"):
+        assert key in schedule.scalars
+    assert schedule.scalars["t"] == 3.0
+
+    # predict_x0 carries the pred_x0 tensor; x_prev carries x_prev + posterior coeffs.
+    assert "pred_x0" in steps[1].tensors
+    assert "x_prev" in steps[2].tensors
+    for key in ("sqrt_abar_prev", "sqrt_one_minus_abar_prev"):
+        assert key in steps[2].scalars
+
+    # Steps must agree with the returned outputs.
+    assert torch.allclose(steps[1].tensors["pred_x0"], res["pred_x0"])
+    assert torch.allclose(steps[2].tensors["x_prev"], res["x_prev"])

--- a/backend/tests/test_edu_layer_norm_node.py
+++ b/backend/tests/test_edu_layer_norm_node.py
@@ -1,0 +1,158 @@
+"""Tests for EduLayerNormNode (lesson I4-3)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from cdui_plugins.deep.nodes.edu_layer_norm_node import EduLayerNormNode
+
+D = 7
+
+
+def _run(x, *, gamma=None, beta=None, context=None, **params):
+    p = {"normalized_dim": 0, "eps": 1e-5, "elementwise_affine": True}
+    p.update(params)
+    inputs: dict = {"x": x}
+    if gamma is not None:
+        inputs["gamma"] = gamma
+    if beta is not None:
+        inputs["beta"] = beta
+    return EduLayerNormNode().execute(inputs, p, context=context)
+
+
+class _Ctx:
+    verbose = True
+    weights_persistent = False
+    node_state_store = None
+    current_node_id = None
+
+
+def test_node_metadata():
+    assert EduLayerNormNode.NODE_NAME == "Edu-LayerNorm"
+    assert EduLayerNormNode.CATEGORY == "Transformer"
+    out_names = [p.name for p in EduLayerNormNode.define_outputs()]
+    assert out_names == ["y", "mean", "var"]
+
+
+def test_matches_f_layer_norm_no_affine():
+    torch.manual_seed(0)
+    x = torch.randn(3, 5, D)
+    res = _run(x, elementwise_affine=False)
+    expected = F.layer_norm(x, (D,), None, None, 1e-5)
+    assert torch.allclose(res["y"], expected, atol=1e-6)
+
+
+def test_matches_f_layer_norm_with_affine():
+    torch.manual_seed(1)
+    x = torch.randn(3, 5, D)
+    gamma = torch.randn(D)
+    beta = torch.randn(D)
+    res = _run(x, gamma=gamma, beta=beta)
+    expected = F.layer_norm(x, (D,), gamma, beta, 1e-5)
+    assert torch.allclose(res["y"], expected, atol=1e-6)
+
+
+def test_output_zero_mean_unit_var_no_affine():
+    torch.manual_seed(2)
+    x = torch.randn(3, 5, D) * 4.0 + 2.0  # non-trivial scale/shift
+    res = _run(x, elementwise_affine=False)
+    y = res["y"]
+    mean = y.mean(dim=-1)
+    var = y.var(dim=-1, unbiased=False)
+    assert torch.allclose(mean, torch.zeros_like(mean), atol=1e-5)
+    assert torch.allclose(var, torch.ones_like(var), atol=1e-3)
+
+
+def test_mean_var_outputs_shape_and_values():
+    torch.manual_seed(3)
+    x = torch.randn(4, D)
+    res = _run(x)
+    assert res["mean"].shape == (4, 1)
+    assert res["var"].shape == (4, 1)
+    assert torch.allclose(res["mean"], x.mean(dim=-1, keepdim=True), atol=1e-6)
+    assert torch.allclose(
+        res["var"], x.var(dim=-1, unbiased=False, keepdim=True), atol=1e-6
+    )
+
+
+def test_affine_applied_correctly():
+    # With xhat ~ standardised, y should equal gamma * xhat + beta exactly.
+    torch.manual_seed(4)
+    x = torch.randn(2, D)
+    gamma = torch.full((D,), 3.0)
+    beta = torch.full((D,), -1.0)
+    res = _run(x, gamma=gamma, beta=beta)
+    xhat = _run(x, elementwise_affine=False)["y"]
+    assert torch.allclose(res["y"], gamma * xhat + beta, atol=1e-6)
+
+
+def test_default_gamma_beta_is_identity_normalize():
+    # Omitting gamma/beta (defaults ones/zeros) must equal the no-affine xhat.
+    torch.manual_seed(5)
+    x = torch.randn(3, D)
+    with_default_affine = _run(x, elementwise_affine=True)["y"]
+    just_xhat = _run(x, elementwise_affine=False)["y"]
+    assert torch.allclose(with_default_affine, just_xhat, atol=1e-6)
+
+
+def test_y_same_shape_as_x():
+    res = _run(torch.zeros(2, 3, D))
+    assert res["y"].shape == (2, 3, D)
+
+
+def test_normalized_dim_inference_and_match():
+    torch.manual_seed(6)
+    x = torch.randn(3, D)
+    # Explicit correct normalized_dim works the same as inferring it.
+    inferred = _run(x, normalized_dim=0)["y"]
+    explicit = _run(x, normalized_dim=D)["y"]
+    assert torch.allclose(inferred, explicit, atol=1e-6)
+
+
+def test_wrong_gamma_length_raises():
+    x = torch.randn(3, D)
+    with pytest.raises(ValueError, match="gamma"):
+        _run(x, gamma=torch.ones(D + 1))
+
+
+def test_wrong_beta_length_raises():
+    x = torch.randn(3, D)
+    with pytest.raises(ValueError, match="beta"):
+        _run(x, beta=torch.ones(D - 1))
+
+
+def test_normalized_dim_mismatch_raises():
+    x = torch.randn(3, D)
+    with pytest.raises(ValueError, match="normalized_dim"):
+        _run(x, normalized_dim=D + 2)
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduLayerNormNode().execute({}, {})
+
+
+def test_scalar_input_rejected():
+    with pytest.raises(ValueError, match="1-D"):
+        _run(torch.tensor(3.0))
+
+
+def test_steps_present_when_verbose():
+    res = _run(torch.randn(3, D), context=_Ctx())
+    assert "__steps__" in res
+    step_names = [s.name for s in res["__steps__"]]
+    assert step_names == ["mean", "var", "normalize", "affine"]
+
+
+def test_steps_absent_without_verbose():
+    res = _run(torch.randn(3, D))
+    assert "__steps__" not in res
+
+
+def test_step_mean_carries_scalars():
+    res = _run(torch.randn(2, D), context=_Ctx())
+    mean_step = next(s for s in res["__steps__"] if s.name == "mean")
+    assert mean_step.scalars["D"] == float(D)
+    assert "eps" in mean_step.scalars

--- a/backend/tests/test_edu_lstm_cell_node.py
+++ b/backend/tests/test_edu_lstm_cell_node.py
@@ -1,0 +1,213 @@
+"""Tests for EduLSTMCellNode (lesson I4-1)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from cdui_plugins.deep.nodes.edu_lstm_cell_node import EduLSTMCellNode
+
+
+def _run(x_seq, *, h0=None, c0=None, **params):
+    p = {"input_size": 4, "hidden_size": 8, "seed": 0}
+    p.update(params)
+    inputs: dict = {"x_seq": x_seq}
+    if h0 is not None:
+        inputs["h0"] = h0
+    if c0 is not None:
+        inputs["c0"] = c0
+    return EduLSTMCellNode().execute(inputs, p)
+
+
+def _reference_lstm_cell(res, input_size, hidden_size):
+    """Build an nn.LSTMCell seeded with the node's four parameter tensors."""
+    cell = nn.LSTMCell(input_size, hidden_size)
+    with torch.no_grad():
+        cell.weight_ih.copy_(res["weight_ih"])
+        cell.weight_hh.copy_(res["weight_hh"])
+        cell.bias_ih.copy_(res["bias_ih"])
+        cell.bias_hh.copy_(res["bias_hh"])
+    return cell
+
+
+def test_node_metadata():
+    assert EduLSTMCellNode.NODE_NAME == "Edu-LSTMCell"
+    assert EduLSTMCellNode.CATEGORY == "RNN"
+    out_names = [p.name for p in EduLSTMCellNode.define_outputs()]
+    assert out_names == [
+        "h_seq",
+        "h_last",
+        "c_last",
+        "weight_ih",
+        "weight_hh",
+        "bias_ih",
+        "bias_hh",
+    ]
+
+
+def test_param_tensor_shapes():
+    res = _run(torch.zeros(3, 4), input_size=4, hidden_size=8)
+    assert res["weight_ih"].shape == (32, 4)
+    assert res["weight_hh"].shape == (32, 8)
+    assert res["bias_ih"].shape == (32,)
+    assert res["bias_hh"].shape == (32,)
+
+
+def test_output_shape_2d():
+    res = _run(torch.randn(5, 4), input_size=4, hidden_size=8)
+    assert res["h_seq"].shape == (5, 8)
+    assert res["h_last"].shape == (8,)
+    assert res["c_last"].shape == (8,)
+    # h_last is exactly the final row of h_seq.
+    assert torch.allclose(res["h_seq"][-1], res["h_last"])
+
+
+def test_output_shape_3d_batch():
+    res = _run(torch.randn(3, 5, 4), input_size=4, hidden_size=8)  # [N, seq, input]
+    assert res["h_seq"].shape == (3, 5, 8)
+    assert res["h_last"].shape == (3, 8)
+    assert res["c_last"].shape == (3, 8)
+    assert torch.allclose(res["h_seq"][:, -1, :], res["h_last"])
+
+
+def test_equivalence_to_torch_lstmcell_2d():
+    """Stepping the same sequence through nn.LSTMCell must match h_seq / c_last."""
+    input_size, hidden_size = 4, 8
+    x = torch.randn(7, input_size, generator=torch.Generator().manual_seed(3))
+    res = _run(x, input_size=input_size, hidden_size=hidden_size, seed=11)
+
+    cell = _reference_lstm_cell(res, input_size, hidden_size)
+    h = torch.zeros(1, hidden_size)
+    c = torch.zeros(1, hidden_size)
+    ref_h_states = []
+    for t in range(x.shape[0]):
+        h, c = cell(x[t].unsqueeze(0), (h, c))
+        ref_h_states.append(h.squeeze(0))
+    ref_h_seq = torch.stack(ref_h_states, dim=0)
+
+    assert torch.allclose(res["h_seq"], ref_h_seq, atol=1e-6)
+    assert torch.allclose(res["h_last"], ref_h_seq[-1], atol=1e-6)
+    assert torch.allclose(res["c_last"], c.squeeze(0), atol=1e-6)
+
+
+def test_equivalence_to_torch_lstmcell_3d_batch():
+    """Batched path must also match nn.LSTMCell stepped over the batch."""
+    input_size, hidden_size = 4, 8
+    x = torch.randn(2, 6, input_size, generator=torch.Generator().manual_seed(5))
+    res = _run(x, input_size=input_size, hidden_size=hidden_size, seed=7)
+
+    cell = _reference_lstm_cell(res, input_size, hidden_size)
+    h = torch.zeros(2, hidden_size)
+    c = torch.zeros(2, hidden_size)
+    ref_h_states = []
+    for t in range(x.shape[1]):
+        h, c = cell(x[:, t, :], (h, c))
+        ref_h_states.append(h)
+    ref_h_seq = torch.stack(ref_h_states, dim=1)
+
+    assert torch.allclose(res["h_seq"], ref_h_seq, atol=1e-6)
+    assert torch.allclose(res["c_last"], c, atol=1e-6)
+
+
+def test_nonzero_initial_state_matches_reference():
+    """Custom h0/c0 must feed the recurrence the same way nn.LSTMCell does."""
+    input_size, hidden_size = 4, 8
+    x = torch.randn(4, input_size, generator=torch.Generator().manual_seed(1))
+    h0 = torch.randn(hidden_size, generator=torch.Generator().manual_seed(2))
+    c0 = torch.randn(hidden_size, generator=torch.Generator().manual_seed(3))
+    res = _run(x, h0=h0, c0=c0, input_size=input_size, hidden_size=hidden_size, seed=9)
+
+    cell = _reference_lstm_cell(res, input_size, hidden_size)
+    h = h0.unsqueeze(0)
+    c = c0.unsqueeze(0)
+    for t in range(x.shape[0]):
+        h, c = cell(x[t].unsqueeze(0), (h, c))
+
+    assert torch.allclose(res["h_last"], h.squeeze(0), atol=1e-6)
+    assert torch.allclose(res["c_last"], c.squeeze(0), atol=1e-6)
+
+
+def test_default_initial_state_is_zeros():
+    """Omitting h0/c0 must behave identically to passing explicit zeros."""
+    x = torch.randn(4, 4, generator=torch.Generator().manual_seed(8))
+    default = _run(x, seed=4)
+    explicit = _run(x, h0=torch.zeros(8), c0=torch.zeros(8), seed=4)
+    assert torch.allclose(default["h_seq"], explicit["h_seq"])
+    assert torch.allclose(default["c_last"], explicit["c_last"])
+
+
+def test_deterministic_given_seed():
+    x = torch.randn(5, 4, generator=torch.Generator().manual_seed(0))
+    a = _run(x, seed=123)
+    b = _run(x, seed=123)
+    assert torch.allclose(a["h_seq"], b["h_seq"])
+    assert torch.allclose(a["weight_ih"], b["weight_ih"])
+    # Different seed → different weights.
+    c = _run(x, seed=124)
+    assert not torch.allclose(a["weight_ih"], c["weight_ih"])
+
+
+def test_input_size_mismatch_raises():
+    with pytest.raises(ValueError, match="input_size"):
+        _run(torch.zeros(3, 5), input_size=4)
+
+
+def test_rejects_4d_input():
+    with pytest.raises(ValueError, match="x_seq"):
+        _run(torch.zeros(2, 3, 4, 4))
+
+
+def test_h0_wrong_length_raises():
+    with pytest.raises(ValueError, match="h0"):
+        _run(torch.zeros(3, 4), h0=torch.zeros(5), input_size=4, hidden_size=8)
+
+
+def test_c0_batch_mismatch_raises():
+    with pytest.raises(ValueError, match="c0"):
+        # x_seq batch is 2, c0 batch is 3.
+        _run(torch.zeros(2, 3, 4), c0=torch.zeros(3, 8), input_size=4, hidden_size=8)
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduLSTMCellNode().execute({}, {"input_size": 4, "hidden_size": 8, "seed": 0})
+
+
+def test_no_steps_when_not_verbose():
+    res = _run(torch.randn(4, 4))
+    assert "__steps__" not in res
+
+
+def test_step_trace_emitted_when_verbose():
+    class _Ctx:
+        verbose = True
+
+    res = EduLSTMCellNode().execute(
+        {"x_seq": torch.randn(3, 4)},
+        {"input_size": 4, "hidden_size": 8, "seed": 0},
+        context=_Ctx(),
+    )
+    assert "__steps__" in res
+    step_names = [s.name for s in res["__steps__"]]
+    # Per-timestep gate steps plus the final stacking step.
+    assert "timestep_0" in step_names
+    assert "h_seq" in step_names
+    # Each timestep step exposes the four gates and the new cell/hidden state.
+    first = res["__steps__"][0]
+    assert {"i", "f", "g", "o", "c_t", "h_t"} <= set(first.tensors.keys())
+
+
+def test_verbose_step_count_capped_for_long_sequence():
+    """A long sequence must not emit one step per timestep."""
+    class _Ctx:
+        verbose = True
+
+    seq = 50
+    res = EduLSTMCellNode().execute(
+        {"x_seq": torch.randn(seq, 4)},
+        {"input_size": 4, "hidden_size": 8, "seed": 0},
+        context=_Ctx(),
+    )
+    timestep_steps = [s for s in res["__steps__"] if s.name.startswith("timestep_")]
+    assert len(timestep_steps) <= 6

--- a/backend/tests/test_edu_maxpool2d_node.py
+++ b/backend/tests/test_edu_maxpool2d_node.py
@@ -1,0 +1,239 @@
+"""Tests for EduMaxPool2dNode (chapter pack I3, lesson I3-1: max pooling)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from cdui_plugins.deep.nodes.edu_maxpool2d_node import EduMaxPool2dNode
+
+
+class _VerboseCtx:
+    """Minimal stand-in for ExecutionContext with verbose step-trace on."""
+
+    verbose = True
+    weights_persistent = False
+    node_state_store = None
+
+
+def _run(x, *, context=None, **params):
+    p = {"kernel_size": 2, "stride": 0, "padding": 0}
+    p.update(params)
+    return EduMaxPool2dNode().execute({"x": x}, p, context=context)
+
+
+# --------------------------------------------------------------------------- #
+# Metadata
+# --------------------------------------------------------------------------- #
+def test_node_metadata():
+    assert EduMaxPool2dNode.NODE_NAME == "Edu-MaxPool2d"
+    assert EduMaxPool2dNode.CATEGORY == "CNN"
+    out_names = [p.name for p in EduMaxPool2dNode.define_outputs()]
+    assert out_names == ["y", "argmax"]
+
+
+def test_input_and_param_names():
+    in_names = [p.name for p in EduMaxPool2dNode.define_inputs()]
+    assert in_names == ["x"]
+    param_names = {p.name for p in EduMaxPool2dNode.define_params()}
+    assert param_names == {"kernel_size", "stride", "padding"}
+
+
+# --------------------------------------------------------------------------- #
+# Equivalence to F.max_pool2d
+# --------------------------------------------------------------------------- #
+def test_matches_max_pool2d_default_stride():
+    """Default stride (0 → kernel_size) must reproduce F.max_pool2d exactly."""
+    torch.manual_seed(0)
+    x = torch.randn(3, 5, 8, 8)
+    res = _run(x, kernel_size=2, stride=0, padding=0)
+    expected = F.max_pool2d(x, kernel_size=2)  # stride defaults to kernel_size
+    assert res["y"].shape == expected.shape
+    assert torch.allclose(res["y"], expected)
+
+
+def test_matches_max_pool2d_explicit_stride_and_padding():
+    """Explicit stride + padding must reproduce F.max_pool2d (incl. indices)."""
+    torch.manual_seed(1)
+    x = torch.randn(2, 4, 9, 7)
+    res = _run(x, kernel_size=3, stride=2, padding=1)
+    expected, expected_idx = F.max_pool2d(
+        x, kernel_size=3, stride=2, padding=1, return_indices=True
+    )
+    assert torch.allclose(res["y"], expected)
+    assert torch.equal(res["argmax"], expected_idx)
+
+
+def test_argmax_indices_point_to_the_max():
+    """argmax indexes the flattened H×W plane; gathering there returns y."""
+    torch.manual_seed(2)
+    x = torch.randn(1, 2, 6, 6)
+    res = _run(x, kernel_size=2, stride=2)
+    y, argmax = res["y"], res["argmax"]
+    N, C, H, W = x.shape
+    flat = x.reshape(N, C, H * W)
+    gathered = flat.gather(2, argmax.reshape(N, C, -1)).reshape_as(y)
+    assert torch.allclose(gathered, y)
+
+
+# --------------------------------------------------------------------------- #
+# Hand-computed 4x4 -> 2x2
+# --------------------------------------------------------------------------- #
+def test_hand_computed_4x4_to_2x2():
+    """A known 4×4 input with 2×2 non-overlapping windows."""
+    x = torch.tensor(
+        [
+            [1.0, 2.0, 5.0, 6.0],
+            [3.0, 4.0, 7.0, 8.0],
+            [9.0, 10.0, 13.0, 14.0],
+            [11.0, 12.0, 15.0, 16.0],
+        ]
+    ).reshape(1, 1, 4, 4)
+    res = _run(x, kernel_size=2, stride=2)
+    # Each 2×2 block's max: TL=4, TR=8, BL=12, BR=16.
+    expected = torch.tensor([[4.0, 8.0], [12.0, 16.0]]).reshape(1, 1, 2, 2)
+    assert res["y"].shape == (1, 1, 2, 2)
+    assert torch.equal(res["y"], expected)
+    # The maxima sit at the bottom-right of each block: flat input indices
+    # 5 (=row1,col1), 7 (=row1,col3), 13 (=row3,col1), 15 (=row3,col3).
+    expected_idx = torch.tensor([[5, 7], [13, 15]]).reshape(1, 1, 2, 2)
+    assert torch.equal(res["argmax"], expected_idx)
+
+
+# --------------------------------------------------------------------------- #
+# [C, H, W] gets a batch dim
+# --------------------------------------------------------------------------- #
+def test_chw_input_gains_batch_dim():
+    """A bare [C, H, W] is promoted to [1, C, H, W]."""
+    torch.manual_seed(3)
+    x = torch.randn(3, 8, 8)  # [C, H, W]
+    res = _run(x, kernel_size=2)
+    assert res["y"].shape == (1, 3, 4, 4)
+    # Same numbers as pooling the explicitly-batched version.
+    expected = F.max_pool2d(x.unsqueeze(0), kernel_size=2)
+    assert torch.allclose(res["y"], expected)
+
+
+# --------------------------------------------------------------------------- #
+# Downsample shape formula
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "H,W,k,s,p",
+    [
+        (8, 8, 2, 0, 0),   # default stride
+        (9, 7, 3, 2, 1),   # padded, overlapping-ish
+        (10, 10, 2, 2, 0),
+        (5, 5, 2, 1, 0),   # stride 1 → overlapping windows
+        (7, 9, 3, 3, 0),
+    ],
+)
+def test_downsample_shape_formula(H, W, k, s, p):
+    torch.manual_seed(4)
+    x = torch.randn(2, 3, H, W)
+    stride = k if s == 0 else s
+    expected_h = math.floor((H + 2 * p - k) / stride) + 1
+    expected_w = math.floor((W + 2 * p - k) / stride) + 1
+    res = _run(x, kernel_size=k, stride=s, padding=p)
+    assert res["y"].shape == (2, 3, expected_h, expected_w)
+
+
+def test_stride_defaults_to_kernel_size():
+    """stride=0 must behave identically to stride=kernel_size."""
+    torch.manual_seed(5)
+    x = torch.randn(1, 2, 8, 8)
+    a = _run(x, kernel_size=2, stride=0)
+    b = _run(x, kernel_size=2, stride=2)
+    assert torch.equal(a["y"], b["y"])
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+def test_invalid_shape_raises():
+    with pytest.raises(ValueError, match="shape"):
+        _run(torch.zeros(8, 8))  # 2-D, not [C,H,W] or [N,C,H,W]
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduMaxPool2dNode().execute({}, {"kernel_size": 2, "stride": 0, "padding": 0})
+
+
+def test_kernel_too_large_raises():
+    """Window bigger than the input → output dim < 1 → ValueError."""
+    with pytest.raises(ValueError, match=">= 1"):
+        _run(torch.zeros(1, 1, 3, 3), kernel_size=5, stride=5, padding=0)
+
+
+def test_kernel_below_one_raises():
+    with pytest.raises(ValueError, match="kernel_size"):
+        _run(torch.zeros(1, 1, 4, 4), kernel_size=0)
+
+
+def test_excessive_padding_raises():
+    """padding must not exceed kernel_size // 2 (mirrors F.max_pool2d)."""
+    with pytest.raises(ValueError, match="padding"):
+        _run(torch.zeros(1, 1, 6, 6), kernel_size=2, padding=3)
+
+
+# --------------------------------------------------------------------------- #
+# Verbose step trace
+# --------------------------------------------------------------------------- #
+def test_no_steps_without_verbose_context():
+    x = torch.randn(1, 1, 4, 4, generator=torch.Generator().manual_seed(6))
+    res = _run(x, kernel_size=2)
+    assert "__steps__" not in res
+
+
+def test_steps_emitted_when_verbose():
+    x = torch.randn(1, 2, 4, 4, generator=torch.Generator().manual_seed(7))
+    res = _run(x, kernel_size=2, context=_VerboseCtx())
+    assert "__steps__" in res
+    step_names = [s.name for s in res["__steps__"]]
+    # A handful of sampled windows followed by the downsample summary.
+    assert "downsample" in step_names
+    assert any(name.startswith("window_") for name in step_names)
+
+
+def test_verbose_window_steps_capped_at_six():
+    """A large map has many windows; per-window steps stay bounded (~6)."""
+    x = torch.randn(1, 1, 16, 16, generator=torch.Generator().manual_seed(8))
+    res = _run(x, kernel_size=2, context=_VerboseCtx())
+    window_steps = [s for s in res["__steps__"] if s.name.startswith("window_")]
+    assert 1 <= len(window_steps) <= 6
+
+
+def test_verbose_window_records_value_and_max():
+    """Each window step carries the window tensor and a scalar max == y cell."""
+    x = torch.tensor(
+        [
+            [1.0, 2.0, 5.0, 6.0],
+            [3.0, 4.0, 7.0, 8.0],
+            [9.0, 10.0, 13.0, 14.0],
+            [11.0, 12.0, 15.0, 16.0],
+        ]
+    ).reshape(1, 1, 4, 4)
+    res = _run(x, kernel_size=2, stride=2, context=_VerboseCtx())
+    window_steps = [s for s in res["__steps__"] if s.name.startswith("window_")]
+    # First sampled window is the top-left block; its max is 4.0.
+    first = window_steps[0]
+    assert "window" in first.tensors
+    assert first.scalars["max"] == pytest.approx(4.0)
+    # The recorded window tensor's own max equals the kept value.
+    assert float(first.tensors["window"].max().item()) == pytest.approx(
+        first.scalars["max"]
+    )
+
+
+def test_downsample_step_carries_before_after_shapes():
+    x = torch.randn(1, 1, 8, 8, generator=torch.Generator().manual_seed(9))
+    res = _run(x, kernel_size=2, stride=2, context=_VerboseCtx())
+    downsample = next(s for s in res["__steps__"] if s.name == "downsample")
+    assert downsample.scalars["H"] == 8.0
+    assert downsample.scalars["W"] == 8.0
+    assert downsample.scalars["Hout"] == 4.0
+    assert downsample.scalars["Wout"] == 4.0
+    assert "y" in downsample.tensors

--- a/backend/tests/test_edu_resample_node.py
+++ b/backend/tests/test_edu_resample_node.py
@@ -1,0 +1,142 @@
+"""Tests for EduResampleNode (lesson I3-2: U-Net down/up sampling)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from cdui_plugins.deep.nodes.edu_resample_node import EduResampleNode
+
+
+class _Ctx:
+    """Minimal stand-in for ExecutionContext exposing only ``.verbose``."""
+
+    def __init__(self, verbose: bool = False) -> None:
+        self.verbose = verbose
+
+
+def _run(x, *, skip=None, context=None, **params):
+    base = {"direction": "down", "factor": 2, "mode": "nearest"}
+    base.update(params)
+    inputs: dict = {"x": x}
+    if skip is not None:
+        inputs["skip"] = skip
+    return EduResampleNode().execute(inputs, base, context=context)
+
+
+def test_node_metadata():
+    assert EduResampleNode.NODE_NAME == "Edu-Resample"
+    assert EduResampleNode.CATEGORY == "Diffusion"
+    out_names = [p.name for p in EduResampleNode.define_outputs()]
+    assert out_names == ["y", "shape"]
+
+
+def test_down_factor_2_halves_spatial_dims():
+    x = torch.randn(2, 3, 16, 16)
+    res = _run(x, direction="down", factor=2, mode="avgpool")
+    assert res["y"].shape == (2, 3, 8, 8)
+    # shape output mirrors the resampled dims.
+    assert res["shape"].tolist() == [2, 3, 8, 8]
+
+
+def test_up_factor_2_doubles_spatial_dims():
+    x = torch.randn(2, 3, 8, 8)
+    res = _run(x, direction="up", factor=2, mode="nearest")
+    assert res["y"].shape == (2, 3, 16, 16)
+    assert res["shape"].tolist() == [2, 3, 16, 16]
+
+
+def test_nearest_up_matches_interpolate():
+    x = torch.randn(1, 4, 5, 7)
+    res = _run(x, direction="up", factor=2, mode="nearest")
+    expected = F.interpolate(x, scale_factor=2, mode="nearest")
+    assert torch.equal(res["y"], expected)
+
+
+def test_avgpool_down_matches_avg_pool2d():
+    x = torch.randn(1, 4, 8, 8)
+    res = _run(x, direction="down", factor=2, mode="avgpool")
+    expected = F.avg_pool2d(x, 2)
+    assert torch.allclose(res["y"], expected)
+
+
+def test_skip_concat_doubles_channels():
+    # x: [1, 3, 8, 8] up by 2 → [1, 3, 16, 16]; skip is same resolution.
+    x = torch.randn(1, 3, 8, 8)
+    skip = torch.randn(1, 3, 16, 16)
+    res = _run(x, skip=skip, direction="up", factor=2, mode="nearest")
+    assert res["y"].shape == (1, 6, 16, 16)
+    assert res["shape"].tolist() == [1, 6, 16, 16]
+    # The concatenated half is the skip tensor verbatim.
+    assert torch.equal(res["y"][:, 3:], skip)
+
+
+def test_skip_ignored_when_direction_down():
+    """A skip on the encoder side has nowhere to splice in — it's a no-op."""
+    x = torch.randn(1, 3, 16, 16)
+    skip = torch.randn(1, 3, 8, 8)
+    res = _run(x, skip=skip, direction="down", factor=2, mode="avgpool")
+    assert res["y"].shape == (1, 3, 8, 8)  # channels unchanged
+
+
+def test_promotes_3d_input_to_batch_one():
+    x = torch.randn(3, 8, 8)
+    res = _run(x, direction="down", factor=2, mode="avgpool")
+    assert res["y"].shape == (1, 3, 4, 4)
+
+
+def test_rejects_invalid_factor():
+    with pytest.raises(ValueError, match="factor"):
+        _run(torch.randn(1, 3, 8, 8), factor=1)
+
+
+def test_rejects_mismatched_skip():
+    x = torch.randn(1, 3, 8, 8)
+    bad_skip = torch.randn(1, 3, 8, 8)  # up→16, but skip is 8 → mismatch
+    with pytest.raises(ValueError, match="skip"):
+        _run(x, skip=bad_skip, direction="up", factor=2, mode="nearest")
+
+
+def test_rejects_non_4d_input():
+    with pytest.raises(ValueError, match="shape"):
+        _run(torch.randn(8))
+
+
+def test_verbose_emits_resample_step():
+    x = torch.randn(1, 3, 8, 8)
+    res = _run(x, direction="down", factor=2, mode="avgpool", context=_Ctx(verbose=True))
+    assert "__steps__" in res
+    step_names = [s.name for s in res["__steps__"]]
+    assert "resample" in step_names
+    resample = next(s for s in res["__steps__"] if s.name == "resample")
+    assert resample.scalars["H_before"] == 8.0
+    assert resample.scalars["H_after"] == 4.0
+
+
+def test_verbose_emits_skip_concat_step():
+    x = torch.randn(1, 3, 8, 8)
+    skip = torch.randn(1, 3, 16, 16)
+    res = _run(
+        x, skip=skip, direction="up", factor=2, mode="nearest", context=_Ctx(verbose=True)
+    )
+    step_names = [s.name for s in res["__steps__"]]
+    assert step_names == ["resample", "skip_concat"]
+    concat = next(s for s in res["__steps__"] if s.name == "skip_concat")
+    assert concat.scalars["channels_before"] == 3.0
+    assert concat.scalars["channels_after"] == 6.0
+
+
+def test_non_verbose_has_no_steps():
+    x = torch.randn(1, 3, 8, 8)
+    # No context at all.
+    res = _run(x, direction="down", factor=2, mode="avgpool")
+    assert "__steps__" not in res
+    # Explicit non-verbose context.
+    res2 = _run(x, direction="down", factor=2, mode="avgpool", context=_Ctx(verbose=False))
+    assert "__steps__" not in res2
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduResampleNode().execute({}, {"direction": "down", "factor": 2, "mode": "nearest"})

--- a/backend/tests/test_edu_rnn_cell_node.py
+++ b/backend/tests/test_edu_rnn_cell_node.py
@@ -1,0 +1,240 @@
+"""Tests for EduRNNCellNode (lesson I4-1)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from cdui_plugins.deep.nodes.edu_rnn_cell_node import EduRNNCellNode
+
+
+def _run(x_seq, *, h0=None, **params):
+    p = {"input_size": 4, "hidden_size": 8, "activation": "tanh", "seed": 0}
+    p.update(params)
+    inputs: dict = {"x_seq": x_seq}
+    if h0 is not None:
+        inputs["h0"] = h0
+    return EduRNNCellNode().execute(inputs, p)
+
+
+class _VerboseCtx:
+    verbose = True
+
+
+def test_node_metadata():
+    assert EduRNNCellNode.NODE_NAME == "Edu-RNNCell"
+    assert EduRNNCellNode.CATEGORY == "RNN"
+    out_names = [p.name for p in EduRNNCellNode.define_outputs()]
+    assert out_names == ["h_seq", "h_last", "weights"]
+
+
+def test_output_shape_2d():
+    res = _run(torch.randn(6, 4), input_size=4, hidden_size=8)
+    assert res["h_seq"].shape == (6, 8)
+    assert res["h_last"].shape == (8,)
+    # weights output is W_ih, [hidden, input].
+    assert res["weights"].shape == (8, 4)
+
+
+def test_output_shape_3d_batch():
+    res = _run(torch.randn(3, 6, 4), input_size=4, hidden_size=8)
+    assert res["h_seq"].shape == (3, 6, 8)
+    assert res["h_last"].shape == (3, 8)
+    assert res["weights"].shape == (8, 4)
+
+
+def test_h_last_is_final_hidden_state():
+    res = _run(torch.randn(5, 4))
+    assert torch.allclose(res["h_last"], res["h_seq"][-1])
+
+    resb = _run(torch.randn(2, 5, 4))
+    assert torch.allclose(resb["h_last"], resb["h_seq"][:, -1, :])
+
+
+def test_default_h0_is_zeros():
+    """With zero h0, the first hidden state depends only on x_0 (Wh = b_hh)."""
+    input_size, hidden_size, seed = 4, 8, 0
+    x_seq = torch.randn(5, input_size)
+
+    res_default = _run(x_seq, input_size=input_size, hidden_size=hidden_size, seed=seed)
+    res_zeros = _run(
+        x_seq,
+        h0=torch.zeros(hidden_size),
+        input_size=input_size,
+        hidden_size=hidden_size,
+        seed=seed,
+    )
+    assert torch.allclose(res_default["h_seq"], res_zeros["h_seq"])
+
+    # Sanity: the first step with zero h0 equals activation(W_ih x_0 + b_ih + b_hh).
+    W_ih, W_hh, b_ih, b_hh = EduRNNCellNode._build_params(input_size, hidden_size, seed)
+    expected_h0 = torch.tanh(x_seq[0] @ W_ih.T + b_ih + b_hh)
+    assert torch.allclose(res_default["h_seq"][0], expected_h0, atol=1e-6)
+
+
+def test_deterministic_given_seed():
+    x = torch.randn(5, 4)
+    a = _run(x, seed=7)
+    b = _run(x, seed=7)
+    assert torch.allclose(a["h_seq"], b["h_seq"])
+    assert torch.allclose(a["weights"], b["weights"])
+    # Different seed → different weights.
+    c = _run(x, seed=8)
+    assert not torch.allclose(a["weights"], c["weights"])
+
+
+def test_weights_output_matches_recomputed_params():
+    """The display `weights` output is exactly the seed-built W_ih."""
+    input_size, hidden_size, seed = 4, 8, 3
+    res = _run(torch.randn(4, input_size), input_size=input_size,
+               hidden_size=hidden_size, seed=seed)
+    W_ih, _, _, _ = EduRNNCellNode._build_params(input_size, hidden_size, seed)
+    assert torch.allclose(res["weights"], W_ih)
+
+
+@pytest.mark.parametrize("activation", ["tanh", "relu"])
+def test_equivalence_to_nn_rnncell_2d(activation):
+    """Unrolled node must match torch.nn.RNNCell stepped over the same sequence."""
+    input_size, hidden_size, seed = 4, 8, 5
+    seq = 7
+    x_seq = torch.randn(seq, input_size, generator=torch.Generator().manual_seed(11))
+
+    res = _run(x_seq, input_size=input_size, hidden_size=hidden_size,
+               activation=activation, seed=seed)
+
+    # Recompute the four parameters with the same seed and load them into a
+    # reference nn.RNNCell (identical layout: weight_ih/weight_hh/bias_ih/bias_hh).
+    W_ih, W_hh, b_ih, b_hh = EduRNNCellNode._build_params(input_size, hidden_size, seed)
+    # The display `weights` output is W_ih — confirm it lines up with what we feed
+    # the reference, so the equivalence really uses the node's own parameters.
+    assert torch.allclose(res["weights"], W_ih)
+
+    ref = nn.RNNCell(input_size, hidden_size, nonlinearity=activation)
+    with torch.no_grad():
+        ref.weight_ih.copy_(W_ih)
+        ref.weight_hh.copy_(W_hh)
+        ref.bias_ih.copy_(b_ih)
+        ref.bias_hh.copy_(b_hh)
+
+    h = torch.zeros(1, hidden_size)
+    ref_states = []
+    for t in range(seq):
+        h = ref(x_seq[t].unsqueeze(0), h)
+        ref_states.append(h.squeeze(0))
+    reference = torch.stack(ref_states, dim=0)  # [seq, hidden]
+
+    assert torch.allclose(res["h_seq"], reference, atol=1e-6)
+    assert torch.allclose(res["h_last"], reference[-1], atol=1e-6)
+
+
+def test_equivalence_to_nn_rnncell_3d_batch():
+    """Batched [N, seq, input] unroll matches nn.RNNCell run per sequence."""
+    input_size, hidden_size, seed = 4, 8, 2
+    N, seq = 3, 6
+    x = torch.randn(N, seq, input_size, generator=torch.Generator().manual_seed(13))
+
+    res = _run(x, input_size=input_size, hidden_size=hidden_size, seed=seed)
+
+    W_ih, W_hh, b_ih, b_hh = EduRNNCellNode._build_params(input_size, hidden_size, seed)
+    ref = nn.RNNCell(input_size, hidden_size, nonlinearity="tanh")
+    with torch.no_grad():
+        ref.weight_ih.copy_(W_ih)
+        ref.weight_hh.copy_(W_hh)
+        ref.bias_ih.copy_(b_ih)
+        ref.bias_hh.copy_(b_hh)
+
+    h = torch.zeros(N, hidden_size)
+    states = []
+    for t in range(seq):
+        h = ref(x[:, t, :], h)
+        states.append(h)
+    reference = torch.stack(states, dim=1)  # [N, seq, hidden]
+
+    assert torch.allclose(res["h_seq"], reference, atol=1e-6)
+
+
+def test_custom_h0_is_used():
+    """A non-zero h0 must flow into the first step's memory contribution."""
+    input_size, hidden_size, seed = 4, 8, 0
+    x_seq = torch.randn(4, input_size)
+    h0 = torch.randn(hidden_size)
+
+    res = _run(x_seq, h0=h0, input_size=input_size, hidden_size=hidden_size, seed=seed)
+
+    W_ih, W_hh, b_ih, b_hh = EduRNNCellNode._build_params(input_size, hidden_size, seed)
+    expected_h0 = torch.tanh(x_seq[0] @ W_ih.T + b_ih + h0 @ W_hh.T + b_hh)
+    assert torch.allclose(res["h_seq"][0], expected_h0, atol=1e-6)
+
+
+def test_h0_batch_broadcast_from_1d():
+    """A 1-D h0 should broadcast across a 3-D batch input."""
+    res = _run(torch.randn(2, 5, 4), h0=torch.randn(8), input_size=4, hidden_size=8)
+    assert res["h_seq"].shape == (2, 5, 8)
+
+
+def test_relu_activation_is_nonnegative():
+    res = _run(torch.randn(6, 4), activation="relu")
+    assert torch.all(res["h_seq"] >= 0)
+
+
+def test_input_size_mismatch_raises():
+    with pytest.raises(ValueError, match="input_size"):
+        _run(torch.randn(5, 3), input_size=4)
+
+
+def test_bad_ndim_raises():
+    with pytest.raises(ValueError, match=r"\[seq, input_size\]"):
+        _run(torch.randn(4))  # 1-D is invalid
+
+
+def test_h0_wrong_shape_raises():
+    with pytest.raises(ValueError, match="h0"):
+        _run(torch.randn(5, 4), h0=torch.randn(3), input_size=4, hidden_size=8)
+
+
+def test_unknown_activation_raises():
+    with pytest.raises(ValueError, match="activation"):
+        _run(torch.randn(5, 4), activation="sigmoid")
+
+
+def test_missing_input_raises():
+    with pytest.raises(ValueError, match="requires"):
+        EduRNNCellNode().execute({}, {"input_size": 4, "hidden_size": 8})
+
+
+def test_steps_absent_without_verbose():
+    res = _run(torch.randn(5, 4))
+    assert "__steps__" not in res
+
+
+def test_steps_present_when_verbose():
+    res = EduRNNCellNode().execute(
+        {"x_seq": torch.randn(5, 4)},
+        {"input_size": 4, "hidden_size": 8, "activation": "tanh", "seed": 0},
+        context=_VerboseCtx(),
+    )
+    assert "__steps__" in res
+    step_names = [s.name for s in res["__steps__"]]
+    # First timestep, last timestep, and the stacked-states summary all present.
+    assert "t=0" in step_names
+    assert "h_seq" in step_names
+    # A recorded timestep exposes x_t, Wx, Wh, h_t.
+    first = next(s for s in res["__steps__"] if s.name == "t=0")
+    assert set(first.tensors) == {"x_t", "Wx", "Wh", "h_t"}
+
+
+def test_verbose_steps_capped_for_long_sequence():
+    """A long sequence samples timesteps rather than recording every one."""
+    seq = 20
+    res = EduRNNCellNode().execute(
+        {"x_seq": torch.randn(seq, 4)},
+        {"input_size": 4, "hidden_size": 8, "activation": "tanh", "seed": 0},
+        context=_VerboseCtx(),
+    )
+    timestep_steps = [s for s in res["__steps__"] if s.name.startswith("t=")]
+    assert len(timestep_steps) <= 6
+    # First and last timesteps are always included.
+    names = {s.name for s in timestep_steps}
+    assert "t=0" in names
+    assert f"t={seq - 1}" in names

--- a/plugins/deep/examples/C3-1/Edu-Conv-MaxPool/graph.json
+++ b/plugins/deep/examples/C3-1/Edu-Conv-MaxPool/graph.json
@@ -1,0 +1,17 @@
+{
+  "name": "Conv + MaxPool: the two CNN operators, stepped out",
+  "description": "A 6x6 single-channel image flows through Edu-Conv2d (2 output channels, 3x3 kernel, padding 1) then Edu-MaxPool2d (2x2). Turn on Verbose mode to watch the convolution as an im2col → matmul → fold chain, then max pooling keep one value per window and halve the spatial size (6x6 → 3x3). The `cols` output makes the 'sliding kernel = one big matmul' identity explicit.",
+  "nodes": [
+    { "id": "start", "type": "Start",                 "position": { "x": -280, "y": 0 }, "data": { "params": {} } },
+    { "id": "img",   "type": "TensorInput",           "position": { "x": -40,  "y": 0 }, "data": { "params": { "shape": "1,1,6,6", "dtype": "float32", "value_mode": "random", "seed": 0 } } },
+    { "id": "conv",  "type": "deep:Edu-Conv2d",       "position": { "x": 240,  "y": 0 }, "data": { "params": { "out_channels": 2, "kernel_size": 3, "stride": 1, "padding": 1, "seed": 0 } } },
+    { "id": "pool",  "type": "deep:Edu-MaxPool2d",    "position": { "x": 520,  "y": 0 }, "data": { "params": { "kernel_size": 2, "stride": 0, "padding": 0 } } },
+    { "id": "print", "type": "Print",                 "position": { "x": 800,  "y": 0 }, "data": { "params": { "label": "pooled feature map" } } }
+  ],
+  "edges": [
+    { "id": "trig", "source": "start", "target": "img",   "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "e1",   "source": "img",   "target": "conv",  "sourceHandle": "tensor",  "targetHandle": "x" },
+    { "id": "e2",   "source": "conv",  "target": "pool",  "sourceHandle": "y",       "targetHandle": "x" },
+    { "id": "e3",   "source": "pool",  "target": "print", "sourceHandle": "y",       "targetHandle": "value" }
+  ]
+}

--- a/plugins/deep/examples/C3-3/Edu-Denoise-Step/graph.json
+++ b/plugins/deep/examples/C3-3/Edu-Denoise-Step/graph.json
@@ -1,0 +1,18 @@
+{
+  "name": "One denoising step: x_t and a predicted noise into x_(t-1)",
+  "description": "A noisy 4x4 latent x_t and a predicted noise epsilon are combined in one deterministic DDIM reverse step. Turn on Verbose mode to see the schedule coefficients (alpha-bar_t, alpha-bar_(t-1) and their square roots), the predicted clean image pred_x0 = (x_t - sqrt(1-abar_t)*eps)/sqrt(abar_t), and the recombined x_(t-1). Chaining many of these is the whole reverse diffusion process.",
+  "nodes": [
+    { "id": "start", "type": "Start",                 "position": { "x": -320, "y": 0 },   "data": { "params": {} } },
+    { "id": "xt",    "type": "TensorInput",           "position": { "x": -80,  "y": -90 }, "data": { "params": { "shape": "1,1,4,4", "dtype": "float32", "value_mode": "random", "seed": 0 } } },
+    { "id": "eps",   "type": "TensorInput",           "position": { "x": -80,  "y": 90 },  "data": { "params": { "shape": "1,1,4,4", "dtype": "float32", "value_mode": "random", "seed": 1 } } },
+    { "id": "dn",    "type": "deep:Edu-DenoiseStep",  "position": { "x": 260,  "y": 0 },   "data": { "params": { "t": 50, "num_steps": 100, "beta_start": 0.0001, "beta_end": 0.02 } } },
+    { "id": "print", "type": "Print",                 "position": { "x": 560,  "y": 0 },   "data": { "params": { "label": "x_(t-1)" } } }
+  ],
+  "edges": [
+    { "id": "trig1", "source": "start", "target": "xt",    "sourceHandle": "trigger",    "type": "trigger" },
+    { "id": "trig2", "source": "start", "target": "eps",   "sourceHandle": "trigger",    "type": "trigger" },
+    { "id": "e1",    "source": "xt",    "target": "dn",    "sourceHandle": "tensor",     "targetHandle": "x_t" },
+    { "id": "e2",    "source": "eps",   "target": "dn",    "sourceHandle": "tensor",     "targetHandle": "noise_pred" },
+    { "id": "e3",    "source": "dn",    "target": "print", "sourceHandle": "x_prev",     "targetHandle": "value" }
+  ]
+}

--- a/plugins/deep/examples/C4-1/Edu-LSTM-Unrolled/graph.json
+++ b/plugins/deep/examples/C4-1/Edu-LSTM-Unrolled/graph.json
@@ -1,0 +1,15 @@
+{
+  "name": "LSTM cell, unrolled gate by gate",
+  "description": "A length-5 sequence of 4-dim vectors is fed through Edu-LSTMCell (hidden size 8). Turn on Verbose mode to watch, at each timestep, the input gate i, forget gate f, candidate g, and output gate o decide what to write to and read from the cell state — the forget gate deciding what to drop, the input gate admitting new candidate memory. The h_seq output is the full hidden-state trajectory.",
+  "nodes": [
+    { "id": "start", "type": "Start",              "position": { "x": -280, "y": 0 }, "data": { "params": {} } },
+    { "id": "seq",   "type": "TensorInput",        "position": { "x": -40,  "y": 0 }, "data": { "params": { "shape": "5,4", "dtype": "float32", "value_mode": "random", "seed": 1 } } },
+    { "id": "lstm",  "type": "deep:Edu-LSTMCell",  "position": { "x": 260,  "y": 0 }, "data": { "params": { "input_size": 4, "hidden_size": 8, "seed": 0 } } },
+    { "id": "print", "type": "Print",              "position": { "x": 560,  "y": 0 }, "data": { "params": { "label": "hidden states h_seq" } } }
+  ],
+  "edges": [
+    { "id": "trig", "source": "start", "target": "seq",   "sourceHandle": "trigger", "type": "trigger" },
+    { "id": "e1",   "source": "seq",   "target": "lstm",  "sourceHandle": "tensor",  "targetHandle": "x_seq" },
+    { "id": "e2",   "source": "lstm",  "target": "print", "sourceHandle": "h_seq",   "targetHandle": "value" }
+  ]
+}

--- a/plugins/deep/nodes/edu_conv2d_node.py
+++ b/plugins/deep/nodes/edu_conv2d_node.py
@@ -1,0 +1,281 @@
+"""EduConv2dNode — a 2-D convolution unrolled into im2col → matmul → reshape.
+
+Supports textbook lesson **I3-1 (CNN / 卷積)**: a convolution layer is *not*
+a mysterious sliding stamp — it is a plain matrix multiply once you lay the
+receptive fields out as columns. This node exposes that identity explicitly:
+
+    1. cols       = im2col(x)              # F.unfold → [N, Cin·kH·kW, L]
+    2. weight_mat = weight.reshape(...)    # [Cout, Cin·kH·kW]
+    3. out_cols   = weight_mat @ cols (+b) # [N, Cout, L]
+    4. y          = fold(out_cols)         # [N, Cout, Hout, Wout]
+
+The numerical result is bit-for-bit what ``F.conv2d`` produces — the point of
+the node is to let students *see* the column matrix and the matmul that a real
+conv layer hides behind a single fused kernel.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+
+class EduConv2dNode(BaseNode):
+    NODE_NAME = "Edu-Conv2d"
+    CATEGORY = "CNN"
+    DESCRIPTION = (
+        "Multi-channel 2-D convolution unrolled as im2col → matmul → reshape. "
+        "F.unfold lays every receptive field out as a column ([N, Cin·kH·kW, L]); "
+        "the weight reshapes to a [Cout, Cin·kH·kW] matrix; one matmul (+bias) "
+        "gives [N, Cout, L]; folding back yields the feature map [N, Cout, Hout, "
+        "Wout]. Numerically identical to F.conv2d, but every intermediate is "
+        "exposed in verbose mode."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="x",
+                data_type=DataType.TENSOR,
+                description="Input feature map [N, Cin, H, W] (or [Cin, H, W], a batch dim is added).",
+            ),
+            PortDefinition(
+                name="weight",
+                data_type=DataType.TENSOR,
+                description="Conv weight [Cout, Cin, kH, kW]. Optional — if absent, random weights are drawn from the `seed` param.",
+                optional=True,
+            ),
+            PortDefinition(
+                name="bias",
+                data_type=DataType.TENSOR,
+                description="Optional per-output-channel bias [Cout].",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="y",
+                data_type=DataType.TENSOR,
+                description="Output feature map [N, Cout, Hout, Wout].",
+            ),
+            PortDefinition(
+                name="cols",
+                data_type=DataType.TENSOR,
+                description="The im2col matrix [N, Cin·kH·kW, L] (display-only — the receptive fields laid out as columns).",
+            ),
+            PortDefinition(
+                name="weight",
+                data_type=DataType.TENSOR,
+                description="The weight actually used [Cout, Cin, kH, kW] (the supplied one, or the freshly initialised random one).",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="out_channels",
+                param_type=ParamType.INT,
+                default=2,
+                min_value=1,
+                description="Number of output channels (Cout). Only used when no `weight` input is connected.",
+            ),
+            ParamDefinition(
+                name="kernel_size",
+                param_type=ParamType.INT,
+                default=3,
+                min_value=1,
+                description="Side length of the square kernel (kH = kW). Only used when no `weight` input is connected.",
+            ),
+            ParamDefinition(
+                name="stride",
+                param_type=ParamType.INT,
+                default=1,
+                min_value=1,
+                description="Stride of the sliding window in both H and W.",
+            ),
+            ParamDefinition(
+                name="padding",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description="Zero-padding added to all four sides of the input before unfolding.",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=0,
+                description="Seed for the random weight initialisation when no `weight` is supplied.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x = inputs.get("x")
+        if x is None:
+            raise ValueError("EduConv2d requires an `x` input.")
+        if not isinstance(x, torch.Tensor):
+            x = torch.as_tensor(x, dtype=torch.float32)
+        x = x.float()
+
+        # Accept [Cin, H, W] by promoting to [1, Cin, H, W]; reject anything else.
+        if x.ndim == 3:
+            x = x.unsqueeze(0)
+        if x.ndim != 4:
+            raise ValueError(
+                f"EduConv2d expects `x` of shape [N, Cin, H, W] (or [Cin, H, W]); got {tuple(x.shape)}."
+            )
+        N, Cin, H, W = x.shape
+
+        stride = int(params.get("stride", 1))
+        padding = int(params.get("padding", 0))
+        if stride < 1:
+            raise ValueError(f"EduConv2d: stride must be >= 1; got {stride}.")
+        if padding < 0:
+            raise ValueError(f"EduConv2d: padding must be >= 0; got {padding}.")
+
+        # Weight: use the supplied one, else initialise a random [Cout, Cin, kH, kW].
+        weight = inputs.get("weight")
+        if weight is not None:
+            if not isinstance(weight, torch.Tensor):
+                weight = torch.as_tensor(weight, dtype=torch.float32)
+            weight = weight.float()
+            if weight.ndim != 4:
+                raise ValueError(
+                    f"EduConv2d: `weight` must be 4-D [Cout, Cin, kH, kW]; got {tuple(weight.shape)}."
+                )
+        else:
+            out_channels = int(params.get("out_channels", 2))
+            kernel_size = int(params.get("kernel_size", 3))
+            if out_channels < 1:
+                raise ValueError(
+                    f"EduConv2d: out_channels must be >= 1; got {out_channels}."
+                )
+            if kernel_size < 1:
+                raise ValueError(
+                    f"EduConv2d: kernel_size must be >= 1; got {kernel_size}."
+                )
+            generator = torch.Generator().manual_seed(int(params.get("seed", 0)))
+            # Kaiming-style fan_in scaling so values stay O(1) regardless of size.
+            fan_in = Cin * kernel_size * kernel_size
+            std = 1.0 / math.sqrt(fan_in)
+            weight = torch.randn(
+                out_channels, Cin, kernel_size, kernel_size, generator=generator
+            ) * std
+
+        Cout, w_cin, kH, kW = weight.shape
+        if w_cin != Cin:
+            raise ValueError(
+                f"EduConv2d: weight Cin={w_cin} doesn't match input Cin={Cin}."
+            )
+
+        # Bias: optional [Cout].
+        bias = inputs.get("bias")
+        if bias is not None:
+            if not isinstance(bias, torch.Tensor):
+                bias = torch.as_tensor(bias, dtype=torch.float32)
+            bias = bias.float()
+            if bias.ndim != 1 or bias.shape[0] != Cout:
+                raise ValueError(
+                    f"EduConv2d: `bias` must have shape [Cout={Cout}]; got {tuple(bias.shape)}."
+                )
+
+        # Output spatial dims (standard conv formula).
+        Hout = (H + 2 * padding - kH) // stride + 1
+        Wout = (W + 2 * padding - kW) // stride + 1
+        if Hout < 1 or Wout < 1:
+            raise ValueError(
+                f"EduConv2d: output dims must be >= 1, got Hout={Hout}, Wout={Wout} "
+                f"(input {H}x{W}, kernel {kH}x{kW}, stride {stride}, padding {padding}). "
+                "Reduce the kernel/stride or add padding."
+            )
+        L = Hout * Wout
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+
+        # --- 1. im2col: lay every receptive field out as a column. ---
+        # cols: [N, Cin*kH*kW, L], where L = Hout*Wout.
+        cols = F.unfold(
+            x, kernel_size=(kH, kW), stride=stride, padding=padding
+        )
+        if recorder is not None:
+            recorder.record(
+                "im2col",
+                "cols = unfold(x): each of the L output positions becomes a "
+                "column holding its Cin·kH·kW receptive-field values.",
+                scalars={
+                    "Cin": float(Cin), "kH": float(kH), "kW": float(kW),
+                    "L": float(L), "Hout": float(Hout), "Wout": float(Wout),
+                },
+                cols=cols,
+            )
+
+        # --- 2. reshape the weight into a [Cout, Cin*kH*kW] matrix. ---
+        weight_mat = weight.reshape(Cout, Cin * kH * kW)
+        if recorder is not None:
+            recorder.record(
+                "weight_matrix",
+                "weight_mat = weight.reshape(Cout, Cin·kH·kW): one row per output "
+                "channel, matching the column layout of cols.",
+                scalars={
+                    "Cout": float(Cout),
+                    "Cin*kH*kW": float(Cin * kH * kW),
+                },
+                weight_mat=weight_mat,
+            )
+
+        # --- 3. the convolution IS this matmul (+ bias). ---
+        # [Cout, K] @ [N, K, L] broadcasts over N → [N, Cout, L].
+        out_cols = torch.matmul(weight_mat, cols)
+        if bias is not None:
+            out_cols = out_cols + bias.view(1, Cout, 1)
+        if recorder is not None:
+            recorder.record(
+                "matmul",
+                "out_cols = weight_mat @ cols (+ bias): a single matrix multiply "
+                "produces every output channel at every position → [N, Cout, L].",
+                scalars={"has_bias": 1.0 if bias is not None else 0.0},
+                out_cols=out_cols,
+            )
+
+        # --- 4. fold the columns back into a feature map. ---
+        y = out_cols.reshape(N, Cout, Hout, Wout)
+        if recorder is not None:
+            recorder.record(
+                "feature_map",
+                "y = out_cols.reshape(N, Cout, Hout, Wout): the L columns fold "
+                "back into the spatial grid — the finished feature map.",
+                scalars={
+                    "N": float(N), "Cout": float(Cout),
+                    "Hout": float(Hout), "Wout": float(Wout),
+                },
+                y=y,
+            )
+
+        result: dict[str, Any] = {"y": y, "cols": cols, "weight": weight}
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result

--- a/plugins/deep/nodes/edu_denoise_step_node.py
+++ b/plugins/deep/nodes/edu_denoise_step_node.py
@@ -1,0 +1,224 @@
+"""EduDenoiseStepNode — one deterministic DDIM reverse diffusion step.
+
+Supports textbook lesson **I3-3 (反向擴散 / sampling)**: instead of a
+black-box sampler loop, expose a SINGLE reverse step and every coefficient
+that goes into it.
+
+Given a noisy latent ``x_t`` and the network's predicted noise ``eps`` at
+timestep ``t``, a DDIM (eta = 0, deterministic) step is:
+
+    1. Build a linear beta schedule  betas = linspace(beta_start, beta_end, num_steps)
+       alphas          = 1 − betas
+       alphas_cumprod  = cumprod(alphas)
+       abar_t          = alphas_cumprod[t]
+       abar_prev       = alphas_cumprod[t-1]
+
+    2. Recover the predicted clean image (the "x0 prediction"):
+           pred_x0 = (x_t − sqrt(1 − abar_t) · eps) / sqrt(abar_t)
+
+    3. Re-noise toward the previous (less noisy) step:
+           x_prev  = sqrt(abar_prev) · pred_x0 + sqrt(1 − abar_prev) · eps
+
+There is no randomness — with eta = 0 the step is fully deterministic, so the
+same inputs always give the same ``x_prev``. ``pred_x0`` is the model's
+current best guess of the final image and is mainly there to *watch* the
+denoising sharpen over the course of a sampling loop; it is display-only and
+not fed forward.
+
+The node operates elementwise and keeps the input shape, so it works on any
+tensor (a ``[N, C, H, W]`` latent, a flat vector, a scalar — whatever the
+upstream produces) as long as ``noise_pred`` matches ``x_t`` exactly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+
+class EduDenoiseStepNode(BaseNode):
+    NODE_NAME = "Edu-DenoiseStep"
+    CATEGORY = "Diffusion"
+    DESCRIPTION = (
+        "One deterministic DDIM (eta=0) reverse diffusion step. From a noisy "
+        "latent x_t and predicted noise eps it recovers pred_x0 = (x_t − "
+        "sqrt(1−ᾱ_t)·eps) / sqrt(ᾱ_t), then re-noises to x_{t-1} = "
+        "sqrt(ᾱ_{t-1})·pred_x0 + sqrt(1−ᾱ_{t-1})·eps. Verbose mode exposes the "
+        "schedule coefficients (ᾱ_t, ᾱ_{t-1}) and the two posterior weights so "
+        "students see exactly how a sampler walks back down the noise schedule."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="x_t",
+                data_type=DataType.TENSOR,
+                description="Noisy latent at timestep t, shape [N, C, H, W] (or any shape).",
+            ),
+            PortDefinition(
+                name="noise_pred",
+                data_type=DataType.TENSOR,
+                description="Predicted noise epsilon, the SAME shape as x_t.",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="x_prev",
+                data_type=DataType.TENSOR,
+                description="Estimate of x_{t-1} (one step less noisy), same shape as x_t.",
+            ),
+            PortDefinition(
+                name="pred_x0",
+                data_type=DataType.TENSOR,
+                description="Predicted clean image x0 from this step. Display-only — not fed forward.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="t",
+                param_type=ParamType.INT,
+                default=50,
+                min_value=1,
+                description="Current timestep index. Must satisfy 1 ≤ t < num_steps.",
+            ),
+            ParamDefinition(
+                name="num_steps",
+                param_type=ParamType.INT,
+                default=100,
+                min_value=2,
+                description="Length of the (linear) beta schedule, i.e. total diffusion steps.",
+            ),
+            ParamDefinition(
+                name="beta_start",
+                param_type=ParamType.FLOAT,
+                default=0.0001,
+                description="First beta in the linear schedule.",
+            ),
+            ParamDefinition(
+                name="beta_end",
+                param_type=ParamType.FLOAT,
+                default=0.02,
+                description="Last beta in the linear schedule.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x_t = inputs.get("x_t")
+        noise_pred = inputs.get("noise_pred")
+        if x_t is None or noise_pred is None:
+            raise ValueError(
+                "EduDenoiseStep requires both `x_t` and `noise_pred` inputs."
+            )
+
+        if not isinstance(x_t, torch.Tensor):
+            x_t = torch.as_tensor(x_t, dtype=torch.float32)
+        if not isinstance(noise_pred, torch.Tensor):
+            noise_pred = torch.as_tensor(noise_pred, dtype=torch.float32)
+        x_t = x_t.float()
+        noise_pred = noise_pred.float()
+
+        if noise_pred.shape != x_t.shape:
+            raise ValueError(
+                "EduDenoiseStep: noise_pred shape "
+                f"{tuple(noise_pred.shape)} must equal x_t shape "
+                f"{tuple(x_t.shape)}."
+            )
+
+        t = int(params.get("t", 50))
+        num_steps = int(params.get("num_steps", 100))
+        beta_start = float(params.get("beta_start", 0.0001))
+        beta_end = float(params.get("beta_end", 0.02))
+
+        if num_steps < 2:
+            raise ValueError(
+                f"EduDenoiseStep: num_steps must be ≥ 2; got {num_steps}."
+            )
+        if not (1 <= t < num_steps):
+            raise ValueError(
+                f"EduDenoiseStep: t must satisfy 1 ≤ t < num_steps ({num_steps}); "
+                f"got t={t}."
+            )
+
+        # Linear beta schedule → alphas → cumulative product ᾱ.
+        betas = torch.linspace(beta_start, beta_end, num_steps, dtype=torch.float32)
+        alphas = 1.0 - betas
+        alphas_cumprod = torch.cumprod(alphas, dim=0)
+        abar_t = alphas_cumprod[t]
+        abar_prev = alphas_cumprod[t - 1]
+
+        sqrt_abar_t = torch.sqrt(abar_t)
+        sqrt_one_minus_abar_t = torch.sqrt(1.0 - abar_t)
+        sqrt_abar_prev = torch.sqrt(abar_prev)
+        sqrt_one_minus_abar_prev = torch.sqrt(1.0 - abar_prev)
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+
+        if recorder is not None:
+            recorder.record(
+                "schedule",
+                "Linear beta schedule → ᾱ. Read off ᾱ_t and ᾱ_{t-1} for this step.",
+                scalars={
+                    "t": float(t),
+                    "abar_t": float(abar_t.item()),
+                    "abar_prev": float(abar_prev.item()),
+                    "sqrt_abar_t": float(sqrt_abar_t.item()),
+                    "sqrt_one_minus_abar_t": float(sqrt_one_minus_abar_t.item()),
+                },
+            )
+
+        # Step 2: recover the predicted clean image x0.
+        pred_x0 = (x_t - sqrt_one_minus_abar_t * noise_pred) / sqrt_abar_t
+        if recorder is not None:
+            recorder.record(
+                "predict_x0",
+                "pred_x0 = (x_t − sqrt(1−ᾱ_t)·eps) / sqrt(ᾱ_t): invert the forward "
+                "noising to guess the clean image.",
+                pred_x0=pred_x0,
+            )
+
+        # Step 3: deterministic DDIM re-noising toward x_{t-1}.
+        x_prev = sqrt_abar_prev * pred_x0 + sqrt_one_minus_abar_prev * noise_pred
+        if recorder is not None:
+            recorder.record(
+                "x_prev",
+                "x_{t-1} = sqrt(ᾱ_{t-1})·pred_x0 + sqrt(1−ᾱ_{t-1})·eps: re-noise to "
+                "one step less noisy (DDIM, eta=0, deterministic).",
+                scalars={
+                    "sqrt_abar_prev": float(sqrt_abar_prev.item()),
+                    "sqrt_one_minus_abar_prev": float(sqrt_one_minus_abar_prev.item()),
+                },
+                x_prev=x_prev,
+            )
+
+        result: dict[str, Any] = {
+            "x_prev": x_prev,
+            "pred_x0": pred_x0,
+        }
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result

--- a/plugins/deep/nodes/edu_layer_norm_node.py
+++ b/plugins/deep/nodes/edu_layer_norm_node.py
@@ -1,0 +1,209 @@
+"""EduLayerNormNode — layer normalization written out step by step.
+
+This is the educational counterpart to the production ``LayerNorm`` node.
+Where that one wraps the framework primitive, this one exposes the four
+pieces of one layer-norm over the last dimension ``D`` so students can watch
+the statistics get computed and applied (textbook lesson **I4-3**):
+
+    mean = x.mean(-1, keepdim=True)                 # per-row average
+    var  = x.var(-1, unbiased=False, keepdim=True)  # biased (population) var
+    xhat = (x - mean) / sqrt(var + eps)             # standardise to ~N(0,1)
+    y    = gamma * xhat + beta                       # learnable affine
+
+The normalization is always over the **last** dimension; everything to its
+left (batch, sequence, …) is treated as independent rows. ``mean`` and
+``var`` are surfaced as ``[*, 1]`` display-only outputs so the inspector can
+show the statistics that drove the standardisation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+
+class EduLayerNormNode(BaseNode):
+    NODE_NAME = "Edu-LayerNorm"
+    CATEGORY = "Transformer"
+    DESCRIPTION = (
+        "Layer normalization over the last dim D, stepped out: mean = x.mean(-1); "
+        "var = x.var(-1) (biased); xhat = (x - mean) / sqrt(var + eps); "
+        "y = gamma * xhat + beta. Exposes mean and var as display-only outputs so "
+        "students see the statistics that standardise each row before the affine."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="x",
+                data_type=DataType.TENSOR,
+                description="Input tensor of shape [*, D]; normalized over the last dim D.",
+            ),
+            PortDefinition(
+                name="gamma",
+                data_type=DataType.TENSOR,
+                description="Optional affine scale of shape [D]. Defaults to ones.",
+                optional=True,
+            ),
+            PortDefinition(
+                name="beta",
+                data_type=DataType.TENSOR,
+                description="Optional affine shift of shape [D]. Defaults to zeros.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="y",
+                data_type=DataType.TENSOR,
+                description="Normalized (and optionally affine-transformed) output, same shape as x.",
+            ),
+            PortDefinition(
+                name="mean",
+                data_type=DataType.TENSOR,
+                description="Per-row mean over the last dim, shape [*, 1]. Display-only.",
+            ),
+            PortDefinition(
+                name="var",
+                data_type=DataType.TENSOR,
+                description="Per-row biased variance over the last dim, shape [*, 1]. Display-only.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="normalized_dim",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description=(
+                    "Size D of the normalized last dimension. 0 means infer D from "
+                    "x's last dim; any other value is checked against x and gamma/beta."
+                ),
+            ),
+            ParamDefinition(
+                name="eps",
+                param_type=ParamType.FLOAT,
+                default=1e-5,
+                min_value=0.0,
+                description="Added to the variance before sqrt for numerical stability.",
+            ),
+            ParamDefinition(
+                name="elementwise_affine",
+                param_type=ParamType.BOOL,
+                default=True,
+                description="If true apply y = gamma * xhat + beta; if false output xhat directly.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x = inputs.get("x")
+        if x is None:
+            raise ValueError("EduLayerNorm requires an `x` input.")
+        if not isinstance(x, torch.Tensor):
+            x = torch.as_tensor(x, dtype=torch.float32)
+        x = x.float()
+
+        if x.ndim < 1:
+            raise ValueError(
+                f"EduLayerNorm: x must be at least 1-D; got shape {tuple(x.shape)}."
+            )
+
+        d = x.shape[-1]
+        normalized_dim = int(params.get("normalized_dim", 0) or 0)
+        if normalized_dim and normalized_dim != d:
+            raise ValueError(
+                f"EduLayerNorm: normalized_dim={normalized_dim} does not match x's "
+                f"last dim {d}. Set normalized_dim=0 to infer it from x."
+            )
+
+        eps = float(params.get("eps", 1e-5))
+        elementwise_affine = bool(params.get("elementwise_affine", True))
+
+        gamma = self._coerce_affine(inputs.get("gamma"), d, name="gamma")
+        beta = self._coerce_affine(inputs.get("beta"), d, name="beta")
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+
+        mean = x.mean(dim=-1, keepdim=True)
+        if recorder is not None:
+            recorder.record(
+                "mean",
+                "Per-row mean over the last dim: $\\mu = \\frac{1}{D}\\sum_i x_i$.",
+                scalars={"D": float(d), "eps": eps},
+                mean=mean,
+            )
+
+        var = x.var(dim=-1, unbiased=False, keepdim=True)
+        if recorder is not None:
+            recorder.record(
+                "var",
+                "Per-row biased variance over the last dim: "
+                "$\\sigma^2 = \\frac{1}{D}\\sum_i (x_i - \\mu)^2$.",
+                var=var,
+            )
+
+        xhat = (x - mean) / torch.sqrt(var + eps)
+        if recorder is not None:
+            recorder.record(
+                "normalize",
+                "Standardise each row: $\\hat{x} = (x - \\mu) / \\sqrt{\\sigma^2 + \\epsilon}$.",
+                xhat=xhat,
+            )
+
+        if elementwise_affine:
+            y = gamma * xhat + beta
+        else:
+            y = xhat
+        if recorder is not None:
+            recorder.record(
+                "affine",
+                "Apply the learnable affine: $y = \\gamma \\hat{x} + \\beta$."
+                if elementwise_affine
+                else "elementwise_affine is off, so $y = \\hat{x}$.",
+                y=y,
+            )
+
+        result: dict[str, Any] = {"y": y, "mean": mean, "var": var}
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result
+
+    @staticmethod
+    def _coerce_affine(value: Any, d: int, *, name: str) -> torch.Tensor:
+        """Validate / default an affine parameter (gamma or beta) to shape [D]."""
+        if value is None:
+            return torch.ones(d) if name == "gamma" else torch.zeros(d)
+        if not isinstance(value, torch.Tensor):
+            value = torch.as_tensor(value, dtype=torch.float32)
+        value = value.float()
+        if value.ndim != 1 or value.shape[0] != d:
+            raise ValueError(
+                f"EduLayerNorm: {name} must have shape [{d}] to match x's last dim; "
+                f"got {tuple(value.shape)}."
+            )
+        return value

--- a/plugins/deep/nodes/edu_lstm_cell_node.py
+++ b/plugins/deep/nodes/edu_lstm_cell_node.py
@@ -1,0 +1,334 @@
+"""EduLSTMCellNode — an LSTM cell unrolled over time, gate by gate.
+
+Educational counterpart to ``torch.nn.LSTMCell`` for lesson **I4-1**. Where the
+library cell is a single opaque call, this node writes out the textbook recurrence
+and surfaces the four gates plus the cell state at every timestep so a learner can
+watch what the network "remembers" and "forgets" step by step:
+
+    f = σ(W_f · [x, h] + b_f)        # forget gate — how much of c_{t-1} to keep
+    i = σ(W_i · [x, h] + b_i)        # input gate — how much new info to admit
+    g = tanh(W_g · [x, h] + b_g)     # candidate — the new info itself
+    o = σ(W_o · [x, h] + b_o)        # output gate — how much of c_t to expose
+    c_t = f ⊙ c_{t-1} + i ⊙ g        # new cell state (the "memory")
+    h_t = o ⊙ tanh(c_t)              # new hidden state (the output)
+
+To stay validatable against ``torch.nn.LSTMCell`` it uses PyTorch's exact
+parameter convention: a single fused ``weight_ih`` ``[4H, input]``, ``weight_hh``
+``[4H, hidden]``, ``bias_ih`` ``[4H]``, ``bias_hh`` ``[4H]``, with the four gate
+chunks laid out in the order **i, f, g, o**. The fused pre-activations are
+
+    gates = x @ weight_ih.T + bias_ih + h @ weight_hh.T + bias_hh
+
+and ``gates`` is split into its i/f/g/o quarters before the non-linearities.
+
+The four parameter tensors are seeded deterministically from ``seed`` and also
+returned as display outputs (``weight_ih``/``weight_hh``/``bias_ih``/``bias_hh``)
+so an external check can copy them straight into ``nn.LSTMCell`` and compare.
+
+Inputs may be unbatched ``[seq, input_size]`` or batched ``[N, seq, input_size]``.
+``h0``/``c0`` are optional and default to zeros.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+# Cap on the number of per-timestep verbose steps. For sequences longer than
+# this we sample evenly so the Teaching Inspector never drowns in steps.
+_MAX_TIMESTEP_STEPS = 6
+
+
+class EduLSTMCellNode(BaseNode):
+    NODE_NAME = "Edu-LSTMCell"
+    CATEGORY = "RNN"
+    DESCRIPTION = (
+        "An LSTM cell unrolled over time. Computes the forget/input/output gates and "
+        "candidate (f, i, g, o), then c_t = f⊙c_{t-1} + i⊙g and h_t = o⊙tanh(c_t) at "
+        "every step. Uses PyTorch's fused weight_ih/weight_hh/bias_ih/bias_hh convention "
+        "(gate order i,f,g,o) so it matches torch.nn.LSTMCell exactly, and exposes the "
+        "four gates and the cell state per timestep in verbose mode."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="x_seq",
+                data_type=DataType.TENSOR,
+                description="Input sequence, shape [seq, input_size] or [N, seq, input_size].",
+            ),
+            PortDefinition(
+                name="h0",
+                data_type=DataType.TENSOR,
+                description="Optional initial hidden state, [hidden_size] or [N, hidden_size]. Defaults to zeros.",
+                optional=True,
+            ),
+            PortDefinition(
+                name="c0",
+                data_type=DataType.TENSOR,
+                description="Optional initial cell state, [hidden_size] or [N, hidden_size]. Defaults to zeros.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="h_seq",
+                data_type=DataType.TENSOR,
+                description="All hidden states stacked over time — [seq, hidden] or [N, seq, hidden].",
+            ),
+            PortDefinition(
+                name="h_last",
+                data_type=DataType.TENSOR,
+                description="Hidden state after the final timestep — [hidden] or [N, hidden].",
+            ),
+            PortDefinition(
+                name="c_last",
+                data_type=DataType.TENSOR,
+                description="Cell state after the final timestep — [hidden] or [N, hidden].",
+            ),
+            PortDefinition(
+                name="weight_ih",
+                data_type=DataType.TENSOR,
+                description="Fused input→gates weight [4*hidden, input] (gate order i,f,g,o). Sync into nn.LSTMCell.",
+            ),
+            PortDefinition(
+                name="weight_hh",
+                data_type=DataType.TENSOR,
+                description="Fused hidden→gates weight [4*hidden, hidden] (gate order i,f,g,o). Sync into nn.LSTMCell.",
+            ),
+            PortDefinition(
+                name="bias_ih",
+                data_type=DataType.TENSOR,
+                description="Input gate bias [4*hidden] (gate order i,f,g,o).",
+            ),
+            PortDefinition(
+                name="bias_hh",
+                data_type=DataType.TENSOR,
+                description="Hidden gate bias [4*hidden] (gate order i,f,g,o).",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="input_size",
+                param_type=ParamType.INT,
+                default=4,
+                min_value=1,
+                description="Dimension of each input vector x_t. Must match x_seq's last dim.",
+            ),
+            ParamDefinition(
+                name="hidden_size",
+                param_type=ParamType.INT,
+                default=8,
+                min_value=1,
+                description="Dimension of the hidden / cell state H.",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=0,
+                description="Seed for the deterministic small-randn weight init. Same seed → same weights.",
+            ),
+        ]
+
+    @staticmethod
+    def _init_weights(
+        input_size: int, hidden_size: int, seed: int
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Deterministic small-randn init in PyTorch's fused [4H, ...] layout."""
+        gen = torch.Generator()
+        gen.manual_seed(int(seed))
+        scale = 0.1
+        weight_ih = torch.randn(4 * hidden_size, input_size, generator=gen) * scale
+        weight_hh = torch.randn(4 * hidden_size, hidden_size, generator=gen) * scale
+        bias_ih = torch.randn(4 * hidden_size, generator=gen) * scale
+        bias_hh = torch.randn(4 * hidden_size, generator=gen) * scale
+        return weight_ih, weight_hh, bias_ih, bias_hh
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x_seq = inputs.get("x_seq")
+        if x_seq is None:
+            raise ValueError("EduLSTMCell requires an `x_seq` input.")
+        if not isinstance(x_seq, torch.Tensor):
+            x_seq = torch.as_tensor(x_seq, dtype=torch.float32)
+        x_seq = x_seq.float()
+
+        input_size = int(params.get("input_size", 4))
+        hidden_size = int(params.get("hidden_size", 8))
+        seed = int(params.get("seed", 0))
+
+        # ---- Validate the input sequence shape ---------------------------------
+        if x_seq.ndim not in (2, 3):
+            raise ValueError(
+                "EduLSTMCell expects x_seq of shape [seq, input_size] or "
+                f"[N, seq, input_size]; got {tuple(x_seq.shape)}."
+            )
+        if x_seq.shape[-1] != input_size:
+            raise ValueError(
+                f"EduLSTMCell: x_seq last dim {x_seq.shape[-1]} does not match "
+                f"input_size={input_size}."
+            )
+
+        # Normalise to batched [N, seq, input_size] so a single code path handles both.
+        batched = x_seq.ndim == 3
+        if batched:
+            n, seq, _ = x_seq.shape
+            x_bn = x_seq
+        else:
+            seq, _ = x_seq.shape
+            n = 1
+            x_bn = x_seq.unsqueeze(0)  # [1, seq, input_size]
+        if seq == 0:
+            raise ValueError("EduLSTMCell: x_seq has zero timesteps.")
+
+        # ---- Resolve / validate the initial states ------------------------------
+        h = self._init_state(inputs.get("h0"), "h0", n, hidden_size, batched, x_seq.dtype)
+        c = self._init_state(inputs.get("c0"), "c0", n, hidden_size, batched, x_seq.dtype)
+
+        # ---- Parameters (PyTorch fused layout, gate order i, f, g, o) -----------
+        weight_ih, weight_hh, bias_ih, bias_hh = self._init_weights(
+            input_size, hidden_size, seed
+        )
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+        record_steps = self._steps_to_record(seq) if recorder is not None else set()
+
+        H = hidden_size
+        h_states: list[torch.Tensor] = []
+        for t in range(seq):
+            x_t = x_bn[:, t, :]  # [N, input_size]
+            # Fused pre-activations, exactly as nn.LSTMCell computes them.
+            gates = (
+                F.linear(x_t, weight_ih, bias_ih)
+                + F.linear(h, weight_hh, bias_hh)
+            )  # [N, 4H]
+            i = torch.sigmoid(gates[:, 0:H])       # input gate
+            f = torch.sigmoid(gates[:, H:2 * H])   # forget gate
+            g = torch.tanh(gates[:, 2 * H:3 * H])  # candidate
+            o = torch.sigmoid(gates[:, 3 * H:4 * H])  # output gate
+            c = f * c + i * g
+            h = o * torch.tanh(c)
+            h_states.append(h)
+
+            if recorder is not None and t in record_steps:
+                recorder.record(
+                    f"timestep_{t}",
+                    f"t={t}: gates i,f,g,o → c_t = f⊙c_{{t-1}} + i⊙g, h_t = o⊙tanh(c_t).",
+                    scalars={"t": float(t)},
+                    x_t=self._unbatch(x_t, batched),
+                    i=self._unbatch(i, batched),
+                    f=self._unbatch(f, batched),
+                    g=self._unbatch(g, batched),
+                    o=self._unbatch(o, batched),
+                    c_t=self._unbatch(c, batched),
+                    h_t=self._unbatch(h, batched),
+                )
+
+        h_seq_bn = torch.stack(h_states, dim=1)  # [N, seq, H]
+
+        if batched:
+            h_seq = h_seq_bn          # [N, seq, H]
+            h_last = h                # [N, H]
+            c_last = c                # [N, H]
+        else:
+            h_seq = h_seq_bn.squeeze(0)  # [seq, H]
+            h_last = h.squeeze(0)        # [H]
+            c_last = c.squeeze(0)        # [H]
+
+        if recorder is not None:
+            recorder.record(
+                "h_seq",
+                "Stack every hidden state over time into h_seq.",
+                scalars={"seq": float(seq), "hidden_size": float(H)},
+                h_seq=h_seq,
+                h_last=h_last,
+                c_last=c_last,
+            )
+
+        result: dict[str, Any] = {
+            "h_seq": h_seq,
+            "h_last": h_last,
+            "c_last": c_last,
+            "weight_ih": weight_ih,
+            "weight_hh": weight_hh,
+            "bias_ih": bias_ih,
+            "bias_hh": bias_hh,
+        }
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result
+
+    @staticmethod
+    def _init_state(
+        raw: Any,
+        name: str,
+        n: int,
+        hidden_size: int,
+        batched: bool,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Return a [N, hidden_size] initial state, validating/broadcasting `raw`."""
+        if raw is None:
+            return torch.zeros(n, hidden_size, dtype=dtype)
+        state = raw if isinstance(raw, torch.Tensor) else torch.as_tensor(raw, dtype=dtype)
+        state = state.float()
+        if state.ndim == 1:
+            if state.shape[0] != hidden_size:
+                raise ValueError(
+                    f"EduLSTMCell: {name} has length {state.shape[0]}, expected "
+                    f"hidden_size={hidden_size}."
+                )
+            # An unbatched state is broadcast across the batch.
+            return state.unsqueeze(0).expand(n, hidden_size).contiguous()
+        if state.ndim == 2:
+            if state.shape != (n, hidden_size):
+                raise ValueError(
+                    f"EduLSTMCell: {name} has shape {tuple(state.shape)}, expected "
+                    f"[{n}, {hidden_size}] to match x_seq's batch."
+                )
+            return state.contiguous()
+        raise ValueError(
+            f"EduLSTMCell: {name} must be 1-D [hidden] or 2-D [N, hidden]; got "
+            f"shape {tuple(state.shape)}."
+        )
+
+    @staticmethod
+    def _steps_to_record(seq: int) -> set[int]:
+        """Pick up to _MAX_TIMESTEP_STEPS timestep indices, sampled evenly."""
+        if seq <= _MAX_TIMESTEP_STEPS:
+            return set(range(seq))
+        # Evenly spaced indices including the first and last timestep.
+        return {
+            round(k * (seq - 1) / (_MAX_TIMESTEP_STEPS - 1))
+            for k in range(_MAX_TIMESTEP_STEPS)
+        }
+
+    @staticmethod
+    def _unbatch(t: torch.Tensor, batched: bool) -> torch.Tensor:
+        """Drop the synthetic batch dim for unbatched input so steps read cleanly."""
+        return t if batched else t.squeeze(0)

--- a/plugins/deep/nodes/edu_maxpool2d_node.py
+++ b/plugins/deep/nodes/edu_maxpool2d_node.py
@@ -1,0 +1,281 @@
+"""EduMaxPool2dNode — max pooling / spatial downsampling, exposed window by window.
+
+Supports textbook lesson **I3-1 (池化 / 下採樣)**: instead of a black-box
+``nn.MaxPool2d``, slide a ``kernel_size × kernel_size`` window across each
+channel and keep only the maximum inside every window. The feature map shrinks
+from ``[N, C, H, W]`` to ``[N, C, Hout, Wout]``:
+
+    Hout = floor((H + 2·padding − kernel_size) / stride) + 1
+    Wout = floor((W + 2·padding − kernel_size) / stride) + 1
+
+The two ideas a student should take away are visible in verbose mode:
+
+    1. *Local maximum* — each output value is just the largest activation in
+       its window, so pooling keeps the strongest response and discards the
+       rest. We record a handful of sampled windows together with the value we
+       kept and the flat ``argmax`` (which position inside the window won).
+    2. *Downsampling* — with ``stride = kernel_size`` (the default) the windows
+       tile without overlap, so the spatial size is divided by the kernel. The
+       final ``downsample`` step shows the ``[H, W] → [Hout, Wout]`` shrink.
+
+``argmax`` is computed by ``F.max_pool2d(..., return_indices=True)`` and is
+display-only (the indices that ``nn.MaxUnpool2d`` would consume); the forward
+result ``y`` matches ``F.max_pool2d`` exactly.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+# How many output windows to sample as individual verbose steps. Pooling a
+# large map produces thousands of windows; surfacing every one would bury the
+# Teaching Inspector, so we cap the per-window steps and add one summary step.
+_MAX_WINDOW_STEPS = 6
+
+
+class EduMaxPool2dNode(BaseNode):
+    NODE_NAME = "Edu-MaxPool2d"
+    CATEGORY = "CNN"
+    DESCRIPTION = (
+        "Max pooling: slide a kernel_size×kernel_size window across each channel "
+        "and keep only the maximum activation inside it, shrinking [N, C, H, W] → "
+        "[N, C, Hout, Wout]. Verbose mode samples a few windows (their values, the "
+        "max kept, and the winning argmax) and shows the overall downsample."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="x",
+                data_type=DataType.TENSOR,
+                description="Feature map of shape [N, C, H, W] (a bare [C, H, W] gains a batch dim).",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="y",
+                data_type=DataType.TENSOR,
+                description="Pooled feature map, shape [N, C, Hout, Wout].",
+            ),
+            PortDefinition(
+                name="argmax",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Integer indices (into the flattened H×W plane) of the max in "
+                    "each window, shape [N, C, Hout, Wout]. Display-only — the input "
+                    "MaxUnpool2d would consume to invert the pooling."
+                ),
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="kernel_size",
+                param_type=ParamType.INT,
+                default=2,
+                min_value=1,
+                description="Side length of the square pooling window, in pixels.",
+            ),
+            ParamDefinition(
+                name="stride",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description=(
+                    "Step between consecutive windows. 0 (the default) means "
+                    "'= kernel_size', i.e. non-overlapping windows that tile the map."
+                ),
+            ),
+            ParamDefinition(
+                name="padding",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description=(
+                    "Implicit −inf padding added to each spatial side before pooling. "
+                    "Must not exceed kernel_size / 2."
+                ),
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x = inputs.get("x")
+        if x is None:
+            raise ValueError("EduMaxPool2d requires an `x` input.")
+        if not isinstance(x, torch.Tensor):
+            x = torch.as_tensor(x, dtype=torch.float32)
+        x = x.float()
+
+        # Accept [C, H, W] by promoting to [1, C, H, W]; reject anything else.
+        if x.ndim == 3:
+            x = x.unsqueeze(0)
+        if x.ndim != 4:
+            raise ValueError(
+                f"EduMaxPool2d expects [N, C, H, W] (or [C, H, W]); got shape {tuple(x.shape)}."
+            )
+
+        N, C, H, W = x.shape
+
+        kernel_size = int(params.get("kernel_size", 2))
+        stride_param = int(params.get("stride", 0))
+        padding = int(params.get("padding", 0))
+        if kernel_size < 1:
+            raise ValueError(f"EduMaxPool2d: kernel_size must be >= 1; got {kernel_size}.")
+        # stride defaults to kernel_size when 0.
+        stride = kernel_size if stride_param == 0 else stride_param
+        if stride < 1:
+            raise ValueError(f"EduMaxPool2d: stride must be >= 1; got {stride}.")
+        if padding < 0:
+            raise ValueError(f"EduMaxPool2d: padding must be >= 0; got {padding}.")
+        if padding > kernel_size // 2:
+            raise ValueError(
+                f"EduMaxPool2d: padding={padding} must not exceed kernel_size//2="
+                f"{kernel_size // 2}."
+            )
+
+        h_out = math.floor((H + 2 * padding - kernel_size) / stride) + 1
+        w_out = math.floor((W + 2 * padding - kernel_size) / stride) + 1
+        if h_out < 1 or w_out < 1:
+            raise ValueError(
+                f"EduMaxPool2d: window too large for input — output dims must be >= 1 but "
+                f"got Hout={h_out}, Wout={w_out} for input [H={H}, W={W}], "
+                f"kernel_size={kernel_size}, stride={stride}, padding={padding}."
+            )
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+
+        y, argmax = F.max_pool2d(
+            x,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            return_indices=True,
+        )
+
+        if recorder is not None:
+            self._record_windows(
+                recorder,
+                x=x,
+                y=y,
+                argmax=argmax,
+                kernel_size=kernel_size,
+                stride=stride,
+                padding=padding,
+                h_out=h_out,
+                w_out=w_out,
+            )
+            recorder.record(
+                "downsample",
+                "Keeping one max per window shrinks the spatial size: "
+                "[H, W] → [Hout, Wout].",
+                scalars={
+                    "kernel_size": float(kernel_size),
+                    "stride": float(stride),
+                    "padding": float(padding),
+                    "H": float(H),
+                    "W": float(W),
+                    "Hout": float(h_out),
+                    "Wout": float(w_out),
+                },
+                y=y,
+            )
+
+        result: dict[str, Any] = {"y": y, "argmax": argmax}
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result
+
+    @staticmethod
+    def _record_windows(
+        recorder: StepRecorder,
+        *,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        argmax: torch.Tensor,
+        kernel_size: int,
+        stride: int,
+        padding: int,
+        h_out: int,
+        w_out: int,
+    ) -> None:
+        """Record up to ``_MAX_WINDOW_STEPS`` sampled output windows.
+
+        For each sampled output cell ``(oh, ow)`` of batch/channel ``(0, 0)`` we
+        slice the corresponding ``kernel_size × kernel_size`` patch out of the
+        (padded) input, then surface that patch, the max we kept, and the flat
+        ``argmax`` index (position within the window). Windows are sampled
+        evenly across the output grid so the steps span the whole map rather
+        than clustering in the top-left corner.
+        """
+        N, C, H, W = x.shape
+        # Pad with −inf so out-of-bounds positions never win the max — this
+        # mirrors what F.max_pool2d does internally for padding > 0.
+        if padding > 0:
+            xp = F.pad(x, (padding, padding, padding, padding), value=float("-inf"))
+        else:
+            xp = x
+
+        total = h_out * w_out
+        n_steps = min(_MAX_WINDOW_STEPS, total)
+        # Evenly spaced flat output positions across [0, total).
+        if n_steps <= 1:
+            flat_positions = [0]
+        else:
+            flat_positions = [
+                round(i * (total - 1) / (n_steps - 1)) for i in range(n_steps)
+            ]
+
+        for step_idx, flat in enumerate(flat_positions):
+            oh = flat // w_out
+            ow = flat % w_out
+            top = oh * stride
+            left = ow * stride
+            window = xp[0, 0, top : top + kernel_size, left : left + kernel_size]
+            max_val = float(y[0, 0, oh, ow].item())
+            # argmax holds the index into the flattened *input* H×W plane; the
+            # position *inside the window* is more instructive, so derive it.
+            flat_in_input = int(argmax[0, 0, oh, ow].item())
+            src_row = flat_in_input // W
+            src_col = flat_in_input % W
+            win_row = src_row - top + padding
+            win_col = src_col - left + padding
+            flat_in_window = win_row * kernel_size + win_col
+            recorder.record(
+                f"window_{step_idx}",
+                f"Output cell (row={oh}, col={ow}): take the max of its "
+                f"{kernel_size}×{kernel_size} window.",
+                scalars={
+                    "out_row": float(oh),
+                    "out_col": float(ow),
+                    "max": max_val,
+                    "argmax_in_window": float(flat_in_window),
+                },
+                window=window,
+            )

--- a/plugins/deep/nodes/edu_resample_node.py
+++ b/plugins/deep/nodes/edu_resample_node.py
@@ -1,0 +1,245 @@
+"""EduResampleNode — the spatial-shape change at the heart of a U-Net.
+
+Supports textbook lesson **I3-2 (U-Net down/up sampling)**: a U-Net is, at its
+core, a sequence of *resolution changes*. The encoder repeatedly halves the
+spatial size (down) while the decoder doubles it back (up), and skip
+connections splice the matching-resolution encoder features back into the
+decoder. This node makes that single move explicit:
+
+    down: [N, C, H, W] → [N, C, H/factor, W/factor]
+    up:   [N, C, H, W] → [N, C, H*factor, W*factor]
+          (+ optional channel-concat of a skip tensor of the same resolution)
+
+Down-sampling uses ``F.avg_pool2d`` (a learnable-free pooling step) or a
+strided ``F.interpolate`` depending on ``mode``; up-sampling always uses
+``F.interpolate``. Nothing here is learned — the lesson is purely about how
+the spatial shape (and, with a skip, the channel count) changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+
+class EduResampleNode(BaseNode):
+    NODE_NAME = "Edu-Resample"
+    CATEGORY = "Diffusion"
+    DESCRIPTION = (
+        "Down- or up-sample a feature map [N, C, H, W] by an integer factor — "
+        "the core move of a U-Net. Down halves the resolution (avg-pool or "
+        "strided interpolate); up doubles it (interpolate). Connect a same-"
+        "resolution `skip` while direction=up to channel-concatenate it and "
+        "demonstrate the skip connection. The spatial-shape change is exposed "
+        "step by step in verbose mode."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="x",
+                data_type=DataType.TENSOR,
+                description="Feature map [N, C, H, W] (or [C, H, W], promoted to batch 1).",
+            ),
+            PortDefinition(
+                name="skip",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Optional encoder feature map [N, C, H, W]. When provided and "
+                    "direction=up, it is channel-concatenated onto the upsampled "
+                    "output (the U-Net skip connection). Spatial dims must match "
+                    "the upsampled result."
+                ),
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="y",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Resampled feature map. Shape is [N, C, H/factor, W/factor] for "
+                    "down and [N, C, H*factor, W*factor] for up; channels double when "
+                    "a skip is concatenated."
+                ),
+            ),
+            PortDefinition(
+                name="shape",
+                data_type=DataType.TENSOR,
+                description="Output dims as a 1-D long tensor [N, C, Hout, Wout] (display-only).",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="direction",
+                param_type=ParamType.SELECT,
+                default="down",
+                options=["down", "up"],
+                description=(
+                    "'down' shrinks the resolution by `factor` (encoder side); "
+                    "'up' grows it by `factor` (decoder side)."
+                ),
+            ),
+            ParamDefinition(
+                name="factor",
+                param_type=ParamType.INT,
+                default=2,
+                min_value=2,
+                description="Integer resampling factor. 2 = halve (down) / double (up) each spatial dim.",
+            ),
+            ParamDefinition(
+                name="mode",
+                param_type=ParamType.SELECT,
+                default="nearest",
+                options=["nearest", "bilinear", "avgpool"],
+                description=(
+                    "Resampling kernel. For up: 'nearest' (default) or 'bilinear' "
+                    "interpolation. For down: 'avgpool' uses F.avg_pool2d(kernel=factor); "
+                    "'nearest'/'bilinear' use a strided F.interpolate(scale_factor=1/factor)."
+                ),
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x = inputs.get("x")
+        if x is None:
+            raise ValueError("EduResample requires an `x` input.")
+        if not isinstance(x, torch.Tensor):
+            x = torch.as_tensor(x, dtype=torch.float32)
+        x = x.float()
+
+        # Accept [C, H, W] by promoting to [1, C, H, W]; reject anything else.
+        if x.ndim == 3:
+            x = x.unsqueeze(0)
+        if x.ndim != 4:
+            raise ValueError(
+                f"EduResample expects x of shape [N, C, H, W] (or [C, H, W]); "
+                f"got {tuple(x.shape)}."
+            )
+
+        direction = str(params.get("direction", "down"))
+        if direction not in ("down", "up"):
+            raise ValueError(
+                f"EduResample: direction must be 'down' or 'up'; got {direction!r}."
+            )
+        factor = int(params.get("factor", 2))
+        if factor < 2:
+            raise ValueError(
+                f"EduResample: factor must be >= 2; got {factor}."
+            )
+        mode = str(params.get("mode", "nearest"))
+        if mode not in ("nearest", "bilinear", "avgpool"):
+            raise ValueError(
+                f"EduResample: mode must be one of 'nearest', 'bilinear', 'avgpool'; "
+                f"got {mode!r}."
+            )
+
+        N, C, H, W = (int(d) for d in x.shape)
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+
+        if direction == "down":
+            if mode == "avgpool":
+                y = F.avg_pool2d(x, kernel_size=factor)
+            else:
+                # nearest/bilinear strided downsample via fractional scale.
+                interp_kwargs: dict[str, Any] = {"scale_factor": 1.0 / factor, "mode": mode}
+                if mode == "bilinear":
+                    interp_kwargs["align_corners"] = False
+                y = F.interpolate(x, **interp_kwargs)
+        else:  # up
+            interp_kwargs = {"scale_factor": float(factor), "mode": mode}
+            if mode == "bilinear":
+                interp_kwargs["align_corners"] = False
+            y = F.interpolate(x, **interp_kwargs)
+
+        Hout, Wout = int(y.shape[2]), int(y.shape[3])
+        if recorder is not None:
+            recorder.record(
+                "resample",
+                f"{direction}-sample by factor {factor} using mode '{mode}': "
+                f"[H={H}, W={W}] → [H={Hout}, W={Wout}].",
+                scalars={
+                    "factor": float(factor),
+                    "H_before": float(H),
+                    "W_before": float(W),
+                    "H_after": float(Hout),
+                    "W_after": float(Wout),
+                },
+                x=x,
+                y=y,
+            )
+
+        # Optional skip connection — only meaningful on the decoder (up) side.
+        skip = inputs.get("skip")
+        if skip is not None and direction == "up":
+            if not isinstance(skip, torch.Tensor):
+                skip = torch.as_tensor(skip, dtype=torch.float32)
+            skip = skip.float()
+            if skip.ndim == 3:
+                skip = skip.unsqueeze(0)
+            if skip.ndim != 4:
+                raise ValueError(
+                    f"EduResample: skip must be [N, C, H, W] (or [C, H, W]); "
+                    f"got {tuple(skip.shape)}."
+                )
+            if skip.shape[2] != Hout or skip.shape[3] != Wout:
+                raise ValueError(
+                    f"EduResample: skip spatial dims {tuple(skip.shape[2:])} must match "
+                    f"the upsampled output {(Hout, Wout)} to concatenate. Check that the "
+                    f"skip was taken at the matching encoder resolution."
+                )
+            if skip.shape[0] != y.shape[0]:
+                raise ValueError(
+                    f"EduResample: skip batch {skip.shape[0]} must match output batch "
+                    f"{y.shape[0]} to concatenate."
+                )
+            c_before = int(y.shape[1])
+            c_skip = int(skip.shape[1])
+            y = torch.cat([y, skip], dim=1)
+            c_after = int(y.shape[1])
+            if recorder is not None:
+                recorder.record(
+                    "skip_concat",
+                    "U-Net skip connection: concatenate the encoder feature map onto "
+                    f"the upsampled output along the channel axis: {c_before} + {c_skip} "
+                    f"= {c_after} channels.",
+                    scalars={
+                        "channels_before": float(c_before),
+                        "channels_skip": float(c_skip),
+                        "channels_after": float(c_after),
+                    },
+                    y=y,
+                )
+
+        shape = torch.tensor(list(y.shape), dtype=torch.long)
+        result: dict[str, Any] = {"y": y, "shape": shape}
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result

--- a/plugins/deep/nodes/edu_rnn_cell_node.py
+++ b/plugins/deep/nodes/edu_rnn_cell_node.py
@@ -1,0 +1,323 @@
+"""EduRNNCellNode — a vanilla RNN cell unrolled over time, every step exposed.
+
+Educational counterpart to the opaque ``nn.RNN`` / ``nn.RNNCell`` node. Where
+those run a whole sequence inside a C++ kernel, this one writes out the
+textbook recurrence one timestep at a time:
+
+    h_t = activation(W_ih @ x_t + b_ih + W_hh @ h_{t-1} + b_hh)
+
+so the lesson (I4-1) can watch the hidden state evolve. The two pre-activation
+contributions are surfaced separately:
+
+    Wx = W_ih @ x_t  + b_ih      # what the *current input* injects
+    Wh = W_hh @ h_{t-1} + b_hh   # what the *memory of the past* carries
+
+and ``h_t = activation(Wx + Wh)``. Seeing Wx and Wh side by side is the whole
+point: it makes "the hidden state is a blend of new input and old memory"
+concrete rather than a slogan.
+
+The four parameter tensors ``W_ih [hidden, input]``, ``W_hh [hidden, hidden]``,
+``b_ih [hidden]``, ``b_hh [hidden]`` are built deterministically from ``seed``
+(a seeded ``torch.Generator``, ``randn * 0.1``). They use exactly the layout of
+``torch.nn.RNNCell``, so a lesson — or a test — can copy them into a reference
+cell and confirm the hand-rolled unroll matches PyTorch bit for bit.
+
+Inputs may be 2-D ``[seq, input_size]`` (a single sequence) or 3-D
+``[N, seq, input_size]`` (a batch of sequences, looped one at a time). Output
+shape mirrors the input: ``[seq, hidden]`` or ``[N, seq, hidden]``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.step_trace import StepRecorder
+
+# How many per-timestep steps to record in verbose mode before we start
+# sampling. Long sequences would otherwise flood the Teaching Inspector.
+_STEP_CAP = 6
+
+
+class EduRNNCellNode(BaseNode):
+    NODE_NAME = "Edu-RNNCell"
+    CATEGORY = "RNN"
+    DESCRIPTION = (
+        "A vanilla RNN unrolled over time. Computes "
+        "h_t = activation(W_ih·x_t + b_ih + W_hh·h_{t-1} + b_hh) one timestep at "
+        "a time, exposing the input contribution (Wx) and the memory contribution "
+        "(Wh) separately so students see the hidden state blend new input with "
+        "past state. Weights are deterministic from a seed and share nn.RNNCell's "
+        "layout, so the unroll matches PyTorch exactly."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="x_seq",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Input sequence of shape [seq, input_size], or a batch "
+                    "[N, seq, input_size] looped one sequence at a time."
+                ),
+            ),
+            PortDefinition(
+                name="h0",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Optional initial hidden state [hidden_size] (or "
+                    "[N, hidden_size] for a batch). Defaults to zeros."
+                ),
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="h_seq",
+                data_type=DataType.TENSOR,
+                description=(
+                    "All hidden states, [seq, hidden] for 2-D input or "
+                    "[N, seq, hidden] for 3-D input."
+                ),
+            ),
+            PortDefinition(
+                name="h_last",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Final hidden state, [hidden] for 2-D input or [N, hidden] "
+                    "for 3-D input."
+                ),
+            ),
+            PortDefinition(
+                name="weights",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Input-to-hidden weight W_ih [hidden, input], display-only so "
+                    "the lesson can inspect the learned/initialised parameters."
+                ),
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="input_size",
+                param_type=ParamType.INT,
+                default=4,
+                min_value=1,
+                description="Dimension of each input vector x_t. Must match x_seq's last dim.",
+            ),
+            ParamDefinition(
+                name="hidden_size",
+                param_type=ParamType.INT,
+                default=8,
+                min_value=1,
+                description="Dimension of the hidden state h_t.",
+            ),
+            ParamDefinition(
+                name="activation",
+                param_type=ParamType.SELECT,
+                default="tanh",
+                options=["tanh", "relu"],
+                description="Nonlinearity applied to the pre-activation sum (matches nn.RNNCell's nonlinearity).",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=0,
+                description="Seed for the deterministic W_ih/W_hh/b_ih/b_hh initialisation (randn * 0.1).",
+            ),
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Parameter construction
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _build_params(
+        input_size: int, hidden_size: int, seed: int
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Deterministically build (W_ih, W_hh, b_ih, b_hh) from a seed.
+
+        Layout matches ``torch.nn.RNNCell``: W_ih is [hidden, input],
+        W_hh is [hidden, hidden], biases are [hidden]. Draw order is fixed
+        so the same seed always yields the same four tensors.
+        """
+        gen = torch.Generator()
+        gen.manual_seed(int(seed))
+        W_ih = torch.randn(hidden_size, input_size, generator=gen) * 0.1
+        W_hh = torch.randn(hidden_size, hidden_size, generator=gen) * 0.1
+        b_ih = torch.randn(hidden_size, generator=gen) * 0.1
+        b_hh = torch.randn(hidden_size, generator=gen) * 0.1
+        return W_ih, W_hh, b_ih, b_hh
+
+    @staticmethod
+    def _activation_fn(name: str):
+        if name == "tanh":
+            return torch.tanh
+        if name == "relu":
+            return F.relu
+        raise ValueError(
+            f"EduRNNCell: unknown activation '{name}'; expected 'tanh' or 'relu'."
+        )
+
+    # ------------------------------------------------------------------ #
+    # Execution
+    # ------------------------------------------------------------------ #
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x_seq = inputs.get("x_seq")
+        if x_seq is None:
+            raise ValueError("EduRNNCell requires an `x_seq` input.")
+        if not isinstance(x_seq, torch.Tensor):
+            x_seq = torch.as_tensor(x_seq, dtype=torch.float32)
+        x_seq = x_seq.float()
+
+        input_size = int(params.get("input_size", 4))
+        hidden_size = int(params.get("hidden_size", 8))
+        activation_name = str(params.get("activation", "tanh"))
+        seed = int(params.get("seed", 0))
+
+        if x_seq.ndim not in (2, 3):
+            raise ValueError(
+                "EduRNNCell expects x_seq of shape [seq, input_size] or "
+                f"[N, seq, input_size]; got {tuple(x_seq.shape)}."
+            )
+        if x_seq.shape[-1] != input_size:
+            raise ValueError(
+                f"EduRNNCell: x_seq last dim {x_seq.shape[-1]} does not match "
+                f"input_size={input_size}."
+            )
+
+        activation = self._activation_fn(activation_name)
+        W_ih, W_hh, b_ih, b_hh = self._build_params(input_size, hidden_size, seed)
+
+        # Normalise to a batched [N, seq, input] view so one code path handles
+        # both 2-D and 3-D inputs.
+        batched = x_seq.ndim == 3
+        if batched:
+            N, seq, _ = x_seq.shape
+            x_b = x_seq
+        else:
+            seq = x_seq.shape[0]
+            N = 1
+            x_b = x_seq.unsqueeze(0)  # [1, seq, input]
+
+        # Resolve the initial hidden state h0 -> [N, hidden].
+        h0 = inputs.get("h0")
+        if h0 is None:
+            h_prev_b = torch.zeros(N, hidden_size, dtype=x_b.dtype)
+        else:
+            if not isinstance(h0, torch.Tensor):
+                h0 = torch.as_tensor(h0, dtype=torch.float32)
+            h0 = h0.float()
+            if h0.ndim == 1:
+                if h0.shape[0] != hidden_size:
+                    raise ValueError(
+                        f"EduRNNCell: h0 has shape {tuple(h0.shape)}, expected "
+                        f"[{hidden_size}] (or [N, {hidden_size}])."
+                    )
+                h_prev_b = h0.unsqueeze(0).expand(N, hidden_size).contiguous()
+            elif h0.ndim == 2:
+                if h0.shape != (N, hidden_size):
+                    raise ValueError(
+                        f"EduRNNCell: h0 has shape {tuple(h0.shape)}, expected "
+                        f"[{N}, {hidden_size}] to match the batch."
+                    )
+                h_prev_b = h0.clone()
+            else:
+                raise ValueError(
+                    f"EduRNNCell: h0 must be 1-D [hidden] or 2-D [N, hidden]; "
+                    f"got {tuple(h0.shape)}."
+                )
+
+        verbose = context is not None and getattr(context, "verbose", False)
+        recorder = StepRecorder() if verbose else None
+        # Which timesteps to record when verbose: all of them if short, else an
+        # evenly-spaced sample (always including the first and last) up to the cap.
+        record_steps: set[int] = set()
+        if recorder is not None:
+            if seq <= _STEP_CAP:
+                record_steps = set(range(seq))
+            else:
+                record_steps = {
+                    int(round(i * (seq - 1) / (_STEP_CAP - 1)))
+                    for i in range(_STEP_CAP)
+                }
+
+        # Unroll: for the visible single-sequence view (or the first sequence of
+        # a batch) we also record intermediate states for the lesson.
+        h_seq_b = torch.empty(N, seq, hidden_size, dtype=x_b.dtype)
+        h_prev = h_prev_b
+        for t in range(seq):
+            x_t = x_b[:, t, :]  # [N, input]
+            Wx = x_t @ W_ih.T + b_ih  # [N, hidden] — input contribution
+            Wh = h_prev @ W_hh.T + b_hh  # [N, hidden] — memory contribution
+            h_t = activation(Wx + Wh)  # [N, hidden]
+            h_seq_b[:, t, :] = h_t
+
+            if recorder is not None and t in record_steps:
+                # Show the first sequence in the batch (index 0) so the recorded
+                # vectors are 1-D [hidden] and read cleanly in the inspector.
+                recorder.record(
+                    f"t={t}",
+                    (
+                        f"Timestep {t}: h_{t} = {activation_name}("
+                        "W_ih·x_t + b_ih + W_hh·h_{prev} + b_hh). "
+                        "Wx is the input's contribution, Wh the memory's."
+                    ),
+                    x_t=x_t[0],
+                    Wx=Wx[0],
+                    Wh=Wh[0],
+                    h_t=h_t[0],
+                )
+            h_prev = h_t
+
+        h_last_b = h_prev  # [N, hidden]
+
+        if batched:
+            h_seq = h_seq_b
+            h_last = h_last_b
+        else:
+            h_seq = h_seq_b.squeeze(0)  # [seq, hidden]
+            h_last = h_last_b.squeeze(0)  # [hidden]
+
+        if recorder is not None:
+            recorder.record(
+                "h_seq",
+                f"Stacked hidden states over all {seq} timesteps, shape {tuple(h_seq.shape)}.",
+                scalars={
+                    "seq": float(seq),
+                    "hidden_size": float(hidden_size),
+                },
+                h_seq=h_seq,
+            )
+
+        result: dict[str, Any] = {
+            "h_seq": h_seq,
+            "h_last": h_last,
+            "weights": W_ih,
+        }
+        if recorder is not None and recorder.steps:
+            result["__steps__"] = recorder.steps
+        return result


### PR DESCRIPTION
**Stacked on #31** (base = `feat/edu-foundations-nodes`). Merge #30 → #31 first.

Fills the **I3–I4** coverage gaps with seven step-traced teaching nodes in
`plugins/deep`. Each is **numerically verified against its `torch.nn` reference**.

### Vision (I3)
| Node | Lesson | Exposes | Verified against |
|------|--------|---------|------------------|
| `Edu-Conv2d` | I3-1 | im2col `cols` → weight matrix → matmul → fold | `F.conv2d` |
| `Edu-MaxPool2d` | I3-1 | per-window patch → max → argmax; downsample shape | `F.max_pool2d` |
| `Edu-Resample` | I3-2 | down/up sampling, before→after `[H,W]`, skip concat | shape + `F.interpolate`/`F.avg_pool2d` |
| `Edu-DenoiseStep` | I3-3 | schedule coeffs (ᾱ_t, ᾱ_{t-1}), `pred_x0`, recombined `x_{t-1}` | hand-derived DDIM formulas |

### Sequence (I4)
| Node | Lesson | Exposes | Verified against |
|------|--------|---------|------------------|
| `Edu-RNNCell` | I4-1 | per-timestep `Wx`, `Wh`, `h_t` | `nn.RNNCell` |
| `Edu-LSTMCell` | I4-1 | per-timestep gates `i/f/g/o`, cell state `c_t` | `nn.LSTMCell` |
| `Edu-LayerNorm` | I4-3 | mean → var → normalize → affine | `F.layer_norm` |

## Visualization

Every node records per-step / per-timestep intermediate states with
`StepRecorder` (verbose → Inspector **Steps** tab) and emits display-only
outputs — e.g. `Edu-LSTMCell` lets you scrub each timestep and watch the forget
gate decide what to drop from the cell state.

## Tests & examples

- **122 new unit tests**, all asserting numerical equivalence to the PyTorch
  reference where one exists.
- **Three executable example graphs** — `Edu-Conv-MaxPool`, `Edu-LSTM-Unrolled`,
  `Edu-Denoise-Step` — verified end-to-end by the example smoke test.

**Backend: 1312 passed, 2 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
