### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ Thumbs.db
 
 # Claude Code
 .claude/settings.local.json
+.claude/worktrees/
 
 # Data
 backend/data/graphs/*.json


### PR DESCRIPTION
Adds `.claude/worktrees/` to .gitignore next to the existing `.claude/settings.local.json` entry. Claude Code session worktrees are created under this directory; leftover directories should never show up as untracked files or risk being committed.

One-line change, no code paths touched (backend/frontend CI does not trigger on .gitignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)