### PR TITLE
feat(graph-fn): GraphInput/GraphOutput nodes + api_contract core (Stage 1, PR 1/3)

### DIFF
--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -374,3 +374,105 @@ def collect_outputs(
         else:
             missing.append(out["name"])
     return outputs, missing
+
+
+# A single tensor/ndarray output above this many elements fails
+# serialization with ``output_too_large`` — callers should use
+# ``record_outputs=true`` + the slicing outputs API instead.
+MAX_TENSOR_ELEMENTS = 65536
+
+
+class OutputSerializationError(Exception):
+    """A value reaching a GraphOutput cannot be returned as JSON."""
+
+    def __init__(self, code: str, reason: str) -> None:
+        super().__init__(reason)
+        self.code = code  # "output_too_large" | "unserializable_output"
+        self.reason = reason
+
+
+def serialize_output(value: Any) -> Any:
+    """Convert a value reaching a GraphOutput into a JSON-compatible form.
+
+    Full values, not summaries (contrast the inspector wire shapes in
+    ``routes_execution_outputs`` / ``ws_execution``). Tagged objects use
+    the ``__type__`` key — intentionally diverging from the internal
+    ``"type"``-keyed shapes so they can never collide with a user dict
+    output that happens to contain a ``"type"`` key.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return {key: serialize_output(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [serialize_output(item) for item in value]
+
+    import numpy as np
+
+    if isinstance(value, np.generic):
+        # numpy scalar (sklearn nodes emit these)
+        return value.item()
+    if isinstance(value, np.ndarray):
+        if value.size > MAX_TENSOR_ELEMENTS:
+            raise OutputSerializationError(
+                "output_too_large",
+                f"array has {value.size} elements (max {MAX_TENSOR_ELEMENTS}); "
+                "use record_outputs=true and the slicing outputs API "
+                "(GET /api/execution/outputs/{run_id}/...) instead",
+            )
+        return {
+            "__type__": "tensor",
+            "shape": list(value.shape),
+            "dtype": str(value.dtype),
+            "values": value.tolist(),
+        }
+
+    try:
+        import torch
+    except ImportError:
+        torch = None
+    if torch is not None:
+        if isinstance(value, torch.Tensor):
+            if value.numel() > MAX_TENSOR_ELEMENTS:
+                raise OutputSerializationError(
+                    "output_too_large",
+                    f"tensor has {value.numel()} elements "
+                    f"(max {MAX_TENSOR_ELEMENTS}); use record_outputs=true and "
+                    "the slicing outputs API "
+                    "(GET /api/execution/outputs/{run_id}/...) instead",
+                )
+            # 0-dim tensors keep shape [] rather than unwrapping — one rule,
+            # no surprises.
+            return {
+                "__type__": "tensor",
+                "shape": list(value.shape),
+                "dtype": str(value.dtype),
+                "values": value.detach().cpu().tolist(),
+            }
+        if isinstance(value, torch.nn.Module):
+            raise OutputSerializationError(
+                "unserializable_output",
+                "torch.nn.Module cannot be returned as JSON — save it with a "
+                "ModelSaver node in-graph and return its path string instead",
+            )
+
+    try:
+        from PIL import Image
+    except ImportError:
+        Image = None
+    if Image is not None and isinstance(value, Image.Image):
+        import base64
+        import io
+
+        buf = io.BytesIO()
+        value.save(buf, format="PNG")
+        return {
+            "__type__": "image",
+            "format": "png",
+            "base64": base64.b64encode(buf.getvalue()).decode("ascii"),
+        }
+
+    raise OutputSerializationError(
+        "unserializable_output",
+        f"value of type {type(value).__name__} is not JSON-serializable",
+    )

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -400,6 +400,14 @@ def serialize_output(value: Any) -> Any:
     ``"type"``-keyed shapes so they can never collide with a user dict
     output that happens to contain a ``"type"`` key.
     """
+    try:  # numpy scalars can subclass Python builtins (np.float64 -> float)
+        import numpy as np
+    except ImportError:
+        np = None
+    if np is not None and isinstance(value, np.generic):
+        # numpy scalar (sklearn nodes emit these)
+        return serialize_output(value.item())
+
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
     if isinstance(value, dict):
@@ -407,12 +415,7 @@ def serialize_output(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [serialize_output(item) for item in value]
 
-    import numpy as np
-
-    if isinstance(value, np.generic):
-        # numpy scalar (sklearn nodes emit these)
-        return value.item()
-    if isinstance(value, np.ndarray):
+    if np is not None and isinstance(value, np.ndarray):
         if value.size > MAX_TENSOR_ELEMENTS:
             raise OutputSerializationError(
                 "output_too_large",

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -154,17 +154,24 @@ def _decode_image(value: Any) -> Any:
     payload = "".join(payload.split())  # tolerate wrapped base64
     try:
         raw = base64.b64decode(payload, validate=True)
-    except (binascii.Error, ValueError):
-        raise InputCoercionError("image value is not valid base64")
-    from PIL import Image, UnidentifiedImageError
+    except (binascii.Error, ValueError) as exc:
+        raise InputCoercionError("image value is not valid base64") from exc
+    from PIL import Image
     from torchvision import transforms
 
+    # Decode AND convert inside one try: PIL can raise a wide range of
+    # exceptions here (UnidentifiedImageError, OSError, and — for crafted
+    # bomb payloads — DecompressionBombError, which subclasses Exception
+    # directly rather than OSError). Any of them must become an enveloped
+    # InputCoercionError, never escape as a raw unenveloped 500.
     try:
         img = Image.open(io.BytesIO(raw))
         img.load()
-    except (UnidentifiedImageError, OSError):
-        raise InputCoercionError("base64 payload does not decode to an image")
-    img = img.convert("RGB")
+        img = img.convert("RGB")
+    except Exception as exc:
+        raise InputCoercionError(
+            f"value does not decode to an image: {exc}"
+        ) from exc
     return transforms.ToTensor()(img)
 
 
@@ -230,6 +237,15 @@ def derive_contract(nodes: list[dict]) -> Contract:
     _check_names(contract.outputs, "output", contract.problems)
 
     for inp in contract.inputs:
+        if inp["type"] not in INPUT_TYPES:
+            # A hand-edited graph JSON with a bogus `type` is a graph
+            # problem (409, fix the graph) — not something to defer to a
+            # per-caller coerce_input failure at run time (422, blaming
+            # the caller).
+            contract.problems.append(
+                f"input node '{inp['node_id']}': unknown type '{inp['type']}'"
+            )
+            continue
         if inp["type"] == "image":
             if not inp["required"]:
                 contract.problems.append(

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -1,0 +1,163 @@
+"""Pure helpers for the graph-as-a-function I/O contract (GraphInput / GraphOutput).
+
+A saved graph declares its transport-agnostic function signature with
+``GraphInput`` / ``GraphOutput`` nodes on the canvas. This module derives
+that contract from raw graph JSON, validates and injects caller-supplied
+inputs, and collects/serializes declared outputs. Everything here is pure
+JSON manipulation — no FastAPI imports (mirrors the CodefyUI-OJ patcher's
+pure-JSON split); the endpoints in ``app.api.routes_graph_run`` stay thin.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# Input `type` values (v1, frozen). `json` stays `json` — it describes
+# exactly what a caller can send; no new DataType is needed.
+INPUT_TYPES = ("string", "number", "integer", "boolean", "json", "image")
+
+
+class InputCoercionError(Exception):
+    """A caller-supplied value cannot be coerced to its declared input type."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def json_type_name(value: Any) -> str:
+    """Name *value*'s JSON type for error messages (bool checked before int)."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def coerce_input(value: Any, declared_type: str, *, from_string: bool = False) -> Any:
+    """Coerce a value to *declared_type*; raise :class:`InputCoercionError`.
+
+    ``from_string=False`` (the API body path) applies the strict JSON table:
+    no string-to-number coercion, bools are never numbers, and ``integer``
+    accepts integral floats (``3.0 -> 3``, JSON Schema / OpenAPI 3.1
+    alignment — JS clients cannot control whether 3 serializes as 3.0).
+
+    ``from_string=True`` (the canvas ``default`` param path / an omitted
+    optional input) additionally parses string values per type — the one
+    deliberate asymmetry, documented on the node's ``default`` param.
+    Primitive values re-coerce idempotently under either mode.
+    """
+    if (
+        from_string
+        and isinstance(value, str)
+        and declared_type in ("number", "integer", "boolean", "json")
+    ):
+        # Parsed value falls through to the strict table below (idempotent).
+        value = _parse_default_string(value, declared_type)
+    if declared_type == "string":
+        if isinstance(value, str):
+            return value
+        raise InputCoercionError(f"expected string, got {json_type_name(value)}")
+    if declared_type == "number":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise InputCoercionError(f"expected number, got {json_type_name(value)}")
+        return float(value)
+    if declared_type == "integer":
+        if isinstance(value, bool):
+            raise InputCoercionError("expected integer, got boolean")
+        if isinstance(value, int):
+            return int(value)
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+        if isinstance(value, float):
+            raise InputCoercionError(f"expected integer, got non-integral number {value}")
+        raise InputCoercionError(f"expected integer, got {json_type_name(value)}")
+    if declared_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        raise InputCoercionError(f"expected boolean, got {json_type_name(value)}")
+    if declared_type == "json":
+        return value
+    if declared_type == "image":
+        return _decode_image(value)
+    raise InputCoercionError(f"unknown input type '{declared_type}'")
+
+
+def _parse_default_string(raw: str, declared_type: str) -> Any:
+    """Parse a string ``default`` param per type (canvas / omitted-optional path)."""
+    text = raw.strip()
+    if declared_type == "number":
+        try:
+            return float(text)
+        except ValueError:
+            raise InputCoercionError(f"default {raw!r} does not parse as number")
+    if declared_type == "integer":
+        try:
+            return int(text)
+        except ValueError:
+            pass
+        try:
+            # Integral float strings like "3.0" pass the strict table below.
+            return float(text)
+        except ValueError:
+            raise InputCoercionError(f"default {raw!r} does not parse as integer")
+    if declared_type == "boolean":
+        lowered = text.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        raise InputCoercionError(
+            f"default {raw!r} does not parse as boolean (use 'true'/'false')"
+        )
+    if declared_type == "json":
+        try:
+            return json.loads(raw)
+        except ValueError:
+            raise InputCoercionError(f"default {raw!r} does not parse as JSON")
+    return raw
+
+
+def _decode_image(value: Any) -> Any:
+    """Decode a base64 image string to a ``(C, H, W)`` float32 tensor in [0, 1].
+
+    Matches what image consumers already receive from ``ImageReader``.
+    Accepts an optional ``data:image/...;base64,`` prefix and tolerates
+    whitespace/newline-wrapped base64. Torch/PIL imports are lazy so
+    torch-free callers of the other helpers never pay for them.
+    """
+    if not isinstance(value, str):
+        raise InputCoercionError(
+            f"expected base64 image string, got {json_type_name(value)}"
+        )
+    import base64
+    import binascii
+    import io
+
+    payload = value
+    if payload.startswith("data:"):
+        _, _, payload = payload.partition(",")
+    payload = "".join(payload.split())  # tolerate wrapped base64
+    try:
+        raw = base64.b64decode(payload, validate=True)
+    except (binascii.Error, ValueError):
+        raise InputCoercionError("image value is not valid base64")
+    from PIL import Image, UnidentifiedImageError
+    from torchvision import transforms
+
+    try:
+        img = Image.open(io.BytesIO(raw))
+        img.load()
+    except (UnidentifiedImageError, OSError):
+        raise InputCoercionError("base64 payload does not decode to an image")
+    img = img.convert("RGB")
+    return transforms.ToTensor()(img)

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -10,6 +10,7 @@ pure-JSON split); the endpoints in ``app.api.routes_graph_run`` stay thin.
 
 from __future__ import annotations
 
+import copy
 import json
 import re
 from dataclasses import dataclass, field
@@ -303,3 +304,73 @@ def check_wiring(
         if out["node_id"] not in reachable:
             report.unreachable.append(out["name"])
     return report
+
+
+def inject_inputs(
+    nodes: list[dict],
+    contract: Contract,
+    request_inputs: dict[str, Any],
+) -> tuple[list[dict], list[dict[str, str]]]:
+    """Deep-copy *nodes* and write each request value into its GraphInput.
+
+    The RAW JSON value — not the coerced result — lands in
+    ``data.params["value"]``: the node's ``execute()`` performs the actual
+    coercion, which avoids double coercion (an endpoint-coerced image
+    tensor would fail the node's own base64 check), keeps injected params
+    JSON-serializable, and decodes images exactly once (in the node);
+    primitive types re-coerce idempotently. ``coerce_input`` is still
+    called here — result discarded — to validate coercibility up front.
+    Unknown names are rejected by case-sensitive exact match. All
+    per-input errors (unknown name, missing required, coercion failure)
+    are aggregated so the 422 reports everything at once.
+    """
+    errors: list[dict[str, str]] = []
+    by_name = {inp["name"]: inp for inp in contract.inputs}
+
+    for key in request_inputs:
+        if key not in by_name:  # case-sensitive exact match
+            errors.append({"input": key, "reason": "unknown input name"})
+
+    to_inject: dict[str, Any] = {}  # node_id -> raw value
+    for inp in contract.inputs:
+        name = inp["name"]
+        if name in request_inputs:
+            raw = request_inputs[name]
+            try:
+                coerce_input(raw, inp["type"])  # validate only; inject raw
+            except InputCoercionError as exc:
+                errors.append({"input": name, "reason": exc.reason})
+                continue
+            to_inject[inp["node_id"]] = raw
+        elif inp["required"]:
+            errors.append({"input": name, "reason": "missing required input"})
+        # Optional + omitted: no injection — the node's execute() falls
+        # back to its parsed `default` param, identical to a canvas run.
+
+    patched = copy.deepcopy(nodes)
+    for node in patched:
+        if node.get("id") in to_inject:
+            data = node.setdefault("data", {})
+            params = data.setdefault("params", {})
+            params["value"] = to_inject[node["id"]]
+    return patched, errors
+
+
+def collect_outputs(
+    contract: Contract,
+    engine_result: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Read each declared output's ``value`` port from the engine result.
+
+    ``missing`` survives only as a safety net behind the
+    ``unreachable_output`` pre-flight check.
+    """
+    outputs: dict[str, Any] = {}
+    missing: list[str] = []
+    for out in contract.outputs:
+        node_result = engine_result.get(out["node_id"])
+        if isinstance(node_result, dict) and "value" in node_result:
+            outputs[out["name"]] = node_result["value"]
+        else:
+            missing.append(out["name"])
+    return outputs, missing

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -15,6 +15,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
+from .graph_engine import find_entry_points, reachable_from_entry_points
+
 # Input `type` values (v1, frozen). `json` stays `json` — it describes
 # exactly what a caller can send; no new DataType is needed.
 INPUT_TYPES = ("string", "number", "integer", "boolean", "json", "image")
@@ -267,3 +269,37 @@ def _check_names(
         if name in seen:
             problems.append(f"duplicate {kind} name '{name}'")
         seen.add(name)
+
+
+@dataclass
+class WiringReport:
+    """Static pre-flight wiring findings on the raw (unexpanded) graph."""
+
+    untriggered: list[str] = field(default_factory=list)  # GraphInput names
+    unreachable: list[str] = field(default_factory=list)  # GraphOutput names
+
+
+def check_wiring(
+    nodes: list[dict], edges: list[dict], contract: Contract
+) -> WiringReport:
+    """Flag untriggered GraphInputs and unreachable GraphOutputs.
+
+    Uses the exact traversal the engine prunes with (``find_entry_points``
+    + ``reachable_from_entry_points``), applied statically to the raw
+    graph: verified engine behaviour silently prunes untriggered data
+    roots, so a clean report is what makes a run's declared I/O real.
+    """
+    report = WiringReport()
+    triggered = {
+        e["target"] for e in edges if e.get("type", "data") == "trigger"
+    }
+    for inp in contract.inputs:
+        if inp["node_id"] not in triggered:
+            report.untriggered.append(inp["name"])
+
+    entry_ids = find_entry_points(nodes, edges)
+    reachable = reachable_from_entry_points(entry_ids, edges)
+    for out in contract.outputs:
+        if out["node_id"] not in reachable:
+            report.unreachable.append(out["name"])
+    return report

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -11,6 +11,8 @@ pure-JSON split); the endpoints in ``app.api.routes_graph_run`` stay thin.
 from __future__ import annotations
 
 import json
+import re
+from dataclasses import dataclass, field
 from typing import Any
 
 # Input `type` values (v1, frozen). `json` stays `json` — it describes
@@ -161,3 +163,107 @@ def _decode_image(value: Any) -> Any:
         raise InputCoercionError("base64 payload does not decode to an image")
     img = img.convert("RGB")
     return transforms.ToTensor()(img)
+
+
+# Registry type strings of the contract nodes (frozen — they serialize into
+# saved graphs forever).
+GRAPH_INPUT_TYPE = "GraphInput"
+GRAPH_OUTPUT_TYPE = "GraphOutput"
+
+# Frozen contract-name charset: tightening later breaks saved graphs,
+# loosening never does. Stage 2 OpenAPI and the future `cdui call
+# --input k=v` need identifier-safe names.
+NAME_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
+
+
+@dataclass
+class Contract:
+    """The graph-level I/O contract derived from GraphInput / GraphOutput nodes.
+
+    ``problems`` is reported non-fatally by ``GET /api/graph/contract`` and
+    blocks ``POST /api/graph/run`` with 409 ``invalid_contract``.
+    """
+
+    inputs: list[dict[str, Any]] = field(default_factory=list)
+    outputs: list[dict[str, Any]] = field(default_factory=list)
+    problems: list[str] = field(default_factory=list)
+
+
+def derive_contract(nodes: list[dict]) -> Contract:
+    """Scan top-level nodes for GraphInput / GraphOutput declarations.
+
+    Presets are NOT expanded — contract derivation scans top-level nodes
+    only (GraphInput/GraphOutput inside presets are a non-goal).
+    """
+    contract = Contract()
+    for node in nodes:
+        node_type = node.get("type", "")
+        if node_type not in (GRAPH_INPUT_TYPE, GRAPH_OUTPUT_TYPE):
+            continue
+        data = node.get("data")
+        params = data.get("params", {}) if isinstance(data, dict) else {}
+        if node_type == GRAPH_INPUT_TYPE:
+            contract.inputs.append({
+                "name": str(params.get("name", "input")),
+                "type": str(params.get("type", "string")),
+                "required": bool(params.get("required", True)),
+                "default": params.get("default", ""),
+                "description": str(params.get("description", "")),
+                "node_id": node.get("id", ""),
+            })
+        else:
+            contract.outputs.append({
+                "name": str(params.get("name", "output")),
+                "description": str(params.get("description", "")),
+                "node_id": node.get("id", ""),
+            })
+
+    if not contract.outputs:
+        contract.problems.append(
+            "graph has no GraphOutput node — declare at least one output"
+        )
+
+    _check_names(contract.inputs, "input", contract.problems)
+    _check_names(contract.outputs, "output", contract.problems)
+
+    for inp in contract.inputs:
+        if inp["type"] == "image":
+            if not inp["required"]:
+                contract.problems.append(
+                    f"image input '{inp['name']}' must be required=true "
+                    "(base64 has no sensible API-side default)"
+                )
+            # The image default is a canvas-only file path, validated at
+            # canvas run time — exempt from default parsing.
+            continue
+        if not inp["required"]:
+            # The API applies only optional inputs' defaults; a required
+            # input's default is a canvas-only test value and must NOT
+            # 409-block API calls.
+            try:
+                coerce_input(inp["default"], inp["type"], from_string=True)
+            except InputCoercionError as exc:
+                contract.problems.append(
+                    f"optional input '{inp['name']}': default does not parse "
+                    f"as {inp['type']} ({exc.reason})"
+                )
+    return contract
+
+
+def _check_names(
+    entries: list[dict[str, Any]], kind: str, problems: list[str]
+) -> None:
+    """Empty-name, charset, and duplicate checks shared by inputs and outputs."""
+    seen: set[str] = set()
+    for entry in entries:
+        name = entry["name"]
+        if name == "":
+            problems.append(f"{kind} node '{entry['node_id']}' has an empty name")
+        elif not NAME_PATTERN.match(name):
+            problems.append(
+                f"{kind} name '{name}' is invalid — must match "
+                "^[a-zA-Z_][a-zA-Z0-9_]{0,63}$"
+            )
+        if name in seen:
+            problems.append(f"duplicate {kind} name '{name}'")
+        seen.add(name)

--- a/backend/app/nodes/io/graph_input_node.py
+++ b/backend/app/nodes/io/graph_input_node.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...core.api_contract import coerce_input
+from ...core.api_contract import INPUT_TYPES, coerce_input
 from ...core.node_base import (
     BaseNode,
     DataType,
@@ -104,7 +104,7 @@ class GraphInputNode(BaseNode):
                 param_type=ParamType.SELECT,
                 default="string",
                 description="JSON type API callers must send for this input.",
-                options=["string", "number", "integer", "boolean", "json", "image"],
+                options=list(INPUT_TYPES),
             ),
             ParamDefinition(
                 name="required",

--- a/backend/app/nodes/io/graph_input_node.py
+++ b/backend/app/nodes/io/graph_input_node.py
@@ -1,0 +1,156 @@
+"""GraphInput node — declares a named input of this graph.
+
+Together with GraphOutput this expresses the graph's transport-agnostic
+function signature on the canvas: the CLI runner and Stage 2 published
+apps consume the same contract. API callers supply the value via
+``POST /api/graph/run/{name}``; canvas runs fall back to the ``default``
+param.
+
+Implementation note (the "hidden" ``value`` param): ``value`` is hidden
+ONLY in the sense of being UNDECLARED in ``define_params`` — do NOT
+declare it. Declaring it would render a text field: the config panel and
+node card iterate declared defs only. The API injects it; the canvas
+never sets it, so canvas runs fall back to ``default``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.api_contract import coerce_input
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+def _load_canvas_image(path_value: Any) -> Any:
+    """Load the canvas-only ``default`` image path the way ImageReader does.
+
+    Only reached on canvas runs — the API path always injects ``value``
+    (a base64 string) and never touches ``default``. Relative paths
+    resolve against IMAGES_DIR so filenames picked from the uploaded-files
+    dropdown work without the user typing a full path.
+    """
+    from pathlib import Path
+
+    from PIL import Image
+    from torchvision import transforms
+
+    from ...config import settings
+
+    path_str = str(path_value or "")
+    if not path_str:
+        raise ValueError(
+            "GraphInput(type=image): set 'default' to a server-local image path "
+            "for canvas runs (API callers send base64 instead)"
+        )
+    p = Path(path_str)
+    if not p.is_absolute():
+        p = settings.IMAGES_DIR / p
+    if not p.exists():
+        raise FileNotFoundError(f"GraphInput default image not found: {path_str}")
+    img = Image.open(p).convert("RGB")
+    return transforms.ToTensor()(img)
+
+
+class GraphInputNode(BaseNode):
+    NODE_NAME = "GraphInput"
+    CATEGORY = "IO"
+    DESCRIPTION = (
+        "Declares a named input of this graph — supplied by API callers via "
+        "POST /api/graph/run, or by the 'default' param when run on the canvas. "
+        "Wire a Start node into this node so it executes."
+    )
+
+    # Params include the injected value, so cache keys stay correct on
+    # canvas runs (BaseNode default, restated here because it is load-bearing).
+    cacheable = True
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="value",
+                data_type=DataType.ANY,
+                description=(
+                    "Value supplied by the API caller (or 'default' when run on canvas)"
+                ),
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="name",
+                param_type=ParamType.STRING,
+                default="input",
+                description=(
+                    "Contract name of this input. Must match "
+                    "^[a-zA-Z_][a-zA-Z0-9_]{0,63}$ (letters, digits, underscore; "
+                    "not starting with a digit)."
+                ),
+            ),
+            ParamDefinition(
+                name="type",
+                param_type=ParamType.SELECT,
+                default="string",
+                description="JSON type API callers must send for this input.",
+                options=["string", "number", "integer", "boolean", "json", "image"],
+            ),
+            ParamDefinition(
+                name="required",
+                param_type=ParamType.BOOL,
+                default=True,
+                description=(
+                    "When false, API callers may omit this input and 'default' "
+                    "applies. Image inputs must stay required."
+                ),
+            ),
+            ParamDefinition(
+                name="default",
+                param_type=ParamType.STRING,
+                default="",
+                description=(
+                    "ALWAYS the canvas test value; an API-side fallback ONLY when "
+                    "required=false. Parsed per 'type' (string parsing applies here "
+                    "only). For type=image: a server-local file path used only by "
+                    "canvas runs."
+                ),
+            ),
+            ParamDefinition(
+                name="description",
+                param_type=ParamType.STRING,
+                default="",
+                description="Shown in the contract for self-documenting APIs.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        declared_type = str(params.get("type", "string"))
+        if "value" in params:
+            # API path: routes_graph_run injected the RAW JSON value; the
+            # coercion (including base64 image decode) happens exactly once,
+            # here. One helper serves both paths, so canvas and API behave
+            # identically.
+            return {"value": coerce_input(params["value"], declared_type)}
+        # Canvas path (or omitted optional API input): fall back to `default`.
+        raw_default = params.get("default", "")
+        if declared_type == "image":
+            return {"value": _load_canvas_image(raw_default)}
+        return {"value": coerce_input(raw_default, declared_type, from_string=True)}

--- a/backend/app/nodes/io/graph_output_node.py
+++ b/backend/app/nodes/io/graph_output_node.py
@@ -1,0 +1,78 @@
+"""GraphOutput node — declares a named output of this graph.
+
+Together with GraphInput this expresses the graph's transport-agnostic
+function signature on the canvas. The run endpoint reads this node's
+``value`` port from the engine result and returns it to API callers under
+the declared name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class GraphOutputNode(BaseNode):
+    NODE_NAME = "GraphOutput"
+    CATEGORY = "IO"
+    DESCRIPTION = (
+        "Declares a named output of this graph — returned to API callers by "
+        "POST /api/graph/run under this node's 'name'. Connect the value you "
+        "want the graph to return."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="value",
+                data_type=DataType.ANY,
+                description="The value to return under this output's name",
+                optional=False,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="name",
+                param_type=ParamType.STRING,
+                default="output",
+                description=(
+                    "Contract name of this output. Must match "
+                    "^[a-zA-Z_][a-zA-Z0-9_]{0,63}$ (letters, digits, underscore; "
+                    "not starting with a digit)."
+                ),
+            ),
+            ParamDefinition(
+                name="description",
+                param_type=ParamType.STRING,
+                default="",
+                description="Shown in the contract for self-documenting APIs.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        # Pass-through: the run endpoint reads this port from the engine
+        # result; returning the value also makes it visible in the
+        # Inspector / edge tooltip on canvas runs for free.
+        return {"value": inputs.get("value")}

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -352,3 +352,81 @@ def test_check_wiring_no_entry_points_marks_everything():
     report = check_wiring(nodes, edges, derive_contract(nodes))
     assert report.untriggered == ["x"]
     assert report.unreachable == ["y"]
+
+
+# ── inject_inputs / collect_outputs ──────────────────────────────────────
+
+from app.core.api_contract import collect_outputs, inject_inputs  # noqa: E402
+
+
+def test_inject_inputs_writes_raw_value_and_preserves_original():
+    nodes = [_other("s", "Start"), _gi("i1", name="x", type="integer"), _go("o1", name="y")]
+    contract = derive_contract(nodes)
+    patched, errors = inject_inputs(nodes, contract, {"x": 3.0})
+    assert errors == []
+    patched_params = patched[1]["data"]["params"]
+    assert patched_params["value"] == 3.0            # RAW value, not int(3)
+    assert isinstance(patched_params["value"], float)
+    assert "value" not in nodes[1]["data"]["params"]  # deep-copy: original untouched
+
+
+def test_inject_inputs_image_stays_base64_string():
+    import json as _json
+
+    nodes = [_gi("i1", name="img", type="image"), _go("o1", name="y")]
+    contract = derive_contract(nodes)
+    b64 = _tiny_png_base64()
+    patched, errors = inject_inputs(nodes, contract, {"img": b64})
+    assert errors == []
+    injected = patched[0]["data"]["params"]["value"]
+    assert injected == b64        # decoded once, in the node — not here
+    _json.dumps(injected)         # injected params stay JSON-serializable
+
+
+def test_inject_inputs_aggregates_all_errors():
+    nodes = [
+        _gi("i1", name="a", type="number"),
+        _gi("i2", name="b", type="string"),
+        _go("o1", name="y"),
+    ]
+    contract = derive_contract(nodes)
+    _, errors = inject_inputs(nodes, contract, {"a": "not-a-number", "typo": 1})
+    reasons = {e["input"]: e["reason"] for e in errors}
+    assert set(reasons) == {"a", "typo", "b"}
+    assert reasons["typo"] == "unknown input name"
+    assert reasons["b"] == "missing required input"
+    assert "expected number" in reasons["a"]
+
+
+def test_inject_inputs_is_case_sensitive_exact_match():
+    nodes = [_gi("i1", name="x"), _go("o1", name="y")]
+    contract = derive_contract(nodes)
+    _, errors = inject_inputs(nodes, contract, {"X": "hi"})
+    reasons = {e["input"]: e["reason"] for e in errors}
+    assert reasons == {"X": "unknown input name", "x": "missing required input"}
+
+
+def test_inject_inputs_optional_omitted_not_injected():
+    nodes = [_gi("i1", name="x", required=False, default="fallback"), _go("o1", name="y")]
+    contract = derive_contract(nodes)
+    patched, errors = inject_inputs(nodes, contract, {})
+    assert errors == []
+    # No injection: the node's execute() falls back to `default`, identical
+    # to a canvas run.
+    assert "value" not in patched[0]["data"]["params"]
+
+
+def test_collect_outputs_reads_value_ports_and_reports_missing():
+    nodes = [_go("o1", name="y1"), _go("o2", name="y2")]
+    contract = derive_contract(nodes)
+    outputs, missing = collect_outputs(contract, {"o1": {"value": 42}})
+    assert outputs == {"y1": 42}
+    assert missing == ["y2"]
+
+
+def test_collect_outputs_none_value_is_present_not_missing():
+    nodes = [_go("o1", name="y")]
+    contract = derive_contract(nodes)
+    outputs, missing = collect_outputs(contract, {"o1": {"value": None}})
+    assert outputs == {"y": None}
+    assert missing == []

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -547,3 +547,30 @@ def test_image_base64_roundtrip_to_tensor():
     tensor = coerce_input(_tiny_png_base64(), "image")
     assert tensor.shape == (3, 2, 4)
     assert tensor.dtype == torch.float32
+
+
+def test_serialize_numpy_builtin_subclass_scalars_normalize():
+    import numpy as np
+
+    out = serialize_output(np.float64(2.5))
+    assert out == 2.5 and type(out) is float
+    s = serialize_output(np.str_("hi"))
+    assert s == "hi" and type(s) is str
+    b = serialize_output(np.bool_(True))
+    assert b is True
+
+
+def test_serialize_numpy_complex_hits_catch_all():
+    import numpy as np
+
+    with pytest.raises(OutputSerializationError):
+        serialize_output(np.complex128(1 + 2j))
+
+
+def test_serialize_ndarray_zero_dim_keeps_empty_shape():
+    import numpy as np
+
+    tagged = serialize_output(np.array(7.5))
+    assert tagged["__type__"] == "tensor"
+    assert tagged["shape"] == []
+    assert tagged["values"] == 7.5

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -1,0 +1,165 @@
+"""Tests for app.core.api_contract — pure graph-as-a-function contract helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.api_contract import InputCoercionError, coerce_input, json_type_name
+
+
+def _tiny_png_base64() -> str:
+    import base64
+    import io
+
+    from PIL import Image
+
+    img = Image.new("RGB", (4, 2), color=(255, 0, 0))  # width=4, height=2
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+# ── coerce_input: strict API table (from_string=False) ──────────────────
+
+
+def test_string_passes_through():
+    assert coerce_input("hi", "string") == "hi"
+
+
+def test_string_rejects_non_strings():
+    for bad in (3, 2.5, True, None, {"a": 1}, [1]):
+        with pytest.raises(InputCoercionError):
+            coerce_input(bad, "string")
+
+
+def test_rejection_names_expected_vs_received():
+    with pytest.raises(InputCoercionError, match="expected string, got number"):
+        coerce_input(3, "string")
+    with pytest.raises(InputCoercionError, match="expected number, got string"):
+        coerce_input("3", "number")
+    with pytest.raises(InputCoercionError, match="expected boolean, got number"):
+        coerce_input(1, "boolean")
+
+
+def test_number_accepts_int_and_float_as_float():
+    assert coerce_input(3, "number") == 3.0
+    assert isinstance(coerce_input(3, "number"), float)
+    assert coerce_input(2.5, "number") == 2.5
+
+
+def test_number_rejects_string_bool_null():
+    for bad in ("3", True, False, None, [1]):
+        with pytest.raises(InputCoercionError):
+            coerce_input(bad, "number")
+
+
+def test_integer_accepts_int_and_integral_float():
+    assert coerce_input(3, "integer") == 3
+    assert coerce_input(3.0, "integer") == 3
+    assert isinstance(coerce_input(3.0, "integer"), int)
+
+
+def test_integer_rejects_fractional_string_bool():
+    for bad in (3.5, "3", True, None):
+        with pytest.raises(InputCoercionError):
+            coerce_input(bad, "integer")
+
+
+def test_boolean_accepts_only_bool():
+    assert coerce_input(True, "boolean") is True
+    assert coerce_input(False, "boolean") is False
+    for bad in (0, 1, "true", None):
+        with pytest.raises(InputCoercionError):
+            coerce_input(bad, "boolean")
+
+
+def test_json_accepts_any_json_value():
+    for val in ({"a": 1}, [1, 2], "s", 3, 2.5, True, None):
+        assert coerce_input(val, "json") == val
+
+
+def test_unknown_declared_type_raises():
+    with pytest.raises(InputCoercionError, match="unknown input type"):
+        coerce_input("x", "tensor")
+
+
+# ── coerce_input: from_string=True (canvas `default` path) ──────────────
+
+
+def test_from_string_parses_number_integer_boolean_json():
+    assert coerce_input("2.5", "number", from_string=True) == 2.5
+    assert coerce_input("3", "integer", from_string=True) == 3
+    assert coerce_input("3.0", "integer", from_string=True) == 3
+    assert coerce_input("true", "boolean", from_string=True) is True
+    assert coerce_input("False", "boolean", from_string=True) is False
+    assert coerce_input('{"k": [1, 2]}', "json", from_string=True) == {"k": [1, 2]}
+
+
+def test_from_string_string_type_stays_verbatim():
+    assert coerce_input("3.5", "string", from_string=True) == "3.5"
+
+
+def test_from_string_bad_parses_raise():
+    with pytest.raises(InputCoercionError):
+        coerce_input("abc", "number", from_string=True)
+    with pytest.raises(InputCoercionError):
+        coerce_input("3.5", "integer", from_string=True)
+    with pytest.raises(InputCoercionError):
+        coerce_input("yes", "boolean", from_string=True)
+    with pytest.raises(InputCoercionError):
+        coerce_input("{not json", "json", from_string=True)
+
+
+def test_from_string_false_never_parses_strings():
+    with pytest.raises(InputCoercionError):
+        coerce_input("2.5", "number")
+
+
+def test_from_string_non_string_value_uses_strict_table():
+    # A hand-edited graph JSON may hold a non-string default; strict rules apply.
+    assert coerce_input(5, "number", from_string=True) == 5.0
+    with pytest.raises(InputCoercionError):
+        coerce_input(True, "number", from_string=True)
+
+
+# ── coerce_input: image ─────────────────────────────────────────────────
+
+
+def test_image_decodes_to_chw_float_tensor():
+    import torch
+
+    tensor = coerce_input(_tiny_png_base64(), "image")
+    assert isinstance(tensor, torch.Tensor)
+    assert tensor.shape == (3, 2, 4)  # (C, H, W)
+    assert tensor.dtype == torch.float32
+    assert float(tensor.min()) >= 0.0 and float(tensor.max()) <= 1.0
+
+
+def test_image_accepts_data_uri_prefix():
+    import torch
+
+    tensor = coerce_input("data:image/png;base64," + _tiny_png_base64(), "image")
+    assert isinstance(tensor, torch.Tensor)
+    assert tensor.shape == (3, 2, 4)
+
+
+def test_image_rejects_non_string_and_garbage():
+    with pytest.raises(InputCoercionError, match="expected base64 image string"):
+        coerce_input(123, "image")
+    with pytest.raises(InputCoercionError, match="not valid base64"):
+        coerce_input("!!!not-base64!!!", "image")
+    with pytest.raises(InputCoercionError, match="does not decode to an image"):
+        coerce_input("aGVsbG8gd29ybGQ=", "image")  # base64("hello world")
+
+
+# ── json_type_name ───────────────────────────────────────────────────────
+
+
+def test_json_type_name_labels():
+    assert json_type_name(None) == "null"
+    assert json_type_name(True) == "boolean"
+    assert json_type_name(3) == "number"
+    assert json_type_name(2.5) == "number"
+    assert json_type_name("s") == "string"
+    assert json_type_name([1]) == "array"
+    assert json_type_name({}) == "object"

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -289,3 +289,66 @@ def test_derive_contract_ignores_preset_and_other_nodes():
     contract = derive_contract(nodes)
     assert contract.inputs == []
     assert len(contract.outputs) == 1
+
+
+# ── check_wiring ─────────────────────────────────────────────────────────
+
+from app.core.api_contract import check_wiring  # noqa: E402
+
+
+def _trigger_edge(eid: str, src: str, tgt: str) -> dict:
+    return {
+        "id": eid, "source": src, "target": tgt,
+        "sourceHandle": "trigger", "targetHandle": "", "type": "trigger",
+    }
+
+
+def _data_edge(eid: str, src: str, tgt: str,
+               src_handle: str = "value", tgt_handle: str = "value") -> dict:
+    return {
+        "id": eid, "source": src, "target": tgt,
+        "sourceHandle": src_handle, "targetHandle": tgt_handle, "type": "data",
+    }
+
+
+def test_check_wiring_clean_graph():
+    nodes = [_other("s", "Start"), _gi("i1", name="x"), _go("o1", name="y")]
+    edges = [_trigger_edge("t1", "s", "i1"), _data_edge("d1", "i1", "o1")]
+    report = check_wiring(nodes, edges, derive_contract(nodes))
+    assert report.untriggered == []
+    assert report.unreachable == []
+
+
+def test_check_wiring_untriggered_input():
+    # i1 feeds o1 but has no trigger; a *different* node is triggered, so the
+    # engine would silently prune i1 and run "successfully" without the
+    # caller's input — exactly what the 409 pre-flight must prevent.
+    nodes = [_other("s", "Start"), _other("src"), _gi("i1", name="x"), _go("o1", name="y")]
+    edges = [_trigger_edge("t1", "s", "src"), _data_edge("d1", "i1", "o1")]
+    report = check_wiring(nodes, edges, derive_contract(nodes))
+    assert report.untriggered == ["x"]
+    # o1 is fed only through the untriggered i1, so it is also unreachable.
+    assert report.unreachable == ["y"]
+
+
+def test_check_wiring_unreachable_output():
+    nodes = [
+        _other("s", "Start"), _gi("i1", name="x"),
+        _go("o1", name="y1"), _go("o2", name="y2"), _other("src2"),
+    ]
+    edges = [
+        _trigger_edge("t1", "s", "i1"),
+        _data_edge("d1", "i1", "o1"),
+        _data_edge("d2", "src2", "o2"),  # src2 untriggered -> pruned at run time
+    ]
+    report = check_wiring(nodes, edges, derive_contract(nodes))
+    assert report.untriggered == []
+    assert report.unreachable == ["y2"]
+
+
+def test_check_wiring_no_entry_points_marks_everything():
+    nodes = [_gi("i1", name="x"), _go("o1", name="y")]
+    edges = [_data_edge("d1", "i1", "o1")]
+    report = check_wiring(nodes, edges, derive_contract(nodes))
+    assert report.untriggered == ["x"]
+    assert report.unreachable == ["y"]

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -430,3 +430,120 @@ def test_collect_outputs_none_value_is_present_not_missing():
     outputs, missing = collect_outputs(contract, {"o1": {"value": None}})
     assert outputs == {"y": None}
     assert missing == []
+
+
+# ── serialize_output ─────────────────────────────────────────────────────
+
+from app.core.api_contract import (  # noqa: E402
+    MAX_TENSOR_ELEMENTS,
+    OutputSerializationError,
+    serialize_output,
+)
+
+
+def test_serialize_primitives_pass_through():
+    for val in (None, True, 3, 2.5, "s"):
+        assert serialize_output(val) == val
+
+
+def test_serialize_containers_recurse_tuple_becomes_list():
+    assert serialize_output({"a": (1, 2), "b": [3.5, "x"]}) == {
+        "a": [1, 2], "b": [3.5, "x"],
+    }
+
+
+def test_serialize_numpy_scalar_item():
+    import numpy as np
+
+    assert serialize_output(np.float32(2.5)) == 2.5
+    assert isinstance(serialize_output(np.int64(7)), int)
+
+
+def test_serialize_ndarray_tagged():
+    import numpy as np
+
+    out = serialize_output(np.zeros((2, 3), dtype=np.float32))
+    assert out["__type__"] == "tensor"
+    assert out["shape"] == [2, 3]
+    assert out["dtype"] == "float32"
+    assert out["values"] == [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+
+
+def test_serialize_tensor_tagged_and_zero_dim():
+    import torch
+
+    out = serialize_output(torch.tensor([[1.0, 2.0]]))
+    assert out == {
+        "__type__": "tensor", "shape": [1, 2],
+        "dtype": "torch.float32", "values": [[1.0, 2.0]],
+    }
+    # 0-dim tensors serialize with shape [] rather than unwrapping.
+    zero_dim = serialize_output(torch.tensor(5.0))
+    assert zero_dim["shape"] == []
+    assert zero_dim["values"] == 5.0
+
+
+def test_serialize_tensor_cap_65536():
+    import torch
+
+    assert MAX_TENSOR_ELEMENTS == 65536
+    ok = serialize_output(torch.zeros(65536))
+    assert len(ok["values"]) == 65536
+    with pytest.raises(OutputSerializationError) as exc_info:
+        serialize_output(torch.zeros(65537))
+    assert exc_info.value.code == "output_too_large"
+    assert "record_outputs" in exc_info.value.reason
+
+
+def test_serialize_ndarray_cap_65536():
+    import numpy as np
+
+    with pytest.raises(OutputSerializationError) as exc_info:
+        serialize_output(np.zeros(65537))
+    assert exc_info.value.code == "output_too_large"
+
+
+def test_serialize_module_rejected_with_modelsaver_hint():
+    import torch
+
+    with pytest.raises(OutputSerializationError) as exc_info:
+        serialize_output(torch.nn.Linear(2, 2))
+    assert exc_info.value.code == "unserializable_output"
+    assert "ModelSaver" in exc_info.value.reason
+
+
+def test_serialize_pil_image_base64_roundtrip():
+    import base64
+    import io
+
+    from PIL import Image
+
+    out = serialize_output(Image.new("RGB", (4, 2), color=(0, 0, 255)))
+    assert out["__type__"] == "image"
+    assert out["format"] == "png"
+    round_tripped = Image.open(io.BytesIO(base64.b64decode(out["base64"])))
+    assert round_tripped.size == (4, 2)
+
+
+def test_serialize_unknown_type_rejected_with_type_name():
+    class Widget:
+        pass
+
+    with pytest.raises(OutputSerializationError) as exc_info:
+        serialize_output(Widget())
+    assert exc_info.value.code == "unserializable_output"
+    assert "Widget" in exc_info.value.reason
+
+
+def test_serialize_base64_plot_string_passes_through():
+    # Base64-string plots (e.g. Visualize node output) are plain strings.
+    assert serialize_output("iVBORw0KGgo=") == "iVBORw0KGgo="
+
+
+def test_image_base64_roundtrip_to_tensor():
+    # Input side of the same story: base64 -> coerce_input -> tensor.
+    import torch
+
+    tensor = coerce_input(_tiny_png_base64(), "image")
+    assert tensor.shape == (3, 2, 4)
+    assert tensor.dtype == torch.float32

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -163,3 +163,129 @@ def test_json_type_name_labels():
     assert json_type_name("s") == "string"
     assert json_type_name([1]) == "array"
     assert json_type_name({}) == "object"
+
+
+# ── derive_contract ──────────────────────────────────────────────────────
+
+from app.core.api_contract import derive_contract  # noqa: E402
+
+
+def _gi(node_id: str, **params) -> dict:
+    merged = {
+        "name": "input", "type": "string", "required": True,
+        "default": "", "description": "",
+    }
+    merged.update(params)
+    return {
+        "id": node_id, "type": "GraphInput",
+        "position": {"x": 0, "y": 0}, "data": {"params": merged},
+    }
+
+
+def _go(node_id: str, **params) -> dict:
+    merged = {"name": "output", "description": ""}
+    merged.update(params)
+    return {
+        "id": node_id, "type": "GraphOutput",
+        "position": {"x": 0, "y": 0}, "data": {"params": merged},
+    }
+
+
+def _other(node_id: str, node_type: str = "_TestSource") -> dict:
+    return {
+        "id": node_id, "type": node_type,
+        "position": {"x": 0, "y": 0}, "data": {"params": {}},
+    }
+
+
+def test_derive_contract_collects_inputs_and_outputs():
+    nodes = [
+        _other("s", "Start"),
+        _gi("i1", name="prompt", type="string"),
+        _go("o1", name="answer", description="the answer"),
+    ]
+    contract = derive_contract(nodes)
+    assert contract.problems == []
+    assert contract.inputs == [{
+        "name": "prompt", "type": "string", "required": True,
+        "default": "", "description": "", "node_id": "i1",
+    }]
+    assert contract.outputs == [
+        {"name": "answer", "description": "the answer", "node_id": "o1"},
+    ]
+
+
+def test_derive_contract_no_graph_output_is_problem():
+    contract = derive_contract([_gi("i1", name="x")])
+    assert any("GraphOutput" in p for p in contract.problems)
+
+
+def test_derive_contract_empty_and_bad_charset_names():
+    contract = derive_contract([
+        _gi("i1", name=""),
+        _gi("i2", name="9lives"),
+        _gi("i3", name="has space"),
+        _go("o1", name="ok_name"),
+    ])
+    assert any("empty name" in p for p in contract.problems)
+    assert sum("is invalid" in p for p in contract.problems) == 2
+
+
+def test_derive_contract_name_at_charset_limits():
+    contract = derive_contract([
+        _gi("i1", name="_x" + "a" * 62),   # 64 chars total: OK
+        _gi("i2", name="b" * 65),          # 65 chars: too long
+        _go("o1", name="y"),
+    ])
+    assert sum("is invalid" in p for p in contract.problems) == 1
+
+
+def test_derive_contract_duplicate_names():
+    contract = derive_contract([
+        _gi("i1", name="x"), _gi("i2", name="x"),
+        _go("o1", name="y"), _go("o2", name="y"),
+    ])
+    assert any(p == "duplicate input name 'x'" for p in contract.problems)
+    assert any(p == "duplicate output name 'y'" for p in contract.problems)
+
+
+def test_derive_contract_optional_default_must_parse():
+    contract = derive_contract([
+        _gi("i1", name="n", type="number", required=False, default="abc"),
+        _go("o1", name="y"),
+    ])
+    assert any("default does not parse" in p for p in contract.problems)
+
+
+def test_derive_contract_required_bad_default_is_not_a_problem():
+    # A required input's default is a canvas-only test value: its failure
+    # surfaces on canvas runs and must NOT 409-block API calls.
+    contract = derive_contract([
+        _gi("i1", name="n", type="number", required=True, default="abc"),
+        _go("o1", name="y"),
+    ])
+    assert contract.problems == []
+
+
+def test_derive_contract_image_default_exempt_from_parsing():
+    # An image default is a canvas-only file path, validated at canvas run time.
+    contract = derive_contract([
+        _gi("i1", name="img", type="image", required=True, default="photo.png"),
+        _go("o1", name="y"),
+    ])
+    assert contract.problems == []
+
+
+def test_derive_contract_optional_image_is_problem():
+    contract = derive_contract([
+        _gi("i1", name="img", type="image", required=False),
+        _go("o1", name="y"),
+    ])
+    assert any("must be required" in p for p in contract.problems)
+
+
+def test_derive_contract_ignores_preset_and_other_nodes():
+    nodes = [_other("p1", "preset:TrainLoop"), _other("t1"), _go("o1", name="y")]
+    contract = derive_contract(nodes)
+    assert contract.inputs == []
+    assert len(contract.outputs) == 1

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -152,6 +152,21 @@ def test_image_rejects_non_string_and_garbage():
         coerce_input("aGVsbG8gd29ybGQ=", "image")  # base64("hello world")
 
 
+def test_image_decompression_bomb_becomes_input_coercion_error(monkeypatch):
+    # PIL.Image.DecompressionBombError subclasses Exception directly (not
+    # OSError), so it must still be caught and enveloped — never escape as
+    # a raw, unenveloped exception through the API layer.
+    import PIL.Image
+
+    def _boom(*_args, **_kwargs):
+        raise PIL.Image.DecompressionBombError("boom")
+
+    monkeypatch.setattr(PIL.Image, "open", _boom)
+    with pytest.raises(InputCoercionError, match="does not decode to an image") as exc_info:
+        coerce_input(_tiny_png_base64(), "image")
+    assert not isinstance(exc_info.value, PIL.Image.DecompressionBombError)
+
+
 # ── json_type_name ───────────────────────────────────────────────────────
 
 
@@ -282,6 +297,24 @@ def test_derive_contract_optional_image_is_problem():
         _go("o1", name="y"),
     ])
     assert any("must be required" in p for p in contract.problems)
+
+
+def test_derive_contract_unknown_type_required_is_problem():
+    # A hand-edited graph with a bogus `type` must 409 (fix the graph) at
+    # GET /contract time, not surface as a per-caller 422 at run time.
+    contract = derive_contract([
+        _gi("i1", name="n", type="tensor", required=True),
+        _go("o1", name="y"),
+    ])
+    assert any("unknown type" in p and "tensor" in p for p in contract.problems)
+
+
+def test_derive_contract_unknown_type_optional_is_problem():
+    contract = derive_contract([
+        _gi("i1", name="n", type="tensor", required=False, default="x"),
+        _go("o1", name="y"),
+    ])
+    assert any("unknown type" in p and "tensor" in p for p in contract.problems)
 
 
 def test_derive_contract_ignores_preset_and_other_nodes():

--- a/backend/tests/test_graph_input_node.py
+++ b/backend/tests/test_graph_input_node.py
@@ -1,0 +1,121 @@
+"""Tests for the GraphInput node — declares a named input of the graph."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.api_contract import InputCoercionError
+from app.core.node_base import DataType, ParamType
+from app.nodes.io.graph_input_node import GraphInputNode
+
+
+def test_metadata():
+    assert GraphInputNode.NODE_NAME == "GraphInput"
+    assert GraphInputNode.CATEGORY == "IO"
+    assert "API" in GraphInputNode.DESCRIPTION  # palette search finds it
+    assert GraphInputNode.cacheable is True
+
+
+def test_ports():
+    assert GraphInputNode.define_inputs() == []
+    outputs = GraphInputNode.define_outputs()
+    assert len(outputs) == 1
+    assert outputs[0].name == "value"
+    assert outputs[0].data_type == DataType.ANY
+
+
+def test_declared_params_exclude_value():
+    params = GraphInputNode.define_params()
+    names = [p.name for p in params]
+    assert names == ["name", "type", "required", "default", "description"]
+    assert "value" not in names  # the injected param must never render in the UI
+    by_name = {p.name: p for p in params}
+    assert by_name["name"].default == "input"
+    assert by_name["type"].param_type == ParamType.SELECT
+    assert by_name["type"].options == [
+        "string", "number", "integer", "boolean", "json", "image",
+    ]
+    assert by_name["type"].default == "string"
+    assert by_name["required"].param_type == ParamType.BOOL
+    assert by_name["required"].default is True
+    assert by_name["default"].default == ""
+    assert by_name["description"].default == ""
+
+
+def test_injected_value_takes_precedence_over_default():
+    res = GraphInputNode().execute(
+        {}, {"type": "string", "value": "from-api", "default": "from-canvas"}
+    )
+    assert res == {"value": "from-api"}
+
+
+def test_canvas_default_string_parsing_number():
+    res = GraphInputNode().execute({}, {"type": "number", "default": "2.5"})
+    assert res == {"value": 2.5}
+
+
+def test_canvas_default_boolean_and_json():
+    assert GraphInputNode().execute({}, {"type": "boolean", "default": "true"}) == {
+        "value": True
+    }
+    assert GraphInputNode().execute({}, {"type": "json", "default": '{"a": 1}'}) == {
+        "value": {"a": 1}
+    }
+
+
+def test_injected_integral_float_integer():
+    assert GraphInputNode().execute({}, {"type": "integer", "value": 3.0}) == {"value": 3}
+    with pytest.raises(InputCoercionError):
+        GraphInputNode().execute({}, {"type": "integer", "value": 3.5})
+
+
+def test_injected_value_strict_no_string_parsing():
+    with pytest.raises(InputCoercionError):
+        GraphInputNode().execute({}, {"type": "number", "value": "2.5"})
+
+
+def test_missing_type_defaults_to_string():
+    assert GraphInputNode().execute({}, {"default": "plain"}) == {"value": "plain"}
+
+
+def test_image_default_empty_raises_clear_canvas_error():
+    with pytest.raises(ValueError, match="server-local image path"):
+        GraphInputNode().execute({}, {"type": "image", "default": ""})
+
+
+def test_image_default_missing_file_raises():
+    with pytest.raises(FileNotFoundError):
+        GraphInputNode().execute({}, {"type": "image", "default": "no_such_file_12345.png"})
+
+
+def test_image_default_loads_file(tmp_path):
+    import torch
+    from PIL import Image
+
+    p = tmp_path / "tiny.png"
+    Image.new("RGB", (4, 2), color=(0, 255, 0)).save(p)
+    res = GraphInputNode().execute({}, {"type": "image", "default": str(p)})
+    assert isinstance(res["value"], torch.Tensor)
+    assert res["value"].shape == (3, 2, 4)
+
+
+def test_image_injected_value_is_decoded_base64():
+    import base64
+    import io
+
+    import torch
+    from PIL import Image
+
+    img = Image.new("RGB", (4, 2), color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    res = GraphInputNode().execute({}, {"type": "image", "value": b64})
+    assert isinstance(res["value"], torch.Tensor)
+    assert res["value"].shape == (3, 2, 4)
+
+
+def test_registry_discovers_graph_input():
+    from app.core.node_registry import registry
+
+    assert registry.get("GraphInput") is GraphInputNode

--- a/backend/tests/test_graph_input_node.py
+++ b/backend/tests/test_graph_input_node.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from app.core.api_contract import InputCoercionError
+from app.core.api_contract import INPUT_TYPES, InputCoercionError
 from app.core.node_base import DataType, ParamType
 from app.nodes.io.graph_input_node import GraphInputNode
 
@@ -32,6 +32,9 @@ def test_declared_params_exclude_value():
     by_name = {p.name: p for p in params}
     assert by_name["name"].default == "input"
     assert by_name["type"].param_type == ParamType.SELECT
+    # Options must track INPUT_TYPES exactly — no hand-maintained duplicate
+    # list that can drift from the contract's source of truth.
+    assert by_name["type"].options == list(INPUT_TYPES)
     assert by_name["type"].options == [
         "string", "number", "integer", "boolean", "json", "image",
     ]

--- a/backend/tests/test_graph_output_node.py
+++ b/backend/tests/test_graph_output_node.py
@@ -1,0 +1,45 @@
+"""Tests for the GraphOutput node — declares a named output of the graph."""
+
+from __future__ import annotations
+
+from app.core.node_base import DataType
+from app.nodes.io.graph_output_node import GraphOutputNode
+
+
+def test_metadata():
+    assert GraphOutputNode.NODE_NAME == "GraphOutput"
+    assert GraphOutputNode.CATEGORY == "IO"
+    assert "API" in GraphOutputNode.DESCRIPTION  # palette search finds it
+
+
+def test_ports():
+    inputs = GraphOutputNode.define_inputs()
+    assert len(inputs) == 1
+    assert inputs[0].name == "value"
+    assert inputs[0].data_type == DataType.ANY
+    assert inputs[0].optional is False  # missing connection -> required-input check
+    assert GraphOutputNode.define_outputs() == []
+
+
+def test_params():
+    params = GraphOutputNode.define_params()
+    names = [p.name for p in params]
+    assert names == ["name", "description"]
+    by_name = {p.name: p for p in params}
+    assert by_name["name"].default == "output"
+    assert by_name["description"].default == ""
+
+
+def test_execute_passes_value_through():
+    res = GraphOutputNode().execute({"value": 42}, {"name": "y"})
+    assert res == {"value": 42}
+
+
+def test_execute_missing_input_yields_none():
+    assert GraphOutputNode().execute({}, {}) == {"value": None}
+
+
+def test_registry_discovers_graph_output():
+    from app.core.node_registry import registry
+
+    assert registry.get("GraphOutput") is GraphOutputNode


### PR DESCRIPTION
## Summary

PR 1 of 3 for Graph-as-a-Function Stage 1 (spec: `docs/superpowers/specs/2026-07-02-graph-as-a-function-stage1.md`): the canvas node pair and the pure core module. No endpoints yet (PR 2), no docs (PR 3).

- New `GraphInput` / `GraphOutput` nodes (`CATEGORY="IO"`, `DataType.ANY` ports) declaring a saved graph's transport-agnostic function signature on the canvas. Node names are frozen — they serialize into saved graphs.
- New pure module `backend/app/core/api_contract.py` (no FastAPI imports): `coerce_input` (strict JSON table; `integer` accepts integral floats; string-parsing applies only on the canvas `default` path), `derive_contract` (contract `problems[]`), `check_wiring` (untriggered inputs / unreachable outputs via the engine's own traversal), `inject_inputs` (deep-copy + RAW-value injection into `data.params["value"]`), `collect_outputs`, `serialize_output` (full-value table, `__type__`-tagged tensors/images, 65,536-element tensor cap).
- `GraphInput`'s injected `value` param is intentionally UNDECLARED in `define_params` so it never renders in the config panel; canvas runs fall back to `default`.
- Image transport is base64-string only, decoded once (in the node) to a `(C,H,W)` float32 tensor in `[0,1]`, matching `ImageReader`.

## Test plan

- [x] `uv run pytest tests/test_api_contract.py tests/test_graph_input_node.py tests/test_graph_output_node.py -v` (new tests, all green)
- [x] `uv run pytest -q` full suite green: 1408 passed / 11 skipped (baseline was 1333 / 11)
- [x] Browser e2e smoke (Chrome, worktree server on :8017): GraphInput/GraphOutput appear under IO in the palette and are found by searching "API"; GraphInput config panel shows exactly the five declared params (name/type/required/default/description) and NO `value` field; built `Start -> GraphInput(default="hello") -> GraphOutput` on canvas, ran it — execution completed successfully and the Teaching Inspector shows `Input string "hello"` arriving at GraphOutput.

Zero frontend files changed. No new pip dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
