### PR TITLE
fix(plugins): re-exec into venv by sys.prefix, not resolved exe path

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -262,8 +262,17 @@ def _exec_into_venv_if_available() -> None:
     """
     if not VENV_PY.exists():
         return
+    # Are we already running *inside* this venv? Discriminate on sys.prefix
+    # (the venv root), NOT the executable path. `uv venv` symlinks
+    # .venv/bin/python straight to the uv-managed base interpreter, so
+    # Path(sys.executable).resolve() collapses the venv python and that base
+    # interpreter to the *same* real binary — a genuine outer interpreter then
+    # compares equal to VENV_PY and the hop is wrongly skipped, leaving the run
+    # on the outer interpreter where `app` is not importable (cdui plugin <cmd>
+    # then dies with "ModuleNotFoundError: No module named 'app'"). sys.prefix
+    # points at the venv only when its python is actually the running one.
     try:
-        if Path(sys.executable).resolve() == VENV_PY.resolve():
+        if Path(sys.prefix).resolve() == VENV.resolve():
             return
     except OSError:
         return


### PR DESCRIPTION
## Problem

`cdui plugin install <owner/repo>` and `cdui plugin list` crash at startup, before any subcommand logic runs:

```
ModuleNotFoundError: No module named 'app'
  File "scripts/plugins.py", line 43, in <module>
    from app.core.plugin_loader import (
```

## Root cause

`_dispatch_plugin_subcommand()` re-execs into `backend/.venv`'s Python (so the venv's site-packages — including the editable `app` package — are importable) before `import plugins`. The "am I already inside the venv, skip the hop" guard was:

```python
if Path(sys.executable).resolve() == VENV_PY.resolve():
    return
```

`uv venv` symlinks `.venv/bin/python` straight to the uv-managed base interpreter:

```
.venv/bin/python -> ~/.local/share/uv/python/cpython-3.11.../bin/python3.11
```

So `.resolve()` collapses **both** the venv python and the genuine outer interpreter to the *same* real binary → the guard returns `True` → the re-exec is skipped → the command keeps running on the outer interpreter, which has none of the venv's site-packages → `app` is unimportable.

`cdui dev`/`start` are unaffected: they invoke venv binaries by absolute path via subprocess, so only the plugin subcommands (which import `app` in-process) hit this.

## Fix

Discriminate on `sys.prefix` (the venv root), which equals the venv directory only when the venv's python is the actual running interpreter — robust to uv's symlink layout and to `--copies` venvs.

## Verification

```
$ cdui plugin list
  No plugins installed yet                      # was: traceback

$ cdui plugin install treeleaves30760/CodefyUI-Plugin-Graph-Copilot
  Ref: default branch (0c09b57)
  ✓ Installed: graph-copilot (0c09b57)          # was: traceback
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
