### PR TITLE
chore(project): cosmetic/doc sweep (csv hint, layout_missing note, adopt .gitkeep, zh-TW polish)

### DIFF
--- a/backend/app/core/project.py
+++ b/backend/app/core/project.py
@@ -106,6 +106,10 @@ def merge_graph(logic: dict, layout: dict | None) -> tuple[dict, bool]:
         else:
             any_missing = True
         if node.get("type") == "note":
+            # Geometry-only absence intentionally does NOT set any_missing:
+            # a note without a notes{} entry just falls back to default
+            # size/binding. Only a missing *position* (above) flags
+            # layout_missing and triggers the frontend auto-layout path.
             note_layout = notes.get(nid, {})
             if isinstance(note_layout, dict):
                 for k, v in note_layout.items():

--- a/backend/app/nodes/data/csv_reader_node.py
+++ b/backend/app/nodes/data/csv_reader_node.py
@@ -78,7 +78,11 @@ class CSVReaderNode(BaseNode):
                 name="path",
                 param_type=ParamType.STRING,
                 default="data/samples/iris.csv",
-                description="Path to the CSV file (absolute or relative to the backend working dir).",
+                description=(
+                    "Path to the CSV file (absolute or relative to the backend "
+                    "working dir; in project mode, relative paths resolve "
+                    "inside the project directory)."
+                ),
             ),
             ParamDefinition(
                 name="target_column",

--- a/backend/tests/test_project_cli_init.py
+++ b/backend/tests/test_project_cli_init.py
@@ -66,6 +66,31 @@ def test_init_adopt_splits_legacy_json(tmp_path):
     assert layout["positions"]["a"] == {"x": 3, "y": 4}
 
 
+def test_init_adopt_removes_stale_gitkeep(tmp_path):
+    src = tmp_path / "old"
+    src.mkdir()
+    (src / "g.json").write_text(json.dumps({
+        "name": "g", "nodes": [], "edges": [],
+    }), encoding="utf-8")
+    target = tmp_path / "svc"
+    assert project.cmd_init(_args(dir=str(target), adopt=str(src))) == 0
+    # Real files landed, so the scaffold placeholders must be gone ...
+    assert (target / "graphs" / "g.graph.json").exists()
+    assert not (target / "graphs" / ".gitkeep").exists()
+    assert not (target / "layout" / ".gitkeep").exists()
+    # ... while still-empty assets dirs keep theirs.
+    assert (target / "assets" / "images" / ".gitkeep").exists()
+
+
+def test_init_adopt_empty_src_keeps_gitkeep(tmp_path):
+    src = tmp_path / "old"
+    src.mkdir()
+    target = tmp_path / "svc"
+    assert project.cmd_init(_args(dir=str(target), adopt=str(src))) == 0
+    assert (target / "graphs" / ".gitkeep").exists()
+    assert (target / "layout" / ".gitkeep").exists()
+
+
 def test_init_git_init_no_commit(tmp_path):
     if not shutil.which("git"):
         pytest.skip("git not installed")

--- a/docs/docs/usage/project-directories.md
+++ b/docs/docs/usage/project-directories.md
@@ -32,6 +32,11 @@ the logic change, not a wall of moved-pixels noise. (Known exception:
 `SequentialModel` sub-graph layer positions live inside `params.layers` and
 stay in the logic file.)
 
+A missing layout file (or a node without a saved position) makes the editor
+auto-layout the graph on load and persist the result at the next save; a note
+missing only its geometry entry (size/binding) simply falls back to defaults --
+geometry-only absence intentionally does not count as a missing layout.
+
 ## A complete walkthrough
 
 ### 1. Create the project

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -19,7 +19,7 @@ const zhTW: Record<TranslationKey, string> = {
   'toolbar.save.success': '圖表「{name}」儲存成功。',
   'toolbar.save.fail': '儲存失敗：{error}',
   'toolbar.save.overwriteConfirm': '已存在名為 {name} 的圖，存檔將會覆蓋它。要繼續嗎？',
-  'toolbar.saveAs': '另存為...',
+  'toolbar.saveAs': '另存新檔...',
   'toolbar.saveAs.title': '以新名稱儲存',
   'toolbar.load': '載入',
   'toolbar.load.title': '載入已儲存的圖表',

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -622,6 +622,11 @@ def _adopt(src: Path, target: Path) -> int:
             payload,
         )
         count += 1
+    if count:
+        # cmd_init scaffolds `.gitkeep` placeholders BEFORE adoption runs;
+        # once real graph/layout files have landed, drop the stray ones.
+        for d in (graphs_dir, layout_dir):
+            (d / ".gitkeep").unlink(missing_ok=True)
     ok(f"已採用並拆分 {count} 個 graph", f"Adopted and split {count} graph(s)")
     return 0
 


### PR DESCRIPTION
Cosmetic/doc sweep batched per issue #89 (follow-ups from the #83 final review, items 13 / 10 / 19 / N4).

## Changes

1. **CSVReader `path` param hint** -- `backend/app/nodes/data/csv_reader_node.py`: the param description (this string surfaces on the UI node card) now mentions project-mode resolution: relative paths resolve inside the project directory when a project is open. Matches the actual `settings.PROJECT_DIR` resolution in `execute` (project-relative, sandboxed; the bundled sample default stays install-relative by design).
2. **`layout_missing` note-geometry semantics documented** -- `docs/docs/usage/project-directories.md` ("Why the split?" section): one line stating that a missing layout file / node without a saved position triggers auto-layout on load, while a note missing only its geometry entry (size/binding) falls back to defaults -- geometry-only absence intentionally does not count as a missing layout. Also added a maintainer-facing comment at the computation site (`merge_graph`, `backend/app/core/project.py`). Note: the zh-TW mirror of this docs page does not exist (the page is untranslated), so the zh-TW build serves the English page via the standard Docusaurus fallback -- the new line appears in both locale builds (verified below) with no new translation file needed.
3. **`cdui project init --adopt` stray `.gitkeep`** -- `scripts/project.py` `_adopt`: once adoption has copied real graph/layout files in, the scaffolded `.gitkeep` placeholders in `graphs/` and `layout/` are removed; they are kept when adoption copied nothing, and `assets/*` placeholders are untouched. Two new tests in `backend/tests/test_project_cli_init.py` following the existing adopt-test patterns (`test_init_adopt_removes_stale_gitkeep`, `test_init_adopt_empty_src_keeps_gitkeep`).
4. **zh-TW "Save As" phrasing** -- `frontend/src/i18n/locales/zh-TW.ts`: `另存為...` -> `另存新檔...`, the standard Traditional Chinese menu term (Windows/Office convention), consistent with the file's sibling imperative entries. The `toolbar.saveAs.title` tooltip (`以新名稱儲存`) is already natural and stays unchanged.

## Verification

- Backend: worktree `uv sync --extra dev`, then `python -m pytest tests -q -k "project or adopt or csv"` -> **79 passed** (includes the 2 new adopt tests; `pyproject.toml` / `uv.lock` untouched).
- Docs: `pnpm install --frozen-lockfile && pnpm build` -> SUCCESS for **both locales** ("Website will be built for all these locales: en, zh-TW"); the new line is present in `usage/project-directories.html` of **both** the en and `zh-TW/` outputs.
- Frontend: `npx vitest run src/i18n/index.test.ts` -> **19 passed**; `npx tsc --noEmit` -> clean (locale value change only, no key/type changes).

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
