### PR TITLE
feat(graph-fn): land PR 2/3 + 3/3 content on main (stacked-merge consolidation)

### DIFF
--- a/backend/app/api/routes_graph.py
+++ b/backend/app/api/routes_graph.py
@@ -11,6 +11,16 @@ from ..schemas import GraphData, GraphValidationResponse
 router = APIRouter(prefix="/api/graph", tags=["graph"])
 
 
+def _sanitize_name(name: str) -> str:
+    """Filesystem-safe graph name: every char outside [alnum, '-', '_'] -> '_'."""
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+
+
+def _graph_path(name: str) -> Path:
+    """Resolve a graph name to its on-disk JSON path under GRAPHS_DIR."""
+    return settings.GRAPHS_DIR / f"{_sanitize_name(name)}.json"
+
+
 @router.post("/validate", response_model=GraphValidationResponse)
 async def validate(graph: GraphData):
     nodes = [n.model_dump() for n in graph.nodes]
@@ -22,16 +32,14 @@ async def validate(graph: GraphData):
 @router.post("/save")
 async def save_graph(graph: GraphData):
     settings.GRAPHS_DIR.mkdir(parents=True, exist_ok=True)
-    safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in graph.name)
-    path = settings.GRAPHS_DIR / f"{safe_name}.json"
+    path = _graph_path(graph.name)
     path.write_text(json.dumps(graph.model_dump(), indent=2))
     return {"message": "Graph saved", "path": str(path)}
 
 
 @router.get("/load/{name}")
 async def load_graph(name: str):
-    safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
-    path = settings.GRAPHS_DIR / f"{safe_name}.json"
+    path = _graph_path(name)
     if not path.exists():
         raise HTTPException(status_code=404, detail=f"Graph '{name}' not found")
     data = json.loads(path.read_text())

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -12,14 +12,23 @@ file. POST is auto-covered by the X-CodefyUI-Token middleware.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
+import time
+from dataclasses import dataclass, field
 from typing import Any
+from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from ..config import settings
 from ..core import api_contract
-from ..core.api_contract import InputCoercionError
+from ..core.api_contract import InputCoercionError, OutputSerializationError
+from ..core.device_utils import resolve_device
+from ..core.execution_context import ExecutionContext
+from ..core.graph_engine import execute_graph, find_entry_points, validate_graph
 from ..core.node_registry import registry
 from ..schemas import (
     ContractInputSchema,
@@ -30,6 +39,8 @@ from ..schemas import (
     RunTiming,
 )
 from .routes_graph import _graph_path, _sanitize_name
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/graph", tags=["graph-run"])
 
@@ -198,3 +209,268 @@ async def get_contract(name: str):
     return GraphContractResponse(
         graph=name, inputs=inputs, outputs=outputs, problems=problems,
     )
+
+
+@dataclass
+class _RunRequest:
+    """Validated fields of the OPTIONAL /run body (absent body == {})."""
+
+    inputs: dict[str, Any] = field(default_factory=dict)
+    timeout_s: float = 300.0
+    device: str | None = None
+    record_outputs: bool = False
+
+
+def _parse_run_body(raw: bytes) -> tuple[_RunRequest, list[dict[str, str]]]:
+    """Manual in-handler body parse.
+
+    Malformed JSON, a non-dict body, a non-dict ``inputs``, or wrong-typed
+    ``timeout_s``/``device``/``record_outputs`` all yield enveloped 422
+    field errors — FastAPI's ``RequestValidationError`` can never bypass
+    the envelope. The Content-Type header is not used for dispatch.
+    Unknown body fields are ignored (forward compatibility).
+    """
+    req = _RunRequest()
+    if not raw or not raw.strip():
+        return req, []
+    try:
+        body = json.loads(raw)
+    except (ValueError, UnicodeDecodeError):
+        return req, [{"field": "body", "reason": "body is not valid JSON"}]
+    if not isinstance(body, dict):
+        return req, [{
+            "field": "body",
+            "reason": (
+                f"body must be a JSON object, got {api_contract.json_type_name(body)}"
+            ),
+        }]
+
+    errors: list[dict[str, str]] = []
+
+    inputs = body.get("inputs", {})
+    if isinstance(inputs, dict):
+        req.inputs = inputs
+    else:
+        errors.append({
+            "field": "inputs",
+            "reason": f"expected object, got {api_contract.json_type_name(inputs)}",
+        })
+
+    timeout_s = body.get("timeout_s", 300)
+    if isinstance(timeout_s, bool) or not isinstance(timeout_s, (int, float)):
+        errors.append({
+            "field": "timeout_s",
+            "reason": f"expected number, got {api_contract.json_type_name(timeout_s)}",
+        })
+    elif not (1 <= timeout_s <= 3600):
+        errors.append({
+            "field": "timeout_s",
+            "reason": f"must be between 1 and 3600, got {timeout_s}",
+        })
+    else:
+        req.timeout_s = float(timeout_s)
+
+    device = body.get("device")
+    if device is not None and not isinstance(device, str):
+        errors.append({
+            "field": "device",
+            "reason": f"expected string, got {api_contract.json_type_name(device)}",
+        })
+    else:
+        req.device = device
+
+    record_outputs = body.get("record_outputs", False)
+    if not isinstance(record_outputs, bool):
+        errors.append({
+            "field": "record_outputs",
+            "reason": (
+                f"expected boolean, got {api_contract.json_type_name(record_outputs)}"
+            ),
+        })
+    else:
+        req.record_outputs = record_outputs
+
+    return req, errors
+
+
+def _retrieve_background_exception(task: asyncio.Task) -> None:
+    """Consume a background run's exception.
+
+    After a timeout (or client disconnect) the shielded task keeps running;
+    without this done-callback asyncio would log 'Task exception was never
+    retrieved' when it eventually fails.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.debug("background graph run ended with error after response: %s", exc)
+
+
+@router.post("/run/{name}")
+async def run_graph_as_function(name: str, request: Request):
+    """Execute a saved graph as a named function: declared inputs in,
+    declared outputs out. Every response uses the 7-key envelope."""
+    # 1. run_id at request entry — every envelope carries it, including
+    #    pre-flight rejections.
+    run_id = uuid4().hex
+
+    # 2. Body size cap, checked against Content-Length BEFORE reading the body.
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            declared_bytes = int(content_length)
+        except ValueError:
+            declared_bytes = 0
+        if declared_bytes > settings.MAX_RUN_BODY_BYTES:
+            return error_response(
+                413, run_id=run_id, graph=name, code="payload_too_large",
+                message=(
+                    f"request body is {declared_bytes} bytes "
+                    f"(max {settings.MAX_RUN_BODY_BYTES})"
+                ),
+            )
+
+    # 3. Strict name matching: execute exactly what was named, or nothing.
+    if _sanitize_name(name) != name:
+        return error_response(404, run_id=run_id, graph=name,
+                              code="graph_not_found",
+                              message=f"Graph '{name}' not found")
+    path = _graph_path(name)
+    if not path.exists():
+        return error_response(404, run_id=run_id, graph=name,
+                              code="graph_not_found",
+                              message=f"Graph '{name}' not found")
+    try:
+        graph_data = json.loads(path.read_text())
+    except (ValueError, OSError):
+        return error_response(500, run_id=run_id, graph=name,
+                              code="graph_unreadable",
+                              message=(
+                                  f"Graph file for '{name}' exists but is not "
+                                  "valid JSON"
+                              ))
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+
+    # 4. Parse + validate the body in-handler (enveloped 422).
+    raw_body = await request.body()
+    run_req, field_errors = _parse_run_body(raw_body)
+    if field_errors:
+        return error_response(422, run_id=run_id, graph=name,
+                              code="invalid_input",
+                              message="invalid request body",
+                              details=field_errors)
+
+    # 5. Pre-flight on the raw graph — nobody pays for a full execution to
+    #    learn about mis-wiring.
+    contract = api_contract.derive_contract(nodes)
+    if contract.problems:
+        return error_response(409, run_id=run_id, graph=name,
+                              code="invalid_contract",
+                              message="graph I/O contract has problems",
+                              details=contract.problems)
+    if not find_entry_points(nodes, edges):
+        return error_response(409, run_id=run_id, graph=name,
+                              code="no_entry_points",
+                              message=(
+                                  "graph has no entry points — wire a Start "
+                                  "node into every GraphInput"
+                              ))
+    wiring = api_contract.check_wiring(nodes, edges, contract)
+    if wiring.untriggered:
+        return error_response(409, run_id=run_id, graph=name,
+                              code="untriggered_input",
+                              message=(
+                                  "GraphInput node(s) have no incoming trigger "
+                                  "edge — wire Start into every GraphInput"
+                              ),
+                              details=wiring.untriggered)
+    if wiring.unreachable:
+        return error_response(409, run_id=run_id, graph=name,
+                              code="unreachable_output",
+                              message=(
+                                  "GraphOutput node(s) are not reachable from "
+                                  "any entry point"
+                              ),
+                              details=wiring.unreachable)
+    validation_errors = validate_graph(nodes, edges)
+    if validation_errors:
+        return error_response(409, run_id=run_id, graph=name,
+                              code="invalid_graph",
+                              message="graph failed validation",
+                              details=validation_errors)
+
+    # 6. Inject the RAW request values; each GraphInput's execute() coerces.
+    patched_nodes, input_errors = api_contract.inject_inputs(
+        nodes, contract, run_req.inputs,
+    )
+    if input_errors:
+        return error_response(422, run_id=run_id, graph=name,
+                              code="invalid_input",
+                              message="invalid inputs",
+                              details=input_errors)
+
+    # 7. Fresh per-request context: with persistence off the stateful mixin
+    #    rebuilds modules per call, so concurrent requests share no mutable
+    #    state; the app-global stores are simply not used.
+    device = resolve_device(run_req.device)
+    ctx = ExecutionContext(
+        device=device,
+        weights_persistent=False,
+        node_state_store=None,
+        graph_id=f"api:{name}",
+    )
+
+    # 8. Launch as an INDEPENDENT task and await it under a shielded
+    #    timeout. The shield means handler cancellation (client disconnect)
+    #    never propagates into the run — only the timeout stops a run.
+    t0 = time.monotonic()
+    task = asyncio.create_task(execute_graph(
+        patched_nodes,
+        edges,
+        context=ctx,
+        error_mode="fail_fast",
+        run_id=run_id,
+    ))
+    task.add_done_callback(_retrieve_background_exception)
+    engine_result = await asyncio.wait_for(
+        asyncio.shield(task), timeout=run_req.timeout_s,
+    )
+    total_s = round(time.monotonic() - t0, 3)
+
+    # 12. Collect + serialize declared outputs.
+    collected, missing = api_contract.collect_outputs(contract, engine_result)
+    if missing:
+        return error_response(500, run_id=run_id, graph=name,
+                              code="output_not_produced",
+                              message=(
+                                  "declared output(s) missing from the engine "
+                                  "result: " + ", ".join(missing)
+                              ),
+                              device=device, details=missing,
+                              timing={"total_s": total_s})
+    outputs_json: dict[str, Any] = {}
+    serialization_errors: list[dict[str, str]] = []
+    serialization_code = "unserializable_output"
+    for output_name, value in collected.items():
+        try:
+            outputs_json[output_name] = api_contract.serialize_output(value)
+        except OutputSerializationError as exc:
+            serialization_errors.append(
+                {"output": output_name, "reason": exc.reason}
+            )
+            if exc.code == "output_too_large":
+                # When both kinds occur, the size violation names the code —
+                # deterministic and the more actionable of the two.
+                serialization_code = "output_too_large"
+    if serialization_errors:
+        return error_response(500, run_id=run_id, graph=name,
+                              code=serialization_code,
+                              message="output serialization failed",
+                              device=device, details=serialization_errors,
+                              timing={"total_s": total_s})
+
+    return build_envelope(status="ok", run_id=run_id, graph=name, device=device,
+                          outputs=outputs_json, error=None,
+                          timing={"total_s": total_s})

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -426,6 +426,12 @@ async def run_graph_as_function(name: str, request: Request):
         node_state_store=None,
         graph_id=f"api:{name}",
     )
+    output_store = None
+    if run_req.record_outputs:
+        # The lifespan does not run under httpx ASGITransport, so the
+        # attribute may be absent — recording is then silently skipped
+        # (ws_execution.py getattr precedent).
+        output_store = getattr(request.app.state, "run_output_store", None)
 
     # 8. Launch as an INDEPENDENT task and await it under a shielded
     #    timeout. The shield means handler cancellation (client disconnect)
@@ -448,6 +454,8 @@ async def run_graph_as_function(name: str, request: Request):
         context=ctx,
         error_mode="fail_fast",
         run_id=run_id,
+        output_store=output_store,
+        record_outputs=run_req.record_outputs and output_store is not None,
     ))
     task.add_done_callback(_retrieve_background_exception)
     try:

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -12,12 +12,24 @@ file. POST is auto-covered by the X-CodefyUI-Token middleware.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 
-from ..schemas import RunEnvelope, RunError, RunTiming
+from ..core import api_contract
+from ..core.api_contract import InputCoercionError
+from ..core.node_registry import registry
+from ..schemas import (
+    ContractInputSchema,
+    ContractOutputSchema,
+    GraphContractResponse,
+    RunEnvelope,
+    RunError,
+    RunTiming,
+)
+from .routes_graph import _graph_path, _sanitize_name
 
 router = APIRouter(prefix="/api/graph", tags=["graph-run"])
 
@@ -77,4 +89,112 @@ def error_response(
             },
             timing=timing,
         ),
+    )
+
+
+def _derive_output_type(
+    node_id: str, nodes: list[dict], edges: list[dict]
+) -> tuple[str, str | None]:
+    """Resolve a GraphOutput's advertised type from its incoming data edge.
+
+    Same lookup the validator does: source node class ->
+    ``define_outputs_dynamic(params)`` -> port ``data_type``. Returns
+    ``(type_label, problem)``; unresolvable outputs advertise ``"ANY"``
+    plus a problem entry.
+    """
+    incoming = [
+        e
+        for e in edges
+        if e.get("target") == node_id
+        and e.get("targetHandle", "") == "value"
+        and e.get("type", "data") == "data"
+    ]
+    if not incoming:
+        return "ANY", (
+            f"output node '{node_id}' has no incoming connection — type unresolved"
+        )
+    edge = incoming[0]
+    node_map = {n.get("id"): n for n in nodes}
+    src = node_map.get(edge.get("source"))
+    if src is None:
+        return "ANY", (
+            f"output node '{node_id}': source node '{edge.get('source')}' not found"
+        )
+    src_cls = registry.get(src.get("type", ""))
+    if src_cls is None:
+        return "ANY", (
+            f"output node '{node_id}': unknown source node type "
+            f"'{src.get('type', '')}'"
+        )
+    src_data = src.get("data")
+    src_params = src_data.get("params", {}) if isinstance(src_data, dict) else {}
+    ports = {p.name: p for p in src_cls.define_outputs_dynamic(src_params)}
+    port = ports.get(edge.get("sourceHandle", ""))
+    if port is None:
+        return "ANY", (
+            f"output node '{node_id}': source port "
+            f"'{edge.get('sourceHandle', '')}' not found"
+        )
+    return port.data_type.value, None
+
+
+@router.get("/contract/{name}", response_model=GraphContractResponse)
+async def get_contract(name: str):
+    """Derived I/O contract for a saved graph.
+
+    Problems are *reported* here (non-fatally, so users can inspect a
+    half-built graph) and *enforced* with 409 only by POST /run.
+    Unauthenticated GET, like /api/graph/load; 404s are plain
+    ``HTTPException`` shapes matching the load endpoint.
+    """
+    if _sanitize_name(name) != name:
+        # Strict-name rule: never silently alias to a different file.
+        raise HTTPException(status_code=404, detail=f"Graph '{name}' not found")
+    path = _graph_path(name)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail=f"Graph '{name}' not found")
+    try:
+        graph_data = json.loads(path.read_text())
+    except (ValueError, OSError):
+        raise HTTPException(
+            status_code=500, detail=f"Graph '{name}' exists but is not valid JSON"
+        )
+
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+    contract = api_contract.derive_contract(nodes)
+    problems = list(contract.problems)
+
+    inputs: list[ContractInputSchema] = []
+    for inp in contract.inputs:
+        if inp["required"] or inp["type"] == "image":
+            # Never advertise a default the API will not apply. (An image
+            # default is a canvas-only file path — also never applied.)
+            advertised_default = None
+        else:
+            try:
+                advertised_default = api_contract.coerce_input(
+                    inp["default"], inp["type"], from_string=True
+                )
+            except InputCoercionError:
+                advertised_default = None  # already reported in problems
+        inputs.append(ContractInputSchema(
+            name=inp["name"],
+            type=inp["type"],
+            required=inp["required"],
+            default=advertised_default,
+            description=inp["description"],
+        ))
+
+    outputs: list[ContractOutputSchema] = []
+    for out in contract.outputs:
+        type_label, problem = _derive_output_type(out["node_id"], nodes, edges)
+        if problem is not None:
+            problems.append(problem)
+        outputs.append(ContractOutputSchema(
+            name=out["name"], type=type_label, description=out["description"],
+        ))
+
+    return GraphContractResponse(
+        graph=name, inputs=inputs, outputs=outputs, problems=problems,
     )

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -13,6 +13,7 @@ file. POST is auto-covered by the X-CodefyUI-Token middleware.
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import logging
 import time
@@ -407,8 +408,13 @@ async def run_graph_as_function(name: str, request: Request):
                               details=validation_errors)
 
     # 6. Inject the RAW request values; each GraphInput's execute() coerces.
-    patched_nodes, input_errors = api_contract.inject_inputs(
-        nodes, contract, run_req.inputs,
+    # inject_inputs does synchronous base64+PIL+ToTensor validation for
+    # image inputs — offload to the default executor so a large/slow image
+    # decode never blocks the event loop. inject_inputs is pure, so running
+    # it off-thread is safe.
+    patched_nodes, input_errors = await asyncio.get_running_loop().run_in_executor(
+        None,
+        functools.partial(api_contract.inject_inputs, nodes, contract, run_req.inputs),
     )
     if input_errors:
         return error_response(422, run_id=run_id, graph=name,
@@ -463,6 +469,23 @@ async def run_graph_as_function(name: str, request: Request):
             asyncio.shield(task), timeout=run_req.timeout_s,
         )
     except asyncio.TimeoutError:
+        # On py3.11+ asyncio.TimeoutError IS builtins.TimeoutError, so a
+        # NODE raising TimeoutError (e.g. a socket timeout) completes the
+        # shielded task with that exact exception before wait_for's own
+        # deadline ever fires — indistinguishable from a genuine timeout by
+        # exception type alone. Disambiguate with task.done(): if the task
+        # already finished, the exception came from graph execution and
+        # must be reported like any other execution_error (with node_id);
+        # only an incomplete task means wait_for's deadline itself expired.
+        if task.done() and not task.cancelled():
+            task_exc = task.exception()
+            if task_exc is not None:
+                return error_response(
+                    500, run_id=run_id, graph=name, code="execution_error",
+                    message=str(task_exc), device=device,
+                    node_id=last_error_node_id["value"],
+                    timing={"total_s": round(time.monotonic() - t0, 3)},
+                )
         # 10. Cooperative cancellation: observed at node boundaries only —
         # the node currently inside run_in_executor finishes in its thread
         # after this 500 is sent (documented limitation).

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -1,0 +1,80 @@
+"""Graph-as-a-function endpoints: call a saved graph headlessly over HTTP.
+
+POST /api/graph/run/{name}      — execute with declared inputs, return declared outputs
+GET  /api/graph/contract/{name} — inspect the derived I/O contract
+
+The contract is declared on the canvas with GraphInput / GraphOutput
+nodes; the pure helpers live in ``app.core.api_contract``. This router
+shares the ``/api/graph`` prefix with ``routes_graph`` (multiple routers
+may share a prefix) but keeps run/serialization logic out of the CRUD
+file. POST is auto-covered by the X-CodefyUI-Token middleware.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from ..schemas import RunEnvelope, RunError, RunTiming
+
+router = APIRouter(prefix="/api/graph", tags=["graph-run"])
+
+
+def build_envelope(
+    *,
+    status: str,
+    run_id: str,
+    graph: str,
+    device: str | None = None,
+    outputs: dict[str, Any] | None = None,
+    error: dict[str, Any] | None = None,
+    timing: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    """Construct the one true /run envelope: all seven keys, always present.
+
+    ``run_id`` is never null — it is assigned at request entry, before any
+    rejection can happen.
+    """
+    return RunEnvelope(
+        status=status,
+        run_id=run_id,
+        graph=graph,
+        device=device,
+        outputs=outputs,
+        error=RunError(**error) if error is not None else None,
+        timing=RunTiming(**timing) if timing is not None else None,
+    ).model_dump()
+
+
+def error_response(
+    http_status: int,
+    *,
+    run_id: str,
+    graph: str,
+    code: str,
+    message: str,
+    device: str | None = None,
+    node_id: str | None = None,
+    details: list[Any] | None = None,
+    timing: dict[str, float] | None = None,
+) -> JSONResponse:
+    """An enveloped error; the HTTP status mirrors ``error.code``."""
+    return JSONResponse(
+        status_code=http_status,
+        content=build_envelope(
+            status="error",
+            run_id=run_id,
+            graph=graph,
+            device=device,
+            outputs=None,
+            error={
+                "code": code,
+                "message": message,
+                "node_id": node_id,
+                "details": details,
+            },
+            timing=timing,
+        ),
+    )

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -28,7 +28,12 @@ from ..core import api_contract
 from ..core.api_contract import InputCoercionError, OutputSerializationError
 from ..core.device_utils import resolve_device
 from ..core.execution_context import ExecutionContext
-from ..core.graph_engine import execute_graph, find_entry_points, validate_graph
+from ..core.graph_engine import (
+    GraphValidationError,
+    execute_graph,
+    find_entry_points,
+    validate_graph,
+)
 from ..core.node_registry import registry
 from ..schemas import (
     ContractInputSchema,
@@ -425,18 +430,56 @@ async def run_graph_as_function(name: str, request: Request):
     # 8. Launch as an INDEPENDENT task and await it under a shielded
     #    timeout. The shield means handler cancellation (client disconnect)
     #    never propagates into the run — only the timeout stops a run.
+    # Minimal error capture: remember the last node that reported an error
+    # so execution_error envelopes carry a node_id.
+    last_error_node_id: dict[str, str | None] = {"value": None}
+
+    async def _on_progress(
+        node_id: str, status: str, data: dict[str, Any] | None
+    ) -> None:
+        if status == "error":
+            last_error_node_id["value"] = node_id
+
     t0 = time.monotonic()
     task = asyncio.create_task(execute_graph(
         patched_nodes,
         edges,
+        on_progress=_on_progress,
         context=ctx,
         error_mode="fail_fast",
         run_id=run_id,
     ))
     task.add_done_callback(_retrieve_background_exception)
-    engine_result = await asyncio.wait_for(
-        asyncio.shield(task), timeout=run_req.timeout_s,
-    )
+    try:
+        engine_result = await asyncio.wait_for(
+            asyncio.shield(task), timeout=run_req.timeout_s,
+        )
+    except asyncio.TimeoutError:
+        # 10. Cooperative cancellation: observed at node boundaries only —
+        # the node currently inside run_in_executor finishes in its thread
+        # after this 500 is sent (documented limitation).
+        ctx.cancel()
+        return error_response(500, run_id=run_id, graph=name, code="timeout",
+                              message=f"run exceeded timeout_s={run_req.timeout_s}",
+                              device=device,
+                              timing={"total_s": round(time.monotonic() - t0, 3)})
+    except GraphValidationError as exc:
+        # 9. Runtime safety net: preset expansion can invalidate a
+        # pre-flight-clean graph (pruning-induced missing required input;
+        # trigger-edges-into-preset-nodes dangling after expand_presets).
+        return error_response(409, run_id=run_id, graph=name,
+                              code="invalid_graph",
+                              message="graph failed validation at runtime",
+                              device=device, details=[str(exc)],
+                              timing={"total_s": round(time.monotonic() - t0, 3)})
+    except Exception as exc:  # noqa: BLE001 — never a raw, unenveloped 500
+        # 11. asyncio.CancelledError (client disconnect) is BaseException,
+        # not Exception — it passes through and the shielded run continues.
+        return error_response(500, run_id=run_id, graph=name,
+                              code="execution_error",
+                              message=str(exc), device=device,
+                              node_id=last_error_node_id["value"],
+                              timing={"total_s": round(time.monotonic() - t0, 3)})
     total_s = round(time.monotonic() - t0, 3)
 
     # 12. Collect + serialize declared outputs.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,6 +37,11 @@ class Settings(BaseSettings):
     PORT: int = 8000
     CORS_ORIGINS: list[str] = ["http://localhost:5173", "http://localhost:5174", "http://localhost:3000"]
     MAX_UPLOAD_SIZE: int = 500 * 1024 * 1024  # 500 MB
+    # Cap for POST /api/graph/run/{name} request bodies, checked against
+    # Content-Length before the body is read (-> 413 payload_too_large).
+    # 64 MB comfortably covers a handful of base64 image inputs.
+    # Env-overridable as CODEFYUI_MAX_RUN_BODY_BYTES.
+    MAX_RUN_BODY_BYTES: int = 64 * 1024 * 1024  # 64 MB
 
     NODES_DIR: Path = Path(__file__).parent / "nodes"
     CUSTOM_NODES_DIR: Path = Path(__file__).parent / "custom_nodes"

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -374,3 +374,105 @@ def collect_outputs(
         else:
             missing.append(out["name"])
     return outputs, missing
+
+
+# A single tensor/ndarray output above this many elements fails
+# serialization with ``output_too_large`` — callers should use
+# ``record_outputs=true`` + the slicing outputs API instead.
+MAX_TENSOR_ELEMENTS = 65536
+
+
+class OutputSerializationError(Exception):
+    """A value reaching a GraphOutput cannot be returned as JSON."""
+
+    def __init__(self, code: str, reason: str) -> None:
+        super().__init__(reason)
+        self.code = code  # "output_too_large" | "unserializable_output"
+        self.reason = reason
+
+
+def serialize_output(value: Any) -> Any:
+    """Convert a value reaching a GraphOutput into a JSON-compatible form.
+
+    Full values, not summaries (contrast the inspector wire shapes in
+    ``routes_execution_outputs`` / ``ws_execution``). Tagged objects use
+    the ``__type__`` key — intentionally diverging from the internal
+    ``"type"``-keyed shapes so they can never collide with a user dict
+    output that happens to contain a ``"type"`` key.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return {key: serialize_output(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [serialize_output(item) for item in value]
+
+    import numpy as np
+
+    if isinstance(value, np.generic):
+        # numpy scalar (sklearn nodes emit these)
+        return value.item()
+    if isinstance(value, np.ndarray):
+        if value.size > MAX_TENSOR_ELEMENTS:
+            raise OutputSerializationError(
+                "output_too_large",
+                f"array has {value.size} elements (max {MAX_TENSOR_ELEMENTS}); "
+                "use record_outputs=true and the slicing outputs API "
+                "(GET /api/execution/outputs/{run_id}/...) instead",
+            )
+        return {
+            "__type__": "tensor",
+            "shape": list(value.shape),
+            "dtype": str(value.dtype),
+            "values": value.tolist(),
+        }
+
+    try:
+        import torch
+    except ImportError:
+        torch = None
+    if torch is not None:
+        if isinstance(value, torch.Tensor):
+            if value.numel() > MAX_TENSOR_ELEMENTS:
+                raise OutputSerializationError(
+                    "output_too_large",
+                    f"tensor has {value.numel()} elements "
+                    f"(max {MAX_TENSOR_ELEMENTS}); use record_outputs=true and "
+                    "the slicing outputs API "
+                    "(GET /api/execution/outputs/{run_id}/...) instead",
+                )
+            # 0-dim tensors keep shape [] rather than unwrapping — one rule,
+            # no surprises.
+            return {
+                "__type__": "tensor",
+                "shape": list(value.shape),
+                "dtype": str(value.dtype),
+                "values": value.detach().cpu().tolist(),
+            }
+        if isinstance(value, torch.nn.Module):
+            raise OutputSerializationError(
+                "unserializable_output",
+                "torch.nn.Module cannot be returned as JSON — save it with a "
+                "ModelSaver node in-graph and return its path string instead",
+            )
+
+    try:
+        from PIL import Image
+    except ImportError:
+        Image = None
+    if Image is not None and isinstance(value, Image.Image):
+        import base64
+        import io
+
+        buf = io.BytesIO()
+        value.save(buf, format="PNG")
+        return {
+            "__type__": "image",
+            "format": "png",
+            "base64": base64.b64encode(buf.getvalue()).decode("ascii"),
+        }
+
+    raise OutputSerializationError(
+        "unserializable_output",
+        f"value of type {type(value).__name__} is not JSON-serializable",
+    )

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -400,6 +400,14 @@ def serialize_output(value: Any) -> Any:
     ``"type"``-keyed shapes so they can never collide with a user dict
     output that happens to contain a ``"type"`` key.
     """
+    try:  # numpy scalars can subclass Python builtins (np.float64 -> float)
+        import numpy as np
+    except ImportError:
+        np = None
+    if np is not None and isinstance(value, np.generic):
+        # numpy scalar (sklearn nodes emit these)
+        return serialize_output(value.item())
+
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
     if isinstance(value, dict):
@@ -407,12 +415,7 @@ def serialize_output(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [serialize_output(item) for item in value]
 
-    import numpy as np
-
-    if isinstance(value, np.generic):
-        # numpy scalar (sklearn nodes emit these)
-        return value.item()
-    if isinstance(value, np.ndarray):
+    if np is not None and isinstance(value, np.ndarray):
         if value.size > MAX_TENSOR_ELEMENTS:
             raise OutputSerializationError(
                 "output_too_large",

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -154,17 +154,24 @@ def _decode_image(value: Any) -> Any:
     payload = "".join(payload.split())  # tolerate wrapped base64
     try:
         raw = base64.b64decode(payload, validate=True)
-    except (binascii.Error, ValueError):
-        raise InputCoercionError("image value is not valid base64")
-    from PIL import Image, UnidentifiedImageError
+    except (binascii.Error, ValueError) as exc:
+        raise InputCoercionError("image value is not valid base64") from exc
+    from PIL import Image
     from torchvision import transforms
 
+    # Decode AND convert inside one try: PIL can raise a wide range of
+    # exceptions here (UnidentifiedImageError, OSError, and — for crafted
+    # bomb payloads — DecompressionBombError, which subclasses Exception
+    # directly rather than OSError). Any of them must become an enveloped
+    # InputCoercionError, never escape as a raw unenveloped 500.
     try:
         img = Image.open(io.BytesIO(raw))
         img.load()
-    except (UnidentifiedImageError, OSError):
-        raise InputCoercionError("base64 payload does not decode to an image")
-    img = img.convert("RGB")
+        img = img.convert("RGB")
+    except Exception as exc:
+        raise InputCoercionError(
+            f"value does not decode to an image: {exc}"
+        ) from exc
     return transforms.ToTensor()(img)
 
 
@@ -230,6 +237,15 @@ def derive_contract(nodes: list[dict]) -> Contract:
     _check_names(contract.outputs, "output", contract.problems)
 
     for inp in contract.inputs:
+        if inp["type"] not in INPUT_TYPES:
+            # A hand-edited graph JSON with a bogus `type` is a graph
+            # problem (409, fix the graph) — not something to defer to a
+            # per-caller coerce_input failure at run time (422, blaming
+            # the caller).
+            contract.problems.append(
+                f"input node '{inp['node_id']}': unknown type '{inp['type']}'"
+            )
+            continue
         if inp["type"] == "image":
             if not inp["required"]:
                 contract.problems.append(

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -1,0 +1,163 @@
+"""Pure helpers for the graph-as-a-function I/O contract (GraphInput / GraphOutput).
+
+A saved graph declares its transport-agnostic function signature with
+``GraphInput`` / ``GraphOutput`` nodes on the canvas. This module derives
+that contract from raw graph JSON, validates and injects caller-supplied
+inputs, and collects/serializes declared outputs. Everything here is pure
+JSON manipulation — no FastAPI imports (mirrors the CodefyUI-OJ patcher's
+pure-JSON split); the endpoints in ``app.api.routes_graph_run`` stay thin.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# Input `type` values (v1, frozen). `json` stays `json` — it describes
+# exactly what a caller can send; no new DataType is needed.
+INPUT_TYPES = ("string", "number", "integer", "boolean", "json", "image")
+
+
+class InputCoercionError(Exception):
+    """A caller-supplied value cannot be coerced to its declared input type."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def json_type_name(value: Any) -> str:
+    """Name *value*'s JSON type for error messages (bool checked before int)."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def coerce_input(value: Any, declared_type: str, *, from_string: bool = False) -> Any:
+    """Coerce a value to *declared_type*; raise :class:`InputCoercionError`.
+
+    ``from_string=False`` (the API body path) applies the strict JSON table:
+    no string-to-number coercion, bools are never numbers, and ``integer``
+    accepts integral floats (``3.0 -> 3``, JSON Schema / OpenAPI 3.1
+    alignment — JS clients cannot control whether 3 serializes as 3.0).
+
+    ``from_string=True`` (the canvas ``default`` param path / an omitted
+    optional input) additionally parses string values per type — the one
+    deliberate asymmetry, documented on the node's ``default`` param.
+    Primitive values re-coerce idempotently under either mode.
+    """
+    if (
+        from_string
+        and isinstance(value, str)
+        and declared_type in ("number", "integer", "boolean", "json")
+    ):
+        # Parsed value falls through to the strict table below (idempotent).
+        value = _parse_default_string(value, declared_type)
+    if declared_type == "string":
+        if isinstance(value, str):
+            return value
+        raise InputCoercionError(f"expected string, got {json_type_name(value)}")
+    if declared_type == "number":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise InputCoercionError(f"expected number, got {json_type_name(value)}")
+        return float(value)
+    if declared_type == "integer":
+        if isinstance(value, bool):
+            raise InputCoercionError("expected integer, got boolean")
+        if isinstance(value, int):
+            return int(value)
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+        if isinstance(value, float):
+            raise InputCoercionError(f"expected integer, got non-integral number {value}")
+        raise InputCoercionError(f"expected integer, got {json_type_name(value)}")
+    if declared_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        raise InputCoercionError(f"expected boolean, got {json_type_name(value)}")
+    if declared_type == "json":
+        return value
+    if declared_type == "image":
+        return _decode_image(value)
+    raise InputCoercionError(f"unknown input type '{declared_type}'")
+
+
+def _parse_default_string(raw: str, declared_type: str) -> Any:
+    """Parse a string ``default`` param per type (canvas / omitted-optional path)."""
+    text = raw.strip()
+    if declared_type == "number":
+        try:
+            return float(text)
+        except ValueError:
+            raise InputCoercionError(f"default {raw!r} does not parse as number")
+    if declared_type == "integer":
+        try:
+            return int(text)
+        except ValueError:
+            pass
+        try:
+            # Integral float strings like "3.0" pass the strict table below.
+            return float(text)
+        except ValueError:
+            raise InputCoercionError(f"default {raw!r} does not parse as integer")
+    if declared_type == "boolean":
+        lowered = text.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        raise InputCoercionError(
+            f"default {raw!r} does not parse as boolean (use 'true'/'false')"
+        )
+    if declared_type == "json":
+        try:
+            return json.loads(raw)
+        except ValueError:
+            raise InputCoercionError(f"default {raw!r} does not parse as JSON")
+    return raw
+
+
+def _decode_image(value: Any) -> Any:
+    """Decode a base64 image string to a ``(C, H, W)`` float32 tensor in [0, 1].
+
+    Matches what image consumers already receive from ``ImageReader``.
+    Accepts an optional ``data:image/...;base64,`` prefix and tolerates
+    whitespace/newline-wrapped base64. Torch/PIL imports are lazy so
+    torch-free callers of the other helpers never pay for them.
+    """
+    if not isinstance(value, str):
+        raise InputCoercionError(
+            f"expected base64 image string, got {json_type_name(value)}"
+        )
+    import base64
+    import binascii
+    import io
+
+    payload = value
+    if payload.startswith("data:"):
+        _, _, payload = payload.partition(",")
+    payload = "".join(payload.split())  # tolerate wrapped base64
+    try:
+        raw = base64.b64decode(payload, validate=True)
+    except (binascii.Error, ValueError):
+        raise InputCoercionError("image value is not valid base64")
+    from PIL import Image, UnidentifiedImageError
+    from torchvision import transforms
+
+    try:
+        img = Image.open(io.BytesIO(raw))
+        img.load()
+    except (UnidentifiedImageError, OSError):
+        raise InputCoercionError("base64 payload does not decode to an image")
+    img = img.convert("RGB")
+    return transforms.ToTensor()(img)

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -10,6 +10,7 @@ pure-JSON split); the endpoints in ``app.api.routes_graph_run`` stay thin.
 
 from __future__ import annotations
 
+import copy
 import json
 import re
 from dataclasses import dataclass, field
@@ -303,3 +304,73 @@ def check_wiring(
         if out["node_id"] not in reachable:
             report.unreachable.append(out["name"])
     return report
+
+
+def inject_inputs(
+    nodes: list[dict],
+    contract: Contract,
+    request_inputs: dict[str, Any],
+) -> tuple[list[dict], list[dict[str, str]]]:
+    """Deep-copy *nodes* and write each request value into its GraphInput.
+
+    The RAW JSON value — not the coerced result — lands in
+    ``data.params["value"]``: the node's ``execute()`` performs the actual
+    coercion, which avoids double coercion (an endpoint-coerced image
+    tensor would fail the node's own base64 check), keeps injected params
+    JSON-serializable, and decodes images exactly once (in the node);
+    primitive types re-coerce idempotently. ``coerce_input`` is still
+    called here — result discarded — to validate coercibility up front.
+    Unknown names are rejected by case-sensitive exact match. All
+    per-input errors (unknown name, missing required, coercion failure)
+    are aggregated so the 422 reports everything at once.
+    """
+    errors: list[dict[str, str]] = []
+    by_name = {inp["name"]: inp for inp in contract.inputs}
+
+    for key in request_inputs:
+        if key not in by_name:  # case-sensitive exact match
+            errors.append({"input": key, "reason": "unknown input name"})
+
+    to_inject: dict[str, Any] = {}  # node_id -> raw value
+    for inp in contract.inputs:
+        name = inp["name"]
+        if name in request_inputs:
+            raw = request_inputs[name]
+            try:
+                coerce_input(raw, inp["type"])  # validate only; inject raw
+            except InputCoercionError as exc:
+                errors.append({"input": name, "reason": exc.reason})
+                continue
+            to_inject[inp["node_id"]] = raw
+        elif inp["required"]:
+            errors.append({"input": name, "reason": "missing required input"})
+        # Optional + omitted: no injection — the node's execute() falls
+        # back to its parsed `default` param, identical to a canvas run.
+
+    patched = copy.deepcopy(nodes)
+    for node in patched:
+        if node.get("id") in to_inject:
+            data = node.setdefault("data", {})
+            params = data.setdefault("params", {})
+            params["value"] = to_inject[node["id"]]
+    return patched, errors
+
+
+def collect_outputs(
+    contract: Contract,
+    engine_result: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Read each declared output's ``value`` port from the engine result.
+
+    ``missing`` survives only as a safety net behind the
+    ``unreachable_output`` pre-flight check.
+    """
+    outputs: dict[str, Any] = {}
+    missing: list[str] = []
+    for out in contract.outputs:
+        node_result = engine_result.get(out["node_id"])
+        if isinstance(node_result, dict) and "value" in node_result:
+            outputs[out["name"]] = node_result["value"]
+        else:
+            missing.append(out["name"])
+    return outputs, missing

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -15,6 +15,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
+from .graph_engine import find_entry_points, reachable_from_entry_points
+
 # Input `type` values (v1, frozen). `json` stays `json` — it describes
 # exactly what a caller can send; no new DataType is needed.
 INPUT_TYPES = ("string", "number", "integer", "boolean", "json", "image")
@@ -267,3 +269,37 @@ def _check_names(
         if name in seen:
             problems.append(f"duplicate {kind} name '{name}'")
         seen.add(name)
+
+
+@dataclass
+class WiringReport:
+    """Static pre-flight wiring findings on the raw (unexpanded) graph."""
+
+    untriggered: list[str] = field(default_factory=list)  # GraphInput names
+    unreachable: list[str] = field(default_factory=list)  # GraphOutput names
+
+
+def check_wiring(
+    nodes: list[dict], edges: list[dict], contract: Contract
+) -> WiringReport:
+    """Flag untriggered GraphInputs and unreachable GraphOutputs.
+
+    Uses the exact traversal the engine prunes with (``find_entry_points``
+    + ``reachable_from_entry_points``), applied statically to the raw
+    graph: verified engine behaviour silently prunes untriggered data
+    roots, so a clean report is what makes a run's declared I/O real.
+    """
+    report = WiringReport()
+    triggered = {
+        e["target"] for e in edges if e.get("type", "data") == "trigger"
+    }
+    for inp in contract.inputs:
+        if inp["node_id"] not in triggered:
+            report.untriggered.append(inp["name"])
+
+    entry_ids = find_entry_points(nodes, edges)
+    reachable = reachable_from_entry_points(entry_ids, edges)
+    for out in contract.outputs:
+        if out["node_id"] not in reachable:
+            report.unreachable.append(out["name"])
+    return report

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -11,6 +11,8 @@ pure-JSON split); the endpoints in ``app.api.routes_graph_run`` stay thin.
 from __future__ import annotations
 
 import json
+import re
+from dataclasses import dataclass, field
 from typing import Any
 
 # Input `type` values (v1, frozen). `json` stays `json` — it describes
@@ -161,3 +163,107 @@ def _decode_image(value: Any) -> Any:
         raise InputCoercionError("base64 payload does not decode to an image")
     img = img.convert("RGB")
     return transforms.ToTensor()(img)
+
+
+# Registry type strings of the contract nodes (frozen — they serialize into
+# saved graphs forever).
+GRAPH_INPUT_TYPE = "GraphInput"
+GRAPH_OUTPUT_TYPE = "GraphOutput"
+
+# Frozen contract-name charset: tightening later breaks saved graphs,
+# loosening never does. Stage 2 OpenAPI and the future `cdui call
+# --input k=v` need identifier-safe names.
+NAME_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]{0,63}$")
+
+
+@dataclass
+class Contract:
+    """The graph-level I/O contract derived from GraphInput / GraphOutput nodes.
+
+    ``problems`` is reported non-fatally by ``GET /api/graph/contract`` and
+    blocks ``POST /api/graph/run`` with 409 ``invalid_contract``.
+    """
+
+    inputs: list[dict[str, Any]] = field(default_factory=list)
+    outputs: list[dict[str, Any]] = field(default_factory=list)
+    problems: list[str] = field(default_factory=list)
+
+
+def derive_contract(nodes: list[dict]) -> Contract:
+    """Scan top-level nodes for GraphInput / GraphOutput declarations.
+
+    Presets are NOT expanded — contract derivation scans top-level nodes
+    only (GraphInput/GraphOutput inside presets are a non-goal).
+    """
+    contract = Contract()
+    for node in nodes:
+        node_type = node.get("type", "")
+        if node_type not in (GRAPH_INPUT_TYPE, GRAPH_OUTPUT_TYPE):
+            continue
+        data = node.get("data")
+        params = data.get("params", {}) if isinstance(data, dict) else {}
+        if node_type == GRAPH_INPUT_TYPE:
+            contract.inputs.append({
+                "name": str(params.get("name", "input")),
+                "type": str(params.get("type", "string")),
+                "required": bool(params.get("required", True)),
+                "default": params.get("default", ""),
+                "description": str(params.get("description", "")),
+                "node_id": node.get("id", ""),
+            })
+        else:
+            contract.outputs.append({
+                "name": str(params.get("name", "output")),
+                "description": str(params.get("description", "")),
+                "node_id": node.get("id", ""),
+            })
+
+    if not contract.outputs:
+        contract.problems.append(
+            "graph has no GraphOutput node — declare at least one output"
+        )
+
+    _check_names(contract.inputs, "input", contract.problems)
+    _check_names(contract.outputs, "output", contract.problems)
+
+    for inp in contract.inputs:
+        if inp["type"] == "image":
+            if not inp["required"]:
+                contract.problems.append(
+                    f"image input '{inp['name']}' must be required=true "
+                    "(base64 has no sensible API-side default)"
+                )
+            # The image default is a canvas-only file path, validated at
+            # canvas run time — exempt from default parsing.
+            continue
+        if not inp["required"]:
+            # The API applies only optional inputs' defaults; a required
+            # input's default is a canvas-only test value and must NOT
+            # 409-block API calls.
+            try:
+                coerce_input(inp["default"], inp["type"], from_string=True)
+            except InputCoercionError as exc:
+                contract.problems.append(
+                    f"optional input '{inp['name']}': default does not parse "
+                    f"as {inp['type']} ({exc.reason})"
+                )
+    return contract
+
+
+def _check_names(
+    entries: list[dict[str, Any]], kind: str, problems: list[str]
+) -> None:
+    """Empty-name, charset, and duplicate checks shared by inputs and outputs."""
+    seen: set[str] = set()
+    for entry in entries:
+        name = entry["name"]
+        if name == "":
+            problems.append(f"{kind} node '{entry['node_id']}' has an empty name")
+        elif not NAME_PATTERN.match(name):
+            problems.append(
+                f"{kind} name '{name}' is invalid — must match "
+                "^[a-zA-Z_][a-zA-Z0-9_]{0,63}$"
+            )
+        if name in seen:
+            problems.append(f"duplicate {kind} name '{name}'")
+        seen.add(name)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,6 +44,7 @@ from .api import (
     routes_execution_outputs,
     routes_execution_state,
     routes_graph,
+    routes_graph_run,
     routes_images,
     routes_llm,
     routes_models,
@@ -240,6 +241,7 @@ async def host_guard(request: Request, call_next):
 app.include_router(routes_nodes.router)
 app.include_router(routes_examples.router)
 app.include_router(routes_graph.router)
+app.include_router(routes_graph_run.router)
 app.include_router(routes_presets.router)
 app.include_router(routes_custom_nodes.router)
 app.include_router(routes_plugins.router)

--- a/backend/app/nodes/io/graph_input_node.py
+++ b/backend/app/nodes/io/graph_input_node.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...core.api_contract import coerce_input
+from ...core.api_contract import INPUT_TYPES, coerce_input
 from ...core.node_base import (
     BaseNode,
     DataType,
@@ -104,7 +104,7 @@ class GraphInputNode(BaseNode):
                 param_type=ParamType.SELECT,
                 default="string",
                 description="JSON type API callers must send for this input.",
-                options=["string", "number", "integer", "boolean", "json", "image"],
+                options=list(INPUT_TYPES),
             ),
             ParamDefinition(
                 name="required",

--- a/backend/app/nodes/io/graph_input_node.py
+++ b/backend/app/nodes/io/graph_input_node.py
@@ -1,0 +1,156 @@
+"""GraphInput node — declares a named input of this graph.
+
+Together with GraphOutput this expresses the graph's transport-agnostic
+function signature on the canvas: the CLI runner and Stage 2 published
+apps consume the same contract. API callers supply the value via
+``POST /api/graph/run/{name}``; canvas runs fall back to the ``default``
+param.
+
+Implementation note (the "hidden" ``value`` param): ``value`` is hidden
+ONLY in the sense of being UNDECLARED in ``define_params`` — do NOT
+declare it. Declaring it would render a text field: the config panel and
+node card iterate declared defs only. The API injects it; the canvas
+never sets it, so canvas runs fall back to ``default``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.api_contract import coerce_input
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+def _load_canvas_image(path_value: Any) -> Any:
+    """Load the canvas-only ``default`` image path the way ImageReader does.
+
+    Only reached on canvas runs — the API path always injects ``value``
+    (a base64 string) and never touches ``default``. Relative paths
+    resolve against IMAGES_DIR so filenames picked from the uploaded-files
+    dropdown work without the user typing a full path.
+    """
+    from pathlib import Path
+
+    from PIL import Image
+    from torchvision import transforms
+
+    from ...config import settings
+
+    path_str = str(path_value or "")
+    if not path_str:
+        raise ValueError(
+            "GraphInput(type=image): set 'default' to a server-local image path "
+            "for canvas runs (API callers send base64 instead)"
+        )
+    p = Path(path_str)
+    if not p.is_absolute():
+        p = settings.IMAGES_DIR / p
+    if not p.exists():
+        raise FileNotFoundError(f"GraphInput default image not found: {path_str}")
+    img = Image.open(p).convert("RGB")
+    return transforms.ToTensor()(img)
+
+
+class GraphInputNode(BaseNode):
+    NODE_NAME = "GraphInput"
+    CATEGORY = "IO"
+    DESCRIPTION = (
+        "Declares a named input of this graph — supplied by API callers via "
+        "POST /api/graph/run, or by the 'default' param when run on the canvas. "
+        "Wire a Start node into this node so it executes."
+    )
+
+    # Params include the injected value, so cache keys stay correct on
+    # canvas runs (BaseNode default, restated here because it is load-bearing).
+    cacheable = True
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="value",
+                data_type=DataType.ANY,
+                description=(
+                    "Value supplied by the API caller (or 'default' when run on canvas)"
+                ),
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="name",
+                param_type=ParamType.STRING,
+                default="input",
+                description=(
+                    "Contract name of this input. Must match "
+                    "^[a-zA-Z_][a-zA-Z0-9_]{0,63}$ (letters, digits, underscore; "
+                    "not starting with a digit)."
+                ),
+            ),
+            ParamDefinition(
+                name="type",
+                param_type=ParamType.SELECT,
+                default="string",
+                description="JSON type API callers must send for this input.",
+                options=["string", "number", "integer", "boolean", "json", "image"],
+            ),
+            ParamDefinition(
+                name="required",
+                param_type=ParamType.BOOL,
+                default=True,
+                description=(
+                    "When false, API callers may omit this input and 'default' "
+                    "applies. Image inputs must stay required."
+                ),
+            ),
+            ParamDefinition(
+                name="default",
+                param_type=ParamType.STRING,
+                default="",
+                description=(
+                    "ALWAYS the canvas test value; an API-side fallback ONLY when "
+                    "required=false. Parsed per 'type' (string parsing applies here "
+                    "only). For type=image: a server-local file path used only by "
+                    "canvas runs."
+                ),
+            ),
+            ParamDefinition(
+                name="description",
+                param_type=ParamType.STRING,
+                default="",
+                description="Shown in the contract for self-documenting APIs.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        declared_type = str(params.get("type", "string"))
+        if "value" in params:
+            # API path: routes_graph_run injected the RAW JSON value; the
+            # coercion (including base64 image decode) happens exactly once,
+            # here. One helper serves both paths, so canvas and API behave
+            # identically.
+            return {"value": coerce_input(params["value"], declared_type)}
+        # Canvas path (or omitted optional API input): fall back to `default`.
+        raw_default = params.get("default", "")
+        if declared_type == "image":
+            return {"value": _load_canvas_image(raw_default)}
+        return {"value": coerce_input(raw_default, declared_type, from_string=True)}

--- a/backend/app/nodes/io/graph_output_node.py
+++ b/backend/app/nodes/io/graph_output_node.py
@@ -1,0 +1,78 @@
+"""GraphOutput node — declares a named output of this graph.
+
+Together with GraphInput this expresses the graph's transport-agnostic
+function signature on the canvas. The run endpoint reads this node's
+``value`` port from the engine result and returns it to API callers under
+the declared name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class GraphOutputNode(BaseNode):
+    NODE_NAME = "GraphOutput"
+    CATEGORY = "IO"
+    DESCRIPTION = (
+        "Declares a named output of this graph — returned to API callers by "
+        "POST /api/graph/run under this node's 'name'. Connect the value you "
+        "want the graph to return."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="value",
+                data_type=DataType.ANY,
+                description="The value to return under this output's name",
+                optional=False,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="name",
+                param_type=ParamType.STRING,
+                default="output",
+                description=(
+                    "Contract name of this output. Must match "
+                    "^[a-zA-Z_][a-zA-Z0-9_]{0,63}$ (letters, digits, underscore; "
+                    "not starting with a digit)."
+                ),
+            ),
+            ParamDefinition(
+                name="description",
+                param_type=ParamType.STRING,
+                default="",
+                description="Shown in the contract for self-documenting APIs.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        # Pass-through: the run endpoint reads this port from the engine
+        # result; returning the value also makes it visible in the
+        # Inspector / edge tooltip on canvas runs for free.
+        return {"value": inputs.get("value")}

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,8 +1,11 @@
 from .models import (
+    ContractInputSchema,
+    ContractOutputSchema,
     CreatePresetRequest,
     EdgeData,
     ExposedParamSchema,
     ExposedPortSchema,
+    GraphContractResponse,
     GraphData,
     GraphValidationResponse,
     InternalEdgeSchema,
@@ -13,13 +16,19 @@ from .models import (
     ParamDefinitionSchema,
     PortDefinitionSchema,
     PresetDefinition,
+    RunEnvelope,
+    RunError,
+    RunTiming,
 )
 
 __all__ = [
+    "ContractInputSchema",
+    "ContractOutputSchema",
     "CreatePresetRequest",
     "EdgeData",
     "ExposedParamSchema",
     "ExposedPortSchema",
+    "GraphContractResponse",
     "GraphData",
     "GraphValidationResponse",
     "InternalEdgeSchema",
@@ -30,4 +39,7 @@ __all__ = [
     "ParamDefinitionSchema",
     "PortDefinitionSchema",
     "PresetDefinition",
+    "RunEnvelope",
+    "RunError",
+    "RunTiming",
 ]

--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -73,6 +73,60 @@ class NodeExecutionStatus(BaseModel):
     data: dict[str, Any] | None = None
 
 
+# ── Graph-as-a-function schemas ─────────────────────────────────
+
+
+class RunError(BaseModel):
+    code: str
+    message: str
+    node_id: str | None = None
+    details: list[Any] | None = None
+
+
+class RunTiming(BaseModel):
+    total_s: float
+
+
+class RunEnvelope(BaseModel):
+    """Response envelope for POST /api/graph/run/{name}.
+
+    Every key is ALWAYS present (null when not applicable); HTTP status
+    mirrors ``status``/``error.code``. Forward compatibility (also stated
+    on the docs page): clients MUST ignore unknown envelope fields, and
+    ``error.code`` is an open enum — treat unknown codes as generic
+    errors. The ``job`` key is reserved by name for the future async mode.
+    """
+
+    status: Literal["ok", "error"]
+    run_id: str
+    graph: str
+    device: str | None = None
+    outputs: dict[str, Any] | None = None
+    error: RunError | None = None
+    timing: RunTiming | None = None
+
+
+class ContractInputSchema(BaseModel):
+    name: str
+    type: str
+    required: bool
+    default: Any = None
+    description: str = ""
+
+
+class ContractOutputSchema(BaseModel):
+    name: str
+    type: str = "ANY"
+    description: str = ""
+
+
+class GraphContractResponse(BaseModel):
+    graph: str
+    inputs: list[ContractInputSchema]
+    outputs: list[ContractOutputSchema]
+    problems: list[str] = []
+
+
 # ── Preset schemas ──────────────────────────────────────────────
 
 class InternalNodeSchema(BaseModel):

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -352,3 +352,81 @@ def test_check_wiring_no_entry_points_marks_everything():
     report = check_wiring(nodes, edges, derive_contract(nodes))
     assert report.untriggered == ["x"]
     assert report.unreachable == ["y"]
+
+
+# ── inject_inputs / collect_outputs ──────────────────────────────────────
+
+from app.core.api_contract import collect_outputs, inject_inputs  # noqa: E402
+
+
+def test_inject_inputs_writes_raw_value_and_preserves_original():
+    nodes = [_other("s", "Start"), _gi("i1", name="x", type="integer"), _go("o1", name="y")]
+    contract = derive_contract(nodes)
+    patched, errors = inject_inputs(nodes, contract, {"x": 3.0})
+    assert errors == []
+    patched_params = patched[1]["data"]["params"]
+    assert patched_params["value"] == 3.0            # RAW value, not int(3)
+    assert isinstance(patched_params["value"], float)
+    assert "value" not in nodes[1]["data"]["params"]  # deep-copy: original untouched
+
+
+def test_inject_inputs_image_stays_base64_string():
+    import json as _json
+
+    nodes = [_gi("i1", name="img", type="image"), _go("o1", name="y")]
+    contract = derive_contract(nodes)
+    b64 = _tiny_png_base64()
+    patched, errors = inject_inputs(nodes, contract, {"img": b64})
+    assert errors == []
+    injected = patched[0]["data"]["params"]["value"]
+    assert injected == b64        # decoded once, in the node — not here
+    _json.dumps(injected)         # injected params stay JSON-serializable
+
+
+def test_inject_inputs_aggregates_all_errors():
+    nodes = [
+        _gi("i1", name="a", type="number"),
+        _gi("i2", name="b", type="string"),
+        _go("o1", name="y"),
+    ]
+    contract = derive_contract(nodes)
+    _, errors = inject_inputs(nodes, contract, {"a": "not-a-number", "typo": 1})
+    reasons = {e["input"]: e["reason"] for e in errors}
+    assert set(reasons) == {"a", "typo", "b"}
+    assert reasons["typo"] == "unknown input name"
+    assert reasons["b"] == "missing required input"
+    assert "expected number" in reasons["a"]
+
+
+def test_inject_inputs_is_case_sensitive_exact_match():
+    nodes = [_gi("i1", name="x"), _go("o1", name="y")]
+    contract = derive_contract(nodes)
+    _, errors = inject_inputs(nodes, contract, {"X": "hi"})
+    reasons = {e["input"]: e["reason"] for e in errors}
+    assert reasons == {"X": "unknown input name", "x": "missing required input"}
+
+
+def test_inject_inputs_optional_omitted_not_injected():
+    nodes = [_gi("i1", name="x", required=False, default="fallback"), _go("o1", name="y")]
+    contract = derive_contract(nodes)
+    patched, errors = inject_inputs(nodes, contract, {})
+    assert errors == []
+    # No injection: the node's execute() falls back to `default`, identical
+    # to a canvas run.
+    assert "value" not in patched[0]["data"]["params"]
+
+
+def test_collect_outputs_reads_value_ports_and_reports_missing():
+    nodes = [_go("o1", name="y1"), _go("o2", name="y2")]
+    contract = derive_contract(nodes)
+    outputs, missing = collect_outputs(contract, {"o1": {"value": 42}})
+    assert outputs == {"y1": 42}
+    assert missing == ["y2"]
+
+
+def test_collect_outputs_none_value_is_present_not_missing():
+    nodes = [_go("o1", name="y")]
+    contract = derive_contract(nodes)
+    outputs, missing = collect_outputs(contract, {"o1": {"value": None}})
+    assert outputs == {"y": None}
+    assert missing == []

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -547,3 +547,30 @@ def test_image_base64_roundtrip_to_tensor():
     tensor = coerce_input(_tiny_png_base64(), "image")
     assert tensor.shape == (3, 2, 4)
     assert tensor.dtype == torch.float32
+
+
+def test_serialize_numpy_builtin_subclass_scalars_normalize():
+    import numpy as np
+
+    out = serialize_output(np.float64(2.5))
+    assert out == 2.5 and type(out) is float
+    s = serialize_output(np.str_("hi"))
+    assert s == "hi" and type(s) is str
+    b = serialize_output(np.bool_(True))
+    assert b is True
+
+
+def test_serialize_numpy_complex_hits_catch_all():
+    import numpy as np
+
+    with pytest.raises(OutputSerializationError):
+        serialize_output(np.complex128(1 + 2j))
+
+
+def test_serialize_ndarray_zero_dim_keeps_empty_shape():
+    import numpy as np
+
+    tagged = serialize_output(np.array(7.5))
+    assert tagged["__type__"] == "tensor"
+    assert tagged["shape"] == []
+    assert tagged["values"] == 7.5

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -1,0 +1,165 @@
+"""Tests for app.core.api_contract — pure graph-as-a-function contract helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.api_contract import InputCoercionError, coerce_input, json_type_name
+
+
+def _tiny_png_base64() -> str:
+    import base64
+    import io
+
+    from PIL import Image
+
+    img = Image.new("RGB", (4, 2), color=(255, 0, 0))  # width=4, height=2
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+# ── coerce_input: strict API table (from_string=False) ──────────────────
+
+
+def test_string_passes_through():
+    assert coerce_input("hi", "string") == "hi"
+
+
+def test_string_rejects_non_strings():
+    for bad in (3, 2.5, True, None, {"a": 1}, [1]):
+        with pytest.raises(InputCoercionError):
+            coerce_input(bad, "string")
+
+
+def test_rejection_names_expected_vs_received():
+    with pytest.raises(InputCoercionError, match="expected string, got number"):
+        coerce_input(3, "string")
+    with pytest.raises(InputCoercionError, match="expected number, got string"):
+        coerce_input("3", "number")
+    with pytest.raises(InputCoercionError, match="expected boolean, got number"):
+        coerce_input(1, "boolean")
+
+
+def test_number_accepts_int_and_float_as_float():
+    assert coerce_input(3, "number") == 3.0
+    assert isinstance(coerce_input(3, "number"), float)
+    assert coerce_input(2.5, "number") == 2.5
+
+
+def test_number_rejects_string_bool_null():
+    for bad in ("3", True, False, None, [1]):
+        with pytest.raises(InputCoercionError):
+            coerce_input(bad, "number")
+
+
+def test_integer_accepts_int_and_integral_float():
+    assert coerce_input(3, "integer") == 3
+    assert coerce_input(3.0, "integer") == 3
+    assert isinstance(coerce_input(3.0, "integer"), int)
+
+
+def test_integer_rejects_fractional_string_bool():
+    for bad in (3.5, "3", True, None):
+        with pytest.raises(InputCoercionError):
+            coerce_input(bad, "integer")
+
+
+def test_boolean_accepts_only_bool():
+    assert coerce_input(True, "boolean") is True
+    assert coerce_input(False, "boolean") is False
+    for bad in (0, 1, "true", None):
+        with pytest.raises(InputCoercionError):
+            coerce_input(bad, "boolean")
+
+
+def test_json_accepts_any_json_value():
+    for val in ({"a": 1}, [1, 2], "s", 3, 2.5, True, None):
+        assert coerce_input(val, "json") == val
+
+
+def test_unknown_declared_type_raises():
+    with pytest.raises(InputCoercionError, match="unknown input type"):
+        coerce_input("x", "tensor")
+
+
+# ── coerce_input: from_string=True (canvas `default` path) ──────────────
+
+
+def test_from_string_parses_number_integer_boolean_json():
+    assert coerce_input("2.5", "number", from_string=True) == 2.5
+    assert coerce_input("3", "integer", from_string=True) == 3
+    assert coerce_input("3.0", "integer", from_string=True) == 3
+    assert coerce_input("true", "boolean", from_string=True) is True
+    assert coerce_input("False", "boolean", from_string=True) is False
+    assert coerce_input('{"k": [1, 2]}', "json", from_string=True) == {"k": [1, 2]}
+
+
+def test_from_string_string_type_stays_verbatim():
+    assert coerce_input("3.5", "string", from_string=True) == "3.5"
+
+
+def test_from_string_bad_parses_raise():
+    with pytest.raises(InputCoercionError):
+        coerce_input("abc", "number", from_string=True)
+    with pytest.raises(InputCoercionError):
+        coerce_input("3.5", "integer", from_string=True)
+    with pytest.raises(InputCoercionError):
+        coerce_input("yes", "boolean", from_string=True)
+    with pytest.raises(InputCoercionError):
+        coerce_input("{not json", "json", from_string=True)
+
+
+def test_from_string_false_never_parses_strings():
+    with pytest.raises(InputCoercionError):
+        coerce_input("2.5", "number")
+
+
+def test_from_string_non_string_value_uses_strict_table():
+    # A hand-edited graph JSON may hold a non-string default; strict rules apply.
+    assert coerce_input(5, "number", from_string=True) == 5.0
+    with pytest.raises(InputCoercionError):
+        coerce_input(True, "number", from_string=True)
+
+
+# ── coerce_input: image ─────────────────────────────────────────────────
+
+
+def test_image_decodes_to_chw_float_tensor():
+    import torch
+
+    tensor = coerce_input(_tiny_png_base64(), "image")
+    assert isinstance(tensor, torch.Tensor)
+    assert tensor.shape == (3, 2, 4)  # (C, H, W)
+    assert tensor.dtype == torch.float32
+    assert float(tensor.min()) >= 0.0 and float(tensor.max()) <= 1.0
+
+
+def test_image_accepts_data_uri_prefix():
+    import torch
+
+    tensor = coerce_input("data:image/png;base64," + _tiny_png_base64(), "image")
+    assert isinstance(tensor, torch.Tensor)
+    assert tensor.shape == (3, 2, 4)
+
+
+def test_image_rejects_non_string_and_garbage():
+    with pytest.raises(InputCoercionError, match="expected base64 image string"):
+        coerce_input(123, "image")
+    with pytest.raises(InputCoercionError, match="not valid base64"):
+        coerce_input("!!!not-base64!!!", "image")
+    with pytest.raises(InputCoercionError, match="does not decode to an image"):
+        coerce_input("aGVsbG8gd29ybGQ=", "image")  # base64("hello world")
+
+
+# ── json_type_name ───────────────────────────────────────────────────────
+
+
+def test_json_type_name_labels():
+    assert json_type_name(None) == "null"
+    assert json_type_name(True) == "boolean"
+    assert json_type_name(3) == "number"
+    assert json_type_name(2.5) == "number"
+    assert json_type_name("s") == "string"
+    assert json_type_name([1]) == "array"
+    assert json_type_name({}) == "object"

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -289,3 +289,66 @@ def test_derive_contract_ignores_preset_and_other_nodes():
     contract = derive_contract(nodes)
     assert contract.inputs == []
     assert len(contract.outputs) == 1
+
+
+# ── check_wiring ─────────────────────────────────────────────────────────
+
+from app.core.api_contract import check_wiring  # noqa: E402
+
+
+def _trigger_edge(eid: str, src: str, tgt: str) -> dict:
+    return {
+        "id": eid, "source": src, "target": tgt,
+        "sourceHandle": "trigger", "targetHandle": "", "type": "trigger",
+    }
+
+
+def _data_edge(eid: str, src: str, tgt: str,
+               src_handle: str = "value", tgt_handle: str = "value") -> dict:
+    return {
+        "id": eid, "source": src, "target": tgt,
+        "sourceHandle": src_handle, "targetHandle": tgt_handle, "type": "data",
+    }
+
+
+def test_check_wiring_clean_graph():
+    nodes = [_other("s", "Start"), _gi("i1", name="x"), _go("o1", name="y")]
+    edges = [_trigger_edge("t1", "s", "i1"), _data_edge("d1", "i1", "o1")]
+    report = check_wiring(nodes, edges, derive_contract(nodes))
+    assert report.untriggered == []
+    assert report.unreachable == []
+
+
+def test_check_wiring_untriggered_input():
+    # i1 feeds o1 but has no trigger; a *different* node is triggered, so the
+    # engine would silently prune i1 and run "successfully" without the
+    # caller's input — exactly what the 409 pre-flight must prevent.
+    nodes = [_other("s", "Start"), _other("src"), _gi("i1", name="x"), _go("o1", name="y")]
+    edges = [_trigger_edge("t1", "s", "src"), _data_edge("d1", "i1", "o1")]
+    report = check_wiring(nodes, edges, derive_contract(nodes))
+    assert report.untriggered == ["x"]
+    # o1 is fed only through the untriggered i1, so it is also unreachable.
+    assert report.unreachable == ["y"]
+
+
+def test_check_wiring_unreachable_output():
+    nodes = [
+        _other("s", "Start"), _gi("i1", name="x"),
+        _go("o1", name="y1"), _go("o2", name="y2"), _other("src2"),
+    ]
+    edges = [
+        _trigger_edge("t1", "s", "i1"),
+        _data_edge("d1", "i1", "o1"),
+        _data_edge("d2", "src2", "o2"),  # src2 untriggered -> pruned at run time
+    ]
+    report = check_wiring(nodes, edges, derive_contract(nodes))
+    assert report.untriggered == []
+    assert report.unreachable == ["y2"]
+
+
+def test_check_wiring_no_entry_points_marks_everything():
+    nodes = [_gi("i1", name="x"), _go("o1", name="y")]
+    edges = [_data_edge("d1", "i1", "o1")]
+    report = check_wiring(nodes, edges, derive_contract(nodes))
+    assert report.untriggered == ["x"]
+    assert report.unreachable == ["y"]

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -430,3 +430,120 @@ def test_collect_outputs_none_value_is_present_not_missing():
     outputs, missing = collect_outputs(contract, {"o1": {"value": None}})
     assert outputs == {"y": None}
     assert missing == []
+
+
+# ── serialize_output ─────────────────────────────────────────────────────
+
+from app.core.api_contract import (  # noqa: E402
+    MAX_TENSOR_ELEMENTS,
+    OutputSerializationError,
+    serialize_output,
+)
+
+
+def test_serialize_primitives_pass_through():
+    for val in (None, True, 3, 2.5, "s"):
+        assert serialize_output(val) == val
+
+
+def test_serialize_containers_recurse_tuple_becomes_list():
+    assert serialize_output({"a": (1, 2), "b": [3.5, "x"]}) == {
+        "a": [1, 2], "b": [3.5, "x"],
+    }
+
+
+def test_serialize_numpy_scalar_item():
+    import numpy as np
+
+    assert serialize_output(np.float32(2.5)) == 2.5
+    assert isinstance(serialize_output(np.int64(7)), int)
+
+
+def test_serialize_ndarray_tagged():
+    import numpy as np
+
+    out = serialize_output(np.zeros((2, 3), dtype=np.float32))
+    assert out["__type__"] == "tensor"
+    assert out["shape"] == [2, 3]
+    assert out["dtype"] == "float32"
+    assert out["values"] == [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+
+
+def test_serialize_tensor_tagged_and_zero_dim():
+    import torch
+
+    out = serialize_output(torch.tensor([[1.0, 2.0]]))
+    assert out == {
+        "__type__": "tensor", "shape": [1, 2],
+        "dtype": "torch.float32", "values": [[1.0, 2.0]],
+    }
+    # 0-dim tensors serialize with shape [] rather than unwrapping.
+    zero_dim = serialize_output(torch.tensor(5.0))
+    assert zero_dim["shape"] == []
+    assert zero_dim["values"] == 5.0
+
+
+def test_serialize_tensor_cap_65536():
+    import torch
+
+    assert MAX_TENSOR_ELEMENTS == 65536
+    ok = serialize_output(torch.zeros(65536))
+    assert len(ok["values"]) == 65536
+    with pytest.raises(OutputSerializationError) as exc_info:
+        serialize_output(torch.zeros(65537))
+    assert exc_info.value.code == "output_too_large"
+    assert "record_outputs" in exc_info.value.reason
+
+
+def test_serialize_ndarray_cap_65536():
+    import numpy as np
+
+    with pytest.raises(OutputSerializationError) as exc_info:
+        serialize_output(np.zeros(65537))
+    assert exc_info.value.code == "output_too_large"
+
+
+def test_serialize_module_rejected_with_modelsaver_hint():
+    import torch
+
+    with pytest.raises(OutputSerializationError) as exc_info:
+        serialize_output(torch.nn.Linear(2, 2))
+    assert exc_info.value.code == "unserializable_output"
+    assert "ModelSaver" in exc_info.value.reason
+
+
+def test_serialize_pil_image_base64_roundtrip():
+    import base64
+    import io
+
+    from PIL import Image
+
+    out = serialize_output(Image.new("RGB", (4, 2), color=(0, 0, 255)))
+    assert out["__type__"] == "image"
+    assert out["format"] == "png"
+    round_tripped = Image.open(io.BytesIO(base64.b64decode(out["base64"])))
+    assert round_tripped.size == (4, 2)
+
+
+def test_serialize_unknown_type_rejected_with_type_name():
+    class Widget:
+        pass
+
+    with pytest.raises(OutputSerializationError) as exc_info:
+        serialize_output(Widget())
+    assert exc_info.value.code == "unserializable_output"
+    assert "Widget" in exc_info.value.reason
+
+
+def test_serialize_base64_plot_string_passes_through():
+    # Base64-string plots (e.g. Visualize node output) are plain strings.
+    assert serialize_output("iVBORw0KGgo=") == "iVBORw0KGgo="
+
+
+def test_image_base64_roundtrip_to_tensor():
+    # Input side of the same story: base64 -> coerce_input -> tensor.
+    import torch
+
+    tensor = coerce_input(_tiny_png_base64(), "image")
+    assert tensor.shape == (3, 2, 4)
+    assert tensor.dtype == torch.float32

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -163,3 +163,129 @@ def test_json_type_name_labels():
     assert json_type_name("s") == "string"
     assert json_type_name([1]) == "array"
     assert json_type_name({}) == "object"
+
+
+# ── derive_contract ──────────────────────────────────────────────────────
+
+from app.core.api_contract import derive_contract  # noqa: E402
+
+
+def _gi(node_id: str, **params) -> dict:
+    merged = {
+        "name": "input", "type": "string", "required": True,
+        "default": "", "description": "",
+    }
+    merged.update(params)
+    return {
+        "id": node_id, "type": "GraphInput",
+        "position": {"x": 0, "y": 0}, "data": {"params": merged},
+    }
+
+
+def _go(node_id: str, **params) -> dict:
+    merged = {"name": "output", "description": ""}
+    merged.update(params)
+    return {
+        "id": node_id, "type": "GraphOutput",
+        "position": {"x": 0, "y": 0}, "data": {"params": merged},
+    }
+
+
+def _other(node_id: str, node_type: str = "_TestSource") -> dict:
+    return {
+        "id": node_id, "type": node_type,
+        "position": {"x": 0, "y": 0}, "data": {"params": {}},
+    }
+
+
+def test_derive_contract_collects_inputs_and_outputs():
+    nodes = [
+        _other("s", "Start"),
+        _gi("i1", name="prompt", type="string"),
+        _go("o1", name="answer", description="the answer"),
+    ]
+    contract = derive_contract(nodes)
+    assert contract.problems == []
+    assert contract.inputs == [{
+        "name": "prompt", "type": "string", "required": True,
+        "default": "", "description": "", "node_id": "i1",
+    }]
+    assert contract.outputs == [
+        {"name": "answer", "description": "the answer", "node_id": "o1"},
+    ]
+
+
+def test_derive_contract_no_graph_output_is_problem():
+    contract = derive_contract([_gi("i1", name="x")])
+    assert any("GraphOutput" in p for p in contract.problems)
+
+
+def test_derive_contract_empty_and_bad_charset_names():
+    contract = derive_contract([
+        _gi("i1", name=""),
+        _gi("i2", name="9lives"),
+        _gi("i3", name="has space"),
+        _go("o1", name="ok_name"),
+    ])
+    assert any("empty name" in p for p in contract.problems)
+    assert sum("is invalid" in p for p in contract.problems) == 2
+
+
+def test_derive_contract_name_at_charset_limits():
+    contract = derive_contract([
+        _gi("i1", name="_x" + "a" * 62),   # 64 chars total: OK
+        _gi("i2", name="b" * 65),          # 65 chars: too long
+        _go("o1", name="y"),
+    ])
+    assert sum("is invalid" in p for p in contract.problems) == 1
+
+
+def test_derive_contract_duplicate_names():
+    contract = derive_contract([
+        _gi("i1", name="x"), _gi("i2", name="x"),
+        _go("o1", name="y"), _go("o2", name="y"),
+    ])
+    assert any(p == "duplicate input name 'x'" for p in contract.problems)
+    assert any(p == "duplicate output name 'y'" for p in contract.problems)
+
+
+def test_derive_contract_optional_default_must_parse():
+    contract = derive_contract([
+        _gi("i1", name="n", type="number", required=False, default="abc"),
+        _go("o1", name="y"),
+    ])
+    assert any("default does not parse" in p for p in contract.problems)
+
+
+def test_derive_contract_required_bad_default_is_not_a_problem():
+    # A required input's default is a canvas-only test value: its failure
+    # surfaces on canvas runs and must NOT 409-block API calls.
+    contract = derive_contract([
+        _gi("i1", name="n", type="number", required=True, default="abc"),
+        _go("o1", name="y"),
+    ])
+    assert contract.problems == []
+
+
+def test_derive_contract_image_default_exempt_from_parsing():
+    # An image default is a canvas-only file path, validated at canvas run time.
+    contract = derive_contract([
+        _gi("i1", name="img", type="image", required=True, default="photo.png"),
+        _go("o1", name="y"),
+    ])
+    assert contract.problems == []
+
+
+def test_derive_contract_optional_image_is_problem():
+    contract = derive_contract([
+        _gi("i1", name="img", type="image", required=False),
+        _go("o1", name="y"),
+    ])
+    assert any("must be required" in p for p in contract.problems)
+
+
+def test_derive_contract_ignores_preset_and_other_nodes():
+    nodes = [_other("p1", "preset:TrainLoop"), _other("t1"), _go("o1", name="y")]
+    contract = derive_contract(nodes)
+    assert contract.inputs == []
+    assert len(contract.outputs) == 1

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -152,6 +152,21 @@ def test_image_rejects_non_string_and_garbage():
         coerce_input("aGVsbG8gd29ybGQ=", "image")  # base64("hello world")
 
 
+def test_image_decompression_bomb_becomes_input_coercion_error(monkeypatch):
+    # PIL.Image.DecompressionBombError subclasses Exception directly (not
+    # OSError), so it must still be caught and enveloped — never escape as
+    # a raw, unenveloped exception through the API layer.
+    import PIL.Image
+
+    def _boom(*_args, **_kwargs):
+        raise PIL.Image.DecompressionBombError("boom")
+
+    monkeypatch.setattr(PIL.Image, "open", _boom)
+    with pytest.raises(InputCoercionError, match="does not decode to an image") as exc_info:
+        coerce_input(_tiny_png_base64(), "image")
+    assert not isinstance(exc_info.value, PIL.Image.DecompressionBombError)
+
+
 # ── json_type_name ───────────────────────────────────────────────────────
 
 
@@ -282,6 +297,24 @@ def test_derive_contract_optional_image_is_problem():
         _go("o1", name="y"),
     ])
     assert any("must be required" in p for p in contract.problems)
+
+
+def test_derive_contract_unknown_type_required_is_problem():
+    # A hand-edited graph with a bogus `type` must 409 (fix the graph) at
+    # GET /contract time, not surface as a per-caller 422 at run time.
+    contract = derive_contract([
+        _gi("i1", name="n", type="tensor", required=True),
+        _go("o1", name="y"),
+    ])
+    assert any("unknown type" in p and "tensor" in p for p in contract.problems)
+
+
+def test_derive_contract_unknown_type_optional_is_problem():
+    contract = derive_contract([
+        _gi("i1", name="n", type="tensor", required=False, default="x"),
+        _go("o1", name="y"),
+    ])
+    assert any("unknown type" in p and "tensor" in p for p in contract.problems)
 
 
 def test_derive_contract_ignores_preset_and_other_nodes():

--- a/backend/tests/test_api_graph.py
+++ b/backend/tests/test_api_graph.py
@@ -60,3 +60,18 @@ async def test_save_and_load_roundtrip(test_client, sample_graph, tmp_path, monk
     assert resp.status_code == 200
     graphs = resp.json()
     assert any(g["name"] == "test-graph" for g in graphs)
+
+
+def test_sanitize_name_helper():
+    from app.api.routes_graph import _sanitize_name
+
+    assert _sanitize_name("my-graph_2") == "my-graph_2"
+    assert _sanitize_name("a b.c/d") == "a_b_c_d"
+
+
+def test_graph_path_helper(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    from app.api.routes_graph import _graph_path
+
+    p = _graph_path("weird name")
+    assert p == tmp_path / "weird_name.json"

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -30,3 +30,50 @@ def test_max_run_body_bytes_env_override(monkeypatch):
     from app.config import Settings
 
     assert Settings().MAX_RUN_BODY_BYTES == 1024
+
+
+# ── envelope builders ────────────────────────────────────────────────
+
+from app.api.routes_graph_run import build_envelope, error_response  # noqa: E402
+
+
+def test_build_envelope_has_all_keys_with_nulls():
+    env = build_envelope(status="ok", run_id="r1", graph="g", outputs={"y": 1})
+    assert set(env.keys()) == ENVELOPE_KEYS
+    assert env["status"] == "ok"
+    assert env["run_id"] == "r1"
+    assert env["graph"] == "g"
+    assert env["device"] is None
+    assert env["outputs"] == {"y": 1}
+    assert env["error"] is None
+    assert env["timing"] is None
+
+
+def test_error_response_mirrors_status_and_keeps_all_keys():
+    resp = error_response(
+        409, run_id="r2", graph="g", code="invalid_contract",
+        message="broken", details=["p1", "p2"],
+    )
+    assert resp.status_code == 409
+    body = json.loads(resp.body)
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["status"] == "error"
+    assert body["run_id"] == "r2"
+    assert body["outputs"] is None
+    assert body["error"] == {
+        "code": "invalid_contract", "message": "broken",
+        "node_id": None, "details": ["p1", "p2"],
+    }
+    assert body["timing"] is None
+
+
+def test_error_response_carries_device_node_id_timing_when_known():
+    resp = error_response(
+        500, run_id="r3", graph="g", code="execution_error",
+        message="node blew up", device="cpu", node_id="n7",
+        timing={"total_s": 1.02},
+    )
+    body = json.loads(resp.body)
+    assert body["device"] == "cpu"
+    assert body["error"]["node_id"] == "n7"
+    assert body["timing"] == {"total_s": 1.02}

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -677,3 +677,108 @@ async def test_run_403_without_token_is_out_of_envelope():
     body = resp.json()
     assert body == {"detail": "Missing or invalid X-CodefyUI-Token header"}
     assert "run_id" not in body
+
+
+# ── record_outputs + concurrency + disconnect policy ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_outputs_retrievable_by_run_id(test_client):
+    # Store set explicitly — the lifespan does not run under ASGITransport
+    # (pattern: test_routes_execution_outputs.py).
+    app.state.run_output_store = RunOutputStore(max_runs=5)
+    await _save_graph(test_client, _echo_graph(name="recorded"))
+    resp = await test_client.post(
+        "/api/graph/run/recorded",
+        json={"inputs": {"x": "keep me"}, "record_outputs": True},
+    )
+    assert resp.status_code == 200
+    run_id = resp.json()["run_id"]
+
+    listing = await test_client.get(f"/api/execution/outputs/{run_id}")
+    assert listing.status_code == 200
+    entries = listing.json()
+    assert any(e["node_id"] == "out" and e["port"] == "value" for e in entries)
+
+
+@pytest.mark.asyncio
+async def test_record_outputs_without_store_still_succeeds(test_client):
+    # getattr fallback: absent attribute means recording is skipped, not a 500.
+    had_store = hasattr(app.state, "run_output_store")
+    saved = getattr(app.state, "run_output_store", None)
+    if had_store:
+        delattr(app.state, "run_output_store")
+    try:
+        await _save_graph(test_client, _echo_graph(name="no-store"))
+        resp = await test_client.post(
+            "/api/graph/run/no-store",
+            json={"inputs": {"x": "hi"}, "record_outputs": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["outputs"] == {"y": "hi"}
+    finally:
+        if had_store:
+            app.state.run_output_store = saved
+
+
+@pytest.mark.asyncio
+async def test_record_outputs_default_off(test_client):
+    app.state.run_output_store = RunOutputStore(max_runs=5)
+    await _save_graph(test_client, _echo_graph(name="not-recorded"))
+    resp = await test_client.post("/api/graph/run/not-recorded",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 200
+    run_id = resp.json()["run_id"]
+    listing = await test_client.get(f"/api/execution/outputs/{run_id}")
+    assert listing.status_code == 404  # nothing recorded by default
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_are_independent(test_client):
+    await _save_graph(test_client, _echo_graph(name="concurrent"))
+    resp_a, resp_b = await asyncio.gather(
+        test_client.post("/api/graph/run/concurrent",
+                         json={"inputs": {"x": "alpha"}}),
+        test_client.post("/api/graph/run/concurrent",
+                         json={"inputs": {"x": "beta"}}),
+    )
+    assert resp_a.status_code == 200 and resp_b.status_code == 200
+    assert resp_a.json()["outputs"] == {"y": "alpha"}
+    assert resp_b.json()["outputs"] == {"y": "beta"}
+    assert resp_a.json()["run_id"] != resp_b.json()["run_id"]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_does_not_cancel_run(test_client):
+    """Spec-normative disconnect policy: a client disconnect never cancels
+    the run; only the timeout stops a run. Cancelling the client request
+    task mid-run simulates the disconnect; the surviving run is observable
+    through the record_outputs store."""
+    store = RunOutputStore(max_runs=5)
+    app.state.run_output_store = store
+    await _save_graph(test_client, _chain_graph("survives", "_SlowPass",
+                                                {"seconds": 1.0}))
+
+    request_task = asyncio.create_task(test_client.post(
+        "/api/graph/run/survives",
+        json={"inputs": {"x": "still here"}, "record_outputs": True},
+    ))
+    await asyncio.sleep(0.3)   # let the run reach the _SlowPass node
+    request_task.cancel()      # the client drops the connection
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+
+    # The shielded run keeps going: poll the store until the GraphOutput
+    # node's value lands (written only when the run reaches the end).
+    deadline = time.monotonic() + 10.0
+    recorded = None
+    while time.monotonic() < deadline:
+        for run_id in await store.list_runs():
+            value = await store.get(run_id, "out", "value")
+            if value is not None:
+                recorded = value
+                break
+        if recorded is not None:
+            break
+        await asyncio.sleep(0.1)
+    assert recorded == "still here"

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -374,6 +374,29 @@ class _BigTensorNode(BaseNode):
         return {"value": torch.zeros(65537)}
 
 
+class _NodeTimeoutNode(BaseNode):
+    """Raises a builtin TimeoutError — e.g. a node-level socket timeout.
+
+    On py3.11+ asyncio.TimeoutError IS builtins.TimeoutError, so this must
+    NOT be misrouted to the run's own "timeout" taxonomy row.
+    """
+
+    NODE_NAME = "_NodeTimeout"
+    CATEGORY = "Test"
+    DESCRIPTION = "Raises TimeoutError"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        raise TimeoutError("node-level timeout")
+
+
 @pytest.fixture(autouse=True)
 def _register_test_nodes():
     """Same direct-injection pattern conftest uses for _TestSource."""
@@ -383,6 +406,7 @@ def _register_test_nodes():
     registry._nodes["_Boom"] = _BoomNode
     registry._nodes["_Opaque"] = _OpaqueNode
     registry._nodes["_BigTensor"] = _BigTensorNode
+    registry._nodes["_NodeTimeout"] = _NodeTimeoutNode
     yield
 
 
@@ -555,6 +579,51 @@ async def test_run_422_input_errors_aggregated(test_client):
     assert "expected number" in by_input["x"]
 
 
+def _tiny_png_base64() -> str:
+    import base64
+    import io
+
+    from PIL import Image
+
+    img = Image.new("RGB", (4, 2), color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+@pytest.mark.asyncio
+async def test_run_422_image_decode_failure_is_enveloped_not_raw_500(
+    test_client, monkeypatch,
+):
+    # Regression guard for app.core.api_contract._decode_image: PIL's
+    # DecompressionBombError subclasses Exception directly (not OSError),
+    # so it used to escape inject_inputs as a raw, unenveloped 500. It must
+    # come back as a normal enveloped 422 invalid_input, like any other
+    # image decode failure.
+    import PIL.Image
+
+    await _save_graph(test_client, _echo_graph(
+        name="image-bomb", input_type="image", required=True,
+    ))
+
+    def _boom(*_args, **_kwargs):
+        raise PIL.Image.DecompressionBombError("boom")
+
+    monkeypatch.setattr(PIL.Image, "open", _boom)
+    resp = await test_client.post(
+        "/api/graph/run/image-bomb",
+        json={"inputs": {"x": _tiny_png_base64()}},
+    )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["error"]["code"] == "invalid_input"
+    assert any(
+        "does not decode to an image" in d["reason"]
+        for d in body["error"]["details"]
+    )
+
+
 @pytest.mark.asyncio
 async def test_run_422_missing_required(test_client):
     await _save_graph(test_client, _echo_graph(name="missing-req"))
@@ -628,6 +697,28 @@ async def test_run_500_timeout(test_client):
     assert body["timing"]["total_s"] >= 0.9
     # The in-flight executor thread finishes in the background (documented
     # limitation); nothing further to assert here.
+
+
+@pytest.mark.asyncio
+async def test_run_500_node_raised_timeouterror_is_execution_error(test_client):
+    # asyncio.TimeoutError IS builtins.TimeoutError on py3.11+: a NODE
+    # raising TimeoutError (e.g. a socket timeout) must be reported as
+    # execution_error with the node's own message — never misrouted to the
+    # run's "timeout" code, which would fabricate a run-exceeded message
+    # and spuriously cancel the context.
+    await _save_graph(
+        test_client, _chain_graph("node-timeout-graph", "_NodeTimeout"),
+    )
+    resp = await test_client.post(
+        "/api/graph/run/node-timeout-graph",
+        json={"inputs": {"x": "hi"}, "timeout_s": 300},  # generous
+    )
+    assert resp.status_code == 500
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["error"]["code"] == "execution_error"
+    assert body["error"]["node_id"] == "mid"
+    assert "node-level timeout" in body["error"]["message"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -1,0 +1,32 @@
+"""Tests for POST /api/graph/run/{name} and GET /api/graph/contract/{name}."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import settings
+from app.core.node_base import BaseNode, DataType, PortDefinition
+from app.core.run_output_store import RunOutputStore
+from app.main import app
+
+ENVELOPE_KEYS = {"status", "run_id", "graph", "device", "outputs", "error", "timing"}
+
+
+# ── config: body cap setting ─────────────────────────────────────────────
+
+
+def test_max_run_body_bytes_default():
+    assert settings.MAX_RUN_BODY_BYTES == 64 * 1024 * 1024
+
+
+def test_max_run_body_bytes_env_override(monkeypatch):
+    monkeypatch.setenv("CODEFYUI_MAX_RUN_BODY_BYTES", "1024")
+    from app.config import Settings
+
+    assert Settings().MAX_RUN_BODY_BYTES == 1024

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -77,3 +77,135 @@ def test_error_response_carries_device_node_id_timing_when_known():
     assert body["device"] == "cpu"
     assert body["error"]["node_id"] == "n7"
     assert body["timing"] == {"total_s": 1.02}
+
+
+# ── shared fixtures + graph builders for endpoint tests ──────────────────
+
+
+@pytest.fixture(autouse=True)
+def _graphs_dir(tmp_path, monkeypatch):
+    """Isolate saved graphs per test (pattern: test_api_graph.py)."""
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    return tmp_path
+
+
+def _echo_graph(
+    name: str = "echo-graph",
+    *,
+    input_name: str = "x",
+    output_name: str = "y",
+    input_type: str = "string",
+    required: bool = True,
+    default: str = "",
+) -> dict:
+    """Start -> GraphInput -> GraphOutput; the minimal contract-complete graph."""
+    return {
+        "name": name,
+        "description": "",
+        "nodes": [
+            {"id": "start", "type": "Start", "position": {"x": 0, "y": 0},
+             "data": {"params": {}}},
+            {"id": "gi", "type": "GraphInput", "position": {"x": 200, "y": 0},
+             "data": {"params": {
+                 "name": input_name, "type": input_type, "required": required,
+                 "default": default, "description": "",
+             }}},
+            {"id": "out", "type": "GraphOutput", "position": {"x": 400, "y": 0},
+             "data": {"params": {"name": output_name, "description": ""}}},
+        ],
+        "edges": [
+            {"id": "t1", "source": "start", "target": "gi",
+             "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+            {"id": "d1", "source": "gi", "target": "out",
+             "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        ],
+    }
+
+
+async def _save_graph(client, graph: dict) -> None:
+    resp = await client.post("/api/graph/save", json=graph)
+    assert resp.status_code == 200, resp.text
+
+
+# ── GET /api/graph/contract/{name} ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_contract_endpoint_schema(test_client):
+    graph = _echo_graph(name="contract-demo")
+    # A typed source gives output type derivation a real port to follow:
+    # TextInput.text is STRING.
+    graph["nodes"].append({"id": "ti", "type": "TextInput",
+                           "position": {"x": 0, "y": 200},
+                           "data": {"params": {"value": "hi"}}})
+    graph["nodes"].append({"id": "out2", "type": "GraphOutput",
+                           "position": {"x": 400, "y": 200},
+                           "data": {"params": {"name": "text_out", "description": ""}}})
+    graph["edges"].append({"id": "t2", "source": "start", "target": "ti",
+                           "sourceHandle": "trigger", "targetHandle": "",
+                           "type": "trigger"})
+    graph["edges"].append({"id": "d2", "source": "ti", "target": "out2",
+                           "sourceHandle": "text", "targetHandle": "value",
+                           "type": "data"})
+    await _save_graph(test_client, graph)
+
+    resp = await test_client.get("/api/graph/contract/contract-demo")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["graph"] == "contract-demo"
+    assert body["problems"] == []
+    # default is null for required inputs — never advertise a default the
+    # API will not apply.
+    assert body["inputs"] == [
+        {"name": "x", "type": "string", "required": True,
+         "default": None, "description": ""},
+    ]
+    by_name = {o["name"]: o for o in body["outputs"]}
+    assert by_name["y"]["type"] == "ANY"            # fed by GraphInput's ANY port
+    assert by_name["text_out"]["type"] == "STRING"  # derived from TextInput.text
+
+
+@pytest.mark.asyncio
+async def test_contract_optional_default_parsed(test_client):
+    await _save_graph(test_client, _echo_graph(
+        name="contract-optional", input_type="number",
+        required=False, default="2.5",
+    ))
+    resp = await test_client.get("/api/graph/contract/contract-optional")
+    body = resp.json()
+    assert body["inputs"][0]["required"] is False
+    assert body["inputs"][0]["default"] == 2.5
+
+
+@pytest.mark.asyncio
+async def test_contract_reports_problems_nonfatally(test_client):
+    await _save_graph(test_client, _echo_graph(
+        name="contract-broken", input_name="has space",
+    ))
+    resp = await test_client.get("/api/graph/contract/contract-broken")
+    assert resp.status_code == 200  # problems are reported here, enforced at /run
+    assert any("is invalid" in p for p in resp.json()["problems"])
+
+
+@pytest.mark.asyncio
+async def test_contract_unconnected_output_is_any_plus_problem(test_client):
+    graph = _echo_graph(name="contract-dangling")
+    graph["edges"] = [e for e in graph["edges"] if e["id"] != "d1"]  # cut gi->out
+    await _save_graph(test_client, graph)
+    resp = await test_client.get("/api/graph/contract/contract-dangling")
+    body = resp.json()
+    assert body["outputs"][0]["type"] == "ANY"
+    assert any("no incoming connection" in p for p in body["problems"])
+
+
+@pytest.mark.asyncio
+async def test_contract_404_missing_and_strict_name(test_client, _graphs_dir):
+    resp = await test_client.get("/api/graph/contract/never-saved")
+    assert resp.status_code == 404
+    # Strict name: the file exists under the SANITIZED name, but the raw
+    # name mismatches -> 404, never alias to a different file.
+    await _save_graph(test_client, _echo_graph(name="strict.name"))
+    assert (_graphs_dir / "strict_name.json").exists()
+    resp = await test_client.get("/api/graph/contract/strict.name")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Graph 'strict.name' not found"}

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -209,3 +209,84 @@ async def test_contract_404_missing_and_strict_name(test_client, _graphs_dir):
     resp = await test_client.get("/api/graph/contract/strict.name")
     assert resp.status_code == 404
     assert resp.json() == {"detail": "Graph 'strict.name' not found"}
+
+
+# ── POST /api/graph/run/{name}: happy path ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_happy_path_all_envelope_keys(test_client):
+    await _save_graph(test_client, _echo_graph(name="run-echo"))
+    resp = await test_client.post("/api/graph/run/run-echo",
+                                  json={"inputs": {"x": "hello"}})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["status"] == "ok"
+    assert body["run_id"]  # non-null, non-empty
+    assert body["graph"] == "run-echo"
+    assert body["device"] == "cpu"  # resolve_device(None) echo
+    assert body["outputs"] == {"y": "hello"}
+    assert body["error"] is None
+    assert body["timing"]["total_s"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_run_body_optional_uses_default(test_client):
+    await _save_graph(test_client, _echo_graph(
+        name="run-default", required=False, default="fallback",
+    ))
+    resp = await test_client.post("/api/graph/run/run-default")  # no body at all
+    assert resp.status_code == 200
+    assert resp.json()["outputs"] == {"y": "fallback"}
+
+
+@pytest.mark.asyncio
+async def test_run_empty_json_body_equals_absent_body(test_client):
+    await _save_graph(test_client, _echo_graph(
+        name="run-empty", required=False, default="fallback",
+    ))
+    resp = await test_client.post("/api/graph/run/run-empty", json={})
+    assert resp.status_code == 200
+    assert resp.json()["outputs"] == {"y": "fallback"}
+
+
+@pytest.mark.asyncio
+async def test_run_device_echo(test_client):
+    await _save_graph(test_client, _echo_graph(name="run-device"))
+    resp = await test_client.post("/api/graph/run/run-device",
+                                  json={"inputs": {"x": "hi"}, "device": "cpu"})
+    assert resp.status_code == 200
+    assert resp.json()["device"] == "cpu"
+
+
+@pytest.mark.asyncio
+async def test_run_typed_inputs_roundtrip(test_client):
+    cases = [
+        ("run-num", "number", 3, 3.0),
+        ("run-int", "integer", 3.0, 3),
+        ("run-bool", "boolean", True, True),
+        ("run-json", "json", {"k": [1, 2]}, {"k": [1, 2]}),
+    ]
+    for graph_name, input_type, sent, expected in cases:
+        await _save_graph(test_client, _echo_graph(
+            name=graph_name, input_type=input_type,
+        ))
+        resp = await test_client.post(f"/api/graph/run/{graph_name}",
+                                      json={"inputs": {"x": sent}})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["outputs"] == {"y": expected}
+
+
+@pytest.mark.asyncio
+async def test_run_content_type_not_used_for_dispatch(test_client):
+    # A valid JSON body with a wrong Content-Type header still parses
+    # (behavior pinned by the spec).
+    await _save_graph(test_client, _echo_graph(name="run-ctype"))
+    resp = await test_client.post(
+        "/api/graph/run/run-ctype",
+        content=b'{"inputs": {"x": "hi"}}',
+        headers={"Content-Type": "text/plain"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["outputs"] == {"y": "hi"}

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -290,3 +290,390 @@ async def test_run_content_type_not_used_for_dispatch(test_client):
     )
     assert resp.status_code == 200
     assert resp.json()["outputs"] == {"y": "hi"}
+
+
+# ── test-support nodes (registered directly, conftest _TestSource pattern) ─
+
+
+class _SlowPassNode(BaseNode):
+    """Sleeps `seconds` in the executor thread, then passes value through."""
+
+    NODE_NAME = "_SlowPass"
+    CATEGORY = "Test"
+    DESCRIPTION = "Sleeps, then passes through"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        time.sleep(float(params.get("seconds", 2.0)))
+        return {"value": inputs.get("value")}
+
+
+class _BoomNode(BaseNode):
+    """Raises on execute — drives the execution_error taxonomy row."""
+
+    NODE_NAME = "_Boom"
+    CATEGORY = "Test"
+    DESCRIPTION = "Raises RuntimeError"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("boom: intentional test failure")
+
+
+class _OpaqueNode(BaseNode):
+    """Emits a non-serializable object — drives unserializable_output."""
+
+    NODE_NAME = "_Opaque"
+    CATEGORY = "Test"
+    DESCRIPTION = "Emits object()"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        return {"value": object()}
+
+
+class _BigTensorNode(BaseNode):
+    """Emits a 65,537-element tensor — drives output_too_large."""
+
+    NODE_NAME = "_BigTensor"
+    CATEGORY = "Test"
+    DESCRIPTION = "Emits a tensor over the serialization cap"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        import torch
+
+        return {"value": torch.zeros(65537)}
+
+
+@pytest.fixture(autouse=True)
+def _register_test_nodes():
+    """Same direct-injection pattern conftest uses for _TestSource."""
+    from app.core.node_registry import registry
+
+    registry._nodes["_SlowPass"] = _SlowPassNode
+    registry._nodes["_Boom"] = _BoomNode
+    registry._nodes["_Opaque"] = _OpaqueNode
+    registry._nodes["_BigTensor"] = _BigTensorNode
+    yield
+
+
+def _chain_graph(name: str, middle_type: str,
+                 middle_params: dict | None = None) -> dict:
+    """Start -> GraphInput -> <middle> -> GraphOutput."""
+    g = _echo_graph(name=name)
+    g["nodes"].insert(2, {"id": "mid", "type": middle_type,
+                          "position": {"x": 300, "y": 0},
+                          "data": {"params": middle_params or {}}})
+    g["edges"] = [
+        {"id": "t1", "source": "start", "target": "gi",
+         "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+        {"id": "d1", "source": "gi", "target": "mid",
+         "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        {"id": "d2", "source": "mid", "target": "out",
+         "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+    ]
+    return g
+
+
+# ── POST /run error taxonomy ─────────────────────────────────────────────
+
+from app.core.graph_engine import GraphValidationError  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_run_404_missing_graph(test_client):
+    resp = await test_client.post("/api/graph/run/never-saved", json={})
+    assert resp.status_code == 404
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "graph_not_found"
+    assert body["run_id"]                    # never null, even on rejections
+    assert body["device"] is None            # rejected before device resolution
+    assert body["timing"] is None            # execution never attempted
+
+
+@pytest.mark.asyncio
+async def test_run_404_strict_name(test_client, _graphs_dir):
+    # The file exists under the SANITIZED name; the raw name mismatches.
+    await _save_graph(test_client, _echo_graph(name="strict.run"))
+    assert (_graphs_dir / "strict_run.json").exists()
+    resp = await test_client.post("/api/graph/run/strict.run",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "graph_not_found"
+
+
+@pytest.mark.asyncio
+async def test_run_500_graph_unreadable(test_client, _graphs_dir):
+    (_graphs_dir / "corrupt.json").write_text("{not json")
+    resp = await test_client.post("/api/graph/run/corrupt", json={})
+    assert resp.status_code == 500
+    assert resp.json()["error"]["code"] == "graph_unreadable"
+
+
+@pytest.mark.asyncio
+async def test_run_409_invalid_contract(test_client):
+    await test_client.post("/api/graph/save",
+                           json=_echo_graph(name="bad-contract",
+                                            input_name="has space"))
+    resp = await test_client.post("/api/graph/run/bad-contract", json={})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_contract"
+    assert any("is invalid" in d for d in body["error"]["details"])
+
+
+@pytest.mark.asyncio
+async def test_run_409_no_entry_points(test_client):
+    graph = _echo_graph(name="no-entry")
+    graph["nodes"] = [n for n in graph["nodes"] if n["type"] != "Start"]
+    graph["edges"] = [e for e in graph["edges"] if e["type"] != "trigger"]
+    await _save_graph(test_client, graph)
+    resp = await test_client.post("/api/graph/run/no-entry", json={})
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "no_entry_points"
+
+
+@pytest.mark.asyncio
+async def test_run_409_untriggered_input(test_client):
+    graph = _echo_graph(name="untriggered")
+    # Retarget the trigger away from the GraphInput to a bystander node.
+    graph["nodes"].append({"id": "src", "type": "_TestSource",
+                           "position": {"x": 0, "y": 200},
+                           "data": {"params": {}}})
+    graph["edges"][0]["target"] = "src"
+    await _save_graph(test_client, graph)
+    resp = await test_client.post("/api/graph/run/untriggered",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "untriggered_input"
+    assert body["error"]["details"] == ["x"]
+
+
+@pytest.mark.asyncio
+async def test_run_409_unreachable_output(test_client):
+    graph = _echo_graph(name="unreachable")
+    graph["nodes"].append({"id": "src2", "type": "_TestSource",
+                           "position": {"x": 0, "y": 200},
+                           "data": {"params": {}}})
+    graph["nodes"].append({"id": "out2", "type": "GraphOutput",
+                           "position": {"x": 400, "y": 200},
+                           "data": {"params": {"name": "y2", "description": ""}}})
+    graph["edges"].append({"id": "d9", "source": "src2", "target": "out2",
+                           "sourceHandle": "value", "targetHandle": "value",
+                           "type": "data"})
+    await _save_graph(test_client, graph)
+    resp = await test_client.post("/api/graph/run/unreachable",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "unreachable_output"
+    assert body["error"]["details"] == ["y2"]
+
+
+@pytest.mark.asyncio
+async def test_run_409_invalid_graph_static(test_client):
+    graph = _echo_graph(name="bad-port")
+    graph["nodes"].append({"id": "pr", "type": "Print",
+                           "position": {"x": 300, "y": 200},
+                           "data": {"params": {}}})
+    graph["edges"].append({"id": "d8", "source": "gi", "target": "pr",
+                           "sourceHandle": "value", "targetHandle": "bogus",
+                           "type": "data"})
+    await _save_graph(test_client, graph)
+    resp = await test_client.post("/api/graph/run/bad-port",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_graph"
+    assert any("bogus" in d for d in body["error"]["details"])
+
+
+@pytest.mark.asyncio
+async def test_run_409_runtime_graph_validation_error_safety_net(
+    test_client, monkeypatch,
+):
+    await _save_graph(test_client, _echo_graph(name="runtime-gve"))
+
+    async def _boom(*args, **kwargs):
+        raise GraphValidationError("preset trigger edge dangling after expansion")
+
+    monkeypatch.setattr("app.api.routes_graph_run.execute_graph", _boom)
+    resp = await test_client.post("/api/graph/run/runtime-gve",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_graph"
+    assert body["error"]["details"] == [
+        "preset trigger edge dangling after expansion",
+    ]
+    assert body["timing"] is not None  # execution WAS attempted
+
+
+@pytest.mark.asyncio
+async def test_run_422_input_errors_aggregated(test_client):
+    await _save_graph(test_client, _echo_graph(name="agg-errors",
+                                               input_type="number"))
+    resp = await test_client.post("/api/graph/run/agg-errors",
+                                  json={"inputs": {"x": "NaN-ish", "typo": 1}})
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_input"
+    by_input = {d["input"]: d["reason"] for d in body["error"]["details"]}
+    assert by_input["typo"] == "unknown input name"
+    assert "expected number" in by_input["x"]
+
+
+@pytest.mark.asyncio
+async def test_run_422_missing_required(test_client):
+    await _save_graph(test_client, _echo_graph(name="missing-req"))
+    resp = await test_client.post("/api/graph/run/missing-req", json={})
+    assert resp.status_code == 422
+    assert resp.json()["error"]["details"] == [
+        {"input": "x", "reason": "missing required input"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_422_malformed_bodies(test_client):
+    await _save_graph(test_client, _echo_graph(name="malformed"))
+    # Bad JSON.
+    resp = await test_client.post("/api/graph/run/malformed",
+                                  content=b"{not json",
+                                  headers={"Content-Type": "application/json"})
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "invalid_input"
+    # Non-dict body.
+    resp = await test_client.post("/api/graph/run/malformed", json=[1, 2])
+    assert resp.status_code == 422
+    assert any(d["field"] == "body" for d in resp.json()["error"]["details"])
+    # Non-dict inputs.
+    resp = await test_client.post("/api/graph/run/malformed",
+                                  json={"inputs": [1]})
+    assert resp.status_code == 422
+    assert any(d["field"] == "inputs" for d in resp.json()["error"]["details"])
+    # Wrong-typed / out-of-range fields.
+    for bad in ({"timeout_s": "fast"}, {"timeout_s": 0}, {"timeout_s": 5000},
+                {"timeout_s": True}, {"device": 3}, {"record_outputs": "yes"}):
+        resp = await test_client.post("/api/graph/run/malformed", json=bad)
+        assert resp.status_code == 422, bad
+        assert resp.json()["error"]["code"] == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_run_413_payload_too_large(test_client, monkeypatch):
+    await _save_graph(test_client, _echo_graph(name="too-big"))
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 16)
+    resp = await test_client.post("/api/graph/run/too-big",
+                                  json={"inputs": {"x": "0123456789abcdef0123"}})
+    assert resp.status_code == 413
+    assert resp.json()["error"]["code"] == "payload_too_large"
+
+
+@pytest.mark.asyncio
+async def test_run_500_execution_error_carries_node_id(test_client):
+    await _save_graph(test_client, _chain_graph("boom-graph", "_Boom"))
+    resp = await test_client.post("/api/graph/run/boom-graph",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["error"]["code"] == "execution_error"
+    assert body["error"]["node_id"] == "mid"
+    assert "boom: intentional test failure" in body["error"]["message"]
+    assert body["timing"] is not None
+
+
+@pytest.mark.asyncio
+async def test_run_500_timeout(test_client):
+    await _save_graph(test_client, _chain_graph("slow-graph", "_SlowPass",
+                                                {"seconds": 3.0}))
+    resp = await test_client.post("/api/graph/run/slow-graph",
+                                  json={"inputs": {"x": "hi"}, "timeout_s": 1})
+    assert resp.status_code == 500  # never 504 — 504 belongs to intermediaries
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["status"] == "error"
+    assert body["error"]["code"] == "timeout"
+    assert body["timing"]["total_s"] >= 0.9
+    # The in-flight executor thread finishes in the background (documented
+    # limitation); nothing further to assert here.
+
+
+@pytest.mark.asyncio
+async def test_run_500_output_not_produced_safety_net(test_client, monkeypatch):
+    await _save_graph(test_client, _echo_graph(name="net-missing"))
+    monkeypatch.setattr("app.core.api_contract.collect_outputs",
+                        lambda contract, result: ({}, ["y"]))
+    resp = await test_client.post("/api/graph/run/net-missing",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["error"]["code"] == "output_not_produced"
+    assert body["error"]["details"] == ["y"]
+
+
+@pytest.mark.asyncio
+async def test_run_500_unserializable_output(test_client):
+    await _save_graph(test_client, _chain_graph("opaque-graph", "_Opaque"))
+    resp = await test_client.post("/api/graph/run/opaque-graph",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["error"]["code"] == "unserializable_output"
+    assert body["error"]["details"][0]["output"] == "y"
+
+
+@pytest.mark.asyncio
+async def test_run_500_output_too_large(test_client):
+    await _save_graph(test_client, _chain_graph("big-graph", "_BigTensor"))
+    resp = await test_client.post("/api/graph/run/big-graph",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["error"]["code"] == "output_too_large"
+    assert "65537" in body["error"]["details"][0]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_run_403_without_token_is_out_of_envelope():
+    # The auth middleware fires before the route; its 403 does NOT carry
+    # the envelope (documented out-of-envelope response).
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url=f"http://127.0.0.1:{settings.PORT}") as anon:
+        resp = await anon.post("/api/graph/run/anything", json={})
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body == {"detail": "Missing or invalid X-CodefyUI-Token header"}
+    assert "run_id" not in body

--- a/backend/tests/test_graph_input_node.py
+++ b/backend/tests/test_graph_input_node.py
@@ -1,0 +1,121 @@
+"""Tests for the GraphInput node — declares a named input of the graph."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.api_contract import InputCoercionError
+from app.core.node_base import DataType, ParamType
+from app.nodes.io.graph_input_node import GraphInputNode
+
+
+def test_metadata():
+    assert GraphInputNode.NODE_NAME == "GraphInput"
+    assert GraphInputNode.CATEGORY == "IO"
+    assert "API" in GraphInputNode.DESCRIPTION  # palette search finds it
+    assert GraphInputNode.cacheable is True
+
+
+def test_ports():
+    assert GraphInputNode.define_inputs() == []
+    outputs = GraphInputNode.define_outputs()
+    assert len(outputs) == 1
+    assert outputs[0].name == "value"
+    assert outputs[0].data_type == DataType.ANY
+
+
+def test_declared_params_exclude_value():
+    params = GraphInputNode.define_params()
+    names = [p.name for p in params]
+    assert names == ["name", "type", "required", "default", "description"]
+    assert "value" not in names  # the injected param must never render in the UI
+    by_name = {p.name: p for p in params}
+    assert by_name["name"].default == "input"
+    assert by_name["type"].param_type == ParamType.SELECT
+    assert by_name["type"].options == [
+        "string", "number", "integer", "boolean", "json", "image",
+    ]
+    assert by_name["type"].default == "string"
+    assert by_name["required"].param_type == ParamType.BOOL
+    assert by_name["required"].default is True
+    assert by_name["default"].default == ""
+    assert by_name["description"].default == ""
+
+
+def test_injected_value_takes_precedence_over_default():
+    res = GraphInputNode().execute(
+        {}, {"type": "string", "value": "from-api", "default": "from-canvas"}
+    )
+    assert res == {"value": "from-api"}
+
+
+def test_canvas_default_string_parsing_number():
+    res = GraphInputNode().execute({}, {"type": "number", "default": "2.5"})
+    assert res == {"value": 2.5}
+
+
+def test_canvas_default_boolean_and_json():
+    assert GraphInputNode().execute({}, {"type": "boolean", "default": "true"}) == {
+        "value": True
+    }
+    assert GraphInputNode().execute({}, {"type": "json", "default": '{"a": 1}'}) == {
+        "value": {"a": 1}
+    }
+
+
+def test_injected_integral_float_integer():
+    assert GraphInputNode().execute({}, {"type": "integer", "value": 3.0}) == {"value": 3}
+    with pytest.raises(InputCoercionError):
+        GraphInputNode().execute({}, {"type": "integer", "value": 3.5})
+
+
+def test_injected_value_strict_no_string_parsing():
+    with pytest.raises(InputCoercionError):
+        GraphInputNode().execute({}, {"type": "number", "value": "2.5"})
+
+
+def test_missing_type_defaults_to_string():
+    assert GraphInputNode().execute({}, {"default": "plain"}) == {"value": "plain"}
+
+
+def test_image_default_empty_raises_clear_canvas_error():
+    with pytest.raises(ValueError, match="server-local image path"):
+        GraphInputNode().execute({}, {"type": "image", "default": ""})
+
+
+def test_image_default_missing_file_raises():
+    with pytest.raises(FileNotFoundError):
+        GraphInputNode().execute({}, {"type": "image", "default": "no_such_file_12345.png"})
+
+
+def test_image_default_loads_file(tmp_path):
+    import torch
+    from PIL import Image
+
+    p = tmp_path / "tiny.png"
+    Image.new("RGB", (4, 2), color=(0, 255, 0)).save(p)
+    res = GraphInputNode().execute({}, {"type": "image", "default": str(p)})
+    assert isinstance(res["value"], torch.Tensor)
+    assert res["value"].shape == (3, 2, 4)
+
+
+def test_image_injected_value_is_decoded_base64():
+    import base64
+    import io
+
+    import torch
+    from PIL import Image
+
+    img = Image.new("RGB", (4, 2), color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    res = GraphInputNode().execute({}, {"type": "image", "value": b64})
+    assert isinstance(res["value"], torch.Tensor)
+    assert res["value"].shape == (3, 2, 4)
+
+
+def test_registry_discovers_graph_input():
+    from app.core.node_registry import registry
+
+    assert registry.get("GraphInput") is GraphInputNode

--- a/backend/tests/test_graph_input_node.py
+++ b/backend/tests/test_graph_input_node.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from app.core.api_contract import InputCoercionError
+from app.core.api_contract import INPUT_TYPES, InputCoercionError
 from app.core.node_base import DataType, ParamType
 from app.nodes.io.graph_input_node import GraphInputNode
 
@@ -32,6 +32,9 @@ def test_declared_params_exclude_value():
     by_name = {p.name: p for p in params}
     assert by_name["name"].default == "input"
     assert by_name["type"].param_type == ParamType.SELECT
+    # Options must track INPUT_TYPES exactly — no hand-maintained duplicate
+    # list that can drift from the contract's source of truth.
+    assert by_name["type"].options == list(INPUT_TYPES)
     assert by_name["type"].options == [
         "string", "number", "integer", "boolean", "json", "image",
     ]

--- a/backend/tests/test_graph_output_node.py
+++ b/backend/tests/test_graph_output_node.py
@@ -1,0 +1,45 @@
+"""Tests for the GraphOutput node — declares a named output of the graph."""
+
+from __future__ import annotations
+
+from app.core.node_base import DataType
+from app.nodes.io.graph_output_node import GraphOutputNode
+
+
+def test_metadata():
+    assert GraphOutputNode.NODE_NAME == "GraphOutput"
+    assert GraphOutputNode.CATEGORY == "IO"
+    assert "API" in GraphOutputNode.DESCRIPTION  # palette search finds it
+
+
+def test_ports():
+    inputs = GraphOutputNode.define_inputs()
+    assert len(inputs) == 1
+    assert inputs[0].name == "value"
+    assert inputs[0].data_type == DataType.ANY
+    assert inputs[0].optional is False  # missing connection -> required-input check
+    assert GraphOutputNode.define_outputs() == []
+
+
+def test_params():
+    params = GraphOutputNode.define_params()
+    names = [p.name for p in params]
+    assert names == ["name", "description"]
+    by_name = {p.name: p for p in params}
+    assert by_name["name"].default == "output"
+    assert by_name["description"].default == ""
+
+
+def test_execute_passes_value_through():
+    res = GraphOutputNode().execute({"value": 42}, {"name": "y"})
+    assert res == {"value": 42}
+
+
+def test_execute_missing_input_yields_none():
+    assert GraphOutputNode().execute({}, {}) == {"value": None}
+
+
+def test_registry_discovers_graph_output():
+    from app.core.node_registry import registry
+
+    assert registry.get("GraphOutput") is GraphOutputNode

--- a/docs/docs/usage/cli-runner.md
+++ b/docs/docs/usage/cli-runner.md
@@ -8,6 +8,8 @@ description: Execute a saved graph.json directly from the command line with run_
 
 You can execute any graph directly from the command line without starting the server. This is handy for batch runs, CI, or reproducing a pipeline headlessly.
 
+If you want to call a *saved* graph on a *running* server instead — declared inputs in, declared outputs out, over HTTP — see **[Graph as a Function](./graph-as-a-function)**.
+
 ```bash
 cd backend
 python run_graph.py ../examples/Usage_Example/CNN-MNIST/TrainCNN-MNIST/graph.json

--- a/docs/docs/usage/graph-as-a-function.md
+++ b/docs/docs/usage/graph-as-a-function.md
@@ -1,0 +1,209 @@
+---
+sidebar_position: 7.5
+title: Graph as a Function
+description: Call any saved graph headlessly over HTTP as a named function — declared inputs in, declared outputs out.
+---
+
+# Graph as a Function
+
+Any graph you can run on the canvas can also be called over HTTP as a named function: you declare its inputs and outputs with two nodes, save it, and `POST /api/graph/run/{name}` executes it and returns JSON.
+
+**When to use this vs the [CLI runner](./cli-runner):** the CLI runner executes a `graph.json` file in a fresh Python process with no server — good for batch jobs and CI. The run API calls a *saved* graph on a *running* CodefyUI server — good for scripts, notebooks, and automations that want a function call with typed inputs and outputs instead of a process launch.
+
+## 1. Declare the contract on the canvas
+
+Two nodes in the palette's **IO** group define the graph's function signature:
+
+- **GraphInput** — one per input. Params: `name` (identifier-safe: `^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`), `type` (`string` / `number` / `integer` / `boolean` / `json` / `image`), `required`, `default`, `description`.
+- **GraphOutput** — one per output. Params: `name`, `description`. Connect the value you want returned into its `value` port.
+
+**Wire Start into every GraphInput.** GraphInput nodes are data roots; the engine only executes nodes reachable from a Start trigger, so an untriggered GraphInput would be silently skipped. The run endpoint rejects such graphs up front (409 `untriggered_input`) instead of running without your input.
+
+```text
+[Start] --trigger--> [GraphInput name="message"] --value--> [Print] --value--> [GraphOutput name="echo"]
+```
+
+The `default` param is always the canvas test value, so the same graph still runs unchanged from the Run button. For API calls, `default` applies only when `required` is off. `default` is a string field parsed per `type` (`2.5`, `true`, `{"k": 1}`) — this string parsing is the one place the API's strict typing does not apply.
+
+## 2. Getting the token for external scripts
+
+Mutating requests need the `X-CodefyUI-Token` header. Two ways to get it:
+
+- Read the token file: `<user_data_dir>/codefyui/session.token` — on Windows `%LOCALAPPDATA%\codefyui\session.token`, on macOS `~/Library/Application Support/codefyui/session.token`, on Linux `~/.local/share/codefyui/session.token`. Honors `CODEFYUI_USER_DATA_DIR` for dev-mode installs.
+- Or `GET /api/auth/bootstrap` returns `{"token": "..."}` (same-host only).
+
+The token rotates on every server restart — scripts should re-read the file rather than caching the value.
+
+## 3. Inspect the contract
+
+```text
+GET /api/graph/contract/{name}     (no auth required, like /api/graph/load)
+```
+
+```json
+{
+  "graph": "my-graph",
+  "inputs":  [{"name": "prompt", "type": "string", "required": true, "default": null, "description": ""}],
+  "outputs": [{"name": "answer", "type": "SCALAR", "description": ""}],
+  "problems": []
+}
+```
+
+- `default` is `null` for required inputs — the API never applies a required input's default, so it never advertises one. Optional inputs show the parsed default value.
+- Output `type` is derived from the port feeding the GraphOutput (`ANY` when it cannot be resolved).
+- `problems` lists contract issues (bad names, duplicates, an optional default that does not parse, an optional image input). They are reported here non-fatally so you can inspect a half-built graph — but they block `/run` with 409.
+
+## 4. Run the graph
+
+```text
+POST /api/graph/run/{name}         (auth: X-CodefyUI-Token header)
+Content-Type: application/json
+```
+
+The body is OPTIONAL (absent body means `{}`), and every field is optional:
+
+```json
+{
+  "inputs": {"prompt": "hello"},   // default {}
+  "timeout_s": 300,                // default 300, min 1, max 3600
+  "device": "cuda",                // "cpu" / "cuda" / "mps"; falls back to CPU when unavailable
+  "record_outputs": false          // default false; see gotchas before enabling
+}
+```
+
+### The response envelope
+
+Every `/run` response — success or failure — is this one shape, with ALL keys always present (`null` when not applicable):
+
+```json
+{
+  "status": "ok",                 // "ok" | "error"
+  "run_id": "9f2c...",            // assigned at request entry; NEVER null
+  "graph": "my-graph",
+  "device": "cuda",               // what you actually got; null on early rejections
+  "outputs": {"answer": 0.93},    // null unless status == "ok"
+  "error": null,                  // null on success, else {"code", "message", "node_id", "details"}
+  "timing": {"total_s": 1.234}    // null when execution was never attempted
+}
+```
+
+The HTTP status mirrors `status`/`error.code`, so `raise_for_status()` works.
+
+Forward compatibility: **Clients MUST ignore unknown envelope fields.** **`error.code` is an open enum — treat unknown codes as generic errors.** A future async mode will return 202 `{"status": "queued", "run_id": ..., "job": {...}}` — sync clients switching on `status` keep working unmodified.
+
+### Error taxonomy
+
+Triage rule: **404 = wrong name; 409 = fix the graph; 413 = shrink your payload; 422 = fix your payload; 500 = run failed.**
+
+| `error.code` | HTTP | Trigger |
+| --- | --- | --- |
+| `graph_not_found` | 404 | no exact-match graph file (strict name matching — `my.graph` never aliases to `my_graph`) |
+| `graph_unreadable` | 500 | graph file exists but is corrupt JSON |
+| `invalid_contract` | 409 | contract `problems[]` non-empty (`details` lists them) |
+| `no_entry_points` | 409 | no Start trigger anywhere in the graph |
+| `untriggered_input` | 409 | a GraphInput has no incoming trigger edge (`details`: input names) |
+| `unreachable_output` | 409 | a GraphOutput is not reachable from any Start (`details`: output names) |
+| `invalid_graph` | 409 | graph validation failed, statically or at runtime (`details`: errors) |
+| `invalid_input` | 422 | unknown input name (case-sensitive), missing required input, type mismatch, malformed body — all aggregated in `details` |
+| `payload_too_large` | 413 | body exceeds `MAX_RUN_BODY_BYTES` (default 64 MB, `CODEFYUI_MAX_RUN_BODY_BYTES`) |
+| `execution_error` | 500 | a node raised; `node_id` names it |
+| `timeout` | 500 | `timeout_s` expired; `timing.total_s` = elapsed |
+| `output_not_produced` | 500 | declared output missing from the engine result (safety net) |
+| `output_too_large` / `unserializable_output` | 500 | see output serialization below |
+
+## 5. Input types
+
+| `type` | Send (JSON) | Rejected |
+| --- | --- | --- |
+| `string` | a JSON string | numbers, booleans, null (no implicit `str()`) |
+| `number` | int or float | strings (`"3"`), booleans, null |
+| `integer` | int, or a float with zero fraction (`3.0` -> `3`) | `3.5`, strings, booleans |
+| `boolean` | `true` / `false` | `0`/`1`, `"true"` |
+| `json` | any JSON value | nothing |
+| `image` | a base64 string (optionally `data:image/...;base64,`-prefixed) | non-strings, undecodable data |
+
+Typing is strict on purpose: JSON already carries types, so typos fail loudly instead of silently coercing. The one loosening is `integer` accepting integral floats (JS clients cannot control whether `3` serializes as `3.0`).
+
+An `image` input arrives at the graph as a `(C, H, W)` float32 tensor in `[0, 1]` — exactly what `ImageReader` produces. Image inputs must be `required` (there is no sensible base64 default); the node's `default` is a server-local file path used only for canvas runs.
+
+```python
+import base64
+from pathlib import Path
+
+img_b64 = base64.b64encode(Path("cat.png").read_bytes()).decode("ascii")
+# ... json={"inputs": {"photo": img_b64}}
+```
+
+## 6. Output serialization
+
+| Value at a GraphOutput | JSON form |
+| --- | --- |
+| `None`, bool, int, float, str | as-is (base64-string plots pass through as plain strings) |
+| dict / list / tuple | recursively serialized (tuples become lists) |
+| numpy scalar | plain number |
+| tensor / ndarray | `{"__type__": "tensor", "shape": [...], "dtype": "torch.float32", "values": [...]}` — capped at **65,536 elements**; 0-dim tensors keep `"shape": []` |
+| PIL image | `{"__type__": "image", "format": "png", "base64": "..."}` |
+| `torch.nn.Module` | error — save it with a ModelSaver node in-graph and return the path string instead |
+| anything else | error `unserializable_output` naming the type |
+
+## 7. Examples
+
+Save your graph on the canvas first (the run API executes *saved* graphs by name). Python `requests`:
+
+```python
+import os
+from pathlib import Path
+
+import requests
+
+# Windows: %LOCALAPPDATA%\codefyui\session.token
+# macOS:   ~/Library/Application Support/codefyui/session.token
+# Linux:   ~/.local/share/codefyui/session.token
+token = (Path(os.environ["LOCALAPPDATA"]) / "codefyui" / "session.token").read_text().strip()
+
+resp = requests.post(
+    "http://127.0.0.1:8000/api/graph/run/Api-Function",
+    headers={"X-CodefyUI-Token": token},
+    json={"inputs": {"message": "hello from Python"}},
+    timeout=310,  # slightly above the server-side default timeout_s=300
+)
+resp.raise_for_status()
+envelope = resp.json()
+print(envelope["outputs"]["echo"])
+```
+
+curl on Windows: use `curl.exe` (PowerShell aliases `curl` to `Invoke-WebRequest`) and ALWAYS pass the body as a file with `--data "@payload.json"` — inline JSON fights cmd's 8191-character limit and PowerShell quoting, and inline base64 images are outright impossible:
+
+```powershell
+# payload.json: {"inputs": {"message": "hello from curl"}}
+$token = Get-Content "$env:LOCALAPPDATA\codefyui\session.token"
+curl.exe -s -X POST "http://127.0.0.1:8000/api/graph/run/Api-Function" `
+  -H "X-CodefyUI-Token: $token" -H "Content-Type: application/json" `
+  --data "@payload.json"
+```
+
+Inspect the contract first when scripting against an unfamiliar graph:
+
+```powershell
+curl.exe -s "http://127.0.0.1:8000/api/graph/contract/Api-Function"
+```
+
+A ready-made graph for these exact calls ships in `examples/Usage_Example/Api-Function/` — open it from the Examples gallery, save it, and the commands above work verbatim.
+
+## 8. Limits and gotchas
+
+- 403 (missing/invalid token) and 421 (Host guard) arrive WITHOUT the envelope — they fire before the route.
+- This server never emits 504; a 504 always came from an intermediary.
+- `record_outputs=true` makes results readable by anyone on the LAN who learns the `run_id` (the GET outputs endpoint is auth-exempt; transport is plain HTTP) — auth on read endpoints is a hard Stage 2 requirement.
+- Do not put secrets in `default` values — `GET /contract` and `/load` are unauthenticated.
+- `device: "auto"` (or an unavailable device) silently resolves to CPU; the envelope's `device` field shows what you actually got.
+- A single >65,536-element tensor output fails the whole call — remove that GraphOutput or use `record_outputs` + the slicing outputs API (`GET /api/execution/outputs/{run_id}/{node_id}/{port}?slice=...`); an outputs filter is deferred.
+- Concurrent runs share the process default thread pool (the per-run parallelism limit of 4 is not a global limit) — heavy runs contend for CPU/GPU.
+- After a timeout, cancellation is cooperative: only nodes that poll `context.cancelled` stop; the node already in flight finishes in the background, including its side effects.
+- Client disconnects do not stop a run; only the timeout does. Results of a disconnected run are discarded unless `record_outputs=true`.
+
+## 9. Roadmap
+
+- `cdui call <graph> --input k=v` — CLI wrapper over this API (fast-follow DX item).
+- Async job mode (202 + `job.status_url`) reusing the same envelope.
+- Stage 2: SQLite run history, publishing, auth on read endpoints.

--- a/docs/docs/usage/graph-as-a-function.md
+++ b/docs/docs/usage/graph-as-a-function.md
@@ -93,7 +93,7 @@ Forward compatibility: **Clients MUST ignore unknown envelope fields.** **`error
 
 ### Error taxonomy
 
-Triage rule: **404 = wrong name; 409 = fix the graph; 413 = shrink your payload; 422 = fix your payload; 500 = run failed.**
+Triage rule: **404 = wrong name; 409 = fix the graph; 413 = shrink your payload; 422 = fix your payload; 500 = run failed (or the graph file was unreadable).**
 
 | `error.code` | HTTP | Trigger |
 | --- | --- | --- |
@@ -194,12 +194,12 @@ A ready-made graph for these exact calls ships in `examples/Usage_Example/Api-Fu
 
 - 403 (missing/invalid token) and 421 (Host guard) arrive WITHOUT the envelope — they fire before the route.
 - This server never emits 504; a 504 always came from an intermediary.
-- `record_outputs=true` makes results readable by anyone on the LAN who learns the `run_id` (the GET outputs endpoint is auth-exempt; transport is plain HTTP) — auth on read endpoints is a hard Stage 2 requirement.
+- `record_outputs=true` makes inputs and results readable by anyone on the LAN who learns the `run_id` (the GET outputs endpoint is auth-exempt; transport is plain HTTP) — auth on read endpoints is a hard Stage 2 requirement.
 - Do not put secrets in `default` values — `GET /contract` and `/load` are unauthenticated.
 - `device: "auto"` (or an unavailable device) silently resolves to CPU; the envelope's `device` field shows what you actually got.
 - A single >65,536-element tensor output fails the whole call — remove that GraphOutput or use `record_outputs` + the slicing outputs API (`GET /api/execution/outputs/{run_id}/{node_id}/{port}?slice=...`); an outputs filter is deferred.
 - Concurrent runs share the process default thread pool (the per-run parallelism limit of 4 is not a global limit) — heavy runs contend for CPU/GPU.
-- After a timeout, cancellation is cooperative: only nodes that poll `context.cancelled` stop; the node already in flight finishes in the background, including its side effects.
+- After a timeout, no new node starts after a cancel; the in-flight node finishes in the background (nodes may poll `context.cancelled` to stop sooner).
 - Client disconnects do not stop a run; only the timeout does. Results of a disconnected run are discarded unless `record_outputs=true`.
 
 ## 9. Roadmap

--- a/examples/Usage_Example/Api-Function/graph.json
+++ b/examples/Usage_Example/Api-Function/graph.json
@@ -1,0 +1,69 @@
+{
+  "name": "Api-Function",
+  "description": "Graph-as-a-Function demo: Start -> GraphInput -> Print -> GraphOutput. Run it on the canvas (uses the input's default) or save it and call POST /api/graph/run/Api-Function with {\"inputs\": {\"message\": \"...\"}} to get {\"outputs\": {\"echo\": \"...\"}} back. See docs: Usage -> Graph as a Function.",
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "Start",
+      "position": { "x": -150, "y": 100 },
+      "data": { "params": {} }
+    },
+    {
+      "id": "input-message",
+      "type": "GraphInput",
+      "position": { "x": 80, "y": 100 },
+      "data": {
+        "params": {
+          "name": "message",
+          "type": "string",
+          "required": false,
+          "default": "hello from the canvas",
+          "description": "Text to echo back"
+        }
+      }
+    },
+    {
+      "id": "print-1",
+      "type": "Print",
+      "position": { "x": 340, "y": 100 },
+      "data": { "params": { "label": "Api-Function" } }
+    },
+    {
+      "id": "output-echo",
+      "type": "GraphOutput",
+      "position": { "x": 600, "y": 100 },
+      "data": {
+        "params": {
+          "name": "echo",
+          "description": "The message, passed through Print"
+        }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "e-trigger",
+      "source": "start-1",
+      "target": "input-message",
+      "sourceHandle": "trigger",
+      "targetHandle": "",
+      "type": "trigger"
+    },
+    {
+      "id": "e-data-1",
+      "source": "input-message",
+      "target": "print-1",
+      "sourceHandle": "value",
+      "targetHandle": "value",
+      "type": "data"
+    },
+    {
+      "id": "e-data-2",
+      "source": "print-1",
+      "target": "output-echo",
+      "sourceHandle": "value",
+      "targetHandle": "value",
+      "type": "data"
+    }
+  ]
+}


### PR DESCRIPTION
## Why this PR exists

Stage 1's three PRs were stacked (#71 base=main, #72 base=PR1-branch, #73 base=PR2-branch). #72 and #73 were merged before their bases were retargeted to `main`, so their squashes landed on the stale base branches — `main` only received #71 (which, via its later squash, already includes the final-review Critical fix for the image-decode envelope escape). This PR lands everything that is still missing from `main` in one reviewable diff (verified: `git diff main...feat/graph-fn-docs` is exactly these 11 files).

## Contents

Everything from #72 (endpoints) and #73 (docs + example) — see those PRs for the full test plans and real-server e2e evidence — plus two final-review fixes that post-date them:

- `fix(graph-run)`: node-raised `TimeoutError` is no longer conflated with the run timeout on Python 3.11+ (`task.done()` disambiguation -> `execution_error` with the node's message; genuine `wait_for` expiry still returns `code:"timeout"`); image input validation moved off the event loop (`run_in_executor`, `inject_inputs` is pure).
- `docs(graph-fn)`: three wording fixes (cancellation gotcha describes engine-boundary semantics; `record_outputs` notes it records inputs AND results; triage mnemonic covers `graph_unreadable`).

## Test plan

- [x] Full suite on this exact tree: 1458 passed / 8 skipped (env-gated MPS), including new tests for the decompression-bomb envelope guarantee, unknown-input-type contract problems (409 not 422), and node-TimeoutError-vs-run-timeout disambiguation
- [x] Real-server e2e (from #72/#73, all on this content): save/contract/run via curl.exe + Python requests; enveloped 404; out-of-envelope 403; gallery -> canvas -> save -> API round-trip incl. no-body default path
- [x] docs `pnpm build` clean (en + zh-TW, broken-link policy `throw`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
