### PR TITLE
chore: align version fields to 1.4.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefyui-backend"
-version = "0.1.0"
+version = "1.4.0"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
 requires-python = ">=3.10"
 # PEP 639 SPDX license expression (bare string). The previous PEP 621

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -352,7 +352,7 @@ wheels = [
 
 [[package]]
 name = "codefyui-backend"
-version = "0.1.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codefyui-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.4.0",
   "license": "AGPL-3.0-only",
   "packageManager": "pnpm@9.15.0",
   "type": "module",


### PR DESCRIPTION
## What

Aligns the project's own version fields to **1.4.0** (the upcoming release tag; the release line is at 1.3.0 while both manifests still said 0.1.0).

| File | Change |
|---|---|
| `backend/pyproject.toml` | `version = "0.1.0"` -> `"1.4.0"` |
| `backend/uv.lock` | regenerated with plain `uv lock` (no `--upgrade`) |
| `frontend/package.json` | `"version": "0.1.0"` -> `"1.4.0"` |

## uv.lock diff size

**1 line changed** (1 insertion, 1 deletion): only the `codefyui-backend` package's `version` field inside its `[[package]]` block. All 128 resolved packages and their resolutions are untouched. `uv lock --check` passes.

`pnpm-lock.yaml` does not record the root importer's version (verified: the `.` importer block has no version field), so there is no frontend lockfile change.

## Other places checked for the app's own version

Grep of `0.1.0` across the repo (excluding node_modules / .venv / lockfiles) plus a sweep for `VERSION` constants, `__version__`, `importlib.metadata`, `--version`, and `FastAPI(version=...)`. Everything found is a *different* package's version or an unrelated concept, so it was left untouched:

- `plugins/{foundations,deep,rl,edu}/cdui.plugin.toml` `version = "0.1.0"` — each bundled plugin's own manifest version, not the app version.
- `scripts/templates/plugin/cdui.plugin.toml` and `scripts/templates/plugin/ui/package.json` — scaffold templates for *new* plugins; 0.1.0 is the correct starting version for a freshly created plugin.
- `scripts/templates/plugin/cdui.plugin.toml` `requires_codefyui = ">=1.3.0"` — plugin host-compatibility floor; still satisfied by 1.4.0, deliberately not raised.
- `docs/docs/advanced/plugin-frontend-extensions.md` + its `docs/i18n/zh-TW/...` translation — documentation examples of plugin manifests.
- `backend/tests/test_plugin_api.py`, `test_plugin_cli.py`, `test_plugin_frontend.py` — test fixtures for plugin manifests (plugin versions, asserted as such).
- No app-version surface exists in code: `FastAPI(title=settings.APP_NAME, lifespan=lifespan)` has no `version` kwarg, `/api/health` returns no version field, there is no `VERSION` constant / `__version__` / `importlib.metadata` lookup anywhere, and `scripts/dev.py` has no `--version` flag. Nothing ambiguous was skipped.

## Tests

- `cd backend && uv lock --check` — passes (CI gate).
- `cd backend && uv sync --extra dev` then `./.venv/Scripts/python.exe -m pytest tests -q -k "health or version or config"` — **29 passed**, 1750 deselected, 19.09s.
- No test asserts on the application's own semver (the 0.1.0 hits in tests are plugin-manifest fixtures, unchanged).
- Frontend: pure `package.json` metadata change, no test run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)