### PR TITLE
docs: pin Graph Copilot / frontend-extensions availability to 1.3.0

### DIFF
--- a/docs/docs/advanced/graph-copilot.md
+++ b/docs/docs/advanced/graph-copilot.md
@@ -9,7 +9,7 @@ description: Chat with an AI assistant to generate, tune, and improve your node 
 Graph Copilot is a CodefyUI plugin that adds a chat panel to the editor. You describe what you want in plain language and the AI generates a sequence of graph operations (add nodes, connect ports, set parameters) that are applied atomically — one undo step per AI edit. You can stop mid-stream, retry failed requests, and resume a conversation across sessions.
 
 :::note Availability
-Graph Copilot is built on two CodefyUI features: the [plugin frontend extension API](/advanced/plugin-frontend-extensions) and the unified LLM proxy endpoint (`/api/llm/chat`). Both are in CodefyUI from the first release after **1.2.1**. If `cdui --version` reports 1.2.1 or earlier, update to the latest release (or run from `main`) before installing.
+Graph Copilot is built on two CodefyUI features: the [plugin frontend extension API](/advanced/plugin-frontend-extensions) and the unified LLM proxy endpoint (`/api/llm/chat`). Both are in CodefyUI **1.3.0** and later. If `cdui --version` reports an older version, run `cdui update` before installing.
 :::
 
 ## Installation

--- a/docs/docs/advanced/plugin-frontend-extensions.md
+++ b/docs/docs/advanced/plugin-frontend-extensions.md
@@ -9,7 +9,7 @@ description: Ship a JavaScript bundle with your plugin so it can add UI widgets,
 A plugin pack can ship a JavaScript bundle alongside its Python nodes. When the CodefyUI editor loads, it discovers and imports that bundle as an ES module, giving the plugin access to a stable JavaScript API for UI, graph manipulation, and proxied HTTP.
 
 :::note Availability
-Frontend extensions are in CodefyUI from the first release after **1.2.1**. Check `cdui --version`; if it reports 1.2.1 or earlier, update to the latest release (or run from `main`).
+Frontend extensions are in CodefyUI **1.3.0** and later. Check `cdui --version`; if it reports an older version, run `cdui update`.
 :::
 
 ## Declaring a frontend entry point
@@ -21,13 +21,13 @@ Add a `[frontend]` section to `cdui.plugin.toml`:
 id = "my-plugin"
 name = "My Plugin"
 version = "0.1.0"
-requires_codefyui = ">=1.3"
+requires_codefyui = ">=1.3.0"
 
 [frontend]
 entry = "frontend/index.js"
 ```
 
-`requires_codefyui` is advisory metadata (it is recorded but not currently enforced at install time); set it to the first CodefyUI release that ships the features your plugin depends on — frontend extensions landed in the release after 1.2.1.
+`requires_codefyui` is advisory metadata (it is recorded but not currently enforced at install time); set it to the first CodefyUI release that ships the features your plugin depends on — frontend extensions landed in 1.3.0.
 
 The `entry` path must be **relative to the plugin root** and must live under `frontend/`. The file must be a valid ES module with a default export (see [The activate contract](#the-activate-contract) below).
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/graph-copilot.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/graph-copilot.md
@@ -9,7 +9,7 @@ description: 以對話方式讓 AI 助理生成、調整並改善你的節點圖
 Graph Copilot 是一個 CodefyUI 外掛，在編輯器中新增一個聊天面板。你用自然語言描述需求，AI 就會產生一系列圖表操作（新增節點、連接連接埠、設定參數），並以原子方式套用——每次 AI 編輯只佔用一個撤銷步驟。你可以在串流過程中中止、重試失敗的請求，並在不同 session 中繼續對話。
 
 :::note 可用性
-Graph Copilot 建構於兩項 CodefyUI 功能之上：[外掛前端擴充 API](/advanced/plugin-frontend-extensions) 與統一的 LLM 代理端點（`/api/llm/chat`）。兩者皆自 **1.2.1** 之後的首個版本起內建於 CodefyUI。若 `cdui --version` 顯示 1.2.1 或更早，請先更新到最新版本（或直接從 `main` 執行）再安裝。
+Graph Copilot 建構於兩項 CodefyUI 功能之上：[外掛前端擴充 API](/advanced/plugin-frontend-extensions) 與統一的 LLM 代理端點（`/api/llm/chat`）。兩者皆自 CodefyUI **1.3.0** 起內建。若 `cdui --version` 顯示更舊的版本，請先執行 `cdui update` 再安裝。
 :::
 
 ## 安裝

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
@@ -9,7 +9,7 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 外掛包可以在 Python 節點之外，附上一個 JavaScript bundle。CodefyUI 編輯器載入時，會探索並以 ES 模組形式匯入該 bundle，讓外掛取得一個穩定的 JavaScript API，用於操作 UI、圖表及代理 HTTP 請求。
 
 :::note 可用性
-前端擴充功能自 **1.2.1** 之後的首個版本起內建於 CodefyUI。請執行 `cdui --version` 確認；若顯示 1.2.1 或更早，請更新到最新版本（或直接從 `main` 執行）。
+前端擴充功能自 CodefyUI **1.3.0** 起內建。請執行 `cdui --version` 確認；若顯示更舊的版本，請執行 `cdui update`。
 :::
 
 ## 宣告前端進入點
@@ -21,13 +21,13 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 id = "my-plugin"
 name = "My Plugin"
 version = "0.1.0"
-requires_codefyui = ">=1.3"
+requires_codefyui = ">=1.3.0"
 
 [frontend]
 entry = "frontend/index.js"
 ```
 
-`requires_codefyui` 為提示性中繼資料（會被記錄，但目前安裝時並不強制檢查）；請將它設為首個內建你外掛所需功能的 CodefyUI 版本——前端擴充功能於 1.2.1 之後的版本登場。
+`requires_codefyui` 為提示性中繼資料（會被記錄，但目前安裝時並不強制檢查）；請將它設為首個內建你外掛所需功能的 CodefyUI 版本——前端擴充功能於 1.3.0 登場。
 
 `entry` 路徑必須**相對於外掛根目錄**，且必須位於 `frontend/` 之下。該檔案必須是合法的 ES 模組，並包含一個預設匯出（參見下方的[activate 合約](#activate-合約)）。
 


### PR DESCRIPTION
Now that **1.3.0** is tagged (it ships the plugin frontend extension API and the LLM proxy), the docs name that version concretely instead of the placeholder "first release after 1.2.1".

## Changes (EN + zh-TW)

- Availability notes on both `advanced/graph-copilot` and `advanced/plugin-frontend-extensions`: "in CodefyUI **1.3.0** and later; run `cdui update` if older."
- `plugin-frontend-extensions` manifest example: `requires_codefyui = ">=1.3.0"` (was `>=1.3`), and the advisory note now says "frontend extensions landed in 1.3.0."

## Verification

`pnpm build` in `docs/` succeeds for both `en` and `zh-TW` with `onBrokenLinks: 'throw'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)