### PR TITLE
fix(windows): device_smoke UTF-8 console fix + remove pictographic emoji

### DIFF
--- a/docs/mlx-spike.md
+++ b/docs/mlx-spike.md
@@ -19,7 +19,7 @@ max abs difference : 1.937e-07
 torch CPU forward  : 0.21 ms
 mlx   GPU forward  : 0.68 ms
 
-✅ PASS — inference-subset parity within 1e-4 tolerance.
+PASS — inference-subset parity within 1e-4 tolerance.
 ```
 
 So: **feasible and correct** for the inference subset. MLX stays an *optional

--- a/frontend/src/components/shared/Toast.test.tsx
+++ b/frontend/src/components/shared/Toast.test.tsx
@@ -28,7 +28,7 @@ describe('ToastContainer', () => {
       success: '✓',
       error: '✗',
       info: 'ⓘ',
-      warning: '⚠',
+      warning: '!',
     };
     useToastStore.setState({
       toasts: (Object.keys(expected) as ToastType[]).map((type, i) => ({

--- a/frontend/src/components/shared/Toast.tsx
+++ b/frontend/src/components/shared/Toast.tsx
@@ -5,7 +5,7 @@ const TYPE_ICONS: Record<ToastType, string> = {
   success: '\u2713',
   error: '\u2717',
   info: '\u24D8',
-  warning: '\u26A0',
+  warning: '!',
 };
 
 export function ToastContainer() {

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -183,7 +183,7 @@ def banner(zh: str, en: str) -> None:
 
 
 def warn(zh: str, en: str) -> None:
-    print(f"{YELLOW}⚠ {t(zh, en)}{RESET}", file=sys.stderr)
+    print(f"{YELLOW}! {t(zh, en)}{RESET}", file=sys.stderr)
 
 
 def err(zh: str, en: str) -> None:
@@ -438,7 +438,7 @@ def _warn_if_dist_stale() -> None:
     src_when = datetime.fromtimestamp(src_mtime).strftime("%Y-%m-%d %H:%M")
     dist_when = datetime.fromtimestamp(dist_mtime).strftime("%Y-%m-%d %H:%M")
     print(
-        f"\n⚠️  警告：frontend/dist 比 src 舊 {delta_min:.0f} 分鐘\n"
+        f"\n警告：frontend/dist 比 src 舊 {delta_min:.0f} 分鐘\n"
         f"    dist mtime: {dist_when}\n"
         f"    src  mtime: {src_when}\n"
         f"    若想看到最新前端，請先執行 'cdui build' 重新打包。\n",

--- a/scripts/device_smoke.py
+++ b/scripts/device_smoke.py
@@ -25,6 +25,16 @@ import sys
 import traceback
 from pathlib import Path
 
+# Force UTF-8 on Windows so the Chinese docstring / argparse help (and any
+# other non-ASCII) print without a cp1252 UnicodeEncodeError on a non-CJK
+# console. Mirrors the same guard in scripts/dev.py.
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, OSError):
+        pass
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _BACKEND = _REPO_ROOT / "backend"
 if str(_BACKEND) not in sys.path:
@@ -119,13 +129,12 @@ async def _main() -> int:
     failures = 0
     for path in graph_paths:
         if not path.exists():
-            print(f"⚠️  [SKIP] {path} (not found)")
+            print(f"[SKIP] {path} (not found)")
             continue
         ok, detail = await _run_one(path, device, cap_epochs)
-        marker = "✅" if ok else "❌"
         status = "OK" if ok else "FAIL"
         label = path.parent.name if path.name == "graph.json" else path.name
-        print(f"{marker} [{status}] {label}")
+        print(f"[{status}] {label}")
         first = detail.splitlines()[0] if detail else ""
         print(f"      {first}")
         if not ok:

--- a/scripts/mlx_spike.py
+++ b/scripts/mlx_spike.py
@@ -106,7 +106,7 @@ def main() -> int:
     print(f"mlx   GPU forward  : {t_mlx * 1e3:.2f} ms")
 
     ok = max_abs < 1e-4
-    print(f"\n{'✅ PASS' if ok else '❌ FAIL'} — inference-subset parity "
+    print(f"\n{'PASS' if ok else 'FAIL'} — inference-subset parity "
           f"{'within' if ok else 'EXCEEDS'} 1e-4 tolerance.")
     print("結論：把已訓練模型的前向推論搬到 MLX 可行且數值一致；"
           "可作為未來可選 MLX 推論加速器的基礎。圖引擎 Apple 預設仍為 MPS。")

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -83,7 +83,7 @@ def info(zh: str, en: str) -> None:
 
 
 def warn(zh: str, en: str) -> None:
-    print(f"  {YELLOW}⚠ {t(zh, en)}{RESET}")
+    print(f"  {YELLOW}! {t(zh, en)}{RESET}")
 
 
 def err(zh: str, en: str) -> None:


### PR DESCRIPTION
## Context

Came out of verifying CUDA / RTX GPU support on Windows (RTX 4080, driver 595.97, torch 2.11.0+cu128). CUDA training works end-to-end: `python scripts/device_smoke.py cuda` passes, and a browser run of the CNN-MNIST training graph used the GPU (VRAM jumped ~3.07 -> 3.44 GB for the CUDA context; training config reported `device=cuda`). `cdui install --gpu auto` already selects the correct cu128 wheel from the PyTorch index before `uv pip install -e .`. Two problems surfaced and are fixed here.

## Changes

- **scripts/device_smoke.py**: reconfigure stdout/stderr to UTF-8 on Windows (the same guard `scripts/dev.py` already has). The tool printed emoji status markers and crashed with `UnicodeEncodeError: 'cp950' codec can't encode` on a Traditional-Chinese Windows console -- i.e. it crashed on the Windows+CUDA machines it is meant to verify. Emoji markers replaced with `[OK]`/`[FAIL]`/`[SKIP]`.
- **Remove pictographic emoji from CLI/UI output**: `dev.py` and `plugins.py` warn() markers, `mlx_spike.py` and `docs/mlx-spike.md` PASS/FAIL lines, and the Toast warning icon (now `!`). Functional glyphs (checks, gear, status dots, progress bars, arrows, box-drawing) are intentionally kept.

## Testing

- `python scripts/device_smoke.py cuda` -> prints cleanly, `1/1 passed on cuda` (previously crashed before printing any result).
- Frontend `Toast.test.tsx`: 6/6 pass with the `!` warning icon.
- No backend test asserts the changed markers.

Generated with [Claude Code](https://claude.com/claude-code)