### PR TITLE
feat(cli): make `cdui status` a btop/k9s-style system dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Open [http://localhost:8000](http://localhost:8000). The single uvicorn process 
 | `cdui install` | Install backend deps; download prebuilt frontend (or local build if `pnpm` available) |
 | `cdui update` | Update to the latest release (prebuilt path) or pull `main` (when building from source) and re-sync the frontend |
 | `cdui start` | Production mode — single uvicorn on `:8000`, in the background (no Node needed). `--foreground`/`-f` runs it attached |
-| `cdui status` | Show the background server's PID and health |
+| `cdui status` | btop / k9s-style dashboard: CPU, memory, disk, GPU, top processes, plus the server's PID and health. Add `--watch` (`-w [seconds]`) to refresh live |
 | `cdui dev` | Developer mode — backend `:8000` + Vite HMR `:5173` (requires Node + pnpm) |
 | `cdui build` | Build the frontend bundle locally (requires Node + pnpm) |
 | `cdui stop` | Stop all services (including the background server) |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Open [http://localhost:8000](http://localhost:8000). The single uvicorn process 
 | `cdui install` | Install backend deps; download prebuilt frontend (or local build if `pnpm` available) |
 | `cdui update` | Update to the latest release (prebuilt path) or pull `main` (when building from source) and re-sync the frontend |
 | `cdui start` | Production mode — single uvicorn on `:8000`, in the background (no Node needed). `--foreground`/`-f` runs it attached |
-| `cdui status` | btop / k9s-style dashboard: CPU, memory, disk, GPU, top processes, plus the server's PID and health. Add `--watch` (`-w [seconds]`) to refresh live |
+| `cdui status` | btop / k9s-style dashboard: CPU, memory, disk, GPU, top processes, plus the server's PID and health. Refreshes live by default (every 2s, `Ctrl+C` to quit); pass a number to set the interval (`cdui status 1`), or `--once` for a single frame. Piped/non-interactive output is single-frame automatically |
 | `cdui dev` | Developer mode — backend `:8000` + Vite HMR `:5173` (requires Node + pnpm) |
 | `cdui build` | Build the frontend bundle locally (requires Node + pnpm) |
 | `cdui stop` | Stop all services (including the background server) |

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
     "huggingface_hub>=0.20.0",
     "scikit-learn>=1.3.0",
     "platformdirs>=4.0.0",
+    # Cross-platform system metrics for `cdui status` (CPU / memory / disk /
+    # process table). dev.py falls back to a stdlib-only view when it's absent.
+    "psutil>=5.9.0",
     # tomllib is stdlib on 3.11+; pull the backport for the 3.10 floor so
     # `routes_plugins.py` and `scripts/plugins.py` import cleanly.
     'tomli>=2.0.0; python_version < "3.11"',

--- a/backend/tests/test_status_dashboard.py
+++ b/backend/tests/test_status_dashboard.py
@@ -1,0 +1,269 @@
+"""Tests for the `cdui status` system dashboard (scripts/dev.py).
+
+The dashboard is a btop / k9s-style snapshot: host + OS, CPU, memory, disk,
+GPU and top processes, plus the CodefyUI server's own PID / health. These
+tests cover the pure formatting helpers, the health-JSON parser, the watch
+flag parsing, and that a full frame renders without raising on this machine
+(with and without psutil available).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+import dev  # scripts/dev.py — put on sys.path by conftest
+
+
+# ── Formatting helpers ─────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, "—"),
+        (0, "0 B"),
+        (512, "512 B"),
+        (1024, "1.0 KiB"),
+        (1536, "1.5 KiB"),
+        (1024 ** 3, "1.0 GiB"),
+        (1024 ** 4, "1.0 TiB"),
+    ],
+)
+def test_human_bytes(value, expected):
+    assert dev._human_bytes(value) == expected
+
+
+@pytest.mark.parametrize(
+    "pct, expected",
+    [(0, dev.GREEN), (59.9, dev.GREEN), (60, dev.YELLOW),
+     (84.9, dev.YELLOW), (85, dev.RED), (100, dev.RED)],
+)
+def test_pct_color(pct, expected):
+    assert dev._pct_color(pct) == expected
+
+
+def test_bar_fill_proportion(monkeypatch):
+    # Force colour off so the bar is plain text we can count.
+    monkeypatch.setattr(dev, "USE_COLOR", False)
+    monkeypatch.setattr(dev, "GRAY", "")
+    monkeypatch.setattr(dev, "RESET", "")
+    monkeypatch.setattr(dev, "GREEN", "")
+    monkeypatch.setattr(dev, "YELLOW", "")
+    monkeypatch.setattr(dev, "RED", "")
+    bar = dev._bar(50, width=10)
+    assert bar.count("█") == 5
+    assert bar.count("░") == 5
+    # Clamping: out-of-range values saturate the bar.
+    assert dev._bar(150, width=10).count("█") == 10
+    assert dev._bar(-5, width=10).count("█") == 0
+
+
+def test_bar_none_is_empty():
+    bar = dev._bar(None, width=8)
+    assert bar.count("█") == 0
+    assert bar.count("░") == 8
+
+
+def test_fmt_uptime_units(monkeypatch):
+    monkeypatch.setattr(dev, "LANG", "en")
+    assert dev._fmt_uptime(90) == "1m"
+    assert dev._fmt_uptime(3 * 3600 + 5 * 60) == "3h 5m"
+    assert dev._fmt_uptime(2 * 86400 + 3 * 3600) == "2d 3h 0m"
+
+
+# ── Health JSON parsing ────────────────────────────────────────────────────
+
+class _FakeResp:
+    def __init__(self, status, body):
+        self.status = status
+        self._body = body.encode()
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_server_health_info_ok(monkeypatch):
+    payload = {"status": "ok", "nodes_loaded": 42, "presets_loaded": 3}
+    monkeypatch.setattr(dev, "urlopen",
+                        lambda *a, **k: _FakeResp(200, json.dumps(payload)))
+    info = dev._server_health_info()
+    assert info == payload
+    assert dev._server_healthy() is True
+
+
+def test_server_health_info_non_200(monkeypatch):
+    monkeypatch.setattr(dev, "urlopen", lambda *a, **k: _FakeResp(500, "nope"))
+    assert dev._server_health_info() is None
+    assert dev._server_healthy() is False
+
+
+def test_server_health_info_unreachable(monkeypatch):
+    def boom(*a, **k):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(dev, "urlopen", boom)
+    assert dev._server_health_info() is None
+
+
+def test_server_health_info_bad_json(monkeypatch):
+    monkeypatch.setattr(dev, "urlopen",
+                        lambda *a, **k: _FakeResp(200, "{not json"))
+    assert dev._server_health_info() is None
+
+
+# ── Watch flag parsing ─────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        (["dev.py", "status"], False),
+        (["dev.py", "status", "--watch"], True),
+        (["dev.py", "status", "-w"], True),
+        (["dev.py", "status", "--once"], False),
+    ],
+)
+def test_watch_requested(monkeypatch, argv, expected):
+    monkeypatch.setattr(dev.sys, "argv", argv)
+    assert dev._watch_requested() is expected
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        (["dev.py", "status", "--watch"], 2.0),       # default
+        (["dev.py", "status", "-w", "1"], 1.0),
+        (["dev.py", "status", "-w", "0.1"], 0.5),     # clamped to floor
+        (["dev.py", "status", "-w", "abc"], 2.0),     # non-numeric → default
+        (["dev.py", "status"], 2.0),                  # flag absent → default
+    ],
+)
+def test_parse_watch_interval(monkeypatch, argv, expected):
+    monkeypatch.setattr(dev.sys, "argv", argv)
+    assert dev._parse_watch_interval() == expected
+
+
+# ── GPU stats ──────────────────────────────────────────────────────────────
+
+def test_gpu_stats_no_nvidia_smi(monkeypatch):
+    monkeypatch.setattr(dev.shutil, "which", lambda _: None)
+    assert dev._gpu_stats() == []
+
+
+def test_gpu_stats_parses_csv(monkeypatch):
+    monkeypatch.setattr(dev.shutil, "which", lambda _: "/usr/bin/nvidia-smi")
+
+    class _Out:
+        returncode = 0
+        stdout = "NVIDIA RTX 4090, 37, 2048, 24576, 55\nbad line\n"
+
+    monkeypatch.setattr(dev.subprocess, "run", lambda *a, **k: _Out())
+    gpus = dev._gpu_stats()
+    assert len(gpus) == 1
+    g = gpus[0]
+    assert g["name"] == "NVIDIA RTX 4090"
+    assert g["util"] == 37.0
+    assert g["temp"] == 55.0
+    assert g["mem_total"] == 24576 * 1024 * 1024
+
+
+def test_gpu_stats_command_fails(monkeypatch):
+    monkeypatch.setattr(dev.shutil, "which", lambda _: "/usr/bin/nvidia-smi")
+
+    def boom(*a, **k):
+        raise OSError("exec failed")
+
+    monkeypatch.setattr(dev.subprocess, "run", boom)
+    assert dev._gpu_stats() == []
+
+
+# ── Full-frame rendering ───────────────────────────────────────────────────
+
+def test_render_dashboard_runs(monkeypatch, capsys):
+    monkeypatch.setattr(dev, "_running_server_pid", lambda: None)
+    monkeypatch.setattr(dev, "_server_health_info", lambda *a, **k: None)
+    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status"])
+    dev._render_dashboard(interval=0.0, first=True)
+    out = capsys.readouterr().out
+    assert "CPU" in out
+    assert "http" not in out or "not running" in out or "未執行" in out
+
+
+def test_render_dashboard_server_running(monkeypatch, capsys):
+    monkeypatch.setattr(dev, "_running_server_pid", lambda: 12345)
+    monkeypatch.setattr(
+        dev, "_server_health_info",
+        lambda *a, **k: {"nodes_loaded": 9, "presets_loaded": 2},
+    )
+    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status"])
+    dev._render_dashboard(interval=0.0, first=False)
+    out = capsys.readouterr().out
+    assert "12345" in out
+    assert "9" in out and "2" in out
+
+
+def test_render_dashboard_without_psutil(monkeypatch, capsys):
+    """When psutil isn't importable the frame still renders a degraded view."""
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError("no psutil")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr(dev, "_running_server_pid", lambda: None)
+    monkeypatch.setattr(dev, "_server_health_info", lambda *a, **k: None)
+    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status"])
+    dev._render_dashboard(interval=0.0, first=True)
+    out = capsys.readouterr().out
+    assert "CPU" in out
+
+
+# ── status() entry point ───────────────────────────────────────────────────
+
+def test_status_oneshot_exits_nonzero_when_down(monkeypatch):
+    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status"])
+    monkeypatch.setattr(dev, "_running_server_pid", lambda: None)
+    monkeypatch.setattr(dev, "_server_healthy", lambda *a, **k: False)
+    monkeypatch.setattr(dev, "_server_health_info", lambda *a, **k: None)
+    with pytest.raises(SystemExit) as exc:
+        dev.status()
+    assert exc.value.code == 1
+
+
+def test_status_oneshot_ok_when_up(monkeypatch):
+    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status"])
+    monkeypatch.setattr(dev, "_running_server_pid", lambda: 999)
+    monkeypatch.setattr(dev, "_server_healthy", lambda *a, **k: True)
+    monkeypatch.setattr(dev, "_server_health_info",
+                        lambda *a, **k: {"nodes_loaded": 1, "presets_loaded": 1})
+    # Should return cleanly (no SystemExit) when the server is up.
+    dev.status()
+
+
+def test_status_watch_single_frame(monkeypatch):
+    """--watch loops until KeyboardInterrupt; feed one frame then interrupt."""
+    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status", "-w", "1"])
+    monkeypatch.setattr(dev, "_running_server_pid", lambda: None)
+    monkeypatch.setattr(dev, "_server_health_info", lambda *a, **k: None)
+
+    calls = {"n": 0}
+
+    def fake_render(interval, first):
+        calls["n"] += 1
+        raise KeyboardInterrupt  # break out after the first frame
+
+    monkeypatch.setattr(dev, "_render_dashboard", fake_render)
+    # Capture cursor show/hide writes without touching the real terminal.
+    monkeypatch.setattr(dev.sys, "stdout", io.StringIO())
+    dev.status()  # should swallow KeyboardInterrupt and return
+    assert calls["n"] == 1

--- a/backend/tests/test_status_dashboard.py
+++ b/backend/tests/test_status_dashboard.py
@@ -122,27 +122,40 @@ def test_server_health_info_bad_json(monkeypatch):
 # ── Watch flag parsing ─────────────────────────────────────────────────────
 
 @pytest.mark.parametrize(
-    "argv, expected",
+    "argv, isatty, expected",
     [
-        (["dev.py", "status"], False),
-        (["dev.py", "status", "--watch"], True),
-        (["dev.py", "status", "-w"], True),
-        (["dev.py", "status", "--once"], False),
+        # Continuous is the default on an interactive terminal...
+        (["dev.py", "status"], True, True),
+        (["dev.py", "status", "1"], True, True),
+        # ...but a single frame when stdout is piped/redirected...
+        (["dev.py", "status"], False, False),
+        # ...or when --once / -1 is explicit (even on a TTY)...
+        (["dev.py", "status", "--once"], True, False),
+        (["dev.py", "status", "-1"], True, False),
+        # ...and --watch forces the loop even off a TTY.
+        (["dev.py", "status", "--watch"], False, True),
+        (["dev.py", "status", "-w"], False, True),
     ],
 )
-def test_watch_requested(monkeypatch, argv, expected):
+def test_continuous_default(monkeypatch, argv, isatty, expected):
     monkeypatch.setattr(dev.sys, "argv", argv)
-    assert dev._watch_requested() is expected
+    monkeypatch.setattr(dev.sys, "stdout", io.StringIO())
+    # io.StringIO.isatty() is always False; override just that for the test.
+    monkeypatch.setattr(dev.sys.stdout, "isatty", lambda: isatty)
+    assert dev._continuous_default() is expected
 
 
 @pytest.mark.parametrize(
     "argv, expected",
     [
-        (["dev.py", "status", "--watch"], 2.0),       # default
+        (["dev.py", "status"], 2.0),                  # default
+        (["dev.py", "status", "1"], 1.0),            # bare positional
+        (["dev.py", "status", "0.1"], 0.5),         # clamped to floor
+        (["dev.py", "status", "--watch"], 2.0),       # flag, no value
         (["dev.py", "status", "-w", "1"], 1.0),
         (["dev.py", "status", "-w", "0.1"], 0.5),     # clamped to floor
         (["dev.py", "status", "-w", "abc"], 2.0),     # non-numeric → default
-        (["dev.py", "status"], 2.0),                  # flag absent → default
+        (["dev.py", "status", "--once"], 2.0),        # only flags → default
     ],
 )
 def test_parse_watch_interval(monkeypatch, argv, expected):
@@ -231,7 +244,7 @@ def test_render_dashboard_without_psutil(monkeypatch, capsys):
 # ── status() entry point ───────────────────────────────────────────────────
 
 def test_status_oneshot_exits_nonzero_when_down(monkeypatch):
-    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status"])
+    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status", "--once"])
     monkeypatch.setattr(dev, "_running_server_pid", lambda: None)
     monkeypatch.setattr(dev, "_server_healthy", lambda *a, **k: False)
     monkeypatch.setattr(dev, "_server_health_info", lambda *a, **k: None)
@@ -241,13 +254,32 @@ def test_status_oneshot_exits_nonzero_when_down(monkeypatch):
 
 
 def test_status_oneshot_ok_when_up(monkeypatch):
-    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status"])
+    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status", "--once"])
     monkeypatch.setattr(dev, "_running_server_pid", lambda: 999)
     monkeypatch.setattr(dev, "_server_healthy", lambda *a, **k: True)
     monkeypatch.setattr(dev, "_server_health_info",
                         lambda *a, **k: {"nodes_loaded": 1, "presets_loaded": 1})
     # Should return cleanly (no SystemExit) when the server is up.
     dev.status()
+
+
+def test_status_loops_by_default_on_tty(monkeypatch):
+    """Plain `cdui status` on a terminal loops (continuous is the default)."""
+    monkeypatch.setattr(dev.sys, "argv", ["dev.py", "status"])
+    monkeypatch.setattr(dev, "_continuous_default", lambda: True)
+    monkeypatch.setattr(dev, "_running_server_pid", lambda: None)
+    monkeypatch.setattr(dev, "_server_health_info", lambda *a, **k: None)
+
+    calls = {"n": 0}
+
+    def fake_render(interval, first):
+        calls["n"] += 1
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(dev, "_render_dashboard", fake_render)
+    monkeypatch.setattr(dev.sys, "stdout", io.StringIO())
+    dev.status()
+    assert calls["n"] == 1
 
 
 def test_status_watch_single_frame(monkeypatch):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -363,6 +363,7 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
     { name = "platformdirs" },
+    { name = "psutil" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
@@ -403,6 +404,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "platformdirs", specifier = ">=4.0.0" },
+    { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -2366,6 +2368,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
     { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
     { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -18,7 +18,10 @@
     start       啟動 production（單一 uvicorn，用 frontend/dist；不需 Node）
                 預設在背景執行（關掉 terminal 也會繼續跑），用 cdui status /
                 cdui stop 管理。加 --foreground / -f 則在前景執行（Ctrl+C 停止）。
-    status      顯示背景伺服器狀態（PID、健康檢查）
+    status      顯示系統與伺服器狀態儀表板（像 btop / k9s：CPU、記憶體、
+                磁碟、GPU、行程、伺服器 PID 與健康檢查）
+                旗標：--watch / -w [秒]   持續刷新（預設 2 秒，Ctrl+C 離開）
+                      --once             只輸出一次（預設行為）
     stop        停止所有服務（含背景伺服器）
     test        執行 backend 測試
     clean       移除虛擬環境、node_modules 與 frontend/dist
@@ -919,11 +922,20 @@ def _pid_alive(pid: int) -> bool:
 
 
 def _server_healthy(timeout: float = 1.0) -> bool:
+    return _server_health_info(timeout) is not None
+
+
+def _server_health_info(timeout: float = 1.0) -> "dict | None":
+    """Fetch and parse /api/health. Returns the JSON dict, or None if the
+    server isn't responding (or returned a non-200 / unparseable body)."""
     try:
         with urlopen(SERVER_HEALTH_URL, timeout=timeout) as resp:
-            return resp.status == 200
-    except (URLError, HTTPError, TimeoutError, OSError):
-        return False
+            if resp.status != 200:
+                return None
+            import json  # noqa: PLC0415 — only needed here
+            return json.loads(resp.read().decode("utf-8", "replace"))
+    except (URLError, HTTPError, TimeoutError, OSError, ValueError):
+        return None
 
 
 def _running_server_pid() -> "int | None":
@@ -1029,24 +1041,326 @@ def _print_log_tail(n: int) -> None:
         pass
 
 
-def status() -> None:
-    """顯示背景伺服器狀態。"""
-    pid = _running_server_pid()
-    healthy = _server_healthy()
-    if pid is not None:
-        print(f"CodefyUI 背景伺服器執行中（PID {pid}）。")
-        print(f"  健康檢查：{'✓ 正常' if healthy else '✗ 尚未回應'}  ({SERVER_HEALTH_URL})")
-        print("  開啟 → http://localhost:8000")
-        print(f"  日誌 → {SERVER_LOG}")
-    elif healthy:
-        # Something is serving :8000 but we have no pidfile for it (e.g. a
-        # foreground `cdui start` in another terminal, or an external process).
-        print("有伺服器在 http://localhost:8000 回應，但不是由 cdui 背景啟動的"
-              "（沒有 PID 檔）。")
-        print("  可能是前景 'cdui start -f' 或其他程序占用了 :8000。")
+# ── System status dashboard (`cdui status`) ───────────────────────────────
+# A btop / k9s-style snapshot: host + OS, CPU (overall + per-core bars),
+# memory, swap, disk, GPU (via nvidia-smi when present) and the top processes,
+# followed by the CodefyUI server's own PID / health. Built on psutil when it's
+# installed (it ships with the backend); degrades to a stdlib-only view when not.
+
+def _human_bytes(n: "float | None") -> str:
+    """Human-readable size, e.g. 1.5 GiB. Returns '—' for None."""
+    if n is None:
+        return "—"
+    units = ("B", "KiB", "MiB", "GiB", "TiB", "PiB")
+    size = float(n)
+    for unit in units:
+        if size < 1024 or unit == units[-1]:
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} PiB"  # pragma: no cover — loop always returns first
+
+
+def _pct_color(pct: float) -> str:
+    """Green < 60% < yellow < 85% < red — the usual saturation gradient."""
+    if pct >= 85:
+        return RED
+    if pct >= 60:
+        return YELLOW
+    return GREEN
+
+
+def _bar(pct: "float | None", width: int = 24) -> str:
+    """A coloured [████░░░░] usage bar. pct is 0–100; None renders empty."""
+    if pct is None:
+        return f"{GRAY}[{'░' * width}]{RESET}"
+    pct = max(0.0, min(100.0, pct))
+    filled = int(round(pct / 100 * width))
+    color = _pct_color(pct)
+    return f"{GRAY}[{color}{'█' * filled}{GRAY}{'░' * (width - filled)}{GRAY}]{RESET}"
+
+
+def _fmt_uptime(seconds: float) -> str:
+    secs = int(seconds)
+    days, secs = divmod(secs, 86400)
+    hours, secs = divmod(secs, 3600)
+    mins, _ = divmod(secs, 60)
+    if days:
+        return t(f"{days} 天 {hours} 小時 {mins} 分", f"{days}d {hours}h {mins}m")
+    if hours:
+        return t(f"{hours} 小時 {mins} 分", f"{hours}h {mins}m")
+    return t(f"{mins} 分", f"{mins}m")
+
+
+def _kv(label: str, value: str) -> None:
+    """Aligned `label  value` line; label padded to a fixed visual width."""
+    pad = max(0, 14 - _display_width(label))
+    print(f"  {DIM}{label}{RESET}{' ' * pad}  {value}")
+
+
+def _gpu_stats() -> "list[dict]":
+    """Per-GPU utilisation via `nvidia-smi` (fast, no torch import). Empty list
+    when nvidia-smi is missing or errors (CPU-only / macOS / AMD machines)."""
+    if not shutil.which("nvidia-smi"):
+        return []
+    try:
+        out = subprocess.run(
+            ["nvidia-smi",
+             "--query-gpu=name,utilization.gpu,memory.used,memory.total,temperature.gpu",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if out.returncode != 0:
+        return []
+    gpus: list[dict] = []
+    for line in out.stdout.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 5:
+            continue
+        try:
+            gpus.append({
+                "name": parts[0],
+                "util": float(parts[1]),
+                "mem_used": float(parts[2]) * 1024 * 1024,
+                "mem_total": float(parts[3]) * 1024 * 1024,
+                "temp": float(parts[4]),
+            })
+        except ValueError:
+            continue
+    return gpus
+
+
+def _render_dashboard(interval: float, first: bool) -> None:
+    """Print one frame of the status dashboard.
+
+    *interval* is the psutil CPU sampling window (also the watch refresh gap);
+    *first* gates a one-line hint that's pointless to repeat every frame.
+    """
+    try:
+        import psutil  # noqa: PLC0415 — optional, ships with the backend
+    except ImportError:
+        psutil = None
+
+    # Prime per-process CPU counters *before* the blocking CPU sample below so
+    # the first read returns a real percentage rather than psutil's initial
+    # 0.0. We hold the Process objects; the cpu_percent(interval=…) call in the
+    # CPU section provides the sampling gap, then we read them back later.
+    primed_procs: list = []
+    if psutil is not None:
+        for p in psutil.process_iter():
+            try:
+                p.cpu_percent(None)
+                primed_procs.append(p)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+
+    section("CodefyUI 系統狀態", "CodefyUI System Status")
+
+    # ── Host / OS ─────────────────────────────────────────────────────────
+    import platform  # noqa: PLC0415
+    _kv(t("主機", "Host"), platform.node() or "—")
+    _kv(t("作業系統", "OS"),
+        f"{platform.system()} {platform.release()} ({platform.machine()})")
+    if psutil is not None:
+        try:
+            _kv(t("開機時間", "Uptime"),
+                _fmt_uptime(time.time() - psutil.boot_time()))
+        except (OSError, AttributeError):
+            pass
+    if hasattr(os, "getloadavg"):
+        try:
+            la = os.getloadavg()
+            _kv(t("負載平均", "Load avg"),
+                f"{la[0]:.2f}  {la[1]:.2f}  {la[2]:.2f}")
+        except OSError:
+            pass
+
+    # ── CPU ───────────────────────────────────────────────────────────────
+    print()
+    section("CPU", "CPU")
+    cores = os.cpu_count() or 1
+    if psutil is not None:
+        overall = psutil.cpu_percent(interval=interval)
+        per_core = psutil.cpu_percent(interval=None, percpu=True)
+        _kv(t("總使用率", "Overall"),
+            f"{_bar(overall)} {_pct_color(overall)}{overall:5.1f}%{RESET}"
+            f"  {DIM}{cores} {t('核心', 'cores')}{RESET}")
+        try:
+            freq = psutil.cpu_freq()
+            if freq and freq.current:
+                _kv(t("時脈", "Freq"), f"{freq.current/1000:.2f} GHz")
+        except (OSError, AttributeError):
+            pass
+        for i, cpct in enumerate(per_core):
+            print(f"    {DIM}core {i:>2}{RESET} {_bar(cpct, 18)} "
+                  f"{_pct_color(cpct)}{cpct:5.1f}%{RESET}")
     else:
-        print("CodefyUI 沒有在背景執行。用 'cdui start' 啟動。")
-        sys.exit(1)
+        _kv(t("核心數", "Cores"), str(cores))
+        print(f"    {DIM}{t('安裝 psutil 以顯示即時使用率', 'install psutil for live usage')}{RESET}")
+
+    # ── Memory ────────────────────────────────────────────────────────────
+    print()
+    section("記憶體", "Memory")
+    if psutil is not None:
+        vm = psutil.virtual_memory()
+        _kv("RAM",
+            f"{_bar(vm.percent)} {_pct_color(vm.percent)}{vm.percent:5.1f}%{RESET}"
+            f"  {_human_bytes(vm.used)} / {_human_bytes(vm.total)}")
+        sm = psutil.swap_memory()
+        if sm.total:
+            _kv("Swap",
+                f"{_bar(sm.percent)} {_pct_color(sm.percent)}{sm.percent:5.1f}%{RESET}"
+                f"  {_human_bytes(sm.used)} / {_human_bytes(sm.total)}")
+    else:
+        print(f"    {DIM}{t('安裝 psutil 以顯示記憶體用量', 'install psutil for memory usage')}{RESET}")
+
+    # ── Disk ──────────────────────────────────────────────────────────────
+    print()
+    section("磁碟", "Disk")
+    root = "C:\\" if sys.platform == "win32" else "/"
+    try:
+        du = shutil.disk_usage(root)
+        pct = du.used / du.total * 100 if du.total else 0.0
+        _kv(root,
+            f"{_bar(pct)} {_pct_color(pct)}{pct:5.1f}%{RESET}"
+            f"  {_human_bytes(du.used)} / {_human_bytes(du.total)}"
+            f"  ({_human_bytes(du.free)} {t('可用', 'free')})")
+    except OSError:
+        pass
+
+    # ── GPU ───────────────────────────────────────────────────────────────
+    gpus = _gpu_stats()
+    if gpus:
+        print()
+        section("GPU", "GPU")
+        for i, g in enumerate(gpus):
+            mem_pct = g["mem_used"] / g["mem_total"] * 100 if g["mem_total"] else 0.0
+            _kv(f"GPU {i}", f"{g['name']}  {g['temp']:.0f}°C")
+            print(f"    {DIM}util {RESET}{_bar(g['util'], 18)} "
+                  f"{_pct_color(g['util'])}{g['util']:5.1f}%{RESET}")
+            print(f"    {DIM}vram {RESET}{_bar(mem_pct, 18)} "
+                  f"{_pct_color(mem_pct)}{mem_pct:5.1f}%{RESET}  "
+                  f"{_human_bytes(g['mem_used'])} / {_human_bytes(g['mem_total'])}")
+
+    # ── Top processes ─────────────────────────────────────────────────────
+    if psutil is not None:
+        print()
+        section("行程（依 CPU 排序）", "Top processes (by CPU)")
+        # psutil reports per-process CPU% relative to a single core, so a busy
+        # core can read >100%; normalise by core count for a system-wide view.
+        cores = os.cpu_count() or 1
+        procs = []
+        for p in primed_procs:
+            try:
+                procs.append({
+                    "pid": p.pid,
+                    "name": p.name(),
+                    "cpu": p.cpu_percent(None) / cores,
+                    "mem": p.memory_percent(),
+                })
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        procs.sort(key=lambda x: x["cpu"], reverse=True)
+        print(f"    {DIM}{'PID':>7}  {'CPU%':>6}  {'MEM%':>6}  {t('名稱', 'NAME')}{RESET}")
+        for info in procs[:8]:
+            name = (info["name"] or "?")[:28]
+            cpu, mem = info["cpu"], info["mem"]
+            print(f"    {info['pid']:>7}  "
+                  f"{_pct_color(cpu)}{cpu:6.1f}{RESET}  {mem:6.1f}  {name}")
+
+    # ── CodefyUI server ───────────────────────────────────────────────────
+    print()
+    section("CodefyUI 伺服器", "CodefyUI Server")
+    pid = _running_server_pid()
+    info = _server_health_info()
+    healthy = info is not None
+    if pid is not None:
+        _kv(t("狀態", "State"),
+            f"{GREEN}● {t('背景執行中', 'running (background)')}{RESET}  PID {pid}")
+        _kv(t("健康檢查", "Health"),
+            f"{GREEN}✓ {t('正常', 'ok')}{RESET}" if healthy
+            else f"{RED}✗ {t('尚未回應', 'not responding')}{RESET}")
+        if info:
+            _kv(t("節點 / 預設", "Nodes / Presets"),
+                f"{info.get('nodes_loaded', '?')} / {info.get('presets_loaded', '?')}")
+        _kv("URL", "http://localhost:8000")
+        _kv(t("日誌", "Log"), str(SERVER_LOG))
+    elif healthy:
+        orphan = t("有伺服器回應，但非 cdui 背景啟動（無 PID 檔）",
+                   "responding, but not a cdui background server (no PID file)")
+        _kv(t("狀態", "State"), f"{YELLOW}● {orphan}{RESET}")
+        _kv("URL", "http://localhost:8000")
+        if info:
+            _kv(t("節點 / 預設", "Nodes / Presets"),
+                f"{info.get('nodes_loaded', '?')} / {info.get('presets_loaded', '?')}")
+    else:
+        _kv(t("狀態", "State"),
+            f"{GRAY}○ {t('未執行', 'not running')}{RESET}  "
+            f"{DIM}{t('用 cdui start 啟動', 'start with: cdui start')}{RESET}")
+
+    if first and not _watch_requested():
+        tip = t("提示：cdui status --watch 可持續刷新（像 btop）",
+                "tip: cdui status --watch refreshes live (like btop)")
+        print()
+        print(f"  {DIM}{tip}{RESET}")
+
+
+def _watch_requested() -> bool:
+    return any(a in ("-w", "--watch") for a in sys.argv[2:])
+
+
+def _parse_watch_interval() -> float:
+    """Read the optional numeric argument after --watch / -w (default 2.0s)."""
+    argv = sys.argv[2:]
+    for i, a in enumerate(argv):
+        if a in ("-w", "--watch"):
+            if i + 1 < len(argv):
+                try:
+                    return max(0.5, float(argv[i + 1]))
+                except ValueError:
+                    pass
+            break
+    return 2.0
+
+
+def status() -> None:
+    """系統與伺服器狀態儀表板（btop / k9s 風格）。"""
+    watch = _watch_requested()
+
+    if not watch:
+        # One-shot. Use a short CPU sampling window so the reading is real
+        # (psutil's first non-blocking call always returns 0.0).
+        _render_dashboard(interval=0.3, first=True)
+        # Mirror the old contract: exit non-zero when nothing is serving :8000,
+        # so scripts can still gate on `cdui status`.
+        if _running_server_pid() is None and not _server_healthy():
+            sys.exit(1)
+        return
+
+    interval = _parse_watch_interval()
+    hide = "\x1b[?25l" if USE_COLOR else ""
+    showp = "\x1b[?25h" if USE_COLOR else ""
+    try:
+        if hide:
+            sys.stdout.write(hide)
+        first = True
+        while True:
+            # Clear screen + home cursor for a stable, btop-like refresh.
+            if USE_COLOR:
+                sys.stdout.write("\x1b[2J\x1b[H")
+            ts = time.strftime("%Y-%m-%d %H:%M:%S")
+            print(f"{DIM}{t('刷新間隔', 'refresh')} {interval:g}s · {ts} · "
+                  f"{t('按 Ctrl+C 離開', 'Ctrl+C to quit')}{RESET}")
+            _render_dashboard(interval=interval, first=first)
+            first = False
+            sys.stdout.flush()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if showp:
+            sys.stdout.write(showp)
+            sys.stdout.flush()
 
 
 def dev() -> None:

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -20,8 +20,10 @@
                 cdui stop 管理。加 --foreground / -f 則在前景執行（Ctrl+C 停止）。
     status      顯示系統與伺服器狀態儀表板（像 btop / k9s：CPU、記憶體、
                 磁碟、GPU、行程、伺服器 PID 與健康檢查）
-                旗標：--watch / -w [秒]   持續刷新（預設 2 秒，Ctrl+C 離開）
-                      --once             只輸出一次（預設行為）
+                預設持續刷新（每 2 秒，Ctrl+C 離開）；輸出被導向管線或非互動
+                環境時自動改為只輸出一次。
+                旗標：[秒] 或 -w [秒]    自訂刷新間隔（如 cdui status 1）
+                      --once / -1       只輸出一次
     stop        停止所有服務（含背景伺服器）
     test        執行 backend 測試
     clean       移除虛擬環境、node_modules 與 frontend/dist
@@ -1299,19 +1301,37 @@ def _render_dashboard(interval: float, first: bool) -> None:
             f"{GRAY}○ {t('未執行', 'not running')}{RESET}  "
             f"{DIM}{t('用 cdui start 啟動', 'start with: cdui start')}{RESET}")
 
-    if first and not _watch_requested():
-        tip = t("提示：cdui status --watch 可持續刷新（像 btop）",
-                "tip: cdui status --watch refreshes live (like btop)")
+    if first and _watch_disabled():
+        tip = t("提示：直接執行 cdui status 會持續刷新（像 btop）",
+                "tip: plain `cdui status` refreshes live (like btop)")
         print()
         print(f"  {DIM}{tip}{RESET}")
 
 
-def _watch_requested() -> bool:
-    return any(a in ("-w", "--watch") for a in sys.argv[2:])
+def _watch_disabled() -> bool:
+    """True when we must print a single frame instead of looping: an explicit
+    --once, or a non-interactive stdout (pipe / CI) where a clearing loop and
+    its never-returning exit code would be useless or harmful."""
+    if any(a in ("-1", "--once") for a in sys.argv[2:]):
+        return True
+    return not sys.stdout.isatty()
+
+
+def _continuous_default() -> bool:
+    """Whether `cdui status` should loop. Continuous is the default; only an
+    explicit --once or a non-TTY stdout falls back to a single frame. An
+    explicit --watch / -w forces the loop even past those (e.g. for testing)."""
+    if any(a in ("-w", "--watch") for a in sys.argv[2:]):
+        return True
+    return not _watch_disabled()
 
 
 def _parse_watch_interval() -> float:
-    """Read the optional numeric argument after --watch / -w (default 2.0s)."""
+    """Read the optional numeric refresh interval (default 2.0s).
+
+    Accepts it after --watch / -w, or as a bare positional number so plain
+    `cdui status 1` works: `cdui status`, `cdui status 1`, `cdui status -w 0.5`.
+    """
     argv = sys.argv[2:]
     for i, a in enumerate(argv):
         if a in ("-w", "--watch"):
@@ -1320,17 +1340,23 @@ def _parse_watch_interval() -> float:
                     return max(0.5, float(argv[i + 1]))
                 except ValueError:
                     pass
-            break
+            return 2.0
+    # Bare positional number, e.g. `cdui status 1`.
+    for a in argv:
+        if not a.startswith("-"):
+            try:
+                return max(0.5, float(a))
+            except ValueError:
+                continue
     return 2.0
 
 
 def status() -> None:
-    """系統與伺服器狀態儀表板（btop / k9s 風格）。"""
-    watch = _watch_requested()
-
-    if not watch:
-        # One-shot. Use a short CPU sampling window so the reading is real
-        # (psutil's first non-blocking call always returns 0.0).
+    """系統與伺服器狀態儀表板（btop / k9s 風格，預設持續刷新）。"""
+    if not _continuous_default():
+        # Single frame (--once, or stdout isn't a TTY). Use a short CPU
+        # sampling window so the reading is real (psutil's first non-blocking
+        # call always returns 0.0).
         _render_dashboard(interval=0.3, first=True)
         # Mirror the old contract: exit non-zero when nothing is serving :8000,
         # so scripts can still gate on `cdui status`.

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1031,7 +1031,7 @@ def start() -> None:
     print(f"    日誌        → {SERVER_LOG}")
     print(f"    dev lockfile → {DEV_LOCKFILE}")
     print("")
-    print("    關掉 terminal 也會繼續執行。管理：cdui status / cdui stop")
+    print("    管理：cdui status / cdui stop")
 
 
 def _print_log_tail(n: int) -> None:

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1365,28 +1365,72 @@ def status() -> None:
         return
 
     interval = _parse_watch_interval()
+    _watch_loop(interval)
+
+
+def _render_frame_text(interval: float, first: bool) -> str:
+    """Render one dashboard frame into a string (incl. the header line) by
+    temporarily redirecting stdout. Lets the watch loop repaint atomically."""
+    import io  # noqa: PLC0415
+    buf = io.StringIO()
+    real = sys.stdout
+    sys.stdout = buf
+    try:
+        ts = time.strftime("%Y-%m-%d %H:%M:%S")
+        print(f"{DIM}{t('刷新間隔', 'refresh')} {interval:g}s · {ts} · "
+              f"{t('按 Ctrl+C 離開', 'Ctrl+C to quit')}{RESET}")
+        _render_dashboard(interval=interval, first=first)
+    finally:
+        sys.stdout = real
+    return buf.getvalue()
+
+
+def _watch_loop(interval: float) -> None:
+    """btop-style live refresh without the full-screen-clear flicker.
+
+    Each frame is rendered into a buffer, then painted by homing the cursor
+    (``\\x1b[H``) and overwriting line by line — each line cleared to its end
+    (``\\x1b[K``) so leftover characters from a longer previous frame vanish —
+    and finally erasing anything below (``\\x1b[J``). The screen is only fully
+    cleared once, up front, so there's never a blank flash between frames.
+    """
     hide = "\x1b[?25l" if USE_COLOR else ""
     showp = "\x1b[?25h" if USE_COLOR else ""
     try:
-        if hide:
-            sys.stdout.write(hide)
+        if USE_COLOR:
+            sys.stdout.write(hide + "\x1b[2J\x1b[H")
+            sys.stdout.flush()
         first = True
         while True:
-            # Clear screen + home cursor for a stable, btop-like refresh.
-            if USE_COLOR:
-                sys.stdout.write("\x1b[2J\x1b[H")
-            ts = time.strftime("%Y-%m-%d %H:%M:%S")
-            print(f"{DIM}{t('刷新間隔', 'refresh')} {interval:g}s · {ts} · "
-                  f"{t('按 Ctrl+C 離開', 'Ctrl+C to quit')}{RESET}")
-            _render_dashboard(interval=interval, first=first)
+            frame = _render_frame_text(interval, first)
             first = False
+            if USE_COLOR:
+                lines = frame.split("\n")
+                # Home, then overwrite each line (clearing trailing leftovers),
+                # then clear everything below the shorter-or-equal new frame.
+                painted = "\x1b[H" + "\x1b[K\n".join(lines) + "\x1b[J"
+                sys.stdout.write(painted)
+            else:
+                sys.stdout.write(frame)
             sys.stdout.flush()
+            # When psutil is absent there's no blocking cpu sample, so the loop
+            # would spin hot — pace it ourselves in that case.
+            if not _has_psutil():
+                time.sleep(interval)
     except KeyboardInterrupt:
         pass
     finally:
         if showp:
             sys.stdout.write(showp)
             sys.stdout.flush()
+
+
+def _has_psutil() -> bool:
+    try:
+        import psutil  # noqa: F401, PLC0415
+        return True
+    except ImportError:
+        return False
 
 
 def dev() -> None:


### PR DESCRIPTION
## What & why

`cdui status` used to print only the background server's PID and health. This turns it into a **btop / k9s-style system dashboard** so you can see what the machine is actually doing — handy on an ML box where a run is hammering CPU/RAM/GPU.

## What you get

```
=== CodefyUI 系統狀態 ===
  主機            my-machine
  作業系統        Darwin 25.5.0 (arm64)
  開機時間        8 天 23 小時 24 分
  負載平均        3.03  3.05  3.68

=== CPU ===
  總使用率        [██████░░░░░░░░░░░░░░░░░░]  23.1%  8 核心
  時脈            4.06 GHz
    core  0 [██████████░░░░░░░░]  53.3%
    ...

=== 記憶體 ===
  RAM             [██████████████████░░░░░░]  75.4%  8.7 GiB / 24.0 GiB
  Swap            [████████████████████░░░░]  84.3%  6.7 GiB / 8.0 GiB

=== 磁碟 ===
  /               [█████████████████████░░░]  85.6%  792.7 GiB / 926.4 GiB  (133.7 GiB 可用)

=== 行程（依 CPU 排序） ===
        PID    CPU%    MEM%  名稱
        959     3.6     0.5  Google Chrome Helper
        ...

=== CodefyUI 伺服器 ===
  狀態            ● 背景執行中  PID 60030
  健康檢查        ✓ 正常
  節點 / 預設     95 / 3
  URL             http://localhost:8000
```

## Highlights

- **Sections:** host/OS/uptime/load, CPU (overall + per-core bars + freq), memory & swap, disk, GPU (via `nvidia-smi`), top processes by CPU, and the CodefyUI server (now enriched with `nodes_loaded` / `presets_loaded` parsed from `/api/health`).
- **`--watch` / `-w [seconds]`** refreshes live like btop (default 2s, `Ctrl+C` to quit, hides the cursor while running).
- **Coloured usage bars** with a green→yellow→red gradient.
- Built on **psutil** (added to backend deps + `uv.lock`); degrades to a stdlib-only view when psutil is absent. Disk uses stdlib `shutil.disk_usage`.
- Per-process CPU counters are **primed before the sampling window** so the first read returns real percentages, normalised by core count.
- One-shot still **exits non-zero** when nothing serves `:8000`, so existing scripts that gate on `cdui status` keep working.
- zh/en localised; honours `NO_COLOR` and non-TTY.

## Tests

New `backend/tests/test_status_dashboard.py` (38 tests) covers the formatting helpers, health-JSON parsing, watch-flag parsing, GPU CSV parsing, and full-frame rendering both with and without psutil. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)