### PR TITLE
feat(plugins): cdui plugin dev — watch mode (auto-reload)

### DIFF
--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -308,3 +308,56 @@ def test_link_unlink_reload_parser_wired():
     assert a._func is plugin_cli.cmd_unlink and a.plugin_id == "foo"
     a = parser.parse_args(["reload"])
     assert a._func is plugin_cli.cmd_reload
+
+
+# ── dev (watch mode) ───────────────────────────────────────────────────────
+
+def test_scan_plugin_files_covers_relevant_dirs(tmp_path):
+    root = tmp_path / "p"
+    _write_plugin_dir(root, "p")  # manifest + nodes/__init__.py
+    (root / "frontend").mkdir()
+    (root / "frontend" / "index.js").write_text("export default function(){}", encoding="utf-8")
+    (root / "README.md").write_text("ignored", encoding="utf-8")
+    (root / "nodes" / "__pycache__").mkdir()
+    (root / "nodes" / "__pycache__" / "x.pyc").write_text("x", encoding="utf-8")
+
+    keys = {Path(k).name for k in plugin_cli._scan_plugin_files(root)}
+    assert {"cdui.plugin.toml", "__init__.py", "index.js"} <= keys
+    assert "README.md" not in keys   # not a reload-relevant dir
+    assert "x.pyc" not in keys       # __pycache__ ignored
+
+
+def test_scan_plugin_files_detects_new_file(tmp_path):
+    root = tmp_path / "p"
+    _write_plugin_dir(root, "p")
+    before = plugin_cli._scan_plugin_files(root)
+    (root / "nodes" / "extra.py").write_text("# new node", encoding="utf-8")
+    after = plugin_cli._scan_plugin_files(root)
+    assert after != before
+    assert any(Path(k).name == "extra.py" for k in after)
+
+
+def test_cmd_dev_once_links_and_returns_zero(isolated_lockfile, tmp_path):
+    root = tmp_path / "devplug"
+    _write_plugin_dir(root, "devplug")
+    rc = plugin_cli.cmd_dev(argparse.Namespace(path=str(root), once=True, interval=1.0))
+    assert rc == 0
+    entry = plugin_loader.load_lockfile()["plugins"]["devplug"]
+    assert entry["source_kind"] == "local"
+    assert Path(entry["path"]) == root.resolve()
+
+
+def test_cmd_dev_once_bad_dir_returns_one(isolated_lockfile, tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    rc = plugin_cli.cmd_dev(argparse.Namespace(path=str(empty), once=True, interval=1.0))
+    assert rc == 1
+    assert plugin_loader.load_lockfile()["plugins"] == {}
+
+
+def test_dev_parser_wired():
+    parser = plugin_cli.build_parser()
+    a = parser.parse_args(["dev", "/p"])
+    assert a._func is plugin_cli.cmd_dev and a.path == "/p" and a.once is False
+    a = parser.parse_args(["dev", "/p", "--once", "--interval", "0.5"])
+    assert a.once is True and a.interval == 0.5

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -64,6 +64,14 @@ cdui plugin reload               # pick up changes in a running server
 cdui plugin unlink my-plugin     # remove the link — your files are untouched
 ```
 
+Even simpler, **`dev`** links and watches in one command, hot-reloading on every save:
+
+```bash
+cdui plugin dev ./my-plugin      # link + watch; reloads on every change
+```
+
+Run the server in another terminal (`cdui start` or `cdui dev`). `dev` polls the plugin's manifest, `nodes/`, `presets/`, and `frontend/`; `--once` links and reloads a single time (no watch), and `--interval` tunes the poll frequency.
+
 `link` reads the id from your `cdui.plugin.toml` and records the directory's absolute path in the lockfile as `source_kind = "local"`, so discovery walks your working tree directly. The AST security gate is skipped for linked plugins (it's your own code, and a warning says so); `unlink` drops only the lockfile entry, never your files. After editing Python nodes, `cdui plugin reload` (or a server restart) reloads them; a changed frontend bundle additionally needs a browser refresh.
 
 :::tip Dev data isolation

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -64,6 +64,14 @@ cdui plugin reload               # 讓執行中的伺服器套用變更
 cdui plugin unlink my-plugin     # 解除連結——你的檔案不會被刪除
 ```
 
+更簡單的方式是用 **`dev`**，一個指令完成連結＋監看，每次存檔都自動熱重載：
+
+```bash
+cdui plugin dev ./my-plugin      # 連結＋監看；每次變更自動重載
+```
+
+請在另一個終端機執行伺服器（`cdui start` 或 `cdui dev`）。`dev` 會輪詢外掛的 manifest、`nodes/`、`presets/` 與 `frontend/`；`--once` 只連結並重載一次（不監看），`--interval` 可調整輪詢間隔。
+
 `link` 會從你的 `cdui.plugin.toml` 讀取 id，並把該目錄的絕對路徑以 `source_kind = "local"` 記入 lockfile，因此探索會直接走訪你的工作目錄。連結的外掛會跳過 AST 安全閘門（這是你自己的程式碼，並會印出警告）；`unlink` 只移除 lockfile 條目，絕不刪除你的檔案。編輯 Python 節點後，執行 `cdui plugin reload`（或重啟伺服器）即可重載；若變更了前端 bundle，還需重新整理瀏覽器。
 
 :::tip 開發資料隔離

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -771,17 +771,14 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
     return 0
 
 
-def cmd_link(args: argparse.Namespace) -> int:
-    """Link a local plugin directory for development — loaded in place, no copy.
+def _link_local(root: Path, *, force: bool) -> int:
+    """Link a local plugin directory in place — shared by ``link`` and ``dev``.
 
-    The dev-loop counterpart to ``install``: instead of downloading a tarball,
-    it records ``source_kind="local"`` with the directory's absolute ``path`` in
-    the lockfile, so the loader walks the author's own working tree. Edits are
-    picked up by ``cdui plugin reload`` (or the next ``cdui start``). The AST
-    security gate is skipped — this is your own code — but a warning is printed,
-    matching the built-in/catalog trust model.
+    Records ``source_kind="local"`` with the directory's absolute ``path`` in the
+    lockfile, so the loader walks the author's own working tree. The AST security
+    gate is skipped — this is your own code — but a warning is printed, matching
+    the built-in/catalog trust model.
     """
-    root = Path(args.path).expanduser().resolve()
     section(f"連結本地外掛：{root}", f"Linking local plugin: {root}")
 
     if not (root / MANIFEST_FILENAME).exists():
@@ -808,7 +805,7 @@ def cmd_link(args: argparse.Namespace) -> int:
         return 1
 
     lockfile = load_lockfile()
-    if plugin_id in lockfile.get("plugins", {}) and not args.force:
+    if plugin_id in lockfile.get("plugins", {}) and not force:
         err(
             f"外掛 {plugin_id} 已安裝/連結。加 --force 覆寫。",
             f"Plugin '{plugin_id}' is already installed/linked. Use --force to overwrite.",
@@ -862,6 +859,17 @@ def cmd_link(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_link(args: argparse.Namespace) -> int:
+    """Link a local plugin directory for development — loaded in place, no copy.
+
+    The dev-loop counterpart to ``install``: instead of downloading a tarball, it
+    points the lockfile at the author's own working tree. Edits are picked up by
+    ``cdui plugin reload`` (or the next ``cdui start``); ``cdui plugin dev``
+    automates that.
+    """
+    return _link_local(Path(args.path).expanduser().resolve(), force=args.force)
+
+
 def cmd_unlink(args: argparse.Namespace) -> int:
     """Remove a linked local plugin — drops the lockfile entry only.
 
@@ -913,6 +921,79 @@ def cmd_reload(args: argparse.Namespace) -> int:
         "伺服器未運行（啟動後變更會自動載入）",
         "Server not running (changes load on next start)",
     )
+    return 0
+
+
+def _scan_plugin_files(root: Path) -> dict[str, float]:
+    """mtime signature of a plugin's reload-relevant files.
+
+    Covers the manifest plus everything under ``nodes/``, ``presets/`` and
+    ``frontend/`` — the directories whose changes affect a running editor.
+    ``__pycache__`` and other files (README, ``ui/`` source before it is built)
+    are ignored so editor-irrelevant saves don't trigger reloads.
+    """
+    sig: dict[str, float] = {}
+    manifest = root / MANIFEST_FILENAME
+    if manifest.is_file():
+        try:
+            sig[str(manifest)] = manifest.stat().st_mtime
+        except OSError:
+            pass
+    for sub in ("nodes", "presets", "frontend"):
+        d = root / sub
+        if not d.is_dir():
+            continue
+        for f in d.rglob("*"):
+            if f.is_file() and "__pycache__" not in f.parts:
+                try:
+                    sig[str(f)] = f.stat().st_mtime
+                except OSError:
+                    pass
+    return sig
+
+
+def cmd_dev(args: argparse.Namespace) -> int:
+    """Link a local plugin and watch it, hot-reloading on every change.
+
+    The one-command dev loop: links the directory (idempotent), then polls its
+    manifest / nodes / presets / frontend for edits and POSTs
+    ``/api/plugins/reload`` whenever something changes. Run the server in another
+    terminal (``cdui start`` / ``cdui dev``). Python edits take effect on the
+    next reload; a changed frontend bundle additionally needs a browser refresh.
+    ``--once`` links + reloads a single time and exits (no watch).
+    """
+    root = Path(args.path).expanduser().resolve()
+    rc = _link_local(root, force=True)
+    if rc != 0:
+        return rc
+    if getattr(args, "once", False):
+        return 0
+
+    interval = max(0.2, float(getattr(args, "interval", 1.0) or 1.0))
+    section("開發監看模式", "Dev watch mode")
+    info(
+        f"監看 {root}（每 {interval:g}s 檢查一次，Ctrl+C 結束）",
+        f"Watching {root} (polling every {interval:g}s; Ctrl+C to stop)",
+    )
+    sig = _scan_plugin_files(root)
+    try:
+        while True:
+            time.sleep(interval)
+            new_sig = _scan_plugin_files(root)
+            if new_sig == sig:
+                continue
+            sig = new_sig
+            info("偵測到變更，重載中…", "Change detected, reloading…")
+            if _backend_reload():
+                ok(
+                    "熱重載完成（前端變更請重新整理瀏覽器）",
+                    "Hot-reloaded (refresh the browser for frontend changes)",
+                )
+            else:
+                warn("伺服器未運行", "Server not running")
+    except KeyboardInterrupt:
+        print()
+        info("已停止監看", "Stopped watching")
     return 0
 
 
@@ -1211,6 +1292,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Hot-reload the running server's plugins/nodes (pick up edits to a linked plugin)",
     )
     p_reload.set_defaults(_func=cmd_reload)
+
+    p_dev = sub.add_parser(
+        "dev",
+        help="Link a local plugin and watch it — hot-reload on every change",
+    )
+    p_dev.add_argument("path", help="path to the local plugin dir (contains cdui.plugin.toml)")
+    p_dev.add_argument("--interval", type=float, default=1.0,
+                       help="seconds between change checks (default 1.0)")
+    p_dev.add_argument("--once", action="store_true",
+                       help="link + reload once and exit (no watch)")
+    p_dev.set_defaults(_func=cmd_dev)
 
     p_en = sub.add_parser(
         "enable",


### PR DESCRIPTION
## What

**Phase 1b** of the plugin local-dev initiative. `cdui plugin dev <path>` is the one-command dev loop: it links the directory (idempotent) and then **watches** it, hot-reloading the running server on every change — no more manual `cdui plugin reload` after each edit.

```bash
cdui plugin dev ./my-plugin            # link + watch; reload on change
cdui plugin dev ./my-plugin --once     # link + reload once, then exit (no watch)
cdui plugin dev ./my-plugin --interval 0.5
```

Run the server in another terminal (`cdui start` / `cdui dev`). On change it POSTs `/api/plugins/reload`; Python edits apply immediately, a changed frontend bundle still needs a browser refresh.

## How

- `_scan_plugin_files(root)` builds an mtime signature of the reload-relevant dirs (manifest + `nodes/` + `presets/` + `frontend/`, ignoring `__pycache__` and non-served files like `ui/` source). The watch loop polls it every `--interval` seconds (stdlib only — no `watchfiles` dependency, cross-platform).
- The link core is refactored into `_link_local(root, *, force)`, shared by `link` and `dev`.

## Tests

- `_scan_plugin_files`: directory coverage + new-file change detection.
- `cmd_dev --once`: links + returns 0; rejects a manifest-less dir.
- Parser wiring for `dev` / `--once` / `--interval`.
- Full plugin suite: **104 passed**. Verified via the real CLI (`dev --once` + `list`).
- Docs: "Local development" section updated (en + zh-TW); Docusaurus build green for both locales.

## Scope

Backend/CLI only — no frontend code changes, so no browser e2e needed. **True frontend hot-reload** (a WS signal + `PluginHost` re-import/re-activate so a frontend edit updates the editor without a refresh) is UI-touching and will be its own PR with Chrome e2e. After that, Phase 2 is the React SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YFEoPUjnuYqUV18SV8ZxT