### PR TITLE
refactor(project): single source for stale-pin check and graph collection rules

### DIFF
--- a/backend/app/api/routes_graph.py
+++ b/backend/app/api/routes_graph.py
@@ -7,6 +7,11 @@ from fastapi import APIRouter, HTTPException
 from ..config import settings
 from ..core.graph_engine import GraphValidationError, build_preset_fallback, validate_graph
 from ..core.node_registry import registry
+from ..core.project import (
+    GraphAmbiguityError,
+    collect_graph_files,
+    resolve_graph_file,
+)
 from ..core.secret_params import (
     scrub_graph_secrets,
     scrub_preset_definition_secrets,
@@ -24,21 +29,6 @@ def _sanitize_name(name: str) -> str:
 
 def _project_mode() -> bool:
     return settings.PROJECT_DIR is not None
-
-
-class GraphAmbiguityError(Exception):
-    """Both `<name>.graph.json` and legacy `<name>.json` exist in project
-    mode — never silently pick one (spec ID2/ID7)."""
-
-    def __init__(self, name: str, canonical: "Path", legacy: "Path") -> None:
-        self.name = name
-        self.canonical = canonical
-        self.legacy = legacy
-        super().__init__(
-            f"Graph '{name}' is ambiguous: both {canonical.name} and "
-            f"{legacy.name} exist in {canonical.parent}. Remove one "
-            "(the legacy single-file form upgrades to the pair on save)."
-        )
 
 
 def _reserved_graph_name(name: str) -> bool:
@@ -76,21 +66,16 @@ def _graph_path(name: str) -> Path:
 
     Non-project: `<GRAPHS_DIR>/<name>.json` (existence not checked — callers
     guard with `.exists()`; identical to legacy behavior).
-    Project: canonical `<name>.graph.json` when present, else legacy
-    `<name>.json`; raises GraphAmbiguityError when BOTH exist; when NEITHER
-    exists returns the canonical (non-existent) path so callers' 404 path
-    still fires.
+    Project: the shared canonical-vs-legacy rule
+    (app.core.project.resolve_graph_file) — canonical `<name>.graph.json`
+    when present, legacy `<name>.json` accepted, GraphAmbiguityError when
+    BOTH exist, and the canonical (non-existent) path when NEITHER does so
+    callers' 404 path still fires.
     """
     safe = _sanitize_name(name)
     if not _project_mode():
         return settings.GRAPHS_DIR / f"{safe}.json"
-    canonical = settings.GRAPHS_DIR / f"{safe}.graph.json"
-    legacy = settings.GRAPHS_DIR / f"{safe}.json"
-    if canonical.exists() and legacy.exists():
-        raise GraphAmbiguityError(name, canonical, legacy)
-    if legacy.exists() and not canonical.exists():
-        return legacy
-    return canonical
+    return resolve_graph_file(settings.GRAPHS_DIR, safe, display_name=name)
 
 
 @router.post("/validate", response_model=GraphValidationResponse)
@@ -184,27 +169,14 @@ async def list_graphs():
                 continue
         return graphs
 
-    # Project mode: canonical `<name>.graph.json` + legacy `<name>.json`.
-    # Path("x.graph.json").stem is "x.graph" — strip the whole ".graph.json"
-    # so the file stem never leaks the double suffix (spec ID7).
-    files: dict[str, Path] = {}
-    for f in settings.GRAPHS_DIR.glob("*.graph.json"):
-        files.setdefault(f.name[: -len(".graph.json")], f)
-    for f in settings.GRAPHS_DIR.glob("*.json"):
-        if f.name.endswith(".graph.json"):
-            continue  # already counted as canonical
-        base = f.stem
-        if base in files:
-            # Both forms present -> fail loudly naming both (no silent pick).
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    f"Graph '{base}' is ambiguous: both {files[base].name} "
-                    f"and {f.name} exist. Remove one."
-                ),
-            )
-        files[base] = f
-    for base, f in sorted(files.items()):
+    # Project mode: the shared canonical-vs-legacy collection rule
+    # (app.core.project.collect_graph_files) — bases never leak the double
+    # suffix (spec ID7) and both-forms-present fails loudly naming both.
+    try:
+        pairs = collect_graph_files(settings.GRAPHS_DIR)
+    except GraphAmbiguityError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    for base, f in pairs:
         try:
             data = json.loads(f.read_text())
             graphs.append({"name": data.get("name", base), "file": base})

--- a/backend/app/core/project.py
+++ b/backend/app/core/project.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -155,6 +155,75 @@ def write_graph_pair(
         legacy_path.unlink()
 
 
+# ── Canonical-vs-legacy graph file rule (spec ID2/ID7) ─────────────────────
+#
+# In project mode a graph named <base> may exist on disk as the canonical
+# `<base>.graph.json` or the legacy single-file `<base>.json`. The rule,
+# defined ONCE here and consumed by the server routes, the `cdui project`
+# CLI (validate/adopt), and the /list endpoint (issue #85):
+#   - canonical when present;
+#   - legacy accepted when only it exists (upgrade-on-save keeps it working);
+#   - BOTH present is an error naming both files -- never silently pick one;
+#   - `*.layout.json` is layout, never a graph.
+
+
+class GraphAmbiguityError(Exception):
+    """Both `<base>.graph.json` and legacy `<base>.json` exist for the same
+    graph — never silently pick one (spec ID2/ID7)."""
+
+    def __init__(self, name: str, canonical: Path, legacy: Path) -> None:
+        self.name = name
+        self.canonical = canonical
+        self.legacy = legacy
+        super().__init__(
+            f"Graph '{name}' is ambiguous: both {canonical.name} and "
+            f"{legacy.name} exist in {canonical.parent}. Remove one "
+            "(the legacy single-file form upgrades to the pair on save)."
+        )
+
+
+def resolve_graph_file(
+    graphs_dir: Path, base: str, display_name: str | None = None
+) -> Path:
+    """THE canonical-vs-legacy read rule for one graph *base* (filesystem)
+    name: canonical `<base>.graph.json` when present; legacy `<base>.json`
+    when only it exists; raises GraphAmbiguityError when BOTH exist; when
+    NEITHER exists returns the canonical (non-existent) path so callers'
+    not-found handling still fires.
+
+    *display_name* only decorates the error message (e.g. the raw, pre-
+    sanitize graph name a route received); it defaults to *base*.
+    """
+    canonical = graphs_dir / f"{base}.graph.json"
+    legacy = graphs_dir / f"{base}.json"
+    if canonical.exists() and legacy.exists():
+        raise GraphAmbiguityError(display_name or base, canonical, legacy)
+    if legacy.exists():
+        return legacy
+    return canonical
+
+
+def collect_graph_files(graphs_dir: Path) -> list[tuple[str, Path]]:
+    """Directory-wide form of the same rule: sorted `(base, file)` pairs for
+    every graph in *graphs_dir* (non-recursive; empty when it is not a
+    directory). `*.layout.json` files are skipped. Each base is resolved via
+    resolve_graph_file, so the first base present in both forms raises
+    GraphAmbiguityError before anything is returned.
+    """
+    if not graphs_dir.is_dir():
+        return []
+    bases: set[str] = set()
+    for f in graphs_dir.glob("*.json"):
+        if f.name.endswith(".layout.json"):
+            continue
+        if f.name.endswith(".graph.json"):
+            bases.add(f.name[: -len(".graph.json")])
+        else:
+            bases.add(f.stem)
+    return [(base, resolve_graph_file(graphs_dir, base))
+            for base in sorted(bases)]
+
+
 def git_provenance(project_dir: Path) -> tuple[str | None, bool | None]:
     """(full_commit_sha, dirty) for *project_dir*, or (None, None) when it is
     not a git repo / git is unavailable (this also covers the common
@@ -192,29 +261,71 @@ def git_provenance(project_dir: Path) -> tuple[str | None, bool | None]:
     return commit, dirty
 
 
-def check_stale_pins_from_manifest(manifest: dict, lockfile: dict) -> list[str]:
-    """Plugin ids that are pinned in the manifest but missing or sha-mismatched
-    in the installed lockfile (spec 7.4)."""
+# ── Stale-pin rule (spec 7.4) ──────────────────────────────────────────────
+#
+# One classification of the manifest's `[plugins]` pins against the installed
+# lockfile, consumed by BOTH the server startup warning (main.py) and
+# `cdui project validate [--strict]` (scripts/project.py) -- issue #85.
+
+
+class PinIssue(NamedTuple):
+    """One problematic `[plugins]` pin.
+
+    kind is one of:
+      "missing"       pinned id absent from the installed lockfile
+      "sha_mismatch"  pin carries a sha and the installed sha differs
+      "malformed"     pin value is not a table -- unenforceable, so every
+                      surface warns and SKIPS it (never stale, never a
+                      --strict failure)
+    """
+
+    plugin_id: str
+    kind: str
+    pinned_sha: str | None = None
+    installed_sha: str | None = None
+
+
+def check_pin_issues(manifest: dict, lockfile: dict) -> list[PinIssue]:
+    """THE stale-pin rule: classify every `[plugins]` pin in *manifest*
+    against the installed *lockfile* (spec 7.4). A well-formed pin without a
+    "sha" key only checks installed-ness. Manifest order is preserved."""
     pins = manifest.get("plugins", {}) or {}
     installed = lockfile.get("plugins", {})
-    stale: list[str] = []
+    issues: list[PinIssue] = []
     for pid, pin in pins.items():
         if not isinstance(pin, dict):
+            issues.append(PinIssue(pid, "malformed"))
             continue
         entry = installed.get(pid)
+        pinned_sha = pin.get("sha")
         if entry is None:
-            stale.append(pid)
-        elif pin.get("sha") and entry.get("sha") != pin["sha"]:
-            stale.append(pid)
-    return stale
+            issues.append(PinIssue(pid, "missing", pinned_sha, None))
+        elif pinned_sha and entry.get("sha") != pinned_sha:
+            issues.append(
+                PinIssue(pid, "sha_mismatch", pinned_sha, entry.get("sha")))
+    return issues
+
+
+def check_stale_pins_from_manifest(manifest: dict, lockfile: dict) -> list[str]:
+    """Plugin ids that are pinned in the manifest but missing or sha-mismatched
+    in the installed lockfile (spec 7.4). Malformed (non-table) pins are NOT
+    stale -- they are reported separately by check_pin_issues and skipped."""
+    return [i.plugin_id for i in check_pin_issues(manifest, lockfile)
+            if i.kind != "malformed"]
+
+
+def read_project_manifest(project_dir: Path) -> dict:
+    """Parse `codefyui.project.toml`; {} on a missing or unparseable manifest
+    (a diagnostics-path reader must never crash startup)."""
+    manifest_path = project_dir / "codefyui.project.toml"
+    try:
+        return tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
 
 
 def check_stale_pins(project_dir: Path, lockfile: dict) -> list[str]:
     """Read the manifest from disk and return stale pin ids (empty on a missing
     or unparseable manifest)."""
-    manifest_path = project_dir / "codefyui.project.toml"
-    try:
-        manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return []
-    return check_stale_pins_from_manifest(manifest, lockfile)
+    return check_stale_pins_from_manifest(
+        read_project_manifest(project_dir), lockfile)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -236,19 +236,35 @@ async def lifespan(app: FastAPI):
 
     # ── Project transparency (spec 7.4) ────────────────────────────────
     if settings.PROJECT_DIR is not None:
-        from .core.project import check_stale_pins, git_provenance
+        from .core.project import (
+            check_pin_issues,
+            git_provenance,
+            read_project_manifest,
+        )
         commit, dirty = git_provenance(settings.PROJECT_DIR)
         if commit is None:
             logger.info("Project: %s (not a repo)", settings.PROJECT_DIR)
         else:
             logger.info("Project: %s (git %s%s)", settings.PROJECT_DIR,
                         commit[:7], " dirty" if dirty else "")
-        stale = check_stale_pins(settings.PROJECT_DIR, lockfile)
+        # Shared stale-pin rule (issue #85): same classification the CLI's
+        # `cdui project validate` consumes.
+        issues = check_pin_issues(
+            read_project_manifest(settings.PROJECT_DIR), lockfile)
+        stale = sorted(i.plugin_id for i in issues if i.kind != "malformed")
+        malformed = sorted(i.plugin_id for i in issues if i.kind == "malformed")
         if stale:
             # ONE warning; no auto-install at startup (spec 7.4).
             logger.warning(
                 "Project plugin pins missing/mismatched: %s -- run "
-                "`cdui project restore`", ", ".join(sorted(stale)))
+                "`cdui project restore`", ", ".join(stale))
+        if malformed:
+            # Warn-and-skip: a non-table pin cannot be enforced or restored.
+            logger.warning(
+                "Project manifest has malformed plugin pins (skipped): %s -- "
+                "each pin must be a table like "
+                "{ url = \"...\", ref = \"...\", sha = \"...\" }",
+                ", ".join(malformed))
 
     # Mount each installed plugin's assets/ dir so the frontend can fetch
     # plugin-shipped CSVs / images at /plugins/<id>/assets/<file>.

--- a/backend/tests/test_graph_paths_project.py
+++ b/backend/tests/test_graph_paths_project.py
@@ -13,6 +13,8 @@ from app.api.routes_graph import (
     _graph_path,
     _reserved_graph_name,
 )
+from app.core import project as core_project
+from app.core.project import collect_graph_files, resolve_graph_file
 
 
 def _project(monkeypatch, tmp_path):
@@ -69,3 +71,65 @@ def test_reserved_names():
     assert _reserved_graph_name("my.layout") is True
     assert _reserved_graph_name("my-graph") is False
     assert _reserved_graph_name("classifier") is False
+
+
+# -- The shared canonical-vs-legacy rule itself (issue #85): ONE source in
+# -- app.core.project consumed by _graph_path, /list, and the project CLI.
+
+
+def test_routes_ambiguity_error_is_the_core_class():
+    """routes_graph re-exports the single shared exception -- catching either
+    import path must catch the same class."""
+    assert routes_graph.GraphAmbiguityError is core_project.GraphAmbiguityError
+
+
+def test_resolve_graph_file_four_branches(tmp_path):
+    # Neither exists -> canonical (non-existent) so callers can 404.
+    assert resolve_graph_file(tmp_path, "foo") == tmp_path / "foo.graph.json"
+    # Only legacy -> legacy accepted.
+    legacy = tmp_path / "foo.json"
+    legacy.write_text("{}")
+    assert resolve_graph_file(tmp_path, "foo") == legacy
+    # Both -> ambiguity error carrying both paths.
+    canonical = tmp_path / "foo.graph.json"
+    canonical.write_text("{}")
+    with pytest.raises(GraphAmbiguityError) as ei:
+        resolve_graph_file(tmp_path, "foo")
+    assert ei.value.canonical == canonical
+    assert ei.value.legacy == legacy
+    # Only canonical -> canonical.
+    legacy.unlink()
+    assert resolve_graph_file(tmp_path, "foo") == canonical
+
+
+def test_resolve_graph_file_display_name_decorates_error(tmp_path):
+    (tmp_path / "weird_name.graph.json").write_text("{}")
+    (tmp_path / "weird_name.json").write_text("{}")
+    with pytest.raises(GraphAmbiguityError) as ei:
+        resolve_graph_file(tmp_path, "weird_name", display_name="weird name")
+    assert ei.value.name == "weird name"
+    assert "weird name" in str(ei.value)
+
+
+def test_collect_graph_files_mixed_dir_sorted_and_layout_skipped(tmp_path):
+    (tmp_path / "b_canon.graph.json").write_text("{}")
+    (tmp_path / "a_legacy.json").write_text("{}")
+    (tmp_path / "stray.layout.json").write_text("{}")
+    got = collect_graph_files(tmp_path)
+    assert got == [
+        ("a_legacy", tmp_path / "a_legacy.json"),
+        ("b_canon", tmp_path / "b_canon.graph.json"),
+    ]
+
+
+def test_collect_graph_files_ambiguity_raises_naming_both(tmp_path):
+    (tmp_path / "dup.graph.json").write_text("{}")
+    (tmp_path / "dup.json").write_text("{}")
+    with pytest.raises(GraphAmbiguityError) as ei:
+        collect_graph_files(tmp_path)
+    assert "dup.graph.json" in str(ei.value)
+    assert "dup.json" in str(ei.value)
+
+
+def test_collect_graph_files_missing_dir_is_empty(tmp_path):
+    assert collect_graph_files(tmp_path / "nope") == []

--- a/backend/tests/test_project_cli_init.py
+++ b/backend/tests/test_project_cli_init.py
@@ -66,6 +66,55 @@ def test_init_adopt_splits_legacy_json(tmp_path):
     assert layout["positions"]["a"] == {"x": 3, "y": 4}
 
 
+def test_init_adopt_canonical_source_keeps_base(tmp_path):
+    """A source file already named `<base>.graph.json` adopts under `<base>`
+    (never a doubled `mix.graph.graph.json`)."""
+    src = tmp_path / "old"
+    src.mkdir()
+    (src / "mix.graph.json").write_text(json.dumps(
+        {"name": "mix", "nodes": [], "edges": []}), encoding="utf-8")
+    target = tmp_path / "svc"
+    assert project.cmd_init(_args(dir=str(target), adopt=str(src))) == 0
+    assert (target / "graphs" / "mix.graph.json").exists()
+    assert not (target / "graphs" / "mix.graph.graph.json").exists()
+
+
+def test_init_adopt_skips_layout_files(tmp_path):
+    """`*.layout.json` in the source dir is layout, not a graph -- never
+    adopted as a graph named '<base>.layout'."""
+    src = tmp_path / "old"
+    src.mkdir()
+    (src / "keep.json").write_text(json.dumps(
+        {"name": "keep", "nodes": [], "edges": []}), encoding="utf-8")
+    (src / "stray.layout.json").write_text(json.dumps(
+        {"format_version": 1, "positions": {}}), encoding="utf-8")
+    target = tmp_path / "svc"
+    assert project.cmd_init(_args(dir=str(target), adopt=str(src))) == 0
+    adopted = sorted(p.name for p in (target / "graphs").glob("*.graph.json"))
+    assert adopted == ["keep.graph.json"]
+
+
+def test_init_adopt_ambiguous_pair_fails_naming_both(tmp_path, capsys):
+    """CONVERGED RULE (issue #85): a source dir holding BOTH `dup.json` and
+    `dup.graph.json` is the same ambiguity the server 409s on and validate
+    fails on -- adopt must surface it identically (it previously wrote both
+    payloads to the same target, so whichever sorted last silently won)."""
+    src = tmp_path / "old"
+    src.mkdir()
+    (src / "dup.json").write_text(json.dumps(
+        {"name": "legacy wins?", "nodes": [], "edges": []}), encoding="utf-8")
+    (src / "dup.graph.json").write_text(json.dumps(
+        {"name": "canonical wins?", "nodes": [], "edges": []}), encoding="utf-8")
+    target = tmp_path / "svc"
+    assert project.cmd_init(_args(dir=str(target), adopt=str(src))) == 1
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "dup.graph.json" in out
+    assert "dup.json" in out
+    # Nothing half-adopted: the ambiguity aborts before any split is written.
+    assert list((target / "graphs").glob("*.json")) == []
+
+
 def test_init_git_init_no_commit(tmp_path):
     if not shutil.which("git"):
         pytest.skip("git not installed")

--- a/backend/tests/test_project_cli_validate.py
+++ b/backend/tests/test_project_cli_validate.py
@@ -134,3 +134,56 @@ def test_strict_pin_missing(tmp_path, monkeypatch):
                         lambda: {"schema": 1, "plugins": {}})
     assert project.cmd_validate(_vargs(proj, strict=False)) == 0  # warn only
     assert project.cmd_validate(_vargs(proj, strict=True)) == 1   # strict error
+
+
+def test_ambiguous_graph_pair_fails_naming_both(tmp_path, capsys):
+    """Both `dup.graph.json` and legacy `dup.json` in graphs/ is never
+    silently resolved: validate fails naming BOTH files (same rule as the
+    server's /list 409 -- single source in app.core.project, issue #85)."""
+    proj = _init(tmp_path)
+    g = _echo_graph(name="dup")
+    _write_graph(proj, g, base="dup")
+    (proj / "graphs" / "dup.json").write_text(json.dumps(g))
+    assert project.cmd_validate(_vargs(proj)) == 1
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "dup.graph.json" in out
+    assert "dup.json" in out
+
+
+def test_malformed_pin_warns_and_skips_even_under_strict(tmp_path, monkeypatch,
+                                                         capsys):
+    """CONVERGED RULE (issue #85): a `[plugins]` entry whose value is not a
+    table cannot be enforced (no url/sha to compare or restore), so every
+    surface warn-and-skips it. validate names the pin but passes -- even
+    under --strict; the CLI previously mislabeled this 'not installed' and
+    failed strict runs, while the server startup check silently ignored it."""
+    proj = _init(tmp_path)
+    _write_graph(proj, _echo_graph())
+    (proj / "codefyui.project.toml").write_text(
+        '[project]\nname = "svc"\nformat_version = 1\n\n'
+        '[plugins]\nbadpin = "not-a-table"\n')
+    monkeypatch.setattr(project, "load_lockfile",
+                        lambda: {"schema": 1, "plugins": {}})
+    assert project.cmd_validate(_vargs(proj, strict=False)) == 0
+    assert project.cmd_validate(_vargs(proj, strict=True)) == 0
+    captured = capsys.readouterr()
+    out = (captured.out + captured.err).lower()
+    assert "badpin" in out
+    assert "malformed" in out
+
+
+def test_malformed_pin_does_not_mask_real_stale_pins(tmp_path, monkeypatch):
+    """A malformed pin alongside a well-formed missing pin: the missing pin
+    still warns (and still fails under --strict)."""
+    proj = _init(tmp_path)
+    _write_graph(proj, _echo_graph())
+    (proj / "codefyui.project.toml").write_text(
+        '[project]\nname = "svc"\nformat_version = 1\n\n'
+        '[plugins]\nbadpin = "not-a-table"\n'
+        'ghostpack = { url = "https://github.com/x/y", '
+        'ref = "v1", sha = "' + "0" * 40 + '" }\n')
+    monkeypatch.setattr(project, "load_lockfile",
+                        lambda: {"schema": 1, "plugins": {}})
+    assert project.cmd_validate(_vargs(proj, strict=False)) == 0
+    assert project.cmd_validate(_vargs(proj, strict=True)) == 1

--- a/backend/tests/test_project_startup.py
+++ b/backend/tests/test_project_startup.py
@@ -7,9 +7,12 @@ import subprocess
 import pytest
 
 from app.core.project import (
+    PinIssue,
+    check_pin_issues,
     check_stale_pins,
     check_stale_pins_from_manifest,
     git_provenance,
+    read_project_manifest,
 )
 
 
@@ -129,3 +132,53 @@ def test_check_stale_pins_reads_manifest_from_disk(tmp_path):
     (tmp_path / "codefyui.project.toml").write_text(
         '[plugins]\npack-a = { sha = "' + "z" * 40 + '" }\n', encoding="utf-8")
     assert check_stale_pins(tmp_path, lockfile) == ["pack-a"]
+
+
+# -- The shared pin-classification rule (issue #85): ONE source consumed by
+# -- both the startup warning above and `cdui project validate [--strict]`.
+
+
+def test_check_pin_issues_classifies_missing_and_mismatch():
+    lockfile = {"plugins": {"pack-a": {"sha": "a" * 40}}}
+    ok = check_pin_issues({"plugins": {"pack-a": {"sha": "a" * 40}}}, lockfile)
+    assert ok == []
+    missing = check_pin_issues({"plugins": {"pack-b": {"sha": "b" * 40}}},
+                               lockfile)
+    assert missing == [PinIssue("pack-b", "missing", "b" * 40, None)]
+    mism = check_pin_issues({"plugins": {"pack-a": {"sha": "z" * 40}}},
+                            lockfile)
+    assert mism == [PinIssue("pack-a", "sha_mismatch", "z" * 40, "a" * 40)]
+
+
+def test_check_pin_issues_pin_without_sha_only_checks_installedness():
+    """A well-formed pin table lacking "sha" can only assert installed-ness:
+    installed -> no issue; absent -> missing (matches the pre-unification
+    behavior of BOTH call sites)."""
+    lockfile = {"plugins": {"pack-a": {"sha": "a" * 40}}}
+    assert check_pin_issues({"plugins": {"pack-a": {"url": "u"}}},
+                            lockfile) == []
+    got = check_pin_issues({"plugins": {"pack-b": {"url": "u"}}}, lockfile)
+    assert got == [PinIssue("pack-b", "missing", None, None)]
+
+
+def test_malformed_pin_reported_and_excluded_from_stale():
+    """CONVERGED RULE (issue #85): a `[plugins]` value that is not a table is
+    classified "malformed" and warn-and-skipped everywhere -- it is never in
+    the stale list (the CLI used to mislabel it 'not installed'; the server
+    used to drop it silently), but it does not mask real stale pins either."""
+    lockfile = {"plugins": {}}
+    manifest = {"plugins": {"bad": "not-a-table",
+                            "ghost": {"sha": "0" * 40}}}
+    issues = check_pin_issues(manifest, lockfile)
+    assert [(i.plugin_id, i.kind) for i in issues] == [
+        ("bad", "malformed"), ("ghost", "missing")]
+    assert check_stale_pins_from_manifest(manifest, lockfile) == ["ghost"]
+
+
+def test_read_project_manifest_never_raises(tmp_path):
+    assert read_project_manifest(tmp_path) == {}
+    manifest_path = tmp_path / "codefyui.project.toml"
+    manifest_path.write_text("not [ valid toml", encoding="utf-8")
+    assert read_project_manifest(tmp_path) == {}
+    manifest_path.write_text('[project]\nname = "svc"\n', encoding="utf-8")
+    assert read_project_manifest(tmp_path)["project"]["name"] == "svc"

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -38,6 +38,11 @@ from app.core.plugin_loader import (
     iter_plugin_dirs,
     load_lockfile,
 )
+from app.core.project import (
+    GraphAmbiguityError,
+    check_pin_issues,
+    collect_graph_files,
+)
 
 MANIFEST_FILENAME = "codefyui.project.toml"
 
@@ -194,26 +199,6 @@ def cmd_init(args: argparse.Namespace) -> int:
     return 0
 
 
-def _collect_graphs(graphs_dir: Path) -> list[tuple[str, Path]]:
-    """(base_name, file) for each graph: canonical `.graph.json` + legacy
-    `.json`; raises RuntimeError naming both files on ambiguity (spec ID2)."""
-    files: dict[str, Path] = {}
-    if not graphs_dir.is_dir():
-        return []
-    for f in sorted(graphs_dir.glob("*.graph.json")):
-        files[f.name[: -len(".graph.json")]] = f
-    for f in sorted(graphs_dir.glob("*.json")):
-        if f.name.endswith(".graph.json"):
-            continue
-        base = f.stem
-        if base in files:
-            raise RuntimeError(
-                f"Graph '{base}' is ambiguous: both {files[base].name} and "
-                f"{f.name} exist. Remove one.")
-        files[base] = f
-    return sorted(files.items())
-
-
 def _init_registries_like_server() -> None:
     """Discover builtin + custom + PLUGIN nodes and presets exactly like the
     server lifespan (main.py) -- run_graph.py's init loads no plugins and is
@@ -309,23 +294,28 @@ def _check_env_not_tracked(proj: Path) -> bool:
 
 def _check_pins(manifest: dict, strict: bool) -> bool:
     """True on FAILURE (only when strict). Missing/mismatched pins warn, and
-    with --strict become errors (spec ID3)."""
+    with --strict become errors (spec ID3). Malformed (non-table) pins are
+    warn-and-skip on EVERY surface -- never a failure, even under --strict
+    (shared rule: app.core.project.check_pin_issues, issue #85)."""
     pins = manifest.get("plugins", {}) or {}
     if not pins:
         return False
-    installed = load_lockfile().get("plugins", {})
     failed = False
-    for pid, pin in pins.items():
-        entry = installed.get(pid)
-        pinned_sha = pin.get("sha") if isinstance(pin, dict) else None
-        if entry is None:
+    for issue in check_pin_issues(manifest, load_lockfile()):
+        pid = issue.plugin_id
+        if issue.kind == "malformed":
+            msg = (f"pin '{pid}' in [plugins] is malformed (expected a table "
+                   'like { url = "...", ref = "...", sha = "..." }) -- skipping')
+            warn(msg, msg)
+            continue
+        if issue.kind == "missing":
             _warn_or_err(strict, f"pinned plugin '{pid}' is not installed -- "
                                  "run `cdui project restore`")
-            failed = failed or strict
-        elif pinned_sha and entry.get("sha") != pinned_sha:
-            _warn_or_err(strict, f"plugin '{pid}' sha {entry.get('sha', '')[:7]} "
-                                 f"!= pinned {pinned_sha[:7]} -- run restore")
-            failed = failed or strict
+        else:  # sha_mismatch
+            _warn_or_err(strict,
+                         f"plugin '{pid}' sha {(issue.installed_sha or '')[:7]} "
+                         f"!= pinned {issue.pinned_sha[:7]} -- run restore")
+        failed = failed or strict
     return failed
 
 
@@ -352,8 +342,9 @@ def cmd_validate(args: argparse.Namespace) -> int:
     _init_registries_like_server()
 
     try:
-        graphs = _collect_graphs(proj / "graphs")
-    except RuntimeError as e:
+        # Shared canonical-vs-legacy collection rule (app.core.project).
+        graphs = collect_graph_files(proj / "graphs")
+    except GraphAmbiguityError as e:
         err(str(e), str(e))
         return 1
 
@@ -606,11 +597,17 @@ def _adopt(src: Path, target: Path) -> int:
         return 1
     graphs_dir = target / "graphs"
     layout_dir = target / "layout"
+    try:
+        # Shared canonical-vs-legacy rule (app.core.project): skips
+        # `*.layout.json`, and a source holding BOTH `x.json` and
+        # `x.graph.json` aborts naming both files instead of silently
+        # letting one overwrite the other (issue #85).
+        pairs = collect_graph_files(src)
+    except GraphAmbiguityError as e:
+        err(str(e), str(e))
+        return 1
     count = 0
-    for jf in sorted(src.glob("*.json")):
-        if jf.name.endswith(".layout.json"):
-            continue
-        base = jf.name[:-len(".graph.json")] if jf.name.endswith(".graph.json") else jf.stem
+    for base, jf in pairs:
         try:
             payload = json.loads(jf.read_text(encoding="utf-8"))
         except (ValueError, OSError) as e:


### PR DESCRIPTION
## Summary

Closes #85 — the two project rules that existed in multiple places are now single importable helpers in `backend/app/core/project.py`, consumed by every surface (server routes, server startup, and the `cdui project` CLI).

## Duplication map

### Rule 1 — stale-pin check (spec 7.4)

| | Before | After |
|---|---|---|
| CLI `cdui project validate [--strict]` | own loop in `scripts/project.py::_check_pins` | consumes `app.core.project.check_pin_issues` |
| Server startup warning | `app.core.project.check_stale_pins_from_manifest` (own loop) | derived view over `check_pin_issues`; `main.py` consumes the classification directly |

New single source: `check_pin_issues(manifest, lockfile) -> list[PinIssue]` classifying each `[plugins]` pin as `missing` / `sha_mismatch` / `malformed`. `check_stale_pins_from_manifest` / `check_stale_pins` are kept as thin derived views (signatures and existing tests untouched), plus `read_project_manifest` as the never-raises disk reader.

### Rule 2 — canonical-vs-legacy graph collection (spec ID2/ID7)

Three copies before, all with their own both-forms-exist handling:

1. `scripts/project.py::_collect_graphs` (CLI validate, `RuntimeError`) — deleted
2. `backend/app/api/routes_graph.py::_graph_path` single-name resolution (`GraphAmbiguityError`) — now delegates
3. `backend/app/api/routes_graph.py::list_graphs` inline dir scan (the third copy, `HTTPException 409`) — now delegates

Plus `scripts/project.py::_adopt`, which had a fourth scan that silently preferred one form (see deltas).

New single source: `resolve_graph_file(graphs_dir, base, display_name=None)` (canonical when present; legacy accepted when only it exists; both -> `GraphAmbiguityError`; neither -> canonical non-existent path so 404 paths still fire) and `collect_graph_files(graphs_dir)` — the directory-wide form built on it (skips `*.layout.json`). `GraphAmbiguityError` moved to `app.core.project`; `routes_graph` re-exports it so `routes_graph_run` / `routes_apps` imports are untouched (class identity is covered by a test).

## Behavior deltas (intentional; called out per the issue)

1. **Malformed (non-table) `[plugins]` pin — converged on warn-and-skip on BOTH surfaces.**
   - CLI validate now warns naming the pin (`pin 'x' in [plugins] is malformed ... -- skipping`) and never fails, even under `--strict`. Before, it mislabeled the pin as "not installed" (failing `--strict` when the id was absent from the lockfile) or said nothing at all (when the id happened to be installed). A malformed pin next to a well-formed missing pin still fails `--strict` for the missing one (covered by test).
   - Server startup now logs a warning listing malformed pins; before it dropped them silently. The stale list itself is unchanged (malformed pins were and are never "stale").
2. **`cdui project init --adopt` on a source dir holding both `x.json` and `x.graph.json` now aborts (rc 1) naming both files** — the same ambiguity rule as validate and `/list`. Before, both payloads were split into the same target and whichever sorted last (`x.json`, the legacy form) silently won.
3. Cosmetic: the ambiguity message everywhere is now the richer one that `_graph_path` already used — `Graph 'x' is ambiguous: both x.graph.json and x.json exist in <dir>. Remove one (the legacy single-file form upgrades to the pair on save).` The `/list` 409 detail and the CLI output gain the directory and the upgrade hint (both still name both files, which is all existing tests assert).
4. Defensive: a stray `*.layout.json` inside `graphs/` is no longer collected as a graph by `/list` or CLI validate (previously it would appear as a bogus `<base>.layout` graph; `_adopt` already skipped these, and names ending `.layout` are save-blocked anyway).

Everything else is behavior-preserving: `_graph_path`'s four branches, `/list` output shape/ordering and double-suffix stripping, per-pin CLI message texts for missing/mismatched pins, `--strict` escalation for real pins, adopt's unreadable-file skip and base naming.

## Tests

- Characterization first: baseline run of the touched test files against the pre-refactor code = **40 passed, 2 failed**, the 2 failures being exactly the two intended deltas above (strict-fail on malformed pin; silent adopt of an ambiguous pair — "Adopted and split 2 graph(s)").
- New/extended tests:
  - `test_project_startup.py`: `check_pin_issues` classification (missing / mismatch / no-sha pins), malformed reported-and-excluded-from-stale, `read_project_manifest` never raises.
  - `test_graph_paths_project.py`: `resolve_graph_file` four branches, display-name decoration, `collect_graph_files` (sorted, layout-skip, ambiguity naming both, missing dir), routes re-export is the core class.
  - `test_project_cli_validate.py`: ambiguous pair fails naming both files; malformed pin warns and passes even under `--strict`; malformed does not mask real stale pins.
  - `test_project_cli_init.py`: adopt ambiguity aborts naming both with nothing half-adopted; adopt skips `*.layout.json`; canonical-named source keeps its base (no doubled suffix).
- Touched test files after the refactor: **65 passed**.
- Full backend suite: **1783 passed, 12 skipped** in 110.65s (local, worktree venv via `uv sync --extra dev`).
- Real-CLI smoke through `project.main()` (the dev.py dispatcher entry): adopt-ambiguity rc 1, validate `--strict` with malformed pin rc 0 with warning, validate ambiguity rc 1 — ASCII-safe output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
