### PR TITLE
feat(nodes): add ScalarMultiply/Conv2dKernel/Conv2dExplicit; fix Split ports & producer-node execution

### DIFF
--- a/backend/app/api/routes_nodes.py
+++ b/backend/app/api/routes_nodes.py
@@ -75,6 +75,7 @@ def _node_to_definition(qualified_name: str, cls: type[BaseNode]) -> NodeDefinit
                 options=_filter_device_options(p.name, p.options),
                 min_value=p.min_value,
                 max_value=p.max_value,
+                visible_when=p.visible_when,
             )
             for p in cls.define_params()
         ],

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -454,6 +454,25 @@ async def execute_graph(
         if e.get("type", "data") == "trigger" and e["target"] in executable_ids:
             executable_ids.add(e["source"])
 
+    # Pull in pure-producer nodes (no incoming edges, e.g. TensorInput /
+    # Conv2dKernel) whose outputs feed into executable nodes. Forward-BFS
+    # from trigger entry points only walks downstream, so a producer that
+    # supplies a `kernel` (or any other input) to an otherwise-reachable
+    # node would be silently pruned and then validate_graph would complain
+    # that the input is missing. Iterate to fixpoint to handle chains
+    # (producer → producer → executable).
+    changed = True
+    while changed:
+        changed = False
+        for e in expanded_edges:
+            if (
+                e.get("type", "data") == "data"
+                and e["target"] in executable_ids
+                and e["source"] not in executable_ids
+            ):
+                executable_ids.add(e["source"])
+                changed = True
+
     # If any internal node of a preset is reachable, include ALL sibling
     # nodes from that preset.  A preset is a logical unit — its internal
     # root nodes (e.g. Dataset, Loss) have no incoming external edges and

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -206,7 +206,12 @@ def validate_graph(nodes: list[dict], edges: list[dict]) -> list[str]:
 
         src_port = edge.get("sourceHandle", "")
         tgt_port = edge.get("targetHandle", "")
-        src_outputs = {p.name: p for p in src_cls.define_outputs()}
+        # define_outputs_dynamic lets param-driven nodes (e.g. SplitNode whose
+        # `chunks` param decides how many chunk_i ports exist) expose their
+        # live port set. Nodes that don't override fall back to the static
+        # define_outputs() via BaseNode's default.
+        src_params = src.get("data", {}).get("params", {}) if isinstance(src.get("data"), dict) else {}
+        src_outputs = {p.name: p for p in src_cls.define_outputs_dynamic(src_params)}
         tgt_inputs = {p.name: p for p in tgt_cls.define_inputs()}
 
         if src_port not in src_outputs:

--- a/backend/app/core/node_base.py
+++ b/backend/app/core/node_base.py
@@ -52,6 +52,13 @@ class ParamDefinition:
     options: list[str] = field(default_factory=list)  # for SELECT type
     min_value: float | None = None
     max_value: float | None = None
+    # Conditional visibility, evaluated client-side. When set, the param
+    # only renders in the config panel / node card if every key in this
+    # dict matches the live value of the corresponding sibling param.
+    # Example: ``visible_when={"preset": "Custom"}`` on Conv2dKernel's
+    # ``weights`` param means the editor only shows when ``preset`` is
+    # set to ``"Custom"``. None means always visible.
+    visible_when: dict[str, Any] | None = None
 
 
 class BaseNode(ABC):

--- a/backend/app/core/node_base.py
+++ b/backend/app/core/node_base.py
@@ -76,6 +76,23 @@ class BaseNode(ABC):
         ...
 
     @classmethod
+    def define_outputs_dynamic(
+        cls,
+        params: dict[str, Any] | None = None,
+    ) -> list[PortDefinition]:
+        """Per-instance output ports, optionally expanded based on params.
+
+        Default delegates to the static ``define_outputs()``. Nodes whose
+        port count depends on a parameter (e.g. ``SplitNode`` whose
+        ``chunks`` param decides how many ``chunk_i`` outputs exist) override
+        this to return the live port list. Callers that have access to a
+        node instance's params (graph validator, renderer) should prefer
+        this; callers that only know the class (palette template, preset
+        registry) keep using the static method.
+        """
+        return cls.define_outputs()
+
+    @classmethod
     def define_params(cls) -> list[ParamDefinition]:
         return []
 

--- a/backend/app/nodes/cnn/conv2d_explicit_node.py
+++ b/backend/app/nodes/cnn/conv2d_explicit_node.py
@@ -1,0 +1,135 @@
+from typing import Any
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+
+class Conv2dExplicitNode(BaseNode):
+    NODE_NAME = "Conv2dExplicit"
+    CATEGORY = "CNN"
+    DESCRIPTION = (
+        "2D convolution with an *explicit* kernel supplied through an input "
+        "port — no learnable weights, no random init. The same kernel is "
+        "applied to every input channel via grouped (depthwise) convolution, "
+        "so a (N, C, H, W) input produces a (N, C, H, W) output with channels "
+        "untouched. Pair with Conv2dKernel to drop in classical filters "
+        "(Laplacian / Sharpen / Prewitt-X) or any hand-edited matrix."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor",
+                data_type=DataType.TENSOR,
+                description="Input tensor (N, C, H, W)",
+            ),
+            PortDefinition(
+                name="kernel",
+                data_type=DataType.TENSOR,
+                description="Kernel tensor — accepted shapes: (k, k), (1, 1, k, k), or (C, 1, k, k)",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor",
+                data_type=DataType.TENSOR,
+                description="Convolved output (N, C, H_out, W_out)",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="stride",
+                param_type=ParamType.INT,
+                default=1,
+                description="Convolution stride",
+                min_value=1,
+            ),
+            ParamDefinition(
+                name="padding",
+                param_type=ParamType.INT,
+                default=1,
+                description="Zero-padding on each side of the spatial dims",
+                min_value=0,
+            ),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        import torch
+        import torch.nn.functional as F
+
+        tensor = inputs["tensor"]
+        kernel = inputs["kernel"]
+
+        if not isinstance(tensor, torch.Tensor):
+            raise ValueError(
+                f"Conv2dExplicit `tensor` input must be a torch.Tensor, "
+                f"got {type(tensor).__name__}"
+            )
+        if not isinstance(kernel, torch.Tensor):
+            raise ValueError(
+                f"Conv2dExplicit `kernel` input must be a torch.Tensor, "
+                f"got {type(kernel).__name__}"
+            )
+        if tensor.dim() != 4:
+            raise ValueError(
+                f"Conv2dExplicit `tensor` must be 4D (N, C, H, W); "
+                f"got shape {list(tensor.shape)}. Use an Unsqueeze on dim=0 "
+                f"if you have a (C, H, W) tensor."
+            )
+
+        c_in = tensor.size(1)
+
+        # Normalise the kernel into (C, 1, k, k) for grouped (depthwise)
+        # conv. The three supported source shapes:
+        #   - (k, k)        — bare 2D matrix, broadcast to every channel
+        #   - (1, 1, k, k)  — already conv-ready, broadcast to every channel
+        #   - (C, 1, k, k)  — one kernel per channel (advanced)
+        if kernel.dim() == 2:
+            k_h, k_w = kernel.shape
+            if k_h != k_w:
+                raise ValueError(f"Kernel must be square; got {list(kernel.shape)}")
+            base = kernel.reshape(1, 1, k_h, k_w)
+            weight = base.expand(c_in, 1, k_h, k_w).contiguous()
+        elif kernel.dim() == 4:
+            kc_out, kc_in, k_h, k_w = kernel.shape
+            if k_h != k_w:
+                raise ValueError(f"Kernel must be square; got {list(kernel.shape)}")
+            if kc_in != 1:
+                raise ValueError(
+                    f"Kernel inner channel must be 1 for depthwise conv; "
+                    f"got shape {list(kernel.shape)}"
+                )
+            if kc_out == 1:
+                weight = kernel.expand(c_in, 1, k_h, k_w).contiguous()
+            elif kc_out == c_in:
+                weight = kernel.contiguous()
+            else:
+                raise ValueError(
+                    f"Kernel out-channel must be 1 (broadcast) or C={c_in} "
+                    f"(one per channel); got shape {list(kernel.shape)}"
+                )
+        else:
+            raise ValueError(
+                f"Kernel must be 2D (k, k) or 4D (out, 1, k, k); "
+                f"got shape {list(kernel.shape)}"
+            )
+
+        stride = max(1, int(params.get("stride", 1) or 1))
+        padding = max(0, int(params.get("padding", 1) or 0))
+
+        weight = weight.to(dtype=tensor.dtype, device=tensor.device)
+        output = F.conv2d(
+            tensor,
+            weight,
+            bias=None,
+            stride=stride,
+            padding=padding,
+            groups=c_in,
+        )
+        return {"tensor": output}

--- a/backend/app/nodes/cnn/conv2d_kernel_node.py
+++ b/backend/app/nodes/cnn/conv2d_kernel_node.py
@@ -1,0 +1,130 @@
+from typing import Any
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+# Built-in 3x3 kernels. Names mirror what students see in image-processing
+# textbooks; the suffix "3x3" makes the shape explicit at the dropdown level.
+PRESETS_3X3: dict[str, list[list[float]]] = {
+    # Laplacian — center +8, neighbours -1. Highlights pixels whose value
+    # differs strongly from the surrounding 8.
+    "EdgeDetection3x3": [
+        [-1.0, -1.0, -1.0],
+        [-1.0,  8.0, -1.0],
+        [-1.0, -1.0, -1.0],
+    ],
+    # Classic sharpening — center +5, axis-aligned neighbours -1, corners 0.
+    "Sharpen3x3": [
+        [ 0.0, -1.0,  0.0],
+        [-1.0,  5.0, -1.0],
+        [ 0.0, -1.0,  0.0],
+    ],
+    # Prewitt-X — responds to horizontal intensity changes (vertical edges).
+    "VerticalEdge3x3": [
+        [-1.0, 0.0, 1.0],
+        [-1.0, 0.0, 1.0],
+        [-1.0, 0.0, 1.0],
+    ],
+}
+
+CUSTOM_OPTION = "Custom"
+PRESET_OPTIONS: list[str] = [*PRESETS_3X3.keys(), CUSTOM_OPTION]
+MIN_KERNEL_SIZE = 1
+MAX_KERNEL_SIZE = 15
+
+
+def _flatten(x: Any) -> list[float]:
+    if isinstance(x, (list, tuple)):
+        out: list[float] = []
+        for v in x:
+            out.extend(_flatten(v))
+        return out
+    return [x]
+
+
+class Conv2dKernelNode(BaseNode):
+    NODE_NAME = "Conv2dKernel"
+    CATEGORY = "CNN"
+    DESCRIPTION = (
+        "Emits a 2D convolution kernel as a tensor (no convolution is "
+        "performed here). Pick a built-in 3x3 preset (EdgeDetection / "
+        "Sharpen / VerticalEdge) or switch preset to 'Custom' to enter an "
+        "NxN matrix by hand. Output shape is (kernel_size, kernel_size). "
+        "Wire the output into a downstream convolution node that accepts "
+        "an explicit kernel."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor",
+                data_type=DataType.TENSOR,
+                description="Kernel as a 2D tensor of shape (kernel_size, kernel_size)",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="preset",
+                param_type=ParamType.SELECT,
+                default="EdgeDetection3x3",
+                description="Built-in 3x3 kernel, or 'Custom' to author your own matrix",
+                options=PRESET_OPTIONS,
+            ),
+            ParamDefinition(
+                name="kernel_size",
+                param_type=ParamType.INT,
+                default=3,
+                description="Kernel side length N for an NxN kernel (Custom preset only)",
+                min_value=MIN_KERNEL_SIZE,
+                max_value=MAX_KERNEL_SIZE,
+                visible_when={"preset": CUSTOM_OPTION},
+            ),
+            ParamDefinition(
+                name="weights",
+                param_type=ParamType.TENSOR_GRID,
+                default=[[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]],
+                description="Custom kernel matrix (NxN); grid size follows kernel_size",
+                visible_when={"preset": CUSTOM_OPTION},
+            ),
+        ]
+
+    def _resolve_kernel(self, params: dict[str, Any]) -> tuple[list[float], int]:
+        preset = str(params.get("preset", "EdgeDetection3x3"))
+        if preset == CUSTOM_OPTION:
+            raw_k = params.get("kernel_size", 3)
+            try:
+                k = int(raw_k)
+            except (TypeError, ValueError):
+                k = 3
+            k = max(MIN_KERNEL_SIZE, min(MAX_KERNEL_SIZE, k))
+            raw_weights = params.get("weights")
+            if raw_weights is None:
+                raise ValueError("preset=Custom requires `weights` to be set (an NxN matrix).")
+            flat = _flatten(raw_weights)
+            expected = k * k
+            if len(flat) != expected:
+                raise ValueError(
+                    f"`weights` has {len(flat)} elements but kernel_size={k} expects {expected} "
+                    f"({k}x{k}). Adjust kernel_size or re-fill the grid."
+                )
+            return flat, k
+        kernel = PRESETS_3X3.get(preset)
+        if kernel is None:
+            raise ValueError(
+                f"Unknown preset: {preset!r}. Choose one of {PRESET_OPTIONS}."
+            )
+        return _flatten(kernel), 3
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        import torch
+
+        flat, k = self._resolve_kernel(params)
+        tensor = torch.tensor(flat, dtype=torch.float32).reshape(k, k)
+        return {"tensor": tensor}

--- a/backend/app/nodes/tensor_ops/scalar_multiply_node.py
+++ b/backend/app/nodes/tensor_ops/scalar_multiply_node.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+
+class ScalarMultiplyNode(BaseNode):
+    NODE_NAME = "ScalarMultiply"
+    CATEGORY = "Tensor Operations"
+    DESCRIPTION = "Multiply a tensor by a constant scalar (no second input needed)."
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="tensor", data_type=DataType.TENSOR, description="Input tensor"),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="tensor", data_type=DataType.TENSOR, description="tensor * scalar"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="scalar",
+                param_type=ParamType.FLOAT,
+                default=1.0,
+                description="Constant scalar multiplied with every element of the input tensor",
+            ),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        tensor = inputs["tensor"]
+        scalar = float(params.get("scalar", 1.0))
+        return {"tensor": tensor * scalar}

--- a/backend/app/nodes/tensor_ops/split_node.py
+++ b/backend/app/nodes/tensor_ops/split_node.py
@@ -2,11 +2,25 @@ from typing import Any
 
 from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
 
+MAX_CHUNKS = 32
+
+
+def _resolve_chunks(params: dict[str, Any] | None) -> int:
+    raw = (params or {}).get("chunks", 2)
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        n = 2
+    return max(1, min(MAX_CHUNKS, n))
+
 
 class SplitNode(BaseNode):
     NODE_NAME = "Split"
     CATEGORY = "Tensor Operations"
-    DESCRIPTION = "Split a tensor into chunks along a dimension"
+    DESCRIPTION = (
+        "Split a tensor into N chunks along a dimension. The number of "
+        "output ports (chunk_0, chunk_1, ...) follows the `chunks` param."
+    )
 
     @classmethod
     def define_inputs(cls) -> list[PortDefinition]:
@@ -16,15 +30,40 @@ class SplitNode(BaseNode):
 
     @classmethod
     def define_outputs(cls) -> list[PortDefinition]:
+        # Baseline schema for the palette template — matches the default
+        # `chunks=2`. The live port count for a placed node comes from
+        # `define_outputs_dynamic` below.
         return [
             PortDefinition(name="chunk_0", data_type=DataType.TENSOR, description="First chunk"),
             PortDefinition(name="chunk_1", data_type=DataType.TENSOR, description="Second chunk"),
         ]
 
     @classmethod
+    def define_outputs_dynamic(
+        cls,
+        params: dict[str, Any] | None = None,
+    ) -> list[PortDefinition]:
+        n = _resolve_chunks(params)
+        return [
+            PortDefinition(
+                name=f"chunk_{i}",
+                data_type=DataType.TENSOR,
+                description=f"Chunk {i} of {n}",
+            )
+            for i in range(n)
+        ]
+
+    @classmethod
     def define_params(cls) -> list[ParamDefinition]:
         return [
-            ParamDefinition(name="chunks", param_type=ParamType.INT, default=2, description="Number of chunks to split into"),
+            ParamDefinition(
+                name="chunks",
+                param_type=ParamType.INT,
+                default=2,
+                description=f"Number of chunks to split into (1..{MAX_CHUNKS}); also drives output port count",
+                min_value=1,
+                max_value=MAX_CHUNKS,
+            ),
             ParamDefinition(name="dim", param_type=ParamType.INT, default=0, description="Dimension along which to split"),
         ]
 
@@ -32,10 +71,7 @@ class SplitNode(BaseNode):
         import torch
 
         tensor = inputs["tensor"]
-        chunks = params.get("chunks", 2)
+        chunks = _resolve_chunks(params)
         dim = params.get("dim", 0)
         parts = torch.chunk(tensor, chunks, dim=dim)
-        result = {}
-        for i, part in enumerate(parts):
-            result[f"chunk_{i}"] = part
-        return result
+        return {f"chunk_{i}": part for i, part in enumerate(parts)}

--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -20,6 +20,9 @@ class ParamDefinitionSchema(BaseModel):
     options: list[str] = []
     min_value: float | None = None
     max_value: float | None = None
+    # Conditional visibility — forwarded verbatim to the frontend.
+    # See ParamDefinition.visible_when for semantics.
+    visible_when: dict[str, Any] | None = None
 
 
 class NodeDefinition(BaseModel):

--- a/backend/tests/test_conv2d_explicit_node.py
+++ b/backend/tests/test_conv2d_explicit_node.py
@@ -1,0 +1,203 @@
+"""Tests for Conv2dExplicitNode (conv with kernel via input port)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.cnn.conv2d_explicit_node import Conv2dExplicitNode
+
+
+def _run(tensor, kernel, **params):
+    return Conv2dExplicitNode().execute({"tensor": tensor, "kernel": kernel}, params)
+
+
+# ── Schema ──
+
+
+def test_node_metadata():
+    assert Conv2dExplicitNode.NODE_NAME == "Conv2dExplicit"
+    assert Conv2dExplicitNode.CATEGORY == "CNN"
+    in_names = [p.name for p in Conv2dExplicitNode.define_inputs()]
+    out_names = [p.name for p in Conv2dExplicitNode.define_outputs()]
+    assert in_names == ["tensor", "kernel"]
+    assert out_names == ["tensor"]
+
+
+def test_param_names_are_just_stride_and_padding():
+    names = [p.name for p in Conv2dExplicitNode.define_params()]
+    assert names == ["stride", "padding"]
+
+
+def test_no_kernel_size_or_in_out_channels_params():
+    # All kernel-shape info is derived from the kernel input tensor.
+    names = {p.name for p in Conv2dExplicitNode.define_params()}
+    assert "kernel_size" not in names
+    assert "in_channels" not in names
+    assert "out_channels" not in names
+
+
+# ── Execution: bare 2D kernel ──
+
+
+def test_identity_2d_kernel_passes_image_through():
+    identity = torch.tensor([
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ])
+    x = torch.arange(25, dtype=torch.float32).reshape(1, 1, 5, 5)
+    res = _run(x, identity, stride=1, padding=1)
+    assert torch.allclose(res["tensor"], x)
+
+
+def test_laplacian_2d_kernel_detects_isolated_pixel():
+    laplacian = torch.tensor([
+        [-1.0, -1.0, -1.0],
+        [-1.0,  8.0, -1.0],
+        [-1.0, -1.0, -1.0],
+    ])
+    x = torch.zeros(1, 1, 5, 5)
+    x[0, 0, 2, 2] = 1.0
+    res = _run(x, laplacian, stride=1, padding=1)
+    y = res["tensor"]
+    assert y[0, 0, 2, 2].item() == pytest.approx(8.0)
+    assert y[0, 0, 1, 1].item() == pytest.approx(-1.0)
+
+
+def test_uniform_input_with_laplacian_is_zero_in_interior():
+    # padding=0 keeps the kernel window away from zero-padding artefacts.
+    laplacian = torch.tensor([
+        [-1.0, -1.0, -1.0],
+        [-1.0,  8.0, -1.0],
+        [-1.0, -1.0, -1.0],
+    ])
+    x = torch.ones(1, 1, 5, 5)
+    res = _run(x, laplacian, stride=1, padding=0)
+    assert res["tensor"].shape == (1, 1, 3, 3)
+    assert torch.allclose(res["tensor"], torch.zeros(1, 1, 3, 3))
+
+
+def test_2d_kernel_rejects_non_square():
+    x = torch.zeros(1, 1, 5, 5)
+    k = torch.zeros(2, 3)
+    with pytest.raises(ValueError, match=r"square"):
+        _run(x, k)
+
+
+# ── Execution: 4D kernel forms ──
+
+
+def test_4d_kernel_with_out_channel_1_is_broadcast():
+    # (1, 1, k, k) → same effective behaviour as a (k, k) kernel.
+    k = torch.tensor([
+        [-1.0, -1.0, -1.0],
+        [-1.0,  8.0, -1.0],
+        [-1.0, -1.0, -1.0],
+    ]).reshape(1, 1, 3, 3)
+    x = torch.zeros(1, 1, 5, 5)
+    x[0, 0, 2, 2] = 1.0
+    res = _run(x, k, padding=1)
+    assert res["tensor"][0, 0, 2, 2].item() == pytest.approx(8.0)
+
+
+def test_4d_kernel_with_out_channel_matching_input_channels():
+    # (C, 1, k, k) — one distinct kernel per input channel.
+    # ch0: identity. ch1: 3x zero (kills the channel).
+    identity = [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]]
+    zero = [[0.0] * 3 for _ in range(3)]
+    k = torch.tensor([identity, zero]).reshape(2, 1, 3, 3)
+    x = torch.stack([
+        torch.full((1, 5, 5), 7.0),
+        torch.full((1, 5, 5), 9.0),
+    ], dim=1)
+    res = _run(x, k, padding=1)
+    assert res["tensor"].shape == (1, 2, 5, 5)
+    # Channel 0 passed through as identity → still 7.
+    assert torch.allclose(res["tensor"][0, 0], torch.full((5, 5), 7.0))
+    # Channel 1 zeroed out by the zero kernel.
+    assert torch.allclose(res["tensor"][0, 1], torch.zeros(5, 5))
+
+
+def test_4d_kernel_rejects_mismatched_out_channels():
+    x = torch.zeros(1, 3, 5, 5)
+    # (2, 1, 3, 3) doesn't match C=3 and isn't 1 (broadcast) — invalid.
+    k = torch.zeros(2, 1, 3, 3)
+    with pytest.raises(ValueError, match=r"out-channel.*1.*C=3"):
+        _run(x, k, padding=1)
+
+
+def test_4d_kernel_rejects_inner_channel_not_one():
+    # (1, 3, 3, 3) — looks like a full Conv2d weight tensor for a multi-channel
+    # convolution. We only support depthwise here.
+    x = torch.zeros(1, 3, 5, 5)
+    k = torch.zeros(1, 3, 3, 3)
+    with pytest.raises(ValueError, match=r"inner channel must be 1"):
+        _run(x, k, padding=1)
+
+
+def test_3d_kernel_rejected():
+    x = torch.zeros(1, 1, 5, 5)
+    k = torch.zeros(3, 3, 3)
+    with pytest.raises(ValueError, match=r"2D \(k, k\) or 4D"):
+        _run(x, k, padding=1)
+
+
+# ── Execution: multi-channel depthwise ──
+
+
+def test_depthwise_applies_same_2d_kernel_per_channel():
+    # 3 channels uniformly 0/1/2. Laplacian on a flat region → 0.
+    laplacian = torch.tensor([
+        [-1.0, -1.0, -1.0],
+        [-1.0,  8.0, -1.0],
+        [-1.0, -1.0, -1.0],
+    ])
+    x = torch.stack([
+        torch.zeros(1, 5, 5),
+        torch.ones(1, 5, 5),
+        torch.full((1, 5, 5), 2.0),
+    ], dim=1)
+    res = _run(x, laplacian, padding=0)
+    assert res["tensor"].shape == (1, 3, 3, 3)
+    assert torch.allclose(res["tensor"], torch.zeros(1, 3, 3, 3))
+
+
+# ── Validation: input shapes ──
+
+
+def test_rejects_3d_input_with_helpful_message():
+    x = torch.zeros(1, 5, 5)
+    k = torch.zeros(3, 3)
+    with pytest.raises(ValueError, match=r"4D \(N, C, H, W\).*Unsqueeze"):
+        _run(x, k)
+
+
+def test_rejects_non_tensor_input():
+    k = torch.zeros(3, 3)
+    with pytest.raises(ValueError, match=r"`tensor` input must be a torch.Tensor"):
+        Conv2dExplicitNode().execute({"tensor": [[1, 2], [3, 4]], "kernel": k}, {})
+
+
+def test_rejects_non_tensor_kernel():
+    x = torch.zeros(1, 1, 5, 5)
+    with pytest.raises(ValueError, match=r"`kernel` input must be a torch.Tensor"):
+        Conv2dExplicitNode().execute({"tensor": x, "kernel": [[1, 0], [0, 1]]}, {})
+
+
+# ── Stride / dtype ──
+
+
+def test_stride_2_halves_spatial_dims():
+    k = torch.ones(3, 3)
+    x = torch.ones(1, 1, 8, 8)
+    res = _run(x, k, stride=2, padding=1)
+    # (8 + 2 - 3) // 2 + 1 = 4
+    assert res["tensor"].shape == (1, 1, 4, 4)
+
+
+def test_preserves_input_dtype():
+    k = torch.ones(3, 3)
+    x = torch.ones(1, 1, 5, 5, dtype=torch.float64)
+    res = _run(x, k, padding=1)
+    assert res["tensor"].dtype == torch.float64

--- a/backend/tests/test_conv2d_kernel_node.py
+++ b/backend/tests/test_conv2d_kernel_node.py
@@ -1,0 +1,180 @@
+"""Tests for Conv2dKernelNode (pure kernel-tensor producer)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.nodes.cnn.conv2d_kernel_node import (
+    CUSTOM_OPTION,
+    MAX_KERNEL_SIZE,
+    PRESET_OPTIONS,
+    PRESETS_3X3,
+    Conv2dKernelNode,
+)
+
+
+def _run(**params):
+    # Conv2dKernel has no inputs — it's a pure producer.
+    return Conv2dKernelNode().execute({}, params)
+
+
+# ── Schema ──
+
+
+def test_node_metadata():
+    assert Conv2dKernelNode.NODE_NAME == "Conv2dKernel"
+    assert Conv2dKernelNode.CATEGORY == "CNN"
+    assert Conv2dKernelNode.define_inputs() == []
+    out_names = [p.name for p in Conv2dKernelNode.define_outputs()]
+    assert out_names == ["tensor"]
+
+
+def test_preset_param_options_include_three_presets_and_custom():
+    params = {p.name: p for p in Conv2dKernelNode.define_params()}
+    assert params["preset"].options == [
+        "EdgeDetection3x3",
+        "Sharpen3x3",
+        "VerticalEdge3x3",
+        "Custom",
+    ]
+    assert PRESET_OPTIONS[-1] == CUSTOM_OPTION
+
+
+def test_kernel_size_and_weights_are_visible_only_when_custom():
+    params = {p.name: p for p in Conv2dKernelNode.define_params()}
+    assert params["kernel_size"].visible_when == {"preset": "Custom"}
+    assert params["weights"].visible_when == {"preset": "Custom"}
+    # The preset selector itself is always visible.
+    assert params["preset"].visible_when is None
+
+
+def test_kernel_size_param_bounds():
+    params = {p.name: p for p in Conv2dKernelNode.define_params()}
+    assert params["kernel_size"].min_value == 1
+    assert params["kernel_size"].max_value == MAX_KERNEL_SIZE
+    assert params["kernel_size"].default == 3
+
+
+def test_no_stride_or_padding_params():
+    # Conv2dKernel emits a kernel — convolution-time options like stride
+    # and padding belong on the downstream conv node, not here.
+    names = {p.name for p in Conv2dKernelNode.define_params()}
+    assert "stride" not in names
+    assert "padding" not in names
+
+
+def test_weights_default_is_identity_3x3():
+    params = {p.name: p for p in Conv2dKernelNode.define_params()}
+    assert params["weights"].default == [
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ]
+
+
+# ── Preset kernel data ──
+
+
+def test_edge_detection_preset_values():
+    assert PRESETS_3X3["EdgeDetection3x3"] == [
+        [-1, -1, -1],
+        [-1,  8, -1],
+        [-1, -1, -1],
+    ]
+
+
+def test_sharpen_preset_values():
+    assert PRESETS_3X3["Sharpen3x3"] == [
+        [ 0, -1,  0],
+        [-1,  5, -1],
+        [ 0, -1,  0],
+    ]
+
+
+def test_vertical_edge_preset_values():
+    assert PRESETS_3X3["VerticalEdge3x3"] == [
+        [-1, 0, 1],
+        [-1, 0, 1],
+        [-1, 0, 1],
+    ]
+
+
+# ── Execution ──
+
+
+def test_emits_edge_detection_preset_as_3x3_tensor():
+    res = _run(preset="EdgeDetection3x3")
+    t = res["tensor"]
+    assert isinstance(t, torch.Tensor)
+    assert t.shape == (3, 3)
+    expected = torch.tensor([
+        [-1.0, -1.0, -1.0],
+        [-1.0,  8.0, -1.0],
+        [-1.0, -1.0, -1.0],
+    ])
+    assert torch.equal(t, expected)
+
+
+def test_emits_sharpen_preset_as_3x3_tensor():
+    res = _run(preset="Sharpen3x3")
+    expected = torch.tensor([
+        [ 0.0, -1.0,  0.0],
+        [-1.0,  5.0, -1.0],
+        [ 0.0, -1.0,  0.0],
+    ])
+    assert torch.equal(res["tensor"], expected)
+
+
+def test_emits_vertical_edge_preset_as_3x3_tensor():
+    res = _run(preset="VerticalEdge3x3")
+    expected = torch.tensor([
+        [-1.0, 0.0, 1.0],
+        [-1.0, 0.0, 1.0],
+        [-1.0, 0.0, 1.0],
+    ])
+    assert torch.equal(res["tensor"], expected)
+
+
+def test_emits_custom_3x3_identity_when_explicitly_provided():
+    identity = [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]]
+    res = _run(preset="Custom", kernel_size=3, weights=identity)
+    expected = torch.tensor(identity)
+    assert torch.equal(res["tensor"], expected)
+
+
+def test_emits_custom_5x5_box_blur():
+    avg = [[1.0 / 25.0] * 5 for _ in range(5)]
+    res = _run(preset="Custom", kernel_size=5, weights=avg)
+    assert res["tensor"].shape == (5, 5)
+    assert torch.allclose(res["tensor"], torch.full((5, 5), 1.0 / 25.0))
+
+
+def test_emits_custom_2x2():
+    weights = [[1.0, 2.0], [3.0, 4.0]]
+    res = _run(preset="Custom", kernel_size=2, weights=weights)
+    expected = torch.tensor(weights)
+    assert torch.equal(res["tensor"], expected)
+
+
+def test_output_dtype_is_float32():
+    res = _run(preset="EdgeDetection3x3")
+    assert res["tensor"].dtype == torch.float32
+
+
+# ── Errors ──
+
+
+def test_custom_rejects_when_weights_size_mismatches_kernel_size():
+    with pytest.raises(ValueError, match=r"weights.*9 elements.*kernel_size=5.*25"):
+        _run(preset="Custom", kernel_size=5, weights=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+
+def test_custom_rejects_when_weights_missing():
+    with pytest.raises(ValueError, match=r"requires `weights` to be set"):
+        _run(preset="Custom", kernel_size=3, weights=None)
+
+
+def test_unknown_preset_rejected():
+    with pytest.raises(ValueError, match=r"Unknown preset"):
+        _run(preset="MysteryKernel")

--- a/backend/tests/test_graph_engine.py
+++ b/backend/tests/test_graph_engine.py
@@ -197,6 +197,113 @@ def test_validate_graph_required_input_satisfied_by_edge():
 from app.core.graph_engine import find_entry_points, reachable_from_entry_points
 
 
+def test_execute_graph_pulls_in_pure_producer_feeding_required_input():
+    """Regression: pure-producer nodes (no inputs, no triggers) whose
+    outputs feed into otherwise-executable nodes must NOT be pruned by
+    the executable-subgraph filter.
+
+    The bug: ``execute_graph`` computes ``executable_ids`` via forward BFS
+    from trigger entry points through DATA edges. Conv2dKernel has no
+    inputs and no trigger → unreachable by forward BFS → got dropped
+    along with its outgoing edges → downstream Conv2dExplicit then
+    failed validation with "Missing required input 'kernel'".
+
+    The fix: after forward BFS, iterate to fixpoint pulling in any
+    producer whose data edge lands on an already-executable target.
+    """
+    nodes = [
+        _start_node(),
+        # Reachable via trigger from Start.
+        {"id": "trig_src", "type": "TensorInput",
+         "data": {"params": {"shape": "1,1,5,5", "value_mode": "zeros"}}},
+        # Pure producer — no inputs, no trigger. Used to fail to get into
+        # executable_ids and would be pruned.
+        {"id": "kernel", "type": "Conv2dKernel",
+         "data": {"params": {"preset": "EdgeDetection3x3"}}},
+        # Downstream node with TWO required inputs, one fed by the
+        # trigger chain and one by the pure producer.
+        {"id": "conv", "type": "Conv2dExplicit",
+         "data": {"params": {"stride": 1, "padding": 1}}},
+        {"id": "sink", "type": "Print",
+         "data": {"params": {"label": "out"}}},
+    ]
+    edges = [
+        _trigger("et", "start", "trig_src"),
+        {"id": "e_src_conv", "source": "trig_src", "target": "conv",
+         "sourceHandle": "tensor", "targetHandle": "tensor"},
+        {"id": "e_kernel_conv", "source": "kernel", "target": "conv",
+         "sourceHandle": "tensor", "targetHandle": "kernel"},
+        {"id": "e_conv_sink", "source": "conv", "target": "sink",
+         "sourceHandle": "tensor", "targetHandle": "value"},
+    ]
+
+    results = asyncio.run(execute_graph(nodes, edges))
+
+    # Without the fix this asyncio.run would raise GraphValidationError
+    # ("Missing required input 'kernel' on node conv (Conv2dExplicit)").
+    # With the fix the pure producer is retained, the conv runs, the
+    # sink prints, and every node id shows up in results.
+    assert "kernel" in results, "Pure producer Conv2dKernel must be executed"
+    assert "conv" in results, "Conv2dExplicit downstream must be executed"
+    assert "sink" in results
+
+
+def test_execute_graph_pure_producer_chain_walks_all_the_way_back():
+    """Producer-A → Producer-B → executable. The iterative fixpoint loop
+    must pull A in via the edge to B (after B was pulled in via the edge
+    to the trigger-reachable consumer). One-shot logic would miss A."""
+    nodes = [
+        _start_node(),
+        {"id": "trig_src", "type": "TensorInput",
+         "data": {"params": {"shape": "1,1,3,3", "value_mode": "zeros"}}},
+        # Producer chain: kernel_a feeds nothing of its own, but is
+        # reachable only because conv requires it AND conv is reachable.
+        # Use TensorInput as a "transit" producer that has no inputs and
+        # outputs a tensor, mimicking a chain where Conv2dKernel's kernel
+        # itself came from another upstream non-triggered node.
+        {"id": "kernel_src", "type": "TensorInput",
+         "data": {"params": {"shape": "3,3", "value_mode": "ones"}}},
+        {"id": "conv", "type": "Conv2dExplicit",
+         "data": {"params": {"stride": 1, "padding": 1}}},
+        {"id": "sink", "type": "Print",
+         "data": {"params": {"label": "x"}}},
+    ]
+    edges = [
+        _trigger("et", "start", "trig_src"),
+        {"id": "e1", "source": "trig_src", "target": "conv",
+         "sourceHandle": "tensor", "targetHandle": "tensor"},
+        # kernel_src has no incoming edges → pure producer; same shape
+        # as the bug above just with TensorInput instead of Conv2dKernel.
+        {"id": "e2", "source": "kernel_src", "target": "conv",
+         "sourceHandle": "tensor", "targetHandle": "kernel"},
+        {"id": "e3", "source": "conv", "target": "sink",
+         "sourceHandle": "tensor", "targetHandle": "value"},
+    ]
+    results = asyncio.run(execute_graph(nodes, edges))
+    assert "kernel_src" in results
+    assert "conv" in results
+
+
+def test_execute_graph_still_prunes_draft_pure_producer():
+    """A pure producer that does NOT feed into anything reachable should
+    still be pruned (the fix doesn't relax the draft-component rule)."""
+    nodes = [
+        _start_node(),
+        {"id": "trig_src", "type": "_TestSource", "data": {"params": {"val": 1}}},
+        # Draft producer: not wired to anything reachable.
+        {"id": "draft_producer", "type": "Conv2dKernel",
+         "data": {"params": {"preset": "EdgeDetection3x3"}}},
+    ]
+    edges = [
+        _trigger("et", "start", "trig_src"),
+    ]
+    results = asyncio.run(execute_graph(nodes, edges))
+    assert "trig_src" in results
+    assert "draft_producer" not in results, (
+        "Producer with no executable consumer should still be pruned"
+    )
+
+
 def test_find_entry_points_only_trigger_targets():
     """Only nodes with incoming trigger edges are entry points."""
     nodes = [

--- a/backend/tests/test_scalar_multiply_node.py
+++ b/backend/tests/test_scalar_multiply_node.py
@@ -1,0 +1,76 @@
+"""Tests for ScalarMultiplyNode."""
+
+from __future__ import annotations
+
+import torch
+
+from app.nodes.tensor_ops.scalar_multiply_node import ScalarMultiplyNode
+
+
+def _run(tensor, **params):
+    return ScalarMultiplyNode().execute({"tensor": tensor}, params)
+
+
+def test_node_metadata():
+    assert ScalarMultiplyNode.NODE_NAME == "ScalarMultiply"
+    assert ScalarMultiplyNode.CATEGORY == "Tensor Operations"
+    in_names = [p.name for p in ScalarMultiplyNode.define_inputs()]
+    out_names = [p.name for p in ScalarMultiplyNode.define_outputs()]
+    param_names = [p.name for p in ScalarMultiplyNode.define_params()]
+    assert in_names == ["tensor"]
+    assert out_names == ["tensor"]
+    assert param_names == ["scalar"]
+
+
+def test_scalar_param_default_is_one():
+    params = {p.name: p for p in ScalarMultiplyNode.define_params()}
+    assert params["scalar"].default == 1.0
+
+
+def test_multiply_by_two():
+    x = torch.tensor([1.0, 2.0, 3.0])
+    res = _run(x, scalar=2.0)
+    assert torch.equal(res["tensor"], torch.tensor([2.0, 4.0, 6.0]))
+
+
+def test_multiply_by_zero_zeroes_tensor():
+    x = torch.tensor([1.0, 2.0, 3.0])
+    res = _run(x, scalar=0.0)
+    assert torch.equal(res["tensor"], torch.zeros(3))
+
+
+def test_multiply_by_negative():
+    x = torch.tensor([1.0, -2.0, 3.0])
+    res = _run(x, scalar=-1.0)
+    assert torch.equal(res["tensor"], torch.tensor([-1.0, 2.0, -3.0]))
+
+
+def test_multiply_by_fractional_scalar():
+    x = torch.ones(3)
+    res = _run(x, scalar=0.299)
+    assert torch.allclose(res["tensor"], torch.full((3,), 0.299))
+
+
+def test_preserves_shape_for_multidim_tensor():
+    x = torch.randn(1, 3, 4, 5)
+    res = _run(x, scalar=2.0)
+    assert res["tensor"].shape == x.shape
+    assert torch.allclose(res["tensor"], x * 2.0)
+
+
+def test_default_scalar_is_identity():
+    x = torch.tensor([1.0, 2.0, 3.0])
+    res = ScalarMultiplyNode().execute({"tensor": x}, {})
+    assert torch.equal(res["tensor"], x)
+
+
+def test_string_scalar_param_gets_coerced():
+    x = torch.tensor([1.0, 2.0])
+    res = _run(x, scalar="2.5")
+    assert torch.allclose(res["tensor"], torch.tensor([2.5, 5.0]))
+
+
+def test_preserves_dtype():
+    x = torch.tensor([1.0, 2.0], dtype=torch.float64)
+    res = _run(x, scalar=2.0)
+    assert res["tensor"].dtype == torch.float64

--- a/backend/tests/test_split_node.py
+++ b/backend/tests/test_split_node.py
@@ -1,27 +1,75 @@
-"""Tests for SplitNode."""
+"""Tests for SplitNode (param-driven port count)."""
 
 from __future__ import annotations
 
 import torch
 
-from app.nodes.tensor_ops.split_node import SplitNode
+from app.core.graph_engine import validate_graph
+from app.nodes.tensor_ops.split_node import MAX_CHUNKS, SplitNode
 
 
 def _run(tensor, **params):
     return SplitNode().execute({"tensor": tensor}, params)
 
 
+# ── Static schema (palette template) ──
+
+
 def test_node_metadata():
     assert SplitNode.NODE_NAME == "Split"
     out_names = [p.name for p in SplitNode.define_outputs()]
+    # Baseline schema matches the default `chunks=2` so the palette renders
+    # two ports for a freshly-dragged node.
     assert out_names == ["chunk_0", "chunk_1"]
+
+
+def test_chunks_param_has_min_max_in_define_params():
+    params = {p.name: p for p in SplitNode.define_params()}
+    assert "chunks" in params
+    assert params["chunks"].min_value == 1
+    assert params["chunks"].max_value == MAX_CHUNKS
+
+
+# ── Dynamic ports ──
+
+
+def test_dynamic_outputs_match_chunks_param():
+    out_names = [p.name for p in SplitNode.define_outputs_dynamic({"chunks": 4})]
+    assert out_names == ["chunk_0", "chunk_1", "chunk_2", "chunk_3"]
+
+
+def test_dynamic_outputs_defaults_to_two_when_no_params():
+    out_names_none = [p.name for p in SplitNode.define_outputs_dynamic(None)]
+    out_names_empty = [p.name for p in SplitNode.define_outputs_dynamic({})]
+    assert out_names_none == ["chunk_0", "chunk_1"]
+    assert out_names_empty == ["chunk_0", "chunk_1"]
+
+
+def test_dynamic_outputs_clamps_to_one_when_below_one():
+    out_names = [p.name for p in SplitNode.define_outputs_dynamic({"chunks": 0})]
+    assert out_names == ["chunk_0"]
+
+
+def test_dynamic_outputs_clamps_to_max():
+    out_names = [p.name for p in SplitNode.define_outputs_dynamic({"chunks": 99})]
+    assert len(out_names) == MAX_CHUNKS
+    assert out_names[0] == "chunk_0"
+    assert out_names[-1] == f"chunk_{MAX_CHUNKS - 1}"
+
+
+def test_dynamic_outputs_tolerates_non_int_chunks():
+    out_names = [p.name for p in SplitNode.define_outputs_dynamic({"chunks": "three"})]
+    # Falls back to default 2 when value can't be coerced to int.
+    assert out_names == ["chunk_0", "chunk_1"]
+
+
+# ── Execution ──
 
 
 def test_split_into_two_along_dim_zero():
     x = torch.arange(8).reshape(4, 2)
     res = _run(x, chunks=2, dim=0)
-    assert "chunk_0" in res
-    assert "chunk_1" in res
+    assert set(res.keys()) == {"chunk_0", "chunk_1"}
     assert res["chunk_0"].shape == (2, 2)
     assert res["chunk_1"].shape == (2, 2)
     assert torch.equal(torch.cat([res["chunk_0"], res["chunk_1"]], dim=0), x)
@@ -34,16 +82,22 @@ def test_split_along_dim_one():
     assert res["chunk_1"].shape == (2, 2)
 
 
-def test_split_into_four_chunks_returns_all():
+def test_split_into_four_chunks_returns_all_keys():
     x = torch.arange(8)
     res = _run(x, chunks=4, dim=0)
-    # Output is whatever torch.chunk returns; only first two are declared outputs
-    # but all chunks are returned in the dict
-    assert "chunk_0" in res
-    assert "chunk_1" in res
-    assert "chunk_2" in res
-    assert "chunk_3" in res
-    assert res["chunk_0"].shape == (2,)
+    assert set(res.keys()) == {"chunk_0", "chunk_1", "chunk_2", "chunk_3"}
+    for v in res.values():
+        assert v.shape == (2,)
+
+
+def test_split_three_chunks_unbalanced_tail():
+    # torch.chunk(size=8, chunks=3) → [3, 3, 2]
+    x = torch.arange(8)
+    res = _run(x, chunks=3, dim=0)
+    assert set(res.keys()) == {"chunk_0", "chunk_1", "chunk_2"}
+    assert res["chunk_0"].shape == (3,)
+    assert res["chunk_1"].shape == (3,)
+    assert res["chunk_2"].shape == (2,)
 
 
 def test_default_two_chunks_along_dim_zero():
@@ -51,3 +105,51 @@ def test_default_two_chunks_along_dim_zero():
     res = SplitNode().execute({"tensor": x}, {})
     assert res["chunk_0"].shape == (3,)
     assert res["chunk_1"].shape == (3,)
+
+
+# ── Validator integration ──
+
+
+def _split_then_print(chunks: int, source_handle: str) -> tuple[list[dict], list[dict]]:
+    """Build a tiny graph: Start → TensorInput → Split → Print.
+
+    The Print pulls from `source_handle` on the Split node so we can probe
+    whether the validator accepts a given chunk port for a given `chunks`
+    setting.
+    """
+    nodes = [
+        {"id": "s", "type": "Start", "data": {"params": {}}},
+        {"id": "t", "type": "TensorInput", "data": {"params": {"shape": "6", "value_mode": "zeros"}}},
+        {"id": "sp", "type": "Split", "data": {"params": {"chunks": chunks, "dim": 0}}},
+        {"id": "p", "type": "Print", "data": {"params": {}}},
+    ]
+    edges = [
+        {"id": "e1", "source": "s", "target": "t", "sourceHandle": "trigger", "type": "trigger"},
+        {"id": "e2", "source": "t", "target": "sp", "sourceHandle": "tensor", "targetHandle": "tensor"},
+        {"id": "e3", "source": "sp", "target": "p", "sourceHandle": source_handle, "targetHandle": "value"},
+    ]
+    return nodes, edges
+
+
+def test_validator_accepts_chunk_2_when_chunks_is_three():
+    nodes, edges = _split_then_print(chunks=3, source_handle="chunk_2")
+    errors = validate_graph(nodes, edges)
+    assert not any("Invalid output port" in e for e in errors), errors
+
+
+def test_validator_rejects_chunk_3_when_chunks_is_three():
+    nodes, edges = _split_then_print(chunks=3, source_handle="chunk_3")
+    errors = validate_graph(nodes, edges)
+    assert any("Invalid output port 'chunk_3' on Split" in e for e in errors), errors
+
+
+def test_validator_accepts_chunk_0_when_chunks_is_one():
+    nodes, edges = _split_then_print(chunks=1, source_handle="chunk_0")
+    errors = validate_graph(nodes, edges)
+    assert not any("Invalid output port" in e for e in errors), errors
+
+
+def test_validator_rejects_chunk_1_when_chunks_is_one():
+    nodes, edges = _split_then_print(chunks=1, source_handle="chunk_1")
+    errors = validate_graph(nodes, edges)
+    assert any("Invalid output port 'chunk_1' on Split" in e for e in errors), errors

--- a/frontend/src/components/ConfigPanel/NodeConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel/NodeConfigPanel.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '../../i18n';
 import { ParamField } from '../shared/ParamField';
 import { MathText } from '../shared/MathText';
 import { CATEGORY_COLORS } from '../../styles/theme';
+import { isParamVisible } from '../../utils';
 import styles from './NodeConfigPanel.module.css';
 
 export function NodeConfigPanel() {
@@ -84,7 +85,9 @@ export function NodeConfigPanel() {
           <div>
             <div className={styles.sectionHeader}>{t('config.parameters')}</div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-              {def.params.map((param) => (
+              {def.params
+                .filter((param) => isParamVisible(param, selectedNode.data.params))
+                .map((param) => (
                 <div key={param.name}>
                   <ParamField
                     param={param}

--- a/frontend/src/components/ConfigPanel/TensorGridEditor.test.tsx
+++ b/frontend/src/components/ConfigPanel/TensorGridEditor.test.tsx
@@ -57,6 +57,46 @@ describe('TensorGridEditor — non-explicit / disabled mode', () => {
     expect(screen.getByText(/to edit values inline/)).toBeInTheDocument();
   });
 
+  it('kernel_size sibling alone (no value_mode) defaults to explicit and renders an editable k×k grid', () => {
+    // Conv2dKernel-style: shape derived from kernel_size, no value_mode
+    // sibling. The grid should be live — no "set value_mode" hint.
+    renderEditor({
+      value: [
+        [0, 0, 0],
+        [0, 1, 0],
+        [0, 0, 0],
+      ],
+      siblingParams: { kernel_size: 3 },
+    });
+    expect(screen.queryByText(/to edit values inline/)).not.toBeInTheDocument();
+    expect(screen.getByText('Fill 0')).toBeInTheDocument();
+    expect(screen.getByText(/\[3, 3\] · 9 cells/)).toBeInTheDocument();
+    const inputs = screen.getAllByRole('spinbutton') as HTMLInputElement[];
+    expect(inputs).toHaveLength(9);
+    expect(inputs.map((i) => i.value)).toEqual(['0', '0', '0', '0', '1', '0', '0', '0', '0']);
+  });
+
+  it('kernel_size as a numeric string is still accepted', () => {
+    renderEditor({
+      value: [
+        [0, 0],
+        [0, 0],
+      ],
+      siblingParams: { kernel_size: '2' },
+    });
+    expect(screen.getByText(/\[2, 2\] · 4 cells/)).toBeInTheDocument();
+  });
+
+  it('explicit shape wins over kernel_size when both are present', () => {
+    // If both sources are present, the shape string takes precedence so
+    // a future node could expose both without ambiguity.
+    renderEditor({
+      value: [0, 0, 0, 0],
+      siblingParams: { shape: '4', kernel_size: 3, value_mode: 'explicit' },
+    });
+    expect(screen.getByText(/\[4\] · 4 cells/)).toBeInTheDocument();
+  });
+
   it('fillAll is a no-op when disabled (no onChange, no buttons)', () => {
     const onChange = vi.fn();
     renderEditor({ siblingParams: { shape: '2', value_mode: 'zeros' }, onChange });

--- a/frontend/src/components/ConfigPanel/TensorGridEditor.tsx
+++ b/frontend/src/components/ConfigPanel/TensorGridEditor.tsx
@@ -115,7 +115,27 @@ function set2D(
 }
 
 export function TensorGridEditor({ param, value, onChange, displayLabel, siblingParams }: Props) {
-  const shape = useMemo(() => parseShape(siblingParams?.shape), [siblingParams?.shape]);
+  // Shape sources, in priority order:
+  //   1. siblingParams.shape — the convention used by TensorInput
+  //      ("3,4,5" comma-separated string).
+  //   2. siblingParams.kernel_size — used by Conv2dKernel and any future
+  //      square-matrix param ("3" → [3, 3]).
+  // We also track which source won so the disabled-by-default rule for
+  // value_mode doesn't fire on kernel_size nodes that don't expose one.
+  const { shape, shapeSource } = useMemo<{
+    shape: number[];
+    shapeSource: 'shape' | 'kernel_size' | 'none';
+  }>(() => {
+    const fromShape = parseShape(siblingParams?.shape);
+    if (fromShape.length > 0) return { shape: fromShape, shapeSource: 'shape' };
+    const k = siblingParams?.kernel_size;
+    const kNum = typeof k === 'number' ? k : parseInt(String(k ?? ''), 10);
+    if (Number.isFinite(kNum) && kNum > 0) {
+      const side = Math.floor(kNum);
+      return { shape: [side, side], shapeSource: 'kernel_size' };
+    }
+    return { shape: [], shapeSource: 'none' };
+  }, [siblingParams?.shape, siblingParams?.kernel_size]);
   const total = numel(shape);
   const rank = shape.length;
   const leadingCount = Math.max(0, rank - 2);
@@ -126,7 +146,13 @@ export function TensorGridEditor({ param, value, onChange, displayLabel, sibling
     setLeading(Array(leadingCount).fill(0));
   }
 
-  const valueMode = siblingParams?.value_mode ?? 'random';
+  // value_mode is a TensorInput-style sibling (SELECT: random / zeros /
+  // ones / arange / explicit). For TensorInput the default is 'random' so
+  // the editor stays disabled until the user opts into 'explicit'. For
+  // kernel_size-driven nodes (Conv2dKernel) there is no such sibling and
+  // the grid is meant to be edit-first → default to 'explicit'.
+  const valueMode =
+    siblingParams?.value_mode ?? (shapeSource === 'kernel_size' ? 'explicit' : 'random');
   const disabled = valueMode !== 'explicit';
 
   // Reshape existing value to current shape — but only if mode is explicit

--- a/frontend/src/components/Nodes/BaseNode.tsx
+++ b/frontend/src/components/Nodes/BaseNode.tsx
@@ -2,7 +2,7 @@ import { memo, useState, type ReactNode } from 'react';
 import { Handle, Position, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import type { AppNode } from '../../types';
-import { getPortColor, isValidConnection, resolveDynamicOutputs } from '../../utils';
+import { getPortColor, isParamVisible, isValidConnection, resolveDynamicOutputs } from '../../utils';
 import { useUIStore } from '../../store/uiStore';
 import { useTabStore } from '../../store/tabStore';
 import { useToastStore } from '../../store/toastStore';
@@ -240,20 +240,22 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
       {/* Params display — normal nodes */}
       {!isSequentialModel && def && def.params.length > 0 && (
         <div className={styles.paramsSection}>
-          {def.params.map((p) => {
-            const val = data.params[p.name] ?? p.default;
-            return (
-              <div key={p.name} className={styles.paramRow}>
-                <span className={styles.paramName}>{p.name}</span>
-                <span
-                  className={styles.paramValue}
-                  title={String(val)}
-                >
-                  {String(val)}
-                </span>
-              </div>
-            );
-          })}
+          {def.params
+            .filter((p) => isParamVisible(p, data.params))
+            .map((p) => {
+              const val = data.params[p.name] ?? p.default;
+              return (
+                <div key={p.name} className={styles.paramRow}>
+                  <span className={styles.paramName}>{p.name}</span>
+                  <span
+                    className={styles.paramValue}
+                    title={String(val)}
+                  >
+                    {String(val)}
+                  </span>
+                </div>
+              );
+            })}
         </div>
       )}
 

--- a/frontend/src/components/Nodes/BaseNode.tsx
+++ b/frontend/src/components/Nodes/BaseNode.tsx
@@ -2,7 +2,7 @@ import { memo, useState, type ReactNode } from 'react';
 import { Handle, Position, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import type { AppNode } from '../../types';
-import { getPortColor, isValidConnection } from '../../utils';
+import { getPortColor, isValidConnection, resolveDynamicOutputs } from '../../utils';
 import { useUIStore } from '../../store/uiStore';
 import { useTabStore } from '../../store/tabStore';
 import { useToastStore } from '../../store/toastStore';
@@ -179,33 +179,38 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
           </div>
         ))}
 
-        {/* Divider between inputs and outputs */}
-        {def && def.inputs.length > 0 && def.outputs.length > 0 && (
-          <div className={styles.divider} />
-        )}
-
-        {/* Output handles */}
-        {def?.outputs.map((output) => (
-          <div
-            key={`out-${output.name}`}
-            className={styles.portRowOutput}
-            title={output.description}
-          >
-            <span
-              className={styles.portLabel}
-              style={{ color: getPortColor(output.data_type) }}
-            >
-              {output.name}
-            </span>
-            <Handle
-              type="source"
-              position={Position.Right}
-              id={output.name}
-              className={`${styles.portHandle} ${styles.portHandleOutput}`}
-              style={{ background: getPortColor(output.data_type) }}
-            />
-          </div>
-        ))}
+        {/* Output handles — param-driven nodes (e.g. Split) expand here */}
+        {(() => {
+          const liveOutputs = resolveDynamicOutputs(def, data.params);
+          return (
+            <>
+              {def && def.inputs.length > 0 && liveOutputs.length > 0 && (
+                <div className={styles.divider} />
+              )}
+              {liveOutputs.map((output) => (
+                <div
+                  key={`out-${output.name}`}
+                  className={styles.portRowOutput}
+                  title={output.description}
+                >
+                  <span
+                    className={styles.portLabel}
+                    style={{ color: getPortColor(output.data_type) }}
+                  >
+                    {output.name}
+                  </span>
+                  <Handle
+                    type="source"
+                    position={Position.Right}
+                    id={output.name}
+                    className={`${styles.portHandle} ${styles.portHandleOutput}`}
+                    style={{ background: getPortColor(output.data_type) }}
+                  />
+                </div>
+              ))}
+            </>
+          );
+        })()}
       </div>
 
       {/* Custom body slot — viz nodes inject animated chips, scatter plots, etc. */}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -15,6 +15,14 @@ export interface ParamDefinition {
   options: string[];
   min_value: number | null;
   max_value: number | null;
+  /**
+   * Conditional visibility — the param renders only when every key in
+   * this dict matches the live value of the corresponding sibling param.
+   * Example: ``{ preset: "Custom" }`` on Conv2dKernel's ``weights`` means
+   * the editor only shows when ``preset === "Custom"``. ``null`` /
+   * undefined means always visible.
+   */
+  visible_when?: Record<string, unknown> | null;
 }
 
 export interface SegmentGroup {

--- a/frontend/src/utils/index.test.ts
+++ b/frontend/src/utils/index.test.ts
@@ -2,13 +2,78 @@ import { describe, expect, it } from 'vitest';
 import {
   generateId,
   getPortColor,
+  isParamVisible,
   isValidConnection,
   DATA_TYPE_COLORS,
   VIZ_NODE_TYPES,
   resolveSerializedNodes,
   resolveSerializedEdges,
 } from './index';
-import type { NodeDefinition, PresetDefinition } from '../types';
+import type { NodeDefinition, ParamDefinition, PresetDefinition } from '../types';
+
+function buildParam(overrides: Partial<ParamDefinition>): ParamDefinition {
+  return {
+    name: 'p',
+    param_type: 'int',
+    default: 0,
+    description: '',
+    options: [],
+    min_value: null,
+    max_value: null,
+    ...overrides,
+  };
+}
+
+describe('isParamVisible', () => {
+  it('returns true when visible_when is omitted', () => {
+    const param = buildParam({ name: 'preset' });
+    expect(isParamVisible(param, { preset: 'EdgeDetection3x3' })).toBe(true);
+  });
+
+  it('returns true when visible_when is null', () => {
+    const param = buildParam({ name: 'preset', visible_when: null });
+    expect(isParamVisible(param, { preset: 'EdgeDetection3x3' })).toBe(true);
+  });
+
+  it('returns true when every key in visible_when matches the live params', () => {
+    const param = buildParam({ name: 'weights', visible_when: { preset: 'Custom' } });
+    expect(isParamVisible(param, { preset: 'Custom' })).toBe(true);
+  });
+
+  it('returns false when a visible_when key does not match', () => {
+    const param = buildParam({ name: 'weights', visible_when: { preset: 'Custom' } });
+    expect(isParamVisible(param, { preset: 'EdgeDetection3x3' })).toBe(false);
+  });
+
+  it('returns false when the sibling param is absent from live params', () => {
+    const param = buildParam({ name: 'weights', visible_when: { preset: 'Custom' } });
+    expect(isParamVisible(param, {})).toBe(false);
+  });
+
+  it('requires every entry in visible_when to match (logical AND)', () => {
+    const param = buildParam({
+      name: 'advanced',
+      visible_when: { preset: 'Custom', mode: 'expert' },
+    });
+    expect(isParamVisible(param, { preset: 'Custom', mode: 'expert' })).toBe(true);
+    expect(isParamVisible(param, { preset: 'Custom', mode: 'beginner' })).toBe(false);
+    expect(isParamVisible(param, { preset: 'Sharpen3x3', mode: 'expert' })).toBe(false);
+  });
+
+  it('coerces non-string values for comparison', () => {
+    const param = buildParam({ name: 'kernel_size', visible_when: { use_custom: 'true' } });
+    expect(isParamVisible(param, { use_custom: true })).toBe(true);
+    expect(isParamVisible(param, { use_custom: false })).toBe(false);
+    const numeric = buildParam({ visible_when: { kernel_size: 5 } });
+    expect(isParamVisible(numeric, { kernel_size: 5 })).toBe(true);
+    expect(isParamVisible(numeric, { kernel_size: '5' })).toBe(true);
+  });
+
+  it('treats undefined live params as no match', () => {
+    const param = buildParam({ name: 'weights', visible_when: { preset: 'Custom' } });
+    expect(isParamVisible(param, undefined)).toBe(false);
+  });
+});
 
 describe('generateId', () => {
   it('returns a valid UUID string', () => {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -38,6 +38,29 @@ export function getPortColor(dataType: string): string {
   return DATA_TYPE_COLORS[dataType.toUpperCase()] ?? DATA_TYPE_COLORS['ANY'];
 }
 
+/**
+ * Evaluate a param's ``visible_when`` rule against the current params on
+ * the node. Returns true when the param should render. The default rule
+ * (no ``visible_when``) is "always visible".
+ *
+ * Matching is shallow equality after string coercion — sufficient for
+ * SELECT / INT / BOOL / FLOAT params, which cover every realistic use of
+ * conditional visibility.
+ */
+export function isParamVisible(
+  param: import('../types').ParamDefinition,
+  params: Record<string, unknown> | undefined,
+): boolean {
+  const rule = param.visible_when;
+  if (!rule) return true;
+  const live = params ?? {};
+  for (const [siblingName, expected] of Object.entries(rule)) {
+    const actual = live[siblingName];
+    if (String(actual) !== String(expected)) return false;
+  }
+  return true;
+}
+
 const SPLIT_MAX_CHUNKS = 32;
 
 function bareName(qualifiedName: string): string {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -38,6 +38,46 @@ export function getPortColor(dataType: string): string {
   return DATA_TYPE_COLORS[dataType.toUpperCase()] ?? DATA_TYPE_COLORS['ANY'];
 }
 
+const SPLIT_MAX_CHUNKS = 32;
+
+function bareName(qualifiedName: string): string {
+  const idx = qualifiedName.lastIndexOf(':');
+  return idx >= 0 ? qualifiedName.slice(idx + 1) : qualifiedName;
+}
+
+/**
+ * Resolve a node's *live* output ports, expanding param-driven nodes whose
+ * port count depends on a runtime parameter. Mirrors the backend
+ * `BaseNode.define_outputs_dynamic` mechanism so palette template and live
+ * canvas agree on what handles exist.
+ *
+ * For nodes whose ports don't depend on params (every node except Split as
+ * of writing) this just returns `definition.outputs` verbatim. New
+ * dynamic-port nodes added in the future should add a clause here.
+ */
+export function resolveDynamicOutputs(
+  definition: import('../types').NodeDefinition | undefined,
+  params: Record<string, unknown> | undefined,
+): import('../types').PortDefinition[] {
+  if (!definition) return [];
+  const bare = bareName(definition.node_name);
+  if (bare === 'Split') {
+    const raw = params?.chunks;
+    const parsed = typeof raw === 'number' ? raw : parseInt(String(raw ?? ''), 10);
+    const chunks = Math.max(
+      1,
+      Math.min(SPLIT_MAX_CHUNKS, Number.isFinite(parsed) ? Math.floor(parsed) : 2),
+    );
+    return Array.from({ length: chunks }, (_, i) => ({
+      name: `chunk_${i}`,
+      data_type: 'TENSOR',
+      description: `Chunk ${i} of ${chunks}`,
+      optional: false,
+    }));
+  }
+  return definition.outputs;
+}
+
 /**
  * Reconstruct full ReactFlow nodes from the minimal serialized graph format.
  * The serialized format (from getSerializedGraph / backend save) only stores:


### PR DESCRIPTION
修正Split node 沒有正確切出對應chunk(參數)數量的問題 (動態節點數量)

新增Scalar Multiply node

新增自訂義Kernel (Conv2d) node 以及對應的Conv2dExplicit node (原Conv2d node kernel為random產生 for training)

改善跑圖邏輯 原本producer-only node: Scalar Tensor, Conv2dKernel在執行時會被ignore 