### PR TITLE
fix(cli): keep stdin attached when re-exec'ing into venv on Windows

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -231,6 +231,28 @@ RELEASE_ASSET = "frontend-dist.tar.gz"
 
 # ── Bootstrap ─────────────────────────────────────────────────────────────────
 
+def _reexec(executable: str, argv: list) -> None:
+    """Replace the current process with ``executable argv...`` (cross-platform).
+
+    POSIX ``os.execv`` is a true in-place replace: the launching shell keeps
+    waiting on the same PID and the console (stdin/stdout) stays attached, so an
+    interactive ``input()`` later in the run still reads the terminal.
+
+    Windows has no real ``exec`` — there ``os.execv`` *spawns* a new process and
+    immediately exits the current one. The shell waiting on us (``cdui.cmd`` ->
+    python) then sees its child exit and returns to its prompt, while the
+    re-exec'd child runs orphaned and races the shell for the console. Any later
+    ``input()`` in the child reads EOF — which is exactly why
+    ``cdui plugin install <owner/repo>`` silently "cancelled" at the [y/N]
+    prompt and dropped back to the command line. So on Windows we run the child
+    synchronously and forward its exit code: one clean chain, one owner of the
+    console at a time.
+    """
+    if sys.platform == "win32":
+        sys.exit(subprocess.run([executable, *argv]).returncode)
+    os.execv(executable, [executable, *argv])
+
+
 def _exec_into_venv_if_available() -> None:
     """Re-exec into backend/.venv's Python when it exists.
 
@@ -245,8 +267,7 @@ def _exec_into_venv_if_available() -> None:
             return
     except OSError:
         return
-    import os
-    os.execv(str(VENV_PY), [str(VENV_PY)] + sys.argv)
+    _reexec(str(VENV_PY), sys.argv)
 
 
 def _require_venv_tool(tool_name: str) -> str:
@@ -292,8 +313,7 @@ def _ensure_uv() -> None:
             check=True,
         )
     # 安裝後重新啟動自身，讓新 PATH 生效
-    import os
-    os.execv(sys.executable, [sys.executable] + sys.argv)
+    _reexec(sys.executable, sys.argv)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`cdui plugin install <owner/repo>` dropped straight back to the shell at the `[y/N]` prompt instead of reading the answer — the install never proceeded.

## Root cause

`scripts/dev.py` re-execs into `backend/.venv`'s Python via `os.execv`. On POSIX that's a true in-place replace (same PID, console/stdin stays attached). **On Windows there is no real `exec`** — `os.execv` *spawns* a new process and immediately exits the current one. So in the chain `cdui.cmd` → uv-python `dev.py` → `os.execv(VENV_PY, …)`:

1. The original process exits → `cmd.exe` sees its child finish → returns to the prompt.
2. The re-exec'd venv-python child runs **orphaned**, racing the shell for the console.
3. The plugin install's `input("Proceed? [y/N]: ")` reads EOF → silently "cancelled".

Reproduced: `os.execv` returns to the shell in ~0.06s while a 2s child keeps running; a piped `y` is **lost** with `os.execv` but **received** with `subprocess.run`.

## Fix

Add a cross-platform `_reexec()` helper and use it at both re-exec sites (`_exec_into_venv_if_available`, `_ensure_uv`):

- **Windows** — run the child synchronously with `subprocess.run([...])` and forward its exit code. One process chain, one owner of the console at a time, stdin stays attached.
- **POSIX** — keep `os.execv` (best semantics).

## Verification

- Timing repro: old `os.execv` → shell returns in 0.06s (orphaned); fixed → shell waits the full 2.11s.
- Piped-stdin repro: old loses `y`; fixed receives `'y'`.
- `echo y | cdui plugin install treeleaves30760/CodefyUI-Plugin-Graph-Copilot` now prints the prompt, **accepts `y`, and proceeds** past it (resolves sha, reads manifest, frontend warning).
- `cdui plugin list` still works through the real launcher (exit 0) — normal command path unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)