### PR TITLE
chore: bump versions to 1.4.2

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefyui-backend"
-version = "1.4.1"
+version = "1.4.2"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
 requires-python = ">=3.10"
 # PEP 639 SPDX license expression (bare string). The previous PEP 621

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -352,7 +352,7 @@ wheels = [
 
 [[package]]
 name = "codefyui-backend"
-version = "1.4.1"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codefyui-frontend",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "AGPL-3.0-only",
   "packageManager": "pnpm@9.15.0",
   "type": "module",


### PR DESCRIPTION
Version fields only: `backend/pyproject.toml`, `frontend/package.json`, `backend/uv.lock`.

Cuts a release carrying the `cdui update` fix from #107. This matters because end users without Node take the prebuilt path, where `update()` pins the checkout to the **latest release tag** (`_resolve_release_tag()`) rather than `main` — so the fix cannot reach them until it ships in a release.

Full backend suite after the bump: **1864 passed, 9 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)