### PR TITLE
feat(apps): Stage 2 PR2 — publish + versioned apps

### DIFF
--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -1,0 +1,236 @@
+"""Published-apps surface (Stage 2): versioned snapshots behind stable slugs.
+
+Management routes (this file, PR2) use ``require_session_token``; the
+invoke + runs + openapi routes (PR3/PR4) use the key dependencies. Every
+route declares exactly ONE auth dependency — enforced by
+tests/test_auth_drift.py, because ``auth_guard`` exempts the /api/apps
+prefix entirely.
+
+Management errors are plain ``{"detail": ...}`` transports whose detail
+object carries a stable ``code`` (``invalid_slug``, ``graph_not_found``,
+``app_not_found``, ``version_not_found``, and the five Stage-1 pre-flight
+codes) — machine-matchable without the run envelope, which belongs to
+execution surfaces only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sqlite3
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from ..core import api_contract
+from ..core.api_contract import InputCoercionError
+from ..core.api_keys import get_db, require_session_token
+from ..core.db import utc_now_iso
+from ..core.graph_engine import find_entry_points, validate_graph
+from .routes_graph import _graph_path, _sanitize_name
+from .routes_graph_run import _derive_output_type
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/apps", tags=["apps"])
+
+# Decision G: URL-and-DNS-safe, case-collision-free, deliberately narrower
+# than the contract-name charset; independent of graph names so renaming a
+# graph never breaks a published URL.
+SLUG_PATTERN = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+
+
+def _manage_error(
+    status_code: int, code: str, message: str,
+    details: list[Any] | None = None,
+) -> HTTPException:
+    """Management-surface error: plain ``{"detail": ...}`` transport with a
+    stable ``code`` inside (publish pre-flight reuses the Stage-1 codes)."""
+    return HTTPException(
+        status_code=status_code,
+        detail={"code": code, "message": message, "details": details},
+    )
+
+
+def _get_app_locks(request: Request) -> dict:
+    """Per-slug invoke locks on app.state (503 when a fixture forgot it —
+    same access rule as get_db)."""
+    locks = getattr(request.app.state, "app_locks", None)
+    if locks is None:
+        raise HTTPException(status_code=503,
+                            detail="app_locks not initialised")
+    return locks
+
+
+def _contract_document(
+    graph_name: str,
+    nodes: list[dict],
+    edges: list[dict],
+    contract: api_contract.Contract,
+) -> dict[str, Any]:
+    """The stored ``contract_json`` document (contract-endpoint shape).
+
+    Same assembly as GET /api/graph/contract/{name}: defaults advertised
+    only when the API would apply them; output types derived from the
+    feeding port. ``problems`` is omitted — publish already 409'd on any.
+    """
+    inputs: list[dict[str, Any]] = []
+    for inp in contract.inputs:
+        if inp["required"] or inp["type"] == "image":
+            advertised_default = None
+        else:
+            try:
+                advertised_default = api_contract.coerce_input(
+                    inp["default"], inp["type"], from_string=True,
+                )
+            except InputCoercionError:
+                advertised_default = None
+        inputs.append({
+            "name": inp["name"], "type": inp["type"],
+            "required": inp["required"], "default": advertised_default,
+            "description": inp["description"],
+        })
+    outputs: list[dict[str, Any]] = []
+    for out in contract.outputs:
+        type_label, _problem = _derive_output_type(out["node_id"], nodes, edges)
+        outputs.append({
+            "name": out["name"], "type": type_label,
+            "description": out["description"],
+        })
+    return {"graph": graph_name, "inputs": inputs, "outputs": outputs}
+
+
+class PublishRequest(BaseModel):
+    graph: str
+    record_io: bool = True
+    note: str | None = None
+    create: bool = False
+
+
+@router.post("/{slug}/publish", dependencies=[Depends(require_session_token)])
+async def publish_app(slug: str, body: PublishRequest, request: Request):
+    """Snapshot the saved graph as the next immutable version and activate
+    it. Publish ACTIVATES IMMEDIATELY — canvas Run + pre-flight parity is
+    the v1 verification story (no staging path).
+
+    Publishing to a NONEXISTENT slug requires ``"create": true`` — a
+    misspelled slug can no longer silently create a second app.
+    """
+    db = get_db(request)
+    if SLUG_PATTERN.match(slug) is None:
+        raise _manage_error(
+            422, "invalid_slug",
+            "slug must match ^[a-z][a-z0-9-]{0,63}$",
+        )
+
+    # Load the saved graph under the strict-name rule
+    # (routes_graph_run.py:341-349): execute exactly what was named.
+    if _sanitize_name(body.graph) != body.graph:
+        raise _manage_error(404, "graph_not_found",
+                            f"Graph '{body.graph}' not found")
+    path = _graph_path(body.graph)
+    if not path.exists():
+        raise _manage_error(404, "graph_not_found",
+                            f"Graph '{body.graph}' not found")
+    try:
+        graph_text = path.read_text()
+        graph_data = json.loads(graph_text)
+    except (ValueError, OSError):
+        raise _manage_error(
+            500, "graph_unreadable",
+            f"Graph file for '{body.graph}' exists but is not valid JSON",
+        )
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+
+    # Stage-1 pre-flight, identical checks in identical order — you can
+    # never publish a graph that POST /api/graph/run would refuse.
+    contract = api_contract.derive_contract(nodes)
+    if contract.problems:
+        raise _manage_error(409, "invalid_contract",
+                            "graph I/O contract has problems",
+                            details=contract.problems)
+    if not find_entry_points(nodes, edges):
+        raise _manage_error(409, "no_entry_points",
+                            "graph has no entry points — wire a Start node "
+                            "into every GraphInput")
+    wiring = api_contract.check_wiring(nodes, edges, contract)
+    if wiring.untriggered:
+        raise _manage_error(409, "untriggered_input",
+                            "GraphInput node(s) have no incoming trigger "
+                            "edge — wire Start into every GraphInput",
+                            details=wiring.untriggered)
+    if wiring.unreachable:
+        raise _manage_error(409, "unreachable_output",
+                            "GraphOutput node(s) are not reachable from any "
+                            "entry point",
+                            details=wiring.unreachable)
+    validation_errors = validate_graph(nodes, edges)
+    if validation_errors:
+        raise _manage_error(409, "invalid_graph", "graph failed validation",
+                            details=validation_errors)
+
+    contract_doc = _contract_document(body.graph, nodes, edges, contract)
+    now = utc_now_iso()
+
+    def _publish(conn: sqlite3.Connection) -> dict[str, Any]:
+        # BEGIN IMMEDIATE + max(version)+1 INSIDE the transaction:
+        # concurrent publishes to one slug serialize safely into
+        # UNIQUE(app_id, version); version-insert and active-pointer flip
+        # commit atomically (Decision B — one source of truth).
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                "SELECT id FROM apps WHERE slug = ?", (slug,),
+            ).fetchone()
+            created = row is None
+            if created:
+                if not body.create:
+                    raise _manage_error(
+                        404, "app_not_found",
+                        f"app '{slug}' does not exist — pass "
+                        '"create": true to create it',
+                    )
+                cur = conn.execute(
+                    "INSERT INTO apps (slug, graph_name, active_version, "
+                    "record_io, created_at, updated_at) "
+                    "VALUES (?, ?, NULL, ?, ?, ?)",
+                    (slug, body.graph, int(body.record_io), now, now),
+                )
+                app_id = cur.lastrowid
+            else:
+                app_id = row["id"]
+            next_version = conn.execute(
+                "SELECT COALESCE(MAX(version), 0) + 1 FROM app_versions "
+                "WHERE app_id = ?",
+                (app_id,),
+            ).fetchone()[0]
+            conn.execute(
+                "INSERT INTO app_versions (app_id, version, graph_json, "
+                "contract_json, source_graph_name, note, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (app_id, next_version, graph_text, json.dumps(contract_doc),
+                 body.graph, body.note, now),
+            )
+            conn.execute(
+                "UPDATE apps SET active_version = ?, graph_name = ?, "
+                "record_io = ?, updated_at = ? WHERE id = ?",
+                (next_version, body.graph, int(body.record_io), now, app_id),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            conn.execute("ROLLBACK")
+            raise
+        return {"version": next_version, "created": created}
+
+    result = await db.run(_publish)
+    return {
+        "slug": slug,
+        "version": result["version"],
+        "active": True,
+        "created": result["created"],
+        "graph_name": body.graph,
+        "note": body.note,
+    }

--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -109,6 +109,14 @@ class PublishRequest(BaseModel):
     create: bool = False
 
 
+class PatchAppRequest(BaseModel):
+    record_io: bool
+
+
+class ActivateRequest(BaseModel):
+    version: int
+
+
 @router.post("/{slug}/publish", dependencies=[Depends(require_session_token)])
 async def publish_app(slug: str, body: PublishRequest, request: Request):
     """Snapshot the saved graph as the next immutable version and activate
@@ -234,3 +242,145 @@ async def publish_app(slug: str, body: PublishRequest, request: Request):
         "graph_name": body.graph,
         "note": body.note,
     }
+
+
+@router.get("", dependencies=[Depends(require_session_token)])
+async def list_apps(request: Request):
+    db = get_db(request)
+
+    def _select(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+        rows = conn.execute(
+            "SELECT a.slug, a.graph_name, a.active_version, a.record_io, "
+            "       a.created_at, a.updated_at, "
+            "       (SELECT COUNT(*) FROM app_versions v "
+            "        WHERE v.app_id = a.id) AS versions_count "
+            "FROM apps a ORDER BY a.slug",
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    rows = await db.run(_select)
+    for row in rows:
+        row["record_io"] = bool(row["record_io"])
+    return rows
+
+
+@router.get("/{slug}/versions", dependencies=[Depends(require_session_token)])
+async def list_versions(slug: str, request: Request):
+    db = get_db(request)
+
+    def _select(conn: sqlite3.Connection) -> list[dict[str, Any]] | None:
+        app_row = conn.execute(
+            "SELECT id, active_version FROM apps WHERE slug = ?", (slug,),
+        ).fetchone()
+        if app_row is None:
+            return None
+        rows = conn.execute(
+            "SELECT version, source_graph_name, note, created_at "
+            "FROM app_versions WHERE app_id = ? ORDER BY version DESC",
+            (app_row["id"],),
+        ).fetchall()
+        return [
+            {**dict(r), "active": r["version"] == app_row["active_version"]}
+            for r in rows
+        ]
+
+    rows = await db.run(_select)
+    if rows is None:
+        raise _manage_error(404, "app_not_found", f"app '{slug}' not found")
+    return rows
+
+
+@router.patch("/{slug}", dependencies=[Depends(require_session_token)])
+async def patch_app(slug: str, body: PatchAppRequest, request: Request):
+    """Recording is app state, not version state — flipping it never
+    creates a version."""
+    db = get_db(request)
+    now = utc_now_iso()
+
+    def _patch(conn: sqlite3.Connection) -> int:
+        return conn.execute(
+            "UPDATE apps SET record_io = ?, updated_at = ? WHERE slug = ?",
+            (int(body.record_io), now, slug),
+        ).rowcount
+
+    if await db.run(_patch) == 0:
+        raise _manage_error(404, "app_not_found", f"app '{slug}' not found")
+    return {"slug": slug, "record_io": body.record_io}
+
+
+@router.post("/{slug}/activate", dependencies=[Depends(require_session_token)])
+async def activate_version(slug: str, body: ActivateRequest, request: Request):
+    """Set ``active_version`` to ANY existing version — including from the
+    unpublished state (activate-after-unpublish restores service at that
+    version). Subsumes rollback; there is no separate rollback route."""
+    db = get_db(request)
+    now = utc_now_iso()
+
+    def _activate(conn: sqlite3.Connection) -> None:
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            app_row = conn.execute(
+                "SELECT id FROM apps WHERE slug = ?", (slug,),
+            ).fetchone()
+            if app_row is None:
+                raise _manage_error(404, "app_not_found",
+                                    f"app '{slug}' not found")
+            exists = conn.execute(
+                "SELECT 1 FROM app_versions WHERE app_id = ? AND version = ?",
+                (app_row["id"], body.version),
+            ).fetchone()
+            if exists is None:
+                raise _manage_error(
+                    404, "version_not_found",
+                    f"app '{slug}' has no version {body.version}",
+                )
+            conn.execute(
+                "UPDATE apps SET active_version = ?, updated_at = ? "
+                "WHERE id = ?",
+                (body.version, now, app_row["id"]),
+            )
+            conn.execute("COMMIT")
+        except BaseException:
+            conn.execute("ROLLBACK")
+            raise
+
+    await db.run(_activate)
+    return {"slug": slug, "active_version": body.version}
+
+
+@router.post("/{slug}/unpublish",
+             dependencies=[Depends(require_session_token)])
+async def unpublish_app(slug: str, request: Request):
+    """``active_version = NULL``; versions and runs are retained."""
+    db = get_db(request)
+    now = utc_now_iso()
+
+    def _unpublish(conn: sqlite3.Connection) -> int:
+        return conn.execute(
+            "UPDATE apps SET active_version = NULL, updated_at = ? "
+            "WHERE slug = ?",
+            (now, slug),
+        ).rowcount
+
+    if await db.run(_unpublish) == 0:
+        raise _manage_error(404, "app_not_found", f"app '{slug}' not found")
+    return {"slug": slug, "active_version": None}
+
+
+@router.delete("/{slug}", dependencies=[Depends(require_session_token)])
+async def delete_app(slug: str, request: Request):
+    """IRREVOCABLY removes the app, ALL its versions AND all its run
+    records (FK cascade); also prunes the slug's app_locks entry."""
+    db = get_db(request)
+
+    def _delete(conn: sqlite3.Connection) -> int:
+        return conn.execute(
+            "DELETE FROM apps WHERE slug = ?", (slug,),
+        ).rowcount
+
+    if await db.run(_delete) == 0:
+        raise _manage_error(404, "app_not_found", f"app '{slug}' not found")
+    locks = getattr(request.app.state, "app_locks", None)
+    if locks is not None:
+        locks.pop(slug, None)
+    return {"slug": slug, "deleted": True}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,7 @@ from fastapi.responses import FileResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 from .api import (
+    routes_apps,
     routes_custom_nodes,
     routes_examples,
     routes_execution_outputs,
@@ -291,6 +292,7 @@ app.include_router(routes_execution_outputs.router)
 app.include_router(routes_execution_state.router)
 app.include_router(routes_system.router)
 app.include_router(routes_llm.router)
+app.include_router(routes_apps.router)
 app.include_router(routes_keys.router)
 app.include_router(ws_execution.router)
 

--- a/backend/tests/test_api_apps_manage.py
+++ b/backend/tests/test_api_apps_manage.py
@@ -257,3 +257,188 @@ async def test_publish_requires_session_token(app_db):
         resp = await anon.post(f"/api/apps/{SLUG}/publish",
                                json={"graph": "pub-src", "create": True})
     assert resp.status_code == 403
+
+
+# ── management: list / versions / record_io / activate / unpublish /
+#    delete (Task 7) ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_apps_fields(test_client, app_db):
+    await _save_graph(test_client, _echo_graph())
+    await _publish(test_client, "app-one", "pub-src")
+    await _publish(test_client, "app-one", "pub-src")
+    await _publish(test_client, "app-two", "pub-src", record_io=False)
+
+    resp = await test_client.get("/api/apps")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert [r["slug"] for r in rows] == ["app-one", "app-two"]
+    one = rows[0]
+    assert set(one.keys()) == {
+        "slug", "graph_name", "active_version", "versions_count",
+        "record_io", "created_at", "updated_at",
+    }
+    assert one["active_version"] == 2
+    assert one["versions_count"] == 2
+    assert one["record_io"] is True
+    assert rows[1]["record_io"] is False
+
+
+@pytest.mark.asyncio
+async def test_versions_list_marks_active_and_echoes_note(test_client, app_db):
+    await _save_graph(test_client, _echo_graph())
+    await _publish(test_client, SLUG, "pub-src", note="v1 note")
+    await _publish(test_client, SLUG, "pub-src")
+
+    resp = await test_client.get(f"/api/apps/{SLUG}/versions")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert [(r["version"], r["active"], r["note"]) for r in rows] == [
+        (2, True, None), (1, False, "v1 note"),
+    ]
+    assert all(set(r.keys()) == {
+        "version", "source_graph_name", "note", "created_at", "active",
+    } for r in rows)
+
+    resp = await test_client.get("/api/apps/nope/versions")
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "app_not_found"
+
+
+@pytest.mark.asyncio
+async def test_patch_record_io_flips_without_new_version(test_client, app_db):
+    await _save_graph(test_client, _echo_graph())
+    await _publish(test_client, SLUG, "pub-src")
+    resp = await test_client.patch(f"/api/apps/{SLUG}",
+                                   json={"record_io": False})
+    assert resp.status_code == 200
+    assert resp.json() == {"slug": SLUG, "record_io": False}
+
+    rows = (await test_client.get("/api/apps")).json()
+    assert rows[0]["record_io"] is False
+    assert rows[0]["versions_count"] == 1   # app state, not version state
+
+    resp = await test_client.patch("/api/apps/nope",
+                                   json={"record_io": True})
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "app_not_found"
+
+
+@pytest.mark.asyncio
+async def test_activate_any_version_including_from_unpublished(
+    test_client, app_db,
+):
+    await _save_graph(test_client, _echo_graph())
+    await _publish(test_client, SLUG, "pub-src")
+    await _publish(test_client, SLUG, "pub-src")
+
+    # Activate subsumes rollback — no separate rollback route.
+    resp = await test_client.post(f"/api/apps/{SLUG}/activate",
+                                  json={"version": 1})
+    assert resp.status_code == 200
+    assert resp.json() == {"slug": SLUG, "active_version": 1}
+
+    # Unpublish keeps versions; activate-after-unpublish restores service.
+    resp = await test_client.post(f"/api/apps/{SLUG}/unpublish")
+    assert resp.status_code == 200
+    assert resp.json() == {"slug": SLUG, "active_version": None}
+    rows = (await test_client.get(f"/api/apps/{SLUG}/versions")).json()
+    assert len(rows) == 2 and not any(r["active"] for r in rows)
+
+    resp = await test_client.post(f"/api/apps/{SLUG}/activate",
+                                  json={"version": 2})
+    assert resp.status_code == 200
+    rows = (await test_client.get(f"/api/apps/{SLUG}/versions")).json()
+    assert [(r["version"], r["active"]) for r in rows] == [
+        (2, True), (1, False),
+    ]
+
+    resp = await test_client.post(f"/api/apps/{SLUG}/activate",
+                                  json={"version": 99})
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "version_not_found"
+
+    resp = await test_client.post("/api/apps/nope/activate",
+                                  json={"version": 1})
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "app_not_found"
+
+
+@pytest.mark.asyncio
+async def test_delete_cascades_versions_and_runs_and_prunes_lock(
+    test_client, app_db,
+):
+    import asyncio as aio
+
+    await _save_graph(test_client, _echo_graph())
+    await _publish(test_client, SLUG, "pub-src")
+
+    # Seed a runs row directly (the invoke route arrives in PR3).
+    def _seed_run(conn: sqlite3.Connection) -> None:
+        app_id = conn.execute("SELECT id FROM apps WHERE slug = ?",
+                              (SLUG,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO runs (run_id, app_id, version, api_key_id, status, "
+            "node_timings_json, inputs_json, outputs_json, created_at) "
+            "VALUES ('seed-run', ?, 1, NULL, 'ok', '{}', '{}', '{}', "
+            "'2026-01-01T00:00:00.000000Z')",
+            (app_id,),
+        )
+
+    await app_db.run(_seed_run)
+    app.state.app_locks[SLUG] = aio.Lock()
+
+    resp = await test_client.delete(f"/api/apps/{SLUG}")
+    assert resp.status_code == 200
+    assert resp.json() == {"slug": SLUG, "deleted": True}
+
+    def _counts(conn: sqlite3.Connection) -> tuple[int, int, int]:
+        return (
+            conn.execute("SELECT COUNT(*) FROM apps").fetchone()[0],
+            conn.execute("SELECT COUNT(*) FROM app_versions").fetchone()[0],
+            conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0],
+        )
+
+    assert await app_db.run(_counts) == (0, 0, 0)   # FK cascade
+    assert SLUG not in app.state.app_locks           # lock entry pruned
+
+    resp = await test_client.delete(f"/api/apps/{SLUG}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_snapshot_immutable_after_canvas_resave(
+    test_client, app_db, _graphs_dir,
+):
+    graph = _echo_graph()
+    await _save_graph(test_client, graph)
+    original_bytes = (_graphs_dir / "pub-src.json").read_text()
+    await _publish(test_client, SLUG, "pub-src")
+
+    # Canvas re-save with different content (renamed output).
+    graph["nodes"][2]["data"]["params"]["name"] = "renamed"
+    await _save_graph(test_client, graph)
+    assert (_graphs_dir / "pub-src.json").read_text() != original_bytes
+
+    def _snapshot(conn: sqlite3.Connection) -> str:
+        return conn.execute(
+            "SELECT graph_json FROM app_versions WHERE version = 1",
+        ).fetchone()[0]
+
+    # The stored snapshot is the EXACT pre-edit file bytes (Decision B).
+    # Invoke-behavior pinning of the same property lands with the invoke
+    # route in PR3 (test_api_apps_invoke.py).
+    assert await app_db.run(_snapshot) == original_bytes
+
+
+@pytest.mark.asyncio
+async def test_management_get_routes_reject_anonymous(app_db):
+    # The auth_guard GET gap, closed at route level.
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url=f"http://127.0.0.1:{settings.PORT}",
+    ) as anon:
+        assert (await anon.get("/api/apps")).status_code == 403
+        assert (await anon.get("/api/apps/x/versions")).status_code == 403
+        assert (await anon.delete("/api/apps/x")).status_code == 403

--- a/backend/tests/test_api_apps_manage.py
+++ b/backend/tests/test_api_apps_manage.py
@@ -1,0 +1,259 @@
+"""Tests for the /api/apps management surface (spec Section 6.2):
+publish / versions / record_io / activate / unpublish / delete."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import settings
+from app.main import app
+
+SLUG = "demo-app"
+
+
+@pytest.fixture(autouse=True)
+def _graphs_dir(tmp_path, monkeypatch):
+    """Isolate saved graphs per test (pattern: test_api_graph_run.py)."""
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    return tmp_path
+
+
+def _echo_graph(
+    name: str = "pub-src",
+    *,
+    input_name: str = "x",
+    output_name: str = "y",
+    input_type: str = "string",
+    required: bool = True,
+    default: str = "",
+) -> dict:
+    """Start -> GraphInput -> GraphOutput (duplicated from
+    test_api_graph_run.py so the test modules stay independent)."""
+    return {
+        "name": name,
+        "description": "",
+        "nodes": [
+            {"id": "start", "type": "Start", "position": {"x": 0, "y": 0},
+             "data": {"params": {}}},
+            {"id": "gi", "type": "GraphInput", "position": {"x": 200, "y": 0},
+             "data": {"params": {
+                 "name": input_name, "type": input_type, "required": required,
+                 "default": default, "description": "",
+             }}},
+            {"id": "out", "type": "GraphOutput", "position": {"x": 400, "y": 0},
+             "data": {"params": {"name": output_name, "description": ""}}},
+        ],
+        "edges": [
+            {"id": "t1", "source": "start", "target": "gi",
+             "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+            {"id": "d1", "source": "gi", "target": "out",
+             "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        ],
+    }
+
+
+async def _save_graph(client, graph: dict) -> None:
+    resp = await client.post("/api/graph/save", json=graph)
+    assert resp.status_code == 200, resp.text
+
+
+async def _publish(client, slug: str, graph_name: str, **overrides) -> dict:
+    payload = {"graph": graph_name, "create": True, **overrides}
+    resp = await client.post(f"/api/apps/{slug}/publish", json=payload)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ── publish (Task 6) ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_publish_new_slug_without_create_flag_404(test_client, app_db):
+    await _save_graph(test_client, _echo_graph())
+    resp = await test_client.post(f"/api/apps/{SLUG}/publish",
+                                  json={"graph": "pub-src"})
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "app_not_found"
+    # Typo-proofing: the rejected publish created nothing.
+    count = await app_db.run(lambda conn: conn.execute(
+        "SELECT COUNT(*) FROM apps").fetchone()[0])
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_publish_create_then_republish_versions(test_client, app_db):
+    await _save_graph(test_client, _echo_graph())
+    first = await _publish(test_client, SLUG, "pub-src", note="first cut")
+    assert first == {
+        "slug": SLUG, "version": 1, "active": True, "created": True,
+        "graph_name": "pub-src", "note": "first cut",
+    }
+    second = await _publish(test_client, SLUG, "pub-src")
+    assert second["version"] == 2
+    assert second["created"] is False
+    assert second["active"] is True
+    assert second["note"] is None
+
+    def _db_state(conn: sqlite3.Connection):
+        app_row = conn.execute(
+            "SELECT active_version, graph_name FROM apps WHERE slug = ?",
+            (SLUG,)).fetchone()
+        versions = conn.execute(
+            "SELECT version, note FROM app_versions ORDER BY version",
+        ).fetchall()
+        return dict(app_row), [tuple(v) for v in versions]
+
+    app_row, versions = await app_db.run(_db_state)
+    assert app_row["active_version"] == 2   # publish activates immediately
+    assert versions == [(1, "first cut"), (2, None)]
+
+
+@pytest.mark.asyncio
+async def test_publish_invalid_slugs_422(test_client, app_db):
+    await _save_graph(test_client, _echo_graph())
+    for bad in ("UPPER", "9starts-with-digit", "has space", "has_underscore",
+                "-leading-dash", "a" * 65):
+        resp = await test_client.post(
+            f"/api/apps/{bad}/publish",
+            json={"graph": "pub-src", "create": True},
+        )
+        assert resp.status_code == 422, bad
+        assert resp.json()["detail"]["code"] == "invalid_slug", bad
+
+
+@pytest.mark.asyncio
+async def test_publish_missing_graph_strict_name_404(test_client, app_db):
+    resp = await test_client.post(
+        f"/api/apps/{SLUG}/publish",
+        json={"graph": "never-saved", "create": True},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "graph_not_found"
+
+    # Strict-name rule (routes_graph_run.py behavior): the file exists
+    # under the SANITIZED name; the raw name must never alias to it.
+    await _save_graph(test_client, _echo_graph(name="strict.pub"))
+    resp = await test_client.post(
+        f"/api/apps/{SLUG}/publish",
+        json={"graph": "strict.pub", "create": True},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "graph_not_found"
+
+
+@pytest.mark.asyncio
+async def test_publish_preflight_blocks_bad_graphs_with_stage1_codes(
+    test_client, app_db,
+):
+    # invalid_contract: bad input name.
+    await _save_graph(test_client, _echo_graph(name="bad-name",
+                                               input_name="has space"))
+    resp = await test_client.post(
+        "/api/apps/pre-a/publish", json={"graph": "bad-name", "create": True})
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["code"] == "invalid_contract"
+    assert any("is invalid" in d for d in detail["details"])
+
+    # untriggered_input: trigger retargeted away from the GraphInput.
+    graph = _echo_graph(name="untriggered-pub")
+    graph["nodes"].append({"id": "src", "type": "_TestSource",
+                           "position": {"x": 0, "y": 200},
+                           "data": {"params": {}}})
+    graph["edges"][0]["target"] = "src"
+    await _save_graph(test_client, graph)
+    resp = await test_client.post(
+        "/api/apps/pre-b/publish",
+        json={"graph": "untriggered-pub", "create": True})
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "untriggered_input"
+
+    # no_entry_points: Start removed.
+    graph = _echo_graph(name="no-entry-pub")
+    graph["nodes"] = [n for n in graph["nodes"] if n["type"] != "Start"]
+    graph["edges"] = [e for e in graph["edges"] if e["type"] != "trigger"]
+    await _save_graph(test_client, graph)
+    resp = await test_client.post(
+        "/api/apps/pre-c/publish",
+        json={"graph": "no-entry-pub", "create": True})
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "no_entry_points"
+
+    # unreachable_output: an output fed only by an untriggered source.
+    graph = _echo_graph(name="unreach-pub")
+    graph["nodes"].append({"id": "src2", "type": "_TestSource",
+                           "position": {"x": 0, "y": 200},
+                           "data": {"params": {}}})
+    graph["nodes"].append({"id": "out2", "type": "GraphOutput",
+                           "position": {"x": 400, "y": 200},
+                           "data": {"params": {"name": "y2",
+                                               "description": ""}}})
+    graph["edges"].append({"id": "d9", "source": "src2", "target": "out2",
+                           "sourceHandle": "value", "targetHandle": "value",
+                           "type": "data"})
+    await _save_graph(test_client, graph)
+    resp = await test_client.post(
+        "/api/apps/pre-d/publish",
+        json={"graph": "unreach-pub", "create": True})
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "unreachable_output"
+
+    # invalid_graph: bogus target handle.
+    graph = _echo_graph(name="badport-pub")
+    graph["nodes"].append({"id": "pr", "type": "Print",
+                           "position": {"x": 300, "y": 200},
+                           "data": {"params": {}}})
+    graph["edges"].append({"id": "d8", "source": "gi", "target": "pr",
+                           "sourceHandle": "value", "targetHandle": "bogus",
+                           "type": "data"})
+    await _save_graph(test_client, graph)
+    resp = await test_client.post(
+        "/api/apps/pre-e/publish",
+        json={"graph": "badport-pub", "create": True})
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "invalid_graph"
+
+    # No rejected pre-flight published anything.
+    count = await app_db.run(lambda conn: conn.execute(
+        "SELECT COUNT(*) FROM apps").fetchone()[0])
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_publish_stores_contract_document_and_exact_snapshot(
+    test_client, app_db, _graphs_dir,
+):
+    await _save_graph(test_client, _echo_graph())
+    original_bytes = (_graphs_dir / "pub-src.json").read_text()
+    await _publish(test_client, SLUG, "pub-src")
+
+    def _stored(conn: sqlite3.Connection):
+        row = conn.execute(
+            "SELECT graph_json, contract_json FROM app_versions "
+            "WHERE version = 1").fetchone()
+        return row["graph_json"], json.loads(row["contract_json"])
+
+    graph_json, contract_doc = await app_db.run(_stored)
+    assert graph_json == original_bytes   # EXACT saved-file bytes (Decision B)
+    assert contract_doc["graph"] == "pub-src"
+    assert contract_doc["inputs"] == [{
+        "name": "x", "type": "string", "required": True,
+        "default": None, "description": "",
+    }]
+    assert contract_doc["outputs"][0]["name"] == "y"
+
+
+@pytest.mark.asyncio
+async def test_publish_requires_session_token(app_db):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url=f"http://127.0.0.1:{settings.PORT}",
+    ) as anon:
+        resp = await anon.post(f"/api/apps/{SLUG}/publish",
+                               json={"graph": "pub-src", "create": True})
+    assert resp.status_code == 403

--- a/backend/tests/test_auth_drift.py
+++ b/backend/tests/test_auth_drift.py
@@ -6,7 +6,7 @@ only this test catches it arriving without route-level auth."""
 
 from __future__ import annotations
 
-from app.api import routes_keys
+from app.api import routes_apps, routes_keys
 from app.core.api_keys import (
     require_api_key,
     require_api_key_or_session,
@@ -14,8 +14,7 @@ from app.core.api_keys import (
 )
 from app.main import _AUTH_EXEMPT_PREFIXES, _prefix_exempt
 
-# PR2 (Task 6) appends routes_apps.router here.
-_EXEMPT_ROUTERS = [routes_keys.router]
+_EXEMPT_ROUTERS = [routes_apps.router, routes_keys.router]
 
 _AUTH_DEPS = {require_api_key, require_api_key_or_session,
               require_session_token}


### PR DESCRIPTION
**Stacked PR — retarget base to main (or merge bottom-up) BEFORE merging**

Stage 2 "Publish" PR 2/4 — publish + versions (stacked on feat/stage2-publish; spec Decisions B/G).

## What
- `POST /api/apps/{slug}/publish`: slug validation (`^[a-z][a-z0-9-]{0,63}$`), strict-name graph load, full Stage-1 pre-flight (same five 409 codes as `/run`), exact saved-file bytes + derived contract snapshotted in one `BEGIN IMMEDIATE` transaction with `max(version)+1` inside, `create:true` required for new slugs, optional immutable `note`. **Publish activates immediately.**
- Management surface: `GET /api/apps`, `GET /{slug}/versions`, `PATCH record_io` (no republish), `POST activate` (any version, incl. from unpublished — subsumes rollback), `POST unpublish`, `DELETE` (FK cascade over versions + runs, `app_locks` pruned).
- Drift test now covers `routes_apps.router` automatically.

## Test plan
- [x] `uv run pytest -q` green: 1502 passed / 11 skipped; snapshot-immutability test pins exact saved-file bytes surviving a canvas re-save (invoke-behavior pinning lands in PR3).
- [x] Real-server curl round-trip (port 8123, isolated env): publish without `create` -> `{"detail":{"code":"app_not_found",...}}` with the self-explanatory message; publish v1 with note (`created:true`); republish v2 (`created:false`); versions list newest-first with per-version `note`/`active`; unpublish -> `active_version:null`; **activate v1 after unpublish restores service at v1**; apps list shows `versions_count:2`.
- [x] No new pip dependencies; zero frontend diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
