### PR TITLE
Add/i3 nodes

### DIFF
--- a/backend/app/nodes/data/dataset_batch_node.py
+++ b/backend/app/nodes/data/dataset_batch_node.py
@@ -1,0 +1,82 @@
+from typing import Any
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+
+class DatasetBatchNode(BaseNode):
+    NODE_NAME = "DatasetBatch"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "從資料集（如 Dataset 節點載入的 MNIST）取出一個批次，"
+        "輸出影像張量 (N, C, H, W) 與對應標籤。"
+        "用來把資料集直接餵進手搭的網路做一次前向傳遞、觀察每層 shape。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="dataset",
+                data_type=DataType.DATASET,
+                description="來源資料集（例如 Dataset 節點輸出的 MNIST）。",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="images",
+                data_type=DataType.TENSOR,
+                description="影像批次張量，形狀 (N, C, H, W)。",
+            ),
+            PortDefinition(
+                name="labels",
+                data_type=DataType.TENSOR,
+                description="對應的標籤張量，形狀 (N,)。",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="batch_size",
+                param_type=ParamType.INT,
+                default=1,
+                description="一次取幾筆樣本（決定輸出的 N）。",
+                min_value=1,
+            ),
+            ParamDefinition(
+                name="start_index",
+                param_type=ParamType.INT,
+                default=0,
+                description="從資料集的第幾筆開始取（方便換不同樣本觀察）。",
+                min_value=0,
+            ),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        import torch
+
+        dataset = inputs["dataset"]
+        batch_size = int(params.get("batch_size", 1))
+        start = int(params.get("start_index", 0))
+
+        n = len(dataset)
+        if n == 0:
+            raise ValueError("Dataset is empty.")
+
+        images: list[Any] = []
+        labels: list[int] = []
+        for offset in range(batch_size):
+            sample, label = dataset[(start + offset) % n]
+            if not torch.is_tensor(sample):
+                sample = torch.as_tensor(sample)
+            images.append(sample)
+            labels.append(int(label))
+
+        images_tensor = torch.stack(images, dim=0)
+        labels_tensor = torch.tensor(labels, dtype=torch.long)
+
+        return {"images": images_tensor, "labels": labels_tensor}

--- a/backend/app/nodes/data/dataset_batch_node.py
+++ b/backend/app/nodes/data/dataset_batch_node.py
@@ -33,7 +33,7 @@ class DatasetBatchNode(BaseNode):
             PortDefinition(
                 name="labels",
                 data_type=DataType.TENSOR,
-                description="對應的標籤張量，形狀 (N,)。",
+                description="對應的標籤：分類資料集是 (N,) 類別；分割資料集是 (N, H, W) 的逐像素遮罩。",
             ),
         ]
 
@@ -68,15 +68,25 @@ class DatasetBatchNode(BaseNode):
             raise ValueError("Dataset is empty.")
 
         images: list[Any] = []
-        labels: list[int] = []
+        labels: list[Any] = []
+        label_is_tensor = False
         for offset in range(batch_size):
             sample, label = dataset[(start + offset) % n]
             if not torch.is_tensor(sample):
                 sample = torch.as_tensor(sample)
             images.append(sample)
-            labels.append(int(label))
+            # Scalar label (classification) -> int; tensor label with spatial
+            # dims (e.g. a segmentation mask (H, W)) -> keep as a tensor.
+            if torch.is_tensor(label) and label.ndim > 0:
+                label_is_tensor = True
+                labels.append(label)
+            else:
+                labels.append(int(label))
 
         images_tensor = torch.stack(images, dim=0)
-        labels_tensor = torch.tensor(labels, dtype=torch.long)
+        if label_is_tensor:
+            labels_tensor = torch.stack(labels, dim=0)
+        else:
+            labels_tensor = torch.tensor(labels, dtype=torch.long)
 
         return {"images": images_tensor, "labels": labels_tensor}

--- a/backend/app/nodes/data/synthetic_segmentation_node.py
+++ b/backend/app/nodes/data/synthetic_segmentation_node.py
@@ -1,0 +1,150 @@
+"""SyntheticSegmentationNode — tiny synthetic image-segmentation dataset.
+
+Counterpart to :class:`SyntheticDatasetNode` (which makes 2D point clouds for
+classifiers). This makes small single-channel images with per-pixel class
+masks, so a UNet can be trained end-to-end on CPU with zero downloads:
+
+    each sample = (image  : float32 (1, H, W)  in [0, 1],
+                   mask   : int64   (H, W)     class id per pixel)
+
+Three classes by design: 0 = background, 1 = circle, 2 = rectangle. Each
+image draws a couple of random shapes; the mask labels every pixel. Designed
+for I3-2 (UNet): train a small segmentation model, then compare with / without
+skip connections.
+
+Outputs a torch ``Dataset`` so it drops straight into DataLoader / TrainingLoop
+/ EvaluateModel / DatasetBatch, exactly like the built-in ``Dataset`` node.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class _SyntheticSegDataset:
+    """A pre-generated (image, mask) dataset. Deterministic given seed."""
+
+    def __init__(self, n_samples: int, image_size: int, noise: float, seed: int):
+        import numpy as np
+        import torch
+
+        rng = np.random.default_rng(seed)
+        H = W = image_size
+        ys, xs = np.mgrid[0:H, 0:W]
+
+        self.images: list[torch.Tensor] = []
+        self.masks: list[torch.Tensor] = []
+
+        for _ in range(n_samples):
+            img = np.zeros((H, W), dtype=np.float32)
+            mask = np.zeros((H, W), dtype=np.int64)
+
+            n_shapes = int(rng.integers(1, 3))  # 1 or 2 shapes
+            for _s in range(n_shapes):
+                if rng.random() < 0.5:
+                    # circle -> class 1
+                    r = int(rng.integers(H // 8, H // 4))
+                    cy = int(rng.integers(r, H - r))
+                    cx = int(rng.integers(r, W - r))
+                    region = (ys - cy) ** 2 + (xs - cx) ** 2 <= r * r
+                    img[region] = 0.7
+                    mask[region] = 1
+                else:
+                    # rectangle -> class 2
+                    h = int(rng.integers(H // 6, H // 3))
+                    w = int(rng.integers(W // 6, W // 3))
+                    top = int(rng.integers(0, H - h))
+                    left = int(rng.integers(0, W - w))
+                    img[top:top + h, left:left + w] = 1.0
+                    mask[top:top + h, left:left + w] = 2
+
+            if noise > 0:
+                img = img + rng.normal(0.0, noise, size=img.shape).astype(np.float32)
+            img = np.clip(img, 0.0, 1.0)
+
+            self.images.append(torch.from_numpy(img).unsqueeze(0))  # (1, H, W)
+            self.masks.append(torch.from_numpy(mask))               # (H, W)
+
+    def __len__(self) -> int:
+        return len(self.images)
+
+    def __getitem__(self, idx: int):
+        return self.images[idx], self.masks[idx]
+
+
+class SyntheticSegmentationNode(BaseNode):
+    NODE_NAME = "SyntheticSegmentation"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "產生一個小型合成「影像分割」資料集（CPU 友善、免下載）：每張單通道小圖上隨機畫"
+        "圓形與方形，並附上逐像素的類別遮罩（0=背景、1=圓形、2=方形）。輸出一個資料集，"
+        "可直接接 DataLoader / TrainingLoop / EvaluateModel / DatasetBatch，用來訓練 UNet 做分割。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="dataset",
+                data_type=DataType.DATASET,
+                description="分割資料集：每筆是 (影像 (1,H,W) float、遮罩 (H,W) 整數，0/1/2 三類)。",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="image_size",
+                param_type=ParamType.INT,
+                default=64,
+                min_value=16,
+                description="正方形影像邊長（像素）。CPU 上建議 32–96。",
+            ),
+            ParamDefinition(
+                name="n_samples",
+                param_type=ParamType.INT,
+                default=200,
+                min_value=4,
+                description="產生幾張影像。",
+            ),
+            ParamDefinition(
+                name="noise",
+                param_type=ParamType.FLOAT,
+                default=0.05,
+                min_value=0.0,
+                description="加到影像上的高斯雜訊強度（不影響遮罩）。",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=42,
+                description="亂數種子；換 seed 換一批不同的圖（train / test 用不同 seed）。",
+            ),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        image_size = int(params.get("image_size", 64))
+        n_samples = int(params.get("n_samples", 200))
+        noise = float(params.get("noise", 0.05))
+        seed = int(params.get("seed", 42))
+
+        dataset = _SyntheticSegDataset(
+            n_samples=n_samples,
+            image_size=image_size,
+            noise=noise,
+            seed=seed,
+        )
+        return {"dataset": dataset}

--- a/backend/app/nodes/data/synthetic_shapes_node.py
+++ b/backend/app/nodes/data/synthetic_shapes_node.py
@@ -1,0 +1,107 @@
+"""SyntheticShapesNode — tiny image dataset for *generative* models.
+
+Where SyntheticSegmentation pairs an image with a per-pixel mask (for
+training a segmentation UNet), this node produces just images — a simple
+distribution a small diffusion model can learn to *generate*: soft
+gaussian blobs of varied position and size, on a dark background.
+
+Images are normalised to [-1, 1] (the usual range for diffusion training),
+single channel. Each sample is (image (1, H, W) float, 0) — the dummy label
+lets it flow through the standard DataLoader; diffusion training ignores it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class _SyntheticShapesDataset:
+    def __init__(self, n_samples: int, image_size: int, seed: int):
+        import numpy as np
+        import torch
+
+        rng = np.random.default_rng(seed)
+        H = image_size
+        ys, xs = np.mgrid[0:H, 0:H].astype("float32")
+        self.images: list[torch.Tensor] = []
+        margin = max(2, H // 3)
+        sig_lo, sig_hi = H / 5.0, H / 3.5
+        for _ in range(n_samples):
+            cy = rng.uniform(margin, H - margin)
+            cx = rng.uniform(margin, H - margin)
+            sig = rng.uniform(sig_lo, sig_hi)
+            blob = np.exp(-(((ys - cy) ** 2 + (xs - cx) ** 2) / (2 * sig * sig))).astype("float32")
+            img = blob * 2.0 - 1.0  # [0,1] -> [-1,1]
+            self.images.append(torch.from_numpy(img).unsqueeze(0))  # (1, H, W)
+
+    def __len__(self) -> int:
+        return len(self.images)
+
+    def __getitem__(self, idx: int):
+        return self.images[idx], 0
+
+
+class SyntheticShapesNode(BaseNode):
+    NODE_NAME = "SyntheticShapes"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "產生一個小型「影像生成」資料集（CPU 友善、免下載）：一批單通道小圖，每張上面有一個"
+        "位置、大小隨機的柔和光斑（gaussian blob），背景為暗。影像正規化到 [-1, 1]（擴散模型訓練"
+        "的慣用範圍）。用來訓練一個小型擴散模型，學會『從雜訊生成這種形狀』。輸出資料集，可接 "
+        "DataLoader / DiffusionTrainingLoop。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="dataset",
+                data_type=DataType.DATASET,
+                description="影像生成資料集：每筆是 (影像 (1,H,W) float、範圍 [-1,1])。",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="image_size",
+                param_type=ParamType.INT,
+                default=24,
+                min_value=8,
+                description="正方形影像邊長（像素）。擴散在 CPU 上偏慢，建議 16–32。",
+            ),
+            ParamDefinition(
+                name="n_samples",
+                param_type=ParamType.INT,
+                default=384,
+                min_value=8,
+                description="產生幾張影像。",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=0,
+                description="亂數種子，決定這批光斑的位置與大小。",
+            ),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        dataset = _SyntheticShapesDataset(
+            n_samples=int(params.get("n_samples", 384)),
+            image_size=int(params.get("image_size", 24)),
+            seed=int(params.get("seed", 0)),
+        )
+        return {"dataset": dataset}

--- a/backend/app/nodes/tensor_ops/argmax_node.py
+++ b/backend/app/nodes/tensor_ops/argmax_node.py
@@ -1,0 +1,54 @@
+from typing import Any
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+
+class ArgmaxNode(BaseNode):
+    NODE_NAME = "Argmax"
+    CATEGORY = "Tensor Operations"
+    DESCRIPTION = (
+        "沿指定維度取最大值的索引（argmax）。常用在分類 / 分割輸出："
+        "對 logits 取 argmax 得到預測類別。例如分割輸出 (N, C, H, W) 沿 dim=1 取 argmax，"
+        "得到每像素的類別 (N, H, W)。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="tensor", data_type=DataType.TENSOR, description="輸入張量（通常是 logits）。"),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="tensor", data_type=DataType.TENSOR, description="argmax 後的索引張量（少掉被取的那一維）。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="dim",
+                param_type=ParamType.INT,
+                default=-1,
+                description="沿哪一維取 argmax。分割輸出 (N,C,H,W) 取類別用 dim=1。",
+            ),
+            ParamDefinition(
+                name="keepdim",
+                param_type=ParamType.BOOL,
+                default=False,
+                description="是否保留被取的那一維（長度變 1）。",
+            ),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        import torch
+
+        tensor = inputs["tensor"]
+        if not torch.is_tensor(tensor):
+            tensor = torch.as_tensor(tensor)
+        dim = int(params.get("dim", -1))
+        keepdim = bool(params.get("keepdim", False))
+
+        output = torch.argmax(tensor, dim=dim, keepdim=keepdim)
+        return {"tensor": output}

--- a/backend/app/nodes/training/diffusion_training_loop_node.py
+++ b/backend/app/nodes/training/diffusion_training_loop_node.py
@@ -1,0 +1,134 @@
+"""DiffusionTrainingLoopNode — train a noise-predicting U-Net (DDPM).
+
+The generic TrainingLoop does supervised ``loss(model(x), y)``; diffusion
+training is different: for each image we pick a random timestep, add that
+much noise, and ask the model to predict the noise we added. This node
+packages that loop so a small diffusion model can be trained on CPU, then
+sampled with ``DDPMSampler``.
+
+CRITICAL: the noise schedule here (``schedule`` / ``num_timesteps`` /
+``beta_start`` / ``beta_end``) must MATCH the ``DDPMSampler`` used to sample
+afterwards, or generation will fail. The defaults (linear, T=160,
+beta_end=0.05) are chosen so the schedule both fully noises the image
+(alpha_bar_T ~ 0) and stays numerically stable in the reverse loop.
+"""
+
+import logging
+from typing import Any
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+logger = logging.getLogger(__name__)
+
+
+class DiffusionTrainingLoopNode(BaseNode):
+    NODE_NAME = "DiffusionTrainingLoop"
+    CATEGORY = "Diffusion"
+    cacheable = False
+    DESCRIPTION = (
+        "訓練一個會去雜訊的 U-Net（DDPM 訓練）。每一步：從資料取一張乾淨圖、隨機挑一個時間步 t、"
+        "加上對應強度的雜訊、讓模型預測『剛剛加了什麼雜訊』，用 MSE 比對更新權重。訓練好的 model "
+        "接 DDPMSampler 就能從純雜訊生成新圖。"
+        "注意：這裡的雜訊排程（schedule / num_timesteps / beta_start / beta_end）必須和之後取樣的 "
+        "DDPMSampler 設成一樣，否則生成會壞掉。"
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="model", data_type=DataType.MODEL, description="會去雜訊的 U-Net（如 DiffusionUNet），forward 吃 (x, t) 吐預測雜訊。"),
+            PortDefinition(name="dataset", data_type=DataType.DATASET, description="乾淨影像資料集（如 SyntheticShapes），每筆 (影像, 標籤)，標籤會被忽略。"),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="model", data_type=DataType.MODEL, description="訓練好的去雜訊模型。"),
+            PortDefinition(name="losses", data_type=DataType.TENSOR, description="每個 epoch 的平均訓練 loss。"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(name="epochs", param_type=ParamType.INT, default=200, min_value=1, description="訓練幾輪。"),
+            ParamDefinition(name="batch_size", param_type=ParamType.INT, default=32, min_value=1, description="每批幾張圖。"),
+            ParamDefinition(name="lr", param_type=ParamType.FLOAT, default=0.002, min_value=0.0, description="學習率（Adam）。"),
+            ParamDefinition(
+                name="num_timesteps", param_type=ParamType.INT, default=160, min_value=2,
+                description="擴散總步數 T。要和取樣的 DDPMSampler 的 num_steps 一致。",
+            ),
+            ParamDefinition(
+                name="schedule", param_type=ParamType.SELECT, default="linear", options=["linear", "cosine"],
+                description="雜訊排程。要和 DDPMSampler 一致。linear + beta_end=0.05 在小 T 下既能噪滿又穩定。",
+            ),
+            ParamDefinition(name="beta_start", param_type=ParamType.FLOAT, default=0.0001, min_value=0.0, description="linear 排程起始 beta（要和 DDPMSampler 一致）。"),
+            ParamDefinition(name="beta_end", param_type=ParamType.FLOAT, default=0.05, min_value=0.0, description="linear 排程結束 beta（要和 DDPMSampler 一致）。"),
+            ParamDefinition(name="device", param_type=ParamType.SELECT, default="cpu", options=["cpu", "cuda"], description="訓練裝置。"),
+            ParamDefinition(name="seed", param_type=ParamType.INT, default=0, description="亂數種子（決定每步挑的時間步與加的雜訊）。"),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any], progress_callback: Any | None = None) -> dict[str, Any]:
+        import torch
+        from torch.utils.data import DataLoader
+
+        from ..diffusion.ddpm_sampler_node import _cosine_betas, _linear_betas
+
+        model = inputs.get("model")
+        dataset = inputs.get("dataset")
+        if model is None:
+            raise ValueError("DiffusionTrainingLoop requires a `model` input.")
+        if dataset is None:
+            raise ValueError("DiffusionTrainingLoop requires a `dataset` input.")
+
+        epochs = int(params.get("epochs", 200))
+        batch_size = max(1, int(params.get("batch_size", 32)))
+        lr = float(params.get("lr", 0.002))
+        T = int(params.get("num_timesteps", 160))
+        schedule = str(params.get("schedule", "linear"))
+        beta_start = float(params.get("beta_start", 0.0001))
+        beta_end = float(params.get("beta_end", 0.05))
+        device = str(params.get("device", "cpu"))
+        seed = int(params.get("seed", 0))
+        if device == "cuda" and not torch.cuda.is_available():
+            device = "cpu"
+
+        torch.manual_seed(seed)
+        if schedule == "cosine":
+            betas = _cosine_betas(T)
+        else:
+            betas = _linear_betas(T, beta_start, beta_end)
+        alpha_bars = torch.cumprod(1.0 - betas, dim=0).to(device)
+
+        model = model.to(device)
+        model.train()
+        optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+        loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+        epoch_losses: list[float] = []
+        for epoch in range(epochs):
+            running, batches = 0.0, 0
+            for batch in loader:
+                x0 = batch[0] if isinstance(batch, (list, tuple)) else batch
+                x0 = x0.to(device).float()
+                b = x0.shape[0]
+                t = torch.randint(0, T, (b,), device=device)
+                eps = torch.randn_like(x0)
+                ab = alpha_bars[t].view(b, *([1] * (x0.dim() - 1)))
+                x_t = torch.sqrt(ab) * x0 + torch.sqrt(1.0 - ab) * eps
+                eps_hat = model(x_t, t)
+                loss = ((eps_hat - eps) ** 2).mean()
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+                running += loss.item()
+                batches += 1
+            avg = running / max(batches, 1)
+            epoch_losses.append(avg)
+            if epoch % max(1, epochs // 10) == 0 or epoch == epochs - 1:
+                logger.info("Diffusion epoch %d/%d - Loss: %.4f", epoch + 1, epochs, avg)
+            if progress_callback:
+                progress_callback({"event": "epoch", "epoch": epoch + 1, "total_epochs": epochs,
+                                   "loss": round(avg, 6), "losses": [round(l, 6) for l in epoch_losses]})
+
+        losses_tensor = torch.tensor(epoch_losses, dtype=torch.float32)
+        return {"model": model, "losses": losses_tensor}

--- a/backend/app/nodes/utility/visualize_node.py
+++ b/backend/app/nodes/utility/visualize_node.py
@@ -84,6 +84,9 @@ class VisualizeNode(BaseNode):
             fig.colorbar(im, ax=ax)
 
         elif plot_type == "image":
+            # Drop a leading batch dim of 1, e.g. (1,C,H,W) -> (C,H,W)
+            if data.ndim == 4 and data.shape[0] == 1:
+                data = data[0]
             # Render an image tensor directly: (C,H,W), (H,W,C), or (H,W)
             if data.ndim == 3 and data.shape[0] in (1, 3, 4):
                 # (C,H,W) -> (H,W,C)

--- a/backend/app/nodes/utility/visualize_node.py
+++ b/backend/app/nodes/utility/visualize_node.py
@@ -84,9 +84,32 @@ class VisualizeNode(BaseNode):
             fig.colorbar(im, ax=ax)
 
         elif plot_type == "image":
-            # Drop a leading batch dim of 1, e.g. (1,C,H,W) -> (C,H,W)
-            if data.ndim == 4 and data.shape[0] == 1:
-                data = data[0]
+            # A batch of images (N,C,H,W): N==1 -> drop batch dim; N>1 -> tile into a grid.
+            if data.ndim == 4:
+                if data.shape[0] == 1:
+                    data = data[0]
+                else:
+                    n, c = data.shape[0], data.shape[1]
+                    if c in (1, 3, 4):
+                        imgs = np.transpose(data, (0, 2, 3, 1))  # (N,H,W,C)
+                        if imgs.shape[-1] == 1:
+                            imgs = imgs[..., 0]                  # (N,H,W)
+                    else:
+                        imgs = data[:, 0]                        # take first channel
+                    cols = int(np.ceil(np.sqrt(n)))
+                    rows = int(np.ceil(n / cols))
+                    ih, iw = imgs.shape[1], imgs.shape[2]
+                    pad = 1
+                    fill = float(imgs.min())
+                    if imgs.ndim == 4:
+                        grid = np.full((rows * ih + (rows + 1) * pad, cols * iw + (cols + 1) * pad, imgs.shape[-1]), fill, dtype=imgs.dtype)
+                    else:
+                        grid = np.full((rows * ih + (rows + 1) * pad, cols * iw + (cols + 1) * pad), fill, dtype=imgs.dtype)
+                    for idx in range(n):
+                        r, cc = idx // cols, idx % cols
+                        y0, x0 = pad + r * (ih + pad), pad + cc * (iw + pad)
+                        grid[y0:y0 + ih, x0:x0 + iw] = imgs[idx]
+                    data = grid
             # Render an image tensor directly: (C,H,W), (H,W,C), or (H,W)
             if data.ndim == 3 and data.shape[0] in (1, 3, 4):
                 # (C,H,W) -> (H,W,C)


### PR DESCRIPTION
## 概述
  為教材 I3（影像處理：CNN / UNet / Diffusion）動手課新增的節點。本 PR 已 rebase 到 `main`、**與 `add/I2-nodes`（I2 PR）互相獨立、不共用任何檔案**，可獨立 review / 合併。diff
  僅含下列 6 個檔（+563 行）。

  ## 新增節點
  | 節點 | 分類 | 用途 |
  |------|------|------|
  | `DatasetBatch` | Data | 從資料集取一個批次影像 `(N,C,H,W)` + 標籤（支援分類純量與分割遮罩 `(N,H,W)`），餵手搭網路做前向/取樣 |
  | `SyntheticSegmentation` | Data | 合成影像分割資料集（圓/方/背景 + 逐像素遮罩），訓練 UNet 分割用，CPU 友善免下載 |
  | `SyntheticShapes` | Data | 合成影像生成資料集（柔和光斑、範圍 [-1,1]），訓練小型擴散模型生成用 |
  | `Argmax` | Tensor Operations | 沿指定維度取類別索引（分割/分類輸出取預測類別） |
  | `DiffusionTrainingLoop` | Diffusion | DDPM 訓練迴圈（挑時間步→加噪→預測噪聲→MSE）；排程需與 `DDPMSampler` 一致 |

  ## 既有節點微調（皆增量、不改既有行為）
  - `Visualize`：image 模式新增「批次 `(N,C,H,W)` → 自動拼 grid」（N=1 路徑不變）。

  ## 測試
  以 `run_graph.py`（CPU、`backend/.venv`）跑過 I3 範例圖：LeNet 前向 shape 全對；UNet 分割逐像素準確率 ~99.9%（拔跳接對照 ~94%）；小型擴散訓練後 `DDPMSampler` 從純雜訊生成 16
  張光斑 grid。既有章節用到 `Visualize`(單圖)/`DatasetBatch`(MNIST) 的圖重跑無異常。

  ## 與 I2（#<I2 PR 編號>）的關係
  程式碼互相獨立、零檔案重疊，可任意順序合併。唯一耦合在「教材的範例圖」：I3-2/lenet_training 範例會用到 I2 新增的 `EvaluateModel` 節點，所以實際跑那些圖時建議 I2
  也已合併——但這不影響本 PR 的程式碼正確性。