### PR TITLE
[codex] Add LLMChat node

### DIFF
--- a/backend/app/core/llm_proxy/_common.py
+++ b/backend/app/core/llm_proxy/_common.py
@@ -30,3 +30,74 @@ def parse_tool_args(raw: str) -> dict[str, Any]:
         return parsed if isinstance(parsed, dict) else {"__parse_error__": raw}
     except json.JSONDecodeError:
         return {"__parse_error__": raw}
+
+
+def content_to_text(content: Any) -> str:
+    """Flatten string or multimodal message content into provider-safe text."""
+    if isinstance(content, str):
+        return content
+    if content is None:
+        return ""
+    if not isinstance(content, list):
+        return str(content)
+
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, dict):
+            ptype = part.get("type")
+            if ptype == "text":
+                text = part.get("text", "")
+                if text:
+                    parts.append(str(text))
+            elif ptype == "image_url":
+                parts.append("[image]")
+            else:
+                parts.append(json.dumps(part, ensure_ascii=False, default=str))
+        else:
+            parts.append(str(part))
+    return "\n".join(p for p in parts if p)
+
+
+def data_url_to_anthropic_source(url: str) -> dict[str, str] | None:
+    """Convert a data:image/... URL into Anthropic's base64 image source."""
+    if not url.startswith("data:") or ";base64," not in url:
+        return None
+    header, data = url[5:].split(",", 1)
+    media_type = header.split(";", 1)[0] or "image/png"
+    if not media_type.startswith("image/") or not data:
+        return None
+    return {"type": "base64", "media_type": media_type, "data": data}
+
+
+def content_to_anthropic_blocks(content: Any) -> str | list[dict[str, Any]]:
+    """Map OpenAI-style content parts to Anthropic Messages content blocks."""
+    if not isinstance(content, list):
+        return content_to_text(content)
+
+    blocks: list[dict[str, Any]] = []
+    for part in content:
+        if not isinstance(part, dict):
+            text = str(part)
+            if text:
+                blocks.append({"type": "text", "text": text})
+            continue
+
+        ptype = part.get("type")
+        if ptype == "text":
+            text = str(part.get("text", ""))
+            if text:
+                blocks.append({"type": "text", "text": text})
+        elif ptype == "image_url":
+            image_url = part.get("image_url") or {}
+            url = image_url.get("url") if isinstance(image_url, dict) else None
+            source = data_url_to_anthropic_source(str(url or ""))
+            if source is not None:
+                blocks.append({"type": "image", "source": source})
+            else:
+                blocks.append({"type": "text", "text": "[unsupported image URL]"})
+        else:
+            blocks.append({
+                "type": "text",
+                "text": json.dumps(part, ensure_ascii=False, default=str),
+            })
+    return blocks or ""

--- a/backend/app/core/llm_proxy/anthropic.py
+++ b/backend/app/core/llm_proxy/anthropic.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import httpx
 
-from ._common import TIMEOUT, parse_tool_args
+from ._common import TIMEOUT, content_to_anthropic_blocks, content_to_text, parse_tool_args
 from .events import done_event, error_event, text_delta
 from .schema import ChatRequest, ToolCall
 
@@ -17,7 +17,11 @@ _VERSION = "2023-06-01"
 
 
 def build_payload(req: ChatRequest) -> dict[str, Any]:
-    system_parts = [m.content for m in req.messages if m.role == "system" and m.content]
+    system_parts = [
+        content_to_text(m.content)
+        for m in req.messages
+        if m.role == "system" and content_to_text(m.content)
+    ]
     messages: list[dict[str, Any]] = []
     for m in req.messages:
         if m.role == "system":
@@ -26,18 +30,19 @@ def build_payload(req: ChatRequest) -> dict[str, Any]:
             messages.append({"role": "user", "content": [{
                 "type": "tool_result",
                 "tool_use_id": m.tool_call_id or "",
-                "content": m.content,
+                "content": content_to_text(m.content),
             }]})
         elif m.role == "assistant" and m.tool_calls:
             blocks: list[dict[str, Any]] = []
-            if m.content:
-                blocks.append({"type": "text", "text": m.content})
+            text_content = content_to_text(m.content)
+            if text_content:
+                blocks.append({"type": "text", "text": text_content})
             blocks.extend({
                 "type": "tool_use", "id": tc.id, "name": tc.name, "input": tc.arguments,
             } for tc in m.tool_calls)
             messages.append({"role": "assistant", "content": blocks})
         else:
-            messages.append({"role": m.role, "content": m.content})
+            messages.append({"role": m.role, "content": content_to_anthropic_blocks(m.content)})
 
     payload: dict[str, Any] = {
         "model": req.model,

--- a/backend/app/core/llm_proxy/codex.py
+++ b/backend/app/core/llm_proxy/codex.py
@@ -16,7 +16,7 @@ from typing import Any
 import httpx
 
 from . import codex_auth
-from ._common import TIMEOUT, parse_tool_args
+from ._common import TIMEOUT, content_to_text, parse_tool_args
 from .events import done_event, error_event, text_delta
 from .schema import ChatRequest, ToolCall
 
@@ -28,25 +28,31 @@ STATIC_MODELS = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"]
 
 
 def build_payload(req: ChatRequest) -> dict[str, Any]:
-    system_parts = [m.content for m in req.messages if m.role == "system" and m.content]
+    system_parts = [
+        content_to_text(m.content)
+        for m in req.messages
+        if m.role == "system" and content_to_text(m.content)
+    ]
     items: list[dict[str, Any]] = []
     for m in req.messages:
         if m.role == "system":
             continue
         if m.role == "tool":
             items.append({"type": "function_call_output",
-                          "call_id": m.tool_call_id or "", "output": m.content})
+                          "call_id": m.tool_call_id or "",
+                          "output": content_to_text(m.content)})
             continue
         if m.role == "assistant":
-            if m.content:
+            text_content = content_to_text(m.content)
+            if text_content:
                 items.append({"type": "message", "role": "assistant",
-                              "content": [{"type": "output_text", "text": m.content}]})
+                              "content": [{"type": "output_text", "text": text_content}]})
             for tc in m.tool_calls or []:
                 items.append({"type": "function_call", "call_id": tc.id,
                               "name": tc.name, "arguments": json.dumps(tc.arguments)})
             continue
         items.append({"type": "message", "role": m.role,
-                      "content": [{"type": "input_text", "text": m.content}]})
+                      "content": [{"type": "input_text", "text": content_to_text(m.content)}]})
 
     payload: dict[str, Any] = {
         "model": req.model,

--- a/backend/app/core/llm_proxy/openai_like.py
+++ b/backend/app/core/llm_proxy/openai_like.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import httpx
 
-from ._common import TIMEOUT, parse_tool_args
+from ._common import TIMEOUT, content_to_text, parse_tool_args
 from .events import done_event, error_event, text_delta
 from .schema import ChatRequest, ToolCall
 
@@ -44,17 +44,20 @@ def build_payload(req: ChatRequest) -> dict[str, Any]:
     for m in req.messages:
         if m.role == "tool":
             messages.append({"role": "tool", "tool_call_id": m.tool_call_id or "",
-                             "content": m.content})
+                             "content": content_to_text(m.content)})
         elif m.role == "assistant" and m.tool_calls:
+            text_content = content_to_text(m.content)
             messages.append({
                 "role": "assistant",
-                "content": m.content or None,
+                "content": text_content or None,
                 "tool_calls": [{
                     "id": tc.id,
                     "type": "function",
                     "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
                 } for tc in m.tool_calls],
             })
+        elif m.role in {"system", "assistant"}:
+            messages.append({"role": m.role, "content": content_to_text(m.content)})
         else:
             messages.append({"role": m.role, "content": m.content})
 

--- a/backend/app/core/llm_proxy/schema.py
+++ b/backend/app/core/llm_proxy/schema.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 Provider = Literal["openai", "openai-codex", "openrouter", "anthropic", "custom"]
+MessageContent = str | list[dict[str, Any]]
 
 
 class ToolSpec(BaseModel):
@@ -25,7 +26,7 @@ class ToolCall(BaseModel):
 
 class ChatMessage(BaseModel):
     role: Literal["system", "user", "assistant", "tool"]
-    content: str = ""
+    content: MessageContent = ""
     tool_calls: list[ToolCall] | None = None
     tool_call_id: str | None = None
 

--- a/backend/app/core/node_registry.py
+++ b/backend/app/core/node_registry.py
@@ -137,8 +137,12 @@ class NodeRegistry:
                 logger.warning("Failed to import %s: %s", modname, e)
                 continue
             for _, obj in inspect.getmembers(module, inspect.isclass):
+                try:
+                    is_node_cls = issubclass(obj, BaseNode)
+                except TypeError:
+                    continue
                 if (
-                    issubclass(obj, BaseNode)
+                    is_node_cls
                     and obj is not BaseNode
                     and obj.NODE_NAME
                 ):

--- a/backend/app/nodes/llm/llm_chat_node.py
+++ b/backend/app/nodes/llm/llm_chat_node.py
@@ -1,0 +1,420 @@
+"""LLMChat node -- call an external chat model from a graph workflow."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import json
+import os
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+import httpx
+
+from ...core.llm_proxy import anthropic, codex, openai_like
+from ...core.llm_proxy.schema import ChatMessage, ChatRequest, Provider
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+ProviderAdapter = Callable[[ChatRequest, httpx.AsyncClient], AsyncIterator[dict[str, Any]]]
+
+PROVIDER_OPTIONS = ["ChatGPT API", "Codex", "Claude API", "Ollama"]
+
+_PROVIDER_ALIASES: dict[str, Provider] = {
+    "chatgpt api": "openai",
+    "openai": "openai",
+    "openai api": "openai",
+    "codex": "openai-codex",
+    "openai-codex": "openai-codex",
+    "claude api": "anthropic",
+    "claude": "anthropic",
+    "anthropic": "anthropic",
+    "anthropic api": "anthropic",
+    "ollama": "custom",
+}
+
+_ADAPTERS: dict[Provider, ProviderAdapter] = {
+    "openai": openai_like.stream_chat,
+    "custom": openai_like.stream_chat,
+    "anthropic": anthropic.stream_chat,
+    "openai-codex": codex.stream_chat,
+}
+
+
+class LLMChatNode(BaseNode):
+    NODE_NAME = "LLMChat"
+    CATEGORY = "LLM"
+    DESCRIPTION = (
+        "Send text, an image tensor, or JSON-like array data to a chat LLM and "
+        "emit the assistant response as STRING. Providers: ChatGPT API, Codex, "
+        "Claude API, and local Ollama."
+    )
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="text",
+                data_type=DataType.STRING,
+                description="Optional text prompt or context from an upstream node.",
+                optional=True,
+            ),
+            PortDefinition(
+                name="image",
+                data_type=DataType.IMAGE,
+                description=(
+                    "Optional image tensor. OpenAI-compatible/Ollama and Claude "
+                    "receive it as multimodal input."
+                ),
+                optional=True,
+            ),
+            PortDefinition(
+                name="array",
+                data_type=DataType.LIST,
+                description="Optional array/object-like context serialized as JSON for the prompt.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="text",
+                data_type=DataType.STRING,
+                description="Assistant response text.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="provider",
+                param_type=ParamType.SELECT,
+                default="ChatGPT API",
+                options=PROVIDER_OPTIONS,
+                description=(
+                    "LLM backend to call. Ollama uses its OpenAI-compatible /v1 endpoint."
+                ),
+            ),
+            ParamDefinition(
+                name="model",
+                param_type=ParamType.STRING,
+                default="gpt-5.2",
+                description="Model id, for example gpt-5.2, claude-sonnet-4-6, or llama3.2.",
+            ),
+            ParamDefinition(
+                name="prompt",
+                param_type=ParamType.STRING,
+                default="Summarize the provided input.",
+                description="User prompt. Connected text/array/image inputs are appended to this prompt.",
+            ),
+            ParamDefinition(
+                name="system_prompt",
+                param_type=ParamType.STRING,
+                default="You are a helpful assistant.",
+                description="System instruction sent before the user prompt.",
+            ),
+            ParamDefinition(
+                name="openai_api_key",
+                param_type=ParamType.STRING,
+                default="",
+                description=(
+                    "OpenAI API key. Prefer OPENAI_API_KEY or CODEFYUI_OPENAI_API_KEY "
+                    "so saved graphs do not contain secrets."
+                ),
+                visible_when={"provider": "ChatGPT API"},
+            ),
+            ParamDefinition(
+                name="anthropic_api_key",
+                param_type=ParamType.STRING,
+                default="",
+                description=(
+                    "Anthropic API key. Prefer ANTHROPIC_API_KEY or "
+                    "CODEFYUI_ANTHROPIC_API_KEY so saved graphs do not contain secrets."
+                ),
+                visible_when={"provider": "Claude API"},
+            ),
+            ParamDefinition(
+                name="ollama_base_url",
+                param_type=ParamType.STRING,
+                default="http://127.0.0.1:11434/v1",
+                description="Ollama OpenAI-compatible endpoint base URL.",
+                visible_when={"provider": "Ollama"},
+            ),
+            ParamDefinition(
+                name="max_tokens",
+                param_type=ParamType.INT,
+                default=1024,
+                description="Maximum output tokens.",
+                min_value=1,
+                max_value=200_000,
+            ),
+            ParamDefinition(
+                name="temperature",
+                param_type=ParamType.FLOAT,
+                default=0.7,
+                description="Sampling temperature.",
+                min_value=0.0,
+                max_value=2.0,
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        provider = _normalize_provider(params.get("provider", "ChatGPT API"))
+        req = _build_request(provider, inputs, params)
+        text, usage = asyncio.run(_collect_chat(req, _ADAPTERS[provider], progress_callback))
+        result: dict[str, Any] = {"text": text}
+        if usage:
+            result["__usage__"] = usage
+        return result
+
+
+def _normalize_provider(raw: Any) -> Provider:
+    key = str(raw or "ChatGPT API").strip().lower()
+    provider = _PROVIDER_ALIASES.get(key)
+    if provider is None:
+        supported = ", ".join(PROVIDER_OPTIONS)
+        raise ValueError(f"Unsupported LLM provider {raw!r}. Choose one of: {supported}")
+    return provider
+
+
+def _build_request(provider: Provider, inputs: dict[str, Any], params: dict[str, Any]) -> ChatRequest:
+    model = str(params.get("model") or "").strip()
+    if not model:
+        raise ValueError("LLMChat requires a model id")
+
+    api_key = _api_key_for(provider, params)
+    base_url = _base_url_for(provider, params)
+
+    if provider == "openai" and not api_key:
+        raise ValueError("ChatGPT API provider requires openai_api_key or OPENAI_API_KEY")
+    if provider == "anthropic" and not api_key:
+        raise ValueError("Claude API provider requires anthropic_api_key or ANTHROPIC_API_KEY")
+
+    system_prompt = str(params.get("system_prompt") or "").strip()
+    user_content = _build_user_content(provider, inputs, params)
+    max_tokens = int(params.get("max_tokens", 1024))
+    temperature = float(params.get("temperature", 0.7))
+
+    messages: list[ChatMessage] = []
+    if system_prompt:
+        messages.append(ChatMessage(role="system", content=system_prompt))
+    messages.append(ChatMessage(role="user", content=user_content))
+
+    return ChatRequest(
+        provider=provider,
+        model=model,
+        messages=messages,
+        api_key=api_key,
+        base_url=base_url,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+
+
+def _api_key_for(provider: Provider, params: dict[str, Any]) -> str | None:
+    if provider == "openai":
+        return _first_non_empty(
+            params.get("openai_api_key"),
+            params.get("api_key"),
+            os.environ.get("CODEFYUI_OPENAI_API_KEY"),
+            os.environ.get("OPENAI_API_KEY"),
+        )
+    if provider == "anthropic":
+        return _first_non_empty(
+            params.get("anthropic_api_key"),
+            params.get("api_key"),
+            os.environ.get("CODEFYUI_ANTHROPIC_API_KEY"),
+            os.environ.get("ANTHROPIC_API_KEY"),
+        )
+    return None
+
+
+def _base_url_for(provider: Provider, params: dict[str, Any]) -> str | None:
+    if provider != "custom":
+        return None
+    return str(params.get("ollama_base_url") or "http://127.0.0.1:11434/v1").strip()
+
+
+def _first_non_empty(*values: Any) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _build_user_content(
+    provider: Provider,
+    inputs: dict[str, Any],
+    params: dict[str, Any],
+) -> str | list[dict[str, Any]]:
+    prompt_parts: list[str] = []
+    prompt = str(params.get("prompt") or "").strip()
+    if prompt:
+        prompt_parts.append(prompt)
+
+    if inputs.get("text") is not None:
+        prompt_parts.append(str(inputs["text"]))
+
+    if inputs.get("array") is not None:
+        prompt_parts.append("Array input:\n" + _jsonish(inputs["array"]))
+
+    image_value = inputs.get("image")
+    image_url = _image_to_data_url(image_value) if image_value is not None else None
+    text = "\n\n".join(part for part in prompt_parts if part).strip()
+
+    if image_url is None:
+        if not text:
+            raise ValueError("LLMChat needs a prompt, text input, image input, or array input")
+        return text
+
+    if provider == "openai-codex":
+        codex_note = (
+            "Image input was provided, but the Codex provider currently accepts "
+            "text only in CodefyUI."
+        )
+        return "\n\n".join(part for part in (text, codex_note) if part)
+
+    return [
+        {"type": "text", "text": text or "Describe the image."},
+        {"type": "image_url", "image_url": {"url": image_url}},
+    ]
+
+
+def _jsonish(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False, indent=2, default=_json_default)
+    except (TypeError, ValueError):
+        return repr(value)
+
+
+def _json_default(value: Any) -> Any:
+    shape = getattr(value, "shape", None)
+    dtype = getattr(value, "dtype", None)
+    if shape is not None:
+        return {
+            "type": type(value).__name__,
+            "shape": [int(x) for x in shape],
+            "dtype": str(dtype) if dtype is not None else "",
+        }
+    return repr(value)
+
+
+def _image_to_data_url(value: Any) -> str:
+    if isinstance(value, str):
+        text = value.strip()
+        if text.startswith("data:image/"):
+            return text
+        if text:
+            return f"data:image/png;base64,{text}"
+
+    if isinstance(value, dict):
+        url = value.get("data_url") or value.get("url")
+        if isinstance(url, str) and url.startswith("data:image/"):
+            return url
+        data = value.get("base64") or value.get("data")
+        if isinstance(data, str) and data:
+            media_type = str(value.get("media_type") or "image/png")
+            return f"data:{media_type};base64,{data}"
+
+    image = _coerce_pil_image(value)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    payload = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{payload}"
+
+
+def _coerce_pil_image(value: Any) -> Any:
+    from PIL import Image
+
+    if isinstance(value, Image.Image):
+        return value.convert("RGB")
+
+    try:
+        import torch
+
+        if isinstance(value, torch.Tensor):
+            arr = value.detach().cpu()
+            if arr.ndim == 4:
+                arr = arr[0]
+            if arr.ndim == 3 and int(arr.shape[0]) in (1, 3, 4):
+                arr = arr.permute(1, 2, 0)
+            if arr.is_floating_point():
+                arr = arr.clamp(0, 1).mul(255).to(torch.uint8)
+            else:
+                arr = arr.clamp(0, 255).to(torch.uint8)
+            np_arr = arr.numpy()
+            if np_arr.ndim == 3 and np_arr.shape[2] == 1:
+                np_arr = np_arr[:, :, 0]
+            return Image.fromarray(np_arr).convert("RGB")
+    except ImportError:
+        pass
+
+    try:
+        import numpy as np
+
+        if isinstance(value, np.ndarray):
+            arr = value
+            if arr.ndim == 4:
+                arr = arr[0]
+            if arr.ndim == 3 and arr.shape[0] in (1, 3, 4):
+                arr = arr.transpose(1, 2, 0)
+            if arr.dtype.kind == "f":
+                arr = (arr.clip(0, 1) * 255).astype("uint8")
+            else:
+                arr = arr.clip(0, 255).astype("uint8")
+            if arr.ndim == 3 and arr.shape[2] == 1:
+                arr = arr[:, :, 0]
+            return Image.fromarray(arr).convert("RGB")
+    except ImportError:
+        pass
+
+    raise TypeError(f"Unsupported image input type for LLMChat: {type(value).__name__}")
+
+
+async def _collect_chat(
+    req: ChatRequest,
+    adapter: ProviderAdapter,
+    progress_callback: Any | None = None,
+) -> tuple[str, dict[str, int]]:
+    chunks: list[str] = []
+    async with httpx.AsyncClient() as client:
+        async for event in adapter(req, client):
+            etype = event.get("type")
+            if etype == "text_delta":
+                delta = str(event.get("text", ""))
+                chunks.append(delta)
+                if progress_callback is not None:
+                    progress_callback({"text": "".join(chunks)})
+            elif etype == "error":
+                raise RuntimeError(str(event.get("message", "LLM provider error")))
+            elif etype == "done":
+                message = event.get("message") or {}
+                content = str(message.get("content") or "".join(chunks))
+                raw_usage = event.get("usage")
+                usage = raw_usage if isinstance(raw_usage, dict) else {}
+                return content, {
+                    str(k): int(v)
+                    for k, v in usage.items()
+                    if isinstance(v, (int, float))
+                }
+    return "".join(chunks), {}

--- a/backend/tests/test_llm_anthropic.py
+++ b/backend/tests/test_llm_anthropic.py
@@ -129,3 +129,17 @@ async def test_upstream_error_becomes_error_event():
     events = await collect(make_req(), handler)
     assert events[-1]["type"] == "error"
     assert "529" in events[-1]["message"]
+
+def test_payload_maps_multimodal_content_blocks():
+    content = [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+    req = make_req(messages=[ChatMessage(role="user", content=content)])
+    p = build_payload(req)
+    blocks = p["messages"][0]["content"]
+    assert blocks[0] == {"type": "text", "text": "look"}
+    assert blocks[1] == {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": "abc"},
+    }

--- a/backend/tests/test_llm_chat_node.py
+++ b/backend/tests/test_llm_chat_node.py
@@ -1,0 +1,148 @@
+"""Tests for the LLMChat workflow node."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from app.core.node_base import DataType, ParamType
+from app.nodes.llm import llm_chat_node
+from app.nodes.llm.llm_chat_node import LLMChatNode, _build_request, _normalize_provider
+
+
+def params(**overrides):
+    base = {
+        "provider": "ChatGPT API",
+        "model": "gpt-5.2",
+        "prompt": "Prompt",
+        "system_prompt": "System",
+        "openai_api_key": "sk-test",
+        "anthropic_api_key": "sk-ant-test",
+        "ollama_base_url": "http://127.0.0.1:11434/v1",
+        "max_tokens": 128,
+        "temperature": 0.2,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_node_metadata():
+    assert LLMChatNode.NODE_NAME == "LLMChat"
+    assert LLMChatNode.CATEGORY == "LLM"
+    assert LLMChatNode.cacheable is False
+
+    inputs = {p.name: p for p in LLMChatNode.define_inputs()}
+    assert inputs["text"].data_type == DataType.STRING
+    assert inputs["image"].data_type == DataType.IMAGE
+    assert inputs["array"].data_type == DataType.LIST
+    assert all(p.optional for p in inputs.values())
+
+    outputs = LLMChatNode.define_outputs()
+    assert len(outputs) == 1
+    assert outputs[0].name == "text"
+    assert outputs[0].data_type == DataType.STRING
+
+    provider_param = next(p for p in LLMChatNode.define_params() if p.name == "provider")
+    assert provider_param.param_type == ParamType.SELECT
+    assert provider_param.options == ["ChatGPT API", "Codex", "Claude API", "Ollama"]
+
+
+def test_provider_aliases():
+    assert _normalize_provider("ChatGPT API") == "openai"
+    assert _normalize_provider("Codex") == "openai-codex"
+    assert _normalize_provider("Claude API") == "anthropic"
+    assert _normalize_provider("Ollama") == "custom"
+    with pytest.raises(ValueError, match="Unsupported"):
+        _normalize_provider("Bedrock")
+
+
+def test_execute_builds_openai_request(monkeypatch):
+    seen = {}
+
+    async def fake_collect(req, adapter, progress_callback=None):
+        seen["req"] = req
+        return "assistant text", {"input_tokens": 3, "output_tokens": 4}
+
+    monkeypatch.setattr(llm_chat_node, "_collect_chat", fake_collect)
+    res = LLMChatNode().execute(
+        {"text": "hello", "array": [{"x": 1}]},
+        params(),
+    )
+
+    assert res == {
+        "text": "assistant text",
+        "__usage__": {"input_tokens": 3, "output_tokens": 4},
+    }
+    req = seen["req"]
+    assert req.provider == "openai"
+    assert req.api_key == "sk-test"
+    assert req.model == "gpt-5.2"
+    assert req.max_tokens == 128
+    assert req.temperature == 0.2
+    assert req.messages[0].content == "System"
+    user_content = req.messages[1].content
+    assert isinstance(user_content, str)
+    assert "Prompt" in user_content
+    assert "hello" in user_content
+    assert '"x": 1' in user_content
+
+
+def test_ollama_maps_to_custom_provider(monkeypatch):
+    seen = {}
+
+    async def fake_collect(req, adapter, progress_callback=None):
+        seen["req"] = req
+        return "local", {}
+
+    monkeypatch.setattr(llm_chat_node, "_collect_chat", fake_collect)
+    res = LLMChatNode().execute(
+        {},
+        params(
+            provider="Ollama",
+            model="llama3.2",
+            prompt="hi",
+            system_prompt="",
+            ollama_base_url="http://localhost:11434/v1/",
+        ),
+    )
+
+    assert res == {"text": "local"}
+    req = seen["req"]
+    assert req.provider == "custom"
+    assert req.base_url == "http://localhost:11434/v1/"
+    assert req.api_key is None
+
+
+def test_image_tensor_becomes_multimodal_content():
+    req = _build_request(
+        "openai",
+        {"image": torch.zeros(3, 2, 2)},
+        params(prompt="Describe it"),
+    )
+
+    content = req.messages[-1].content
+    assert isinstance(content, list)
+    assert content[0] == {"type": "text", "text": "Describe it"}
+    assert content[1]["type"] == "image_url"
+    assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_codex_image_input_falls_back_to_text():
+    req = _build_request(
+        "openai-codex",
+        {"image": torch.zeros(3, 2, 2)},
+        params(provider="Codex", prompt="Look"),
+    )
+
+    content = req.messages[-1].content
+    assert isinstance(content, str)
+    assert "Look" in content
+    assert "text only" in content
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("CODEFYUI_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="requires openai_api_key"):
+        _build_request("openai", {}, params(openai_api_key="", prompt="hi"))

--- a/backend/tests/test_llm_codex.py
+++ b/backend/tests/test_llm_codex.py
@@ -146,3 +146,14 @@ async def test_response_failed_becomes_error():
 
 def test_static_models_list():
     assert "gpt-5.5" in codex.STATIC_MODELS
+
+def test_payload_flattens_multimodal_content_to_text():
+    content = [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+    req = make_req(messages=[ChatMessage(role="user", content=content)])
+    p = codex.build_payload(req)
+    text = p["input"][0]["content"][0]["text"]
+    assert "look" in text
+    assert "[image]" in text

--- a/backend/tests/test_llm_openai_like.py
+++ b/backend/tests/test_llm_openai_like.py
@@ -178,3 +178,12 @@ async def test_bad_base_url_yields_error_event():
     events = await collect(req, lambda r: httpx.Response(500))
     assert events == [{"type": "error",
                        "message": "custom provider requires an http(s) base_url"}]
+
+def test_payload_preserves_user_multimodal_content():
+    content = [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+    req = make_req(messages=[ChatMessage(role="user", content=content)])
+    p = build_payload(req)
+    assert p["messages"][0]["content"] == content

--- a/backend/tests/test_llm_schema.py
+++ b/backend/tests/test_llm_schema.py
@@ -55,3 +55,11 @@ def test_sse_format_is_data_line_json():
     assert line.startswith("data: ")
     assert line.endswith("\n\n")
     assert json.loads(line[len("data: "):]) == {"type": "text_delta", "text": "x"}
+
+def test_chat_message_accepts_multimodal_content():
+    content = [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+    ]
+    msg = ChatMessage(role="user", content=content)
+    assert msg.content == content

--- a/backend/tests/test_node_registry.py
+++ b/backend/tests/test_node_registry.py
@@ -2,6 +2,7 @@
 
 from app.config import settings
 from app.core.node_base import BaseNode, DataType, PortDefinition
+from app.core import node_registry as node_registry_module
 from app.core.node_registry import NodeRegistry
 
 
@@ -45,15 +46,18 @@ def test_discover_skips_non_issubclassable_members(monkeypatch, tmp_path):
     marker = object()
 
     monkeypatch.setattr(
-        "app.core.node_registry.pkgutil.walk_packages",
+        node_registry_module.pkgutil,
+        "walk_packages",
         lambda *args, **kwargs: [(None, "fake_nodes.good", False)],
     )
     monkeypatch.setattr(
-        "app.core.node_registry.importlib.import_module",
+        node_registry_module.importlib,
+        "import_module",
         lambda name: object(),
     )
     monkeypatch.setattr(
-        "app.core.node_registry.inspect.getmembers",
+        node_registry_module.inspect,
+        "getmembers",
         lambda module, predicate: [("bad", marker), ("good", GoodNode)],
     )
 

--- a/backend/tests/test_node_registry.py
+++ b/backend/tests/test_node_registry.py
@@ -38,6 +38,29 @@ def test_discover_builtin_nodes():
     assert reg.get("TrainingLoop") is not None
 
 
+def test_discover_skips_non_issubclassable_members(monkeypatch, tmp_path):
+    class GoodNode(DummyNode):
+        NODE_NAME = "Good"
+
+    marker = object()
+
+    monkeypatch.setattr(
+        "app.core.node_registry.pkgutil.walk_packages",
+        lambda *args, **kwargs: [(None, "fake_nodes.good", False)],
+    )
+    monkeypatch.setattr(
+        "app.core.node_registry.importlib.import_module",
+        lambda name: object(),
+    )
+    monkeypatch.setattr(
+        "app.core.node_registry.inspect.getmembers",
+        lambda module, predicate: [("bad", marker), ("good", GoodNode)],
+    )
+
+    reg = NodeRegistry()
+    assert reg.discover(tmp_path, "fake_nodes") == 1
+    assert reg.get("Good") is GoodNode
+
 def test_clear():
     reg = NodeRegistry()
     reg.register(DummyNode)

--- a/docs/docs/usage/node-reference.md
+++ b/docs/docs/usage/node-reference.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 8
 title: Node Reference
-description: Every built-in node — 94 nodes across 15 categories, from CNN and Transformer layers to RL, LLM, Diffusion, and classical ML.
+description: Every built-in node — 95 nodes across 15 categories, from CNN and Transformer layers to RL, LLM, Diffusion, and classical ML.
 ---
 
 # Node Reference
 
-CodefyUI ships **94 built-in nodes** across **15 categories**. Installed [plugin packs](/advanced/plugins) and your own [custom nodes](/advanced/custom-nodes) add more.
+CodefyUI ships **95 built-in nodes** across **15 categories**. Installed [plugin packs](/advanced/plugins) and your own [custom nodes](/advanced/custom-nodes) add more.
 
 :::tip
 This list is the source of truth at the time of writing, but the backend is authoritative: the live palette and `GET /api/nodes` always reflect exactly what your install has. Use the in-app search (double-click the canvas) to find a node fast.
@@ -26,7 +26,7 @@ This list is the source of truth at the time of writing, but the backend is auth
 | **Utility** | Print, Reshape, Concat, Flatten, Linear, Visualize, Embedding | 7 |
 | **Normalization** | BatchNorm1d, LayerNorm, GroupNorm, InstanceNorm2d | 4 |
 | **Tensor Operations** | Add, MatMul, Mean, Multiply, Permute, Softmax, Split, Squeeze, Stack, TensorCreate, Unsqueeze | 11 |
-| **LLM** | Tokenizer, WordVector, EmbeddingScatter, CosineSimilarity, AttentionMask, AttentionHeatmap, PositionalEncoding | 7 |
+| **LLM** | LLMChat, Tokenizer, WordVector, EmbeddingScatter, CosineSimilarity, AttentionMask, AttentionHeatmap, PositionalEncoding | 8 |
 | **Classical** | KNN, LinearRegression, LogisticRegression, DecisionTreeClassifier, SVMClassifier, MLPClassifier, Accuracy | 7 |
 | **Diffusion** | Upsample, TimestepEmbedding, Lerp, GaussianNoise, DDPMSampler, DiffusionUNet | 6 |
 

--- a/frontend/src/api/rest.test.ts
+++ b/frontend/src/api/rest.test.ts
@@ -25,6 +25,9 @@ import {
   uploadImageFile,
   deleteImageFile,
   downloadImageFile,
+  fetchCodexStatus,
+  startCodexLogin,
+  logoutCodex,
 } from './rest';
 import { _setSessionTokenForTesting } from './_auth';
 
@@ -297,6 +300,40 @@ describe('createPreset', () => {
   });
 });
 
+
+describe('Codex auth endpoints', () => {
+  it('fetchCodexStatus GETs the status endpoint', async () => {
+    const fetchMock = mockFetch(200, { status: 'logged_in', email: 'me@example.com' });
+    await expect(fetchCodexStatus()).resolves.toEqual({
+      status: 'logged_in',
+      email: 'me@example.com',
+    });
+    expect(fetchMock).toHaveBeenCalledWith('/api/llm/codex/status');
+  });
+
+  it('fetchCodexStatus throws on failure', async () => {
+    mockFetch(500, {});
+    await expect(fetchCodexStatus()).rejects.toThrow(/Codex status failed/);
+  });
+
+  it('startCodexLogin POSTs with the auth token and returns auth_url', async () => {
+    const fetchMock = mockFetch(200, { auth_url: 'https://auth.example' });
+    await expect(startCodexLogin()).resolves.toEqual({ auth_url: 'https://auth.example' });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/llm/codex/login');
+    expect(init.method).toBe('POST');
+    expect(new Headers(init.headers).get('X-CodefyUI-Token')).toBe('test-token');
+  });
+
+  it('logoutCodex POSTs with the auth token', async () => {
+    const fetchMock = mockFetch(200, { status: 'logged_out' });
+    await expect(logoutCodex()).resolves.toEqual({ status: 'logged_out' });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/llm/codex/logout');
+    expect(init.method).toBe('POST');
+    expect(new Headers(init.headers).get('X-CodefyUI-Token')).toBe('test-token');
+  });
+});
 describe('reloadNodes', () => {
   it('POSTs to /api/nodes/reload and returns the body', async () => {
     const fetchMock = mockFetch(200, { reloaded: true });

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -146,6 +146,31 @@ export async function reloadNodes() {
   return res.json();
 }
 
+
+// LLM / Codex auth
+
+export type CodexAuthStatus =
+  | { status: 'logged_out' }
+  | { status: 'pending' }
+  | { status: 'logged_in'; email?: string };
+
+export async function fetchCodexStatus(): Promise<CodexAuthStatus> {
+  const res = await fetch(`${BASE_URL}/llm/codex/status`);
+  if (!res.ok) throw new Error(`Codex status failed: ${res.statusText}`);
+  return res.json();
+}
+
+export async function startCodexLogin(): Promise<{ auth_url: string }> {
+  const res = await apiFetch(`${BASE_URL}/llm/codex/login`, { method: 'POST' });
+  if (!res.ok) throw new Error(`Codex login failed: ${res.statusText}`);
+  return res.json();
+}
+
+export async function logoutCodex(): Promise<{ status: 'logged_out' }> {
+  const res = await apiFetch(`${BASE_URL}/llm/codex/logout`, { method: 'POST' });
+  if (!res.ok) throw new Error(`Codex logout failed: ${res.statusText}`);
+  return res.json();
+}
 // ── Custom Node Manager ──
 
 export interface CustomNodeInfo {

--- a/frontend/src/components/Toolbar/SettingsPopover.module.css
+++ b/frontend/src/components/Toolbar/SettingsPopover.module.css
@@ -215,6 +215,14 @@
   color: #cbd5e1;
 }
 
+
+.buttonGroup {
+  display: inline-flex;
+  gap: 0.375rem;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
 /* ----- Action button (Compare, Reset) ----- */
 .action {
   background: transparent;

--- a/frontend/src/components/Toolbar/SettingsPopover.test.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.test.tsx
@@ -7,11 +7,20 @@ import { useUIStore } from '../../store/uiStore';
 import { useToastStore } from '../../store/toastStore';
 import { useDialogStore } from '../../store/dialogStore';
 import { useI18n } from '../../i18n';
-import { resetWeights, fetchDevices } from '../../api/rest';
+import {
+  resetWeights,
+  fetchDevices,
+  fetchCodexStatus,
+  startCodexLogin,
+  logoutCodex,
+} from '../../api/rest';
 import { computeSegmentNodes } from '../../utils/segmentPath';
 
 vi.mock('../../api/rest', () => ({
   resetWeights: vi.fn(),
+  fetchCodexStatus: vi.fn(() => Promise.resolve({ status: 'logged_out' })),
+  startCodexLogin: vi.fn(() => Promise.resolve({ auth_url: 'https://auth.example' })),
+  logoutCodex: vi.fn(() => Promise.resolve({ status: 'logged_out' })),
   fetchDevices: vi.fn(() =>
     Promise.resolve({
       default: 'cpu',
@@ -28,6 +37,9 @@ vi.mock('../../utils/segmentPath', () => ({
 }));
 
 const mockedResetWeights = vi.mocked(resetWeights);
+const mockedFetchCodexStatus = vi.mocked(fetchCodexStatus);
+const mockedStartCodexLogin = vi.mocked(startCodexLogin);
+const mockedLogoutCodex = vi.mocked(logoutCodex);
 const mockedComputeSegment = vi.mocked(computeSegmentNodes);
 
 function makeTriggerRef() {
@@ -70,6 +82,9 @@ describe('SettingsPopover', () => {
       beginnerMode: false,
       globalDevice: 'cpu',
     });
+    mockedFetchCodexStatus.mockResolvedValue({ status: 'logged_out' });
+    mockedStartCodexLogin.mockResolvedValue({ auth_url: 'https://auth.example' });
+    mockedLogoutCodex.mockResolvedValue({ status: 'logged_out' });
     vi.mocked(fetchDevices).mockResolvedValue({
       default: 'cpu',
       devices: [
@@ -101,6 +116,41 @@ describe('SettingsPopover', () => {
     expect(screen.getByText('Training Behavior')).toBeInTheDocument();
     expect(screen.getByText('Editor')).toBeInTheDocument();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+
+  it('renders Codex auth controls and starts login in a new tab', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+
+    expect(screen.getByText('LLM Providers')).toBeInTheDocument();
+    expect(screen.getByText('ChatGPT Codex account')).toBeInTheDocument();
+    await waitFor(() => expect(mockedFetchCodexStatus).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await waitFor(() => expect(mockedStartCodexLogin).toHaveBeenCalledTimes(1));
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://auth.example',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument());
+    expect(useToastStore.getState().toasts.some((t) => t.type === 'success')).toBe(true);
+  });
+
+  it('shows logged-in Codex state and signs out', async () => {
+    mockedFetchCodexStatus.mockResolvedValueOnce({
+      status: 'logged_in',
+      email: 'me@example.com',
+    });
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+
+    await screen.findByText(/me@example.com/);
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
+
+    await waitFor(() => expect(mockedLogoutCodex).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole('button', { name: 'Sign in' })).toBeInTheDocument();
   });
 
   // ── Execution: global device selector ─────────────────────────────

--- a/frontend/src/components/Toolbar/SettingsPopover.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.tsx
@@ -3,7 +3,15 @@ import { useTabStore } from '../../store/tabStore';
 import { useUIStore } from '../../store/uiStore';
 import { useToastStore } from '../../store/toastStore';
 import { useI18n } from '../../i18n';
-import { resetWeights, fetchDevices, type DeviceInfo } from '../../api/rest';
+import {
+  resetWeights,
+  fetchDevices,
+  fetchCodexStatus,
+  startCodexLogin,
+  logoutCodex,
+  type CodexAuthStatus,
+  type DeviceInfo,
+} from '../../api/rest';
 import { computeSegmentNodes } from '../../utils/segmentPath';
 import { generateId } from '../../utils';
 import { confirm } from '../../utils/dialog';
@@ -69,6 +77,32 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
 
   const addToast = useToastStore((s) => s.addToast);
 
+  const [codexStatus, setCodexStatus] = useState<CodexAuthStatus>({ status: 'logged_out' });
+  const [codexBusy, setCodexBusy] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    fetchCodexStatus()
+      .then((status) => {
+        if (!cancelled) setCodexStatus(status);
+      })
+      .catch(() => {
+        /* keep logged_out fallback */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (codexStatus.status !== 'pending') return undefined;
+    const id = window.setInterval(() => {
+      fetchCodexStatus()
+        .then((status) => setCodexStatus(status))
+        .catch(() => undefined);
+    }, 2000);
+    return () => window.clearInterval(id);
+  }, [codexStatus.status]);
+
   // Compare segment selection state
   const selected = activeTab.nodes.filter((n) => n.selected);
   const canCreateSegment = selected.length === 2;
@@ -115,6 +149,42 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
     }
   };
 
+  const handleCodexRefresh = async () => {
+    setCodexBusy(true);
+    try {
+      setCodexStatus(await fetchCodexStatus());
+    } catch (e) {
+      addToast(`${t('settings.codex.statusFailed')}: ${(e as Error).message}`, 'error');
+    } finally {
+      setCodexBusy(false);
+    }
+  };
+
+  const handleCodexLogin = async () => {
+    setCodexBusy(true);
+    try {
+      const { auth_url } = await startCodexLogin();
+      window.open(auth_url, '_blank', 'noopener,noreferrer');
+      setCodexStatus({ status: 'pending' });
+      addToast(t('settings.codex.signInOpened'), 'success');
+    } catch (e) {
+      addToast(`${t('settings.codex.signInFailed')}: ${(e as Error).message}`, 'error');
+    } finally {
+      setCodexBusy(false);
+    }
+  };
+
+  const handleCodexLogout = async () => {
+    setCodexBusy(true);
+    try {
+      await logoutCodex();
+      setCodexStatus({ status: 'logged_out' });
+    } catch (e) {
+      addToast(`${t('settings.codex.logoutFailed')}: ${(e as Error).message}`, 'error');
+    } finally {
+      setCodexBusy(false);
+    }
+  };
   const handleCompare = () => {
     if (canCreateSegment) {
       const [left, right] =
@@ -145,6 +215,12 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
     /* v8 ignore stop */
   };
 
+  const codexDesc =
+    codexStatus.status === 'logged_in'
+      ? t('settings.codex.descLoggedIn', { email: codexStatus.email ?? 'ChatGPT' })
+      : codexStatus.status === 'pending'
+        ? t('settings.codex.descPending')
+        : t('settings.codex.descLoggedOut');
   const compareLabel = canCreateSegment
     ? t('settings.compare.actionCreate')
     : canClearSegment
@@ -189,6 +265,58 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
           />
         </section>
 
+        <section className={styles.section}>
+          <div className={styles.sectionTitle}>
+            {t('toolbar.settings.section.llm')}
+          </div>
+
+          <Row
+            name={t('settings.codex.name')}
+            desc={codexDesc}
+            ctrl={
+              <div className={styles.buttonGroup}>
+                {codexStatus.status === 'logged_in' ? (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleCodexLogout();
+                    }}
+                    className={styles.action}
+                    disabled={codexBusy}
+                  >
+                    {t('settings.codex.actionSignOut')}
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleCodexLogin();
+                    }}
+                    className={styles.action}
+                    disabled={codexBusy || codexStatus.status === 'pending'}
+                  >
+                    {t('settings.codex.actionSignIn')}
+                  </button>
+                )}
+                {codexStatus.status !== 'logged_out' && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleCodexRefresh();
+                    }}
+                    className={styles.action}
+                    disabled={codexBusy}
+                  >
+                    {t('settings.codex.actionRefresh')}
+                  </button>
+                )}
+              </div>
+            }
+          />
+        </section>
         {/* ── Recording & Inspection ─────────────────────────────── */}
         <section className={styles.section}>
           <div className={styles.sectionTitle}>

--- a/frontend/src/components/Toolbar/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.test.tsx
@@ -36,6 +36,9 @@ vi.mock('../../api/rest', () => ({
   fetchDevices: vi.fn(() =>
     Promise.resolve({ default: 'cpu', devices: [{ value: 'cpu', label: 'CPU', detail: '', available: true }] }),
   ),
+  fetchCodexStatus: vi.fn(() => Promise.resolve({ status: 'logged_out' })),
+  startCodexLogin: vi.fn(() => Promise.resolve({ auth_url: 'https://auth.example' })),
+  logoutCodex: vi.fn(() => Promise.resolve({ status: 'logged_out' })),
 }));
 
 const mockedRest = vi.mocked(rest);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -327,6 +327,7 @@ const en = {
   'toolbar.settings.section.recording': 'Recording & Inspection',
   'toolbar.settings.section.training': 'Training Behavior',
   'toolbar.settings.section.editor': 'Editor',
+  'toolbar.settings.section.llm': 'LLM Providers',
   'settings.device.name': 'Compute device',
   'settings.device.desc': 'Run the graph on this device. Nodes set to "auto" follow it.',
 
@@ -363,7 +364,17 @@ const en = {
   'settings.nodeMode.desc': 'Basic shows only the essential categories in the sidebar; All shows every category.',
   'settings.nodeMode.basic': 'Basic',
   'settings.nodeMode.all': 'All',
-
+  'settings.codex.name': 'ChatGPT Codex account',
+  'settings.codex.descLoggedOut': 'Sign in to use the Codex provider in LLMChat. This uses your ChatGPT account session.',
+  'settings.codex.descPending': 'Sign-in is in progress. Complete it in the browser tab, then return here.',
+  'settings.codex.descLoggedIn': 'Signed in as {email}. Codex nodes can use your ChatGPT session.',
+  'settings.codex.actionSignIn': 'Sign in',
+  'settings.codex.actionSignOut': 'Sign out',
+  'settings.codex.actionRefresh': 'Refresh',
+  'settings.codex.signInOpened': 'Opened ChatGPT sign-in in a new tab.',
+  'settings.codex.signInFailed': 'Codex sign-in failed',
+  'settings.codex.logoutFailed': 'Codex sign-out failed',
+  'settings.codex.statusFailed': 'Codex status check failed',
   // LLM
   'tokenizer.tokenCount': '{count} tokens',
   'tokenizer.emptyOutput': 'No tokens — input text was empty.',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -329,6 +329,7 @@ const zhTW: Record<TranslationKey, string> = {
   'toolbar.settings.section.recording': '錄製與檢視',
   'toolbar.settings.section.training': '訓練行為',
   'toolbar.settings.section.editor': '編輯器',
+  'toolbar.settings.section.llm': 'LLM 提供者',
   'settings.device.name': '運算裝置',
   'settings.device.desc': '在此裝置上執行圖。設為「auto」的節點會跟隨此設定。',
 
@@ -365,7 +366,17 @@ const zhTW: Record<TranslationKey, string> = {
   'settings.nodeMode.desc': 'Basic 只在側欄顯示新手會用到的基礎類別；All 則顯示全部類別。',
   'settings.nodeMode.basic': '入門',
   'settings.nodeMode.all': '全部',
-
+  'settings.codex.name': 'ChatGPT Codex 帳號',
+  'settings.codex.descLoggedOut': '登入後即可在 LLMChat 使用 Codex provider。這會使用你的 ChatGPT 帳號 session。',
+  'settings.codex.descPending': '登入流程進行中。請在瀏覽器分頁完成登入，再回到這裡。',
+  'settings.codex.descLoggedIn': '已登入為 {email}。Codex 節點可以使用你的 ChatGPT session。',
+  'settings.codex.actionSignIn': '登入',
+  'settings.codex.actionSignOut': '登出',
+  'settings.codex.actionRefresh': '重新檢查',
+  'settings.codex.signInOpened': '已在新分頁開啟 ChatGPT 登入。',
+  'settings.codex.signInFailed': 'Codex 登入失敗',
+  'settings.codex.logoutFailed': 'Codex 登出失敗',
+  'settings.codex.statusFailed': 'Codex 狀態檢查失敗',
   // LLM
   'tokenizer.tokenCount': '{count} 個 token',
   'tokenizer.emptyOutput': '沒有 token — 輸入文字為空。',


### PR DESCRIPTION
## Summary

Adds an `LLMChat` node for workflow-level text generation with selectable providers: ChatGPT API, Codex, Claude API, and Ollama.

## What changed

- Added the backend `LLMChat` node with text, image, and array inputs and string output.
- Extended the LLM proxy schema/helpers to preserve multimodal message content where supported and flatten it where required.
- Added Settings UI controls for ChatGPT/Codex authentication status, sign-in, refresh, and sign-out.
- Updated node reference docs and added backend/frontend tests.

## Impact

This lets CodefyUI workflows call modern LLM providers directly and use the Codex provider after signing in through Settings > LLM Providers.

## Validation

- `python -m pytest tests\test_llm_chat_node.py tests\test_llm_schema.py tests\test_llm_openai_like.py tests\test_llm_anthropic.py tests\test_llm_codex.py tests\test_node_registry.py tests\test_api_nodes.py`
- `pnpm test -- --run src\components\Toolbar\SettingsPopover.test.tsx src\api\rest.test.ts`
- `pnpm exec tsc -b --pretty false`