### PR TITLE
chore: THIRD_PARTY_NOTICES + include notices in release tarball

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -121,6 +121,11 @@ jobs:
       - name: Package dist
         id: pack
         run: |
+          # The tarball redistributes compiled third-party code (React, KaTeX
+          # and its fonts, ...), so the AGPL license text and the third-party
+          # attribution notices must travel with it. Copy them into dist so
+          # they land at the top level of the archive.
+          cp LICENSE THIRD_PARTY_NOTICES.md frontend/dist/
           # Pack from inside the dist dir so extraction lands cleanly with
           # `tar -xzf frontend-dist.tar.gz -C frontend/dist` (no strip needed).
           tar -czf frontend-dist.tar.gz -C frontend/dist .

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,136 @@
+# Third-Party Notices
+
+CodefyUI is licensed under the GNU Affero General Public License v3.0 only
+(AGPL-3.0-only); see [LICENSE](LICENSE). Commercial licensing is described in
+[COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md).
+
+This document lists the third-party software and data that CodefyUI
+redistributes or depends on, together with their licenses. It is included in
+the `frontend-dist.tar.gz` release asset alongside the repository `LICENSE`,
+because that asset redistributes compiled third-party code.
+
+License information below was verified on 2026-07-18 against the installed
+packages (the `license` field of each package's `package.json` for npm
+packages, and installed distribution metadata for Python packages). Versions
+listed are the versions verified at that time; the authoritative version
+ranges are `frontend/package.json` and `backend/pyproject.toml`.
+
+## 1. Frontend dependencies (redistributed in compiled form)
+
+The release asset `frontend-dist.tar.gz` contains the compiled frontend
+bundle (`frontend/dist`). The production dependencies below are compiled into
+that bundle and are therefore redistributed with every release.
+
+| Package | Verified version | License | Upstream |
+|---------|------------------|---------|----------|
+| @dagrejs/dagre | 3.0.0 | MIT | https://github.com/dagrejs/dagre |
+| @xyflow/react (React Flow) | 12.10.1 | MIT | https://github.com/xyflow/xyflow |
+| katex | 0.16.45 | MIT | https://github.com/KaTeX/KaTeX |
+| react | 19.2.4 | MIT | https://github.com/facebook/react |
+| react-dom | 19.2.4 | MIT | https://github.com/facebook/react |
+| react-katex | 3.1.0 | MIT | https://github.com/talyssonoc/react-katex |
+| zustand | 5.0.12 | MIT | https://github.com/pmndrs/zustand |
+
+The full production dependency closure (direct and transitive packages, as
+resolved by `frontend/pnpm-lock.yaml`) was checked with
+`pnpm licenses list --prod`. Every package in the closure is licensed under
+one of:
+
+- MIT (all packages not listed below);
+- ISC (the D3 modules d3-color, d3-dispatch, d3-drag, d3-interpolate,
+  d3-selection, d3-timer, d3-transition, d3-zoom);
+- BSD-3-Clause (d3-ease).
+
+### 1.1 KaTeX and bundled fonts
+
+KaTeX (https://katex.org, https://github.com/KaTeX/KaTeX) is used for math
+rendering. The compiled bundle includes KaTeX's JavaScript and CSS, and the
+KaTeX web fonts (the `KaTeX_*` font files in woff, woff2, and ttf formats)
+are copied into `frontend/dist/assets` by the build. These fonts ship inside
+`frontend-dist.tar.gz`. The fonts are part of the KaTeX distribution and are
+covered by the same MIT license as KaTeX itself, reproduced here from the
+`LICENSE` file of the katex npm package:
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2013-2020 Khan Academy and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## 2. Backend Python dependencies (not redistributed)
+
+CodefyUI release artifacts do **not** redistribute the backend's Python
+dependencies. Users install them from PyPI (or another index of their choice)
+at install time. The direct runtime dependencies declared in
+`backend/pyproject.toml` `[project.dependencies]` are listed below with their
+license names for reference. This is a best-effort summary verified from
+installed distribution metadata; consult each project for the authoritative
+license text.
+
+| Package | License |
+|---------|---------|
+| fastapi | MIT |
+| starlette | BSD-3-Clause |
+| uvicorn | BSD-3-Clause |
+| pydantic | MIT |
+| pydantic-settings | MIT |
+| websockets | BSD-3-Clause |
+| python-multipart | Apache-2.0 |
+| numpy | BSD-3-Clause (with bundled components under 0BSD, MIT, Zlib, CC0-1.0) |
+| matplotlib | Matplotlib License (PSF-based) |
+| Pillow | MIT-CMU |
+| torch | BSD-3-Clause |
+| torchvision | BSD-3-Clause |
+| gymnasium | MIT |
+| safetensors | Apache-2.0 |
+| datasets | Apache-2.0 |
+| kagglehub | Apache-2.0 |
+| kagglesdk | Apache-2.0 |
+| pyarrow | Apache-2.0 |
+| pandas | BSD-3-Clause |
+| tiktoken | MIT |
+| tokenizers | Apache-2.0 |
+| huggingface_hub | Apache-2.0 |
+| scikit-learn | BSD-3-Clause |
+| platformdirs | MIT |
+| psutil | BSD-3-Clause |
+| httpx | BSD-3-Clause |
+| tomli (Python < 3.11 only) | MIT |
+
+Notable transitive dependencies: certifi is licensed under MPL-2.0, and tqdm
+under MPL-2.0 AND MIT. MPL-2.0 is a file-level copyleft license; CodefyUI
+uses these packages unmodified and does not redistribute them.
+
+The torch and torchvision wheels published on PyPI bundle additional native
+components (for example CUDA libraries in GPU builds) under their own terms;
+consult those projects' distributions for details.
+
+## 3. MNIST sample data
+
+The source repository contains a copy of the MNIST database of handwritten
+digits under `backend/data/MNIST/raw/` (IDX-format image and label files),
+used as sample data for the built-in training examples. This data is not part
+of `frontend-dist.tar.gz`; it is distributed with the source repository.
+
+The MNIST database was created by Yann LeCun (Courant Institute, NYU),
+Corinna Cortes (Google Labs), and Christopher J. C. Burges (Microsoft
+Research), derived from NIST Special Databases 1 and 3. Source:
+http://yann.lecun.com/exdb/mnist/.


### PR DESCRIPTION
## Problem

Every GitHub Release attaches `frontend-dist.tar.gz`, which redistributes the compiled frontend bundle -- including third-party code and assets (React, React Flow, dagre, zustand, and notably KaTeX plus its web fonts, which ship as `KaTeX_*` woff/woff2/ttf files inside `dist/assets/`). The repo had no attribution file anywhere, and the tarball carried neither the AGPL license text nor any third-party notices. This closes that legal gap.

## What the new file covers

`THIRD_PARTY_NOTICES.md` (repo root):

1. **Frontend runtime dependencies** (redistributed in compiled form): all 7 `dependencies` from `frontend/package.json` with license and upstream URL, plus a statement of the full production closure's license set.
2. **KaTeX subsection**: notes the bundled KaTeX fonts and reproduces the full KaTeX MIT license text verbatim from `node_modules/katex/LICENSE`.
3. **Backend Python dependencies**: explicitly notes they are NOT redistributed in release artifacts (installed from PyPI at install time), then a best-effort license table for all direct `[project.dependencies]`, with certifi (MPL-2.0) and tqdm (MPL-2.0 AND MIT) called out among transitive deps.
4. **MNIST sample data**: source attribution for `backend/data/MNIST/raw/` (LeCun, Cortes, Burges; derived from NIST SD-1/SD-3), noting it is repo-only, not in the tarball.

## How licenses were verified

- Frontend: ran `pnpm install` and read the `license` field of each direct dependency's installed `package.json` -- all 7 are MIT (@dagrejs/dagre 3.0.0, @xyflow/react 12.10.1, katex 0.16.45, react 19.2.4, react-dom 19.2.4, react-katex 3.1.0, zustand 5.0.12). The full production closure was checked with `pnpm licenses list --prod`: MIT, ISC (d3-* modules), and BSD-3-Clause (d3-ease) only.
- Backend: read installed distribution metadata (`License-Expression` / `License` / trove classifiers via `importlib.metadata`, plus dist-info LICENSE files for torch/torchvision) for every direct dependency. No package was left unverified.

## Workflow change

Minimal edit to the `Package dist` step of `.github/workflows/release-build.yml`: copy `LICENSE` and `THIRD_PARTY_NOTICES.md` into `frontend/dist/` before the existing (unchanged) `tar -czf frontend-dist.tar.gz -C frontend/dist .` command, so both files land at the top level of the archive and also extract into `frontend/dist` for installed users.

## Local verification

Ran `pnpm build` and then the exact packing commands from the workflow. `tar -tzf` shows the archive top level is:

```
./
./index.html
./LICENSE
./THIRD_PARTY_NOTICES.md
```

plus 62 `./assets/` entries (JS, CSS, and the KaTeX fonts). The workflow file also round-trips through `yaml.safe_load` with all 13 steps intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
