### PR TITLE
style(nodes): retune node proportions toward ComfyUI density

### DIFF
--- a/frontend/src/components/Nodes/BaseNode.module.css
+++ b/frontend/src/components/Nodes/BaseNode.module.css
@@ -3,11 +3,11 @@
   position: relative;
   background: #1e1e1e;
   border-radius: 8px;
-  min-width: 180px;
+  min-width: 160px;
   font-size: 0.8125rem;
   color: #eeeeee;
   /* Dynamic border is injected via --border-color custom property */
-  border: 2px solid var(--border-color, #444444);
+  border: 1px solid var(--border-color, #444444);
   transition: border-color 0.2s, box-shadow 0.2s;
 }
 
@@ -45,8 +45,8 @@
 /* ── Header ── */
 .header {
   /* Dynamic: background set via inline style (headerColor from category) */
-  padding: 7px 12px;
-  border-radius: 6px 6px 0 0;
+  padding: 6px 10px;
+  border-radius: 7px 7px 0 0;
   font-weight: 600;
   font-size: 0.875rem;
   display: flex;
@@ -64,9 +64,9 @@
 
 .headerCategory {
   font-size: 0.625rem;
-  opacity: 0.85;
-  background: rgba(0, 0, 0, 0.25);
-  padding: 2px 5px;
+  opacity: 0.65;
+  background: transparent;
+  padding: 2px 0;
   border-radius: 3px;
   white-space: nowrap;
   flex-shrink: 0;
@@ -81,7 +81,7 @@
 /* ── Port row ── */
 .portRowInput {
   position: relative;
-  padding: 4px 12px 4px 18px;
+  padding: 3px 12px 3px 18px;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -89,7 +89,7 @@
 
 .portRowOutput {
   position: relative;
-  padding: 4px 18px 4px 12px;
+  padding: 3px 18px 3px 12px;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -118,13 +118,13 @@
 }
 
 .portHandleInput {
-  left: -5px !important;
+  left: -5.5px !important;
   top: 50% !important;
   transform: translateY(-50%) !important;
 }
 
 .portHandleOutput {
-  right: -5px !important;
+  right: -5.5px !important;
   top: 50% !important;
   transform: translateY(-50%) !important;
 }
@@ -147,7 +147,7 @@
   justify-content: space-between;
   align-items: center;
   gap: 8px;
-  padding: 1px 0;
+  padding: 2px 0;
 }
 
 .paramName {
@@ -159,7 +159,7 @@
   font-size: 0.6875rem;
   color: #bbb;
   font-family: monospace;
-  max-width: 100px;
+  max-width: 120px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/frontend/src/components/Nodes/EmbeddingScatterVizNode.module.css
+++ b/frontend/src/components/Nodes/EmbeddingScatterVizNode.module.css
@@ -2,7 +2,7 @@
   border-top: 1px solid #2a2a2a;
   padding: 10px;
   background: #161616;
-  width: 340px;
+  width: 320px;
 }
 
 .emptyHint {

--- a/frontend/src/components/Nodes/EmbeddingScatterVizNode.tsx
+++ b/frontend/src/components/Nodes/EmbeddingScatterVizNode.tsx
@@ -62,8 +62,8 @@ function EmbeddingScatterVizNode(props: NodeProps<AppNode>) {
       {points !== null && (
         <ScatterPlot
           points={points}
-          width={320}
-          height={220}
+          width={300}
+          height={207}
           showLabels
           onExpand={() => setExpanded(true)}
         />

--- a/frontend/src/components/Nodes/PresetNode.module.css
+++ b/frontend/src/components/Nodes/PresetNode.module.css
@@ -3,7 +3,7 @@
 .node {
   background: #1e1e1e;
   border-radius: 8px;
-  min-width: 200px;
+  min-width: 180px;
   font-size: 0.8125rem;
   color: #eeeeee;
   transition: border-color 0.2s, box-shadow 0.2s;
@@ -12,8 +12,8 @@
 /* Gold gradient header */
 .header {
   background: linear-gradient(135deg, #B8860B, #D4A017, #C5941A);
-  padding: 7px 12px;
-  border-radius: 6px 6px 0 0;
+  padding: 6px 10px;
+  border-radius: 7px 7px 0 0;
   font-weight: 600;
   font-size: 0.875rem;
   display: flex;
@@ -50,7 +50,7 @@
 
 .inputRow {
   position: relative;
-  padding: 4px 12px 4px 18px;
+  padding: 3px 12px 3px 18px;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -58,7 +58,7 @@
 
 .outputRow {
   position: relative;
-  padding: 4px 18px 4px 12px;
+  padding: 3px 18px 3px 12px;
   display: flex;
   align-items: center;
   justify-content: flex-end;

--- a/frontend/src/components/Nodes/PresetNode.test.tsx
+++ b/frontend/src/components/Nodes/PresetNode.test.tsx
@@ -136,7 +136,7 @@ describe('PresetNode', () => {
     const { container } = renderPreset(presetData(), { selected: true });
     const node = container.querySelector('[class*="node"]') as HTMLElement;
     // jsdom normalizes the border shorthand color #ffffff → rgb(255, 255, 255).
-    expect(node.style.border).toBe('2px solid rgb(255, 255, 255)');
+    expect(node.style.border).toBe('1px solid rgb(255, 255, 255)');
     expect(node.style.boxShadow).toContain('rgba(212,160,23,0.3)');
   });
 
@@ -144,7 +144,7 @@ describe('PresetNode', () => {
     const { container } = renderPreset(presetData());
     const node = container.querySelector('[class*="node"]') as HTMLElement;
     // #6B5B00 → rgb(107, 91, 0)
-    expect(node.style.border).toBe('2px solid rgb(107, 91, 0)');
+    expect(node.style.border).toBe('1px solid rgb(107, 91, 0)');
     expect(node.style.boxShadow).toContain('rgba(0,0,0,0.4)');
   });
 
@@ -158,7 +158,7 @@ describe('PresetNode', () => {
       presetData({ executionStatus: status, error: status === 'error' ? 'x' : undefined }),
     );
     const node = container.querySelector('[class*="node"]') as HTMLElement;
-    expect(node.style.border).toBe(`2px solid ${rgb}`);
+    expect(node.style.border).toBe(`1px solid ${rgb}`);
   });
 
   // ── Status footers ──

--- a/frontend/src/components/Nodes/PresetNode.tsx
+++ b/frontend/src/components/Nodes/PresetNode.tsx
@@ -50,7 +50,7 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
       onClick={handleClick}
       className={`${styles.node}${isTriggerTarget ? ` ${baseStyles.entryPoint}` : ''}${isDraggingTrigger ? ` ${baseStyles.triggerDropTarget}` : ''}`}
       style={{
-        border: `2px solid ${borderColor}`,
+        border: `1px solid ${borderColor}`,
         boxShadow: selected
           ? '0 0 16px rgba(212,160,23,0.3)'
           : '0 4px 12px rgba(0,0,0,0.4)',
@@ -88,7 +88,7 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
                 width: 10,
                 height: 10,
                 border: '2px solid #1e1e1e',
-                left: -5,
+                left: -5.5,
                 top: '50%',
                 transform: 'translateY(-50%)',
                 borderRadius: '50%',
@@ -131,7 +131,7 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
                 width: 10,
                 height: 10,
                 border: '2px solid #1e1e1e',
-                right: -5,
+                right: -5.5,
                 top: '50%',
                 transform: 'translateY(-50%)',
                 borderRadius: '50%',

--- a/frontend/src/components/Nodes/TokenizerVizNode.module.css
+++ b/frontend/src/components/Nodes/TokenizerVizNode.module.css
@@ -2,7 +2,7 @@
   border-top: 1px solid #2a2a2a;
   padding: 8px 10px;
   background: #161616;
-  max-width: 360px;
+  max-width: 320px;
 }
 
 .chipRow {


### PR DESCRIPTION
Retunes node visual proportions toward ComfyUI/LiteGraph density (compact rows, quiet chrome, thin borders that recede, typography and port dots carrying the hierarchy) while keeping the "Crafted dark" theme fully intact: no color/hue changes, no logic or markup changes, numeric CSS/style values only.

Reference targets at zoom 1: node min width 140, ~30px title bar, ~20px slot rows, 1px borders with shadow depth, 9-10px socket dots.

## Before/after table (every numeric value changed)

| File | Item | Before | After | Rationale |
|---|---|---|---|---|
| `BaseNode.module.css` | `.node` border | `2px solid var(--border-color)` | `1px solid var(--border-color)` | Thin ComfyUI-style outline; depth is carried by the pre-existing inline shadow `0 4px 12px rgba(0,0,0,0.4)`, which stays. |
| `BaseNode.module.css` | `.node` min-width | `180px` | `160px` | Step toward ComfyUI's 140px min; verified safe (see width check below). |
| `BaseNode.module.css` | `.header` padding | `7px 12px` | `6px 10px` | Tighter title bar (~31px to ~29px), closer to the 30px reference. |
| `BaseNode.module.css` | `.header` border-radius | `6px 6px 0 0` | `7px 7px 0 0` | Inner radius flush with the 8px outer radius minus the new 1px border. |
| `BaseNode.module.css` | `.headerCategory` opacity | `0.85` | `0.65` | Chip recedes; title carries the header. |
| `BaseNode.module.css` | `.headerCategory` background | `rgba(0, 0, 0, 0.25)` | `transparent` | Removes the dark pill box - the chip's contrast footprint - per "quiet chrome". Text color still inherits (no color-coding change). |
| `BaseNode.module.css` | `.headerCategory` padding | `2px 5px` | `2px 0` | With no pill box, the horizontal inset only pushed the text off the header's right padding edge. |
| `BaseNode.module.css` | `.portRowInput` padding | `4px 12px 4px 18px` | `3px 12px 3px 18px` | Port row goes ~21px to ~19px, hitting the ~20px slot-row rhythm. |
| `BaseNode.module.css` | `.portRowOutput` padding | `4px 18px 4px 12px` | `3px 18px 3px 12px` | Mirror of the input row. |
| `BaseNode.module.css` | `.portHandleInput` left | `-5px` | `-5.5px` | Centers the 10px dot exactly on the 1px border stroke (dot center at stroke center; was 1px inside on the 2px border). |
| `BaseNode.module.css` | `.portHandleOutput` right | `-5px` | `-5.5px` | Same, output side. |
| `BaseNode.module.css` | `.paramRow` padding | `1px 0` | `2px 0` | Slight air between param rows so the denser card does not feel cramped. |
| `BaseNode.module.css` | `.paramValue` max-width | `100px` | `120px` | Fewer ellipsized values; balances the narrower min-width. |
| `PresetNode.module.css` | `.node` min-width | `200px` | `180px` | Keeps the preset card's +20px presence over BaseNode at the new scale. |
| `PresetNode.module.css` | `.header` padding | `7px 12px` | `6px 10px` | Matches BaseNode header rhythm. |
| `PresetNode.module.css` | `.header` border-radius | `6px 6px 0 0` | `7px 7px 0 0` | Same flush-radius fix as BaseNode. |
| `PresetNode.module.css` | `.inputRow` padding | `4px 12px 4px 18px` | `3px 12px 3px 18px` | Same ~20px row rhythm. |
| `PresetNode.module.css` | `.outputRow` padding | `4px 18px 4px 12px` | `3px 18px 3px 12px` | Mirror. |
| `PresetNode.tsx` | inline node border | `` `2px solid ${borderColor}` `` | `` `1px solid ${borderColor}` `` | PresetNode carries its border inline; kept in lockstep with BaseNode (numeric constant only). |
| `PresetNode.tsx` | inline handle `left` | `-5` | `-5.5` | Same dot-centering fix as the CSS handles. |
| `PresetNode.tsx` | inline handle `right` | `-5` | `-5.5` | Same. |
| `PresetNode.test.tsx` | 3 border assertions | `2px solid ...` | `1px solid ...` | Test strings follow the changed value (x3: selected, idle, status matrix). |
| `TokenizerVizNode.module.css` | `.vizArea` max-width | `360px` | `320px` | Media widths converge on a 300-320px band relative to the new node scale. |
| `EmbeddingScatterVizNode.module.css` | `.vizArea` width | `340px` | `320px` | Same band; matches Tokenizer viz. |
| `EmbeddingScatterVizNode.tsx` | `ScatterPlot` width | `320` | `300` | Fits the 320px container exactly (minus 2 x 10px padding). |
| `EmbeddingScatterVizNode.tsx` | `ScatterPlot` height | `220` | `207` | Proportional to the width change (220 x 300/320 = 206.25). |

## Explicitly unchanged

Handle dot size (10px + 2px ring), node outer radius (8px), edge strokes (2px), all colors/hues, category header colors, root font size, StartNode pill, NoteNode, EduKNN scatter (240x200), attention heatmaps (220px), toolbar/settings/panels. Selection and run-status visibility still ride the `--border-color` mechanism: 1px white border + the existing `0 0 16px` glow for selected, colored 1px border + status footer text/dot for run states - matching how ComfyUI renders its own thin selection/running outlines. No component logic touched.

## Width sanity check

ReactFlow node wrappers are `position: absolute` with no width, so cards are shrink-to-fit: long content (e.g. the longest built-in names `early_stopping_patience`, `show_support_vectors`, `routing_weights`) widens the node instead of wrapping or clipping. `min-width` only governs short-content cards, so 160/180 cannot clip labels; longest port-row max-content (~130px) also fits inside 160 outright.

## Testing

- `pnpm test`: 93 files, 1712 tests, all passing (includes the 3 updated PresetNode border assertions).
- `pnpm build`: tsc + vite build clean (only the pre-existing >500 kB chunk-size warning).
- Not done here: live Chrome visual pass (isolated worktree, no backend venv). Recommend a quick visual once-over on the canvas before merge per the usual UI-change workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
