### PR TITLE
ci: bump pnpm/action-setup v4 → v6 (Node.js 24)

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           # Pinned to the major matching frontend/pnpm-lock.yaml's
           # `lockfileVersion: '9.0'`. `latest` would silently jump to a new

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -90,7 +90,7 @@ jobs:
           echo "Tag message ($(wc -l < release-body.md) lines):"
           head -20 release-body.md
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           # Pin to the major that matches frontend/pnpm-lock.yaml. Floating to
           # `latest` would silently break `pnpm install --frozen-lockfile`


### PR DESCRIPTION
## Why

`pnpm/action-setup@v4` runs on the deprecated **Node.js 20** runtime. GitHub Actions surfaces this as a warning on every workflow run and will force Node.js 24 by default after 2026-06-16, removing Node.js 20 from runners after 2026-09-16.

## What

Bump `pnpm/action-setup@v4` → `@v6` in `frontend-build.yml` and `release-build.yml`. v6 runs on **Node.js 24**.

The `version: 9` input (pinned to match `frontend/pnpm-lock.yaml`'s `lockfileVersion: '9.0'`) is unchanged — v6 keeps the same input contract, so `pnpm install --frozen-lockfile` behaves identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)