### PR TITLE
feat(publish): Stage 2 PR1 — SQLite storage + API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ backend/data/images/*
 !backend/data/images/.gitkeep
 backend/data/cifar-10-batches-py/
 backend/data/cifar-10-python.tar.gz
+backend/data/*.db
+backend/data/*.db-*
 
 # ML model weights
 *.pt

--- a/backend/app/api/routes_keys.py
+++ b/backend/app/api/routes_keys.py
@@ -1,0 +1,97 @@
+"""API-key management endpoints (Stage 2): mint, list, soft-revoke.
+
+Session-token-only (``require_session_token`` on every route) — key
+management is the operator's surface. The token plaintext appears in the
+POST response ONCE and is never stored or logged; lists show ``prefix``
+(first 12 chars) only. Nothing is ever deleted from ``api_keys`` —
+revoke sets ``revoked_at`` so ``runs.api_key_id`` stays meaningful.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from ..core.api_keys import (
+    PREFIX_DISPLAY_CHARS,
+    get_db,
+    hash_token,
+    mint_token,
+    require_session_token,
+)
+from ..core.db import utc_now_iso
+
+router = APIRouter(prefix="/api/keys", tags=["api-keys"])
+
+_KEY_COLUMNS = "id, name, prefix, created_at, last_used_at, revoked_at"
+
+
+class CreateKeyRequest(BaseModel):
+    name: str
+
+
+@router.post("", dependencies=[Depends(require_session_token)])
+async def create_key(body: CreateKeyRequest, request: Request):
+    """Mint a key. The token is in THIS response only — copy it now."""
+    db = get_db(request)
+    token = mint_token()
+    token_hash = hash_token(token)
+    prefix = token[:PREFIX_DISPLAY_CHARS]
+    now = utc_now_iso()
+
+    def _insert(conn: sqlite3.Connection) -> int:
+        cur = conn.execute(
+            "INSERT INTO api_keys (name, prefix, token_hash, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (body.name, prefix, token_hash, now),
+        )
+        return cur.lastrowid
+
+    key_id = await db.run(_insert)
+    return {"id": key_id, "name": body.name, "prefix": prefix, "token": token}
+
+
+@router.get("", dependencies=[Depends(require_session_token)])
+async def list_keys(request: Request):
+    """All keys newest-first, secrets never included; revoked rows REMAIN."""
+    db = get_db(request)
+
+    def _select(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+        rows = conn.execute(
+            f"SELECT {_KEY_COLUMNS} FROM api_keys ORDER BY id DESC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    return await db.run(_select)
+
+
+@router.post("/{key_id}/revoke", dependencies=[Depends(require_session_token)])
+async def revoke_key(key_id: int, request: Request):
+    """Soft revoke: set ``revoked_at`` once; the row stays listed.
+
+    Deliberately POST /revoke, not DELETE — nothing is ever removed from
+    ``api_keys``. Revoking an already-revoked key keeps the original
+    ``revoked_at``.
+    """
+    db = get_db(request)
+    now = utc_now_iso()
+
+    def _revoke(conn: sqlite3.Connection) -> dict[str, Any] | None:
+        conn.execute(
+            "UPDATE api_keys SET revoked_at = ? "
+            "WHERE id = ? AND revoked_at IS NULL",
+            (now, key_id),
+        )
+        row = conn.execute(
+            f"SELECT {_KEY_COLUMNS} FROM api_keys WHERE id = ?", (key_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    row = await db.run(_revoke)
+    if row is None:
+        raise HTTPException(status_code=404,
+                            detail=f"API key {key_id} not found")
+    return row

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -43,6 +43,19 @@ class Settings(BaseSettings):
     # Env-overridable as CODEFYUI_MAX_RUN_BODY_BYTES.
     MAX_RUN_BODY_BYTES: int = 64 * 1024 * 1024  # 64 MB
 
+    # ── Stage-2 publish storage + limits (spec Section 8) ──────────────
+    # All env-overridable via the CODEFYUI_ prefix like everything else.
+    # SQLite file for published apps / API keys / run records; sibling of
+    # GRAPHS_DIR so a dev clone and a global install stay isolated.
+    DB_PATH: Path = Path(__file__).parent.parent / "data" / "codefyui.db"
+    MAX_IMAGE_PIXELS: int = 25_000_000  # per-image decode budget (Decision H2)
+    RUN_IO_CAP_BYTES: int = 64 * 1024   # per-field runs.inputs_json/outputs_json cap
+    RUNS_RETENTION_DAYS: int = 0        # 0 = keep forever (default); >0 prunes loudly
+    # Comma-separated extra Host-whitelist entries, e.g.
+    # "192.168.1.20:8000,mybox:8000". A str, not list[str]: pydantic list
+    # env vars demand JSON-in-env quote hell; split in init_allowed_hosts.
+    EXTRA_ALLOWED_HOSTS: str = ""
+
     NODES_DIR: Path = Path(__file__).parent / "nodes"
     CUSTOM_NODES_DIR: Path = Path(__file__).parent / "custom_nodes"
     GRAPHS_DIR: Path = Path(__file__).parent.parent / "data" / "graphs"

--- a/backend/app/core/api_keys.py
+++ b/backend/app/core/api_keys.py
@@ -1,0 +1,158 @@
+"""API-key minting/verification + the three Stage-2 auth dependencies.
+
+Three-tier rule (spec Section 7):
+
+- ``require_api_key``            — invoke only; NON-RAISING result object
+  (the handler assigns run_id FIRST and envelopes the 401 itself, with
+  ``WWW-Authenticate: Bearer``).
+- ``require_api_key_or_session`` — published reads; RAISING, plain
+  ``{"detail": ...}`` 401. Exists because Stage 3's editor UI reads runs
+  with the session token — an API key must never need to live in the
+  browser.
+- ``require_session_token``      — management surface; RAISING; reuses the
+  ``auth_guard`` compare and 403 shape (app/main.py).
+
+Keys survive restarts by construction (DB, not process memory) — the
+deliberate contrast with the rotating session token (app/core/auth.py).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+from .auth import TOKEN_HEADER, constant_time_equals, session_token
+from .db import Database, utc_now_iso
+
+KEY_PREFIX = "cdui_"
+PREFIX_DISPLAY_CHARS = 12
+
+_MISSING_KEY_MESSAGE = "missing or malformed Authorization: Bearer header"
+_NOT_AN_API_KEY_MESSAGE = (
+    "this endpoint takes an API key (cdui_...), not the editor session token"
+)
+_UNKNOWN_KEY_MESSAGE = "unknown or revoked API key"
+
+
+def mint_token() -> str:
+    """A fresh API key: ``cdui_`` + 256-bit urlsafe secret (Decision C2).
+
+    256-bit CSPRNG secrets make slow hashes pointless — sha256 storage is
+    the deliberate choice; bcrypt exists for low-entropy passwords.
+    """
+    return KEY_PREFIX + secrets.token_urlsafe(32)
+
+
+def hash_token(token: str) -> str:
+    """sha256 hex of the FULL token string (prefix included)."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def get_db(request: Request) -> Database:
+    """App-state DB with the getattr-or-503 access rule
+    (routes_execution_outputs._get_store precedent) — never a raw
+    AttributeError when the lifespan didn't run (ASGITransport tests)."""
+    db = getattr(request.app.state, "db", None)
+    if db is None:
+        raise HTTPException(status_code=503, detail="database unavailable")
+    return db
+
+
+@dataclass
+class ApiKeyResult:
+    """Outcome of the NON-RAISING invoke key check.
+
+    ``key_row`` is the api_keys row (as a dict) when the key verified,
+    else None with ``failure`` naming why — the invoke handler envelopes
+    the 401 itself so the response still carries a ``run_id``.
+    """
+
+    key_row: dict[str, Any] | None
+    failure: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.key_row is not None
+
+
+async def require_api_key(request: Request) -> ApiKeyResult:
+    """NON-RAISING key check for the invoke route (spec Section 7).
+
+    Steps: parse ``Authorization: Bearer`` and require the ``cdui_``
+    prefix; sha256 the credential; SELECT by hash where not revoked;
+    ``hmac.compare_digest`` the fetched hash (belt-and-braces, the
+    auth.constant_time_equals precedent); UPDATE ``last_used_at`` on the
+    same serialized connection.
+    """
+    header = request.headers.get("Authorization", "")
+    scheme, _, credential = header.partition(" ")
+    credential = credential.strip()
+    if scheme.lower() != "bearer" or not credential:
+        return ApiKeyResult(None, _MISSING_KEY_MESSAGE)
+    if not credential.startswith(KEY_PREFIX):
+        # Self-diagnosing (spec Section 6.3): the expected failure mode is
+        # someone pasting the editor session token where a key belongs.
+        return ApiKeyResult(None, _NOT_AN_API_KEY_MESSAGE)
+
+    db = get_db(request)
+    computed = hash_token(credential)
+
+    def _lookup(conn: sqlite3.Connection) -> dict[str, Any] | None:
+        row = conn.execute(
+            "SELECT id, name, prefix, token_hash, created_at, last_used_at, "
+            "revoked_at FROM api_keys "
+            "WHERE token_hash = ? AND revoked_at IS NULL",
+            (computed,),
+        ).fetchone()
+        if row is None:
+            return None
+        if not hmac.compare_digest(row["token_hash"], computed):
+            return None
+        conn.execute(
+            "UPDATE api_keys SET last_used_at = ? WHERE id = ?",
+            (utc_now_iso(), row["id"]),
+        )
+        return dict(row)
+
+    row = await db.run(_lookup)
+    if row is None:
+        return ApiKeyResult(None, _UNKNOWN_KEY_MESSAGE)
+    return ApiKeyResult(row)
+
+
+async def require_session_token(request: Request) -> None:
+    """Management-surface auth: the exact ``auth_guard`` compare + 403
+    shape, applied at route level because the middleware exempts the
+    /api/apps and /api/keys prefixes (and never covered GETs anyway)."""
+    provided = request.headers.get(TOKEN_HEADER)
+    if not constant_time_equals(provided, session_token()):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Missing or invalid {TOKEN_HEADER} header",
+        )
+
+
+async def require_api_key_or_session(request: Request) -> None:
+    """Published reads: EITHER a valid API key or the editor session token.
+
+    Raising, plain ``{"detail": ...}`` 401 (the contract-endpoint style).
+    """
+    provided = request.headers.get(TOKEN_HEADER)
+    if constant_time_equals(provided, session_token()):
+        return
+    result = await require_api_key(request)
+    if result.ok:
+        return
+    raise HTTPException(
+        status_code=401,
+        detail=(
+            "provide a valid API key (Authorization: Bearer cdui_...) "
+            f"or the editor session token ({TOKEN_HEADER} header)"
+        ),
+    )

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -1,0 +1,148 @@
+"""SQLite storage for published apps, API keys, and run records (Stage 2).
+
+Decision A2 contract, verbatim:
+
+- ``sqlite3.connect(path, check_same_thread=False, isolation_level=None)``
+  — both kwargs MANDATORY. The default isolation level silently
+  de-atomizes DDL migrations and breaks ``BEGIN IMMEDIATE`` (proven by
+  test during spec review). All transaction control is explicit.
+- ONE shared ``asyncio.Lock`` lives on the ``Database`` object (never
+  created per-call). Every DB operation is one sync fn executed via ONE
+  ``asyncio.to_thread`` call under that lock — ``Database.run`` is the
+  seam, so swapping in a pool or aiosqlite later is a one-module change.
+- Kept FastAPI-free (``api_contract`` pure-module precedent); the
+  dependency plumbing lives in ``app.core.api_keys``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, TypeVar
+
+from .migrations import MIGRATIONS, iter_statements
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def utc_now_iso() -> str:
+    """ISO-8601 UTC timestamp, microsecond precision, trailing ``Z``.
+
+    One fixed format so TEXT comparison (retention's ``created_at < ?``,
+    the runs ``before=`` cursor) is lexicographically correct.
+    """
+    return datetime.now(timezone.utc).strftime(_TIMESTAMP_FORMAT)
+
+
+class Database:
+    """Serialized async facade over one sqlite3 connection."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self._conn: sqlite3.Connection | None = None
+        self._lock = asyncio.Lock()
+        self._last_prune_monotonic: float | None = None
+
+    def connect(self) -> None:
+        """Open the connection, apply pragmas, run pending migrations.
+
+        Sync on purpose: called once from the lifespan (via
+        ``asyncio.to_thread``) or directly from a test fixture.
+        """
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(
+            str(self.path), check_same_thread=False, isolation_level=None,
+        )
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute("PRAGMA foreign_keys=ON")
+            self._apply_migrations(conn)
+        except BaseException:
+            conn.close()
+            raise
+        self._conn = conn
+
+    @staticmethod
+    def _apply_migrations(conn: sqlite3.Connection) -> None:
+        """Run ``MIGRATIONS[user_version:]``, bumping ``user_version``.
+
+        Each migration and its version bump commit atomically —
+        ``BEGIN IMMEDIATE`` works only because ``isolation_level=None``.
+        """
+        current = conn.execute("PRAGMA user_version").fetchone()[0]
+        for index in range(current, len(MIGRATIONS)):
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                for statement in iter_statements(MIGRATIONS[index]):
+                    conn.execute(statement)
+                # PRAGMA user_version cannot take bound params — interpolate
+                # the int (it is our own loop index, not user input).
+                conn.execute(f"PRAGMA user_version = {index + 1}")
+                conn.execute("COMMIT")
+            except BaseException:
+                conn.execute("ROLLBACK")
+                raise
+
+    def close(self) -> None:
+        """Release the handle (Windows needs this to free the WAL sidecars)."""
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    async def run(self, fn: Callable[[sqlite3.Connection], T]) -> T:
+        """Execute ``fn(conn)`` in a worker thread, serialized by the lock.
+
+        THE seam: every route-level DB operation goes through here (one
+        sync fn, one ``to_thread``, one lock — Decision A2). Multi-statement
+        transactions live INSIDE ``fn`` with explicit BEGIN/COMMIT/ROLLBACK.
+        """
+        async with self._lock:
+            conn = self._conn
+            if conn is None:
+                raise RuntimeError("Database is not connected")
+            return await asyncio.to_thread(fn, conn)
+
+    async def prune_runs(self, retention_days: int, *, force: bool = False) -> int:
+        """Delete runs older than ``retention_days`` days; 0 disables.
+
+        ``force=True`` (lifespan startup) always prunes; otherwise the call
+        is the piggyback-on-writes path, rate-limited to once per hour via
+        a monotonic timestamp on this object. Every prune logs loudly.
+        """
+        if retention_days <= 0:
+            return 0
+        now = time.monotonic()
+        if (
+            not force
+            and self._last_prune_monotonic is not None
+            and now - self._last_prune_monotonic < 3600.0
+        ):
+            return 0
+        self._last_prune_monotonic = now
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(days=retention_days)
+        ).strftime(_TIMESTAMP_FORMAT)
+
+        def _prune(conn: sqlite3.Connection) -> int:
+            return conn.execute(
+                "DELETE FROM runs WHERE created_at < ?", (cutoff,)
+            ).rowcount
+
+        pruned = await self.run(_prune)
+        if pruned:
+            logger.warning(
+                "pruned %d runs older than %dd; "
+                "set CODEFYUI_RUNS_RETENTION_DAYS=0 to keep",
+                pruned, retention_days,
+            )
+        return pruned

--- a/backend/app/core/migrations.py
+++ b/backend/app/core/migrations.py
@@ -1,0 +1,86 @@
+"""Stage-2 SQLite schema migrations.
+
+``MIGRATIONS[i]`` moves ``PRAGMA user_version`` from ``i`` to ``i + 1``.
+Append-only: NEVER edit a shipped migration — add a new list entry.
+Timestamps are ISO-8601 UTC TEXT (``app.core.db.utc_now_iso``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterator
+
+MIGRATION_001 = """
+CREATE TABLE apps (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug            TEXT NOT NULL UNIQUE,
+  graph_name      TEXT NOT NULL,            -- source graph at last publish (informational)
+  active_version  INTEGER,                  -- NULL = unpublished. app-enforced ref to app_versions.version
+  record_io       INTEGER NOT NULL DEFAULT 1,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL
+);
+CREATE TABLE app_versions (
+  id                INTEGER PRIMARY KEY AUTOINCREMENT,
+  app_id            INTEGER NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  version           INTEGER NOT NULL,       -- 1,2,3... per app
+  graph_json        TEXT NOT NULL,          -- immutable snapshot (exact saved-file bytes)
+  contract_json     TEXT NOT NULL,          -- derived contract at publish. feeds openapi.json
+  source_graph_name TEXT NOT NULL,
+  note              TEXT,                   -- optional publish note. immutable version metadata
+  created_at        TEXT NOT NULL,
+  UNIQUE (app_id, version)
+);
+CREATE TABLE api_keys (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  name         TEXT NOT NULL,
+  prefix       TEXT NOT NULL,               -- first 12 chars, display only
+  token_hash   TEXT NOT NULL UNIQUE,        -- sha256 hex of the full token
+  created_at   TEXT NOT NULL,
+  last_used_at TEXT,
+  revoked_at   TEXT                          -- NULL = active (soft revoke keeps runs.api_key_id meaningful)
+);
+CREATE TABLE runs (
+  run_id            TEXT PRIMARY KEY,        -- same uuid4 hex as the envelope run_id
+  app_id            INTEGER NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  version           INTEGER NOT NULL,        -- row exists iff resolution succeeded, so never NULL
+  api_key_id        INTEGER REFERENCES api_keys(id),
+                    -- no ON DELETE action: api_keys rows are soft-revoked, never deleted.
+                    -- NULL is RESERVED for future editor-originated invokes (Stage-3 test
+                    -- button). Stage 2 never writes NULL here.
+  status            TEXT NOT NULL,           -- "ok" | "error"
+  error_code        TEXT, error_message TEXT, error_node_id TEXT,
+  device            TEXT,
+  total_s           REAL,
+  node_timings_json TEXT,                    -- {"<node_id>": seconds}
+  inputs_json       TEXT,                    -- capped/redacted JSON (marker objects when not stored)
+  outputs_json      TEXT,
+  created_at        TEXT NOT NULL
+);
+CREATE INDEX idx_runs_app_created ON runs(app_id, created_at DESC);
+CREATE INDEX idx_runs_created     ON runs(created_at);
+"""
+
+MIGRATIONS: list[str] = [MIGRATION_001]
+
+
+def iter_statements(script: str) -> Iterator[str]:
+    """Split a migration script into single executable statements.
+
+    ``Connection.execute`` runs exactly one statement, and
+    ``executescript`` force-COMMITs first — useless inside the explicit
+    ``BEGIN IMMEDIATE`` the migration runner holds. Accumulate lines until
+    ``sqlite3.complete_statement`` says a full statement (comments and
+    string literals understood) is buffered.
+    """
+    buffer = ""
+    for line in script.splitlines(keepends=True):
+        buffer += line
+        if sqlite3.complete_statement(buffer):
+            statement = buffer.strip()
+            if statement:
+                yield statement
+            buffer = ""
+    tail = buffer.strip()
+    if tail:
+        yield tail

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -199,6 +199,7 @@ async def lifespan(app: FastAPI):
     # Release the SQLite handle so `cdui stop` on Windows frees the DB and
     # its WAL sidecar files (spec Section 13, Windows file locking).
     db.close()
+    app.state.db = None
 
 
 app = FastAPI(title=settings.APP_NAME, lifespan=lifespan)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,4 @@
-import logging
-import mimetypes
-from contextlib import asynccontextmanager
-from pathlib import Path
-from urllib.parse import urlparse
-
+import asyncio
 import logging
 import mimetypes
 import sys
@@ -46,6 +41,7 @@ from .api import (
     routes_graph,
     routes_graph_run,
     routes_images,
+    routes_keys,
     routes_llm,
     routes_models,
     routes_nodes,
@@ -64,6 +60,7 @@ from .core.auth import (
     session_token,
     write_token_file,
 )
+from .core.db import Database
 from .core.logging_config import setup_logging
 from .core.node_registry import registry
 from .core.node_state_store import NodeStateStore
@@ -92,6 +89,23 @@ _MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 _AUTH_EXEMPT_PATHS = frozenset({
     "/api/auth/bootstrap",
 })
+
+# Router prefixes whose routes carry their OWN route-level auth dependency
+# (exactly one each — enforced by tests/test_auth_drift.py). auth_guard
+# skips them entirely; host_guard still applies to everything.
+_AUTH_EXEMPT_PREFIXES = ("/api/apps", "/api/keys")
+
+
+def _prefix_exempt(path: str) -> bool:
+    """Exact-or-slash prefix match: '/api/apps' and '/api/apps/x' are
+    exempt, '/api/appsfoo' is not. Footgun (spec Section 8): a future
+    bare route at an exempt prefix matches ``path == p`` and is ALSO
+    exempt — the drift test, not this middleware, is the guarantee.
+    """
+    return any(
+        path == prefix or path.startswith(prefix + "/")
+        for prefix in _AUTH_EXEMPT_PREFIXES
+    )
 
 
 @asynccontextmanager
@@ -165,7 +179,26 @@ async def lifespan(app: FastAPI):
     # Lifetime: server process. Survives Run clicks; lost on restart.
     app.state.node_state_store = NodeStateStore(max_modules=200)
 
+    # ── Stage-2 storage: published apps, API keys, run records ─────────
+    # Routes access it via getattr(app.state, "db", None) and 503 when
+    # absent (routes_execution_outputs precedent) — the lifespan does not
+    # run under httpx ASGITransport, so tests set app.state.db directly.
+    db = Database(settings.DB_PATH)
+    await asyncio.to_thread(db.connect)
+    app.state.db = db
+    logger.info("SQLite storage ready at %s", settings.DB_PATH)
+    # Startup retention prune (no-op at the default RUNS_RETENTION_DAYS=0;
+    # prune_runs itself logs loudly when it deletes anything).
+    await db.prune_runs(settings.RUNS_RETENTION_DAYS, force=True)
+    # Per-slug invoke serialization (spec Decision I); entries are pruned
+    # on app delete.
+    app.state.app_locks = {}
+
     yield
+
+    # Release the SQLite handle so `cdui stop` on Windows frees the DB and
+    # its WAL sidecar files (spec Section 13, Windows file locking).
+    db.close()
 
 
 app = FastAPI(title=settings.APP_NAME, lifespan=lifespan)
@@ -187,7 +220,7 @@ app.add_middleware(
     allow_origins=settings.CORS_ORIGINS,
     allow_credentials=False,
     allow_methods=["GET", "POST", "PUT", "DELETE"],
-    allow_headers=["Content-Type", TOKEN_HEADER],
+    allow_headers=["Content-Type", TOKEN_HEADER, "Authorization"],
     expose_headers=[],
 )
 
@@ -203,6 +236,11 @@ async def auth_guard(request: Request, call_next):
     """
     path = request.url.path
     if path in _AUTH_EXEMPT_PATHS:
+        return await call_next(request)
+    if _prefix_exempt(path):
+        # /api/apps + /api/keys routes each declare exactly one explicit
+        # auth dependency (require_session_token / require_api_key /
+        # require_api_key_or_session) — enforced by the drift test.
         return await call_next(request)
     if request.method not in _MUTATING_METHODS:
         return await call_next(request)
@@ -252,6 +290,7 @@ app.include_router(routes_execution_outputs.router)
 app.include_router(routes_execution_state.router)
 app.include_router(routes_system.router)
 app.include_router(routes_llm.router)
+app.include_router(routes_keys.router)
 app.include_router(ws_execution.router)
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -137,3 +137,28 @@ def sample_graph():
         "name": "test-graph",
         "description": "A test graph",
     }
+
+
+@pytest.fixture
+async def app_db(tmp_path):
+    """Per-test Stage-2 Database on app.state (+ empty app_locks).
+
+    PER TEST, never module/session-scoped: asyncio locks bind to the
+    running event loop on first use. The lifespan does not run under
+    httpx ASGITransport, so tests set app.state directly (the
+    run_output_store precedent in test_api_graph_run.py).
+    """
+    from app.core.db import Database
+
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    app.state.db = db
+    app.state.app_locks = {}
+    try:
+        yield db
+    finally:
+        db.close()
+        if hasattr(app.state, "db"):
+            delattr(app.state, "db")
+        if hasattr(app.state, "app_locks"):
+            delattr(app.state, "app_locks")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,6 +12,8 @@ _SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
+import os
+
 from app.config import settings
 from app.core.auth import TOKEN_HEADER, init_allowed_hosts, session_token
 from app.core.node_base import BaseNode, DataType, PortDefinition
@@ -45,6 +47,52 @@ install_plugin_finder(
         },
     },
 )
+
+
+_ISOLATION_TEMP_PATH = None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_db_path(tmp_path_factory):
+    """Keep every test run's SQLite DB out of backend/data/ (lifespan-driving
+    TestClient tests would otherwise create a real codefyui.db there)."""
+    global _ISOLATION_TEMP_PATH
+    _ISOLATION_TEMP_PATH = tmp_path_factory.mktemp("db") / "codefyui-test.db"
+    # Start with isolation disabled; enable it per-test based on which test is running.
+    yield
+
+
+def pytest_runtest_setup(item):
+    """Apply DB isolation only to non-config tests."""
+    global _ISOLATION_TEMP_PATH
+    # Config tests verify the default path; keep it unchanged.
+    if "test_config_stage2" in str(item.fspath):
+        return
+    # All other tests get isolation to prevent backend/data/codefyui.db creation.
+    original = getattr(item, "_original_db_path", None)
+    if original is None:
+        item._original_db_path = settings.DB_PATH
+        settings.DB_PATH = _ISOLATION_TEMP_PATH
+        original_env = os.environ.get("CODEFYUI_DB_PATH")
+        if original_env is None:
+            item._original_env = None
+        else:
+            item._original_env = original_env
+        os.environ["CODEFYUI_DB_PATH"] = str(_ISOLATION_TEMP_PATH)
+
+
+def pytest_runtest_teardown(item):
+    """Restore DB path after test."""
+    global _ISOLATION_TEMP_PATH
+    if "test_config_stage2" in str(item.fspath):
+        return
+    original = getattr(item, "_original_db_path", None)
+    if original is not None:
+        settings.DB_PATH = original
+        if getattr(item, "_original_env", None) is None:
+            os.environ.pop("CODEFYUI_DB_PATH", None)
+        else:
+            os.environ["CODEFYUI_DB_PATH"] = item._original_env
 
 
 class _TestSourceNode(BaseNode):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest fixtures for CodefyUI backend tests."""
 
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -12,8 +13,6 @@ _SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
-import os
-
 from app.config import settings
 from app.core.auth import TOKEN_HEADER, init_allowed_hosts, session_token
 from app.core.node_base import BaseNode, DataType, PortDefinition
@@ -21,6 +20,17 @@ from app.core.node_registry import NodeRegistry, registry
 from app.core.plugin_loader import install_plugin_finder, purge_all_plugin_modules
 from app.core.preset_registry import preset_registry
 from app.main import app
+
+# Captured before the redirect below -- test_config_stage2.py asserts
+# against this exact production value (see the fixture near the bottom of
+# this file that hands it back for the duration of those tests only).
+_DEFAULT_DB_PATH = settings.DB_PATH
+
+# DB isolation: every test run's SQLite DB lives in a temp dir, never in
+# backend/data/ (lifespan-driving TestClient tests would otherwise create a
+# real codefyui.db there). Module-level on purpose: conftest import runs
+# before any hook or fixture, so there is no ordering race.
+settings.DB_PATH = Path(tempfile.mkdtemp(prefix="codefyui-test-db-")) / "codefyui-test.db"
 
 # Tests use ``base_url="http://127.0.0.1:8000"`` which the production Host
 # whitelist already accepts, but seed it explicitly here so tests don't rely
@@ -49,50 +59,20 @@ install_plugin_finder(
 )
 
 
-_ISOLATION_TEMP_PATH = None
+@pytest.fixture(autouse=True)
+def _config_tests_see_default_db_path(request, monkeypatch):
+    """test_config_stage2.py asserts the untouched production DB_PATH; hand
+    it back for the duration of those tests only.
 
-
-@pytest.fixture(scope="session", autouse=True)
-def _isolate_db_path(tmp_path_factory):
-    """Keep every test run's SQLite DB out of backend/data/ (lifespan-driving
-    TestClient tests would otherwise create a real codefyui.db there)."""
-    global _ISOLATION_TEMP_PATH
-    _ISOLATION_TEMP_PATH = tmp_path_factory.mktemp("db") / "codefyui-test.db"
-    # Start with isolation disabled; enable it per-test based on which test is running.
+    A plain fixture, not a ``pytest_runtest_setup``/``teardown`` hook -- it
+    only ever runs as part of normal per-item fixture resolution, which
+    pytest guarantees happens before that item's test body regardless of
+    collection order. ``monkeypatch`` restores the isolated path afterward,
+    so no hand-rolled restore bookkeeping is needed.
+    """
+    if "test_config_stage2" in str(request.node.fspath):
+        monkeypatch.setattr(settings, "DB_PATH", _DEFAULT_DB_PATH)
     yield
-
-
-def pytest_runtest_setup(item):
-    """Apply DB isolation only to non-config tests."""
-    global _ISOLATION_TEMP_PATH
-    # Config tests verify the default path; keep it unchanged.
-    if "test_config_stage2" in str(item.fspath):
-        return
-    # All other tests get isolation to prevent backend/data/codefyui.db creation.
-    original = getattr(item, "_original_db_path", None)
-    if original is None:
-        item._original_db_path = settings.DB_PATH
-        settings.DB_PATH = _ISOLATION_TEMP_PATH
-        original_env = os.environ.get("CODEFYUI_DB_PATH")
-        if original_env is None:
-            item._original_env = None
-        else:
-            item._original_env = original_env
-        os.environ["CODEFYUI_DB_PATH"] = str(_ISOLATION_TEMP_PATH)
-
-
-def pytest_runtest_teardown(item):
-    """Restore DB path after test."""
-    global _ISOLATION_TEMP_PATH
-    if "test_config_stage2" in str(item.fspath):
-        return
-    original = getattr(item, "_original_db_path", None)
-    if original is not None:
-        settings.DB_PATH = original
-        if getattr(item, "_original_env", None) is None:
-            os.environ.pop("CODEFYUI_DB_PATH", None)
-        else:
-            os.environ["CODEFYUI_DB_PATH"] = item._original_env
 
 
 class _TestSourceNode(BaseNode):

--- a/backend/tests/test_api_keys.py
+++ b/backend/tests/test_api_keys.py
@@ -185,3 +185,100 @@ async def test_require_api_key_or_session_accepts_either_rejects_neither(app_db)
     with pytest.raises(HTTPException) as exc_info:
         await require_api_key_or_session(_fake_request())
     assert exc_info.value.status_code == 401
+
+
+# ── /api/keys endpoints (Task 4) ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_key_returns_token_once_and_stores_only_hash(
+    test_client, app_db,
+):
+    resp = await test_client.post("/api/keys", json={"name": "ci-bot"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body.keys()) == {"id", "name", "prefix", "token"}
+    assert body["name"] == "ci-bot"
+    assert body["token"].startswith(KEY_PREFIX)
+    assert body["prefix"] == body["token"][:PREFIX_DISPLAY_CHARS]
+
+    # The row stores the hash only.
+    def _row(conn: sqlite3.Connection) -> dict[str, Any]:
+        return dict(conn.execute(
+            "SELECT * FROM api_keys WHERE id = ?", (body["id"],)
+        ).fetchone())
+
+    row = await app_db.run(_row)
+    assert row["token_hash"] == hash_token(body["token"])
+    assert body["token"] not in json.dumps(row)
+
+    # ...and the plaintext appears nowhere in the DB file (+ WAL sidecar).
+    await app_db.run(
+        lambda conn: conn.execute("PRAGMA wal_checkpoint(FULL)").fetchone())
+    blob = app_db.path.read_bytes()
+    wal = app_db.path.with_name(app_db.path.name + "-wal")
+    if wal.exists():
+        blob += wal.read_bytes()
+    assert body["token"].encode("ascii") not in blob
+
+
+@pytest.mark.asyncio
+async def test_list_keys_no_secrets_newest_first(test_client, app_db):
+    first = (await test_client.post("/api/keys", json={"name": "a"})).json()
+    second = (await test_client.post("/api/keys", json={"name": "b"})).json()
+    resp = await test_client.get("/api/keys")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert [r["id"] for r in rows] == [second["id"], first["id"]]
+    for row in rows:
+        assert set(row.keys()) == {
+            "id", "name", "prefix", "created_at", "last_used_at", "revoked_at",
+        }
+
+
+@pytest.mark.asyncio
+async def test_revoke_is_soft_and_row_stays_listed(test_client, app_db):
+    created = (await test_client.post("/api/keys", json={"name": "r"})).json()
+    resp = await test_client.post(f"/api/keys/{created['id']}/revoke")
+    assert resp.status_code == 200
+    assert resp.json()["revoked_at"] is not None
+
+    rows = (await test_client.get("/api/keys")).json()
+    assert len(rows) == 1                     # deliberately not DELETE
+    assert rows[0]["revoked_at"] is not None
+
+    # A revoked key immediately fails auth.
+    result = await require_api_key(
+        _fake_request({"Authorization": f"Bearer {created['token']}"})
+    )
+    assert not result.ok
+
+
+@pytest.mark.asyncio
+async def test_revoke_unknown_id_404(test_client, app_db):
+    resp = await test_client.post("/api/keys/9999/revoke")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_keys_routes_require_session_token(app_db):
+    # THE auth_guard GET gap this design closes: without the route-level
+    # dependency, GET /api/keys would be world-readable (the middleware
+    # never covered GETs, and now exempts this prefix entirely).
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url=f"http://127.0.0.1:{settings.PORT}",
+    ) as anon:
+        assert (await anon.get("/api/keys")).status_code == 403
+        assert (await anon.post(
+            "/api/keys", json={"name": "x"})).status_code == 403
+        assert (await anon.post("/api/keys/1/revoke")).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_keys_routes_503_without_db(test_client):
+    if hasattr(app.state, "db"):
+        delattr(app.state, "db")
+    resp = await test_client.get("/api/keys")
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "database unavailable"}

--- a/backend/tests/test_api_keys.py
+++ b/backend/tests/test_api_keys.py
@@ -1,0 +1,187 @@
+"""API-key helpers + the three Stage-2 auth dependencies (spec Section 7).
+
+Unit half (dependencies exercised via a minimal starlette Request whose
+.app is the real app); Task 4 appends the /api/keys endpoint tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from typing import Any
+
+import pytest
+from fastapi import HTTPException, Request
+from httpx import ASGITransport, AsyncClient
+
+from app.config import settings
+from app.core.api_keys import (
+    KEY_PREFIX,
+    PREFIX_DISPLAY_CHARS,
+    hash_token,
+    mint_token,
+    require_api_key,
+    require_api_key_or_session,
+    require_session_token,
+)
+from app.core.auth import TOKEN_HEADER, session_token
+from app.core.db import utc_now_iso
+from app.main import app
+
+
+def _fake_request(headers: dict[str, str] | None = None) -> Request:
+    """A minimal Request whose .app is the real app, so dependencies can
+    reach the app.state.db set by the app_db fixture."""
+    encoded = [
+        (k.lower().encode("latin-1"), v.encode("latin-1"))
+        for k, v in (headers or {}).items()
+    ]
+    return Request({
+        "type": "http",
+        "method": "POST",
+        "path": "/api/apps/x/invoke",
+        "headers": encoded,
+        "query_string": b"",
+        "app": app,
+    })
+
+
+async def _insert_key(db, token: str, *, name: str = "unit",
+                      revoked_at: str | None = None) -> int:
+    token_hash = hash_token(token)
+    prefix = token[:PREFIX_DISPLAY_CHARS]
+    now = utc_now_iso()
+
+    def _ins(conn: sqlite3.Connection) -> int:
+        cur = conn.execute(
+            "INSERT INTO api_keys (name, prefix, token_hash, created_at, "
+            "revoked_at) VALUES (?, ?, ?, ?, ?)",
+            (name, prefix, token_hash, now, revoked_at),
+        )
+        return cur.lastrowid
+
+    return await db.run(_ins)
+
+
+def test_mint_token_format():
+    token = mint_token()
+    assert token.startswith(KEY_PREFIX)
+    assert len(token) >= len(KEY_PREFIX) + 40  # 32 CSPRNG bytes -> 43 chars
+    assert mint_token() != token
+
+
+def test_hash_token_is_sha256_hex_of_full_token():
+    token = "cdui_example"
+    assert hash_token(token) == hashlib.sha256(
+        token.encode("utf-8")).hexdigest()
+    assert len(hash_token(token)) == 64
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_missing_or_malformed(app_db):
+    for headers in (
+        None,
+        {"Authorization": "Basic abc"},
+        {"Authorization": "Bearer "},
+        {"Authorization": "Bearer"},
+    ):
+        result = await require_api_key(_fake_request(headers))
+        assert not result.ok
+        assert result.failure == (
+            "missing or malformed Authorization: Bearer header"
+        )
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_non_cdui_bearer_self_diagnoses(app_db):
+    # The expected failure mode: someone pastes the editor session token.
+    result = await require_api_key(
+        _fake_request({"Authorization": f"Bearer {session_token()}"})
+    )
+    assert not result.ok
+    assert result.failure == (
+        "this endpoint takes an API key (cdui_...), "
+        "not the editor session token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_unknown_and_revoked(app_db):
+    result = await require_api_key(
+        _fake_request({"Authorization": "Bearer cdui_neverminted"})
+    )
+    assert not result.ok
+    assert result.failure == "unknown or revoked API key"
+
+    token = mint_token()
+    await _insert_key(app_db, token, revoked_at=utc_now_iso())
+    result = await require_api_key(
+        _fake_request({"Authorization": f"Bearer {token}"})
+    )
+    assert not result.ok
+    assert result.failure == "unknown or revoked API key"
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_valid_returns_row_and_touches_last_used(app_db):
+    token = mint_token()
+    key_id = await _insert_key(app_db, token)
+    result = await require_api_key(
+        _fake_request({"Authorization": f"Bearer {token}"})
+    )
+    assert result.ok
+    assert result.failure is None
+    assert result.key_row["id"] == key_id
+    assert result.key_row["name"] == "unit"
+
+    def _last_used(conn: sqlite3.Connection) -> str | None:
+        return conn.execute(
+            "SELECT last_used_at FROM api_keys WHERE id = ?", (key_id,)
+        ).fetchone()[0]
+
+    assert await app_db.run(_last_used) is not None
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_503_when_db_absent():
+    if hasattr(app.state, "db"):
+        delattr(app.state, "db")
+    with pytest.raises(HTTPException) as exc_info:
+        await require_api_key(
+            _fake_request({"Authorization": "Bearer cdui_x"})
+        )
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "database unavailable"
+
+
+@pytest.mark.asyncio
+async def test_require_session_token_shapes(app_db):
+    # Valid: returns silently.
+    await require_session_token(_fake_request({TOKEN_HEADER: session_token()}))
+    # Invalid / missing: the exact auth_guard 403 shape.
+    for headers in ({TOKEN_HEADER: "wrong"}, None):
+        with pytest.raises(HTTPException) as exc_info:
+            await require_session_token(_fake_request(headers))
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == (
+            f"Missing or invalid {TOKEN_HEADER} header"
+        )
+
+
+@pytest.mark.asyncio
+async def test_require_api_key_or_session_accepts_either_rejects_neither(app_db):
+    token = mint_token()
+    await _insert_key(app_db, token)
+    # Session token alone works (Stage 3's editor UI reads runs with it).
+    await require_api_key_or_session(
+        _fake_request({TOKEN_HEADER: session_token()})
+    )
+    # API key alone works.
+    await require_api_key_or_session(
+        _fake_request({"Authorization": f"Bearer {token}"})
+    )
+    # Neither -> plain 401.
+    with pytest.raises(HTTPException) as exc_info:
+        await require_api_key_or_session(_fake_request())
+    assert exc_info.value.status_code == 401

--- a/backend/tests/test_auth_drift.py
+++ b/backend/tests/test_auth_drift.py
@@ -1,0 +1,57 @@
+"""Auth-drift guarantee (spec Decision E): every route under the
+auth_guard-exempt prefixes declares exactly ONE of the three Stage-2 auth
+dependencies. The middleware exemption alone is NEVER trusted — a future
+bare route matching an exempt prefix silently skips the middleware, and
+only this test catches it arriving without route-level auth."""
+
+from __future__ import annotations
+
+from app.api import routes_keys
+from app.core.api_keys import (
+    require_api_key,
+    require_api_key_or_session,
+    require_session_token,
+)
+from app.main import _AUTH_EXEMPT_PREFIXES, _prefix_exempt
+
+# PR2 (Task 6) appends routes_apps.router here.
+_EXEMPT_ROUTERS = [routes_keys.router]
+
+_AUTH_DEPS = {require_api_key, require_api_key_or_session,
+              require_session_token}
+
+
+def test_exempt_prefixes_are_the_spec_pair():
+    assert _AUTH_EXEMPT_PREFIXES == ("/api/apps", "/api/keys")
+
+
+def test_prefix_matching_is_exact_or_slash():
+    assert _prefix_exempt("/api/apps")
+    assert _prefix_exempt("/api/apps/some-slug/invoke")
+    assert _prefix_exempt("/api/keys")
+    assert _prefix_exempt("/api/keys/3/revoke")
+    assert not _prefix_exempt("/api/appsfoo")   # sibling: no false match
+    assert not _prefix_exempt("/api/keysx")
+    assert not _prefix_exempt("/api/app")
+
+
+def test_every_exempt_route_declares_exactly_one_auth_dependency():
+    for router in _EXEMPT_ROUTERS:
+        for route in router.routes:
+            calls = [
+                d.call for d in route.dependant.dependencies
+                if d.call in _AUTH_DEPS
+            ]
+            assert len(calls) == 1, (
+                f"{sorted(route.methods)} {route.path} declares "
+                f"{len(calls)} auth dependencies — every route under an "
+                "exempt prefix MUST declare exactly one of "
+                "require_session_token / require_api_key / "
+                "require_api_key_or_session"
+            )
+
+
+def test_exempt_router_prefixes_are_actually_exempt():
+    # Belt-and-braces: each router's prefix really is covered by the tuple.
+    for router in _EXEMPT_ROUTERS:
+        assert _prefix_exempt(router.prefix), router.prefix

--- a/backend/tests/test_config_stage2.py
+++ b/backend/tests/test_config_stage2.py
@@ -1,0 +1,40 @@
+"""Stage-2 settings: defaults + CODEFYUI_ env overrides (spec Section 8)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import app.config
+from app.config import Settings, settings
+
+
+def test_stage2_defaults():
+    backend_dir = Path(app.config.__file__).resolve().parent.parent
+    assert settings.DB_PATH.resolve() == (
+        backend_dir / "data" / "codefyui.db"
+    ).resolve()
+    assert settings.MAX_IMAGE_PIXELS == 25_000_000
+    assert settings.RUN_IO_CAP_BYTES == 64 * 1024
+    assert settings.RUNS_RETENTION_DAYS == 0        # 0 = keep forever
+    assert settings.EXTRA_ALLOWED_HOSTS == ""
+
+
+def test_db_path_is_sibling_of_graphs_dir():
+    # data/codefyui.db lives next to data/graphs (spec Section 5); the
+    # repo-relative default isolates dev clones from a global install.
+    assert settings.DB_PATH.name == "codefyui.db"
+    assert settings.DB_PATH.parent.name == "data"
+
+
+def test_stage2_env_overrides(monkeypatch, tmp_path):
+    monkeypatch.setenv("CODEFYUI_DB_PATH", str(tmp_path / "custom.db"))
+    monkeypatch.setenv("CODEFYUI_RUNS_RETENTION_DAYS", "14")
+    monkeypatch.setenv("CODEFYUI_RUN_IO_CAP_BYTES", "1024")
+    monkeypatch.setenv(
+        "CODEFYUI_EXTRA_ALLOWED_HOSTS", "192.168.1.20:8000,mybox:8000",
+    )
+    fresh = Settings()
+    assert fresh.DB_PATH == tmp_path / "custom.db"
+    assert fresh.RUNS_RETENTION_DAYS == 14
+    assert fresh.RUN_IO_CAP_BYTES == 1024
+    assert fresh.EXTRA_ALLOWED_HOSTS == "192.168.1.20:8000,mybox:8000"

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -1,0 +1,219 @@
+"""Tests for app.core.db.Database + app.core.migrations (Stage-2 storage).
+
+Pins the Decision-A2 connection contract: check_same_thread=False +
+isolation_level=None are MANDATORY (the default isolation level silently
+de-atomizes DDL migrations — proven by test during spec review), one
+shared asyncio.Lock, explicit BEGIN IMMEDIATE transactions, and the
+WAL / busy_timeout / foreign_keys pragmas.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+import pytest
+
+from app.core.db import Database, utc_now_iso
+from app.core.migrations import MIGRATIONS, iter_statements
+
+
+def test_connect_migrates_empty_file(tmp_path):
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    try:
+        assert db._conn.execute("PRAGMA user_version").fetchone()[0] \
+            == len(MIGRATIONS) == 1
+        names = {
+            r[0] for r in db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert {"apps", "app_versions", "api_keys", "runs"} <= names
+    finally:
+        db.close()
+
+
+def test_connect_applies_pragmas(tmp_path):
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    try:
+        assert db._conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        assert db._conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert db._conn.execute("PRAGMA busy_timeout").fetchone()[0] == 5000
+    finally:
+        db.close()
+
+
+def test_reopen_is_idempotent(tmp_path):
+    path = tmp_path / "codefyui.db"
+    first = Database(path)
+    first.connect()
+    first.close()
+    second = Database(path)
+    second.connect()  # nothing left to migrate; must not raise
+    try:
+        assert second._conn.execute("PRAGMA user_version").fetchone()[0] \
+            == len(MIGRATIONS)
+    finally:
+        second.close()
+
+
+def test_failed_migration_rolls_back_atomically(tmp_path, monkeypatch):
+    # With the DEFAULT isolation level the first CREATE would auto-commit
+    # and survive the failure — the mandatory isolation_level=None +
+    # explicit BEGIN IMMEDIATE make the whole migration atomic.
+    monkeypatch.setattr(
+        "app.core.db.MIGRATIONS",
+        [
+            "CREATE TABLE mig_ok (x INTEGER);\n"
+            "CREATE TABLE mig_ok (x INTEGER);\n"  # duplicate -> fails
+        ],
+    )
+    path = tmp_path / "broken.db"
+    db = Database(path)
+    with pytest.raises(sqlite3.OperationalError):
+        db.connect()
+    conn = sqlite3.connect(str(path))
+    try:
+        tables = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "mig_ok" not in tables  # rolled back, never half-applied
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_iter_statements_handles_comments_and_multistatement():
+    script = (
+        "-- leading comment\n"
+        "CREATE TABLE a (x INTEGER);\n"
+        "CREATE INDEX idx_a ON a(x);  -- trailing comment\n"
+    )
+    statements = list(iter_statements(script))
+    assert len(statements) == 2
+    assert "CREATE TABLE a" in statements[0]
+    assert "CREATE INDEX idx_a" in statements[1]
+
+
+def test_utc_now_iso_is_sortable_utc():
+    stamp = utc_now_iso()
+    assert stamp.endswith("Z")
+    assert len(stamp) == len("2026-07-03T00:00:00.000000Z")
+    assert stamp > "2026-01-01T00:00:00.000000Z"  # lexicographic order works
+
+
+@pytest.mark.asyncio
+async def test_run_seam_executes_and_returns(tmp_path):
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    try:
+        def _insert(conn: sqlite3.Connection) -> int:
+            cur = conn.execute(
+                "INSERT INTO api_keys (name, prefix, token_hash, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                ("t", "cdui_abcdefg", "h" * 64, utc_now_iso()),
+            )
+            return cur.lastrowid
+
+        key_id = await db.run(_insert)
+        assert key_id == 1
+
+        def _count(conn: sqlite3.Connection) -> int:
+            return conn.execute("SELECT COUNT(*) FROM api_keys").fetchone()[0]
+
+        assert await db.run(_count) == 1
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_run_raises_when_not_connected(tmp_path):
+    db = Database(tmp_path / "codefyui.db")
+    with pytest.raises(RuntimeError, match="not connected"):
+        await db.run(lambda conn: None)
+
+
+# ── retention ────────────────────────────────────────────────────────────
+
+
+def _seed_app_and_run(conn: sqlite3.Connection, run_id: str,
+                      created_at: str) -> None:
+    """FK-satisfying seed rows (direct insert, not the invoke path — the
+    NULL api_key_id is allowed by schema, reserved for Stage-3 editor
+    invokes)."""
+    now = utc_now_iso()
+    conn.execute(
+        "INSERT OR IGNORE INTO apps (id, slug, graph_name, active_version, "
+        "record_io, created_at, updated_at) VALUES (1, 'prune-app', 'g', 1, "
+        "1, ?, ?)",
+        (now, now),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO app_versions (app_id, version, graph_json, "
+        "contract_json, source_graph_name, note, created_at) "
+        "VALUES (1, 1, '{}', '{}', 'g', NULL, ?)",
+        (now,),
+    )
+    conn.execute(
+        "INSERT INTO runs (run_id, app_id, version, api_key_id, status, "
+        "node_timings_json, inputs_json, outputs_json, created_at) "
+        "VALUES (?, 1, 1, NULL, 'ok', '{}', '{}', '{}', ?)",
+        (run_id, created_at),
+    )
+
+
+@pytest.mark.asyncio
+async def test_prune_disabled_at_default_zero(tmp_path):
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    try:
+        await db.run(lambda conn: _seed_app_and_run(
+            conn, "old-run", "2000-01-01T00:00:00.000000Z"))
+        assert await db.prune_runs(0, force=True) == 0
+        count = await db.run(lambda conn: conn.execute(
+            "SELECT COUNT(*) FROM runs").fetchone()[0])
+        assert count == 1  # keep forever by default
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_prune_deletes_only_older_and_logs_loudly(tmp_path, caplog):
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    try:
+        def _seed(conn: sqlite3.Connection) -> None:
+            _seed_app_and_run(conn, "ancient", "2000-01-01T00:00:00.000000Z")
+            _seed_app_and_run(conn, "fresh", utc_now_iso())
+
+        await db.run(_seed)
+        with caplog.at_level(logging.WARNING, logger="app.core.db"):
+            pruned = await db.prune_runs(30, force=True)
+        assert pruned == 1
+        assert "pruned 1 runs older than 30d" in caplog.text
+        assert "CODEFYUI_RUNS_RETENTION_DAYS=0" in caplog.text
+        remaining = await db.run(lambda conn: [r[0] for r in conn.execute(
+            "SELECT run_id FROM runs").fetchall()])
+        assert remaining == ["fresh"]
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_prune_piggyback_rate_limited_to_hourly(tmp_path):
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    try:
+        await db.run(lambda conn: _seed_app_and_run(
+            conn, "ancient", "2000-01-01T00:00:00.000000Z"))
+        assert await db.prune_runs(30) == 1     # first non-forced call prunes
+        await db.run(lambda conn: _seed_app_and_run(
+            conn, "ancient-2", "2000-01-01T00:00:00.000000Z"))
+        assert await db.prune_runs(30) == 0     # within the hour -> no-op
+        assert await db.prune_runs(30, force=True) == 1  # force bypasses
+    finally:
+        db.close()


### PR DESCRIPTION
**Stacked PR — retarget base to main (or merge bottom-up) BEFORE merging**

Stage 2 "Publish" PR 1/4 — storage + keys (spec: docs/superpowers/specs/2026-07-03-publish-stage2.md, Decision A1/A2/C2/C3/E).

## What
- `app/core/migrations.py` + `app/core/db.py`: stdlib-sqlite3 `Database` (one connection with `check_same_thread=False, isolation_level=None`, one shared `asyncio.Lock`, every op one sync fn via one `to_thread`, explicit `BEGIN IMMEDIATE` transactions, WAL/busy_timeout/foreign_keys, atomic migration runner on `PRAGMA user_version`, retention pruning defaulting to keep-forever).
- Stage-2 settings: `DB_PATH`, `MAX_IMAGE_PIXELS`, `RUN_IO_CAP_BYTES`, `RUNS_RETENTION_DAYS`, `EXTRA_ALLOWED_HOSTS` (consumers arrive in PR3/PR4).
- `app/core/api_keys.py`: `cdui_`-prefixed 256-bit keys, sha256-hex storage, and the three auth dependencies (`require_session_token`, non-raising `require_api_key` with the self-diagnosing message, `require_api_key_or_session`).
- `/api/keys` routes: create (token shown once), list (no secrets), `POST /{id}/revoke` (soft revoke, row stays listed).
- `main.py`: `_AUTH_EXEMPT_PREFIXES` with exact-or-slash matching, lifespan DB + `app_locks`, CORS `Authorization` header.
- Auth-drift test: every route under the exempt prefixes declares exactly one auth dependency — the guarantee is the test, not the middleware.

## Test plan
- [x] `uv run pytest -q` green: 1488 passed / 11 skipped (baseline 1455/11 + 33 new; env-gated skips float).
- [x] Real-server curl round-trip (port 8123, isolated user-data dir + DB): create returned the token exactly once with `prefix` = first 12 chars; list rows carry no `token`/`token_hash`; `POST /api/keys/1/revoke` set `revoked_at` and the row remains listed; anonymous `GET /api/keys` -> 403 (the middleware GET gap is closed at route level).
- [x] No new pip dependencies (pyproject diff vs main empty); zero frontend diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
