### PR TITLE
fix(server): serve index.html no-cache so upgrades don't run a stale bundle

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -291,11 +291,31 @@ async def reload_nodes():
 DIST_DIR = Path(__file__).resolve().parents[2] / "frontend" / "dist"
 
 if (DIST_DIR / "index.html").exists():
+    # Vite emits content-hashed asset filenames (e.g. index-LKCMvfbh.js), so a
+    # given URL's bytes never change — cache them aggressively & immutably.
+    class _ImmutableStaticFiles(StaticFiles):
+        def file_response(self, *args, **kwargs):
+            resp = super().file_response(*args, **kwargs)
+            resp.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+            return resp
+
     app.mount(
         "/assets",
-        StaticFiles(directory=DIST_DIR / "assets"),
+        _ImmutableStaticFiles(directory=DIST_DIR / "assets"),
         name="assets",
     )
+
+    # index.html, by contrast, must NEVER be cached: it's the only file that
+    # references the current hashed bundles by name. If a browser serves a
+    # stale index.html after an upgrade, it loads an OLD bundle against the NEW
+    # backend — and that old bundle predates the session-token handshake, so
+    # every WebSocket / mutating request is rejected 403 ("loads but the Run
+    # button does nothing"). `no-cache` forces revalidation on every load so
+    # the document always matches the running server.
+    _INDEX_HEADERS = {"Cache-Control": "no-cache, no-store, must-revalidate"}
+
+    def _index_response() -> FileResponse:
+        return FileResponse(DIST_DIR / "index.html", headers=_INDEX_HEADERS)
 
     # Paths that should 404 instead of falling through to index.html so that
     # frontend fetch() errors stay distinguishable from "the SPA loaded".
@@ -318,4 +338,4 @@ if (DIST_DIR / "index.html").exists():
             raise HTTPException(status_code=400, detail="Invalid path")
         if full_path and candidate.is_file():
             return FileResponse(candidate)
-        return FileResponse(DIST_DIR / "index.html")
+        return _index_response()

--- a/backend/tests/test_spa_cache_headers.py
+++ b/backend/tests/test_spa_cache_headers.py
@@ -1,0 +1,54 @@
+"""SPA cache-header policy.
+
+Regression guard for the "loads but the Run button does nothing" bug: a
+browser that cached a stale ``index.html`` after an upgrade loads an OLD JS
+bundle against the NEW backend. The old bundle predates the session-token
+handshake, so every WebSocket / mutating request is rejected 403.
+
+The contract that prevents this:
+  * ``index.html`` is served ``no-cache`` so the browser always revalidates
+    and picks up the current hashed bundle names.
+  * hashed ``/assets/*`` files are content-addressed, so they're served
+    ``immutable`` with a long max-age.
+"""
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+_DIST = Path(__file__).resolve().parents[2] / "frontend" / "dist"
+_pytestmark_reason = "frontend/dist not built; SPA routes are not registered"
+pytestmark = pytest.mark.skipif(
+    not (_DIST / "index.html").exists(), reason=_pytestmark_reason
+)
+
+
+def test_index_html_is_not_cached():
+    with TestClient(app, base_url="http://localhost") as client:
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        cc = resp.headers.get("cache-control", "")
+        assert "no-cache" in cc or "no-store" in cc, cc
+
+
+def test_spa_fallback_route_is_not_cached():
+    # An arbitrary client-side route also serves index.html and must not cache.
+    with TestClient(app, base_url="http://localhost") as client:
+        resp = client.get("/some/deep/spa/route")
+        assert resp.status_code == 200
+        cc = resp.headers.get("cache-control", "")
+        assert "no-cache" in cc or "no-store" in cc, cc
+
+
+def test_hashed_assets_are_immutable():
+    asset = next((_DIST / "assets").glob("*.js"), None)
+    if asset is None:
+        pytest.skip("no built JS asset to check")
+    with TestClient(app, base_url="http://localhost") as client:
+        resp = client.get(f"/assets/{asset.name}")
+        assert resp.status_code == 200
+        cc = resp.headers.get("cache-control", "")
+        assert "immutable" in cc and "max-age=" in cc, cc


### PR DESCRIPTION
## 問題：升級後 `localhost:8000` 打得開但按執行沒反應(WebSocket 403)

瀏覽器升級後仍從快取載入**舊的 `index.html`**,於是跑舊的 JS bundle。舊 bundle 早於 session-token 機制,連 WebSocket(與寫入請求)時**不帶 token**,被後端擋成 403。實測:後端日誌 `index.html` 指向新 bundle,但瀏覽器載入的是磁碟上不存在的舊 bundle,WS handshake `token_present=False` → 403。

## 修復
- `index.html` → `Cache-Control: no-cache, no-store, must-revalidate`,每次載入都重新驗證,一定拿到當前 hash 的 bundle。
- hash 命名的 `/assets/*`(content-addressed)→ `immutable` + 1 年 max-age。
- 新增 `test_spa_cache_headers.py` 鎖住此政策。

> 已快取舊 `index.html` 的瀏覽器仍需**一次硬重新整理**;此 header 之後就不會再發生。

## 驗證
- Curl:`/` → `no-cache, no-store, must-revalidate`;`/assets/<hash>.js` → `public, max-age=31536000, immutable`。
- Chrome 實測:載入正確 bundle 後 WS `[accepted]`、管線執行完成。
- 新增 3 個 cache-header 測試通過;後端全套測試通過(1 個 pre-existing 無關失敗)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)