### PR TITLE
fix(install): pin backend checkout to the prebuilt frontend's release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl -fsSL https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/insta
 powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.ps1 | iex"
 ```
 
-Installs only what's needed to run the app: `git`, `uv`, and Python (via uv). The frontend bundle is downloaded prebuilt from the latest GitHub release — **no Node.js or pnpm required for end users**. After install, **open a new terminal** and run from anywhere:
+Installs only what's needed to run the app: `git`, `uv`, and Python (via uv). The frontend bundle is downloaded prebuilt from the latest GitHub release, and the backend is **checked out at that same release tag** so the two stay in sync — **no Node.js or pnpm required for end users**. After install, **open a new terminal** and run from anywhere:
 
 ```bash
 cdui start
@@ -49,7 +49,7 @@ Open [http://localhost:8000](http://localhost:8000). The single uvicorn process 
 | Command | Description |
 |---------|-------------|
 | `cdui install` | Install backend deps; download prebuilt frontend (or local build if `pnpm` available) |
-| `cdui update` | Pull latest `main` and re-fetch the frontend bundle |
+| `cdui update` | Update to the latest release (prebuilt path) or pull `main` (when building from source) and re-sync the frontend |
 | `cdui start` | Production mode — single uvicorn on `:8000` (no Node needed) |
 | `cdui dev` | Developer mode — backend `:8000` + Vite HMR `:5173` (requires Node + pnpm) |
 | `cdui build` | Build the frontend bundle locally (requires Node + pnpm) |
@@ -63,7 +63,7 @@ Open [http://localhost:8000](http://localhost:8000). The single uvicorn process 
 
 > `cdui` is a thin launcher (`cdui.cmd` on Windows) placed at `~/.local/bin/cdui` by the installer. If you didn't restart your terminal yet, invoke the absolute path: `~/CodefyUI/cdui start`. `python scripts/dev.py <cmd>` still works too — `dev.py` re-execs into the venv's Python automatically.
 
-**Contributors:** if you want hot-reload (`cdui dev`), pass `CODEFYUI_FORCE_BUILD=1` to the installer or install Node 24+ and pnpm separately. Pin a specific release with `CODEFYUI_RELEASE_TAG=<tag>`.
+**Contributors:** if you want hot-reload (`cdui dev`), pass `CODEFYUI_FORCE_BUILD=1` to the installer or install Node 24+ and pnpm separately. `CODEFYUI_FORCE_BUILD=1` also tracks the bleeding-edge `main` branch (building the frontend from source so it matches the backend), whereas the default prebuilt path pins to the latest tagged release. Pin a specific release with `CODEFYUI_RELEASE_TAG=<tag>`.
 
 #### `cdui install` flags & environment variables
 

--- a/install.ps1
+++ b/install.ps1
@@ -133,6 +133,18 @@ function Fetch-ReleaseDist {
     return $true
 }
 
+# 解析要安裝的 release tag（把 "latest" 解析成具體版號）；失敗回傳 $null。
+function Resolve-ReleaseTag {
+    if ($ReleaseTag -ne 'latest') { return $ReleaseTag }
+    try {
+        $api = "https://api.github.com/repos/$ReleaseRepo/releases/latest"
+        $resp = Invoke-RestMethod -UseBasicParsing -Uri $api -TimeoutSec 30 `
+            -Headers @{ 'User-Agent' = 'CodefyUI-installer' }
+        if ($resp.tag_name) { return $resp.tag_name }
+    } catch { }
+    return $null
+}
+
 # ══════════════════════════════════════════════════════════════════════════════
 Write-Host ""
 Write-Host "+======================================+"
@@ -168,18 +180,47 @@ $PythonCmd = (uv python find 3.11).Trim()
 if (-not (Test-Path $PythonCmd)) { Die "uv python find returned invalid path: $PythonCmd" }
 Ok "$(& $PythonCmd --version) ($PythonCmd)"
 
+# ── Resolve release tag ────────────────────────────────────────────────────────
+# 預編 dist 路徑會把 backend 鎖到與 dist 同一個 release tag，避免「main 後端 +
+# 舊 release 前端」版本漂移（舊前端不會跟新後端做 token bootstrap，寫入請求被
+# auth_guard 擋成 403，導致 localhost:8000 打得開卻無法執行）。
+$PinnedTag = $null
+if (-not $ForceBuild) {
+    $PinnedTag = Resolve-ReleaseTag
+    if ($PinnedTag) {
+        $ReleaseTag = $PinnedTag
+        Write-Host "  鎖定 release：$PinnedTag（前後端同版）"
+    } else {
+        Warn "無法解析 latest release tag；改用 main（前後端可能版本漂移）"
+    }
+}
+
 # ── Clone / Update ────────────────────────────────────────────────────────────
 Step "Downloading CodefyUI"
 if (Test-Path (Join-Path $InstallDir '.git')) {
     Warn "Directory exists, updating..."
-    git -C $InstallDir pull --ff-only
-    if ($LASTEXITCODE -ne 0) { Die "git pull failed" }
-    Ok "Updated"
+    git -C $InstallDir fetch --tags --depth 1 origin
+    if ($PinnedTag) {
+        git -C $InstallDir fetch --depth 1 origin "refs/tags/${PinnedTag}:refs/tags/${PinnedTag}" 2>$null
+        git -C $InstallDir checkout -f $PinnedTag
+        if ($LASTEXITCODE -ne 0) { Die "git checkout $PinnedTag failed" }
+        Ok "Updated and pinned to $PinnedTag"
+    } else {
+        git -C $InstallDir pull --ff-only
+        if ($LASTEXITCODE -ne 0) { Die "git pull failed" }
+        Ok "Updated"
+    }
 } else {
     New-Item -ItemType Directory -Path (Split-Path -Parent $InstallDir) -Force | Out-Null
-    git clone --depth 1 $Repo $InstallDir
-    if ($LASTEXITCODE -ne 0) { Die "git clone failed" }
-    Ok "Clone complete"
+    if ($PinnedTag) {
+        git clone --depth 1 --branch $PinnedTag $Repo $InstallDir
+        if ($LASTEXITCODE -ne 0) { Die "git clone failed" }
+        Ok "Clone complete ($PinnedTag)"
+    } else {
+        git clone --depth 1 $Repo $InstallDir
+        if ($LASTEXITCODE -ne 0) { Die "git clone failed" }
+        Ok "Clone complete"
+    }
 }
 
 # ── Frontend dist：先試 release，失敗才裝 Node 本地 build ─────────────────────

--- a/install.sh
+++ b/install.sh
@@ -131,6 +131,21 @@ fetch_release_dist() {
   ok "Prebuilt dist 解壓至 $dist_dir"
 }
 
+# 解析要安裝的 release tag。回傳實際 tag（把 "latest" 解析成具體版號），
+# 解析失敗則回傳空字串。用 GitHub API，不依賴 jq。
+resolve_release_tag() {
+  if [[ "$RELEASE_TAG" != "latest" ]]; then
+    echo "$RELEASE_TAG"
+    return 0
+  fi
+  local api="https://api.github.com/repos/${RELEASE_REPO}/releases/latest"
+  local tag
+  tag="$(curl -fsSL --connect-timeout 10 --retry 2 "$api" 2>/dev/null \
+    | grep -m1 '"tag_name"' \
+    | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+  [[ -n "$tag" ]] && echo "$tag"
+}
+
 # ══════════════════════════════════════════════════════════════════════
 echo ""
 echo -e "${BOLD}╔══════════════════════════════════════╗${NC}"
@@ -164,16 +179,46 @@ PYTHON="$(uv python find 3.11)"
 [[ -x "$PYTHON" ]] || die "uv python find 回傳無效路徑：$PYTHON"
 ok "$("$PYTHON" --version) ($PYTHON)"
 
+# ── 解析 release tag ──────────────────────────────────────────────────
+# 預編 dist 路徑（非 FORCE_BUILD）會把 backend 鎖到與 dist 同一個 release
+# tag，避免「main 後端 + 舊 release 前端」版本漂移——那正是 cdui start 後
+# 打開 localhost:8000 卻無法執行的根因（舊前端不會跟新後端做 token bootstrap，
+# 所有寫入請求被 auth_guard 擋成 403）。
+PINNED_TAG=""
+if [[ "$FORCE_BUILD" != "1" ]]; then
+  PINNED_TAG="$(resolve_release_tag)"
+  if [[ -n "$PINNED_TAG" ]]; then
+    # fetch_release_dist 用 RELEASE_TAG 決定下載哪個 dist；鎖成解析後的具體
+    # tag，確保前後端來自同一版。
+    RELEASE_TAG="$PINNED_TAG"
+    echo -e "  ${BOLD}鎖定 release：${NC}$PINNED_TAG（前後端同版）"
+  else
+    warn "無法解析 latest release tag；改用 main（前後端可能版本漂移）"
+  fi
+fi
+
 # ── Clone / Update ────────────────────────────────────────────────────
 # Clone 先做，這樣後面才能把 dist 解壓到 $INSTALL_DIR/frontend/dist
 step "下載 CodefyUI"
 if [[ -d "$INSTALL_DIR/.git" ]]; then
   warn "目錄已存在，執行更新..."
-  git -C "$INSTALL_DIR" pull --ff-only
-  ok "已更新至最新版本"
+  git -C "$INSTALL_DIR" fetch --tags --depth 1 origin
+  if [[ -n "$PINNED_TAG" ]]; then
+    git -C "$INSTALL_DIR" fetch --depth 1 origin "refs/tags/${PINNED_TAG}:refs/tags/${PINNED_TAG}" 2>/dev/null || true
+    git -C "$INSTALL_DIR" checkout -f "$PINNED_TAG"
+    ok "已更新並鎖定至 $PINNED_TAG"
+  else
+    git -C "$INSTALL_DIR" pull --ff-only
+    ok "已更新至最新版本"
+  fi
 else
-  git clone --depth 1 "$REPO" "$INSTALL_DIR"
-  ok "Clone 完成"
+  if [[ -n "$PINNED_TAG" ]]; then
+    git clone --depth 1 --branch "$PINNED_TAG" "$REPO" "$INSTALL_DIR"
+    ok "Clone 完成（$PINNED_TAG）"
+  else
+    git clone --depth 1 "$REPO" "$INSTALL_DIR"
+    ok "Clone 完成"
+  fi
 fi
 
 # ── Frontend dist：先試 release，失敗才裝 Node 本地 build ────────────────

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -45,6 +45,7 @@
 """
 
 import argparse
+import json
 import os
 import platform
 import shutil
@@ -310,6 +311,29 @@ def _release_dist_url() -> str:
     if tag == "latest":
         return f"https://github.com/{RELEASE_REPO}/releases/latest/download/{RELEASE_ASSET}"
     return f"https://github.com/{RELEASE_REPO}/releases/download/{tag}/{RELEASE_ASSET}"
+
+
+def _resolve_release_tag() -> "str | None":
+    """Resolve the release tag to install (``latest`` → concrete version).
+
+    Returns the concrete tag, or ``None`` when the GitHub API can't be
+    reached. Used to pin the backend checkout to the same release the
+    prebuilt frontend dist comes from, so the two never drift apart.
+    """
+    tag = os.environ.get("CODEFYUI_RELEASE_TAG", "latest").strip() or "latest"
+    if tag != "latest":
+        return tag
+    url = f"https://api.github.com/repos/{RELEASE_REPO}/releases/latest"
+    try:
+        req = Request(url, headers={"User-Agent": "cdui-installer",
+                                    "Accept": "application/vnd.github+json"})
+        with urlopen(req, timeout=30) as resp:
+            data = json.load(resp)
+        name = data.get("tag_name")
+        return name or None
+    except (URLError, HTTPError, TimeoutError, ValueError) as e:
+        print(f"  無法解析 latest release tag：{e}")
+        return None
 
 
 def fetch_release_dist() -> bool:
@@ -799,12 +823,31 @@ def update() -> None:
         err("此目錄不是 git clone，無法 update",
             "Not a git checkout — cannot update")
         sys.exit(1)
-    section("拉取最新版本（main）", "Pulling latest (main)")
-    # Explicit remote/branch so the command works even on a detached HEAD or
-    # a branch that doesn't track upstream.
-    run(["git", "fetch", "origin", "main"], cwd=ROOT)
-    run(["git", "checkout", "main"], cwd=ROOT)
-    run(["git", "merge", "--ff-only", "origin/main"], cwd=ROOT)
+    # Decide whether this install will use a prebuilt release dist (no Node) or
+    # build the frontend from source (pnpm available / forced). On the prebuilt
+    # path we MUST pin the backend to the same release tag as the dist — pulling
+    # `main` while fetching an older release's frontend leaves the SPA out of
+    # sync with the API (e.g. it never bootstraps the session token, so every
+    # mutating request is rejected 403 and the app "loads but doesn't work").
+    force_build = os.environ.get("CODEFYUI_FORCE_BUILD", "").strip() in ("1", "true", "yes")
+    will_build_from_source = force_build or bool(shutil.which("pnpm"))
+
+    pinned_tag = None if will_build_from_source else _resolve_release_tag()
+
+    if pinned_tag:
+        section(f"切換至 release {pinned_tag}（前後端同版）",
+                f"Checking out release {pinned_tag} (frontend/backend in sync)")
+        run(["git", "fetch", "--tags", "origin"], cwd=ROOT)
+        run(["git", "checkout", "-f", pinned_tag], cwd=ROOT)
+        # install() reads this to fetch the matching dist.
+        os.environ["CODEFYUI_RELEASE_TAG"] = pinned_tag
+    else:
+        section("拉取最新版本（main）", "Pulling latest (main)")
+        # Explicit remote/branch so the command works even on a detached HEAD or
+        # a branch that doesn't track upstream.
+        run(["git", "fetch", "origin", "main"], cwd=ROOT)
+        run(["git", "checkout", "main"], cwd=ROOT)
+        run(["git", "merge", "--ff-only", "origin/main"], cwd=ROOT)
 
     # Old dist is for the previous source — wipe it so install re-downloads
     # (or re-builds, when pnpm is on PATH) for the new code.


### PR DESCRIPTION
## 問題（為什麼 `cdui start` 打開 localhost:8000 無法執行）

使用者回報：
```
curl -fsSL https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.sh | bash
cdui start    # 打開 localhost:8000 卻無法正確執行
```

**根因：前後端版本漂移。**

- `install.sh` 會 `git clone` 滾動的 **`main` 後端**，
- 但前端 bundle 是從 **最新 GitHub release 下載的預編 dist**。

最新 release `1.0.3`（2026-05-05）的前端 dist 早於 `main` 上的 session-token 認證 + Host guard（commit `09ca115`，2026-05-16）。舊版預編 SPA **不會呼叫 `/api/auth/bootstrap`、也不會帶 token header**，所以新後端的 `auth_guard` 會把所有寫入請求擋成 **403** —— 頁面打得開，但任何操作都失敗。

實測確認：在 port 8000 跑起新後端，`GET /` 回 200、`/api/health` 正常，但前端與後端的認證握手對不上。

## 修復

從結構上消除漂移：在 **預編（免 Node）路徑**，把後端 checkout 到與 dist 同一個 release tag，確保前後端永遠成對出貨。

- **install.sh / install.ps1**：用 GitHub API 把 `latest` 解析成具體 tag，clone/checkout 該 tag，並透傳給 dist 下載，確保兩者同版。
- **scripts/dev.py**：`cdui update` 有相同 bug（checkout `main` 後又抓舊 release dist）。改為在預編路徑鎖到 release tag；只有在從原始碼 build 前端時（`CODEFYUI_FORCE_BUILD=1` 或有 pnpm）才跟隨 `main`。
- **README**：說明預設安裝鎖定最新 release，`CODEFYUI_FORCE_BUILD=1` 追蹤 `main`。

## 後續（maintainer action）

要讓免 Node 使用者拿到 `main` 的新功能（plugins、安全強化、新節點），仍需**重新發一個 release**，其 `frontend-dist.tar.gz` 從該 commit build。本 PR 確保無論何時發版，前後端都一致、不會再出現「打得開但不能用」的狀態。

## 驗證

- `bash -n install.sh` 通過；tag resolver 實測回傳 `1.0.3`。
- `dev.py` 語法檢查通過；`_resolve_release_tag()` 實測回傳 `1.0.3`。
- 後端在 port 8000 啟動正常（94 nodes、health/bootstrap OK）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)