### PR TITLE
feat: project directories — self-contained git-trackable service projects (cdui project)

### DIFF
--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -42,7 +42,7 @@ from ..core.api_keys import (
 from ..core.db import Database, utc_now_iso
 from ..core.graph_engine import find_entry_points, validate_graph
 from ..core.secret_params import find_secret_violations
-from .routes_graph import _graph_path, _sanitize_name
+from .routes_graph import GraphAmbiguityError, _graph_path, _sanitize_name
 from .routes_graph_run import (
     _derive_output_type,
     _parse_run_body,
@@ -159,7 +159,10 @@ async def publish_app(slug: str, body: PublishRequest, request: Request):
     if _sanitize_name(body.graph) != body.graph:
         raise _manage_error(404, "graph_not_found",
                             f"Graph '{body.graph}' not found")
-    path = _graph_path(body.graph)
+    try:
+        path = _graph_path(body.graph)
+    except GraphAmbiguityError as e:
+        raise _manage_error(409, "invalid_graph", str(e))
     if not path.exists():
         raise _manage_error(404, "graph_not_found",
                             f"Graph '{body.graph}' not found")

--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -128,6 +128,9 @@ class PublishRequest(BaseModel):
     record_io: bool | None = None
     note: str | None = None
     create: bool = False
+    # Publish provenance (spec 9). git_commit validated IN-HANDLER (below).
+    git_commit: str | None = None
+    git_dirty: bool | None = None
 
 
 class PatchAppRequest(BaseModel):
@@ -153,6 +156,11 @@ async def publish_app(slug: str, body: PublishRequest, request: Request):
             422, "invalid_slug",
             "slug must match ^[a-z][a-z0-9-]{0,63}$",
         )
+    if body.git_commit is not None and re.match(r"^[0-9a-f]{7,40}$", body.git_commit) is None:
+        # Management error shape (not FastAPI's default 422 list) for
+        # consistency with the other publish errors.
+        raise _manage_error(422, "invalid_git_commit",
+                            "git_commit must match ^[0-9a-f]{7,40}$")
 
     # Load the saved graph under the strict-name rule
     # (routes_graph_run.py:341-349): execute exactly what was named.
@@ -214,7 +222,15 @@ async def publish_app(slug: str, body: PublishRequest, request: Request):
                             "GraphOutput node(s) are not reachable from any "
                             "entry point",
                             details=wiring.unreachable)
-    validation_errors = validate_graph(nodes, edges)
+    # ID6 fallback: a preset defined ONLY in this graph's own embedded
+    # presets[] (never registered server-side) must resolve here exactly as
+    # it does at POST /api/graph/validate (routes_graph.py) -- otherwise a
+    # graph that is CI-green under `cdui project validate` could 409 here.
+    from ..core.graph_engine import build_preset_fallback
+    validation_errors = validate_graph(
+        nodes, edges,
+        preset_fallback=build_preset_fallback(graph_data.get("presets", [])),
+    )
     if validation_errors:
         raise _manage_error(409, "invalid_graph", "graph failed validation",
                             details=validation_errors)
@@ -268,10 +284,13 @@ async def publish_app(slug: str, body: PublishRequest, request: Request):
             ).fetchone()[0]
             conn.execute(
                 "INSERT INTO app_versions (app_id, version, graph_json, "
-                "contract_json, source_graph_name, note, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "contract_json, source_graph_name, note, git_commit, "
+                "git_dirty, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (app_id, next_version, graph_text, json.dumps(contract_doc),
-                 body.graph, body.note, now),
+                 body.graph, body.note, body.git_commit,
+                 (None if body.git_dirty is None else int(body.git_dirty)),
+                 now),
             )
             conn.execute(
                 "UPDATE apps SET active_version = ?, graph_name = ?, "
@@ -292,6 +311,8 @@ async def publish_app(slug: str, body: PublishRequest, request: Request):
         "created": result["created"],
         "graph_name": body.graph,
         "note": body.note,
+        "git_commit": body.git_commit,
+        "git_dirty": body.git_dirty,
     }
 
 
@@ -326,12 +347,15 @@ async def list_versions(slug: str, request: Request):
         if app_row is None:
             return None
         rows = conn.execute(
-            "SELECT version, source_graph_name, note, created_at "
+            "SELECT version, source_graph_name, note, git_commit, git_dirty, "
+            "created_at "
             "FROM app_versions WHERE app_id = ? ORDER BY version DESC",
             (app_row["id"],),
         ).fetchall()
         return [
-            {**dict(r), "active": r["version"] == app_row["active_version"]}
+            {**dict(r),
+             "active": r["version"] == app_row["active_version"],
+             "git_dirty": (None if r["git_dirty"] is None else bool(r["git_dirty"]))}
             for r in rows
         ]
 
@@ -701,6 +725,7 @@ _CONTRACT_TYPE_TO_SCHEMA: dict[str, dict[str, Any]] = {
 
 def _openapi_document(
     slug: str, version: int, contract_doc: dict[str, Any], host: str,
+    git_commit: str | None = None, git_dirty: int | None = None,
 ) -> dict[str, Any]:
     """A COMPLETE standalone OpenAPI 3.1 document for the active version.
 
@@ -793,6 +818,10 @@ def _openapi_document(
                 "optional; record_outputs is accepted and ignored on "
                 "published invokes (run records live in SQLite)."
             ),
+            **({"x-codefyui-git-commit": git_commit}
+               if git_commit is not None else {}),
+            **({"x-codefyui-git-dirty": bool(git_dirty)}
+               if git_dirty is not None else {}),
         },
         "servers": [{"url": base_url}],
         "security": [{"bearerAuth": []}],
@@ -889,7 +918,8 @@ async def get_app_openapi(slug: str, request: Request):
 
     def _resolve(conn: sqlite3.Connection) -> dict[str, Any] | None:
         row = conn.execute(
-            "SELECT a.active_version, v.contract_json "
+            "SELECT a.active_version, v.contract_json, v.git_commit, "
+            "       v.git_dirty "
             "FROM apps a "
             "LEFT JOIN app_versions v "
             "  ON v.app_id = a.id AND v.version = a.active_version "
@@ -909,6 +939,7 @@ async def get_app_openapi(slug: str, request: Request):
     host = request.headers.get("host", f"{settings.HOST}:{settings.PORT}")
     return _openapi_document(
         slug, int(resolved["active_version"]), contract_doc, host,
+        git_commit=resolved["git_commit"], git_dirty=resolved["git_dirty"],
     )
 
 

--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -671,8 +671,10 @@ async def invoke_app(
         )
         # output_store=None: Decision H1 — isolation is structural, not a
         # flag. The editor inspector store can never contain this data.
+        from ..core.graph_engine import build_preset_fallback
         http_status, envelope, node_timings = await execute_contract_run(
             slug, nodes, edges, exec_req, run_id, output_store=None,
+            preset_fallback=build_preset_fallback(snapshot.get("presets", [])),
         )
     finally:
         # On an execution timeout the lock releases here while the

--- a/backend/app/api/routes_graph.py
+++ b/backend/app/api/routes_graph.py
@@ -17,9 +17,75 @@ def _sanitize_name(name: str) -> str:
     return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
 
 
+def _project_mode() -> bool:
+    return settings.PROJECT_DIR is not None
+
+
+class GraphAmbiguityError(Exception):
+    """Both `<name>.graph.json` and legacy `<name>.json` exist in project
+    mode — never silently pick one (spec ID2/ID7)."""
+
+    def __init__(self, name: str, canonical: "Path", legacy: "Path") -> None:
+        self.name = name
+        self.canonical = canonical
+        self.legacy = legacy
+        super().__init__(
+            f"Graph '{name}' is ambiguous: both {canonical.name} and "
+            f"{legacy.name} exist in {canonical.parent}. Remove one "
+            "(the legacy single-file form upgrades to the pair on save)."
+        )
+
+
+def _reserved_graph_name(name: str) -> bool:
+    """True when the (pre-sanitize) name would collide with the split
+    suffixes.
+
+    Checked against the RAW name, not `_sanitize_name(name)`: sanitization
+    maps every '.' to '_', so a sanitized name can never contain a literal
+    '.' and this check would be unreachable dead code if run post-sanitize.
+    """
+    return name.endswith(".graph") or name.endswith(".layout")
+
+
+def _graph_logic_path(name: str) -> Path:
+    """Canonical write target for a graph's LOGIC file.
+
+    Non-project: `<GRAPHS_DIR>/<name>.json` (byte-for-byte legacy).
+    Project:     `<GRAPHS_DIR>/<name>.graph.json`.
+    """
+    safe = _sanitize_name(name)
+    if not _project_mode():
+        return settings.GRAPHS_DIR / f"{safe}.json"
+    return settings.GRAPHS_DIR / f"{safe}.graph.json"
+
+
+def _graph_layout_path(name: str) -> "Path | None":
+    """Project-mode LAYOUT file path, else None (non-project has no layout)."""
+    if not _project_mode():
+        return None
+    return settings.LAYOUT_DIR / f"{_sanitize_name(name)}.layout.json"
+
+
 def _graph_path(name: str) -> Path:
-    """Resolve a graph name to its on-disk JSON path under GRAPHS_DIR."""
-    return settings.GRAPHS_DIR / f"{_sanitize_name(name)}.json"
+    """Resolve a graph name to the on-disk file to READ.
+
+    Non-project: `<GRAPHS_DIR>/<name>.json` (existence not checked — callers
+    guard with `.exists()`; identical to legacy behavior).
+    Project: canonical `<name>.graph.json` when present, else legacy
+    `<name>.json`; raises GraphAmbiguityError when BOTH exist; when NEITHER
+    exists returns the canonical (non-existent) path so callers' 404 path
+    still fires.
+    """
+    safe = _sanitize_name(name)
+    if not _project_mode():
+        return settings.GRAPHS_DIR / f"{safe}.json"
+    canonical = settings.GRAPHS_DIR / f"{safe}.graph.json"
+    legacy = settings.GRAPHS_DIR / f"{safe}.json"
+    if canonical.exists() and legacy.exists():
+        raise GraphAmbiguityError(name, canonical, legacy)
+    if legacy.exists() and not canonical.exists():
+        return legacy
+    return canonical
 
 
 @router.post("/validate", response_model=GraphValidationResponse)
@@ -32,6 +98,14 @@ async def validate(graph: GraphData):
 
 @router.post("/save")
 async def save_graph(graph: GraphData):
+    if _project_mode() and _reserved_graph_name(graph.name):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Graph name '{graph.name}' is reserved: names ending in "
+                "'.graph' or '.layout' collide with the project file split."
+            ),
+        )
     settings.GRAPHS_DIR.mkdir(parents=True, exist_ok=True)
     path = _graph_path(graph.name)
     payload = graph.model_dump()
@@ -44,7 +118,10 @@ async def save_graph(graph: GraphData):
 
 @router.get("/load/{name}")
 async def load_graph(name: str):
-    path = _graph_path(name)
+    try:
+        path = _graph_path(name)
+    except GraphAmbiguityError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     if not path.exists():
         raise HTTPException(status_code=404, detail=f"Graph '{name}' not found")
     data = json.loads(path.read_text())
@@ -55,10 +132,39 @@ async def load_graph(name: str):
 async def list_graphs():
     settings.GRAPHS_DIR.mkdir(parents=True, exist_ok=True)
     graphs = []
+    if not _project_mode():
+        for f in settings.GRAPHS_DIR.glob("*.json"):
+            try:
+                data = json.loads(f.read_text())
+                graphs.append({"name": data.get("name", f.stem), "file": f.stem})
+            except Exception:
+                continue
+        return graphs
+
+    # Project mode: canonical `<name>.graph.json` + legacy `<name>.json`.
+    # Path("x.graph.json").stem is "x.graph" — strip the whole ".graph.json"
+    # so the file stem never leaks the double suffix (spec ID7).
+    files: dict[str, Path] = {}
+    for f in settings.GRAPHS_DIR.glob("*.graph.json"):
+        files.setdefault(f.name[: -len(".graph.json")], f)
     for f in settings.GRAPHS_DIR.glob("*.json"):
+        if f.name.endswith(".graph.json"):
+            continue  # already counted as canonical
+        base = f.stem
+        if base in files:
+            # Both forms present -> fail loudly naming both (no silent pick).
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Graph '{base}' is ambiguous: both {files[base].name} "
+                    f"and {f.name} exist. Remove one."
+                ),
+            )
+        files[base] = f
+    for base, f in sorted(files.items()):
         try:
             data = json.loads(f.read_text())
-            graphs.append({"name": data.get("name", f.stem), "file": f.stem})
+            graphs.append({"name": data.get("name", base), "file": base})
         except Exception:
             continue
     return graphs

--- a/backend/app/api/routes_graph.py
+++ b/backend/app/api/routes_graph.py
@@ -107,11 +107,18 @@ async def save_graph(graph: GraphData):
             ),
         )
     settings.GRAPHS_DIR.mkdir(parents=True, exist_ok=True)
-    path = _graph_path(graph.name)
     payload = graph.model_dump()
     # Defense-in-depth: even if a client bypasses the editor (which already
     # blanks SECRET params before sending), never write a secret to disk.
     scrub_graph_secrets(payload.get("nodes", []))
+    if _project_mode():
+        from ..core.project import write_graph_pair
+        logic_path = _graph_logic_path(graph.name)
+        layout_path = _graph_layout_path(graph.name)
+        legacy = settings.GRAPHS_DIR / f"{_sanitize_name(graph.name)}.json"
+        write_graph_pair(logic_path, layout_path, payload, legacy_path=legacy)
+        return {"message": "Graph saved", "path": str(logic_path)}
+    path = _graph_path(graph.name)
     path.write_text(json.dumps(payload, indent=2))
     return {"message": "Graph saved", "path": str(path)}
 
@@ -125,6 +132,19 @@ async def load_graph(name: str):
     if not path.exists():
         raise HTTPException(status_code=404, detail=f"Graph '{name}' not found")
     data = json.loads(path.read_text())
+    # Legacy single-file `<name>.json` (project or non-project) loads verbatim
+    # with embedded positions (spec 6.4); only the canonical pair is merged.
+    if _project_mode() and path.name.endswith(".graph.json"):
+        from ..core.project import merge_graph
+        layout_path = _graph_layout_path(name)
+        layout = None
+        if layout_path is not None and layout_path.exists():
+            try:
+                layout = json.loads(layout_path.read_text())
+            except (ValueError, OSError):
+                layout = None
+        merged, _missing = merge_graph(data, layout)
+        return merged
     return data
 
 

--- a/backend/app/api/routes_graph.py
+++ b/backend/app/api/routes_graph.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
@@ -10,6 +11,7 @@ from ..core.secret_params import scrub_graph_secrets
 from ..schemas import GraphData, GraphValidationResponse
 
 router = APIRouter(prefix="/api/graph", tags=["graph"])
+logger = logging.getLogger(__name__)
 
 
 def _sanitize_name(name: str) -> str:
@@ -146,9 +148,19 @@ async def load_graph(name: str):
                 layout = json.loads(layout_path.read_text())
             except (ValueError, OSError):
                 layout = None
-        merged, _missing = merge_graph(data, layout)
-        return merged
+        data, _missing = merge_graph(data, layout)
+    _warn_if_newer_format(name, data)
     return data
+
+
+def _warn_if_newer_format(name: str, data: dict) -> None:
+    from ..core.project import FORMAT_VERSION
+    fmt = data.get("format_version", 1)
+    if isinstance(fmt, int) and fmt > FORMAT_VERSION:
+        # Read policy: warn, never block (ID8). The editor opens it read-only.
+        logger.warning(
+            "Graph '%s' has format_version %d newer than this build (%d) -- "
+            "opening read-only", name, fmt, FORMAT_VERSION)
 
 
 @router.get("/list")

--- a/backend/app/api/routes_graph.py
+++ b/backend/app/api/routes_graph.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException
 
 from ..config import settings
-from ..core.graph_engine import GraphValidationError, validate_graph
+from ..core.graph_engine import GraphValidationError, build_preset_fallback, validate_graph
 from ..core.node_registry import registry
 from ..core.secret_params import scrub_graph_secrets
 from ..schemas import GraphData, GraphValidationResponse
@@ -92,7 +92,10 @@ def _graph_path(name: str) -> Path:
 async def validate(graph: GraphData):
     nodes = [n.model_dump() for n in graph.nodes]
     edges = [e.model_dump() for e in graph.edges]
-    errors = validate_graph(nodes, edges)
+    errors = validate_graph(
+        nodes, edges,
+        preset_fallback=build_preset_fallback([p.model_dump() for p in graph.presets]),
+    )
     return GraphValidationResponse(valid=len(errors) == 0, errors=errors)
 
 
@@ -206,9 +209,13 @@ async def export_graph(graph: GraphData):
     # node's internalParams before expand_presets injects it downstream.
     scrub_graph_secrets(nodes)
 
+    # ID6: the graph's own presets[] resolve even when the server's preset
+    # registry doesn't know them (portability).
+    preset_fallback = build_preset_fallback([p.model_dump() for p in graph.presets])
+
     # Validate the user-authored graph (presets are validated against the
     # preset registry rather than expanded here).
-    errors = validate_graph(nodes, edges)
+    errors = validate_graph(nodes, edges, preset_fallback=preset_fallback)
     if errors:
         raise HTTPException(status_code=400, detail=errors)
 
@@ -218,7 +225,7 @@ async def export_graph(graph: GraphData):
         for _ in range(10):  # support nested presets, same depth cap as execution
             if not any(n.get("type", "").startswith("preset:") for n in nodes):
                 break
-            nodes, edges, _ = expand_presets(nodes, edges)
+            nodes, edges, _ = expand_presets(nodes, edges, preset_fallback=preset_fallback)
     except GraphValidationError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -44,7 +44,7 @@ from ..schemas import (
     RunError,
     RunTiming,
 )
-from .routes_graph import _graph_path, _sanitize_name
+from .routes_graph import GraphAmbiguityError, _graph_path, _sanitize_name
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +181,10 @@ async def get_contract(name: str):
     if _sanitize_name(name) != name:
         # Strict-name rule: never silently alias to a different file.
         raise HTTPException(status_code=404, detail=f"Graph '{name}' not found")
-    path = _graph_path(name)
+    try:
+        path = _graph_path(name)
+    except GraphAmbiguityError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     if not path.exists():
         raise HTTPException(status_code=404, detail=f"Graph '{name}' not found")
     try:
@@ -594,7 +597,11 @@ async def run_graph_as_function(name: str, request: Request):
         return error_response(404, run_id=run_id, graph=name,
                               code="graph_not_found",
                               message=f"Graph '{name}' not found")
-    path = _graph_path(name)
+    try:
+        path = _graph_path(name)
+    except GraphAmbiguityError as e:
+        return error_response(409, run_id=run_id, graph=name,
+                              code="invalid_graph", message=str(e))
     if not path.exists():
         return error_response(404, run_id=run_id, graph=name,
                               code="graph_not_found",

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -337,6 +337,7 @@ async def execute_contract_run(
     run_req: _RunRequest,
     run_id: str,
     output_store: Any,
+    preset_fallback: dict | None = None,
 ) -> tuple[int, dict[str, Any], dict[str, float]]:
     """Steps 5-12 of a contract run: pre-flight, inject, execute, collect,
     serialize. Shared by the editor route below and Stage-2 invoke
@@ -413,7 +414,7 @@ async def execute_contract_run(
                           "any entry point"
                       ),
                       details=wiring.unreachable)
-    validation_errors = validate_graph(nodes, edges)
+    validation_errors = validate_graph(nodes, edges, preset_fallback=preset_fallback)
     if validation_errors:
         return _error(409, code="invalid_graph",
                       message="graph failed validation",
@@ -480,6 +481,7 @@ async def execute_contract_run(
         run_id=run_id,
         output_store=output_store,
         record_outputs=run_req.record_outputs and output_store is not None,
+        preset_fallback=preset_fallback,
     ))
     task.add_done_callback(_retrieve_background_exception)
     try:
@@ -636,8 +638,11 @@ async def run_graph_as_function(name: str, request: Request):
         # (ws_execution.py getattr precedent).
         output_store = getattr(request.app.state, "run_output_store", None)
 
+    from ..core.graph_engine import build_preset_fallback
+    preset_fallback = build_preset_fallback(graph_data.get("presets", []))
     http_status, envelope, _node_timings = await execute_contract_run(
         name, nodes, edges, run_req, run_id, output_store,
+        preset_fallback=preset_fallback,
     )
     if http_status != 200:
         return JSONResponse(status_code=http_status, content=envelope)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 from platformdirs import user_data_dir
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
 
 # Let the handful of ops not yet implemented for Apple MPS fall back to CPU
@@ -64,6 +64,13 @@ class Settings(BaseSettings):
     IMAGES_DIR: Path = Path(__file__).parent.parent / "data" / "images"
     EXAMPLES_DIR: Path = Path(__file__).parent.parent.parent / "examples"
 
+    # ── Project directory (spec 7.1) ───────────────────────────────────
+    # Set by `cdui start|dev --project <dir>` (CODEFYUI_PROJECT_DIR=<abs>).
+    # None = non-project mode (byte-for-byte legacy behavior). When set,
+    # the graph/asset roots derive from it UNLESS the specific root was
+    # explicitly provided (env/init) — see _derive_project_roots.
+    PROJECT_DIR: Path | None = None
+
     # First-party plugin packs shipped with the repo (<REPO>/plugins/).
     PLUGINS_BUILTIN_DIR: Path = Path(__file__).parent.parent.parent / "plugins"
     # Third-party downloads + lockfile. Resolved per-instance so the
@@ -78,6 +85,43 @@ class Settings(BaseSettings):
     LOG_JSON: bool = False
 
     MAX_PARALLEL_NODES: int = 4
+
+    @model_validator(mode="after")
+    def _derive_project_roots(self) -> "Settings":
+        """Project mode repoints graphs/assets roots (spec 7.1).
+
+        Precedence: an explicitly-set root (CODEFYUI_GRAPHS_DIR etc., or an
+        init kwarg) beats project derivation — detected via model_fields_set,
+        which lists ONLY fields provided from env/init, never class defaults.
+        DB_PATH / CUSTOM_NODES_DIR are intentionally NOT derived (install-
+        global in v1). No module-level settings caching exists, so setting
+        these here (before any node reads settings at call time) is safe.
+        """
+        if self.PROJECT_DIR is None:
+            return self
+        explicit = set(self.model_fields_set)
+        proj = self.PROJECT_DIR.resolve()
+        self.PROJECT_DIR = proj
+        assets = proj / "assets"
+        if "GRAPHS_DIR" not in explicit:
+            self.GRAPHS_DIR = proj / "graphs"
+        if "IMAGES_DIR" not in explicit:
+            self.IMAGES_DIR = assets / "images"
+        if "MODELS_DIR" not in explicit:
+            self.MODELS_DIR = assets / "models"
+        return self
+
+    @property
+    def LAYOUT_DIR(self) -> Path | None:
+        """Server-side layout dir (<proj>/layout) in project mode, else None.
+
+        Only read by the project-mode save/load split (Task 3); non-project
+        mode never touches it. A property (not a field) so it always tracks
+        PROJECT_DIR and needs no precedence handling of its own.
+        """
+        if self.PROJECT_DIR is None:
+            return None
+        return self.PROJECT_DIR / "layout"
 
     model_config = {"env_prefix": "CODEFYUI_"}
 

--- a/backend/app/core/dotenv.py
+++ b/backend/app/core/dotenv.py
@@ -42,7 +42,7 @@ def load_dotenv_file(path: Path) -> int:
     """os.environ.setdefault each KEY=VALUE from *path*. Returns the number of
     NEW variables applied. Absent/unreadable file -> 0. Never logs values."""
     try:
-        text = path.read_text(encoding="utf-8")
+        text = path.read_text(encoding="utf-8-sig")  # tolerates a leading UTF-8 BOM
     except (OSError, UnicodeDecodeError):
         return 0
     applied = 0

--- a/backend/app/core/dotenv.py
+++ b/backend/app/core/dotenv.py
@@ -1,0 +1,53 @@
+"""Minimal stdlib .env loader for project directories (spec 7.3).
+
+No python-dotenv dependency. Loaded ONCE at server start, BEFORE node/plugin
+discovery, with os.environ.setdefault semantics (an already-set variable
+wins). Values are execution-time secrets only and are NEVER logged. Because
+the Settings singleton materializes at import (config.py), CODEFYUI_* CONFIG
+keys placed here do not reconfigure the running server -- only execution-time
+keys (LLM API keys, arbitrary secrets read via os.environ at execute time)
+take effect.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def parse_dotenv(text: str) -> dict[str, str]:
+    """Parse KEY=VALUE lines. Skips blanks/comments, tolerates a leading
+    `export `, strips matching surrounding single/double quotes."""
+    result: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        val = val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        result[key] = val
+    return result
+
+
+def load_dotenv_file(path: Path) -> int:
+    """os.environ.setdefault each KEY=VALUE from *path*. Returns the number of
+    NEW variables applied. Absent/unreadable file -> 0. Never logs values."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return 0
+    applied = 0
+    for key, val in parse_dotenv(text).items():
+        if key not in os.environ:
+            os.environ[key] = val
+            applied += 1
+    return applied

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -29,14 +29,37 @@ class GraphValidationError(Exception):
     pass
 
 
+def build_preset_fallback(presets: Any) -> dict:
+    """Map preset_name -> PresetDefinition for graph-embedded presets (ID6).
+
+    Accepts PresetDefinition objects or plain dicts (json.loads output);
+    malformed entries are skipped so a stray preset never breaks a run.
+    """
+    from ..schemas.models import PresetDefinition
+
+    out: dict[str, Any] = {}
+    for p in presets or []:
+        try:
+            model = p if isinstance(p, PresetDefinition) else PresetDefinition(**p)
+        except Exception:
+            continue
+        out[model.preset_name] = model
+    return out
+
+
 def expand_presets(
     nodes: list[dict],
     edges: list[dict],
+    preset_fallback: dict | None = None,
 ) -> tuple[list[dict], list[dict], dict[str, str]]:
     """Expand preset nodes into their sub-graph of real nodes.
 
     Returns (expanded_nodes, expanded_edges, internal_to_preset_map).
     internal_to_preset_map maps internal node IDs to the preset node ID they came from.
+
+    ``preset_fallback`` (ID6) is consulted when the server's preset
+    registry does not know the preset name -- lets a graph carrying its
+    own ``presets[]`` expand on a machine whose registry lacks it.
     """
     from .preset_registry import preset_registry
 
@@ -51,7 +74,7 @@ def expand_presets(
             continue
 
         preset_name = node_type[len("preset:"):]
-        preset = preset_registry.get(preset_name)
+        preset = preset_registry.get(preset_name) or (preset_fallback or {}).get(preset_name)
         if not preset:
             raise GraphValidationError(f"Unknown preset: {preset_name}")
 
@@ -117,8 +140,17 @@ def expand_presets(
     return expanded_nodes, expanded_edges, internal_to_preset
 
 
-def validate_graph(nodes: list[dict], edges: list[dict]) -> list[str]:
-    """Validate a graph definition. Returns list of errors (empty = valid)."""
+def validate_graph(
+    nodes: list[dict],
+    edges: list[dict],
+    preset_fallback: dict | None = None,
+) -> list[str]:
+    """Validate a graph definition. Returns list of errors (empty = valid).
+
+    ``preset_fallback`` (ID6) lets a graph-embedded preset (one the
+    server's registry does not know) validate as present -- see
+    ``build_preset_fallback``.
+    """
     errors: list[str] = []
     node_map = {n["id"]: n for n in nodes}
 
@@ -133,7 +165,7 @@ def validate_graph(nodes: list[dict], edges: list[dict]) -> list[str]:
         # Preset nodes are expanded at execution time; validate they exist in preset registry
         if node_type.startswith("preset:"):
             preset_name = node_type[len("preset:"):]
-            if not preset_registry.get(preset_name):
+            if not (preset_registry.get(preset_name) or (preset_fallback or {}).get(preset_name)):
                 errors.append(f"Unknown preset: {preset_name} (node {node['id']})")
             else:
                 preset_node_ids.add(node["id"])
@@ -407,6 +439,7 @@ async def execute_graph(
     run_id: str | None = None,
     output_store: "RunOutputStore | None" = None,
     record_outputs: bool = False,
+    preset_fallback: dict | None = None,
 ) -> dict[str, Any]:
     """Execute the graph with parallel levels, cancellation, error recovery, and caching.
 
@@ -425,6 +458,8 @@ async def execute_graph(
             is True, each node's full output is written under ``run_id``.
         record_outputs: When True, capture every node's output into
             ``output_store`` for later retrieval via the REST endpoint.
+        preset_fallback: Graph-embedded preset definitions (ID6), consulted
+            when the server's preset registry lacks a referenced preset.
     """
     from .execution_context import CancellationError
 
@@ -435,7 +470,8 @@ async def execute_graph(
         has_preset = any(n.get("type", "").startswith("preset:") for n in expanded_nodes)
         if not has_preset:
             break
-        expanded_nodes, expanded_edges, mapping = expand_presets(expanded_nodes, expanded_edges)
+        expanded_nodes, expanded_edges, mapping = expand_presets(
+            expanded_nodes, expanded_edges, preset_fallback=preset_fallback)
         internal_to_preset.update(mapping)
 
     # Filter to the executable subgraph: the nodes reachable from any entry
@@ -481,7 +517,7 @@ async def execute_graph(
         if e["source"] in executable_ids and e["target"] in executable_ids
     ]
 
-    errors = validate_graph(expanded_nodes, expanded_edges)
+    errors = validate_graph(expanded_nodes, expanded_edges, preset_fallback=preset_fallback)
     if errors:
         raise GraphValidationError("; ".join(errors))
 

--- a/backend/app/core/migrations.py
+++ b/backend/app/core/migrations.py
@@ -61,7 +61,12 @@ CREATE INDEX idx_runs_app_created ON runs(app_id, created_at DESC);
 CREATE INDEX idx_runs_created     ON runs(created_at);
 """
 
-MIGRATIONS: list[str] = [MIGRATION_001]
+MIGRATION_002 = """
+ALTER TABLE app_versions ADD COLUMN git_commit TEXT;
+ALTER TABLE app_versions ADD COLUMN git_dirty INTEGER;
+"""
+
+MIGRATIONS: list[str] = [MIGRATION_001, MIGRATION_002]
 
 
 def _is_comment_only(statement: str) -> bool:

--- a/backend/app/core/project.py
+++ b/backend/app/core/project.py
@@ -1,0 +1,148 @@
+"""Server-side logic/layout split for project directories (spec 6.1-6.4).
+
+In project mode a saved graph is stored as a PAIR:
+  graphs/<name>.graph.json   logic  {format_version, name, description,
+                                      nodes[], edges[], presets[]}
+  layout/<name>.layout.json  layout {format_version, positions{}, notes{},
+                                      segmentGroups[]}
+
+Non-project mode never calls this module (byte-for-byte single-file legacy).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+FORMAT_VERSION = 1
+
+# Note-node data keys that are canvas GEOMETRY (spec 6.2): extracted into the
+# layout file so a re-bind / resize never dirties the reviewable logic file.
+_NOTE_LAYOUT_KEYS = ("boundToNodeId", "boundOffset", "noteWidth", "noteHeight")
+
+
+def _int_xy(pos: dict) -> dict:
+    """Pin x/y to JSON integers so the round-trip is idempotent (spec 6.2)."""
+    return {"x": int(round(pos.get("x", 0))), "y": int(round(pos.get("y", 0)))}
+
+
+def split_graph(payload: dict) -> tuple[dict, dict]:
+    """Split a merged graph dict (GraphData.model_dump()) into (logic, layout).
+
+    The layout file is a COMPLETE SNAPSHOT of the current node ids (never a
+    patch) so deleted-node orphans cannot accrete (spec 6.2).
+    """
+    logic_nodes: list[dict] = []
+    positions: dict[str, dict] = {}
+    notes: dict[str, dict] = {}
+
+    for node in payload.get("nodes", []):
+        nid = node.get("id")
+        pos = node.get("position")
+        if isinstance(pos, dict) and "x" in pos and "y" in pos:
+            positions[nid] = _int_xy(pos)
+        data = node.get("data")
+        data = dict(data) if isinstance(data, dict) else {}
+        if node.get("type") == "note":
+            note_layout: dict[str, Any] = {}
+            for k in _NOTE_LAYOUT_KEYS:
+                if k in data:
+                    note_layout[k] = data.pop(k)
+            if note_layout:
+                notes[nid] = note_layout
+        logic_nodes.append({"id": nid, "type": node.get("type"), "data": data})
+
+    logic = {
+        "format_version": FORMAT_VERSION,
+        "name": payload.get("name", "Untitled"),
+        "description": payload.get("description", ""),
+        "nodes": logic_nodes,
+        "edges": payload.get("edges", []),
+        "presets": payload.get("presets", []),
+    }
+    layout = {
+        "format_version": FORMAT_VERSION,
+        "positions": positions,
+        "notes": notes,
+        "segmentGroups": payload.get("segmentGroups", []),
+    }
+    return logic, layout
+
+
+def merge_graph(logic: dict, layout: dict | None) -> tuple[dict, bool]:
+    """Merge a logic + layout pair into the single-file shape the editor loads.
+
+    Returns (merged, layout_missing). layout_missing is True when the layout
+    file is absent OR any node ends up without a position; those nodes get NO
+    position key so the frontend auto-layouts (spec 6.3). A logic file that
+    still carries an embedded position (legacy / transitional `.graph.json`)
+    is tolerated. Unknown ids in the layout file are ignored.
+    """
+    has_layout = isinstance(layout, dict)
+    positions = layout.get("positions", {}) if has_layout else {}
+    notes = layout.get("notes", {}) if has_layout else {}
+    any_missing = not has_layout
+
+    merged_nodes: list[dict] = []
+    for node in logic.get("nodes", []):
+        nid = node.get("id")
+        data = node.get("data")
+        data = dict(data) if isinstance(data, dict) else {}
+        out: dict[str, Any] = {"id": nid, "type": node.get("type"), "data": data}
+        pos = positions.get(nid)
+        if pos is None and isinstance(node.get("position"), dict):
+            pos = node["position"]
+        if isinstance(pos, dict) and "x" in pos and "y" in pos:
+            out["position"] = {"x": pos["x"], "y": pos["y"]}
+        else:
+            any_missing = True
+        if node.get("type") == "note":
+            note_layout = notes.get(nid, {})
+            if isinstance(note_layout, dict):
+                for k, v in note_layout.items():
+                    data.setdefault(k, v)
+        merged_nodes.append(out)
+
+    merged = {
+        "format_version": logic.get("format_version", FORMAT_VERSION),
+        "name": logic.get("name", "Untitled"),
+        "description": logic.get("description", ""),
+        "nodes": merged_nodes,
+        "edges": logic.get("edges", []),
+        "presets": logic.get("presets", []),
+        "segmentGroups": layout.get("segmentGroups", []) if has_layout else [],
+        "layout_missing": any_missing,
+    }
+    return merged, any_missing
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write text via a temp file + os.replace (atomic per file, spec 13)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + f".tmp-{os.getpid()}")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def write_graph_pair(
+    logic_path: Path,
+    layout_path: Path,
+    payload: dict,
+    legacy_path: Path | None = None,
+) -> None:
+    """Write the split pair atomically. LAYOUT first, LOGIC last (spec 13: the
+    logic file is precious; a crash leaves a stale layout that self-heals via
+    merge tolerance + auto-layout). A legacy single-file `<name>.json` is
+    removed AFTER the logic write (upgrade-on-save, spec 6.4 / ID2).
+    """
+    logic, layout = split_graph(payload)
+    _atomic_write(layout_path, json.dumps(layout, indent=2) + "\n")
+    _atomic_write(logic_path, json.dumps(logic, indent=2) + "\n")
+    if (
+        legacy_path is not None
+        and legacy_path != logic_path
+        and legacy_path.exists()
+    ):
+        legacy_path.unlink()

--- a/backend/app/core/project.py
+++ b/backend/app/core/project.py
@@ -13,8 +13,15 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # 3.10 backport — same API.
 
 FORMAT_VERSION = 1
 
@@ -146,3 +153,68 @@ def write_graph_pair(
         and legacy_path.exists()
     ):
         legacy_path.unlink()
+
+
+def git_provenance(project_dir: Path) -> tuple[str | None, bool | None]:
+    """(full_commit_sha, dirty) for *project_dir*, or (None, None) when it is
+    not a git repo / git is unavailable (this also covers the common
+    fresh-scaffold state: `cdui project init` runs `git init` with NO initial
+    commit, leaving an unborn HEAD that `rev-parse HEAD` reports as a
+    non-zero exit). dirty = any uncommitted change, including untracked files
+    (`git status --porcelain`).
+
+    Both git invocations are decoded as utf-8 (errors replaced rather than
+    raised) instead of the platform-default text encoding: on this project's
+    actual Windows deployments (Traditional Chinese locale, cp950) the
+    default encoding cannot decode arbitrary UTF-8 bytes, which would
+    otherwise crash on a non-ASCII path in `git status` output. The status
+    call is also individually guarded so a timeout/spawn failure there
+    degrades to dirty=None instead of losing an already-resolved commit.
+    """
+    try:
+        head = subprocess.run(
+            ["git", "-C", str(project_dir), "rev-parse", "HEAD"],
+            capture_output=True, encoding="utf-8", errors="replace", timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return None, None
+    if head.returncode != 0:
+        return None, None
+    commit = head.stdout.strip() or None
+    if commit is None:
+        return None, None
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(project_dir), "status", "--porcelain"],
+            capture_output=True, encoding="utf-8", errors="replace", timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return commit, None
+    dirty = bool(status.stdout.strip()) if status.returncode == 0 else None
+    return commit, dirty
+
+
+def check_stale_pins_from_manifest(manifest: dict, lockfile: dict) -> list[str]:
+    """Plugin ids that are pinned in the manifest but missing or sha-mismatched
+    in the installed lockfile (spec 7.4)."""
+    pins = manifest.get("plugins", {}) or {}
+    installed = lockfile.get("plugins", {})
+    stale: list[str] = []
+    for pid, pin in pins.items():
+        if not isinstance(pin, dict):
+            continue
+        entry = installed.get(pid)
+        if entry is None:
+            stale.append(pid)
+        elif pin.get("sha") and entry.get("sha") != pin["sha"]:
+            stale.append(pid)
+    return stale
+
+
+def check_stale_pins(project_dir: Path, lockfile: dict) -> list[str]:
+    """Read the manifest from disk and return stale pin ids (empty on a missing
+    or unparseable manifest)."""
+    manifest_path = project_dir / "codefyui.project.toml"
+    try:
+        manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return []
+    return check_stale_pins_from_manifest(manifest, lockfile)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -234,6 +234,22 @@ async def lifespan(app: FastAPI):
     for name in sorted(preset_registry.presets.keys()):
         logger.debug("  * %s", name)
 
+    # ── Project transparency (spec 7.4) ────────────────────────────────
+    if settings.PROJECT_DIR is not None:
+        from .core.project import check_stale_pins, git_provenance
+        commit, dirty = git_provenance(settings.PROJECT_DIR)
+        if commit is None:
+            logger.info("Project: %s (not a repo)", settings.PROJECT_DIR)
+        else:
+            logger.info("Project: %s (git %s%s)", settings.PROJECT_DIR,
+                        commit[:7], " dirty" if dirty else "")
+        stale = check_stale_pins(settings.PROJECT_DIR, lockfile)
+        if stale:
+            # ONE warning; no auto-install at startup (spec 7.4).
+            logger.warning(
+                "Project plugin pins missing/mismatched: %s -- run "
+                "`cdui project restore`", ", ".join(sorted(stale)))
+
     # Mount each installed plugin's assets/ dir so the frontend can fetch
     # plugin-shipped CSVs / images at /plugins/<id>/assets/<file>.
     for plugin_id, plugin_dir in iter_plugin_dirs(
@@ -373,11 +389,19 @@ app.include_router(ws_execution.router)
 
 @app.get("/api/health")
 async def health():
-    return {
+    body = {
         "status": "ok",
         "nodes_loaded": len(registry.nodes),
         "presets_loaded": len(preset_registry.presets),
     }
+    if settings.PROJECT_DIR is not None:
+        # Additive (spec ID4), project mode ONLY: the refactor guard requires
+        # non-project responses to stay byte-for-byte identical, so this key
+        # is omitted entirely (not even null) when PROJECT_DIR is unset.
+        # The frontend (Tasks 12/13) and the Task 15 publish CLI's mismatch
+        # refusal both read this to detect project mode + identity.
+        body["project"] = str(settings.PROJECT_DIR)
+    return body
 
 
 @app.get("/api/auth/bootstrap")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -168,6 +168,16 @@ async def lifespan(app: FastAPI):
         json_format=settings.LOG_JSON,
     )
 
+    # Project .env: execution-time secrets only, os.environ.setdefault
+    # semantics, loaded before node/plugin discovery. CODEFYUI_* config keys
+    # here are IGNORED (settings already materialized at import) -- spec 7.3.
+    if settings.PROJECT_DIR is not None:
+        from .core.dotenv import load_dotenv_file
+        env_applied = load_dotenv_file(settings.PROJECT_DIR / ".env")
+        if env_applied:
+            # Log the COUNT only, never the values.
+            logger.info("Loaded %d value(s) from project .env", env_applied)
+
     # Populate Host whitelist and persist the session token before any handler
     # can fire. Frontend bootstrap reads the token via /api/auth/bootstrap; CLI
     # tools (e.g. `cdui plugin install` → POST /api/plugins/reload) read it

--- a/backend/app/nodes/data/csv_reader_node.py
+++ b/backend/app/nodes/data/csv_reader_node.py
@@ -113,10 +113,25 @@ class CSVReaderNode(BaseNode):
     ) -> dict[str, Any]:
         import pandas as pd
 
+        from ...config import settings
+
         path_str = str(params.get("path", "")).strip()
         if not path_str:
             raise ValueError("CSVReader requires a non-empty `path` param.")
         path = Path(path_str)
+        if settings.PROJECT_DIR is not None and not path.is_absolute():
+            # The bundled sample is special-cased to the install (cwd stays
+            # backend/ even in project mode) so demos keep working (spec 7.2).
+            if path_str.replace("\\", "/") == "data/samples/iris.csv":
+                path = path.resolve()
+            else:
+                proj = settings.PROJECT_DIR.resolve()
+                resolved = (proj / path).resolve()
+                if not resolved.is_relative_to(proj):
+                    raise ValueError(
+                        f"CSVReader: path {path_str!r} escapes the project directory"
+                    )
+                path = resolved
         if not path.exists():
             raise FileNotFoundError(f"CSVReader: file not found at {path}")
 

--- a/backend/app/nodes/data/dataset_node.py
+++ b/backend/app/nodes/data/dataset_node.py
@@ -49,6 +49,16 @@ class DatasetNode(BaseNode):
         name = params.get("name", "MNIST")
         split = params.get("split", "train")
         data_dir = params.get("data_dir", "./data")
+
+        from pathlib import Path
+
+        from ...config import settings
+
+        if settings.PROJECT_DIR is not None and not Path(data_dir).is_absolute():
+            # torchvision downloads land in the project, not the install CWD
+            # (spec 7.2). kagglehub / HF caches stay machine-global.
+            data_dir = str(settings.PROJECT_DIR / "assets" / "data")
+
         is_train = split == "train"
 
         transform = transforms.Compose([

--- a/backend/app/nodes/io/file_reader_node.py
+++ b/backend/app/nodes/io/file_reader_node.py
@@ -69,7 +69,11 @@ class FileReaderNode(BaseNode):
 
         p = Path(path)
         if not p.is_absolute():
-            p = settings.GRAPHS_DIR / p
+            if settings.PROJECT_DIR is not None:
+                # Project mode: relative paths live under assets/data (spec 7.2).
+                p = settings.PROJECT_DIR / "assets" / "data" / p
+            else:
+                p = settings.GRAPHS_DIR / p
         p = p.resolve()
 
         # Restrict file reading to project data directories
@@ -78,6 +82,9 @@ class FileReaderNode(BaseNode):
             settings.MODELS_DIR.resolve(),
             settings.EXAMPLES_DIR.resolve(),
         ]
+        if settings.PROJECT_DIR is not None:
+            # The whole assets/ tree is readable in project mode.
+            allowed_roots.append((settings.PROJECT_DIR / "assets").resolve())
         if not any(p.is_relative_to(root) for root in allowed_roots):
             raise ValueError(
                 "File path must be within the project data directories "

--- a/backend/run_graph.py
+++ b/backend/run_graph.py
@@ -24,7 +24,13 @@ from typing import Any
 sys.path.insert(0, str(Path(__file__).parent))
 
 from app.config import settings
-from app.core.graph_engine import GraphValidationError, execute_graph, expand_presets, validate_graph
+from app.core.graph_engine import (
+    GraphValidationError,
+    build_preset_fallback,
+    execute_graph,
+    expand_presets,
+    validate_graph,
+)
 from app.core.logging_config import setup_logging
 from app.core.node_registry import registry
 from app.core.preset_registry import preset_registry
@@ -93,14 +99,19 @@ async def run(
     logger.info("  Nodes: %d, Edges: %d", len(nodes), len(edges))
     logger.info("=" * 60)
 
+    # ID6: the graph's own presets[] resolve even when the server's preset
+    # registry doesn't know them (portability).
+    preset_fallback = build_preset_fallback(graph.get("presets", []))
+
     # Expand presets
-    expanded_nodes, expanded_edges, preset_map = expand_presets(nodes, edges)
+    expanded_nodes, expanded_edges, preset_map = expand_presets(
+        nodes, edges, preset_fallback=preset_fallback)
     if len(expanded_nodes) != len(nodes):
         logger.info("Expanded %d nodes -> %d (presets resolved)", len(nodes), len(expanded_nodes))
 
     # Validate
     logger.info("Checking graph...")
-    errors = validate_graph(expanded_nodes, expanded_edges)
+    errors = validate_graph(expanded_nodes, expanded_edges, preset_fallback=preset_fallback)
     if errors:
         logger.error("Validation FAILED:")
         for e in errors:
@@ -129,6 +140,7 @@ async def run(
             edges,
             on_progress=_on_progress if verbose else _on_progress,
             context=context,
+            preset_fallback=preset_fallback,
         )
     except GraphValidationError as e:
         logger.error("Validation error: %s", e)

--- a/backend/tests/test_api_apps_manage.py
+++ b/backend/tests/test_api_apps_manage.py
@@ -116,6 +116,7 @@ async def test_publish_create_then_republish_versions(test_client, app_db):
     assert first == {
         "slug": SLUG, "version": 1, "active": True, "created": True,
         "graph_name": "pub-src", "note": "first cut",
+        "git_commit": None, "git_dirty": None,
     }
     second = await _publish(test_client, SLUG, "pub-src")
     assert second["version"] == 2
@@ -358,6 +359,77 @@ async def test_publish_rejects_preset_embedded_secret(
     assert count == 0
 
 
+def _embedded_preset_def(preset_name: str) -> dict:
+    """A trivial PresetDefinition dict (no secrets, one inner node) used to
+    prove a preset embedded ONLY in a graph's own ``presets[]`` resolves at
+    publish -- never registered in the server-side preset_registry."""
+    return {
+        "preset_name": preset_name, "category": "Test", "description": "",
+        "tags": [],
+        "nodes": [{"id": "n1", "type": "_TestSource", "params": {}}],
+        "edges": [], "exposed_inputs": [], "exposed_outputs": [],
+        "exposed_params": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_publish_preflight_resolves_embedded_only_preset(
+    test_client, app_db, _graphs_dir,
+):
+    """Controller addition: publish's pre-flight ``validate_graph`` call
+    must resolve a preset defined ONLY in the graph's own embedded
+    ``presets[]`` (ID6 fallback) exactly as ``POST /api/graph/validate``
+    already does -- otherwise a graph that is CI-green under
+    ``cdui project validate`` would 409 (invalid_graph) at publish, an
+    incoherence between the two surfaces."""
+    assert preset_registry.get("EmbeddedOnly") is None  # never registered
+
+    graph = _echo_graph(name="embedded-preset-ok")
+    graph["nodes"].append({
+        "id": "p1", "type": "preset:EmbeddedOnly",
+        "position": {"x": 0, "y": 300},
+        "data": {"internalParams": {}},
+    })
+    graph["presets"] = [_embedded_preset_def("EmbeddedOnly")]
+    await _save_graph(test_client, graph)
+
+    resp = await test_client.post(
+        "/api/apps/embedded-preset-ok/publish",
+        json={"graph": "embedded-preset-ok", "create": True})
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_publish_preflight_rejects_unresolvable_preset(
+    test_client, app_db, _graphs_dir,
+):
+    """Same graph WITHOUT the embedded presets[] definition still 409s --
+    proves the fallback above does real work rather than masking the
+    unknown-preset check."""
+    assert preset_registry.get("EmbeddedOnly") is None  # never registered
+
+    graph = _echo_graph(name="embedded-preset-missing")
+    graph["nodes"].append({
+        "id": "p1", "type": "preset:EmbeddedOnly",
+        "position": {"x": 0, "y": 300},
+        "data": {"internalParams": {}},
+    })
+    await _save_graph(test_client, graph)
+
+    resp = await test_client.post(
+        "/api/apps/embedded-preset-missing/publish",
+        json={"graph": "embedded-preset-missing", "create": True})
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["code"] == "invalid_graph"
+    assert any("Unknown preset: EmbeddedOnly" in d for d in detail["details"])
+
+    # Rejected publish created nothing.
+    count = await app_db.run(lambda conn: conn.execute(
+        "SELECT COUNT(*) FROM apps").fetchone()[0])
+    assert count == 0
+
+
 @pytest.mark.asyncio
 async def test_publish_stores_contract_document_and_exact_snapshot(
     test_client, app_db, _graphs_dir,
@@ -433,6 +505,7 @@ async def test_versions_list_marks_active_and_echoes_note(test_client, app_db):
     ]
     assert all(set(r.keys()) == {
         "version", "source_graph_name", "note", "created_at", "active",
+        "git_commit", "git_dirty",
     } for r in rows)
 
     resp = await test_client.get("/api/apps/nope/versions")

--- a/backend/tests/test_config_project.py
+++ b/backend/tests/test_config_project.py
@@ -1,0 +1,42 @@
+"""Project-mode Settings derivation (spec 7.1): PROJECT_DIR repoints the
+graph/asset roots, with an explicitly-provided root always winning."""
+
+from pathlib import Path
+
+from app.config import Settings
+
+
+def test_no_project_dir_keeps_install_defaults():
+    s = Settings()
+    assert s.PROJECT_DIR is None
+    assert s.LAYOUT_DIR is None
+    # Install-relative defaults are untouched.
+    assert s.GRAPHS_DIR.name == "graphs"
+    assert s.MODELS_DIR.name == "models"
+
+
+def test_project_dir_derives_all_roots(tmp_path):
+    s = Settings(PROJECT_DIR=tmp_path)
+    proj = tmp_path.resolve()
+    assert s.PROJECT_DIR == proj
+    assert s.GRAPHS_DIR == proj / "graphs"
+    assert s.IMAGES_DIR == proj / "assets" / "images"
+    assert s.MODELS_DIR == proj / "assets" / "models"
+    assert s.LAYOUT_DIR == proj / "layout"
+
+
+def test_explicit_graphs_dir_beats_project_derivation(tmp_path):
+    other = tmp_path / "custom-graphs"
+    s = Settings(PROJECT_DIR=tmp_path, GRAPHS_DIR=other)
+    # Explicit CODEFYUI_GRAPHS_DIR (here via init kwarg) wins...
+    assert s.GRAPHS_DIR == other
+    # ...but the roots NOT explicitly set still derive from the project.
+    assert s.MODELS_DIR == tmp_path.resolve() / "assets" / "models"
+    assert s.IMAGES_DIR == tmp_path.resolve() / "assets" / "images"
+
+
+def test_models_dir_parent_is_assets(tmp_path):
+    # The io nodes' confinement invariant: assets/models is a direct child of
+    # assets/ (spec 7.2). Guard it here so a future refactor can't break it.
+    s = Settings(PROJECT_DIR=tmp_path)
+    assert s.MODELS_DIR.parent == tmp_path.resolve() / "assets"

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -23,7 +23,7 @@ def test_connect_migrates_empty_file(tmp_path):
     db.connect()
     try:
         assert db._conn.execute("PRAGMA user_version").fetchone()[0] \
-            == len(MIGRATIONS) == 1
+            == len(MIGRATIONS) == 2
         names = {
             r[0] for r in db._conn.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table'"

--- a/backend/tests/test_dotenv.py
+++ b/backend/tests/test_dotenv.py
@@ -1,0 +1,49 @@
+"""Project .env loader (spec 7.3): stdlib parse, setdefault semantics, and the
+scoping guarantee that CODEFYUI_* CONFIG keys never reconfigure the already-
+materialized settings singleton."""
+
+import os
+
+from app.core.dotenv import load_dotenv_file, parse_dotenv
+
+
+def test_parse_basic_and_comments():
+    text = "# comment\n\nOPENAI_API_KEY=sk-123\nexport FOO=bar\nQUOTED=\"a b\"\n"
+    parsed = parse_dotenv(text)
+    assert parsed["OPENAI_API_KEY"] == "sk-123"
+    assert parsed["FOO"] == "bar"       # `export ` prefix tolerated
+    assert parsed["QUOTED"] == "a b"    # surrounding quotes stripped
+    assert "comment" not in parsed
+
+
+def test_absent_file_is_fine(tmp_path):
+    assert load_dotenv_file(tmp_path / "nope.env") == 0
+
+
+def test_setdefault_existing_env_wins(tmp_path, monkeypatch):
+    env = tmp_path / ".env"
+    env.write_text("MY_SECRET=new\n")
+    monkeypatch.setenv("MY_SECRET", "keep")
+    load_dotenv_file(env)
+    assert os.environ["MY_SECRET"] == "keep"  # already set -> not overwritten
+
+
+def test_secret_reaches_environ(tmp_path, monkeypatch):
+    env = tmp_path / ".env"
+    env.write_text("CODEFYUI_OPENAI_API_KEY=sk-xyz\n")
+    monkeypatch.delenv("CODEFYUI_OPENAI_API_KEY", raising=False)
+    load_dotenv_file(env)
+    # Execution-time secret (read by llm_chat at execute time) is available.
+    assert os.environ.get("CODEFYUI_OPENAI_API_KEY") == "sk-xyz"
+
+
+def test_config_keys_do_not_reconfigure_running_settings(tmp_path, monkeypatch):
+    from app.config import settings
+    original_port = settings.PORT
+    env = tmp_path / ".env"
+    env.write_text("CODEFYUI_PORT=59999\n")
+    monkeypatch.delenv("CODEFYUI_PORT", raising=False)  # teardown restores absent
+    load_dotenv_file(env)
+    # A CODEFYUI_* CONFIG key in .env never changes the running server: the
+    # settings singleton materialized at import, before .env loads (spec 7.3).
+    assert settings.PORT == original_port

--- a/backend/tests/test_dotenv.py
+++ b/backend/tests/test_dotenv.py
@@ -1,10 +1,31 @@
 """Project .env loader (spec 7.3): stdlib parse, setdefault semantics, and the
 scoping guarantee that CODEFYUI_* CONFIG keys never reconfigure the already-
-materialized settings singleton."""
+materialized settings singleton.
+
+load_dotenv_file writes via a raw os.environ[...] = val (setdefault
+semantics), not monkeypatch.setenv, so monkeypatch's own undo stack cannot
+see or revert those writes. The autouse _isolate_environ fixture below
+snapshots/restores os.environ around every test in this module so nothing a
+test causes to be written (e.g. CODEFYUI_OPENAI_API_KEY, CODEFYUI_PORT) leaks
+into later tests in this process.
+"""
 
 import os
 
+import pytest
+
 from app.core.dotenv import load_dotenv_file, parse_dotenv
+
+
+@pytest.fixture(autouse=True)
+def _isolate_environ():
+    """Snapshot/restore os.environ around each test in this module. Needed
+    because load_dotenv_file's raw os.environ writes are invisible to
+    monkeypatch's undo stack (see module docstring)."""
+    snapshot = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(snapshot)
 
 
 def test_parse_basic_and_comments():
@@ -47,3 +68,23 @@ def test_config_keys_do_not_reconfigure_running_settings(tmp_path, monkeypatch):
     # A CODEFYUI_* CONFIG key in .env never changes the running server: the
     # settings singleton materialized at import, before .env loads (spec 7.3).
     assert settings.PORT == original_port
+
+
+def test_bom_prefixed_env_key_loads_clean(tmp_path, monkeypatch):
+    """A UTF-8 BOM (b"\\xef\\xbb\\xbf") at the start of the file must not
+    corrupt the first key: utf-8-sig strips it, plain utf-8 would not."""
+    env = tmp_path / ".env"
+    env.write_bytes(b"\xef\xbb\xbfBOM_KEY=clean\n")
+    monkeypatch.delenv("BOM_KEY", raising=False)
+    load_dotenv_file(env)
+    assert os.environ.get("BOM_KEY") == "clean"
+    assert "\ufeffBOM_KEY" not in os.environ
+
+
+def test_no_env_leak_after_module():
+    # Regression guard for _isolate_environ above: by the time this test runs
+    # (last, in file order), CODEFYUI_OPENAI_API_KEY and CODEFYUI_PORT --
+    # written directly into os.environ by earlier tests in this file via
+    # load_dotenv_file -- must already be restored to absent.
+    assert "CODEFYUI_OPENAI_API_KEY" not in os.environ
+    assert "CODEFYUI_PORT" not in os.environ

--- a/backend/tests/test_embedded_presets.py
+++ b/backend/tests/test_embedded_presets.py
@@ -1,0 +1,61 @@
+"""ID6: a graph carrying its own preset definition resolves even when the
+server's preset registry does not know the preset (portability)."""
+
+from app.core.graph_engine import (
+    build_preset_fallback,
+    expand_presets,
+    validate_graph,
+)
+from app.core.preset_registry import preset_registry
+
+
+def _preset_dict(name="EmbeddedPr"):
+    # An internal Print node exposed as one input; a name the registry lacks.
+    return {
+        "preset_name": name,
+        "category": "Custom",
+        "description": "",
+        "tags": [],
+        "nodes": [{"id": "inner", "type": "Print", "params": {"label": "x"}}],
+        "edges": [],
+        "exposed_inputs": [
+            {"name": "in", "internal_node": "inner", "internal_port": "value",
+             "data_type": "ANY", "description": ""},
+        ],
+        "exposed_outputs": [],
+        "exposed_params": [],
+    }
+
+
+def test_registry_lacks_embedded_preset():
+    assert preset_registry.get("EmbeddedPr") is None  # sanity: truly absent
+
+
+def test_build_preset_fallback_maps_names():
+    fb = build_preset_fallback([_preset_dict()])
+    assert "EmbeddedPr" in fb
+    assert fb["EmbeddedPr"].preset_name == "EmbeddedPr"
+    # Tolerates junk without raising.
+    assert build_preset_fallback([{"bogus": 1}, None]) == {}
+
+
+def test_validate_unknown_without_fallback():
+    nodes = [{"id": "p", "type": "preset:EmbeddedPr", "data": {}}]
+    errors = validate_graph(nodes, [])
+    assert any("Unknown preset: EmbeddedPr" in e for e in errors)
+
+
+def test_validate_ok_with_fallback():
+    nodes = [{"id": "p", "type": "preset:EmbeddedPr", "data": {}}]
+    fb = build_preset_fallback([_preset_dict()])
+    errors = validate_graph(nodes, [], preset_fallback=fb)
+    assert not any("Unknown preset" in e for e in errors)
+
+
+def test_expand_uses_fallback():
+    nodes = [{"id": "p", "type": "preset:EmbeddedPr",
+              "position": {"x": 0, "y": 0}, "data": {}}]
+    fb = build_preset_fallback([_preset_dict()])
+    expanded, _edges, mapping = expand_presets(nodes, [], preset_fallback=fb)
+    assert any(n["id"] == "p__inner" and n["type"] == "Print" for n in expanded)
+    assert mapping["p__inner"] == "p"

--- a/backend/tests/test_format_version.py
+++ b/backend/tests/test_format_version.py
@@ -1,0 +1,16 @@
+"""format_version read policy (ID8): loads warn but NEVER block."""
+
+import json
+import logging
+
+
+async def test_load_newer_format_warns_never_blocks(test_client, monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr("app.config.settings.PROJECT_DIR", None)
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    (tmp_path / "foo.json").write_text(json.dumps(
+        {"format_version": 999, "name": "foo", "nodes": [], "edges": []}))
+    with caplog.at_level(logging.WARNING):
+        r = await test_client.get("/api/graph/load/foo")
+    assert r.status_code == 200
+    assert r.json()["format_version"] == 999  # returned, never blocked
+    assert any("format_version" in rec.getMessage() for rec in caplog.records)

--- a/backend/tests/test_graph_paths_project.py
+++ b/backend/tests/test_graph_paths_project.py
@@ -1,0 +1,71 @@
+"""Project-aware graph path resolution, reserved names, legacy acceptance,
+and the both-files-exist ambiguity guard (spec ID2/ID7)."""
+
+import json
+
+import pytest
+
+from app.api import routes_graph
+from app.api.routes_graph import (
+    GraphAmbiguityError,
+    _graph_layout_path,
+    _graph_logic_path,
+    _graph_path,
+    _reserved_graph_name,
+)
+
+
+def _project(monkeypatch, tmp_path):
+    """Repoint settings into a fresh project dir for the duration of a test."""
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", tmp_path)
+    monkeypatch.setattr(routes_graph.settings, "GRAPHS_DIR", tmp_path / "graphs")
+    (tmp_path / "graphs").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "layout").mkdir(parents=True, exist_ok=True)
+
+
+def test_non_project_path_is_legacy_single_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", None)
+    monkeypatch.setattr(routes_graph.settings, "GRAPHS_DIR", tmp_path)
+    assert _graph_path("foo") == tmp_path / "foo.json"
+    assert _graph_logic_path("foo") == tmp_path / "foo.json"
+    assert _graph_layout_path("foo") is None
+
+
+def test_project_logic_and_layout_paths(monkeypatch, tmp_path):
+    _project(monkeypatch, tmp_path)
+    assert _graph_logic_path("foo") == tmp_path / "graphs" / "foo.graph.json"
+    assert _graph_layout_path("foo") == tmp_path / "layout" / "foo.layout.json"
+
+
+def test_project_prefers_canonical_over_missing(monkeypatch, tmp_path):
+    _project(monkeypatch, tmp_path)
+    # Neither exists -> canonical (non-existent) so callers' .exists() -> 404.
+    assert _graph_path("foo") == tmp_path / "graphs" / "foo.graph.json"
+
+
+def test_project_accepts_legacy_when_only_legacy_exists(monkeypatch, tmp_path):
+    _project(monkeypatch, tmp_path)
+    legacy = tmp_path / "graphs" / "foo.json"
+    legacy.write_text(json.dumps({"nodes": [], "edges": []}))
+    assert _graph_path("foo") == legacy
+
+
+def test_project_ambiguity_raises_naming_both(monkeypatch, tmp_path):
+    _project(monkeypatch, tmp_path)
+    canonical = tmp_path / "graphs" / "foo.graph.json"
+    legacy = tmp_path / "graphs" / "foo.json"
+    canonical.write_text("{}")
+    legacy.write_text("{}")
+    with pytest.raises(GraphAmbiguityError) as ei:
+        _graph_path("foo")
+    assert ei.value.canonical == canonical
+    assert ei.value.legacy == legacy
+    assert "foo.graph.json" in str(ei.value)
+    assert "foo.json" in str(ei.value)
+
+
+def test_reserved_names():
+    assert _reserved_graph_name("my.graph") is True
+    assert _reserved_graph_name("my.layout") is True
+    assert _reserved_graph_name("my-graph") is False
+    assert _reserved_graph_name("classifier") is False

--- a/backend/tests/test_graph_save_load_project.py
+++ b/backend/tests/test_graph_save_load_project.py
@@ -1,0 +1,152 @@
+"""Project-mode save/load round-trip (spec 10): the pair is written, a drag
+only changes layout/, a param edit only changes graphs/, and load merges.
+
+Also covers two endpoint-level gaps flagged by Task 2's reviewer (carried
+into this task's spec): `/list`'s double-suffix stripping + both-forms 409
+exercised over real HTTP (not just the path-resolution helpers), and the
+reserved-name save guard's actual status code in both modes.
+"""
+
+import json
+
+import pytest
+
+from app.api import routes_graph
+
+
+@pytest.fixture
+def project_settings(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", tmp_path)
+    monkeypatch.setattr(routes_graph.settings, "GRAPHS_DIR", tmp_path / "graphs")
+    (tmp_path / "graphs").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "layout").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _graph(param_val="MNIST", x=10, name="demo"):
+    return {
+        "name": name,
+        "description": "",
+        "nodes": [
+            {"id": "a", "type": "Dataset", "position": {"x": x, "y": 0},
+             "data": {"params": {"name": param_val}}},
+        ],
+        "edges": [],
+        "presets": [],
+        "segmentGroups": [],
+    }
+
+
+async def test_save_writes_pair(project_settings, test_client):
+    r = await test_client.post("/api/graph/save", json=_graph())
+    assert r.status_code == 200
+    assert (project_settings / "graphs" / "demo.graph.json").exists()
+    assert (project_settings / "layout" / "demo.layout.json").exists()
+
+
+async def test_drag_touches_only_layout(project_settings, test_client):
+    await test_client.post("/api/graph/save", json=_graph(x=10))
+    logic1 = (project_settings / "graphs" / "demo.graph.json").read_text()
+    layout1 = (project_settings / "layout" / "demo.layout.json").read_text()
+    # Same params, moved node.
+    await test_client.post("/api/graph/save", json=_graph(x=999))
+    logic2 = (project_settings / "graphs" / "demo.graph.json").read_text()
+    layout2 = (project_settings / "layout" / "demo.layout.json").read_text()
+    assert logic1 == logic2          # logic file untouched by a drag
+    assert layout1 != layout2        # only the layout file changed
+
+
+async def test_param_edit_touches_only_logic(project_settings, test_client):
+    await test_client.post("/api/graph/save", json=_graph(param_val="MNIST"))
+    logic1 = (project_settings / "graphs" / "demo.graph.json").read_text()
+    layout1 = (project_settings / "layout" / "demo.layout.json").read_text()
+    await test_client.post("/api/graph/save", json=_graph(param_val="CIFAR10"))
+    logic2 = (project_settings / "graphs" / "demo.graph.json").read_text()
+    layout2 = (project_settings / "layout" / "demo.layout.json").read_text()
+    assert layout1 == layout2        # layout file untouched by a param edit
+    assert logic1 != logic2          # only the logic file changed
+
+
+async def test_load_merges_pair(project_settings, test_client):
+    await test_client.post("/api/graph/save", json=_graph(x=42))
+    r = await test_client.get("/api/graph/load/demo")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["nodes"][0]["position"] == {"x": 42, "y": 0}
+    assert data["layout_missing"] is False
+
+
+async def test_load_missing_layout_flags(project_settings, test_client):
+    await test_client.post("/api/graph/save", json=_graph())
+    (project_settings / "layout" / "demo.layout.json").unlink()
+    r = await test_client.get("/api/graph/load/demo")
+    data = r.json()
+    assert data["layout_missing"] is True
+    assert "position" not in data["nodes"][0]
+
+
+async def test_legacy_upgrades_on_save(project_settings, test_client):
+    legacy = project_settings / "graphs" / "demo.json"
+    legacy.write_text(json.dumps(_graph(x=7)))
+    # Loads via the legacy path (embedded positions).
+    r = await test_client.get("/api/graph/load/demo")
+    assert r.json()["nodes"][0]["position"] == {"x": 7, "y": 0}
+    # First save upgrades to the pair and removes the legacy file.
+    await test_client.post("/api/graph/save", json=_graph(x=7))
+    assert (project_settings / "graphs" / "demo.graph.json").exists()
+    assert not legacy.exists()
+
+
+# -- Carried from Task 2 review: endpoint-level /list + reserved-name gaps --
+
+
+async def test_list_project_mode_strips_double_suffix(project_settings, test_client):
+    """Mixed canonical `.graph.json` + legacy `.json` names: /list must not
+    leak the double suffix (`Path("canon.graph.json").stem` is "canon.graph",
+    not "canon" -- the endpoint has to strip the whole ".graph.json")."""
+    (project_settings / "graphs" / "canon.graph.json").write_text(
+        json.dumps({"name": "Canon Graph", "nodes": [], "edges": []})
+    )
+    (project_settings / "graphs" / "legacyonly.json").write_text(
+        json.dumps({"name": "Legacy Only", "nodes": [], "edges": []})
+    )
+    r = await test_client.get("/api/graph/list")
+    assert r.status_code == 200
+    by_file = {g["file"]: g["name"] for g in r.json()}
+    assert by_file == {"canon": "Canon Graph", "legacyonly": "Legacy Only"}
+    assert "canon.graph" not in by_file  # double suffix must not leak
+
+
+async def test_list_project_mode_ambiguous_pair_409(project_settings, test_client):
+    """Both `x.json` and `x.graph.json` coexisting for the same base name is
+    never silently resolved -- /list 409s naming BOTH files."""
+    (project_settings / "graphs" / "dup.graph.json").write_text("{}")
+    (project_settings / "graphs" / "dup.json").write_text("{}")
+    r = await test_client.get("/api/graph/list")
+    assert r.status_code == 409
+    detail = r.json()["detail"]
+    assert "dup.graph.json" in detail
+    assert "dup.json" in detail
+
+
+async def test_save_reserved_name_400_in_project_mode(project_settings, test_client):
+    """A graph literally named `weird.graph` collides with the split suffix
+    in project mode -- rejected outright, nothing written."""
+    r = await test_client.post("/api/graph/save", json=_graph(name="weird.graph"))
+    assert r.status_code == 400
+    assert "reserved" in r.json()["detail"].lower()
+    # Sanitized would-be targets (weird_graph.graph.json / weird_graph.json)
+    # must not exist either -- the guard fires before any write is attempted.
+    assert list((project_settings / "graphs").iterdir()) == []
+
+
+async def test_save_reserved_name_200_in_non_project_mode(test_client, tmp_path, monkeypatch):
+    """The same name is unremarkable outside a project: no split ever
+    happens, so '.graph' cannot collide with anything -- sanitized straight
+    to `weird_graph.json`, same as any other punctuation (byte-for-byte
+    refactor guard)."""
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", None)
+    monkeypatch.setattr(routes_graph.settings, "GRAPHS_DIR", tmp_path)
+    r = await test_client.post("/api/graph/save", json=_graph(name="weird.graph"))
+    assert r.status_code == 200
+    assert (tmp_path / "weird_graph.json").exists()

--- a/backend/tests/test_health_project.py
+++ b/backend/tests/test_health_project.py
@@ -1,0 +1,23 @@
+"""/api/health gains an additive `project` field (spec ID4).
+
+Additive is scoped to PROJECT MODE ONLY: the byte-for-byte non-project
+refactor guard (spec header Global Constraints) means the key must be
+ABSENT -- not merely null -- when settings.PROJECT_DIR is None, so a
+non-project response body stays identical to pre-Task-10 main.py.
+"""
+
+from app.api import routes_graph  # for the shared settings object
+
+
+async def test_health_project_key_absent_when_unset(test_client, monkeypatch):
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", None)
+    r = await test_client.get("/api/health")
+    body = r.json()
+    assert body["status"] == "ok"
+    assert "project" not in body
+
+
+async def test_health_project_dir_in_project_mode(test_client, monkeypatch, tmp_path):
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", tmp_path)
+    r = await test_client.get("/api/health")
+    assert r.json()["project"] == str(tmp_path)

--- a/backend/tests/test_node_resolution_project.py
+++ b/backend/tests/test_node_resolution_project.py
@@ -1,0 +1,75 @@
+"""Project-mode node file resolution (spec 7.2): FileReader/CSVReader resolve
+under the project, DatasetNode downloads into the project, all confined."""
+
+from pathlib import Path
+
+import pytest
+
+from app.config import settings
+from app.nodes.data.csv_reader_node import CSVReaderNode
+from app.nodes.data.dataset_node import DatasetNode
+from app.nodes.io.file_reader_node import FileReaderNode
+
+
+@pytest.fixture
+def project(monkeypatch, tmp_path):
+    (tmp_path / "assets" / "data").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(settings, "PROJECT_DIR", tmp_path.resolve())
+    return tmp_path.resolve()
+
+
+def test_filereader_relative_resolves_under_assets_data(project):
+    (project / "assets" / "data" / "note.txt").write_text("hello", encoding="utf-8")
+    out = FileReaderNode().execute({}, {"path": "note.txt", "mode": "text"})
+    assert out["text"] == "hello"
+
+
+def test_filereader_escape_is_rejected(project):
+    with pytest.raises(ValueError):
+        FileReaderNode().execute({}, {"path": "../../secret.txt", "mode": "text"})
+
+
+def test_csvreader_relative_resolves_under_project(project):
+    (project / "mydata.csv").write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+    out = CSVReaderNode().execute({}, {"path": "mydata.csv"})
+    assert out["tensor"].shape[0] == 2
+
+
+def test_csvreader_escape_is_rejected(project):
+    with pytest.raises(ValueError):
+        CSVReaderNode().execute({}, {"path": "../escape.csv"})
+
+
+def test_csvreader_iris_default_special_cased_to_install(project):
+    # The bundled sample resolves against the install CWD (backend/), not the
+    # project, so demos keep working with no copy. cwd is backend/ under pytest.
+    if not Path("data/samples/iris.csv").exists():
+        pytest.skip("iris sample not present in this checkout")
+    out = CSVReaderNode().execute(
+        {}, {"path": "data/samples/iris.csv", "target_column": "species"})
+    assert out["tensor"].shape[0] > 0
+
+
+def test_datasetnode_relative_data_dir_remaps_into_project(project, monkeypatch):
+    captured = {}
+
+    class _FakeDS:
+        def __init__(self, root, train, download, transform):
+            captured["root"] = root
+
+    monkeypatch.setattr("torchvision.datasets.MNIST", _FakeDS)
+    DatasetNode().execute({}, {"name": "MNIST", "split": "train", "data_dir": "./data"})
+    assert Path(captured["root"]) == project / "assets" / "data"
+
+
+def test_datasetnode_absolute_data_dir_is_honored(project, monkeypatch, tmp_path):
+    captured = {}
+
+    class _FakeDS:
+        def __init__(self, root, train, download, transform):
+            captured["root"] = root
+
+    monkeypatch.setattr("torchvision.datasets.MNIST", _FakeDS)
+    abs_dir = str(tmp_path / "elsewhere")
+    DatasetNode().execute({}, {"name": "MNIST", "data_dir": abs_dir})
+    assert captured["root"] == abs_dir

--- a/backend/tests/test_project_cli_init.py
+++ b/backend/tests/test_project_cli_init.py
@@ -1,0 +1,85 @@
+"""cdui project init scaffolds a self-contained project dir and (via --adopt)
+splits legacy graphs. Called in-process (conftest puts scripts/ on sys.path)."""
+
+import argparse
+import json
+import shutil
+import subprocess
+
+import pytest
+
+import project
+
+
+def _args(**kw):
+    ns = argparse.Namespace(dir=None, adopt=None, force=False)
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def test_init_scaffolds_all_files(tmp_path):
+    target = tmp_path / "svc"
+    assert project.cmd_init(_args(dir=str(target))) == 0
+    for rel in (
+        "codefyui.project.toml", "graphs", "layout",
+        "assets/images", "assets/models", "assets/data",
+        ".env.example", ".gitignore", ".gitattributes", "README.md",
+    ):
+        assert (target / rel).exists(), rel
+    toml_text = (target / "codefyui.project.toml").read_text(encoding="utf-8")
+    assert 'name = "svc"' in toml_text
+    assert "format_version = 1" in toml_text
+    gi = (target / ".gitignore").read_text(encoding="utf-8")
+    assert ".env" in gi and "*.safetensors" in gi
+    # Controller-mandated addition (from the Task 3 review, carried forward
+    # as a binding requirement on Task 7): the server's atomic two-file graph
+    # writes (app.core.project._atomic_write) create `<name>.tmp-<suffix>`
+    # temp files; an interrupted write can orphan one, so committed projects
+    # must not track them.
+    assert "*.tmp-*" in gi
+    ga = (target / ".gitattributes").read_text(encoding="utf-8")
+    assert "layout/*.layout.json linguist-generated=true" in ga
+
+
+def test_init_refuses_nonempty_dir(tmp_path):
+    target = tmp_path / "svc"
+    target.mkdir()
+    (target / "junk.txt").write_text("x", encoding="utf-8")
+    assert project.cmd_init(_args(dir=str(target))) == 1
+
+
+def test_init_adopt_splits_legacy_json(tmp_path):
+    src = tmp_path / "old"
+    src.mkdir()
+    (src / "classifier.json").write_text(json.dumps({
+        "name": "classifier",
+        "nodes": [{"id": "a", "type": "Dataset",
+                   "position": {"x": 3, "y": 4}, "data": {"params": {}}}],
+        "edges": [],
+    }), encoding="utf-8")
+    target = tmp_path / "svc"
+    assert project.cmd_init(_args(dir=str(target), adopt=str(src))) == 0
+    assert (target / "graphs" / "classifier.graph.json").exists()
+    layout = json.loads(
+        (target / "layout" / "classifier.layout.json").read_text(encoding="utf-8"))
+    assert layout["positions"]["a"] == {"x": 3, "y": 4}
+
+
+def test_init_git_init_no_commit(tmp_path):
+    if not shutil.which("git"):
+        pytest.skip("git not installed")
+    target = tmp_path / "svc"
+    project.cmd_init(_args(dir=str(target)))
+    assert (target / ".git").is_dir()
+    head = subprocess.run(
+        ["git", "-C", str(target), "rev-parse", "--verify", "HEAD"],
+        capture_output=True)
+    assert head.returncode != 0  # scaffold made NO initial commit
+
+
+def test_dev_parse_project_flag():
+    dev = pytest.importorskip("dev")
+    assert dev._parse_project(["--project", "/tmp/svc"]) == "/tmp/svc"
+    assert dev._parse_project(["--project=/tmp/svc"]) == "/tmp/svc"
+    assert dev._parse_project(["--host", "0.0.0.0"]) is None

--- a/backend/tests/test_project_cli_pins.py
+++ b/backend/tests/test_project_cli_pins.py
@@ -1,0 +1,67 @@
+"""freeze writes github pins (skipping linked/local); restore installs each pin
+BY ITS SHA, no-confirm, skipping already-satisfied pins (spec ID11)."""
+
+import argparse
+
+import project
+from app.core.plugin_loader import tomllib
+
+
+def _init(tmp_path):
+    target = tmp_path / "svc"
+    project.cmd_init(argparse.Namespace(dir=str(target), adopt=None, force=False))
+    return target
+
+
+def test_freeze_writes_github_pins_skips_local_and_builtin(tmp_path, monkeypatch):
+    proj = _init(tmp_path)
+    fake_lock = {"schema": 1, "plugins": {
+        "pack-a": {"source_kind": "github_url",
+                   "url": "https://github.com/o/pack-a", "ref": "v1.2",
+                   "sha": "a" * 40, "enabled": True},
+        "linked": {"source_kind": "local", "path": "/abs/linked",
+                   "enabled": True},
+        "builtin-pack": {"source_kind": "builtin", "source": "builtin-pack"},
+    }}
+    monkeypatch.setattr(project, "load_lockfile", lambda: fake_lock)
+    assert project.cmd_freeze(argparse.Namespace(dir=str(proj))) == 0
+    manifest = tomllib.loads(
+        (proj / "codefyui.project.toml").read_text(encoding="utf-8"))
+    assert manifest["plugins"]["pack-a"]["sha"] == "a" * 40
+    assert manifest["plugins"]["pack-a"]["ref"] == "v1.2"
+    assert "linked" not in manifest["plugins"]       # local skipped (warned)
+    assert "builtin-pack" not in manifest["plugins"]  # builtins not pinned
+
+
+def test_restore_installs_pin_by_sha(tmp_path, monkeypatch):
+    proj = _init(tmp_path)
+    (proj / "codefyui.project.toml").write_text(
+        '[project]\nname = "svc"\nformat_version = 1\n\n'
+        '[plugins]\npack-a = { url = "https://github.com/o/pack-a", '
+        'ref = "v1.2", sha = "' + "b" * 40 + '" }\n', encoding="utf-8")
+    monkeypatch.setattr(project, "load_lockfile",
+                        lambda: {"schema": 1, "plugins": {}})
+    calls = []
+
+    def fake_install(owner, repo, ref, args, lockfile):
+        calls.append((owner, repo, ref, args.pinned_sha, args.no_confirm))
+        return 0
+
+    monkeypatch.setattr(project, "_install_github", fake_install)
+    assert project.cmd_restore(argparse.Namespace(dir=str(proj))) == 0
+    assert calls == [("o", "pack-a", "v1.2", "b" * 40, True)]
+
+
+def test_restore_skips_already_satisfied(tmp_path, monkeypatch):
+    proj = _init(tmp_path)
+    (proj / "codefyui.project.toml").write_text(
+        '[project]\nname = "svc"\nformat_version = 1\n\n'
+        '[plugins]\npack-a = { url = "https://github.com/o/pack-a", '
+        'ref = "v1.2", sha = "' + "c" * 40 + '" }\n', encoding="utf-8")
+    monkeypatch.setattr(project, "load_lockfile", lambda: {"schema": 1, "plugins": {
+        "pack-a": {"source_kind": "github_url", "sha": "c" * 40}}})
+    called = []
+    monkeypatch.setattr(project, "_install_github",
+                        lambda *a, **k: called.append(1) or 0)
+    assert project.cmd_restore(argparse.Namespace(dir=str(proj))) == 0
+    assert called == []  # already at the pinned sha -> no reinstall

--- a/backend/tests/test_project_cli_publish.py
+++ b/backend/tests/test_project_cli_publish.py
@@ -1,0 +1,82 @@
+"""cdui project publish: local-only, refuses on a health.project mismatch,
+sends git provenance, warns loudly on a dirty tree (spec 8 / ID4 / ID12)."""
+
+import argparse
+
+import project
+
+
+def _init_with_publish_defaults(tmp_path):
+    target = tmp_path / "svc"
+    project.cmd_init(argparse.Namespace(dir=str(target), adopt=None, force=False))
+    (target / "codefyui.project.toml").write_text(
+        '[project]\nname = "svc"\nformat_version = 1\n\n'
+        '[publish]\ngraph = "echo-graph"\nslug = "myslug"\n', encoding="utf-8")
+    return target
+
+
+def _pargs(proj, **kw):
+    ns = argparse.Namespace(dir=str(proj), graph=None, slug=None, note=None)
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def _patch_common(monkeypatch, proj, *, project_reported=None, provenance=("d" * 40, False)):
+    monkeypatch.setattr(project, "_read_session_token", lambda: "tok")
+    monkeypatch.setattr(project, "_server_base",
+                        lambda: ("http://127.0.0.1:8000", "127.0.0.1:8000"))
+    reported = str(proj.resolve()) if project_reported is None else project_reported
+    monkeypatch.setattr(project, "_http_get_json",
+                        lambda url, host: {"project": reported})
+    monkeypatch.setattr("app.core.project.git_provenance", lambda p: provenance)
+
+
+def test_publish_sends_provenance_and_manifest_defaults(tmp_path, monkeypatch):
+    proj = _init_with_publish_defaults(tmp_path)
+    _patch_common(monkeypatch, proj)
+    posted = {}
+
+    def fake_post(url, host, token, body):
+        posted.update(body)
+        posted["_url"] = url
+        return {"version": 1, "_status": 200}
+
+    monkeypatch.setattr(project, "_http_post_json", fake_post)
+    assert project.cmd_publish(_pargs(proj, note="cut1")) == 0
+    assert posted["slug"] == "myslug"          # from manifest [publish]
+    assert posted["graph"] == "echo-graph"
+    assert posted["git_commit"] == "d" * 40
+    assert posted["git_dirty"] is False
+    assert posted["note"] == "cut1"
+    assert posted["_url"].endswith("/api/apps/myslug/publish")
+
+
+def test_publish_refuses_on_project_mismatch(tmp_path, monkeypatch):
+    proj = _init_with_publish_defaults(tmp_path)
+    _patch_common(monkeypatch, proj, project_reported="/some/other/project")
+    posted = []
+    monkeypatch.setattr(project, "_http_post_json",
+                        lambda *a, **k: posted.append(1) or {"_status": 200})
+    assert project.cmd_publish(_pargs(proj)) == 1
+    assert posted == []  # never published against a foreign project
+
+
+def test_publish_warns_loudly_on_dirty(tmp_path, monkeypatch, capsys):
+    proj = _init_with_publish_defaults(tmp_path)
+    _patch_common(monkeypatch, proj, provenance=("e" * 40, True))
+    monkeypatch.setattr(project, "_http_post_json",
+                        lambda *a, **k: {"version": 2, "_status": 200})
+    assert project.cmd_publish(_pargs(proj)) == 0
+    assert "dirty" in capsys.readouterr().out.lower()
+
+
+def test_publish_not_a_repo_null_provenance(tmp_path, monkeypatch):
+    proj = _init_with_publish_defaults(tmp_path)
+    _patch_common(monkeypatch, proj, provenance=(None, None))
+    posted = {}
+    monkeypatch.setattr(project, "_http_post_json",
+                        lambda url, host, token, body: posted.update(body)
+                        or {"version": 1, "_status": 200})
+    assert project.cmd_publish(_pargs(proj)) == 0
+    assert "git_commit" not in posted  # NULL provenance -> field omitted

--- a/backend/tests/test_project_cli_validate.py
+++ b/backend/tests/test_project_cli_validate.py
@@ -1,0 +1,136 @@
+"""cdui project validate mirrors the publish six-gate pre-flight per graph,
+plus project-level .env-tracked and plugin-pin checks (spec ID3)."""
+
+import argparse
+import json
+import shutil
+import subprocess
+
+import pytest
+
+import project
+from app.core.plugin_loader import tomllib
+from app.core.secret_params import secret_param_names
+
+
+def _init(tmp_path):
+    target = tmp_path / "svc"
+    project.cmd_init(argparse.Namespace(dir=str(target), adopt=None, force=False))
+    return target
+
+
+def _echo_graph(name="echo"):
+    return {
+        "format_version": 1, "name": name, "description": "",
+        "nodes": [
+            {"id": "start", "type": "Start", "data": {"params": {}}},
+            {"id": "gi", "type": "GraphInput", "data": {"params": {
+                "name": "x", "type": "string", "required": True,
+                "default": "", "description": ""}}},
+            {"id": "out", "type": "GraphOutput",
+             "data": {"params": {"name": "y", "description": ""}}},
+        ],
+        "edges": [
+            {"id": "t1", "source": "start", "target": "gi",
+             "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+            {"id": "d1", "source": "gi", "target": "out",
+             "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        ],
+        "presets": [],
+    }
+
+
+def _write_graph(proj, graph, base=None):
+    base = base or graph["name"]
+    (proj / "graphs" / f"{base}.graph.json").write_text(json.dumps(graph))
+
+
+def _vargs(proj, strict=False):
+    return argparse.Namespace(dir=str(proj), strict=strict)
+
+
+def test_valid_contract_graph_passes(tmp_path):
+    proj = _init(tmp_path)
+    _write_graph(proj, _echo_graph())
+    assert project.cmd_validate(_vargs(proj)) == 0
+
+
+def test_no_entry_points_fails(tmp_path):
+    proj = _init(tmp_path)
+    g = _echo_graph()
+    g["nodes"] = [n for n in g["nodes"] if n["type"] != "Start"]
+    g["edges"] = [e for e in g["edges"] if e.get("type") != "trigger"]
+    _write_graph(proj, g)
+    assert project.cmd_validate(_vargs(proj)) == 1
+
+
+def test_unknown_node_type_specific_message(tmp_path, capsys):
+    proj = _init(tmp_path)
+    g = _echo_graph()
+    g["nodes"].append({"id": "ghost", "type": "GhostPluginNode",
+                       "data": {"params": {}}})
+    _write_graph(proj, g)
+    assert project.cmd_validate(_vargs(proj)) == 1
+    # FAIL lines print via err() (stderr, per this CLI's convention -- see
+    # plugins.py) rather than stdout; check both streams combined so this
+    # assertion reflects what a CI log actually shows.
+    captured = capsys.readouterr()
+    out = (captured.out + captured.err).lower()
+    assert "unknown node type" in out and "restore" in out
+
+
+def test_secret_in_graph_fails(tmp_path):
+    proj = _init(tmp_path)
+    names = secret_param_names("LLMChat")
+    assert names, "LLMChat must declare a SECRET param"
+    secret = sorted(names)[0]
+    g = _echo_graph()
+    g["nodes"].append({"id": "llm", "type": "LLMChat",
+                       "data": {"params": {secret: "sk-leak"}}})
+    _write_graph(proj, g)
+    assert project.cmd_validate(_vargs(proj)) == 1
+
+
+def test_embedded_preset_graph_passes(tmp_path):
+    proj = _init(tmp_path)
+    g = _echo_graph()
+    g["nodes"].append({"id": "p", "type": "preset:EmbeddedPr", "data": {}})
+    g["presets"] = [{
+        "preset_name": "EmbeddedPr", "category": "Custom", "description": "",
+        "tags": [],
+        "nodes": [{"id": "inner", "type": "Print", "params": {"label": "x"}}],
+        "edges": [],
+        "exposed_inputs": [{"name": "in", "internal_node": "inner",
+                            "internal_port": "value", "data_type": "ANY",
+                            "description": ""}],
+        "exposed_outputs": [], "exposed_params": [],
+    }]
+    _write_graph(proj, g)
+    assert project.cmd_validate(_vargs(proj)) == 0
+    # Without the embedded definition it fails (Unknown preset).
+    g["presets"] = []
+    _write_graph(proj, g)
+    assert project.cmd_validate(_vargs(proj)) == 1
+
+
+def test_env_tracked_fails(tmp_path):
+    if not shutil.which("git"):
+        pytest.skip("git not installed")
+    proj = _init(tmp_path)
+    _write_graph(proj, _echo_graph())
+    (proj / ".env").write_text("SECRET=1")
+    subprocess.run(["git", "-C", str(proj), "add", "-f", ".env"],
+                   capture_output=True)
+    assert project.cmd_validate(_vargs(proj)) == 1
+
+
+def test_strict_pin_missing(tmp_path, monkeypatch):
+    proj = _init(tmp_path)
+    (proj / "codefyui.project.toml").write_text(
+        '[project]\nname = "svc"\nformat_version = 1\n\n'
+        '[plugins]\nghostpack = { url = "https://github.com/x/y", '
+        'ref = "v1", sha = "' + "0" * 40 + '" }\n')
+    monkeypatch.setattr(project, "load_lockfile",
+                        lambda: {"schema": 1, "plugins": {}})
+    assert project.cmd_validate(_vargs(proj, strict=False)) == 0  # warn only
+    assert project.cmd_validate(_vargs(proj, strict=True)) == 1   # strict error

--- a/backend/tests/test_project_split.py
+++ b/backend/tests/test_project_split.py
@@ -1,0 +1,101 @@
+"""Logic/layout split + merge (spec 6.1-6.4): geometry lives only in the
+layout file, params only in the logic file, and the layout is a full snapshot."""
+
+import json
+
+from app.core.project import (
+    FORMAT_VERSION,
+    merge_graph,
+    split_graph,
+    write_graph_pair,
+)
+
+
+def _payload():
+    return {
+        "name": "demo",
+        "description": "d",
+        "nodes": [
+            {"id": "a", "type": "Dataset", "position": {"x": 10, "y": 20},
+             "data": {"params": {"name": "MNIST"}}},
+            {"id": "n1", "type": "note", "position": {"x": 5, "y": 6},
+             "data": {"noteKind": "text", "noteContent": "hi",
+                      "noteColor": "#333", "boundToNodeId": "a",
+                      "boundOffset": {"x": 1, "y": 2}, "noteWidth": 200,
+                      "noteHeight": 80}},
+        ],
+        "edges": [{"id": "e", "source": "a", "target": "a"}],
+        "presets": [],
+        "segmentGroups": [{"id": "s", "headNodeId": "a", "tailNodeId": "a"}],
+    }
+
+
+def test_split_extracts_geometry_only():
+    logic, layout = split_graph(_payload())
+    assert logic["format_version"] == FORMAT_VERSION
+    # Logic nodes carry NO position and NO note geometry.
+    a = next(n for n in logic["nodes"] if n["id"] == "a")
+    assert "position" not in a
+    assert a["data"]["params"]["name"] == "MNIST"
+    note = next(n for n in logic["nodes"] if n["id"] == "n1")
+    assert "position" not in note
+    for k in ("boundToNodeId", "boundOffset", "noteWidth", "noteHeight"):
+        assert k not in note["data"]
+    assert note["data"]["noteContent"] == "hi"
+    # Layout carries positions (as ints) + note geometry + segmentGroups.
+    assert layout["positions"]["a"] == {"x": 10, "y": 20}
+    assert layout["notes"]["n1"]["boundToNodeId"] == "a"
+    assert layout["notes"]["n1"]["noteWidth"] == 80 or layout["notes"]["n1"]["noteWidth"] == 200
+    assert layout["segmentGroups"][0]["id"] == "s"
+
+
+def test_merge_round_trips():
+    logic, layout = split_graph(_payload())
+    merged, missing = merge_graph(logic, layout)
+    assert missing is False
+    a = next(n for n in merged["nodes"] if n["id"] == "a")
+    assert a["position"] == {"x": 10, "y": 20}
+    note = next(n for n in merged["nodes"] if n["id"] == "n1")
+    assert note["data"]["boundToNodeId"] == "a"
+    assert merged["segmentGroups"][0]["id"] == "s"
+    assert merged["layout_missing"] is False
+
+
+def test_merge_missing_layout_flags_and_omits_position():
+    logic, _ = split_graph(_payload())
+    merged, missing = merge_graph(logic, None)
+    assert missing is True
+    assert merged["layout_missing"] is True
+    for n in merged["nodes"]:
+        assert "position" not in n  # frontend will auto-layout
+
+
+def test_positions_pinned_to_int():
+    payload = _payload()
+    payload["nodes"][0]["position"] = {"x": 10.7, "y": 20.2}
+    _logic, layout = split_graph(payload)
+    assert layout["positions"]["a"] == {"x": 11, "y": 20}
+
+
+def test_write_pair_is_full_snapshot(tmp_path):
+    logic_path = tmp_path / "graphs" / "demo.graph.json"
+    layout_path = tmp_path / "layout" / "demo.layout.json"
+    write_graph_pair(logic_path, layout_path, _payload())
+    assert json.loads(logic_path.read_text())["name"] == "demo"
+    assert set(json.loads(layout_path.read_text())["positions"]) == {"a", "n1"}
+    # Save again with the note deleted -> its layout entry is gone (no orphan).
+    p2 = _payload()
+    p2["nodes"] = [p2["nodes"][0]]
+    write_graph_pair(logic_path, layout_path, p2)
+    assert set(json.loads(layout_path.read_text())["positions"]) == {"a"}
+
+
+def test_write_pair_removes_legacy(tmp_path):
+    legacy = tmp_path / "graphs" / "demo.json"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text("{}")
+    logic_path = tmp_path / "graphs" / "demo.graph.json"
+    layout_path = tmp_path / "layout" / "demo.layout.json"
+    write_graph_pair(logic_path, layout_path, _payload(), legacy_path=legacy)
+    assert logic_path.exists()
+    assert not legacy.exists()  # upgraded to the pair

--- a/backend/tests/test_project_startup.py
+++ b/backend/tests/test_project_startup.py
@@ -1,0 +1,131 @@
+"""git provenance + stale-pin detection used by the startup transparency log
+(spec 7.4)."""
+
+import shutil
+import subprocess
+
+import pytest
+
+from app.core.project import (
+    check_stale_pins,
+    check_stale_pins_from_manifest,
+    git_provenance,
+)
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, capture_output=True, check=True)
+
+
+def test_git_provenance_non_repo(tmp_path):
+    assert git_provenance(tmp_path) == (None, None)
+
+
+def test_git_provenance_repo_no_commits(tmp_path):
+    """`cdui project init` runs `git init` and deliberately makes NO initial
+    commit (scripts/project.py cmd_init) -- so a freshly-scaffolded project is
+    a git repo with an unborn HEAD. That is the common post-init state, not
+    an edge case, and must degrade the same as a non-repo dir: (None, None)."""
+    if not shutil.which("git"):
+        pytest.skip("git not installed")
+    _git("init", cwd=tmp_path)
+    assert git_provenance(tmp_path) == (None, None)
+
+
+def test_git_provenance_clean_then_dirty(tmp_path):
+    if not shutil.which("git"):
+        pytest.skip("git not installed")
+    _git("init", cwd=tmp_path)
+    _git("config", "user.email", "t@t.t", cwd=tmp_path)
+    _git("config", "user.name", "t", cwd=tmp_path)
+    (tmp_path / "a.txt").write_text("1")
+    _git("add", "-A", cwd=tmp_path)
+    _git("commit", "-m", "init", cwd=tmp_path)
+    commit, dirty = git_provenance(tmp_path)
+    assert commit and len(commit) == 40
+    assert dirty is False
+    (tmp_path / "a.txt").write_text("2")
+    _commit, dirty2 = git_provenance(tmp_path)
+    assert dirty2 is True
+
+
+def test_git_provenance_dirty_with_unicode_filename(tmp_path):
+    """A non-ASCII untracked filename must not crash the STATUS call. This is
+    a regression guard for forcing utf-8 decoding of git's output rather than
+    the platform-default encoding, which on this project's actual Windows
+    deployments (Traditional Chinese locale) is cp950 and cannot decode
+    arbitrary UTF-8 bytes -- exactly the crash class called out in project
+    memory for other subprocess/console output."""
+    if not shutil.which("git"):
+        pytest.skip("git not installed")
+    _git("init", cwd=tmp_path)
+    _git("config", "user.email", "t@t.t", cwd=tmp_path)
+    _git("config", "user.name", "t", cwd=tmp_path)
+    (tmp_path / "a.txt").write_text("1")
+    _git("add", "-A", cwd=tmp_path)
+    _git("commit", "-m", "init", cwd=tmp_path)
+    # Built from chr() codepoints (0x65e5 0x672c 0x8a9e) so this source file
+    # stays ASCII-only; the resulting filename is still non-ASCII (CJK) at
+    # runtime, which is what this test targets.
+    cjk_name = chr(0x65E5) + chr(0x672C) + chr(0x8A9E) + ".txt"
+    (tmp_path / cjk_name).write_text("x", encoding="utf-8")
+    commit, dirty = git_provenance(tmp_path)
+    assert commit and len(commit) == 40
+    assert dirty is True
+
+
+def test_git_provenance_status_call_failure_keeps_commit(tmp_path, monkeypatch):
+    """If the STATUS call fails (timeout / spawn error) after a successful
+    rev-parse, degrade to dirty=None instead of losing the already-resolved
+    commit -- the original status call was unguarded, asymmetric with the
+    try/except already wrapping the rev-parse call."""
+    if not shutil.which("git"):
+        pytest.skip("git not installed")
+    _git("init", cwd=tmp_path)
+    _git("config", "user.email", "t@t.t", cwd=tmp_path)
+    _git("config", "user.name", "t", cwd=tmp_path)
+    (tmp_path / "a.txt").write_text("1")
+    _git("add", "-A", cwd=tmp_path)
+    _git("commit", "-m", "init", cwd=tmp_path)
+
+    real_run = subprocess.run
+
+    def _flaky_run(cmd, *a, **k):
+        if "status" in cmd:
+            raise subprocess.TimeoutExpired(cmd, 5)
+        return real_run(cmd, *a, **k)
+
+    monkeypatch.setattr(subprocess, "run", _flaky_run)
+    commit, dirty = git_provenance(tmp_path)
+    assert commit and len(commit) == 40
+    assert dirty is None
+
+
+def test_check_stale_pins():
+    manifest_dir = None  # unused; pins read from a written manifest
+    lockfile = {"plugins": {"pack-a": {"sha": "a" * 40}}}
+    # pack-a present + matching -> not stale; pack-b missing -> stale;
+    # pack-a mismatched sha -> stale.
+    ok_pins = {"plugins": {"pack-a": {"sha": "a" * 40}}}
+    assert check_stale_pins_from_manifest(ok_pins, lockfile) == []
+    missing = {"plugins": {"pack-b": {"sha": "b" * 40}}}
+    assert check_stale_pins_from_manifest(missing, lockfile) == ["pack-b"]
+    mism = {"plugins": {"pack-a": {"sha": "z" * 40}}}
+    assert check_stale_pins_from_manifest(mism, lockfile) == ["pack-a"]
+
+
+def test_check_stale_pins_missing_or_bad_manifest_returns_empty(tmp_path):
+    """check_stale_pins (the disk-reading wrapper) must never crash startup:
+    no manifest at all, and an unparseable one, both resolve to []."""
+    lockfile = {"plugins": {"pack-a": {"sha": "a" * 40}}}
+    assert check_stale_pins(tmp_path, lockfile) == []
+    (tmp_path / "codefyui.project.toml").write_text("not [ valid toml",
+                                                     encoding="utf-8")
+    assert check_stale_pins(tmp_path, lockfile) == []
+
+
+def test_check_stale_pins_reads_manifest_from_disk(tmp_path):
+    lockfile = {"plugins": {"pack-a": {"sha": "a" * 40}}}
+    (tmp_path / "codefyui.project.toml").write_text(
+        '[plugins]\npack-a = { sha = "' + "z" * 40 + '" }\n', encoding="utf-8")
+    assert check_stale_pins(tmp_path, lockfile) == ["pack-a"]

--- a/backend/tests/test_provenance.py
+++ b/backend/tests/test_provenance.py
@@ -1,0 +1,145 @@
+"""Publish provenance (spec 9): migration 002 columns, publish fields, the
+in-handler git_commit validator, and the versions + OpenAPI surfaces."""
+
+import pytest
+
+from app.core.db import Database
+
+
+def _echo_graph(name="echo-graph"):
+    return {
+        "name": name, "description": "",
+        "nodes": [
+            {"id": "start", "type": "Start", "position": {"x": 0, "y": 0},
+             "data": {"params": {}}},
+            {"id": "gi", "type": "GraphInput", "position": {"x": 1, "y": 0},
+             "data": {"params": {"name": "x", "type": "string",
+                                 "required": True, "default": "",
+                                 "description": ""}}},
+            {"id": "out", "type": "GraphOutput", "position": {"x": 2, "y": 0},
+             "data": {"params": {"name": "y", "description": ""}}},
+        ],
+        "edges": [
+            {"id": "t1", "source": "start", "target": "gi",
+             "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+            {"id": "d1", "source": "gi", "target": "out",
+             "sourceHandle": "value", "targetHandle": "value", "type": "data"},
+        ],
+    }
+
+
+@pytest.fixture
+def graphs_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    return tmp_path
+
+
+def _table_columns(db: Database, table: str) -> set[str]:
+    rows = db._conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {r["name"] for r in rows}
+
+
+def _user_version(db: Database) -> int:
+    return db._conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+def test_migration_002_columns_and_idempotent(tmp_path):
+    db = Database(tmp_path / "p.db")
+    db.connect()
+    assert _user_version(db) == 2
+    cols = _table_columns(db, "app_versions")
+    assert "git_commit" in cols and "git_dirty" in cols
+    db.close()
+    # Re-connecting an already-migrated DB is a no-op (user_version gate).
+    db2 = Database(tmp_path / "p.db")
+    db2.connect()
+    assert _user_version(db2) == 2
+    db2.close()
+
+
+def test_migration_002_upgrades_a_v1_db(tmp_path, monkeypatch):
+    from app.core import db as dbmod
+    from app.core.migrations import MIGRATION_001, MIGRATION_002
+    monkeypatch.setattr(dbmod, "MIGRATIONS", [MIGRATION_001])
+    d1 = Database(tmp_path / "u.db")
+    d1.connect()
+    assert _user_version(d1) == 1
+    assert "git_commit" not in _table_columns(d1, "app_versions")
+
+    # Seed a published row under the v1 schema (no git_commit/git_dirty
+    # columns exist yet) so the in-place upgrade is exercised against real
+    # data, not just an empty schema -- a pre-migration row must survive
+    # the ALTER TABLE and read back with the new columns NULL (unknown),
+    # never silently defaulted to 0/False/"".
+    now = "2026-01-01T00:00:00.000000Z"
+    d1._conn.execute(
+        "INSERT INTO apps (id, slug, graph_name, active_version, "
+        "record_io, created_at, updated_at) "
+        "VALUES (1, 'legacy-app', 'g', 1, 1, ?, ?)", (now, now),
+    )
+    d1._conn.execute(
+        "INSERT INTO app_versions (app_id, version, graph_json, "
+        "contract_json, source_graph_name, note, created_at) "
+        "VALUES (1, 1, '{}', '{}', 'g', 'pre-migration note', ?)", (now,),
+    )
+    d1.close()
+
+    monkeypatch.setattr(dbmod, "MIGRATIONS", [MIGRATION_001, MIGRATION_002])
+    d2 = Database(tmp_path / "u.db")
+    d2.connect()
+    assert _user_version(d2) == 2
+    assert "git_commit" in _table_columns(d2, "app_versions")
+
+    row = d2._conn.execute(
+        "SELECT note, source_graph_name, git_commit, git_dirty "
+        "FROM app_versions WHERE app_id = 1 AND version = 1",
+    ).fetchone()
+    assert row["note"] == "pre-migration note"        # old data intact
+    assert row["source_graph_name"] == "g"
+    assert row["git_commit"] is None                  # NULL = unknown
+    assert row["git_dirty"] is None
+    d2.close()
+
+
+async def _save_echo(client):
+    r = await client.post("/api/graph/save", json=_echo_graph())
+    assert r.status_code == 200, r.text
+
+
+async def test_publish_records_and_surfaces_provenance(test_client, app_db, graphs_dir):
+    await _save_echo(test_client)
+    commit = "a" * 40
+    r = await test_client.post("/api/apps/svc/publish", json={
+        "graph": "echo-graph", "create": True,
+        "git_commit": commit, "git_dirty": True})
+    assert r.status_code == 200, r.text
+    assert r.json()["git_commit"] == commit
+
+    row = (await test_client.get("/api/apps/svc/versions")).json()[0]
+    assert row["git_commit"] == commit
+    assert row["git_dirty"] is True
+
+    info = (await test_client.get("/api/apps/svc/openapi.json")).json()["info"]
+    assert info["x-codefyui-git-commit"] == commit
+    assert info["x-codefyui-git-dirty"] is True
+
+
+async def test_publish_without_provenance(test_client, app_db, graphs_dir):
+    await _save_echo(test_client)
+    r = await test_client.post("/api/apps/svc2/publish",
+                               json={"graph": "echo-graph", "create": True})
+    assert r.status_code == 200
+    row = (await test_client.get("/api/apps/svc2/versions")).json()[0]
+    assert row["git_commit"] is None
+    assert row["git_dirty"] is None
+    info = (await test_client.get("/api/apps/svc2/openapi.json")).json()["info"]
+    assert "x-codefyui-git-commit" not in info
+    assert "x-codefyui-git-dirty" not in info
+
+
+async def test_publish_invalid_git_commit_422(test_client, app_db, graphs_dir):
+    await _save_echo(test_client)
+    r = await test_client.post("/api/apps/svc3/publish", json={
+        "graph": "echo-graph", "create": True, "git_commit": "NOT-hex-!!"})
+    assert r.status_code == 422
+    assert r.json()["detail"]["code"] == "invalid_git_commit"

--- a/backend/tests/test_publish_snapshot_project.py
+++ b/backend/tests/test_publish_snapshot_project.py
@@ -1,0 +1,71 @@
+"""ID5: in project mode, publish snapshots the LOGIC file's exact bytes
+(positionless), and invoke runs that positionless snapshot."""
+
+import pytest
+
+from app.api import routes_graph
+
+
+def _echo_graph():
+    return {
+        "name": "echo-graph", "description": "",
+        "nodes": [
+            {"id": "start", "type": "Start", "position": {"x": 0, "y": 0}, "data": {"params": {}}},
+            {"id": "gi", "type": "GraphInput", "position": {"x": 9, "y": 9},
+             "data": {"params": {"name": "x", "type": "string", "required": True,
+                                 "default": "", "description": ""}}},
+            {"id": "out", "type": "GraphOutput", "position": {"x": 5, "y": 5},
+             "data": {"params": {"name": "y", "description": ""}}},
+        ],
+        "edges": [
+            {"id": "t1", "source": "start", "target": "gi", "sourceHandle": "trigger",
+             "targetHandle": "", "type": "trigger"},
+            {"id": "d1", "source": "gi", "target": "out", "sourceHandle": "value",
+             "targetHandle": "value", "type": "data"},
+        ],
+    }
+
+
+@pytest.fixture
+def project(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", tmp_path)
+    monkeypatch.setattr(routes_graph.settings, "GRAPHS_DIR", tmp_path / "graphs")
+    (tmp_path / "graphs").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "layout").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_publish_snapshots_positionless_logic_bytes(test_client, app_db, project):
+    await test_client.post("/api/graph/save", json=_echo_graph())
+    logic_bytes = (project / "graphs" / "echo-graph.graph.json").read_text()
+    assert '"position"' not in logic_bytes  # split kept positions out of logic
+
+    r = await test_client.post("/api/apps/echo/publish",
+                               json={"graph": "echo-graph", "create": True})
+    assert r.status_code == 200, r.text
+
+    def _snap(conn):
+        return conn.execute(
+            "SELECT graph_json FROM app_versions WHERE version = 1").fetchone()[0]
+
+    assert await app_db.run(_snap) == logic_bytes  # snapshot == logic bytes
+
+    # And it still invokes (execution never reads positions). Mint a real key
+    # through the actual endpoint (mirrors the `api_key` fixture in
+    # test_api_apps_invoke.py) rather than a raw INSERT, so the bearer token
+    # actually authenticates.
+    key_resp = await test_client.post("/api/keys", json={"name": "id5-test"})
+    assert key_resp.status_code == 200, key_resp.text
+    token = key_resp.json()["token"]
+
+    inv = await test_client.post(
+        "/api/apps/echo/invoke",
+        json={"inputs": {"x": "hello"}},
+        headers=_bearer(token),
+    )
+    assert inv.status_code == 200, inv.text
+    assert inv.json()["outputs"] == {"y": "hello"}

--- a/docs/docs/usage/project-directories.md
+++ b/docs/docs/usage/project-directories.md
@@ -1,0 +1,196 @@
+---
+sidebar_position: 7.8
+title: Project Directories
+description: Turn a service into a self-contained git repo (cdui project) with a logic/layout split, per-project assets and secrets, CI validation, and publish provenance.
+---
+
+# Project Directories
+
+A **project directory** is a self-contained git repo that IS your service's
+storage. The editor reads and writes its files directly: one clean logic file
+per graph, positions in a sibling layout file, per-project assets and secrets,
+CI-able validation, and a git commit recorded at every publish.
+
+```
+my-service/
+  codefyui.project.toml   manifest: name, plugin pins, default publish target
+  graphs/    <name>.graph.json    logic (nodes/edges/params/presets)
+  layout/    <name>.layout.json   positions (reviewable, generated)
+  assets/images/   assets/models/   assets/data/    scaffolded empty
+  assets/output/                                    created on demand (e.g. ImageWriter)
+  .env.example     committed template of required secret keys
+  .env             your secrets (gitignored, never committed)
+```
+
+## Why the split?
+
+`graphs/<name>.graph.json` holds only what changes the *behavior* of the graph
+(nodes, edges, parameters, embedded presets). Node **positions** and note
+geometry live in `layout/<name>.layout.json`. So a drag produces a diff only
+in `layout/`, and a parameter edit a diff only in `graphs/` -- code review sees
+the logic change, not a wall of moved-pixels noise. (Known exception:
+`SequentialModel` sub-graph layer positions live inside `params.layers` and
+stay in the logic file.)
+
+## A complete walkthrough
+
+### 1. Create the project
+
+```bash
+cdui project init my-service
+cd my-service
+```
+
+`init` scaffolds `graphs/`, `layout/`, and `assets/{images,models,data}/`
+(empty, `.gitkeep`-tracked), writes `.gitignore` / `.gitattributes` /
+`.env.example` / `README.md`, and runs `git init` (no commit -- it prints the
+next steps). `assets/output/` is not created up front; it appears the first
+time a node (for example ImageWriter) writes to it.
+
+### 2. Add a graph
+
+Either build it in the editor (`cdui start --project .`, drop a **Start**, a
+**GraphInput** named `x`, and a **GraphOutput** named `y`, wire Start's trigger
+into GraphInput and GraphInput's value into GraphOutput, then press
+**Ctrl/Cmd+S** and name it `echo`), or drop this file at
+`graphs/echo.graph.json`:
+
+```json
+{
+  "format_version": 1,
+  "name": "echo",
+  "description": "Echo the input string",
+  "nodes": [
+    {"id": "start", "type": "Start", "data": {"params": {}}},
+    {"id": "gi", "type": "GraphInput", "data": {"params": {"name": "x", "type": "string", "required": true, "default": "", "description": "text to echo"}}},
+    {"id": "out", "type": "GraphOutput", "data": {"params": {"name": "y", "description": "the echoed text"}}}
+  ],
+  "edges": [
+    {"id": "t1", "source": "start", "target": "gi", "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+    {"id": "d1", "source": "gi", "target": "out", "sourceHandle": "value", "targetHandle": "value", "type": "data"}
+  ],
+  "presets": []
+}
+```
+
+### 3. Commit
+
+```bash
+git config user.name  "You"
+git config user.email "you@example.com"
+git add -A
+git commit -m "echo service"
+```
+
+`.env` is gitignored; `.env.example` is committed. Commit a small fetch script
+for large data, never the data or weights themselves.
+
+### 4. Validate (the CI gate)
+
+```bash
+cdui project validate .
+```
+
+`validate` initializes the FULL registry (builtin + custom + plugin nodes and
+presets, exactly like the server) and runs the publish pre-flight on every
+graph: contract, entry points, wiring, node/preset validity, and the
+secret-in-graph check. It also errors if `.env` is tracked by git, and warns
+(errors with `--strict`) on missing plugin pins. In CI, run **restore then
+validate**:
+
+```bash
+cdui project restore .   # install the manifest's plugin pins by exact SHA
+cdui project validate .
+```
+
+### 5. Start the server on the project
+
+```bash
+cdui start --project .
+```
+
+The log prints `Project: <abs> (git <short-sha>)` and warns once, naming
+`cdui project restore`, if any pinned plugin is missing.
+
+### 6. Create an API key (invoke needs one)
+
+The session token lives at `%LOCALAPPDATA%\codefyui\session.token` (Windows) or
+`~/.local/share/codefyui/session.token` (Linux/macOS).
+
+```bash
+TOKEN=$(cat ~/.local/share/codefyui/session.token)
+curl -s -X POST http://127.0.0.1:8000/api/keys \
+  -H "X-CodefyUI-Token: $TOKEN" -H "Content-Type: application/json" \
+  --data '{"name": "demo"}'
+# -> {"id": 1, "name": "demo", "prefix": "cdui_xxxxxxxx", "token": "cdui_..."}  (the full key is shown ONCE, in the "token" field)
+```
+
+### 7. Publish (records the git commit)
+
+Set the default target once in `codefyui.project.toml`:
+
+```toml
+[publish]
+graph = "echo"
+slug = "echo-svc"
+```
+
+Commit it -- an uncommitted manifest change is exactly the kind of dirty tree
+the next step warns about -- then publish:
+
+```bash
+git add -A && git commit -m "set publish target"
+cdui project publish .
+# -> Published echo-svc v1 (git 1a2b3c4)
+```
+
+Publish is **local-only** in v1: it confirms `GET /api/health` reports THIS
+project open (so it can never record the wrong commit against foreign bytes),
+computes `git rev-parse HEAD` + `git status --porcelain`, and warns LOUDLY if
+the tree is dirty. Publishing from a dirty tree records `git_dirty = true`.
+
+> **Remote / CI deploy is out of scope for v1.** `cdui project validate` runs
+> in CI, but publishing requires a local server with the project open. The
+> named follow-up is a management-scoped, API-key publish (`--url` / `--key`).
+
+### 8. Invoke
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/api/apps/echo-svc/invoke \
+  -H "Authorization: Bearer cdui_YOUR_KEY" -H "Content-Type: application/json" \
+  --data '{"inputs": {"x": "hello"}}'
+# -> {"status": "ok", "outputs": {"y": "hello"}, ...}
+```
+
+### 9. See "which commit built this"
+
+```bash
+curl -s http://127.0.0.1:8000/api/apps/echo-svc/versions \
+  -H "X-CodefyUI-Token: $TOKEN"
+# -> [{"version": 1, "git_commit": "1a2b...", "git_dirty": false, "active": true, ...}]
+```
+
+The active version's `GET /api/apps/echo-svc/openapi.json` `info` block also
+carries `x-codefyui-git-commit` and `x-codefyui-git-dirty`.
+
+## Migrating an existing flat graphs dir
+
+If you followed the older "version control your graphs" recipe (a flat dir of
+`*.json` behind `CODEFYUI_GRAPHS_DIR`), adopt it in one command:
+
+```bash
+cdui project init my-service --adopt /path/to/old-graphs
+```
+
+Every `*.json` is copied into `graphs/` and split into the logic/layout pair.
+
+## Notes and limits (v1)
+
+- One project per server instance (no in-editor project switcher yet).
+- `DB_PATH` and custom nodes stay install-global; plugins are the portable
+  mechanism (pinned by SHA in the manifest).
+- Last-write-wins between the editor and hand-edits (a "changed on disk"
+  warning is a follow-up). Exclude project dirs from OneDrive/Dropbox sync --
+  sync clients corrupt `.git` and race atomic renames; use a real git remote.
+- A graph written by a newer CodefyUI opens **read-only** (view/run allowed,
+  Save disabled) so an older build can never drop fields it does not know.

--- a/docs/docs/usage/project-directories.md
+++ b/docs/docs/usage/project-directories.md
@@ -93,14 +93,24 @@ cdui project validate .
 
 `validate` initializes the FULL registry (builtin + custom + plugin nodes and
 presets, exactly like the server) and runs the publish pre-flight on every
-graph: contract, entry points, wiring, node/preset validity, and the
-secret-in-graph check. It also errors if `.env` is tracked by git, and warns
+graph: the secret-in-graph check, contract, entry points, wiring, and
+node/preset validity. It also errors if `.env` is tracked by git, and warns
 (errors with `--strict`) on missing plugin pins. In CI, run **restore then
 validate**:
 
 ```bash
 cdui project restore .   # install the manifest's plugin pins by exact SHA
 cdui project validate .
+```
+
+Pins come from `cdui project freeze .`: it reads your locally-installed
+plugins and writes each one's exact commit SHA into `codefyui.project.toml`'s
+`[plugins]` table (a plugin you installed as a local dev link is skipped --
+there is no SHA to pin for a machine-specific path). Run it after installing
+or updating a plugin, and commit the manifest change before your next push:
+
+```bash
+cdui project freeze .
 ```
 
 ### 5. Start the server on the project
@@ -114,20 +124,37 @@ The log prints `Project: <abs> (git <short-sha>)` and warns once, naming
 
 ### 6. Create an API key (invoke needs one)
 
-The session token lives at `%LOCALAPPDATA%\codefyui\session.token` (Windows) or
-`~/.local/share/codefyui/session.token` (Linux/macOS).
+The session token lives at `<user_data_dir>/codefyui/session.token` -- on
+Windows `%LOCALAPPDATA%\codefyui\session.token`, on macOS `~/Library/Application
+Support/codefyui/session.token`, on Linux `~/.local/share/codefyui/session.token`
+(see [Graph as a Function](./graph-as-a-function.md) for the full breakdown).
+
+PowerShell:
+
+```powershell
+# payload.json: {"name": "demo"}
+$token = Get-Content "$env:LOCALAPPDATA\codefyui\session.token"
+curl.exe -s -X POST "http://127.0.0.1:8000/api/keys" `
+  -H "X-CodefyUI-Token: $token" -H "Content-Type: application/json" `
+  --data "@payload.json"
+```
+
+bash:
 
 ```bash
-TOKEN=$(cat ~/.local/share/codefyui/session.token)
+TOKEN=$(cat ~/.local/share/codefyui/session.token)   # macOS: ~/Library/Application Support/codefyui/session.token
 curl -s -X POST http://127.0.0.1:8000/api/keys \
   -H "X-CodefyUI-Token: $TOKEN" -H "Content-Type: application/json" \
   --data '{"name": "demo"}'
-# -> {"id": 1, "name": "demo", "prefix": "cdui_xxxxxxxx", "token": "cdui_..."}  (the full key is shown ONCE, in the "token" field)
 ```
+
+`# -> {"id": 1, "name": "demo", "prefix": "cdui_xxxxxxxx", "token": "cdui_..."}` (the full key is shown ONCE, in the "token" field)
 
 ### 7. Publish (records the git commit)
 
-Set the default target once in `codefyui.project.toml`:
+`cdui project publish` wraps the same [publish](./publish.md) endpoint
+(`POST /api/apps/{slug}/publish`) with a project-mode guard and automatic git
+provenance. Set the default target once in `codefyui.project.toml`:
 
 ```toml
 [publish]
@@ -147,7 +174,9 @@ cdui project publish .
 Publish is **local-only** in v1: it confirms `GET /api/health` reports THIS
 project open (so it can never record the wrong commit against foreign bytes),
 computes `git rev-parse HEAD` + `git status --porcelain`, and warns LOUDLY if
-the tree is dirty. Publishing from a dirty tree records `git_dirty = true`.
+the tree is dirty. Every publish from a git repo records `git_dirty` as
+`true` or `false` alongside the commit -- a dirty tree additionally prints
+the warning banner above.
 
 > **Remote / CI deploy is out of scope for v1.** `cdui project validate` runs
 > in CI, but publishing requires a local server with the project open. The
@@ -155,28 +184,50 @@ the tree is dirty. Publishing from a dirty tree records `git_dirty = true`.
 
 ### 8. Invoke
 
+PowerShell:
+
+```powershell
+# payload.json: {"inputs": {"x": "hello"}}
+curl.exe -s -X POST "http://127.0.0.1:8000/api/apps/echo-svc/invoke" `
+  -H "Authorization: Bearer cdui_YOUR_KEY" -H "Content-Type: application/json" `
+  --data "@payload.json"
+```
+
+bash:
+
 ```bash
 curl -s -X POST http://127.0.0.1:8000/api/apps/echo-svc/invoke \
   -H "Authorization: Bearer cdui_YOUR_KEY" -H "Content-Type: application/json" \
   --data '{"inputs": {"x": "hello"}}'
-# -> {"status": "ok", "outputs": {"y": "hello"}, ...}
 ```
 
+`# -> {"status": "ok", "outputs": {"y": "hello"}, ...}`
+
 ### 9. See "which commit built this"
+
+PowerShell:
+
+```powershell
+curl.exe -s "http://127.0.0.1:8000/api/apps/echo-svc/versions" -H "X-CodefyUI-Token: $token"
+```
+
+bash:
 
 ```bash
 curl -s http://127.0.0.1:8000/api/apps/echo-svc/versions \
   -H "X-CodefyUI-Token: $TOKEN"
-# -> [{"version": 1, "git_commit": "1a2b...", "git_dirty": false, "active": true, ...}]
 ```
+
+`# -> [{"version": 1, "git_commit": "1a2b...", "git_dirty": false, "active": true, ...}]`
 
 The active version's `GET /api/apps/echo-svc/openapi.json` `info` block also
 carries `x-codefyui-git-commit` and `x-codefyui-git-dirty`.
 
 ## Migrating an existing flat graphs dir
 
-If you followed the older "version control your graphs" recipe (a flat dir of
-`*.json` behind `CODEFYUI_GRAPHS_DIR`), adopt it in one command:
+If you followed the older ["version control your graphs"](./version-control-graphs.md)
+recipe (a flat dir of `*.json` behind `CODEFYUI_GRAPHS_DIR`), adopt it in one
+command:
 
 ```bash
 cdui project init my-service --adopt /path/to/old-graphs
@@ -187,10 +238,13 @@ Every `*.json` is copied into `graphs/` and split into the logic/layout pair.
 ## Notes and limits (v1)
 
 - One project per server instance (no in-editor project switcher yet).
-- `DB_PATH` and custom nodes stay install-global; plugins are the portable
-  mechanism (pinned by SHA in the manifest).
+- `DB_PATH` and custom nodes stay install-global; [plugins](/advanced/plugins)
+  are the portable mechanism (pinned by SHA in the manifest).
 - Last-write-wins between the editor and hand-edits (a "changed on disk"
   warning is a follow-up). Exclude project dirs from OneDrive/Dropbox sync --
   sync clients corrupt `.git` and race atomic renames; use a real git remote.
 - A graph written by a newer CodefyUI opens **read-only** (view/run allowed,
   Save disabled) so an older build can never drop fields it does not know.
+  Save As is blocked by the identical guard, by design: the in-memory graph
+  already lost those unknown fields the moment it loaded, so Save As would
+  just write that lossy copy out under a different name.

--- a/docs/docs/usage/publish.md
+++ b/docs/docs/usage/publish.md
@@ -22,6 +22,8 @@ All management calls below use the editor session token (`X-CodefyUI-Token`, obt
 POST /api/apps/{slug}/publish        (session token)
 body: {"graph": "<saved name>", "note": "optional", "create": false}
       (optional "record_io": true|false — omitted inherits the app's current setting; see below)
+      (optional "git_commit": "<7-40 hex>", "git_dirty": true|false — publish provenance;
+       normally set for you by `cdui project publish`)
 ```
 
 - `slug` is the stable public name: `^[a-z][a-z0-9-]{0,63}$`, chosen by you, independent of the graph name — renaming a graph never breaks a published URL.
@@ -30,7 +32,8 @@ body: {"graph": "<saved name>", "note": "optional", "create": false}
 - `note` is optional, immutable version metadata, echoed in the versions list.
 - Publish runs the exact `/run` pre-flight first: a graph that `POST /api/graph/run/{name}` would refuse (409 `invalid_contract` / `no_entry_points` / `untriggered_input` / `unreachable_output` / `invalid_graph`) cannot be published either.
 - Publish also rejects (409 `secret_in_graph`) a graph whose saved file still holds a non-empty `SECRET`-typed parameter (for example an LLMChat API key), naming the offending node and param. **Graphs never persist secrets** — the editor masks `SECRET` fields and drops them on save/export, and `POST /api/graph/save` scrubs them server-side, so this pre-flight only ever fires on a hand-edited file. Keep API keys in the environment (`CODEFYUI_OPENAI_API_KEY` / `OPENAI_API_KEY`, `CODEFYUI_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`) instead.
-- Success: `{"slug", "version", "active": true, "created", "graph_name", "note"}`.
+- Success: `{"slug", "version", "active": true, "created", "graph_name", "note", "git_commit", "git_dirty"}`.
+- **Provenance.** `git_commit` (validated `^[0-9a-f]{7,40}$`; a bad value is 422 `invalid_git_commit`) and `git_dirty` are recorded on the version. `cdui project publish` fills them from `git rev-parse HEAD` + `git status --porcelain` and warns loudly when the tree is dirty. They surface in `GET /api/apps/{slug}/versions` and as `x-codefyui-git-commit` / `x-codefyui-git-dirty` in the per-app OpenAPI `info` block. See [Project directories](./project-directories.md).
 
 **Publish activates immediately.** There is no staging path in v1: canvas Run plus the identical pre-flight IS the verification story. If the graph runs from the Run button and `/run` accepts it, the published version serves that same behavior.
 
@@ -46,7 +49,7 @@ Managing versions:
 
 ```text
 GET    /api/apps                       -> [{slug, graph_name, active_version, versions_count, record_io, ...}]
-GET    /api/apps/{slug}/versions       -> [{version, source_graph_name, note, created_at, active}]
+GET    /api/apps/{slug}/versions       -> [{version, source_graph_name, note, git_commit, git_dirty, created_at, active}]
 POST   /api/apps/{slug}/activate       body {"version": n} — point the slug at ANY existing version
 POST   /api/apps/{slug}/unpublish      -> active_version = null; versions and runs are kept
 PATCH  /api/apps/{slug}                body {"record_io": bool} — flips run-recording, no republish
@@ -134,7 +137,7 @@ Retention: `CODEFYUI_RUNS_RETENTION_DAYS` defaults to **0 = keep forever**. When
 GET /api/apps/{slug}/openapi.json      (API key or session token)
 ```
 
-A complete, standalone OpenAPI 3.1 document for the ACTIVE version — importable into Swagger UI, Postman, or openapi-generator as-is. It carries the typed input schema derived from the graph's contract, the 9-key envelope schema, the bearer security scheme, and an `x-codefyui-curl` object with ready-to-paste `powershell` and `bash` invoke commands. JSON only; there is no generated HTML page.
+A complete, standalone OpenAPI 3.1 document for the ACTIVE version — importable into Swagger UI, Postman, or openapi-generator as-is. It carries the typed input schema derived from the graph's contract, the 9-key envelope schema, the bearer security scheme, and an `x-codefyui-curl` object with ready-to-paste `powershell` and `bash` invoke commands. JSON only; there is no generated HTML page. When the active version was published with provenance, the OpenAPI `info` block also carries `x-codefyui-git-commit` and `x-codefyui-git-dirty`.
 
 ## 6. Serving on your LAN
 

--- a/docs/docs/usage/publish.md
+++ b/docs/docs/usage/publish.md
@@ -6,13 +6,13 @@ description: Freeze a saved graph as a versioned app behind a stable, API-key-pr
 
 # Publish (Graphs as Apps)
 
-[Graph as a Function](./graph-as-a-function) makes any saved graph callable over HTTP — but that endpoint is a moving target: every canvas save changes what it runs, and its session token rotates on every server restart. **Publishing** turns a working graph into a stable product endpoint:
+[Graph as a Function](./graph-as-a-function) makes any saved graph callable over HTTP -- but that endpoint is a moving target: every canvas save changes what it runs, and its session token rotates on every server restart. **Publishing** turns a working graph into a stable product endpoint:
 
 - an immutable **version** snapshot served at `POST /api/apps/{slug}/invoke`,
 - protected by durable **API keys** (`Authorization: Bearer cdui_...`) that survive restarts,
 - with every resolved invoke recorded to SQLite (`backend/data/codefyui.db`).
 
-Canvas edits touch only the saved graph file; invokes read only the stored snapshot — editing the canvas can never change a published app until you re-publish.
+Canvas edits touch only the saved graph file; invokes read only the stored snapshot -- editing the canvas can never change a published app until you re-publish.
 
 All management calls below use the editor session token (`X-CodefyUI-Token`, obtained exactly as on the [Graph as a Function](./graph-as-a-function) page). On Windows use `curl.exe` and pass bodies as files (`--data "@payload.json"`), never inline JSON.
 
@@ -21,17 +21,17 @@ All management calls below use the editor session token (`X-CodefyUI-Token`, obt
 ```text
 POST /api/apps/{slug}/publish        (session token)
 body: {"graph": "<saved name>", "note": "optional", "create": false}
-      (optional "record_io": true|false — omitted inherits the app's current setting; see below)
-      (optional "git_commit": "<7-40 hex>", "git_dirty": true|false — publish provenance;
+      (optional "record_io": true|false -- omitted inherits the app's current setting; see below)
+      (optional "git_commit": "<7-40 hex>", "git_dirty": true|false -- publish provenance;
        normally set for you by `cdui project publish`)
 ```
 
-- `slug` is the stable public name: `^[a-z][a-z0-9-]{0,63}$`, chosen by you, independent of the graph name — renaming a graph never breaks a published URL.
-- Publishing to a slug that does not exist yet requires `"create": true`, otherwise 404 `app_not_found` — a misspelled slug on a re-publish can never silently create a second app.
-- Publishing to an existing slug appends the next version — that IS the re-publish path.
+- `slug` is the stable public name: `^[a-z][a-z0-9-]{0,63}$`, chosen by you, independent of the graph name -- renaming a graph never breaks a published URL.
+- Publishing to a slug that does not exist yet requires `"create": true`, otherwise 404 `app_not_found` -- a misspelled slug on a re-publish can never silently create a second app.
+- Publishing to an existing slug appends the next version -- that IS the re-publish path.
 - `note` is optional, immutable version metadata, echoed in the versions list.
 - Publish runs the exact `/run` pre-flight first: a graph that `POST /api/graph/run/{name}` would refuse (409 `invalid_contract` / `no_entry_points` / `untriggered_input` / `unreachable_output` / `invalid_graph`) cannot be published either.
-- Publish also rejects (409 `secret_in_graph`) a graph whose saved file still holds a non-empty `SECRET`-typed parameter (for example an LLMChat API key), naming the offending node and param. **Graphs never persist secrets** — the editor masks `SECRET` fields and drops them on save/export, and `POST /api/graph/save` scrubs them server-side, so this pre-flight only ever fires on a hand-edited file. Keep API keys in the environment (`CODEFYUI_OPENAI_API_KEY` / `OPENAI_API_KEY`, `CODEFYUI_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`) instead.
+- Publish also rejects (409 `secret_in_graph`) a graph whose saved file still holds a non-empty `SECRET`-typed parameter (for example an LLMChat API key), naming the offending node and param. **Graphs never persist secrets** -- the editor masks `SECRET` fields and drops them on save/export, and `POST /api/graph/save` scrubs them server-side, so this pre-flight only ever fires on a hand-edited file. Keep API keys in the environment (`CODEFYUI_OPENAI_API_KEY` / `OPENAI_API_KEY`, `CODEFYUI_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`) instead.
 - Success: `{"slug", "version", "active": true, "created", "graph_name", "note", "git_commit", "git_dirty"}`.
 - **Provenance.** `git_commit` (validated `^[0-9a-f]{7,40}$`; a bad value is 422 `invalid_git_commit`) and `git_dirty` are recorded on the version. `cdui project publish` fills them from `git rev-parse HEAD` + `git status --porcelain` and warns loudly when the tree is dirty. They surface in `GET /api/apps/{slug}/versions` and as `x-codefyui-git-commit` / `x-codefyui-git-dirty` in the per-app OpenAPI `info` block. See [Project directories](./project-directories.md).
 
@@ -50,26 +50,26 @@ Managing versions:
 ```text
 GET    /api/apps                       -> [{slug, graph_name, active_version, versions_count, record_io, ...}]
 GET    /api/apps/{slug}/versions       -> [{version, source_graph_name, note, git_commit, git_dirty, created_at, active}]
-POST   /api/apps/{slug}/activate       body {"version": n} — point the slug at ANY existing version
+POST   /api/apps/{slug}/activate       body {"version": n} -- point the slug at ANY existing version
 POST   /api/apps/{slug}/unpublish      -> active_version = null; versions and runs are kept
-PATCH  /api/apps/{slug}                body {"record_io": bool} — flips run-recording, no republish
+PATCH  /api/apps/{slug}                body {"record_io": bool} -- flips run-recording, no republish
 DELETE /api/apps/{slug}
 ```
 
 - `activate` subsumes rollback: activating an older version restores it, and activating from the unpublished state restores service at that version.
-- `record_io` on publish is tri-state: omit it (or pass `null`) to **inherit** the app's current `record_io` — a republish that doesn't mention it never flips a setting you changed via `PATCH`. A brand-new app (first publish with `"create": true`) defaults to `true` when omitted. Pass an explicit `true`/`false` to override, at create time or on any republish.
-- While unpublished, invokes return 409 `app_unpublished` — nothing is lost.
+- `record_io` on publish is tri-state: omit it (or pass `null`) to **inherit** the app's current `record_io` -- a republish that doesn't mention it never flips a setting you changed via `PATCH`. A brand-new app (first publish with `"create": true`) defaults to `true` when omitted. Pass an explicit `true`/`false` to override, at create time or on any republish.
+- While unpublished, invokes return 409 `app_unpublished` -- nothing is lost.
 - **`DELETE /api/apps/{slug}` irrevocably removes the app, ALL its versions AND all its run records.** There is no undo. Prefer `unpublish` unless you truly mean delete.
 
 ## 2. API keys
 
 ```text
 POST /api/keys                (session token)  body {"name": "ci-bot"}
-GET  /api/keys                (session token)  — id, name, prefix, timestamps; never secrets
-POST /api/keys/{id}/revoke    (session token)  — soft revoke; the row stays listed
+GET  /api/keys                (session token)  -- id, name, prefix, timestamps; never secrets
+POST /api/keys/{id}/revoke    (session token)  -- soft revoke; the row stays listed
 ```
 
-**The full key (`cdui_...`) appears ONCE, in the create response, and is never stored or logged.** Copy it immediately; lists show only the first 12 characters (`prefix`). Keys are stored as sha256 hashes and survive restarts — the deliberate contrast with the rotating session token. Revoked keys fail auth immediately but remain listed with their `revoked_at`, so old run records stay attributable.
+**The full key (`cdui_...`) appears ONCE, in the create response, and is never stored or logged.** Copy it immediately; lists show only the first 12 characters (`prefix`). Keys are stored as sha256 hashes and survive restarts -- the deliberate contrast with the rotating session token. Revoked keys fail auth immediately but remain listed with their `revoked_at`, so old run records stay attributable.
 
 ## 3. Invoke
 
@@ -79,10 +79,10 @@ POST /api/apps/{slug}/invoke          (auth: Authorization: Bearer cdui_...)
 
 The body is the same as [`/api/graph/run`](./graph-as-a-function): optional, with optional `inputs`, `timeout_s`, `device`. Two differences:
 
-- `record_outputs` is **accepted and ignored** — published runs are recorded in SQLite (below), never in the editor's inspector store.
+- `record_outputs` is **accepted and ignored** -- published runs are recorded in SQLite (below), never in the editor's inspector store.
 - `timeout_s` covers TOTAL request time INCLUDING queue wait: invokes of one app run one-at-a-time (per-slug lock), and a call that spends its budget waiting behind another invoke fails with the `timeout` envelope noting it expired while queued. Different slugs run in parallel.
 
-The editor session token is NEVER accepted on invoke — pasting it produces a self-diagnosing 401: "this endpoint takes an API key (cdui_...), not the editor session token".
+The editor session token is NEVER accepted on invoke -- pasting it produces a self-diagnosing 401: "this endpoint takes an API key (cdui_...), not the editor session token".
 
 Every response is the same 9-key envelope as `/run` (see [the envelope](./graph-as-a-function)), with the two Stage-2 keys filled in: `graph` and `app` are the slug on every outcome, and `version` is the executed version (`null` on errors before a version was resolved). New error codes on top of the Stage-1 taxonomy:
 
@@ -92,7 +92,7 @@ Every response is the same 9-key envelope as `/run` (see [the envelope](./graph-
 | `app_not_found` | 404 | slug does not exist |
 | `app_unpublished` | 409 | app exists but no version is active |
 
-Oversized images are rejected up front on BOTH run routes: 422 `invalid_input` when a single image exceeds `MAX_IMAGE_PIXELS` (default 25,000,000; `CODEFYUI_MAX_IMAGE_PIXELS`). Match on the code, not the message — far above the budget, PIL's own decompression-bomb error text appears instead of ours.
+Oversized images are rejected up front on BOTH run routes: 422 `invalid_input` when a single image exceeds `MAX_IMAGE_PIXELS` (default 25,000,000; `CODEFYUI_MAX_IMAGE_PIXELS`). Match on the code, not the message -- far above the budget, PIL's own decompression-bomb error text appears instead of ours.
 
 PowerShell:
 
@@ -118,8 +118,8 @@ curl -s -X POST "http://127.0.0.1:8000/api/apps/classifier/invoke" \
 Every invoke that resolves to an app version writes one row (status, error code, device, `total_s`, per-node timings, capped inputs/outputs, key id). Pre-resolution rejections (`invalid_key`, `app_not_found`, `app_unpublished`) write nothing. Recording is best-effort: a storage failure after execution is logged and the run result is still returned.
 
 ```text
-GET /api/apps/{slug}/runs?limit=50&before=<iso>   — newest-first metadata only
-GET /api/apps/{slug}/runs/{run_id}                — the full row incl. inputs/outputs/node_timings
+GET /api/apps/{slug}/runs?limit=50&before=<iso>   -- newest-first metadata only
+GET /api/apps/{slug}/runs/{run_id}                -- the full row incl. inputs/outputs/node_timings
 ```
 
 Reads accept EITHER a valid API key or the editor session token (the editor UI reads runs without ever holding an API key), and reject requests with neither.
@@ -137,7 +137,7 @@ Retention: `CODEFYUI_RUNS_RETENTION_DAYS` defaults to **0 = keep forever**. When
 GET /api/apps/{slug}/openapi.json      (API key or session token)
 ```
 
-A complete, standalone OpenAPI 3.1 document for the ACTIVE version — importable into Swagger UI, Postman, or openapi-generator as-is. It carries the typed input schema derived from the graph's contract, the 9-key envelope schema, the bearer security scheme, and an `x-codefyui-curl` object with ready-to-paste `powershell` and `bash` invoke commands. JSON only; there is no generated HTML page. When the active version was published with provenance, the OpenAPI `info` block also carries `x-codefyui-git-commit` and `x-codefyui-git-dirty`.
+A complete, standalone OpenAPI 3.1 document for the ACTIVE version -- importable into Swagger UI, Postman, or openapi-generator as-is. It carries the typed input schema derived from the graph's contract, the 9-key envelope schema, the bearer security scheme, and an `x-codefyui-curl` object with ready-to-paste `powershell` and `bash` invoke commands. JSON only; there is no generated HTML page. When the active version was published with provenance, the OpenAPI `info` block also carries `x-codefyui-git-commit` and `x-codefyui-git-dirty`.
 
 ## 6. Serving on your LAN
 
@@ -148,10 +148,10 @@ cdui start --host 192.168.1.20             # one concrete interface
 
 The Host-header whitelist follows the bind automatically (a concrete LAN IP is whitelisted; a `0.0.0.0` bind whitelists each local interface IP), extra names can be added via `CODEFYUI_EXTRA_ALLOWED_HOSTS="mybox:8000,192.168.1.20:8000"`, and the effective whitelist plus reachable URLs are printed at startup. `cdui status` and `cdui stop` report the real address. `cdui dev` remains loopback-only by design.
 
-Understand what a LAN bind exposes — plainly:
+Understand what a LAN bind exposes -- plainly:
 
 - Binding a LAN address serves the FULL editor, and `GET /api/auth/bootstrap` hands out the session token to any allowed-Host request. **Anyone who can reach the port controls the instance; use only on trusted networks.**
 - API keys on the published surface are therefore attribution and off-box script hygiene, NOT LAN access control.
-- Transport is plain HTTP — no TLS in v1.
-- CORS settings change nothing about this: the exposure is same-origin, and the `Authorization` CORS header exists only so future cross-origin JS callers can be preflighted — it is not a mitigation.
+- Transport is plain HTTP -- no TLS in v1.
+- CORS settings change nothing about this: the exposure is same-origin, and the `Authorization` CORS header exists only so future cross-origin JS callers can be preflighted -- it is not a mitigation.
 - Editor-scoped LAN hardening (loopback-gated bootstrap; published-surface-only on non-loopback Hosts) is a named follow-up, not in v1.

--- a/docs/docs/usage/version-control-graphs.md
+++ b/docs/docs/usage/version-control-graphs.md
@@ -15,23 +15,23 @@ in one command: `cdui project init my-service --adopt /path/to/my-graphs`.
 
 CodefyUI saves each graph as a plain JSON file, so graphs are a natural fit for git: you get history, review, and rollback for the pipelines you build. This page is a recipe for keeping your graphs in their own git repository, validating them in CI, and publishing from a versioned source.
 
-One catch up front: the default save location is **not** version-controlled. Saved graphs land in `backend/data/graphs/`, which the repo's own `.gitignore` excludes (`backend/data/graphs/*.json`, keeping only `.gitkeep`). To version your work you point CodefyUI's graph directory at a repo you own — the rest of this page shows how.
+One catch up front: the default save location is **not** version-controlled. Saved graphs land in `backend/data/graphs/`, which the repo's own `.gitignore` excludes (`backend/data/graphs/*.json`, keeping only `.gitkeep`). To version your work you point CodefyUI's graph directory at a repo you own -- the rest of this page shows how.
 
 ## What to version, and what never to
 
 **Version these:**
 
-- Your graph JSON files — one `<name>.json` per saved graph.
+- Your graph JSON files -- one `<name>.json` per saved graph.
 - Small data or model files you own and want reproducible, or a script that fetches the large ones.
 
-**Never commit these.** They are machine-local state, secrets, or derived data, and none of them live in the graph JSON — most sit outside your graphs directory entirely by default, so keep them there:
+**Never commit these.** They are machine-local state, secrets, or derived data, and none of them live in the graph JSON -- most sit outside your graphs directory entirely by default, so keep them there:
 
 - The SQLite database `codefyui.db` (default `backend/data/codefyui.db`, overridable with `CODEFYUI_DB_PATH`). It holds published apps, versioned snapshots, API keys, and run records.
-- Run records — stored only in that database, never in a file you would commit.
-- Published-app API keys (the `cdui_...` bearer tokens) — also database-only, kept as sha256 hashes.
+- Run records -- stored only in that database, never in a file you would commit.
+- Published-app API keys (the `cdui_...` bearer tokens) -- also database-only, kept as sha256 hashes.
 - `.env` files and any local secrets.
 - The editor session token file at `<user_data_dir>/codefyui/session.token` (Windows `%LOCALAPPDATA%\codefyui\session.token`). It is written outside your graphs directory and rotates on every server restart, so it should never be copied into a repo.
-- LLM provider API keys — see [Secrets](#secrets-keep-keys-out-of-your-graphs) below, because these are the one secret that can end up *inside* a graph you commit.
+- LLM provider API keys -- see [Secrets](#secrets-keep-keys-out-of-your-graphs) below, because these are the one secret that can end up *inside* a graph you commit.
 
 ## Set up a service repo
 
@@ -72,7 +72,7 @@ git add .
 git commit -m "Add my first classifier graph"
 ```
 
-**`CODEFYUI_GRAPHS_DIR` must be set every time the server starts** — it is not persisted anywhere. Launch a fresh terminal without it and `cdui start` falls back to the default `backend/data/graphs/`, so your service repo will look empty. Set it once in your shell profile (PowerShell `$PROFILE`, or `~/.bashrc` / `~/.zshrc`), or wrap the two lines in a tiny start script you keep next to the repo:
+**`CODEFYUI_GRAPHS_DIR` must be set every time the server starts** -- it is not persisted anywhere. Launch a fresh terminal without it and `cdui start` falls back to the default `backend/data/graphs/`, so your service repo will look empty. Set it once in your shell profile (PowerShell `$PROFILE`, or `~/.bashrc` / `~/.zshrc`), or wrap the two lines in a tiny start script you keep next to the repo:
 
 ```bash
 # start.sh
@@ -95,16 +95,16 @@ Drop this in the root of your graphs repo so weights, databases, and secrets nev
 __pycache__/
 ```
 
-For large datasets, commit a small download script (or a URL plus a checksum) rather than the data itself — keep the repo to graphs and the code that fetches everything else.
+For large datasets, commit a small download script (or a URL plus a checksum) rather than the data itself -- keep the repo to graphs and the code that fetches everything else.
 
 ## Secrets: keep keys out of your graphs
 
-The LLM nodes (for example LLMChat) expose API-key parameter fields such as `openai_api_key` and `anthropic_api_key`. **A value typed into one of these fields is saved verbatim into the graph JSON** — so if you commit that graph, you commit your key. Do not do that.
+The LLM nodes (for example LLMChat) expose API-key parameter fields such as `openai_api_key` and `anthropic_api_key`. **A value typed into one of these fields is saved verbatim into the graph JSON** -- so if you commit that graph, you commit your key. Do not do that.
 
 Leave the field blank and provide the key through the environment instead. The node reads the first non-empty value it finds, in this order:
 
-1. the node's `openai_api_key` field (saved in the graph — avoid)
-2. a generic `api_key` field on the node (also saved in the graph — avoid)
+1. the node's `openai_api_key` field (saved in the graph -- avoid)
+2. a generic `api_key` field on the node (also saved in the graph -- avoid)
 3. `CODEFYUI_OPENAI_API_KEY` (environment)
 4. `OPENAI_API_KEY` (environment)
 
@@ -112,7 +112,7 @@ Anthropic works the same way with `CODEFYUI_ANTHROPIC_API_KEY` then `ANTHROPIC_A
 
 ## Validate every graph in CI
 
-`run_graph.py` can check a graph without executing it: it discovers all nodes, validates the DAG, types, ports, and Start wiring, and exits non-zero if anything is wrong. That is exactly what you want in CI — a broken graph fails the build. See [CLI Graph Runner](./cli-runner) for the runner itself.
+`run_graph.py` can check a graph without executing it: it discovers all nodes, validates the DAG, types, ports, and Start wiring, and exits non-zero if anything is wrong. That is exactly what you want in CI -- a broken graph fails the build. See [CLI Graph Runner](./cli-runner) for the runner itself.
 
 ```bash
 # locally, from a CodefyUI checkout
@@ -120,7 +120,7 @@ cd backend
 python run_graph.py /path/to/my-graphs/classifier.json --validate-only
 ```
 
-The runner lives inside the CodefyUI backend, and there is no standalone package on PyPI today, so the most reliable way to get it in a *separate* graphs repo is to check CodefyUI out alongside your repo at a pinned release tag and install its backend with uv (mirroring how CodefyUI's own CI installs itself). Installing the backend pulls the full runtime, including PyTorch, so the job is not featherweight — cache the venv or expect a few minutes on a cold run. This is the honest state today; a lightweight validate command is a natural future.
+The runner lives inside the CodefyUI backend, and there is no standalone package on PyPI today, so the most reliable way to get it in a *separate* graphs repo is to check CodefyUI out alongside your repo at a pinned release tag and install its backend with uv (mirroring how CodefyUI's own CI installs itself). Installing the backend pulls the full runtime, including PyTorch, so the job is not featherweight -- cache the venv or expect a few minutes on a cold run. This is the honest state today; a lightweight validate command is a natural future.
 
 The job below assumes this repo carries the project-directory layout (a `codefyui.project.toml` manifest plus `graphs/`/`layout/`) rather than a bare flat `*.json` folder, since `cdui project validate` needs that manifest -- see [Project directories](./project-directories.md) to migrate with `cdui project init <dir> --adopt <this-repo>`. Staying on the flat layout instead? Keep validating file-by-file with `run_graph.py` as shown above.
 
@@ -169,7 +169,7 @@ validation (CI order: restore, then validate).
 
 Version control does not change how you publish: save the graph, then [publish](./publish) it. Because publish snapshots the exact bytes of the saved graph file into the database at publish time, the version you ship is frozen independently of any later edit or commit.
 
-To tie a published version back to its source, put the graph's git commit hash in the publish `note` field — it is free-text, stored with the version, and echoed in the versions list:
+To tie a published version back to its source, put the graph's git commit hash in the publish `note` field -- it is free-text, stored with the version, and echoed in the versions list:
 
 ```json
 {"graph": "classifier", "create": true, "note": "git 1a2b3c4"}
@@ -183,4 +183,4 @@ Versioning graphs works today, but a few things produce friction and are being a
 
 - **Node positions add diff noise.** Dragging a node changes its saved coordinates, so rearranging the canvas produces JSON diffs even when the pipeline is unchanged.
 - **Copy/paste regenerates node ids.** Duplicating nodes assigns fresh ids, which can make a small logical change look like a large diff.
-- **Saving over an existing name overwrites silently.** Saving a graph under a name that already exists replaces the file with no warning — commit early and lean on git to recover a previous version.
+- **Saving over an existing name overwrites silently.** Saving a graph under a name that already exists replaces the file with no warning -- commit early and lean on git to recover a previous version.

--- a/docs/docs/usage/version-control-graphs.md
+++ b/docs/docs/usage/version-control-graphs.md
@@ -6,6 +6,13 @@ description: Keep your graph JSON in a git service repo, validate every graph in
 
 # Version Control Your Graphs
 
+:::tip First-class project directories now exist
+This page describes an older flat-directory recipe whose shape does **not**
+forward-map to the split logic/layout format. For new services use
+[Project directories](./project-directories.md); migrate an existing graphs dir
+in one command: `cdui project init my-service --adopt /path/to/my-graphs`.
+:::
+
 CodefyUI saves each graph as a plain JSON file, so graphs are a natural fit for git: you get history, review, and rollback for the pipelines you build. This page is a recipe for keeping your graphs in their own git repository, validating them in CI, and publishing from a versioned source.
 
 One catch up front: the default save location is **not** version-controlled. Saved graphs land in `backend/data/graphs/`, which the repo's own `.gitignore` excludes (`backend/data/graphs/*.json`, keeping only `.gitkeep`). To version your work you point CodefyUI's graph directory at a repo you own — the rest of this page shows how.
@@ -115,6 +122,8 @@ python run_graph.py /path/to/my-graphs/classifier.json --validate-only
 
 The runner lives inside the CodefyUI backend, and there is no standalone package on PyPI today, so the most reliable way to get it in a *separate* graphs repo is to check CodefyUI out alongside your repo at a pinned release tag and install its backend with uv (mirroring how CodefyUI's own CI installs itself). Installing the backend pulls the full runtime, including PyTorch, so the job is not featherweight — cache the venv or expect a few minutes on a cold run. This is the honest state today; a lightweight validate command is a natural future.
 
+The job below assumes this repo carries the project-directory layout (a `codefyui.project.toml` manifest plus `graphs/`/`layout/`) rather than a bare flat `*.json` folder, since `cdui project validate` needs that manifest -- see [Project directories](./project-directories.md) to migrate with `cdui project init <dir> --adopt <this-repo>`. Staying on the flat layout instead? Keep validating file-by-file with `run_graph.py` as shown above.
+
 ```yaml
 name: validate-graphs
 on: [push, pull_request]
@@ -144,18 +153,17 @@ jobs:
           uv venv
           uv pip install -e .
 
-      - name: Validate every graph
+      - name: Restore plugin pins, then validate the project
         run: |
-          status=0
-          for f in $(git ls-files '*.json'); do
-            echo "== validating $f =="
-            CodefyUI/backend/.venv/bin/python \
-              CodefyUI/backend/run_graph.py "$f" --validate-only || status=1
-          done
-          exit $status
+          cdui project restore .    # or: CodefyUI/backend/.venv/bin/python CodefyUI/scripts/dev.py project restore .
+          cdui project validate .   # runs the full publish pre-flight on every graph
 ```
 
-`git ls-files '*.json'` lists only the JSON files tracked in *your* graphs repo, so the loop skips the nested CodefyUI checkout automatically. Any single failure sets `status=1`, and the final `exit $status` fails the whole job.
+`cdui project validate .` validates every graph in the project through the same
+pre-flight the publish gate uses. It never hands `layout/*.layout.json` files
+to the validator, so there is no `*.json` glob to get wrong. Run
+`cdui project restore` first so plugin-provided nodes are installed before
+validation (CI order: restore, then validate).
 
 ## Publishing from a versioned graph
 
@@ -167,7 +175,7 @@ To tie a published version back to its source, put the graph's git commit hash i
 {"graph": "classifier", "create": true, "note": "git 1a2b3c4"}
 ```
 
-That gives you a trail from a running app version back to the exact commit it came from. First-class project directories and richer publish provenance are on the roadmap.
+That gives you a trail from a running app version back to the exact commit it came from -- or skip the manual `note` convention entirely: [Project directories](./project-directories.md) ship first-class publish provenance, where `cdui project publish` records the exact `git_commit`/`git_dirty` on every version automatically.
 
 ## Known rough edges
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import App from './App';
 import { useTabStore } from './store/tabStore';
 import { useUIStore } from './store/uiStore';
+import { useProjectStore } from './store/projectStore';
+import { fetchHealth } from './api/rest';
 
 // ── Mock heavy children so we test only App's composition logic ───────────────
 // Each stub renders a stable testid so we can assert presence / counts.
@@ -48,6 +50,17 @@ vi.mock('./components/shared/DialogContainer', () => ({
   DialogContainer: () => <div data-testid="dialog-container" />,
 }));
 
+// fetchHealth drives the bootstrap effect's project branch (App.tsx:87-101).
+// Left unmocked, the real implementation's fetch() call rejects in jsdom (no
+// server) and the effect's .catch swallows it silently, so that branch never
+// ran under test. Mocking it here lets the non-project shape PIN the existing
+// tests' behavior below (rather than it being accidental) and lets one
+// dedicated test drive the project-mode rehydration path.
+vi.mock('./api/rest', () => ({
+  fetchHealth: vi.fn(),
+}));
+const mockedFetchHealth = vi.mocked(fetchHealth);
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function resetToSingleTab() {
@@ -60,14 +73,27 @@ function resetToSingleTab() {
 }
 
 beforeEach(() => {
+  useProjectStore.setState({ projectDir: null, projectName: null, loaded: false });
   resetToSingleTab();
   useUIStore.setState({ fontSize: 'default' });
   document.documentElement.style.fontSize = '';
+  localStorage.clear();
+  // Default: non-project health shape, so the pre-existing tests below
+  // exercise (and pin) the same bootstrap branch the real server takes
+  // outside project mode, instead of silently skipping it.
+  mockedFetchHealth.mockReset();
+  mockedFetchHealth.mockResolvedValue({
+    status: 'ok',
+    nodes_loaded: 0,
+    presets_loaded: 0,
+    project: null,
+  });
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   document.documentElement.style.fontSize = '';
+  localStorage.clear();
 });
 
 describe('App', () => {
@@ -195,5 +221,32 @@ describe('App', () => {
     expect(flexContents.length).toBeGreaterThanOrEqual(1);
     // Switching active away (no other tab) keeps it active; sanity: id unchanged.
     expect(useTabStore.getState().activeTabId).toBe(tabId);
+  });
+
+  // -- Health bootstrap -> per-project rehydration (Task 13 review gap, ID10) --
+  // App's bootstrap effect calls setProject(h.project) then
+  // rehydrateForProject(h.project) once fetchHealth resolves (App.tsx:90-94).
+  // The tests above pin the non-project shape via the beforeEach default;
+  // this one drives the project branch and asserts the tab store actually
+  // rehydrated from the project-scoped localStorage key.
+  it('rehydrates tabs for the resolved project once fetchHealth reports one', async () => {
+    localStorage.setItem(
+      'codefyui-tabs::/proj',
+      JSON.stringify({
+        activeTabId: 'p1',
+        tabs: [{ id: 'p1', name: 'project-tab', nodes: [], edges: [] }],
+      }),
+    );
+    mockedFetchHealth.mockResolvedValueOnce({
+      status: 'ok',
+      nodes_loaded: 0,
+      presets_loaded: 0,
+      project: '/proj',
+    });
+    render(<App />);
+    await waitFor(() => {
+      expect(useTabStore.getState().tabs.some((t) => t.name === 'project-tab')).toBe(true);
+    });
+    expect(useProjectStore.getState().projectDir).toBe('/proj');
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,8 @@ import { PluginHost } from './plugins/PluginHost';
 import { useTabStore } from './store/tabStore';
 import { useUIStore } from './store/uiStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import { fetchHealth } from './api/rest';
+import { useProjectStore } from './store/projectStore';
 import styles from './App.module.css';
 
 // Map user font-size choice to the documentElement. Setting an empty string
@@ -81,6 +83,20 @@ function App() {
   useEffect(() => {
     document.documentElement.style.fontSize = FONT_SIZE_PX[fontSize] ?? '';
   }, [fontSize]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchHealth()
+      .then((h) => {
+        if (!cancelled) useProjectStore.getState().setProject(h.project);
+      })
+      .catch(() => {
+        /* health unreachable -- stay in non-project defaults */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <div className={styles.root}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -88,7 +88,9 @@ function App() {
     let cancelled = false;
     fetchHealth()
       .then((h) => {
-        if (!cancelled) useProjectStore.getState().setProject(h.project);
+        if (cancelled) return;
+        useProjectStore.getState().setProject(h.project);
+        useTabStore.getState().rehydrateForProject(h.project);
       })
       .catch(() => {
         /* health unreachable -- stay in non-project defaults */

--- a/frontend/src/api/rest.test.ts
+++ b/frontend/src/api/rest.test.ts
@@ -4,6 +4,7 @@ import {
   fetchNodeDefinitions,
   fetchPresetDefinitions,
   fetchDevices,
+  fetchHealth,
   validateGraph,
   saveGraph,
   loadGraph,
@@ -176,6 +177,35 @@ describe('GET endpoints', () => {
       await expect(c.fn()).rejects.toThrow(c.errorRe);
     });
   }
+});
+
+// fetchHealth is NOT a plain passthrough GET (unlike the `cases` table
+// above): it normalizes the backend's project-mode-only `project` key so
+// callers never see `undefined`. Covered separately so that distinction is
+// pinned explicitly (Task 12 controller item 1).
+describe('fetchHealth', () => {
+  it('passes through the project path string when present (project mode)', async () => {
+    const fetchMock = mockFetch(200, {
+      status: 'ok', nodes_loaded: 3, presets_loaded: 1, project: '/home/me/my-service',
+    });
+    const out = await fetchHealth();
+    expect(fetchMock).toHaveBeenCalledWith('/api/health');
+    expect(out).toEqual({
+      status: 'ok', nodes_loaded: 3, presets_loaded: 1, project: '/home/me/my-service',
+    });
+  });
+
+  it('normalizes an ABSENT project key (non-project mode) to null, never undefined', async () => {
+    mockFetch(200, { status: 'ok', nodes_loaded: 3, presets_loaded: 1 });
+    const out = await fetchHealth();
+    expect(out.project).toBeNull();
+    expect('project' in out).toBe(true);
+  });
+
+  it('throws on a non-ok response', async () => {
+    mockFetch(500, {});
+    await expect(fetchHealth()).rejects.toThrow(/Health failed/);
+  });
 });
 
 describe('loadGraph', () => {

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -15,6 +15,35 @@ export async function fetchPresetDefinitions(): Promise<PresetDefinition[]> {
   return res.json();
 }
 
+export interface HealthInfo {
+  status: string;
+  nodes_loaded: number;
+  presets_loaded: number;
+  project: string | null;
+}
+
+/**
+ * /api/health, including the additive `project` field (spec ID4).
+ *
+ * The backend (backend/app/main.py) OMITS the `project` key entirely in
+ * non-project mode -- it is never sent as `null`. Normalize that gap here so
+ * `HealthInfo.project` is always exactly `string | null`, never `undefined`:
+ * `useProjectStore.setProject` / `isProjectMode` key off a strict
+ * `!== null` check, which `undefined` would satisfy and misreport project
+ * mode as active.
+ */
+export async function fetchHealth(): Promise<HealthInfo> {
+  const res = await fetch(`${BASE_URL}/health`);
+  if (!res.ok) throw new Error(`Health failed: ${res.statusText}`);
+  const data = await res.json();
+  return {
+    status: data.status,
+    nodes_loaded: data.nodes_loaded,
+    presets_loaded: data.presets_loaded,
+    project: data.project ?? null,
+  };
+}
+
 export interface DeviceInfo {
   value: string;
   label: string;

--- a/frontend/src/components/Toolbar/ProjectBadge.test.tsx
+++ b/frontend/src/components/Toolbar/ProjectBadge.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ProjectBadge } from './ProjectBadge';
+import { useProjectStore } from '../../store/projectStore';
+
+beforeEach(() => useProjectStore.setState({ projectDir: null, projectName: null, loaded: false }));
+
+describe('ProjectBadge', () => {
+  it('renders nothing in non-project mode', () => {
+    const { container } = render(<ProjectBadge />);
+    expect(container.firstChild).toBeNull();
+  });
+  it('shows the project name in project mode', () => {
+    useProjectStore.getState().setProject('/home/me/my-service');
+    render(<ProjectBadge />);
+    expect(screen.queryByText('my-service')).not.toBeNull();
+  });
+});

--- a/frontend/src/components/Toolbar/ProjectBadge.tsx
+++ b/frontend/src/components/Toolbar/ProjectBadge.tsx
@@ -1,0 +1,21 @@
+import { useProjectStore } from '../../store/projectStore';
+import { useI18n } from '../../i18n';
+
+/** Editor-header badge naming the active project (nothing in non-project mode). */
+export function ProjectBadge() {
+  const projectName = useProjectStore((s) => s.projectName);
+  const { t } = useI18n();
+  if (!projectName) return null;
+  return (
+    <span
+      title={t('project.badge.title')}
+      style={{
+        marginLeft: '0.5rem', padding: '0.1rem 0.5rem', fontSize: '0.75rem',
+        borderRadius: '4px', background: 'rgba(6,182,212,0.15)',
+        color: '#06b6d4', fontWeight: 600, whiteSpace: 'nowrap',
+      }}
+    >
+      {projectName}
+    </span>
+  );
+}

--- a/frontend/src/components/Toolbar/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.test.tsx
@@ -797,6 +797,70 @@ describe('Toolbar', () => {
     );
   });
 
+  // -- Import: readOnly handling (ID8 fast-follow, task 16 review Adjudication B) --
+  // handleImportFile previously never touched `readOnly`: importing an
+  // ordinary file into a tab that had loaded a too-new graph left it stuck
+  // read-only forever (over-blocking), while importing a NEWER-format file
+  // into a normal tab left it editable (the same lossy-copy hazard Ruling A
+  // documented for loads, but unguarded on the import path). Scoped in its
+  // own describe, like the sibling "Load: project origin stamping" block
+  // above, because `setActiveTab()` (outer beforeEach) copies `readOnly`
+  // forward from whatever the previous test's tab was left with via
+  // `...real` -- pin a clean baseline here and reset after so later tests
+  // in this file can't inherit a stuck read-only flag from run order.
+  describe('Import: readOnly handling (ID8 fast-follow)', () => {
+    beforeEach(() => {
+      setActiveTab({ readOnly: false, projectOrigin: null });
+    });
+
+    afterEach(() => {
+      useTabStore.getState().setTabReadOnly(false);
+    });
+
+    it('importing a current-format file into a read-only tab clears readOnly and Save is no longer refused', async () => {
+      mockedRest.saveGraph.mockResolvedValueOnce({} as never);
+      setActiveTab({ readOnly: true, projectOrigin: null });
+      render(<Toolbar />);
+
+      const payload = JSON.stringify({ nodes: [], edges: [], format_version: 1 });
+      const file = new File([payload], 'current.json', { type: 'application/json' });
+      fireEvent.change(fileInput(), { target: { files: [file] } });
+
+      await waitFor(() => expect(useTabStore.getState().tabs[0].readOnly).toBe(false));
+
+      // Save is no longer refused: saveGraph is actually reached (the
+      // read-only guard in saveActiveGraph would otherwise short-circuit
+      // before ever calling it).
+      fireEvent.click(screen.getByText('File'));
+      fireEvent.click(screen.getByText('Save'));
+      await resolveDialog('now-editable');
+      await waitFor(() =>
+        expect(mockedRest.saveGraph).toHaveBeenCalledWith(expect.objectContaining({ name: 'now-editable' })),
+      );
+    });
+
+    it('importing a current-format file into an already-editable tab leaves readOnly false', async () => {
+      render(<Toolbar />);
+      const payload = JSON.stringify({ nodes: [], edges: [], format_version: 1 });
+      const file = new File([payload], 'current.json', { type: 'application/json' });
+      fireEvent.change(fileInput(), { target: { files: [file] } });
+      await waitFor(() => expect(fileInput().value).toBe(''));
+      expect(useTabStore.getState().tabs[0].readOnly).toBe(false);
+    });
+
+    it('importing a newer-format file into a normal tab sets readOnly and toasts a warning', async () => {
+      render(<Toolbar />);
+      const payload = JSON.stringify({ nodes: [], edges: [], format_version: 999 });
+      const file = new File([payload], 'newer.json', { type: 'application/json' });
+      fireEvent.change(fileInput(), { target: { files: [file] } });
+
+      await waitFor(() => expect(useTabStore.getState().tabs[0].readOnly).toBe(true));
+      expect(
+        useToastStore.getState().toasts.some((t) => t.type === 'warning' && t.message.includes('v999')),
+      ).toBe(true);
+    });
+  });
+
   // ── Export menu actions ─────────────────────────────────────────────
 
   it('Export JSON: empty canvas warns', () => {

--- a/frontend/src/components/Toolbar/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.test.tsx
@@ -539,6 +539,60 @@ describe('Toolbar', () => {
     });
   });
 
+  // -- Load: project-mode origin stamping (Task 13 review gap, ID10) --
+  // handleLoadGraph stamps the active tab's projectOrigin with the open
+  // project's dir right after a successful load (Toolbar.tsx:317-318), but
+  // only while a project is open. Scoped in its own describe so the extra
+  // localStorage reset doesn't touch the rest of this file's tests.
+  describe('Load: project origin stamping (ID10)', () => {
+    beforeEach(() => {
+      localStorage.clear();
+      // setActiveTab() (outer beforeEach) copies forward whatever
+      // `projectOrigin` the previous test's tab was left with via `...real` --
+      // pin a clean baseline here so these two tests are independent of run
+      // order and of each other.
+      setActiveTab({ projectOrigin: null });
+    });
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('project mode: stamps the active tab projectOrigin with the open project dir', async () => {
+      useProjectStore.setState({ projectDir: '/proj', projectName: 'proj', loaded: true });
+      mockedRest.listGraphs.mockResolvedValueOnce([{ name: 'Alpha', file: 'alpha' }] as never);
+      mockedRest.loadGraph.mockResolvedValueOnce({ nodes: [], edges: [] } as never);
+      render(<Toolbar />);
+      fireEvent.click(screen.getByText('Load'));
+      await waitFor(() => expect(screen.getByText('Alpha')).toBeInTheDocument());
+      fireEvent.click(screen.getByText('Alpha'));
+      await waitFor(() => expect(mockedRest.loadGraph).toHaveBeenCalledWith('alpha'));
+      await waitFor(() => {
+        const tab = useTabStore.getState().tabs[0];
+        expect(tab.projectOrigin).toBe('/proj');
+        expect(tab.currentGraphFile).toBe('alpha');
+      });
+    });
+
+    it('non-project mode: projectOrigin stays null after the same load', async () => {
+      // projectDir stays null via the outer beforeEach default -- no project open.
+      mockedRest.listGraphs.mockResolvedValueOnce([{ name: 'Alpha', file: 'alpha' }] as never);
+      mockedRest.loadGraph.mockResolvedValueOnce({ nodes: [], edges: [] } as never);
+      render(<Toolbar />);
+      fireEvent.click(screen.getByText('Load'));
+      await waitFor(() => expect(screen.getByText('Alpha')).toBeInTheDocument());
+      fireEvent.click(screen.getByText('Alpha'));
+      await waitFor(() => expect(mockedRest.loadGraph).toHaveBeenCalledWith('alpha'));
+      await waitFor(() => {
+        const tab = useTabStore.getState().tabs[0];
+        // Load still ran to completion (proves the guard's false branch, not
+        // just an untouched default) -- only projectOrigin stays unset.
+        expect(tab.currentGraphFile).toBe('alpha');
+        expect(tab.projectOrigin).toBeNull();
+      });
+    });
+  });
+
   // ── Load: layout_missing branch (Task 11 gate; Task 12 controller item 2) ──
   //
   // Pins handleLoadGraph's project-mode fallback: a `layout_missing: true`

--- a/frontend/src/components/Toolbar/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.test.tsx
@@ -7,6 +7,7 @@ import { useUIStore } from '../../store/uiStore';
 import { useNodeDefStore } from '../../store/nodeDefStore';
 import { useToastStore } from '../../store/toastStore';
 import { useDialogStore } from '../../store/dialogStore';
+import { useProjectStore } from '../../store/projectStore';
 import { useI18n } from '../../i18n';
 import * as rest from '../../api/rest';
 import * as exportDiagram from '../../utils/exportDiagram';
@@ -102,6 +103,7 @@ describe('Toolbar', () => {
       fontSize: 'default',
     });
     useNodeDefStore.setState({ definitions: [], presets: [], categorized: {}, presetCategorized: {} });
+    useProjectStore.setState({ projectDir: null, projectName: null, loaded: false });
     setActiveTab();
 
     // Stub blob-download plumbing (jsdom lacks createObjectURL).
@@ -347,6 +349,35 @@ describe('Toolbar', () => {
     );
   });
 
+  // ── Project-mode Save / Save As (delegated through saveActiveGraph -- ID9) ──
+
+  it('Save (project mode, bound): overwrites the bound file in place, no prompt', async () => {
+    useProjectStore.setState({ projectDir: '/proj', projectName: 'proj', loaded: true });
+    mockedRest.saveGraph.mockResolvedValueOnce({} as never);
+    setActiveTab({ currentGraphFile: 'bound-graph' });
+    render(<Toolbar />);
+    fireEvent.click(screen.getByText('File'));
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() =>
+      expect(mockedRest.saveGraph).toHaveBeenCalledWith(expect.objectContaining({ name: 'bound-graph' })),
+    );
+    // No dialog was ever opened for the in-place overwrite.
+    expect(useDialogStore.getState().active).toBeNull();
+  });
+
+  it('Save As (project mode, bound): still prompts, saving under the entered name', async () => {
+    useProjectStore.setState({ projectDir: '/proj', projectName: 'proj', loaded: true });
+    mockedRest.saveGraph.mockResolvedValueOnce({} as never);
+    setActiveTab({ currentGraphFile: 'bound-graph' });
+    render(<Toolbar />);
+    fireEvent.click(screen.getByText('File'));
+    fireEvent.click(screen.getByText('Save As...'));
+    await resolveDialog('bound-graph-copy');
+    await waitFor(() =>
+      expect(mockedRest.saveGraph).toHaveBeenCalledWith(expect.objectContaining({ name: 'bound-graph-copy' })),
+    );
+  });
+
   // ── Clear action ────────────────────────────────────────────────────
 
   it('Clear: confirmed clears the canvas', async () => {
@@ -506,6 +537,80 @@ describe('Toolbar', () => {
       // Bound to the loaded file so re-saving under the same name is silent.
       expect(tab.currentGraphFile).toBe('alpha');
     });
+  });
+
+  // ── Load: layout_missing branch (Task 11 gate; Task 12 controller item 2) ──
+  //
+  // Pins handleLoadGraph's project-mode fallback: a `layout_missing: true`
+  // response runs the nodes through autoLayout + stackUnboundNotes (instead
+  // of using the file's stored positions) with NO toast and NO undo-stack
+  // push (setNodes is called directly, bypassing applyLayout). Black-box
+  // against handleLoadGraph's public behavior only -- no internal spies.
+
+  it('Load: layout_missing true auto-lays-out nodes and stacks unbound notes, with no toast/undo push', async () => {
+    mockedRest.listGraphs.mockResolvedValueOnce([{ name: 'Proj', file: 'proj' }] as never);
+    mockedRest.loadGraph.mockResolvedValueOnce({
+      nodes: [
+        // 9999,9999 is not a placement dagre's LR ranked layout would ever
+        // produce for a 2-node graph -- any change proves a real layout ran,
+        // independent of dagre's own coordinate convention (which may start
+        // a rank at x=0, indistinguishable from an untouched (0,0) input).
+        { id: 'n1', type: 'Add', position: { x: 9999, y: 9999 }, data: { params: {} } },
+        { id: 'n2', type: 'Add', position: { x: 9999, y: 9999 }, data: { params: {} } },
+        { id: 'note1', type: 'note', position: { x: 999, y: 999 }, data: {} },
+      ],
+      edges: [{ id: 'e1', source: 'n1', target: 'n2', sourceHandle: '', targetHandle: '' }],
+      layout_missing: true,
+    } as never);
+    render(<Toolbar />);
+    fireEvent.click(screen.getByText('Load'));
+    await waitFor(() => expect(screen.getByText('Proj')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Proj'));
+    await waitFor(() => expect(mockedRest.loadGraph).toHaveBeenCalledWith('proj'));
+
+    await waitFor(() => {
+      const tab = useTabStore.getState().tabs[0];
+      const n1 = tab.nodes.find((n) => n.id === 'n1')!;
+      const n2 = tab.nodes.find((n) => n.id === 'n2')!;
+      const note = tab.nodes.find((n) => n.id === 'note1')!;
+      // dagre actually laid the connected pair out (positions diverge from
+      // the identical (9999,9999)/(9999,9999) the "file" supplied, and from
+      // each other -- LR rank order puts n1/n2 at different x).
+      expect(n1.position).not.toEqual({ x: 9999, y: 9999 });
+      expect(n2.position).not.toEqual({ x: 9999, y: 9999 });
+      expect(n1.position.x).not.toBe(n2.position.x);
+      // stackUnboundNotes deterministically places the lone unbound note.
+      expect(note.position).toEqual({ x: -320, y: 0 });
+    });
+    // No success toast and no undo snapshot from the layout_missing path.
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+    expect(useTabStore.getState().tabs[0].undoStack).toHaveLength(0);
+  });
+
+  it('Load: layout_missing absent (or false) keeps the file positions unchanged', async () => {
+    mockedRest.listGraphs.mockResolvedValueOnce([{ name: 'Proj', file: 'proj' }] as never);
+    mockedRest.loadGraph.mockResolvedValueOnce({
+      nodes: [
+        { id: 'n1', type: 'Add', position: { x: 123, y: 456 }, data: { params: {} } },
+        { id: 'note1', type: 'note', position: { x: 50, y: 50 }, data: {} },
+      ],
+      edges: [],
+      // layout_missing intentionally omitted
+    } as never);
+    render(<Toolbar />);
+    fireEvent.click(screen.getByText('Load'));
+    await waitFor(() => expect(screen.getByText('Proj')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Proj'));
+    await waitFor(() => expect(mockedRest.loadGraph).toHaveBeenCalledWith('proj'));
+
+    await waitFor(() => {
+      const tab = useTabStore.getState().tabs[0];
+      expect(tab.nodes.find((n) => n.id === 'n1')!.position).toEqual({ x: 123, y: 456 });
+      // Unbound note is untouched too -- stackUnboundNotes never runs on this branch.
+      expect(tab.nodes.find((n) => n.id === 'note1')!.position).toEqual({ x: 50, y: 50 });
+    });
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+    expect(useTabStore.getState().tabs[0].undoStack).toHaveLength(0);
   });
 
   it('Load: loadGraph rejection toasts an error', async () => {

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -12,6 +12,7 @@ import { confirm, prompt } from '../../utils/dialog';
 import { saveActiveGraph } from '../../utils/saveActiveGraph';
 import { CustomNodeManager } from '../CustomNodeManager/CustomNodeManager';
 import { useToastStore } from '../../store/toastStore';
+import { useProjectStore } from '../../store/projectStore';
 import { autoLayout, stackUnboundNotes, type LayoutMode } from '../../utils/autoLayout';
 // Aliased: this file already casts DOM MouseEvent targets to the ambient
 // lib.dom `Node` type (see the mousedown handlers below) -- importing
@@ -20,6 +21,7 @@ import type { Node as FlowNode } from '@xyflow/react';
 import type { NodeData } from '../../types';
 import { SettingsPopover } from './SettingsPopover';
 import { FontSizeMenu } from './FontSizeMenu';
+import { ProjectBadge } from './ProjectBadge';
 import styles from './Toolbar.module.css';
 
 /* ── Shared dropdown menu ───────────────────────────────────────── */
@@ -312,6 +314,8 @@ export function Toolbar() {
         // `name` is the sanitized file stem — bind the tab to it so re-saving
         // under the same name doesn't trigger the overwrite warning.
         setCurrentGraphFile(name);
+        const projectDir = useProjectStore.getState().projectDir;
+        if (projectDir !== null) useTabStore.getState().stampActiveTabProject(projectDir);
         if (savedPresets.length > 0) {
           useNodeDefStore.setState({ presets: mergedPresets });
         }
@@ -498,6 +502,7 @@ export function Toolbar() {
         <span className={styles.logoBrand}>Codefy</span>
         <span className={styles.logoSuffix}>UI</span>
       </div>
+      <ProjectBadge />
 
       {/* Run / Stop */}
       <div className={styles.cluster}>

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -11,7 +11,12 @@ import { graphToSvg, svgToPngBlob } from '../../utils/exportDiagram';
 import { confirm, prompt } from '../../utils/dialog';
 import { CustomNodeManager } from '../CustomNodeManager/CustomNodeManager';
 import { useToastStore } from '../../store/toastStore';
-import type { LayoutMode } from '../../utils/autoLayout';
+import { autoLayout, stackUnboundNotes, type LayoutMode } from '../../utils/autoLayout';
+// Aliased: this file already casts DOM MouseEvent targets to the ambient
+// lib.dom `Node` type (see the mousedown handlers below) -- importing
+// @xyflow/react's `Node` unaliased would shadow that global and break them.
+import type { Node as FlowNode } from '@xyflow/react';
+import type { NodeData } from '../../types';
 import { SettingsPopover } from './SettingsPopover';
 import { FontSizeMenu } from './FontSizeMenu';
 import styles from './Toolbar.module.css';
@@ -333,7 +338,18 @@ export function Toolbar() {
         }
         const resolvedNodes = resolveSerializedNodes(rawNodes, store.definitions, mergedPresets);
         const resolvedEdges = resolveSerializedEdges(rawEdges);
-        setNodes(resolvedNodes);
+        // Missing/incomplete layout (project mode): dagre-lay-out ALL nodes
+        // directly -- NOT via applyLayout, which pushes an undo snapshot and a
+        // toast -- then deterministically place unbound notes. The next save
+        // persists the computed layout (spec 6.3).
+        if (graphData.layout_missing) {
+          const laid = stackUnboundNotes(
+            autoLayout(resolvedNodes, resolvedEdges, 'all'),
+          ) as FlowNode<NodeData>[];
+          setNodes(laid);
+        } else {
+          setNodes(resolvedNodes);
+        }
         setEdges(resolvedEdges);
         setDescription(typeof graphData.description === 'string' ? graphData.description : '');
         setSegmentGroups(Array.isArray(graphData.segmentGroups) ? graphData.segmentGroups : []);

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -3,12 +3,13 @@ import { useGraphExecution } from '../../hooks/useGraphExecution';
 import { useTabStore } from '../../store/tabStore';
 import { useNodeDefStore } from '../../store/nodeDefStore';
 import { useUIStore } from '../../store/uiStore';
-import { saveGraph, loadGraph, listGraphs, createPreset, exportGraph } from '../../api/rest';
+import { loadGraph, listGraphs, createPreset, exportGraph } from '../../api/rest';
 import { useI18n, SUPPORTED_LOCALES } from '../../i18n';
 import type { TranslationKey } from '../../i18n';
-import { resolveSerializedNodes, resolveSerializedEdges, sanitizeGraphName, findGraphNameCollision } from '../../utils';
+import { resolveSerializedNodes, resolveSerializedEdges } from '../../utils';
 import { graphToSvg, svgToPngBlob } from '../../utils/exportDiagram';
 import { confirm, prompt } from '../../utils/dialog';
+import { saveActiveGraph } from '../../utils/saveActiveGraph';
 import { CustomNodeManager } from '../CustomNodeManager/CustomNodeManager';
 import { useToastStore } from '../../store/toastStore';
 import { autoLayout, stackUnboundNotes, type LayoutMode } from '../../utils/autoLayout';
@@ -265,53 +266,8 @@ export function Toolbar() {
   const handleRun = useCallback(() => execute(), [execute]);
   const handleStop = useCallback(() => stop(), [stop]);
 
-  const handleSave = useCallback(async () => {
-    const name = await prompt({
-      title: t('toolbar.save.prompt'),
-      placeholder: 'graph-name',
-    });
-    const trimmed = name?.trim();
-    if (!trimmed) return;
-
-    // Overwrite guard: two different display names can sanitize to the same
-    // file, so warn only when the sanitized target collides with a DIFFERENT
-    // saved graph (re-saving the currently-open graph is silent). A failed
-    // list fetch must not block saving — default to no collision.
-    let existing: { name: string; file: string }[] = [];
-    try {
-      const result = await listGraphs();
-      if (Array.isArray(result)) existing = result;
-    } catch {
-      /* list unavailable — skip the overwrite check and proceed to save */
-    }
-    const collidingName = findGraphNameCollision(trimmed, existing, activeTab.currentGraphFile);
-    if (collidingName !== null) {
-      const ok = await confirm({
-        title: t('toolbar.save.overwriteConfirm', { name: collidingName }),
-        confirmText: t('toolbar.save'),
-        variant: 'danger',
-      });
-      if (!ok) return;
-    }
-
-    try {
-      const { nodes, edges, presets, segmentGroups } = getSerializedGraph();
-      await saveGraph({
-        nodes,
-        edges,
-        name: trimmed,
-        description: activeTab.description ?? '',
-        presets,
-        segmentGroups,
-      });
-      // Bind the tab to the graph it was just saved as (drives the overwrite
-      // guard on the next save).
-      setCurrentGraphFile(sanitizeGraphName(trimmed));
-      addToast(t('toolbar.save.success', { name: trimmed }), 'success');
-    } catch (e) {
-      addToast(t('toolbar.save.fail', { error: (e as Error).message }), 'error');
-    }
-  }, [getSerializedGraph, t, addToast, activeTab.currentGraphFile, activeTab.description, setCurrentGraphFile]);
+  const handleSave = useCallback(() => saveActiveGraph(), []);
+  const handleSaveAs = useCallback(() => saveActiveGraph({ saveAs: true }), []);
 
   const handleClear = useCallback(async () => {
     const ok = await confirm({
@@ -507,6 +463,7 @@ export function Toolbar() {
 
   const fileMenuItems: MenuItem[] = [
     { label: t('toolbar.save'), title: t('toolbar.save.title'), onClick: handleSave },
+    { label: t('toolbar.saveAs'), title: t('toolbar.saveAs.title'), onClick: handleSaveAs },
     { label: t('toolbar.clear'), title: t('toolbar.clear.title'), onClick: handleClear },
   ];
 

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -10,6 +10,7 @@ import { resolveSerializedNodes, resolveSerializedEdges } from '../../utils';
 import { graphToSvg, svgToPngBlob } from '../../utils/exportDiagram';
 import { confirm, prompt } from '../../utils/dialog';
 import { saveActiveGraph } from '../../utils/saveActiveGraph';
+import { GRAPH_FORMAT_VERSION } from '../../utils/formatVersion';
 import { CustomNodeManager } from '../CustomNodeManager/CustomNodeManager';
 import { useToastStore } from '../../store/toastStore';
 import { useProjectStore } from '../../store/projectStore';
@@ -311,6 +312,12 @@ export function Toolbar() {
         setEdges(resolvedEdges);
         setDescription(typeof graphData.description === 'string' ? graphData.description : '');
         setSegmentGroups(Array.isArray(graphData.segmentGroups) ? graphData.segmentGroups : []);
+        const tooNew = typeof graphData.format_version === 'number'
+          && graphData.format_version > GRAPH_FORMAT_VERSION;
+        useTabStore.getState().setTabReadOnly(tooNew);
+        if (tooNew) {
+          addToast(t('project.readOnly.loadNotice', { version: graphData.format_version }), 'warning');
+        }
         // `name` is the sanitized file stem — bind the tab to it so re-saving
         // under the same name doesn't trigger the overwrite warning.
         setCurrentGraphFile(name);

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -10,7 +10,7 @@ import { resolveSerializedNodes, resolveSerializedEdges } from '../../utils';
 import { graphToSvg, svgToPngBlob } from '../../utils/exportDiagram';
 import { confirm, prompt } from '../../utils/dialog';
 import { saveActiveGraph } from '../../utils/saveActiveGraph';
-import { GRAPH_FORMAT_VERSION } from '../../utils/formatVersion';
+import { isFormatTooNew } from '../../utils/formatVersion';
 import { CustomNodeManager } from '../CustomNodeManager/CustomNodeManager';
 import { useToastStore } from '../../store/toastStore';
 import { useProjectStore } from '../../store/projectStore';
@@ -312,8 +312,7 @@ export function Toolbar() {
         setEdges(resolvedEdges);
         setDescription(typeof graphData.description === 'string' ? graphData.description : '');
         setSegmentGroups(Array.isArray(graphData.segmentGroups) ? graphData.segmentGroups : []);
-        const tooNew = typeof graphData.format_version === 'number'
-          && graphData.format_version > GRAPH_FORMAT_VERSION;
+        const tooNew = isFormatTooNew(graphData.format_version);
         useTabStore.getState().setTabReadOnly(tooNew);
         if (tooNew) {
           addToast(t('project.readOnly.loadNotice', { version: graphData.format_version }), 'warning');
@@ -360,6 +359,15 @@ export function Toolbar() {
           setEdges(resolvedEdges);
           setDescription(typeof data.description === 'string' ? data.description : '');
           setSegmentGroups(Array.isArray(data.segmentGroups) ? data.segmentGroups : []);
+          // Same format-version gate as handleLoadGraph (ID8 fast-follow):
+          // importing a newer-format file must open it read-only too, and
+          // importing an ordinary file into a previously read-only tab must
+          // clear the stale flag -- called unconditionally either way.
+          const tooNew = isFormatTooNew(data.format_version);
+          useTabStore.getState().setTabReadOnly(tooNew);
+          if (tooNew) {
+            addToast(t('project.readOnly.loadNotice', { version: data.format_version }), 'warning');
+          }
           // An imported file is a fresh, unsaved graph — not bound to any
           // saved file yet, so the next save always runs the overwrite check.
           setCurrentGraphFile(null);

--- a/frontend/src/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.test.ts
@@ -3,6 +3,12 @@ import { renderHook } from '@testing-library/react';
 import { useKeyboardShortcuts } from './useKeyboardShortcuts';
 import { useTabStore } from '../store/tabStore';
 import { useUIStore } from '../store/uiStore';
+import { useProjectStore } from '../store/projectStore';
+import { saveActiveGraph } from '../utils/saveActiveGraph';
+
+vi.mock('../utils/saveActiveGraph', () => ({
+  saveActiveGraph: vi.fn(),
+}));
 
 // Spy holders for the store actions the handler dispatches to.
 let undo: ReturnType<typeof vi.fn>;
@@ -23,6 +29,8 @@ beforeEach(() => {
   // Override only the actions exercised here; leave the rest of the store intact.
   useTabStore.setState({ undo, redo, copySelectedNodes, pasteNodes, applyLayout } as any);
   useUIStore.setState({ toggleShortcutsModal, lastLayoutMode: 'all' } as any);
+  useProjectStore.setState({ projectDir: null, projectName: null, loaded: false });
+  vi.mocked(saveActiveGraph).mockClear();
 });
 
 afterEach(() => {
@@ -84,6 +92,35 @@ describe('useKeyboardShortcuts', () => {
     const e = dispatchKey({ key: 'v', ctrlKey: true });
     expect(pasteNodes).toHaveBeenCalledTimes(1);
     expect(e.defaultPrevented).toBe(true);
+  });
+
+  it('Ctrl+S saves in project mode and prevents the browser default', () => {
+    useProjectStore.setState({ projectDir: '/proj', projectName: 'proj', loaded: true });
+    renderHook(() => useKeyboardShortcuts());
+    const e = dispatchKey({ key: 's', ctrlKey: true });
+    expect(saveActiveGraph).toHaveBeenCalledTimes(1);
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it('Cmd+S (metaKey) also saves in project mode', () => {
+    useProjectStore.setState({ projectDir: '/proj', projectName: 'proj', loaded: true });
+    renderHook(() => useKeyboardShortcuts());
+    dispatchKey({ key: 's', metaKey: true });
+    expect(saveActiveGraph).toHaveBeenCalledTimes(1);
+  });
+
+  it('Ctrl+S is a no-op in non-project mode, leaving the browser Save dialog untouched', () => {
+    renderHook(() => useKeyboardShortcuts());
+    const e = dispatchKey({ key: 's', ctrlKey: true });
+    expect(saveActiveGraph).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it('Ctrl+Shift+S does not trigger save (reserved combination, shiftKey excluded)', () => {
+    useProjectStore.setState({ projectDir: '/proj', projectName: 'proj', loaded: true });
+    renderHook(() => useKeyboardShortcuts());
+    dispatchKey({ key: 's', ctrlKey: true, shiftKey: true });
+    expect(saveActiveGraph).not.toHaveBeenCalled();
   });
 
   it('? toggles the shortcuts modal', () => {

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { useTabStore } from '../store/tabStore';
 import { useUIStore } from '../store/uiStore';
+import { useProjectStore } from '../store/projectStore';
+import { saveActiveGraph } from '../utils/saveActiveGraph';
 
 export function useKeyboardShortcuts() {
   useEffect(() => {
@@ -44,6 +46,16 @@ export function useKeyboardShortcuts() {
       if (mod && !e.shiftKey && e.key === 'v') {
         e.preventDefault();
         useTabStore.getState().pasteNodes();
+        return;
+      }
+
+      // Ctrl+S / Cmd+S — Save. Project mode only, so non-project keeps the
+      // browser's native behavior and this never hijacks it (ID9).
+      if (mod && !e.shiftKey && e.key === 's') {
+        if (useProjectStore.getState().projectDir !== null) {
+          e.preventDefault();
+          void saveActiveGraph();
+        }
         return;
       }
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -17,6 +17,8 @@ const en = {
   'toolbar.save.success': 'Graph "{name}" saved successfully.',
   'toolbar.save.fail': 'Save failed: {error}',
   'toolbar.save.overwriteConfirm': 'A graph named {name} already exists and will be overwritten - continue?',
+  'toolbar.saveAs': 'Save As...',
+  'toolbar.saveAs.title': 'Save under a new name',
   'toolbar.load': 'Load',
   'toolbar.load.title': 'Load a saved graph',
   'toolbar.load.fail': 'Load failed: {error}',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -425,6 +425,10 @@ const en = {
   'toolbar.layoutMode.aria': 'Layout mode',
   'toolbar.language.aria': 'Language',
   'persistence.quotaError': 'Could not save tabs — browser storage is full.',
+
+  // Per-project tab scoping (ID10): header badge + cross-project save refusal.
+  'project.badge.title': 'Active project directory',
+  'project.save.crossProjectRefused': 'This graph belongs to another project ({origin}) and cannot be saved into the open project.',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -429,6 +429,11 @@ const en = {
   // Per-project tab scoping (ID10): header badge + cross-project save refusal.
   'project.badge.title': 'Active project directory',
   'project.save.crossProjectRefused': 'This graph belongs to another project ({origin}) and cannot be saved into the open project.',
+
+  // format_version read policy (ID8): newer-than-this-build graphs open
+  // read-only, never blocked on load.
+  'project.readOnly.loadNotice': 'Opened read-only: this graph uses a newer format (v{version}) than this CodefyUI build.',
+  'project.readOnly.saveBlocked': 'Save is disabled: this graph was written by a newer CodefyUI. Update CodefyUI to edit it.',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -19,6 +19,8 @@ const zhTW: Record<TranslationKey, string> = {
   'toolbar.save.success': '圖表「{name}」儲存成功。',
   'toolbar.save.fail': '儲存失敗：{error}',
   'toolbar.save.overwriteConfirm': '已存在名為 {name} 的圖，存檔將會覆蓋它。要繼續嗎？',
+  'toolbar.saveAs': '另存為...',
+  'toolbar.saveAs.title': '以新名稱儲存',
   'toolbar.load': '載入',
   'toolbar.load.title': '載入已儲存的圖表',
   'toolbar.load.fail': '載入失敗：{error}',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -430,6 +430,10 @@ const zhTW: Record<TranslationKey, string> = {
   // 專案範圍的分頁持久化（ID10）：標題徽章 + 跨專案儲存拒絕
   'project.badge.title': '目前的專案目錄',
   'project.save.crossProjectRefused': '此圖屬於另一個專案（{origin}），無法儲存到目前開啟的專案。',
+
+  // format_version 讀取政策（ID8）：比目前版本更新的圖只會以唯讀開啟，載入時絕不阻擋
+  'project.readOnly.loadNotice': '以唯讀開啟：此圖使用比目前版本更新的格式（v{version}）。',
+  'project.readOnly.saveBlocked': '儲存已停用：此圖由較新版本的 CodefyUI 寫入，請更新 CodefyUI 後再編輯。',
 };
 
 export default zhTW;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -426,6 +426,10 @@ const zhTW: Record<TranslationKey, string> = {
   'toolbar.layoutMode.aria': '排版模式',
   'toolbar.language.aria': '語言',
   'persistence.quotaError': '無法儲存分頁 — 瀏覽器儲存空間已滿。',
+
+  // 專案範圍的分頁持久化（ID10）：標題徽章 + 跨專案儲存拒絕
+  'project.badge.title': '目前的專案目錄',
+  'project.save.crossProjectRefused': '此圖屬於另一個專案（{origin}），無法儲存到目前開啟的專案。',
 };
 
 export default zhTW;

--- a/frontend/src/store/projectStore.test.ts
+++ b/frontend/src/store/projectStore.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useProjectStore, isProjectMode } from './projectStore';
+
+beforeEach(() => {
+  useProjectStore.setState({ projectDir: null, projectName: null, loaded: false });
+});
+
+describe('projectStore', () => {
+  it('defaults to non-project mode', () => {
+    expect(isProjectMode()).toBe(false);
+    expect(useProjectStore.getState().projectDir).toBeNull();
+  });
+
+  it('setProject records dir + derives basename', () => {
+    useProjectStore.getState().setProject('/home/me/my-service');
+    expect(useProjectStore.getState().projectName).toBe('my-service');
+    expect(isProjectMode()).toBe(true);
+  });
+
+  it('setProject(null) returns to non-project mode', () => {
+    useProjectStore.getState().setProject('/x/y');
+    useProjectStore.getState().setProject(null);
+    expect(isProjectMode()).toBe(false);
+    expect(useProjectStore.getState().projectName).toBeNull();
+  });
+
+  it('handles trailing separators and windows paths', () => {
+    useProjectStore.getState().setProject('C:\\svc\\my-app\\');
+    expect(useProjectStore.getState().projectName).toBe('my-app');
+  });
+});

--- a/frontend/src/store/projectStore.ts
+++ b/frontend/src/store/projectStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+/** Basename of a project dir path (POSIX or Windows, trailing seps tolerated). */
+function baseName(dir: string): string {
+  const cleaned = dir.replace(/[\\/]+$/, '');
+  const parts = cleaned.split(/[\\/]/);
+  return parts[parts.length - 1] || cleaned;
+}
+
+interface ProjectState {
+  /** Absolute project dir from /api/health, or null in non-project mode. */
+  projectDir: string | null;
+  /** Basename of projectDir, shown in the editor header badge. */
+  projectName: string | null;
+  /** True once /api/health has resolved (avoids acting on the unknown state). */
+  loaded: boolean;
+  setProject: (dir: string | null) => void;
+}
+
+export const useProjectStore = create<ProjectState>((set) => ({
+  projectDir: null,
+  projectName: null,
+  loaded: false,
+  setProject: (dir) =>
+    set({ projectDir: dir, projectName: dir ? baseName(dir) : null, loaded: true }),
+}));
+
+export function isProjectMode(): boolean {
+  return useProjectStore.getState().projectDir !== null;
+}

--- a/frontend/src/store/tabStore.project.test.ts
+++ b/frontend/src/store/tabStore.project.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTabStore } from './tabStore';
+import { useProjectStore } from './projectStore';
+
+function reset() {
+  useProjectStore.setState({ projectDir: null, projectName: null, loaded: false });
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  useTabStore.getState().addTab('base');
+  localStorage.clear();
+}
+
+beforeEach(reset);
+
+describe('per-project tab scoping (ID10)', () => {
+  it('rehydrateForProject(null) is a no-op (keeps non-project tabs)', () => {
+    const before = useTabStore.getState().tabs.map((t) => t.id);
+    useTabStore.getState().rehydrateForProject(null);
+    expect(useTabStore.getState().tabs.map((t) => t.id)).toEqual(before);
+  });
+
+  it('rehydrateForProject loads the project-scoped key', () => {
+    localStorage.setItem('codefyui-tabs::/proj', JSON.stringify({
+      activeTabId: 'p1',
+      tabs: [{ id: 'p1', name: 'projtab', nodes: [], edges: [] }],
+    }));
+    useProjectStore.getState().setProject('/proj');
+    useTabStore.getState().rehydrateForProject('/proj');
+    const tabs = useTabStore.getState().tabs;
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0].name).toBe('projtab');
+  });
+
+  it('opening a fresh project does not resurrect base-key tabs', () => {
+    // Base key has tabs; scoped key for /b is empty -> a fresh default tab.
+    localStorage.setItem('codefyui-tabs', JSON.stringify({
+      activeTabId: 'a1', tabs: [{ id: 'a1', name: 'A-secret', nodes: [], edges: [] }],
+    }));
+    useProjectStore.getState().setProject('/b');
+    useTabStore.getState().rehydrateForProject('/b');
+    expect(useTabStore.getState().tabs.some((t) => t.name === 'A-secret')).toBe(false);
+  });
+
+  it('stampActiveTabProject records the origin', () => {
+    useTabStore.getState().stampActiveTabProject('/proj');
+    const tab = useTabStore.getState().tabs.find(
+      (t) => t.id === useTabStore.getState().activeTabId)!;
+    expect(tab.projectOrigin).toBe('/proj');
+  });
+});

--- a/frontend/src/store/tabStore.readonly.test.ts
+++ b/frontend/src/store/tabStore.readonly.test.ts
@@ -26,3 +26,26 @@ describe('tab readOnly (ID8)', () => {
     expect(useTabStore.getState().tabs[0].readOnly).toBe(true);
   });
 });
+
+// -- ID8 fast-follow (task 16 review Adjudication B / Important finding 1) --
+// `readOnly` was only ever set/cleared by handleLoadGraph. clear() wiped the
+// rest of the tab's graph-bound metadata but left a stale `readOnly: true`,
+// so a cleared (empty, trivially current-format) tab refused Save forever.
+describe('clear() resets readOnly (ID8 fast-follow)', () => {
+  it('clear() on a read-only tab resets readOnly to false', () => {
+    useTabStore.getState().setTabReadOnly(true);
+    expect(useTabStore.getState().getActiveTab().readOnly).toBe(true);
+
+    useTabStore.getState().clear();
+
+    expect(useTabStore.getState().getActiveTab().readOnly).toBe(false);
+  });
+
+  it('clear() on an already-editable tab leaves readOnly false', () => {
+    expect(useTabStore.getState().getActiveTab().readOnly).toBe(false);
+
+    useTabStore.getState().clear();
+
+    expect(useTabStore.getState().getActiveTab().readOnly).toBe(false);
+  });
+});

--- a/frontend/src/store/tabStore.readonly.test.ts
+++ b/frontend/src/store/tabStore.readonly.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTabStore } from './tabStore';
+import { useProjectStore } from './projectStore';
+
+beforeEach(() => {
+  useProjectStore.setState({ projectDir: null, projectName: null, loaded: false });
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  useTabStore.getState().addTab('t');
+  localStorage.clear();
+});
+
+describe('tab readOnly (ID8)', () => {
+  it('setTabReadOnly toggles the active tab', () => {
+    useTabStore.getState().setTabReadOnly(true);
+    const st = useTabStore.getState();
+    expect(st.tabs.find((t) => t.id === st.activeTabId)!.readOnly).toBe(true);
+  });
+
+  it('rehydrate restores readOnly from storage', () => {
+    localStorage.setItem('codefyui-tabs::/p', JSON.stringify({
+      activeTabId: 'r1',
+      tabs: [{ id: 'r1', name: 'ro', nodes: [], edges: [], readOnly: true }],
+    }));
+    useProjectStore.getState().setProject('/p');
+    useTabStore.getState().rehydrateForProject('/p');
+    expect(useTabStore.getState().tabs[0].readOnly).toBe(true);
+  });
+});

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -800,6 +800,11 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
         currentGraphFile: null,
         segmentGroups: [],
         activeSegment: null,
+        // An empty graph is trivially current-format -- never leave a tab
+        // that became read-only from a newer-format load stuck refusing
+        // Save forever after Clear (ID8 fast-follow, task 16 review
+        // Adjudication B / Important finding 1).
+        readOnly: false,
       })),
     });
   },

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -7,6 +7,7 @@ import type { NodeData, NodeDefinition, PresetDefinition, ExecutionStatus, Outpu
 import { ExecutionWebSocket } from '../api/ws';
 import { useToastStore } from './toastStore';
 import { useI18n } from '../i18n';
+import { useProjectStore } from './projectStore';
 
 // ── Per-tab state ──
 
@@ -34,6 +35,11 @@ export interface TabState {
   // when re-saving the same graph.
   description: string;
   currentGraphFile: string | null;
+  // Project directory (absolute path) this tab's bound graph was last saved
+  // into or loaded from. `null` for a tab never touched by a project save
+  // (e.g. a brand-new tab, or one opened before any project was resolved).
+  // Used by saveActiveGraph's cross-project refusal guard (ID10).
+  projectOrigin: string | null;
   // flow
   nodes: Node<NodeData>[];
   edges: Edge[];
@@ -74,6 +80,7 @@ function createTabState(id: string, name: string): TabState {
     name,
     description: '',
     currentGraphFile: null,
+    projectOrigin: null,
     nodes: [],
     edges: [],
     selectedNodeId: null,
@@ -115,6 +122,9 @@ interface TabStoreState {
   // graph-level metadata (active tab)
   setDescription: (description: string) => void;
   setCurrentGraphFile: (file: string | null) => void;
+  // Per-project persistence scoping (ID10)
+  rehydrateForProject: (projectId: string | null) => void;
+  stampActiveTabProject: (projectId: string | null) => void;
 
   // flow actions (operate on active tab)
   setNodes: (nodes: Node<NodeData>[]) => void;
@@ -310,13 +320,22 @@ function stripNodeSecretsForPersist(
 
 // ── LocalStorage persistence ──
 
-const STORAGE_KEY = 'codefyui-tabs';
+const STORAGE_KEY_BASE = 'codefyui-tabs';
+
+// Persistence key is scoped to the active project so `--project B` never
+// resurrects project A's tabs (ID10). Non-project mode keeps the bare base key
+// -> byte-for-byte unchanged.
+function _storageKey(): string {
+  const pid = useProjectStore.getState().projectDir;
+  return pid ? `${STORAGE_KEY_BASE}::${pid}` : STORAGE_KEY_BASE;
+}
 
 interface PersistedTab {
   id: string;
   name: string;
   description?: string;
   currentGraphFile?: string | null;
+  projectOrigin?: string | null;
   nodes: Node<NodeData>[];
   edges: Edge[];
   segmentGroups?: SegmentGroup[];
@@ -342,6 +361,8 @@ function saveTabs(tabs: TabState[], activeTabId: string) {
         name: t.name,
         description: t.description,
         currentGraphFile: t.currentGraphFile,
+        // Only persisted when set, so non-project localStorage is byte-identical.
+        ...(t.projectOrigin != null ? { projectOrigin: t.projectOrigin } : {}),
         // Never persist SECRET param values (typed API keys) to localStorage:
         // they must not survive a page refresh — the field is "Session only".
         nodes: stripNodeSecretsForPersist(t.nodes),
@@ -355,7 +376,7 @@ function saveTabs(tabs: TabState[], activeTabId: string) {
         autoBackward: t.autoBackward,
       })),
     };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    localStorage.setItem(_storageKey(), JSON.stringify(data));
   } catch {
     // QuotaExceededError / SecurityError / private mode etc. The README
     // promises auto-save; failing silently lets the user lose work without
@@ -375,7 +396,7 @@ function saveTabs(tabs: TabState[], activeTabId: string) {
 
 function loadTabs(): { tabs: TabState[]; activeTabId: string } {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(_storageKey());
     if (raw) {
       const data = JSON.parse(raw);
       if (Array.isArray(data.tabs) && data.tabs.length > 0) {
@@ -385,6 +406,7 @@ function loadTabs(): { tabs: TabState[]; activeTabId: string } {
             ...base,
             description: t.description ?? '',
             currentGraphFile: t.currentGraphFile ?? null,
+            projectOrigin: t.projectOrigin ?? null,
             nodes: t.nodes ?? [],
             edges: t.edges ?? [],
             segmentGroups: Array.isArray(t.segmentGroups) ? t.segmentGroups : [],
@@ -453,6 +475,15 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
 
   setCurrentGraphFile: (file) =>
     set({ tabs: updateTab(get().tabs, get().activeTabId, () => ({ currentGraphFile: file })) }),
+
+  rehydrateForProject: (projectId) => {
+    // Non-project mode keeps the import-time base-key tabs untouched.
+    if (projectId === null) return;
+    const loaded = loadTabs(); // reads the now-scoped key
+    set({ tabs: loaded.tabs, activeTabId: loaded.activeTabId });
+  },
+  stampActiveTabProject: (projectId) =>
+    set({ tabs: updateTab(get().tabs, get().activeTabId, () => ({ projectOrigin: projectId })) }),
 
   // ── Helpers ──
 

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -40,6 +40,11 @@ export interface TabState {
   // (e.g. a brand-new tab, or one opened before any project was resolved).
   // Used by saveActiveGraph's cross-project refusal guard (ID10).
   projectOrigin: string | null;
+  // True when the loaded graph's format_version is NEWER than this build
+  // understands (ID8). The editor opens it read-only -- saveActiveGraph
+  // refuses to write it -- so an older CodefyUI build can never
+  // destructively down-save a newer file.
+  readOnly: boolean;
   // flow
   nodes: Node<NodeData>[];
   edges: Edge[];
@@ -81,6 +86,7 @@ function createTabState(id: string, name: string): TabState {
     description: '',
     currentGraphFile: null,
     projectOrigin: null,
+    readOnly: false,
     nodes: [],
     edges: [],
     selectedNodeId: null,
@@ -122,6 +128,7 @@ interface TabStoreState {
   // graph-level metadata (active tab)
   setDescription: (description: string) => void;
   setCurrentGraphFile: (file: string | null) => void;
+  setTabReadOnly: (v: boolean) => void;
   // Per-project persistence scoping (ID10)
   rehydrateForProject: (projectId: string | null) => void;
   stampActiveTabProject: (projectId: string | null) => void;
@@ -336,6 +343,7 @@ interface PersistedTab {
   description?: string;
   currentGraphFile?: string | null;
   projectOrigin?: string | null;
+  readOnly?: boolean;
   nodes: Node<NodeData>[];
   edges: Edge[];
   segmentGroups?: SegmentGroup[];
@@ -363,6 +371,9 @@ function saveTabs(tabs: TabState[], activeTabId: string) {
         currentGraphFile: t.currentGraphFile,
         // Only persisted when set, so non-project localStorage is byte-identical.
         ...(t.projectOrigin != null ? { projectOrigin: t.projectOrigin } : {}),
+        // Only persisted when true, so an editable graph's localStorage shape
+        // stays byte-identical to before this task.
+        ...(t.readOnly ? { readOnly: true } : {}),
         // Never persist SECRET param values (typed API keys) to localStorage:
         // they must not survive a page refresh — the field is "Session only".
         nodes: stripNodeSecretsForPersist(t.nodes),
@@ -407,6 +418,7 @@ function loadTabs(): { tabs: TabState[]; activeTabId: string } {
             description: t.description ?? '',
             currentGraphFile: t.currentGraphFile ?? null,
             projectOrigin: t.projectOrigin ?? null,
+            readOnly: t.readOnly ?? false,
             nodes: t.nodes ?? [],
             edges: t.edges ?? [],
             segmentGroups: Array.isArray(t.segmentGroups) ? t.segmentGroups : [],
@@ -475,6 +487,9 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
 
   setCurrentGraphFile: (file) =>
     set({ tabs: updateTab(get().tabs, get().activeTabId, () => ({ currentGraphFile: file })) }),
+
+  setTabReadOnly: (v) =>
+    set({ tabs: updateTab(get().tabs, get().activeTabId, () => ({ readOnly: v })) }),
 
   rehydrateForProject: (projectId) => {
     // Non-project mode keeps the import-time base-key tabs untouched.

--- a/frontend/src/utils/autoLayout.ts
+++ b/frontend/src/utils/autoLayout.ts
@@ -323,3 +323,25 @@ export function autoLayout(
     };
   });
 }
+
+/**
+ * Deterministically place UNBOUND note nodes in an offset column. dagre skips
+ * notes (they have no edges), so a `layout_missing` load would otherwise leave
+ * them stacked at the origin. Bound notes are already repositioned relative to
+ * their parent by autoLayout. Ordering is by node id for stability (spec 6.3).
+ */
+export function stackUnboundNotes(nodes: Node[]): Node[] {
+  const NOTE_X = -320;
+  const NOTE_GAP = 140;
+  const unbound = nodes
+    .filter((n) => n.type === 'noteNode' && !(n.data as { boundToNodeId?: string }).boundToNodeId)
+    .map((n) => n.id)
+    .sort();
+  const order = new Map(unbound.map((id, i) => [id, i]));
+  return nodes.map((n) => {
+    if (n.type !== 'noteNode') return n;
+    const idx = order.get(n.id);
+    if (idx === undefined) return n; // bound note -> untouched
+    return { ...n, position: { x: NOTE_X, y: idx * NOTE_GAP } };
+  });
+}

--- a/frontend/src/utils/formatVersion.ts
+++ b/frontend/src/utils/formatVersion.ts
@@ -2,3 +2,12 @@
  * whose format_version exceeds this opens read-only (ID8). Keep in lockstep
  * with backend app/core/project.py FORMAT_VERSION. */
 export const GRAPH_FORMAT_VERSION = 1;
+
+/** True when `formatVersion` (an untrusted `format_version` field read off a
+ * loaded or imported graph payload) is newer than this build understands --
+ * i.e. the graph was written by a newer CodefyUI and must open read-only
+ * (ID8). Shared by every load/import call site so the comparison lives in
+ * exactly one place instead of being copy-pasted at each one. */
+export function isFormatTooNew(formatVersion: unknown): boolean {
+  return typeof formatVersion === 'number' && formatVersion > GRAPH_FORMAT_VERSION;
+}

--- a/frontend/src/utils/formatVersion.ts
+++ b/frontend/src/utils/formatVersion.ts
@@ -1,0 +1,4 @@
+/** The graph format version this build knows how to WRITE. A loaded graph
+ * whose format_version exceeds this opens read-only (ID8). Keep in lockstep
+ * with backend app/core/project.py FORMAT_VERSION. */
+export const GRAPH_FORMAT_VERSION = 1;

--- a/frontend/src/utils/saveActiveGraph.test.ts
+++ b/frontend/src/utils/saveActiveGraph.test.ts
@@ -92,4 +92,17 @@ describe('saveActiveGraph read-only guard (ID8)', () => {
     await saveActiveGraph();
     expect(saveGraph).not.toHaveBeenCalled();
   });
+
+  // ID8 fast-follow (task 16 review Adjudication B / Important finding 1):
+  // clear() must reset readOnly, otherwise a cleared (fresh, empty) graph is
+  // stuck refusing Save forever even though it is trivially current-format.
+  it('clear() resets readOnly so a subsequent save is no longer refused', async () => {
+    (prompt as unknown as ReturnType<typeof vi.fn>).mockResolvedValue('fresh-after-clear');
+    useTabStore.getState().setTabReadOnly(true);
+
+    useTabStore.getState().clear();
+
+    await saveActiveGraph();
+    expect(saveGraph).toHaveBeenCalledWith(expect.objectContaining({ name: 'fresh-after-clear' }));
+  });
 });

--- a/frontend/src/utils/saveActiveGraph.test.ts
+++ b/frontend/src/utils/saveActiveGraph.test.ts
@@ -85,3 +85,11 @@ describe('saveActiveGraph cross-project guard (ID10)', () => {
     expect(tab.projectOrigin).toBe('/b');
   });
 });
+
+describe('saveActiveGraph read-only guard (ID8)', () => {
+  it('refuses to save a read-only (newer-format) graph', async () => {
+    useTabStore.getState().setTabReadOnly(true);
+    await saveActiveGraph();
+    expect(saveGraph).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/saveActiveGraph.test.ts
+++ b/frontend/src/utils/saveActiveGraph.test.ts
@@ -66,3 +66,22 @@ describe('saveActiveGraph', () => {
     expect(saveGraph).not.toHaveBeenCalled();
   });
 });
+
+describe('saveActiveGraph cross-project guard (ID10)', () => {
+  it('refuses to save a tab whose origin differs from the open project', async () => {
+    useProjectStore.setState({ projectDir: '/b', projectName: 'b', loaded: true });
+    useTabStore.getState().setCurrentGraphFile('classifier');
+    useTabStore.getState().stampActiveTabProject('/a'); // belongs to project A
+    await saveActiveGraph();
+    expect(saveGraph).not.toHaveBeenCalled();
+  });
+
+  it('stamps the origin after a successful project save', async () => {
+    useProjectStore.setState({ projectDir: '/b', projectName: 'b', loaded: true });
+    useTabStore.getState().setCurrentGraphFile('classifier');
+    await saveActiveGraph();
+    const st = useTabStore.getState();
+    const tab = st.tabs.find((t) => t.id === st.activeTabId)!;
+    expect(tab.projectOrigin).toBe('/b');
+  });
+});

--- a/frontend/src/utils/saveActiveGraph.test.ts
+++ b/frontend/src/utils/saveActiveGraph.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api/rest', () => ({
+  saveGraph: vi.fn().mockResolvedValue({}),
+  listGraphs: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('./dialog', () => ({
+  prompt: vi.fn(),
+  confirm: vi.fn().mockResolvedValue(true),
+}));
+
+import { saveActiveGraph } from './saveActiveGraph';
+import { saveGraph } from '../api/rest';
+import { prompt } from './dialog';
+import { useTabStore } from '../store/tabStore';
+import { useProjectStore } from '../store/projectStore';
+
+function freshTab() {
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  useTabStore.getState().addTab('test');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  freshTab();
+  useProjectStore.setState({ projectDir: null, projectName: null, loaded: true });
+});
+
+describe('saveActiveGraph', () => {
+  it('non-project mode always prompts (legacy behavior)', async () => {
+    (prompt as unknown as ReturnType<typeof vi.fn>).mockResolvedValue('legacy');
+    useTabStore.getState().setCurrentGraphFile('bound');
+    await saveActiveGraph();
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(saveGraph).toHaveBeenCalledWith(expect.objectContaining({ name: 'legacy' }));
+  });
+
+  it('project mode + bound overwrites IN PLACE with no prompt', async () => {
+    useProjectStore.setState({ projectDir: '/proj', projectName: 'proj', loaded: true });
+    useTabStore.getState().setCurrentGraphFile('classifier');
+    await saveActiveGraph();
+    expect(prompt).not.toHaveBeenCalled();
+    expect(saveGraph).toHaveBeenCalledWith(expect.objectContaining({ name: 'classifier' }));
+  });
+
+  it('project mode Save As prompts even when bound', async () => {
+    useProjectStore.setState({ projectDir: '/proj', projectName: 'proj', loaded: true });
+    useTabStore.getState().setCurrentGraphFile('classifier');
+    (prompt as unknown as ReturnType<typeof vi.fn>).mockResolvedValue('copy');
+    await saveActiveGraph({ saveAs: true });
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(saveGraph).toHaveBeenCalledWith(expect.objectContaining({ name: 'copy' }));
+  });
+
+  it('project mode + unbound (gallery/import) prompts', async () => {
+    useProjectStore.setState({ projectDir: '/proj', projectName: 'proj', loaded: true });
+    (prompt as unknown as ReturnType<typeof vi.fn>).mockResolvedValue('fresh');
+    await saveActiveGraph();
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(saveGraph).toHaveBeenCalledWith(expect.objectContaining({ name: 'fresh' }));
+  });
+
+  it('empty prompt aborts the save', async () => {
+    (prompt as unknown as ReturnType<typeof vi.fn>).mockResolvedValue('');
+    await saveActiveGraph();
+    expect(saveGraph).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/saveActiveGraph.ts
+++ b/frontend/src/utils/saveActiveGraph.ts
@@ -15,6 +15,8 @@ import { sanitizeGraphName, findGraphNameCollision } from './index';
  * - Save As (or unbound gallery/import graphs): prompt + collision guard.
  *
  * Task 13 extends this with project-origin stamping + cross-project refusal.
+ * Task 16 (ID8) refuses outright when the active tab is read-only (its graph
+ * was loaded from a newer format_version than this build writes).
  */
 export async function saveActiveGraph(opts: { saveAs?: boolean } = {}): Promise<void> {
   const t = useI18n.getState().t;
@@ -22,6 +24,12 @@ export async function saveActiveGraph(opts: { saveAs?: boolean } = {}): Promise<
   const store = useTabStore.getState();
   const tab = store.tabs.find((tb) => tb.id === store.activeTabId);
   if (!tab) return;
+  if (tab.readOnly) {
+    // A graph written by a newer CodefyUI opens read-only so an older build
+    // can never round-trip-drop fields it does not understand (ID8).
+    useToastStore.getState().addToast(t('project.readOnly.saveBlocked'), 'error');
+    return;
+  }
   const projectDir = useProjectStore.getState().projectDir;
   const projectMode = projectDir !== null;
 

--- a/frontend/src/utils/saveActiveGraph.ts
+++ b/frontend/src/utils/saveActiveGraph.ts
@@ -25,6 +25,13 @@ export async function saveActiveGraph(opts: { saveAs?: boolean } = {}): Promise<
   const projectDir = useProjectStore.getState().projectDir;
   const projectMode = projectDir !== null;
 
+  // Cross-project footgun guard (ID10): a tab stamped with a DIFFERENT project
+  // must never overwrite into the currently-open project.
+  if (projectMode && tab.projectOrigin != null && tab.projectOrigin !== projectDir) {
+    addToast(t('project.save.crossProjectRefused', { origin: tab.projectOrigin }), 'error');
+    return;
+  }
+
   const inPlace = projectMode && !!tab.currentGraphFile && !opts.saveAs;
 
   let targetName: string;
@@ -60,6 +67,7 @@ export async function saveActiveGraph(opts: { saveAs?: boolean } = {}): Promise<
       description: tab.description ?? '', presets, segmentGroups,
     });
     store.setCurrentGraphFile(sanitizeGraphName(targetName));
+    if (projectMode) store.stampActiveTabProject(projectDir);
     addToast(t('toolbar.save.success', { name: targetName }), 'success');
   } catch (e) {
     addToast(t('toolbar.save.fail', { error: (e as Error).message }), 'error');

--- a/frontend/src/utils/saveActiveGraph.ts
+++ b/frontend/src/utils/saveActiveGraph.ts
@@ -1,0 +1,67 @@
+import { saveGraph, listGraphs } from '../api/rest';
+import { useTabStore } from '../store/tabStore';
+import { useProjectStore } from '../store/projectStore';
+import { useToastStore } from '../store/toastStore';
+import { useI18n } from '../i18n';
+import { confirm, prompt } from './dialog';
+import { sanitizeGraphName, findGraphNameCollision } from './index';
+
+/**
+ * Save the active tab's graph.
+ *
+ * - Non-project mode: ALWAYS prompt for a name (legacy behavior, Toolbar.tsx).
+ * - Project mode + bound + !saveAs: overwrite the bound file IN PLACE, no
+ *   prompt (git is the undo -- ID9).
+ * - Save As (or unbound gallery/import graphs): prompt + collision guard.
+ *
+ * Task 13 extends this with project-origin stamping + cross-project refusal.
+ */
+export async function saveActiveGraph(opts: { saveAs?: boolean } = {}): Promise<void> {
+  const t = useI18n.getState().t;
+  const addToast = useToastStore.getState().addToast;
+  const store = useTabStore.getState();
+  const tab = store.tabs.find((tb) => tb.id === store.activeTabId);
+  if (!tab) return;
+  const projectDir = useProjectStore.getState().projectDir;
+  const projectMode = projectDir !== null;
+
+  const inPlace = projectMode && !!tab.currentGraphFile && !opts.saveAs;
+
+  let targetName: string;
+  if (inPlace) {
+    targetName = tab.currentGraphFile as string;
+  } else {
+    const entered = await prompt({ title: t('toolbar.save.prompt'), placeholder: 'graph-name' });
+    const trimmed = entered?.trim();
+    if (!trimmed) return;
+    let existing: { name: string; file: string }[] = [];
+    try {
+      const r = await listGraphs();
+      if (Array.isArray(r)) existing = r;
+    } catch {
+      /* list unavailable -- proceed without the overwrite check */
+    }
+    const colliding = findGraphNameCollision(trimmed, existing, tab.currentGraphFile);
+    if (colliding !== null) {
+      const okConfirm = await confirm({
+        title: t('toolbar.save.overwriteConfirm', { name: colliding }),
+        confirmText: t('toolbar.save'),
+        variant: 'danger',
+      });
+      if (!okConfirm) return;
+    }
+    targetName = trimmed;
+  }
+
+  try {
+    const { nodes, edges, presets, segmentGroups } = store.getSerializedGraph();
+    await saveGraph({
+      nodes, edges, name: targetName,
+      description: tab.description ?? '', presets, segmentGroups,
+    });
+    store.setCurrentGraphFile(sanitizeGraphName(targetName));
+    addToast(t('toolbar.save.success', { name: targetName }), 'success');
+  } catch (e) {
+    addToast(t('toolbar.save.fail', { error: (e as Error).message }), 'error');
+  }
+}

--- a/frontend/src/utils/stackUnboundNotes.test.ts
+++ b/frontend/src/utils/stackUnboundNotes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@xyflow/react';
+import { stackUnboundNotes } from './autoLayout';
+
+function note(id: string, boundTo: string | null = null): Node {
+  return { id, type: 'noteNode', position: { x: 0, y: 0 },
+    data: { boundToNodeId: boundTo } } as unknown as Node;
+}
+function comp(id: string): Node {
+  return { id, type: 'baseNode', position: { x: 50, y: 60 }, data: {} } as unknown as Node;
+}
+
+describe('stackUnboundNotes', () => {
+  it('places unbound notes in a deterministic offset column', () => {
+    const out = stackUnboundNotes([note('n2'), note('n1'), comp('c')]);
+    const n1 = out.find((n) => n.id === 'n1')!;
+    const n2 = out.find((n) => n.id === 'n2')!;
+    // Sorted by id -> n1 first, n2 below it; same x; distinct y.
+    expect(n1.position.x).toBe(n2.position.x);
+    expect(n2.position.y).toBeGreaterThan(n1.position.y);
+    expect(n1.position.x).toBeLessThan(0); // offset column, off to the side
+  });
+
+  it('leaves bound notes and computational nodes untouched', () => {
+    const bound = note('b', 'c');
+    const out = stackUnboundNotes([bound, comp('c')]);
+    expect(out.find((n) => n.id === 'b')!.position).toEqual({ x: 0, y: 0 });
+    expect(out.find((n) => n.id === 'c')!.position).toEqual({ x: 50, y: 60 });
+  });
+
+  it('is deterministic across calls', () => {
+    const a = stackUnboundNotes([note('z'), note('a')]);
+    const b = stackUnboundNotes([note('a'), note('z')]);
+    expect(a.find((n) => n.id === 'a')!.position)
+      .toEqual(b.find((n) => n.id === 'a')!.position);
+  });
+});

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -955,6 +955,34 @@ def _parse_host_port(argv: list) -> "tuple[str, int]":
     return host, port
 
 
+def _parse_project(argv: list) -> "str | None":
+    """Read --project <dir> from start/dev argv (same lightweight style as
+    --host)."""
+    for i, a in enumerate(argv):
+        if a == "--project" and i + 1 < len(argv):
+            return argv[i + 1]
+        if a.startswith("--project="):
+            return a.split("=", 1)[1]
+    return None
+
+
+def _activate_project(raw: str) -> None:
+    """Validate the project manifest and export CODEFYUI_PROJECT_DIR (abs) into
+    the child env so uvicorn derives its roots (spec 7.1). Exits on a missing
+    manifest."""
+    proj = Path(raw).expanduser().resolve()
+    manifest = proj / "codefyui.project.toml"
+    if not manifest.exists():
+        print(t(f"錯誤：找不到專案 manifest：{manifest}",
+                f"Error: project manifest not found: {manifest}"),
+              file=sys.stderr)
+        print(t("  用 'cdui project init <dir>' 建立專案。",
+                "  Create one with 'cdui project init <dir>'."), file=sys.stderr)
+        sys.exit(1)
+    os.environ["CODEFYUI_PROJECT_DIR"] = str(proj)
+    print(t(f"    專案 → {proj}", f"    Project -> {proj}"))
+
+
 def _probe_host(host: str) -> str:
     """The address to PROBE for a bind host: 0.0.0.0/:: listen everywhere
     but answer on loopback; a concrete LAN IP answers only on itself."""
@@ -1098,6 +1126,9 @@ def start() -> None:
 
     _warn_if_dist_stale()
     _apply_dev_env()
+    project = _parse_project(sys.argv[2:])
+    if project is not None:
+        _activate_project(project)
     # settings.HOST/PORT (and therefore init_allowed_hosts) must agree
     # with the actual bind — binding a concrete LAN IP whitelists it
     # automatically (app.core.auth.init_allowed_hosts).
@@ -1583,6 +1614,9 @@ def dev() -> None:
         sys.exit(1)
     _install_frontend_deps_if_needed()
     _apply_dev_env()
+    project = _parse_project(sys.argv[2:])
+    if project is not None:
+        _activate_project(project)
 
     uvicorn = _require_venv_tool("uvicorn")
     backend_cmd = [uvicorn, "app.main:app", "--reload"]
@@ -1754,10 +1788,30 @@ def _dispatch_plugin_subcommand() -> int:
     return plugin_cli.main(sys.argv[2:])
 
 
+def _dispatch_project_subcommand() -> int:
+    """Hand off `cdui project <subcmd> ...` to scripts/project.py.
+
+    Same venv hop as the plugin subgroup: project.py imports app.core.* so it
+    must run inside the backend venv with token/env resolution matching the
+    server (spec Section 5).
+    """
+    _exec_into_venv_if_available()
+    _ensure_uv()
+    _apply_dev_env()
+    scripts_dir = str(Path(__file__).resolve().parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    import project as project_cli  # noqa: PLC0415 — late import: needs venv
+    return project_cli.main(sys.argv[2:])
+
+
 if __name__ == "__main__":
     # Long-form sub-grouped commands come first.
     if len(sys.argv) >= 2 and sys.argv[1] == "plugin":
         sys.exit(_dispatch_plugin_subcommand())
+
+    if len(sys.argv) >= 2 and sys.argv[1] == "project":
+        sys.exit(_dispatch_project_subcommand())
 
     if len(sys.argv) < 2 or sys.argv[1] not in COMMANDS:
         print(__doc__)

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -569,11 +569,17 @@ def _manifest_has_frontend(manifest: dict) -> bool:
 def _install_github(owner: str, repo: str, ref: str, args, lockfile) -> int:
     url = f"https://github.com/{owner}/{repo}"
     info(f"來源：{url}", f"Source: {url}")
-    try:
-        sha = resolve_sha(owner, repo, ref)
-    except RuntimeError as e:
-        err(str(e), str(e))
-        return 1
+    pinned_sha = getattr(args, "pinned_sha", None)
+    if pinned_sha:
+        # Restore path (spec ID11): install BY the pinned sha -- never re-resolve
+        # a possibly-moved tag. Using the pinned value verifies resolved==pinned.
+        sha = pinned_sha
+    else:
+        try:
+            sha = resolve_sha(owner, repo, ref)
+        except RuntimeError as e:
+            err(str(e), str(e))
+            return 1
 
     short_sha = sha[:7]
     info(

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -2,23 +2,28 @@
 scripts/dev.py's _dispatch_project_subcommand hop, so `import app.*` works.
 
 This module mirrors scripts/plugins.py: a build_parser() with subcommands, a
-main(argv) that dispatches to args._func. This file ships `init` and
-`validate`; restore / freeze / publish are added by later tasks.
+main(argv) that dispatches to args._func. This file ships `init`, `validate`,
+`freeze`, `restore`, and `publish`.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
+import urllib.request
 from pathlib import Path
+from urllib.error import HTTPError, URLError
 
 # Reuse the tested bilingual print helpers + stdio reconfigure from plugins.py
 # (both are scripts/ siblings loaded onto sys.path by the dispatcher).
 from plugins import (
+    USER_AGENT,
     _install_github,
+    _read_session_token,
     _reconfigure_stdio,
     err,
     info,
@@ -469,6 +474,125 @@ def cmd_restore(args: argparse.Namespace) -> int:
     return rc_all
 
 
+def _server_base() -> tuple[str, str]:
+    """(base_url, host_header) for the local server, mirroring the plugin CLI's
+    port resolution (CODEFYUI_PORT env, then settings.PORT, then 8000). The
+    client always connects on loopback, which is always whitelisted."""
+    port = 8000
+    env = os.environ.get("CODEFYUI_PORT", "").strip()
+    if env.isdigit():
+        port = int(env)
+    else:
+        try:
+            from app.config import settings
+            port = int(settings.PORT)
+        except Exception:  # noqa: BLE001
+            port = 8000
+    netloc = f"127.0.0.1:{port}"
+    return f"http://{netloc}", netloc
+
+
+def _http_get_json(url: str, host: str) -> dict | None:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": USER_AGENT, "Host": host})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (URLError, HTTPError, OSError, ValueError):
+        return None
+
+
+def _http_post_json(url: str, host: str, token: str, body: dict) -> dict | None:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, method="POST", data=data, headers={
+        "User-Agent": USER_AGENT, "Host": host,
+        "Content-Type": "application/json", "X-CodefyUI-Token": token,
+        "Content-Length": str(len(data))})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            out = json.loads(resp.read().decode("utf-8"))
+            out["_status"] = resp.status
+            return out
+    except HTTPError as e:
+        try:
+            out = json.loads(e.read().decode("utf-8"))
+        except Exception:  # noqa: BLE001
+            out = {}
+        out["_status"] = e.code
+        return out
+    except (URLError, OSError, ValueError):
+        return None
+
+
+def cmd_publish(args: argparse.Namespace) -> int:
+    proj = Path(args.dir).expanduser().resolve()
+    manifest_path = proj / MANIFEST_FILENAME
+    from app.core.plugin_loader import tomllib
+    if not manifest_path.exists():
+        err(f"找不到 manifest：{manifest_path}", f"Manifest not found: {manifest_path}")
+        return 1
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    defaults = manifest.get("publish", {}) or {}
+    graph = args.graph or defaults.get("graph")
+    slug = args.slug or defaults.get("slug")
+    if not graph:
+        err("需要 --graph 或 manifest [publish].graph",
+            "A graph is required: pass --graph or set [publish].graph")
+        return 1
+    if not slug:
+        err("需要 --slug 或 manifest [publish].slug",
+            "A slug is required: pass --slug or set [publish].slug")
+        return 1
+
+    token = _read_session_token()
+    if token is None:
+        err("找不到 session token -- 伺服器未執行？先 cdui start --project .",
+            "No session token -- is the server running? Run `cdui start --project .`")
+        return 1
+    base, host = _server_base()
+
+    # Local-only verification (ID4): the server must have THIS project open.
+    health = _http_get_json(f"{base}/api/health", host)
+    if health is None:
+        err(f"無法連線到 {base}/api/health", f"Cannot reach {base}/api/health")
+        return 1
+    server_project = health.get("project")
+    if server_project is None or Path(server_project).resolve() != proj:
+        err(f"伺服器開啟的專案（{server_project}）與 {proj} 不符",
+            f"Server has a different project open ({server_project}) -- run "
+            f"`cdui start --project {proj}` first")
+        return 1
+
+    from app.core.project import git_provenance
+    commit, dirty = git_provenance(proj)
+    if commit is None:
+        print("NOTE: not a git repo -- publishing with NULL provenance")
+    elif dirty:
+        # Loud, locale-independent warning (ID12).
+        print("=" * 70)
+        print("WARNING: working tree is DIRTY -- the recorded commit does NOT "
+              "match the published bytes.")
+        print("=" * 70)
+
+    body: dict = {"graph": graph, "slug": slug, "create": True, "note": args.note}
+    if "record_io" in defaults:
+        body["record_io"] = bool(defaults["record_io"])
+    if commit is not None:
+        body["git_commit"] = commit
+        body["git_dirty"] = bool(dirty)
+
+    resp = _http_post_json(f"{base}/api/apps/{slug}/publish", host, token, body)
+    if resp is None or resp.get("_status", 500) != 200:
+        detail = resp.get("detail") if isinstance(resp, dict) else resp
+        err(f"發佈失敗：{detail}", f"Publish failed: {detail}")
+        return 1
+    prov = (f" (git {commit[:7]}{' dirty' if dirty else ''})"
+            if commit else " (no provenance)")
+    ok(f"已發佈 {slug} v{resp.get('version')}{prov}",
+       f"Published {slug} v{resp.get('version')}{prov}")
+    return 0
+
+
 def _write_if_absent(path: Path, content: str) -> None:
     if not path.exists():
         path.write_text(content, encoding="utf-8")
@@ -528,6 +652,13 @@ def build_parser() -> argparse.ArgumentParser:
     p_restore = sub.add_parser("restore", help="Install the manifest's plugin pins by their exact SHA")
     p_restore.add_argument("dir", help="project directory")
     p_restore.set_defaults(_func=cmd_restore)
+
+    p_pub = sub.add_parser("publish", help="Publish a graph to the local server, recording git provenance")
+    p_pub.add_argument("dir", help="project directory")
+    p_pub.add_argument("--graph", default=None, help="saved graph name (default: manifest [publish].graph)")
+    p_pub.add_argument("--slug", default=None, help="published slug (default: manifest [publish].slug)")
+    p_pub.add_argument("--note", default=None, help="optional immutable version note")
+    p_pub.set_defaults(_func=cmd_publish)
 
     return p
 

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -17,7 +17,17 @@ from pathlib import Path
 
 # Reuse the tested bilingual print helpers + stdio reconfigure from plugins.py
 # (both are scripts/ siblings loaded onto sys.path by the dispatcher).
-from plugins import _reconfigure_stdio, err, info, ok, section, t, warn
+from plugins import (
+    _install_github,
+    _reconfigure_stdio,
+    err,
+    info,
+    ok,
+    parse_source,
+    section,
+    t,
+    warn,
+)
 
 from app.core.plugin_loader import (
     iter_plugin_dirs,
@@ -361,6 +371,104 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return 0
 
 
+def _render_manifest(project_tbl: dict, pins: dict, publish: dict) -> str:
+    """Regenerate the manifest with a machine-written [plugins] table (spec
+    5). Comments in [plugins] are not preserved -- it is a generated section."""
+    lines = ["[project]"]
+    lines.append(f'name = "{project_tbl.get("name", "")}"')
+    lines.append(f'format_version = {int(project_tbl.get("format_version", 1))}')
+    if project_tbl.get("requires_codefyui"):
+        lines.append(f'requires_codefyui = "{project_tbl["requires_codefyui"]}"')
+    lines.append("")
+    lines.append("[plugins]")
+    lines.append("# written by `cdui project freeze`; installed by `cdui project restore`")
+    for pid in sorted(pins):
+        p = pins[pid]
+        lines.append(
+            f'{pid} = {{ url = "{p["url"]}", ref = "{p["ref"]}", '
+            f'sha = "{p["sha"]}" }}')
+    lines.append("")
+    if publish:
+        lines.append("[publish]")
+        for k in ("graph", "slug"):
+            if publish.get(k):
+                lines.append(f'{k} = "{publish[k]}"')
+        if "record_io" in publish:
+            lines.append(f'record_io = {"true" if publish["record_io"] else "false"}')
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def cmd_freeze(args: argparse.Namespace) -> int:
+    proj = Path(args.dir).expanduser().resolve()
+    manifest_path = proj / MANIFEST_FILENAME
+    from app.core.plugin_loader import tomllib
+    if not manifest_path.exists():
+        err(f"找不到 manifest：{manifest_path}", f"Manifest not found: {manifest_path}")
+        return 1
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    section("凍結外掛版本", "Freezing plugin pins")
+    pins: dict = {}
+    for pid, entry in load_lockfile().get("plugins", {}).items():
+        kind = entry.get("source_kind")
+        if kind == "local":
+            warn(f"略過本地連結：{pid}",
+                 f"Skipping linked/local plugin: {pid} (machine-specific path)")
+            continue
+        if kind == "builtin":
+            continue  # ships with cdui; nothing to pin
+        url, sha, ref = entry.get("url"), entry.get("sha"), entry.get("ref", "")
+        if not url or not sha:
+            warn(f"略過 {pid}（缺 url/sha）", f"Skipping {pid} (missing url/sha)")
+            continue
+        pins[pid] = {"url": url, "ref": ref, "sha": sha}
+        ok(f"釘選 {pid} @ {sha[:7]}", f"Pinned {pid} @ {sha[:7]}")
+    manifest_path.write_text(
+        _render_manifest(manifest.get("project", {}), pins,
+                         manifest.get("publish", {})),
+        encoding="utf-8")
+    ok(f"已寫入 {len(pins)} 個釘選", f"Wrote {len(pins)} pin(s) to the manifest")
+    return 0
+
+
+def cmd_restore(args: argparse.Namespace) -> int:
+    proj = Path(args.dir).expanduser().resolve()
+    manifest_path = proj / MANIFEST_FILENAME
+    from app.core.plugin_loader import tomllib
+    if not manifest_path.exists():
+        err(f"找不到 manifest：{manifest_path}", f"Manifest not found: {manifest_path}")
+        return 1
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    pins = manifest.get("plugins", {}) or {}
+    if not pins:
+        info("manifest 沒有外掛釘選", "No plugin pins in the manifest")
+        return 0
+    section("還原外掛版本", "Restoring plugin pins")
+    lockfile = load_lockfile()
+    installed = lockfile.get("plugins", {})
+    rc_all = 0
+    for pid, pin in pins.items():
+        sha, url, ref = pin.get("sha"), pin.get("url"), pin.get("ref", "")
+        if not sha or not url:
+            err(f"{pid}：釘選缺 url/sha", f"{pid}: pin missing url/sha")
+            rc_all = 1
+            continue
+        cur = installed.get(pid)
+        if cur and cur.get("sha") == sha:
+            ok(f"{pid} 已是 {sha[:7]}", f"{pid} already at {sha[:7]}")
+            continue
+        _kind, owner, repo, _ref = parse_source(url)
+        inst_args = argparse.Namespace(
+            force=True, no_confirm=True, trust_author=True, pinned_sha=sha)
+        # Trust _install_github's return code (spec ID11: install BY the pinned
+        # sha). It never re-resolves the ref when pinned_sha is set, so success
+        # (rc == 0) already means the installed plugin is at this exact sha.
+        rc = _install_github(owner, repo, ref, inst_args, lockfile)
+        if rc != 0:
+            rc_all = 1
+    return rc_all
+
+
 def _write_if_absent(path: Path, content: str) -> None:
     if not path.exists():
         path.write_text(content, encoding="utf-8")
@@ -412,6 +520,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_val.add_argument("--strict", action="store_true",
                        help="treat missing/mismatched plugin pins as errors")
     p_val.set_defaults(_func=cmd_validate)
+
+    p_freeze = sub.add_parser("freeze", help="Write installed github plugin pins into the manifest")
+    p_freeze.add_argument("dir", help="project directory")
+    p_freeze.set_defaults(_func=cmd_freeze)
+
+    p_restore = sub.add_parser("restore", help="Install the manifest's plugin pins by their exact SHA")
+    p_restore.add_argument("dir", help="project directory")
+    p_restore.set_defaults(_func=cmd_restore)
 
     return p
 

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -1,0 +1,234 @@
+"""`cdui project ...` CLI (spec Section 8). Runs under the backend venv via
+scripts/dev.py's _dispatch_project_subcommand hop, so `import app.*` works.
+
+This module mirrors scripts/plugins.py: a build_parser() with subcommands, a
+main(argv) that dispatches to args._func. This file ships `init`; validate /
+restore / freeze / publish are added by later tasks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Reuse the tested bilingual print helpers + stdio reconfigure from plugins.py
+# (both are scripts/ siblings loaded onto sys.path by the dispatcher).
+from plugins import _reconfigure_stdio, err, info, ok, section, t, warn
+
+MANIFEST_FILENAME = "codefyui.project.toml"
+
+_PROJECT_TOML = """[project]
+name = "{name}"
+format_version = 1
+requires_codefyui = ">=1.4"   # advisory metadata; NOT enforced
+
+[plugins]
+# written by `cdui project freeze`; installed by `cdui project restore`
+# some-pack = {{ url = "https://github.com/owner/repo", ref = "v1.2", sha = "<40-hex>" }}
+
+[publish]                      # optional single default target
+# graph = "my-graph"
+# slug = "my-service"
+# record_io = true
+"""
+
+_GITIGNORE = """.env
+*.pt
+*.pth
+*.safetensors
+*.onnx
+*.ckpt
+*.pkl
+__pycache__/
+*.db
+.DS_Store
+# interrupted atomic writes
+*.tmp-*
+"""
+
+_GITATTRIBUTES = "layout/*.layout.json linguist-generated=true\n"
+
+_ENV_EXAMPLE = """# CodefyUI project secrets (runtime only). Copy to .env and fill in.
+# .env is gitignored; this .env.example is committed as the required-keys template.
+#
+# Loaded at server start with os.environ.setdefault semantics (an already-set
+# environment variable wins). Values are execution-time only and are never
+# written to a saved graph. CODEFYUI_* SERVER CONFIG keys placed here are
+# IGNORED (server settings materialize before .env loads); pass `cdui start`
+# flags or the process environment for those.
+#
+# LLM keys, read at node execute time:
+# OPENAI_API_KEY=
+# CODEFYUI_OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=
+# CODEFYUI_ANTHROPIC_API_KEY=
+"""
+
+_README = """# {name}
+
+A CodefyUI **project directory**: a self-contained git repo where the graph
+files ARE the storage. Open it with:
+
+    cdui start --project .
+
+## Layout
+
+    codefyui.project.toml   project manifest (name, plugin pins, default publish target)
+    graphs/                 <name>.graph.json  -- logic (nodes/edges/params/presets)
+    layout/                 <name>.layout.json -- node positions (reviewable, generated)
+    assets/images/          IMAGES_DIR
+    assets/models/          MODELS_DIR (weights land here; gitignored)
+    assets/data/            CSVs / datasets / FileReader inputs
+    assets/output/          ImageWriter output (created on demand)
+    .env.example            committed template of required secret keys
+    .env                    your secrets (gitignored, never committed)
+
+## Quickstart
+
+    cdui start --project .          # edit graphs in the browser; Save writes the pair
+    cdui project validate .         # CI gate: every graph must pass the publish pre-flight
+    cdui project publish . --graph my-graph --slug my-service   # local publish + provenance
+
+## Version control
+
+Set a git identity if you have not:
+
+    git config user.name  "You"
+    git config user.email "you@example.com"
+
+Then:
+
+    git add -A && git commit -m "Initial project"
+
+Commit `.env.example`, never `.env`. Commit a small **fetch script** that
+downloads large data on demand -- do NOT commit datasets or weights (they are
+gitignored). Model checkpoints written to `assets/models/` and images written
+to `assets/output/` are local artifacts, not source.
+
+## Continuous integration
+
+Run `cdui project restore .` THEN `cdui project validate .` (restore installs
+the plugin pins the graphs need; validate needs the full backend env incl.
+torch -- cache the venv in CI). Validate `.` -- do NOT feed a raw `*.json` glob
+to the validator, or it would pick up `layout/*.layout.json` files too.
+"""
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    target = Path(args.dir).expanduser().resolve()
+    section(f"建立專案：{target}", f"Creating project: {target}")
+
+    if target.exists() and any(target.iterdir()) and not args.adopt and not args.force:
+        err(
+            f"目錄非空：{target}（用 --adopt <src> 遷移既有 graphs，或 --force）",
+            f"Directory not empty: {target} (use --adopt <src> to migrate an "
+            "existing graphs dir, or --force)",
+        )
+        return 1
+
+    # Scaffold directories.
+    for rel in ("graphs", "layout", "assets/images", "assets/models",
+                "assets/data"):
+        (target / rel).mkdir(parents=True, exist_ok=True)
+        # Keep otherwise-empty dirs trackable by git.
+        keep = target / rel / ".gitkeep"
+        if not any((target / rel).iterdir()):
+            keep.write_text("", encoding="utf-8")
+
+    # Scaffold files (never clobber an existing manifest/README under --force).
+    name = target.name
+    _write_if_absent(target / MANIFEST_FILENAME, _PROJECT_TOML.format(name=name))
+    _write_if_absent(target / ".gitignore", _GITIGNORE)
+    _write_if_absent(target / ".gitattributes", _GITATTRIBUTES)
+    _write_if_absent(target / ".env.example", _ENV_EXAMPLE)
+    _write_if_absent(target / "README.md", _README.format(name=name))
+
+    # Adopt: copy every *.json from src into graphs/ and split immediately.
+    if args.adopt:
+        rc = _adopt(Path(args.adopt).expanduser().resolve(), target)
+        if rc != 0:
+            return rc
+
+    # git init, NO initial commit (spec D3 / Section 5).
+    if shutil.which("git"):
+        if not (target / ".git").exists():
+            subprocess.run(["git", "init"], cwd=target, capture_output=True)
+        info("已初始化 git 儲存庫（未建立 commit）",
+             "Initialized a git repo (no commit made)")
+        info("接下來：設定 git 身分並提交：",
+             "Next: set a git identity and commit:")
+        print('    git config user.name  "You"')
+        print('    git config user.email "you@example.com"')
+        print("    git add -A && git commit -m \"Initial project\"")
+    else:
+        warn("找不到 git；已建立專案但沒有版本庫",
+             "git not found; created the project without a repository")
+
+    ok(f"專案就緒：{target}", f"Project ready: {target}")
+    print(t(f"    啟動：cdui start --project {target}",
+            f"    Start it: cdui start --project {target}"))
+    return 0
+
+
+def _write_if_absent(path: Path, content: str) -> None:
+    if not path.exists():
+        path.write_text(content, encoding="utf-8")
+
+
+def _adopt(src: Path, target: Path) -> int:
+    from app.core.project import write_graph_pair
+
+    if not src.is_dir():
+        err(f"--adopt 來源不是目錄：{src}", f"--adopt source is not a directory: {src}")
+        return 1
+    graphs_dir = target / "graphs"
+    layout_dir = target / "layout"
+    count = 0
+    for jf in sorted(src.glob("*.json")):
+        if jf.name.endswith(".layout.json"):
+            continue
+        base = jf.name[:-len(".graph.json")] if jf.name.endswith(".graph.json") else jf.stem
+        try:
+            payload = json.loads(jf.read_text(encoding="utf-8"))
+        except (ValueError, OSError) as e:
+            warn(f"略過 {jf.name}：{e}", f"Skipping {jf.name}: {e}")
+            continue
+        write_graph_pair(
+            graphs_dir / f"{base}.graph.json",
+            layout_dir / f"{base}.layout.json",
+            payload,
+        )
+        count += 1
+    ok(f"已採用並拆分 {count} 個 graph", f"Adopted and split {count} graph(s)")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="cdui project", description="Manage a CodefyUI project directory")
+    sub = p.add_subparsers(dest="project_cmd", required=True)
+
+    p_init = sub.add_parser("init", help="Scaffold a new project directory")
+    p_init.add_argument("dir", help="path to create the project in")
+    p_init.add_argument("--adopt", default=None,
+                        help="copy every *.json from this dir into graphs/ and split")
+    p_init.add_argument("--force", action="store_true",
+                        help="write into an existing non-empty directory")
+    p_init.set_defaults(_func=cmd_init)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    _reconfigure_stdio()
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args._func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -2,8 +2,8 @@
 scripts/dev.py's _dispatch_project_subcommand hop, so `import app.*` works.
 
 This module mirrors scripts/plugins.py: a build_parser() with subcommands, a
-main(argv) that dispatches to args._func. This file ships `init`; validate /
-restore / freeze / publish are added by later tasks.
+main(argv) that dispatches to args._func. This file ships `init` and
+`validate`; restore / freeze / publish are added by later tasks.
 """
 
 from __future__ import annotations
@@ -18,6 +18,11 @@ from pathlib import Path
 # Reuse the tested bilingual print helpers + stdio reconfigure from plugins.py
 # (both are scripts/ siblings loaded onto sys.path by the dispatcher).
 from plugins import _reconfigure_stdio, err, info, ok, section, t, warn
+
+from app.core.plugin_loader import (
+    iter_plugin_dirs,
+    load_lockfile,
+)
 
 MANIFEST_FILENAME = "codefyui.project.toml"
 
@@ -174,6 +179,188 @@ def cmd_init(args: argparse.Namespace) -> int:
     return 0
 
 
+def _collect_graphs(graphs_dir: Path) -> list[tuple[str, Path]]:
+    """(base_name, file) for each graph: canonical `.graph.json` + legacy
+    `.json`; raises RuntimeError naming both files on ambiguity (spec ID2)."""
+    files: dict[str, Path] = {}
+    if not graphs_dir.is_dir():
+        return []
+    for f in sorted(graphs_dir.glob("*.graph.json")):
+        files[f.name[: -len(".graph.json")]] = f
+    for f in sorted(graphs_dir.glob("*.json")):
+        if f.name.endswith(".graph.json"):
+            continue
+        base = f.stem
+        if base in files:
+            raise RuntimeError(
+                f"Graph '{base}' is ambiguous: both {files[base].name} and "
+                f"{f.name} exist. Remove one.")
+        files[base] = f
+    return sorted(files.items())
+
+
+def _init_registries_like_server() -> None:
+    """Discover builtin + custom + PLUGIN nodes and presets exactly like the
+    server lifespan (main.py) -- run_graph.py's init loads no plugins and is
+    NOT sufficient (spec ID3)."""
+    import app.core.plugin_loader as plugin_loader
+    from app.config import settings
+    from app.core.node_registry import registry
+    from app.core.plugin_loader import install_plugin_finder
+    from app.core.preset_registry import preset_registry
+
+    registry.discover(settings.NODES_DIR, "app.nodes")
+    registry.discover(settings.CUSTOM_NODES_DIR, "app.custom_nodes")
+    lockfile = load_lockfile()
+    builtin_root = plugin_loader.plugins_builtin_root()
+    user_root = plugin_loader.plugins_user_root()
+    for nodes_dir, pkg_name in install_plugin_finder(builtin_root, user_root, lockfile):
+        registry.discover(nodes_dir, pkg_name)
+    preset_registry.discover(settings.PRESETS_DIR, registry)
+    for _pid, pdir in iter_plugin_dirs(builtin_root, user_root, lockfile):
+        preset_registry.discover(pdir / "presets", registry)
+
+
+def _validate_one_graph(path: Path, base: str) -> list[str]:
+    """The publish six-gate pre-flight, IN PUBLISH ORDER (routes_apps): secret
+    -> contract -> entry -> wiring -> validate. Returns problems (empty=pass)."""
+    from app.core import api_contract
+    from app.core.graph_engine import (
+        build_preset_fallback,
+        find_entry_points,
+        validate_graph,
+    )
+    from app.core.project import FORMAT_VERSION
+    from app.core.secret_params import find_secret_violations
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as e:
+        return [f"unreadable: {e}"]
+    nodes = data.get("nodes", [])
+    edges = data.get("edges", [])
+    fb = build_preset_fallback(data.get("presets", []))
+
+    fmt = data.get("format_version", 1)
+    if isinstance(fmt, int) and fmt > FORMAT_VERSION:
+        # Read policy: warn-never-block (spec ID8).
+        warn(f"{base}: format_version {fmt} is newer than this build "
+             f"(known {FORMAT_VERSION})",
+             f"{base}: format_version {fmt} is newer than this build "
+             f"(known {FORMAT_VERSION})")
+
+    # 1. secrets (publish checks these FIRST, routes_apps.py).
+    violations = find_secret_violations(nodes)
+    if violations:
+        v = violations[0]
+        return [f"secret_in_graph: node '{v['node_id']}' param '{v['param']}'"]
+    # 2. contract.
+    contract = api_contract.derive_contract(nodes)
+    if contract.problems:
+        return [f"invalid_contract: {contract.problems[0]}"]
+    # 3. entry points.
+    if not find_entry_points(nodes, edges):
+        return ["no_entry_points: wire a Start node into every GraphInput"]
+    # 4. wiring.
+    wiring = api_contract.check_wiring(nodes, edges, contract)
+    if wiring.untriggered:
+        return [f"untriggered_input: {wiring.untriggered[0]}"]
+    if wiring.unreachable:
+        return [f"unreachable_output: {wiring.unreachable[0]}"]
+    # 5. validate_graph (unknown-type errors get the specific ID3 message).
+    errors = validate_graph(nodes, edges, preset_fallback=fb)
+    if errors:
+        first = errors[0]
+        if first.startswith("Unknown node type"):
+            first = first + " -- run `cdui project restore` (or install the plugin that provides it)"
+        return [f"invalid_graph: {first}"]
+    return []
+
+
+def _check_env_not_tracked(proj: Path) -> bool:
+    """True on FAILURE: .env is tracked by git. No git -> notice + pass."""
+    if not shutil.which("git"):
+        info("git 不存在，略過 .env 追蹤檢查",
+             "git not found; skipping the .env-tracked check")
+        return False
+    res = subprocess.run(["git", "-C", str(proj), "ls-files", ".env"],
+                         capture_output=True, text=True)
+    if res.stdout.strip():
+        err(".env 已被 git 追蹤（絕不可提交機密）",
+            ".env is tracked by git -- secrets must never be committed")
+        return True
+    return False
+
+
+def _check_pins(manifest: dict, strict: bool) -> bool:
+    """True on FAILURE (only when strict). Missing/mismatched pins warn, and
+    with --strict become errors (spec ID3)."""
+    pins = manifest.get("plugins", {}) or {}
+    if not pins:
+        return False
+    installed = load_lockfile().get("plugins", {})
+    failed = False
+    for pid, pin in pins.items():
+        entry = installed.get(pid)
+        pinned_sha = pin.get("sha") if isinstance(pin, dict) else None
+        if entry is None:
+            _warn_or_err(strict, f"pinned plugin '{pid}' is not installed -- "
+                                 "run `cdui project restore`")
+            failed = failed or strict
+        elif pinned_sha and entry.get("sha") != pinned_sha:
+            _warn_or_err(strict, f"plugin '{pid}' sha {entry.get('sha', '')[:7]} "
+                                 f"!= pinned {pinned_sha[:7]} -- run restore")
+            failed = failed or strict
+    return failed
+
+
+def _warn_or_err(strict: bool, msg: str) -> None:
+    (err if strict else warn)(msg, msg)
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    proj = Path(args.dir).expanduser().resolve()
+    section(f"驗證專案：{proj}", f"Validating project: {proj}")
+
+    manifest_path = proj / MANIFEST_FILENAME
+    if not manifest_path.exists():
+        err(f"找不到 manifest：{manifest_path}",
+            f"Manifest not found: {manifest_path}")
+        return 1
+    from app.core.plugin_loader import tomllib
+    try:
+        manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        err(f"manifest 解析失敗：{e}", f"Manifest parse error: {e}")
+        return 1
+
+    _init_registries_like_server()
+
+    try:
+        graphs = _collect_graphs(proj / "graphs")
+    except RuntimeError as e:
+        err(str(e), str(e))
+        return 1
+
+    all_ok = True
+    for base, path in graphs:
+        problems = _validate_one_graph(path, base)
+        if problems:
+            all_ok = False
+            err(f"FAIL {base}: {problems[0]}", f"FAIL {base}: {problems[0]}")
+        else:
+            ok(f"PASS {base}", f"PASS {base}")
+
+    pin_fail = _check_pins(manifest, args.strict)
+    env_fail = _check_env_not_tracked(proj)
+
+    if not all_ok or pin_fail or env_fail:
+        err("驗證失敗", "Validation FAILED")
+        return 1
+    ok("驗證通過", "Validation passed")
+    return 0
+
+
 def _write_if_absent(path: Path, content: str) -> None:
     if not path.exists():
         path.write_text(content, encoding="utf-8")
@@ -219,6 +406,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.add_argument("--force", action="store_true",
                         help="write into an existing non-empty directory")
     p_init.set_defaults(_func=cmd_init)
+
+    p_val = sub.add_parser("validate", help="Validate every graph (publish pre-flight) + project checks")
+    p_val.add_argument("dir", help="project directory to validate")
+    p_val.add_argument("--strict", action="store_true",
+                       help="treat missing/mismatched plugin pins as errors")
+    p_val.set_defaults(_func=cmd_validate)
 
     return p
 


### PR DESCRIPTION
Single self-contained PR, base = main (merge-base ccb8f47 verified intact). Ships the full "project directories" feature: a CodefyUI service becomes a self-contained, git-trackable repo.

## What

**`cdui project` CLI + `--project` server mode.**
- `cdui project init <dir>` scaffolds `codefyui.project.toml`, `graphs/`, `layout/`, `assets/`, `.env.example`, README, `.gitignore` (incl. `*.tmp-*` for interrupted atomic writes) and runs `git init` (no initial commit; next steps printed). `--adopt` migrates an existing flat graphs dir.
- `cdui start|dev --project <dir>` repoints the server's graph/asset roots into the project (`CODEFYUI_PROJECT_DIR`, explicit-env-wins); startup logs the project + git state; `/api/health` gains a `project` field (resolved dir path; key absent in non-project mode).

**Logic/layout split — reviewable diffs.**
- Project-mode saves write `graphs/<name>.graph.json` (logic only, positionless) + `layout/<name>.layout.json` (positions/notes/segmentGroups) atomically; loads merge them. Dragging nodes diffs only `layout/`; param edits diff only `graphs/`.
- Legacy single-file `<name>.json` loads forever (upgrade-on-save); canonical+legacy ambiguity → 409; reserved names rejected; missing layout → dagre auto-layout (no toast/undo).

**Portability + CI.**
- Graph-embedded presets resolve everywhere it matters (validate / export / run-as-function / invoke / publish pre-flight) when the registry lacks them — a cloned project runs without pre-installing presets.
- `cdui project validate` = the server's six publish gates (imported, not reimplemented) over every graph, full registry init incl. plugins, `--strict` SHA-pin check, warns if `.env` is git-tracked. Exit 0/1 — the CI primitive.
- `cdui project freeze` pins installed plugins by SHA into the manifest (skips linked/local dev plugins); `cdui project restore` reinstalls by pin, no confirmation.
- Per-project `.env` (gitignored; `.env.example` scaffolded) loads at startup via `os.environ.setdefault` — runtime secrets only; provably cannot override `CODEFYUI_` settings; BOM/CRLF tolerant.

**Editor project mode.**
- Save binds to the loaded file and overwrites (no dialog); Save As; Ctrl/Cmd+S (project-mode-only interception); project badge in the toolbar.
- Per-project tab persistence (`codefyui-tabs::<projectDir>`) kills cross-project tab leakage; cross-project saves refused; SECRET-param stripping preserved on every persistence path.
- `format_version` newer than this build → backend warns (never blocks), editor opens the graph read-only (Save/Save As refused with an honest notice; import/clear re-evaluate the flag).

**Publish provenance.**
- Migration 002 (idempotent, in-place upgrade verified) adds nullable `git_commit`/`git_dirty` to `app_versions`; publish API accepts them; versions list + per-app OpenAPI (`x-codefyui-git-commit`/`x-codefyui-git-dirty`) surface them; NULL trichotomy (unknown/clean/dirty) preserved end-to-end.
- `cdui project publish` wraps publish local-only (target hardcoded to 127.0.0.1 — no server argument exists), refuses when the server's health `project` mismatches the CLI's project, warns loudly on a dirty tree, and records `git rev-parse HEAD` + dirty flag.

**Docs (hard deliverable).**
- New `docs/docs/usage/project-directories.md` — the walkthrough was executed verbatim against a real server (init → validate → restore → start → publish → invoke → provenance) before merge; 6 doc-vs-reality bugs found and fixed by that run.
- `version-control-graphs.md` updated (old flat-file recipe does not forward-map; points here); `publish.md` documents the provenance fields.

## Quality evidence

- Backend: **1671 passed / 8 skipped** (branch baseline 1585; +86 new tests). Frontend: **1692 passed / 93 files** (+43); `npm run build` green. Docs build green (en + zh-TW).
- Non-project mode byte-for-byte unchanged (global refactor guard): every gate is `settings.PROJECT_DIR is not None` / store-mode checks; per-task and whole-branch sweeps found no ungated change.
- Process: 18 tasks, each implemented by a fresh subagent and reviewed by an independent reviewer running empirical probes (env-precedence, fault-injected atomicity, path-confinement escapes incl. prefix-confusable siblings, migration idempotence, pre-image test swaps); 5 fix rounds, all re-reviewed. Final whole-branch review (max-capability model): **SHIP, zero must-fix**.
- Live end-to-end on the built bundle (real Chrome): project badge; drag + Ctrl+S saved with **logic file hash byte-identical** across a drag-only save (only `layout/` changed); scoped localStorage key confirmed; `layout_missing` auto-layout; format v2 file opened read-only with save refusal and **zero disk writes**; CLI publish recorded provenance (full SHA + dirty=false) visible in versions and OpenAPI; publishing from a different project refused with an actionable message.

## Known follow-ups (tracked, deliberately out of scope)

- Interactive WS canvas runs don't resolve graph-embedded presets (protocol change; all five other surfaces do).
- Stale-pin rule exists in CLI and core (brief-mandated sequencing artifact) — unify; same for a third copy of the canonical-vs-legacy collection rule.
- Publish CLI polish: `create:true` always sent; degraded git-status silently reports clean; freeze drops unknown manifest keys.
- Test hardening batch (fail-side gate tests, git_dirty=false e2e leg, Toolbar setActiveTab helper reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
