### PR TITLE
feat(graph-run): POST /api/graph/run + GET /api/graph/contract (Stage 1, PR 2/3)

### DIFF
--- a/backend/app/api/routes_graph.py
+++ b/backend/app/api/routes_graph.py
@@ -11,6 +11,16 @@ from ..schemas import GraphData, GraphValidationResponse
 router = APIRouter(prefix="/api/graph", tags=["graph"])
 
 
+def _sanitize_name(name: str) -> str:
+    """Filesystem-safe graph name: every char outside [alnum, '-', '_'] -> '_'."""
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+
+
+def _graph_path(name: str) -> Path:
+    """Resolve a graph name to its on-disk JSON path under GRAPHS_DIR."""
+    return settings.GRAPHS_DIR / f"{_sanitize_name(name)}.json"
+
+
 @router.post("/validate", response_model=GraphValidationResponse)
 async def validate(graph: GraphData):
     nodes = [n.model_dump() for n in graph.nodes]
@@ -22,16 +32,14 @@ async def validate(graph: GraphData):
 @router.post("/save")
 async def save_graph(graph: GraphData):
     settings.GRAPHS_DIR.mkdir(parents=True, exist_ok=True)
-    safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in graph.name)
-    path = settings.GRAPHS_DIR / f"{safe_name}.json"
+    path = _graph_path(graph.name)
     path.write_text(json.dumps(graph.model_dump(), indent=2))
     return {"message": "Graph saved", "path": str(path)}
 
 
 @router.get("/load/{name}")
 async def load_graph(name: str):
-    safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
-    path = settings.GRAPHS_DIR / f"{safe_name}.json"
+    path = _graph_path(name)
     if not path.exists():
         raise HTTPException(status_code=404, detail=f"Graph '{name}' not found")
     data = json.loads(path.read_text())

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -12,14 +12,23 @@ file. POST is auto-covered by the X-CodefyUI-Token middleware.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
+import time
+from dataclasses import dataclass, field
 from typing import Any
+from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from ..config import settings
 from ..core import api_contract
-from ..core.api_contract import InputCoercionError
+from ..core.api_contract import InputCoercionError, OutputSerializationError
+from ..core.device_utils import resolve_device
+from ..core.execution_context import ExecutionContext
+from ..core.graph_engine import execute_graph, find_entry_points, validate_graph
 from ..core.node_registry import registry
 from ..schemas import (
     ContractInputSchema,
@@ -30,6 +39,8 @@ from ..schemas import (
     RunTiming,
 )
 from .routes_graph import _graph_path, _sanitize_name
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/graph", tags=["graph-run"])
 
@@ -198,3 +209,268 @@ async def get_contract(name: str):
     return GraphContractResponse(
         graph=name, inputs=inputs, outputs=outputs, problems=problems,
     )
+
+
+@dataclass
+class _RunRequest:
+    """Validated fields of the OPTIONAL /run body (absent body == {})."""
+
+    inputs: dict[str, Any] = field(default_factory=dict)
+    timeout_s: float = 300.0
+    device: str | None = None
+    record_outputs: bool = False
+
+
+def _parse_run_body(raw: bytes) -> tuple[_RunRequest, list[dict[str, str]]]:
+    """Manual in-handler body parse.
+
+    Malformed JSON, a non-dict body, a non-dict ``inputs``, or wrong-typed
+    ``timeout_s``/``device``/``record_outputs`` all yield enveloped 422
+    field errors — FastAPI's ``RequestValidationError`` can never bypass
+    the envelope. The Content-Type header is not used for dispatch.
+    Unknown body fields are ignored (forward compatibility).
+    """
+    req = _RunRequest()
+    if not raw or not raw.strip():
+        return req, []
+    try:
+        body = json.loads(raw)
+    except (ValueError, UnicodeDecodeError):
+        return req, [{"field": "body", "reason": "body is not valid JSON"}]
+    if not isinstance(body, dict):
+        return req, [{
+            "field": "body",
+            "reason": (
+                f"body must be a JSON object, got {api_contract.json_type_name(body)}"
+            ),
+        }]
+
+    errors: list[dict[str, str]] = []
+
+    inputs = body.get("inputs", {})
+    if isinstance(inputs, dict):
+        req.inputs = inputs
+    else:
+        errors.append({
+            "field": "inputs",
+            "reason": f"expected object, got {api_contract.json_type_name(inputs)}",
+        })
+
+    timeout_s = body.get("timeout_s", 300)
+    if isinstance(timeout_s, bool) or not isinstance(timeout_s, (int, float)):
+        errors.append({
+            "field": "timeout_s",
+            "reason": f"expected number, got {api_contract.json_type_name(timeout_s)}",
+        })
+    elif not (1 <= timeout_s <= 3600):
+        errors.append({
+            "field": "timeout_s",
+            "reason": f"must be between 1 and 3600, got {timeout_s}",
+        })
+    else:
+        req.timeout_s = float(timeout_s)
+
+    device = body.get("device")
+    if device is not None and not isinstance(device, str):
+        errors.append({
+            "field": "device",
+            "reason": f"expected string, got {api_contract.json_type_name(device)}",
+        })
+    else:
+        req.device = device
+
+    record_outputs = body.get("record_outputs", False)
+    if not isinstance(record_outputs, bool):
+        errors.append({
+            "field": "record_outputs",
+            "reason": (
+                f"expected boolean, got {api_contract.json_type_name(record_outputs)}"
+            ),
+        })
+    else:
+        req.record_outputs = record_outputs
+
+    return req, errors
+
+
+def _retrieve_background_exception(task: asyncio.Task) -> None:
+    """Consume a background run's exception.
+
+    After a timeout (or client disconnect) the shielded task keeps running;
+    without this done-callback asyncio would log 'Task exception was never
+    retrieved' when it eventually fails.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.debug("background graph run ended with error after response: %s", exc)
+
+
+@router.post("/run/{name}")
+async def run_graph_as_function(name: str, request: Request):
+    """Execute a saved graph as a named function: declared inputs in,
+    declared outputs out. Every response uses the 7-key envelope."""
+    # 1. run_id at request entry — every envelope carries it, including
+    #    pre-flight rejections.
+    run_id = uuid4().hex
+
+    # 2. Body size cap, checked against Content-Length BEFORE reading the body.
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            declared_bytes = int(content_length)
+        except ValueError:
+            declared_bytes = 0
+        if declared_bytes > settings.MAX_RUN_BODY_BYTES:
+            return error_response(
+                413, run_id=run_id, graph=name, code="payload_too_large",
+                message=(
+                    f"request body is {declared_bytes} bytes "
+                    f"(max {settings.MAX_RUN_BODY_BYTES})"
+                ),
+            )
+
+    # 3. Strict name matching: execute exactly what was named, or nothing.
+    if _sanitize_name(name) != name:
+        return error_response(404, run_id=run_id, graph=name,
+                              code="graph_not_found",
+                              message=f"Graph '{name}' not found")
+    path = _graph_path(name)
+    if not path.exists():
+        return error_response(404, run_id=run_id, graph=name,
+                              code="graph_not_found",
+                              message=f"Graph '{name}' not found")
+    try:
+        graph_data = json.loads(path.read_text())
+    except (ValueError, OSError):
+        return error_response(500, run_id=run_id, graph=name,
+                              code="graph_unreadable",
+                              message=(
+                                  f"Graph file for '{name}' exists but is not "
+                                  "valid JSON"
+                              ))
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+
+    # 4. Parse + validate the body in-handler (enveloped 422).
+    raw_body = await request.body()
+    run_req, field_errors = _parse_run_body(raw_body)
+    if field_errors:
+        return error_response(422, run_id=run_id, graph=name,
+                              code="invalid_input",
+                              message="invalid request body",
+                              details=field_errors)
+
+    # 5. Pre-flight on the raw graph — nobody pays for a full execution to
+    #    learn about mis-wiring.
+    contract = api_contract.derive_contract(nodes)
+    if contract.problems:
+        return error_response(409, run_id=run_id, graph=name,
+                              code="invalid_contract",
+                              message="graph I/O contract has problems",
+                              details=contract.problems)
+    if not find_entry_points(nodes, edges):
+        return error_response(409, run_id=run_id, graph=name,
+                              code="no_entry_points",
+                              message=(
+                                  "graph has no entry points — wire a Start "
+                                  "node into every GraphInput"
+                              ))
+    wiring = api_contract.check_wiring(nodes, edges, contract)
+    if wiring.untriggered:
+        return error_response(409, run_id=run_id, graph=name,
+                              code="untriggered_input",
+                              message=(
+                                  "GraphInput node(s) have no incoming trigger "
+                                  "edge — wire Start into every GraphInput"
+                              ),
+                              details=wiring.untriggered)
+    if wiring.unreachable:
+        return error_response(409, run_id=run_id, graph=name,
+                              code="unreachable_output",
+                              message=(
+                                  "GraphOutput node(s) are not reachable from "
+                                  "any entry point"
+                              ),
+                              details=wiring.unreachable)
+    validation_errors = validate_graph(nodes, edges)
+    if validation_errors:
+        return error_response(409, run_id=run_id, graph=name,
+                              code="invalid_graph",
+                              message="graph failed validation",
+                              details=validation_errors)
+
+    # 6. Inject the RAW request values; each GraphInput's execute() coerces.
+    patched_nodes, input_errors = api_contract.inject_inputs(
+        nodes, contract, run_req.inputs,
+    )
+    if input_errors:
+        return error_response(422, run_id=run_id, graph=name,
+                              code="invalid_input",
+                              message="invalid inputs",
+                              details=input_errors)
+
+    # 7. Fresh per-request context: with persistence off the stateful mixin
+    #    rebuilds modules per call, so concurrent requests share no mutable
+    #    state; the app-global stores are simply not used.
+    device = resolve_device(run_req.device)
+    ctx = ExecutionContext(
+        device=device,
+        weights_persistent=False,
+        node_state_store=None,
+        graph_id=f"api:{name}",
+    )
+
+    # 8. Launch as an INDEPENDENT task and await it under a shielded
+    #    timeout. The shield means handler cancellation (client disconnect)
+    #    never propagates into the run — only the timeout stops a run.
+    t0 = time.monotonic()
+    task = asyncio.create_task(execute_graph(
+        patched_nodes,
+        edges,
+        context=ctx,
+        error_mode="fail_fast",
+        run_id=run_id,
+    ))
+    task.add_done_callback(_retrieve_background_exception)
+    engine_result = await asyncio.wait_for(
+        asyncio.shield(task), timeout=run_req.timeout_s,
+    )
+    total_s = round(time.monotonic() - t0, 3)
+
+    # 12. Collect + serialize declared outputs.
+    collected, missing = api_contract.collect_outputs(contract, engine_result)
+    if missing:
+        return error_response(500, run_id=run_id, graph=name,
+                              code="output_not_produced",
+                              message=(
+                                  "declared output(s) missing from the engine "
+                                  "result: " + ", ".join(missing)
+                              ),
+                              device=device, details=missing,
+                              timing={"total_s": total_s})
+    outputs_json: dict[str, Any] = {}
+    serialization_errors: list[dict[str, str]] = []
+    serialization_code = "unserializable_output"
+    for output_name, value in collected.items():
+        try:
+            outputs_json[output_name] = api_contract.serialize_output(value)
+        except OutputSerializationError as exc:
+            serialization_errors.append(
+                {"output": output_name, "reason": exc.reason}
+            )
+            if exc.code == "output_too_large":
+                # When both kinds occur, the size violation names the code —
+                # deterministic and the more actionable of the two.
+                serialization_code = "output_too_large"
+    if serialization_errors:
+        return error_response(500, run_id=run_id, graph=name,
+                              code=serialization_code,
+                              message="output serialization failed",
+                              device=device, details=serialization_errors,
+                              timing={"total_s": total_s})
+
+    return build_envelope(status="ok", run_id=run_id, graph=name, device=device,
+                          outputs=outputs_json, error=None,
+                          timing={"total_s": total_s})

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -426,6 +426,12 @@ async def run_graph_as_function(name: str, request: Request):
         node_state_store=None,
         graph_id=f"api:{name}",
     )
+    output_store = None
+    if run_req.record_outputs:
+        # The lifespan does not run under httpx ASGITransport, so the
+        # attribute may be absent — recording is then silently skipped
+        # (ws_execution.py getattr precedent).
+        output_store = getattr(request.app.state, "run_output_store", None)
 
     # 8. Launch as an INDEPENDENT task and await it under a shielded
     #    timeout. The shield means handler cancellation (client disconnect)
@@ -448,6 +454,8 @@ async def run_graph_as_function(name: str, request: Request):
         context=ctx,
         error_mode="fail_fast",
         run_id=run_id,
+        output_store=output_store,
+        record_outputs=run_req.record_outputs and output_store is not None,
     ))
     task.add_done_callback(_retrieve_background_exception)
     try:

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -12,12 +12,24 @@ file. POST is auto-covered by the X-CodefyUI-Token middleware.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 
-from ..schemas import RunEnvelope, RunError, RunTiming
+from ..core import api_contract
+from ..core.api_contract import InputCoercionError
+from ..core.node_registry import registry
+from ..schemas import (
+    ContractInputSchema,
+    ContractOutputSchema,
+    GraphContractResponse,
+    RunEnvelope,
+    RunError,
+    RunTiming,
+)
+from .routes_graph import _graph_path, _sanitize_name
 
 router = APIRouter(prefix="/api/graph", tags=["graph-run"])
 
@@ -77,4 +89,112 @@ def error_response(
             },
             timing=timing,
         ),
+    )
+
+
+def _derive_output_type(
+    node_id: str, nodes: list[dict], edges: list[dict]
+) -> tuple[str, str | None]:
+    """Resolve a GraphOutput's advertised type from its incoming data edge.
+
+    Same lookup the validator does: source node class ->
+    ``define_outputs_dynamic(params)`` -> port ``data_type``. Returns
+    ``(type_label, problem)``; unresolvable outputs advertise ``"ANY"``
+    plus a problem entry.
+    """
+    incoming = [
+        e
+        for e in edges
+        if e.get("target") == node_id
+        and e.get("targetHandle", "") == "value"
+        and e.get("type", "data") == "data"
+    ]
+    if not incoming:
+        return "ANY", (
+            f"output node '{node_id}' has no incoming connection — type unresolved"
+        )
+    edge = incoming[0]
+    node_map = {n.get("id"): n for n in nodes}
+    src = node_map.get(edge.get("source"))
+    if src is None:
+        return "ANY", (
+            f"output node '{node_id}': source node '{edge.get('source')}' not found"
+        )
+    src_cls = registry.get(src.get("type", ""))
+    if src_cls is None:
+        return "ANY", (
+            f"output node '{node_id}': unknown source node type "
+            f"'{src.get('type', '')}'"
+        )
+    src_data = src.get("data")
+    src_params = src_data.get("params", {}) if isinstance(src_data, dict) else {}
+    ports = {p.name: p for p in src_cls.define_outputs_dynamic(src_params)}
+    port = ports.get(edge.get("sourceHandle", ""))
+    if port is None:
+        return "ANY", (
+            f"output node '{node_id}': source port "
+            f"'{edge.get('sourceHandle', '')}' not found"
+        )
+    return port.data_type.value, None
+
+
+@router.get("/contract/{name}", response_model=GraphContractResponse)
+async def get_contract(name: str):
+    """Derived I/O contract for a saved graph.
+
+    Problems are *reported* here (non-fatally, so users can inspect a
+    half-built graph) and *enforced* with 409 only by POST /run.
+    Unauthenticated GET, like /api/graph/load; 404s are plain
+    ``HTTPException`` shapes matching the load endpoint.
+    """
+    if _sanitize_name(name) != name:
+        # Strict-name rule: never silently alias to a different file.
+        raise HTTPException(status_code=404, detail=f"Graph '{name}' not found")
+    path = _graph_path(name)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail=f"Graph '{name}' not found")
+    try:
+        graph_data = json.loads(path.read_text())
+    except (ValueError, OSError):
+        raise HTTPException(
+            status_code=500, detail=f"Graph '{name}' exists but is not valid JSON"
+        )
+
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+    contract = api_contract.derive_contract(nodes)
+    problems = list(contract.problems)
+
+    inputs: list[ContractInputSchema] = []
+    for inp in contract.inputs:
+        if inp["required"] or inp["type"] == "image":
+            # Never advertise a default the API will not apply. (An image
+            # default is a canvas-only file path — also never applied.)
+            advertised_default = None
+        else:
+            try:
+                advertised_default = api_contract.coerce_input(
+                    inp["default"], inp["type"], from_string=True
+                )
+            except InputCoercionError:
+                advertised_default = None  # already reported in problems
+        inputs.append(ContractInputSchema(
+            name=inp["name"],
+            type=inp["type"],
+            required=inp["required"],
+            default=advertised_default,
+            description=inp["description"],
+        ))
+
+    outputs: list[ContractOutputSchema] = []
+    for out in contract.outputs:
+        type_label, problem = _derive_output_type(out["node_id"], nodes, edges)
+        if problem is not None:
+            problems.append(problem)
+        outputs.append(ContractOutputSchema(
+            name=out["name"], type=type_label, description=out["description"],
+        ))
+
+    return GraphContractResponse(
+        graph=name, inputs=inputs, outputs=outputs, problems=problems,
     )

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -1,0 +1,80 @@
+"""Graph-as-a-function endpoints: call a saved graph headlessly over HTTP.
+
+POST /api/graph/run/{name}      — execute with declared inputs, return declared outputs
+GET  /api/graph/contract/{name} — inspect the derived I/O contract
+
+The contract is declared on the canvas with GraphInput / GraphOutput
+nodes; the pure helpers live in ``app.core.api_contract``. This router
+shares the ``/api/graph`` prefix with ``routes_graph`` (multiple routers
+may share a prefix) but keeps run/serialization logic out of the CRUD
+file. POST is auto-covered by the X-CodefyUI-Token middleware.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from ..schemas import RunEnvelope, RunError, RunTiming
+
+router = APIRouter(prefix="/api/graph", tags=["graph-run"])
+
+
+def build_envelope(
+    *,
+    status: str,
+    run_id: str,
+    graph: str,
+    device: str | None = None,
+    outputs: dict[str, Any] | None = None,
+    error: dict[str, Any] | None = None,
+    timing: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    """Construct the one true /run envelope: all seven keys, always present.
+
+    ``run_id`` is never null — it is assigned at request entry, before any
+    rejection can happen.
+    """
+    return RunEnvelope(
+        status=status,
+        run_id=run_id,
+        graph=graph,
+        device=device,
+        outputs=outputs,
+        error=RunError(**error) if error is not None else None,
+        timing=RunTiming(**timing) if timing is not None else None,
+    ).model_dump()
+
+
+def error_response(
+    http_status: int,
+    *,
+    run_id: str,
+    graph: str,
+    code: str,
+    message: str,
+    device: str | None = None,
+    node_id: str | None = None,
+    details: list[Any] | None = None,
+    timing: dict[str, float] | None = None,
+) -> JSONResponse:
+    """An enveloped error; the HTTP status mirrors ``error.code``."""
+    return JSONResponse(
+        status_code=http_status,
+        content=build_envelope(
+            status="error",
+            run_id=run_id,
+            graph=graph,
+            device=device,
+            outputs=None,
+            error={
+                "code": code,
+                "message": message,
+                "node_id": node_id,
+                "details": details,
+            },
+            timing=timing,
+        ),
+    )

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -28,7 +28,12 @@ from ..core import api_contract
 from ..core.api_contract import InputCoercionError, OutputSerializationError
 from ..core.device_utils import resolve_device
 from ..core.execution_context import ExecutionContext
-from ..core.graph_engine import execute_graph, find_entry_points, validate_graph
+from ..core.graph_engine import (
+    GraphValidationError,
+    execute_graph,
+    find_entry_points,
+    validate_graph,
+)
 from ..core.node_registry import registry
 from ..schemas import (
     ContractInputSchema,
@@ -425,18 +430,56 @@ async def run_graph_as_function(name: str, request: Request):
     # 8. Launch as an INDEPENDENT task and await it under a shielded
     #    timeout. The shield means handler cancellation (client disconnect)
     #    never propagates into the run — only the timeout stops a run.
+    # Minimal error capture: remember the last node that reported an error
+    # so execution_error envelopes carry a node_id.
+    last_error_node_id: dict[str, str | None] = {"value": None}
+
+    async def _on_progress(
+        node_id: str, status: str, data: dict[str, Any] | None
+    ) -> None:
+        if status == "error":
+            last_error_node_id["value"] = node_id
+
     t0 = time.monotonic()
     task = asyncio.create_task(execute_graph(
         patched_nodes,
         edges,
+        on_progress=_on_progress,
         context=ctx,
         error_mode="fail_fast",
         run_id=run_id,
     ))
     task.add_done_callback(_retrieve_background_exception)
-    engine_result = await asyncio.wait_for(
-        asyncio.shield(task), timeout=run_req.timeout_s,
-    )
+    try:
+        engine_result = await asyncio.wait_for(
+            asyncio.shield(task), timeout=run_req.timeout_s,
+        )
+    except asyncio.TimeoutError:
+        # 10. Cooperative cancellation: observed at node boundaries only —
+        # the node currently inside run_in_executor finishes in its thread
+        # after this 500 is sent (documented limitation).
+        ctx.cancel()
+        return error_response(500, run_id=run_id, graph=name, code="timeout",
+                              message=f"run exceeded timeout_s={run_req.timeout_s}",
+                              device=device,
+                              timing={"total_s": round(time.monotonic() - t0, 3)})
+    except GraphValidationError as exc:
+        # 9. Runtime safety net: preset expansion can invalidate a
+        # pre-flight-clean graph (pruning-induced missing required input;
+        # trigger-edges-into-preset-nodes dangling after expand_presets).
+        return error_response(409, run_id=run_id, graph=name,
+                              code="invalid_graph",
+                              message="graph failed validation at runtime",
+                              device=device, details=[str(exc)],
+                              timing={"total_s": round(time.monotonic() - t0, 3)})
+    except Exception as exc:  # noqa: BLE001 — never a raw, unenveloped 500
+        # 11. asyncio.CancelledError (client disconnect) is BaseException,
+        # not Exception — it passes through and the shielded run continues.
+        return error_response(500, run_id=run_id, graph=name,
+                              code="execution_error",
+                              message=str(exc), device=device,
+                              node_id=last_error_node_id["value"],
+                              timing={"total_s": round(time.monotonic() - t0, 3)})
     total_s = round(time.monotonic() - t0, 3)
 
     # 12. Collect + serialize declared outputs.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,6 +37,11 @@ class Settings(BaseSettings):
     PORT: int = 8000
     CORS_ORIGINS: list[str] = ["http://localhost:5173", "http://localhost:5174", "http://localhost:3000"]
     MAX_UPLOAD_SIZE: int = 500 * 1024 * 1024  # 500 MB
+    # Cap for POST /api/graph/run/{name} request bodies, checked against
+    # Content-Length before the body is read (-> 413 payload_too_large).
+    # 64 MB comfortably covers a handful of base64 image inputs.
+    # Env-overridable as CODEFYUI_MAX_RUN_BODY_BYTES.
+    MAX_RUN_BODY_BYTES: int = 64 * 1024 * 1024  # 64 MB
 
     NODES_DIR: Path = Path(__file__).parent / "nodes"
     CUSTOM_NODES_DIR: Path = Path(__file__).parent / "custom_nodes"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,6 +44,7 @@ from .api import (
     routes_execution_outputs,
     routes_execution_state,
     routes_graph,
+    routes_graph_run,
     routes_images,
     routes_llm,
     routes_models,
@@ -240,6 +241,7 @@ async def host_guard(request: Request, call_next):
 app.include_router(routes_nodes.router)
 app.include_router(routes_examples.router)
 app.include_router(routes_graph.router)
+app.include_router(routes_graph_run.router)
 app.include_router(routes_presets.router)
 app.include_router(routes_custom_nodes.router)
 app.include_router(routes_plugins.router)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,8 +1,11 @@
 from .models import (
+    ContractInputSchema,
+    ContractOutputSchema,
     CreatePresetRequest,
     EdgeData,
     ExposedParamSchema,
     ExposedPortSchema,
+    GraphContractResponse,
     GraphData,
     GraphValidationResponse,
     InternalEdgeSchema,
@@ -13,13 +16,19 @@ from .models import (
     ParamDefinitionSchema,
     PortDefinitionSchema,
     PresetDefinition,
+    RunEnvelope,
+    RunError,
+    RunTiming,
 )
 
 __all__ = [
+    "ContractInputSchema",
+    "ContractOutputSchema",
     "CreatePresetRequest",
     "EdgeData",
     "ExposedParamSchema",
     "ExposedPortSchema",
+    "GraphContractResponse",
     "GraphData",
     "GraphValidationResponse",
     "InternalEdgeSchema",
@@ -30,4 +39,7 @@ __all__ = [
     "ParamDefinitionSchema",
     "PortDefinitionSchema",
     "PresetDefinition",
+    "RunEnvelope",
+    "RunError",
+    "RunTiming",
 ]

--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -73,6 +73,60 @@ class NodeExecutionStatus(BaseModel):
     data: dict[str, Any] | None = None
 
 
+# ── Graph-as-a-function schemas ─────────────────────────────────
+
+
+class RunError(BaseModel):
+    code: str
+    message: str
+    node_id: str | None = None
+    details: list[Any] | None = None
+
+
+class RunTiming(BaseModel):
+    total_s: float
+
+
+class RunEnvelope(BaseModel):
+    """Response envelope for POST /api/graph/run/{name}.
+
+    Every key is ALWAYS present (null when not applicable); HTTP status
+    mirrors ``status``/``error.code``. Forward compatibility (also stated
+    on the docs page): clients MUST ignore unknown envelope fields, and
+    ``error.code`` is an open enum — treat unknown codes as generic
+    errors. The ``job`` key is reserved by name for the future async mode.
+    """
+
+    status: Literal["ok", "error"]
+    run_id: str
+    graph: str
+    device: str | None = None
+    outputs: dict[str, Any] | None = None
+    error: RunError | None = None
+    timing: RunTiming | None = None
+
+
+class ContractInputSchema(BaseModel):
+    name: str
+    type: str
+    required: bool
+    default: Any = None
+    description: str = ""
+
+
+class ContractOutputSchema(BaseModel):
+    name: str
+    type: str = "ANY"
+    description: str = ""
+
+
+class GraphContractResponse(BaseModel):
+    graph: str
+    inputs: list[ContractInputSchema]
+    outputs: list[ContractOutputSchema]
+    problems: list[str] = []
+
+
 # ── Preset schemas ──────────────────────────────────────────────
 
 class InternalNodeSchema(BaseModel):

--- a/backend/tests/test_api_graph.py
+++ b/backend/tests/test_api_graph.py
@@ -60,3 +60,18 @@ async def test_save_and_load_roundtrip(test_client, sample_graph, tmp_path, monk
     assert resp.status_code == 200
     graphs = resp.json()
     assert any(g["name"] == "test-graph" for g in graphs)
+
+
+def test_sanitize_name_helper():
+    from app.api.routes_graph import _sanitize_name
+
+    assert _sanitize_name("my-graph_2") == "my-graph_2"
+    assert _sanitize_name("a b.c/d") == "a_b_c_d"
+
+
+def test_graph_path_helper(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    from app.api.routes_graph import _graph_path
+
+    p = _graph_path("weird name")
+    assert p == tmp_path / "weird_name.json"

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -30,3 +30,50 @@ def test_max_run_body_bytes_env_override(monkeypatch):
     from app.config import Settings
 
     assert Settings().MAX_RUN_BODY_BYTES == 1024
+
+
+# ── envelope builders ────────────────────────────────────────────────
+
+from app.api.routes_graph_run import build_envelope, error_response  # noqa: E402
+
+
+def test_build_envelope_has_all_keys_with_nulls():
+    env = build_envelope(status="ok", run_id="r1", graph="g", outputs={"y": 1})
+    assert set(env.keys()) == ENVELOPE_KEYS
+    assert env["status"] == "ok"
+    assert env["run_id"] == "r1"
+    assert env["graph"] == "g"
+    assert env["device"] is None
+    assert env["outputs"] == {"y": 1}
+    assert env["error"] is None
+    assert env["timing"] is None
+
+
+def test_error_response_mirrors_status_and_keeps_all_keys():
+    resp = error_response(
+        409, run_id="r2", graph="g", code="invalid_contract",
+        message="broken", details=["p1", "p2"],
+    )
+    assert resp.status_code == 409
+    body = json.loads(resp.body)
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["status"] == "error"
+    assert body["run_id"] == "r2"
+    assert body["outputs"] is None
+    assert body["error"] == {
+        "code": "invalid_contract", "message": "broken",
+        "node_id": None, "details": ["p1", "p2"],
+    }
+    assert body["timing"] is None
+
+
+def test_error_response_carries_device_node_id_timing_when_known():
+    resp = error_response(
+        500, run_id="r3", graph="g", code="execution_error",
+        message="node blew up", device="cpu", node_id="n7",
+        timing={"total_s": 1.02},
+    )
+    body = json.loads(resp.body)
+    assert body["device"] == "cpu"
+    assert body["error"]["node_id"] == "n7"
+    assert body["timing"] == {"total_s": 1.02}

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -677,3 +677,108 @@ async def test_run_403_without_token_is_out_of_envelope():
     body = resp.json()
     assert body == {"detail": "Missing or invalid X-CodefyUI-Token header"}
     assert "run_id" not in body
+
+
+# ── record_outputs + concurrency + disconnect policy ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_outputs_retrievable_by_run_id(test_client):
+    # Store set explicitly — the lifespan does not run under ASGITransport
+    # (pattern: test_routes_execution_outputs.py).
+    app.state.run_output_store = RunOutputStore(max_runs=5)
+    await _save_graph(test_client, _echo_graph(name="recorded"))
+    resp = await test_client.post(
+        "/api/graph/run/recorded",
+        json={"inputs": {"x": "keep me"}, "record_outputs": True},
+    )
+    assert resp.status_code == 200
+    run_id = resp.json()["run_id"]
+
+    listing = await test_client.get(f"/api/execution/outputs/{run_id}")
+    assert listing.status_code == 200
+    entries = listing.json()
+    assert any(e["node_id"] == "out" and e["port"] == "value" for e in entries)
+
+
+@pytest.mark.asyncio
+async def test_record_outputs_without_store_still_succeeds(test_client):
+    # getattr fallback: absent attribute means recording is skipped, not a 500.
+    had_store = hasattr(app.state, "run_output_store")
+    saved = getattr(app.state, "run_output_store", None)
+    if had_store:
+        delattr(app.state, "run_output_store")
+    try:
+        await _save_graph(test_client, _echo_graph(name="no-store"))
+        resp = await test_client.post(
+            "/api/graph/run/no-store",
+            json={"inputs": {"x": "hi"}, "record_outputs": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["outputs"] == {"y": "hi"}
+    finally:
+        if had_store:
+            app.state.run_output_store = saved
+
+
+@pytest.mark.asyncio
+async def test_record_outputs_default_off(test_client):
+    app.state.run_output_store = RunOutputStore(max_runs=5)
+    await _save_graph(test_client, _echo_graph(name="not-recorded"))
+    resp = await test_client.post("/api/graph/run/not-recorded",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 200
+    run_id = resp.json()["run_id"]
+    listing = await test_client.get(f"/api/execution/outputs/{run_id}")
+    assert listing.status_code == 404  # nothing recorded by default
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_are_independent(test_client):
+    await _save_graph(test_client, _echo_graph(name="concurrent"))
+    resp_a, resp_b = await asyncio.gather(
+        test_client.post("/api/graph/run/concurrent",
+                         json={"inputs": {"x": "alpha"}}),
+        test_client.post("/api/graph/run/concurrent",
+                         json={"inputs": {"x": "beta"}}),
+    )
+    assert resp_a.status_code == 200 and resp_b.status_code == 200
+    assert resp_a.json()["outputs"] == {"y": "alpha"}
+    assert resp_b.json()["outputs"] == {"y": "beta"}
+    assert resp_a.json()["run_id"] != resp_b.json()["run_id"]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_does_not_cancel_run(test_client):
+    """Spec-normative disconnect policy: a client disconnect never cancels
+    the run; only the timeout stops a run. Cancelling the client request
+    task mid-run simulates the disconnect; the surviving run is observable
+    through the record_outputs store."""
+    store = RunOutputStore(max_runs=5)
+    app.state.run_output_store = store
+    await _save_graph(test_client, _chain_graph("survives", "_SlowPass",
+                                                {"seconds": 1.0}))
+
+    request_task = asyncio.create_task(test_client.post(
+        "/api/graph/run/survives",
+        json={"inputs": {"x": "still here"}, "record_outputs": True},
+    ))
+    await asyncio.sleep(0.3)   # let the run reach the _SlowPass node
+    request_task.cancel()      # the client drops the connection
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+
+    # The shielded run keeps going: poll the store until the GraphOutput
+    # node's value lands (written only when the run reaches the end).
+    deadline = time.monotonic() + 10.0
+    recorded = None
+    while time.monotonic() < deadline:
+        for run_id in await store.list_runs():
+            value = await store.get(run_id, "out", "value")
+            if value is not None:
+                recorded = value
+                break
+        if recorded is not None:
+            break
+        await asyncio.sleep(0.1)
+    assert recorded == "still here"

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -1,0 +1,32 @@
+"""Tests for POST /api/graph/run/{name} and GET /api/graph/contract/{name}."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import settings
+from app.core.node_base import BaseNode, DataType, PortDefinition
+from app.core.run_output_store import RunOutputStore
+from app.main import app
+
+ENVELOPE_KEYS = {"status", "run_id", "graph", "device", "outputs", "error", "timing"}
+
+
+# ── config: body cap setting ─────────────────────────────────────────────
+
+
+def test_max_run_body_bytes_default():
+    assert settings.MAX_RUN_BODY_BYTES == 64 * 1024 * 1024
+
+
+def test_max_run_body_bytes_env_override(monkeypatch):
+    monkeypatch.setenv("CODEFYUI_MAX_RUN_BODY_BYTES", "1024")
+    from app.config import Settings
+
+    assert Settings().MAX_RUN_BODY_BYTES == 1024

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -77,3 +77,135 @@ def test_error_response_carries_device_node_id_timing_when_known():
     assert body["device"] == "cpu"
     assert body["error"]["node_id"] == "n7"
     assert body["timing"] == {"total_s": 1.02}
+
+
+# ── shared fixtures + graph builders for endpoint tests ──────────────────
+
+
+@pytest.fixture(autouse=True)
+def _graphs_dir(tmp_path, monkeypatch):
+    """Isolate saved graphs per test (pattern: test_api_graph.py)."""
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    return tmp_path
+
+
+def _echo_graph(
+    name: str = "echo-graph",
+    *,
+    input_name: str = "x",
+    output_name: str = "y",
+    input_type: str = "string",
+    required: bool = True,
+    default: str = "",
+) -> dict:
+    """Start -> GraphInput -> GraphOutput; the minimal contract-complete graph."""
+    return {
+        "name": name,
+        "description": "",
+        "nodes": [
+            {"id": "start", "type": "Start", "position": {"x": 0, "y": 0},
+             "data": {"params": {}}},
+            {"id": "gi", "type": "GraphInput", "position": {"x": 200, "y": 0},
+             "data": {"params": {
+                 "name": input_name, "type": input_type, "required": required,
+                 "default": default, "description": "",
+             }}},
+            {"id": "out", "type": "GraphOutput", "position": {"x": 400, "y": 0},
+             "data": {"params": {"name": output_name, "description": ""}}},
+        ],
+        "edges": [
+            {"id": "t1", "source": "start", "target": "gi",
+             "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+            {"id": "d1", "source": "gi", "target": "out",
+             "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        ],
+    }
+
+
+async def _save_graph(client, graph: dict) -> None:
+    resp = await client.post("/api/graph/save", json=graph)
+    assert resp.status_code == 200, resp.text
+
+
+# ── GET /api/graph/contract/{name} ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_contract_endpoint_schema(test_client):
+    graph = _echo_graph(name="contract-demo")
+    # A typed source gives output type derivation a real port to follow:
+    # TextInput.text is STRING.
+    graph["nodes"].append({"id": "ti", "type": "TextInput",
+                           "position": {"x": 0, "y": 200},
+                           "data": {"params": {"value": "hi"}}})
+    graph["nodes"].append({"id": "out2", "type": "GraphOutput",
+                           "position": {"x": 400, "y": 200},
+                           "data": {"params": {"name": "text_out", "description": ""}}})
+    graph["edges"].append({"id": "t2", "source": "start", "target": "ti",
+                           "sourceHandle": "trigger", "targetHandle": "",
+                           "type": "trigger"})
+    graph["edges"].append({"id": "d2", "source": "ti", "target": "out2",
+                           "sourceHandle": "text", "targetHandle": "value",
+                           "type": "data"})
+    await _save_graph(test_client, graph)
+
+    resp = await test_client.get("/api/graph/contract/contract-demo")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["graph"] == "contract-demo"
+    assert body["problems"] == []
+    # default is null for required inputs — never advertise a default the
+    # API will not apply.
+    assert body["inputs"] == [
+        {"name": "x", "type": "string", "required": True,
+         "default": None, "description": ""},
+    ]
+    by_name = {o["name"]: o for o in body["outputs"]}
+    assert by_name["y"]["type"] == "ANY"            # fed by GraphInput's ANY port
+    assert by_name["text_out"]["type"] == "STRING"  # derived from TextInput.text
+
+
+@pytest.mark.asyncio
+async def test_contract_optional_default_parsed(test_client):
+    await _save_graph(test_client, _echo_graph(
+        name="contract-optional", input_type="number",
+        required=False, default="2.5",
+    ))
+    resp = await test_client.get("/api/graph/contract/contract-optional")
+    body = resp.json()
+    assert body["inputs"][0]["required"] is False
+    assert body["inputs"][0]["default"] == 2.5
+
+
+@pytest.mark.asyncio
+async def test_contract_reports_problems_nonfatally(test_client):
+    await _save_graph(test_client, _echo_graph(
+        name="contract-broken", input_name="has space",
+    ))
+    resp = await test_client.get("/api/graph/contract/contract-broken")
+    assert resp.status_code == 200  # problems are reported here, enforced at /run
+    assert any("is invalid" in p for p in resp.json()["problems"])
+
+
+@pytest.mark.asyncio
+async def test_contract_unconnected_output_is_any_plus_problem(test_client):
+    graph = _echo_graph(name="contract-dangling")
+    graph["edges"] = [e for e in graph["edges"] if e["id"] != "d1"]  # cut gi->out
+    await _save_graph(test_client, graph)
+    resp = await test_client.get("/api/graph/contract/contract-dangling")
+    body = resp.json()
+    assert body["outputs"][0]["type"] == "ANY"
+    assert any("no incoming connection" in p for p in body["problems"])
+
+
+@pytest.mark.asyncio
+async def test_contract_404_missing_and_strict_name(test_client, _graphs_dir):
+    resp = await test_client.get("/api/graph/contract/never-saved")
+    assert resp.status_code == 404
+    # Strict name: the file exists under the SANITIZED name, but the raw
+    # name mismatches -> 404, never alias to a different file.
+    await _save_graph(test_client, _echo_graph(name="strict.name"))
+    assert (_graphs_dir / "strict_name.json").exists()
+    resp = await test_client.get("/api/graph/contract/strict.name")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Graph 'strict.name' not found"}

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -209,3 +209,84 @@ async def test_contract_404_missing_and_strict_name(test_client, _graphs_dir):
     resp = await test_client.get("/api/graph/contract/strict.name")
     assert resp.status_code == 404
     assert resp.json() == {"detail": "Graph 'strict.name' not found"}
+
+
+# ── POST /api/graph/run/{name}: happy path ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_happy_path_all_envelope_keys(test_client):
+    await _save_graph(test_client, _echo_graph(name="run-echo"))
+    resp = await test_client.post("/api/graph/run/run-echo",
+                                  json={"inputs": {"x": "hello"}})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["status"] == "ok"
+    assert body["run_id"]  # non-null, non-empty
+    assert body["graph"] == "run-echo"
+    assert body["device"] == "cpu"  # resolve_device(None) echo
+    assert body["outputs"] == {"y": "hello"}
+    assert body["error"] is None
+    assert body["timing"]["total_s"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_run_body_optional_uses_default(test_client):
+    await _save_graph(test_client, _echo_graph(
+        name="run-default", required=False, default="fallback",
+    ))
+    resp = await test_client.post("/api/graph/run/run-default")  # no body at all
+    assert resp.status_code == 200
+    assert resp.json()["outputs"] == {"y": "fallback"}
+
+
+@pytest.mark.asyncio
+async def test_run_empty_json_body_equals_absent_body(test_client):
+    await _save_graph(test_client, _echo_graph(
+        name="run-empty", required=False, default="fallback",
+    ))
+    resp = await test_client.post("/api/graph/run/run-empty", json={})
+    assert resp.status_code == 200
+    assert resp.json()["outputs"] == {"y": "fallback"}
+
+
+@pytest.mark.asyncio
+async def test_run_device_echo(test_client):
+    await _save_graph(test_client, _echo_graph(name="run-device"))
+    resp = await test_client.post("/api/graph/run/run-device",
+                                  json={"inputs": {"x": "hi"}, "device": "cpu"})
+    assert resp.status_code == 200
+    assert resp.json()["device"] == "cpu"
+
+
+@pytest.mark.asyncio
+async def test_run_typed_inputs_roundtrip(test_client):
+    cases = [
+        ("run-num", "number", 3, 3.0),
+        ("run-int", "integer", 3.0, 3),
+        ("run-bool", "boolean", True, True),
+        ("run-json", "json", {"k": [1, 2]}, {"k": [1, 2]}),
+    ]
+    for graph_name, input_type, sent, expected in cases:
+        await _save_graph(test_client, _echo_graph(
+            name=graph_name, input_type=input_type,
+        ))
+        resp = await test_client.post(f"/api/graph/run/{graph_name}",
+                                      json={"inputs": {"x": sent}})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["outputs"] == {"y": expected}
+
+
+@pytest.mark.asyncio
+async def test_run_content_type_not_used_for_dispatch(test_client):
+    # A valid JSON body with a wrong Content-Type header still parses
+    # (behavior pinned by the spec).
+    await _save_graph(test_client, _echo_graph(name="run-ctype"))
+    resp = await test_client.post(
+        "/api/graph/run/run-ctype",
+        content=b'{"inputs": {"x": "hi"}}',
+        headers={"Content-Type": "text/plain"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["outputs"] == {"y": "hi"}

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -290,3 +290,390 @@ async def test_run_content_type_not_used_for_dispatch(test_client):
     )
     assert resp.status_code == 200
     assert resp.json()["outputs"] == {"y": "hi"}
+
+
+# ── test-support nodes (registered directly, conftest _TestSource pattern) ─
+
+
+class _SlowPassNode(BaseNode):
+    """Sleeps `seconds` in the executor thread, then passes value through."""
+
+    NODE_NAME = "_SlowPass"
+    CATEGORY = "Test"
+    DESCRIPTION = "Sleeps, then passes through"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        time.sleep(float(params.get("seconds", 2.0)))
+        return {"value": inputs.get("value")}
+
+
+class _BoomNode(BaseNode):
+    """Raises on execute — drives the execution_error taxonomy row."""
+
+    NODE_NAME = "_Boom"
+    CATEGORY = "Test"
+    DESCRIPTION = "Raises RuntimeError"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("boom: intentional test failure")
+
+
+class _OpaqueNode(BaseNode):
+    """Emits a non-serializable object — drives unserializable_output."""
+
+    NODE_NAME = "_Opaque"
+    CATEGORY = "Test"
+    DESCRIPTION = "Emits object()"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        return {"value": object()}
+
+
+class _BigTensorNode(BaseNode):
+    """Emits a 65,537-element tensor — drives output_too_large."""
+
+    NODE_NAME = "_BigTensor"
+    CATEGORY = "Test"
+    DESCRIPTION = "Emits a tensor over the serialization cap"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        import torch
+
+        return {"value": torch.zeros(65537)}
+
+
+@pytest.fixture(autouse=True)
+def _register_test_nodes():
+    """Same direct-injection pattern conftest uses for _TestSource."""
+    from app.core.node_registry import registry
+
+    registry._nodes["_SlowPass"] = _SlowPassNode
+    registry._nodes["_Boom"] = _BoomNode
+    registry._nodes["_Opaque"] = _OpaqueNode
+    registry._nodes["_BigTensor"] = _BigTensorNode
+    yield
+
+
+def _chain_graph(name: str, middle_type: str,
+                 middle_params: dict | None = None) -> dict:
+    """Start -> GraphInput -> <middle> -> GraphOutput."""
+    g = _echo_graph(name=name)
+    g["nodes"].insert(2, {"id": "mid", "type": middle_type,
+                          "position": {"x": 300, "y": 0},
+                          "data": {"params": middle_params or {}}})
+    g["edges"] = [
+        {"id": "t1", "source": "start", "target": "gi",
+         "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+        {"id": "d1", "source": "gi", "target": "mid",
+         "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        {"id": "d2", "source": "mid", "target": "out",
+         "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+    ]
+    return g
+
+
+# ── POST /run error taxonomy ─────────────────────────────────────────────
+
+from app.core.graph_engine import GraphValidationError  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_run_404_missing_graph(test_client):
+    resp = await test_client.post("/api/graph/run/never-saved", json={})
+    assert resp.status_code == 404
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "graph_not_found"
+    assert body["run_id"]                    # never null, even on rejections
+    assert body["device"] is None            # rejected before device resolution
+    assert body["timing"] is None            # execution never attempted
+
+
+@pytest.mark.asyncio
+async def test_run_404_strict_name(test_client, _graphs_dir):
+    # The file exists under the SANITIZED name; the raw name mismatches.
+    await _save_graph(test_client, _echo_graph(name="strict.run"))
+    assert (_graphs_dir / "strict_run.json").exists()
+    resp = await test_client.post("/api/graph/run/strict.run",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "graph_not_found"
+
+
+@pytest.mark.asyncio
+async def test_run_500_graph_unreadable(test_client, _graphs_dir):
+    (_graphs_dir / "corrupt.json").write_text("{not json")
+    resp = await test_client.post("/api/graph/run/corrupt", json={})
+    assert resp.status_code == 500
+    assert resp.json()["error"]["code"] == "graph_unreadable"
+
+
+@pytest.mark.asyncio
+async def test_run_409_invalid_contract(test_client):
+    await test_client.post("/api/graph/save",
+                           json=_echo_graph(name="bad-contract",
+                                            input_name="has space"))
+    resp = await test_client.post("/api/graph/run/bad-contract", json={})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_contract"
+    assert any("is invalid" in d for d in body["error"]["details"])
+
+
+@pytest.mark.asyncio
+async def test_run_409_no_entry_points(test_client):
+    graph = _echo_graph(name="no-entry")
+    graph["nodes"] = [n for n in graph["nodes"] if n["type"] != "Start"]
+    graph["edges"] = [e for e in graph["edges"] if e["type"] != "trigger"]
+    await _save_graph(test_client, graph)
+    resp = await test_client.post("/api/graph/run/no-entry", json={})
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "no_entry_points"
+
+
+@pytest.mark.asyncio
+async def test_run_409_untriggered_input(test_client):
+    graph = _echo_graph(name="untriggered")
+    # Retarget the trigger away from the GraphInput to a bystander node.
+    graph["nodes"].append({"id": "src", "type": "_TestSource",
+                           "position": {"x": 0, "y": 200},
+                           "data": {"params": {}}})
+    graph["edges"][0]["target"] = "src"
+    await _save_graph(test_client, graph)
+    resp = await test_client.post("/api/graph/run/untriggered",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "untriggered_input"
+    assert body["error"]["details"] == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_run_409_unreachable_output(test_client):
+    graph = _echo_graph(name="unreachable")
+    graph["nodes"].append({"id": "src2", "type": "_TestSource",
+                           "position": {"x": 0, "y": 200},
+                           "data": {"params": {}}})
+    graph["nodes"].append({"id": "out2", "type": "GraphOutput",
+                           "position": {"x": 400, "y": 200},
+                           "data": {"params": {"name": "y2", "description": ""}}})
+    graph["edges"].append({"id": "d9", "source": "src2", "target": "out2",
+                           "sourceHandle": "value", "targetHandle": "value",
+                           "type": "data"})
+    await _save_graph(test_client, graph)
+    resp = await test_client.post("/api/graph/run/unreachable",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "unreachable_output"
+    assert body["error"]["details"] == ["y2"]
+
+
+@pytest.mark.asyncio
+async def test_run_409_invalid_graph_static(test_client):
+    graph = _echo_graph(name="bad-port")
+    graph["nodes"].append({"id": "pr", "type": "Print",
+                           "position": {"x": 300, "y": 200},
+                           "data": {"params": {}}})
+    graph["edges"].append({"id": "d8", "source": "gi", "target": "pr",
+                           "sourceHandle": "value", "targetHandle": "bogus",
+                           "type": "data"})
+    await _save_graph(test_client, graph)
+    resp = await test_client.post("/api/graph/run/bad-port",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_graph"
+    assert any("bogus" in d for d in body["error"]["details"])
+
+
+@pytest.mark.asyncio
+async def test_run_409_runtime_graph_validation_error_safety_net(
+    test_client, monkeypatch,
+):
+    await _save_graph(test_client, _echo_graph(name="runtime-gve"))
+
+    async def _boom(*args, **kwargs):
+        raise GraphValidationError("preset trigger edge dangling after expansion")
+
+    monkeypatch.setattr("app.api.routes_graph_run.execute_graph", _boom)
+    resp = await test_client.post("/api/graph/run/runtime-gve",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_graph"
+    assert body["error"]["details"] == [
+        "preset trigger edge dangling after expansion",
+    ]
+    assert body["timing"] is not None  # execution WAS attempted
+
+
+@pytest.mark.asyncio
+async def test_run_422_input_errors_aggregated(test_client):
+    await _save_graph(test_client, _echo_graph(name="agg-errors",
+                                               input_type="number"))
+    resp = await test_client.post("/api/graph/run/agg-errors",
+                                  json={"inputs": {"x": "NaN-ish", "typo": 1}})
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_input"
+    by_input = {d["input"]: d["reason"] for d in body["error"]["details"]}
+    assert by_input["typo"] == "unknown input name"
+    assert "expected number" in by_input["x"]
+
+
+@pytest.mark.asyncio
+async def test_run_422_missing_required(test_client):
+    await _save_graph(test_client, _echo_graph(name="missing-req"))
+    resp = await test_client.post("/api/graph/run/missing-req", json={})
+    assert resp.status_code == 422
+    assert resp.json()["error"]["details"] == [
+        {"input": "x", "reason": "missing required input"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_422_malformed_bodies(test_client):
+    await _save_graph(test_client, _echo_graph(name="malformed"))
+    # Bad JSON.
+    resp = await test_client.post("/api/graph/run/malformed",
+                                  content=b"{not json",
+                                  headers={"Content-Type": "application/json"})
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "invalid_input"
+    # Non-dict body.
+    resp = await test_client.post("/api/graph/run/malformed", json=[1, 2])
+    assert resp.status_code == 422
+    assert any(d["field"] == "body" for d in resp.json()["error"]["details"])
+    # Non-dict inputs.
+    resp = await test_client.post("/api/graph/run/malformed",
+                                  json={"inputs": [1]})
+    assert resp.status_code == 422
+    assert any(d["field"] == "inputs" for d in resp.json()["error"]["details"])
+    # Wrong-typed / out-of-range fields.
+    for bad in ({"timeout_s": "fast"}, {"timeout_s": 0}, {"timeout_s": 5000},
+                {"timeout_s": True}, {"device": 3}, {"record_outputs": "yes"}):
+        resp = await test_client.post("/api/graph/run/malformed", json=bad)
+        assert resp.status_code == 422, bad
+        assert resp.json()["error"]["code"] == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_run_413_payload_too_large(test_client, monkeypatch):
+    await _save_graph(test_client, _echo_graph(name="too-big"))
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 16)
+    resp = await test_client.post("/api/graph/run/too-big",
+                                  json={"inputs": {"x": "0123456789abcdef0123"}})
+    assert resp.status_code == 413
+    assert resp.json()["error"]["code"] == "payload_too_large"
+
+
+@pytest.mark.asyncio
+async def test_run_500_execution_error_carries_node_id(test_client):
+    await _save_graph(test_client, _chain_graph("boom-graph", "_Boom"))
+    resp = await test_client.post("/api/graph/run/boom-graph",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["error"]["code"] == "execution_error"
+    assert body["error"]["node_id"] == "mid"
+    assert "boom: intentional test failure" in body["error"]["message"]
+    assert body["timing"] is not None
+
+
+@pytest.mark.asyncio
+async def test_run_500_timeout(test_client):
+    await _save_graph(test_client, _chain_graph("slow-graph", "_SlowPass",
+                                                {"seconds": 3.0}))
+    resp = await test_client.post("/api/graph/run/slow-graph",
+                                  json={"inputs": {"x": "hi"}, "timeout_s": 1})
+    assert resp.status_code == 500  # never 504 — 504 belongs to intermediaries
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "timeout"
+    assert body["timing"]["total_s"] >= 0.9
+    # The in-flight executor thread finishes in the background (documented
+    # limitation); nothing further to assert here.
+
+
+@pytest.mark.asyncio
+async def test_run_500_output_not_produced_safety_net(test_client, monkeypatch):
+    await _save_graph(test_client, _echo_graph(name="net-missing"))
+    monkeypatch.setattr("app.core.api_contract.collect_outputs",
+                        lambda contract, result: ({}, ["y"]))
+    resp = await test_client.post("/api/graph/run/net-missing",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["error"]["code"] == "output_not_produced"
+    assert body["error"]["details"] == ["y"]
+
+
+@pytest.mark.asyncio
+async def test_run_500_unserializable_output(test_client):
+    await _save_graph(test_client, _chain_graph("opaque-graph", "_Opaque"))
+    resp = await test_client.post("/api/graph/run/opaque-graph",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["error"]["code"] == "unserializable_output"
+    assert body["error"]["details"][0]["output"] == "y"
+
+
+@pytest.mark.asyncio
+async def test_run_500_output_too_large(test_client):
+    await _save_graph(test_client, _chain_graph("big-graph", "_BigTensor"))
+    resp = await test_client.post("/api/graph/run/big-graph",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["error"]["code"] == "output_too_large"
+    assert "65537" in body["error"]["details"][0]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_run_403_without_token_is_out_of_envelope():
+    # The auth middleware fires before the route; its 403 does NOT carry
+    # the envelope (documented out-of-envelope response).
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url=f"http://127.0.0.1:{settings.PORT}") as anon:
+        resp = await anon.post("/api/graph/run/anything", json={})
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body == {"detail": "Missing or invalid X-CodefyUI-Token header"}
+    assert "run_id" not in body


### PR DESCRIPTION
## Summary

PR 2 of 3 for Graph-as-a-Function Stage 1 (spec: `docs/superpowers/specs/2026-07-02-graph-as-a-function-stage1.md`). **Stacked on PR 1** (`feat/graph-io-contract`) — retarget this PR's base to `main` after PR 1 merges.

- New router `backend/app/api/routes_graph_run.py` (shares the `/api/graph` prefix; run/serialization logic stays out of the CRUD file):
  - `POST /api/graph/run/{name}` — headless execution. `run_id` assigned at request entry; Content-Length checked against the new `MAX_RUN_BODY_BYTES` setting (64 MB, `CODEFYUI_` overridable) before the body is read; strict-name 404; in-handler body parse so FastAPI's `RequestValidationError` can never bypass the envelope; five-stage 409 pre-flight (contract problems, entry points, untriggered GraphInputs, unreachable GraphOutputs, `validate_graph`); RAW-value injection; fresh per-request `ExecutionContext(weights_persistent=False)`; run launched as an INDEPENDENT task under `asyncio.wait_for(asyncio.shield(task))`.
  - `GET /api/graph/contract/{name}` — derived schema; `default: null` for required inputs; output types derived from the upstream port via `define_outputs_dynamic`; problems reported non-fatally.
- One 7-key envelope for every /run response (all keys always present; `run_id` never null); HTTP mirrors `error.code`; timeout is HTTP 500 (never 504). Clients MUST ignore unknown envelope fields; `error.code` is an open enum.
- Disconnect policy (spec-normative, tested): a client disconnect never cancels execution — only the timeout stops a run; results are discarded unless `record_outputs=true`.
- `record_outputs=true` writes into the app `RunOutputStore` (getattr fallback when absent); readable via `GET /api/execution/outputs/{run_id}`.
- `_graph_path`/`_sanitize_name` extracted in `routes_graph.py` (save/load behavior unchanged, round-trip test still green).

## Test plan

- [x] `uv run pytest tests/test_api_graph_run.py -v` — happy paths, every error-taxonomy row (404 strict-name, 500 graph_unreadable, 409 x5 incl. the runtime GraphValidationError safety net, aggregated 422 incl. malformed bodies, 413, 500 execution_error with node_id, 500 timeout with elapsed timing, output safety nets), auth-403 out-of-envelope, concurrency (asyncio.gather x2), disconnect-continues
- [x] `uv run pytest -q` full suite green: 1453 passed / 8 skipped
- [x] Manual Windows end-to-end against a real uvicorn server (port 8017, isolated `CODEFYUI_USER_DATA_DIR`, token file): saved an echo graph via `POST /api/graph/save`; `GET /contract` returned the derived schema with `"default": null`; `POST /run` via `curl.exe --data @file` returned `{"status":"ok","outputs":{"y":"hello from curl"},...}` with all seven envelope keys; same via Python `requests` (`hello from python`); `POST /run/no-such` returned the enveloped 404 `graph_not_found` (with `run_id`); tokenless POST returned the documented out-of-envelope 403 `{"detail": ...}`.

Zero frontend files changed. No new pip dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
