### PR TITLE
feat(cli): Stage 2 PR4 — LAN serving + per-app OpenAPI + docs

### DIFF
--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -651,6 +651,230 @@ async def invoke_app(
     return await _finish(http_status, envelope, node_timings, run_req.inputs)
 
 
+# ── per-app OpenAPI document (spec Section 6.1) ─────────────────────────
+
+# Contract type -> JSON Schema fragment (api_contract.INPUT_TYPES table).
+_CONTRACT_TYPE_TO_SCHEMA: dict[str, dict[str, Any]] = {
+    "string": {"type": "string"},
+    "number": {"type": "number"},
+    "integer": {"type": "integer"},
+    "boolean": {"type": "boolean"},
+    "json": {},  # any JSON value
+    "image": {"type": "string", "contentEncoding": "base64"},
+}
+
+
+def _openapi_document(
+    slug: str, version: int, contract_doc: dict[str, Any], host: str,
+) -> dict[str, Any]:
+    """A COMPLETE standalone OpenAPI 3.1 document for the active version.
+
+    Top-level ``openapi``/``info``/``paths``/``components``/``security``
+    are all always present — never a fragment (openapi-generator chokes on
+    partials). Generated from the version's stored ``contract_json``;
+    ``servers`` derives from the validated request Host (host_guard
+    already vetted it). JSON only — no HTML (Stage-5 veto).
+    """
+    input_properties: dict[str, Any] = {}
+    required_inputs: list[str] = []
+    for inp in contract_doc.get("inputs", []):
+        schema = dict(_CONTRACT_TYPE_TO_SCHEMA.get(inp.get("type", "json"),
+                                                   {}))
+        if inp.get("description"):
+            schema["description"] = inp["description"]
+        if inp.get("default") is not None:
+            schema["default"] = inp["default"]
+        input_properties[inp["name"]] = schema
+        if inp.get("required"):
+            required_inputs.append(inp["name"])
+    inputs_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": input_properties,
+        # Unknown input names are rejected 422 by the API — say so.
+        "additionalProperties": False,
+    }
+    if required_inputs:
+        inputs_schema["required"] = required_inputs
+
+    envelope_schema: dict[str, Any] = {
+        "type": "object",
+        "description": (
+            "The one run envelope: all nine keys always present (null when "
+            "not applicable); the HTTP status mirrors status/error.code. "
+            "Clients MUST ignore unknown envelope fields; error.code is an "
+            "open enum — treat unknown codes as generic errors."
+        ),
+        "required": ["status", "run_id", "graph", "app", "version",
+                     "device", "outputs", "error", "timing"],
+        "properties": {
+            "status": {"type": "string", "enum": ["ok", "error"]},
+            "run_id": {"type": "string"},
+            "graph": {"type": "string"},
+            "app": {"type": ["string", "null"]},
+            "version": {"type": ["integer", "null"]},
+            "device": {"type": ["string", "null"]},
+            "outputs": {"type": ["object", "null"]},
+            "error": {
+                "type": ["object", "null"],
+                "properties": {
+                    "code": {"type": "string"},
+                    "message": {"type": "string"},
+                    "node_id": {"type": ["string", "null"]},
+                    "details": {"type": ["array", "null"]},
+                },
+            },
+            "timing": {
+                "type": ["object", "null"],
+                "properties": {"total_s": {"type": "number"}},
+            },
+        },
+    }
+
+    base_url = f"http://{host}/api/apps/{slug}"
+    bash_curl = (
+        f'curl -s -X POST "{base_url}/invoke" \\\n'
+        '  -H "Authorization: Bearer cdui_YOUR_KEY" \\\n'
+        '  -H "Content-Type: application/json" \\\n'
+        '  --data "@payload.json"'
+    )
+    powershell_curl = (
+        f'curl.exe -s -X POST "{base_url}/invoke" `\n'
+        '  -H "Authorization: Bearer cdui_YOUR_KEY" `\n'
+        '  -H "Content-Type: application/json" `\n'
+        '  --data "@payload.json"'
+    )
+
+    return {
+        "openapi": "3.1.0",
+        "info": {
+            "title": f"CodefyUI app: {slug}",
+            "version": str(version),
+            "description": (
+                f"Published CodefyUI graph behind the stable slug '{slug}' "
+                f"(active version {version}). Auth: an API key in "
+                "'Authorization: Bearer cdui_...'. The request body is "
+                "optional; record_outputs is accepted and ignored on "
+                "published invokes (run records live in SQLite)."
+            ),
+        },
+        "servers": [{"url": base_url}],
+        "security": [{"bearerAuth": []}],
+        "paths": {
+            "/invoke": {
+                "post": {
+                    "operationId": "invoke_" + slug.replace("-", "_"),
+                    "summary": f"Invoke the active version of '{slug}'",
+                    "requestBody": {
+                        "required": False,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "inputs": inputs_schema,
+                                        "timeout_s": {
+                                            "type": "number",
+                                            "minimum": 1,
+                                            "maximum": 3600,
+                                            "default": 300,
+                                            "description": (
+                                                "Total budget in seconds, "
+                                                "INCLUDING queue wait "
+                                                "behind other invokes of "
+                                                "this app."
+                                            ),
+                                        },
+                                        "device": {
+                                            "type": ["string", "null"],
+                                            "description": (
+                                                "cpu / cuda / mps; an "
+                                                "unavailable device falls "
+                                                "back to cpu."
+                                            ),
+                                        },
+                                        "record_outputs": {
+                                            "type": "boolean",
+                                            "description": (
+                                                "Accepted and ignored on "
+                                                "published invokes."
+                                            ),
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    "responses": {
+                        "200": {
+                            "description": 'Run succeeded (status == "ok").',
+                            "content": {"application/json": {"schema": {
+                                "$ref": "#/components/schemas/RunEnvelope",
+                            }}},
+                        },
+                        "default": {
+                            "description": (
+                                "Enveloped error — the HTTP status mirrors "
+                                "error.code (401 invalid_key, 404 "
+                                "app_not_found, 409 app_unpublished, plus "
+                                "all Stage-1 codes)."
+                            ),
+                            "content": {"application/json": {"schema": {
+                                "$ref": "#/components/schemas/RunEnvelope",
+                            }}},
+                        },
+                    },
+                },
+            },
+        },
+        "components": {
+            "schemas": {"RunEnvelope": envelope_schema},
+            "securitySchemes": {
+                "bearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer",
+                    "description": "CodefyUI API key (cdui_...)",
+                },
+            },
+        },
+        "x-codefyui-curl": {
+            "powershell": powershell_curl,
+            "bash": bash_curl,
+        },
+    }
+
+
+@router.get("/{slug}/openapi.json",
+            dependencies=[Depends(require_api_key_or_session)])
+async def get_app_openapi(slug: str, request: Request):
+    """The per-app OpenAPI 3.1 document for the ACTIVE version, generated
+    from the stored contract_json. Either-credential read."""
+    db = get_db(request)
+
+    def _resolve(conn: sqlite3.Connection) -> dict[str, Any] | None:
+        row = conn.execute(
+            "SELECT a.active_version, v.contract_json "
+            "FROM apps a "
+            "LEFT JOIN app_versions v "
+            "  ON v.app_id = a.id AND v.version = a.active_version "
+            "WHERE a.slug = ?",
+            (slug,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    resolved = await db.run(_resolve)
+    if resolved is None:
+        raise _manage_error(404, "app_not_found", f"app '{slug}' not found")
+    if resolved["active_version"] is None or resolved["contract_json"] is None:
+        raise _manage_error(409, "app_unpublished",
+                            f"app '{slug}' has no active version — "
+                            "publish or activate one first")
+    contract_doc = json.loads(resolved["contract_json"])
+    host = request.headers.get("host", f"{settings.HOST}:{settings.PORT}")
+    return _openapi_document(
+        slug, int(resolved["active_version"]), contract_doc, host,
+    )
+
+
 @router.get("/{slug}/runs",
             dependencies=[Depends(require_api_key_or_session)])
 async def list_runs(

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -147,3 +147,36 @@ def host_is_allowed(host_header: str) -> bool:
 def allowed_hosts() -> frozenset[str]:
     """Snapshot of the current whitelist (mostly for tests / error messages)."""
     return frozenset(_ALLOWED_HOSTS)
+
+
+def local_interface_ips() -> list[str]:
+    """Best-effort enumeration of this machine's IPv4 addresses.
+
+    Used when binding 0.0.0.0: ``init_allowed_hosts`` deliberately skips
+    the wildcard itself, so each concrete interface IP gets whitelisted as
+    ``{ip}:{port}`` instead. This does NOT weaken the DNS-rebinding
+    defense — a rebound browser still sends the attacker's hostname in
+    ``Host``, which stays unlisted.
+    """
+    import socket
+
+    ips: set[str] = set()
+    try:
+        for info in socket.getaddrinfo(socket.gethostname(), None,
+                                       socket.AF_INET):
+            ips.add(info[4][0])
+    except OSError:
+        pass
+    # UDP-connect trick: finds the outbound-default interface without
+    # sending a packet (helps when the hostname resolves to 127.0.1.1).
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("192.0.2.1", 80))  # TEST-NET-1, never routed
+            ips.add(s.getsockname()[0])
+        finally:
+            s.close()
+    except OSError:
+        pass
+    ips.discard("127.0.0.1")
+    return sorted(ips)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,9 +55,11 @@ from .api import (
 from .config import settings
 from .core.auth import (
     TOKEN_HEADER,
+    allowed_hosts,
     constant_time_equals,
     host_is_allowed,
     init_allowed_hosts,
+    local_interface_ips,
     session_token,
     write_token_file,
 )
@@ -109,6 +111,25 @@ def _prefix_exempt(path: str) -> bool:
     )
 
 
+def _extra_allowed_host_entries() -> list[str]:
+    """Extra Host-whitelist entries beyond the bind address.
+
+    ``EXTRA_ALLOWED_HOSTS`` (comma-separated str — see config.py) split
+    and stripped; plus, when binding a wildcard (which init_allowed_hosts
+    deliberately skips), each concrete interface IP as ``{ip}:{port}``.
+    """
+    entries = [
+        entry.strip()
+        for entry in settings.EXTRA_ALLOWED_HOSTS.split(",")
+        if entry.strip()
+    ]
+    if settings.HOST in ("0.0.0.0", "::"):
+        entries.extend(
+            f"{ip}:{settings.PORT}" for ip in local_interface_ips()
+        )
+    return entries
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     setup_logging(
@@ -123,7 +144,22 @@ async def lifespan(app: FastAPI):
     # from the file.
     init_allowed_hosts(settings.HOST, settings.PORT, extra=[
         urlparse(o).netloc for o in settings.CORS_ORIGINS
-    ])
+    ] + _extra_allowed_host_entries())
+    if settings.HOST not in ("127.0.0.1", "localhost", "::1"):
+        # Startup transparency for non-loopback binds (spec Section 9):
+        # print the effective whitelist and the reachable URLs. Anyone who
+        # can reach the port controls the instance — the docs carry the
+        # full framing; this log makes the exposure visible at start.
+        logger.warning(
+            "Serving on a non-loopback bind (%s:%s) — anyone who can "
+            "reach this port controls the instance; use only on trusted "
+            "networks.",
+            settings.HOST, settings.PORT,
+        )
+        logger.info("Host whitelist: %s", ", ".join(sorted(allowed_hosts())))
+        logger.info("Reachable at: %s", ", ".join(sorted(
+            f"http://{h}" for h in allowed_hosts() if ":" in h
+        )))
     token_path = write_token_file()
     logger.info("Session token written to %s", token_path)
 

--- a/backend/tests/test_api_apps_openapi.py
+++ b/backend/tests/test_api_apps_openapi.py
@@ -1,0 +1,182 @@
+"""GET /api/apps/{slug}/openapi.json — a COMPLETE standalone OpenAPI 3.1
+document for the ACTIVE version (spec Section 6.1): never a fragment
+(openapi-generator chokes on partials), contract-typed requestBody, 9-key
+envelope schema, bearerAuth, servers from the validated Host, and the
+x-codefyui-curl {powershell, bash} snippet object."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import settings
+from app.main import app
+
+SLUG = "openapi-app"
+
+
+@pytest.fixture(autouse=True)
+def _graphs_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    return tmp_path
+
+
+def _typed_graph(name: str = "openapi-src") -> dict:
+    """Start triggering three typed GraphInputs (string + image required,
+    json optional with default "{}") + one GraphOutput fed from x."""
+    return {
+        "name": name,
+        "description": "",
+        "nodes": [
+            {"id": "start", "type": "Start", "position": {"x": 0, "y": 0},
+             "data": {"params": {}}},
+            {"id": "gi-x", "type": "GraphInput",
+             "position": {"x": 200, "y": 0},
+             "data": {"params": {"name": "x", "type": "string",
+                                 "required": True, "default": "",
+                                 "description": ""}}},
+            {"id": "gi-photo", "type": "GraphInput",
+             "position": {"x": 200, "y": 150},
+             "data": {"params": {"name": "photo", "type": "image",
+                                 "required": True, "default": "",
+                                 "description": ""}}},
+            {"id": "gi-j", "type": "GraphInput",
+             "position": {"x": 200, "y": 300},
+             "data": {"params": {"name": "j", "type": "json",
+                                 "required": False, "default": "{}",
+                                 "description": ""}}},
+            {"id": "out", "type": "GraphOutput",
+             "position": {"x": 400, "y": 0},
+             "data": {"params": {"name": "echo", "description": ""}}},
+        ],
+        "edges": [
+            {"id": "t1", "source": "start", "target": "gi-x",
+             "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+            {"id": "t2", "source": "start", "target": "gi-photo",
+             "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+            {"id": "t3", "source": "start", "target": "gi-j",
+             "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+            {"id": "d1", "source": "gi-x", "target": "out",
+             "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        ],
+    }
+
+
+async def _publish(client, slug: str, graph: dict) -> None:
+    resp = await client.post("/api/graph/save", json=graph)
+    assert resp.status_code == 200, resp.text
+    resp = await client.post(
+        f"/api/apps/{slug}/publish",
+        json={"graph": graph["name"], "create": True},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_openapi_document_is_complete_and_typed(test_client, app_db):
+    await _publish(test_client, SLUG, _typed_graph())
+    resp = await test_client.get(f"/api/apps/{SLUG}/openapi.json")
+    assert resp.status_code == 200
+    doc = resp.json()
+
+    # COMPLETE standalone document — never a fragment.
+    for key in ("openapi", "info", "paths", "components", "security"):
+        assert key in doc, key
+    assert doc["openapi"] == "3.1.0"
+    assert doc["info"]["version"] == "1"
+    assert doc["servers"] == [
+        {"url": f"http://127.0.0.1:{settings.PORT}/api/apps/{SLUG}"},
+    ]
+
+    post = doc["paths"]["/invoke"]["post"]
+    body_schema = post["requestBody"]["content"]["application/json"]["schema"]
+    inputs_schema = body_schema["properties"]["inputs"]
+    # Contract type table (spec 6.1 + api_contract.INPUT_TYPES).
+    assert inputs_schema["properties"]["x"] == {"type": "string"}
+    assert inputs_schema["properties"]["photo"] == {
+        "type": "string", "contentEncoding": "base64",
+    }
+    assert inputs_schema["properties"]["j"] == {"default": {}}  # json -> {}
+    assert inputs_schema["required"] == ["x", "photo"]
+
+    envelope = doc["components"]["schemas"]["RunEnvelope"]
+    assert set(envelope["required"]) == {
+        "status", "run_id", "graph", "app", "version",
+        "device", "outputs", "error", "timing",
+    }
+    ref = {"$ref": "#/components/schemas/RunEnvelope"}
+    assert post["responses"]["200"]["content"]["application/json"]["schema"] \
+        == ref
+    assert post["responses"]["default"]["content"]["application/json"]["schema"] \
+        == ref
+    assert doc["components"]["securitySchemes"]["bearerAuth"] == {
+        "type": "http", "scheme": "bearer",
+        "description": "CodefyUI API key (cdui_...)",
+    }
+    assert doc["security"] == [{"bearerAuth": []}]
+
+
+@pytest.mark.asyncio
+async def test_openapi_curl_object_carries_both_shells(test_client, app_db):
+    await _publish(test_client, SLUG, _typed_graph())
+    doc = (await test_client.get(f"/api/apps/{SLUG}/openapi.json")).json()
+    curl = doc["x-codefyui-curl"]
+    assert set(curl.keys()) == {"powershell", "bash"}
+    base = f"http://127.0.0.1:{settings.PORT}/api/apps/{SLUG}/invoke"
+    for snippet in curl.values():
+        assert base in snippet
+        assert "Authorization: Bearer" in snippet
+        assert '--data "@payload.json"' in snippet
+    # PowerShell aliases `curl` to Invoke-WebRequest — always curl.exe.
+    assert curl["powershell"].startswith("curl.exe")
+    assert curl["bash"].startswith("curl ")
+
+
+@pytest.mark.asyncio
+async def test_openapi_auth_either_credential_and_error_codes(
+    test_client, app_db,
+):
+    await _publish(test_client, SLUG, _typed_graph())
+    key = (await test_client.post(
+        "/api/keys", json={"name": "openapi"})).json()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url=f"http://127.0.0.1:{settings.PORT}",
+    ) as anon:
+        ok = await anon.get(
+            f"/api/apps/{SLUG}/openapi.json",
+            headers={"Authorization": f"Bearer {key['token']}"},
+        )
+        assert ok.status_code == 200            # API key alone
+        denied = await anon.get(f"/api/apps/{SLUG}/openapi.json")
+        assert denied.status_code == 401        # neither credential
+        assert set(denied.json().keys()) == {"detail"}
+
+    # Session token alone (test_client default headers).
+    assert (await test_client.get(
+        f"/api/apps/{SLUG}/openapi.json")).status_code == 200
+
+    resp = await test_client.get("/api/apps/ghost/openapi.json")
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "app_not_found"
+
+    await test_client.post(f"/api/apps/{SLUG}/unpublish")
+    resp = await test_client.get(f"/api/apps/{SLUG}/openapi.json")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "app_unpublished"
+
+
+@pytest.mark.asyncio
+async def test_openapi_tracks_the_active_version(test_client, app_db):
+    graph = _typed_graph()
+    await _publish(test_client, SLUG, graph)
+    resp = await test_client.post(
+        f"/api/apps/{SLUG}/publish", json={"graph": graph["name"]})
+    assert resp.status_code == 200
+    doc = (await test_client.get(f"/api/apps/{SLUG}/openapi.json")).json()
+    assert doc["info"]["version"] == "2"
+    await test_client.post(f"/api/apps/{SLUG}/activate",
+                           json={"version": 1})
+    doc = (await test_client.get(f"/api/apps/{SLUG}/openapi.json")).json()
+    assert doc["info"]["version"] == "1"        # the ACTIVE version's doc

--- a/backend/tests/test_dev_cli.py
+++ b/backend/tests/test_dev_cli.py
@@ -1,0 +1,57 @@
+"""Unit tests for the cdui start --host/--port plumbing in scripts/dev.py
+(spec Section 9). The full LAN behavior is exercised manually in the PR4
+gate; these pin the pure helpers."""
+
+from __future__ import annotations
+
+import dev  # scripts/dev.py — conftest puts scripts/ on sys.path
+
+
+def test_parse_host_port_defaults():
+    assert dev._parse_host_port([]) == ("127.0.0.1", 8000)
+
+
+def test_parse_host_port_flags_both_styles():
+    assert dev._parse_host_port(
+        ["--host", "0.0.0.0", "--port", "8080"]) == ("0.0.0.0", 8080)
+    assert dev._parse_host_port(
+        ["--host=192.168.1.20", "--port=9000"]) == ("192.168.1.20", 9000)
+    # Unrelated flags pass through; a bogus port falls back to default.
+    assert dev._parse_host_port(
+        ["--foreground", "--port", "bogus"]) == ("127.0.0.1", 8000)
+
+
+def test_probe_host_wildcard_answers_on_loopback():
+    assert dev._probe_host("0.0.0.0") == "127.0.0.1"
+    assert dev._probe_host("::") == "127.0.0.1"
+    assert dev._probe_host("192.168.1.20") == "192.168.1.20"
+
+
+def test_server_health_url():
+    assert dev._server_health_url("0.0.0.0", 8080) == \
+        "http://127.0.0.1:8080/api/health"
+    assert dev._server_health_url("192.168.1.20", 8000) == \
+        "http://192.168.1.20:8000/api/health"
+
+
+def test_server_addr_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(dev, "SERVER_ADDRFILE", tmp_path / "server.addr")
+    assert dev._server_addr() == ("127.0.0.1", 8000)   # absent -> defaults
+    dev.SERVER_ADDRFILE.write_text("192.168.1.20:8080")
+    assert dev._server_addr() == ("192.168.1.20", 8080)
+    dev.SERVER_ADDRFILE.write_text("garbage")
+    assert dev._server_addr() == ("127.0.0.1", 8000)   # corrupt -> defaults
+
+
+def test_display_url():
+    assert dev._display_url("127.0.0.1", 8000) == "http://localhost:8000"
+    assert dev._display_url("0.0.0.0", 8080) == "http://localhost:8080"
+    assert dev._display_url("192.168.1.20", 8080) == \
+        "http://192.168.1.20:8080"
+
+
+def test_local_ips_returns_non_loopback_strings():
+    ips = dev._local_ips()
+    assert isinstance(ips, list)
+    assert "127.0.0.1" not in ips
+    assert all(isinstance(ip, str) for ip in ips)

--- a/backend/tests/test_lan_hosts.py
+++ b/backend/tests/test_lan_hosts.py
@@ -1,0 +1,55 @@
+"""EXTRA_ALLOWED_HOSTS splitting + wildcard-bind interface whitelisting
+(spec Sections 8/9). init_allowed_hosts mutates a module-global whitelist,
+so every test here restores the conftest seed afterwards."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import settings
+from app.core.auth import (
+    allowed_hosts,
+    host_is_allowed,
+    init_allowed_hosts,
+    local_interface_ips,
+)
+from app.main import _extra_allowed_host_entries
+
+
+@pytest.fixture(autouse=True)
+def _restore_whitelist():
+    yield
+    init_allowed_hosts(settings.HOST, settings.PORT)  # conftest seed
+
+
+def test_local_interface_ips_no_loopback_no_raise():
+    ips = local_interface_ips()
+    assert isinstance(ips, list)
+    assert "127.0.0.1" not in ips
+
+
+def test_extra_allowed_hosts_split_and_stripped(monkeypatch):
+    monkeypatch.setattr(
+        "app.config.settings.EXTRA_ALLOWED_HOSTS",
+        " 192.168.1.20:8000, mybox:8000 ,,",
+    )
+    monkeypatch.setattr("app.config.settings.HOST", "127.0.0.1")
+    assert _extra_allowed_host_entries() == [
+        "192.168.1.20:8000", "mybox:8000",
+    ]
+
+
+def test_wildcard_bind_whitelists_each_interface_ip(monkeypatch):
+    monkeypatch.setattr("app.config.settings.EXTRA_ALLOWED_HOSTS", "")
+    monkeypatch.setattr("app.config.settings.HOST", "0.0.0.0")
+    monkeypatch.setattr("app.config.settings.PORT", 8000)
+    monkeypatch.setattr(
+        "app.main.local_interface_ips", lambda: ["192.168.9.9"])
+    assert _extra_allowed_host_entries() == ["192.168.9.9:8000"]
+
+
+def test_extra_entries_reach_the_whitelist():
+    init_allowed_hosts("127.0.0.1", 8000, extra=["192.168.1.20:8000"])
+    assert "192.168.1.20:8000" in allowed_hosts()
+    assert host_is_allowed("192.168.1.20:8000")
+    assert not host_is_allowed("attacker.example:8000")  # rebinding stays closed

--- a/docs/docs/usage/graph-as-a-function.md
+++ b/docs/docs/usage/graph-as-a-function.md
@@ -6,7 +6,7 @@ description: Call any saved graph headlessly over HTTP as a named function — d
 
 # Graph as a Function
 
-Any graph you can run on the canvas can also be called over HTTP as a named function: you declare its inputs and outputs with two nodes, save it, and `POST /api/graph/run/{name}` executes it and returns JSON.
+Any graph you can run on the canvas can also be called over HTTP as a named function: you declare its inputs and outputs with two nodes, save it, and `POST /api/graph/run/{name}` executes it and returns JSON. This endpoint always runs the **latest saved file** under the restart-rotating session token — to make it stable: [publish it](./publish) as a versioned app behind a durable API key.
 
 **When to use this vs the [CLI runner](./cli-runner):** the CLI runner executes a `graph.json` file in a fresh Python process with no server — good for batch jobs and CI. The run API calls a *saved* graph on a *running* CodefyUI server — good for scripts, notebooks, and automations that want a function call with typed inputs and outputs instead of a process launch.
 
@@ -80,12 +80,16 @@ Every `/run` response — success or failure — is this one shape, with ALL key
   "status": "ok",                 // "ok" | "error"
   "run_id": "9f2c...",            // assigned at request entry; NEVER null
   "graph": "my-graph",
+  "app": null,                    // published-app slug; always null on this editor route
+  "version": null,                // published version; always null on this editor route
   "device": "cuda",               // what you actually got; null on early rejections
   "outputs": {"answer": 0.93},    // null unless status == "ok"
   "error": null,                  // null on success, else {"code", "message", "node_id", "details"}
   "timing": {"total_s": 1.234}    // null when execution was never attempted
 }
 ```
+
+`app` and `version` identify the published app on [`POST /api/apps/{slug}/invoke`](./publish) — the invoke route fills them (slug on every outcome; version once resolved), while this editor route always emits `null` for both.
 
 The HTTP status mirrors `status`/`error.code`, so `raise_for_status()` works.
 
@@ -194,7 +198,7 @@ A ready-made graph for these exact calls ships in `examples/Usage_Example/Api-Fu
 
 - 403 (missing/invalid token) and 421 (Host guard) arrive WITHOUT the envelope — they fire before the route.
 - This server never emits 504; a 504 always came from an intermediary.
-- `record_outputs=true` makes inputs and results readable by anyone on the LAN who learns the `run_id` (the GET outputs endpoint is auth-exempt; transport is plain HTTP) — auth on read endpoints is a hard Stage 2 requirement.
+- `record_outputs=true` makes inputs and results readable by anyone on the LAN who learns the `run_id` (the GET outputs endpoint is auth-exempt; transport is plain HTTP). Published apps: run records are key-protected in SQLite; the inspector store is editor-only — invokes never write to it. To make a graph stable and key-protected: [publish it](./publish).
 - Do not put secrets in `default` values — `GET /contract` and `/load` are unauthenticated.
 - `device: "auto"` (or an unavailable device) silently resolves to CPU; the envelope's `device` field shows what you actually got.
 - A single >65,536-element tensor output fails the whole call — remove that GraphOutput or use `record_outputs` + the slicing outputs API (`GET /api/execution/outputs/{run_id}/{node_id}/{port}?slice=...`); an outputs filter is deferred.
@@ -204,6 +208,6 @@ A ready-made graph for these exact calls ships in `examples/Usage_Example/Api-Fu
 
 ## 9. Roadmap
 
-- `cdui call <graph> --input k=v` — CLI wrapper over this API (fast-follow DX item).
+- **Stage 2 (shipped): [Publish](./publish)** — versioned apps behind `POST /api/apps/{slug}/invoke` with durable API keys, key-protected SQLite run records, a per-image pixel budget, per-app OpenAPI documents, and `cdui start --host/--port` for LAN serving.
+- `cdui call <graph> --input k=v` / `cdui publish` / `cdui keys` — CLI wrappers over these APIs (fast-follow DX items).
 - Async job mode (202 + `job.status_url`) reusing the same envelope.
-- Stage 2: SQLite run history, publishing, auth on read endpoints.

--- a/docs/docs/usage/publish.md
+++ b/docs/docs/usage/publish.md
@@ -1,0 +1,151 @@
+---
+sidebar_position: 7.6
+title: Publish (Graphs as Apps)
+description: Freeze a saved graph as a versioned app behind a stable, API-key-protected invoke endpoint, with every run recorded to SQLite.
+---
+
+# Publish (Graphs as Apps)
+
+[Graph as a Function](./graph-as-a-function) makes any saved graph callable over HTTP — but that endpoint is a moving target: every canvas save changes what it runs, and its session token rotates on every server restart. **Publishing** turns a working graph into a stable product endpoint:
+
+- an immutable **version** snapshot served at `POST /api/apps/{slug}/invoke`,
+- protected by durable **API keys** (`Authorization: Bearer cdui_...`) that survive restarts,
+- with every resolved invoke recorded to SQLite (`backend/data/codefyui.db`).
+
+Canvas edits touch only the saved graph file; invokes read only the stored snapshot — editing the canvas can never change a published app until you re-publish.
+
+All management calls below use the editor session token (`X-CodefyUI-Token`, obtained exactly as on the [Graph as a Function](./graph-as-a-function) page). On Windows use `curl.exe` and pass bodies as files (`--data "@payload.json"`), never inline JSON.
+
+## 1. Publish lifecycle
+
+```text
+POST /api/apps/{slug}/publish        (session token)
+body: {"graph": "<saved name>", "record_io": true, "note": "optional", "create": false}
+```
+
+- `slug` is the stable public name: `^[a-z][a-z0-9-]{0,63}$`, chosen by you, independent of the graph name — renaming a graph never breaks a published URL.
+- Publishing to a slug that does not exist yet requires `"create": true`, otherwise 404 `app_not_found` — a misspelled slug on a re-publish can never silently create a second app.
+- Publishing to an existing slug appends the next version — that IS the re-publish path.
+- `note` is optional, immutable version metadata, echoed in the versions list.
+- Publish runs the exact `/run` pre-flight first: a graph that `POST /api/graph/run/{name}` would refuse (409 `invalid_contract` / `no_entry_points` / `untriggered_input` / `unreachable_output` / `invalid_graph`) cannot be published either.
+- Success: `{"slug", "version", "active": true, "created", "graph_name", "note"}`.
+
+**Publish activates immediately.** There is no staging path in v1: canvas Run plus the identical pre-flight IS the verification story. If the graph runs from the Run button and `/run` accepts it, the published version serves that same behavior.
+
+```powershell
+# payload.json: {"graph": "my-classifier", "create": true, "note": "first cut"}
+$token = Get-Content "$env:LOCALAPPDATA\codefyui\session.token"
+curl.exe -s -X POST "http://127.0.0.1:8000/api/apps/classifier/publish" `
+  -H "X-CodefyUI-Token: $token" -H "Content-Type: application/json" `
+  --data "@payload.json"
+```
+
+Managing versions:
+
+```text
+GET    /api/apps                       -> [{slug, graph_name, active_version, versions_count, record_io, ...}]
+GET    /api/apps/{slug}/versions       -> [{version, source_graph_name, note, created_at, active}]
+POST   /api/apps/{slug}/activate       body {"version": n} — point the slug at ANY existing version
+POST   /api/apps/{slug}/unpublish      -> active_version = null; versions and runs are kept
+PATCH  /api/apps/{slug}                body {"record_io": bool} — flips run-recording, no republish
+DELETE /api/apps/{slug}
+```
+
+- `activate` subsumes rollback: activating an older version restores it, and activating from the unpublished state restores service at that version.
+- While unpublished, invokes return 409 `app_unpublished` — nothing is lost.
+- **`DELETE /api/apps/{slug}` irrevocably removes the app, ALL its versions AND all its run records.** There is no undo. Prefer `unpublish` unless you truly mean delete.
+
+## 2. API keys
+
+```text
+POST /api/keys                (session token)  body {"name": "ci-bot"}
+GET  /api/keys                (session token)  — id, name, prefix, timestamps; never secrets
+POST /api/keys/{id}/revoke    (session token)  — soft revoke; the row stays listed
+```
+
+**The full key (`cdui_...`) appears ONCE, in the create response, and is never stored or logged.** Copy it immediately; lists show only the first 12 characters (`prefix`). Keys are stored as sha256 hashes and survive restarts — the deliberate contrast with the rotating session token. Revoked keys fail auth immediately but remain listed with their `revoked_at`, so old run records stay attributable.
+
+## 3. Invoke
+
+```text
+POST /api/apps/{slug}/invoke          (auth: Authorization: Bearer cdui_...)
+```
+
+The body is the same as [`/api/graph/run`](./graph-as-a-function): optional, with optional `inputs`, `timeout_s`, `device`. Two differences:
+
+- `record_outputs` is **accepted and ignored** — published runs are recorded in SQLite (below), never in the editor's inspector store.
+- `timeout_s` covers TOTAL request time INCLUDING queue wait: invokes of one app run one-at-a-time (per-slug lock), and a call that spends its budget waiting behind another invoke fails with the `timeout` envelope noting it expired while queued. Different slugs run in parallel.
+
+The editor session token is NEVER accepted on invoke — pasting it produces a self-diagnosing 401: "this endpoint takes an API key (cdui_...), not the editor session token".
+
+Every response is the same 9-key envelope as `/run` (see [the envelope](./graph-as-a-function)), with the two Stage-2 keys filled in: `graph` and `app` are the slug on every outcome, and `version` is the executed version (`null` on errors before a version was resolved). New error codes on top of the Stage-1 taxonomy:
+
+| `error.code` | HTTP | Trigger |
+| --- | --- | --- |
+| `invalid_key` | 401 | missing/malformed/unknown/revoked bearer token (response carries `WWW-Authenticate: Bearer`) |
+| `app_not_found` | 404 | slug does not exist |
+| `app_unpublished` | 409 | app exists but no version is active |
+
+Oversized images are rejected up front on BOTH run routes: 422 `invalid_input` when a single image exceeds `MAX_IMAGE_PIXELS` (default 25,000,000; `CODEFYUI_MAX_IMAGE_PIXELS`). Match on the code, not the message — far above the budget, PIL's own decompression-bomb error text appears instead of ours.
+
+PowerShell:
+
+```powershell
+# payload.json: {"inputs": {"x": "hello"}}
+curl.exe -s -X POST "http://127.0.0.1:8000/api/apps/classifier/invoke" `
+  -H "Authorization: Bearer cdui_YOUR_KEY" `
+  -H "Content-Type: application/json" `
+  --data "@payload.json"
+```
+
+bash:
+
+```bash
+curl -s -X POST "http://127.0.0.1:8000/api/apps/classifier/invoke" \
+  -H "Authorization: Bearer cdui_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  --data "@payload.json"
+```
+
+## 4. Run records
+
+Every invoke that resolves to an app version writes one row (status, error code, device, `total_s`, per-node timings, capped inputs/outputs, key id). Pre-resolution rejections (`invalid_key`, `app_not_found`, `app_unpublished`) write nothing. Recording is best-effort: a storage failure after execution is logged and the run result is still returned.
+
+```text
+GET /api/apps/{slug}/runs?limit=50&before=<iso>   — newest-first metadata only
+GET /api/apps/{slug}/runs/{run_id}                — the full row incl. inputs/outputs/node_timings
+```
+
+Reads accept EITHER a valid API key or the editor session token (the editor UI reads runs without ever holding an API key), and reject requests with neither.
+
+Stored inputs/outputs are per-field capped at `RUN_IO_CAP_BYTES` (default 64 KB; base64 images are self-limiting). Fields that are not stored stay parseable via pinned marker objects:
+
+- over the cap: `{"__codefyui__": "truncated", "bytes": N}`
+- withheld because the app has `record_io: false`: `{"__codefyui__": "redacted"}`
+
+Retention: `CODEFYUI_RUNS_RETENTION_DAYS` defaults to **0 = keep forever**. When set > 0, older rows are pruned at startup and at most hourly on writes, and every prune logs loudly with the row count.
+
+## 5. Per-app OpenAPI document
+
+```text
+GET /api/apps/{slug}/openapi.json      (API key or session token)
+```
+
+A complete, standalone OpenAPI 3.1 document for the ACTIVE version — importable into Swagger UI, Postman, or openapi-generator as-is. It carries the typed input schema derived from the graph's contract, the 9-key envelope schema, the bearer security scheme, and an `x-codefyui-curl` object with ready-to-paste `powershell` and `bash` invoke commands. JSON only; there is no generated HTML page.
+
+## 6. Serving on your LAN
+
+```text
+cdui start --host 0.0.0.0 --port 8000      # all interfaces
+cdui start --host 192.168.1.20             # one concrete interface
+```
+
+The Host-header whitelist follows the bind automatically (a concrete LAN IP is whitelisted; a `0.0.0.0` bind whitelists each local interface IP), extra names can be added via `CODEFYUI_EXTRA_ALLOWED_HOSTS="mybox:8000,192.168.1.20:8000"`, and the effective whitelist plus reachable URLs are printed at startup. `cdui status` and `cdui stop` report the real address. `cdui dev` remains loopback-only by design.
+
+Understand what a LAN bind exposes — plainly:
+
+- Binding a LAN address serves the FULL editor, and `GET /api/auth/bootstrap` hands out the session token to any allowed-Host request. **Anyone who can reach the port controls the instance; use only on trusted networks.**
+- API keys on the published surface are therefore attribution and off-box script hygiene, NOT LAN access control.
+- Transport is plain HTTP — no TLS in v1.
+- CORS settings change nothing about this: the exposure is same-origin, and the `Authorization` CORS header exists only so future cross-origin JS callers can be preflighted — it is not a mitigation.
+- Editor-scoped LAN hardening (loopback-gated bootstrap; published-surface-only on non-loopback Hosts) is a named follow-up, not in v1.

--- a/docs/docs/usage/publish.md
+++ b/docs/docs/usage/publish.md
@@ -52,6 +52,7 @@ DELETE /api/apps/{slug}
 ```
 
 - `activate` subsumes rollback: activating an older version restores it, and activating from the unpublished state restores service at that version.
+- Publishing always sets `record_io` (its body default is `true`). If you disabled recording via `PATCH`, pass `"record_io": false` again when you republish — otherwise recording is silently re-enabled.
 - While unpublished, invokes return 409 `app_unpublished` — nothing is lost.
 - **`DELETE /api/apps/{slug}` irrevocably removes the app, ALL its versions AND all its run records.** There is no undo. Prefer `unpublish` unless you truly mean delete.
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -18,6 +18,10 @@
     start       啟動 production（單一 uvicorn，用 frontend/dist；不需 Node）
                 預設在背景執行（關掉 terminal 也會繼續跑），用 cdui status /
                 cdui stop 管理。加 --foreground / -f 則在前景執行（Ctrl+C 停止）。
+                旗標：--host <addr>   綁定位址（預設 127.0.0.1）。0.0.0.0 或
+                                      區網 IP 可讓其他裝置存取 — 任何能連到該埠
+                                      的人都能控制此實例，只在信任的網路使用。
+                      --port <n>      埠號（預設 8000）
     status      顯示系統與伺服器狀態儀表板（像 btop / k9s：CPU、記憶體、
                 磁碟、GPU、行程、伺服器 PID 與健康檢查）
                 預設持續刷新（每 2 秒，Ctrl+C 離開）；輸出被導向管線或非互動
@@ -925,7 +929,83 @@ def build() -> None:
 # + log live under the repo-local dev data dir alongside the session token.
 SERVER_PIDFILE = DEV_USER_DATA_DIR / "server.pid"
 SERVER_LOG = DEV_USER_DATA_DIR / "server.log"
-SERVER_HEALTH_URL = "http://127.0.0.1:8000/api/health"
+# host:port of the last-started server, so status/stop report real URLs.
+SERVER_ADDRFILE = DEV_USER_DATA_DIR / "server.addr"
+
+
+def _parse_host_port(argv: list) -> "tuple[str, int]":
+    """Read --host/--port from start's argv (same lightweight style as
+    --foreground). Defaults unchanged: 127.0.0.1:8000."""
+    host, port = "127.0.0.1", 8000
+    for i, a in enumerate(argv):
+        if a == "--host" and i + 1 < len(argv):
+            host = argv[i + 1]
+        elif a.startswith("--host="):
+            host = a.split("=", 1)[1]
+        elif a == "--port" and i + 1 < len(argv):
+            try:
+                port = int(argv[i + 1])
+            except ValueError:
+                pass
+        elif a.startswith("--port="):
+            try:
+                port = int(a.split("=", 1)[1])
+            except ValueError:
+                pass
+    return host, port
+
+
+def _probe_host(host: str) -> str:
+    """The address to PROBE for a bind host: 0.0.0.0/:: listen everywhere
+    but answer on loopback; a concrete LAN IP answers only on itself."""
+    return "127.0.0.1" if host in ("0.0.0.0", "::") else host
+
+
+def _display_url(host: str, port: int) -> str:
+    """Clickable URL for a bind host: wildcard/loopback render as
+    localhost; a concrete LAN IP renders as itself."""
+    shown = "localhost" if host in (
+        "127.0.0.1", "0.0.0.0", "::", "::1", "localhost") else host
+    return f"http://{shown}:{port}"
+
+
+def _local_ips() -> "list[str]":
+    """Best-effort local IPv4 addresses. Stdlib-only duplicate of
+    app.core.auth.local_interface_ips — dev.py must run without the venv."""
+    import socket
+    ips: "set[str]" = set()
+    try:
+        for info in socket.getaddrinfo(socket.gethostname(), None,
+                                       socket.AF_INET):
+            ips.add(info[4][0])
+    except OSError:
+        pass
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("192.0.2.1", 80))  # TEST-NET-1: never routed
+            ips.add(s.getsockname()[0])
+        finally:
+            s.close()
+    except OSError:
+        pass
+    ips.discard("127.0.0.1")
+    return sorted(ips)
+
+
+def _server_addr() -> "tuple[str, int]":
+    """The last-started server's (host, port) from server.addr; defaults
+    for pre-Stage-2 servers or when never started."""
+    try:
+        raw = SERVER_ADDRFILE.read_text().strip()
+        host, _, port = raw.rpartition(":")
+        return (host or "127.0.0.1"), int(port)
+    except (OSError, ValueError):
+        return "127.0.0.1", 8000
+
+
+def _server_health_url(host: str, port: int) -> str:
+    return f"http://{_probe_host(host)}:{port}/api/health"
 
 
 def _read_server_pid() -> "int | None":
@@ -952,15 +1032,23 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
-def _server_healthy(timeout: float = 1.0) -> bool:
-    return _server_health_info(timeout) is not None
+def _server_healthy(host: "str | None" = None, port: "int | None" = None,
+                    timeout: float = 1.0) -> bool:
+    return _server_health_info(host, port, timeout) is not None
 
 
-def _server_health_info(timeout: float = 1.0) -> "dict | None":
+def _server_health_info(host: "str | None" = None,
+                        port: "int | None" = None,
+                        timeout: float = 1.0) -> "dict | None":
     """Fetch and parse /api/health. Returns the JSON dict, or None if the
-    server isn't responding (or returned a non-200 / unparseable body)."""
+    server isn't responding (or returned a non-200 / unparseable body).
+    Host/port default to the recorded server.addr of the last start."""
+    if host is None or port is None:
+        addr_host, addr_port = _server_addr()
+        host = host if host is not None else addr_host
+        port = port if port is not None else addr_port
     try:
-        with urlopen(SERVER_HEALTH_URL, timeout=timeout) as resp:
+        with urlopen(_server_health_url(host, port), timeout=timeout) as resp:
             if resp.status != 200:
                 return None
             import json  # noqa: PLC0415 — only needed here
@@ -997,6 +1085,7 @@ def start() -> None:
         sys.exit(1)
 
     foreground = any(a in ("-f", "--foreground") for a in sys.argv[2:])
+    host, port = _parse_host_port(sys.argv[2:])
 
     existing = _running_server_pid()
     if existing is not None:
@@ -1006,12 +1095,31 @@ def start() -> None:
 
     _warn_if_dist_stale()
     _apply_dev_env()
+    # settings.HOST/PORT (and therefore init_allowed_hosts) must agree
+    # with the actual bind — binding a concrete LAN IP whitelists it
+    # automatically (app.core.auth.init_allowed_hosts).
+    os.environ["CODEFYUI_HOST"] = host
+    os.environ["CODEFYUI_PORT"] = str(port)
     uvicorn = _require_venv_tool("uvicorn")
-    cmd = [uvicorn, "app.main:app", "--host", "127.0.0.1", "--port", "8000"]
+    cmd = [uvicorn, "app.main:app", "--host", host, "--port", str(port)]
+    SERVER_ADDRFILE.parent.mkdir(parents=True, exist_ok=True)
+    SERVER_ADDRFILE.write_text(f"{host}:{port}")
+
+    def _print_reach_lines() -> None:
+        print(f"    開啟 → {_display_url(host, port)}")
+        if host not in ("127.0.0.1", "localhost", "::1"):
+            lan_ips = _local_ips() if host in ("0.0.0.0", "::") else [host]
+            for ip in lan_ips:
+                print(f"    LAN  → http://{ip}:{port}")
+            print(t(
+                "    注意：任何能連到這個埠的人都能控制此實例；只在信任的網路使用。",
+                "    NOTE: anyone who can reach this port controls the "
+                "instance; use only on trusted networks.",
+            ))
 
     if foreground:
         print("=== CodefyUI 啟動（前景；Ctrl+C 停止）===")
-        print("    開啟 → http://localhost:8000")
+        _print_reach_lines()
         print(f"    dev lockfile → {DEV_LOCKFILE}")
         print("")
         run(cmd, cwd=BACKEND_DIR)
@@ -1048,7 +1156,7 @@ def start() -> None:
             print("錯誤：伺服器啟動後隨即結束。最後的日誌：", file=sys.stderr)
             _print_log_tail(20)
             sys.exit(1)
-        if _server_healthy():
+        if _server_healthy(host, port):
             break
         time.sleep(0.5)
     else:
@@ -1056,7 +1164,7 @@ def start() -> None:
 
     print("=== CodefyUI 已在背景啟動 ===")
     print(f"    PID         → {proc.pid}")
-    print("    開啟        → http://localhost:8000")
+    _print_reach_lines()
     print(f"    日誌        → {SERVER_LOG}")
     print(f"    dev lockfile → {DEV_LOCKFILE}")
     print("")
@@ -1315,13 +1423,13 @@ def _render_dashboard(interval: float, first: bool) -> None:
         if info:
             _kv(t("節點 / 預設", "Nodes / Presets"),
                 f"{info.get('nodes_loaded', '?')} / {info.get('presets_loaded', '?')}")
-        _kv("URL", "http://localhost:8000")
+        _kv("URL", _display_url(*_server_addr()))
         _kv(t("日誌", "Log"), str(SERVER_LOG))
     elif healthy:
         orphan = t("有伺服器回應，但非 cdui 背景啟動（無 PID 檔）",
                    "responding, but not a cdui background server (no PID file)")
         _kv(t("狀態", "State"), f"{YELLOW}● {orphan}{RESET}")
-        _kv("URL", "http://localhost:8000")
+        _kv("URL", _display_url(*_server_addr()))
         if info:
             _kv(t("節點 / 預設", "Nodes / Presets"),
                 f"{info.get('nodes_loaded', '?')} / {info.get('presets_loaded', '?')}")
@@ -1520,13 +1628,16 @@ def stop() -> None:
     # process-group leader — kill the whole group to catch any children.
     pid = _read_server_pid()
     if pid is not None and _pid_alive(pid):
-        print(f"  停止背景伺服器（PID {pid}）...")
+        # Printing the stopped URL is a small NEW feature (stop printed no
+        # URL before Stage 2), so later shells know what just went away.
+        print(f"  停止背景伺服器（PID {pid}，{_display_url(*_server_addr())}）...")
         if sys.platform == "win32":
             subprocess.run(["taskkill", "/F", "/T", "/PID", str(pid)],
                            capture_output=True)
         else:
             _terminate_posix(pid)
     SERVER_PIDFILE.unlink(missing_ok=True)
+    SERVER_ADDRFILE.unlink(missing_ok=True)
 
     # Sweep up anything else (foreground starts, dev-mode vite, stray workers).
     if sys.platform == "win32":


### PR DESCRIPTION
**Stacked PR — retarget base to main (or merge bottom-up) BEFORE merging**

Stage 2 "Publish" PR 4/4 — LAN + per-app docs (stacked on feat/stage2-invoke; spec Sections 8/9 + Decision E followups).

## What
- `cdui start --host <addr> [--port <n>]`: unhardcodes the 127.0.0.1:8000 bind; child env keeps `settings`/Host-whitelist in agreement with the actual bind; `server.addr` beside `server.pid` so `cdui status`/`stop` report real URLs; health probing threads through the chosen address (0.0.0.0 probes loopback); startup prints the effective Host whitelist + reachable URLs on every bind; binding `0.0.0.0` auto-whitelists each local interface IP (bare wildcard is never whitelisted — DNS-rebinding defense intact, test-proven). `cdui dev` stays loopback-only by design.
- `CODEFYUI_EXTRA_ALLOWED_HOSTS` (comma-separated) feeds the whitelist.
- `GET /api/apps/{slug}/openapi.json`: complete standalone OpenAPI 3.1 document per app (validated with openapi-spec-validator), contract-derived request schema, 9-key envelope response schema, bearerAuth, `x-codefyui-curl` snippets for PowerShell AND bash.
- Docs: new `usage/publish.md` (lifecycle with **publish activates immediately**, key show-once warning, Bearer examples, runs/records, DELETE cascade warning, LAN truth sentence: anyone who can reach the port controls the instance) + `graph-as-a-function.md` updated to the 9-key envelope.

## Test plan
- [x] `uv run pytest -q` green: 1553 passed (11 new CLI/whitelist tests; env-gated skips float 8-11)
- [x] Docs `pnpm build` clean, en + zh-TW, broken-link policy `throw` (run independently by the task reviewer as well)
- [x] LAN simulation against a real interface bind (`--host 192.168.0.15`): correct Host -> 200; forged `Host: evil.example.com` -> **421**; loopback probe cannot connect (bind is genuinely non-loopback); startup printed the whitelist + reachable URLs
- [x] `cdui start` with no flags verified byte-identical behavior (bind/probe/status/stop)
- [x] No new pip dependencies; zero frontend diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
