### PR TITLE
fix(install): brace $PINNED_TAG before CJK char to survive C locale

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -189,7 +189,7 @@ if (-not $ForceBuild) {
     $PinnedTag = Resolve-ReleaseTag
     if ($PinnedTag) {
         $ReleaseTag = $PinnedTag
-        Write-Host "  鎖定 release：$PinnedTag（前後端同版）"
+        Write-Host "  鎖定 release：${PinnedTag}（前後端同版）"
     } else {
         Warn "無法解析 latest release tag；改用 main（前後端可能版本漂移）"
     }

--- a/install.sh
+++ b/install.sh
@@ -191,7 +191,7 @@ if [[ "$FORCE_BUILD" != "1" ]]; then
     # fetch_release_dist 用 RELEASE_TAG 決定下載哪個 dist；鎖成解析後的具體
     # tag，確保前後端來自同一版。
     RELEASE_TAG="$PINNED_TAG"
-    echo -e "  ${BOLD}鎖定 release：${NC}$PINNED_TAG（前後端同版）"
+    echo -e "  ${BOLD}鎖定 release：${NC}${PINNED_TAG}（前後端同版）"
   else
     warn "無法解析 latest release tag；改用 main（前後端可能版本漂移）"
   fi
@@ -214,7 +214,7 @@ if [[ -d "$INSTALL_DIR/.git" ]]; then
 else
   if [[ -n "$PINNED_TAG" ]]; then
     git clone --depth 1 --branch "$PINNED_TAG" "$REPO" "$INSTALL_DIR"
-    ok "Clone 完成（$PINNED_TAG）"
+    ok "Clone 完成（${PINNED_TAG}）"
   else
     git clone --depth 1 "$REPO" "$INSTALL_DIR"
     ok "Clone 完成"


### PR DESCRIPTION
Follow-up hotfix to #35. In a `curl | bash` shell (C/POSIX locale), bash swallows the leading byte of the CJK char following `$PINNED_TAG` into the variable name, and `set -u` aborts with `unbound variable` right after the Python step — breaking install entirely. Braced as `${PINNED_TAG}`; reproduced the failure under `LANG=C` and verified the fix. Same bracing applied to install.ps1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)