### PR TITLE
feat(frontend): skip-aware valley auto-layout (no more row wrapping)

### DIFF
--- a/docs/docs/usage/canvas-basics.md
+++ b/docs/docs/usage/canvas-basics.md
@@ -13,7 +13,7 @@ CodefyUI is a single-page app: a **canvas** in the middle, a **node palette** on
 - **Add a node** — drag it from the palette, or **double-click the canvas** to open the quick search panel and type a node or preset name.
 - **Connect nodes** — drag from an output port to an input port. Edges are **type-safe**: ports carry an explicit data type (Tensor, Model, Dataset, DataLoader, Optimizer, Loss, Scalar, String, Image, List, Trigger, …) and incompatible connections are rejected with a tooltip.
 - **Select** — click a node; **Shift**+click to multi-select; drag a box to marquee-select.
-- **Auto layout** — press `Shift`+`L` to lay the graph out hierarchically.
+- **Auto layout** — press `Shift`+`L` to lay the graph out left-to-right in one flow direction; the viewport then re-fits to the result. The layout is **skip-aware**: parts of a pipeline bypassed by a skip connection sink below it, so a U-Net reads as a U, residual blocks as small dips under their bypass edges, and plain chains stay a single straight line.
 
 See all shortcuts in **[Key Bindings](./keybindings)**.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,7 +64,7 @@ function TabContent({ tabId }: { tabId: string }) {
           <NodePalette />
           <div className={styles.canvasHost}>
             <div className={styles.canvasFill}>
-              <FlowCanvas />
+              <FlowCanvas tabId={tabId} />
             </div>
           </div>
           <RightColumn />

--- a/frontend/src/components/Canvas/FlowCanvas.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.tsx
@@ -14,7 +14,7 @@ import {
   type Edge,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { CATEGORY_COLORS } from '../../styles/theme';
+import { CANVAS_MIN_ZOOM, CATEGORY_COLORS } from '../../styles/theme';
 
 import BaseNode from '../Nodes/BaseNode';
 import PluginNodeBridge from '../Nodes/PluginNodeBridge';
@@ -86,7 +86,7 @@ const minimapNodeColor = (node: any) => {
 };
 
 
-export function FlowCanvas() {
+export function FlowCanvas({ tabId }: { tabId?: string } = {}) {
   const activeTab = useTabStore((s) => s.tabs.find((t) => t.id === s.activeTabId)!);
   const onNodesChange = useTabStore((s) => s.onNodesChange);
   const onEdgesChange = useTabStore((s) => s.onEdgesChange);
@@ -100,7 +100,7 @@ export function FlowCanvas() {
   const setCanvasPanning = useUIStore((s) => s.setCanvasPanning);
   const setNodes = useTabStore((s) => s.setNodes);
   const layoutFitRequest = useUIStore((s) => s.layoutFitRequest);
-  const { screenToFlowPosition, fitBounds, getNodesBounds } = useReactFlow();
+  const { screenToFlowPosition, fitBounds } = useReactFlow();
 
   // Snap all existing nodes to grid when grid snap is enabled
   useEffect(() => {
@@ -126,23 +126,41 @@ export function FlowCanvas() {
   const containerRef = useRef<HTMLDivElement>(null);
   const reactFlowId = useId();
 
-  // Re-fit the viewport to the nodes that were just auto-laid-out (mirrors the
-  // subgraph editor's post-layout fit; 50ms lets the new positions commit).
-  // fitBounds sets the viewport directly — the queued fitView() from
-  // useReactFlow only flushes on the next node change, which never comes when
-  // the layout left node objects untouched. One FlowCanvas is mounted per tab
-  // (hidden via display:none), so only the visible canvas may answer: a 0×0
-  // canvas would compute a degenerate viewport.
+  // Re-fit the viewport after auto-layout. The request already carries the
+  // laid-out bounding box (computed from store data), so this needs nothing
+  // from React Flow's internal position sync — fitBounds sets the viewport
+  // directly and immediately. (The queued fitView() from useReactFlow only
+  // flushes on the next node change, and reading positions back via
+  // getNodesBounds races the sync — both failure modes seen in e2e.) One
+  // FlowCanvas is mounted per tab behind display:none, so only the active,
+  // visible canvas answers, then clears the one-shot request so a canvas
+  // remount can't replay it.
   useEffect(() => {
     if (!layoutFitRequest) return;
-    const timerId = setTimeout(() => {
-      if (!containerRef.current || containerRef.current.offsetWidth === 0) return;
-      const bounds = getNodesBounds(layoutFitRequest.nodeIds);
-      if (!bounds.width || !bounds.height) return;
-      fitBounds(bounds, { padding: 0.2, duration: 300 });
-    }, 50);
-    return () => clearTimeout(timerId);
-  }, [layoutFitRequest, fitBounds, getNodesBounds]);
+    const el = containerRef.current;
+    if (!el || el.offsetWidth === 0) return;
+    if (tabId !== undefined && tabId !== useTabStore.getState().activeTabId) return;
+    // Fits are for overview: inflate small bounds (e.g. a single selected
+    // node) so the fit never zooms IN aggressively toward maxZoom.
+    let { x, y, width, height } = layoutFitRequest.bounds;
+    const minW = el.offsetWidth * 0.85;
+    const minH = el.offsetHeight * 0.85;
+    if (width < minW) {
+      x -= (minW - width) / 2;
+      width = minW;
+    }
+    if (height < minH) {
+      y -= (minH - height) / 2;
+      height = minH;
+    }
+    // Instant fit (no duration): animated viewport transitions run on
+    // requestAnimationFrame, which Chrome throttles to zero in occluded or
+    // background windows — the animation then never applies at all. The
+    // subgraph editor's post-layout fit and the Controls button are instant
+    // for the same reason.
+    fitBounds({ x, y, width, height }, { padding: 0.2 });
+    useUIStore.getState().clearLayoutFit();
+  }, [layoutFitRequest, fitBounds, tabId]);
 
   const [quickSearch, setQuickSearch] = useState<{
     screen: { x: number; y: number };
@@ -492,7 +510,7 @@ export function FlowCanvas() {
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         fitView
-        minZoom={0.1}
+        minZoom={CANVAS_MIN_ZOOM}
         proOptions={proOptions}
         deleteKeyCode="Delete"
         multiSelectionKeyCode="Shift"

--- a/frontend/src/components/Canvas/FlowCanvas.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.tsx
@@ -100,23 +100,7 @@ export function FlowCanvas() {
   const setCanvasPanning = useUIStore((s) => s.setCanvasPanning);
   const setNodes = useTabStore((s) => s.setNodes);
   const layoutFitRequest = useUIStore((s) => s.layoutFitRequest);
-  const { screenToFlowPosition, fitView } = useReactFlow();
-
-  // Re-fit the viewport to the nodes that were just auto-laid-out (mirrors the
-  // subgraph editor's post-layout fit; 50ms lets the new positions commit).
-  useEffect(() => {
-    if (!layoutFitRequest) return;
-    const timerId = setTimeout(
-      () =>
-        fitView({
-          padding: 0.2,
-          duration: 300,
-          nodes: layoutFitRequest.nodeIds.map((id) => ({ id })),
-        }),
-      50,
-    );
-    return () => clearTimeout(timerId);
-  }, [layoutFitRequest, fitView]);
+  const { screenToFlowPosition, fitBounds, getNodesBounds } = useReactFlow();
 
   // Snap all existing nodes to grid when grid snap is enabled
   useEffect(() => {
@@ -141,6 +125,24 @@ export function FlowCanvas() {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const reactFlowId = useId();
+
+  // Re-fit the viewport to the nodes that were just auto-laid-out (mirrors the
+  // subgraph editor's post-layout fit; 50ms lets the new positions commit).
+  // fitBounds sets the viewport directly — the queued fitView() from
+  // useReactFlow only flushes on the next node change, which never comes when
+  // the layout left node objects untouched. One FlowCanvas is mounted per tab
+  // (hidden via display:none), so only the visible canvas may answer: a 0×0
+  // canvas would compute a degenerate viewport.
+  useEffect(() => {
+    if (!layoutFitRequest) return;
+    const timerId = setTimeout(() => {
+      if (!containerRef.current || containerRef.current.offsetWidth === 0) return;
+      const bounds = getNodesBounds(layoutFitRequest.nodeIds);
+      if (!bounds.width || !bounds.height) return;
+      fitBounds(bounds, { padding: 0.2, duration: 300 });
+    }, 50);
+    return () => clearTimeout(timerId);
+  }, [layoutFitRequest, fitBounds, getNodesBounds]);
 
   const [quickSearch, setQuickSearch] = useState<{
     screen: { x: number; y: number };
@@ -490,6 +492,7 @@ export function FlowCanvas() {
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         fitView
+        minZoom={0.1}
         proOptions={proOptions}
         deleteKeyCode="Delete"
         multiSelectionKeyCode="Shift"

--- a/frontend/src/components/Canvas/FlowCanvas.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.tsx
@@ -99,7 +99,24 @@ export function FlowCanvas() {
   const gridSnapEnabled = useUIStore((s) => s.gridSnapEnabled);
   const setCanvasPanning = useUIStore((s) => s.setCanvasPanning);
   const setNodes = useTabStore((s) => s.setNodes);
-  const { screenToFlowPosition } = useReactFlow();
+  const layoutFitRequest = useUIStore((s) => s.layoutFitRequest);
+  const { screenToFlowPosition, fitView } = useReactFlow();
+
+  // Re-fit the viewport to the nodes that were just auto-laid-out (mirrors the
+  // subgraph editor's post-layout fit; 50ms lets the new positions commit).
+  useEffect(() => {
+    if (!layoutFitRequest) return;
+    const timerId = setTimeout(
+      () =>
+        fitView({
+          padding: 0.2,
+          duration: 300,
+          nodes: layoutFitRequest.nodeIds.map((id) => ({ id })),
+        }),
+      50,
+    );
+    return () => clearTimeout(timerId);
+  }, [layoutFitRequest, fitView]);
 
   // Snap all existing nodes to grid when grid snap is enabled
   useEffect(() => {

--- a/frontend/src/components/SubgraphEditor/SubgraphEditorModal.tsx
+++ b/frontend/src/components/SubgraphEditor/SubgraphEditorModal.tsx
@@ -23,6 +23,7 @@ import { useTabStore } from '../../store/tabStore';
 import { useToastStore } from '../../store/toastStore';
 import { useI18n } from '../../i18n';
 import { generateId } from '../../utils';
+import { CANVAS_MIN_ZOOM } from '../../styles/theme';
 import { SmartDataEdge } from '../Canvas/SmartDataEdge';
 import { LayerNode } from './LayerNode';
 import { InputNode } from './InputNode';
@@ -994,7 +995,7 @@ function SubgraphFlowInner({
               nodeTypes={nodeTypes}
               edgeTypes={edgeTypes}
               fitView
-              minZoom={0.1}
+              minZoom={CANVAS_MIN_ZOOM}
               snapToGrid={snapEnabled}
               snapGrid={[20, 20]}
               proOptions={{ hideAttribution: true }}

--- a/frontend/src/components/SubgraphEditor/SubgraphEditorModal.tsx
+++ b/frontend/src/components/SubgraphEditor/SubgraphEditorModal.tsx
@@ -994,6 +994,7 @@ function SubgraphFlowInner({
               nodeTypes={nodeTypes}
               edgeTypes={edgeTypes}
               fitView
+              minZoom={0.1}
               snapToGrid={snapEnabled}
               snapGrid={[20, 20]}
               proOptions={{ hideAttribution: true }}

--- a/frontend/src/components/SubgraphEditor/graphSerialization.test.ts
+++ b/frontend/src/components/SubgraphEditor/graphSerialization.test.ts
@@ -494,10 +494,9 @@ describe('graphToFlow', () => {
     expect(res.nodes[1].position).toEqual({ x: 0, y: 0 });
   });
 
-  it('runs auto-layout but leaves a short topology un-wrapped (height under target)', () => {
-    // 5-node chain: enough nodes to pass the wrap min (>=4) yet short enough that
-    // the laid-out height stays <= SUBGRAPH_TARGET_COL_HEIGHT, hitting the early
-    // `height <= TARGET` return in wrapIntoColumns.
+  it('auto-layout keeps a short chain in a single column', () => {
+    // 5-node chain with no skips: the valley pass is a no-op, so dagre's
+    // single-column TB layout comes through untouched.
     const nodes = Array.from({ length: 5 }, (_, i) => ({ id: `s${i}`, type: 'Conv2d' }));
     const edges = Array.from({ length: 4 }, (_, i) => ({
       id: `se${i}`,
@@ -564,9 +563,9 @@ describe('graphToFlow', () => {
     expect(res.nodes).toHaveLength(2);
   });
 
-  it('wraps a tall topology into multiple columns during auto-layout', () => {
-    // A long vertical chain exceeds SUBGRAPH_TARGET_COL_HEIGHT (700) and triggers
-    // wrapIntoColumns, producing more than one distinct x column.
+  it('a long chain never wraps into columns — single column preserved', () => {
+    // 40-node vertical chain: column wrapping is gone, so however tall the
+    // layout gets it stays one column (pan/zoom handles the length).
     const n = 40;
     const nodes = Array.from({ length: n }, (_, i) => ({ id: `n${i}`, type: 'Conv2d' }));
     const edges = Array.from({ length: n - 1 }, (_, i) => ({
@@ -576,43 +575,33 @@ describe('graphToFlow', () => {
     }));
     const res = graphToFlow(JSON.stringify({ version: 2, nodes, edges }));
     const xs = new Set(res.nodes.map((node) => node.position.x));
-    // Wrapping shifts later ranks into new columns -> multiple distinct x values.
-    expect(xs.size).toBeGreaterThan(1);
+    expect(xs.size).toBe(1);
+    // y strictly increases down the chain (no carriage-return columns).
+    const ys = res.nodes.map((node) => node.position.y);
+    for (let i = 1; i < ys.length; i++) expect(ys[i]).toBeGreaterThan(ys[i - 1]);
   });
 
-  it('wraps a tall branched topology whose deepest rank holds multiple nodes', () => {
-    // A long chain that forks into two equal-length tails so the final rank holds
-    // TWO nodes sharing the same bottom edge. While scanning for maxY in
-    // wrapIntoColumns, the second sibling does NOT exceed the running max,
-    // exercising the `p.y + p.height > maxY` false branch.
-    const chain = 22;
-    const nodes: GraphSpec['nodes'] = Array.from({ length: chain }, (_, i) => ({
-      id: `c${i}`,
+  it('a skip connection sinks its covered ranks rightward (transposed valley)', () => {
+    // 12-node TB chain with a skip n1 -> n7: ranks 2..6 are covered and shift
+    // right by a full valley step; the skip endpoints stay in the base column
+    // (within dagre's dummy-lane jitter, which is smaller than one step).
+    const n = 12;
+    const nodes: GraphSpec['nodes'] = Array.from({ length: n }, (_, i) => ({
+      id: `n${i}`,
       type: 'Conv2d',
     }));
-    const edges: GraphSpec['edges'] = Array.from({ length: chain - 1 }, (_, i) => ({
-      id: `ce${i}`,
-      source: `c${i}`,
-      target: `c${i + 1}`,
+    const edges: GraphSpec['edges'] = Array.from({ length: n - 1 }, (_, i) => ({
+      id: `e${i}`,
+      source: `n${i}`,
+      target: `n${i + 1}`,
     }));
-    // Fork two parallel tails off the chain tail; both reach the same depth.
-    const tail = 8;
-    for (let i = 0; i < tail; i++) {
-      nodes.push({ id: `a${i}`, type: 'Conv2d' });
-      nodes.push({ id: `b${i}`, type: 'Conv2d' });
-      const srcA = i === 0 ? `c${chain - 1}` : `a${i - 1}`;
-      const srcB = i === 0 ? `c${chain - 1}` : `b${i - 1}`;
-      edges.push({ id: `ae${i}`, source: srcA, target: `a${i}` });
-      edges.push({ id: `be${i}`, source: srcB, target: `b${i}` });
-    }
+    edges.push({ id: 'skip', source: 'n1', target: 'n7' });
     const res = graphToFlow(JSON.stringify({ version: 2, nodes, edges }));
-    // The two final-rank siblings share the same y (same rank).
-    const ay = res.nodes.find((n) => n.id === `a${tail - 1}`)!.position.y;
-    const by = res.nodes.find((n) => n.id === `b${tail - 1}`)!.position.y;
-    expect(ay).toBe(by);
-    // And the tall graph still wrapped into more than one column.
-    const xs = new Set(res.nodes.map((node) => node.position.x));
-    expect(xs.size).toBeGreaterThan(1);
+    const xOf = (id: string) => res.nodes.find((node) => node.id === id)!.position.x;
+    // Covered trunk (n4) sits clearly right of both skip endpoints.
+    expect(xOf('n4')).toBeGreaterThan(Math.max(xOf('n1'), xOf('n7')) + 60);
+    // Outside the skip, head and tail share the base column band.
+    expect(Math.abs(xOf('n0') - xOf('n11'))).toBeLessThan(1);
   });
 });
 
@@ -669,12 +658,9 @@ describe('autoLayoutSubgraph', () => {
     expect(laid).toHaveLength(2);
   });
 
-  it('skips column-wrapping when few rank-units span a tall layout (large nodes)', () => {
-    // wrapIntoColumns derives ranks from a FIXED rankUnit (NODE_H + RANKSEP = 100),
-    // not the measured node height. Very tall nodes make the pixel height exceed
-    // the 700 target (so we pass the early height return) while only occupying a
-    // handful of rank-units, so `totalRanks <= maxRanksPerCol` short-circuits and
-    // positions are returned unwrapped.
+  it('very tall nodes still lay out in a single column (no wrapping by pixel height)', () => {
+    // Column wrapping used to fire on pixel height; with the valley pass a
+    // skip-free chain is returned untouched regardless of how tall it renders.
     const tall = (id: string): Node<LayerNodeData> =>
       flowNode(id, {}, { width: 160, height: 2000 });
     const nodes = [tall('t0'), tall('t1'), tall('t2'), tall('t3')];

--- a/frontend/src/components/SubgraphEditor/graphSerialization.ts
+++ b/frontend/src/components/SubgraphEditor/graphSerialization.ts
@@ -2,7 +2,7 @@
 import dagre from '@dagrejs/dagre';
 import type { Node, Edge } from '@xyflow/react';
 import { generateId } from '../../utils';
-import { applyValleyPass } from '../../utils/autoLayout';
+import { applyValleyPass, isTriggerEdge } from '../../utils/autoLayout';
 
 export interface PortDef {
   id: string;
@@ -359,11 +359,14 @@ function assignPositionsFromTopology(spec: GraphSpec): void {
       height: SUBGRAPH_NODE_H,
     });
   }
-  const wrapped = applyValleyPass(raw, spec.edges, { axis: 'x' });
+  const wrapped = applyValleyPass(raw, spec.edges, {
+    axis: 'x',
+    skipPredicate: (e) => !isTriggerEdge(e),
+  });
   for (const n of spec.nodes) {
     const p = wrapped.get(n.id);
-    // wrapIntoColumns returns an entry for every input id, so `p` is always defined
-    // (the falsy branch is unreachable).
+    // applyValleyPass returns an entry for every input id, so `p` is always
+    // defined (the falsy branch is unreachable).
     /* v8 ignore start */
     if (p) {
       /* v8 ignore stop */
@@ -422,11 +425,14 @@ export function autoLayoutSubgraph(
       height: h,
     });
   }
-  const wrapped = applyValleyPass(raw, edges, { axis: 'x' });
+  const wrapped = applyValleyPass(raw, edges, {
+    axis: 'x',
+    skipPredicate: (e) => !isTriggerEdge(e),
+  });
 
   return nodes.map((n) => {
     const p = wrapped.get(n.id);
-    // wrapIntoColumns returns an entry for every input id, so `p` is always defined.
+    // applyValleyPass returns an entry for every input id, so `p` is always defined.
     /* v8 ignore start */
     if (!p) return n;
     /* v8 ignore stop */

--- a/frontend/src/components/SubgraphEditor/graphSerialization.ts
+++ b/frontend/src/components/SubgraphEditor/graphSerialization.ts
@@ -2,6 +2,7 @@
 import dagre from '@dagrejs/dagre';
 import type { Node, Edge } from '@xyflow/react';
 import { generateId } from '../../utils';
+import { applyValleyPass } from '../../utils/autoLayout';
 
 export interface PortDef {
   id: string;
@@ -258,10 +259,6 @@ const SUBGRAPH_NODE_W = 160;
 const SUBGRAPH_NODE_H = 40;
 const SUBGRAPH_NODESEP = 40;
 const SUBGRAPH_RANKSEP = 60;
-const SUBGRAPH_TARGET_COL_HEIGHT = 700;
-const SUBGRAPH_COL_GAP = 120;
-const SUBGRAPH_MIN_NODES_FOR_WRAP = 4;
-
 function getSubgraphLayoutConfig(
   nodeCount: number,
 ): { nodesep: number; ranksep: number } {
@@ -272,84 +269,9 @@ function getSubgraphLayoutConfig(
 
 type SubgraphPos = { x: number; y: number; width: number; height: number };
 
-/**
- * Transposed wrap: if the TB layout exceeds SUBGRAPH_TARGET_COL_HEIGHT, split
- * its vertical ranks into multiple columns and shift each column rightward.
- * Mirror of wrapIntoGrid in autoLayout.ts.
- */
-function wrapIntoColumns(positions: Map<string, SubgraphPos>): Map<string, SubgraphPos> {
-  if (positions.size < SUBGRAPH_MIN_NODES_FOR_WRAP) return positions;
-
-  const values = Array.from(positions.values());
-  let minY = Infinity;
-  let maxY = -Infinity;
-  for (const p of values) {
-    if (p.y < minY) minY = p.y;
-    if (p.y + p.height > maxY) maxY = p.y + p.height;
-  }
-  const height = maxY - minY;
-  if (height <= SUBGRAPH_TARGET_COL_HEIGHT) return positions;
-
-  const rankUnit = SUBGRAPH_NODE_H + SUBGRAPH_RANKSEP;
-  const rankSet = new Set<number>();
-  const rankOf = new Map<string, number>();
-  for (const [id, p] of positions) {
-    const rank = Math.round((p.y - minY) / rankUnit);
-    rankOf.set(id, rank);
-    rankSet.add(rank);
-  }
-  // rankSet always has at least one entry once we reach here (size >= 4 nodes), so
-  // the `|| 1` fallback is unreachable.
-  /* v8 ignore start */
-  const totalRanks = rankSet.size || 1;
-  /* v8 ignore stop */
-  const maxRanksPerCol = Math.max(1, Math.floor(SUBGRAPH_TARGET_COL_HEIGHT / rankUnit));
-  if (totalRanks <= maxRanksPerCol) return positions;
-
-  const colCount = Math.ceil(totalRanks / maxRanksPerCol);
-  const ranksPerCol = Math.ceil(totalRanks / colCount);
-  const colHeight = ranksPerCol * rankUnit;
-
-  const colOf = new Map<string, number>();
-  for (const [id, rank] of rankOf) {
-    const col = Math.min(colCount - 1, Math.floor(rank / ranksPerCol));
-    colOf.set(id, col);
-  }
-
-  const colXOffset: number[] = new Array(colCount).fill(0);
-  let cumX = 0;
-  for (let c = 0; c < colCount; c++) {
-    let cMinX = Infinity;
-    let cMaxX = -Infinity;
-    for (const [id, p] of positions) {
-      if (colOf.get(id) !== c) continue;
-      if (p.x < cMinX) cMinX = p.x;
-      if (p.x + p.width > cMaxX) cMaxX = p.x + p.width;
-    }
-    // Each column is derived by partitioning existing ranks, so every column has at
-    // least one node and cMinX is never left at Infinity.
-    /* v8 ignore start */
-    if (cMinX === Infinity) {
-      cMinX = 0;
-      cMaxX = 0;
-    }
-    /* v8 ignore stop */
-    colXOffset[c] = cumX - cMinX;
-    cumX += cMaxX - cMinX + SUBGRAPH_COL_GAP;
-  }
-
-  const result = new Map<string, SubgraphPos>();
-  for (const [id, p] of positions) {
-    const col = colOf.get(id)!;
-    result.set(id, {
-      x: p.x + colXOffset[col],
-      y: p.y - col * colHeight,
-      width: p.width,
-      height: p.height,
-    });
-  }
-  return result;
-}
+// Column wrapping was removed in favor of the shared skip-aware valley pass
+// (applyValleyPass with axis 'x'): a TB subgraph never splits into columns;
+// ranks covered by a skip connection shift rightward instead.
 
 /**
  * Topological-sort ids and return the order.
@@ -437,7 +359,7 @@ function assignPositionsFromTopology(spec: GraphSpec): void {
       height: SUBGRAPH_NODE_H,
     });
   }
-  const wrapped = wrapIntoColumns(raw);
+  const wrapped = applyValleyPass(raw, spec.edges, { axis: 'x' });
   for (const n of spec.nodes) {
     const p = wrapped.get(n.id);
     // wrapIntoColumns returns an entry for every input id, so `p` is always defined
@@ -500,7 +422,7 @@ export function autoLayoutSubgraph(
       height: h,
     });
   }
-  const wrapped = wrapIntoColumns(raw);
+  const wrapped = applyValleyPass(raw, edges, { axis: 'x' });
 
   return nodes.map((n) => {
     const p = wrapped.get(n.id);

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -130,7 +130,7 @@ describe('applyLayout', () => {
     expect(tab.undoStack.length).toBe(1);
   });
 
-  it('publishes a layout-fit request naming the laid-out nodes', () => {
+  it('publishes a one-shot layout-fit request naming the laid-out nodes and their bound notes', () => {
     const tabId = useTabStore.getState().activeTabId!;
     useTabStore.setState((state) => ({
       tabs: state.tabs.map((t) =>
@@ -154,6 +154,19 @@ describe('applyLayout', () => {
                   height: 80,
                   data: { id: 'a', type: 'Dataset' },
                 },
+                {
+                  id: 'note1',
+                  type: 'noteNode',
+                  position: { x: 0, y: 0 },
+                  width: 200,
+                  height: 100,
+                  data: {
+                    id: 'note1',
+                    type: 'note',
+                    boundToNodeId: 'a',
+                    boundOffset: { x: 20, y: -40 },
+                  },
+                },
               ] as any,
               edges: [{ id: 'et', source: 's', target: 'a', data: { type: 'trigger' } }] as any,
             }
@@ -166,11 +179,21 @@ describe('applyLayout', () => {
 
     const req = useUIStore.getState().layoutFitRequest;
     expect(req).not.toBeNull();
-    expect(new Set(req!.nodeIds)).toEqual(new Set(['s', 'a']));
+    const { bounds } = req!;
+    expect(bounds.width).toBeGreaterThan(0);
+    expect(bounds.height).toBeGreaterThan(0);
+    // The bound note follows its parent during layout at offset (20, -40), so
+    // the fitted box must extend above the computational nodes to include it.
+    const tab = useTabStore.getState().getActiveTab();
+    const parentY = tab.nodes.find((n) => n.id === 'a')!.position.y;
+    expect(bounds.y).toBeLessThanOrEqual(parentY - 40);
 
-    // A second layout bumps the sequence so the canvas effect re-fires.
+    // Requests are one-shot: the consumer clears, and a later layout
+    // publishes a fresh request object.
+    useUIStore.getState().clearLayoutFit();
+    expect(useUIStore.getState().layoutFitRequest).toBeNull();
     useTabStore.getState().applyLayout('experiments');
-    expect(useUIStore.getState().layoutFitRequest!.seq).toBe(req!.seq + 1);
+    expect(useUIStore.getState().layoutFitRequest).not.toBeNull();
   });
 });
 

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useTabStore } from './tabStore';
 import { useToastStore } from './toastStore';
+import { useUIStore } from './uiStore';
 import type { NodeDefinition, PresetDefinition } from '../types';
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
@@ -127,6 +128,49 @@ describe('applyLayout', () => {
 
     // Undo snapshot was pushed so Ctrl+Z reverts the layout
     expect(tab.undoStack.length).toBe(1);
+  });
+
+  it('publishes a layout-fit request naming the laid-out nodes', () => {
+    const tabId = useTabStore.getState().activeTabId!;
+    useTabStore.setState((state) => ({
+      tabs: state.tabs.map((t) =>
+        t.id === tabId
+          ? {
+              ...t,
+              nodes: [
+                {
+                  id: 's',
+                  type: 'start',
+                  position: { x: 0, y: 0 },
+                  width: 80,
+                  height: 40,
+                  data: { id: 's', type: 'Start' },
+                },
+                {
+                  id: 'a',
+                  type: 'baseNode',
+                  position: { x: 0, y: 0 },
+                  width: 200,
+                  height: 80,
+                  data: { id: 'a', type: 'Dataset' },
+                },
+              ] as any,
+              edges: [{ id: 'et', source: 's', target: 'a', data: { type: 'trigger' } }] as any,
+            }
+          : t,
+      ),
+    }));
+    useUIStore.setState({ layoutFitRequest: null });
+
+    useTabStore.getState().applyLayout('experiments');
+
+    const req = useUIStore.getState().layoutFitRequest;
+    expect(req).not.toBeNull();
+    expect(new Set(req!.nodeIds)).toEqual(new Set(['s', 'a']));
+
+    // A second layout bumps the sequence so the canvas effect re-fires.
+    useTabStore.getState().applyLayout('experiments');
+    expect(useUIStore.getState().layoutFitRequest!.seq).toBe(req!.seq + 1);
   });
 });
 

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { applyNodeChanges, applyEdgeChanges } from '@xyflow/react';
 import type { Node, Edge, NodeChange, EdgeChange, Connection } from '@xyflow/react';
 import { generateId, buildFlowNode } from '../utils';
-import { autoLayout, layoutTargetIds, type LayoutMode } from '../utils/autoLayout';
+import { autoLayoutWithTargets, nodesBoundingBox, type LayoutMode } from '../utils/autoLayout';
 import type { NodeData, NodeDefinition, PresetDefinition, ExecutionStatus, OutputSummary, NodeProgress, SegmentGroup } from '../types';
 import { ExecutionWebSocket } from '../api/ws';
 import { useToastStore } from './toastStore';
@@ -1027,35 +1027,45 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
   applyLayout: (mode) => {
     const tabId = get().activeTabId;
     if (!tabId) return;
+    const activeTab = get().getActiveTab();
+    const selectedIds = new Set(
+      activeTab.nodes.filter((n) => n.selected).map((n) => n.id),
+    );
+    const { nodes: laidNodes, targetIds } = autoLayoutWithTargets(
+      activeTab.nodes as Node[],
+      activeTab.edges as Edge[],
+      mode,
+      selectedIds,
+    );
+    const newNodes = laidNodes as Node<NodeData>[];
     get().pushUndoSnapshot();
     set((state) => ({
-      tabs: state.tabs.map((tab) => {
-        if (tab.id !== tabId) return tab;
-        const selectedIds = new Set(
-          tab.nodes.filter((n) => n.selected).map((n) => n.id),
-        );
-        const newNodes = autoLayout(tab.nodes, tab.edges, mode, selectedIds) as Node<NodeData>[];
-        return {
-          ...tab,
-          nodes: newNodes,
-        };
-      }),
+      tabs: state.tabs.map((tab) =>
+        tab.id === tabId ? { ...tab, nodes: newNodes } : tab,
+      ),
     }));
-    // Ask the canvas to re-fit the viewport to the nodes that were laid out
-    // (scoped so "selected" mode focuses the selection, not the whole graph).
-    const laidTab = get().getActiveTab();
-    const fitIds = layoutTargetIds(
-      laidTab.nodes as Node[],
-      laidTab.edges as Edge[],
-      mode,
-      new Set(laidTab.nodes.filter((n) => n.selected).map((n) => n.id)),
-    );
-    if (fitIds.size > 0) {
-      useUIStore.getState().requestLayoutFit(Array.from(fitIds));
+    // Ask the canvas to re-fit the viewport to what was laid out (scoped so
+    // "selected" mode focuses the selection). Bound notes follow their parents
+    // during layout, so include them or they could end up cropped off-screen.
+    // The request carries the bounding box computed from the fresh store nodes
+    // so the canvas never races React Flow's internal position sync.
+    if (targetIds.size > 0) {
+      const fitIds = new Set(targetIds);
+      for (const n of newNodes) {
+        const boundTo = n.data.boundToNodeId;
+        if (n.type === 'noteNode' && boundTo && fitIds.has(boundTo)) {
+          fitIds.add(n.id);
+        }
+      }
+      const bounds = nodesBoundingBox(
+        newNodes.filter((n) => fitIds.has(n.id)) as Node[],
+      );
+      if (bounds && bounds.width > 0 && bounds.height > 0) {
+        useUIStore.getState().requestLayoutFit(bounds);
+      }
     }
     // Warn if there are unbound notes on the canvas
-    const tab = get().getActiveTab();
-    const hasUnboundNotes = tab.nodes.some(
+    const hasUnboundNotes = newNodes.some(
       (n) => n.type === 'noteNode' && !n.data.boundToNodeId
     );
     if (hasUnboundNotes) {

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -2,10 +2,11 @@ import { create } from 'zustand';
 import { applyNodeChanges, applyEdgeChanges } from '@xyflow/react';
 import type { Node, Edge, NodeChange, EdgeChange, Connection } from '@xyflow/react';
 import { generateId, buildFlowNode } from '../utils';
-import { autoLayout, type LayoutMode } from '../utils/autoLayout';
+import { autoLayout, layoutTargetIds, type LayoutMode } from '../utils/autoLayout';
 import type { NodeData, NodeDefinition, PresetDefinition, ExecutionStatus, OutputSummary, NodeProgress, SegmentGroup } from '../types';
 import { ExecutionWebSocket } from '../api/ws';
 import { useToastStore } from './toastStore';
+import { useUIStore } from './uiStore';
 import { useI18n } from '../i18n';
 import { useProjectStore } from './projectStore';
 
@@ -1040,6 +1041,18 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
         };
       }),
     }));
+    // Ask the canvas to re-fit the viewport to the nodes that were laid out
+    // (scoped so "selected" mode focuses the selection, not the whole graph).
+    const laidTab = get().getActiveTab();
+    const fitIds = layoutTargetIds(
+      laidTab.nodes as Node[],
+      laidTab.edges as Edge[],
+      mode,
+      new Set(laidTab.nodes.filter((n) => n.selected).map((n) => n.id)),
+    );
+    if (fitIds.size > 0) {
+      useUIStore.getState().requestLayoutFit(Array.from(fitIds));
+    }
     // Warn if there are unbound notes on the canvas
     const tab = get().getActiveTab();
     const hasUnboundNotes = tab.nodes.some(

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -17,6 +17,10 @@ interface UIState {
   toggleBeginnerMode: () => void;
   lastLayoutMode: 'experiments' | 'all' | 'selected';
   setLastLayoutMode: (mode: 'experiments' | 'all' | 'selected') => void;
+  /** Bumped after auto-layout so the canvas re-fits the viewport to the
+   * laid-out nodes. `seq` distinguishes repeated requests over the same ids. */
+  layoutFitRequest: { seq: number; nodeIds: string[] } | null;
+  requestLayoutFit: (nodeIds: string[]) => void;
   fontSize: FontSize;
   setFontSize: (size: FontSize) => void;
   /** Global compute device sent with every graph run ('cpu' | 'cuda' | 'mps').
@@ -79,6 +83,11 @@ export const useUIStore = create<UIState>((set) => ({
     localStorage.setItem(LAYOUT_MODE_KEY, mode);
     set({ lastLayoutMode: mode });
   },
+  layoutFitRequest: null,
+  requestLayoutFit: (nodeIds) =>
+    set((state) => ({
+      layoutFitRequest: { seq: (state.layoutFitRequest?.seq ?? 0) + 1, nodeIds },
+    })),
   fontSize: loadFontSize(),
   setFontSize: (size) => {
     localStorage.setItem(FONT_SIZE_KEY, size);

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -17,10 +17,13 @@ interface UIState {
   toggleBeginnerMode: () => void;
   lastLayoutMode: 'experiments' | 'all' | 'selected';
   setLastLayoutMode: (mode: 'experiments' | 'all' | 'selected') => void;
-  /** Bumped after auto-layout so the canvas re-fits the viewport to the
-   * laid-out nodes. `seq` distinguishes repeated requests over the same ids. */
-  layoutFitRequest: { seq: number; nodeIds: string[] } | null;
-  requestLayoutFit: (nodeIds: string[]) => void;
+  /** Set after auto-layout so the visible canvas re-fits the viewport to the
+   * laid-out nodes' bounding box; the consumer clears it once handled
+   * (one-shot). Carrying the bounds (not node ids) lets the canvas fit from
+   * store data without racing React Flow's internal position sync. */
+  layoutFitRequest: { bounds: { x: number; y: number; width: number; height: number } } | null;
+  requestLayoutFit: (bounds: { x: number; y: number; width: number; height: number }) => void;
+  clearLayoutFit: () => void;
   fontSize: FontSize;
   setFontSize: (size: FontSize) => void;
   /** Global compute device sent with every graph run ('cpu' | 'cuda' | 'mps').
@@ -84,10 +87,8 @@ export const useUIStore = create<UIState>((set) => ({
     set({ lastLayoutMode: mode });
   },
   layoutFitRequest: null,
-  requestLayoutFit: (nodeIds) =>
-    set((state) => ({
-      layoutFitRequest: { seq: (state.layoutFitRequest?.seq ?? 0) + 1, nodeIds },
-    })),
+  requestLayoutFit: (bounds) => set({ layoutFitRequest: { bounds } }),
+  clearLayoutFit: () => set({ layoutFitRequest: null }),
   fontSize: loadFontSize(),
   setFontSize: (size) => {
     localStorage.setItem(FONT_SIZE_KEY, size);

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -56,6 +56,11 @@ export const STATUS_COLORS: Record<string, string> = {
   idle: '#444',
 };
 
+/** Shared zoom-out floor for both React Flow canvases. Wide skip-aware valley
+ * layouts (long UNet-style graphs) need well below React Flow's 0.5 default
+ * to fit on screen. */
+export const CANVAS_MIN_ZOOM = 0.1;
+
 export const SURFACE = {
   bg: '#121212',
   panel: '#161616',

--- a/frontend/src/utils/autoLayout.test.ts
+++ b/frontend/src/utils/autoLayout.test.ts
@@ -483,6 +483,60 @@ describe('applyValleyPass (unit)', () => {
     const result = applyValleyPass(positions, edges, { axis: 'y' });
     expect(result).toBe(positions);
   });
+
+  it('empty positions map is returned as-is', () => {
+    const positions = new Map<string, Pos>();
+    expect(applyValleyPass(positions, [], { axis: 'y' })).toBe(positions);
+  });
+
+  it('components are isolated: a skip in one never shifts another', () => {
+    // Two side-by-side chains sharing rank centers (how one dagre call places
+    // disconnected components); the skip lives only in chain A.
+    const positions = new Map<string, Pos>();
+    const edges: ValleyEdge[] = [];
+    for (let i = 0; i < 7; i++) {
+      positions.set(`a${i}`, { x: i * UNIT, y: 0, width: W, height: H });
+      positions.set(`b${i}`, { x: i * UNIT, y: 300, width: W, height: H });
+      if (i > 0) {
+        edges.push({ source: `a${i - 1}`, target: `a${i}` });
+        edges.push({ source: `b${i - 1}`, target: `b${i}` });
+      }
+    }
+    edges.push({ source: 'a1', target: 'a5' });
+    const result = applyValleyPass(positions, edges, { axis: 'y' });
+    for (let i = 0; i < 7; i++) {
+      expect(result.get(`b${i}`)!.y).toBe(300); // chain B untouched
+    }
+    expect(yOf(result, 'a3')).toBe(STEP); // chain A dips under its skip
+    expect(yOf(result, 'a1')).toBe(0);
+    expect(yOf(result, 'a5')).toBe(0);
+  });
+
+  it('a branch sibling sharing a covered rank sinks with its whole rank', () => {
+    // t sits beside n3 in the same rank; whole-rank shifting keeps the rank
+    // together, so t sinks along with n3 under the skip.
+    const positions = chainPositions(8);
+    positions.set('t', { x: 3 * UNIT, y: 200, width: W, height: H });
+    const edges = [...chainEdges(8, [[1, 6]]), { source: 'n2', target: 't' }];
+    const result = applyValleyPass(positions, edges, { axis: 'y' });
+    expect(yOf(result, 'n3')).toBe(STEP);
+    expect(result.get('t')!.y).toBe(200 + STEP);
+  });
+
+  it('recovers ranks from centers with non-uniform node widths', () => {
+    // Mixed widths but consistent per-rank centers (dagre's invariant): the
+    // valley must still align skip endpoints and dip the covered ranks.
+    const positions = new Map<string, Pos>();
+    const widths = [120, 320, 200, 80, 260, 200, 140, 300];
+    for (let i = 0; i < 8; i++) {
+      const w = widths[i];
+      positions.set(`n${i}`, { x: i * UNIT + (W - w) / 2, y: 0, width: w, height: H });
+    }
+    const result = applyValleyPass(positions, chainEdges(8, [[1, 6]]), { axis: 'y' });
+    expect(yOf(result, 'n1')).toBe(0);
+    expect(yOf(result, 'n6')).toBe(0);
+    expect(yOf(result, 'n3')).toBe(STEP);
+  });
 });
 
 describe('isTriggerEdge', () => {

--- a/frontend/src/utils/autoLayout.test.ts
+++ b/frontend/src/utils/autoLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { autoLayout } from './autoLayout';
+import { autoLayout, applyValleyPass, isTriggerEdge, type ValleyEdge } from './autoLayout';
 import type { Node, Edge } from '@xyflow/react';
 
 function makeStartNode(id: string, x = 0, y = 0): Node {
@@ -206,24 +206,6 @@ describe('autoLayout', () => {
     expect(result[0].position).toEqual({ x: 1, y: 1 });
   });
 
-  it('long chain exceeding the row-width budget wraps into a multi-row grid', () => {
-    // rankUnit = NODE_W(200)+RANKSEP(80) = 280; TARGET_ROW_WIDTH = 2400.
-    // A 14-node chain has a pre-wrap trunk far wider than 2400 → wrapIntoGrid runs.
-    const N = 14;
-    const ids = Array.from({ length: N }, (_, i) => `c${i}`);
-    const nodes = ids.map((id) => makeNode(id));
-    const edges = ids.slice(1).map((id, i) => makeEdge(`e${i}`, ids[i], id));
-    const result = autoLayout(nodes, edges, 'all');
-    const ys = result.map((n) => n.position.y);
-    const yRange = Math.max(...ys) - Math.min(...ys);
-    // Wrapping pushes later ranks onto new rows → vertical spread well beyond one node.
-    expect(yRange).toBeGreaterThan(100);
-    for (const n of result) {
-      expect(Number.isFinite(n.position.x)).toBe(true);
-      expect(Number.isFinite(n.position.y)).toBe(true);
-    }
-  });
-
   it('excludes note nodes from layout in mode=all and leaves unbound notes put', () => {
     const nodes = [
       makeStartNode('s'),
@@ -343,27 +325,6 @@ describe('autoLayout', () => {
     expect(result).toHaveLength(N);
   });
 
-  it('skips grid wrapping when the trunk is wide but has few ranks', () => {
-    // 5 very wide nodes: pre-wrap pixel width exceeds TARGET_ROW_WIDTH (2400) so
-    // the width guard passes, but there are only ~5 distinct ranks (<= the
-    // maxRanksPerRow budget of 8) → wrapIntoGrid returns the positions as-is and
-    // everything stays on a single row band.
-    const widths = [700, 700, 700, 700, 700];
-    const ids = widths.map((_, i) => `w${i}`);
-    const nodes: Node[] = widths.map((w, i) => ({
-      id: ids[i],
-      position: { x: 0, y: 0 },
-      data: { id: ids[i], type: 'Dataset' },
-      type: 'baseNode',
-      width: w,
-      height: 80,
-    }));
-    const edges = ids.slice(1).map((id, i) => makeEdge(`e${i}`, ids[i], id));
-    const result = autoLayout(nodes, edges, 'all');
-    const yBands = new Set(result.map((n) => Math.round(n.position.y)));
-    expect(yBands.size).toBe(1);
-  });
-
   it('selected mode falls back to default dimensions for bare nodes when centering', () => {
     // Bare nodes (no measured/width/height) force the NODE_W / NODE_H fallbacks
     // in both the original-centroid and new-centroid calculations.
@@ -418,5 +379,163 @@ describe('autoLayout', () => {
     const liveY = result.find((n) => n.id === 'live')!.position.y;
     const draftAY = result.find((n) => n.id === 'draftA')!.position.y;
     expect(liveY).toBeLessThan(draftAY);
+  });
+});
+
+describe('applyValleyPass (unit)', () => {
+  const W = 200;
+  const H = 80;
+  const UNIT = 280;
+  const STEP = H + 60; // max node height in set + default gap
+
+  type Pos = { x: number; y: number; width: number; height: number };
+  // Hand-built layered positions: n0..n{k-1} left-to-right, all at y=0.
+  function chainPositions(k: number): Map<string, Pos> {
+    const m = new Map<string, Pos>();
+    for (let i = 0; i < k; i++) m.set(`n${i}`, { x: i * UNIT, y: 0, width: W, height: H });
+    return m;
+  }
+  function chainEdges(k: number, skips: Array<[number, number]> = []): ValleyEdge[] {
+    const edges: ValleyEdge[] = [];
+    for (let i = 0; i < k - 1; i++) edges.push({ source: `n${i}`, target: `n${i + 1}` });
+    for (const [a, b] of skips) edges.push({ source: `n${a}`, target: `n${b}` });
+    return edges;
+  }
+  const yOf = (m: Map<string, Pos>, id: string) => m.get(id)!.y;
+
+  it('no skips -> returns the input unchanged (identity)', () => {
+    const positions = chainPositions(10);
+    const result = applyValleyPass(positions, chainEdges(10), { axis: 'y' });
+    expect(result).toBe(positions);
+  });
+
+  it('UNet-style nested skips: exact staircase, level skip endpoints', () => {
+    // outer n1->n13 covers ranks 2..12; inner n4->n10 covers ranks 5..9.
+    const result = applyValleyPass(chainPositions(18), chainEdges(18, [[1, 13], [4, 10]]), {
+      axis: 'y',
+    });
+    expect(yOf(result, 'n0')).toBe(0);
+    expect(yOf(result, 'n1')).toBe(0);
+    expect(yOf(result, 'n13')).toBe(0); // outer endpoints level
+    expect(yOf(result, 'n2')).toBe(STEP); // under outer only
+    expect(yOf(result, 'n4')).toBe(STEP); // inner endpoints level...
+    expect(yOf(result, 'n10')).toBe(STEP);
+    expect(yOf(result, 'n7')).toBe(2 * STEP); // under both
+    expect(yOf(result, 'n15')).toBe(0); // tail back to top
+  });
+
+  it('sequential residuals (ResNet-style) dip independently to equal depth', () => {
+    const result = applyValleyPass(chainPositions(14), chainEdges(14, [[1, 5], [6, 10]]), {
+      axis: 'y',
+    });
+    expect(yOf(result, 'n3')).toBe(STEP); // inside block 1
+    expect(yOf(result, 'n8')).toBe(STEP); // inside block 2
+    expect(yOf(result, 'n5')).toBe(0); // between blocks
+    expect(yOf(result, 'n0')).toBe(0);
+    expect(yOf(result, 'n13')).toBe(0);
+  });
+
+  it('short span (< 3) does not dip', () => {
+    const positions = chainPositions(8);
+    const result = applyValleyPass(positions, chainEdges(8, [[2, 4]]), { axis: 'y' });
+    expect(result).toBe(positions);
+  });
+
+  it('skips whose endpoint is off the spine are ignored', () => {
+    // t sits beside rank 2 and feeds n6/n10: long spans, but t is off-spine.
+    const positions = chainPositions(12);
+    positions.set('t', { x: 2 * UNIT, y: 300, width: W, height: H });
+    const edges = [
+      ...chainEdges(12),
+      { source: 'n1', target: 't' },
+      { source: 't', target: 'n6' },
+      { source: 't', target: 'n10' },
+    ];
+    const result = applyValleyPass(positions, edges, { axis: 'y' });
+    expect(result).toBe(positions);
+  });
+
+  it('skipPredicate excludes trigger edges', () => {
+    const positions = chainPositions(10);
+    const edges: ValleyEdge[] = [...chainEdges(10), { source: 'n1', target: 'n8', type: 'triggerEdge' }];
+    const result = applyValleyPass(positions, edges, {
+      axis: 'y',
+      skipPredicate: (e) => !isTriggerEdge(e),
+    });
+    expect(result).toBe(positions);
+  });
+
+  it('axis "x" transposes the shift for TB layouts', () => {
+    const m = new Map<string, Pos>();
+    for (let i = 0; i < 10; i++) m.set(`n${i}`, { x: 0, y: i * 140, width: 260, height: H });
+    const result = applyValleyPass(m, chainEdges(10, [[1, 7]]), { axis: 'x' });
+    const xStep = 260 + 60; // max width + gap
+    expect(result.get('n0')!.x).toBe(0);
+    expect(result.get('n1')!.x).toBe(0);
+    expect(result.get('n7')!.x).toBe(0);
+    expect(result.get('n4')!.x).toBe(xStep);
+    expect(result.get('n4')!.y).toBe(4 * 140); // flow axis untouched
+  });
+
+  it('cycle edges (backward in rank) are ignored safely', () => {
+    const positions = chainPositions(8);
+    const edges = [...chainEdges(8), { source: 'n6', target: 'n1' }]; // back edge
+    const result = applyValleyPass(positions, edges, { axis: 'y' });
+    expect(result).toBe(positions);
+  });
+});
+
+describe('isTriggerEdge', () => {
+  it('recognizes all three trigger edge shapes', () => {
+    expect(isTriggerEdge({ source: 'a', target: 'b', type: 'triggerEdge' })).toBe(true);
+    expect(isTriggerEdge({ source: 'a', target: 'b', data: { type: 'trigger' } })).toBe(true);
+    expect(isTriggerEdge({ source: 'a', target: 'b', sourceHandle: 'trigger' })).toBe(true);
+    expect(isTriggerEdge({ source: 'a', target: 'b' })).toBe(false);
+  });
+});
+
+describe('valley layout through autoLayout (integration)', () => {
+  // Chain helper: start -> n0 -> n1 -> ... -> n{k-1}, plus extra data skips.
+  function chainWithSkips(k: number, skips: Array<[number, number]>) {
+    const nodes = [makeStartNode('s'), ...Array.from({ length: k }, (_, i) => makeNode(`n${i}`))];
+    const edges = [
+      makeEdge('et', 's', 'n0', 'trigger'),
+      ...Array.from({ length: k - 1 }, (_, i) => makeEdge(`e${i}`, `n${i}`, `n${i + 1}`)),
+      ...skips.map(([a, b], i) => makeEdge(`sk${i}`, `n${a}`, `n${b}`)),
+    ];
+    return { nodes, edges };
+  }
+  const posOf = (result: Node[], id: string) => result.find((n) => n.id === id)!.position;
+
+  it('long plain chain stays on ONE row — wrapping is gone', () => {
+    const { nodes, edges } = chainWithSkips(14, []);
+    const result = autoLayout(nodes, edges, 'all');
+    const ys = new Set(
+      Array.from({ length: 14 }, (_, i) => Math.round(posOf(result, `n${i}`).y / 10)),
+    );
+    expect(ys.size).toBe(1);
+    const xs = Array.from({ length: 14 }, (_, i) => posOf(result, `n${i}`).x);
+    for (let i = 1; i < xs.length; i++) expect(xs[i]).toBeGreaterThan(xs[i - 1]);
+  });
+
+  it('nested skips produce a valley: covered trunk sinks by full steps, x stays monotone', () => {
+    const { nodes, edges } = chainWithSkips(18, [[1, 13], [4, 10]]);
+    const result = autoLayout(nodes, edges, 'all');
+    // STEP = max node height (200x80 base nodes) + 60 = 140; dagre lane jitter
+    // from skip-edge dummy nodes is < 130, so a full step is distinguishable.
+    expect(posOf(result, 'n7').y - posOf(result, 'n1').y).toBeGreaterThan(140);
+    expect(posOf(result, 'n7').y - posOf(result, 'n2').y).toBeGreaterThan(70);
+    // tail comes back up to the outer level
+    expect(Math.abs(posOf(result, 'n16').y - posOf(result, 'n0').y)).toBeLessThan(70);
+    // no wrapping: trunk x strictly increases (no carriage-return rows)
+    const xs = Array.from({ length: 18 }, (_, i) => posOf(result, `n${i}`).x);
+    for (let i = 1; i < xs.length; i++) expect(xs[i]).toBeGreaterThan(xs[i - 1]);
+  });
+
+  it('valley output is deterministic across runs', () => {
+    const { nodes, edges } = chainWithSkips(18, [[1, 13], [4, 10]]);
+    const a = autoLayout(nodes, edges, 'all').map((n) => ({ id: n.id, ...n.position }));
+    const b = autoLayout(nodes, edges, 'all').map((n) => ({ id: n.id, ...n.position }));
+    expect(a).toEqual(b);
   });
 });

--- a/frontend/src/utils/autoLayout.ts
+++ b/frontend/src/utils/autoLayout.ts
@@ -302,6 +302,17 @@ function pickTargetIds(
   return targets;
 }
 
+/** The set of node ids a layout call would move — used by callers to scope
+ * the post-layout viewport fit (e.g. "selected" mode fits the selection). */
+export function layoutTargetIds(
+  nodes: Node[],
+  edges: Edge[],
+  mode: LayoutMode,
+  selectedIds?: Set<string>,
+): Set<string> {
+  return pickTargetIds(nodes, edges, mode, selectedIds);
+}
+
 export function autoLayout(
   nodes: Node[],
   edges: Edge[],

--- a/frontend/src/utils/autoLayout.ts
+++ b/frontend/src/utils/autoLayout.ts
@@ -119,13 +119,17 @@ export function isTriggerEdge(e: ValleyEdge): boolean {
 type ValleyPos = { x: number; y: number; width: number; height: number };
 
 /**
- * Skip-aware "valley" pass (replaces the old width wrapping). Ranks spanned by
- * a skip connection are shifted along the cross axis, so the trunk dips under
- * its skips: a UNet reads as a U, residual blocks as small dips, and graphs
- * without skips are returned untouched. A skip is a non-trigger edge whose
- * endpoints both lie on the spine (longest forward path) and whose rank span
- * is at least `minSpan`. Cycle-safe: only forward edges (rank increasing) are
- * walked, so back edges are simply ignored.
+ * Skip-aware "valley" pass (replaces the old width wrapping). Within each
+ * connected component, ranks spanned by a skip connection are shifted along
+ * the cross axis, so the trunk dips under its skips: a UNet reads as a U,
+ * residual blocks as small dips, and graphs without skips are returned
+ * untouched. A skip is an eligible edge whose endpoints both lie on the spine
+ * (longest forward path) and whose rank span is at least `minSpan`.
+ * Components are processed independently because a single dagre call over a
+ * disconnected graph (the subgraph editor does this) places components side
+ * by side with shared rank coordinates — a whole-map pass would let one
+ * component's skip bend another. Cycle-safe: only forward edges (rank
+ * increasing) are walked, so back edges are simply ignored.
  */
 export function applyValleyPass(
   positions: Map<string, ValleyPos>,
@@ -140,101 +144,142 @@ export function applyValleyPass(
   const { axis, skipPredicate = () => true, minSpan = VALLEY_MIN_SPAN, gap = VALLEY_GAP } = opts;
   if (positions.size === 0) return positions;
 
-  // 1. Geometric ranks: cluster distinct centers along the flow axis. Dagre
-  //    gives every node of a rank the same center coordinate, so this recovers
-  //    true ranks regardless of node sizes or spacing tier.
-  const centerOf = (p: ValleyPos) => (axis === 'y' ? p.x + p.width / 2 : p.y + p.height / 2);
-  const centers = Array.from(positions.values(), centerOf).sort((a, b) => a - b);
-  const rankCenters: number[] = [];
-  for (const c of centers) {
-    if (rankCenters.length === 0 || c - rankCenters[rankCenters.length - 1] > 1) {
-      rankCenters.push(c);
-    }
-  }
-  const rankOf = new Map<string, number>();
-  for (const [id, p] of positions) {
-    const c = centerOf(p);
-    let lo = 0;
-    let hi = rankCenters.length - 1;
-    while (lo < hi) {
-      const mid = (lo + hi) >> 1;
-      if (rankCenters[mid] < c - 1) lo = mid + 1;
-      else hi = mid;
-    }
-    rankOf.set(id, lo);
-  }
-  const maxRank = rankCenters.length - 1;
-  if (maxRank < minSpan) return positions;
+  const innerEdges = edges.filter((e) => positions.has(e.source) && positions.has(e.target));
 
-  // 2. Spine: longest path over FORWARD edges (rank strictly increasing),
-  //    deterministic tie-break by id.
-  const ids = Array.from(positions.keys()).sort();
-  const byRank = ids
-    .slice()
-    .sort((a, b) => rankOf.get(a)! - rankOf.get(b)! || a.localeCompare(b));
-  const forwardIn = new Map<string, string[]>(ids.map((id) => [id, []]));
-  for (const e of edges) {
-    if (!positions.has(e.source) || !positions.has(e.target)) continue;
-    if (rankOf.get(e.target)! > rankOf.get(e.source)!) {
-      forwardIn.get(e.target)!.push(e.source);
+  // Union-find the connected components of the laid-out subgraph.
+  const parent = new Map<string, string>();
+  for (const id of positions.keys()) parent.set(id, id);
+  const find = (x: string): string => {
+    let root = x;
+    while (parent.get(root) !== root) root = parent.get(root)!;
+    let cur = x;
+    while (cur !== root) {
+      const next = parent.get(cur)!;
+      parent.set(cur, root);
+      cur = next;
     }
+    return root;
+  };
+  for (const e of innerEdges) {
+    const ra = find(e.source);
+    const rb = find(e.target);
+    if (ra !== rb) parent.set(ra, rb);
   }
-  const pathLen = new Map<string, number>();
-  const pred = new Map<string, string | null>();
-  for (const id of byRank) {
-    let best = 0;
-    let bestPred: string | null = null;
-    for (const p of forwardIn.get(id)!.sort()) {
-      const cand = pathLen.get(p)! + 1;
-      if (cand > best) {
-        best = cand;
-        bestPred = p;
+  const components = new Map<string, string[]>();
+  for (const id of positions.keys()) {
+    const root = find(id);
+    if (!components.has(root)) components.set(root, []);
+    components.get(root)!.push(id);
+  }
+
+  const result = new Map<string, ValleyPos>(positions);
+  let anyShift = false;
+  for (const componentIds of components.values()) {
+    if (valleyOneComponent(componentIds)) anyShift = true;
+  }
+  return anyShift ? result : positions;
+
+  /** Shift one component's covered ranks in `result`; true if it shifted. */
+  function valleyOneComponent(ids: string[]): boolean {
+    // 1. Geometric ranks: cluster distinct centers along the flow axis. Dagre
+    //    gives every node of a rank the same center coordinate, so this
+    //    recovers true ranks regardless of node sizes or spacing tier.
+    const centerOf = (p: ValleyPos) => (axis === 'y' ? p.x + p.width / 2 : p.y + p.height / 2);
+    const centers = ids.map((id) => centerOf(positions.get(id)!)).sort((a, b) => a - b);
+    const rankByCenter = new Map<number, number>();
+    let maxRank = -1;
+    let prev = Number.NEGATIVE_INFINITY;
+    for (const c of centers) {
+      if (c - prev > 1) maxRank++;
+      rankByCenter.set(c, maxRank);
+      prev = c;
+    }
+    if (maxRank < minSpan) return false;
+    const rankOf = new Map<string, number>();
+    for (const id of ids) rankOf.set(id, rankByCenter.get(centerOf(positions.get(id)!))!);
+
+    const componentEdges = innerEdges.filter((e) => rankOf.has(e.source) && rankOf.has(e.target));
+
+    // 2. Cheap necessary condition: some eligible edge spans >= minSpan ranks.
+    //    Most graphs have no skip at all — skip the spine machinery for them.
+    const candidates = componentEdges.filter(
+      (e) => skipPredicate(e) && rankOf.get(e.target)! - rankOf.get(e.source)! >= minSpan,
+    );
+    if (candidates.length === 0) return false;
+
+    // 3. Spine: longest path over FORWARD edges (rank strictly increasing),
+    //    deterministic smallest-id tie-breaks.
+    const byRank = ids
+      .slice()
+      .sort((a, b) => rankOf.get(a)! - rankOf.get(b)! || (a < b ? -1 : a > b ? 1 : 0));
+    const forwardIn = new Map<string, string[]>(ids.map((id) => [id, []]));
+    for (const e of componentEdges) {
+      if (rankOf.get(e.target)! > rankOf.get(e.source)!) {
+        forwardIn.get(e.target)!.push(e.source);
       }
     }
-    pathLen.set(id, best);
-    pred.set(id, bestPred);
-  }
-  let tail = ids[0];
-  for (const id of ids) {
-    if (
-      pathLen.get(id)! > pathLen.get(tail)! ||
-      (pathLen.get(id) === pathLen.get(tail) && id < tail)
-    ) {
-      tail = id;
+    const pathLen = new Map<string, number>();
+    const pred = new Map<string, string | null>();
+    for (const id of byRank) {
+      let best = 0;
+      let bestPred: string | null = null;
+      for (const p of forwardIn.get(id)!) {
+        const cand = pathLen.get(p)! + 1;
+        if (cand > best || (cand === best && bestPred !== null && p < bestPred)) {
+          best = cand;
+          bestPred = p;
+        }
+      }
+      pathLen.set(id, best);
+      pred.set(id, bestPred);
     }
-  }
-  const spine = new Set<string>();
-  for (let cur: string | null = tail; cur !== null; cur = pred.get(cur) ?? null) {
-    spine.add(cur);
-  }
+    let tail = byRank[0];
+    for (const id of byRank) {
+      if (
+        pathLen.get(id)! > pathLen.get(tail)! ||
+        (pathLen.get(id) === pathLen.get(tail) && id < tail)
+      ) {
+        tail = id;
+      }
+    }
+    const spine = new Set<string>();
+    for (let cur: string | null = tail; cur !== null; cur = pred.get(cur) ?? null) {
+      spine.add(cur);
+    }
 
-  // 3. Skips: eligible edges with both endpoints on the spine spanning >= minSpan.
-  const coverage = new Array(maxRank + 1).fill(0);
-  let hasSkip = false;
-  for (const e of edges) {
-    if (!skipPredicate(e)) continue;
-    if (!spine.has(e.source) || !spine.has(e.target)) continue;
-    // Off-map endpoints are filtered by the spine check (spine ⊆ positions keys)
-    const rs = rankOf.get(e.source)!;
-    const rt = rankOf.get(e.target)!;
-    if (rt - rs < minSpan) continue;
-    hasSkip = true;
-    for (let r = rs + 1; r < rt; r++) coverage[r]++;
-  }
-  if (!hasSkip) return positions;
+    // 4. Skips: candidates with both endpoints on the spine. Coverage counts
+    //    how many skips span each rank (difference array + prefix sum).
+    const coverageDelta = new Array(maxRank + 2).fill(0);
+    let hasSkip = false;
+    for (const e of candidates) {
+      if (!spine.has(e.source) || !spine.has(e.target)) continue;
+      hasSkip = true;
+      coverageDelta[rankOf.get(e.source)! + 1]++;
+      coverageDelta[rankOf.get(e.target)!]--;
+    }
+    if (!hasSkip) return false;
 
-  // 4. Shift whole ranks along the cross axis by coverage * step.
-  let maxCross = 0;
-  for (const p of positions.values()) {
-    maxCross = Math.max(maxCross, axis === 'y' ? p.height : p.width);
+    // 5. Shift whole ranks along the cross axis by coverage * step.
+    let maxCross = 0;
+    for (const id of ids) {
+      const p = positions.get(id)!;
+      maxCross = Math.max(maxCross, axis === 'y' ? p.height : p.width);
+    }
+    const step = maxCross + gap;
+    const coverage = new Array(maxRank + 1).fill(0);
+    let running = 0;
+    for (let r = 0; r <= maxRank; r++) {
+      running += coverageDelta[r];
+      coverage[r] = running;
+    }
+    for (const id of ids) {
+      const shift = coverage[rankOf.get(id)!] * step;
+      if (shift === 0) continue;
+      const p = positions.get(id)!;
+      result.set(id, axis === 'y' ? { ...p, y: p.y + shift } : { ...p, x: p.x + shift });
+    }
+    return true;
   }
-  const step = maxCross + gap;
-  const result = new Map<string, ValleyPos>();
-  for (const [id, p] of positions) {
-    const shift = coverage[rankOf.get(id)!] * step;
-    result.set(id, axis === 'y' ? { ...p, y: p.y + shift } : { ...p, x: p.x + shift });
-  }
-  return result;
 }
 
 function packIntoSwimLanes(
@@ -302,25 +347,50 @@ function pickTargetIds(
   return targets;
 }
 
-/** The set of node ids a layout call would move — used by callers to scope
- * the post-layout viewport fit (e.g. "selected" mode fits the selection). */
-export function layoutTargetIds(
-  nodes: Node[],
-  edges: Edge[],
-  mode: LayoutMode,
-  selectedIds?: Set<string>,
-): Set<string> {
-  return pickTargetIds(nodes, edges, mode, selectedIds);
-}
-
 export function autoLayout(
   nodes: Node[],
   edges: Edge[],
   mode: LayoutMode,
   selectedIds?: Set<string>,
 ): Node[] {
+  return autoLayoutWithTargets(nodes, edges, mode, selectedIds).nodes;
+}
+
+/** Bounding box over the given nodes using the same size fallbacks layout
+ * uses. Lets callers fit the viewport from store data without racing React
+ * Flow's internal lookup. Null for an empty list. */
+export function nodesBoundingBox(
+  nodes: Node[],
+): { x: number; y: number; width: number; height: number } | null {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const n of nodes) {
+    const w = n.measured?.width ?? n.width ?? NODE_W;
+    const h = n.measured?.height ?? n.height ?? NODE_H;
+    minX = Math.min(minX, n.position.x);
+    minY = Math.min(minY, n.position.y);
+    maxX = Math.max(maxX, n.position.x + w);
+    maxY = Math.max(maxY, n.position.y + h);
+  }
+  if (!Number.isFinite(minX)) return null;
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+/**
+ * Like autoLayout, but also reports which node ids the layout targeted so
+ * callers can scope the post-layout viewport fit (e.g. "selected" mode fits
+ * the selection) without recomputing the target set.
+ */
+export function autoLayoutWithTargets(
+  nodes: Node[],
+  edges: Edge[],
+  mode: LayoutMode,
+  selectedIds?: Set<string>,
+): { nodes: Node[]; targetIds: Set<string> } {
   const targetIds = pickTargetIds(nodes, edges, mode, selectedIds);
-  if (targetIds.size === 0) return nodes;
+  if (targetIds.size === 0) return { nodes, targetIds };
 
   const componentIds = findConnectedComponents(targetIds, edges);
 
@@ -379,7 +449,7 @@ export function autoLayout(
   });
 
   // Reposition bound notes relative to their parent's new position
-  return result.map((n) => {
+  const withNotes = result.map((n) => {
     if (!isNoteNode(n)) return n;
     const data = n.data as any;
     if (!data.boundToNodeId || !data.boundOffset) return n;
@@ -393,6 +463,7 @@ export function autoLayout(
       },
     };
   });
+  return { nodes: withNotes, targetIds };
 }
 
 /**

--- a/frontend/src/utils/autoLayout.ts
+++ b/frontend/src/utils/autoLayout.ts
@@ -8,9 +8,8 @@ const NODE_H = 80;
 const NODESEP = 40;
 const RANKSEP = 80;
 const LANE_GAP = 60;
-const TARGET_ROW_WIDTH = 2400;
-const ROW_GAP = 120;
-const MIN_NODES_FOR_WRAP = 4;
+const VALLEY_MIN_SPAN = 3;
+const VALLEY_GAP = 60;
 
 function getLayoutConfig(nodeCount: number): { nodesep: number; ranksep: number } {
   if (nodeCount > 50) return { nodesep: 28, ranksep: 56 };
@@ -101,81 +100,139 @@ interface LaidOutComponent {
   bounds: { minY: number; maxY: number };
 }
 
+export type ValleyEdge = {
+  source: string;
+  target: string;
+  type?: string;
+  data?: unknown;
+  sourceHandle?: string | null;
+};
+
+export function isTriggerEdge(e: ValleyEdge): boolean {
+  return (
+    e.type === 'triggerEdge' ||
+    (e.data as { type?: string } | undefined)?.type === 'trigger' ||
+    e.sourceHandle === 'trigger'
+  );
+}
+
+type ValleyPos = { x: number; y: number; width: number; height: number };
+
 /**
- * If a component's trunk exceeds TARGET_ROW_WIDTH, split its ranks into multiple
- * rows and shift each row downward. Keeps intra-rank lane layout intact (nodes
- * sharing a rank stay vertically aligned).
+ * Skip-aware "valley" pass (replaces the old width wrapping). Ranks spanned by
+ * a skip connection are shifted along the cross axis, so the trunk dips under
+ * its skips: a UNet reads as a U, residual blocks as small dips, and graphs
+ * without skips are returned untouched. A skip is a non-trigger edge whose
+ * endpoints both lie on the spine (longest forward path) and whose rank span
+ * is at least `minSpan`. Cycle-safe: only forward edges (rank increasing) are
+ * walked, so back edges are simply ignored.
  */
-function wrapIntoGrid(
-  positions: Map<string, { x: number; y: number; width: number; height: number }>,
-): Map<string, { x: number; y: number; width: number; height: number }> {
-  if (positions.size < MIN_NODES_FOR_WRAP) return positions;
+export function applyValleyPass(
+  positions: Map<string, ValleyPos>,
+  edges: ValleyEdge[],
+  opts: {
+    axis: 'y' | 'x';
+    skipPredicate?: (e: ValleyEdge) => boolean;
+    minSpan?: number;
+    gap?: number;
+  },
+): Map<string, ValleyPos> {
+  const { axis, skipPredicate = () => true, minSpan = VALLEY_MIN_SPAN, gap = VALLEY_GAP } = opts;
+  if (positions.size === 0) return positions;
 
-  const values = Array.from(positions.values());
-  let minX = Infinity;
-  let maxX = -Infinity;
-  for (const p of values) {
-    if (p.x < minX) minX = p.x;
-    if (p.x + p.width > maxX) maxX = p.x + p.width;
+  // 1. Geometric ranks: cluster distinct centers along the flow axis. Dagre
+  //    gives every node of a rank the same center coordinate, so this recovers
+  //    true ranks regardless of node sizes or spacing tier.
+  const centerOf = (p: ValleyPos) => (axis === 'y' ? p.x + p.width / 2 : p.y + p.height / 2);
+  const centers = Array.from(positions.values(), centerOf).sort((a, b) => a - b);
+  const rankCenters: number[] = [];
+  for (const c of centers) {
+    if (rankCenters.length === 0 || c - rankCenters[rankCenters.length - 1] > 1) {
+      rankCenters.push(c);
+    }
   }
-  const width = maxX - minX;
-  if (width <= TARGET_ROW_WIDTH) return positions;
-
-  const rankUnit = NODE_W + RANKSEP;
-  const rankSet = new Set<number>();
   const rankOf = new Map<string, number>();
   for (const [id, p] of positions) {
-    const rank = Math.round((p.x - minX) / rankUnit);
-    rankOf.set(id, rank);
-    rankSet.add(rank);
-  }
-  // width > TARGET_ROW_WIDTH implies nodes exist, so rankSet.size is always ≥ 1
-  /* v8 ignore start */
-  const totalRanks = rankSet.size || 1;
-  /* v8 ignore stop */
-  const maxRanksPerRow = Math.max(1, Math.floor(TARGET_ROW_WIDTH / rankUnit));
-  if (totalRanks <= maxRanksPerRow) return positions;
-
-  const rowCount = Math.ceil(totalRanks / maxRanksPerRow);
-  const ranksPerRow = Math.ceil(totalRanks / rowCount);
-  const rowWidth = ranksPerRow * rankUnit;
-
-  const rowOf = new Map<string, number>();
-  for (const [id, rank] of rankOf) {
-    const row = Math.min(rowCount - 1, Math.floor(rank / ranksPerRow));
-    rowOf.set(id, row);
-  }
-
-  const rowYOffset: number[] = new Array(rowCount).fill(0);
-  let cumY = 0;
-  for (let r = 0; r < rowCount; r++) {
-    let rMinY = Infinity;
-    let rMaxY = -Infinity;
-    for (const [id, p] of positions) {
-      if (rowOf.get(id) !== r) continue;
-      if (p.y < rMinY) rMinY = p.y;
-      if (p.y + p.height > rMaxY) rMaxY = p.y + p.height;
+    const c = centerOf(p);
+    let lo = 0;
+    let hi = rankCenters.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (rankCenters[mid] < c - 1) lo = mid + 1;
+      else hi = mid;
     }
-    // Every intermediate grid row gets at least one rank, so a row is never empty
-    /* v8 ignore start */
-    if (rMinY === Infinity) {
-      rMinY = 0;
-      rMaxY = 0;
+    rankOf.set(id, lo);
+  }
+  const maxRank = rankCenters.length - 1;
+  if (maxRank < minSpan) return positions;
+
+  // 2. Spine: longest path over FORWARD edges (rank strictly increasing),
+  //    deterministic tie-break by id.
+  const ids = Array.from(positions.keys()).sort();
+  const byRank = ids
+    .slice()
+    .sort((a, b) => rankOf.get(a)! - rankOf.get(b)! || a.localeCompare(b));
+  const forwardIn = new Map<string, string[]>(ids.map((id) => [id, []]));
+  for (const e of edges) {
+    if (!positions.has(e.source) || !positions.has(e.target)) continue;
+    if (rankOf.get(e.target)! > rankOf.get(e.source)!) {
+      forwardIn.get(e.target)!.push(e.source);
     }
-    /* v8 ignore stop */
-    rowYOffset[r] = cumY - rMinY;
-    cumY += rMaxY - rMinY + ROW_GAP;
+  }
+  const pathLen = new Map<string, number>();
+  const pred = new Map<string, string | null>();
+  for (const id of byRank) {
+    let best = 0;
+    let bestPred: string | null = null;
+    for (const p of forwardIn.get(id)!.sort()) {
+      const cand = pathLen.get(p)! + 1;
+      if (cand > best) {
+        best = cand;
+        bestPred = p;
+      }
+    }
+    pathLen.set(id, best);
+    pred.set(id, bestPred);
+  }
+  let tail = ids[0];
+  for (const id of ids) {
+    if (
+      pathLen.get(id)! > pathLen.get(tail)! ||
+      (pathLen.get(id) === pathLen.get(tail) && id < tail)
+    ) {
+      tail = id;
+    }
+  }
+  const spine = new Set<string>();
+  for (let cur: string | null = tail; cur !== null; cur = pred.get(cur) ?? null) {
+    spine.add(cur);
   }
 
-  const result = new Map<string, { x: number; y: number; width: number; height: number }>();
+  // 3. Skips: eligible edges with both endpoints on the spine spanning >= minSpan.
+  const coverage = new Array(maxRank + 1).fill(0);
+  let hasSkip = false;
+  for (const e of edges) {
+    if (!skipPredicate(e)) continue;
+    if (!spine.has(e.source) || !spine.has(e.target)) continue;
+    // Off-map endpoints are filtered by the spine check (spine ⊆ positions keys)
+    const rs = rankOf.get(e.source)!;
+    const rt = rankOf.get(e.target)!;
+    if (rt - rs < minSpan) continue;
+    hasSkip = true;
+    for (let r = rs + 1; r < rt; r++) coverage[r]++;
+  }
+  if (!hasSkip) return positions;
+
+  // 4. Shift whole ranks along the cross axis by coverage * step.
+  let maxCross = 0;
+  for (const p of positions.values()) {
+    maxCross = Math.max(maxCross, axis === 'y' ? p.height : p.width);
+  }
+  const step = maxCross + gap;
+  const result = new Map<string, ValleyPos>();
   for (const [id, p] of positions) {
-    const row = rowOf.get(id)!;
-    result.set(id, {
-      x: p.x - row * rowWidth,
-      y: p.y + rowYOffset[row],
-      width: p.width,
-      height: p.height,
-    });
+    const shift = coverage[rankOf.get(id)!] * step;
+    result.set(id, axis === 'y' ? { ...p, y: p.y + shift } : { ...p, x: p.x + shift });
   }
   return result;
 }
@@ -269,7 +326,10 @@ export function autoLayout(
   // Lay out each component independently
   const laidOut: LaidOutComponent[] = componentIds.map((ids) => {
     const rawPositions = layoutComponentWithDagre(ids, nodes, edges);
-    const positions = wrapIntoGrid(rawPositions);
+    const positions = applyValleyPass(rawPositions, edges, {
+      axis: 'y',
+      skipPredicate: (e) => !isTriggerEdge(e),
+    });
     const ys = Array.from(positions.values()).map((p) => p.y);
     const heights = Array.from(positions.values()).map((p) => p.height);
     const minY = Math.min(...ys);


### PR DESCRIPTION
## Summary

Auto-layout no longer folds wide graphs into stacked rows. Instead, a skip-aware "valley" pass sinks the ranks that a skip connection spans, so architectures lay out in their canonical shapes:

- **UNet** reads as a staircase **U** (nested skips -> coverage levels 0/1/2/1/0), skip edges arc over the valley
- **ResNet / Transformer blocks / Mamba-style blocks**: each residual's interior dips under its bypass edge
- **EfficientNet MBConv**: nested depth-2 (SE squeeze chain sinks below the block dip)
- **Plain chains** (incl. BERT/GPT/LLaMA/ViT examples that use monolithic block nodes): provably byte-identical to plain dagre output — one straight line
- The viewport now re-fits to the laid-out nodes after every auto-layout (main canvas previously never re-fit)

## Why the old behavior broke complex graphs

`wrapIntoGrid` (and the subgraph editor's `wrapIntoColumns`) folded any component wider than 2400px into rows shifted straight left, which by construction produced:

1. a far-right -> far-left "carriage-return" trunk edge at every row boundary;
2. skip connections crossing rows as giant diagonals (the UNet fixture's skips — which its own description calls "the U-shape" — became the worst spaghetti);
3. mis-binned ranks on >25-node components: rank recovery divided x by a hardcoded 280px unit while the adaptive `ranksep` had shrunk real spacing to 264/256px, so nodes landed in wrong rows/columns;
4. even a 12-node plain chain wrapped (3280px > 2400px) — 13 of the repo's own example graphs fold today, including pure chains like LLaMA and ViT.

No mainstream tool wraps dataflow graphs (Netron, TensorBoard, ComfyUI, n8n, mermaid, torchview all keep one flow direction + pan/zoom), so deleting the fold also moves us to the industry norm.

## How the valley pass works (`applyValleyPass`)

1. Recover ranks geometrically: cluster distinct node centers along the flow axis (dagre gives every rank one shared center) — no hardcoded pixel unit, works with measured sizes and all spacing tiers.
2. Spine = longest path over forward edges (rank strictly increasing; cycle-safe by construction, deterministic id tie-breaks).
3. Skips = non-trigger edges with **both endpoints on the spine** and rank span >= 3. This keeps broadcast feeders (e.g. Mini-UNet's `t_emb`, out-degree 5) and short local bypasses from creating false valleys.
4. Coverage per rank = number of skips spanning it; shift each whole rank along the cross axis by `coverage x (max node size + 60)`.
5. No skips -> the input positions are returned untouched (identity).

The same implementation serves the main canvas (axis `y`, LR) and the subgraph editor (axis `x`, TB).

## Viewport re-fit

`applyLayout` publishes a `layoutFitRequest` (uiStore) naming the laid-out node ids; the visible `FlowCanvas` answers with `getNodesBounds` + `fitBounds` scoped to those ids, so "Layout Selected" focuses the selection. Two React Flow findings from browser testing are handled:

- `fitView()` from `useReactFlow` in v12.10 only queues and flushes on the next node change (which never comes when layout leaves node objects untouched) — `fitBounds` sets the viewport directly;
- default `minZoom` 0.5 made wide graphs impossible to fit (the UNet valley needs ~0.32); both canvases now allow zoom-out to 0.1;
- one `FlowCanvas` is mounted per tab behind `display:none` — hidden (0-size) canvases skip the fit request.

## Review round (8-angle multi-agent review, all findings addressed)

- **Component isolation**: `applyValleyPass` runs per connected component — a single dagre call over a disconnected graph (subgraph editor) shares rank coordinates across components, so one component's skip used to bend another (empirically confirmed against dagre output; regression test added).
- **Race-free fit**: the fit request carries the laid-out bounding box computed from store data instead of node ids — reading positions back from React Flow raced its internal sync and could fit the pre-layout geometry.
- **Instant fit**: animated `setViewport` rides requestAnimationFrame, which Chrome throttles to zero in occluded/background windows (observed live: the animation never applies). Instant fits match the subgraph editor and the Controls button.
- One-shot fit requests (cleared after consumption; tab-id guard instead of CSS-geometry only), bound notes included in fit bounds, small-selection fits no longer slam to maxZoom, `autoLayoutWithTargets` removes duplicated target computation, efficiency batch in the valley pass (candidate pre-scan, Map rank lookup, numeric sorts, difference-array coverage), shared `CANVAS_MIN_ZOOM` constant, stale comments fixed.
- Noted for follow-up (not in this PR): consolidating the 7+ divergent inline trigger-edge checks across the codebase onto `isTriggerEdge`, and unifying the subgraph editor's post-layout fit with the store-driven mechanism.

## Validation

- Unit: `applyValleyPass` exact-shift tests (UNet staircase, sequential residuals, nested MBConv, off-spine broadcast, trigger exclusion, span<3, back-edge cycle, transposed axis, no-skip identity) + integration tests through `autoLayout` + store test for the fit request. Full suite: 93 files / 1707 tests green.
- Headless sweep of all 61 example graphs in `examples/` + `plugins/`: zero skip-level mismatches, zero crossing skip pairs, straight-line crossing count never worse than the no-wrap baseline.
- Browser e2e (production dist): imported UNet-Segmentation, ResNet-SkipConnection, and BERT-Encoder examples, ran Shift+L — UNet renders the U with fitted viewport, ResNet shows two bypass dips, BERT stays a single line; existing user tabs unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
