### PR TITLE
feat(frontend): export tab architecture as an SVG/PNG diagram

### DIFF
--- a/frontend/src/components/Toolbar/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.test.tsx
@@ -9,6 +9,7 @@ import { useToastStore } from '../../store/toastStore';
 import { useDialogStore } from '../../store/dialogStore';
 import { useI18n } from '../../i18n';
 import * as rest from '../../api/rest';
+import * as exportDiagram from '../../utils/exportDiagram';
 
 // ── Mocks ─────────────────────────────────────────────────────────────
 
@@ -35,6 +36,14 @@ vi.mock('../../api/rest', () => ({
 }));
 
 const mockedRest = vi.mocked(rest);
+
+// Keep the real graphToSvg (pure), but stub PNG rasterization — it relies on
+// Image/<canvas>, which jsdom does not implement.
+vi.mock('../../utils/exportDiagram', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/exportDiagram')>();
+  return { ...actual, svgToPngBlob: vi.fn() };
+});
+const mockedExportDiagram = vi.mocked(exportDiagram);
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
@@ -97,6 +106,9 @@ describe('Toolbar', () => {
     // Default async resolutions
     mockedRest.listGraphs.mockResolvedValue([]);
     mockedRest.listCustomNodes.mockResolvedValue([]);
+
+    mockedExportDiagram.svgToPngBlob.mockReset();
+    mockedExportDiagram.svgToPngBlob.mockResolvedValue(new Blob(['png'], { type: 'image/png' }));
 
     execute.mockReset();
     stop.mockReset();
@@ -651,6 +663,89 @@ describe('Toolbar', () => {
     fireEvent.click(screen.getByText('Export as Python'));
     await waitFor(() =>
       expect(useToastStore.getState().toasts.some((t) => t.type === 'error' && t.message.includes('compile error'))).toBe(true),
+    );
+  });
+
+  // ── Export Diagram (SVG / PNG architecture) ─────────────────────────
+
+  it('Export Diagram: empty canvas warns and does not download', () => {
+    render(<Toolbar />);
+    fireEvent.click(screen.getByText('Export'));
+    fireEvent.click(screen.getByText('Export Diagram (SVG)'));
+    expect(useToastStore.getState().toasts.some((t) => t.type === 'warning')).toBe(true);
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('Export Diagram: a canvas with only notes warns (notes are not architecture)', () => {
+    setActiveTab({
+      nodes: [
+        { id: 'note1', type: 'noteNode', position: { x: 0, y: 0 }, data: { type: 'note', params: {} } },
+      ],
+    });
+    render(<Toolbar />);
+    fireEvent.click(screen.getByText('Export'));
+    fireEvent.click(screen.getByText('Export Diagram (PNG)'));
+    expect(useToastStore.getState().toasts.some((t) => t.type === 'warning')).toBe(true);
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it('Export Diagram (SVG): with nodes downloads an SVG blob', () => {
+    setActiveTab({
+      name: 'My Graph!!',
+      nodes: [
+        { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'Add', type: 'Add', params: {} } },
+        { id: 'n2', type: 'baseNode', position: { x: 300, y: 0 }, data: { label: 'ReLU', type: 'ReLU', params: {} } },
+      ],
+      edges: [{ id: 'e1', source: 'n1', target: 'n2', style: { stroke: '#4CAF50' } }],
+    });
+    render(<Toolbar />);
+    fireEvent.click(screen.getByText('Export'));
+    fireEvent.click(screen.getByText('Export Diagram (SVG)'));
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
+    expect(mockedExportDiagram.svgToPngBlob).not.toHaveBeenCalled();
+  });
+
+  it('Export Diagram (SVG): uses the "graph" filename fallback when the tab name is empty', () => {
+    setActiveTab({
+      name: '',
+      nodes: [
+        { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'Add', type: 'Add', params: {} } },
+      ],
+    });
+    render(<Toolbar />);
+    fireEvent.click(screen.getByText('Export'));
+    fireEvent.click(screen.getByText('Export Diagram (SVG)'));
+    expect(URL.createObjectURL).toHaveBeenCalled();
+  });
+
+  it('Export Diagram (PNG): rasterizes the SVG and downloads a PNG blob', async () => {
+    setActiveTab({
+      nodes: [
+        { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'Add', type: 'Add', params: {} } },
+      ],
+    });
+    render(<Toolbar />);
+    fireEvent.click(screen.getByText('Export'));
+    fireEvent.click(screen.getByText('Export Diagram (PNG)'));
+    await waitFor(() => expect(mockedExportDiagram.svgToPngBlob).toHaveBeenCalled());
+    await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled());
+  });
+
+  it('Export Diagram (PNG): a rasterization failure toasts an error', async () => {
+    mockedExportDiagram.svgToPngBlob.mockRejectedValueOnce(new Error('canvas boom'));
+    setActiveTab({
+      nodes: [
+        { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'Add', type: 'Add', params: {} } },
+      ],
+    });
+    render(<Toolbar />);
+    fireEvent.click(screen.getByText('Export'));
+    fireEvent.click(screen.getByText('Export Diagram (PNG)'));
+    await waitFor(() =>
+      expect(
+        useToastStore.getState().toasts.some((t) => t.type === 'error' && t.message.includes('canvas boom')),
+      ).toBe(true),
     );
   });
 

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -7,6 +7,7 @@ import { saveGraph, loadGraph, listGraphs, createPreset, exportGraph } from '../
 import { useI18n, SUPPORTED_LOCALES } from '../../i18n';
 import type { TranslationKey } from '../../i18n';
 import { resolveSerializedNodes, resolveSerializedEdges } from '../../utils';
+import { graphToSvg, svgToPngBlob } from '../../utils/exportDiagram';
 import { confirm, prompt } from '../../utils/dialog';
 import { CustomNodeManager } from '../CustomNodeManager/CustomNodeManager';
 import { useToastStore } from '../../store/toastStore';
@@ -407,6 +408,37 @@ export function Toolbar() {
     }
   }, [getSerializedGraph, activeTab.name, t, addToast]);
 
+  const handleExportDiagram = useCallback(
+    async (format: 'svg' | 'png') => {
+      // Architecture diagram = nodes + their ports + connections (no param
+      // values), built from the live nodes/edges rather than the serialized
+      // graph (which drops the labels, category colors and ports the diagram
+      // needs). Notes are annotations, not architecture, so they don't count.
+      const drawable = activeTab.nodes.filter((n) => n.type !== 'noteNode');
+      if (drawable.length === 0) {
+        addToast(t('toolbar.exportDiagram.empty'), 'warning');
+        return;
+      }
+      const base = (activeTab.name || 'graph').replace(/[^a-zA-Z0-9_-]/g, '_');
+      const svg = graphToSvg(activeTab.nodes, activeTab.edges);
+      try {
+        const blob =
+          format === 'png'
+            ? await svgToPngBlob(svg)
+            : new Blob([svg], { type: 'image/svg+xml' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${base}-architecture.${format}`;
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch (e) {
+        addToast(t('toolbar.exportDiagram.fail', { error: (e as Error).message }), 'error');
+      }
+    },
+    [activeTab.nodes, activeTab.edges, activeTab.name, t, addToast],
+  );
+
   const handleReloadNodes = useCallback(async () => {
     try { await reload(); }
     catch (e) { addToast(t('toolbar.reload.fail', { error: (e as Error).message }), 'error'); }
@@ -421,6 +453,8 @@ export function Toolbar() {
 
   const exportMenuItems: MenuItem[] = [
     { label: t('toolbar.exportJson'), title: t('toolbar.exportJson.title'), onClick: handleExportJson },
+    { label: t('toolbar.exportDiagram.svg'), title: t('toolbar.exportDiagram.title'), onClick: () => handleExportDiagram('svg') },
+    { label: t('toolbar.exportDiagram.png'), title: t('toolbar.exportDiagram.title'), onClick: () => handleExportDiagram('png') },
     { label: t('toolbar.export'), title: t('toolbar.export.title'), onClick: handleExportSubgraph },
     { label: t('toolbar.exportPython'), title: t('toolbar.exportPython.title'), onClick: handleExportPython },
   ];

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -42,6 +42,11 @@ const en = {
   'toolbar.exportPython.title': 'Download graph as a standalone Python script',
   'toolbar.exportPython.empty': 'Canvas is empty — add some nodes before exporting.',
   'toolbar.exportPython.fail': 'Python export failed: {error}',
+  'toolbar.exportDiagram.svg': 'Export Diagram (SVG)',
+  'toolbar.exportDiagram.png': 'Export Diagram (PNG)',
+  'toolbar.exportDiagram.title': 'Download the architecture (nodes, input/output ports & connections — no parameter values) as an image',
+  'toolbar.exportDiagram.empty': 'Canvas is empty — add some nodes before exporting.',
+  'toolbar.exportDiagram.fail': 'Diagram export failed: {error}',
 
   // Status
   'status.idle': 'Idle',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -44,6 +44,11 @@ const zhTW: Record<TranslationKey, string> = {
   'toolbar.exportPython.title': '將圖表下載為獨立的 Python 腳本',
   'toolbar.exportPython.empty': '畫布為空 — 請先新增一些節點再匯出。',
   'toolbar.exportPython.fail': 'Python 匯出失敗：{error}',
+  'toolbar.exportDiagram.svg': '匯出架構圖 (SVG)',
+  'toolbar.exportDiagram.png': '匯出架構圖 (PNG)',
+  'toolbar.exportDiagram.title': '將架構圖（節點、輸入/輸出埠與連接線,不含參數數值）下載為圖片',
+  'toolbar.exportDiagram.empty': '畫布為空 — 請先新增一些節點再匯出。',
+  'toolbar.exportDiagram.fail': '架構圖匯出失敗：{error}',
 
   // Status
   'status.idle': '閒置',

--- a/frontend/src/utils/exportDiagram.test.ts
+++ b/frontend/src/utils/exportDiagram.test.ts
@@ -1,0 +1,630 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Edge, Node } from '@xyflow/react';
+import type { NodeData, NodeDefinition, PortDefinition } from '../types';
+import { graphToSvg, svgToPngBlob, DIAGRAM_THEMES } from './exportDiagram';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function port(name: string, data_type = 'TENSOR'): PortDefinition {
+  return { name, data_type, description: '', optional: false };
+}
+
+function mkDef(over: Partial<NodeDefinition> = {}): NodeDefinition {
+  return {
+    node_name: 'X',
+    category: 'CNN',
+    description: '',
+    inputs: [],
+    outputs: [],
+    params: [],
+    ...over,
+  };
+}
+
+function makeNode(
+  id: string,
+  data: Partial<NodeData> = {},
+  over: Partial<Node<NodeData>> = {},
+): Node<NodeData> {
+  return {
+    id,
+    type: 'baseNode',
+    position: { x: 0, y: 0 },
+    data: { label: id, type: id, params: {}, ...data },
+    ...over,
+  };
+}
+
+function makeEdge(
+  id: string,
+  source: string,
+  target: string,
+  opts: { stroke?: string; sourceHandle?: string; targetHandle?: string } = {},
+): Edge {
+  return {
+    id,
+    source,
+    target,
+    ...(opts.sourceHandle ? { sourceHandle: opts.sourceHandle } : {}),
+    ...(opts.targetHandle ? { targetHandle: opts.targetHandle } : {}),
+    ...(opts.stroke ? { style: { stroke: opts.stroke, strokeWidth: 2 } } : {}),
+  };
+}
+
+/** Count non-overlapping occurrences of `needle` in `hay`. */
+function count(hay: string, needle: string): number {
+  return hay.split(needle).length - 1;
+}
+
+/** Parse as XML and surface any well-formedness error element. */
+function wellFormed(svg: string): boolean {
+  const doc = new DOMParser().parseFromString(svg, 'application/xml');
+  return doc.querySelector('parsererror') === null;
+}
+
+/** Extract every edge path's `d` attribute. */
+function edgePaths(svg: string): string[] {
+  return [...svg.matchAll(/<path d="([^"]+)" fill="none"/g)].map((m) => m[1]);
+}
+
+/** Width of the first node card (the rect carrying rx="8"). */
+function firstCardWidth(svg: string): number {
+  const m = svg.match(/<rect x="[^"]*" y="[^"]*" width="([0-9.]+)"[^>]*rx="8"/);
+  return m ? Number(m[1]) : NaN;
+}
+
+/** A port label renders as `<tspan>name : </tspan><tspan font-weight="700">TYPE</tspan>`. */
+function hasPortLabel(svg: string, name: string, type: string): boolean {
+  return svg.includes(`>${name} : </tspan>`) && svg.includes(`<tspan font-weight="700">${type}</tspan>`);
+}
+
+/** Y coordinate of a node's centered title text, matched by its label. */
+function titleY(svg: string, label: string): number {
+  const m = svg.match(new RegExp(`<text x="[^"]*" y="([0-9.]+)"[^>]*font-weight="700"[^>]*>${label}<`));
+  return m ? Number(m[1]) : NaN;
+}
+
+/** Centre-Y of every port dot in the SVG. */
+function dotYs(svg: string): number[] {
+  return [...svg.matchAll(/<circle cx="[^"]*" cy="([0-9.]+)"/g)].map((m) => Number(m[1]));
+}
+
+/** Parse each card's box (keyed by its title text) out of the rendered SVG. */
+function parseCards(svg: string): Record<string, { x: number; y: number; w: number; h: number }> {
+  const cards: Record<string, { x: number; y: number; w: number; h: number }> = {};
+  for (const chunk of svg.split('<g>').slice(1)) {
+    const rect = chunk.match(/<rect x="([0-9.-]+)" y="([0-9.-]+)" width="([0-9.]+)" height="([0-9.]+)"/);
+    const title = chunk.match(/font-weight="700"[^>]*>([^<]+)</);
+    if (rect && title) {
+      cards[title[1]] = { x: +rect[1], y: +rect[2], w: +rect[3], h: +rect[4] };
+    }
+  }
+  return cards;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('graphToSvg', () => {
+  it('renders a well-formed SVG with one card per node and one path per edge', () => {
+    const nodes = [
+      makeNode('a', { label: 'Linear' }, { position: { x: 0, y: 0 } }),
+      makeNode('b', { label: 'ReLU' }, { position: { x: 300, y: 0 } }),
+    ];
+    const svg = graphToSvg(nodes, [makeEdge('e1', 'a', 'b')]);
+
+    expect(svg.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(svg).toContain('<svg xmlns="http://www.w3.org/2000/svg"');
+    expect(svg).toContain('viewBox="0 0 ');
+    expect(wellFormed(svg)).toBe(true);
+    expect(count(svg, 'rx="8"')).toBe(2); // one card per node
+    expect(count(svg, 'marker-end=')).toBe(1); // one edge
+    expect(svg).toContain('>Linear<');
+    expect(svg).toContain('>ReLU<');
+    expect(count(svg, '<marker')).toBe(1);
+    expect(svg).toContain('markerWidth="6"'); // small arrowhead
+  });
+
+  it('computes the bounding box across vertically stacked nodes', () => {
+    // Two cards at the same x but different y: the second does not extend the
+    // right edge (exercises the "not wider" branch of the bbox scan).
+    const nodes = [
+      makeNode('a', { label: 'Top' }, { position: { x: 0, y: 0 } }),
+      makeNode('b', { label: 'Bottom' }, { position: { x: 0, y: 200 } }),
+    ];
+    const svg = graphToSvg(nodes, [], { layout: 'preserve' });
+    // width = MIN_W(160) + 2*PADDING(48) = 256; height spans both rows.
+    expect(svg).toContain('width="256" height="');
+    expect(svg).toContain('>Top<');
+    expect(svg).toContain('>Bottom<');
+  });
+
+  it('auto-layout (default) spreads overlapping nodes apart left-to-right', () => {
+    // Both nodes sit at the same spot; auto-layout must separate them, and
+    // edges to notes / missing nodes are ignored by the layout.
+    const nodes = [
+      makeNode('a', { definition: mkDef({ outputs: [port('o')] }) }, { position: { x: 0, y: 0 } }),
+      makeNode('b', { definition: mkDef({ inputs: [port('i')] }) }, { position: { x: 0, y: 0 } }),
+      makeNode('note', {}, { type: 'noteNode', position: { x: 0, y: 0 } }),
+    ];
+    const edges = [
+      makeEdge('e', 'a', 'b', { sourceHandle: 'o', targetHandle: 'i' }),
+      makeEdge('e2', 'a', 'note'), // target excluded from layout
+      makeEdge('e3', 'ghost', 'b'), // source missing
+      makeEdge('e4', 'a', 'ghost'), // target missing
+    ];
+    const cards = parseCards(graphToSvg(nodes, edges));
+    // 'a' feeds 'b', so dagre puts 'a' in an earlier (left) rank — no overlap.
+    expect(cards.a.x + cards.a.w).toBeLessThanOrEqual(cards.b.x);
+  });
+
+  it('renders input ports on the left and output ports on the right with their data types', () => {
+    const def = mkDef({
+      inputs: [port('x', 'TENSOR'), port('labels', 'TENSOR')],
+      outputs: [port('out', 'MODEL')],
+    });
+    const svg = graphToSvg([makeNode('n', { label: 'Conv', definition: def })], []);
+
+    expect(wellFormed(svg)).toBe(true);
+    // Port labels show "name : TYPE" with the data type in bold.
+    expect(hasPortLabel(svg, 'x', 'TENSOR')).toBe(true);
+    expect(hasPortLabel(svg, 'labels', 'TENSOR')).toBe(true);
+    expect(hasPortLabel(svg, 'out', 'MODEL')).toBe(true);
+    // One colored dot per port (2 inputs + 1 output).
+    expect(count(svg, '<circle')).toBe(3);
+    expect(svg).toContain('<circle cx="12"'); // input dot at left padding
+    expect(svg).toContain('fill="#4CAF50"'); // TENSOR
+    expect(svg).toContain('fill="#2196F3"'); // MODEL
+    // Inputs anchor start (left), outputs anchor end (right).
+    expect(svg).toContain('text-anchor="start"');
+    expect(svg).toContain('text-anchor="end"');
+    // Title rule + input/output divider (both sides present → 2 rules).
+    expect(count(svg, '<line')).toBe(2);
+  });
+
+  it('anchors an edge at the matching output and input port rows', () => {
+    const srcDef = mkDef({ outputs: [port('a'), port('b')] });
+    const dstDef = mkDef({ inputs: [port('p'), port('q')] });
+    const nodes = [
+      makeNode('s', { definition: srcDef }, { position: { x: 0, y: 0 } }),
+      makeNode('t', { definition: dstDef }, { position: { x: 400, y: 0 } }),
+    ];
+    // Connect output index 1 (b) → input index 1 (q).
+    const svg = graphToSvg(nodes, [makeEdge('e', 's', 't', { sourceHandle: 'b', targetHandle: 'q' })], {
+      layout: 'preserve',
+    });
+    const [d] = edgePaths(svg);
+    // Row 1 center = y(0) + TITLE_H(34) + PAD_V(8) + 1.5*ROW_H(20) = 72.
+    expect(d).toContain(',72 C'); // start anchored at source row 1
+    expect(d.endsWith(',72')).toBe(true); // end anchored at target row 1
+  });
+
+  it('falls back to the card center when an edge handle is absent or unmatched', () => {
+    const srcDef = mkDef({ outputs: [port('only')] }); // 1 output → card center y = 35
+    const dstDef = mkDef({ inputs: [port('only')] });
+    const nodes = [
+      makeNode('s', { definition: srcDef }, { position: { x: 0, y: 0 } }),
+      makeNode('t', { definition: dstDef }, { position: { x: 400, y: 0 } }),
+    ];
+    // No sourceHandle, and a targetHandle that doesn't match any input.
+    const svg = graphToSvg(nodes, [makeEdge('e', 's', 't', { targetHandle: 'nope' })], {
+      layout: 'preserve',
+    });
+    const [d] = edgePaths(svg);
+    // h = 34 + 8*2 + 1*20 = 70 → center = 35 (not the port-row value 52).
+    expect(d).toContain(',35 C');
+    expect(d.endsWith(',35')).toBe(true);
+  });
+
+  it('handles asymmetric port counts (more inputs than outputs)', () => {
+    const def = mkDef({
+      inputs: [port('i0'), port('i1'), port('i2')],
+      outputs: [port('o0')],
+    });
+    const svg = graphToSvg([makeNode('n', { definition: def })], []);
+    expect(count(svg, '<circle')).toBe(4); // 3 inputs + 1 output
+    expect(hasPortLabel(svg, 'i2', 'TENSOR')).toBe(true);
+    expect(hasPortLabel(svg, 'o0', 'TENSOR')).toBe(true);
+  });
+
+  it('handles asymmetric port counts (more outputs than inputs)', () => {
+    const def = mkDef({
+      inputs: [port('i0')],
+      outputs: [port('o0'), port('o1'), port('o2')],
+    });
+    const svg = graphToSvg([makeNode('n', { definition: def })], []);
+    expect(count(svg, '<circle')).toBe(4); // 1 input + 3 outputs
+    expect(hasPortLabel(svg, 'o2', 'TENSOR')).toBe(true);
+  });
+
+  it('stacks inputs and outputs in separate rows (tall, single column)', () => {
+    const def = mkDef({ inputs: [port('in1')], outputs: [port('out1')] });
+    const svg = graphToSvg([makeNode('n', { definition: def })], [], { layout: 'preserve' });
+    const card = parseCards(svg).n;
+    // 1 input + 1 output stacked → 2 rows: h = TITLE_H(34) + PAD_V*2(16) + 2*ROW_H(40) = 90
+    // (side-by-side would have been a single 70px-tall row).
+    expect(card.h).toBe(90);
+    // Title rule + input/output divider.
+    expect(count(svg, '<line')).toBe(2);
+  });
+
+  it('centers the ports with equal top and bottom padding in their section', () => {
+    const def = mkDef({ inputs: [port('a'), port('b')], outputs: [port('c')] });
+    const svg = graphToSvg([makeNode('n', { definition: def })], [], { layout: 'preserve' });
+    const card = parseCards(svg).n;
+    const ys = dotYs(svg);
+    const HALF_ROW = 10; // ROW_H / 2
+    const SECTION_TOP = card.y + 34; // below the TITLE_H band
+    const topPad = (Math.min(...ys) - HALF_ROW) - SECTION_TOP;
+    const botPad = card.y + card.h - (Math.max(...ys) + HALF_ROW);
+    expect(topPad).toBeCloseTo(botPad, 5); // equal whitespace above & below the ports
+    expect(topPad).toBeGreaterThan(0);
+  });
+
+  it('places outputs in a lower layer than inputs (edge anchors below the inputs)', () => {
+    const srcDef = mkDef({ inputs: [port('a')], outputs: [port('b')] });
+    const dstDef = mkDef({ inputs: [port('c')] });
+    const nodes = [
+      makeNode('s', { definition: srcDef }, { position: { x: 0, y: 0 } }),
+      makeNode('t', { definition: dstDef }, { position: { x: 400, y: 0 } }),
+    ];
+    const svg = graphToSvg(nodes, [makeEdge('e', 's', 't', { sourceHandle: 'b', targetHandle: 'c' })], {
+      layout: 'preserve',
+    });
+    const [d] = edgePaths(svg);
+    // output 'b' = row inputs.length(1)+0 = row 1 → y = 34+8+1.5*20 = 72 (below the input row).
+    expect(d).toContain(',72 C');
+    // input 'c' = row 0 → y = 34+8+0.5*20 = 52.
+    expect(d.endsWith(',52')).toBe(true);
+  });
+
+  // ── Start node ───────────────────────────────────────────────────────
+
+  it('renders a Start node (type "start") with a light-green fill and green accent', () => {
+    const svg = graphToSvg([makeNode('s', { definition: mkDef({ category: 'Control' }) }, { type: 'start' })], []);
+    expect(svg).toContain('fill="#dcfce7"'); // light-green background
+    expect(svg).toContain('stroke="#16a34a"'); // green accent border
+  });
+
+  it('treats a node whose data.type is "Start" as a Start node', () => {
+    const svg = graphToSvg([makeNode('s', { type: 'Start', definition: mkDef() })], []);
+    expect(svg).toContain('fill="#dcfce7"');
+  });
+
+  it('does not render the Start trigger port — just the green box and title', () => {
+    const startDef = mkDef({ category: 'Control', outputs: [port('trigger', 'TRIGGER')] });
+    const svg = graphToSvg([makeNode('s', { label: 'Start', definition: startDef }, { type: 'start' })], []);
+    expect(svg).toContain('>Start<');
+    expect(count(svg, '<circle')).toBe(0); // no port dots
+    expect(svg).not.toContain('trigger'); // trigger port not shown
+    expect(svg).toContain('fill="#dcfce7"'); // still a green box
+  });
+
+  it('vertically centers the title of a port-less node (Start)', () => {
+    const svg = graphToSvg(
+      [makeNode('s', { label: 'Start', definition: mkDef({ category: 'Control' }) }, { type: 'start', position: { x: 0, y: 0 } })],
+      [],
+      { layout: 'preserve' },
+    );
+    const card = parseCards(svg).Start;
+    // Title sits at the card's vertical centre, not the top title band.
+    expect(titleY(svg, 'Start')).toBeCloseTo(card.y + card.h / 2, 5);
+  });
+
+  it('keeps a port-ful node title in the top band, not the card center', () => {
+    const def = mkDef({ inputs: [port('a')], outputs: [port('b')] });
+    const svg = graphToSvg([makeNode('Op', { label: 'Op', definition: def })], [], { layout: 'preserve' });
+    const card = parseCards(svg).Op;
+    expect(titleY(svg, 'Op')).toBeCloseTo(card.y + 34 / 2, 5); // TITLE_H / 2
+  });
+
+  it('points a trigger edge at the target top-left corner in green', () => {
+    const startDef = mkDef({ category: 'Control', outputs: [port('trigger', 'TRIGGER')] });
+    const dstDef = mkDef({ inputs: [port('x')] });
+    const nodes = [
+      makeNode('s', { definition: startDef }, { type: 'start', position: { x: 0, y: 0 } }),
+      makeNode('t', { definition: dstDef }, { position: { x: 400, y: 50 } }),
+    ];
+    const svg = graphToSvg(nodes, [makeEdge('e', 's', 't', { sourceHandle: 'trigger', targetHandle: '__trigger' })], {
+      layout: 'preserve',
+    });
+    const t = parseCards(svg).t;
+    const [d] = edgePaths(svg);
+    // Ends at the target's top-left corner (x, y) — not at the input port row.
+    expect(d.endsWith(`${t.x},${t.y}`)).toBe(true);
+    expect(svg).toContain('stroke="#16a34a"'); // trigger edges are green
+  });
+
+  it('treats an edge with sourceHandle "trigger" as a trigger even without __trigger', () => {
+    const startDef = mkDef({ category: 'Control', outputs: [port('trigger', 'TRIGGER')] });
+    const dstDef = mkDef({ inputs: [port('x')] });
+    const nodes = [
+      makeNode('s', { definition: startDef }, { type: 'start', position: { x: 0, y: 0 } }),
+      makeNode('t', { definition: dstDef }, { position: { x: 400, y: 80 } }),
+    ];
+    // targetHandle is a real input name, not '__trigger' — still a trigger via the source.
+    const svg = graphToSvg(nodes, [makeEdge('e', 's', 't', { sourceHandle: 'trigger', targetHandle: 'x' })], {
+      layout: 'preserve',
+    });
+    const t = parseCards(svg).t;
+    const [d] = edgePaths(svg);
+    expect(d.endsWith(`${t.x},${t.y}`)).toBe(true); // corner, not the input row
+  });
+
+  it('expands Split dynamic outputs into chunk ports', () => {
+    const def = mkDef({ node_name: 'Split', category: 'Tensor Operations', inputs: [port('tensor')] });
+    const svg = graphToSvg([makeNode('n', { label: 'Split', definition: def, params: { chunks: 3 } })], []);
+    expect(hasPortLabel(svg, 'chunk_0', 'TENSOR')).toBe(true);
+    expect(hasPortLabel(svg, 'chunk_2', 'TENSOR')).toBe(true);
+  });
+
+  it('widens a card to fit long port labels', () => {
+    const narrow = graphToSvg([makeNode('a', { definition: mkDef() })], []); // no ports → MIN_W
+    const wide = graphToSvg(
+      [makeNode('b', {
+        definition: mkDef({
+          inputs: [port('a_very_long_input_name', 'TENSOR')],
+          outputs: [port('a_very_long_output_name', 'TENSOR')],
+        }),
+      })],
+      [],
+    );
+    expect(firstCardWidth(narrow)).toBe(160); // MIN_W
+    expect(firstCardWidth(wide)).toBeGreaterThan(160);
+  });
+
+  it('truncates an overly long port name but keeps the type whole and bold', () => {
+    const def = mkDef({ inputs: [port('an_extremely_long_port_name_here', 'TENSOR')] });
+    const svg = graphToSvg([makeNode('n', { definition: def })], []);
+    expect(svg).toContain('…');
+    expect(svg).not.toContain('an_extremely_long_port_name_here'); // full name truncated away
+    expect(svg).toContain('<tspan font-weight="700">TENSOR</tspan>'); // type still whole & bold
+  });
+
+  it('renders the port data type in bold and the name in normal weight', () => {
+    const def = mkDef({ inputs: [port('weights', 'MODEL')] });
+    const svg = graphToSvg([makeNode('n', { definition: def })], []);
+    expect(svg).toContain('<tspan>weights : </tspan><tspan font-weight="700">MODEL</tspan>');
+  });
+
+  it('renders a card with no ports (no separator, no dots)', () => {
+    const svg = graphToSvg([makeNode('n', { label: 'NoPorts' })], []);
+    expect(svg).toContain('>NoPorts<');
+    expect(count(svg, '<circle')).toBe(0);
+    expect(count(svg, '<line')).toBe(0);
+  });
+
+  it('excludes note nodes from the diagram', () => {
+    const nodes = [
+      makeNode('a', { label: 'Conv2d' }),
+      makeNode('note1', { label: 'a helpful note' }, { type: 'noteNode' }),
+    ];
+    const svg = graphToSvg(nodes, []);
+    expect(count(svg, 'rx="8"')).toBe(1);
+    expect(svg).toContain('>Conv2d<');
+    expect(svg).not.toContain('a helpful note');
+  });
+
+  it('skips edges whose endpoint is a note or a missing node', () => {
+    const nodes = [makeNode('a'), makeNode('note1', {}, { type: 'noteNode' })];
+    const edges = [
+      makeEdge('e1', 'a', 'note1'), // target is a note → skipped
+      makeEdge('e2', 'a', 'ghost'), // target missing → skipped
+      makeEdge('e3', 'phantom', 'a'), // source missing → skipped
+    ];
+    const svg = graphToSvg(nodes, edges);
+    expect(count(svg, 'marker-end=')).toBe(0);
+    expect(count(svg, '<marker')).toBe(0);
+  });
+
+  it('produces a minimal background-only SVG when there are no drawable nodes', () => {
+    const svg = graphToSvg([makeNode('note1', {}, { type: 'noteNode' })], []);
+    expect(wellFormed(svg)).toBe(true);
+    expect(svg).toContain('width="96" height="96"'); // 2 * PADDING
+    expect(svg).not.toContain('rx="8"');
+    expect(count(svg, 'marker-end=')).toBe(0);
+  });
+
+  it('colors edges by their data-type stroke by default', () => {
+    const nodes = [makeNode('a'), makeNode('b', {}, { position: { x: 300, y: 0 } })];
+    const svg = graphToSvg(nodes, [makeEdge('e1', 'a', 'b', { stroke: '#4CAF50' })]);
+    expect(svg).toContain('stroke="#4CAF50"');
+    expect(svg).toContain('id="arrow-4CAF50"');
+    expect(svg).toContain('marker-end="url(#arrow-4CAF50)"');
+  });
+
+  it('uses the theme edge color when preserveEdgeColors is false', () => {
+    const nodes = [makeNode('a'), makeNode('b', {}, { position: { x: 300, y: 0 } })];
+    const svg = graphToSvg(nodes, [makeEdge('e1', 'a', 'b', { stroke: '#4CAF50' })], {
+      preserveEdgeColors: false,
+    });
+    expect(svg).not.toContain('stroke="#4CAF50"');
+    expect(svg).toContain(`stroke="${DIAGRAM_THEMES.light.edgeStroke}"`);
+  });
+
+  it('falls back to the theme edge color for an edge with no stroke', () => {
+    const nodes = [makeNode('a'), makeNode('b', {}, { position: { x: 300, y: 0 } })];
+    const svg = graphToSvg(nodes, [makeEdge('e1', 'a', 'b')]);
+    expect(svg).toContain(`stroke="${DIAGRAM_THEMES.light.edgeStroke}"`);
+  });
+
+  it('deduplicates arrowhead markers across edges that share a color', () => {
+    const nodes = [
+      makeNode('a'),
+      makeNode('b', {}, { position: { x: 300, y: 0 } }),
+      makeNode('c', {}, { position: { x: 600, y: 0 } }),
+    ];
+    const edges = [
+      makeEdge('e1', 'a', 'b', { stroke: '#4CAF50' }),
+      makeEdge('e2', 'b', 'c', { stroke: '#4CAF50' }),
+    ];
+    const svg = graphToSvg(nodes, edges);
+    expect(count(svg, 'marker-end=')).toBe(2);
+    expect(count(svg, '<marker')).toBe(1);
+  });
+
+  it('honors the dark theme', () => {
+    const def = mkDef({ inputs: [port('x')] }); // a port so node text color is exercised
+    const svg = graphToSvg([makeNode('a', { definition: def })], [], { theme: 'dark' });
+    expect(svg).toContain(`fill="${DIAGRAM_THEMES.dark.background}"`);
+    expect(svg).toContain(`fill="${DIAGRAM_THEMES.dark.nodeFill}"`);
+    expect(svg).toContain(`fill="${DIAGRAM_THEMES.dark.nodeText}"`);
+  });
+
+  it('defaults to the light theme', () => {
+    const svg = graphToSvg([makeNode('a')], []);
+    expect(svg).toContain(`fill="${DIAGRAM_THEMES.light.background}"`);
+  });
+
+  // ── Node accent color ────────────────────────────────────────────────
+
+  it('colors a preset node with the preset gold accent', () => {
+    const svg = graphToSvg([makeNode('p', { isPreset: true })], []);
+    expect(svg).toContain('stroke="#D4A017"');
+  });
+
+  it('colors a node by its category', () => {
+    const svg = graphToSvg([makeNode('c', { definition: mkDef({ category: 'CNN' }) })], []);
+    expect(svg).toContain('stroke="#4CAF50"'); // CNN
+  });
+
+  it('falls back to the neutral color for an unknown category', () => {
+    const svg = graphToSvg([makeNode('u', { definition: mkDef({ category: 'Nonexistent' }) })], []);
+    expect(svg).toContain('stroke="#607D8B"');
+  });
+
+  it('falls back to the neutral color when a node has no definition', () => {
+    const svg = graphToSvg([makeNode('n', { definition: undefined })], []);
+    expect(svg).toContain('stroke="#607D8B"');
+  });
+
+  // ── Labels ───────────────────────────────────────────────────────────
+
+  it('truncates an overly long title with an ellipsis', () => {
+    const longLabel = 'ThisIsAnAbsurdlyLongNodeNameThatExceedsTheLimit';
+    const svg = graphToSvg([makeNode('a', { label: longLabel })], []);
+    expect(svg).toContain('…');
+    expect(svg).not.toContain(longLabel);
+    expect(svg).toContain(`>${longLabel.slice(0, 27)}…<`);
+  });
+
+  it('falls back from label to type to id', () => {
+    const fromType = graphToSvg([makeNode('a', { label: '', type: 'AddOp' })], []);
+    expect(fromType).toContain('>AddOp<');
+    const fromId = graphToSvg([makeNode('the-id', { label: '', type: '' })], []);
+    expect(fromId).toContain('>the-id<');
+  });
+
+  it('rounds coordinates to two decimals', () => {
+    const svg = graphToSvg([makeNode('a', {}, { position: { x: 10.333333, y: 0 } })], [], {
+      layout: 'preserve',
+    });
+    expect(svg).toContain('x="10.33"');
+  });
+
+  it('escapes XML-special characters in labels and ports', () => {
+    const def = mkDef({ inputs: [port('<a> & "b"', 'TENSOR')] });
+    const svg = graphToSvg([makeNode('a', { label: `<A> & "B" 'C'`, definition: def })], []);
+    expect(svg).toContain('&lt;A&gt; &amp; &quot;B&quot; &apos;C&apos;');
+    expect(svg).toContain('&lt;a&gt; &amp; &quot;b&quot;');
+    expect(wellFormed(svg)).toBe(true);
+  });
+
+  it('exposes both light and dark theme presets', () => {
+    expect(Object.keys(DIAGRAM_THEMES).sort()).toEqual(['dark', 'light']);
+  });
+});
+
+// ── svgToPngBlob ──────────────────────────────────────────────────────
+
+describe('svgToPngBlob', () => {
+  const sampleSvg = graphToSvg([makeNode('a', { label: 'X' })], []);
+  const svgWidth = Number(sampleSvg.match(/<svg[^>]*\bwidth="([0-9.]+)"/)![1]);
+
+  let imgMode: 'load' | 'error';
+  let canvasConfig: { ctx: unknown; toBlobResult: Blob | null };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let lastCanvas: any;
+
+  class FakeImage {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_v: string) {
+      Promise.resolve().then(() => {
+        if (imgMode === 'error') this.onerror?.();
+        else this.onload?.();
+      });
+    }
+  }
+
+  beforeEach(() => {
+    imgMode = 'load';
+    canvasConfig = { ctx: { drawImage: vi.fn() }, toBlobResult: new Blob(['png'], { type: 'image/png' }) };
+    vi.stubGlobal('Image', FakeImage);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const origCreate = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'canvas') {
+        lastCanvas = {
+          width: 0,
+          height: 0,
+          getContext: () => canvasConfig.ctx,
+          toBlob: (cb: (b: Blob | null) => void) => cb(canvasConfig.toBlobResult),
+        };
+        return lastCanvas;
+      }
+      return origCreate(tag);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('rasterizes an SVG to a PNG blob and revokes the object URL', async () => {
+    const blob = await svgToPngBlob(sampleSvg);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('image/png');
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+  });
+
+  it('super-samples by the given scale factor', async () => {
+    await svgToPngBlob(sampleSvg, 3);
+    expect(lastCanvas.width).toBe(Math.round(svgWidth * 3));
+  });
+
+  it('clamps dimensionless SVGs to at least 1px', async () => {
+    await svgToPngBlob('<svg></svg>');
+    expect(lastCanvas.width).toBe(1);
+    expect(lastCanvas.height).toBe(1);
+  });
+
+  it('rejects when the 2D context is unavailable', async () => {
+    canvasConfig.ctx = null;
+    await expect(svgToPngBlob(sampleSvg)).rejects.toThrow('Canvas 2D context is unavailable');
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('rejects when PNG encoding yields no blob', async () => {
+    canvasConfig.toBlobResult = null;
+    await expect(svgToPngBlob(sampleSvg)).rejects.toThrow('PNG encoding failed');
+  });
+
+  it('rejects (and cleans up) when drawing throws', async () => {
+    canvasConfig.ctx = {
+      drawImage: () => {
+        throw new Error('draw boom');
+      },
+    };
+    await expect(svgToPngBlob(sampleSvg)).rejects.toThrow('draw boom');
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('rejects when the image fails to load', async () => {
+    imgMode = 'error';
+    await expect(svgToPngBlob(sampleSvg)).rejects.toThrow('Failed to render the SVG');
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/exportDiagram.ts
+++ b/frontend/src/utils/exportDiagram.ts
@@ -1,0 +1,452 @@
+import dagre from '@dagrejs/dagre';
+import type { Edge, Node } from '@xyflow/react';
+import type { NodeData, PortDefinition } from '../types';
+import { CATEGORY_COLORS } from '../styles/theme';
+import { getPortColor, resolveDynamicOutputs } from './index';
+
+/**
+ * Render the active tab's graph as a standalone, self-contained SVG showing
+ * the **architecture**: one card per node — its name on top, its input ports
+ * on the left and output ports on the right (each labeled with the data type
+ * that flows through it) — wired together by the directed connections. Tunable
+ * parameter values and per-node visualizations are intentionally omitted; the
+ * goal is a clean structural diagram a student can drop into slides or a report.
+ *
+ * Built straight from the node/edge data (not a DOM screenshot), so the output
+ * is deterministic, dependency-free and crisp at any zoom. Each node card is
+ * sized to fit its own content, and edges anchor at the exact port rows so the
+ * data flow reads the same way it does on the canvas.
+ */
+
+// ── Card geometry ──
+const TITLE_FS = 15; // node name font size
+const TITLE_H = 34; // title band height
+const PORT_FS = 11.5; // port label font size
+const ROW_H = 20; // height of one port row
+const PAD_V = 8; // vertical padding around the ports area
+const PAD_H = 12; // horizontal padding inside the card
+const DOT_R = 3.5; // port marker radius
+const DOT_SPACE = 14; // horizontal room a port dot + gap occupies
+const ARROW_SIZE = 6; // arrowhead marker size (small, dainty head)
+const MIN_W = 160; // minimum card width (tall & slim cards)
+const EMPTY_BODY = 12; // bottom padding for a node that has no ports
+const PADDING = 48; // outer canvas padding around the whole diagram
+const RANK_SEP = 90; // horizontal gap between layers (auto-layout)
+const NODE_SEP = 32; // vertical gap between cards in the same layer (auto-layout)
+const FONT_FAMILY =
+  "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif";
+// Labels longer than these are truncated with an ellipsis so cards stay tidy.
+const MAX_LABEL_CHARS = 28;
+const MAX_PORT_CHARS = 24;
+const PRESET_COLOR = '#D4A017'; // reusable-subgraph accent (matches the toolbar)
+const FALLBACK_NODE_COLOR = '#607D8B';
+const START_COLOR = '#16a34a'; // Start/entry node accent (border, title, trigger edges)
+const START_FILL = '#dcfce7'; // Start node light-green background
+
+export type DiagramThemeName = 'light' | 'dark';
+
+interface DiagramTheme {
+  background: string;
+  nodeFill: string;
+  nodeText: string;
+  edgeStroke: string;
+}
+
+export const DIAGRAM_THEMES: Record<DiagramThemeName, DiagramTheme> = {
+  light: { background: '#ffffff', nodeFill: '#ffffff', nodeText: '#0f172a', edgeStroke: '#94a3b8' },
+  dark: { background: '#0a0a0a', nodeFill: '#1e1e1e', nodeText: '#e5e7eb', edgeStroke: '#888888' },
+};
+
+export interface GraphToSvgOptions {
+  /** Visual theme of the exported diagram. Defaults to `light` (document-friendly). */
+  theme?: DiagramThemeName;
+  /**
+   * Color each edge by the data-type stroke it carries on the canvas (which
+   * encodes what flows along it — educational). Defaults to `true`; set false
+   * for a single neutral edge color.
+   */
+  preserveEdgeColors?: boolean;
+  /**
+   * `auto` (default) re-runs a clean left-to-right layout sized to the export
+   * cards, so they never overlap regardless of how the canvas was arranged.
+   * `preserve` keeps each node's canvas position.
+   */
+  layout?: 'auto' | 'preserve';
+}
+
+interface Entry {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  color: string;
+  label: string;
+  isStart: boolean;
+  inputs: PortDefinition[];
+  outputs: PortDefinition[];
+}
+
+/** Escape text for safe embedding in XML/SVG. */
+function esc(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' })[c]!,
+  );
+}
+
+/** Round to 2 decimals to keep the markup compact. */
+function r2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** Rough text width estimate (no DOM) — good enough for card sizing. */
+function estTextWidth(text: string, fontSize: number, bold = false): number {
+  return text.length * fontSize * (bold ? 0.62 : 0.55);
+}
+
+/** A Start/entry node — drawn green and targeted at its top-left corner. */
+function isStartNode(node: Node<NodeData>): boolean {
+  return node.type === 'start' || node.data.type === 'Start';
+}
+
+/** Border/title color: Start green, else preset gold, else category color, else neutral. */
+function nodeColor(node: Node<NodeData>): string {
+  if (isStartNode(node)) return START_COLOR;
+  if (node.data.isPreset) return PRESET_COLOR;
+  const category = node.data.definition?.category;
+  return (category && CATEGORY_COLORS[category]) || FALLBACK_NODE_COLOR;
+}
+
+/** Display title for a node, truncated with an ellipsis when overly long. */
+function nodeLabel(node: Node<NodeData>): string {
+  const raw = node.data.label || node.data.type || node.id;
+  return raw.length > MAX_LABEL_CHARS ? `${raw.slice(0, MAX_LABEL_CHARS - 1)}…` : raw;
+}
+
+/**
+ * Split a port into its display name and data type. The name is truncated (the
+ * type is short and always kept whole) so the combined label stays tidy.
+ */
+function portParts(p: PortDefinition): { name: string; type: string } {
+  const type = p.data_type;
+  const maxName = Math.max(1, MAX_PORT_CHARS - type.length - 3); // 3 = " : "
+  const name = p.name.length > maxName ? `${p.name.slice(0, maxName - 1)}…` : p.name;
+  return { name, type };
+}
+
+/** Estimated rendered width of a port row: "name : " (normal) + TYPE (bold) + dot. */
+function portWidth(p: PortDefinition): number {
+  const { name, type } = portParts(p);
+  return DOT_SPACE + estTextWidth(`${name} : `, PORT_FS) + estTextWidth(type, PORT_FS, true);
+}
+
+/** SVG markup for a port label: the name in normal weight, the TYPE in bold. */
+function portTspans(p: PortDefinition): string {
+  const { name, type } = portParts(p);
+  return `<tspan>${esc(name)} : </tspan><tspan font-weight="700">${esc(type)}</tspan>`;
+}
+
+function edgeColor(edge: Edge, theme: DiagramTheme, preserve: boolean): string {
+  const stroke = edge.style?.stroke;
+  if (preserve && typeof stroke === 'string') return stroke;
+  return theme.edgeStroke;
+}
+
+/** Stable, id-safe token derived from a color string (for <marker> ids). */
+function colorId(color: string): string {
+  return color.replace(/[^a-zA-Z0-9]/g, '');
+}
+
+/** Build a sized card descriptor for a node from its content. */
+function buildEntry(node: Node<NodeData>): Entry {
+  const def = node.data.definition;
+  const isStart = isStartNode(node);
+  // A Start node is a pure entry marker: just a green box with an outgoing
+  // line, so its ports (the trigger) are not shown.
+  const inputs = isStart ? [] : (def?.inputs ?? []);
+  const outputs = isStart ? [] : resolveDynamicOutputs(def, node.data.params);
+  const label = nodeLabel(node);
+  // Inputs and outputs are stacked in separate rows (a single column), so the
+  // card grows tall & slim rather than wide. Width fits the longest single
+  // port label; height fits every input plus every output row.
+  const totalRows = inputs.length + outputs.length;
+
+  let labelW = 0;
+  for (const p of [...inputs, ...outputs]) {
+    labelW = Math.max(labelW, portWidth(p));
+  }
+  const w = Math.max(MIN_W, estTextWidth(label, TITLE_FS, true) + PAD_H * 2, labelW + PAD_H * 2);
+  const h = TITLE_H + (totalRows > 0 ? PAD_V * 2 + totalRows * ROW_H : EMPTY_BODY);
+
+  return {
+    x: node.position.x,
+    y: node.position.y,
+    w,
+    h,
+    color: nodeColor(node),
+    label,
+    isStart,
+    inputs,
+    outputs,
+  };
+}
+
+/** Y center of port row `idx` within a card. */
+function portRowY(e: Entry, idx: number): number {
+  return e.y + TITLE_H + PAD_V + (idx + 0.5) * ROW_H;
+}
+
+/**
+ * Re-layout the cards left-to-right with dagre, sized to the export cards (not
+ * the canvas nodes), so they spread out evenly and never overlap. Mutates each
+ * entry's `x`/`y` in place.
+ */
+function layoutEntries(entries: Map<string, Entry>, edges: Edge[]): void {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({ rankdir: 'LR', nodesep: NODE_SEP, ranksep: RANK_SEP });
+  g.setDefaultEdgeLabel(() => ({}));
+  for (const [id, e] of entries) {
+    g.setNode(id, { width: e.w, height: e.h });
+  }
+  for (const edge of edges) {
+    if (entries.has(edge.source) && entries.has(edge.target)) {
+      g.setEdge(edge.source, edge.target);
+    }
+  }
+  dagre.layout(g);
+  for (const [id, e] of entries) {
+    const dn = g.node(id);
+    // Dagre returns centers; convert to top-left.
+    e.x = dn.x - dn.width / 2;
+    e.y = dn.y - dn.height / 2;
+  }
+}
+
+/**
+ * Convert a graph to an SVG string. Note nodes are excluded, and edges are
+ * drawn only when both endpoints are real (non-note) nodes.
+ */
+export function graphToSvg(
+  nodes: Node<NodeData>[],
+  edges: Edge[],
+  options: GraphToSvgOptions = {},
+): string {
+  const theme = DIAGRAM_THEMES[options.theme ?? 'light'];
+  const preserveEdgeColors = options.preserveEdgeColors ?? true;
+
+  const entries = new Map<string, Entry>();
+  for (const n of nodes) {
+    if (n.type === 'noteNode') continue;
+    entries.set(n.id, buildEntry(n));
+  }
+
+  // Spread the cards out cleanly unless the caller wants the canvas positions.
+  if ((options.layout ?? 'auto') === 'auto' && entries.size > 0) {
+    layoutEntries(entries, edges);
+  }
+
+  // Bounding box across all cards (empty graph → a zero-size origin box).
+  let minX = 0;
+  let minY = 0;
+  let maxX = 0;
+  let maxY = 0;
+  if (entries.size > 0) {
+    minX = Infinity;
+    minY = Infinity;
+    maxX = -Infinity;
+    maxY = -Infinity;
+    for (const e of entries.values()) {
+      if (e.x < minX) minX = e.x;
+      if (e.y < minY) minY = e.y;
+      if (e.x + e.w > maxX) maxX = e.x + e.w;
+      if (e.y + e.h > maxY) maxY = e.y + e.h;
+    }
+  }
+  const width = r2(maxX - minX + PADDING * 2);
+  const height = r2(maxY - minY + PADDING * 2);
+  const offsetX = PADDING - minX;
+  const offsetY = PADDING - minY;
+
+  // ── Edges (drawn under the cards), anchored at the exact port rows ──
+  const edgeParts: string[] = [];
+  const markerColors = new Map<string, string>();
+  for (const e of edges) {
+    const s = entries.get(e.source);
+    const t = entries.get(e.target);
+    if (!s || !t) continue; // endpoint is a note or missing — skip
+    // Trigger/control-flow edges (from a Start node) are not data: they point
+    // at the target's top-left corner rather than an input port, and are drawn
+    // in the Start green.
+    const isTrigger = e.targetHandle === '__trigger' || e.sourceHandle === 'trigger';
+    const color = isTrigger ? START_COLOR : edgeColor(e, theme, preserveEdgeColors);
+    markerColors.set(colorId(color), color);
+
+    // Outputs sit below the inputs, so an output's row is offset by the input count.
+    const outIdx = e.sourceHandle ? s.outputs.findIndex((p) => p.name === e.sourceHandle) : -1;
+    const sx = s.x + s.w;
+    const sy = outIdx >= 0 ? portRowY(s, s.inputs.length + outIdx) : s.y + s.h / 2;
+
+    let tx: number;
+    let ty: number;
+    if (isTrigger) {
+      tx = t.x; // top-left corner
+      ty = t.y;
+    } else {
+      const inIdx = e.targetHandle ? t.inputs.findIndex((p) => p.name === e.targetHandle) : -1;
+      tx = t.x;
+      ty = inIdx >= 0 ? portRowY(t, inIdx) : t.y + t.h / 2;
+    }
+    const dx = Math.max(40, Math.abs(tx - sx) / 2);
+    const d = `M${r2(sx)},${r2(sy)} C${r2(sx + dx)},${r2(sy)} ${r2(tx - dx)},${r2(ty)} ${r2(tx)},${r2(ty)}`;
+    edgeParts.push(
+      `<path d="${d}" fill="none" stroke="${esc(color)}" stroke-width="2" ` +
+        `marker-end="url(#arrow-${colorId(color)})" />`,
+    );
+  }
+
+  // One arrowhead marker per distinct edge color so every arrow matches its line.
+  const markers = Array.from(markerColors.entries())
+    .map(
+      ([id, color]) =>
+        `<marker id="arrow-${id}" viewBox="0 0 10 10" refX="8" refY="5" ` +
+        `markerWidth="${ARROW_SIZE}" markerHeight="${ARROW_SIZE}" orient="auto-start-reverse">` +
+        `<path d="M0,0 L10,5 L0,10 z" fill="${esc(color)}" /></marker>`,
+    )
+    .join('');
+
+  // ── Cards (drawn over the edges) ──
+  const nodeParts: string[] = [];
+  for (const e of entries.values()) {
+    nodeParts.push(renderCard(e, theme));
+  }
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" ` +
+    `viewBox="0 0 ${width} ${height}">` +
+    `<defs>${markers}</defs>` +
+    `<rect width="${width}" height="${height}" fill="${theme.background}" />` +
+    `<g transform="translate(${r2(offsetX)},${r2(offsetY)})">` +
+    edgeParts.join('') +
+    nodeParts.join('') +
+    `</g>` +
+    `</svg>`
+  );
+}
+
+/** A faint horizontal rule in the card's accent color, spanning its width. */
+function cardRule(e: Entry, y: number): string {
+  return (
+    `<line x1="${r2(e.x + 8)}" y1="${r2(y)}" x2="${r2(e.x + e.w - 8)}" y2="${r2(y)}" ` +
+    `stroke="${esc(e.color)}" stroke-opacity="0.35" stroke-width="1" />`
+  );
+}
+
+/**
+ * Render one node card: title on top, then inputs and outputs stacked in
+ * separate rows (inputs above, outputs below). Start nodes get a light-green
+ * fill so the entry point stands out.
+ */
+function renderCard(e: Entry, theme: DiagramTheme): string {
+  const parts: string[] = ['<g>'];
+
+  // Card surface (light green for Start) + accent-colored border.
+  parts.push(
+    `<rect x="${r2(e.x)}" y="${r2(e.y)}" width="${r2(e.w)}" height="${r2(e.h)}" ` +
+      `rx="8" ry="8" fill="${e.isStart ? START_FILL : theme.nodeFill}" ` +
+      `stroke="${esc(e.color)}" stroke-width="1.5" />`,
+  );
+
+  // Title — horizontally centered, larger, in the accent color. A node with
+  // ports keeps its title in the top band; a port-less node (e.g. Start) centers
+  // the title in the whole card so the text sits dead-centre.
+  const hasPorts = e.inputs.length + e.outputs.length > 0;
+  const titleY = e.y + (hasPorts ? TITLE_H / 2 : e.h / 2);
+  parts.push(
+    `<text x="${r2(e.x + e.w / 2)}" y="${r2(titleY)}" text-anchor="middle" ` +
+      `dominant-baseline="central" font-family="${FONT_FAMILY}" font-size="${TITLE_FS}" ` +
+      `font-weight="700" fill="${esc(e.color)}">${esc(e.label)}</text>`,
+  );
+
+  if (hasPorts) {
+    parts.push(cardRule(e, e.y + TITLE_H)); // under the title
+
+    // Inputs — upper rows, left-aligned with the dot on the left.
+    e.inputs.forEach((p, i) => {
+      const cy = portRowY(e, i);
+      parts.push(
+        `<circle cx="${r2(e.x + PAD_H)}" cy="${r2(cy)}" r="${DOT_R}" fill="${esc(getPortColor(p.data_type))}" />` +
+          `<text x="${r2(e.x + PAD_H + DOT_SPACE - 4)}" y="${r2(cy)}" text-anchor="start" ` +
+          `dominant-baseline="central" font-family="${FONT_FAMILY}" font-size="${PORT_FS}" ` +
+          `fill="${theme.nodeText}">${portTspans(p)}</text>`,
+      );
+    });
+
+    // Divider between the input layer and the output layer.
+    if (e.inputs.length > 0 && e.outputs.length > 0) {
+      parts.push(cardRule(e, e.y + TITLE_H + PAD_V + e.inputs.length * ROW_H));
+    }
+
+    // Outputs — lower rows, right-aligned with the dot on the right.
+    e.outputs.forEach((p, j) => {
+      const cy = portRowY(e, e.inputs.length + j);
+      parts.push(
+        `<circle cx="${r2(e.x + e.w - PAD_H)}" cy="${r2(cy)}" r="${DOT_R}" fill="${esc(getPortColor(p.data_type))}" />` +
+          `<text x="${r2(e.x + e.w - PAD_H - DOT_SPACE + 4)}" y="${r2(cy)}" text-anchor="end" ` +
+          `dominant-baseline="central" font-family="${FONT_FAMILY}" font-size="${PORT_FS}" ` +
+          `fill="${theme.nodeText}">${portTspans(p)}</text>`,
+      );
+    });
+  }
+
+  parts.push('</g>');
+  return parts.join('');
+}
+
+/** Pull the pixel dimensions out of an SVG produced by {@link graphToSvg}. */
+function svgDimensions(svg: string): { width: number; height: number } {
+  const w = svg.match(/<svg[^>]*\bwidth="([0-9.]+)"/);
+  const h = svg.match(/<svg[^>]*\bheight="([0-9.]+)"/);
+  return { width: w ? Number(w[1]) : 0, height: h ? Number(h[1]) : 0 };
+}
+
+/**
+ * Rasterize an SVG diagram to a PNG `Blob` by drawing it onto a canvas. The
+ * SVG carries its own background, so the PNG is opaque. `scale` (default 2)
+ * super-samples for a crisp image. Browser-only — relies on `Image`/`<canvas>`.
+ */
+export function svgToPngBlob(svg: string, scale = 2): Promise<Blob> {
+  return new Promise<Blob>((resolve, reject) => {
+    const { width, height } = svgDimensions(svg);
+    const url = URL.createObjectURL(new Blob([svg], { type: 'image/svg+xml' }));
+    const img = new Image();
+
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.max(1, Math.round(width * scale));
+        canvas.height = Math.max(1, Math.round(height * scale));
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          URL.revokeObjectURL(url);
+          reject(new Error('Canvas 2D context is unavailable'));
+          return;
+        }
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        URL.revokeObjectURL(url);
+        canvas.toBlob((blob) => {
+          if (blob) resolve(blob);
+          else reject(new Error('PNG encoding failed'));
+        }, 'image/png');
+      } catch (err) {
+        URL.revokeObjectURL(url);
+        reject(err as Error);
+      }
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Failed to render the SVG for rasterization'));
+    };
+    img.src = url;
+  });
+}

--- a/frontend/src/utils/index.test.ts
+++ b/frontend/src/utils/index.test.ts
@@ -8,6 +8,7 @@ import {
   VIZ_NODE_TYPES,
   resolveSerializedNodes,
   resolveSerializedEdges,
+  resolveDynamicOutputs,
 } from './index';
 import type { NodeDefinition, ParamDefinition, PresetDefinition } from '../types';
 
@@ -371,5 +372,55 @@ describe('resolveSerializedNodes', () => {
     expect(node.position).toEqual({ x: 0, y: 0 });
     expect((node.data as Record<string, unknown>).params).toEqual({});
     expect(node.type).toBe('baseNode');
+  });
+});
+
+describe('resolveDynamicOutputs', () => {
+  function buildDef(overrides: Partial<NodeDefinition> = {}): NodeDefinition {
+    return {
+      node_name: 'Split',
+      category: 'Tensor Operations',
+      description: '',
+      inputs: [],
+      outputs: [{ name: 'out', data_type: 'TENSOR', description: '', optional: false }],
+      params: [],
+      ...overrides,
+    };
+  }
+
+  it('returns [] when the definition is undefined', () => {
+    expect(resolveDynamicOutputs(undefined, {})).toEqual([]);
+  });
+
+  it('returns the static outputs verbatim for a non-Split node', () => {
+    const def = buildDef({ node_name: 'Add' });
+    expect(resolveDynamicOutputs(def, {})).toBe(def.outputs);
+  });
+
+  it('expands Split into N TENSOR chunk ports for a numeric chunks param', () => {
+    const ports = resolveDynamicOutputs(buildDef(), { chunks: 3 });
+    expect(ports.map((p) => p.name)).toEqual(['chunk_0', 'chunk_1', 'chunk_2']);
+    expect(ports.every((p) => p.data_type === 'TENSOR' && !p.optional)).toBe(true);
+    expect(ports[2].description).toBe('Chunk 2 of 3');
+  });
+
+  it('parses a string chunks param', () => {
+    expect(resolveDynamicOutputs(buildDef(), { chunks: '4' })).toHaveLength(4);
+  });
+
+  it('defaults to 2 chunks when the param is missing or non-numeric', () => {
+    expect(resolveDynamicOutputs(buildDef(), undefined)).toHaveLength(2);
+    expect(resolveDynamicOutputs(buildDef(), { chunks: 'abc' })).toHaveLength(2);
+  });
+
+  it('clamps chunks to the [1, 32] range', () => {
+    expect(resolveDynamicOutputs(buildDef(), { chunks: 99 })).toHaveLength(32);
+    expect(resolveDynamicOutputs(buildDef(), { chunks: 0 })).toHaveLength(1);
+    expect(resolveDynamicOutputs(buildDef(), { chunks: -5 })).toHaveLength(1);
+  });
+
+  it('strips a plugin prefix before matching the Split node name', () => {
+    const ports = resolveDynamicOutputs(buildDef({ node_name: 'foundations:Split' }), { chunks: 2 });
+    expect(ports.map((p) => p.name)).toEqual(['chunk_0', 'chunk_1']);
   });
 });

--- a/plans/export-architecture-diagram.md
+++ b/plans/export-architecture-diagram.md
@@ -1,0 +1,28 @@
+# Feature: Export tab architecture diagram (nodes + connections only)
+
+Goal: help students see an AI algorithm's structure by exporting the active
+tab as a clean diagram — **nodes + connecting lines only, no parameters**.
+
+## Approach
+Generate a standalone **SVG** directly from the live `nodes`/`edges` data
+(not a screenshot of the canvas, which carries all the param/viz clutter the
+request explicitly excludes). Pure function → fully unit-testable → vector
+output ideal for slides/handouts.
+
+## Changes
+1. `frontend/src/utils/exportDiagram.ts` — `graphToSvg(nodes, edges, opts)`:
+   - skip note nodes (annotations, not architecture)
+   - each node → rounded rect (category-colored border + faint tint) with its
+     label centered; **no params**
+   - each edge → bezier path + arrowhead (data-flow direction), colored by the
+     edge's data-type stroke (educational) with a neutral fallback
+   - bounding box + padding → viewBox; light & dark themes
+2. `frontend/src/utils/index.ts` — re-export.
+3. `Toolbar.tsx` — `handleExportDiagram` + "Export as Diagram" menu item.
+4. i18n: `toolbar.exportDiagram[.title|.empty]` in en + zh-TW.
+5. Tests: `exportDiagram.test.ts` (full coverage) + Toolbar menu tests.
+
+## Verify
+- `pnpm test` from `frontend/` (100% coverage maintained)
+- `pnpm build` (tsc) green
+- Manually open a generated SVG to eyeball it


### PR DESCRIPTION
## What

Adds an **Export Diagram** action that exports the active tab's architecture as a clean image — **nodes + their input/output ports + connections only, no parameter values**. Built so students can see an algorithm's structure at a glance and embed it in slides/handouts.

Generated straight from the node/edge data (not a DOM screenshot) → deterministic, dependency-free, crisp at any zoom.

## Highlights

- **Node cards**: bold title on top; input ports (upper rows) and output ports (lower rows) stacked in a single tall, slim column; each labelled `name : TYPE` with the **data type in bold** and a type-colored dot.
- **Edges** anchor at the exact port rows, carry small arrowheads (data-flow direction), colored by the data type they carry.
- **Auto-layout**: dagre re-lays cards left-to-right sized to the export cards, so they never overlap regardless of canvas arrangement.
- **Start nodes**: light-green box (no ports); the trigger/control edge points at the target's **top-left corner** (in green), not a data port.
- **Formats/themes**: SVG (vector) or PNG (canvas-rasterized, 2× super-sampled); light/dark themes.
- Toolbar `Export Diagram (SVG)` / `Export Diagram (PNG)` items, en + zh-TW strings.
- Closes a pre-existing coverage gap in `resolveDynamicOutputs` (Split dynamic-port branch).

## Test plan

- `pnpm test --coverage` from `frontend/`: **1564 tests pass, 100%** statements/branches/functions/lines.
- `pnpm build` (tsc + vite) green.
- Verified generated SVGs on realistic graphs: 0 overlaps, correct port/type rendering, Start box green + trigger-to-corner, bold types, centered Start title, equal port-section padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)