### PR TITLE
feat(plugins): local dev loop — cdui plugin link/unlink/reload

### DIFF
--- a/backend/app/core/plugin_loader.py
+++ b/backend/app/core/plugin_loader.py
@@ -106,8 +106,17 @@ def _resolve_plugin_dir(
     builtin_root: Path,
     user_root: Path,
 ) -> Path:
-    if entry.get("source_kind") == "builtin":
+    source_kind = entry.get("source_kind")
+    if source_kind == "builtin":
         return builtin_root / plugin_id
+    if source_kind == "local":
+        # Linked dev plugins (`cdui plugin link <path>`) record an absolute
+        # path that lives outside both roots — the author's own checkout, loaded
+        # in place with no copy. A malformed entry without a path falls back to
+        # user_root (where it has no manifest and is skipped) rather than
+        # crashing discovery on a KeyError.
+        path = entry.get("path")
+        return Path(path) if path else user_root / plugin_id
     return user_root / plugin_id
 
 

--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 from pathlib import Path
 from textwrap import dedent
@@ -194,3 +195,116 @@ def test_manifest_has_frontend_detection():
     assert plugin_cli._manifest_has_frontend({}) is False
     assert plugin_cli._manifest_has_frontend({"frontend": {}}) is False
     assert plugin_cli._manifest_has_frontend({"frontend": {"entry": ""}}) is False
+
+
+# ── link / unlink / reload (local dev loop) ────────────────────────────────
+
+@pytest.fixture
+def isolated_lockfile(tmp_path, monkeypatch):
+    """Redirect the lockfile to a temp dir and stub the server hot-reload so
+    CLI tests never touch real user data or a running server."""
+    target = tmp_path / "plugins"
+    target.mkdir()
+    monkeypatch.setattr(plugin_loader, "plugins_user_root", lambda: target)
+    monkeypatch.setattr(plugin_cli, "_backend_reload", lambda: False)
+    return target
+
+
+def _write_plugin_dir(root: Path, plugin_id: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "cdui.plugin.toml").write_text(
+        dedent(f"""\
+            [plugin]
+            id = "{plugin_id}"
+            name = "Local {plugin_id}"
+            version = "0.1.0"
+            schema_version = 1
+            """),
+        encoding="utf-8",
+    )
+    nodes = root / "nodes"
+    nodes.mkdir(exist_ok=True)
+    (nodes / "__init__.py").write_text("", encoding="utf-8")
+
+
+def test_cmd_link_writes_local_lockfile_entry(isolated_lockfile, tmp_path):
+    work = tmp_path / "work" / "my-dev-plugin"
+    _write_plugin_dir(work, "my-dev-plugin")
+
+    rc = plugin_cli.cmd_link(argparse.Namespace(path=str(work), force=False))
+    assert rc == 0
+
+    entry = plugin_loader.load_lockfile()["plugins"]["my-dev-plugin"]
+    assert entry["source_kind"] == "local"
+    assert Path(entry["path"]) == work.resolve()
+    assert entry["enabled"] is True
+
+
+def test_cmd_link_rejects_dir_without_manifest(isolated_lockfile, tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    rc = plugin_cli.cmd_link(argparse.Namespace(path=str(empty), force=False))
+    assert rc == 1
+    assert plugin_loader.load_lockfile()["plugins"] == {}
+
+
+def test_cmd_link_rejects_catalog_id_collision(isolated_lockfile, tmp_path):
+    work = tmp_path / "shadow"
+    _write_plugin_dir(work, "foundations")  # a real built-in catalog id
+    rc = plugin_cli.cmd_link(argparse.Namespace(path=str(work), force=False))
+    assert rc == 1
+    assert "foundations" not in plugin_loader.load_lockfile()["plugins"]
+
+
+def test_cmd_link_existing_id_requires_force(isolated_lockfile, tmp_path):
+    work = tmp_path / "dup"
+    _write_plugin_dir(work, "dup-plugin")
+    assert plugin_cli.cmd_link(argparse.Namespace(path=str(work), force=False)) == 0
+    # Re-linking without --force is rejected; with --force it succeeds.
+    assert plugin_cli.cmd_link(argparse.Namespace(path=str(work), force=False)) == 1
+    assert plugin_cli.cmd_link(argparse.Namespace(path=str(work), force=True)) == 0
+
+
+def test_cmd_unlink_removes_entry_without_deleting_files(isolated_lockfile, tmp_path):
+    work = tmp_path / "work" / "linked"
+    _write_plugin_dir(work, "linked")
+    plugin_cli.cmd_link(argparse.Namespace(path=str(work), force=False))
+
+    rc = plugin_cli.cmd_unlink(argparse.Namespace(plugin_id="linked"))
+    assert rc == 0
+    assert "linked" not in plugin_loader.load_lockfile()["plugins"]
+    # The author's working tree is untouched.
+    assert (work / "cdui.plugin.toml").exists()
+
+
+def test_cmd_unlink_refuses_non_local_entry(isolated_lockfile):
+    lockfile = plugin_loader.load_lockfile()
+    lockfile.setdefault("plugins", {})["deep"] = {
+        "source_kind": "builtin", "source": "deep", "enabled": True,
+    }
+    plugin_loader.save_lockfile(lockfile)
+
+    rc = plugin_cli.cmd_unlink(argparse.Namespace(plugin_id="deep"))
+    assert rc == 1
+    assert "deep" in plugin_loader.load_lockfile()["plugins"]  # refused to drop it
+
+
+def test_cmd_unlink_missing_plugin_errors(isolated_lockfile):
+    assert plugin_cli.cmd_unlink(argparse.Namespace(plugin_id="nope")) == 1
+
+
+def test_cmd_reload_no_server_returns_zero(isolated_lockfile):
+    # _backend_reload stubbed to False (no server) — reload is a graceful no-op.
+    assert plugin_cli.cmd_reload(argparse.Namespace()) == 0
+
+
+def test_link_unlink_reload_parser_wired():
+    parser = plugin_cli.build_parser()
+    a = parser.parse_args(["link", "/some/path"])
+    assert a._func is plugin_cli.cmd_link and a.path == "/some/path" and a.force is False
+    a = parser.parse_args(["link", "/p", "--force"])
+    assert a.force is True
+    a = parser.parse_args(["unlink", "foo"])
+    assert a._func is plugin_cli.cmd_unlink and a.plugin_id == "foo"
+    a = parser.parse_args(["reload"])
+    assert a._func is plugin_cli.cmd_reload

--- a/backend/tests/test_plugin_loader.py
+++ b/backend/tests/test_plugin_loader.py
@@ -164,6 +164,48 @@ def test_install_plugin_finder_skips_plugin_without_nodes_dir(tmp_path):
     assert pairs == []
 
 
+def test_install_plugin_finder_resolves_local_path_entries(tmp_path):
+    """A linked (source_kind='local') plugin loads from its recorded ``path``,
+    which may live outside both the builtin and user roots — e.g. the author's
+    own working checkout, the way ``cdui plugin link`` registers it."""
+    builtin = tmp_path / "builtin"
+    user = tmp_path / "user"
+    builtin.mkdir()
+    user.mkdir()
+    work = tmp_path / "work" / "my-plugin"  # outside both roots
+    _write_plugin(work, "my-plugin")
+    lockfile = {
+        "plugins": {
+            "my-plugin": {
+                "source_kind": "local",
+                "source": str(work),
+                "path": str(work),
+            }
+        }
+    }
+
+    pairs = plugin_loader.install_plugin_finder(builtin, user, lockfile)
+
+    assert "cdui_plugins.my_plugin" in sys.modules
+    assert len(pairs) == 1
+    nodes_dir, pkg_name = pairs[0]
+    assert nodes_dir == work / "nodes"
+    assert pkg_name == "cdui_plugins.my_plugin.nodes"
+
+
+def test_install_plugin_finder_local_without_path_is_skipped(tmp_path):
+    """A malformed local entry missing ``path`` must not crash discovery —
+    it falls back to a location with no manifest and is skipped silently."""
+    builtin = tmp_path / "builtin"
+    user = tmp_path / "user"
+    builtin.mkdir()
+    user.mkdir()
+    lockfile = {"plugins": {"broken": {"source_kind": "local"}}}
+
+    pairs = plugin_loader.install_plugin_finder(builtin, user, lockfile)
+    assert pairs == []
+
+
 # ──────────────────────────────────────────────────────────────────────
 # purge_plugin_modules
 # ──────────────────────────────────────────────────────────────────────
@@ -217,3 +259,18 @@ def test_iter_plugin_dirs_yields_only_plugins_with_manifest(tmp_path):
     out = plugin_loader.iter_plugin_dirs(builtin, user, lockfile)
     ids = [pid for pid, _ in out]
     assert ids == ["c2"]
+
+
+def test_iter_plugin_dirs_resolves_local_path_entries(tmp_path):
+    """iter_plugin_dirs (used by examples / assets / presets / the plugin list)
+    resolves a linked plugin from its recorded ``path``."""
+    builtin = tmp_path / "builtin"
+    user = tmp_path / "user"
+    builtin.mkdir()
+    user.mkdir()
+    work = tmp_path / "elsewhere" / "loc"
+    _write_plugin(work, "loc")
+    lockfile = {"plugins": {"loc": {"source_kind": "local", "path": str(work)}}}
+
+    out = plugin_loader.iter_plugin_dirs(builtin, user, lockfile)
+    assert out == [("loc", work)]

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -53,6 +53,23 @@ A pack ships any of: a `nodes/` directory (auto-discovered), a `presets/` direct
 The chapter packs `c1`–`c6` were repackaged into three direction packs `foundations` / `deep` / `rl`, and every Edu node's type id gained a dash (`EduKNN` → `Edu-KNN`). Saved graphs referencing the old `cN:EduFoo` types must be updated to `<pack>:Edu-Foo` and the packs reinstalled with `cdui plugin install foundations deep rl`.
 :::
 
+## Local development
+
+You don't need to push to GitHub between iterations while building a plugin. **Link** your working directory and CodefyUI loads it in place:
+
+```bash
+cdui plugin link ./my-plugin     # register the local dir in place (no copy)
+# ...edit nodes/ or frontend/...
+cdui plugin reload               # pick up changes in a running server
+cdui plugin unlink my-plugin     # remove the link — your files are untouched
+```
+
+`link` reads the id from your `cdui.plugin.toml` and records the directory's absolute path in the lockfile as `source_kind = "local"`, so discovery walks your working tree directly. The AST security gate is skipped for linked plugins (it's your own code, and a warning says so); `unlink` drops only the lockfile entry, never your files. After editing Python nodes, `cdui plugin reload` (or a server restart) reloads them; a changed frontend bundle additionally needs a browser refresh.
+
+:::tip Dev data isolation
+Running plugin commands through `scripts/dev.py` — or setting `CODEFYUI_USER_DATA_DIR` — keeps a clone's lockfile inside the repo (`.codefyui_dev/`) instead of the machine-wide user-data dir, so multiple clones don't clobber each other.
+:::
+
 ## REST API
 
 | Endpoint | Method | Description |

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -53,6 +53,23 @@ cdui plugin install your-username/your-fork
 章節外掛包 `c1`–`c6` 已重新封裝為三個方向外掛包 `foundations` / `deep` / `rl`，而且每個 Edu 節點的型別 id 都加上了一個破折號（`EduKNN` → `Edu-KNN`）。引用舊有 `cN:EduFoo` 型別的已儲存圖必須更新為 `<pack>:Edu-Foo`，並以 `cdui plugin install foundations deep rl` 重新安裝這些外掛包。
 :::
 
+## 本地開發
+
+開發外掛時，不必每次迭代都先推上 GitHub。用 **link** 連結你的工作目錄，CodefyUI 會就地載入：
+
+```bash
+cdui plugin link ./my-plugin     # 就地註冊本地目錄（不複製）
+# ...編輯 nodes/ 或 frontend/...
+cdui plugin reload               # 讓執行中的伺服器套用變更
+cdui plugin unlink my-plugin     # 解除連結——你的檔案不會被刪除
+```
+
+`link` 會從你的 `cdui.plugin.toml` 讀取 id，並把該目錄的絕對路徑以 `source_kind = "local"` 記入 lockfile，因此探索會直接走訪你的工作目錄。連結的外掛會跳過 AST 安全閘門（這是你自己的程式碼，並會印出警告）；`unlink` 只移除 lockfile 條目，絕不刪除你的檔案。編輯 Python 節點後，執行 `cdui plugin reload`（或重啟伺服器）即可重載；若變更了前端 bundle，還需重新整理瀏覽器。
+
+:::tip 開發資料隔離
+透過 `scripts/dev.py` 執行外掛指令——或設定 `CODEFYUI_USER_DATA_DIR`——可讓某個 clone 的 lockfile 留在 repo 內（`.codefyui_dev/`），而非全機共用的 user-data 目錄，避免多個 clone 互相覆蓋。
+:::
+
 ## REST API
 
 | 端點 | 方法 | 說明 |

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -771,6 +771,151 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_link(args: argparse.Namespace) -> int:
+    """Link a local plugin directory for development — loaded in place, no copy.
+
+    The dev-loop counterpart to ``install``: instead of downloading a tarball,
+    it records ``source_kind="local"`` with the directory's absolute ``path`` in
+    the lockfile, so the loader walks the author's own working tree. Edits are
+    picked up by ``cdui plugin reload`` (or the next ``cdui start``). The AST
+    security gate is skipped — this is your own code — but a warning is printed,
+    matching the built-in/catalog trust model.
+    """
+    root = Path(args.path).expanduser().resolve()
+    section(f"連結本地外掛：{root}", f"Linking local plugin: {root}")
+
+    if not (root / MANIFEST_FILENAME).exists():
+        err(
+            f"目錄缺少 {MANIFEST_FILENAME}：{root}",
+            f"No {MANIFEST_FILENAME} found in {root}",
+        )
+        return 1
+
+    try:
+        manifest = read_manifest(root)
+        validate_manifest(manifest)
+    except (ValueError, FileNotFoundError) as e:
+        err(str(e), str(e))
+        return 1
+
+    plugin_id = manifest["plugin"]["id"]
+
+    if plugin_id in load_catalog().get("plugins", {}):
+        err(
+            f"id '{plugin_id}' 與內建套件衝突，請在 manifest 改用其他 id",
+            f"id '{plugin_id}' collides with a built-in pack — rename it in the manifest",
+        )
+        return 1
+
+    lockfile = load_lockfile()
+    if plugin_id in lockfile.get("plugins", {}) and not args.force:
+        err(
+            f"外掛 {plugin_id} 已安裝/連結。加 --force 覆寫。",
+            f"Plugin '{plugin_id}' is already installed/linked. Use --force to overwrite.",
+        )
+        return 1
+
+    info(f"id：{plugin_id}", f"id: {plugin_id}")
+    warn(
+        "本地連結會跳過 AST 安全檢查（視為你信任的程式碼）",
+        "Local link skips the AST security gate (treated as your own trusted code)",
+    )
+    if _manifest_has_frontend(manifest):
+        warn(
+            "此外掛含前端 JS，會在編輯器中以完整權限執行",
+            "This plugin ships frontend JS that runs in the editor with full access",
+        )
+
+    deps = manifest.get("python_deps", {})
+    if deps:
+        info(
+            f"安裝 python_deps：{', '.join(deps)}",
+            f"Installing python_deps: {', '.join(deps)}",
+        )
+        rc = _install_deps(deps)
+        if rc != 0:
+            return rc
+
+    allowed = manifest.get("security", {}).get("allowed_modules") or []
+    lockfile.setdefault("plugins", {})[plugin_id] = {
+        "source_kind": "local",
+        "source": str(root),
+        "path": str(root),
+        "installed_at": now_iso(),
+        "manifest": manifest.get("plugin", {}),
+        "trusted_modules": list(allowed),
+        "enabled": True,
+    }
+    save_lockfile(lockfile)
+
+    if _backend_reload():
+        ok("熱重載完成", "Hot-reloaded backend")
+    else:
+        info(
+            "伺服器未運行，下次 cdui start 會自動載入",
+            "Server not running; next `cdui start` will pick this up.",
+        )
+    ok(
+        f"已連結：{plugin_id}（編輯後執行 cdui plugin reload 更新）",
+        f"Linked: {plugin_id} (run `cdui plugin reload` after edits to refresh)",
+    )
+    return 0
+
+
+def cmd_unlink(args: argparse.Namespace) -> int:
+    """Remove a linked local plugin — drops the lockfile entry only.
+
+    Unlike ``uninstall``, this never deletes files: a linked plugin's files are
+    the author's own working directory. Refuses non-local entries so a real
+    install isn't silently dropped.
+    """
+    plugin_id = args.plugin_id.lower()
+    section(f"取消連結：{plugin_id}", f"Unlinking plugin: {plugin_id}")
+
+    lockfile = load_lockfile()
+    entry = lockfile.get("plugins", {}).get(plugin_id)
+    if not entry:
+        err(f"找不到外掛 {plugin_id}", f"Plugin '{plugin_id}' is not installed")
+        return 1
+    if entry.get("source_kind") != "local":
+        err(
+            f"{plugin_id} 不是本地連結（請改用 cdui plugin uninstall）",
+            f"'{plugin_id}' is not a local link — use `cdui plugin uninstall` instead",
+        )
+        return 1
+
+    lockfile["plugins"].pop(plugin_id, None)
+    save_lockfile(lockfile)
+
+    if _backend_reload():
+        ok("熱重載完成", "Hot-reloaded backend")
+    else:
+        info("伺服器未運行", "Server not running")
+
+    ok(
+        f"已取消連結 {plugin_id}（你的檔案未被刪除）",
+        f"Unlinked {plugin_id} (your files were not deleted)",
+    )
+    return 0
+
+
+def cmd_reload(args: argparse.Namespace) -> int:
+    """Ask the running server to hot-reload nodes/presets.
+
+    The manual trigger for the dev loop: edit a linked plugin, then
+    ``cdui plugin reload`` to see the change without restarting the server.
+    """
+    section("熱重載外掛", "Reloading plugins")
+    if _backend_reload():
+        ok("熱重載完成", "Hot-reloaded backend")
+        return 0
+    info(
+        "伺服器未運行（啟動後變更會自動載入）",
+        "Server not running (changes load on next start)",
+    )
+    return 0
+
+
 def cmd_info(args: argparse.Namespace) -> int:
     spec = args.source_or_id
     lockfile = load_lockfile()
@@ -1044,6 +1189,28 @@ def build_parser() -> argparse.ArgumentParser:
     p_un = sub.add_parser("uninstall", help="Remove an installed plugin")
     p_un.add_argument("plugin_id")
     p_un.set_defaults(_func=cmd_uninstall)
+
+    p_link = sub.add_parser(
+        "link",
+        help="Link a local plugin directory for development (loaded in place, no copy)",
+    )
+    p_link.add_argument("path", help="path to the local plugin dir (contains cdui.plugin.toml)")
+    p_link.add_argument("--force", action="store_true",
+                        help="overwrite an existing entry with the same id")
+    p_link.set_defaults(_func=cmd_link)
+
+    p_unlink = sub.add_parser(
+        "unlink",
+        help="Remove a linked local plugin (lockfile entry only; your files are untouched)",
+    )
+    p_unlink.add_argument("plugin_id")
+    p_unlink.set_defaults(_func=cmd_unlink)
+
+    p_reload = sub.add_parser(
+        "reload",
+        help="Hot-reload the running server's plugins/nodes (pick up edits to a linked plugin)",
+    )
+    p_reload.set_defaults(_func=cmd_reload)
 
     p_en = sub.add_parser(
         "enable",


### PR DESCRIPTION
## What

**Phase 1a** of the plugin local-dev / React initiative — the Chrome "load unpacked" equivalent for plugin authors. Lets you develop an in-progress plugin against a local checkout without the push-to-GitHub-then-install round-trip.

- **`cdui plugin link <path>`** — register a local plugin dir *in place* (no copy, no tarball) via a `source_kind = "local"` lockfile entry recording the dir's absolute path. Skips the AST gate (your own code) with a warning; rejects ids that collide with a built-in catalog pack.
- **`cdui plugin unlink <id>`** — drop the lockfile entry only; **never deletes your files**, and refuses non-local entries so a real install isn't dropped by mistake.
- **`cdui plugin reload`** — manual hot-reload trigger, so `edit → reload` works without restarting the server.

Loop: `cdui plugin link ./my-plugin` once, then `edit` + `cdui plugin reload`.

## How

One surgical loader change carries it: `_resolve_plugin_dir` gains a `"local"` branch that returns the recorded absolute `path`. Because every consumer (node discovery, examples, presets, assets, `/api/plugins`, frontend serving) resolves the plugin dir through that one function, linked plugins flow through the whole system unchanged.

## Tests

- `test_plugin_loader.py`: local-path resolution via `install_plugin_finder` + `iter_plugin_dirs`; malformed entry (no `path`) degrades safely.
- `test_plugin_cli.py`: lockfile-entry shape, missing-manifest / catalog-collision / `--force` handling, unlink safety (files untouched, non-local refused), reload no-op, parser wiring.
- Full plugin suite: **99 passed**. Verified end-to-end via the real CLI (`link`/`list`/`reload`/`unlink`).
- Docs: "Local development" section added to the Plugins page (en + zh-TW); Docusaurus build green for both locales.

## Scope

This is the static half of the foundation. **Phase 1b** (`cdui plugin dev` watch mode + frontend hot-reload over WS) and the later React-SDK phases are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YFEoPUjnuYqUV18SV8ZxT