### PR TITLE
fix(cli): make `cdui update` survive the shallow, tag-pinned install clone

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -852,11 +852,15 @@ def update() -> None:
         os.environ["CODEFYUI_RELEASE_TAG"] = pinned_tag
     else:
         section("拉取最新版本（main）", "Pulling latest (main)")
-        # Explicit remote/branch so the command works even on a detached HEAD or
-        # a branch that doesn't track upstream.
-        run(["git", "fetch", "origin", "main"], cwd=ROOT)
-        run(["git", "checkout", "main"], cwd=ROOT)
-        run(["git", "merge", "--ff-only", "origin/main"], cwd=ROOT)
+        # install.sh makes a *shallow* (`--depth 1`), tag-pinned clone, so the
+        # local history is grafted and `main` can share no common ancestor with
+        # the fetched tip — `git merge --ff-only origin/main` then dies with
+        # "refusing to merge unrelated histories". An install dir is a
+        # deployment, not a dev checkout, so just hard-realign `main` to the
+        # fetched commit regardless of ancestry. `checkout -B` from FETCH_HEAD
+        # works whether or not the branch existed / tracked upstream.
+        run(["git", "fetch", "origin", "main", "--depth", "1"], cwd=ROOT)
+        run(["git", "checkout", "-B", "main", "FETCH_HEAD"], cwd=ROOT)
 
     # Old dist is for the previous source — wipe it so install re-downloads
     # (or re-builds, when pnpm is on PATH) for the new code.


### PR DESCRIPTION
## 問題
使用者 `cdui update` 失敗:
```
=== Pulling latest (main) ===
Your branch and 'origin/main' have diverged, and have 30 and 1 different commits each
fatal: refusing to merge unrelated histories
CalledProcessError: ... 'git merge --ff-only origin/main' ... status 128
```

## 根因
`install.sh` 用 `git clone --depth 1 --branch <tag>` 建立**淺層(shallow)、鎖 tag** 的 clone。在 build-from-source 更新路徑(有 pnpm 時),`update()` 做:
```
git checkout main
git merge --ff-only origin/main
```
但淺層 clone 的本地 `main` 是 grafted 歷史,與抓下來的新 tip **沒有共同祖先** → merge 報 "refusing to merge unrelated histories" 而中止。

## 修復
安裝目錄是**部署**而非開發 checkout,所以直接把 `main` 硬對齊到抓下來的 commit(不管祖先關係):
```
git fetch origin main --depth 1
git checkout -B main FETCH_HEAD
```
`checkout -B` 不論分支是否存在/追蹤上游都能用,也不會踩到 unrelated-histories 的檢查。prebuilt(無 pnpm)路徑原本就用穩健的 `git checkout -f <tag>`,不受影響。

## 驗證
在實際出問題的淺層安裝上重現並修復:`git fetch origin main --depth 1 && git checkout -B main FETCH_HEAD` 成功對齊到當前 main,重建 dist 後 `cdui start` 正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)