### PR TITLE
feat(plugins): frontend hot-reload for linked plugins

### DIFF
--- a/backend/app/api/routes_plugins.py
+++ b/backend/app/api/routes_plugins.py
@@ -92,6 +92,18 @@ async def list_plugins() -> list[dict[str, Any]]:
     return out
 
 
+@router.get("/generation")
+async def plugins_generation() -> dict[str, int]:
+    """Monotonic counter bumped on every reload (plugin/node/enable-disable).
+
+    The editor polls this in dev mode (when a linked plugin is present) to learn
+    when to re-activate plugin frontends without a manual refresh. Declared
+    before ``/{plugin_id}`` so it isn't swallowed by the dynamic route; a GET, so
+    it needs no session token.
+    """
+    return {"generation": plugin_loader.reload_generation()}
+
+
 @router.get("/{plugin_id}")
 async def get_plugin(plugin_id: str) -> dict[str, Any]:
     lockfile = load_lockfile()

--- a/backend/app/core/plugin_loader.py
+++ b/backend/app/core/plugin_loader.py
@@ -35,6 +35,16 @@ LOCKFILE_SCHEMA = 1
 MANIFEST_FILENAME = "cdui.plugin.toml"
 NAMESPACE_PACKAGE = "cdui_plugins"
 
+# Bumped on every full re-discovery (plugin/node reload, enable/disable). The
+# editor polls this in dev mode — when a linked plugin is present — to know when
+# to re-activate plugin frontends without a manual browser refresh.
+_reload_generation = 0
+
+
+def reload_generation() -> int:
+    """Current reload generation; increases by one on each ``rediscover_all``."""
+    return _reload_generation
+
 
 def plugins_builtin_root() -> Path:
     """``<REPO>/plugins/`` — packs shipped with the CodefyUI distribution.
@@ -273,6 +283,9 @@ def rediscover_all(
     preset_count = preset_registry.discover(presets_dir, registry)
     for _plugin_id, plugin_dir in iter_plugin_dirs(builtin_root, user_root, lockfile):
         preset_count += preset_registry.discover(plugin_dir / "presets", registry)
+
+    global _reload_generation
+    _reload_generation += 1
 
     return {
         "builtin": builtin,

--- a/backend/tests/test_plugin_api.py
+++ b/backend/tests/test_plugin_api.py
@@ -122,6 +122,30 @@ def test_reload_plugins_returns_counts(client):
     assert data["total"] == data["builtin"] + data["custom"] + data["plugins"]
 
 
+def test_generation_increments_on_reload(client):
+    """The reload-generation counter (polled by the dev frontend hot-reload)
+    is a token-free GET that bumps on every reload/toggle."""
+    g0 = client.get("/api/plugins/generation").json()["generation"]
+    assert isinstance(g0, int)
+
+    client.post("/api/plugins/reload")
+    g1 = client.get("/api/plugins/generation").json()["generation"]
+    assert g1 == g0 + 1
+
+    # enable/disable also re-discovers, so it bumps too
+    client.post("/api/plugins/foundations/disable")
+    g2 = client.get("/api/plugins/generation").json()["generation"]
+    assert g2 == g1 + 1
+    client.post("/api/plugins/foundations/enable")  # restore for other tests
+
+
+def test_generation_route_not_shadowed_by_plugin_id(client):
+    """`/generation` must resolve to the counter, not the {plugin_id} route."""
+    r = client.get("/api/plugins/generation")
+    assert r.status_code == 200
+    assert set(r.json().keys()) == {"generation"}
+
+
 # ── /api/plugins/{id}/enable|disable ───────────────────────────────────────
 
 def test_list_plugins_includes_enabled_flag(client):

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -72,7 +72,7 @@ cdui plugin dev ./my-plugin      # link + watch; reloads on every change
 
 Run the server in another terminal (`cdui start` or `cdui dev`). `dev` polls the plugin's manifest, `nodes/`, `presets/`, and `frontend/`; `--once` links and reloads a single time (no watch), and `--interval` tunes the poll frequency.
 
-`link` reads the id from your `cdui.plugin.toml` and records the directory's absolute path in the lockfile as `source_kind = "local"`, so discovery walks your working tree directly. The AST security gate is skipped for linked plugins (it's your own code, and a warning says so); `unlink` drops only the lockfile entry, never your files. After editing Python nodes, `cdui plugin reload` (or a server restart) reloads them; a changed frontend bundle additionally needs a browser refresh.
+`link` reads the id from your `cdui.plugin.toml` and records the directory's absolute path in the lockfile as `source_kind = "local"`, so discovery walks your working tree directly. The AST security gate is skipped for linked plugins (it's your own code, and a warning says so); `unlink` drops only the lockfile entry, never your files. After editing Python nodes, `cdui plugin reload` (or `cdui plugin dev`) reloads them. **Frontend edits to a linked plugin reload automatically too** — while a linked plugin is installed the editor watches for reloads and re-mounts the plugin's UI in place, no browser refresh needed.
 
 :::tip Dev data isolation
 Running plugin commands through `scripts/dev.py` — or setting `CODEFYUI_USER_DATA_DIR` — keeps a clone's lockfile inside the repo (`.codefyui_dev/`) instead of the machine-wide user-data dir, so multiple clones don't clobber each other.

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -72,7 +72,7 @@ cdui plugin dev ./my-plugin      # 連結＋監看；每次變更自動重載
 
 請在另一個終端機執行伺服器（`cdui start` 或 `cdui dev`）。`dev` 會輪詢外掛的 manifest、`nodes/`、`presets/` 與 `frontend/`；`--once` 只連結並重載一次（不監看），`--interval` 可調整輪詢間隔。
 
-`link` 會從你的 `cdui.plugin.toml` 讀取 id，並把該目錄的絕對路徑以 `source_kind = "local"` 記入 lockfile，因此探索會直接走訪你的工作目錄。連結的外掛會跳過 AST 安全閘門（這是你自己的程式碼，並會印出警告）；`unlink` 只移除 lockfile 條目，絕不刪除你的檔案。編輯 Python 節點後，執行 `cdui plugin reload`（或重啟伺服器）即可重載；若變更了前端 bundle，還需重新整理瀏覽器。
+`link` 會從你的 `cdui.plugin.toml` 讀取 id，並把該目錄的絕對路徑以 `source_kind = "local"` 記入 lockfile，因此探索會直接走訪你的工作目錄。連結的外掛會跳過 AST 安全閘門（這是你自己的程式碼，並會印出警告）；`unlink` 只移除 lockfile 條目，絕不刪除你的檔案。編輯 Python 節點後，執行 `cdui plugin reload`（或 `cdui plugin dev`）即可重載。**連結中的外掛，前端變更也會自動重載**——只要安裝著連結的外掛，編輯器就會偵測重載並就地重新掛載外掛 UI，不需手動重新整理瀏覽器。
 
 :::tip 開發資料隔離
 透過 `scripts/dev.py` 執行外掛指令——或設定 `CODEFYUI_USER_DATA_DIR`——可讓某個 clone 的 lockfile 留在 repo 內（`.codefyui_dev/`），而非全機共用的 user-data 目錄，避免多個 clone 互相覆蓋。

--- a/frontend/src/plugins/PluginHost.tsx
+++ b/frontend/src/plugins/PluginHost.tsx
@@ -6,6 +6,12 @@
  * double-mounts effects in dev). A plugin that throws during import or
  * activate() is reported and skipped; it cannot break the app or other
  * plugins.
+ *
+ * Dev hot-reload: when a linked (source_kind="local") plugin is present, the
+ * host polls /api/plugins/generation and, on a bump, tears down and
+ * re-activates plugin frontends with a cache-busted import — so a linked
+ * plugin's frontend edits appear without a manual browser refresh. Production
+ * installs (no linked plugin) never poll.
  */
 import { useEffect, useRef } from 'react';
 import { useNodeDefStore } from '../store/nodeDefStore';
@@ -16,6 +22,7 @@ import styles from './PluginHost.module.css';
 interface PluginListItem {
   id: string;
   enabled: boolean;
+  source_kind?: string;
   frontend_entry: string | null;
 }
 
@@ -29,9 +36,12 @@ interface ActivatablePlugin {
 type Importer = (url: string) => Promise<{ default?: unknown }>;
 
 const IMPORT_TIMEOUT_MS = 10000;
+const DEV_POLL_MS = 1500;
 
 let hostStarted = false;
 let stackEl: HTMLElement | null = null;
+let cleanups: Array<() => void> = [];
+let pollTimer: ReturnType<typeof setInterval> | null = null;
 
 function widgetContainer(pluginId: string, widgetId: string): HTMLElement {
   const host = stackEl ?? document.body;
@@ -42,6 +52,25 @@ function widgetContainer(pluginId: string, widgetId: string): HTMLElement {
   el.id = domId;
   host.appendChild(el);
   return el;
+}
+
+/**
+ * Run tracked cleanups and remove plugin-created widget DOM. Called before a
+ * dev re-activation so subscriptions don't accumulate and a plugin's
+ * createRoot() isn't invoked twice on the same (already-rooted) node.
+ */
+function teardownPlugins(): void {
+  for (const fn of cleanups) {
+    try {
+      fn();
+    } catch (err) {
+      console.warn('[plugins] cleanup failed:', err);
+    }
+  }
+  cleanups = [];
+  if (stackEl) {
+    while (stackEl.firstChild) stackEl.removeChild(stackEl.firstChild);
+  }
 }
 
 /** Wait (bounded) for node definitions so plugins see a usable catalog. */
@@ -95,7 +124,11 @@ export async function loadPluginFrontends(
       if (typeof mod.default !== 'function') {
         throw new Error('frontend entry has no default export function');
       }
-      mod.default(buildPluginAPI(p.id, (widgetId) => getContainer(p.id, widgetId)));
+      mod.default(buildPluginAPI(
+        p.id,
+        (widgetId) => getContainer(p.id, widgetId),
+        (fn) => cleanups.push(fn),
+      ));
       activated.push(p.id);
     } catch (err) {
       console.warn(`[plugins] failed to activate '${p.id}' frontend:`, err);
@@ -107,6 +140,61 @@ export async function loadPluginFrontends(
   return activated;
 }
 
+async function fetchGeneration(): Promise<number | null> {
+  try {
+    const res = await fetch('/api/plugins/generation');
+    if (!res.ok) return null;
+    const data = await res.json();
+    return typeof data?.generation === 'number' ? data.generation : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Dev-only: if a linked (local) plugin is installed, poll the reload
+ * generation and re-activate plugin frontends whenever it bumps. The bundle is
+ * re-imported with a `?v=<generation>` cache-buster (the browser keeps the ESM
+ * module registry keyed by URL, so the query bump is required even though the
+ * server already sends Cache-Control: no-cache). No-ops in production.
+ */
+async function maybeStartDevHotReload(): Promise<void> {
+  if (pollTimer !== null) return;
+
+  let plugins: PluginListItem[];
+  try {
+    const res = await fetch('/api/plugins');
+    if (!res.ok) return;
+    const data = await res.json();
+    if (!Array.isArray(data)) return;
+    plugins = data;
+  } catch {
+    return;
+  }
+
+  const hasLocal = plugins.some(
+    (p) => p && p.source_kind === 'local' && p.enabled === true,
+  );
+  if (!hasLocal) return;
+
+  let lastGen = await fetchGeneration();
+  if (lastGen === null) return;
+
+  pollTimer = setInterval(() => {
+    void (async () => {
+      const gen = await fetchGeneration();
+      if (gen === null || gen === lastGen) return;
+      lastGen = gen;
+      teardownPlugins();
+      await loadPluginFrontends(
+        widgetContainer,
+        (url) => import(/* @vite-ignore */ `${url}?v=${gen}`),
+      );
+      useToastStore.getState().addToast('Plugin frontends reloaded', 'info');
+    })();
+  }, DEV_POLL_MS);
+}
+
 export function PluginHost() {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -114,7 +202,7 @@ export function PluginHost() {
     stackEl = ref.current;
     if (hostStarted) return;
     hostStarted = true;
-    void loadPluginFrontends();
+    void loadPluginFrontends().then(() => maybeStartDevHotReload());
     return () => { stackEl = null; };
   }, []);
 

--- a/frontend/src/plugins/api.test.ts
+++ b/frontend/src/plugins/api.test.ts
@@ -81,6 +81,23 @@ describe('graph surface', () => {
     api.graph.applyOperations([{ op: 'add_node', node_type: 'Sink' }]);
     expect(calls).toBe(seen);
   });
+
+  it('onGraphChanged registers its unsubscribe with trackCleanup', () => {
+    const tracked: Array<() => void> = [];
+    const api = buildPluginAPI(
+      'test-plugin',
+      () => document.createElement('div'),
+      (fn) => tracked.push(fn),
+    );
+    let calls = 0;
+    api.graph.onGraphChanged(() => { calls += 1; });
+    expect(tracked).toHaveLength(1);
+
+    // Running the tracked cleanup unsubscribes — later mutations don't fire it.
+    tracked[0]();
+    api.graph.applyOperations([{ op: 'add_node', node_type: 'Source' }]);
+    expect(calls).toBe(0);
+  });
 });
 
 describe('storage surface', () => {

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -90,6 +90,7 @@ function subscribeGraphChanged(cb: () => void): () => void {
 export function buildPluginAPI(
   pluginId: string,
   getWidgetContainer: (id: string) => HTMLElement,
+  trackCleanup?: (fn: () => void) => void,
 ): CodefyUIPluginAPI {
   const ns = (key: string) => `plugin:${pluginId}:${key}`;
   return {
@@ -104,7 +105,13 @@ export function buildPluginAPI(
       getGraph: () => useTabStore.getState().getSerializedGraph(),
       getNodeDefinitions: () => useNodeDefStore.getState().definitions,
       applyOperations: (ops) => commitGraphOperations(ops),
-      onGraphChanged: (cb) => subscribeGraphChanged(cb),
+      onGraphChanged: (cb) => {
+        // Track the unsubscribe so the host can tear it down on a dev
+        // hot-reload — otherwise re-activation would stack subscriptions.
+        const unsubscribe = subscribeGraphChanged(cb);
+        trackCleanup?.(unsubscribe);
+        return unsubscribe;
+      },
     },
     http: {
       fetch: (url, init) => apiFetch(url, init),


### PR DESCRIPTION
## What

Completes the local dev loop (the foundation). A **linked** plugin's *frontend* edits now appear in the editor **without a manual refresh** — edit `frontend/index.js`, reload (`cdui plugin dev`/`reload`), and the editor re-mounts the plugin UI on its own.

## How

- **Backend:** a monotonic reload-generation counter in `plugin_loader`, bumped in `rediscover_all` (so plugin/node reload + enable/disable all count), exposed via `GET /api/plugins/generation` — token-free, and declared before `/{plugin_id}` so the dynamic route doesn't swallow it.
- **Frontend (`PluginHost`):** when a linked (`source_kind:"local"`) plugin is present, poll the generation every 1.5 s; on a bump, **tear down + re-activate** plugin frontends with a cache-busted dynamic import (`?v=<gen>`). Teardown runs tracked `onGraphChanged` unsubscribes (new optional `trackCleanup` arg on `buildPluginAPI`) and clears the widget DOM, so re-activation never stacks subscriptions or calls `createRoot()` twice on the same node. **Production installs (no linked plugin) never poll.**

## Why polling, not a WS push

The execution WebSocket is **per-tab and opens only on the first "Run"**, so a server broadcast can't reach an idle editor. A polled GET works regardless of WS state, needs zero connection-management code, and (gated to dev) adds no production overhead. If sub-second push is ever wanted, the unused `executionWs` singleton is the natural control channel.

## Tests

- Backend (TestClient): generation increments on reload/toggle; `/generation` not shadowed by `/{plugin_id}`.
- Frontend: `trackCleanup` wiring; the existing `loadPluginFrontends` suite is unchanged (**26 frontend plugin tests pass**); `tsc` + `vite build` clean.
- **Chrome e2e** (isolated backend on :8200, linked plugin): edited the plugin frontend **A → B → C**; the editor re-activated automatically each time, showing the new text with a **single** widget (no duplicates), no manual refresh.

## Scope

This finishes Phase 1 (local dev loop). Next is **Phase 2** — the React authoring SDK (generated types + `defineTool`/hooks + `registerNodeRenderer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YFEoPUjnuYqUV18SV8ZxT