### PR TITLE
feat: multi-backend device support — global device setting, MPS hardening, MLX spike

### DIFF
--- a/backend/app/api/routes_nodes.py
+++ b/backend/app/api/routes_nodes.py
@@ -9,11 +9,15 @@ router = APIRouter(prefix="/api/nodes", tags=["nodes"])
 
 
 def _filter_device_options(param_name: str, options: list[str]) -> list[str]:
-    """For params named 'device', remove backends that aren't available in this environment."""
+    """For params named 'device', remove backends that aren't available in this environment.
+
+    ``"auto"`` (follow the global device selector) is always kept — it's not a
+    physical backend so it bypasses the availability filter.
+    """
     if param_name != "device" or not options:
         return options
     available = set(get_available_devices())
-    filtered = [o for o in options if o in available]
+    filtered = [o for o in options if o == "auto" or o in available]
     return filtered if filtered else ["cpu"]
 
 
@@ -70,7 +74,7 @@ def _node_to_definition(qualified_name: str, cls: type[BaseNode]) -> NodeDefinit
             ParamDefinitionSchema(
                 name=p.name,
                 param_type=p.param_type.value,
-                default=p.default if p.name != "device" or p.default in get_available_devices() else "cpu",
+                default=p.default if p.name != "device" or p.default == "auto" or p.default in get_available_devices() else "cpu",
                 description=p.description,
                 options=_filter_device_options(p.name, p.options),
                 min_value=p.min_value,

--- a/backend/app/api/routes_system.py
+++ b/backend/app/api/routes_system.py
@@ -1,0 +1,18 @@
+"""System / environment introspection endpoints (compute devices, etc.)."""
+from fastapi import APIRouter
+
+from ..core.device_utils import describe_accelerator
+
+router = APIRouter(prefix="/api/system", tags=["system"])
+
+
+@router.get("/devices")
+async def list_devices() -> dict:
+    """Compute devices available for graph execution.
+
+    Returns ``describe_accelerator()`` — the best-available ``default`` plus a
+    ``devices`` list with human-friendly labels that distinguish NVIDIA CUDA
+    from AMD ROCm and label Apple MPS. The frontend's global device selector
+    renders this.
+    """
+    return describe_accelerator()

--- a/backend/app/api/ws_execution.py
+++ b/backend/app/api/ws_execution.py
@@ -16,6 +16,7 @@ from ..core.auth import (
     session_token,
 )
 from ..core.cache import ExecutionCache
+from ..core.device_utils import resolve_device
 from ..core.execution_context import CancellationError, ExecutionContext
 from ..core.graph_engine import GraphValidationError, execute_graph
 
@@ -186,7 +187,13 @@ async def websocket_execution(ws: WebSocket):
                 auto_backward = bool(data.get("auto_backward", False))
                 node_state_store = getattr(ws.app.state, "node_state_store", None)
 
+                # Global compute device. resolve_device falls back to CPU (with
+                # a warning) when an unavailable backend is requested, so a
+                # client that asks for "mps" on a CUDA box still runs.
+                device = resolve_device(data.get("device"))
+
                 current_context = ExecutionContext(
+                    device=device,
                     verbose=verbose_mode,
                     graph_id=graph_id,
                     weights_persistent=weights_persistent,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,6 +4,13 @@ from platformdirs import user_data_dir
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
+# Let the handful of ops not yet implemented for Apple MPS fall back to CPU
+# instead of hard-crashing the graph run. Set here (before torch is imported
+# anywhere) so it applies to the server, the CLI runner, and tests alike.
+# ``setdefault`` keeps an explicit external value (e.g. a test pinning "0" to
+# assert native MPS support) authoritative.
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
 
 def _user_data_root() -> Path:
     """Resolve the per-user data root (lockfile, downloaded plugins, session token).

--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -19,10 +19,25 @@ class ExecutionCache:
         self._max_entries = max_entries
 
     @staticmethod
-    def compute_key(node_type: str, params: dict[str, Any], upstream_keys: list[str]) -> str:
-        """Compute a deterministic SHA-256 cache key."""
+    def compute_key(
+        node_type: str,
+        params: dict[str, Any],
+        upstream_keys: list[str],
+        device: str = "cpu",
+    ) -> str:
+        """Compute a deterministic SHA-256 cache key.
+
+        ``device`` is part of the key: a device-aware source node (e.g.
+        TensorCreate) produces tensors on the run's global device, so a CPU
+        result must not be served for a later MPS run.
+        """
         payload = json.dumps(
-            {"type": node_type, "params": params, "upstream": sorted(upstream_keys)},
+            {
+                "type": node_type,
+                "params": params,
+                "upstream": sorted(upstream_keys),
+                "device": device,
+            },
             sort_keys=True,
             default=str,
         )

--- a/backend/app/core/device_utils.py
+++ b/backend/app/core/device_utils.py
@@ -1,7 +1,14 @@
-"""Utility for detecting available PyTorch devices at runtime."""
+"""Utilities for detecting and targeting PyTorch devices at runtime."""
 from __future__ import annotations
 
+import logging
 from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+
+logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=1)
@@ -23,3 +30,197 @@ def get_available_devices() -> list[str]:
     except ImportError:
         pass
     return devices
+
+
+def resolve_device(requested: str | None) -> str:
+    """Resolve a requested device string to one that is actually available.
+
+    Falls back to "cpu" (with a warning) when "cuda"/"mps" is requested but
+    unavailable. Centralizes the availability check that the device-aware
+    "sink" nodes (Training/Inference/Checkpoint/ModelLoader) used to each
+    duplicate inline.
+    """
+    device = (requested or "cpu").strip().lower() or "cpu"
+    try:
+        import torch
+    except ImportError:
+        return "cpu"
+
+    if device == "cpu":
+        return "cpu"
+    if device.startswith("cuda"):
+        if not torch.cuda.is_available():
+            logger.warning("CUDA not available, falling back to CPU")
+            return "cpu"
+        return device
+    if device.startswith("mps"):
+        if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
+            logger.warning("MPS not available, falling back to CPU")
+            return "cpu"
+        return device
+    # Unknown value (e.g. "auto" sent as a global device) — never hand an
+    # invalid string to torch; degrade to CPU.
+    logger.warning("Unknown device %r, falling back to CPU", device)
+    return "cpu"
+
+
+def is_mps_device(device: Any) -> bool:
+    """True when `device` names the Apple MPS backend (str or torch.device)."""
+    try:
+        import torch
+    except ImportError:
+        return False
+    if isinstance(device, torch.device):
+        return device.type == "mps"
+    return isinstance(device, str) and device.startswith("mps")
+
+
+def resolve_node_device(param_value: str | None, context: Any) -> str:
+    """Resolve a sink node's ``device`` param against the global run device.
+
+    ``"auto"`` (or empty) means "follow the global device" (``context.device``,
+    already resolved). An explicit ``"cpu"/"cuda"/"mps"`` overrides the global
+    setting and is availability-checked via :func:`resolve_device`. This lets a
+    saved graph pin a node to a device while fresh nodes default to ``"auto"``
+    and ride the global selector.
+    """
+    value = (param_value or "auto").strip().lower() or "auto"
+    if value == "auto":
+        return context_device(context)
+    return resolve_device(value)
+
+
+def context_device(context: Any, fallback: str = "cpu") -> str:
+    """Read the resolved global device off an ExecutionContext.
+
+    Returns ``fallback`` when there is no context or no device set (e.g. the
+    CLI runner passes ``context=None``), so device-aware nodes degrade to CPU.
+    The value stored on the context is already ``resolve_device``-d at the
+    execution entry point, so it is safe to use directly.
+    """
+    dev = getattr(context, "device", None)
+    return dev or fallback
+
+
+def mlx_available() -> bool:
+    """True when Apple's native **MLX** framework is importable.
+
+    MLX is a *separate* array framework, not a PyTorch backend — there is no
+    ``tensor.to("mlx")``. It is surfaced for the inference-subset spike
+    (see ``scripts/mlx_spike.py``), not as a selectable torch execution device.
+    Apple acceleration in the graph engine is provided by PyTorch **MPS**.
+    """
+    import importlib.util
+
+    return importlib.util.find_spec("mlx") is not None
+
+
+def describe_accelerator() -> dict[str, Any]:
+    """Describe the compute devices available, with human-friendly labels.
+
+    Distinguishes **AMD ROCm** from **NVIDIA CUDA** (both surface through the
+    ``torch.cuda`` API — tell them apart via ``torch.version.hip``) and labels
+    Apple **MPS**. Shape::
+
+        {
+          "default": "mps",                      # best available
+          "devices": [
+            {"value": "cpu", "label": "CPU", "detail": "...", "available": true},
+            {"value": "mps", "label": "Apple MPS", "detail": "Metal", ...},
+          ],
+        }
+
+    Falls back to CPU-only when torch is missing.
+    """
+    cpu_entry = {"value": "cpu", "label": "CPU", "detail": "", "available": True}
+    devices: list[dict[str, Any]] = [cpu_entry]
+    default = "cpu"
+
+    try:
+        import torch
+    except ImportError:
+        return {"default": default, "devices": devices}
+
+    if torch.cuda.is_available():
+        is_rocm = getattr(torch.version, "hip", None) is not None
+        try:
+            name = torch.cuda.get_device_name(0)
+        except Exception:  # noqa: BLE001 — name lookup is best-effort
+            name = ""
+        devices.append({
+            "value": "cuda",
+            "label": "AMD ROCm" if is_rocm else "NVIDIA CUDA",
+            "detail": name,
+            "available": True,
+        })
+        default = "cuda"
+
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        devices.append({
+            "value": "mps",
+            "label": "Apple MPS",
+            "detail": "Metal Performance Shaders",
+            "available": True,
+        })
+        if default == "cpu":
+            default = "mps"
+
+    return {"default": default, "devices": devices}
+
+
+def _downcast_float64_module(module: "torch.nn.Module") -> None:
+    """In-place downcast a module's float64 params/buffers to float32.
+
+    MPS rejects float64, so any double-precision parameter or buffer must be
+    converted before the module is moved to an MPS device. Other floating
+    dtypes (float16/bfloat16) and integer buffers are left untouched.
+    """
+    import torch
+
+    for mod in module.modules():
+        for param in mod.parameters(recurse=False):
+            if param.dtype == torch.float64:
+                param.data = param.data.to(torch.float32)
+                if param.grad is not None and param.grad.dtype == torch.float64:
+                    param.grad.data = param.grad.data.to(torch.float32)
+        for name, buf in list(mod._buffers.items()):
+            if buf is not None and buf.dtype == torch.float64:
+                mod._buffers[name] = buf.to(torch.float32)
+
+
+def to_device(obj: Any, device: Any) -> Any:
+    """Move a tensor / module / (nested) collection to `device`.
+
+    When targeting MPS, float64 values are downcast to float32 first, because
+    MPS raises "Cannot convert a MPS Tensor to float64 dtype as the MPS
+    framework doesn't support float64." Tensors of other dtypes (e.g. int64
+    targets) and non-tensor leaves pass through unchanged. Lists/tuples/dicts
+    are mapped element-wise so a ``(data, targets)`` batch can be moved in one
+    call.
+    """
+    import torch
+
+    if obj is None:
+        return obj
+
+    mps = is_mps_device(device)
+
+    if isinstance(obj, torch.Tensor):
+        if mps and obj.dtype == torch.float64:
+            obj = obj.to(torch.float32)
+        return obj.to(device)
+
+    if isinstance(obj, torch.nn.Module):
+        if mps:
+            _downcast_float64_module(obj)
+        return obj.to(device)
+
+    if isinstance(obj, (list, tuple)):
+        moved = [to_device(v, device) for v in obj]
+        return type(obj)(moved)
+
+    if isinstance(obj, dict):
+        return {k: to_device(v, device) for k, v in obj.items()}
+
+    # Unknown leaf (int, str, sklearn model, ...) — best effort .to(), else pass.
+    return obj

--- a/backend/app/core/execution_context.py
+++ b/backend/app/core/execution_context.py
@@ -24,6 +24,13 @@ class ExecutionContext:
     max_workers: int = 4
     _cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
 
+    # Global compute device ("cpu" / "cuda" / "mps") for the whole run. Already
+    # resolved (availability-checked) at the execution entry point. Tensor-
+    # source nodes create on it and StatefulModuleMixin moves layer modules to
+    # it, so the entire graph — not just the device-aware sink nodes — runs on
+    # the chosen accelerator.
+    device: str = "cpu"
+
     # A1: verbose step-trace mode. Instrumented nodes emit __steps__ when True.
     verbose: bool = False
 

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -619,7 +619,10 @@ async def execute_graph(
                 node_cache_keys[src_id]
                 for src_id, _, _ in incoming.get(node_id, [])
             ]
-            cache_key = cache.compute_key(node_type, params, upstream_keys)
+            cache_key = cache.compute_key(
+                node_type, params, upstream_keys,
+                device=context.device if context is not None else "cpu",
+            )
             node_cache_keys[node_id] = cache_key
             if node_id not in force_rerun:
                 cached = cache.get(cache_key)

--- a/backend/app/core/stateful_module.py
+++ b/backend/app/core/stateful_module.py
@@ -76,6 +76,12 @@ class StatefulModuleMixin:
 
         Falls back to a fresh build when persistence isn't wired up — keeps
         stateless behaviour for tests / CLI / direct ``execute()`` calls.
+
+        The returned module is moved to ``context.device`` (the global run
+        device), so every layer node runs on the chosen accelerator without
+        each node needing its own device handling. Moving is idempotent and,
+        for a persisted module, carries its trained weights across a
+        device switch.
         """
         if (
             context is None
@@ -83,12 +89,18 @@ class StatefulModuleMixin:
             or context.node_state_store is None
             or not context.current_node_id
         ):
-            return self.build_module(params)
+            module = self.build_module(params)
+        else:
+            h = self._structure_hash(params)
+            module = context.node_state_store.get_or_create(
+                context.graph_id,
+                context.current_node_id,
+                h,
+                lambda: self.build_module(params),
+            )
 
-        h = self._structure_hash(params)
-        return context.node_state_store.get_or_create(
-            context.graph_id,
-            context.current_node_id,
-            h,
-            lambda: self.build_module(params),
-        )
+        if context is not None and getattr(context, "device", None):
+            from .device_utils import to_device
+
+            module = to_device(module, context.device)
+        return module

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,6 +49,7 @@ from .api import (
     routes_nodes,
     routes_plugins,
     routes_presets,
+    routes_system,
     ws_execution,
 )
 from .config import settings
@@ -243,6 +244,7 @@ app.include_router(routes_models.router)
 app.include_router(routes_images.router)
 app.include_router(routes_execution_outputs.router)
 app.include_router(routes_execution_state.router)
+app.include_router(routes_system.router)
 app.include_router(ws_execution.router)
 
 

--- a/backend/app/nodes/data/tensor_input_node.py
+++ b/backend/app/nodes/data/tensor_input_node.py
@@ -64,6 +64,8 @@ class TensorInputNode(BaseNode):
     ) -> dict[str, Any]:
         import torch
 
+        from ...core.device_utils import context_device, to_device
+
         shape_str = params.get("shape", "1,4,4")
         shape = tuple(int(s.strip()) for s in shape_str.split(",") if s.strip())
         if not shape:
@@ -115,6 +117,11 @@ class TensorInputNode(BaseNode):
             tensor = torch.arange(numel, dtype=dtype).reshape(shape)
         else:
             raise ValueError(f"Unsupported value_mode: {mode}")
+
+        # Move to the run's global device. Seeded RNG above runs on the CPU
+        # generator for reproducibility, so we generate on CPU then move —
+        # this also downcasts float64→float32 for MPS via to_device.
+        tensor = to_device(tensor, context_device(context))
 
         # When the graph runs in backward mode, opt floating tensors into
         # autograd so .grad becomes available after the post-forward

--- a/backend/app/nodes/diffusion/ddpm_sampler_node.py
+++ b/backend/app/nodes/diffusion/ddpm_sampler_node.py
@@ -173,6 +173,14 @@ class DDPMSamplerNode(BaseNode):
         gen = torch.Generator()
         gen.manual_seed(seed)
         x = noise.clone().float()
+
+        # Align the schedule tensors with x's (global) device so the per-step
+        # scalar arithmetic doesn't mix cpu/mps. The model was already moved to
+        # the device by its layer node.
+        betas = betas.to(x.device)
+        alphas = alphas.to(x.device)
+        alpha_bars = alpha_bars.to(x.device)
+
         if hasattr(model, "eval"):
             model.eval()
 
@@ -192,7 +200,8 @@ class DDPMSamplerNode(BaseNode):
                 mean = inv_sqrt_alpha * (x - eps_coef * eps_hat)
 
                 if t > 0:
-                    z = torch.randn(x.shape, generator=gen, dtype=x.dtype)
+                    # CPU generator (reproducible) → move to x's device.
+                    z = torch.randn(x.shape, generator=gen, dtype=x.dtype).to(x.device)
                     sigma = torch.sqrt(beta_t)
                     x = mean + sigma * z
                 else:

--- a/backend/app/nodes/diffusion/gaussian_noise_node.py
+++ b/backend/app/nodes/diffusion/gaussian_noise_node.py
@@ -129,4 +129,10 @@ class GaussianNoiseNode(BaseNode):
             noise = noise * std
         if mean != 0.0:
             noise = noise + mean
-        return {"noise": noise}
+
+        # CPU generator above keeps the seed reproducible; move the result to
+        # the reference tensor's device (if any) or the global run device so it
+        # composes with on-device tensors downstream (e.g. Lerp, DDPMSampler).
+        from ...core.device_utils import context_device, to_device
+        dev = ref.device if (ref is not None and isinstance(ref, torch.Tensor)) else context_device(context)
+        return {"noise": to_device(noise, dev)}

--- a/backend/app/nodes/io/checkpoint_node.py
+++ b/backend/app/nodes/io/checkpoint_node.py
@@ -114,29 +114,24 @@ class CheckpointLoaderNode(BaseNode):
             ParamDefinition(
                 name="device",
                 param_type=ParamType.SELECT,
-                default="cpu",
-                description="Device to load onto",
-                options=["cpu", "cuda", "mps"],
+                default="auto",
+                description="Device to load onto ('auto' follows the global device)",
+                options=["auto", "cpu", "cuda", "mps"],
             ),
         ]
 
-    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any], *, context: Any = None) -> dict[str, Any]:
         import torch
         from pathlib import Path
 
         from ...config import settings
 
+        from ...core.device_utils import is_mps_device, resolve_node_device, to_device
+
         model = inputs["model"]
         optimizer = inputs["optimizer"]
         path = params.get("path", "checkpoint.pt")
-        device = params.get("device", "cpu")
-
-        if device == "cuda" and not torch.cuda.is_available():
-            logger.warning("CUDA not available, falling back to CPU")
-            device = "cpu"
-        elif device == "mps" and not torch.backends.mps.is_available():
-            logger.warning("MPS not available, falling back to CPU")
-            device = "cpu"
+        device = resolve_node_device(params.get("device"), context)
 
         p = Path(path)
         if not p.is_absolute():
@@ -151,10 +146,13 @@ class CheckpointLoaderNode(BaseNode):
         if not p.exists():
             raise FileNotFoundError(f"Checkpoint file not found: {p}")
 
-        checkpoint = torch.load(str(p), map_location=device, weights_only=True)
+        # MPS can't receive float64 via map_location, so stage doubles on CPU
+        # and let to_device downcast them on the way to the device.
+        load_device = "cpu" if is_mps_device(device) else device
+        checkpoint = torch.load(str(p), map_location=load_device, weights_only=True)
 
         model.load_state_dict(checkpoint["model_state_dict"])
-        model = model.to(device)
+        model = to_device(model, device)
 
         # Re-bind optimizer to device-mapped parameters before restoring state
         for param_group in optimizer.param_groups:
@@ -166,7 +164,7 @@ class CheckpointLoaderNode(BaseNode):
         for state in optimizer.state.values():
             for k, v in state.items():
                 if isinstance(v, torch.Tensor):
-                    state[k] = v.to(device)
+                    state[k] = to_device(v, device)
 
         epoch = checkpoint.get("epoch", 0)
         losses = checkpoint.get("losses", torch.tensor([]))

--- a/backend/app/nodes/io/inference_node.py
+++ b/backend/app/nodes/io/inference_node.py
@@ -31,28 +31,25 @@ class InferenceNode(BaseNode):
             ParamDefinition(
                 name="device",
                 param_type=ParamType.SELECT,
-                default="cpu",
-                description="Device to run inference on",
-                options=["cpu", "cuda", "mps"],
+                default="auto",
+                description="Device to run inference on ('auto' follows the global device)",
+                options=["auto", "cpu", "cuda", "mps"],
             ),
         ]
 
-    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any], *, context: Any = None) -> dict[str, Any]:
         import torch
+
+        from ...core.device_utils import resolve_node_device, to_device
 
         model = inputs["model"]
         input_tensor = inputs["input"]
-        device = params.get("device", "cpu")
+        device = resolve_node_device(params.get("device"), context)
 
-        if device == "cuda" and not torch.cuda.is_available():
-            logger.warning("CUDA not available, falling back to CPU")
-            device = "cpu"
-        elif device == "mps" and not torch.backends.mps.is_available():
-            logger.warning("MPS not available, falling back to CPU")
-            device = "cpu"
-
-        model = model.to(device)
-        input_tensor = input_tensor.to(device)
+        # to_device downcasts float64 → float32 when targeting MPS (MPS has no
+        # float64), so a TensorInput(dtype=float64) feeding inference won't crash.
+        model = to_device(model, device)
+        input_tensor = to_device(input_tensor, device)
 
         model.eval()
         with torch.no_grad():

--- a/backend/app/nodes/io/model_loader_node.py
+++ b/backend/app/nodes/io/model_loader_node.py
@@ -47,9 +47,9 @@ class ModelLoaderNode(BaseNode):
             ParamDefinition(
                 name="device",
                 param_type=ParamType.SELECT,
-                default="cpu",
-                description="Device to load weights onto",
-                options=["cpu", "cuda", "mps"],
+                default="auto",
+                description="Device to load weights onto ('auto' follows the global device)",
+                options=["auto", "cpu", "cuda", "mps"],
             ),
             ParamDefinition(
                 name="strict",
@@ -59,23 +59,22 @@ class ModelLoaderNode(BaseNode):
             ),
         ]
 
-    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any], *, context: Any = None) -> dict[str, Any]:
         import torch
         from pathlib import Path
 
         from ...config import settings
 
+        from ...core.device_utils import is_mps_device, resolve_node_device, to_device
+
         path = params.get("path", "model_weights.pt")
         load_mode = params.get("load_mode", "state_dict")
-        device = params.get("device", "cpu")
+        device = resolve_node_device(params.get("device"), context)
         strict = params.get("strict", True)
 
-        if device == "cuda" and not torch.cuda.is_available():
-            logger.warning("CUDA not available, falling back to CPU")
-            device = "cpu"
-        elif device == "mps" and not torch.backends.mps.is_available():
-            logger.warning("MPS not available, falling back to CPU")
-            device = "cpu"
+        # MPS can't receive float64 via map_location, so stage doubles on CPU
+        # and let to_device downcast them on the way to the device.
+        load_device = "cpu" if is_mps_device(device) else device
 
         p = Path(path)
         if not p.is_absolute():
@@ -101,11 +100,11 @@ class ModelLoaderNode(BaseNode):
                 )
             if is_safetensors:
                 from safetensors.torch import load_file
-                state_dict = load_file(str(p), device=device)
+                state_dict = load_file(str(p), device=load_device)
             else:
-                state_dict = torch.load(str(p), map_location=device, weights_only=True)
+                state_dict = torch.load(str(p), map_location=load_device, weights_only=True)
             model.load_state_dict(state_dict, strict=strict)
-            model = model.to(device)
+            model = to_device(model, device)
             param_count = sum(p_.numel() for p_ in model.parameters())
             logger.info("Loaded state_dict from %s (%s parameters, strict=%s)", p, f"{param_count:,}", strict)
         else:
@@ -115,8 +114,8 @@ class ModelLoaderNode(BaseNode):
                 "full_model mode uses weights_only=True for safety. "
                 "If loading fails, re-save the model as state_dict."
             )
-            model = torch.load(str(p), map_location=device, weights_only=True)
-            model = model.to(device)
+            model = torch.load(str(p), map_location=load_device, weights_only=True)
+            model = to_device(model, device)
             logger.info("Loaded full model from %s", p)
 
         return {"model": model}

--- a/backend/app/nodes/llm/attention_mask_node.py
+++ b/backend/app/nodes/llm/attention_mask_node.py
@@ -95,6 +95,8 @@ class AttentionMaskNode(BaseNode):
         *,
         context: Any = None,
     ) -> dict[str, Any]:
+        from ...core.device_utils import context_device, to_device
+
         mode = str(params.get("mode", "causal"))
         pad_token = str(params.get("pad_token", "<pad>"))
 
@@ -104,12 +106,16 @@ class AttentionMaskNode(BaseNode):
         if tensor is None and tokens is None:
             raise ValueError("AttentionMask requires either `tensor` or `tokens` input.")
 
+        # The mask feeds attention ops on the global device; build on CPU then
+        # move so it matches the (possibly on-device) attention scores.
+        dev = tensor.device if isinstance(tensor, torch.Tensor) else context_device(context)
+
         if mode == "causal":
             seq = self._infer_seq_len(tensor, tokens)
             # Upper-triangular True (diagonal=1 means strictly above the main diagonal)
             # so each position can still attend to itself.
             mask = torch.triu(torch.ones(seq, seq, dtype=torch.bool), diagonal=1)
-            return {"mask": mask}
+            return {"mask": to_device(mask, dev)}
 
         if mode == "padding":
             if tokens is None:
@@ -122,7 +128,7 @@ class AttentionMaskNode(BaseNode):
             # Block whole columns where the key is padding — every query is
             # forbidden from attending to a pad slot.
             mask = is_pad.unsqueeze(0).expand(seq, seq).clone()
-            return {"mask": mask}
+            return {"mask": to_device(mask, dev)}
 
         raise ValueError(f"Unknown AttentionMask mode: {mode!r}")
 

--- a/backend/app/nodes/llm/positional_encoding_node.py
+++ b/backend/app/nodes/llm/positional_encoding_node.py
@@ -140,6 +140,9 @@ class PositionalEncodingNode(BaseNode):
         else:
             raise ValueError(f"Unknown PositionalEncoding mode: {mode!r}")
 
+        # PE is built on CPU; match it to the input's device before adding.
+        pe = pe.to(x.device)
+
         if x.ndim == 2:
             out = x + pe
         else:  # [seq, batch, d]: broadcast over batch dim

--- a/backend/app/nodes/llm/word_vector_node.py
+++ b/backend/app/nodes/llm/word_vector_node.py
@@ -222,6 +222,11 @@ class WordVectorNode(BaseNode):
                     embeddings=tensor,
                 )
 
+        # Embeddings come from numpy on CPU; move them to the global run device
+        # so downstream tensor ops (Add, CosineSimilarity) stay on one device.
+        from ...core.device_utils import context_device, to_device
+        tensor = to_device(tensor, context_device(context))
+
         result: dict[str, Any] = {"embeddings": tensor, "labels": labels}
         if recorder is not None:
             result["__steps__"] = recorder.steps

--- a/backend/app/nodes/rl/dqn_node.py
+++ b/backend/app/nodes/rl/dqn_node.py
@@ -47,6 +47,9 @@ class DQNNode(BaseNode):
 
         state = inputs.get("state")
         if state is not None:
+            # Match the network to the input's (global) device before applying.
+            from ...core.device_utils import to_device
+            model = to_device(model, state.device)
             with torch.no_grad():
                 q_values = model(state)
         else:

--- a/backend/app/nodes/rl/ppo_node.py
+++ b/backend/app/nodes/rl/ppo_node.py
@@ -59,6 +59,9 @@ class PPONode(BaseNode):
 
         state = inputs.get("state")
         if state is not None:
+            # Match the network to the input's (global) device before applying.
+            from ...core.device_utils import to_device
+            model = to_device(model, state.device)
             with torch.no_grad():
                 action_probs, _value = model(state)
         else:

--- a/backend/app/nodes/rl/reward_model_node.py
+++ b/backend/app/nodes/rl/reward_model_node.py
@@ -105,6 +105,9 @@ class RewardModelNode(BaseNode):
         else:
             if not isinstance(h, torch.Tensor):
                 h = torch.as_tensor(h, dtype=torch.float32)
+            # Match the head to the input's (global) device before applying.
+            from ...core.device_utils import to_device
+            model = to_device(model, h.device)
             with torch.no_grad():
                 rewards = model(h.float())
 

--- a/backend/app/nodes/tensor_ops/tensor_create_node.py
+++ b/backend/app/nodes/tensor_ops/tensor_create_node.py
@@ -38,8 +38,16 @@ class TensorCreateNode(BaseNode):
             ParamDefinition(name="requires_grad", param_type=ParamType.BOOL, default=False, description="Whether the tensor requires gradient"),
         ]
 
-    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
         import torch
+
+        from ...core.device_utils import context_device, to_device
 
         shape_str = params.get("shape", "1,3,224,224")
         shape = tuple(int(s.strip()) for s in shape_str.split(","))
@@ -60,7 +68,9 @@ class TensorCreateNode(BaseNode):
         if create_fn is None:
             raise ValueError(f"Unsupported fill method: {fill}")
 
-        tensor = create_fn()
+        # Build on CPU then move to the run's global device — keeps the leaf
+        # tensor on-device so requires_grad_ marks an on-device autograd leaf.
+        tensor = to_device(create_fn(), context_device(context))
         if requires_grad:
             tensor = tensor.requires_grad_(True)
         return {"tensor": tensor}

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -41,9 +41,9 @@ class TrainingLoopNode(BaseNode):
             ParamDefinition(
                 name="device",
                 param_type=ParamType.SELECT,
-                default="cpu",
-                description="Device to train on",
-                options=["cpu", "cuda", "mps"],
+                default="auto",
+                description="Device to train on ('auto' follows the global device)",
+                options=["auto", "cpu", "cuda", "mps"],
             ),
             ParamDefinition(
                 name="early_stopping_patience",
@@ -66,8 +66,12 @@ class TrainingLoopNode(BaseNode):
         inputs: dict[str, Any],
         params: dict[str, Any],
         progress_callback: Any | None = None,
+        *,
+        context: Any = None,
     ) -> dict[str, Any]:
         import torch
+
+        from ...core.device_utils import resolve_node_device, to_device
 
         model = inputs["model"]
         dataloader = inputs["dataloader"]
@@ -77,19 +81,12 @@ class TrainingLoopNode(BaseNode):
         lr_scheduler = inputs.get("lr_scheduler")
 
         epochs = params.get("epochs", 5)
-        device = params.get("device", "cpu")
+        device = resolve_node_device(params.get("device"), context)
         patience = params.get("early_stopping_patience", 0)
         grad_clip = params.get("grad_clip_norm", 0.0)
 
-        if device == "cuda" and not torch.cuda.is_available():
-            logger.warning("CUDA not available, falling back to CPU")
-            device = "cpu"
-        elif device == "mps" and not torch.backends.mps.is_available():
-            logger.warning("MPS not available, falling back to CPU")
-            device = "cpu"
-
-        model = model.to(device)
-        loss_fn = loss_fn.to(device)
+        model = to_device(model, device)
+        loss_fn = to_device(loss_fn, device)
 
         # Recreate the optimizer so its param list, momentum buffers and state are
         # freshly bound to the moved model parameters. The Optimizer node runs before
@@ -171,10 +168,10 @@ class TrainingLoopNode(BaseNode):
             for batch_data in dataloader:
                 if isinstance(batch_data, (list, tuple)) and len(batch_data) == 2:
                     data, targets = batch_data
-                    data = data.to(device)
-                    targets = targets.to(device)
+                    data = to_device(data, device)
+                    targets = to_device(targets, device)
                 else:
-                    data = batch_data.to(device) if hasattr(batch_data, "to") else batch_data
+                    data = to_device(batch_data, device) if hasattr(batch_data, "to") else batch_data
                     targets = None
 
                 optimizer.zero_grad()
@@ -211,10 +208,10 @@ class TrainingLoopNode(BaseNode):
                     for batch_data in val_dataloader:
                         if isinstance(batch_data, (list, tuple)) and len(batch_data) == 2:
                             data, targets = batch_data
-                            data = data.to(device)
-                            targets = targets.to(device)
+                            data = to_device(data, device)
+                            targets = to_device(targets, device)
                         else:
-                            data = batch_data.to(device) if hasattr(batch_data, "to") else batch_data
+                            data = to_device(batch_data, device) if hasattr(batch_data, "to") else batch_data
                             targets = None
 
                         outputs = model(data)

--- a/backend/app/nodes/transformer/moe_layer_node.py
+++ b/backend/app/nodes/transformer/moe_layer_node.py
@@ -153,6 +153,11 @@ class MoELayerNode(BaseNode):
         finally:
             torch.random.set_rng_state(gen_state)
 
+        # The layer is built fresh on CPU; move it to the input's device so the
+        # gate/expert weights match x under the global device setting.
+        from ...core.device_utils import to_device
+        layer = to_device(layer, x.device)
+
         with torch.no_grad():
             out, routing_w, idx = layer(x)
 

--- a/backend/run_graph.py
+++ b/backend/run_graph.py
@@ -67,7 +67,13 @@ def _on_progress(node_id: str, status: str, data: dict[str, Any] | None) -> None
         logger.error("  [%s] ERROR: %s", node_id, err)
 
 
-async def run(graph_path: str, *, validate_only: bool = False, verbose: bool = False) -> None:
+async def run(
+    graph_path: str,
+    *,
+    validate_only: bool = False,
+    verbose: bool = False,
+    device: str | None = None,
+) -> None:
     t0 = time.time()
 
     # Load graph
@@ -109,11 +115,20 @@ async def run(graph_path: str, *, validate_only: bool = False, verbose: bool = F
     # Execute
     logger.info("Starting graph execution...")
     logger.info("-" * 60)
+    context = None
+    if device:
+        from app.core.device_utils import resolve_device
+        from app.core.execution_context import ExecutionContext
+
+        resolved = resolve_device(device)
+        logger.info("Global device: %s", resolved)
+        context = ExecutionContext(device=resolved)
     try:
         outputs = await execute_graph(
             nodes,
             edges,
             on_progress=_on_progress if verbose else _on_progress,
+            context=context,
         )
     except GraphValidationError as e:
         logger.error("Validation error: %s", e)
@@ -164,13 +179,14 @@ def main() -> None:
     parser.add_argument("graph", help="Path to graph.json file")
     parser.add_argument("--validate-only", action="store_true", help="Only validate, do not execute")
     parser.add_argument("--verbose", "-v", action="store_true", help="Show detailed output and tracebacks")
+    parser.add_argument("--device", default=None, help="Global compute device: cpu / cuda / mps (default cpu)")
     args = parser.parse_args()
 
     level = "DEBUG" if args.verbose else "INFO"
     setup_logging(level=level)
 
     _init_registries()
-    asyncio.run(run(args.graph, validate_only=args.validate_only, verbose=args.verbose))
+    asyncio.run(run(args.graph, validate_only=args.validate_only, verbose=args.verbose, device=args.device))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -53,6 +53,16 @@ def test_cache_different_params_different_key():
     assert k1 != k2
 
 
+def test_cache_key_includes_device():
+    # A device switch must miss the cache so a CPU tensor isn't served for an
+    # MPS run (and vice-versa).
+    cpu = ExecutionCache.compute_key("TensorCreate", {"shape": "2"}, [], device="cpu")
+    mps = ExecutionCache.compute_key("TensorCreate", {"shape": "2"}, [], device="mps")
+    assert cpu != mps
+    # Default device keeps backward-compatible keys (device defaults to "cpu").
+    assert cpu == ExecutionCache.compute_key("TensorCreate", {"shape": "2"}, [])
+
+
 def test_cache_put_and_get():
     cache = ExecutionCache()
     cache.put("key1", {"output": 42})

--- a/backend/tests/test_device_utils.py
+++ b/backend/tests/test_device_utils.py
@@ -1,0 +1,212 @@
+"""Tests for core.device_utils — device resolution and MPS-safe tensor moves.
+
+The float64→float32 coercion only matters on Apple MPS (which has no float64).
+CPU-path behaviour is asserted unconditionally so this file is still meaningful
+on Linux CI; the actual MPS downcast assertions are gated behind availability.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import pytest
+
+from app.core.device_utils import (
+    context_device,
+    describe_accelerator,
+    get_available_devices,
+    is_mps_device,
+    mlx_available,
+    resolve_device,
+    resolve_node_device,
+    to_device,
+)
+
+mps_available = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+requires_mps = pytest.mark.skipif(not mps_available, reason="MPS not available")
+
+
+# ── resolve_device ──────────────────────────────────────────────────
+
+def test_resolve_device_cpu_passthrough():
+    assert resolve_device("cpu") == "cpu"
+
+
+def test_resolve_device_none_defaults_cpu():
+    assert resolve_device(None) == "cpu"
+    assert resolve_device("") == "cpu"
+
+
+def test_resolve_device_cuda_falls_back_when_unavailable():
+    expected = "cuda" if torch.cuda.is_available() else "cpu"
+    assert resolve_device("cuda") == expected
+
+
+def test_resolve_device_mps_matches_availability():
+    expected = "mps" if mps_available else "cpu"
+    assert resolve_device("mps") == expected
+
+
+# ── is_mps_device ───────────────────────────────────────────────────
+
+def test_is_mps_device_recognises_strings_and_torch_device():
+    assert is_mps_device("mps") is True
+    assert is_mps_device("mps:0") is True
+    assert is_mps_device("cpu") is False
+    assert is_mps_device("cuda") is False
+    assert is_mps_device(torch.device("cpu")) is False
+
+
+# ── to_device: device-agnostic behaviour (always runs) ──────────────
+
+def test_to_device_cpu_is_noop_for_tensor():
+    x = torch.randn(2, 3, dtype=torch.float64)
+    y = to_device(x, "cpu")
+    # No MPS → no coercion: dtype is preserved.
+    assert y.dtype == torch.float64
+    assert y.device.type == "cpu"
+
+
+def test_to_device_passes_through_non_tensor_leaves():
+    assert to_device(None, "mps") is None
+    assert to_device(7, "mps") == 7
+    assert to_device("hello", "mps") == "hello"
+
+
+def test_to_device_recurses_into_tuple_and_dict_on_cpu():
+    x = torch.randn(2, 2)
+    t = torch.randint(0, 5, (2,))
+    moved = to_device((x, t), "cpu")
+    assert isinstance(moved, tuple) and len(moved) == 2
+    d = to_device({"a": x, "b": 1}, "cpu")
+    assert d["b"] == 1 and d["a"].shape == (2, 2)
+
+
+# ── to_device: MPS float64 coercion (gated) ─────────────────────────
+
+@requires_mps
+def test_to_device_downcasts_float64_tensor_on_mps():
+    x = torch.randn(2, 3, dtype=torch.float64)
+    y = to_device(x, "mps")
+    assert y.dtype == torch.float32
+    assert y.device.type == "mps"
+
+
+@requires_mps
+def test_to_device_preserves_int64_on_mps():
+    # CrossEntropy targets are int64 — MPS supports it, must not be touched.
+    t = torch.randint(0, 10, (4,), dtype=torch.int64)
+    ty = to_device(t, "mps")
+    assert ty.dtype == torch.int64
+    assert ty.device.type == "mps"
+
+
+@requires_mps
+def test_to_device_downcasts_float64_module_on_mps():
+    model = nn.Linear(3, 2).double()  # all params float64
+    moved = to_device(model, "mps")
+    param = next(moved.parameters())
+    assert param.dtype == torch.float32
+    assert param.device.type == "mps"
+    # And it can actually run a forward pass (input also routed through
+    # to_device so the float64 source is downcast before the move).
+    out = moved(to_device(torch.randn(1, 3, dtype=torch.float64), "mps"))
+    assert out.shape == (1, 2)
+
+
+@requires_mps
+def test_inference_node_accepts_float64_input_on_mps():
+    """The original bug: float64 tensor → Inference(mps) raised
+    'Cannot convert a MPS Tensor to float64'. to_device now downcasts it."""
+    from app.nodes.io.inference_node import InferenceNode
+
+    model = nn.Linear(4, 2)  # float32 weights
+    x = torch.randn(1, 4, dtype=torch.float64)  # float64 input
+    res = InferenceNode().execute({"model": model, "input": x}, {"device": "mps"})
+    assert res["output"].shape == (1, 2)
+    assert res["output"].device.type == "mps"
+
+
+def test_mps_listed_in_available_devices_when_present():
+    devices = get_available_devices()
+    assert "cpu" in devices
+    assert ("mps" in devices) == mps_available
+
+
+# ── resolve_device strictness ───────────────────────────────────────
+
+def test_resolve_device_unknown_value_falls_back_to_cpu():
+    # "auto" is meaningful only as a per-node param, never a global device.
+    assert resolve_device("auto") == "cpu"
+    assert resolve_device("bogus") == "cpu"
+
+
+# ── context_device ──────────────────────────────────────────────────
+
+class _Ctx:
+    def __init__(self, device):
+        self.device = device
+
+
+def test_context_device_reads_device_off_context():
+    assert context_device(_Ctx("mps")) == "mps"
+
+
+def test_context_device_falls_back_without_context():
+    assert context_device(None) == "cpu"
+    assert context_device(_Ctx(None)) == "cpu"
+    assert context_device(None, fallback="cuda") == "cuda"
+
+
+# ── resolve_node_device ─────────────────────────────────────────────
+
+def test_resolve_node_device_auto_follows_context():
+    assert resolve_node_device("auto", _Ctx("mps" if mps_available else "cpu")) == (
+        "mps" if mps_available else "cpu"
+    )
+    assert resolve_node_device(None, _Ctx("cpu")) == "cpu"
+    assert resolve_node_device("", _Ctx("cpu")) == "cpu"
+
+
+def test_resolve_node_device_explicit_overrides_global():
+    # An explicit device wins over the global one (and is availability-checked).
+    assert resolve_node_device("cpu", _Ctx("mps")) == "cpu"
+
+
+# ── describe_accelerator ────────────────────────────────────────────
+
+def test_describe_accelerator_shape_and_cpu_always_present():
+    info = describe_accelerator()
+    assert "default" in info and "devices" in info
+    values = {d["value"] for d in info["devices"]}
+    assert "cpu" in values
+    # Every entry has the documented keys.
+    for d in info["devices"]:
+        assert {"value", "label", "detail", "available"} <= set(d)
+    # default must be one of the listed devices.
+    assert info["default"] in values
+
+
+@requires_mps
+def test_describe_accelerator_labels_mps_and_defaults_to_it():
+    info = describe_accelerator()
+    mps_entry = next(d for d in info["devices"] if d["value"] == "mps")
+    assert mps_entry["label"] == "Apple MPS"
+    # With only CPU + MPS available, MPS is the best default.
+    if not torch.cuda.is_available():
+        assert info["default"] == "mps"
+
+
+def test_describe_accelerator_never_lists_mlx_as_a_torch_device():
+    # MLX is not a torch backend — it must not appear in the device selector.
+    info = describe_accelerator()
+    assert "mlx" not in {d["value"] for d in info["devices"]}
+
+
+# ── mlx_available (Phase 3 spike detection) ─────────────────────────
+
+def test_mlx_available_returns_bool_matching_import():
+    import importlib.util
+
+    expected = importlib.util.find_spec("mlx") is not None
+    assert mlx_available() is expected

--- a/backend/tests/test_global_device_flow.py
+++ b/backend/tests/test_global_device_flow.py
@@ -1,0 +1,116 @@
+"""Global device setting: the /api/system/devices endpoint, the
+ExecutionContext.device flow into tensor-source nodes, and the
+StatefulModuleMixin device move.
+
+MPS-specific assertions are gated on availability so the file still runs on
+Linux CI (where it exercises the CPU paths).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from app.core.execution_context import ExecutionContext
+from app.core.graph_engine import execute_graph
+from app.core.stateful_module import StatefulModuleMixin
+from app.core.node_base import BaseNode
+
+mps_available = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+requires_mps = pytest.mark.skipif(not mps_available, reason="MPS not available")
+
+
+# ── /api/system/devices endpoint ────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_devices_endpoint(test_client):
+    resp = await test_client.get("/api/system/devices")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "default" in data and "devices" in data
+    values = {d["value"] for d in data["devices"]}
+    assert "cpu" in values
+    assert data["default"] in values
+
+
+# ── ExecutionContext.device flows into a tensor-source node ──────────
+
+def _tensor_create_graph() -> tuple[list[dict], list[dict]]:
+    nodes = [
+        {"id": "start", "type": "Start", "data": {"params": {}}},
+        {
+            "id": "tc",
+            "type": "TensorCreate",
+            "data": {"params": {"shape": "2,3", "fill": "randn"}},
+        },
+    ]
+    edges = [
+        {"id": "t", "source": "start", "target": "tc", "sourceHandle": "trigger", "type": "trigger"},
+    ]
+    return nodes, edges
+
+
+@pytest.mark.asyncio
+async def test_tensor_create_runs_on_context_device_cpu():
+    nodes, edges = _tensor_create_graph()
+    outs = await execute_graph(nodes, edges, context=ExecutionContext(device="cpu"))
+    assert outs["tc"]["tensor"].device.type == "cpu"
+
+
+@requires_mps
+@pytest.mark.asyncio
+async def test_tensor_create_runs_on_context_device_mps():
+    nodes, edges = _tensor_create_graph()
+    outs = await execute_graph(nodes, edges, context=ExecutionContext(device="mps"))
+    assert outs["tc"]["tensor"].device.type == "mps"
+
+
+@pytest.mark.asyncio
+async def test_default_context_keeps_tensors_on_cpu():
+    # No context (CLI-style) → tensors stay on CPU.
+    nodes, edges = _tensor_create_graph()
+    outs = await execute_graph(nodes, edges)
+    assert outs["tc"]["tensor"].device.type == "cpu"
+
+
+# ── StatefulModuleMixin moves the module to context.device ──────────
+
+class _LinearNode(StatefulModuleMixin, BaseNode):
+    NODE_NAME = "_TestLinear"
+    CATEGORY = "Test"
+    DESCRIPTION = "test"
+    structural_params = ("n",)
+
+    @classmethod
+    def define_inputs(cls):
+        return []
+
+    @classmethod
+    def define_outputs(cls):
+        return []
+
+    def build_module(self, params):
+        return nn.Linear(params.get("n", 4), 2)
+
+    def execute(self, inputs, params, *, context=None):
+        return {"module": self.get_or_build_module(context, params)}
+
+
+def test_get_or_build_module_moves_to_context_device_cpu():
+    node = _LinearNode()
+    mod = node.get_or_build_module(ExecutionContext(device="cpu"), {"n": 4})
+    assert next(mod.parameters()).device.type == "cpu"
+
+
+@requires_mps
+def test_get_or_build_module_moves_to_context_device_mps():
+    node = _LinearNode()
+    mod = node.get_or_build_module(ExecutionContext(device="mps"), {"n": 4})
+    assert next(mod.parameters()).device.type == "mps"
+
+
+def test_get_or_build_module_no_context_builds_on_cpu():
+    node = _LinearNode()
+    mod = node.get_or_build_module(None, {"n": 4})
+    assert next(mod.parameters()).device.type == "cpu"

--- a/docs/mlx-spike.md
+++ b/docs/mlx-spike.md
@@ -1,0 +1,80 @@
+# Native MLX Spike (Phase 3 — inference-subset, non-blocking)
+
+> Status: **spike / proof-of-concept**. Not a shipped execution backend.
+> Apple acceleration in the graph engine is provided by **PyTorch MPS** (Phase 1 + 2).
+
+## TL;DR
+
+A small MLP's **forward inference** was ported from PyTorch to Apple's
+[MLX](https://github.com/ml-explore/mlx) framework and produced numerically
+identical results:
+
+```
+$ python scripts/mlx_spike.py
+MLX default device: Device(gpu, 0)
+torch MPS available: True
+
+output shape       : torch (256, 10)  |  mlx (256, 10)
+max abs difference : 1.937e-07
+torch CPU forward  : 0.21 ms
+mlx   GPU forward  : 0.68 ms
+
+✅ PASS — inference-subset parity within 1e-4 tolerance.
+```
+
+So: **feasible and correct** for the inference subset. MLX stays an *optional
+future accelerator*, not a replacement for the MPS path.
+
+## Why MLX is separate from the device selector
+
+MLX is a **distinct array framework**, not a PyTorch backend. There is no
+`tensor.to("mlx")` and no `torch.device("mlx")`. The graph engine is built on
+`torch` tensors / `nn.Module`s, so MLX cannot be a value in the global device
+selector (`cpu` / `cuda` / `mps`) — that selector drives `torch`. Apple GPU
+execution for the real graph is therefore **PyTorch MPS** (already wired and
+verified end-to-end). MLX is surfaced only via:
+
+- `device_utils.mlx_available()` — detection (does not import torch).
+- `scripts/mlx_spike.py` — this runnable PoC.
+
+## What the spike does
+
+1. Build a `Linear→ReLU→Linear→ReLU→Linear` MLP in torch; run inference on CPU.
+2. Export the `state_dict` to numpy, then to `mlx.core` arrays.
+3. Reimplement the forward with MLX ops (`mx.matmul`, `mx.maximum`), mirroring
+   torch's `y = x @ Wᵀ + b` Linear convention.
+4. `mx.eval()` (MLX is lazy), compare outputs, time each side.
+
+## Scope & constraints (deliberate)
+
+- **Inference only.** Training/autograd parity in MLX is explicitly out of
+  scope — far larger, and unnecessary for the spike's question ("can we run a
+  trained model's forward on MLX?").
+- **float32.** MLX is float32-native on Apple silicon (same constraint that
+  makes MPS reject float64 — see `device_utils.to_device`).
+- Manual op-by-op port. A general `nn.Module → MLX` translator (covering Conv,
+  attention, norms, …) is the next increment if this is ever productized.
+
+## Conversion approach (for a future increment)
+
+```
+torch model (trained, on CPU/MPS)
+        │  state_dict → numpy → mx.array
+        ▼
+MLX arrays + hand-written / generated forward
+        │  mx.eval()
+        ▼
+outputs  ──(numpy)──▶ compare to torch reference
+```
+
+A productized version would generate the MLX forward from the same layer-graph
+the `SequentialModel` / `GraphModelModule` already builds, reusing the node
+metadata rather than hand-porting.
+
+## Recommendation
+
+- Keep **MPS** as the Apple default for all execution (training + inference).
+- Treat MLX as an **optional inference accelerator** to revisit only if there's
+  a measured win on Apple hardware for inference-heavy teaching demos.
+- `mlx` is **not** a committed dependency. Install ad-hoc to run the spike:
+  `uv pip install mlx` (Apple Silicon only). The main app never imports it.

--- a/examples/Usage_Example/CNN-MNIST/InferenceCNN-MNIST/graph.json
+++ b/examples/Usage_Example/CNN-MNIST/InferenceCNN-MNIST/graph.json
@@ -37,7 +37,7 @@
         "params": {
           "path": "model_weights.pt",
           "load_mode": "state_dict",
-          "device": "cpu",
+          "device": "auto",
           "strict": true
         }
       }
@@ -79,7 +79,7 @@
       },
       "data": {
         "params": {
-          "device": "cpu"
+          "device": "auto"
         }
       }
     },

--- a/examples/Usage_Example/CNN-MNIST/TrainCNN-MNIST/graph.json
+++ b/examples/Usage_Example/CNN-MNIST/TrainCNN-MNIST/graph.json
@@ -56,7 +56,7 @@
           },
           "train_loop": {
             "epochs": 5,
-            "device": "cpu"
+            "device": "auto"
           }
         }
       }

--- a/examples/Usage_Example/GPT-Mini/TrainGPT-Mini/graph.json
+++ b/examples/Usage_Example/GPT-Mini/TrainGPT-Mini/graph.json
@@ -56,7 +56,7 @@
           },
           "train_loop": {
             "epochs": 3,
-            "device": "cpu"
+            "device": "auto"
           }
         }
       }

--- a/examples/Usage_Example/ResNet-CIFAR10/TrainResNet-CIFAR10/graph.json
+++ b/examples/Usage_Example/ResNet-CIFAR10/TrainResNet-CIFAR10/graph.json
@@ -56,7 +56,7 @@
           },
           "train_loop": {
             "epochs": 3,
-            "device": "cpu"
+            "device": "auto"
           }
         }
       }

--- a/frontend/src/api/rest.test.ts
+++ b/frontend/src/api/rest.test.ts
@@ -3,6 +3,7 @@ import {
   exportGraph,
   fetchNodeDefinitions,
   fetchPresetDefinitions,
+  fetchDevices,
   validateGraph,
   saveGraph,
   loadGraph,
@@ -120,6 +121,12 @@ describe('GET endpoints', () => {
       fn: () => fetchPresetDefinitions(),
       url: '/api/presets',
       errorRe: /Failed to fetch presets/,
+    },
+    {
+      name: 'fetchDevices',
+      fn: () => fetchDevices(),
+      url: '/api/system/devices',
+      errorRe: /Failed to fetch devices/,
     },
     {
       name: 'listGraphs',

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -15,6 +15,27 @@ export async function fetchPresetDefinitions(): Promise<PresetDefinition[]> {
   return res.json();
 }
 
+export interface DeviceInfo {
+  value: string;
+  label: string;
+  detail: string;
+  available: boolean;
+}
+
+export interface DevicesResponse {
+  default: string;
+  devices: DeviceInfo[];
+}
+
+/** Compute devices available for graph execution (CPU + any GPU backend,
+ * with NVIDIA-CUDA / AMD-ROCm / Apple-MPS labels). Powers the global device
+ * selector. */
+export async function fetchDevices(): Promise<DevicesResponse> {
+  const res = await fetch(`${BASE_URL}/system/devices`);
+  if (!res.ok) throw new Error(`Failed to fetch devices: ${res.statusText}`);
+  return res.json();
+}
+
 export async function validateGraph(nodes: any[], edges: any[]) {
   const res = await apiFetch(`${BASE_URL}/graph/validate`, {
     method: 'POST',

--- a/frontend/src/components/Toolbar/SettingsPopover.module.css
+++ b/frontend/src/components/Toolbar/SettingsPopover.module.css
@@ -259,3 +259,20 @@
 .action.accent:hover:not(:disabled) {
   background: rgba(6, 182, 212, 0.15);
 }
+
+.select {
+  background: #0f172a;
+  border: 1px solid #334155;
+  color: #cbd5e1;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.71875rem;
+  font-weight: 600;
+  border-radius: 0.3125rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.select:hover {
+  border-color: #475569;
+  color: #e5e7eb;
+}

--- a/frontend/src/components/Toolbar/SettingsPopover.test.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.test.tsx
@@ -7,11 +7,20 @@ import { useUIStore } from '../../store/uiStore';
 import { useToastStore } from '../../store/toastStore';
 import { useDialogStore } from '../../store/dialogStore';
 import { useI18n } from '../../i18n';
-import { resetWeights } from '../../api/rest';
+import { resetWeights, fetchDevices } from '../../api/rest';
 import { computeSegmentNodes } from '../../utils/segmentPath';
 
 vi.mock('../../api/rest', () => ({
   resetWeights: vi.fn(),
+  fetchDevices: vi.fn(() =>
+    Promise.resolve({
+      default: 'cpu',
+      devices: [
+        { value: 'cpu', label: 'CPU', detail: '', available: true },
+        { value: 'mps', label: 'Apple MPS', detail: 'Metal Performance Shaders', available: true },
+      ],
+    }),
+  ),
 }));
 
 vi.mock('../../utils/segmentPath', () => ({
@@ -59,6 +68,14 @@ describe('SettingsPopover', () => {
       gridSnapEnabled: false,
       tooltipsEnabled: true,
       beginnerMode: false,
+      globalDevice: 'cpu',
+    });
+    vi.mocked(fetchDevices).mockResolvedValue({
+      default: 'cpu',
+      devices: [
+        { value: 'cpu', label: 'CPU', detail: '', available: true },
+        { value: 'mps', label: 'Apple MPS', detail: 'Metal Performance Shaders', available: true },
+      ],
     });
     useToastStore.setState({ toasts: [] });
     useDialogStore.setState({ active: null, resolve: null });
@@ -77,12 +94,48 @@ describe('SettingsPopover', () => {
     expect(container.querySelector('[role="dialog"]')).toBeNull();
   });
 
-  it('renders all three sections when open', () => {
+  it('renders all sections when open', () => {
     render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+    expect(screen.getByText('Execution')).toBeInTheDocument();
     expect(screen.getByText('Recording & Inspection')).toBeInTheDocument();
     expect(screen.getByText('Training Behavior')).toBeInTheDocument();
     expect(screen.getByText('Editor')).toBeInTheDocument();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  // ── Execution: global device selector ─────────────────────────────
+
+  it('populates the device selector from the backend and reflects the store value', async () => {
+    useUIStore.setState({ globalDevice: 'mps' });
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+    const select = screen.getByRole('combobox', { name: 'Compute device' }) as HTMLSelectElement;
+    // Options arrive asynchronously from fetchDevices.
+    await waitFor(() =>
+      expect(within(select).getByRole('option', { name: /Apple MPS/ })).toBeInTheDocument(),
+    );
+    expect(select.value).toBe('mps');
+    expect(within(select).getByRole('option', { name: 'CPU' })).toBeInTheDocument();
+  });
+
+  it('changing the device select updates the UI store', async () => {
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+    const select = screen.getByRole('combobox', { name: 'Compute device' });
+    await waitFor(() =>
+      expect(within(select).getByRole('option', { name: /Apple MPS/ })).toBeInTheDocument(),
+    );
+    fireEvent.change(select, { target: { value: 'mps' } });
+    expect(useUIStore.getState().globalDevice).toBe('mps');
+  });
+
+  it('falls back to a CPU-only option when the devices fetch fails', async () => {
+    vi.mocked(fetchDevices).mockRejectedValueOnce(new Error('offline'));
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+    const select = screen.getByRole('combobox', { name: 'Compute device' });
+    // The rejection settles on a microtask; flush it.
+    await waitFor(() => expect(fetchDevices).toHaveBeenCalled());
+    const options = within(select).getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('CPU');
   });
 
   // ── outside-click / esc behaviour ─────────────────────────────────

--- a/frontend/src/components/Toolbar/SettingsPopover.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTabStore } from '../../store/tabStore';
 import { useUIStore } from '../../store/uiStore';
 import { useToastStore } from '../../store/toastStore';
 import { useI18n } from '../../i18n';
-import { resetWeights } from '../../api/rest';
+import { resetWeights, fetchDevices, type DeviceInfo } from '../../api/rest';
 import { computeSegmentNodes } from '../../utils/segmentPath';
 import { generateId } from '../../utils';
 import { confirm } from '../../utils/dialog';
@@ -45,6 +45,27 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
   const toggleGridSnap = useUIStore((s) => s.toggleGridSnap);
   const toggleTooltips = useUIStore((s) => s.toggleTooltips);
   const toggleBeginnerMode = useUIStore((s) => s.toggleBeginnerMode);
+
+  // Global execution device. Options come from the backend (CPU + any GPU
+  // backend present); fall back to CPU-only if the fetch fails.
+  const globalDevice = useUIStore((s) => s.globalDevice);
+  const setGlobalDevice = useUIStore((s) => s.setGlobalDevice);
+  const [devices, setDevices] = useState<DeviceInfo[]>([
+    { value: 'cpu', label: 'CPU', detail: '', available: true },
+  ]);
+  useEffect(() => {
+    let cancelled = false;
+    fetchDevices()
+      .then((r) => {
+        if (!cancelled && r.devices.length > 0) setDevices(r.devices);
+      })
+      .catch(() => {
+        /* keep the CPU-only fallback */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const addToast = useToastStore((s) => s.addToast);
 
@@ -142,6 +163,32 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
       </div>
 
       <div className={styles.body}>
+        {/* ── Execution ──────────────────────────────────────────── */}
+        <section className={styles.section}>
+          <div className={styles.sectionTitle}>
+            {t('toolbar.settings.section.execution')}
+          </div>
+
+          <Row
+            name={t('settings.device.name')}
+            desc={t('settings.device.desc')}
+            ctrl={
+              <select
+                aria-label={t('settings.device.name')}
+                className={styles.select}
+                value={globalDevice}
+                onChange={(e) => setGlobalDevice(e.target.value)}
+              >
+                {devices.map((d) => (
+                  <option key={d.value} value={d.value}>
+                    {d.detail ? `${d.label} — ${d.detail}` : d.label}
+                  </option>
+                ))}
+              </select>
+            }
+          />
+        </section>
+
         {/* ── Recording & Inspection ─────────────────────────────── */}
         <section className={styles.section}>
           <div className={styles.sectionTitle}>

--- a/frontend/src/components/Toolbar/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.test.tsx
@@ -33,6 +33,9 @@ vi.mock('../../api/rest', () => ({
   deleteCustomNode: vi.fn(),
   // Used by the child SettingsPopover
   resetWeights: vi.fn(),
+  fetchDevices: vi.fn(() =>
+    Promise.resolve({ default: 'cpu', devices: [{ value: 'cpu', label: 'CPU', detail: '', available: true }] }),
+  ),
 }));
 
 const mockedRest = vi.mocked(rest);

--- a/frontend/src/hooks/useGraphExecution.test.ts
+++ b/frontend/src/hooks/useGraphExecution.test.ts
@@ -3,6 +3,7 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { useGraphExecution } from './useGraphExecution';
 import { useTabStore } from '../store/tabStore';
 import { useToastStore } from '../store/toastStore';
+import { useUIStore } from '../store/uiStore';
 
 // Mock the REST validation endpoint — the hook calls validateGraph() before
 // sending. Each test drives its resolved/rejected value.
@@ -464,6 +465,19 @@ describe('useGraphExecution - execute', () => {
     });
 
     expect('changed_nodes' in ws.send.mock.calls[0][0]).toBe(false);
+  });
+
+  it('sends the global device from the UI store in the execute payload', async () => {
+    useUIStore.getState().setGlobalDevice('mps');
+    const ws = tabById('t1').ws as FakeWs;
+    const { result } = renderHook(() => useGraphExecution());
+
+    await act(async () => {
+      await result.current.execute();
+    });
+
+    expect(ws.send.mock.calls[0][0].device).toBe('mps');
+    useUIStore.getState().setGlobalDevice('cpu'); // reset for other tests
   });
 
   it('uses the crypto.randomUUID run id when available', async () => {

--- a/frontend/src/hooks/useGraphExecution.ts
+++ b/frontend/src/hooks/useGraphExecution.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import { useTabStore, type TabState } from '../store/tabStore';
 import { useToastStore } from '../store/toastStore';
+import { useUIStore } from '../store/uiStore';
 import { validateGraph } from '../api/rest';
 import { findEntryPoints } from '../utils/findEntryPoints';
 import { useI18n } from '../i18n';
@@ -227,6 +228,8 @@ export function useGraphExecution() {
       // A3: gradient capture
       backward_mode: tab.backwardMode,
       auto_backward: tab.autoBackward,
+      // Global compute device (nodes with device='auto' follow this).
+      device: useUIStore.getState().globalDevice,
       ...(changedNodes.length > 0 ? { changed_nodes: changedNodes } : {}),
     });
   }, [getActiveTab, getSerializedGraph, clearLogs, clearExecutionStatus, clearOutputSummaries, setTabStatus, addTabLog]);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -323,9 +323,12 @@ const en = {
   'toolbar.settings': 'Settings',
   'toolbar.settings.title': 'Open settings',
   'toolbar.settings.search': 'Search settings…',
+  'toolbar.settings.section.execution': 'Execution',
   'toolbar.settings.section.recording': 'Recording & Inspection',
   'toolbar.settings.section.training': 'Training Behavior',
   'toolbar.settings.section.editor': 'Editor',
+  'settings.device.name': 'Compute device',
+  'settings.device.desc': 'Run the graph on this device. Nodes set to "auto" follow it.',
 
   // Font-size menu
   'toolbar.fontSize.title': 'Font size',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -325,9 +325,12 @@ const zhTW: Record<TranslationKey, string> = {
   'toolbar.settings': '設定',
   'toolbar.settings.title': '開啟設定',
   'toolbar.settings.search': '搜尋設定…',
+  'toolbar.settings.section.execution': '執行',
   'toolbar.settings.section.recording': '錄製與檢視',
   'toolbar.settings.section.training': '訓練行為',
   'toolbar.settings.section.editor': '編輯器',
+  'settings.device.name': '運算裝置',
+  'settings.device.desc': '在此裝置上執行圖。設為「auto」的節點會跟隨此設定。',
 
   // 字級選單
   'toolbar.fontSize.title': '字級',

--- a/frontend/src/store/uiStore.test.ts
+++ b/frontend/src/store/uiStore.test.ts
@@ -7,6 +7,7 @@ const KEYS = {
   BEGINNER: 'codefyui-beginner-mode',
   LAYOUT_MODE: 'codefyui-last-layout-mode',
   FONT_SIZE: 'codefyui-font-size',
+  GLOBAL_DEVICE: 'codefyui-global-device',
 };
 
 describe('useUIStore', () => {
@@ -23,6 +24,7 @@ describe('useUIStore', () => {
       beginnerMode: false,
       lastLayoutMode: 'experiments',
       fontSize: 'default',
+      globalDevice: 'cpu',
     });
   });
 
@@ -135,6 +137,18 @@ describe('useUIStore', () => {
     });
   });
 
+  describe('setGlobalDevice', () => {
+    it('updates the device and persists it', () => {
+      useUIStore.getState().setGlobalDevice('mps');
+      expect(useUIStore.getState().globalDevice).toBe('mps');
+      expect(localStorage.getItem(KEYS.GLOBAL_DEVICE)).toBe('mps');
+
+      useUIStore.getState().setGlobalDevice('cuda');
+      expect(useUIStore.getState().globalDevice).toBe('cuda');
+      expect(localStorage.getItem(KEYS.GLOBAL_DEVICE)).toBe('cuda');
+    });
+  });
+
   // ── module-load loaders (loadLayoutMode / loadFontSize) ──────────────────────
   // These run once at import time. To exercise every branch we reset the module
   // registry with localStorage pre-seeded and re-import, observing the initial
@@ -187,6 +201,19 @@ describe('useUIStore', () => {
       const mod = await import('./uiStore');
       expect(mod.useUIStore.getState().gridSnapEnabled).toBe(true);
       expect(mod.useUIStore.getState().beginnerMode).toBe(true);
+    });
+
+    it('globalDevice defaults to cpu when nothing is persisted', async () => {
+      vi.resetModules();
+      const mod = await import('./uiStore');
+      expect(mod.useUIStore.getState().globalDevice).toBe('cpu');
+    });
+
+    it('globalDevice loads the persisted value', async () => {
+      vi.resetModules();
+      localStorage.setItem(KEYS.GLOBAL_DEVICE, 'mps');
+      const mod = await import('./uiStore');
+      expect(mod.useUIStore.getState().globalDevice).toBe('mps');
     });
   });
 });

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -19,6 +19,10 @@ interface UIState {
   setLastLayoutMode: (mode: 'experiments' | 'all' | 'selected') => void;
   fontSize: FontSize;
   setFontSize: (size: FontSize) => void;
+  /** Global compute device sent with every graph run ('cpu' | 'cuda' | 'mps').
+   * Nodes whose own device param is 'auto' follow this. */
+  globalDevice: string;
+  setGlobalDevice: (device: string) => void;
 }
 
 const TOOLTIPS_KEY = 'codefyui-tooltips';
@@ -26,6 +30,9 @@ const GRIDSNAP_KEY = 'codefyui-gridsnap';
 const BEGINNER_KEY = 'codefyui-beginner-mode';
 const LAYOUT_MODE_KEY = 'codefyui-last-layout-mode';
 const FONT_SIZE_KEY = 'codefyui-font-size';
+const GLOBAL_DEVICE_KEY = 'codefyui-global-device';
+
+const loadGlobalDevice = (): string => localStorage.getItem(GLOBAL_DEVICE_KEY) || 'cpu';
 
 const loadLayoutMode = (): 'experiments' | 'all' | 'selected' => {
   const saved = localStorage.getItem(LAYOUT_MODE_KEY);
@@ -76,5 +83,10 @@ export const useUIStore = create<UIState>((set) => ({
   setFontSize: (size) => {
     localStorage.setItem(FONT_SIZE_KEY, size);
     set({ fontSize: size });
+  },
+  globalDevice: loadGlobalDevice(),
+  setGlobalDevice: (device) => {
+    localStorage.setItem(GLOBAL_DEVICE_KEY, device);
+    set({ globalDevice: device });
   },
 }));

--- a/scripts/device_smoke.py
+++ b/scripts/device_smoke.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""跨裝置煙霧測試：把範例 graph 強制跑在指定裝置上（cpu / cuda / mps）。
+
+用途：multi-backend 工作流程的「真機驗證」工具。把 device-aware 範例的
+device 參數覆寫成目標裝置後實際執行，藉此確認該裝置（尤其 Apple MPS、
+NVIDIA CUDA、AMD ROCm）能端到端跑完訓練/推論路徑。
+
+用法：
+    python scripts/device_smoke.py                 # 自動挑最佳可用裝置
+    python scripts/device_smoke.py mps             # 指定裝置
+    python scripts/device_smoke.py cuda --full     # 不限制 epochs（完整跑）
+    python scripts/device_smoke.py mps a.json b.json   # 指定自訂 graph
+
+預設會挑選 repo 內「會實際使用裝置」的範例（含 TrainingLoop / Inference /
+Checkpoint / ModelLoader 這類 sink 節點）。device 不相容（例如 MPS 不支援
+float64）會在第一個 batch 就拋錯，因此預設把 epochs 上限設為 1 以加速。
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_BACKEND = _REPO_ROOT / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+# Datasets default to a relative ``./data`` dir; the server runs from backend/,
+# so chdir there too and the already-downloaded MNIST/CIFAR are reused instead
+# of re-fetched.
+os.chdir(_BACKEND)
+
+from app.config import settings  # noqa: E402
+from app.core.device_utils import get_available_devices  # noqa: E402
+from app.core.graph_engine import execute_graph  # noqa: E402
+from app.core.logging_config import setup_logging  # noqa: E402
+from app.core.node_registry import registry  # noqa: E402
+from app.core.preset_registry import preset_registry  # noqa: E402
+
+# device 會實際生效的範例（透過 sink 節點 .to(device)）。其餘純前向範例沒有
+# device 參數，永遠跑 CPU，故不在預設清單內。
+_DEFAULT_EXAMPLES = [
+    "examples/Usage_Example/GPT-Mini/TrainGPT-Mini/graph.json",
+    "examples/Usage_Example/CNN-MNIST/TrainCNN-MNIST/graph.json",
+    "examples/Usage_Example/ResNet-CIFAR10/TrainResNet-CIFAR10/graph.json",
+]
+
+
+def _best_device() -> str:
+    avail = get_available_devices()
+    for preferred in ("cuda", "mps"):
+        if preferred in avail:
+            return preferred
+    return "cpu"
+
+
+def patch_device(graph: dict, device: str, cap_epochs: int | None) -> int:
+    """把每個 device 參數（含 preset internalParams）覆寫成 device，回傳數量。
+
+    同時把 epochs 上限設為 cap_epochs（None 表示不限制）以加速煙霧測試。
+    """
+    n = 0
+
+    def _patch(params: dict) -> None:
+        nonlocal n
+        if "device" in params:
+            params["device"] = device
+            n += 1
+        if cap_epochs is not None and "epochs" in params:
+            try:
+                params["epochs"] = min(int(params["epochs"]), cap_epochs)
+            except (TypeError, ValueError):
+                pass
+
+    for node in graph.get("nodes", []):
+        data = node.get("data", {})
+        _patch(data.get("params", {}))
+        for sub in data.get("internalParams", {}).values():
+            if isinstance(sub, dict):
+                _patch(sub)
+    return n
+
+
+async def _run_one(path: Path, device: str, cap_epochs: int | None) -> tuple[bool, str]:
+    graph = json.loads(path.read_text(encoding="utf-8"))
+    n = patch_device(graph, device, cap_epochs)
+    try:
+        await execute_graph(graph["nodes"], graph["edges"])
+        return True, f"patched {n} device param(s)"
+    except Exception as exc:  # noqa: BLE001
+        return False, f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+
+
+async def _main() -> int:
+    parser = argparse.ArgumentParser(description="Run example graphs on a chosen device.")
+    parser.add_argument("device", nargs="?", default=None, help="cpu / cuda / mps (預設自動)")
+    parser.add_argument("graphs", nargs="*", help="自訂 graph.json 路徑（預設用內建範例清單）")
+    parser.add_argument("--full", action="store_true", help="不限制 epochs，完整執行")
+    args = parser.parse_args()
+
+    setup_logging(level="WARNING")
+    registry.discover(settings.NODES_DIR, "app.nodes")
+    registry.discover(settings.CUSTOM_NODES_DIR, "app.custom_nodes")
+    preset_registry.discover(settings.PRESETS_DIR, registry)
+
+    device = args.device or _best_device()
+    cap_epochs = None if args.full else 1
+    graph_paths = [Path(g) for g in args.graphs] or [_REPO_ROOT / p for p in _DEFAULT_EXAMPLES]
+
+    print(f"available devices: {get_available_devices()}")
+    print(f"target device    : {device}")
+    print(f"epoch cap        : {'none (full)' if cap_epochs is None else cap_epochs}\n")
+
+    failures = 0
+    for path in graph_paths:
+        if not path.exists():
+            print(f"⚠️  [SKIP] {path} (not found)")
+            continue
+        ok, detail = await _run_one(path, device, cap_epochs)
+        marker = "✅" if ok else "❌"
+        status = "OK" if ok else "FAIL"
+        label = path.parent.name if path.name == "graph.json" else path.name
+        print(f"{marker} [{status}] {label}")
+        first = detail.splitlines()[0] if detail else ""
+        print(f"      {first}")
+        if not ok:
+            failures += 1
+            for line in detail.splitlines()[1:]:
+                print(f"      {line}")
+
+    print(f"\n{len(graph_paths) - failures}/{len(graph_paths)} passed on {device}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/mlx_spike.py
+++ b/scripts/mlx_spike.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Phase-3 spike：原生 MLX 推論子集 proof-of-concept（非阻塞、僅推論）。
+
+背景：Apple 加速在 CodefyUI 的圖引擎是用 **PyTorch MPS**（已接好）。MLX 是
+Apple 另一套陣列框架，**不是 torch backend**（沒有 `tensor.to("mlx")`），所以
+不能直接塞進現有 torch 執行路徑。本 spike 驗證「把一個已訓練好的小模型的
+**前向推論**搬到 MLX 跑」是否可行、數值是否一致、效能如何——這是未來把 MLX
+當成可選推論加速器的最小起點。
+
+做法：
+  1. 用 torch 建一個小 MLP（Linear→ReLU→Linear→ReLU→Linear），在 CPU 跑推論。
+  2. 把 torch 的權重（state_dict）轉成 MLX 陣列。
+  3. 用 mlx.core 重寫同一條前向（matmul + relu），在 MLX(GPU/Metal) 上跑。
+  4. 比對兩邊輸出的數值誤差，並各量一次 wall-clock。
+
+範圍與限制（刻意）：
+  - **只做推論**：不追求 autograd/訓練在 MLX 上的對等，那是更大的工程。
+  - 權重以 float32 轉移（MLX 在 Apple 上原生 float32）。
+  - 這是 spike，不是正式 backend；圖引擎仍以 MPS 為 Apple 預設。
+
+用法：
+    python scripts/mlx_spike.py
+未安裝 mlx 時會印出安裝指引並以非錯誤狀態結束。
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+import torch
+import torch.nn as nn
+
+
+def build_torch_mlp(seed: int = 0) -> nn.Module:
+    torch.manual_seed(seed)
+    return nn.Sequential(
+        nn.Linear(64, 128),
+        nn.ReLU(),
+        nn.Linear(128, 128),
+        nn.ReLU(),
+        nn.Linear(128, 10),
+    )
+
+
+def mlx_forward(state: dict, x_np):
+    """Reimplement the Sequential MLP forward with mlx.core ops.
+
+    torch ``nn.Linear`` stores weight as [out, in] and computes
+    ``y = x @ W.T + b``; we mirror that with mx.matmul.
+    """
+    import mlx.core as mx
+
+    def linear(x, w, b):
+        return mx.matmul(x, w.T) + b
+
+    def relu(x):
+        return mx.maximum(x, 0)
+
+    x = mx.array(x_np)
+    # Sequential indices: 0=Linear, 2=Linear, 4=Linear (1,3 are ReLU).
+    x = relu(linear(x, mx.array(state["0.weight"]), mx.array(state["0.bias"])))
+    x = relu(linear(x, mx.array(state["2.weight"]), mx.array(state["2.bias"])))
+    x = linear(x, mx.array(state["4.weight"]), mx.array(state["4.bias"]))
+    mx.eval(x)  # force evaluation (MLX is lazy) before we read/time it
+    return x
+
+
+def main() -> int:
+    from importlib.util import find_spec
+
+    if find_spec("mlx") is None:
+        print("MLX 尚未安裝。這個 spike 需要 Apple 的 MLX 框架。")
+        print("安裝： uv pip install mlx   （或 pip install mlx），僅限 Apple Silicon。")
+        print("未安裝不影響主程式：Apple 加速在圖引擎是走 PyTorch MPS。")
+        return 0
+
+    import mlx.core as mx
+    import numpy as np
+
+    print(f"MLX default device: {mx.default_device()}")
+    print(f"torch MPS available: {torch.backends.mps.is_available()}\n")
+
+    model = build_torch_mlp().eval()
+    state = {k: v.detach().cpu().numpy() for k, v in model.state_dict().items()}
+
+    rng = np.random.default_rng(0)
+    x_np = rng.standard_normal((256, 64)).astype(np.float32)
+
+    # ── torch (CPU) reference ──
+    with torch.no_grad():
+        t0 = time.perf_counter()
+        torch_out = model(torch.from_numpy(x_np)).numpy()
+        t_torch = time.perf_counter() - t0
+
+    # ── MLX (GPU/Metal) ──
+    mlx_forward(state, x_np)  # warm-up (compile kernels)
+    t0 = time.perf_counter()
+    mlx_out = mlx_forward(state, x_np)
+    t_mlx = time.perf_counter() - t0
+    mlx_np = np.array(mlx_out)
+
+    max_abs = float(np.max(np.abs(torch_out - mlx_np)))
+    print(f"output shape       : torch {torch_out.shape}  |  mlx {mlx_np.shape}")
+    print(f"max abs difference : {max_abs:.3e}")
+    print(f"torch CPU forward  : {t_torch * 1e3:.2f} ms")
+    print(f"mlx   GPU forward  : {t_mlx * 1e3:.2f} ms")
+
+    ok = max_abs < 1e-4
+    print(f"\n{'✅ PASS' if ok else '❌ FAIL'} — inference-subset parity "
+          f"{'within' if ok else 'EXCEEDS'} 1e-4 tolerance.")
+    print("結論：把已訓練模型的前向推論搬到 MLX 可行且數值一致；"
+          "可作為未來可選 MLX 推論加速器的基礎。圖引擎 Apple 預設仍為 MPS。")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Makes CodefyUI run on Apple **MPS** end-to-end and adds a **global device** setting, while keeping CUDA/ROCm in place for verification on other platforms. MLX is explored as a separate, non-blocking inference spike (deliberately *not* a device-selector option).

## Phase 1 — MPS correctness
- Centralized device handling in `core/device_utils` (`resolve_device` + `to_device`); downcasts MPS-unsupported **float64 → float32** at the device boundary. Wired into the 4 device-aware sink nodes (Training / Inference / Checkpoint / ModelLoader).
- `PYTORCH_ENABLE_MPS_FALLBACK=1` defaulted as a safety net for the op long-tail.

## Phase 2 — global device + node device-awareness + ROCm/CUDA distinction
- `ExecutionContext.device` (set from the WS `device` field) is the global run device. `StatefulModuleMixin.get_or_build_module` moves every layer module to it; tensor-source nodes build on CPU (keeps seeded-RNG reproducibility) then `to_device`; inline-module nodes (MoE/DQN/PPO/RewardModel) match the input device. `ExecutionCache` key includes the device.
- Sink nodes gain an `"auto"` default that follows the global device; explicit `cpu/cuda/mps` overrides. **18 forward-only examples now run on MPS** (were CPU-only).
- `describe_accelerator()` distinguishes **NVIDIA CUDA / AMD ROCm** (`torch.version.hip`) **/ Apple MPS**; `GET /api/system/devices` serves it. Frontend: `uiStore.globalDevice` (persisted), device selector in the Settings "Execution" section, device injected into the execute payload (en + zh-TW).

## Phase 3 — native MLX spike (inference-subset, non-blocking)
- `scripts/mlx_spike.py`: a trained MLP's forward ported to MLX — torch↔MLX parity **1.9e-7**. `device_utils.mlx_available()` detection only; **MLX is not a device-selector option** (it is a separate framework, not a torch backend). Design note in `docs/mlx-spike.md`. `mlx` is not a committed dependency.

## Verification
- Backend **1239 passed** (only the pre-existing Apple-only `test_timestep_embedding_node` epsilon flake remains). Frontend **1573 passed @ 100% coverage**.
- **Chrome E2E**: selected Apple MPS in Settings → persisted; Run sent WS `{device:"mps"}`; GPT-Mini trained 3/3 epochs in-browser on MPS (loss 0.337 → 0.1158, matching the CLI MPS run).
- `scripts/device_smoke.py <cpu|cuda|mps>` reruns the device verification on the CUDA/ROCm machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)