### PR TITLE
fix(llm): codex OAuth callback also listens on IPv6 loopback

### DIFF
--- a/backend/app/core/llm_proxy/codex_auth.py
+++ b/backend/app/core/llm_proxy/codex_auth.py
@@ -214,6 +214,7 @@ class _LoginFlow:
         self.verifier, self.challenge = generate_pkce()
         self.port: int = 0
         self.server: asyncio.AbstractServer | None = None
+        self.server_v6: asyncio.AbstractServer | None = None
         self.exchange_client: httpx.AsyncClient | None = None
         self.settled = asyncio.Event()
         self.timeout_task: asyncio.Task | None = None
@@ -346,6 +347,11 @@ def _settle() -> None:
             flow.server.close()
         except Exception:
             pass  # loop already closed (e.g. sync fixture teardown on Windows)
+    if flow.server_v6 is not None:
+        try:
+            flow.server_v6.close()
+        except Exception:
+            pass
     if flow.timeout_task is not None:
         try:
             flow.timeout_task.cancel()
@@ -390,6 +396,14 @@ async def start_login(*, ports: tuple[int, ...] = CALLBACK_PORTS,
             last_err = exc
     if flow.server is None:
         raise RuntimeError(f"Could not bind a callback port {ports}: {last_err}")
+    # The redirect_uri host is `localhost` (fixed by the registered OAuth
+    # client), which some resolvers answer with ::1 first -- listen on the
+    # IPv6 loopback at the same port too. Best-effort: IPv4-only hosts keep
+    # the plain 127.0.0.1 listener.
+    try:
+        flow.server_v6 = await asyncio.start_server(_handle_conn, "::1", flow.port)
+    except OSError:
+        flow.server_v6 = None
 
     async def _timeout() -> None:
         await asyncio.sleep(LOGIN_TIMEOUT_S)

--- a/backend/tests/test_llm_codex_auth.py
+++ b/backend/tests/test_llm_codex_auth.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import socket
 import time
 from urllib.parse import parse_qs, urlparse
 
@@ -13,6 +14,18 @@ import httpx
 import pytest
 
 from app.core.llm_proxy import codex_auth
+
+
+def _ipv6_loopback_available() -> bool:
+    try:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        try:
+            s.bind(("::1", 0))
+        finally:
+            s.close()
+        return True
+    except OSError:
+        return False
 
 
 @pytest.fixture(autouse=True)
@@ -231,6 +244,79 @@ async def test_login_flow_end_to_end():
     assert st["status"] == "logged_in"
     assert st["email"] == "u@example.com"
     assert codex_auth.load_tokens()["account_id"] == "acc-7"
+
+
+@pytest.mark.asyncio
+async def test_login_callback_reachable_over_ipv6_loopback():
+    # The redirect_uri says `localhost`; a browser may resolve that to ::1
+    # first, so the callback must answer on the IPv6 loopback too.
+    if not _ipv6_loopback_available():
+        pytest.skip("host has no IPv6 loopback")
+
+    def token_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "id_token": make_jwt({
+                "email": "v6@example.com",
+                "https://api.openai.com/auth": {"chatgpt_account_id": "acc-v6"},
+            }),
+            "access_token": make_jwt({"exp": int(time.time()) + 3600}),
+            "refresh_token": "rt-v6",
+        })
+
+    exchange_client = httpx.AsyncClient(transport=httpx.MockTransport(token_handler))
+    auth_url = await codex_auth.start_login(ports=(0,), exchange_client=exchange_client)
+    state = parse_qs(urlparse(auth_url).query)["state"][0]
+    port = codex_auth.active_login_port()
+
+    async with httpx.AsyncClient() as browser:
+        r = await browser.get(
+            f"http://[::1]:{port}/auth/callback",
+            params={"code": "the-code", "state": state})
+    assert r.status_code == 200
+    assert "close this tab" in r.text
+
+    await codex_auth.wait_login_settled()
+    st = codex_auth.status()
+    assert st["status"] == "logged_in"
+    assert st["email"] == "v6@example.com"
+
+
+@pytest.mark.asyncio
+async def test_login_flow_survives_hosts_without_ipv6(monkeypatch):
+    # An IPv4-only host must keep the pre-existing behavior: bind 127.0.0.1
+    # and complete the flow even though the ::1 bind is impossible.
+    real_start_server = asyncio.start_server
+
+    async def no_v6_start_server(handler, host=None, port=None, **kwargs):
+        if host == "::1":
+            raise OSError("address family not supported")
+        return await real_start_server(handler, host, port, **kwargs)
+
+    monkeypatch.setattr(asyncio, "start_server", no_v6_start_server)
+
+    def token_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "id_token": make_jwt({
+                "email": "v4@example.com",
+                "https://api.openai.com/auth": {"chatgpt_account_id": "acc-v4"},
+            }),
+            "access_token": make_jwt({"exp": int(time.time()) + 3600}),
+            "refresh_token": "rt-v4",
+        })
+
+    exchange_client = httpx.AsyncClient(transport=httpx.MockTransport(token_handler))
+    auth_url = await codex_auth.start_login(ports=(0,), exchange_client=exchange_client)
+    state = parse_qs(urlparse(auth_url).query)["state"][0]
+    port = codex_auth.active_login_port()
+
+    async with httpx.AsyncClient() as browser:
+        r = await browser.get(
+            f"http://127.0.0.1:{port}/auth/callback",
+            params={"code": "the-code", "state": state})
+    assert r.status_code == 200
+
+    await codex_auth.wait_login_settled()
+    assert codex_auth.status()["status"] == "logged_in"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The ChatGPT (codex) sign-in callback server binds only `127.0.0.1:<port>`, while the OAuth `redirect_uri` registered for the codex CLI client is `http://localhost:<port>/auth/callback`. On machines whose resolver answers `localhost` with `::1` first, the post-authorize browser redirect connects to `[::1]:<port>`, nothing is listening there, and sign-in fails. (Follow-up identified during the 2026-06-19 live codex e2e.)

## Fix

`start_login()` keeps the IPv4 bind as the primary listener (port fallback across 1455/1457 unchanged), then best-effort binds the IPv6 loopback `::1` on the same resolved port. Hosts without IPv6 keep the previous IPv4-only behavior. `_settle()` now closes both listeners.

## Testing

- TDD: new test `test_login_callback_reachable_over_ipv6_loopback` (full login flow with the browser hitting `http://[::1]:<port>/auth/callback`) failed with `httpx.ConnectError` before the fix, passes after. New pinning test `test_login_flow_survives_hosts_without_ipv6` (monkeypatched `::1` bind failure) protects IPv4-only hosts.
- Full backend suite: 1766 passed, 12 skipped.
- Live server drive (uvicorn on an isolated data dir): `POST /api/llm/codex/login` -> real listener on 1455; wrong-state callback answered `400 State mismatch` on BOTH `127.0.0.1` and `[::1]`; bogus path answered 404 on the v6 listener; after `POST /api/llm/codex/logout` both listeners are closed (connection refused on both families).

🤖 Generated with [Claude Code](https://claude.com/claude-code)