### PR TITLE
feat(apps): Stage 2 PR3 — invoke + run records

### DIFF
--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -25,7 +25,7 @@ from dataclasses import replace
 from typing import Any
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -36,6 +36,7 @@ from ..core.api_keys import (
     ApiKeyResult,
     get_db,
     require_api_key,
+    require_api_key_or_session,
     require_session_token,
 )
 from ..core.db import Database, utc_now_iso
@@ -648,3 +649,78 @@ async def invoke_app(
 
     # 8. Best-effort runs INSERT, then the envelope.
     return await _finish(http_status, envelope, node_timings, run_req.inputs)
+
+
+@router.get("/{slug}/runs",
+            dependencies=[Depends(require_api_key_or_session)])
+async def list_runs(
+    slug: str,
+    request: Request,
+    limit: int = Query(default=50, ge=1, le=500),
+    before: str | None = Query(default=None),
+):
+    """Newest-first METADATA-ONLY rows; IO lives on the detail endpoint.
+
+    Either-credential read (Stage 3's editor UI uses the session token).
+    ``before`` is an ISO timestamp cursor over ``created_at``.
+    """
+    db = get_db(request)
+
+    def _select(conn: sqlite3.Connection) -> list[dict[str, Any]] | None:
+        app_row = conn.execute(
+            "SELECT id FROM apps WHERE slug = ?", (slug,),
+        ).fetchone()
+        if app_row is None:
+            return None
+        sql = (
+            "SELECT run_id, version, status, error_code, error_node_id, "
+            "device, total_s, api_key_id, created_at "
+            "FROM runs WHERE app_id = ?"
+        )
+        params: list[Any] = [app_row["id"]]
+        if before is not None:
+            sql += " AND created_at < ?"
+            params.append(before)
+        sql += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+        return [dict(r) for r in conn.execute(sql, params).fetchall()]
+
+    rows = await db.run(_select)
+    if rows is None:
+        raise _manage_error(404, "app_not_found", f"app '{slug}' not found")
+    return rows
+
+
+@router.get("/{slug}/runs/{run_id}",
+            dependencies=[Depends(require_api_key_or_session)])
+async def get_run(slug: str, run_id: str, request: Request):
+    """The full row, with inputs/outputs/node_timings parsed back to JSON
+    (marker objects included verbatim). Unknown run_id -> plain 404."""
+    db = get_db(request)
+
+    def _select(conn: sqlite3.Connection):
+        app_row = conn.execute(
+            "SELECT id FROM apps WHERE slug = ?", (slug,),
+        ).fetchone()
+        if app_row is None:
+            return "app_not_found"
+        row = conn.execute(
+            "SELECT run_id, version, api_key_id, status, error_code, "
+            "error_message, error_node_id, device, total_s, "
+            "node_timings_json, inputs_json, outputs_json, created_at "
+            "FROM runs WHERE run_id = ? AND app_id = ?",
+            (run_id, app_row["id"]),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    result = await db.run(_select)
+    if result == "app_not_found":
+        raise _manage_error(404, "app_not_found", f"app '{slug}' not found")
+    if result is None:
+        raise _manage_error(404, "run_not_found",
+                            f"run '{run_id}' not found for app '{slug}'")
+    result["node_timings"] = json.loads(
+        result.pop("node_timings_json") or "{}")
+    result["inputs"] = json.loads(result.pop("inputs_json") or "{}")
+    result["outputs"] = json.loads(result.pop("outputs_json") or "{}")
+    return result

--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -15,22 +15,39 @@ execution surfaces only.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
 import sqlite3
+import time
+from dataclasses import replace
 from typing import Any
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from ..config import settings
 from ..core import api_contract
 from ..core.api_contract import InputCoercionError
-from ..core.api_keys import get_db, require_session_token
-from ..core.db import utc_now_iso
+from ..core.api_keys import (
+    ApiKeyResult,
+    get_db,
+    require_api_key,
+    require_session_token,
+)
+from ..core.db import Database, utc_now_iso
 from ..core.graph_engine import find_entry_points, validate_graph
 from .routes_graph import _graph_path, _sanitize_name
-from .routes_graph_run import _derive_output_type
+from .routes_graph_run import (
+    _derive_output_type,
+    _parse_run_body,
+    build_envelope,
+    error_response,
+    execute_contract_run,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -384,3 +401,250 @@ async def delete_app(slug: str, request: Request):
     if locks is not None:
         locks.pop(slug, None)
     return {"slug": slug, "deleted": True}
+
+
+def _encode_io(fields: dict[str, Any], *, record_io: bool,
+               cap_bytes: int) -> str:
+    """Encode one runs IO column (inputs_json / outputs_json).
+
+    Every stored field stays parseable JSON: an over-cap field becomes the
+    PINNED marker ``{"__codefyui__": "truncated", "bytes": N}``; with
+    ``record_io=false`` every field becomes ``{"__codefyui__":
+    "redacted"}``. Never partial JSON — the marker shapes are a
+    cross-stage contract Stage 3 switches on.
+    """
+    if not record_io:
+        return json.dumps(
+            {name: {"__codefyui__": "redacted"} for name in fields}
+        )
+    capped: dict[str, Any] = {}
+    for name, value in fields.items():
+        blob = json.dumps(value)
+        size = len(blob.encode("utf-8"))
+        if size > cap_bytes:
+            capped[name] = {"__codefyui__": "truncated", "bytes": size}
+        else:
+            capped[name] = value
+    return json.dumps(capped)
+
+
+async def _record_run(
+    db: Database,
+    *,
+    run_id: str,
+    app_id: int,
+    version: int,
+    api_key_id: int,
+    envelope: dict[str, Any],
+    node_timings: dict[str, float],
+    raw_inputs: dict[str, Any],
+    record_io: bool,
+) -> None:
+    """BEST-EFFORT runs INSERT (row-only-if-resolved rule, spec 6.1).
+
+    A failure here loses one audit row, never a run result: log at ERROR
+    and return — the run outcome outranks bookkeeping. Also piggybacks
+    the retention prune (rate-limited to hourly inside prune_runs).
+    """
+    error = envelope.get("error") or {}
+    timing = envelope.get("timing") or {}
+    cap = settings.RUN_IO_CAP_BYTES
+    row = (
+        run_id, app_id, version, api_key_id, envelope["status"],
+        error.get("code"), error.get("message"), error.get("node_id"),
+        envelope.get("device"), timing.get("total_s"),
+        json.dumps(node_timings),
+        _encode_io(raw_inputs, record_io=record_io, cap_bytes=cap),
+        _encode_io(envelope.get("outputs") or {}, record_io=record_io,
+                   cap_bytes=cap),
+        utc_now_iso(),
+    )
+
+    def _insert(conn: sqlite3.Connection) -> None:
+        # NOTE: keep this closure named `_insert` — the best-effort test
+        # injects a fault by matching fn.__name__.
+        conn.execute(
+            "INSERT INTO runs (run_id, app_id, version, api_key_id, status, "
+            "error_code, error_message, error_node_id, device, total_s, "
+            "node_timings_json, inputs_json, outputs_json, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            row,
+        )
+
+    try:
+        await db.run(_insert)
+    except Exception:
+        logger.error(
+            "failed to record run %s for app_id=%s "
+            "(run result still returned)",
+            run_id, app_id, exc_info=True,
+        )
+        return
+    try:
+        await db.prune_runs(settings.RUNS_RETENTION_DAYS)
+    except Exception:
+        logger.error("runs retention prune failed", exc_info=True)
+
+
+@router.post("/{slug}/invoke")
+async def invoke_app(
+    slug: str,
+    request: Request,
+    key_result: ApiKeyResult = Depends(require_api_key),
+):
+    """Execute the app's ACTIVE snapshot version.
+
+    Key-only auth (the session token is NEVER accepted here); every
+    response is the 9-key envelope with ``graph`` = ``app`` = slug; a runs
+    row is written (best-effort) for every outcome that resolved to an
+    app version. Body identical to Stage-1 /run — ``record_outputs`` is
+    accepted-and-ignored (Decision H1).
+    """
+    # 1. run_id at entry — before any rejection (Stage-1 rule).
+    run_id = uuid4().hex
+    started = time.monotonic()
+
+    # 2. NON-RAISING key check; THIS handler envelopes the 401 and adds
+    #    WWW-Authenticate (spec Section 6.3 taxonomy row).
+    if not key_result.ok:
+        return error_response(
+            401, run_id=run_id, graph=slug, app=slug, code="invalid_key",
+            message=key_result.failure or "invalid API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # 3. Body cap against Content-Length, before reading the body
+    #    (routes_graph_run step-2 pattern).
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            declared_bytes = int(content_length)
+        except ValueError:
+            declared_bytes = 0
+        if declared_bytes > settings.MAX_RUN_BODY_BYTES:
+            return error_response(
+                413, run_id=run_id, graph=slug, app=slug,
+                code="payload_too_large",
+                message=(
+                    f"request body is {declared_bytes} bytes "
+                    f"(max {settings.MAX_RUN_BODY_BYTES})"
+                ),
+            )
+
+    # 4. Resolve slug -> (app, active version, record_io) in ONE SELECT
+    #    join — atomic against concurrent publish (the row shows either
+    #    the old or the new active version, never a mix).
+    db = get_db(request)
+    app_locks = _get_app_locks(request)
+
+    def _resolve(conn: sqlite3.Connection) -> dict[str, Any] | None:
+        row = conn.execute(
+            "SELECT a.id AS app_id, a.active_version, a.record_io, "
+            "       v.graph_json "
+            "FROM apps a "
+            "LEFT JOIN app_versions v "
+            "  ON v.app_id = a.id AND v.version = a.active_version "
+            "WHERE a.slug = ?",
+            (slug,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    resolved = await db.run(_resolve)
+    if resolved is None:
+        return error_response(404, run_id=run_id, graph=slug, app=slug,
+                              code="app_not_found",
+                              message=f"app '{slug}' not found")
+    if resolved["active_version"] is None or resolved["graph_json"] is None:
+        # graph_json None = belt-and-braces for a dangling active_version
+        # (publish/activate both validate, so it cannot normally happen).
+        return error_response(409, run_id=run_id, graph=slug, app=slug,
+                              code="app_unpublished",
+                              message=(
+                                  f"app '{slug}' has no active version — "
+                                  "publish or activate one first"
+                              ))
+    version = int(resolved["active_version"])
+    record_io = bool(resolved["record_io"])
+    api_key_id = int(key_result.key_row["id"])
+
+    # From here the request RESOLVED to an app version: every outcome
+    # records a runs row (best-effort) and carries version in the envelope.
+    async def _finish(
+        http_status: int,
+        envelope: dict[str, Any],
+        node_timings: dict[str, float],
+        raw_inputs: dict[str, Any],
+    ):
+        envelope["app"] = slug
+        envelope["version"] = version
+        await _record_run(
+            db, run_id=run_id, app_id=int(resolved["app_id"]),
+            version=version, api_key_id=api_key_id, envelope=envelope,
+            node_timings=node_timings, raw_inputs=raw_inputs,
+            record_io=record_io,
+        )
+        if http_status == 200:
+            return envelope
+        return JSONResponse(status_code=http_status, content=envelope)
+
+    snapshot = json.loads(resolved["graph_json"])
+    nodes = snapshot.get("nodes", [])
+    edges = snapshot.get("edges", [])
+
+    # 5. Parse the body via the shared Stage-1 parser (enveloped 422; the
+    #    row records whatever inputs parsed — for malformed bodies, {}).
+    raw_body = await request.body()
+    run_req, field_errors = _parse_run_body(raw_body)
+    if field_errors:
+        return await _finish(422, build_envelope(
+            status="error", run_id=run_id, graph=slug,
+            error={"code": "invalid_input", "message": "invalid request body",
+                   "node_id": None, "details": field_errors},
+        ), {}, run_req.inputs)
+
+    # 6. Per-slug lock (Decision I): the timeout budget covers TOTAL
+    #    request time INCLUDING queue wait. FIFO fairness is asyncio.Lock's
+    #    default wake order. A client that disconnects while queued is
+    #    cancelled before any envelope exists — no runs row.
+    lock = app_locks.setdefault(slug, asyncio.Lock())
+    remaining = max(0.001, run_req.timeout_s - (time.monotonic() - started))
+    try:
+        await asyncio.wait_for(lock.acquire(), timeout=remaining)
+    except asyncio.TimeoutError:
+        return await _finish(500, build_envelope(
+            status="error", run_id=run_id, graph=slug,
+            error={
+                "code": "timeout",
+                "message": (
+                    f"run exceeded timeout_s={run_req.timeout_s} — "
+                    "expired while queued behind another invoke of this app"
+                ),
+                "node_id": None,
+                "details": None,
+            },
+            timing={"total_s": round(time.monotonic() - started, 3)},
+        ), {}, run_req.inputs)
+    try:
+        # 7. Remaining-budget COPY: execute_contract_run reads
+        #    run_req.timeout_s internally — without the copy, queue time
+        #    would not count against the execution wait and the
+        #    total-budget rule of step 6 would be broken.
+        exec_req = replace(
+            run_req,
+            timeout_s=max(
+                0.001, run_req.timeout_s - (time.monotonic() - started),
+            ),
+        )
+        # output_store=None: Decision H1 — isolation is structural, not a
+        # flag. The editor inspector store can never contain this data.
+        http_status, envelope, node_timings = await execute_contract_run(
+            slug, nodes, edges, exec_req, run_id, output_store=None,
+        )
+    finally:
+        # On an execution timeout the lock releases here while the
+        # shielded task's in-flight node drains — documented residual
+        # overlap, mirrors Stage-1 timeout semantics (spec Section 13).
+        lock.release()
+
+    # 8. Best-effort runs INSERT, then the envelope.
+    return await _finish(http_status, envelope, node_timings, run_req.inputs)

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -56,20 +56,25 @@ def build_envelope(
     status: str,
     run_id: str,
     graph: str,
+    app: str | None = None,
+    version: int | None = None,
     device: str | None = None,
     outputs: dict[str, Any] | None = None,
     error: dict[str, Any] | None = None,
     timing: dict[str, float] | None = None,
 ) -> dict[str, Any]:
-    """Construct the one true /run envelope: all seven keys, always present.
+    """Construct the one true run envelope: all nine keys, always present.
 
     ``run_id`` is never null — it is assigned at request entry, before any
-    rejection can happen.
+    rejection can happen. ``app``/``version`` stay None on the editor
+    route; the invoke route fills them per the spec value rules.
     """
     return RunEnvelope(
         status=status,
         run_id=run_id,
         graph=graph,
+        app=app,
+        version=version,
         device=device,
         outputs=outputs,
         error=RunError(**error) if error is not None else None,
@@ -84,18 +89,27 @@ def error_response(
     graph: str,
     code: str,
     message: str,
+    app: str | None = None,
+    version: int | None = None,
     device: str | None = None,
     node_id: str | None = None,
     details: list[Any] | None = None,
     timing: dict[str, float] | None = None,
+    headers: dict[str, str] | None = None,
 ) -> JSONResponse:
-    """An enveloped error; the HTTP status mirrors ``error.code``."""
+    """An enveloped error; the HTTP status mirrors ``error.code``.
+
+    ``headers`` lets the invoke 401 carry ``WWW-Authenticate: Bearer``.
+    """
     return JSONResponse(
         status_code=http_status,
+        headers=headers,
         content=build_envelope(
             status="error",
             run_id=run_id,
             graph=graph,
+            app=app,
+            version=version,
             device=device,
             outputs=None,
             error={
@@ -313,10 +327,248 @@ def _retrieve_background_exception(task: asyncio.Task) -> None:
         logger.debug("background graph run ended with error after response: %s", exc)
 
 
+async def execute_contract_run(
+    graph_label: str,
+    nodes: list[dict],
+    edges: list[dict],
+    run_req: _RunRequest,
+    run_id: str,
+    output_store: Any,
+) -> tuple[int, dict[str, Any], dict[str, float]]:
+    """Steps 5-12 of a contract run: pre-flight, inject, execute, collect,
+    serialize. Shared by the editor route below and Stage-2 invoke
+    (``routes_apps`` imports it — cross-route import precedent: this
+    module already imports from ``routes_graph``).
+
+    Structured return ``(http_status, envelope_dict, node_timings)`` — no
+    Response objects inside, so each route wraps it in its own transport
+    shape while staying WIRE-IDENTICAL to the pre-extraction handler.
+
+    - ``graph_label`` fills the envelope's ``graph`` key ("the name you
+      addressed"): graph name on the editor route, slug on invoke.
+    - ``run_req.timeout_s`` is read internally — the invoke route passes
+      a COPY holding only the remaining post-queue budget (Decision I).
+    - ``output_store`` is the hoisted app.state getattr; invoke passes
+      None so published runs can NEVER reach the unauthenticated
+      inspector store (Decision H1 — structural isolation).
+    - ``node_timings`` maps node_id -> seconds (Decision F2); ``cached``/
+      ``skipped`` arrive without a prior "running" and record 0.0. It
+      rides the return value for runs-row persistence; the envelope
+      ``timing`` stays ``{"total_s": ...}``.
+    """
+
+    def _error(
+        http_status: int,
+        *,
+        code: str,
+        message: str,
+        device: str | None = None,
+        node_id: str | None = None,
+        details: list[Any] | None = None,
+        timing: dict[str, float] | None = None,
+        node_timings: dict[str, float] | None = None,
+    ) -> tuple[int, dict[str, Any], dict[str, float]]:
+        return (
+            http_status,
+            build_envelope(
+                status="error", run_id=run_id, graph=graph_label,
+                device=device, outputs=None,
+                error={"code": code, "message": message,
+                       "node_id": node_id, "details": details},
+                timing=timing,
+            ),
+            node_timings or {},
+        )
+
+    # 5. Pre-flight on the raw graph — nobody pays for a full execution to
+    #    learn about mis-wiring. On invoke this also catches STALE
+    #    snapshots (e.g. a plugin-provided node type uninstalled after
+    #    publish) as 409 invalid_graph instead of a raw 500.
+    contract = api_contract.derive_contract(nodes)
+    if contract.problems:
+        return _error(409, code="invalid_contract",
+                      message="graph I/O contract has problems",
+                      details=contract.problems)
+    if not find_entry_points(nodes, edges):
+        return _error(409, code="no_entry_points",
+                      message=(
+                          "graph has no entry points — wire a Start "
+                          "node into every GraphInput"
+                      ))
+    wiring = api_contract.check_wiring(nodes, edges, contract)
+    if wiring.untriggered:
+        return _error(409, code="untriggered_input",
+                      message=(
+                          "GraphInput node(s) have no incoming trigger "
+                          "edge — wire Start into every GraphInput"
+                      ),
+                      details=wiring.untriggered)
+    if wiring.unreachable:
+        return _error(409, code="unreachable_output",
+                      message=(
+                          "GraphOutput node(s) are not reachable from "
+                          "any entry point"
+                      ),
+                      details=wiring.unreachable)
+    validation_errors = validate_graph(nodes, edges)
+    if validation_errors:
+        return _error(409, code="invalid_graph",
+                      message="graph failed validation",
+                      details=validation_errors)
+
+    # 6. Inject the RAW request values; each GraphInput's execute() coerces.
+    # inject_inputs does synchronous base64+PIL+ToTensor validation for
+    # image inputs — offload to the default executor so a large/slow image
+    # decode never blocks the event loop. inject_inputs is pure, so running
+    # it off-thread is safe.
+    patched_nodes, input_errors = await asyncio.get_running_loop().run_in_executor(
+        None,
+        functools.partial(api_contract.inject_inputs, nodes, contract, run_req.inputs),
+    )
+    if input_errors:
+        return _error(422, code="invalid_input", message="invalid inputs",
+                      details=input_errors)
+
+    # 7. Fresh per-request context: with persistence off the stateful mixin
+    #    rebuilds modules per call, so concurrent requests share no mutable
+    #    state; the app-global stores are simply not used.
+    device = resolve_device(run_req.device)
+    ctx = ExecutionContext(
+        device=device,
+        weights_persistent=False,
+        node_state_store=None,
+        graph_id=f"api:{graph_label}",
+    )
+
+    # 8. Launch as an INDEPENDENT task and await it under a shielded
+    #    timeout. The shield means handler cancellation (client disconnect)
+    #    never propagates into the run — only the timeout stops a run.
+    # Minimal error capture: remember the last node that reported an error
+    # so execution_error envelopes carry a node_id. Per-node timings stamp
+    # on "running" and close on completed/cached/skipped/error (F2).
+    last_error_node_id: dict[str, str | None] = {"value": None}
+    node_started: dict[str, float] = {}
+    node_timings: dict[str, float] = {}
+
+    async def _on_progress(
+        node_id: str, status: str, data: dict[str, Any] | None
+    ) -> None:
+        if status == "running":
+            node_started[node_id] = time.monotonic()
+            return
+        if status in ("completed", "cached", "skipped", "error"):
+            # cached/skipped arrive WITHOUT a prior "running" (the engine
+            # emits them directly): the dict.get guard records 0.0.
+            started = node_started.get(node_id)
+            node_timings[node_id] = (
+                round(time.monotonic() - started, 3)
+                if started is not None else 0.0
+            )
+        if status == "error":
+            last_error_node_id["value"] = node_id
+
+    t0 = time.monotonic()
+    task = asyncio.create_task(execute_graph(
+        patched_nodes,
+        edges,
+        on_progress=_on_progress,
+        context=ctx,
+        error_mode="fail_fast",
+        run_id=run_id,
+        output_store=output_store,
+        record_outputs=run_req.record_outputs and output_store is not None,
+    ))
+    task.add_done_callback(_retrieve_background_exception)
+    try:
+        engine_result = await asyncio.wait_for(
+            asyncio.shield(task), timeout=run_req.timeout_s,
+        )
+    except asyncio.TimeoutError:
+        # On py3.11+ asyncio.TimeoutError IS builtins.TimeoutError, so a
+        # NODE raising TimeoutError (e.g. a socket timeout) completes the
+        # shielded task with that exact exception before wait_for's own
+        # deadline ever fires — indistinguishable from a genuine timeout by
+        # exception type alone. Disambiguate with task.done(): if the task
+        # already finished, the exception came from graph execution and
+        # must be reported like any other execution_error (with node_id);
+        # only an incomplete task means wait_for's deadline itself expired.
+        if task.done() and not task.cancelled():
+            task_exc = task.exception()
+            if task_exc is not None:
+                return _error(
+                    500, code="execution_error", message=str(task_exc),
+                    device=device, node_id=last_error_node_id["value"],
+                    timing={"total_s": round(time.monotonic() - t0, 3)},
+                    node_timings=node_timings,
+                )
+        # 10. Cooperative cancellation: observed at node boundaries only —
+        # the node currently inside run_in_executor finishes in its thread
+        # after this 500 is sent (documented limitation).
+        ctx.cancel()
+        return _error(500, code="timeout",
+                      message=f"run exceeded timeout_s={run_req.timeout_s}",
+                      device=device,
+                      timing={"total_s": round(time.monotonic() - t0, 3)},
+                      node_timings=node_timings)
+    except GraphValidationError as exc:
+        # 9. Runtime safety net: preset expansion can invalidate a
+        # pre-flight-clean graph (pruning-induced missing required input;
+        # trigger-edges-into-preset-nodes dangling after expand_presets).
+        return _error(409, code="invalid_graph",
+                      message="graph failed validation at runtime",
+                      device=device, details=[str(exc)],
+                      timing={"total_s": round(time.monotonic() - t0, 3)},
+                      node_timings=node_timings)
+    except Exception as exc:  # noqa: BLE001 — never a raw, unenveloped 500
+        # 11. asyncio.CancelledError (client disconnect) is BaseException,
+        # not Exception — it passes through and the shielded run continues.
+        return _error(500, code="execution_error", message=str(exc),
+                      device=device, node_id=last_error_node_id["value"],
+                      timing={"total_s": round(time.monotonic() - t0, 3)},
+                      node_timings=node_timings)
+    total_s = round(time.monotonic() - t0, 3)
+
+    # 12. Collect + serialize declared outputs.
+    collected, missing = api_contract.collect_outputs(contract, engine_result)
+    if missing:
+        return _error(500, code="output_not_produced",
+                      message=(
+                          "declared output(s) missing from the engine "
+                          "result: " + ", ".join(missing)
+                      ),
+                      device=device, details=missing,
+                      timing={"total_s": total_s}, node_timings=node_timings)
+    outputs_json: dict[str, Any] = {}
+    serialization_errors: list[dict[str, str]] = []
+    serialization_code = "unserializable_output"
+    for output_name, value in collected.items():
+        try:
+            outputs_json[output_name] = api_contract.serialize_output(value)
+        except OutputSerializationError as exc:
+            serialization_errors.append(
+                {"output": output_name, "reason": exc.reason}
+            )
+            if exc.code == "output_too_large":
+                # When both kinds occur, the size violation names the code —
+                # deterministic and the more actionable of the two.
+                serialization_code = "output_too_large"
+    if serialization_errors:
+        return _error(500, code=serialization_code,
+                      message="output serialization failed",
+                      device=device, details=serialization_errors,
+                      timing={"total_s": total_s}, node_timings=node_timings)
+
+    return 200, build_envelope(
+        status="ok", run_id=run_id, graph=graph_label, device=device,
+        outputs=outputs_json, error=None, timing={"total_s": total_s},
+    ), node_timings
+
+
 @router.post("/run/{name}")
 async def run_graph_as_function(name: str, request: Request):
     """Execute a saved graph as a named function: declared inputs in,
-    declared outputs out. Every response uses the 7-key envelope."""
+    declared outputs out. Every response uses the 9-key envelope
+    (``app``/``version`` stay null on this editor route)."""
     # 1. run_id at request entry — every envelope carries it, including
     #    pre-flight rejections.
     run_id = uuid4().hex
@@ -368,70 +620,8 @@ async def run_graph_as_function(name: str, request: Request):
                               message="invalid request body",
                               details=field_errors)
 
-    # 5. Pre-flight on the raw graph — nobody pays for a full execution to
-    #    learn about mis-wiring.
-    contract = api_contract.derive_contract(nodes)
-    if contract.problems:
-        return error_response(409, run_id=run_id, graph=name,
-                              code="invalid_contract",
-                              message="graph I/O contract has problems",
-                              details=contract.problems)
-    if not find_entry_points(nodes, edges):
-        return error_response(409, run_id=run_id, graph=name,
-                              code="no_entry_points",
-                              message=(
-                                  "graph has no entry points — wire a Start "
-                                  "node into every GraphInput"
-                              ))
-    wiring = api_contract.check_wiring(nodes, edges, contract)
-    if wiring.untriggered:
-        return error_response(409, run_id=run_id, graph=name,
-                              code="untriggered_input",
-                              message=(
-                                  "GraphInput node(s) have no incoming trigger "
-                                  "edge — wire Start into every GraphInput"
-                              ),
-                              details=wiring.untriggered)
-    if wiring.unreachable:
-        return error_response(409, run_id=run_id, graph=name,
-                              code="unreachable_output",
-                              message=(
-                                  "GraphOutput node(s) are not reachable from "
-                                  "any entry point"
-                              ),
-                              details=wiring.unreachable)
-    validation_errors = validate_graph(nodes, edges)
-    if validation_errors:
-        return error_response(409, run_id=run_id, graph=name,
-                              code="invalid_graph",
-                              message="graph failed validation",
-                              details=validation_errors)
-
-    # 6. Inject the RAW request values; each GraphInput's execute() coerces.
-    # inject_inputs does synchronous base64+PIL+ToTensor validation for
-    # image inputs — offload to the default executor so a large/slow image
-    # decode never blocks the event loop. inject_inputs is pure, so running
-    # it off-thread is safe.
-    patched_nodes, input_errors = await asyncio.get_running_loop().run_in_executor(
-        None,
-        functools.partial(api_contract.inject_inputs, nodes, contract, run_req.inputs),
-    )
-    if input_errors:
-        return error_response(422, run_id=run_id, graph=name,
-                              code="invalid_input",
-                              message="invalid inputs",
-                              details=input_errors)
-
-    # 7. Fresh per-request context: with persistence off the stateful mixin
-    #    rebuilds modules per call, so concurrent requests share no mutable
-    #    state; the app-global stores are simply not used.
-    device = resolve_device(run_req.device)
-    ctx = ExecutionContext(
-        device=device,
-        weights_persistent=False,
-        node_state_store=None,
-        graph_id=f"api:{name}",
-    )
+    # Steps 5-12 live in execute_contract_run. The output_store getattr is
+    # hoisted HERE (editor-only surface); the invoke route passes None.
     output_store = None
     if run_req.record_outputs:
         # The lifespan does not run under httpx ASGITransport, so the
@@ -439,112 +629,9 @@ async def run_graph_as_function(name: str, request: Request):
         # (ws_execution.py getattr precedent).
         output_store = getattr(request.app.state, "run_output_store", None)
 
-    # 8. Launch as an INDEPENDENT task and await it under a shielded
-    #    timeout. The shield means handler cancellation (client disconnect)
-    #    never propagates into the run — only the timeout stops a run.
-    # Minimal error capture: remember the last node that reported an error
-    # so execution_error envelopes carry a node_id.
-    last_error_node_id: dict[str, str | None] = {"value": None}
-
-    async def _on_progress(
-        node_id: str, status: str, data: dict[str, Any] | None
-    ) -> None:
-        if status == "error":
-            last_error_node_id["value"] = node_id
-
-    t0 = time.monotonic()
-    task = asyncio.create_task(execute_graph(
-        patched_nodes,
-        edges,
-        on_progress=_on_progress,
-        context=ctx,
-        error_mode="fail_fast",
-        run_id=run_id,
-        output_store=output_store,
-        record_outputs=run_req.record_outputs and output_store is not None,
-    ))
-    task.add_done_callback(_retrieve_background_exception)
-    try:
-        engine_result = await asyncio.wait_for(
-            asyncio.shield(task), timeout=run_req.timeout_s,
-        )
-    except asyncio.TimeoutError:
-        # On py3.11+ asyncio.TimeoutError IS builtins.TimeoutError, so a
-        # NODE raising TimeoutError (e.g. a socket timeout) completes the
-        # shielded task with that exact exception before wait_for's own
-        # deadline ever fires — indistinguishable from a genuine timeout by
-        # exception type alone. Disambiguate with task.done(): if the task
-        # already finished, the exception came from graph execution and
-        # must be reported like any other execution_error (with node_id);
-        # only an incomplete task means wait_for's deadline itself expired.
-        if task.done() and not task.cancelled():
-            task_exc = task.exception()
-            if task_exc is not None:
-                return error_response(
-                    500, run_id=run_id, graph=name, code="execution_error",
-                    message=str(task_exc), device=device,
-                    node_id=last_error_node_id["value"],
-                    timing={"total_s": round(time.monotonic() - t0, 3)},
-                )
-        # 10. Cooperative cancellation: observed at node boundaries only —
-        # the node currently inside run_in_executor finishes in its thread
-        # after this 500 is sent (documented limitation).
-        ctx.cancel()
-        return error_response(500, run_id=run_id, graph=name, code="timeout",
-                              message=f"run exceeded timeout_s={run_req.timeout_s}",
-                              device=device,
-                              timing={"total_s": round(time.monotonic() - t0, 3)})
-    except GraphValidationError as exc:
-        # 9. Runtime safety net: preset expansion can invalidate a
-        # pre-flight-clean graph (pruning-induced missing required input;
-        # trigger-edges-into-preset-nodes dangling after expand_presets).
-        return error_response(409, run_id=run_id, graph=name,
-                              code="invalid_graph",
-                              message="graph failed validation at runtime",
-                              device=device, details=[str(exc)],
-                              timing={"total_s": round(time.monotonic() - t0, 3)})
-    except Exception as exc:  # noqa: BLE001 — never a raw, unenveloped 500
-        # 11. asyncio.CancelledError (client disconnect) is BaseException,
-        # not Exception — it passes through and the shielded run continues.
-        return error_response(500, run_id=run_id, graph=name,
-                              code="execution_error",
-                              message=str(exc), device=device,
-                              node_id=last_error_node_id["value"],
-                              timing={"total_s": round(time.monotonic() - t0, 3)})
-    total_s = round(time.monotonic() - t0, 3)
-
-    # 12. Collect + serialize declared outputs.
-    collected, missing = api_contract.collect_outputs(contract, engine_result)
-    if missing:
-        return error_response(500, run_id=run_id, graph=name,
-                              code="output_not_produced",
-                              message=(
-                                  "declared output(s) missing from the engine "
-                                  "result: " + ", ".join(missing)
-                              ),
-                              device=device, details=missing,
-                              timing={"total_s": total_s})
-    outputs_json: dict[str, Any] = {}
-    serialization_errors: list[dict[str, str]] = []
-    serialization_code = "unserializable_output"
-    for output_name, value in collected.items():
-        try:
-            outputs_json[output_name] = api_contract.serialize_output(value)
-        except OutputSerializationError as exc:
-            serialization_errors.append(
-                {"output": output_name, "reason": exc.reason}
-            )
-            if exc.code == "output_too_large":
-                # When both kinds occur, the size violation names the code —
-                # deterministic and the more actionable of the two.
-                serialization_code = "output_too_large"
-    if serialization_errors:
-        return error_response(500, run_id=run_id, graph=name,
-                              code=serialization_code,
-                              message="output serialization failed",
-                              device=device, details=serialization_errors,
-                              timing={"total_s": total_s})
-
-    return build_envelope(status="ok", run_id=run_id, graph=name, device=device,
-                          outputs=outputs_json, error=None,
-                          timing={"total_s": total_s})
+    http_status, envelope, _node_timings = await execute_contract_run(
+        name, nodes, edges, run_req, run_id, output_store,
+    )
+    if http_status != 200:
+        return JSONResponse(status_code=http_status, content=envelope)
+    return envelope

--- a/backend/app/core/api_contract.py
+++ b/backend/app/core/api_contract.py
@@ -18,6 +18,11 @@ from typing import Any
 
 from .graph_engine import find_entry_points, reachable_from_entry_points
 
+# Settings import is allowed here — the module constraint is
+# no-FastAPI-imports (pure JSON manipulation), and the pixel budget
+# (Decision H2) is config, not transport.
+from ..config import settings
+
 # Input `type` values (v1, frozen). `json` stays `json` — it describes
 # exactly what a caller can send; no new DataType is needed.
 INPUT_TYPES = ("string", "number", "integer", "boolean", "json", "image")
@@ -166,8 +171,25 @@ def _decode_image(value: Any) -> Any:
     # InputCoercionError, never escape as a raw unenveloped 500.
     try:
         img = Image.open(io.BytesIO(raw))
+        # Pixel budget (Decision H2): PIL parses dimensions WITHOUT
+        # decoding, so this header-only check costs nothing and bounds
+        # decode memory before img.load() pays it (25 MP RGB float32 CHW
+        # is ~300 MB worst case). Above ~179 MP PIL's own
+        # DecompressionBombError fires FIRST inside Image.open — PIL is
+        # the front-stop for that range; this budget covers everything
+        # between it and MAX_IMAGE_PIXELS.
+        width, height = img.size
+        if width * height > settings.MAX_IMAGE_PIXELS:
+            raise InputCoercionError(
+                "image exceeds MAX_IMAGE_PIXELS "
+                f"({width}x{height}={width * height})"
+            )
         img.load()
         img = img.convert("RGB")
+    except InputCoercionError:
+        # Our own budget rejection — must NOT be re-wrapped by the generic
+        # arm below into a "does not decode" message.
+        raise
     except Exception as exc:
         raise InputCoercionError(
             f"value does not decode to an image: {exc}"

--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -88,11 +88,16 @@ class RunTiming(BaseModel):
 
 
 class RunEnvelope(BaseModel):
-    """Response envelope for POST /api/graph/run/{name}.
+    """Response envelope for POST /api/graph/run/{name} AND
+    POST /api/apps/{slug}/invoke.
 
     Every key is ALWAYS present (null when not applicable); HTTP status
-    mirrors ``status``/``error.code``. Forward compatibility (also stated
-    on the docs page): clients MUST ignore unknown envelope fields, and
+    mirrors ``status``/``error.code``. ``app``/``version`` identify the
+    published app and executed version on the invoke route; on the editor
+    route both are always null. On invoke, ``graph`` and ``app`` are the
+    slug on EVERY outcome, and ``version`` is null on errors before an
+    app version was resolved. Forward compatibility (also stated on the
+    docs page): clients MUST ignore unknown envelope fields, and
     ``error.code`` is an open enum — treat unknown codes as generic
     errors. The ``job`` key is reserved by name for the future async mode.
     """
@@ -100,6 +105,8 @@ class RunEnvelope(BaseModel):
     status: Literal["ok", "error"]
     run_id: str
     graph: str
+    app: str | None = None
+    version: int | None = None
     device: str | None = None
     outputs: dict[str, Any] | None = None
     error: RunError | None = None

--- a/backend/tests/test_api_apps_invoke.py
+++ b/backend/tests/test_api_apps_invoke.py
@@ -1,0 +1,560 @@
+"""Tests for POST /api/apps/{slug}/invoke: 9-key envelope value rules, the
+new error taxonomy rows, row-only-if-resolved run recording, pinned marker
+shapes, structural RunOutputStore isolation (H1), per-slug locks with
+queue-aware budgets, and snapshot-behavior immutability."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import time
+from typing import Any
+
+import pytest
+
+from app.config import settings
+from app.core.db import Database
+from app.core.node_base import BaseNode, DataType, PortDefinition
+from app.core.run_output_store import RunOutputStore
+from app.main import app
+
+ENVELOPE_KEYS = {
+    "status", "run_id", "graph", "app", "version",
+    "device", "outputs", "error", "timing",
+}
+
+SLUG = "invoke-app"
+
+
+@pytest.fixture(autouse=True)
+def _graphs_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    return tmp_path
+
+
+# ── test-support nodes (test_api_graph_run.py direct-injection pattern) ──
+
+
+class _SlowPassNode(BaseNode):
+    """Sleeps `seconds` in the executor thread, then passes value through."""
+
+    NODE_NAME = "_SlowPass"
+    CATEGORY = "Test"
+    DESCRIPTION = "Sleeps, then passes through"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any],
+                params: dict[str, Any]) -> dict[str, Any]:
+        time.sleep(float(params.get("seconds", 2.0)))
+        return {"value": inputs.get("value")}
+
+
+class _BoomNode(BaseNode):
+    """Raises on execute — drives the execution_error taxonomy row."""
+
+    NODE_NAME = "_Boom"
+    CATEGORY = "Test"
+    DESCRIPTION = "Raises RuntimeError"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any],
+                params: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("boom: intentional test failure")
+
+
+@pytest.fixture(autouse=True)
+def _register_test_nodes():
+    from app.core.node_registry import registry
+
+    registry._nodes["_SlowPass"] = _SlowPassNode
+    registry._nodes["_Boom"] = _BoomNode
+    yield
+
+
+# ── graph builders (duplicated so test modules stay independent) ─────────
+
+
+def _echo_graph(name: str = "invoke-src", *, input_type: str = "string",
+                required: bool = True, output_name: str = "y") -> dict:
+    return {
+        "name": name,
+        "description": "",
+        "nodes": [
+            {"id": "start", "type": "Start", "position": {"x": 0, "y": 0},
+             "data": {"params": {}}},
+            {"id": "gi", "type": "GraphInput", "position": {"x": 200, "y": 0},
+             "data": {"params": {
+                 "name": "x", "type": input_type, "required": required,
+                 "default": "", "description": "",
+             }}},
+            {"id": "out", "type": "GraphOutput", "position": {"x": 400, "y": 0},
+             "data": {"params": {"name": output_name, "description": ""}}},
+        ],
+        "edges": [
+            {"id": "t1", "source": "start", "target": "gi",
+             "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+            {"id": "d1", "source": "gi", "target": "out",
+             "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        ],
+    }
+
+
+def _chain_graph(name: str, middle_type: str,
+                 middle_params: dict | None = None) -> dict:
+    """Start -> GraphInput -> <middle> -> GraphOutput."""
+    g = _echo_graph(name=name)
+    g["nodes"].insert(2, {"id": "mid", "type": middle_type,
+                          "position": {"x": 300, "y": 0},
+                          "data": {"params": middle_params or {}}})
+    g["edges"] = [
+        {"id": "t1", "source": "start", "target": "gi",
+         "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+        {"id": "d1", "source": "gi", "target": "mid",
+         "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        {"id": "d2", "source": "mid", "target": "out",
+         "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+    ]
+    return g
+
+
+async def _save_graph(client, graph: dict) -> None:
+    resp = await client.post("/api/graph/save", json=graph)
+    assert resp.status_code == 200, resp.text
+
+
+async def _publish(client, slug: str, graph: dict, **overrides) -> int:
+    await _save_graph(client, graph)
+    payload = {"graph": graph["name"], "create": True, **overrides}
+    resp = await client.post(f"/api/apps/{slug}/publish", json=payload)
+    assert resp.status_code == 200, resp.text
+    return resp.json()["version"]
+
+
+@pytest.fixture
+async def api_key(test_client, app_db) -> dict:
+    resp = await test_client.post("/api/keys", json={"name": "invoke-tests"})
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _run_rows(db: Database) -> list[dict[str, Any]]:
+    def _select(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+        return [dict(r) for r in conn.execute(
+            "SELECT * FROM runs ORDER BY created_at").fetchall()]
+    return await db.run(_select)
+
+
+# ── envelope value rules + happy path ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_invoke_happy_path_nine_key_envelope(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG, _echo_graph())
+    resp = await test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json={"inputs": {"x": "hello"}},
+        headers=_bearer(api_key["token"]),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["status"] == "ok"
+    assert body["run_id"]
+    assert body["graph"] == SLUG          # "the name you addressed"
+    assert body["app"] == SLUG
+    assert body["version"] == 1
+    assert body["outputs"] == {"y": "hello"}
+    assert body["error"] is None
+    assert body["timing"]["total_s"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_invoke_401_invalid_key_enveloped_with_www_authenticate(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG, _echo_graph())
+    # No Authorization header at all — the session token on test_client
+    # must NOT be accepted (invoke is key-only).
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={"inputs": {"x": "hi"}})
+    assert resp.status_code == 401
+    assert resp.headers["WWW-Authenticate"] == "Bearer"
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["error"]["code"] == "invalid_key"
+    assert body["run_id"]
+    assert body["graph"] == SLUG
+    assert body["app"] == SLUG            # app = slug even pre-resolution
+    assert body["version"] is None        # no version resolved
+
+    # Self-diagnosing message for a pasted session token.
+    from app.core.auth import session_token
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={"inputs": {"x": "hi"}},
+                                  headers=_bearer(session_token()))
+    assert resp.status_code == 401
+    assert resp.json()["error"]["message"] == (
+        "this endpoint takes an API key (cdui_...), "
+        "not the editor session token"
+    )
+
+    # Revoked key.
+    await test_client.post(f"/api/keys/{api_key['id']}/revoke")
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={"inputs": {"x": "hi"}},
+                                  headers=_bearer(api_key["token"]))
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_key"
+
+
+@pytest.mark.asyncio
+async def test_invoke_404_and_409_pre_resolution_envelopes(
+    test_client, app_db, api_key,
+):
+    key_headers = _bearer(api_key["token"])
+    resp = await test_client.post("/api/apps/no-such-app/invoke",
+                                  json={}, headers=key_headers)
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["code"] == "app_not_found"
+    assert body["graph"] == "no-such-app"
+    assert body["app"] == "no-such-app"
+    assert body["version"] is None
+
+    await _publish(test_client, SLUG, _echo_graph())
+    await test_client.post(f"/api/apps/{SLUG}/unpublish")
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={}, headers=key_headers)
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == "app_unpublished"
+    assert body["app"] == SLUG            # the APP resolved; no VERSION did
+    assert body["version"] is None
+
+
+# ── row-only-if-resolved ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pre_resolution_failures_write_no_runs_rows(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG, _echo_graph())
+    await _publish(test_client, "parked-app", _echo_graph(name="parked-src"))
+    await test_client.post("/api/apps/parked-app/unpublish")
+
+    # invalid_key / app_not_found / app_unpublished: never a row.
+    await test_client.post(f"/api/apps/{SLUG}/invoke", json={})
+    await test_client.post("/api/apps/ghost/invoke", json={},
+                           headers=_bearer(api_key["token"]))
+    await test_client.post("/api/apps/parked-app/invoke", json={},
+                           headers=_bearer(api_key["token"]))
+    assert await _run_rows(app_db) == []
+
+
+@pytest.mark.asyncio
+async def test_resolved_outcomes_write_exactly_one_row_each(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG, _echo_graph())
+    key_headers = _bearer(api_key["token"])
+
+    ok = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                json={"inputs": {"x": "hi"}},
+                                headers=key_headers)
+    assert ok.status_code == 200
+    bad = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                 json={"inputs": {"x": 42, "typo": 1}},
+                                 headers=key_headers)
+    assert bad.status_code == 422
+
+    rows = await _run_rows(app_db)
+    assert len(rows) == 2
+    by_run_id = {r["run_id"]: r for r in rows}
+
+    ok_row = by_run_id[ok.json()["run_id"]]
+    assert ok_row["status"] == "ok"
+    assert ok_row["version"] == 1
+    assert ok_row["api_key_id"] == api_key["id"]   # never NULL in Stage 2
+    assert ok_row["device"] == ok.json()["device"]
+    assert ok_row["total_s"] == ok.json()["timing"]["total_s"]
+    assert json.loads(ok_row["inputs_json"]) == {"x": "hi"}
+    assert json.loads(ok_row["outputs_json"]) == {"y": "hi"}
+
+    # The 422 row records the offending RAW inputs — the debugging payoff.
+    bad_row = by_run_id[bad.json()["run_id"]]
+    assert bad_row["status"] == "error"
+    assert bad_row["error_code"] == "invalid_input"
+    assert bad.json()["version"] == 1     # post-resolution error carries version
+    assert json.loads(bad_row["inputs_json"]) == {"x": 42, "typo": 1}
+
+
+@pytest.mark.asyncio
+async def test_execution_error_row_carries_node_id_and_timings(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG, _chain_graph("boom-pub", "_Boom"))
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={"inputs": {"x": "hi"}},
+                                  headers=_bearer(api_key["token"]))
+    assert resp.status_code == 500
+    assert resp.json()["error"]["code"] == "execution_error"
+
+    rows = await _run_rows(app_db)
+    assert len(rows) == 1
+    assert rows[0]["error_code"] == "execution_error"
+    assert rows[0]["error_node_id"] == "mid"
+    assert "boom: intentional test failure" in rows[0]["error_message"]
+
+
+@pytest.mark.asyncio
+async def test_per_node_timings_persisted_zero_allowed(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG, _echo_graph())
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={"inputs": {"x": "hi"}},
+                                  headers=_bearer(api_key["token"]))
+    assert resp.status_code == 200
+    # The envelope timing shape stays frozen: {total_s} only.
+    assert set(resp.json()["timing"].keys()) == {"total_s"}
+
+    rows = await _run_rows(app_db)
+    timings = json.loads(rows[0]["node_timings_json"])
+    assert {"gi", "out"} <= set(timings.keys())
+    # No nonzero assumption: cached/skipped nodes legitimately record 0.0.
+    assert all(isinstance(v, (int, float)) and v >= 0.0
+               for v in timings.values())
+
+
+# ── markers + redaction ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_over_cap_field_stores_pinned_truncation_marker(
+    test_client, app_db, api_key, monkeypatch,
+):
+    monkeypatch.setattr("app.config.settings.RUN_IO_CAP_BYTES", 64)
+    await _publish(test_client, SLUG, _echo_graph())
+    big = "A" * 100                      # json.dumps adds 2 quote bytes
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={"inputs": {"x": big}},
+                                  headers=_bearer(api_key["token"]))
+    assert resp.status_code == 200
+    assert resp.json()["outputs"] == {"y": big}   # the RESPONSE is uncapped
+
+    rows = await _run_rows(app_db)
+    stored_inputs = json.loads(rows[0]["inputs_json"])
+    stored_outputs = json.loads(rows[0]["outputs_json"])
+    # The EXACT pinned shape — a cross-stage contract Stage 3 switches on.
+    assert stored_inputs == {"x": {"__codefyui__": "truncated", "bytes": 102}}
+    assert stored_outputs == {"y": {"__codefyui__": "truncated", "bytes": 102}}
+
+
+@pytest.mark.asyncio
+async def test_record_io_false_stores_pinned_redaction_markers(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG, _echo_graph(), record_io=False)
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={"inputs": {"x": "secret"}},
+                                  headers=_bearer(api_key["token"]))
+    assert resp.status_code == 200
+
+    rows = await _run_rows(app_db)
+    assert json.loads(rows[0]["inputs_json"]) == {
+        "x": {"__codefyui__": "redacted"},
+    }
+    assert json.loads(rows[0]["outputs_json"]) == {
+        "y": {"__codefyui__": "redacted"},
+    }
+    assert "secret" not in rows[0]["inputs_json"]
+
+
+# ── best-effort INSERT + H1 isolation ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_best_effort_insert_failure_still_returns_envelope(
+    test_client, app_db, api_key, monkeypatch, caplog,
+):
+    import logging
+
+    await _publish(test_client, SLUG, _echo_graph())
+    real_run = Database.run
+
+    async def _failing_run(self, fn):
+        # Fail ONLY the runs INSERT (the closure is named _insert by
+        # contract); resolution and key lookup proceed normally.
+        if getattr(fn, "__name__", "") == "_insert":
+            raise sqlite3.OperationalError("disk I/O error (injected)")
+        return await real_run(self, fn)
+
+    monkeypatch.setattr(Database, "run", _failing_run)
+    with caplog.at_level(logging.ERROR, logger="app.api.routes_apps"):
+        resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                      json={"inputs": {"x": "hi"}},
+                                      headers=_bearer(api_key["token"]))
+    assert resp.status_code == 200                # run outcome outranks bookkeeping
+    assert resp.json()["outputs"] == {"y": "hi"}
+    assert "failed to record run" in caplog.text
+
+    monkeypatch.setattr(Database, "run", real_run)
+    assert await _run_rows(app_db) == []          # the row really was lost
+
+
+@pytest.mark.asyncio
+async def test_record_outputs_structurally_inert_on_invoke(
+    test_client, app_db, api_key,
+):
+    # H1 regression pin: output_store=None is structural — even with
+    # record_outputs=true the RunOutputStore stays empty, so the
+    # unauthenticated GET /api/execution/outputs/* can never see
+    # published-app data.
+    store = RunOutputStore(max_runs=5)
+    app.state.run_output_store = store
+    await _publish(test_client, SLUG, _echo_graph())
+    resp = await test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json={"inputs": {"x": "hi"}, "record_outputs": True},
+        headers=_bearer(api_key["token"]),
+    )
+    assert resp.status_code == 200                # accepted-and-ignored
+    run_id = resp.json()["run_id"]
+    assert await store.list_runs() == []
+    listing = await test_client.get(f"/api/execution/outputs/{run_id}")
+    assert listing.status_code == 404
+
+
+# ── immutability (invoke-behavior pinning, deferred from PR2) ────────────
+
+
+@pytest.mark.asyncio
+async def test_canvas_resave_does_not_change_invoke_until_republish(
+    test_client, app_db, api_key,
+):
+    graph = _echo_graph()
+    await _publish(test_client, SLUG, graph)
+    key_headers = _bearer(api_key["token"])
+
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={"inputs": {"x": "hi"}},
+                                  headers=key_headers)
+    assert resp.json()["outputs"] == {"y": "hi"}
+
+    # Edit the canvas: rename the output y -> z, re-save the file.
+    graph["nodes"][2]["data"]["params"]["name"] = "z"
+    await _save_graph(test_client, graph)
+
+    # Invoke still runs the SNAPSHOT (pre-edit behavior).
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={"inputs": {"x": "hi"}},
+                                  headers=key_headers)
+    assert resp.json()["outputs"] == {"y": "hi"}
+    assert resp.json()["version"] == 1
+
+    # Re-publish flips it.
+    resp = await test_client.post(
+        f"/api/apps/{SLUG}/publish", json={"graph": graph["name"]})
+    assert resp.status_code == 200
+    resp = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                  json={"inputs": {"x": "hi"}},
+                                  headers=key_headers)
+    assert resp.json()["outputs"] == {"z": "hi"}
+    assert resp.json()["version"] == 2
+
+
+# ── concurrency (Decision I) ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_invokes_on_one_slug_serialize(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG,
+                   _chain_graph("slow-one", "_SlowPass", {"seconds": 0.7}))
+    key_headers = _bearer(api_key["token"])
+    t0 = time.monotonic()
+    r1, r2 = await asyncio.gather(
+        test_client.post(f"/api/apps/{SLUG}/invoke",
+                         json={"inputs": {"x": "a"}}, headers=key_headers),
+        test_client.post(f"/api/apps/{SLUG}/invoke",
+                         json={"inputs": {"x": "b"}}, headers=key_headers),
+    )
+    elapsed = time.monotonic() - t0
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert elapsed >= 1.3          # two 0.7s runs back-to-back, never overlapped
+    assert len(await _run_rows(app_db)) == 2
+
+
+@pytest.mark.asyncio
+async def test_invokes_on_different_slugs_interleave(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, "para-one",
+                   _chain_graph("slow-a", "_SlowPass", {"seconds": 0.7}))
+    await _publish(test_client, "para-two",
+                   _chain_graph("slow-b", "_SlowPass", {"seconds": 0.7}))
+    key_headers = _bearer(api_key["token"])
+    t0 = time.monotonic()
+    r1, r2 = await asyncio.gather(
+        test_client.post("/api/apps/para-one/invoke",
+                         json={"inputs": {"x": "a"}}, headers=key_headers),
+        test_client.post("/api/apps/para-two/invoke",
+                         json={"inputs": {"x": "b"}}, headers=key_headers),
+    )
+    elapsed = time.monotonic() - t0
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert elapsed < 1.3           # different slugs never queue on each other
+
+
+@pytest.mark.asyncio
+async def test_queue_timeout_expires_while_queued(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG,
+                   _chain_graph("slow-hold", "_SlowPass", {"seconds": 2.0}))
+    key_headers = _bearer(api_key["token"])
+
+    first = asyncio.create_task(test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json={"inputs": {"x": "a"}}, headers=key_headers))
+    await asyncio.sleep(0.3)       # let the first invoke take the lock
+    second = await test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json={"inputs": {"x": "b"}, "timeout_s": 1}, headers=key_headers)
+    # The budget covers TOTAL time including queue wait: the second call
+    # dies waiting for the lock, with the queue-specific message.
+    assert second.status_code == 500
+    body = second.json()
+    assert body["error"]["code"] == "timeout"
+    assert "expired while queued" in body["error"]["message"]
+    assert body["version"] == 1    # resolved before queueing -> row written
+
+    resp1 = await first
+    assert resp1.status_code == 200
+
+    rows = await _run_rows(app_db)
+    assert len(rows) == 2          # one ok row + one queue-timeout row
+    assert {r["error_code"] for r in rows} == {None, "timeout"}

--- a/backend/tests/test_api_apps_invoke.py
+++ b/backend/tests/test_api_apps_invoke.py
@@ -788,3 +788,45 @@ async def test_runs_reads_accept_either_credential_reject_neither(
     # Session token alone (test_client default headers) works.
     assert (await test_client.get(
         f"/api/apps/{SLUG}/runs")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_run_detail_cross_app_isolation(
+    test_client, app_db, api_key,
+):
+    """Verify that a run from app A cannot be accessed via app B's run-detail
+    endpoint. The run must be structurally isolated by app_id, so fetching
+    a valid run_id with a different app slug returns 404 with
+    detail.code == 'run_not_found', indistinguishable from a nonexistent run.
+    Positive control: the same run_id is accessible via app A's slug."""
+    # Publish two apps.
+    await _publish(test_client, SLUG, _echo_graph())
+    other_slug = "other-app"
+    await _publish(test_client, other_slug, _echo_graph(name="other-src"))
+    key_headers = _bearer(api_key["token"])
+
+    # Invoke app A once to create a runs row.
+    invoke_resp = await test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json={"inputs": {"x": "test"}},
+        headers=key_headers,
+    )
+    assert invoke_resp.status_code == 200
+    run_id = invoke_resp.json()["run_id"]
+
+    # Attempt to access the run from app B -> 404 with run_not_found code.
+    cross_app_resp = await test_client.get(
+        f"/api/apps/{other_slug}/runs/{run_id}",
+        headers=key_headers,
+    )
+    assert cross_app_resp.status_code == 404
+    detail = cross_app_resp.json()["detail"]
+    assert detail["code"] == "run_not_found"
+
+    # Positive control: the same run_id is accessible via app A's slug.
+    same_app_resp = await test_client.get(
+        f"/api/apps/{SLUG}/runs/{run_id}",
+        headers=key_headers,
+    )
+    assert same_app_resp.status_code == 200
+    assert same_app_resp.json()["run_id"] == run_id

--- a/backend/tests/test_api_apps_invoke.py
+++ b/backend/tests/test_api_apps_invoke.py
@@ -687,3 +687,104 @@ async def test_invoke_succeeds_after_queued_timeout(
     assert by_run_id[resp_b.json()["run_id"]]["status"] == "error"
     assert by_run_id[resp_b.json()["run_id"]]["error_code"] == "timeout"
     assert by_run_id[resp_c.json()["run_id"]]["status"] == "ok"
+
+
+# ── runs reads: metadata list + full detail, either-credential (Task 11) ─
+
+
+@pytest.mark.asyncio
+async def test_runs_list_metadata_only_newest_first(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG, _echo_graph())
+    key_headers = _bearer(api_key["token"])
+    first = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                   json={"inputs": {"x": "one"}},
+                                   headers=key_headers)
+    second = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                    json={"inputs": {"x": 2}},  # 422
+                                    headers=key_headers)
+
+    resp = await test_client.get(f"/api/apps/{SLUG}/runs")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert [r["run_id"] for r in rows] == [
+        second.json()["run_id"], first.json()["run_id"],
+    ]
+    for row in rows:
+        assert set(row.keys()) == {
+            "run_id", "version", "status", "error_code", "error_node_id",
+            "device", "total_s", "api_key_id", "created_at",
+        }  # metadata ONLY — no inputs/outputs/node_timings
+
+    # limit + before cursor.
+    resp = await test_client.get(f"/api/apps/{SLUG}/runs?limit=1")
+    assert [r["run_id"] for r in resp.json()] == [second.json()["run_id"]]
+    cursor = rows[0]["created_at"]
+    resp = await test_client.get(
+        f"/api/apps/{SLUG}/runs?before={cursor}")
+    assert [r["run_id"] for r in resp.json()] == [first.json()["run_id"]]
+
+    resp = await test_client.get("/api/apps/ghost/runs")
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "app_not_found"
+
+
+@pytest.mark.asyncio
+async def test_run_detail_full_row_with_parsed_io(
+    test_client, app_db, api_key,
+):
+    await _publish(test_client, SLUG, _echo_graph())
+    invoke = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                    json={"inputs": {"x": "hi"}},
+                                    headers=_bearer(api_key["token"]))
+    run_id = invoke.json()["run_id"]
+
+    resp = await test_client.get(f"/api/apps/{SLUG}/runs/{run_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_id"] == run_id
+    assert body["version"] == 1
+    assert body["status"] == "ok"
+    assert body["api_key_id"] == api_key["id"]
+    assert body["inputs"] == {"x": "hi"}
+    assert body["outputs"] == {"y": "hi"}
+    assert isinstance(body["node_timings"], dict)
+    assert "inputs_json" not in body        # parsed, not raw columns
+
+    resp = await test_client.get(f"/api/apps/{SLUG}/runs/never-ran")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_runs_reads_accept_either_credential_reject_neither(
+    test_client, app_db, api_key,
+):
+    from httpx import ASGITransport, AsyncClient
+
+    await _publish(test_client, SLUG, _echo_graph())
+    invoke = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                    json={"inputs": {"x": "hi"}},
+                                    headers=_bearer(api_key["token"]))
+    run_id = invoke.json()["run_id"]
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url=f"http://127.0.0.1:{settings.PORT}",
+    ) as anon:
+        # API key alone (no session header) works.
+        key_only = await anon.get(f"/api/apps/{SLUG}/runs",
+                                  headers=_bearer(api_key["token"]))
+        assert key_only.status_code == 200
+        detail = await anon.get(f"/api/apps/{SLUG}/runs/{run_id}",
+                                headers=_bearer(api_key["token"]))
+        assert detail.status_code == 200
+        # Neither credential -> plain {"detail": ...} 401.
+        denied = await anon.get(f"/api/apps/{SLUG}/runs")
+        assert denied.status_code == 401
+        assert set(denied.json().keys()) == {"detail"}
+        denied = await anon.get(f"/api/apps/{SLUG}/runs/{run_id}")
+        assert denied.status_code == 401
+    # Session token alone (test_client default headers) works.
+    assert (await test_client.get(
+        f"/api/apps/{SLUG}/runs")).status_code == 200

--- a/backend/tests/test_api_apps_invoke.py
+++ b/backend/tests/test_api_apps_invoke.py
@@ -558,3 +558,132 @@ async def test_queue_timeout_expires_while_queued(
     rows = await _run_rows(app_db)
     assert len(rows) == 2          # one ok row + one queue-timeout row
     assert {r["error_code"] for r in rows} == {None, "timeout"}
+
+
+# ── coverage pins: 413 body-cap, route-level 422, post-timeout recovery ────
+
+
+@pytest.mark.asyncio
+async def test_invoke_413_body_cap_writes_no_row(
+    test_client, app_db, api_key, monkeypatch,
+):
+    """POST with Content-Length > MAX_RUN_BODY_BYTES returns 413 with no
+    runs row. The cap is checked against the header before the body is
+    read; the envelope has all 9 keys, error.code == "payload_too_large",
+    and version is None (pre-resolution failure)."""
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 10)
+    await _publish(test_client, SLUG, _echo_graph())
+    key_headers = _bearer(api_key["token"])
+
+    # Send a body larger than the tiny cap (10 bytes). The actual body
+    # content is small, but Content-Length header declares the size.
+    big_body = {"inputs": {"x": "hello world this is larger than 10"}}
+    resp = await test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json=big_body,
+        headers=key_headers,
+    )
+    assert resp.status_code == 413
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["error"]["code"] == "payload_too_large"
+    assert body["app"] == SLUG
+    assert body["version"] is None        # pre-resolution (413 happens early)
+    assert "payload_too_large" in body["error"]["message"] or "max" in body["error"]["message"]
+
+    # No rows written for pre-resolution failures.
+    rows = await _run_rows(app_db)
+    assert len(rows) == 0
+
+
+@pytest.mark.asyncio
+async def test_invoke_route_level_422_malformed_body_writes_row(
+    test_client, app_db, api_key,
+):
+    """POST with malformed body (e.g. 'inputs' is a list instead of dict)
+    fails at the _parse_run_body route level. Returns 422 envelope with
+    error.code == "invalid_input", version == resolved version (not None),
+    and EXACTLY ONE runs row with status "error" and error_code "invalid_input".
+
+    This test exercises the case where the body is valid JSON and passes
+    app resolution, but the 'inputs' field is not a dict — causing
+    _parse_run_body to return field_errors."""
+    await _publish(test_client, SLUG, _echo_graph())
+    key_headers = _bearer(api_key["token"])
+
+    # Send a body where 'inputs' is a list instead of a dict.
+    # This passes JSON parsing and reaches _parse_run_body, which rejects it.
+    resp = await test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json={"inputs": ["not", "a", "dict"]},  # inputs must be dict, not list
+        headers=key_headers,
+    )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["error"]["code"] == "invalid_input"
+    assert body["app"] == SLUG
+    assert body["version"] == 1    # resolved after app lookup -> version is set
+    assert body["run_id"]
+
+    # Exactly one row written with error status.
+    rows = await _run_rows(app_db)
+    assert len(rows) == 1
+    assert rows[0]["status"] == "error"
+    assert rows[0]["error_code"] == "invalid_input"
+    assert rows[0]["version"] == 1
+    assert rows[0]["run_id"] == body["run_id"]
+
+
+@pytest.mark.asyncio
+async def test_invoke_succeeds_after_queued_timeout(
+    test_client, app_db, api_key,
+):
+    """Lock recovery after a queued timeout:
+    - Invoke A: slow graph (1.5s), holds the lock
+    - Invoke B: timeout_s=1 (dies waiting in queue with timeout message)
+    - Await A: succeeds (lock released cleanly)
+    - Invoke C: fresh invoke succeeds (lock available again)
+
+    Proves the lock is healthy post-timeout: the lock releases in the
+    finally block even when a queued request times out."""
+    await _publish(test_client, SLUG,
+                   _chain_graph("slow-recovery", "_SlowPass", {"seconds": 1.5}))
+    key_headers = _bearer(api_key["token"])
+
+    # Start invoke A (will hold the lock for ~1.5s)
+    task_a = asyncio.create_task(test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json={"inputs": {"x": "a"}}, headers=key_headers))
+    await asyncio.sleep(0.2)  # let A acquire the lock
+
+    # Invoke B with a short timeout (will queue and time out)
+    resp_b = await test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json={"inputs": {"x": "b"}, "timeout_s": 1},
+        headers=key_headers,
+    )
+    assert resp_b.status_code == 500
+    assert resp_b.json()["error"]["code"] == "timeout"
+    assert "expired while queued" in resp_b.json()["error"]["message"]
+
+    # Await A to complete (should succeed after ~1.5s total)
+    resp_a = await task_a
+    assert resp_a.status_code == 200
+    assert resp_a.json()["outputs"] == {"y": "a"}
+
+    # Invoke C fresh (lock should be free now)
+    resp_c = await test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json={"inputs": {"x": "c"}}, headers=key_headers)
+    assert resp_c.status_code == 200
+    assert resp_c.json()["outputs"] == {"y": "c"}
+
+    # Three rows: A ok, B timeout error, C ok
+    rows = await _run_rows(app_db)
+    assert len(rows) == 3
+    by_run_id = {r["run_id"]: r for r in rows}
+    assert by_run_id[resp_a.json()["run_id"]]["status"] == "ok"
+    assert by_run_id[resp_b.json()["run_id"]]["status"] == "error"
+    assert by_run_id[resp_b.json()["run_id"]]["error_code"] == "timeout"
+    assert by_run_id[resp_c.json()["run_id"]]["status"] == "ok"

--- a/backend/tests/test_api_graph_run.py
+++ b/backend/tests/test_api_graph_run.py
@@ -15,7 +15,10 @@ from app.core.node_base import BaseNode, DataType, PortDefinition
 from app.core.run_output_store import RunOutputStore
 from app.main import app
 
-ENVELOPE_KEYS = {"status", "run_id", "graph", "device", "outputs", "error", "timing"}
+ENVELOPE_KEYS = {
+    "status", "run_id", "graph", "app", "version",
+    "device", "outputs", "error", "timing",
+}
 
 
 # ── config: body cap setting ─────────────────────────────────────────────

--- a/backend/tests/test_envelope_v2.py
+++ b/backend/tests/test_envelope_v2.py
@@ -1,0 +1,49 @@
+"""Unit pins for the Stage-2 envelope additions (spec Section 6): nine
+always-present keys, app/version kwargs, and error_response's headers=
+passthrough (the invoke 401 carries WWW-Authenticate: Bearer)."""
+
+from __future__ import annotations
+
+import json
+
+from app.api.routes_graph_run import build_envelope, error_response
+
+ENVELOPE_KEYS = {
+    "status", "run_id", "graph", "app", "version",
+    "device", "outputs", "error", "timing",
+}
+
+
+def test_build_envelope_emits_nine_keys_with_null_app_version_by_default():
+    env = build_envelope(status="ok", run_id="r1", graph="g",
+                         outputs={"y": 1})
+    assert set(env.keys()) == ENVELOPE_KEYS
+    assert env["app"] is None       # editor route: always null
+    assert env["version"] is None
+
+
+def test_build_envelope_carries_app_and_version_when_given():
+    env = build_envelope(status="ok", run_id="r1", graph="my-app",
+                         app="my-app", version=3, outputs={})
+    assert env["app"] == "my-app"
+    assert env["version"] == 3
+
+
+def test_error_response_carries_app_version_and_headers():
+    resp = error_response(
+        401, run_id="r2", graph="my-app", app="my-app",
+        code="invalid_key", message="nope",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    assert resp.status_code == 401
+    assert resp.headers["WWW-Authenticate"] == "Bearer"
+    body = json.loads(resp.body)
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["app"] == "my-app"
+    assert body["version"] is None   # pre-resolution: version stays null
+
+
+def test_error_response_headers_default_adds_nothing():
+    resp = error_response(500, run_id="r", graph="g", code="timeout",
+                          message="m")
+    assert "WWW-Authenticate" not in resp.headers

--- a/backend/tests/test_pixel_budget.py
+++ b/backend/tests/test_pixel_budget.py
@@ -1,0 +1,170 @@
+"""Per-image pixel budget (spec Decision H2): enforced header-only in
+_decode_image between Image.open and img.load(), so decode memory is
+bounded on BOTH run routes.
+
+Deliberately NOT run with warnings-as-errors: PIL emits
+DecompressionBombWarning above ~89.5 MP, and above ~179 MP PIL's own
+DecompressionBombError fires FIRST inside Image.open (front-stop) — in
+that range tests match the CODE only, never the reason text.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+
+from app.config import Settings
+from app.core import api_contract
+from app.core.api_contract import InputCoercionError
+
+
+def _png_base64(width: int, height: int, mode: str = "RGB") -> str:
+    from PIL import Image
+
+    img = Image.new(mode, (width, height),
+                    color=0 if mode == "1" else (255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _bilevel_png_base64(width: int, height: int) -> str:
+    """Small-bytes / huge-dimensions PNG: 1-bit mode keeps the in-test
+    allocation at ~w*h/8 bytes and the file KB-scale."""
+    return _png_base64(width, height, mode="1")
+
+
+# ── unit level ───────────────────────────────────────────────────────────
+
+
+def test_default_budget_env_overridable(monkeypatch):
+    assert Settings().MAX_IMAGE_PIXELS == 25_000_000
+    monkeypatch.setenv("CODEFYUI_MAX_IMAGE_PIXELS", "123")
+    assert Settings().MAX_IMAGE_PIXELS == 123
+
+
+def test_decode_image_rejects_over_budget_before_load(monkeypatch):
+    monkeypatch.setattr("app.config.settings.MAX_IMAGE_PIXELS", 7)
+    with pytest.raises(InputCoercionError) as exc_info:
+        api_contract.coerce_input(_png_base64(4, 2), "image")
+    # Our message names dimensions and product: "(WxH=N)".
+    assert "image exceeds MAX_IMAGE_PIXELS (4x2=8)" in exc_info.value.reason
+
+
+def test_decode_image_under_budget_still_decodes(monkeypatch):
+    monkeypatch.setattr("app.config.settings.MAX_IMAGE_PIXELS", 9)
+    tensor = api_contract.coerce_input(_png_base64(4, 2), "image")
+    assert tuple(tensor.shape) == (3, 2, 4)   # (C, H, W)
+
+
+def test_real_default_budget_rejects_100_megapixel_png():
+    # No monkeypatch: a genuine 100 MP crafted PNG (success criterion 5)
+    # against the real 25 MP default. The 10000x10000 bilevel PNG
+    # allocates ~12.5 MB in-test and rejects BEFORE decode pays the
+    # full-size cost. (PIL emits DecompressionBombWarning above ~89.5 MP
+    # — expected, harmless, and exactly why this path never runs
+    # warnings-as-errors.)
+    with pytest.raises(InputCoercionError) as exc_info:
+        api_contract.coerce_input(_bilevel_png_base64(10000, 10000), "image")
+    assert "exceeds MAX_IMAGE_PIXELS (10000x10000=100000000)" \
+        in exc_info.value.reason
+
+
+# ── endpoint level: BOTH routes (decode is shared) ───────────────────────
+
+
+def _image_graph(name: str = "img-graph") -> dict:
+    return {
+        "name": name,
+        "description": "",
+        "nodes": [
+            {"id": "start", "type": "Start", "position": {"x": 0, "y": 0},
+             "data": {"params": {}}},
+            {"id": "gi", "type": "GraphInput", "position": {"x": 200, "y": 0},
+             "data": {"params": {
+                 "name": "photo", "type": "image", "required": True,
+                 "default": "", "description": "",
+             }}},
+            {"id": "out", "type": "GraphOutput", "position": {"x": 400, "y": 0},
+             "data": {"params": {"name": "echo", "description": ""}}},
+        ],
+        "edges": [
+            {"id": "t1", "source": "start", "target": "gi",
+             "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+            {"id": "d1", "source": "gi", "target": "out",
+             "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _graphs_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_editor_run_rejects_100mp_png_422(test_client):
+    # Small-bytes / huge-dimensions PNG at the REAL default budget
+    # (success criterion 5, editor route).
+    resp = await test_client.post("/api/graph/save", json=_image_graph())
+    assert resp.status_code == 200
+    resp = await test_client.post(
+        "/api/graph/run/img-graph",
+        json={"inputs": {"photo": _bilevel_png_base64(10000, 10000)}},
+    )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_input"
+    assert any("MAX_IMAGE_PIXELS" in d["reason"]
+               for d in body["error"]["details"])
+
+
+@pytest.mark.asyncio
+async def test_invoke_rejects_100mp_png_422(test_client, app_db):
+    # Same crafted PNG on the published-invoke route (decode is shared).
+    key = (await test_client.post(
+        "/api/keys", json={"name": "px"})).json()
+    resp = await test_client.post("/api/graph/save",
+                                  json=_image_graph("img-pub"))
+    assert resp.status_code == 200
+    resp = await test_client.post(
+        "/api/apps/img-app/publish",
+        json={"graph": "img-pub", "create": True},
+    )
+    assert resp.status_code == 200, resp.text
+    resp = await test_client.post(
+        "/api/apps/img-app/invoke",
+        json={"inputs": {"photo": _bilevel_png_base64(10000, 10000)}},
+        headers={"Authorization": f"Bearer {key['token']}"},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "invalid_input"
+
+
+@pytest.mark.asyncio
+async def test_pil_front_stop_range_matches_code_never_reason(
+    test_client, monkeypatch,
+):
+    # Above ~179 MP PIL's DecompressionBombError fires FIRST inside
+    # Image.open — simulate it exactly like the Stage-1 regression test.
+    # Clients and tests match on the CODE only in that range: the reason
+    # text is PIL's, not ours.
+    import PIL.Image
+
+    resp = await test_client.post("/api/graph/save", json=_image_graph())
+    assert resp.status_code == 200
+
+    def _boom(*_args, **_kwargs):
+        raise PIL.Image.DecompressionBombError("boom")
+
+    monkeypatch.setattr(PIL.Image, "open", _boom)
+    resp = await test_client.post(
+        "/api/graph/run/img-graph",
+        json={"inputs": {"photo": _png_base64(4, 2)}},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "invalid_input"
+    # Deliberately NO assertion on the reason text (spec Section 6.3).


### PR DESCRIPTION
**Stacked PR — retarget base to main (or merge bottom-up) BEFORE merging**

Stage 2 "Publish" PR 3/4 — invoke + run records (stacked on feat/stage2-apps; spec Decisions D/F1/F2/H1/H2/I).

## What
- `execute_contract_run` extraction from the Stage-1 handler: structured `(http_status, envelope_dict, node_timings)` return, wire-identical wrapping on both routes; refactor guard held (Stage-1 test file green with ONLY the `ENVELOPE_KEYS` 7->9 edit). Envelope gains always-present `app`/`version` (editor route: null/null).
- `POST /api/apps/{slug}/invoke`: run_id-first non-raising key auth (enveloped 401 + `WWW-Authenticate: Bearer`, self-diagnosing message for a pasted session token), body cap, ONE-SELECT resolution, queue-aware per-slug lock (`timeout_s` covers queue wait; remaining budget passed into execution), `output_store=None` (published runs can NEVER reach the unauthenticated inspector store — structural), best-effort runs INSERT (row-only-if-resolved; 422 rows carry capped raw inputs; INSERT failure logs ERROR and never eats the envelope).
- Runs read surface: metadata-only list (+cursor) and full-detail single run (parsed io + per-node timings), either-credential auth (session token works — Stage 3's editor UI needs no API key in the browser); cross-app run access 404s indistinguishably (test-pinned).
- `MAX_IMAGE_PIXELS` budget (25 MP default) in `_decode_image` between header parse and pixel decode; PIL's DecompressionBombError is the front-stop above ~179 MP.

## Test plan
- [x] `uv run pytest -q` green: 1535 passed / 11 skipped (+31 over PR2; 3 warnings are PIL DecompressionBombWarning from the deliberate 100 MP tests)
- [x] Real-server e2e (port 8123): mint key -> publish -> invoke ok (9-key envelope, version 1) -> **edit + resave canvas -> invoke STILL returns the v1 snapshot value** -> republish -> invoke returns v2 value; runs list shows exactly the 3 resolved rows (the enveloped-401 attempts wrote nothing); run detail returns parsed inputs/outputs/node_timings; session-token-as-Bearer got the self-diagnosing message verbatim
- [x] Chrome editor smoke: Examples gallery -> Api-Function -> Run — execution completes, log prints `[Api-Function] hello from the canvas` (editor WS flow unaffected by the envelope change)
- [x] No new pip dependencies; zero frontend diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
