### PR TITLE
feat(plugins): plugin authoring DX — cdui plugin new scaffold + canonical SDK contract + reload-port fix

### DIFF
--- a/backend/tests/test_plugin_dx.py
+++ b/backend/tests/test_plugin_dx.py
@@ -1,0 +1,36 @@
+"""Tests for the plugin developer-experience batch:
+
+- ``_reload_target`` — hot-reload POST honors the configured server port.
+- plugin SDK contract sync — the vendored scaffold copy matches the canonical
+  ``frontend/src/plugins/contract.ts``.
+- ``cdui plugin new`` — the scaffold generates a valid, loadable plugin.
+"""
+
+from __future__ import annotations
+
+import plugins as plugin_cli
+
+
+# ── item 4: reload targets the configured port ───────────────────────────────
+
+def test_reload_target_defaults_to_8000(monkeypatch):
+    monkeypatch.delenv("CODEFYUI_PORT", raising=False)
+    url, host = plugin_cli._reload_target()
+    assert url == "http://127.0.0.1:8000/api/plugins/reload"
+    assert host == "127.0.0.1:8000"
+
+
+def test_reload_target_honors_codefyui_port(monkeypatch):
+    monkeypatch.setenv("CODEFYUI_PORT", "8200")
+    url, host = plugin_cli._reload_target()
+    assert url == "http://127.0.0.1:8200/api/plugins/reload"
+    assert host == "127.0.0.1:8200"
+
+
+def test_reload_target_ignores_non_numeric_port(monkeypatch):
+    # A garbage override must not crash or produce a malformed URL — fall back.
+    monkeypatch.setenv("CODEFYUI_PORT", "not-a-port")
+    url, host = plugin_cli._reload_target()
+    assert url.startswith("http://127.0.0.1:")
+    assert url.endswith("/api/plugins/reload")
+    assert host == url[len("http://"):-len("/api/plugins/reload")]

--- a/backend/tests/test_plugin_dx.py
+++ b/backend/tests/test_plugin_dx.py
@@ -34,3 +34,14 @@ def test_reload_target_ignores_non_numeric_port(monkeypatch):
     assert url.startswith("http://127.0.0.1:")
     assert url.endswith("/api/plugins/reload")
     assert host == url[len("http://"):-len("/api/plugins/reload")]
+
+
+# ── item 3: vendored SDK types stay in sync with the canonical contract ───────
+
+def test_plugin_sdk_types_in_sync():
+    """The scaffold's vendored ``ui/src/sdk/types.ts`` must match the canonical
+    ``frontend/src/plugins/contract.ts``. If this fails, run:
+    ``python scripts/sync_plugin_sdk.py``."""
+    import sync_plugin_sdk
+
+    assert sync_plugin_sdk.check() == 0

--- a/backend/tests/test_plugin_dx.py
+++ b/backend/tests/test_plugin_dx.py
@@ -140,3 +140,38 @@ def test_new_scaffold_refuses_existing_nonempty(tmp_path):
     assert plugin_cli.main(["new", "dupe", "--dir", str(tmp_path)]) == 1
     # The pre-existing file is untouched.
     assert (existing / "keep.txt").read_text(encoding="utf-8") == "do not clobber"
+
+
+# ── cp950: status glyphs must degrade to ASCII, never crash ───────────────────
+
+def test_cli_output_survives_cp950_console(tmp_path):
+    """On a console whose encoding can't represent ▶/✓ (legacy Windows cp950, or
+    a redirected pipe), the CLI must print ASCII markers instead of raising
+    UnicodeEncodeError. Runs the real entry point in a subprocess with stdout
+    forced to cp950."""
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    scripts = Path(plugin_cli.__file__).resolve().parent
+    backend = scripts.parent / "backend"
+
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp950"   # reproduce the crashing encoding
+    env["PYTHONPATH"] = str(backend)    # so the subprocess can import `app`
+    env["CODEFYUI_LANG"] = "en"         # deterministic ASCII messages
+    env["NO_COLOR"] = "1"
+
+    proc = subprocess.run(
+        [sys.executable, str(scripts / "plugins.py"), "new", "cp-probe", "--dir", str(tmp_path)],
+        capture_output=True,
+        env=env,
+    )
+    out = proc.stdout.decode("cp950", "replace")
+    assert proc.returncode == 0, proc.stderr.decode("cp950", "replace")
+    assert "Traceback" not in proc.stderr.decode("cp950", "replace")
+    assert "Creating new plugin" in out
+    assert "▶" not in out and "✓" not in out      # glyphs fell back
+    assert "> Creating new plugin" in out          # ASCII section marker
+    assert "+ Created" in out                       # ASCII ok marker

--- a/backend/tests/test_plugin_dx.py
+++ b/backend/tests/test_plugin_dx.py
@@ -45,3 +45,98 @@ def test_plugin_sdk_types_in_sync():
     import sync_plugin_sdk
 
     assert sync_plugin_sdk.check() == 0
+
+
+# ── item 1: cdui plugin new scaffold ─────────────────────────────────────────
+
+def _no_unrendered_placeholders(root):
+    """Every generated text file must have its {{...}} tokens substituted."""
+    for f in root.rglob("*"):
+        if f.is_file() and "__pycache__" not in f.parts:
+            assert "{{" not in f.read_text(encoding="utf-8"), f"unrendered token in {f}"
+
+
+def _assert_python_compiles(path):
+    """The generated .py is at least syntactically valid post-substitution.
+
+    Uses the builtin ``compile`` (not ``py_compile``) so no .pyc is written into
+    the scaffolded directory.
+    """
+    compile(path.read_text(encoding="utf-8"), str(path), "exec")
+
+
+def test_new_scaffold_backend_only(tmp_path):
+    from app.core.plugin_validator import validate_python_source
+
+    rc = plugin_cli.main(["new", "my-test-plugin", "--dir", str(tmp_path)])
+    assert rc == 0
+    root = tmp_path / "my-test-plugin"
+
+    # Core files exist; the ui/ subtree is absent without --ui.
+    assert (root / "cdui.plugin.toml").is_file()
+    assert (root / "nodes" / "example_node.py").is_file()
+    assert (root / "tests" / "conftest.py").is_file()
+    assert (root / "tests" / "test_example_node.py").is_file()
+    assert not (root / "ui").exists()
+
+    # Manifest validates and carries the substituted id; no frontend stanza.
+    manifest = plugin_cli.read_manifest(root)
+    plugin_cli.validate_manifest(manifest)
+    assert manifest["plugin"]["id"] == "my-test-plugin"
+    assert manifest["plugin"]["name"] == "My Test Plugin"
+    assert "frontend" not in manifest
+
+    # conftest wires the right namespace id; generated python is valid.
+    conftest = (root / "tests" / "conftest.py").read_text(encoding="utf-8")
+    assert 'PLUGIN_ID = "my-test-plugin"' in conftest
+    _assert_python_compiles(root / "nodes" / "example_node.py")
+    _assert_python_compiles(root / "tests" / "conftest.py")
+    _assert_python_compiles(root / "tests" / "test_example_node.py")
+
+    # The example node passes the AST security gate installs run.
+    validate_python_source(
+        (root / "nodes" / "example_node.py").read_bytes(),
+        "example_node.py",
+        allowed_modules=[],
+    )
+    _no_unrendered_placeholders(root)
+
+
+def test_new_scaffold_with_ui(tmp_path):
+    rc = plugin_cli.main(["new", "ui-plugin", "--ui", "--dir", str(tmp_path)])
+    assert rc == 0
+    root = tmp_path / "ui-plugin"
+
+    assert (root / "ui" / "src" / "index.tsx").is_file()
+    assert (root / "ui" / "src" / "sdk" / "types.ts").is_file()
+    assert (root / "ui" / "src" / "sdk" / "react.tsx").is_file()
+    assert (root / "ui" / "package.json").is_file()
+
+    # --ui appends the [frontend] entry to the manifest.
+    manifest = plugin_cli.read_manifest(root)
+    plugin_cli.validate_manifest(manifest)
+    assert manifest["frontend"]["entry"] == "frontend/index.js"
+
+    # The node renderer registration uses the snake_case namespace.
+    index_tsx = (root / "ui" / "src" / "index.tsx").read_text(encoding="utf-8")
+    assert "ui_plugin:Example" in index_tsx
+    # The vendored types match the canonical contract.
+    import sync_plugin_sdk
+
+    assert sync_plugin_sdk._norm((root / "ui" / "src" / "sdk" / "types.ts").read_text(encoding="utf-8")) \
+        == sync_plugin_sdk.rendered()
+    _no_unrendered_placeholders(root)
+
+
+def test_new_scaffold_rejects_invalid_id(tmp_path):
+    assert plugin_cli.main(["new", "Bad_Id", "--dir", str(tmp_path)]) == 2
+    assert not (tmp_path / "Bad_Id").exists()
+
+
+def test_new_scaffold_refuses_existing_nonempty(tmp_path):
+    existing = tmp_path / "dupe"
+    existing.mkdir()
+    (existing / "keep.txt").write_text("do not clobber", encoding="utf-8")
+    assert plugin_cli.main(["new", "dupe", "--dir", str(tmp_path)]) == 1
+    # The pre-existing file is untouched.
+    assert (existing / "keep.txt").read_text(encoding="utf-8") == "do not clobber"

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -37,7 +37,16 @@ Plugin nodes are namespaced to avoid collisions and to self-document graphs — 
 
 ## Writing your own plugin
 
-Fork the **[Official Plugin Template](https://github.com/treeleaves30760/CodefyUI-Plugin-Official)** — a working, MIT-licensed plugin with two example nodes, a sample example graph, a test suite, and a fully-commented manifest. Its README walks through every field and the AST security gate.
+The fastest start is **`cdui plugin new`**, which scaffolds a ready-to-edit plugin in one command:
+
+```bash
+cdui plugin new my-plugin          # backend-only skeleton
+cdui plugin new my-plugin --ui     # also a React frontend wired to the SDK
+```
+
+It generates a manifest, an example node, a test (with the `cdui_plugins.<id>` namespace shim so `pytest` works locally), and — with `--ui` — a Vite + React `ui/` whose `src/sdk/` is the typed plugin SDK. The plugin lands in `./my-plugin/`; link it with `cdui plugin dev` (below) and start editing.
+
+For a richer reference, fork the **[Official Plugin Template](https://github.com/treeleaves30760/CodefyUI-Plugin-Official)** — a working, MIT-licensed plugin with two example nodes, a sample example graph, a test suite, and a fully-commented manifest. Its README walks through every field and the AST security gate.
 
 ```bash
 # Install the template itself to see the pattern live
@@ -70,7 +79,7 @@ Even simpler, **`dev`** links and watches in one command, hot-reloading on every
 cdui plugin dev ./my-plugin      # link + watch; reloads on every change
 ```
 
-Run the server in another terminal (`cdui start` or `cdui dev`). `dev` polls the plugin's manifest, `nodes/`, `presets/`, and `frontend/`; `--once` links and reloads a single time (no watch), and `--interval` tunes the poll frequency.
+Run the server in another terminal (`cdui start` or `cdui dev`). `dev` polls the plugin's manifest, `nodes/`, `presets/`, and `frontend/`; `--once` links and reloads a single time (no watch), and `--interval` tunes the poll frequency. `link`, `dev`, and `reload` reach the server on its configured port (`CODEFYUI_PORT`, default `8000`), so running on a non-default port needs no extra flags.
 
 `link` reads the id from your `cdui.plugin.toml` and records the directory's absolute path in the lockfile as `source_kind = "local"`, so discovery walks your working tree directly. The AST security gate is skipped for linked plugins (it's your own code, and a warning says so); `unlink` drops only the lockfile entry, never your files. After editing Python nodes, `cdui plugin reload` (or `cdui plugin dev`) reloads them. **Frontend edits to a linked plugin reload automatically too** — while a linked plugin is installed the editor watches for reloads and re-mounts the plugin's UI in place, no browser refresh needed.
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -37,7 +37,16 @@ cdui plugin uninstall deep
 
 ## 撰寫你自己的外掛
 
-Fork **[官方外掛模板](https://github.com/treeleaves30760/CodefyUI-Plugin-Official)**——一個可運作、採 MIT 授權的外掛，包含兩個範例節點、一張範例圖、一套測試，以及一份完整註解的資訊清單 (manifest)。它的 README 逐欄解說每個欄位與 AST 安全閘門。
+最快的起手式是 **`cdui plugin new`**，一個指令就能產生可直接編輯的外掛骨架：
+
+```bash
+cdui plugin new my-plugin          # 純後端骨架
+cdui plugin new my-plugin --ui     # 另含一個接好 SDK 的 React 前端
+```
+
+它會產生 manifest、一個範例節點、一個測試（內含 `cdui_plugins.<id>` 命名空間 shim，讓本地 `pytest` 可直接執行），並在加上 `--ui` 時產生一個 Vite + React 的 `ui/`，其 `src/sdk/` 即為型別化的外掛 SDK。外掛會建立在 `./my-plugin/`；用下方的 `cdui plugin dev` 連結後即可開始編輯。
+
+若需更完整的參考，可 Fork **[官方外掛模板](https://github.com/treeleaves30760/CodefyUI-Plugin-Official)**——一個可運作、採 MIT 授權的外掛，包含兩個範例節點、一張範例圖、一套測試，以及一份完整註解的資訊清單 (manifest)。它的 README 逐欄解說每個欄位與 AST 安全閘門。
 
 ```bash
 # Install the template itself to see the pattern live
@@ -70,7 +79,7 @@ cdui plugin unlink my-plugin     # 解除連結——你的檔案不會被刪除
 cdui plugin dev ./my-plugin      # 連結＋監看；每次變更自動重載
 ```
 
-請在另一個終端機執行伺服器（`cdui start` 或 `cdui dev`）。`dev` 會輪詢外掛的 manifest、`nodes/`、`presets/` 與 `frontend/`；`--once` 只連結並重載一次（不監看），`--interval` 可調整輪詢間隔。
+請在另一個終端機執行伺服器（`cdui start` 或 `cdui dev`）。`dev` 會輪詢外掛的 manifest、`nodes/`、`presets/` 與 `frontend/`；`--once` 只連結並重載一次（不監看），`--interval` 可調整輪詢間隔。`link`、`dev`、`reload` 會連到伺服器設定的連接埠（`CODEFYUI_PORT`，預設 `8000`），因此跑在非預設埠時不需額外旗標。
 
 `link` 會從你的 `cdui.plugin.toml` 讀取 id，並把該目錄的絕對路徑以 `source_kind = "local"` 記入 lockfile，因此探索會直接走訪你的工作目錄。連結的外掛會跳過 AST 安全閘門（這是你自己的程式碼，並會印出警告）；`unlink` 只移除 lockfile 條目，絕不刪除你的檔案。編輯 Python 節點後，執行 `cdui plugin reload`（或 `cdui plugin dev`）即可重載。**連結中的外掛，前端變更也會自動重載**——只要安裝著連結的外掛，編輯器就會偵測重載並就地重新掛載外掛 UI，不需手動重新整理瀏覽器。
 

--- a/frontend/src/plugins/contract.assert.ts
+++ b/frontend/src/plugins/contract.assert.ts
@@ -1,0 +1,51 @@
+/**
+ * Compile-time guard: the published plugin contract (`./contract`) must stay in
+ * sync with the host's real implementation types. If the host changes a
+ * contract-relevant type without updating `contract.ts`, one of the assertions
+ * below resolves to something other than `true` and `tsc -b` fails — caught by
+ * the Frontend Build Check before any plugin sees stale autocomplete.
+ *
+ * This file emits no runtime code; it exists purely so the type checker visits
+ * these assertions.
+ */
+import type { GraphOp as HGraphOp, OpResult as HOpResult } from './ops';
+import type { ApplyResult as HApplyResult, CodefyUIPluginAPI as HApi } from './api';
+import type {
+  NodeDefinition as HNodeDef,
+  ParamDefinition as HParamDef,
+  PortDefinition as HPortDef,
+} from '../types';
+import type { PluginNodeRenderer as HRenderer } from './nodeRenderers';
+import type {
+  ApplyResult as CApplyResult,
+  CodefyUIPluginAPI as CApi,
+  GraphOp as CGraphOp,
+  NodeDefinition as CNodeDef,
+  OpResult as COpResult,
+  ParamDefinition as CParamDef,
+  PluginNodeRenderer as CRenderer,
+  PortDefinition as CPortDef,
+} from './contract';
+
+type Extends<A, B> = A extends B ? true : false;
+/** True only when A and B are mutually assignable (structurally equal). */
+type Mutual<A, B> = Extends<A, B> extends true ? Extends<B, A> : false;
+/** Compile error unless the argument resolves to exactly `true`. */
+type Expect<T extends true> = T;
+
+// ── data contracts: must match the host structurally, both directions ──
+// (ParamDefinition.default is `any` on the host and `unknown` in the contract;
+// the two are mutually assignable, so this still catches every real drift —
+// an added/removed/renamed field or a changed param_type/op union member.)
+export type _GraphOp = Expect<Mutual<HGraphOp, CGraphOp>>;
+export type _OpResult = Expect<Mutual<HOpResult, COpResult>>;
+export type _ApplyResult = Expect<Mutual<HApplyResult, CApplyResult>>;
+export type _NodeDef = Expect<Mutual<HNodeDef, CNodeDef>>;
+export type _PortDef = Expect<Mutual<HPortDef, CPortDef>>;
+export type _ParamDef = Expect<Mutual<HParamDef, CParamDef>>;
+export type _Renderer = Expect<Mutual<HRenderer, CRenderer>>;
+
+// ── API surface: same top-level sections; apiVersion is intentionally widened
+// from the host's literal `2` to `number` so plugins can defensively check it. ──
+export type _ApiKeys = Expect<Mutual<keyof HApi, keyof CApi>>;
+export type _ApiVersion = Expect<Extends<HApi['apiVersion'], CApi['apiVersion']>>;

--- a/frontend/src/plugins/contract.ts
+++ b/frontend/src/plugins/contract.ts
@@ -1,0 +1,156 @@
+/**
+ * CodefyUI plugin frontend API — the CANONICAL, self-contained type contract.
+ *
+ * This is the single source of truth for the public plugin surface. It has NO
+ * imports, so it drops verbatim into any plugin's `ui/src/sdk/types.ts`:
+ *
+ *   - `scripts/sync_plugin_sdk.py` copies it into the `cdui plugin new` scaffold
+ *     payload (`scripts/templates/plugin/ui/src/sdk/types.ts`); a backend test
+ *     (`tests/test_plugin_dx.py`) fails if that copy drifts.
+ *   - The clone-and-own template `CodefyUI-Plugin-Official/ui/src/sdk/types.ts`
+ *     is refreshed from this file too.
+ *
+ * `contract.assert.ts` (next to this file) statically asserts that the host's
+ * real implementation types (`./api`, `./ops`, `../types`, `./nodeRenderers`)
+ * stay structurally compatible with the declarations here, so `tsc -b` fails the
+ * moment the host drifts from the published contract. A future hardening step
+ * could have the host import these types directly to make drift impossible
+ * rather than merely detected.
+ */
+
+export type ToastType = 'success' | 'error' | 'info' | 'warning';
+
+export interface PortDefinition {
+  name: string;
+  data_type: string;
+  description: string;
+  optional: boolean;
+}
+
+export interface ParamDefinition {
+  name: string;
+  param_type:
+    | 'int' | 'float' | 'string' | 'bool'
+    | 'select' | 'model_file' | 'image_file' | 'tensor_grid';
+  default: unknown;
+  description: string;
+  options: string[];
+  min_value: number | null;
+  max_value: number | null;
+  visible_when?: Record<string, unknown> | null;
+}
+
+export interface NodeDefinition {
+  node_name: string;
+  category: string;
+  description: string;
+  inputs: PortDefinition[];
+  outputs: PortDefinition[];
+  params: ParamDefinition[];
+}
+
+/** A batch operation accepted by `api.graph.applyOperations`. Field names are exact. */
+export type GraphOp =
+  | { op: 'add_node'; node_type: string; ref?: string;
+      params?: Record<string, unknown>; position?: { x: number; y: number } }
+  | { op: 'connect'; source: string; source_handle: string;
+      target: string; target_handle: string }
+  | { op: 'set_params'; node_id: string; params: Record<string, unknown> }
+  | { op: 'remove_node'; node_id: string }
+  | { op: 'remove_edge'; source: string; target: string;
+      source_handle?: string; target_handle?: string }
+  | { op: 'clear_graph' }
+  | { op: 'auto_layout' };
+
+export interface OpResult {
+  index: number;
+  ok: boolean;
+  error?: string;
+  node_id?: string;
+}
+
+export interface ApplyResult {
+  results: OpResult[];
+  refs: Record<string, string>;
+  node_count: number;
+  edge_count: number;
+}
+
+export interface SerializedGraphNode {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: { params: Record<string, unknown>; [key: string]: unknown };
+}
+
+export interface SerializedGraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  sourceHandle: string;
+  targetHandle: string;
+}
+
+export interface SerializedGraph {
+  nodes: SerializedGraphNode[];
+  edges: SerializedGraphEdge[];
+  presets?: unknown[];
+  segmentGroups?: unknown[];
+  name?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+export interface NodeRenderContext {
+  node: {
+    id: string;
+    type: string;
+    params: Record<string, unknown>;
+    definition?: unknown;
+  };
+}
+
+/**
+ * Imperative renderer for a node's card body. The SDK's `defineNodeRenderer`
+ * adapts a React component to this shape; the host calls mount once, update on
+ * param changes, and unmount when the node is removed.
+ */
+export interface PluginNodeRenderer {
+  mount(container: HTMLElement, ctx: NodeRenderContext): void;
+  update?(container: HTMLElement, ctx: NodeRenderContext): void;
+  unmount?(container: HTMLElement): void;
+}
+
+/** The object the editor hands every plugin frontend at activation. */
+export interface CodefyUIPluginAPI {
+  apiVersion: number;
+  pluginId: string;
+  ui: {
+    /** Create (or reuse) a container `<div>` in the editor's widget stack. */
+    addFloatingWidget(opts: { id: string }): HTMLElement;
+    toast(message: string, type?: ToastType): void;
+  };
+  graph: {
+    getGraph(): SerializedGraph;
+    getNodeDefinitions(): NodeDefinition[];
+    /** Synchronous — returns the result directly, committed as one undo step. */
+    applyOperations(ops: GraphOp[]): ApplyResult;
+    onGraphChanged(cb: () => void): () => void;
+  };
+  /** Custom node renderers — requires apiVersion >= 2. */
+  nodes: {
+    registerRenderer(nodeType: string, renderer: PluginNodeRenderer): () => void;
+  };
+  http: {
+    /** Browser `fetch`, with the CodefyUI session token attached. */
+    fetch(url: string, init?: RequestInit): Promise<Response>;
+  };
+  storage: {
+    get(key: string): string | null;
+    set(key: string, value: string): void;
+    remove(key: string): void;
+  };
+}
+
+/** The default-export contract: the editor calls this once with the API. */
+export type ActivateFn = (api: CodefyUIPluginAPI) => void;

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -291,6 +291,34 @@ def _read_session_token() -> str | None:
         return None
 
 
+def _reload_target() -> tuple[str, str]:
+    """``(url, host_header)`` for ``POST /api/plugins/reload``.
+
+    Targets the port the server is actually configured to bind rather than a
+    hardcoded ``:8000``, so ``link`` / ``dev`` / ``reload`` keep working when the
+    user runs the server elsewhere (``CODEFYUI_PORT`` env or a ``.env`` file).
+    Resolution order: the ``CODEFYUI_PORT`` env override (explicit + easy to test),
+    then ``settings.PORT`` (which also honors ``.env``), then the ``8000`` default.
+
+    The client always connects over the loopback address; ``auth.init_allowed_hosts``
+    always whitelists ``127.0.0.1:<port>``, so a matching ``Host`` header passes the
+    guard even when the server binds ``HOST=0.0.0.0``.
+    """
+    port = 8000
+    env = os.environ.get("CODEFYUI_PORT", "").strip()
+    if env.isdigit():
+        port = int(env)
+    else:
+        try:
+            from app.config import settings
+
+            port = int(settings.PORT)
+        except Exception:
+            port = 8000
+    netloc = f"127.0.0.1:{port}"
+    return (f"http://{netloc}/api/plugins/reload", netloc)
+
+
 def _backend_reload() -> bool:
     """POST /api/plugins/reload — best-effort hot reload.
 
@@ -302,15 +330,16 @@ def _backend_reload() -> bool:
     token = _read_session_token()
     if token is None:
         return False
+    url, host = _reload_target()
     try:
         req = urllib.request.Request(
-            "http://127.0.0.1:8000/api/plugins/reload",
+            url,
             method="POST",
             headers={
                 "User-Agent": USER_AGENT,
                 "Content-Length": "0",
                 "X-CodefyUI-Token": token,
-                "Host": "127.0.0.1:8000",  # Match the Host whitelist.
+                "Host": host,  # Match the Host whitelist.
             },
             data=b"",
         )

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -62,6 +62,47 @@ YELLOW = "\033[33m" if _USE_COLOR else ""
 CYAN = "\033[36m" if _USE_COLOR else ""
 
 
+def _supports_unicode() -> bool:
+    """Whether stdout can encode our status glyphs.
+
+    On a legacy Windows console (cp950 / cp1252) or a pipe whose encoding is the
+    locale codepage, glyphs like ``▶`` / ``✓`` aren't encodable and ``print``
+    raises UnicodeEncodeError, taking the whole command down. When that's the
+    case we fall back to ASCII markers instead.
+    """
+    enc = getattr(sys.stdout, "encoding", None)
+    if not enc:
+        return False
+    try:
+        "▶✓✗●→".encode(enc)
+        return True
+    except (UnicodeEncodeError, LookupError):
+        return False
+
+
+_UNICODE = _supports_unicode()
+MARK_SECTION = "▶" if _UNICODE else ">"
+MARK_OK = "✓" if _UNICODE else "+"
+MARK_ERR = "✗" if _UNICODE else "x"
+MARK_INSTALLED = "●" if _UNICODE else "*"
+ARROW = "→" if _UNICODE else "->"
+
+
+def _reconfigure_stdio() -> None:
+    """Best-effort safety net so output never crashes on an unencodable char.
+
+    Keeps the console's native encoding — so Traditional Chinese still renders on
+    a cp950 console — but replaces anything it can't encode rather than raising.
+    Called from ``main`` so importing this module (e.g. in tests) leaves the
+    captured stdio untouched.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(errors="replace")  # type: ignore[union-attr]
+        except (AttributeError, ValueError, OSError):
+            pass
+
+
 def _lang() -> str:
     forced = os.environ.get("CODEFYUI_LANG")
     if forced:
@@ -75,7 +116,7 @@ def t(zh: str, en: str) -> str:
 
 
 def section(zh: str, en: str) -> None:
-    print(f"\n{BOLD}{CYAN}▶ {t(zh, en)}{RESET}")
+    print(f"\n{BOLD}{CYAN}{MARK_SECTION} {t(zh, en)}{RESET}")
 
 
 def info(zh: str, en: str) -> None:
@@ -87,11 +128,11 @@ def warn(zh: str, en: str) -> None:
 
 
 def err(zh: str, en: str) -> None:
-    print(f"  {RED}✗ {t(zh, en)}{RESET}", file=sys.stderr)
+    print(f"  {RED}{MARK_ERR} {t(zh, en)}{RESET}", file=sys.stderr)
 
 
 def ok(zh: str, en: str) -> None:
-    print(f"  {GREEN}✓ {t(zh, en)}{RESET}")
+    print(f"  {GREEN}{MARK_OK} {t(zh, en)}{RESET}")
 
 
 # ── catalog ────────────────────────────────────────────────────────────────
@@ -1207,8 +1248,8 @@ def cmd_update(args: argparse.Namespace) -> int:
             continue
 
         section(
-            f"更新 {plugin_id}: {entry.get('sha', '')[:7]} → {new_sha[:7]}",
-            f"Updating {plugin_id}: {entry.get('sha', '')[:7]} → {new_sha[:7]}",
+            f"更新 {plugin_id}: {entry.get('sha', '')[:7]} {ARROW} {new_sha[:7]}",
+            f"Updating {plugin_id}: {entry.get('sha', '')[:7]} {ARROW} {new_sha[:7]}",
         )
         synthetic_args = argparse.Namespace(
             force=True,
@@ -1261,7 +1302,7 @@ def cmd_search(args: argparse.Namespace) -> int:
     section(f"目錄 ({len(matches)})", f"Catalog ({len(matches)} entries)")
     width = max(len(pid) for pid, _ in matches) + 2
     for plugin_id, entry in sorted(matches):
-        marker = f"{GREEN}●{RESET}" if plugin_id in lockfile_ids else " "
+        marker = f"{GREEN}{MARK_INSTALLED}{RESET}" if plugin_id in lockfile_ids else " "
         print(
             f"  {marker} {BOLD}{plugin_id.ljust(width)}{RESET}"
             f"{entry.get('name', plugin_id)}"
@@ -1269,7 +1310,7 @@ def cmd_search(args: argparse.Namespace) -> int:
         desc = entry.get("description", "")
         if desc:
             print(f"    {' ' * width}{DIM}{desc}{RESET}")
-    print(f"\n  {DIM}{t('● = 已安裝', '● = installed')}{RESET}")
+    print(f"\n  {DIM}{t(f'{MARK_INSTALLED} = 已安裝', f'{MARK_INSTALLED} = installed')}{RESET}")
     return 0
 
 
@@ -1498,6 +1539,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    _reconfigure_stdio()
     parser = build_parser()
     args = parser.parse_args(argv)
     return args._func(args)

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -1273,6 +1273,123 @@ def cmd_search(args: argparse.Namespace) -> int:
     return 0
 
 
+# ── scaffolding (cdui plugin new) ────────────────────────────────────────────
+
+# The scaffold payload ships next to this module (scripts/templates/plugin/),
+# so `cdui plugin new` works from any repo checkout the CLI runs from. types.ts
+# under ui/src/sdk/ is generated from the canonical contract by
+# scripts/sync_plugin_sdk.py (guarded by tests/test_plugin_dx.py).
+_TEMPLATE_ROOT = Path(__file__).resolve().parent / "templates" / "plugin"
+
+# Appended to the manifest only with --ui, so backend-only plugins don't carry a
+# [frontend] entry pointing at a bundle they will never build.
+_FRONTEND_STANZA = (
+    "\n[frontend]\n"
+    "# Built bundle the editor imports; `cd ui && pnpm install && pnpm build`\n"
+    "# emits it. Commit the built frontend/index.js.\n"
+    'entry = "frontend/index.js"\n'
+)
+
+
+def _titleize(plugin_id: str) -> str:
+    """`my-cool-plugin` -> `My Cool Plugin` (default display name)."""
+    return " ".join(word.capitalize() for word in plugin_id.split("-") if word)
+
+
+def _render(text: str, ctx: dict[str, str]) -> str:
+    """Substitute ``{{token}}`` placeholders. Tokens absent from a file are a
+    no-op, so the same renderer runs over every payload file uniformly."""
+    for key, value in ctx.items():
+        text = text.replace("{{" + key + "}}", value)
+    return text
+
+
+def cmd_new(args: argparse.Namespace) -> int:
+    """Scaffold a new plugin directory from the built-in template.
+
+    Generates a ready-to-edit plugin: manifest, an example node, a test + the
+    ``cdui_plugins.<id>`` namespace shim, and (with ``--ui``) a React frontend
+    wired to the typed SDK. Link it immediately with ``cdui plugin dev``.
+    """
+    plugin_id = args.id.lower()
+    section(f"建立新外掛：{plugin_id}", f"Creating new plugin: {plugin_id}")
+
+    if not PLUGIN_ID_RE.match(plugin_id):
+        err(
+            f"無效的 id：{plugin_id!r}（需符合 {PLUGIN_ID_RE.pattern}）",
+            f"Invalid plugin id {plugin_id!r} (must match {PLUGIN_ID_RE.pattern})",
+        )
+        return 2
+    if plugin_id in load_catalog().get("plugins", {}):
+        err(
+            f"id '{plugin_id}' 與內建套件保留名稱衝突，請換一個",
+            f"id '{plugin_id}' is reserved by the built-in catalog — pick another",
+        )
+        return 2
+    if not _TEMPLATE_ROOT.is_dir():
+        err(
+            f"找不到範本目錄：{_TEMPLATE_ROOT}",
+            f"Scaffold template not found at {_TEMPLATE_ROOT}",
+        )
+        return 1
+
+    base = Path(args.dir).expanduser().resolve() if args.dir else Path.cwd()
+    dest = base / plugin_id
+    if dest.exists() and any(dest.iterdir()) and not args.force:
+        err(
+            f"目標目錄已存在且非空：{dest}（加 --force 覆寫）",
+            f"Destination exists and is not empty: {dest} (use --force to write into it)",
+        )
+        return 1
+
+    snake = plugin_id.replace("-", "_")
+    name = args.name or _titleize(plugin_id)
+    ctx = {"plugin_id": plugin_id, "plugin_snake": snake, "plugin_name": name}
+    include_ui = bool(args.ui)
+
+    created = 0
+    for src in sorted(_TEMPLATE_ROOT.rglob("*")):
+        rel = src.relative_to(_TEMPLATE_ROOT)
+        # The ui/ subtree ships only when the author opts in with --ui.
+        if not include_ui and rel.parts and rel.parts[0] == "ui":
+            continue
+        target = dest / rel
+        if src.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            _render(src.read_text(encoding="utf-8"), ctx),
+            encoding="utf-8",
+            newline="\n",
+        )
+        created += 1
+
+    if include_ui:
+        manifest = dest / MANIFEST_FILENAME
+        manifest.write_text(
+            manifest.read_text(encoding="utf-8") + _FRONTEND_STANZA,
+            encoding="utf-8",
+            newline="\n",
+        )
+
+    ok(f"已建立 {created} 個檔案於 {dest}", f"Created {created} files in {dest}")
+    section("後續步驟", "Next steps")
+    info(
+        "1. 編輯 nodes/example_node.py，換成你的節點",
+        "1. Edit nodes/example_node.py — replace it with your node",
+    )
+    step = 2
+    if include_ui:
+        info("2. cd ui && pnpm install && pnpm build", "2. cd ui && pnpm install && pnpm build")
+        step = 3
+    info(
+        f"{step}. cdui plugin dev \"{dest}\"（連結 + 監看 + 熱重載）",
+        f"{step}. cdui plugin dev \"{dest}\"  (link + watch + hot-reload)",
+    )
+    return 0
+
+
 # ── argparse routing ───────────────────────────────────────────────────────
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1332,6 +1449,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_dev.add_argument("--once", action="store_true",
                        help="link + reload once and exit (no watch)")
     p_dev.set_defaults(_func=cmd_dev)
+
+    p_new = sub.add_parser(
+        "new",
+        help="Scaffold a new plugin directory from the built-in template",
+    )
+    p_new.add_argument("id", help="new plugin id (lowercase kebab-case)")
+    p_new.add_argument("--name", default=None,
+                       help="display name (default: derived from the id)")
+    p_new.add_argument("--ui", action="store_true",
+                       help="include a React frontend (ui/) wired to the SDK")
+    p_new.add_argument("--dir", default=None,
+                       help="parent directory to create the plugin in (default: cwd)")
+    p_new.add_argument("--force", action="store_true",
+                       help="write into an existing non-empty directory")
+    p_new.set_defaults(_func=cmd_new)
 
     p_en = sub.add_parser(
         "enable",

--- a/scripts/sync_plugin_sdk.py
+++ b/scripts/sync_plugin_sdk.py
@@ -34,8 +34,9 @@ TARGETS = [
 ]
 
 BANNER = (
-    "// AUTO-GENERATED from frontend/src/plugins/contract.ts — DO NOT EDIT.\n"
-    "// Refresh with:  python scripts/sync_plugin_sdk.py\n\n"
+    "// CodefyUI plugin SDK — type contract (mirrors the host's plugin API).\n"
+    "// Generated from CodefyUI's frontend/src/plugins/contract.ts — do not edit\n"
+    "// by hand; refresh it when you target a newer CodefyUI release.\n\n"
 )
 
 

--- a/scripts/sync_plugin_sdk.py
+++ b/scripts/sync_plugin_sdk.py
@@ -22,6 +22,7 @@ lives in a separate repo this script can't see; refresh it from the same
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -47,7 +48,13 @@ def _norm(text: str) -> str:
 
 
 def rendered() -> str:
-    return _norm(BANNER + CONTRACT.read_text(encoding="utf-8"))
+    """The vendored copy: the plugin-facing BANNER plus the contract body, with
+    the canonical file's host-internal header comment (which references
+    contract.assert.ts / this script) stripped — a plugin author shouldn't see
+    files they don't have."""
+    body = CONTRACT.read_text(encoding="utf-8")
+    body = re.sub(r"\A\s*/\*\*.*?\*/\s*", "", body, count=1, flags=re.DOTALL)
+    return _norm(BANNER + body)
 
 
 def check() -> int:

--- a/scripts/sync_plugin_sdk.py
+++ b/scripts/sync_plugin_sdk.py
@@ -1,0 +1,92 @@
+"""Copy the canonical plugin contract into the vendored SDK type files.
+
+The single source of truth for the plugin frontend API is
+``frontend/src/plugins/contract.ts`` (guarded against the host's real
+implementation types by ``contract.assert.ts``). Plugins, however, vendor their
+own ``ui/src/sdk/types.ts`` (clone-and-own, no host import). This script stamps a
+"generated" banner on the contract and writes it into every vendored copy that
+ships inside this repo::
+
+    python scripts/sync_plugin_sdk.py            # write the copies
+    python scripts/sync_plugin_sdk.py --check    # exit 1 if any copy is stale
+
+``--check`` runs in CI (``backend/tests/test_plugin_dx.py``) so a contract change
+that forgets to re-sync fails the build instead of silently shipping stale types
+in the ``cdui plugin new`` scaffold.
+
+The clone-and-own template repo (``CodefyUI-Plugin-Official/ui/src/sdk/types.ts``)
+lives in a separate repo this script can't see; refresh it from the same
+``contract.ts`` whenever the contract changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = REPO_ROOT / "frontend" / "src" / "plugins" / "contract.ts"
+
+# Vendored copies inside this repo, kept byte-for-byte in sync with CONTRACT.
+TARGETS = [
+    REPO_ROOT / "scripts" / "templates" / "plugin" / "ui" / "src" / "sdk" / "types.ts",
+]
+
+BANNER = (
+    "// AUTO-GENERATED from frontend/src/plugins/contract.ts — DO NOT EDIT.\n"
+    "// Refresh with:  python scripts/sync_plugin_sdk.py\n\n"
+)
+
+
+def _norm(text: str) -> str:
+    """Normalize line endings so the LF/CRLF git checkout setting can't cause a
+    spurious drift report."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def rendered() -> str:
+    return _norm(BANNER + CONTRACT.read_text(encoding="utf-8"))
+
+
+def check() -> int:
+    """Return 0 when every vendored copy matches the canonical contract, else 1."""
+    if not CONTRACT.exists():
+        print(f"missing canonical contract: {CONTRACT}")
+        return 1
+    want = rendered()
+    stale = [
+        t for t in TARGETS
+        if not t.exists() or _norm(t.read_text(encoding="utf-8")) != want
+    ]
+    for t in stale:
+        print(f"stale: {t.relative_to(REPO_ROOT)}")
+    if stale:
+        print("Run: python scripts/sync_plugin_sdk.py")
+        return 1
+    return 0
+
+
+def write() -> int:
+    want = rendered()
+    for t in TARGETS:
+        t.parent.mkdir(parents=True, exist_ok=True)
+        t.write_text(want, encoding="utf-8", newline="\n")
+        print(f"wrote: {t.relative_to(REPO_ROOT)}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Sync vendored plugin SDK types from the canonical contract.",
+    )
+    ap.add_argument(
+        "--check", action="store_true",
+        help="exit 1 if any vendored copy is stale (does not write)",
+    )
+    args = ap.parse_args(argv)
+    return check() if args.check else write()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/templates/plugin/.gitignore
+++ b/scripts/templates/plugin/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.coverage
+.venv/
+.env
+.DS_Store
+*.swp

--- a/scripts/templates/plugin/README.md
+++ b/scripts/templates/plugin/README.md
@@ -1,0 +1,46 @@
+# {{plugin_name}}
+
+A [CodefyUI](https://github.com/treeleaves30760/CodefyUI) plugin, scaffolded with `cdui plugin new`.
+
+## Develop
+
+With the CodefyUI server running (`cdui start` or `cdui dev`):
+
+```bash
+# from the CodefyUI repo:
+cdui plugin dev path/to/{{plugin_id}}     # link + watch + hot-reload on every edit
+```
+
+Replace `nodes/example_node.py` with your node(s). Every `.py` under `nodes/`
+whose classes subclass `BaseNode` and define `NODE_NAME` is auto-registered and
+appears in the editor palette.
+
+## Frontend UI (optional)
+
+If you scaffolded with `--ui`, an editor tool panel + a custom node renderer
+live in `ui/` (React + TypeScript):
+
+```bash
+cd ui
+pnpm install
+pnpm build      # emits ../frontend/index.js (commit it)
+pnpm dev        # rebuild on save — pair with `cdui plugin dev`
+```
+
+The typed SDK is vendored under `ui/src/sdk/` (clone-and-own). It mirrors the
+host plugin API, so you get autocomplete for `defineTool`, the hooks, and
+`defineNodeRenderer`.
+
+## Test
+
+```bash
+uv run --directory path/to/CodefyUI/backend pytest path/to/{{plugin_id}}/tests/
+```
+
+## Publish
+
+Push to GitHub, tag a release, and your users install with:
+
+```bash
+cdui plugin install <your-username>/<your-repo>
+```

--- a/scripts/templates/plugin/cdui.plugin.toml
+++ b/scripts/templates/plugin/cdui.plugin.toml
@@ -1,0 +1,44 @@
+# cdui.plugin.toml — manifest for your CodefyUI plugin.
+# Scaffolded by `cdui plugin new`. Edit the fields below to describe your plugin.
+
+[plugin]
+# REQUIRED. Globally-unique lowercase kebab-case id. Also the install-dir name
+# and part of the Python import path (cdui_plugins.<id_with_underscores>).
+id              = "{{plugin_id}}"
+
+# REQUIRED. Display name shown in `cdui plugin list` and the plugin manager.
+name            = "{{plugin_name}}"
+
+# REQUIRED. Semantic version. Bump on every release.
+version         = "0.1.0"
+
+# REQUIRED. One-paragraph description — shown by `cdui plugin info` / `search`.
+description     = "A CodefyUI plugin. Replace this description and the example node with your own."
+
+# REQUIRED. Manifest format version (currently 1).
+schema_version  = 1
+
+# REQUIRED. Lowest CodefyUI version you've tested against (PEP 440 specifier).
+# The ui/ React extension ([frontend] section) needs >= 1.3.0.
+requires_codefyui = ">=1.3.0"
+
+# OPTIONAL metadata, surfaced by `cdui plugin info`.
+authors         = []
+license         = "MIT"
+
+[content]
+# Where the plugin's content lives, relative to this manifest. Defaults shown.
+nodes_dir       = "nodes"
+presets_dir     = "presets"
+examples_dir    = "examples"
+assets_dir      = "assets"
+
+# OPTIONAL. Extra Python packages installed via `uv pip install` on install:
+#   [python_deps]
+#   numpy = ">=1.24"
+
+# OPTIONAL. The AST validator blocks dangerous imports (os, subprocess, …) on
+# install. If your nodes legitimately need one, list it here; users then have to
+# install with --trust-author.
+[security]
+allowed_modules = []

--- a/scripts/templates/plugin/nodes/example_node.py
+++ b/scripts/templates/plugin/nodes/example_node.py
@@ -1,0 +1,60 @@
+"""ExampleNode — a starting point. Replace it with your plugin's real node.
+
+Demonstrates the BaseNode contract: one STRING param, one STRING output, and a
+pure-Python ``execute`` (no torch). Add inputs / params / a real computation as
+your plugin needs; the node shows up in the editor palette under ``CATEGORY``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class ExampleNode(BaseNode):
+    NODE_NAME = "Example"
+    CATEGORY = "{{plugin_name}}"
+    DESCRIPTION = "Greets the name in the `name` param. Replace with your plugin's logic."
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="greeting",
+                data_type=DataType.STRING,
+                description="The composed greeting string.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="name",
+                param_type=ParamType.STRING,
+                default="world",
+                description="Who to greet.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        name = str(params.get("name", "world")).strip() or "world"
+        return {"greeting": f"Hello, {name}!"}

--- a/scripts/templates/plugin/tests/conftest.py
+++ b/scripts/templates/plugin/tests/conftest.py
@@ -1,0 +1,31 @@
+"""pytest conftest — makes the plugin importable during local development.
+
+When installed via ``cdui plugin install``, CodefyUI registers this plugin under
+the ``cdui_plugins.{{plugin_snake}}.*`` synthetic namespace. For local pytest we
+set that up by hand so
+``from cdui_plugins.{{plugin_snake}}.nodes.example_node import ExampleNode``
+works. If you rename the plugin id in cdui.plugin.toml, update PLUGIN_ID below.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+PLUGIN_ID = "{{plugin_id}}"
+_PY_ID = PLUGIN_ID.replace("-", "_")
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_pkg = sys.modules.get("cdui_plugins")
+if _pkg is None:
+    _pkg = types.ModuleType("cdui_plugins")
+    _pkg.__path__ = []
+    sys.modules["cdui_plugins"] = _pkg
+
+_sub_name = f"cdui_plugins.{_PY_ID}"
+if _sub_name not in sys.modules:
+    _sub = types.ModuleType(_sub_name)
+    _sub.__path__ = [str(_REPO_ROOT)]
+    sys.modules[_sub_name] = _sub
+    setattr(_pkg, _PY_ID, _sub)

--- a/scripts/templates/plugin/tests/test_example_node.py
+++ b/scripts/templates/plugin/tests/test_example_node.py
@@ -1,0 +1,18 @@
+"""Starter test for ExampleNode. Run from the CodefyUI backend venv:
+
+    uv run --directory path/to/CodefyUI/backend pytest path/to/{{plugin_id}}/tests/
+"""
+
+from __future__ import annotations
+
+from cdui_plugins.{{plugin_snake}}.nodes.example_node import ExampleNode
+
+
+def test_example_node_greets_by_name():
+    out = ExampleNode().execute({}, {"name": "CodefyUI"})
+    assert out["greeting"] == "Hello, CodefyUI!"
+
+
+def test_example_node_defaults_to_world():
+    out = ExampleNode().execute({}, {})
+    assert "world" in out["greeting"]

--- a/scripts/templates/plugin/ui/.gitignore
+++ b/scripts/templates/plugin/ui/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.tsbuildinfo
+dist/

--- a/scripts/templates/plugin/ui/package.json
+++ b/scripts/templates/plugin/ui/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "{{plugin_id}}-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit && vite build",
+    "dev": "vite build --watch"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.4.0",
+    "typescript": "~5.8.0",
+    "vite": "^6.0.0",
+    "vite-plugin-css-injected-by-js": "^3.5.2"
+  }
+}

--- a/scripts/templates/plugin/ui/src/index.tsx
+++ b/scripts/templates/plugin/ui/src/index.tsx
@@ -1,0 +1,57 @@
+import './styles.css';
+import {
+  mountTool,
+  defineNodeRenderer,
+  useGraph,
+  useToast,
+  type CodefyUIPluginAPI,
+  type NodeRenderContext,
+} from './sdk';
+
+// A floating tool panel. The hooks (useGraph / useToast / ...) work anywhere
+// inside a component mounted by mountTool or defineTool.
+function Panel() {
+  const graph = useGraph();
+  const toast = useToast();
+  return (
+    <div className="cdui-panel">
+      <div className="cdui-panel__title">{{plugin_name}}</div>
+      <div className="cdui-panel__row">
+        Nodes on canvas: <b>{graph.nodes.length}</b>
+      </div>
+      <button
+        className="cdui-panel__btn"
+        onClick={() => toast(`${graph.nodes.length} node(s) on the canvas`)}
+      >
+        Toast node count
+      </button>
+    </div>
+  );
+}
+
+// A custom React body for a node's card. It receives the live node context
+// (id, type, params) and re-renders whenever the node's params change.
+function ExampleNodeBody({ node }: { node: NodeRenderContext['node'] }) {
+  return (
+    <div className="cdui-node-body">
+      <div className="cdui-node-body__title">{{plugin_name}}</div>
+      <div className="cdui-node-body__row">
+        <span>params</span>
+        <b>{Object.keys(node.params).length}</b>
+      </div>
+    </div>
+  );
+}
+
+// The editor imports this bundle and calls the default export once at startup,
+// passing the plugin API. You can mount tool panels and register node renderers.
+export default function activate(api: CodefyUIPluginAPI) {
+  mountTool(api, { id: '{{plugin_id}}-panel', title: '{{plugin_name}}' }, Panel);
+
+  // Draw the Example node's card body with React. Plugin node types use the
+  // snake_case namespace — id "{{plugin_id}}" exposes "{{plugin_snake}}:Example".
+  api.nodes.registerRenderer(
+    '{{plugin_snake}}:Example',
+    defineNodeRenderer(ExampleNodeBody),
+  );
+}

--- a/scripts/templates/plugin/ui/src/sdk/index.ts
+++ b/scripts/templates/plugin/ui/src/sdk/index.ts
@@ -1,0 +1,13 @@
+/**
+ * CodefyUI plugin SDK — types + React bindings.
+ *
+ * This `sdk/` folder is vendored into your plugin (clone-and-own). It mirrors
+ * the host's plugin API; keep it in sync with the CodefyUI release you target.
+ * Import everything from here:
+ *
+ * ```tsx
+ * import { defineTool, useGraph, type CodefyUIPluginAPI } from './sdk';
+ * ```
+ */
+export * from './types';
+export * from './react';

--- a/scripts/templates/plugin/ui/src/sdk/react.tsx
+++ b/scripts/templates/plugin/ui/src/sdk/react.tsx
@@ -1,0 +1,155 @@
+/**
+ * React bindings for the CodefyUI plugin API.
+ *
+ * `defineTool` turns a React component into the editor's `activate(api)` default
+ * export — mounting it into a floating widget and providing the API to the whole
+ * subtree via context, so the hooks below work anywhere inside your component.
+ *
+ * React is bundled with your plugin (peer of your `ui/`), so your components run
+ * on their own React root inside the editor.
+ */
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type {
+  ActivateFn, ApplyResult, CodefyUIPluginAPI, GraphOp,
+  NodeDefinition, NodeRenderContext, PluginNodeRenderer,
+  SerializedGraph, ToastType,
+} from './types';
+
+const ApiContext = React.createContext<CodefyUIPluginAPI | null>(null);
+
+/** The plugin API, from the nearest `defineTool` provider. Throws if absent. */
+export function useCodefyUI(): CodefyUIPluginAPI {
+  const api = React.useContext(ApiContext);
+  if (!api) {
+    throw new Error(
+      'CodefyUI hooks must be used inside a component mounted by defineTool().',
+    );
+  }
+  return api;
+}
+
+export interface ToolOptions {
+  /** Unique-per-plugin widget id. */
+  id: string;
+  /** Accessible label for the widget container. */
+  title?: string;
+}
+
+/**
+ * Wrap a React component as a plugin entry point. Use it as your default export:
+ *
+ * ```tsx
+ * export default defineTool({ id: 'my-panel', title: 'My Panel' }, MyPanel);
+ * ```
+ */
+export function mountTool(
+  api: CodefyUIPluginAPI,
+  opts: ToolOptions,
+  Component: React.ComponentType<{ api: CodefyUIPluginAPI }>,
+): void {
+  const el = api.ui.addFloatingWidget({ id: opts.id });
+  if (opts.title) el.setAttribute('aria-label', opts.title);
+  createRoot(el).render(
+    <React.StrictMode>
+      <ApiContext.Provider value={api}>
+        <Component api={api} />
+      </ApiContext.Provider>
+    </React.StrictMode>,
+  );
+}
+
+export function defineTool(
+  opts: ToolOptions,
+  Component: React.ComponentType<{ api: CodefyUIPluginAPI }>,
+): ActivateFn {
+  return (api) => mountTool(api, opts, Component);
+}
+
+/**
+ * Adapt a React component into a node-body renderer for
+ * `api.nodes.registerRenderer`. The component receives the live node context
+ * (id, type, params) and re-renders whenever the node's params change.
+ *
+ * ```tsx
+ * api.nodes.registerRenderer('my_plugin:MyNode', defineNodeRenderer(MyBody));
+ * ```
+ */
+export function defineNodeRenderer(
+  Component: React.ComponentType<{ node: NodeRenderContext['node'] }>,
+): PluginNodeRenderer {
+  const roots = new WeakMap<HTMLElement, Root>();
+  const render = (el: HTMLElement, ctx: NodeRenderContext) => {
+    let root = roots.get(el);
+    if (!root) {
+      root = createRoot(el);
+      roots.set(el, root);
+    }
+    root.render(<Component node={ctx.node} />);
+  };
+  return {
+    mount: render,
+    update: render,
+    unmount: (el) => {
+      const root = roots.get(el);
+      if (root) {
+        root.unmount();
+        roots.delete(el);
+      }
+    },
+  };
+}
+
+/** Live serialized graph; the component re-renders whenever the graph changes. */
+export function useGraph(): SerializedGraph {
+  const api = useCodefyUI();
+  const [graph, setGraph] = React.useState<SerializedGraph>(() => api.graph.getGraph());
+  React.useEffect(
+    () => api.graph.onGraphChanged(() => setGraph(api.graph.getGraph())),
+    [api],
+  );
+  return graph;
+}
+
+/** The node palette (types, ports, params). Stable for the session. */
+export function useNodeDefinitions(): NodeDefinition[] {
+  const api = useCodefyUI();
+  return React.useMemo(() => api.graph.getNodeDefinitions(), [api]);
+}
+
+/** Run your own callback whenever the graph changes. */
+export function useGraphChanged(cb: () => void): void {
+  const api = useCodefyUI();
+  const ref = React.useRef(cb);
+  ref.current = cb;
+  React.useEffect(() => api.graph.onGraphChanged(() => ref.current()), [api]);
+}
+
+/** A stable function to apply a batch of graph operations. */
+export function useApplyOperations(): (ops: GraphOp[]) => ApplyResult {
+  const api = useCodefyUI();
+  return React.useCallback((ops) => api.graph.applyOperations(ops), [api]);
+}
+
+/** A stable toast notifier. */
+export function useToast(): (message: string, type?: ToastType) => void {
+  const api = useCodefyUI();
+  return React.useCallback((message, type) => api.ui.toast(message, type), [api]);
+}
+
+/** Session-aware fetch bound to the CodefyUI backend (relative paths only). */
+export function useCodefyFetch(): (url: string, init?: RequestInit) => Promise<Response> {
+  const api = useCodefyUI();
+  return React.useCallback((url, init) => api.http.fetch(url, init), [api]);
+}
+
+/** Persistent, plugin-namespaced string state — like useState backed by storage. */
+export function useStorage(key: string, initial = ''): [string, (v: string) => void] {
+  const api = useCodefyUI();
+  const [value, setValue] = React.useState<string>(() => api.storage.get(key) ?? initial);
+  const set = React.useCallback((v: string) => {
+    api.storage.set(key, v);
+    setValue(v);
+  }, [api, key]);
+  return [value, set];
+}

--- a/scripts/templates/plugin/ui/src/sdk/types.ts
+++ b/scripts/templates/plugin/ui/src/sdk/types.ts
@@ -1,0 +1,159 @@
+// AUTO-GENERATED from frontend/src/plugins/contract.ts — DO NOT EDIT.
+// Refresh with:  python scripts/sync_plugin_sdk.py
+
+/**
+ * CodefyUI plugin frontend API — the CANONICAL, self-contained type contract.
+ *
+ * This is the single source of truth for the public plugin surface. It has NO
+ * imports, so it drops verbatim into any plugin's `ui/src/sdk/types.ts`:
+ *
+ *   - `scripts/sync_plugin_sdk.py` copies it into the `cdui plugin new` scaffold
+ *     payload (`scripts/templates/plugin/ui/src/sdk/types.ts`); a backend test
+ *     (`tests/test_plugin_dx.py`) fails if that copy drifts.
+ *   - The clone-and-own template `CodefyUI-Plugin-Official/ui/src/sdk/types.ts`
+ *     is refreshed from this file too.
+ *
+ * `contract.assert.ts` (next to this file) statically asserts that the host's
+ * real implementation types (`./api`, `./ops`, `../types`, `./nodeRenderers`)
+ * stay structurally compatible with the declarations here, so `tsc -b` fails the
+ * moment the host drifts from the published contract. A future hardening step
+ * could have the host import these types directly to make drift impossible
+ * rather than merely detected.
+ */
+
+export type ToastType = 'success' | 'error' | 'info' | 'warning';
+
+export interface PortDefinition {
+  name: string;
+  data_type: string;
+  description: string;
+  optional: boolean;
+}
+
+export interface ParamDefinition {
+  name: string;
+  param_type:
+    | 'int' | 'float' | 'string' | 'bool'
+    | 'select' | 'model_file' | 'image_file' | 'tensor_grid';
+  default: unknown;
+  description: string;
+  options: string[];
+  min_value: number | null;
+  max_value: number | null;
+  visible_when?: Record<string, unknown> | null;
+}
+
+export interface NodeDefinition {
+  node_name: string;
+  category: string;
+  description: string;
+  inputs: PortDefinition[];
+  outputs: PortDefinition[];
+  params: ParamDefinition[];
+}
+
+/** A batch operation accepted by `api.graph.applyOperations`. Field names are exact. */
+export type GraphOp =
+  | { op: 'add_node'; node_type: string; ref?: string;
+      params?: Record<string, unknown>; position?: { x: number; y: number } }
+  | { op: 'connect'; source: string; source_handle: string;
+      target: string; target_handle: string }
+  | { op: 'set_params'; node_id: string; params: Record<string, unknown> }
+  | { op: 'remove_node'; node_id: string }
+  | { op: 'remove_edge'; source: string; target: string;
+      source_handle?: string; target_handle?: string }
+  | { op: 'clear_graph' }
+  | { op: 'auto_layout' };
+
+export interface OpResult {
+  index: number;
+  ok: boolean;
+  error?: string;
+  node_id?: string;
+}
+
+export interface ApplyResult {
+  results: OpResult[];
+  refs: Record<string, string>;
+  node_count: number;
+  edge_count: number;
+}
+
+export interface SerializedGraphNode {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: { params: Record<string, unknown>; [key: string]: unknown };
+}
+
+export interface SerializedGraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  sourceHandle: string;
+  targetHandle: string;
+}
+
+export interface SerializedGraph {
+  nodes: SerializedGraphNode[];
+  edges: SerializedGraphEdge[];
+  presets?: unknown[];
+  segmentGroups?: unknown[];
+  name?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+export interface NodeRenderContext {
+  node: {
+    id: string;
+    type: string;
+    params: Record<string, unknown>;
+    definition?: unknown;
+  };
+}
+
+/**
+ * Imperative renderer for a node's card body. The SDK's `defineNodeRenderer`
+ * adapts a React component to this shape; the host calls mount once, update on
+ * param changes, and unmount when the node is removed.
+ */
+export interface PluginNodeRenderer {
+  mount(container: HTMLElement, ctx: NodeRenderContext): void;
+  update?(container: HTMLElement, ctx: NodeRenderContext): void;
+  unmount?(container: HTMLElement): void;
+}
+
+/** The object the editor hands every plugin frontend at activation. */
+export interface CodefyUIPluginAPI {
+  apiVersion: number;
+  pluginId: string;
+  ui: {
+    /** Create (or reuse) a container `<div>` in the editor's widget stack. */
+    addFloatingWidget(opts: { id: string }): HTMLElement;
+    toast(message: string, type?: ToastType): void;
+  };
+  graph: {
+    getGraph(): SerializedGraph;
+    getNodeDefinitions(): NodeDefinition[];
+    /** Synchronous — returns the result directly, committed as one undo step. */
+    applyOperations(ops: GraphOp[]): ApplyResult;
+    onGraphChanged(cb: () => void): () => void;
+  };
+  /** Custom node renderers — requires apiVersion >= 2. */
+  nodes: {
+    registerRenderer(nodeType: string, renderer: PluginNodeRenderer): () => void;
+  };
+  http: {
+    /** Browser `fetch`, with the CodefyUI session token attached. */
+    fetch(url: string, init?: RequestInit): Promise<Response>;
+  };
+  storage: {
+    get(key: string): string | null;
+    set(key: string, value: string): void;
+    remove(key: string): void;
+  };
+}
+
+/** The default-export contract: the editor calls this once with the API. */
+export type ActivateFn = (api: CodefyUIPluginAPI) => void;

--- a/scripts/templates/plugin/ui/src/sdk/types.ts
+++ b/scripts/templates/plugin/ui/src/sdk/types.ts
@@ -2,26 +2,6 @@
 // Generated from CodefyUI's frontend/src/plugins/contract.ts — do not edit
 // by hand; refresh it when you target a newer CodefyUI release.
 
-/**
- * CodefyUI plugin frontend API — the CANONICAL, self-contained type contract.
- *
- * This is the single source of truth for the public plugin surface. It has NO
- * imports, so it drops verbatim into any plugin's `ui/src/sdk/types.ts`:
- *
- *   - `scripts/sync_plugin_sdk.py` copies it into the `cdui plugin new` scaffold
- *     payload (`scripts/templates/plugin/ui/src/sdk/types.ts`); a backend test
- *     (`tests/test_plugin_dx.py`) fails if that copy drifts.
- *   - The clone-and-own template `CodefyUI-Plugin-Official/ui/src/sdk/types.ts`
- *     is refreshed from this file too.
- *
- * `contract.assert.ts` (next to this file) statically asserts that the host's
- * real implementation types (`./api`, `./ops`, `../types`, `./nodeRenderers`)
- * stay structurally compatible with the declarations here, so `tsc -b` fails the
- * moment the host drifts from the published contract. A future hardening step
- * could have the host import these types directly to make drift impossible
- * rather than merely detected.
- */
-
 export type ToastType = 'success' | 'error' | 'info' | 'warning';
 
 export interface PortDefinition {

--- a/scripts/templates/plugin/ui/src/sdk/types.ts
+++ b/scripts/templates/plugin/ui/src/sdk/types.ts
@@ -1,5 +1,6 @@
-// AUTO-GENERATED from frontend/src/plugins/contract.ts — DO NOT EDIT.
-// Refresh with:  python scripts/sync_plugin_sdk.py
+// CodefyUI plugin SDK — type contract (mirrors the host's plugin API).
+// Generated from CodefyUI's frontend/src/plugins/contract.ts — do not edit
+// by hand; refresh it when you target a newer CodefyUI release.
 
 /**
  * CodefyUI plugin frontend API — the CANONICAL, self-contained type contract.

--- a/scripts/templates/plugin/ui/src/styles.css
+++ b/scripts/templates/plugin/ui/src/styles.css
@@ -1,0 +1,33 @@
+.cdui-panel {
+  width: 220px;
+  padding: 12px 14px;
+  background: #1e1e1e;
+  color: #e6e6e6;
+  border: 1px solid #333;
+  border-radius: 8px;
+  font: 13px/1.5 system-ui, -apple-system, sans-serif;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+.cdui-panel__title { font-weight: 600; margin-bottom: 8px; color: #2dd4bf; }
+.cdui-panel__row { margin: 2px 0; color: #b8b8b8; }
+.cdui-panel__row b { color: #e6e6e6; }
+
+.cdui-panel__btn {
+  margin-top: 10px;
+  width: 100%;
+  padding: 6px 10px;
+  background: #0d9488;
+  color: #fff;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+}
+.cdui-panel__btn:hover { background: #0f766e; }
+
+/* Custom node body (api.nodes.registerRenderer) */
+.cdui-node-body { padding: 6px 8px; font: 12px/1.4 system-ui, -apple-system, sans-serif; color: #cde9e4; }
+.cdui-node-body__title { font-weight: 600; color: #2dd4bf; margin-bottom: 4px; }
+.cdui-node-body__row { display: flex; justify-content: space-between; gap: 12px; }
+.cdui-node-body__row b { color: #fff; }

--- a/scripts/templates/plugin/ui/tsconfig.json
+++ b/scripts/templates/plugin/ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/scripts/templates/plugin/ui/vite.config.ts
+++ b/scripts/templates/plugin/ui/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
+import { resolve } from 'path';
+
+// Library build: bundle src/index.tsx (your React app + the SDK + React itself)
+// into a single ESM file at ../frontend/index.js — the bundle the editor imports
+// and whose default export it calls as activate(api). CSS is inlined into the JS
+// so there is exactly one shippable file.
+export default defineConfig({
+  plugins: [react(), cssInjectedByJsPlugin()],
+  define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.tsx'),
+      formats: ['es'],
+      fileName: () => 'index.js',
+    },
+    outDir: resolve(__dirname, '../frontend'),
+    emptyOutDir: true,
+    rollupOptions: { output: { inlineDynamicImports: true } },
+    cssCodeSplit: false,
+  },
+});


### PR DESCRIPTION
Plugin authoring DX — three independent improvements the user requested (items **1 + 4 + 3**). All verified end-to-end.

## 1. `cdui plugin new` — one-command scaffold
```bash
cdui plugin new my-plugin          # backend-only skeleton
cdui plugin new my-plugin --ui     # + a React frontend wired to the SDK
```
Generates a manifest, an example `BaseNode`, a test + the `cdui_plugins.<id>` namespace shim, and (with `--ui`) a Vite/React `ui/` whose `src/sdk/` is the typed SDK. Payload lives at `scripts/templates/plugin/`, read relative to the CLI module so it ships with every checkout `cdui` runs from. Then `cdui plugin dev <dir>` links + watches it.

## 4. Reload targets the configured port
`_backend_reload` (install/uninstall/link/dev/reload) hardcoded `127.0.0.1:8000`, so hot-reload silently missed a server on another port. New `_reload_target()` resolves `CODEFYUI_PORT` -> `settings.PORT` (also honors `.env`) -> `8000`; client stays on loopback with a matching `Host` header (always whitelisted by `auth.init_allowed_hosts`).

## 3. Canonical SDK contract + compile-time anti-drift guard
The plugin frontend API was mirrored by hand in three places and the docs had already drifted. Now there's one source of truth:
- **`frontend/src/plugins/contract.ts`** — canonical, self-contained, drops verbatim into any plugin's `sdk/types.ts`.
- **`contract.assert.ts`** — mutual-assignability assertions binding the contract to the host's real `api.ts`/`ops.ts`/`types`/`nodeRenderers`. `tsc -b` (Frontend Build Check) fails the moment the host drifts. *Verified it catches an injected field-type change.*
- **`scripts/sync_plugin_sdk.py`** + a backend test keep the vendored scaffold copy in sync.

## Verification
- Backend: `test_plugin_dx.py` (reload-target, SDK sync, scaffold) + existing CLI/loader/api tests — **114 plugin tests pass**.
- Frontend: `tsc -b` clean (drift guard passes; proven to fail on drift) — **1611 vitest tests pass**.
- Scaffold e2e: backend-only plugin's *own* pytest suite passes; `--ui` scaffold does `pnpm install` + `tsc --noEmit` + `vite build` -> emits a 321 kB `frontend/index.js`.

## Notes
- No editor-runtime/UI behavior changes: `contract.ts`/`contract.assert.ts` are type-only and not in the app's import graph, so the shipped bundle is unchanged (no Chrome e2e warranted).
- The clone-and-own template repo (`CodefyUI-Plugin-Official`) gets a companion PR refreshing its `ui/src/sdk/types.ts` header to point at the canonical contract (body already matches).
- Deferred (per the user): Phase 4 shared-React via import map; kebab/snake id-ergonomics helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YFEoPUjnuYqUV18SV8ZxT
