### PR TITLE
Add/i2 nodes

### DIFF
--- a/backend/app/nodes/classical/random_forest_classifier_node.py
+++ b/backend/app/nodes/classical/random_forest_classifier_node.py
@@ -1,0 +1,125 @@
+"""RandomForestClassifierNode — 隨機森林分類器（sklearn）。
+
+補上 classical 類原本缺的隨機森林：多棵決策樹各自在隨機子集上訓練、預測時投票。
+比單棵決策樹平滑、穩定（重跑種子形狀變化小），是決策樹家族最常用的集成版。
+
+介面與其他 classical 分類器一致（`SVMClassifier` / `DecisionTreeClassifier` /
+`KNN`）：吃 `x_train, y_train(標籤), x_query`，吐 `predictions` / `probabilities` /
+`classes`，可在同一條 pipeline 上直接互換。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class RandomForestClassifierNode(BaseNode):
+    NODE_NAME = "RandomForestClassifier"
+    CATEGORY = "Classical"
+    DESCRIPTION = (
+        "隨機森林分類器（sklearn）：多棵決策樹投票，比單棵樹平滑、穩定。介面與 "
+        "SVMClassifier / DecisionTreeClassifier / KNN 一致（吃標籤、吐標籤），可直接互換。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="x_train", data_type=DataType.TENSOR, description="訓練特徵 [N, F]。"),
+            PortDefinition(name="y_train", data_type=DataType.LIST, description="訓練標籤（長度 N）。"),
+            PortDefinition(name="x_query", data_type=DataType.TENSOR, description="要分類的查詢特徵 [M, F]。"),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="predictions", data_type=DataType.LIST, description="每筆查詢的預測標籤。"),
+            PortDefinition(name="probabilities", data_type=DataType.TENSOR, description="各類別的投票機率 [M, C]。"),
+            PortDefinition(name="classes", data_type=DataType.LIST, description="類別標籤，與 probabilities 欄序一致（排序後）。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="n_estimators",
+                param_type=ParamType.INT,
+                default=100,
+                min_value=1,
+                description="森林裡的樹數量。越多通常越穩、越慢。",
+            ),
+            ParamDefinition(
+                name="max_depth",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description="每棵樹的最大深度，0 = 不限。",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=0,
+                description="隨機種子，固定後結果可重現。",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import numpy as np
+        from sklearn.ensemble import RandomForestClassifier
+
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError("RandomForestClassifier requires `x_train`, `y_train`, and `x_query` inputs.")
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+        x_train_np = x_train.detach().cpu().float().numpy()
+        x_query_np = x_query.detach().cpu().float().numpy()
+
+        labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
+        labels = [str(l) for l in labels]
+        if x_train_np.shape[0] != len(labels):
+            raise ValueError(
+                f"RandomForestClassifier: features and labels length mismatch — "
+                f"{x_train_np.shape[0]} rows vs {len(labels)} labels."
+            )
+
+        n_estimators = max(1, int(params.get("n_estimators", 100)))
+        depth = int(params.get("max_depth", 0))
+        seed = int(params.get("seed", 0))
+
+        clf = RandomForestClassifier(
+            n_estimators=n_estimators,
+            max_depth=(None if depth <= 0 else depth),
+            random_state=seed,
+        )
+        clf.fit(x_train_np, labels)
+        predictions = [str(p) for p in clf.predict(x_query_np)]
+        proba = clf.predict_proba(x_query_np)
+        classes = [str(c) for c in clf.classes_.tolist()]
+
+        return {
+            "predictions": predictions,
+            "probabilities": torch.from_numpy(np.asarray(proba, dtype=np.float32)).float(),
+            "classes": classes,
+        }

--- a/backend/app/nodes/training/evaluate_model_node.py
+++ b/backend/app/nodes/training/evaluate_model_node.py
@@ -1,0 +1,108 @@
+"""EvaluateModelNode — 算一個訓練好的分類模型在某個 dataset 上的準確率。
+
+通用訓練流原本只到「訓練」（Dataset → DataLoader → Optimizer → Loss → TrainingLoop），
+缺一塊「評估」：把訓練好的 model 拿來在測試集上跑一遍、看分對幾成。這顆補上那塊。
+
+吃一個 `model`（任何吃 batch、吐 [B, C] logits 的分類網路）和一個 `dataset`
+（如 Dataset 節點載入的 MNIST 測試集），內部建一個 DataLoader 跑完整個資料集，
+對每筆取 argmax 當預測、跟標籤比，輸出準確率。對應教材 I2-4：訓練完 MNIST MLP 後
+用它看驗證準確率有沒有到約 98%。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class EvaluateModelNode(BaseNode):
+    NODE_NAME = "EvaluateModel"
+    CATEGORY = "Training"
+    DESCRIPTION = (
+        "算訓練好的分類模型在一個 dataset 上的準確率。吃 model + dataset，內部建 "
+        "DataLoader 跑完整個資料集、對每筆取 argmax 跟標籤比，輸出 accuracy / correct / total。"
+        "補上通用訓練流缺的「評估」那一塊（對應 I2-4 看 MNIST 測試準確率）。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="model", data_type=DataType.MODEL, description="訓練好的分類模型（吃 batch、吐 [B, C] logits）。"),
+            PortDefinition(name="dataset", data_type=DataType.DATASET, description="要評估的資料集（如 Dataset 節點的 MNIST test）。"),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="accuracy", data_type=DataType.SCALAR, description="準確率，落在 [0, 1]。"),
+            PortDefinition(name="correct", data_type=DataType.SCALAR, description="分對的筆數。"),
+            PortDefinition(name="total", data_type=DataType.SCALAR, description="總筆數。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="batch_size",
+                param_type=ParamType.INT,
+                default=256,
+                min_value=1,
+                description="評估時每批跑幾筆（不影響結果，只影響速度/記憶體）。",
+            ),
+            ParamDefinition(
+                name="device",
+                param_type=ParamType.SELECT,
+                default="cpu",
+                options=["cpu", "cuda"],
+                description="跑在 cpu 還是 cuda。",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import torch
+        from torch.utils.data import DataLoader
+
+        model = inputs.get("model")
+        dataset = inputs.get("dataset")
+        if model is None:
+            raise ValueError("EvaluateModel requires a `model` input.")
+        if dataset is None:
+            raise ValueError("EvaluateModel requires a `dataset` input.")
+
+        batch_size = max(1, int(params.get("batch_size", 256)))
+        device = str(params.get("device", "cpu"))
+        if device == "cuda" and not torch.cuda.is_available():
+            device = "cpu"
+
+        loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
+        model = model.to(device)
+        model.eval()
+
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for batch in loader:
+                x, y = batch[0], batch[1]
+                x = x.to(device)
+                y = torch.as_tensor(y).to(device)
+                logits = model(x)
+                pred = logits.argmax(dim=1)
+                correct += int((pred == y).sum().item())
+                total += int(y.numel())
+
+        accuracy = float(correct) / float(total) if total else 0.0
+        return {"accuracy": accuracy, "correct": int(correct), "total": int(total)}

--- a/backend/app/nodes/utility/decision_boundary_node.py
+++ b/backend/app/nodes/utility/decision_boundary_node.py
@@ -1,0 +1,143 @@
+"""DecisionBoundaryNode — 畫一個已訓練分類器的 2D 決策邊界（base64 PNG）。
+
+給 **I2** 用：把整個 2D 平面鋪成密格、每一點都丟給分類器問「這裡會被分成哪一
+類」，染色後就看到分類器的「形狀偏好」——KNN 的邊界彎彎曲曲貼著資料、線性 /
+邏輯斯是一條直線。這正是「準確率數字一樣、但邊界形狀不同」唯一看得出來的地方。
+
+它**吃 `Classifier` 節點吐出的 `model`**（接在分類器後面），所以換 Classifier 的
+kind、邊界就跟著換——真正做到「只改一個下拉選單」。另外吃 `x_train` / `y_train`
+用來決定畫布範圍、並把訓練點疊在邊界上。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class DecisionBoundaryNode(BaseNode):
+    NODE_NAME = "DecisionBoundary"
+    CATEGORY = "Utility"
+    DESCRIPTION = (
+        "畫已訓練分類器的 2D 決策邊界：吃 Classifier 的 model，把平面鋪成密格、每點"
+        "問分類器分到哪一類，染色成區域，再疊上訓練點。接在 Classifier 後面，換 kind "
+        "邊界就跟著換。看「同一份資料、不同分類器」的邊界形狀差異。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="model", data_type=DataType.MODEL, description="Classifier 節點吐出的 model（訓練好的分類器）。"),
+            PortDefinition(name="x_train", data_type=DataType.TENSOR, description="訓練特徵 [N, 2]（決定畫布範圍、疊點；只支援 2D）。"),
+            PortDefinition(name="y_train", data_type=DataType.LIST, description="訓練標籤（長度 N，給疊點上色）。"),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="image", data_type=DataType.STRING, description="base64 編碼的 PNG 決策邊界圖。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="grid_steps",
+                param_type=ParamType.INT,
+                default=200,
+                min_value=20,
+                max_value=500,
+                description="每軸鋪幾格（越大邊界越平滑、越慢）。",
+            ),
+            ParamDefinition(name="title", param_type=ParamType.STRING, default="", description="圖標題。"),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import base64
+        import io
+
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from matplotlib.colors import ListedColormap
+        import numpy as np
+
+        model = inputs.get("model")
+        x = inputs.get("x_train")
+        y = inputs.get("y_train")
+        if model is None or not hasattr(model, "predict"):
+            raise ValueError(
+                "DecisionBoundary needs a `model` input — connect a Classifier node's `model` output."
+            )
+        if x is None or y is None:
+            raise ValueError("DecisionBoundary requires `x_train` and `y_train` inputs.")
+
+        if hasattr(x, "detach"):
+            x_np = x.detach().cpu().float().numpy()
+        else:
+            x_np = np.asarray(x, dtype=float)
+        x_np = np.atleast_2d(x_np)
+        if x_np.ndim != 2 or x_np.shape[1] != 2:
+            raise ValueError(
+                f"DecisionBoundary only supports 2D features [N, 2]; got {tuple(x_np.shape)}."
+            )
+        labels = y.tolist() if hasattr(y, "tolist") else list(y)
+        labels = [str(l) for l in labels]
+
+        steps = max(20, min(500, int(params.get("grid_steps", 200))))
+        title = str(params.get("title", ""))
+
+        classes = sorted(set(labels))
+        idx = {c: i for i, c in enumerate(classes)}
+
+        pad_x = 0.5 + 0.05 * (x_np[:, 0].max() - x_np[:, 0].min())
+        pad_y = 0.5 + 0.05 * (x_np[:, 1].max() - x_np[:, 1].min())
+        x_min, x_max = x_np[:, 0].min() - pad_x, x_np[:, 0].max() + pad_x
+        y_min, y_max = x_np[:, 1].min() - pad_y, x_np[:, 1].max() + pad_y
+        xx, yy = np.meshgrid(
+            np.linspace(x_min, x_max, steps),
+            np.linspace(y_min, y_max, steps),
+        )
+        grid = np.c_[xx.ravel(), yy.ravel()]
+
+        grid_pred = model.predict(grid)
+        zz = np.array([idx.get(str(p), 0) for p in grid_pred]).reshape(xx.shape)
+
+        cmap = plt.get_cmap("tab10")
+        colors = [cmap(i % 10) for i in range(len(classes))]
+        region_cmap = ListedColormap(colors)
+
+        fig, ax = plt.subplots(figsize=(6, 6))
+        ax.contourf(xx, yy, zz, levels=np.arange(-0.5, len(classes), 1.0), cmap=region_cmap, alpha=0.3)
+        arr = np.asarray(labels)
+        for i, c in enumerate(classes):
+            mask = arr == c
+            ax.scatter(x_np[mask, 0], x_np[mask, 1], s=18, color=colors[i], edgecolor="white", linewidth=0.4, label=c)
+        ax.legend(title="class", loc="best", fontsize=8)
+        ax.set_xlabel("x0")
+        ax.set_ylabel("x1")
+        ax.set_xlim(x_min, x_max)
+        ax.set_ylim(y_min, y_max)
+        if title:
+            ax.set_title(title)
+        fig.tight_layout()
+
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=100)
+        plt.close(fig)
+        buf.seek(0)
+        return {"image": base64.b64encode(buf.read()).decode("utf-8")}

--- a/backend/app/nodes/utility/decision_boundary_node.py
+++ b/backend/app/nodes/utility/decision_boundary_node.py
@@ -56,6 +56,12 @@ class DecisionBoundaryNode(BaseNode):
                 max_value=500,
                 description="每軸鋪幾格（越大邊界越平滑、越慢）。",
             ),
+            ParamDefinition(
+                name="show_support_vectors",
+                param_type=ParamType.BOOL,
+                default=False,
+                description="標出支持向量（只有 SVM 的 model 帶這個資訊；其他分類器會自動忽略）。",
+            ),
             ParamDefinition(name="title", param_type=ParamType.STRING, default="", description="圖標題。"),
         ]
 
@@ -127,6 +133,16 @@ class DecisionBoundaryNode(BaseNode):
         for i, c in enumerate(classes):
             mask = arr == c
             ax.scatter(x_np[mask, 0], x_np[mask, 1], s=18, color=colors[i], edgecolor="white", linewidth=0.4, label=c)
+
+        if bool(params.get("show_support_vectors", False)):
+            sv = getattr(model, "support_vectors", None)
+            if sv is not None and len(sv) > 0:
+                sv = np.asarray(sv, dtype=float)
+                ax.scatter(
+                    sv[:, 0], sv[:, 1], s=140, facecolors="none",
+                    edgecolors="black", linewidths=1.6, label="support vectors",
+                )
+
         ax.legend(title="class", loc="best", fontsize=8)
         ax.set_xlabel("x0")
         ax.set_ylabel("x1")

--- a/backend/app/nodes/utility/scatter_plot_2d_node.py
+++ b/backend/app/nodes/utility/scatter_plot_2d_node.py
@@ -1,0 +1,110 @@
+"""ScatterPlot2DNode — 把 2D 點雲依類別上色畫成散點圖（base64 PNG）。
+
+給 **I2** 用：`SyntheticDataset` 輸出 `(N, 2)` 特徵 + 標籤，接這顆就能讓學生「看到
+資料分布」——兩類點落在平面哪裡、能不能用一條直線分開。輸出與 `Visualize` 一致，
+是一張 base64 編碼的 PNG，可直接在節點上預覽。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class ScatterPlot2DNode(BaseNode):
+    NODE_NAME = "ScatterPlot2D"
+    CATEGORY = "Utility"
+    DESCRIPTION = (
+        "把 (N, 2) 的 2D 點雲畫成散點圖，依 labels 給每一類不同顏色，輸出 base64 PNG。"
+        "給分類資料看分布用：接在 SyntheticDataset 之後就能看到各類點落在平面哪裡。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="points", data_type=DataType.TENSOR, description="2D 點，shape [N, 2]。"),
+            PortDefinition(
+                name="labels",
+                data_type=DataType.LIST,
+                description="每點的類別標籤（長度 N）；沒接就全部畫成同一色。",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="image", data_type=DataType.STRING, description="base64 編碼的 PNG 散點圖。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(name="title", param_type=ParamType.STRING, default="", description="圖標題。"),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import base64
+        import io
+
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+
+        pts = inputs.get("points")
+        if pts is None:
+            raise ValueError("ScatterPlot2D requires a `points` input of shape [N, 2].")
+        if hasattr(pts, "detach"):
+            pts = pts.detach().cpu().numpy()
+        else:
+            pts = np.asarray(pts, dtype=float)
+        pts = np.atleast_2d(pts)
+        if pts.ndim != 2 or pts.shape[1] != 2:
+            raise ValueError(
+                f"ScatterPlot2D expects points of shape [N, 2]; got {tuple(pts.shape)}."
+            )
+
+        labels = inputs.get("labels")
+        title = str(params.get("title", ""))
+
+        fig, ax = plt.subplots(figsize=(6, 6))
+        if labels is None:
+            ax.scatter(pts[:, 0], pts[:, 1], s=18, alpha=0.8)
+        else:
+            labels_list = labels.tolist() if hasattr(labels, "tolist") else list(labels)
+            labels_s = [str(l) for l in labels_list]
+            classes = sorted(set(labels_s))
+            cmap = plt.get_cmap("tab10")
+            arr = np.asarray(labels_s)
+            for i, c in enumerate(classes):
+                mask = arr == c
+                ax.scatter(pts[mask, 0], pts[mask, 1], s=18, alpha=0.8, color=cmap(i % 10), label=c)
+            ax.legend(title="class", loc="best", fontsize=8)
+
+        ax.set_xlabel("x0")
+        ax.set_ylabel("x1")
+        if title:
+            ax.set_title(title)
+        ax.set_aspect("equal", adjustable="datalim")
+        fig.tight_layout()
+
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=100)
+        plt.close(fig)
+        buf.seek(0)
+        return {"image": base64.b64encode(buf.read()).decode("utf-8")}

--- a/plugins/edu/cdui.plugin.toml
+++ b/plugins/edu/cdui.plugin.toml
@@ -2,7 +2,7 @@
 id              = "edu"
 name            = "EDU — 動手做教學節點"
 version         = "0.1.0"
-description     = "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). Each node exposes its intermediate steps in verbose mode so the Teaching Inspector can show the work."
+description     = "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). I2: Classifier (可切換 knn / linear / logistic 的分類器). Each node exposes its intermediate steps in verbose mode so the Teaching Inspector can show the work."
 schema_version  = 1
 requires_codefyui = ">=0.2.0"
 
@@ -10,8 +10,8 @@ requires_codefyui = ">=0.2.0"
 nodes_dir = "nodes"
 
 [lessons]
-chapters = ["I1"]
-lessons  = ["I1-1", "I1-2", "I1-3"]
+chapters = ["I1", "I2"]
+lessons  = ["I1-1", "I1-2", "I1-3", "I2-1"]
 
 # SentenceEmbedding 用 model2vec 算真正帶語意的句子向量（純 CPU、靜態嵌入）。
 # `cdui plugin install edu` 會自動把它裝進 codefyui 的 venv。

--- a/plugins/edu/cdui.plugin.toml
+++ b/plugins/edu/cdui.plugin.toml
@@ -2,7 +2,7 @@
 id              = "edu"
 name            = "EDU — 動手做教學節點"
 version         = "0.1.0"
-description     = "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). I2: Classifier (可切換 knn / linear / logistic 的分類器), AdvancedClassifier (可切換 svm / tree / rf 的進階分類器). Each node exposes its intermediate steps in verbose mode so the Teaching Inspector can show the work."
+description     = "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). I2: Classifier (可切換 knn / linear / logistic 的分類器), AdvancedClassifier (可切換 svm / tree / rf 的進階分類器), FFNLayer / ActivationLayer / TrainAndEvaluate (堆疊式 MLP 積木 + 訓練節點). Each node exposes its intermediate steps in verbose mode so the Teaching Inspector can show the work."
 schema_version  = 1
 requires_codefyui = ">=0.2.0"
 
@@ -11,7 +11,7 @@ nodes_dir = "nodes"
 
 [lessons]
 chapters = ["I1", "I2"]
-lessons  = ["I1-1", "I1-2", "I1-3", "I2-1"]
+lessons  = ["I1-1", "I1-2", "I1-3", "I2-1", "I2-2", "I2-3"]
 
 # SentenceEmbedding 用 model2vec 算真正帶語意的句子向量（純 CPU、靜態嵌入）。
 # `cdui plugin install edu` 會自動把它裝進 codefyui 的 venv。

--- a/plugins/edu/cdui.plugin.toml
+++ b/plugins/edu/cdui.plugin.toml
@@ -2,7 +2,7 @@
 id              = "edu"
 name            = "EDU — 動手做教學節點"
 version         = "0.1.0"
-description     = "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). I2: Classifier (可切換 knn / linear / logistic 的分類器). Each node exposes its intermediate steps in verbose mode so the Teaching Inspector can show the work."
+description     = "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). I2: Classifier (可切換 knn / linear / logistic 的分類器), AdvancedClassifier (可切換 svm / tree / rf 的進階分類器). Each node exposes its intermediate steps in verbose mode so the Teaching Inspector can show the work."
 schema_version  = 1
 requires_codefyui = ">=0.2.0"
 

--- a/plugins/edu/nodes/activation_layer_node.py
+++ b/plugins/edu/nodes/activation_layer_node.py
@@ -1,0 +1,89 @@
+"""ActivationLayerNode — 在 MLP 堆疊裡夾一個激活函數（非線性）。
+
+對應教材 **I2-3**：神經網路「有意義的深度」全靠層與層之間那個非線性。這顆就是
+那個非線性積木——把它夾在兩個 `FFNLayer` 之間，整個堆疊才彎得起來。
+
+故意做成**獨立一顆**（而不是塞進 FFNLayer），這樣「拿掉激活」這個關鍵實驗就只是
+把 `function` 設成 `identity`——你會親眼看到不管堆幾層，網路都塌回一條直線、同心圓
+退回約 50%。
+
+跟 FFNLayer 一樣傳「正在組裝的網路」：往尾端加一個激活模組。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class ActivationLayerNode(BaseNode):
+    NODE_NAME = "ActivationLayer"
+    CATEGORY = "EDU"
+    DESCRIPTION = (
+        "在 MLP 堆疊裡夾一個激活函數（非線性）。夾在兩個 FFNLayer 之間，堆疊才彎得起來。"
+        "function 設 identity = 等於沒有激活，堆幾層都會塌回一條直線（I2-3 的關鍵實驗）。"
+        "跟 FFNLayer 一樣傳「正在組裝的網路」。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="model",
+                data_type=DataType.MODEL,
+                description="上游正在組裝的網路（通常接在一個 FFNLayer 後面）。",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="model", data_type=DataType.MODEL, description="尾端加上一個激活函數後的網路。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="function",
+                param_type=ParamType.SELECT,
+                default="relu",
+                options=["relu", "tanh", "sigmoid", "identity"],
+                description="激活函數。relu / tanh 帶非線性；sigmoid 兩端梯度易消失；identity = 沒有激活（讓堆疊塌成線性）。",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import torch.nn as nn
+
+        prev = inputs.get("model")
+        if not isinstance(prev, nn.Module):
+            raise ValueError(
+                "ActivationLayer needs a `model` input — connect it after an FFNLayer."
+            )
+        fn = str(params.get("function", "relu"))
+        act = {
+            "relu": nn.ReLU(),
+            "tanh": nn.Tanh(),
+            "sigmoid": nn.Sigmoid(),
+            "identity": nn.Identity(),
+        }.get(fn)
+        if act is None:
+            raise ValueError(f"ActivationLayer: unknown function {fn!r}.")
+        modules = list(prev.children())
+        modules.append(act)
+        return {"model": nn.Sequential(*modules)}

--- a/plugins/edu/nodes/advanced_classifier_node.py
+++ b/plugins/edu/nodes/advanced_classifier_node.py
@@ -1,0 +1,171 @@
+"""AdvancedClassifierNode — 一顆可切換 SVM / 決策樹 / 隨機森林的進階分類器。
+
+對應教材 **I2-2**：C2-3 的兩種「比線性聰明」的世界觀——SVM（升維後一刀切，
+邊界是平滑曲線）與決策樹（軸對齊切很多刀，邊界是階梯方框），再加上決策樹的
+集成版隨機森林。跟 I2-1 的 `Classifier`（knn / linear / logistic）刻意分成兩顆，
+這樣 I2-2 的圖一眼就跟 I2-1 不同。
+
+介面跟 `Classifier` 一致：吃 `x_train, y_train(標籤), x_query`，吐
+`predictions(標籤)` 與 `model`。`model` 餵給 `DecisionBoundary` 就能畫邊界；
+SVM 的 model 還帶著支持向量座標，搭配 DecisionBoundary 的「標出支持向量」選配
+就能把決定邊界的那幾顆點圈出來。
+
+三種 kind：
+* svm  — sklearn SVC（kernel 選 rbf / linear / poly；rbf 解同心圓、linear 退回直線）
+* tree — sklearn DecisionTreeClassifier（max_depth 控制切幾層，0=不限；太深會過擬合）
+* rf   — sklearn RandomForestClassifier（n_estimators 棵樹投票，比單棵穩）
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class _FittedAdvanced:
+    """包住已訓練的進階分類器，統一 ``predict(X) -> 標籤list``，並在 SVM 時帶出支持向量。"""
+
+    def __init__(self, estimator: Any, classes: list[str]) -> None:
+        self.estimator = estimator
+        self.classes = list(classes)
+        # SVC 才有 support_vectors_；其餘分類器是 None，DecisionBoundary 會自動忽略。
+        sv = getattr(estimator, "support_vectors_", None)
+        self.support_vectors = None if sv is None else sv
+
+    def predict(self, x: Any) -> list[str]:
+        import numpy as np
+
+        return [str(p) for p in self.estimator.predict(np.asarray(x, dtype=float))]
+
+
+class AdvancedClassifierNode(BaseNode):
+    NODE_NAME = "AdvancedClassifier"
+    CATEGORY = "EDU"
+    DESCRIPTION = (
+        "一顆可切換的進階分類器：kind 選 svm / tree / rf。吃 x_train,y_train(標籤),x_query "
+        "→ predictions(標籤)，另吐 model 給 DecisionBoundary 畫邊界（SVM 的 model 還帶支持"
+        "向量）。對應 I2-2 SVM 的 kernel 與決策樹 / 隨機森林。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="x_train", data_type=DataType.TENSOR, description="訓練特徵 [N, F]。"),
+            PortDefinition(name="y_train", data_type=DataType.LIST, description="訓練標籤（長度 N）。"),
+            PortDefinition(name="x_query", data_type=DataType.TENSOR, description="要分類的查詢特徵 [M, F]。"),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="predictions", data_type=DataType.LIST, description="每筆查詢的預測標籤。"),
+            PortDefinition(name="classes", data_type=DataType.LIST, description="類別標籤（排序後）。"),
+            PortDefinition(name="model", data_type=DataType.MODEL, description="訓練好的分類器包裝，接給 DecisionBoundary 畫邊界。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="kind",
+                param_type=ParamType.SELECT,
+                default="SVM",
+                options=["SVM", "Decision Tree", "Random Forest"],
+                description="進階分類器種類：SVM 支持向量機、Decision Tree 決策樹、Random Forest 隨機森林。",
+            ),
+            ParamDefinition(
+                name="kernel",
+                param_type=ParamType.SELECT,
+                default="rbf",
+                options=["rbf", "linear", "poly"],
+                description="SVM 的 kernel（只有 kind=SVM 用到）。rbf 能解同心圓、linear 退回直線。",
+                visible_when={"kind": "SVM"},
+            ),
+            ParamDefinition(
+                name="max_depth",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description="決策樹最大深度，0 = 不限（只有 kind=Decision Tree 用到）。太深會過擬合。",
+                visible_when={"kind": "Decision Tree"},
+            ),
+            ParamDefinition(
+                name="n_estimators",
+                param_type=ParamType.INT,
+                default=50,
+                min_value=1,
+                description="隨機森林的樹數量（只有 kind=Random Forest 用到）。越多通常越穩、越慢。",
+                visible_when={"kind": "Random Forest"},
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError("AdvancedClassifier requires `x_train`, `y_train`, and `x_query` inputs.")
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+        x_train_np = x_train.detach().cpu().float().numpy()
+        x_query_np = x_query.detach().cpu().float().numpy()
+
+        labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
+        labels = [str(l) for l in labels]
+        if x_train_np.shape[0] != len(labels):
+            raise ValueError(
+                f"AdvancedClassifier: features and labels length mismatch — "
+                f"{x_train_np.shape[0]} rows vs {len(labels)} labels."
+            )
+
+        kind = str(params.get("kind", "SVM"))
+        classes = sorted(set(labels))
+
+        if kind == "SVM":
+            from sklearn.svm import SVC
+
+            kernel = str(params.get("kernel", "rbf"))
+            est = SVC(kernel=kernel)
+        elif kind == "Decision Tree":
+            from sklearn.tree import DecisionTreeClassifier
+
+            depth = int(params.get("max_depth", 0))
+            est = DecisionTreeClassifier(max_depth=(None if depth <= 0 else depth), random_state=0)
+        elif kind == "Random Forest":
+            from sklearn.ensemble import RandomForestClassifier
+
+            n = max(1, int(params.get("n_estimators", 50)))
+            est = RandomForestClassifier(n_estimators=n, random_state=0)
+        else:
+            raise ValueError(
+                f"AdvancedClassifier: unknown kind {kind!r}. Choose 'SVM' / 'Decision Tree' / 'Random Forest'."
+            )
+
+        est.fit(x_train_np, labels)
+        predictions = [str(p) for p in est.predict(x_query_np)]
+        model = _FittedAdvanced(est, classes)
+
+        return {
+            "predictions": predictions,
+            "classes": classes,
+            "model": model,
+        }

--- a/plugins/edu/nodes/classifier_node.py
+++ b/plugins/edu/nodes/classifier_node.py
@@ -1,0 +1,171 @@
+"""ClassifierNode — 一顆可切換 KNN / 線性 / 邏輯斯的分類器。
+
+對應教材 **I2-1**：C2-2 的核心是「很多分類器共用同一條 pipeline，只差中間那塊」。
+這顆把三種經典分類器收成**一顆節點 + 一個下拉選單**——`kind` 選 knn / linear /
+logistic，行為就跟對應的單獨節點一模一樣。學生只要改下拉、不必重拉節點，就能驗證
+「只換中間這顆、其餘不動」。
+
+介面：吃 `x_train, y_train(標籤), x_query`，吐 `predictions(標籤)`。另外吐一個
+`model` 輸出（訓練好的分類器包裝），餵給 `DecisionBoundary` 就能畫出「這一顆」的
+決策邊界——所以邊界節點接在分類器後面、換 kind 邊界也跟著換。
+
+三種 kind：
+* knn      — sklearn KNeighborsClassifier（吃 k 個鄰居投票）
+* logistic — sklearn LogisticRegression（內積 + sigmoid）
+* linear   — 線性回歸當分類器（對 one-hot 標籤做最小平方 + argmax）
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class _FittedClassifier:
+    """包住已訓練的分類器，提供統一的 ``predict(X) -> 標籤list``。
+
+    給 ``DecisionBoundary`` 用：不管底層是 knn / logistic（sklearn 直接吐標籤）
+    還是 linear（one-hot 回歸 + argmax），對外都是「吃 [M, F]、吐 M 個標籤」。
+    """
+
+    def __init__(self, kind: str, estimator: Any, classes: list[str]) -> None:
+        self.kind = kind
+        self.estimator = estimator
+        self.classes = list(classes)
+
+    def predict(self, x: Any) -> list[str]:
+        import numpy as np
+
+        feats = np.asarray(x, dtype=float)
+        if self.kind == "linear":
+            scores = np.atleast_2d(self.estimator.predict(feats))
+            idx = scores.argmax(axis=1)
+            return [self.classes[int(i)] for i in idx]
+        return [str(p) for p in self.estimator.predict(feats)]
+
+
+class ClassifierNode(BaseNode):
+    NODE_NAME = "Classifier"
+    CATEGORY = "EDU"
+    DESCRIPTION = (
+        "一顆可切換的分類器：kind 選 knn / linear / logistic，行為就跟對應的單獨節點"
+        "一樣（吃 x_train,y_train(標籤),x_query → predictions(標籤)）。另吐 model 給"
+        "DecisionBoundary 畫邊界。對應 I2-1「只換中間這顆、其餘不動」。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="x_train", data_type=DataType.TENSOR, description="訓練特徵 [N, F]。"),
+            PortDefinition(name="y_train", data_type=DataType.LIST, description="訓練標籤（長度 N）。"),
+            PortDefinition(name="x_query", data_type=DataType.TENSOR, description="要分類的查詢特徵 [M, F]。"),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="predictions", data_type=DataType.LIST, description="每筆查詢的預測標籤。"),
+            PortDefinition(name="probabilities", data_type=DataType.TENSOR, description="每類分數 [M, C]（knn/logistic 是機率，linear 是回歸分數）。"),
+            PortDefinition(name="classes", data_type=DataType.LIST, description="類別標籤，與 probabilities 欄序一致（排序後）。"),
+            PortDefinition(name="model", data_type=DataType.MODEL, description="訓練好的分類器包裝，接給 DecisionBoundary 畫邊界。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="kind",
+                param_type=ParamType.SELECT,
+                default="knn",
+                options=["knn", "linear", "logistic"],
+                description="要用哪一種分類器：knn 鄰居投票、linear 線性回歸當分類器、logistic 邏輯斯回歸。",
+            ),
+            ParamDefinition(
+                name="n_neighbors",
+                param_type=ParamType.INT,
+                default=5,
+                min_value=1,
+                description="KNN 的鄰居數 k（只有 kind=knn 時用到）。",
+                visible_when={"kind": "knn"},
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import numpy as np
+
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError("Classifier requires `x_train`, `y_train`, and `x_query` inputs.")
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+        x_train_np = x_train.detach().cpu().float().numpy()
+        x_query_np = x_query.detach().cpu().float().numpy()
+
+        labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
+        labels = [str(l) for l in labels]
+        if x_train_np.shape[0] != len(labels):
+            raise ValueError(
+                f"Classifier: features and labels length mismatch — "
+                f"{x_train_np.shape[0]} rows vs {len(labels)} labels."
+            )
+
+        kind = str(params.get("kind", "knn"))
+        classes = sorted(set(labels))
+
+        if kind == "knn":
+            from sklearn.neighbors import KNeighborsClassifier
+
+            k = max(1, min(int(params.get("n_neighbors", 5)), len(labels)))
+            est = KNeighborsClassifier(n_neighbors=k)
+            est.fit(x_train_np, labels)
+            predictions = [str(p) for p in est.predict(x_query_np)]
+            proba = est.predict_proba(x_query_np)
+        elif kind == "logistic":
+            from sklearn.linear_model import LogisticRegression
+
+            est = LogisticRegression(max_iter=1000)
+            est.fit(x_train_np, labels)
+            predictions = [str(p) for p in est.predict(x_query_np)]
+            proba = est.predict_proba(x_query_np)
+        elif kind == "linear":
+            from sklearn.linear_model import LinearRegression
+
+            one_hot = np.zeros((len(labels), len(classes)), dtype=np.float32)
+            idx = {c: i for i, c in enumerate(classes)}
+            for r, lab in enumerate(labels):
+                one_hot[r, idx[lab]] = 1.0
+            est = LinearRegression()
+            est.fit(x_train_np, one_hot)
+            proba = np.atleast_2d(est.predict(x_query_np))
+            predictions = [classes[int(i)] for i in proba.argmax(axis=1)]
+        else:
+            raise ValueError(f"Classifier: unknown kind {kind!r}. Choose knn / linear / logistic.")
+
+        model = _FittedClassifier(kind, est, classes)
+        return {
+            "predictions": [str(p) for p in predictions],
+            "probabilities": torch.from_numpy(np.asarray(proba, dtype=np.float32)).float(),
+            "classes": classes,
+            "model": model,
+        }

--- a/plugins/edu/nodes/ffn_layer_node.py
+++ b/plugins/edu/nodes/ffn_layer_node.py
@@ -1,0 +1,96 @@
+"""FFNLayerNode — 一個全連接（線性）層，串成多層 MLP 的積木。
+
+對應教材 **I2-3**：C2-4 說「神經網路 = 把線性單元堆很多層、層之間夾非線性」。這顆
+就是那個「線性」積木——一個全連接層。把它跟 `ActivationLayer` 交錯串起來，就堆出
+一個多層 MLP，最後接 `TrainAndEvaluate` 訓練。
+
+它**傳的不是 tensor、而是「正在組裝的網路」**（一個 nn.Sequential）：每接一顆
+FFNLayer 就往網路尾端加一個 `nn.Linear(in_features, out_features)`。輸入維度會**自動
+從上一層的輸出維度推得**，所以你通常只要設 `out_features`；只有第一顆（沒有上游）
+要在 `in_features` 指定輸入維度（2D 玩具資料就設 2）。
+
+每層參數量 = `out_features x in_features + out_features`，節點面板會直接顯示——這正是
+C2-5 要你會算的東西。`out_features` 就是這一層的 hidden size，越大表達力越強、參數越多。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class FFNLayerNode(BaseNode):
+    NODE_NAME = "FFNLayer"
+    CATEGORY = "EDU"
+    DESCRIPTION = (
+        "一個全連接（線性）層，串成多層 MLP 的積木。傳的是「正在組裝的網路」：每接一顆"
+        "就往尾端加一個 nn.Linear(in_features, out_features)，輸入維度自動從上一層推得"
+        "（第一顆用 in_features 參數）。跟 ActivationLayer 交錯串、最後接 TrainAndEvaluate。"
+        "面板會顯示每層參數量 = out_features x in_features + out_features。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="model",
+                data_type=DataType.MODEL,
+                description="上游正在組裝的網路；第一顆 FFNLayer 不用接，會自己開一個新網路。",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="model", data_type=DataType.MODEL, description="尾端加上一個線性層後的網路。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="in_features",
+                param_type=ParamType.INT,
+                default=2,
+                min_value=1,
+                description="輸入維度。只有第一顆 FFNLayer 會用到（2D 資料設 2）；接在別層後面時自動從上一層推得、此值忽略。",
+            ),
+            ParamDefinition(
+                name="out_features",
+                param_type=ParamType.INT,
+                default=16,
+                min_value=1,
+                description="這一層的輸出維度（hidden size）。越大表達力越強、參數越多。",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import torch.nn as nn
+
+        prev = inputs.get("model")
+        modules = list(prev.children()) if isinstance(prev, nn.Module) else []
+        # 輸入維度：從上一層的最後一個 Linear 推得；第一顆沒有上游就用 in_features 參數。
+        in_features = None
+        for m in modules:
+            if isinstance(m, nn.Linear):
+                in_features = m.out_features
+        if in_features is None:
+            in_features = max(1, int(params.get("in_features", 2)))
+        out_features = max(1, int(params.get("out_features", 16)))
+        modules.append(nn.Linear(in_features, out_features))
+        return {"model": nn.Sequential(*modules)}

--- a/plugins/edu/nodes/train_and_evaluate_node.py
+++ b/plugins/edu/nodes/train_and_evaluate_node.py
@@ -1,0 +1,166 @@
+"""TrainAndEvaluateNode — 把你堆好的 MLP 拿來訓練 + 預測（I2-3 的「result」節點）。
+
+對應教材 **I2-3**：`FFNLayer` / `ActivationLayer` 串出來的只是一個**還沒訓練**的網路
+（隨機權重，直接用會 ~50%）。這顆把它接過來，在訓練資料上跑梯度下降把它**練到會**，
+再對查詢資料預測。它把通用訓練流（Loss + Optimizer + 訓練迴圈）包在一顆裡，畫布上
+不用拉那一整坨。
+
+介面刻意跟 I2-1 的 `Classifier`、I2-2 的 `AdvancedClassifier` 一致——吐 `predictions`
+（→ Accuracy）和 `model`（→ DecisionBoundary），所以 I2-3 跟前兩章用的是同一條 pipeline，
+只是中間那塊從「現成分類器」換成「你堆的網路 + 這顆訓練節點」。
+
+自動補一個輸出層：你的 FFNLayer 都當隱藏層，這顆會在尾端補一個線性層壓到「類別數」，
+用 CrossEntropy 訓練（多類、二類都通用）。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class _FittedNet:
+    """包住訓練好的網路，提供統一的 ``predict(X) -> 標籤list`` 給 DecisionBoundary。"""
+
+    def __init__(self, net: Any, classes: list[str]) -> None:
+        self.net = net
+        self.classes = list(classes)
+
+    def predict(self, x: Any) -> list[str]:
+        import numpy as np
+        import torch
+
+        self.net.eval()
+        with torch.no_grad():
+            logits = self.net(torch.as_tensor(np.asarray(x, dtype="float32")))
+            idx = logits.argmax(dim=1).tolist()
+        return [self.classes[int(i)] for i in idx]
+
+
+class TrainAndEvaluateNode(BaseNode):
+    NODE_NAME = "TrainAndEvaluate"
+    CATEGORY = "EDU"
+    DESCRIPTION = (
+        "把 FFNLayer / ActivationLayer 堆好的網路拿來訓練 + 預測。在訓練資料上跑梯度下降"
+        "把網路練到會，再對 x_query 預測。介面跟 Classifier / AdvancedClassifier 一致："
+        "吐 predictions(→Accuracy) 和 model(→DecisionBoundary)。輸出層自動補、用 CrossEntropy 訓練。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="model", data_type=DataType.MODEL, description="FFNLayer / ActivationLayer 串好的網路（隱藏層堆疊）。"),
+            PortDefinition(name="x_train", data_type=DataType.TENSOR, description="訓練特徵 [N, F]。"),
+            PortDefinition(name="y_train", data_type=DataType.LIST, description="訓練標籤（長度 N）。"),
+            PortDefinition(name="x_query", data_type=DataType.TENSOR, description="要分類的查詢特徵 [M, F]。"),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="predictions", data_type=DataType.LIST, description="每筆查詢的預測標籤。"),
+            PortDefinition(name="classes", data_type=DataType.LIST, description="類別標籤（排序後）。"),
+            PortDefinition(name="model", data_type=DataType.MODEL, description="訓練好的網路包裝，接給 DecisionBoundary 畫邊界。"),
+            PortDefinition(name="losses", data_type=DataType.TENSOR, description="每個 epoch 的訓練 loss（可接 Visualize 看收斂）。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="epochs",
+                param_type=ParamType.INT,
+                default=400,
+                min_value=1,
+                description="訓練輪數。越多通常越收斂、越慢。",
+            ),
+            ParamDefinition(
+                name="lr",
+                param_type=ParamType.FLOAT,
+                default=0.05,
+                min_value=0.0,
+                description="學習率（梯度下降的步伐大小）。",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import torch
+        import torch.nn as nn
+
+        net_in = inputs.get("model")
+        x_train = inputs.get("x_train")
+        y_train = inputs.get("y_train")
+        x_query = inputs.get("x_query")
+        if net_in is None or not isinstance(net_in, nn.Module):
+            raise ValueError(
+                "TrainAndEvaluate needs a `model` input — connect your FFNLayer / ActivationLayer stack."
+            )
+        if x_train is None or y_train is None or x_query is None:
+            raise ValueError("TrainAndEvaluate requires `x_train`, `y_train`, and `x_query` inputs.")
+
+        if not isinstance(x_train, torch.Tensor):
+            x_train = torch.as_tensor(x_train, dtype=torch.float32)
+        if not isinstance(x_query, torch.Tensor):
+            x_query = torch.as_tensor(x_query, dtype=torch.float32)
+        x_train = x_train.float()
+        x_query = x_query.float()
+
+        labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
+        labels = [str(l) for l in labels]
+        classes = sorted(set(labels))
+        idx = {c: i for i, c in enumerate(classes)}
+        y_idx = torch.tensor([idx[l] for l in labels], dtype=torch.long)
+
+        # 把隱藏堆疊接上一個輸出層（壓到類別數）。輸入維度從堆疊最後一個 Linear 推得。
+        modules = list(net_in.children())
+        last_out = None
+        for m in modules:
+            if isinstance(m, nn.Linear):
+                last_out = m.out_features
+        if last_out is None:
+            raise ValueError(
+                "TrainAndEvaluate: the stacked model has no Linear layer — add at least one FFNLayer."
+            )
+        modules.append(nn.Linear(last_out, len(classes)))
+        net = nn.Sequential(*modules)
+
+        epochs = max(1, int(params.get("epochs", 400)))
+        lr = float(params.get("lr", 0.05))
+        opt = torch.optim.Adam(net.parameters(), lr=lr)
+        loss_fn = nn.CrossEntropyLoss()
+
+        losses: list[float] = []
+        net.train()
+        for _ in range(epochs):
+            opt.zero_grad()
+            out = net(x_train)
+            loss = loss_fn(out, y_idx)
+            loss.backward()
+            opt.step()
+            losses.append(float(loss.detach()))
+
+        net.eval()
+        with torch.no_grad():
+            pred_idx = net(x_query).argmax(dim=1).tolist()
+        predictions = [classes[int(i)] for i in pred_idx]
+
+        return {
+            "predictions": predictions,
+            "classes": classes,
+            "model": _FittedNet(net, classes),
+            "losses": torch.tensor(losses, dtype=torch.float32),
+        }

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -3,10 +3,10 @@
   "plugins": {
     "edu": {
       "name": "EDU — 動手做教學節點",
-      "description": "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). Each node exposes its intermediate steps in verbose mode.",
+      "description": "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). I2: Classifier (可切換 knn / linear / logistic 的分類器). Each node exposes its intermediate steps in verbose mode.",
       "kind": "builtin",
       "path": "plugins/edu",
-      "chapters": ["I1"]
+      "chapters": ["I1", "I2"]
     },
     "foundations": {
       "name": "Foundations — 資料表示與經典 ML",

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -3,7 +3,7 @@
   "plugins": {
     "edu": {
       "name": "EDU — 動手做教學節點",
-      "description": "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). I2: Classifier (可切換 knn / linear / logistic 的分類器), AdvancedClassifier (可切換 svm / tree / rf 的進階分類器). Each node exposes its intermediate steps in verbose mode.",
+      "description": "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). I2: Classifier (可切換 knn / linear / logistic 的分類器), AdvancedClassifier (可切換 svm / tree / rf 的進階分類器), FFNLayer / ActivationLayer / TrainAndEvaluate (堆疊式 MLP 積木 + 訓練節點). Each node exposes its intermediate steps in verbose mode.",
       "kind": "builtin",
       "path": "plugins/edu",
       "chapters": ["I1", "I2"]

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -3,7 +3,7 @@
   "plugins": {
     "edu": {
       "name": "EDU — 動手做教學節點",
-      "description": "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). I2: Classifier (可切換 knn / linear / logistic 的分類器). Each node exposes its intermediate steps in verbose mode.",
+      "description": "Hands-on teaching nodes for the textbook's I-series labs. I1: FilterRows (條件篩選表格列), SlidingWindow2D (影像滑動視窗 / 卷積), SentenceEmbedding (句子語意向量, model2vec). I2: Classifier (可切換 knn / linear / logistic 的分類器), AdvancedClassifier (可切換 svm / tree / rf 的進階分類器). Each node exposes its intermediate steps in verbose mode.",
       "kind": "builtin",
       "path": "plugins/edu",
       "chapters": ["I1", "I2"]


### PR DESCRIPTION
接續 EDU plugin(#49),為教材 I2 模組(對應 C2 經典 AI) 的四堂動手課補上所需節點。沿用同一條 pipeline 骨架:SyntheticDataset → TrainTestSplit → [分類器] → Accuracy + ScatterPlot2D /
  DecisionBoundary,每章換中間那塊。

  新增節點
   
  edu plugin(教學節點,面板 EDU 分類)
  - Classifier(I2-1)— 一顆可切換 knn / linear / logistic 的分類器,輸出 predictions + model。
  - AdvancedClassifier(I2-2)— 一顆可切換 SVM / Decision Tree / Random Forest 的進階分類器;SVM 的 model 帶支持向量座標。
  - FFNLayer / ActivationLayer / TrainAndEvaluate(I2-3)— 把神經網路「攤開」成積木:線性層、激活、訓練節點,讓學生自己堆一個 MLP 並訓練。

  內建節點(通用)
  - RandomForestClassifier(classical)— 補上 classical 缺的隨機森林,介面與 SVMClassifier / DecisionTreeClassifier 一致。
  - EvaluateModel(training)— 吃 model + dataset,跑完整資料集算準確率,補上通用訓練流缺的「評估」那一塊(I2-4 用它看 MNIST 測試準確率)。
  - ScatterPlot2D(utility)— 2D 點雲依類別上色,看資料分布。
  - DecisionBoundary(utility)— 吃 Classifier.model 畫 2D 決策邊界;支援「標出支持向量」選配(SVM 用)。

  設計原則

  - 教學專用節點放 edu plugin、通用工具放內建:Classifier / AdvancedClassifier / FFN 系列是面向教材的 → edu;RandomForestClassifier / EvaluateModel / 視覺化是通用件 → 內建。I2-4
  直接用既有的 SequentialModel + Training Pipeline preset,不另造節點。
  - 介面一致:所有分類器(含 TrainAndEvaluate)都吐 predictions(→ Accuracy)與 model(→ DecisionBoundary),所以四章共用同一條 pipeline、只換中間那顆。
  - 不含解答/資料:各題的 complete.json / starter.json 與輸入檔不進此 repo(屬課堂材料,公開 repo 不附解答)。