### PR TITLE
fix(plugins): revalidate plugin frontend bundles (Cache-Control: no-cache)

### DIFF
--- a/backend/app/api/routes_plugin_frontend.py
+++ b/backend/app/api/routes_plugin_frontend.py
@@ -48,7 +48,15 @@ async def serve_plugin_frontend(plugin_id: str, resource_path: str) -> FileRespo
         target = (base / resource_path).resolve()
         if not target.is_relative_to(base) or not target.is_file():
             break
+        # Plugin bundles ship under a fixed filename (e.g. frontend/index.js)
+        # and change on `cdui plugin update`, so they must be revalidated --
+        # without this header browsers heuristically cache (ETag/Last-Modified
+        # only) and keep serving stale plugin code after an update. "no-cache"
+        # still allows caching but forces revalidation; FileResponse answers
+        # conditional requests with 304 when the file is unchanged.
         return FileResponse(
-            target, media_type=_MEDIA_TYPES.get(target.suffix.lower())
+            target,
+            media_type=_MEDIA_TYPES.get(target.suffix.lower()),
+            headers={"Cache-Control": "no-cache"},
         )
     raise HTTPException(status_code=404, detail="Plugin frontend resource not found")

--- a/backend/tests/test_plugin_frontend.py
+++ b/backend/tests/test_plugin_frontend.py
@@ -120,6 +120,15 @@ def test_serves_frontend_js_with_module_mime(fe_client):
     assert r.headers["content-type"].startswith("text/javascript")
 
 
+def test_frontend_bundle_sets_revalidation_cache_control(fe_client):
+    # Plugin bundles ship under a fixed filename and change on
+    # `cdui plugin update`, so the route must force revalidation — otherwise
+    # browsers heuristically cache the JS and keep serving stale plugin code.
+    r = fe_client.get("/plugins/fe-pack/frontend/index.js")
+    assert r.status_code == 200
+    assert "no-cache" in r.headers.get("cache-control", "")
+
+
 def test_serves_css(fe_client):
     r = fe_client.get("/plugins/fe-pack/frontend/style.css")
     assert r.status_code == 200


### PR DESCRIPTION
## Summary

Plugin frontend bundles were served with only `ETag`/`Last-Modified` and **no `Cache-Control`**, so browsers heuristically cache the JS and keep serving stale plugin code after `cdui plugin update` (bundles ship under a fixed filename, e.g. `frontend/index.js`).

Found during a live e2e of the Graph Copilot plugin: a freshly-deployed plugin fix wouldn't load in the browser — even `Ctrl+Shift+R` didn't help, because the bundle loads via dynamic `import()`, which bypasses hard-reload cache-busting. `index.html` already uses `no-cache` for the same reason (non-content-hashed); this applies the same to the plugin-frontend route.

## Change
`routes_plugin_frontend.py` now serves bundles with `Cache-Control: no-cache` — browsers revalidate every request; `FileResponse` still answers conditional requests with `304` when the file is unchanged, so it stays efficient.

## Testing
- `test_plugin_frontend.py` → 17 pass (incl. a new assertion that the route sends a revalidation directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
