### PR TITLE
feat(plugins): custom node renderers — api.nodes.registerRenderer + PluginNodeBridge

### DIFF
--- a/docs/docs/advanced/plugin-frontend-extensions.md
+++ b/docs/docs/advanced/plugin-frontend-extensions.md
@@ -123,6 +123,38 @@ interface ApplyResult {
 
 **Batch semantics:** All ops in a single `applyOperations` call form one undo snapshot — pressing Ctrl+Z after an AI edit undoes the entire batch at once. Ops are applied in order; a failing op is skipped and reported in its `results` entry (`ok: false` plus an `error`), while the remaining ops continue. A `ref` alias created by an earlier `add_node` in the same batch is available to later ops, and is echoed back in `refs`.
 
+### `api.nodes` — custom node renderers
+
+Requires `api.apiVersion >= 2`.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `registerRenderer` | `(nodeType, renderer) => () => void` | Draw a plugin node type's card body with your own UI. Returns an unregister function. |
+
+`nodeType` is the node's **namespaced** type as it appears in `getNodeDefinitions()`. Note the namespace is the snake_case form of your plugin id — plugin `my-plugin` exposes node type `my_plugin:MyNode`. The renderer is imperative, so the host stays framework-agnostic:
+
+```ts
+interface NodeRenderContext {
+  node: { id: string; type: string; params: Record<string, unknown> };
+}
+interface PluginNodeRenderer {
+  mount(container: HTMLElement, ctx: NodeRenderContext): void;
+  update?(container: HTMLElement, ctx: NodeRenderContext): void; // on param change
+  unmount?(container: HTMLElement): void;
+}
+```
+
+The editor still renders the standard node card (title, ports, param list) and hands your renderer a `<div>` for the **body** — slotted between the ports and the params. A node type with no registered renderer renders exactly like a default node.
+
+```js
+api.nodes.registerRenderer('my_plugin:MyNode', {
+  mount(el, ctx) { el.textContent = `value: ${ctx.node.params.value}`; },
+  update(el, ctx) { el.textContent = `value: ${ctx.node.params.value}`; },
+});
+```
+
+The [plugin template](https://github.com/treeleaves30760/CodefyUI-Plugin-Official)'s SDK wraps this with `createRoot`, so you can write the body as a React component.
+
 ### `api.http` — session-aware fetch
 
 | Method | Signature | Description |

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
@@ -123,6 +123,38 @@ interface ApplyResult {
 
 **批次語義：** 單次 `applyOperations` 呼叫中的所有操作形成一個撤銷快照——在 AI 編輯後按 Ctrl+Z 會一次撤銷整個批次。操作依序套用；失敗的操作會被跳過並回報於其 `results` 條目（`ok: false` 加上 `error`），其餘操作仍會繼續。同一批次中先前 `add_node` 建立的 `ref` 別名可供後續操作使用，並會回傳於 `refs`。
 
+### `api.nodes` — 自訂 node 渲染
+
+需要 `api.apiVersion >= 2`。
+
+| 方法 | 簽名 | 說明 |
+|------|------|------|
+| `registerRenderer` | `(nodeType, renderer) => () => void` | 用你自己的 UI 繪製某個外掛 node 型別的卡片內容。回傳一個取消註冊函式。 |
+
+`nodeType` 是該 node 在 `getNodeDefinitions()` 中的**命名空間化**型別。注意命名空間是你外掛 id 的 snake_case 形式——外掛 `my-plugin` 對應 node 型別 `my_plugin:MyNode`。renderer 採命令式介面，讓宿主與框架無關：
+
+```ts
+interface NodeRenderContext {
+  node: { id: string; type: string; params: Record<string, unknown> };
+}
+interface PluginNodeRenderer {
+  mount(container: HTMLElement, ctx: NodeRenderContext): void;
+  update?(container: HTMLElement, ctx: NodeRenderContext): void; // 參數變更時
+  unmount?(container: HTMLElement): void;
+}
+```
+
+編輯器仍會渲染標準的 node 卡片（標題、連接埠、參數列），並把一個 `<div>` 交給你的 renderer 當作**內容區**——位於連接埠與參數之間。沒有註冊 renderer 的 node 型別，渲染結果與預設 node 完全相同。
+
+```js
+api.nodes.registerRenderer('my_plugin:MyNode', {
+  mount(el, ctx) { el.textContent = `value: ${ctx.node.params.value}`; },
+  update(el, ctx) { el.textContent = `value: ${ctx.node.params.value}`; },
+});
+```
+
+[外掛模板](https://github.com/treeleaves30760/CodefyUI-Plugin-Official)的 SDK 會用 `createRoot` 包裝它，讓你能以 React 元件撰寫內容區。
+
 ### `api.http` — 具 session 意識的 fetch
 
 | 方法 | 簽名 | 說明 |

--- a/frontend/src/components/Canvas/FlowCanvas.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.tsx
@@ -17,6 +17,7 @@ import '@xyflow/react/dist/style.css';
 import { CATEGORY_COLORS } from '../../styles/theme';
 
 import BaseNode from '../Nodes/BaseNode';
+import PluginNodeBridge from '../Nodes/PluginNodeBridge';
 import PresetNode from '../Nodes/PresetNode';
 import { StartNode } from '../Nodes/StartNode';
 import NoteNode from '../Nodes/NoteNode';
@@ -56,6 +57,7 @@ import styles from './FlowCanvas.module.css';
 
 const nodeTypes: NodeTypes = {
   baseNode: BaseNode,
+  pluginNode: PluginNodeBridge,
   presetNode: PresetNode,
   start: StartNode,
   noteNode: NoteNode,

--- a/frontend/src/components/Nodes/PluginNodeBridge.tsx
+++ b/frontend/src/components/Nodes/PluginNodeBridge.tsx
@@ -1,0 +1,84 @@
+/**
+ * xyflow node component for plugin-provided nodes.
+ *
+ * Namespaced plugin nodes (e.g. `my-plugin:Foo`) that have no first-party viz
+ * renderer route here. When the plugin has registered a custom renderer for the
+ * node's type, we render the standard node card (`BaseNodeBody`) with the
+ * plugin's UI injected into the body slot; otherwise this is identical to the
+ * default `baseNode`. The renderer registry is observable, so a renderer
+ * registered after the node mounts shows up without a reload.
+ */
+import { memo, useEffect, useRef, useSyncExternalStore } from 'react';
+import type { NodeProps } from '@xyflow/react';
+import type { AppNode } from '../../types';
+import { BaseNodeBody } from './BaseNode';
+import {
+  getNodeRenderer,
+  subscribeNodeRenderers,
+  type PluginNodeContext,
+  type PluginNodeRenderer,
+} from '../../plugins/nodeRenderers';
+
+function nodeContext(props: NodeProps<AppNode>): PluginNodeContext {
+  return {
+    node: {
+      id: props.id,
+      type: props.data.type,
+      params: props.data.params,
+      definition: props.data.definition,
+    },
+  };
+}
+
+/** Hosts the plugin's own (React) root inside the node card body slot. */
+function PluginNodeBody({
+  nodeProps, renderer,
+}: { nodeProps: NodeProps<AppNode>; renderer: PluginNodeRenderer }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Mount once per renderer; tear down on unmount or renderer change.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    try {
+      renderer.mount(el, nodeContext(nodeProps));
+    } catch (err) {
+      console.warn('[plugins] node renderer mount failed:', err);
+    }
+    return () => {
+      try { renderer.unmount?.(el); } catch { /* ignore plugin teardown errors */ }
+    };
+    // nodeProps intentionally omitted — updates flow through the effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [renderer]);
+
+  // Push fresh node state to the renderer whenever params/type change.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    try {
+      renderer.update?.(el, nodeContext(nodeProps));
+    } catch (err) {
+      console.warn('[plugins] node renderer update failed:', err);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [renderer, nodeProps.data.params, nodeProps.data.type]);
+
+  return <div className="cdui-plugin-node-body" ref={ref} />;
+}
+
+function PluginNodeBridge(props: NodeProps<AppNode>) {
+  const renderer = useSyncExternalStore(
+    subscribeNodeRenderers,
+    () => getNodeRenderer(props.data.type),
+  );
+  if (!renderer) return <BaseNodeBody {...props} />;
+  return (
+    <BaseNodeBody
+      {...props}
+      bodyExtra={<PluginNodeBody nodeProps={props} renderer={renderer} />}
+    />
+  );
+}
+
+export default memo(PluginNodeBridge);

--- a/frontend/src/plugins/api.test.ts
+++ b/frontend/src/plugins/api.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { useTabStore } from '../store/tabStore';
 import { useNodeDefStore } from '../store/nodeDefStore';
 import { buildPluginAPI } from './api';
+import { getNodeRenderer, _clearNodeRenderers, type PluginNodeRenderer } from './nodeRenderers';
 import type { NodeDefinition } from '../types';
 
 const DEFS: NodeDefinition[] = [
@@ -97,7 +98,20 @@ describe('storage surface', () => {
 describe('meta', () => {
   it('exposes apiVersion and pluginId', () => {
     const api = freshApi();
-    expect(api.apiVersion).toBe(1);
+    expect(api.apiVersion).toBe(2);
     expect(api.pluginId).toBe('test-plugin');
+  });
+});
+
+describe('nodes surface', () => {
+  afterEach(() => _clearNodeRenderers());
+
+  it('registerRenderer registers, and the returned fn unregisters', () => {
+    const api = freshApi();
+    const renderer: PluginNodeRenderer = { mount: () => {} };
+    const off = api.nodes.registerRenderer('test-plugin:Foo', renderer);
+    expect(getNodeRenderer('test-plugin:Foo')).toBe(renderer);
+    off();
+    expect(getNodeRenderer('test-plugin:Foo')).toBeUndefined();
   });
 });

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -12,6 +12,7 @@ import type { ToastType } from '../store/toastStore';
 import { apiFetch } from '../api/_auth';
 import type { NodeDefinition } from '../types';
 import { applyGraphOps, type ApplyOutcome, type GraphOp, type OpResult } from './ops';
+import { registerNodeRenderer, type PluginNodeRenderer } from './nodeRenderers';
 
 export interface ApplyResult {
   results: OpResult[];
@@ -25,7 +26,7 @@ export type SerializedGraph = ReturnType<
 >;
 
 export interface CodefyUIPluginAPI {
-  apiVersion: 1;
+  apiVersion: 2;
   pluginId: string;
   ui: {
     addFloatingWidget(opts: { id: string }): HTMLElement;
@@ -36,6 +37,10 @@ export interface CodefyUIPluginAPI {
     getNodeDefinitions(): NodeDefinition[];
     applyOperations(ops: GraphOp[]): ApplyResult;
     onGraphChanged(cb: () => void): () => void;
+  };
+  nodes: {
+    /** Register a custom renderer for a node type's card body. Returns an unregister fn. */
+    registerRenderer(nodeType: string, renderer: PluginNodeRenderer): () => void;
   };
   http: {
     fetch(url: string, init?: RequestInit): Promise<Response>;
@@ -93,7 +98,7 @@ export function buildPluginAPI(
 ): CodefyUIPluginAPI {
   const ns = (key: string) => `plugin:${pluginId}:${key}`;
   return {
-    apiVersion: 1,
+    apiVersion: 2,
     pluginId,
     ui: {
       addFloatingWidget: ({ id }) => getWidgetContainer(id),
@@ -105,6 +110,9 @@ export function buildPluginAPI(
       getNodeDefinitions: () => useNodeDefStore.getState().definitions,
       applyOperations: (ops) => commitGraphOperations(ops),
       onGraphChanged: (cb) => subscribeGraphChanged(cb),
+    },
+    nodes: {
+      registerRenderer: (nodeType, renderer) => registerNodeRenderer(nodeType, renderer),
     },
     http: {
       fetch: (url, init) => apiFetch(url, init),

--- a/frontend/src/plugins/nodeRenderers.test.ts
+++ b/frontend/src/plugins/nodeRenderers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  registerNodeRenderer, getNodeRenderer, subscribeNodeRenderers,
+  _clearNodeRenderers, type PluginNodeRenderer,
+} from './nodeRenderers';
+
+const noop: PluginNodeRenderer = { mount: () => {} };
+
+afterEach(() => _clearNodeRenderers());
+
+describe('nodeRenderers registry', () => {
+  it('registers and looks up a renderer by node type', () => {
+    registerNodeRenderer('p:Foo', noop);
+    expect(getNodeRenderer('p:Foo')).toBe(noop);
+    expect(getNodeRenderer('p:Bar')).toBeUndefined();
+  });
+
+  it('notifies subscribers on register and unregister', () => {
+    const cb = vi.fn();
+    const unsub = subscribeNodeRenderers(cb);
+    const unregister = registerNodeRenderer('p:Foo', noop);
+    expect(cb).toHaveBeenCalledTimes(1);
+    unregister();
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(getNodeRenderer('p:Foo')).toBeUndefined();
+    unsub();
+  });
+
+  it('re-registering the same type overwrites (no accumulation across reloads)', () => {
+    const a: PluginNodeRenderer = { mount: () => {} };
+    const b: PluginNodeRenderer = { mount: () => {} };
+    registerNodeRenderer('p:Foo', a);
+    registerNodeRenderer('p:Foo', b);
+    expect(getNodeRenderer('p:Foo')).toBe(b);
+  });
+
+  it('a stale unregister does not remove a newer renderer for the same type', () => {
+    const a: PluginNodeRenderer = { mount: () => {} };
+    const b: PluginNodeRenderer = { mount: () => {} };
+    const unregA = registerNodeRenderer('p:Foo', a);
+    registerNodeRenderer('p:Foo', b); // overwrites a
+    unregA(); // a is no longer current — must be a no-op
+    expect(getNodeRenderer('p:Foo')).toBe(b);
+  });
+});

--- a/frontend/src/plugins/nodeRenderers.ts
+++ b/frontend/src/plugins/nodeRenderers.ts
@@ -1,0 +1,65 @@
+/**
+ * Registry of plugin-provided custom node renderers.
+ *
+ * A plugin calls `api.nodes.registerRenderer(nodeType, renderer)` inside its
+ * `activate()`. `PluginNodeBridge` looks the renderer up by the node's
+ * (namespaced) type and mounts it into the node card's body slot. The registry
+ * is observable (subscribe + snapshot) so a renderer registered *after* nodes
+ * are already on the canvas still appears, and re-registering the same type
+ * overwrites — so a dev hot-reload doesn't accumulate stale renderers.
+ *
+ * The renderer is framework-agnostic (imperative mount/update/unmount), so the
+ * host stays decoupled from whichever React the plugin bundles. The SDK's
+ * `defineNodeRenderer` adapts a React component to this shape.
+ */
+export interface PluginNodeContext {
+  node: {
+    id: string;
+    type: string;
+    params: Record<string, unknown>;
+    definition?: unknown;
+  };
+}
+
+export interface PluginNodeRenderer {
+  mount(container: HTMLElement, ctx: PluginNodeContext): void;
+  update?(container: HTMLElement, ctx: PluginNodeContext): void;
+  unmount?(container: HTMLElement): void;
+}
+
+const renderers = new Map<string, PluginNodeRenderer>();
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  listeners.forEach((l) => l());
+}
+
+/** Register a renderer for a (namespaced) node type. Returns an unregister fn. */
+export function registerNodeRenderer(
+  nodeType: string,
+  renderer: PluginNodeRenderer,
+): () => void {
+  renderers.set(nodeType, renderer);
+  notify();
+  return () => {
+    if (renderers.get(nodeType) === renderer) {
+      renderers.delete(nodeType);
+      notify();
+    }
+  };
+}
+
+export function getNodeRenderer(nodeType: string): PluginNodeRenderer | undefined {
+  return renderers.get(nodeType);
+}
+
+export function subscribeNodeRenderers(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => { listeners.delete(cb); };
+}
+
+/** Test helper — drop all registered renderers. */
+export function _clearNodeRenderers(): void {
+  renderers.clear();
+  notify();
+}

--- a/frontend/src/utils/index.test.ts
+++ b/frontend/src/utils/index.test.ts
@@ -455,9 +455,14 @@ describe('buildFlowNode', () => {
     expect(n.type).toBe('start');
   });
 
-  it('strips plugin namespace when resolving the viz renderer', () => {
+  it('routes a namespaced plugin node (no first-party viz) to the plugin bridge', () => {
     const n = buildFlowNode({ ...def, node_name: 'somepack:FancyNode' }, { x: 0, y: 0 });
-    expect(n.type).toBe('baseNode');
+    expect(n.type).toBe('pluginNode');
     expect(n.data.type).toBe('somepack:FancyNode');
+  });
+
+  it('still resolves a first-party viz when a namespaced node\'s bare name has one', () => {
+    const n = buildFlowNode({ ...def, node_name: 'foundations:Edu-KNN' }, { x: 0, y: 0 });
+    expect(n.type).toBe('eduKNNNode');
   });
 });

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -23,6 +23,22 @@ export const VIZ_NODE_TYPES: Record<string, string> = {
   'Edu-KNN': 'eduKNNNode',
 };
 
+/**
+ * Pick the xyflow node component for a (possibly namespaced) node type:
+ * a first-party viz renderer if one is registered for the bare NODE_NAME, else
+ * the plugin bridge for namespaced plugin nodes (`<plugin>:Name`), else the
+ * default card. Routing plugin nodes through the bridge lets a plugin attach a
+ * custom React renderer; with no renderer registered the bridge renders exactly
+ * like `baseNode`.
+ */
+export function resolveNodeComponentType(nodeType: string): string {
+  const bare = nodeType.includes(':')
+    ? nodeType.slice(nodeType.lastIndexOf(':') + 1)
+    : nodeType;
+  if (VIZ_NODE_TYPES[bare]) return VIZ_NODE_TYPES[bare];
+  return nodeType.includes(':') ? 'pluginNode' : 'baseNode';
+}
+
 export const DATA_TYPE_COLORS: Record<string, string> = {
   TENSOR: '#4CAF50',
   MODEL: '#2196F3',
@@ -203,15 +219,12 @@ export function resolveSerializedNodes(
       };
     }
 
-    // Regular node
+    // Regular node. resolveNodeComponentType handles namespaced plugin types
+    // ("foundations:Edu-KNN") — first-party viz, else the plugin bridge, else base.
     const def = defMap.get(nodeType);
-    // VIZ_NODE_TYPES is keyed by the bare NODE_NAME, but a serialized plugin node
-    // carries a namespaced type ("foundations:Edu-KNN"). Strip the "<plugin>:" prefix
-    // so the custom renderer still fires regardless of which pack ships the node.
-    const bareType = nodeType.includes(':') ? nodeType.slice(nodeType.lastIndexOf(':') + 1) : nodeType;
     return {
       id: raw.id,
-      type: VIZ_NODE_TYPES[bareType] ?? 'baseNode',
+      type: resolveNodeComponentType(nodeType),
       position,
       data: {
         label: raw.data?.label ?? nodeType,
@@ -250,10 +263,9 @@ export function buildFlowNode(
     defaultParams[p.name] = p.default;
   }
   const name = definition.node_name;
-  const bare = name.includes(':') ? name.slice(name.lastIndexOf(':') + 1) : name;
   return {
     id: generateId(),
-    type: name === 'Start' ? 'start' : (VIZ_NODE_TYPES[bare] ?? 'baseNode'),
+    type: name === 'Start' ? 'start' : resolveNodeComponentType(name),
     position,
     data: {
       label: name,

--- a/frontend/src/utils/resolveNodeComponentType.test.ts
+++ b/frontend/src/utils/resolveNodeComponentType.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { resolveNodeComponentType } from './index';
+
+describe('resolveNodeComponentType', () => {
+  it('uses a first-party viz renderer for known bare names (incl. namespaced)', () => {
+    expect(resolveNodeComponentType('Tokenizer')).toBe('tokenizerNode');
+    // namespaced plugin node whose bare name has a first-party viz still uses it
+    expect(resolveNodeComponentType('foundations:Edu-KNN')).toBe('eduKNNNode');
+  });
+
+  it('routes namespaced plugin nodes without a viz to the plugin bridge', () => {
+    expect(resolveNodeComponentType('my-plugin:Foo')).toBe('pluginNode');
+  });
+
+  it('routes bare built-in nodes to the default card', () => {
+    expect(resolveNodeComponentType('Linear')).toBe('baseNode');
+  });
+});


### PR DESCRIPTION
## What

Lets a plugin draw a **node's card body** with its own React (or any) UI — the second half of "author plugin frontend in React". Pairs with the floating-tool SDK (template repo) to cover both UI surfaces. `apiVersion` → **2** (purely additive; apiVersion-1 plugins keep working).

```js
api.nodes.registerRenderer('my_plugin:MyNode', {
  mount(el, ctx)  { /* fill the node body; ctx.node = { id, type, params } */ },
  update(el, ctx) { /* called when the node's params change */ },
  unmount(el)     { /* optional teardown */ },
});
```

## How

- **`nodeRenderers.ts`** — an observable registry (`register` / `get` / `subscribe`). Re-registering a type overwrites, so a dev hot-reload never accumulates stale renderers.
- **`api.nodes.registerRenderer(nodeType, renderer)`** — imperative `mount/update/unmount` so the host stays framework-agnostic; the SDK adapts a React component to it.
- **`PluginNodeBridge`** — an xyflow node component that **reuses `BaseNodeBody`'s existing `bodyExtra` slot**: it renders the standard card (title, ports, params) and mounts the plugin renderer in the body. It reads the registry via `useSyncExternalStore`, so a renderer registered *after* the node mounts appears with no reload. With **no** renderer registered it's byte-identical to `baseNode`.
- **`resolveNodeComponentType`** — namespaced plugin nodes without a first-party viz now route to `pluginNode`; first-party viz nodes and bare built-ins are unchanged.

## Tests

- Registry (register / notify / overwrite / stale-unregister), resolution (viz vs bridge vs base), API wiring + `apiVersion === 2`. **177 frontend tests pass**; `tsc` + `vite build` clean.
- **Chrome e2e**: a plugin registered a renderer for `noderender_test:NodeRenderDemo` and added its node — the card shows the standard frame (title, `out` port, `label` param) **plus the plugin's custom body ("CUSTOM: demo")**.
- Docs: `api.nodes` section added to the frontend-extensions reference (en + zh-TW), build green.

## Note

A node's type uses the **snake_case** namespace (plugin `my-plugin` → `my_plugin:MyNode`) — documented in the new section. The next template-repo PR adds an SDK `defineNodeRenderer` React wrapper + an example so authors don't touch the imperative API directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YFEoPUjnuYqUV18SV8ZxT