### PR TITLE
Add dynamic GPT-5.6 model catalog and reasoning effort

### DIFF
--- a/backend/app/api/routes_llm.py
+++ b/backend/app/api/routes_llm.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from ..core.llm_proxy import anthropic, codex, codex_auth, openai_like
+from ..core.llm_proxy import anthropic, codex, codex_auth, codex_models, openai_like
 from ..core.llm_proxy.events import error_event, sse_format
 from ..core.llm_proxy.schema import ChatRequest, Provider
 
@@ -47,6 +47,12 @@ def _validate(req: ChatRequest) -> None:
         raise HTTPException(400, "custom provider requires an http(s) base_url")
     if req.provider == "openai-codex" and codex_auth.status()["status"] != "logged_in":
         raise HTTPException(400, "openai-codex requires ChatGPT sign-in - open Settings to sign in")
+    if req.provider == "openai-codex" and req.reasoning_effort == "ultra":
+        raise HTTPException(
+            400,
+            "reasoning_effort 'ultra' requires Codex multi-agent orchestration "
+            "and is not supported by this proxy",
+        )
 
 
 @router.post("/chat")
@@ -86,10 +92,27 @@ _MODEL_ENDPOINTS = {
 }
 
 
+def _model_capabilities(provider: Provider) -> dict[str, bool]:
+    """Advertise only fields this proxy intentionally routes for a provider."""
+    return {
+        "reasoning_effort": provider in {"openai", "openai-codex"},
+        # The Codex catalog is the only provider catalog currently enriched
+        # with display names and effort metadata; other providers retain the
+        # legacy id-only model shape.
+        "rich_model_catalog": provider == "openai-codex",
+    }
+
+
 @router.post("/models")
 async def list_models(req: ModelsRequest) -> dict:
     if req.provider == "openai-codex":
-        return {"models": [{"id": m} for m in codex.STATIC_MODELS]}
+        client = _client_factory()
+        try:
+            result = await codex_models.list_models(client)
+            result["capabilities"] = _model_capabilities(req.provider)
+            return result
+        finally:
+            await client.aclose()
 
     if req.provider == "custom":
         base = (req.base_url or "").strip().rstrip("/")
@@ -114,7 +137,10 @@ async def list_models(req: ModelsRequest) -> dict:
             raise HTTPException(502, f"upstream {resp.status_code} from {req.provider}")
         data = resp.json().get("data", [])
         models = sorted({m.get("id", "") for m in data if isinstance(m, dict)} - {""})
-        return {"models": [{"id": m} for m in models]}
+        return {
+            "models": [{"id": m} for m in models],
+            "capabilities": _model_capabilities(req.provider),
+        }
     except httpx.HTTPError as exc:
         raise HTTPException(502, f"could not reach {req.provider}: {exc}") from exc
     finally:
@@ -135,4 +161,5 @@ async def codex_status() -> dict:
 @router.post("/codex/logout")
 async def codex_logout() -> dict:
     codex_auth.logout()
+    codex_models.clear_cache()
     return {"status": "logged_out"}

--- a/backend/app/core/llm_proxy/codex.py
+++ b/backend/app/core/llm_proxy/codex.py
@@ -15,16 +15,16 @@ from typing import Any
 
 import httpx
 
-from . import codex_auth
+from . import codex_auth, codex_models
 from ._common import TIMEOUT, content_to_text, parse_tool_args
 from .events import done_event, error_event, text_delta
 from .schema import ChatRequest, ToolCall
 
 _URL = "https://chatgpt.com/backend-api/codex/responses"
 
-# ChatGPT-plan model slugs (mid-2026); the picker shows these because the
-# backend has no public list endpoint for subscription accounts.
-STATIC_MODELS = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"]
+# Backward-compatible id-only view for older in-process callers.  The HTTP
+# route uses the dynamic rich catalog in ``codex_models``.
+STATIC_MODELS = [model["id"] for model in codex_models.fallback_models()]
 
 
 def build_payload(req: ChatRequest) -> dict[str, Any]:
@@ -65,6 +65,8 @@ def build_payload(req: ChatRequest) -> dict[str, Any]:
         "store": False,
         "stream": True,
     }
+    if req.reasoning_effort is not None:
+        payload["reasoning"] = {"effort": req.reasoning_effort}
     return payload
 
 

--- a/backend/app/core/llm_proxy/codex_auth.py
+++ b/backend/app/core/llm_proxy/codex_auth.py
@@ -91,6 +91,23 @@ def email_from_id_token(id_token: str) -> str | None:
 
 # -- token storage ------------------------------------------------------------
 
+# Process-local lineage for the stored ChatGPT session.  Route handlers and
+# OAuth callbacks run on one event loop, so synchronous increments plus a
+# compare-before-write are sufficient to invalidate work that was suspended at
+# an HTTP await.  Refreshes within the same session deliberately do not bump it.
+_SESSION_GENERATION = 0
+
+
+def session_generation() -> int:
+    """Return the current in-process auth-session lineage."""
+    return _SESSION_GENERATION
+
+
+def _advance_session_generation() -> None:
+    global _SESSION_GENERATION
+    _SESSION_GENERATION += 1
+
+
 def load_tokens() -> dict[str, Any] | None:
     p = auth_file()
     if not p.exists():
@@ -102,7 +119,7 @@ def load_tokens() -> dict[str, Any] | None:
     return data if isinstance(data, dict) and data.get("access_token") else None
 
 
-def save_tokens(tokens: dict[str, Any]) -> None:
+def _write_tokens(tokens: dict[str, Any]) -> None:
     p = auth_file()
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(json.dumps(tokens, indent=2), encoding="utf-8")
@@ -112,11 +129,21 @@ def save_tokens(tokens: dict[str, Any]) -> None:
         pass  # best-effort on Windows
 
 
+def save_tokens(tokens: dict[str, Any]) -> None:
+    """Replace the stored session and invalidate suspended prior-session work."""
+    _write_tokens(tokens)
+    _advance_session_generation()
+
+
 def clear_tokens() -> None:
     try:
         auth_file().unlink(missing_ok=True)
     except OSError:
         pass
+    finally:
+        # Bump even when no file exists: logout is an explicit invalidation of
+        # any refresh or catalog operation already suspended at an await.
+        _advance_session_generation()
 
 
 # -- refresh ------------------------------------------------------------------
@@ -160,8 +187,22 @@ async def get_valid_access(
     if not tokens:
         raise CodexNotLoggedIn("Not signed in to ChatGPT")
     if force_refresh or needs_refresh(tokens):
-        tokens = await _refresh(client, tokens)
-        save_tokens(tokens)
+        generation = session_generation()
+        refresh_source = dict(tokens)
+        refreshed = await _refresh(client, refresh_source)
+        current = load_tokens()
+        if (
+            generation != session_generation()
+            or current is None
+            or current.get("access_token") != refresh_source.get("access_token")
+            or current.get("refresh_token") != refresh_source.get("refresh_token")
+        ):
+            raise CodexNotLoggedIn("ChatGPT session changed during token refresh")
+        # Same event loop and no await between the CAS above and this write.
+        # Keep the generation stable: this is credential rotation within the
+        # same authenticated session, not a login/session replacement.
+        _write_tokens(refreshed)
+        tokens = refreshed
     return tokens["access_token"], tokens.get("account_id", "")
 
 
@@ -258,6 +299,7 @@ async def _handle_conn(reader: asyncio.StreamReader,
         if not code:
             writer.write(_http_response(400, "Missing authorization code."))
             return
+        exchange_generation = session_generation()
         client = flow.exchange_client or httpx.AsyncClient()
         try:
             tokens = await _exchange_code(client, code=code,
@@ -265,6 +307,12 @@ async def _handle_conn(reader: asyncio.StreamReader,
         finally:
             if flow.exchange_client is None:
                 await client.aclose()
+        # Logout, cancellation, or a newer login flow may have happened while
+        # the OAuth token exchange was awaiting the network.  The captured
+        # callback must not resurrect or replace that newer session.
+        if _flow is not flow or session_generation() != exchange_generation:
+            writer.write(_http_response(400, "Sign-in was cancelled or superseded."))
+            return
         save_tokens(tokens)
         writer.write(_http_response(
             200,

--- a/backend/app/core/llm_proxy/codex_models.py
+++ b/backend/app/core/llm_proxy/codex_models.py
@@ -1,0 +1,423 @@
+"""Account-aware model discovery for the ChatGPT Codex backend.
+
+The Codex backend exposes richer metadata than the public OpenAI ``/v1/models``
+endpoint.  Treat that response as an untrusted, best-effort catalog: retain only
+picker fields this proxy understands, cache by ChatGPT account, and keep a
+built-in catalog so settings remain usable while logged out or offline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from time import monotonic
+from typing import Any
+
+import httpx
+
+from . import codex_auth
+
+logger = logging.getLogger(__name__)
+
+MODELS_URL = "https://chatgpt.com/backend-api/codex/models"
+CLIENT_VERSION = "0.144.0"
+CACHE_TTL_S = 5 * 60
+FETCH_TIMEOUT_S = 5.0
+
+_MAX_ID_LENGTH = 256
+_MAX_DISPLAY_NAME_LENGTH = 120
+_MAX_DESCRIPTION_LENGTH = 500
+_MAX_EFFORT_LENGTH = 64
+_MAX_MODELS = 500
+
+_MODEL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._:/-]*$")
+_EFFORT_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+_EFFORT_DESCRIPTIONS = {
+    "low": "Fast responses with lighter reasoning",
+    "medium": "Balances speed and reasoning depth for everyday tasks",
+    "high": "Greater reasoning depth for complex problems",
+    "xhigh": "Extra high reasoning depth for complex problems",
+    "max": "Maximum reasoning depth for the hardest problems",
+}
+
+# The three GPT-5.6 variants mirror the compatible portion of the Codex client
+# catalog.  ``ultra`` is deliberately absent: it is a Codex orchestration mode
+# backed by automatic delegation, not a portable single-request effort value.
+_FALLBACK_SPECS: tuple[
+    tuple[str, str, str, str | None, tuple[str, ...]], ...
+] = (
+    (
+        "gpt-5.6-sol",
+        "GPT-5.6 Sol",
+        "Latest frontier agentic coding model.",
+        "low",
+        ("low", "medium", "high", "xhigh", "max"),
+    ),
+    (
+        "gpt-5.6-terra",
+        "GPT-5.6 Terra",
+        "Balanced agentic coding model for everyday work.",
+        "medium",
+        ("low", "medium", "high", "xhigh", "max"),
+    ),
+    (
+        "gpt-5.6-luna",
+        "GPT-5.6 Luna",
+        "Fast and affordable agentic coding model.",
+        "medium",
+        ("low", "medium", "high", "xhigh", "max"),
+    ),
+    (
+        "gpt-5.5",
+        "GPT-5.5",
+        "Previous frontier model for complex coding and research.",
+        "medium",
+        ("low", "medium", "high", "xhigh"),
+    ),
+    (
+        "gpt-5.4",
+        "GPT-5.4",
+        "Legacy general-purpose coding model.",
+        "medium",
+        ("low", "medium", "high", "xhigh"),
+    ),
+    (
+        "gpt-5.4-mini",
+        "GPT-5.4 Mini",
+        "Legacy small and cost-efficient coding model.",
+        "medium",
+        ("low", "medium", "high", "xhigh"),
+    ),
+    (
+        "gpt-5.3-codex-spark",
+        "GPT-5.3 Codex Spark",
+        "Legacy low-latency Codex research-preview model.",
+        None,
+        (),
+    ),
+)
+
+
+@dataclass
+class _CacheEntry:
+    models: list[dict[str, Any]]
+    etag: str | None
+    fetched_at: float
+
+
+_CACHE: dict[str, _CacheEntry] = {}
+_CACHE_GENERATION = 0
+
+
+def clear_cache() -> None:
+    """Discard all sanitized model metadata (used on logout and in tests)."""
+    global _CACHE_GENERATION
+    _CACHE.clear()
+    # Invalidate in-flight fetches so a response that started before logout or
+    # an explicit clear cannot repopulate the cache after this point.
+    _CACHE_GENERATION += 1
+
+
+def _clean_text(value: Any, max_length: int) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value or len(value) > max_length:
+        return None
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        return None
+    return value
+
+
+def _clean_effort(value: Any) -> str | None:
+    effort = _clean_text(value, _MAX_EFFORT_LENGTH)
+    if effort is None or not _EFFORT_RE.fullmatch(effort) or effort == "ultra":
+        return None
+    return effort
+
+
+def _clean_model_id(value: Any) -> str | None:
+    model_id = _clean_text(value, _MAX_ID_LENGTH)
+    if model_id is None or not _MODEL_ID_RE.fullmatch(model_id):
+        return None
+    return model_id
+
+
+def _sanitize_model(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    visibility = raw.get("visibility")
+    if visibility not in (None, "list") or raw.get("supported_in_api") is False:
+        return None
+
+    model_id = _clean_model_id(raw.get("slug")) or _clean_model_id(raw.get("id"))
+    if model_id is None:
+        return None
+    display_name = (
+        _clean_text(raw.get("display_name"), _MAX_DISPLAY_NAME_LENGTH)
+        or model_id
+    )
+    description = _clean_text(raw.get("description"), _MAX_DESCRIPTION_LENGTH)
+
+    raw_levels = raw.get(
+        "supported_reasoning_levels",
+        raw.get("supported_reasoning_efforts", []),
+    )
+    levels: list[dict[str, str]] = []
+    seen_efforts: set[str] = set()
+    if isinstance(raw_levels, list):
+        for raw_level in raw_levels:
+            if isinstance(raw_level, dict):
+                effort = _clean_effort(
+                    raw_level.get(
+                        "effort",
+                        raw_level.get("reasoning_effort", raw_level.get("level")),
+                    )
+                )
+                level_description = _clean_text(
+                    raw_level.get("description"), _MAX_DESCRIPTION_LENGTH
+                )
+            else:
+                effort = _clean_effort(raw_level)
+                level_description = None
+            if effort is None or effort in seen_efforts:
+                continue
+            seen_efforts.add(effort)
+            levels.append({
+                "effort": effort,
+                "description": level_description or effort,
+            })
+
+    default_effort = _clean_effort(
+        raw.get("default_reasoning_level", raw.get("default_reasoning_effort"))
+    )
+    if default_effort not in seen_efforts:
+        default_effort = (
+            "medium" if "medium" in seen_efforts
+            else levels[0]["effort"] if levels
+            else None
+        )
+
+    return {
+        # ``id`` preserves the existing /api/llm/models client contract.
+        "id": model_id,
+        "display_name": display_name,
+        "description": description,
+        "default_reasoning_effort": default_effort,
+        "supported_reasoning_efforts": levels,
+    }
+
+
+def _sanitize_catalog(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
+        return []
+    raw_models = payload["models"]
+    # The upstream catalog assigns lower numbers to preferred models.  Do not
+    # expose priority itself, but preserve its picker order where valid.
+    raw_models = sorted(
+        raw_models,
+        key=lambda model: (
+            model.get("priority", 1_000_000)
+            if isinstance(model, dict) and isinstance(model.get("priority"), int)
+            else 1_000_000
+        ),
+    )
+
+    models: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for raw_model in raw_models:
+        model = _sanitize_model(raw_model)
+        if model is None or model["id"] in seen_ids:
+            continue
+        seen_ids.add(model["id"])
+        models.append(model)
+        if len(models) >= _MAX_MODELS:
+            break
+    return models
+
+
+def fallback_models() -> list[dict[str, Any]]:
+    models: list[dict[str, Any]] = []
+    for model_id, display_name, description, default_effort, efforts in _FALLBACK_SPECS:
+        models.append({
+            "id": model_id,
+            "display_name": display_name,
+            "description": description,
+            "default_reasoning_effort": default_effort,
+            "supported_reasoning_efforts": [
+                {
+                    "effort": effort,
+                    "description": _EFFORT_DESCRIPTIONS.get(effort, effort),
+                }
+                for effort in efforts
+            ],
+        })
+    return models
+
+
+def _cache_key(account_id: str, access_token: str) -> str:
+    if account_id:
+        return f"account:{account_id}"
+    # Older/incomplete sessions may lack account_id.  Hashing the access token
+    # still prevents one account from receiving another account's catalog.
+    digest = hashlib.sha256(access_token.encode()).hexdigest()
+    return f"token:{digest}"
+
+
+def _stored_cache_key() -> str | None:
+    tokens = codex_auth.load_tokens()
+    if not tokens:
+        return None
+    access_token = tokens.get("access_token")
+    account_id = tokens.get("account_id", "")
+    if not isinstance(access_token, str) or not access_token:
+        return None
+    return _cache_key(account_id if isinstance(account_id, str) else "", access_token)
+
+
+def _rotate_legacy_cache_key(
+    previous_key: str | None, current_key: str, *, lineage_matches: bool
+) -> _CacheEntry | None:
+    """Carry a legacy token-keyed cache across an access-token refresh.
+
+    Modern sessions use the stable ChatGPT account id, but older saved sessions
+    can lack it and therefore fall back to an access-token hash.  Refreshing
+    such a session may rotate only the token or may also recover a stable
+    account id.  Move (and do not copy) the old entry to either resulting key
+    so subsequent failures can still use stale data without leaving the same
+    catalog reachable under an obsolete token key.
+    """
+    if (
+        not lineage_matches
+        or previous_key is None
+        or not previous_key.startswith("token:")
+        or previous_key == current_key
+    ):
+        return _CACHE.get(current_key)
+
+    previous_entry = _CACHE.pop(previous_key, None)
+    if previous_entry is not None:
+        # A cache already associated with the rotated token is more recent and
+        # must not be replaced by the legacy entry.
+        _CACHE.setdefault(current_key, previous_entry)
+    return _CACHE.get(current_key)
+
+
+def _response(
+    models: list[dict[str, Any]], *, source: str, stale: bool = False
+) -> dict[str, Any]:
+    return {"models": deepcopy(models), "source": source, "stale": stale}
+
+
+def _context_is_current(auth_generation: int, cache_generation: int) -> bool:
+    return (
+        codex_auth.session_generation() == auth_generation
+        and _CACHE_GENERATION == cache_generation
+    )
+
+
+def _stale_or_fallback(
+    cache_key: str | None, *, auth_generation: int, cache_generation: int
+) -> dict[str, Any]:
+    if not _context_is_current(auth_generation, cache_generation):
+        return _response(fallback_models(), source="fallback")
+    if cache_key is not None and (entry := _CACHE.get(cache_key)) is not None:
+        return _response(entry.models, source="stale", stale=True)
+    return _response(fallback_models(), source="fallback")
+
+
+async def list_models(client: httpx.AsyncClient) -> dict[str, Any]:
+    """Return a sanitized account catalog with cache/stale/fallback behavior."""
+    cache_generation = _CACHE_GENERATION
+    initial_auth_generation = codex_auth.session_generation()
+    stored_cache_key = _stored_cache_key()
+    try:
+        access_token, account_id = await codex_auth.get_valid_access(client)
+    except codex_auth.CodexNotLoggedIn:
+        return _response(fallback_models(), source="fallback")
+    except httpx.HTTPError as exc:
+        logger.warning("Codex model auth refresh failed: %s", type(exc).__name__)
+        return _stale_or_fallback(
+            stored_cache_key,
+            auth_generation=initial_auth_generation,
+            cache_generation=cache_generation,
+        )
+
+    auth_generation = codex_auth.session_generation()
+    if _CACHE_GENERATION != cache_generation:
+        return _response(fallback_models(), source="fallback")
+    cache_key = _cache_key(account_id, access_token)
+    entry = _rotate_legacy_cache_key(
+        stored_cache_key,
+        cache_key,
+        lineage_matches=initial_auth_generation == auth_generation,
+    )
+    now = monotonic()
+    if entry is not None and now - entry.fetched_at < CACHE_TTL_S:
+        if _context_is_current(auth_generation, cache_generation):
+            return _response(entry.models, source="cache")
+        return _response(fallback_models(), source="fallback")
+
+    async def request_catalog(token: str, account: str) -> httpx.Response:
+        headers = {
+            "authorization": f"Bearer {token}",
+            "chatgpt-account-id": account,
+            "originator": codex_auth.ORIGINATOR,
+            "accept": "application/json",
+        }
+        if entry is not None and entry.etag:
+            headers["if-none-match"] = entry.etag
+        return await client.get(
+            MODELS_URL,
+            params={"client_version": CLIENT_VERSION},
+            headers=headers,
+            timeout=FETCH_TIMEOUT_S,
+        )
+
+    try:
+        response = await request_catalog(access_token, account_id)
+        if response.status_code == 401:
+            previous_cache_key = cache_key
+            previous_auth_generation = auth_generation
+            access_token, account_id = await codex_auth.get_valid_access(
+                client, force_refresh=True
+            )
+            auth_generation = codex_auth.session_generation()
+            if _CACHE_GENERATION != cache_generation:
+                return _response(fallback_models(), source="fallback")
+            cache_key = _cache_key(account_id, access_token)
+            entry = _rotate_legacy_cache_key(
+                previous_cache_key,
+                cache_key,
+                lineage_matches=previous_auth_generation == auth_generation,
+            )
+            response = await request_catalog(access_token, account_id)
+
+        if response.status_code == 304 and entry is not None:
+            if not _context_is_current(auth_generation, cache_generation):
+                return _response(fallback_models(), source="fallback")
+            entry.fetched_at = monotonic()
+            return _response(entry.models, source="cache")
+        response.raise_for_status()
+        models = _sanitize_catalog(response.json())
+        if not models:
+            raise ValueError("Codex model catalog contained no visible valid models")
+        if not _context_is_current(auth_generation, cache_generation):
+            return _response(fallback_models(), source="fallback")
+        _CACHE[cache_key] = _CacheEntry(
+            models=deepcopy(models),
+            etag=response.headers.get("etag"),
+            fetched_at=monotonic(),
+        )
+        return _response(models, source="live")
+    except (codex_auth.CodexNotLoggedIn, httpx.HTTPError, ValueError) as exc:
+        logger.warning("Codex model catalog refresh failed: %s", type(exc).__name__)
+        return _stale_or_fallback(
+            cache_key,
+            auth_generation=auth_generation,
+            cache_generation=cache_generation,
+        )

--- a/backend/app/core/llm_proxy/openai_like.py
+++ b/backend/app/core/llm_proxy/openai_like.py
@@ -65,8 +65,16 @@ def build_payload(req: ChatRequest) -> dict[str, Any]:
         "model": req.model,
         "messages": messages,
         "stream": True,
-        "max_tokens": req.max_tokens,
     }
+    if req.provider == "openai":
+        # First-party Chat Completions deprecated max_tokens for newer models.
+        payload["max_completion_tokens"] = req.max_tokens
+        if req.reasoning_effort is not None:
+            payload["reasoning_effort"] = req.reasoning_effort
+    else:
+        # Preserve the long-standing OpenAI-compatible contract for OpenRouter
+        # and custom servers; many reject newer first-party-only fields.
+        payload["max_tokens"] = req.max_tokens
     # Older OpenAI-compatible servers (Ollama, LM Studio, etc.) reject unknown
     # fields -- only send stream_options for first-party providers.
     if req.provider != "custom":

--- a/backend/app/core/llm_proxy/schema.py
+++ b/backend/app/core/llm_proxy/schema.py
@@ -42,3 +42,13 @@ class ChatRequest(BaseModel):
     base_url: str | None = None  # "custom" provider only
     max_tokens: int = Field(default=4096, ge=1, le=200_000)
     temperature: float | None = Field(default=None, ge=0.0, le=2.0)
+    # Keep this open to future provider-advertised effort names instead of a
+    # closed Literal.  The conservative slug shape prevents control/whitespace
+    # values from riding through the proxy while accepting additions beyond
+    # today's none/low/medium/high/xhigh/max set.
+    reasoning_effort: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z][a-z0-9_-]*$",
+    )

--- a/backend/tests/test_llm_anthropic.py
+++ b/backend/tests/test_llm_anthropic.py
@@ -47,11 +47,14 @@ def test_payload_extracts_system_and_maps_tools():
                         tool_calls=[ToolCall(id="t1", name="apply", arguments={"x": 2})]),
             ChatMessage(role="tool", tool_call_id="t1", content="ok"),
         ],
+        reasoning_effort="high",
     )
     p = build_payload(req)
     assert p["system"] == "be brief"
     assert p["model"] == "claude-sonnet-4-6"
     assert p["stream"] is True
+    assert "reasoning" not in p
+    assert "reasoning_effort" not in p
     assert p["tools"] == [{"name": "apply", "description": "d",
                            "input_schema": {"type": "object", "properties": {}}}]
     assert all(m["role"] != "system" for m in p["messages"])

--- a/backend/tests/test_llm_codex.py
+++ b/backend/tests/test_llm_codex.py
@@ -47,12 +47,14 @@ def test_payload_shapes():
                     tool_calls=[ToolCall(id="c1", name="apply", arguments={"x": 1})]),
         ChatMessage(role="tool", tool_call_id="c1", content="done"),
     ], tools=[ToolSpec(name="apply", description="d",
-                       input_schema={"type": "object", "properties": {}})])
+                       input_schema={"type": "object", "properties": {}})],
+        reasoning_effort="xhigh")
     p = codex.build_payload(req)
     assert p["model"] == "gpt-5.5"
     assert p["instructions"] == "be terse"
     assert p["store"] is False
     assert p["stream"] is True
+    assert p["reasoning"] == {"effort": "xhigh"}
     items = p["input"]
     assert items[0] == {"type": "message", "role": "user",
                         "content": [{"type": "input_text", "text": "go"}]}
@@ -144,8 +146,14 @@ async def test_response_failed_becomes_error():
     assert "usage limit" in events[-1]["message"]
 
 
-def test_static_models_list():
-    assert "gpt-5.5" in codex.STATIC_MODELS
+def test_static_models_compatibility_view_includes_gpt_5_6_and_legacy():
+    assert {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"} <= set(
+        codex.STATIC_MODELS
+    )
+
+
+def test_payload_omits_reasoning_when_unspecified():
+    assert "reasoning" not in codex.build_payload(make_req())
 
 def test_payload_flattens_multimodal_content_to_text():
     content = [

--- a/backend/tests/test_llm_codex_auth.py
+++ b/backend/tests/test_llm_codex_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import json
@@ -139,6 +140,60 @@ async def test_get_valid_access_raises_when_logged_out():
             await codex_auth.get_valid_access(client)
 
 
+@pytest.mark.asyncio
+async def test_logout_during_refresh_cannot_restore_the_old_session():
+    codex_auth.save_tokens(seeded_tokens(exp_offset=10))
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        refresh_started.set()
+        await release_refresh.wait()
+        return httpx.Response(200, json={
+            "access_token": make_jwt({"exp": int(time.time()) + 7200}),
+            "refresh_token": "rt-2",
+        })
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        pending = asyncio.create_task(codex_auth.get_valid_access(client))
+        await refresh_started.wait()
+        codex_auth.logout()
+        release_refresh.set()
+        with pytest.raises(codex_auth.CodexNotLoggedIn, match="session changed"):
+            await pending
+
+    assert codex_auth.load_tokens() is None
+
+
+@pytest.mark.asyncio
+async def test_new_login_during_refresh_cannot_be_overwritten():
+    codex_auth.save_tokens(seeded_tokens(exp_offset=10, account_id="acc-a"))
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        refresh_started.set()
+        await release_refresh.wait()
+        return httpx.Response(200, json={
+            "access_token": make_jwt({"exp": int(time.time()) + 7200}),
+            "refresh_token": "rt-a-rotated",
+        })
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        pending = asyncio.create_task(codex_auth.get_valid_access(client))
+        await refresh_started.wait()
+        replacement = seeded_tokens(account_id="acc-b")
+        replacement["refresh_token"] = "rt-b"
+        codex_auth.save_tokens(replacement)
+        release_refresh.set()
+        with pytest.raises(codex_auth.CodexNotLoggedIn, match="session changed"):
+            await pending
+
+    stored = codex_auth.load_tokens()
+    assert stored["account_id"] == "acc-b"
+    assert stored["refresh_token"] == "rt-b"
+
+
 # -- full login flow over a real localhost socket ------------------------------
 
 @pytest.mark.asyncio
@@ -191,3 +246,40 @@ async def test_login_flow_rejects_bad_state():
             params={"code": "x", "state": "WRONG"})
     assert r.status_code == 400
     assert codex_auth.status()["status"] == "pending"  # flow still waiting
+
+
+@pytest.mark.asyncio
+async def test_logout_during_code_exchange_cannot_restore_session():
+    exchange_started = asyncio.Event()
+    release_exchange = asyncio.Event()
+
+    async def token_handler(request: httpx.Request) -> httpx.Response:
+        exchange_started.set()
+        await release_exchange.wait()
+        return httpx.Response(200, json={
+            "id_token": make_jwt({
+                "email": "late@example.com",
+                "https://api.openai.com/auth": {"chatgpt_account_id": "acc-late"},
+            }),
+            "access_token": make_jwt({"exp": int(time.time()) + 3600}),
+            "refresh_token": "rt-late",
+        })
+
+    exchange_client = httpx.AsyncClient(transport=httpx.MockTransport(token_handler))
+    auth_url = await codex_auth.start_login(ports=(0,), exchange_client=exchange_client)
+    query = parse_qs(urlparse(auth_url).query)
+    port = codex_auth.active_login_port()
+
+    async with httpx.AsyncClient() as browser:
+        callback = asyncio.create_task(browser.get(
+            f"http://127.0.0.1:{port}/auth/callback",
+            params={"code": "late-code", "state": query["state"][0]},
+        ))
+        await exchange_started.wait()
+        codex_auth.logout()
+        release_exchange.set()
+        response = await callback
+
+    assert response.status_code == 400
+    assert codex_auth.load_tokens() is None
+    assert codex_auth.status()["status"] == "logged_out"

--- a/backend/tests/test_llm_codex_models.py
+++ b/backend/tests/test_llm_codex_models.py
@@ -1,0 +1,420 @@
+"""Dynamic, account-isolated Codex model catalog tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from app.core.llm_proxy import codex_auth, codex_models
+
+
+@pytest.fixture(autouse=True)
+def reset_catalog_cache():
+    codex_models.clear_cache()
+    yield
+    codex_models.clear_cache()
+
+
+def _model(model_id: str, **overrides):
+    model = {
+        "slug": model_id,
+        "display_name": model_id.upper(),
+        "description": f"Description for {model_id}",
+        "visibility": "list",
+        "supported_in_api": True,
+        "default_reasoning_level": "medium",
+        "supported_reasoning_levels": [
+            {"effort": "low", "description": "Low"},
+            {"effort": "medium", "description": "Medium"},
+        ],
+    }
+    model.update(overrides)
+    return model
+
+
+def _client(handler):
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_live_catalog_is_sanitized_and_uses_expected_request(monkeypatch):
+    async def fake_access(client, *, force_refresh=False):
+        return "access-secret", "account-1"
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", fake_access)
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["headers"] = request.headers
+        seen["timeout"] = request.extensions["timeout"]
+        return httpx.Response(200, headers={"etag": '"catalog-v1"'}, json={"models": [
+            _model(
+                "gpt-5.6-sol",
+                priority=1,
+                default_reasoning_level="ultra",
+                supported_reasoning_levels=[
+                    {"effort": "low", "description": "Low"},
+                    {"effort": "ultra", "description": "Orchestration"},
+                    {"effort": "High", "description": "Uppercase"},
+                    {"effort": "very high", "description": "Space"},
+                    {"reasoning_effort": "future_effort", "description": "Future"},
+                ],
+                model_provider="secret-provider-field",
+                system_instructions="do not expose this",
+            ),
+            _model("hidden-model", priority=2, visibility="hide"),
+            _model("unsupported-model", priority=3, supported_in_api=False),
+            _model("bad model id", priority=4),
+            _model("gpt-5.6-sol", priority=5, description="duplicate"),
+        ]})
+
+    async with _client(handler) as client:
+        result = await codex_models.list_models(client)
+
+    assert seen["url"] == (
+        "https://chatgpt.com/backend-api/codex/models?client_version=0.144.0"
+    )
+    assert seen["headers"]["authorization"] == "Bearer access-secret"
+    assert seen["headers"]["chatgpt-account-id"] == "account-1"
+    assert seen["headers"]["originator"] == codex_auth.ORIGINATOR
+    assert set(seen["timeout"].values()) == {5.0}
+    assert result["source"] == "live"
+    assert result["stale"] is False
+    assert len(result["models"]) == 1
+
+    model = result["models"][0]
+    assert set(model) == {
+        "id",
+        "display_name",
+        "description",
+        "default_reasoning_effort",
+        "supported_reasoning_efforts",
+    }
+    assert model["id"] == "gpt-5.6-sol"
+    assert model["default_reasoning_effort"] == "low"
+    assert model["supported_reasoning_efforts"] == [
+        {"effort": "low", "description": "Low"},
+        {"effort": "future_effort", "description": "Future"},
+    ]
+    assert "system_instructions" not in model
+    assert "model_provider" not in model
+    assert "priority" not in model
+
+
+@pytest.mark.asyncio
+async def test_fresh_cache_is_reused_for_the_same_account(monkeypatch):
+    async def fake_access(client, *, force_refresh=False):
+        return "token-1", "account-1"
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", fake_access)
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"models": [_model("model-one")]})
+
+    async with _client(handler) as client:
+        first = await codex_models.list_models(client)
+        second = await codex_models.list_models(client)
+
+    assert first["source"] == "live"
+    assert second["source"] == "cache"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_is_isolated_by_account(monkeypatch):
+    current = {"account": "account-a"}
+
+    async def fake_access(client, *, force_refresh=False):
+        account = current["account"]
+        return f"token-{account}", account
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", fake_access)
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        account = request.headers["chatgpt-account-id"]
+        return httpx.Response(200, json={"models": [_model(f"model-{account}")]})
+
+    async with _client(handler) as client:
+        account_a = await codex_models.list_models(client)
+        current["account"] = "account-b"
+        account_b = await codex_models.list_models(client)
+
+    assert account_a["models"][0]["id"] == "model-account-a"
+    assert account_b["models"][0]["id"] == "model-account-b"
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_expired_cache_revalidates_with_etag(monkeypatch):
+    clock = {"now": 0.0}
+    monkeypatch.setattr(codex_models, "monotonic", lambda: clock["now"])
+
+    async def fake_access(client, *, force_refresh=False):
+        return "token-1", "account-1"
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", fake_access)
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(
+                200,
+                headers={"etag": '"v1"'},
+                json={"models": [_model("model-one")]},
+            )
+        assert request.headers["if-none-match"] == '"v1"'
+        return httpx.Response(304)
+
+    async with _client(handler) as client:
+        first = await codex_models.list_models(client)
+        clock["now"] = codex_models.CACHE_TTL_S + 1
+        second = await codex_models.list_models(client)
+
+    assert first["source"] == "live"
+    assert second["source"] == "cache"
+    assert second["models"] == first["models"]
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_expired_cache_is_returned_stale_on_timeout(monkeypatch):
+    clock = {"now": 0.0}
+    monkeypatch.setattr(codex_models, "monotonic", lambda: clock["now"])
+
+    async def fake_access(client, *, force_refresh=False):
+        return "token-1", "account-1"
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", fake_access)
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(200, json={"models": [_model("model-one")]})
+        raise httpx.ReadTimeout("catalog timeout", request=request)
+
+    async with _client(handler) as client:
+        first = await codex_models.list_models(client)
+        clock["now"] = codex_models.CACHE_TTL_S + 1
+        second = await codex_models.list_models(client)
+
+    assert first["source"] == "live"
+    assert second["source"] == "stale"
+    assert second["stale"] is True
+    assert second["models"] == first["models"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rotated_account_id", ["", "account-1"], ids=["token-key", "account-key"]
+)
+async def test_legacy_token_key_rotation_preserves_stale_cache_on_timeout(
+    monkeypatch, rotated_account_id
+):
+    clock = {"now": 0.0}
+    session = {
+        "stored_token": "legacy-token",
+        "stored_account_id": "",
+        "access_calls": 0,
+    }
+    monkeypatch.setattr(codex_models, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(
+        codex_auth,
+        "load_tokens",
+        lambda: {
+            "access_token": session["stored_token"],
+            "account_id": session["stored_account_id"],
+        },
+    )
+
+    async def rotating_access(client, *, force_refresh=False):
+        session["access_calls"] += 1
+        if session["access_calls"] == 1:
+            return "legacy-token", ""
+        # Mirror an auth refresh: the persisted access token changes before
+        # get_valid_access returns, and the refresh may also recover a stable
+        # account id for the legacy session.
+        session["stored_token"] = "rotated-token"
+        session["stored_account_id"] = rotated_account_id
+        return "rotated-token", rotated_account_id
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", rotating_access)
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            assert request.headers["authorization"] == "Bearer legacy-token"
+            return httpx.Response(200, json={"models": [_model("model-one")]})
+        assert request.headers["authorization"] == "Bearer rotated-token"
+        assert request.headers["chatgpt-account-id"] == rotated_account_id
+        raise httpx.ReadTimeout("catalog timeout", request=request)
+
+    async with _client(handler) as client:
+        first = await codex_models.list_models(client)
+        clock["now"] = codex_models.CACHE_TTL_S + 1
+        second = await codex_models.list_models(client)
+        # The persisted token is now the rotated value.  A third failed fetch
+        # proves the stale entry was moved to that key instead of being used
+        # only once through an old-key fallback.
+        third = await codex_models.list_models(client)
+
+    assert first["source"] == "live"
+    assert second["source"] == "stale"
+    assert second["stale"] is True
+    assert second["models"] == first["models"]
+    assert third["source"] == "stale"
+    assert third["models"] == first["models"]
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_401_session_switch_does_not_move_legacy_cache_to_new_account(
+    monkeypatch,
+):
+    clock = {"now": 0.0}
+    session = {"generation": 1, "token": "a-token", "account_id": ""}
+    monkeypatch.setattr(codex_models, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(
+        codex_auth, "session_generation", lambda: session["generation"]
+    )
+    monkeypatch.setattr(
+        codex_auth,
+        "load_tokens",
+        lambda: {
+            "access_token": session["token"],
+            "account_id": session["account_id"],
+        },
+    )
+
+    async def switching_access(client, *, force_refresh=False):
+        if force_refresh:
+            session.update({
+                "generation": 2,
+                "token": "b-token",
+                "account_id": "account-b",
+            })
+        return session["token"], session["account_id"]
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", switching_access)
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(200, json={"models": [_model("model-account-a")]})
+        if calls == 2:
+            assert request.headers["authorization"] == "Bearer a-token"
+            return httpx.Response(401, json={"detail": "expired"})
+        assert request.headers["authorization"] == "Bearer b-token"
+        assert request.headers["chatgpt-account-id"] == "account-b"
+        raise httpx.ReadTimeout("account-b catalog timeout", request=request)
+
+    async with _client(handler) as client:
+        first = await codex_models.list_models(client)
+        clock["now"] = codex_models.CACHE_TTL_S + 1
+        switched = await codex_models.list_models(client)
+
+    a_key = codex_models._cache_key("", "a-token")
+    b_key = codex_models._cache_key("account-b", "b-token")
+    assert first["source"] == "live"
+    assert switched["source"] == "fallback"
+    assert a_key in codex_models._CACHE
+    assert b_key not in codex_models._CACHE
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_clear_cache_prevents_inflight_success_from_repopulating(monkeypatch):
+    async def fake_access(client, *, force_refresh=False):
+        return "token-1", "account-1"
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", fake_access)
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            request_started.set()
+            await release_response.wait()
+            return httpx.Response(200, json={"models": [_model("model-one")]})
+        raise httpx.ReadTimeout("catalog timeout", request=request)
+
+    async with _client(handler) as client:
+        pending = asyncio.create_task(codex_models.list_models(client))
+        await request_started.wait()
+        codex_models.clear_cache()
+        release_response.set()
+        invalidated = await pending
+        after_clear = await codex_models.list_models(client)
+
+    assert invalidated["source"] == "fallback"
+    assert after_clear["source"] == "fallback"
+    assert codex_models._CACHE == {}
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_logout_during_401_refresh_returns_fallback(monkeypatch):
+    calls = 0
+
+    async def fake_access(client, *, force_refresh=False):
+        if force_refresh:
+            raise codex_auth.CodexNotLoggedIn("logged out during refresh")
+        return "expired-token", "account-1"
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", fake_access)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(401, json={"detail": "expired"})
+
+    async with _client(handler) as client:
+        result = await codex_models.list_models(client)
+
+    assert calls == 1
+    assert result["source"] == "fallback"
+    assert any(model["id"] == "gpt-5.6-sol" for model in result["models"])
+
+
+@pytest.mark.asyncio
+async def test_logged_out_fallback_includes_gpt_5_6_and_excludes_ultra(monkeypatch):
+    async def not_logged_in(client, *, force_refresh=False):
+        raise codex_auth.CodexNotLoggedIn("logged out")
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", not_logged_in)
+    async with _client(lambda request: httpx.Response(500)) as client:
+        result = await codex_models.list_models(client)
+
+    by_id = {model["id"]: model for model in result["models"]}
+    assert result["source"] == "fallback"
+    assert {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"} <= set(by_id)
+    for model_id in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+        efforts = {
+            item["effort"] for item in by_id[model_id]["supported_reasoning_efforts"]
+        }
+        assert "ultra" not in efforts
+
+
+def test_sanitized_catalog_is_bounded_to_500_models():
+    payload = {"models": [_model(f"model-{index}") for index in range(505)]}
+    models = codex_models._sanitize_catalog(payload)
+    assert len(models) == 500

--- a/backend/tests/test_llm_openai_like.py
+++ b/backend/tests/test_llm_openai_like.py
@@ -61,12 +61,15 @@ def test_payload_maps_messages_tools_and_sampling():
             ChatMessage(role="tool", tool_call_id="c1", content="done"),
         ],
         temperature=0.3,
+        reasoning_effort="high",
     )
     p = build_payload(req)
     assert p["model"] == "gpt-5.2"
     assert p["stream"] is True
     assert p["stream_options"] == {"include_usage": True}
-    assert p["max_tokens"] == 4096
+    assert p["max_completion_tokens"] == 4096
+    assert "max_tokens" not in p
+    assert p["reasoning_effort"] == "high"
     assert p["temperature"] == 0.3
     assert p["tools"][0]["function"]["name"] == "apply"
     assert p["tools"][0]["function"]["parameters"]["properties"]["x"]["type"] == "integer"
@@ -167,9 +170,25 @@ async def test_custom_provider_hits_custom_base():
 
 
 def test_custom_payload_has_no_stream_options():
-    req = make_req(provider="custom", base_url="http://127.0.0.1:11434/v1", api_key=None)
+    req = make_req(
+        provider="custom",
+        base_url="http://127.0.0.1:11434/v1",
+        api_key=None,
+        reasoning_effort="high",
+    )
     p = build_payload(req)
     assert "stream_options" not in p
+    assert p["max_tokens"] == 4096
+    assert "max_completion_tokens" not in p
+    assert "reasoning_effort" not in p
+
+
+def test_openrouter_keeps_compatible_token_field_and_omits_effort():
+    req = make_req(provider="openrouter", reasoning_effort="high")
+    p = build_payload(req)
+    assert p["max_tokens"] == 4096
+    assert "max_completion_tokens" not in p
+    assert "reasoning_effort" not in p
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_llm_routes.py
+++ b/backend/tests/test_llm_routes.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.api import routes_llm
-from app.core.llm_proxy import codex_auth
+from app.core.llm_proxy import codex_auth, codex_models
 
 
 @pytest.fixture
@@ -98,12 +98,61 @@ def test_models_openai(client, monkeypatch):
     r = client.post("/api/llm/models", json={"provider": "openai", "api_key": "sk-x"})
     assert r.status_code == 200
     assert {"id": "gpt-4.1"} in r.json()["models"]
+    assert r.json()["capabilities"] == {
+        "reasoning_effort": True,
+        "rich_model_catalog": False,
+    }
 
 
-def test_models_codex_static(client):
+def test_models_codex_fallback_is_rich_and_backward_compatible(client):
+    codex_models.clear_cache()
     r = client.post("/api/llm/models", json={"provider": "openai-codex"})
     assert r.status_code == 200
-    assert {"id": "gpt-5.5"} in r.json()["models"]
+    body = r.json()
+    assert any(model["id"] == "gpt-5.5" for model in body["models"])
+    sol = next(model for model in body["models"] if model["id"] == "gpt-5.6-sol")
+    assert sol["default_reasoning_effort"] == "low"
+    assert {item["effort"] for item in sol["supported_reasoning_efforts"]} == {
+        "low", "medium", "high", "xhigh", "max",
+    }
+    assert body["capabilities"] == {
+        "reasoning_effort": True,
+        "rich_model_catalog": True,
+    }
+
+
+@pytest.mark.parametrize("provider", ["openrouter", "anthropic", "custom"])
+def test_models_non_forwarding_provider_capabilities_are_false(
+    client, monkeypatch, provider
+):
+    mock_upstream(
+        monkeypatch,
+        lambda request: httpx.Response(200, json={"data": [{"id": "model-1"}]}),
+    )
+    body = {"provider": provider, "api_key": "key"}
+    if provider == "custom":
+        body.update({"api_key": None, "base_url": "http://127.0.0.1:11434/v1"})
+    r = client.post("/api/llm/models", json=body)
+    assert r.status_code == 200
+    assert r.json()["capabilities"] == {
+        "reasoning_effort": False,
+        "rich_model_catalog": False,
+    }
+
+
+def test_chat_rejects_codex_ultra_even_when_logged_in(client, monkeypatch):
+    monkeypatch.setattr(codex_auth, "status", lambda: {"status": "logged_in"})
+    r = client.post(
+        "/api/llm/chat",
+        json=chat_body(
+            provider="openai-codex",
+            model="gpt-5.6-sol",
+            api_key=None,
+            reasoning_effort="ultra",
+        ),
+    )
+    assert r.status_code == 400
+    assert "multi-agent orchestration" in r.json()["detail"]
 
 
 def test_models_upstream_error_becomes_502(client, monkeypatch):

--- a/backend/tests/test_llm_schema.py
+++ b/backend/tests/test_llm_schema.py
@@ -17,6 +17,29 @@ def test_chat_request_minimal():
     assert req.max_tokens == 4096
     assert req.tools == []
     assert req.api_key is None
+    assert req.reasoning_effort is None
+
+
+@pytest.mark.parametrize("effort", ["none", "low", "max", "future_effort"])
+def test_chat_request_accepts_safe_reasoning_effort_slugs(effort):
+    req = ChatRequest(
+        provider="openai",
+        model="gpt-5.6-sol",
+        messages=[ChatMessage(role="user", content="hi")],
+        reasoning_effort=effort,
+    )
+    assert req.reasoning_effort == effort
+
+
+@pytest.mark.parametrize("effort", ["", "High", "very high", "ultra\n", "a" * 65])
+def test_chat_request_rejects_unsafe_reasoning_effort_values(effort):
+    with pytest.raises(ValidationError):
+        ChatRequest(
+            provider="openai",
+            model="gpt-5.6-sol",
+            messages=[ChatMessage(role="user", content="hi")],
+            reasoning_effort=effort,
+        )
 
 
 def test_chat_request_rejects_unknown_provider():


### PR DESCRIPTION
## What changed

- add GPT-5.6 Sol, Terra, and Luna fallbacks plus a dynamic Codex model catalog
- expose provider/model capability metadata from `/api/llm/models`
- forward supported reasoning-effort values through OpenAI and Codex requests
- cache Codex catalogs with ETag, stale fallback, credential isolation, and sanitized bounds
- harden Codex login, logout, OAuth callback, refresh, and catalog races with generation/CAS guards
- add focused coverage for routes, schemas, proxies, auth, and model catalog behavior

## Why

Graph Copilot needs current model choices and reasoning-effort controls without requiring a host release for every model update. The capability contract also prevents unsupported effort values from leaking to providers that do not support them.

## Validation

- full backend suite: 1,698 passed, 11 skipped
- targeted auth and model-catalog tests: 24 passed
- `git diff --check`