### PR TITLE
fix(canvas): dragging a connected input detaches its edge (redirect to reconnect anchor)

### DIFF
--- a/frontend/src/components/Nodes/BaseNode.test.tsx
+++ b/frontend/src/components/Nodes/BaseNode.test.tsx
@@ -661,6 +661,109 @@ describe('BaseNode', () => {
   });
 });
 
+// ── Detach drag redirect (connected input pulls its edge off) ──────────────
+
+describe('BaseNode detach drag redirect', () => {
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+
+  /**
+   * Real React Flow edge DOM shape (verified against @xyflow/react 12.10.1):
+   * `<g class="react-flow__edge" data-id>` wrapping the invisible
+   * `<circle class="react-flow__edgeupdater react-flow__edgeupdater-target">`
+   * reconnect anchor. A spy listener records redirected mousedowns.
+   */
+  function mountAnchorFixture(edgeId: string) {
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    svg.setAttribute('data-fixture', 'anchor');
+    const group = document.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', 'react-flow__edge react-flow__edge-default');
+    group.setAttribute('data-id', edgeId);
+    const circle = document.createElementNS(SVG_NS, 'circle');
+    circle.setAttribute('class', 'react-flow__edgeupdater react-flow__edgeupdater-target');
+    circle.setAttribute('r', '10');
+    group.appendChild(circle);
+    svg.appendChild(group);
+    document.body.appendChild(svg);
+    const received: MouseEvent[] = [];
+    circle.addEventListener('mousedown', (e) => received.push(e as MouseEvent));
+    return { received };
+  }
+
+  function seedEdges(edges: Edge[]) {
+    useTabStore.setState((s) => ({ tabs: [{ ...s.tabs[0], edges }] }));
+  }
+
+  const twoInputDef = () =>
+    makeDef({
+      inputs: [
+        { name: 'a', data_type: 'TENSOR', description: '', optional: false },
+        { name: 'b', data_type: 'TENSOR', description: '', optional: false },
+      ],
+    });
+
+  afterEach(() => {
+    document.querySelectorAll('svg[data-fixture="anchor"]').forEach((el) => el.remove());
+  });
+
+  it('mousedown on a CONNECTED input redirects to the edge anchor and suppresses the default connection start', () => {
+    seedEdges([{ id: 'e1', source: 's1', sourceHandle: 'out', target: 'n1', targetHandle: 'a' }]);
+    const { received } = mountAnchorFixture('e1');
+    const { container } = renderBody(baseData({ definition: twoInputDef() }), { id: 'n1' });
+    const handle = container.querySelector('[data-handleid="a"]') as HTMLElement;
+
+    const notCancelled = fireEvent.mouseDown(handle, { button: 0, clientX: 120, clientY: 45 });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].clientX).toBe(120);
+    expect(received[0].clientY).toBe(45);
+    // fireEvent returns false when preventDefault was called on the original.
+    expect(notCancelled).toBe(false);
+  });
+
+  it('mousedown on an UNCONNECTED input keeps the normal new-connection behavior', () => {
+    seedEdges([{ id: 'e1', source: 's1', sourceHandle: 'out', target: 'n1', targetHandle: 'a' }]);
+    const { received } = mountAnchorFixture('e1');
+    const { container } = renderBody(baseData({ definition: twoInputDef() }), { id: 'n1' });
+    const handle = container.querySelector('[data-handleid="b"]') as HTMLElement;
+
+    const notCancelled = fireEvent.mouseDown(handle, { button: 0, clientX: 5, clientY: 6 });
+
+    expect(received).toHaveLength(0);
+    expect(notCancelled).toBe(true);
+  });
+
+  it('ctrl-modified mousedown on a connected input is NOT redirected (escape hatch)', () => {
+    seedEdges([{ id: 'e1', source: 's1', sourceHandle: 'out', target: 'n1', targetHandle: 'a' }]);
+    const { received } = mountAnchorFixture('e1');
+    const { container } = renderBody(baseData({ definition: twoInputDef() }), { id: 'n1' });
+    const handle = container.querySelector('[data-handleid="a"]') as HTMLElement;
+
+    const notCancelled = fireEvent.mouseDown(handle, {
+      button: 0,
+      ctrlKey: true,
+      clientX: 120,
+      clientY: 45,
+    });
+
+    expect(received).toHaveLength(0);
+    expect(notCancelled).toBe(true);
+  });
+
+  it('output handles never intercept, even if an edge coincidentally targets that handle id', () => {
+    // Bogus edge whose target handle shares the OUTPUT handle's name — proves
+    // the capture handler simply is not attached on source handles.
+    seedEdges([{ id: 'e9', source: 's1', sourceHandle: 'x', target: 'n1', targetHandle: 'out' }]);
+    const { received } = mountAnchorFixture('e9');
+    const { container } = renderBody(baseData(), { id: 'n1' });
+    const handle = container.querySelector('[data-handleid="out"]') as HTMLElement;
+
+    const notCancelled = fireEvent.mouseDown(handle, { button: 0, clientX: 1, clientY: 2 });
+
+    expect(received).toHaveLength(0);
+    expect(notCancelled).toBe(true);
+  });
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
 });

--- a/frontend/src/components/Nodes/BaseNode.test.tsx
+++ b/frontend/src/components/Nodes/BaseNode.test.tsx
@@ -671,8 +671,13 @@ describe('BaseNode detach drag redirect', () => {
    * `<g class="react-flow__edge" data-id>` wrapping the invisible
    * `<circle class="react-flow__edgeupdater react-flow__edgeupdater-target">`
    * reconnect anchor. A spy listener records redirected mousedowns.
+   *
+   * Default parent is document.body: `renderBody` mounts the node WITHOUT a
+   * `.react-flow` container, so those tests exercise the helper's
+   * document-wide fallback; the cross-canvas test below mounts real
+   * `.react-flow` containers to exercise the scoped path.
    */
-  function mountAnchorFixture(edgeId: string) {
+  function mountAnchorFixture(edgeId: string, parent: Element = document.body) {
     const svg = document.createElementNS(SVG_NS, 'svg');
     svg.setAttribute('data-fixture', 'anchor');
     const group = document.createElementNS(SVG_NS, 'g');
@@ -683,10 +688,24 @@ describe('BaseNode detach drag redirect', () => {
     circle.setAttribute('r', '10');
     group.appendChild(circle);
     svg.appendChild(group);
-    document.body.appendChild(svg);
+    parent.appendChild(svg);
     const received: MouseEvent[] = [];
     circle.addEventListener('mousedown', (e) => received.push(e as MouseEvent));
     return { received };
+  }
+
+  /**
+   * A `.react-flow` canvas container div — the class the ReactFlow root
+   * carries (verified in @xyflow/react 12.10.1: `<div
+   * data-testid="rf__wrapper" ... className={cc(['react-flow', ...])}>`).
+   * The app mounts one such (hidden) canvas per open tab.
+   */
+  function mountCanvas() {
+    const canvas = document.createElement('div');
+    canvas.className = 'react-flow';
+    canvas.setAttribute('data-fixture', 'anchor');
+    document.body.appendChild(canvas);
+    return canvas;
   }
 
   function seedEdges(edges: Edge[]) {
@@ -702,7 +721,7 @@ describe('BaseNode detach drag redirect', () => {
     });
 
   afterEach(() => {
-    document.querySelectorAll('svg[data-fixture="anchor"]').forEach((el) => el.remove());
+    document.querySelectorAll('[data-fixture="anchor"]').forEach((el) => el.remove());
   });
 
   it('mousedown on a CONNECTED input redirects to the edge anchor and suppresses the default connection start', () => {
@@ -761,6 +780,40 @@ describe('BaseNode detach drag redirect', () => {
 
     expect(received).toHaveLength(0);
     expect(notCancelled).toBe(true);
+  });
+
+  it("with duplicate edge ids across canvases, redirects to the anchor in the handle's OWN canvas", () => {
+    // Edge ids are only unique PER TAB (example graphs carry fixed ids) and
+    // the app mounts one hidden FlowCanvas per open tab — so the same
+    // data-id can exist in several `.react-flow` containers at once. The
+    // decoy canvas comes FIRST in document order; an unscoped document
+    // query would dispatch into that wrong (hidden) canvas.
+    seedEdges([{ id: 'dup', source: 's1', sourceHandle: 'out', target: 'n1', targetHandle: 'a' }]);
+
+    const decoyCanvas = mountCanvas();
+    const decoy = mountAnchorFixture('dup', decoyCanvas);
+
+    const ownCanvas = mountCanvas();
+    renderWithFlow(
+      <BaseNodeBody
+        id="n1"
+        type="baseNode"
+        data={baseData({ definition: twoInputDef() })}
+        selected={false}
+        {...flowProps}
+      />,
+      { container: ownCanvas },
+    );
+    // React's createRoot clears the container on first render — mount the
+    // anchor fixture AFTER rendering so it survives inside the canvas.
+    const own = mountAnchorFixture('dup', ownCanvas);
+
+    const handle = ownCanvas.querySelector('[data-handleid="a"]') as HTMLElement;
+    const notCancelled = fireEvent.mouseDown(handle, { button: 0, clientX: 9, clientY: 9 });
+
+    expect(own.received).toHaveLength(1);
+    expect(decoy.received).toHaveLength(0);
+    expect(notCancelled).toBe(false);
   });
 });
 

--- a/frontend/src/components/Nodes/BaseNode.tsx
+++ b/frontend/src/components/Nodes/BaseNode.tsx
@@ -3,6 +3,7 @@ import { Handle, Position, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import type { AppNode } from '../../types';
 import { getPortColor, isParamVisible, isValidConnection, resolveDynamicOutputs } from '../../utils';
+import { findDetachableEdge, redirectMouseDownToReconnectAnchor } from '../../utils/reconnect';
 import { useUIStore } from '../../store/uiStore';
 import { useTabStore } from '../../store/tabStore';
 import { useToastStore } from '../../store/toastStore';
@@ -61,6 +62,41 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
   const isTriggerTarget = getEdges().some(
     (e) => e.target === id && ((e.data as { type?: string } | undefined)?.type === 'trigger'),
   );
+
+  // ComfyUI-style detach: a plain left-button press on a CONNECTED input
+  // grabs the existing edge off the port instead of starting a second
+  // connection. The Handle DOM sits above React Flow's invisible reconnect
+  // anchor (edge SVG layer renders below nodes), so we intercept the
+  // connection-starting mousedown in the CAPTURE phase — the Handle starts
+  // connections from its bubble-phase onMouseDown (verified in @xyflow/react
+  // 12.10.1, see utils/reconnect.ts) — and re-dispatch it onto the edge's
+  // anchor, which drives the full native reconnect lifecycle
+  // (onReconnectStart red ring, live drag following the real mouse,
+  // drop-on-pane delete / drop-on-handle rewire). A plain click without
+  // moving stays a no-op: React Flow only starts the reconnect after its
+  // drag threshold.
+  const interceptConnectedInputMouseDown = (
+    event: React.MouseEvent,
+    handleId: string,
+  ) => {
+    // Escape hatch: modified drags (or non-left buttons) keep the old
+    // start-a-new-connection behavior.
+    if (
+      event.button !== 0 ||
+      event.shiftKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      event.metaKey
+    ) {
+      return;
+    }
+    // Read edges at event time straight from the store (same imperative,
+    // no-subscription pattern as the getEdges() trigger check above).
+    const { tabs, activeTabId } = useTabStore.getState();
+    const tab = tabs.find((t) => t.id === activeTabId);
+    const edge = tab ? findDetachableEdge(tab.edges, id, handleId) : null;
+    if (edge) redirectMouseDownToReconnectAnchor(event, edge.id);
+  };
 
   const handleClick = (e: React.MouseEvent) => {
     if (e.detail === 2 && isSequentialModel) {
@@ -168,6 +204,7 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
               type="target"
               position={Position.Left}
               id={input.name}
+              onMouseDownCapture={(e) => interceptConnectedInputMouseDown(e, input.name)}
               className={`${styles.portHandle} ${styles.portHandleInput}${
                 isDetaching(input.name, 'target')
                   ? ` ${styles.portDetaching}`

--- a/frontend/src/components/Nodes/PresetNode.test.tsx
+++ b/frontend/src/components/Nodes/PresetNode.test.tsx
@@ -294,4 +294,49 @@ describe('PresetNode', () => {
     await waitFor(() => expect(screen.getByText('NoTrig')).toBeTruthy());
     expect([...document.querySelectorAll('div')].some((d) => /entryPoint/.test(d.className))).toBe(false);
   });
+
+  it('mousedown on a CONNECTED exposed input redirects to the edge reconnect anchor', () => {
+    // The edge whose target endpoint is p1/x — grabbing that input should
+    // hand the mousedown to this edge's reconnect anchor (detach drag).
+    useTabStore.setState((s) => ({
+      tabs: [
+        {
+          ...s.tabs[0],
+          edges: [
+            { id: 'pe1', source: 's1', sourceHandle: 'out', target: 'p1', targetHandle: 'x' },
+          ],
+        },
+      ],
+    }));
+    // Anchor fixture matching the real React Flow edge DOM shape (verified
+    // against @xyflow/react 12.10.1 EdgeWrapper/EdgeAnchor).
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    const group = document.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', 'react-flow__edge react-flow__edge-default');
+    group.setAttribute('data-id', 'pe1');
+    const circle = document.createElementNS(SVG_NS, 'circle');
+    circle.setAttribute('class', 'react-flow__edgeupdater react-flow__edgeupdater-target');
+    circle.setAttribute('r', '10');
+    group.appendChild(circle);
+    svg.appendChild(group);
+    document.body.appendChild(svg);
+    const received: MouseEvent[] = [];
+    circle.addEventListener('mousedown', (e) => received.push(e as MouseEvent));
+
+    try {
+      const { container } = renderPreset(presetData(), { id: 'p1' });
+      const handle = container.querySelector('[data-handleid="x"]') as HTMLElement;
+
+      const notCancelled = fireEvent.mouseDown(handle, { button: 0, clientX: 33, clientY: 44 });
+
+      expect(received).toHaveLength(1);
+      expect(received[0].clientX).toBe(33);
+      expect(received[0].clientY).toBe(44);
+      // fireEvent returns false when preventDefault was called on the original.
+      expect(notCancelled).toBe(false);
+    } finally {
+      svg.remove();
+    }
+  });
 });

--- a/frontend/src/components/Nodes/PresetNode.tsx
+++ b/frontend/src/components/Nodes/PresetNode.tsx
@@ -3,6 +3,7 @@ import { Handle, Position, useReactFlow } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import type { AppNode } from '../../types';
 import { getPortColor } from '../../utils';
+import { findDetachableEdge, redirectMouseDownToReconnectAnchor } from '../../utils/reconnect';
 import { useTabStore } from '../../store/tabStore';
 import { useUIStore } from '../../store/uiStore';
 import { useI18n } from '../../i18n';
@@ -32,6 +33,34 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
     reconnectingHandle.nodeId === id &&
     reconnectingHandle.type === type &&
     reconnectingHandle.handleId === handleId;
+
+  // ComfyUI-style detach: a plain left-button press on a CONNECTED exposed
+  // input grabs the existing edge off the port instead of starting a second
+  // connection. Same capture-phase redirect as BaseNode — the Handle starts
+  // connections from its bubble-phase onMouseDown (verified in @xyflow/react
+  // 12.10.1, see utils/reconnect.ts), so intercepting the capture phase and
+  // re-dispatching onto the edge's reconnect anchor drives the full native
+  // reconnect lifecycle. Modified drags keep the old behavior.
+  const interceptConnectedInputMouseDown = (
+    event: React.MouseEvent,
+    handleId: string,
+  ) => {
+    if (
+      event.button !== 0 ||
+      event.shiftKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      event.metaKey
+    ) {
+      return;
+    }
+    // Read edges at event time straight from the store — no per-node
+    // subscription (same imperative pattern as the getEdges() trigger check).
+    const { tabs, activeTabId } = useTabStore.getState();
+    const tab = tabs.find((t) => t.id === activeTabId);
+    const edge = tab ? findDetachableEdge(tab.edges, id, handleId) : null;
+    if (edge) redirectMouseDownToReconnectAnchor(event, edge.id);
+  };
 
   const statusBorderColor =
     data.executionStatus === 'running'
@@ -96,6 +125,7 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
               type="target"
               position={Position.Left}
               id={input.name}
+              onMouseDownCapture={(e) => interceptConnectedInputMouseDown(e, input.name)}
               className={isDetaching(input.name, 'target') ? baseStyles.portDetaching : undefined}
               style={{
                 background: getPortColor(input.data_type),

--- a/frontend/src/utils/reconnect.test.ts
+++ b/frontend/src/utils/reconnect.test.ts
@@ -80,9 +80,14 @@ describe('redirectMouseDownToReconnectAnchor', () => {
    * @xyflow/react 12.10.1 EdgeWrapper/EdgeAnchor): an svg containing
    * `<g class="react-flow__edge" data-id="<edgeId>">` with the invisible
    * `<circle class="react-flow__edgeupdater react-flow__edgeupdater-<type>">`
-   * reconnect anchor inside.
+   * reconnect anchor inside. Mounted under `parent` (a `.react-flow`
+   * canvas container in the scoping tests, document.body otherwise).
    */
-  function mountAnchorFixture(edgeId: string, anchorType: 'target' | 'source' = 'target') {
+  function mountAnchorFixture(
+    edgeId: string,
+    anchorType: 'target' | 'source' = 'target',
+    parent: Element = document.body,
+  ) {
     const svg = document.createElementNS(SVG_NS, 'svg');
     const group = document.createElementNS(SVG_NS, 'g');
     group.setAttribute('class', 'react-flow__edge react-flow__edge-default');
@@ -96,12 +101,24 @@ describe('redirectMouseDownToReconnectAnchor', () => {
     circle.setAttribute('r', '10');
     group.appendChild(circle);
     svg.appendChild(group);
-    document.body.appendChild(svg);
+    parent.appendChild(svg);
     const received: MouseEvent[] = [];
     circle.addEventListener('mousedown', (e) => received.push(e as MouseEvent));
     return { circle, received };
   }
 
+  /** Create a `.react-flow` canvas container div (one per open tab in the app). */
+  function mountCanvas() {
+    const canvas = document.createElement('div');
+    canvas.className = 'react-flow';
+    document.body.appendChild(canvas);
+    return canvas;
+  }
+
+  // NOTE: the default currentTarget (document.body) has no `.react-flow`
+  // ancestor, so tests using this stub exercise the document-wide FALLBACK
+  // path — real handles always sit inside a canvas (covered by the
+  // canvas-scoping tests below and the component tests).
   function stubEvent(overrides: Partial<{
     clientX: number;
     clientY: number;
@@ -174,5 +191,45 @@ describe('redirectMouseDownToReconnectAnchor', () => {
     const event = stubEvent();
     expect(redirectMouseDownToReconnectAnchor(event, hostileId)).toBe(true);
     expect(received).toHaveLength(1);
+  });
+
+  it("scopes the lookup to the handle's OWN canvas when edge ids collide across canvases", () => {
+    // The app mounts one hidden <FlowCanvas> per open tab, and graphs
+    // loaded from example files reuse fixed edge ids — the same id can
+    // exist in several canvases at once. The decoy canvas comes FIRST in
+    // document order, so an unscoped document query would dispatch into
+    // the wrong (hidden) canvas.
+    const decoyCanvas = mountCanvas();
+    const decoy = mountAnchorFixture('dup-edge', 'target', decoyCanvas);
+
+    const ownCanvas = mountCanvas();
+    const own = mountAnchorFixture('dup-edge', 'target', ownCanvas);
+    const handle = document.createElement('div');
+    ownCanvas.appendChild(handle);
+
+    const event = stubEvent({ currentTarget: handle });
+    expect(redirectMouseDownToReconnectAnchor(event, 'dup-edge')).toBe(true);
+
+    expect(own.received).toHaveLength(1);
+    expect(decoy.received).toHaveLength(0);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT borrow an anchor from outside the canvas when the handle sits inside one', () => {
+    // Anchor exists only OUTSIDE the handle's canvas (e.g. another tab's
+    // edge) — the scoped lookup must miss and leave the event untouched
+    // rather than falling back to the whole document.
+    const outside = mountAnchorFixture('e1');
+    const canvas = mountCanvas();
+    const handle = document.createElement('div');
+    canvas.appendChild(handle);
+
+    const event = stubEvent({ currentTarget: handle });
+    expect(redirectMouseDownToReconnectAnchor(event, 'e1')).toBe(false);
+
+    expect(outside.received).toHaveLength(0);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/utils/reconnect.test.ts
+++ b/frontend/src/utils/reconnect.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { computeDetachedEndpoint } from './reconnect';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  computeDetachedEndpoint,
+  findDetachableEdge,
+  redirectMouseDownToReconnectAnchor,
+} from './reconnect';
 
 // `handleType` semantics (verified against @xyflow/react 12.10.1
 // EdgeUpdateAnchors): it names the end that STAYS connected — the drag-origin
@@ -36,5 +40,139 @@ describe('computeDetachedEndpoint', () => {
     expect(
       computeDetachedEndpoint({ source: 'a', target: 'b', sourceHandle: 'out' }, 'target'),
     ).toEqual({ nodeId: 'a', handleId: 'out', type: 'source' });
+  });
+});
+
+describe('findDetachableEdge', () => {
+  const edges = [
+    { id: 'e1', source: 's1', sourceHandle: 'out', target: 'n1', targetHandle: 'a' },
+    { id: 'e2', source: 's2', sourceHandle: 'out', target: 'n1', targetHandle: 'b' },
+    { id: 'e3', source: 's3', sourceHandle: 'out', target: 'n1', targetHandle: 'a' },
+  ];
+
+  it('returns the LAST edge into the given input (topmost-rendered wins)', () => {
+    expect(findDetachableEdge(edges, 'n1', 'a')?.id).toBe('e3');
+  });
+
+  it('returns a single match', () => {
+    expect(findDetachableEdge(edges, 'n1', 'b')?.id).toBe('e2');
+  });
+
+  it('returns null when nothing targets the handle', () => {
+    expect(findDetachableEdge(edges, 'n1', 'c')).toBeNull();
+    expect(findDetachableEdge(edges, 'n2', 'a')).toBeNull();
+    expect(findDetachableEdge([], 'n1', 'a')).toBeNull();
+  });
+
+  it('ignores edges that merely ORIGINATE at the node/handle', () => {
+    const outgoing = [
+      { id: 'e4', source: 'n1', sourceHandle: 'a', target: 'x', targetHandle: 'in' },
+    ];
+    expect(findDetachableEdge(outgoing, 'n1', 'a')).toBeNull();
+  });
+});
+
+describe('redirectMouseDownToReconnectAnchor', () => {
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+
+  /**
+   * Build the real React Flow edge DOM shape (verified against
+   * @xyflow/react 12.10.1 EdgeWrapper/EdgeAnchor): an svg containing
+   * `<g class="react-flow__edge" data-id="<edgeId>">` with the invisible
+   * `<circle class="react-flow__edgeupdater react-flow__edgeupdater-<type>">`
+   * reconnect anchor inside.
+   */
+  function mountAnchorFixture(edgeId: string, anchorType: 'target' | 'source' = 'target') {
+    const svg = document.createElementNS(SVG_NS, 'svg');
+    const group = document.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', 'react-flow__edge react-flow__edge-default');
+    group.setAttribute('data-id', edgeId);
+    group.setAttribute('data-testid', `rf__edge-${edgeId}`);
+    const circle = document.createElementNS(SVG_NS, 'circle');
+    circle.setAttribute(
+      'class',
+      `react-flow__edgeupdater react-flow__edgeupdater-${anchorType}`,
+    );
+    circle.setAttribute('r', '10');
+    group.appendChild(circle);
+    svg.appendChild(group);
+    document.body.appendChild(svg);
+    const received: MouseEvent[] = [];
+    circle.addEventListener('mousedown', (e) => received.push(e as MouseEvent));
+    return { circle, received };
+  }
+
+  function stubEvent(overrides: Partial<{
+    clientX: number;
+    clientY: number;
+    currentTarget: EventTarget | null;
+  }> = {}) {
+    return {
+      clientX: 111,
+      clientY: 222,
+      currentTarget: document.body as EventTarget | null,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('dispatches a left-button mousedown with the source coordinates on the anchor and suppresses the original event', () => {
+    const { received } = mountAnchorFixture('e1');
+    const event = stubEvent({ clientX: 120, clientY: 45 });
+
+    expect(redirectMouseDownToReconnectAnchor(event, 'e1')).toBe(true);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].clientX).toBe(120);
+    expect(received[0].clientY).toBe(45);
+    expect(received[0].button).toBe(0);
+    expect(received[0].buttons).toBe(1);
+    expect(received[0].bubbles).toBe(true);
+    expect(received[0].cancelable).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false and leaves the event untouched when no anchor exists', () => {
+    const event = stubEvent();
+    expect(redirectMouseDownToReconnectAnchor(event, 'e1')).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it("does not match a DIFFERENT edge's anchor", () => {
+    const { received } = mountAnchorFixture('other-edge');
+    const event = stubEvent();
+    expect(redirectMouseDownToReconnectAnchor(event, 'e1')).toBe(false);
+    expect(received).toHaveLength(0);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('only targets the TARGET anchor, never the source anchor', () => {
+    const { received } = mountAnchorFixture('e1', 'source');
+    const event = stubEvent();
+    expect(redirectMouseDownToReconnectAnchor(event, 'e1')).toBe(false);
+    expect(received).toHaveLength(0);
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the global document when currentTarget is not an element', () => {
+    const { received } = mountAnchorFixture('e1');
+    const event = stubEvent({ currentTarget: null });
+    expect(redirectMouseDownToReconnectAnchor(event, 'e1')).toBe(true);
+    expect(received).toHaveLength(1);
+  });
+
+  it('escapes CSS-hostile characters in the edge id', () => {
+    const hostileId = 'xy-edge__a"b\\c';
+    const { received } = mountAnchorFixture(hostileId);
+    const event = stubEvent();
+    expect(redirectMouseDownToReconnectAnchor(event, hostileId)).toBe(true);
+    expect(received).toHaveLength(1);
   });
 });

--- a/frontend/src/utils/reconnect.ts
+++ b/frontend/src/utils/reconnect.ts
@@ -41,3 +41,133 @@ export function computeDetachedEndpoint(
   if (edge.sourceHandle == null) return null;
   return { nodeId: edge.source, handleId: edge.sourceHandle, type: 'source' };
 }
+
+// ── Detach-drag redirect ────────────────────────────────────────────────────
+//
+// ComfyUI-style detach: grabbing a CONNECTED input port should pull the
+// existing edge's endpoint off (React Flow "reconnect"), not start a second
+// connection. React Flow's invisible reconnect anchor (`<circle
+// class="react-flow__edgeupdater react-flow__edgeupdater-target" r=10>` in
+// the edge SVG layer) sits BELOW the node layer, so the port `Handle` DOM
+// always wins the hit-test and the anchor can never be grabbed directly.
+// The two helpers below fix that by redirecting the connection-starting
+// mousedown from the Handle to the matching edge's anchor.
+//
+// Event bindings verified against the installed libraries
+// (@xyflow/react 12.10.1 dist/esm/index.js, @xyflow/system 0.0.75):
+//
+// - `HandleComponent` binds exactly `onMouseDown: onPointerDown,
+//   onTouchStart: onPointerDown` (React synthetic, bubble phase). The mouse
+//   branch requires `event.button === 0` and calls
+//   `XYHandle.onPointerDown(event.nativeEvent, ...)` — so the ONLY mouse
+//   event that starts a connection from a Handle is the synthetic bubble
+//   `mousedown`. Intercepting `onMouseDownCapture` on our own <Handle> fires
+//   first (the prop reaches the DOM via the component's `...rest` spread);
+//   React's synthetic `stopPropagation()` also calls the NATIVE event's
+//   `stopPropagation()`, halting it at the React root's capture listener, so
+//   the Handle's internal bubble `onMouseDown` never runs. Touch
+//   (`onTouchStart`) is deliberately left alone.
+//
+// - `EdgeUpdateAnchors`/`EdgeAnchor` render the anchor as `<circle
+//   onMouseDown=... class="react-flow__edgeupdater
+//   react-flow__edgeupdater-<target|source>">`; the handler ignores
+//   `event.button !== 0` and calls `XYHandle.onPointerDown` wired with the
+//   reconnect callbacks. One synthetic native `mousedown` dispatched on the
+//   circle therefore drives the entire native reconnect lifecycle
+//   (`onReconnectStart`, original edge unmounts, document-level move/up
+//   listeners follow the REAL mouse, `onReconnect`/`onReconnectEnd` on drop).
+//
+// - The edge group is `<g class="react-flow__edge ..." data-id="<edge.id>"
+//   data-testid="rf__edge-<edge.id>">` (`EdgeWrapper`) — the `data-id`
+//   attribute is confirmed present, so the anchor is addressable as
+//   `.react-flow__edge[data-id="<edgeId>"] .react-flow__edgeupdater-target`.
+
+/**
+ * Find the edge a grab on a connected input handle should detach: the LAST
+ * edge in the array whose target endpoint is `nodeId`/`handleId`. Later edges
+ * render on top in React Flow, so the last match is the one visually grabbed.
+ * Returns null when nothing is connected to that input.
+ */
+export function findDetachableEdge<
+  E extends Pick<Edge, 'id' | 'target' | 'targetHandle'>,
+>(edges: readonly E[], nodeId: string, handleId: string): E | null {
+  for (let i = edges.length - 1; i >= 0; i--) {
+    const edge = edges[i];
+    if (edge.target === nodeId && edge.targetHandle === handleId) return edge;
+  }
+  return null;
+}
+
+/**
+ * The subset of a React synthetic mouse event the redirect needs. Structural
+ * so the helper stays DOM-light and unit-testable with a plain stub object.
+ */
+export interface RedirectableMouseDownEvent {
+  clientX: number;
+  clientY: number;
+  currentTarget: EventTarget | null;
+  preventDefault: () => void;
+  stopPropagation: () => void;
+}
+
+/**
+ * Escape a string for use inside a double-quoted CSS attribute selector.
+ * Per the CSS string grammar only backslash and the quote character need
+ * escaping (edge ids never contain newlines).
+ */
+const escapeCssString = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+/**
+ * Redirect a connection-starting mousedown from a connected input Handle to
+ * the given edge's target reconnect anchor.
+ *
+ * Locates `.react-flow__edge[data-id="<edgeId>"] .react-flow__edgeupdater-target`
+ * in the handle's own document (resolved from `event.currentTarget`, so the
+ * anchor found is guaranteed to live in the SAME document as the handle).
+ * If found, dispatches a fresh left-button native `mousedown` carrying the
+ * original pointer coordinates on the circle — which starts the full native
+ * reconnect lifecycle — then suppresses the original event
+ * (`preventDefault` + `stopPropagation`) and returns true.
+ *
+ * If the anchor cannot be found, returns false WITHOUT touching the event so
+ * the Handle keeps today's start-a-new-connection behavior as a graceful
+ * fallback.
+ */
+export function redirectMouseDownToReconnectAnchor(
+  event: RedirectableMouseDownEvent,
+  edgeId: string,
+): boolean {
+  const doc =
+    event.currentTarget instanceof Element
+      ? event.currentTarget.ownerDocument
+      : typeof document === 'undefined'
+        ? null
+        : document;
+  if (!doc) return false;
+
+  const anchor = doc.querySelector(
+    `.react-flow__edge[data-id="${escapeCssString(edgeId)}"] .react-flow__edgeupdater-target`,
+  );
+  if (!anchor) return false;
+
+  // The anchor's own handler requires button === 0 and reads the pointer
+  // position from the event, so mirror the original press exactly. `view` is
+  // intentionally omitted: nothing downstream reads `event.view`
+  // (@xyflow/system resolves the document from `event.target`), and jsdom's
+  // UIEvent init rejects window objects passed through vitest's copied
+  // globals (same reason @testing-library/dom omits it).
+  anchor.dispatchEvent(
+    new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      buttons: 1,
+      clientX: event.clientX,
+      clientY: event.clientY,
+    }),
+  );
+  event.preventDefault();
+  event.stopPropagation();
+  return true;
+}

--- a/frontend/src/utils/reconnect.ts
+++ b/frontend/src/utils/reconnect.ts
@@ -123,11 +123,13 @@ const escapeCssString = (value: string): string =>
  * the given edge's target reconnect anchor.
  *
  * Locates `.react-flow__edge[data-id="<edgeId>"] .react-flow__edgeupdater-target`
- * in the handle's own document (resolved from `event.currentTarget`, so the
- * anchor found is guaranteed to live in the SAME document as the handle).
- * If found, dispatches a fresh left-button native `mousedown` carrying the
- * original pointer coordinates on the circle — which starts the full native
- * reconnect lifecycle — then suppresses the original event
+ * inside the handle's OWN canvas — `event.currentTarget.closest('.react-flow')`
+ * — falling back to the handle's whole document only when no such container
+ * exists (real handles always live inside one; the fallback is effectively
+ * test-only). Either way the anchor found lives in the SAME document as the
+ * handle. If found, dispatches a fresh left-button native `mousedown`
+ * carrying the original pointer coordinates on the circle — which starts the
+ * full native reconnect lifecycle — then suppresses the original event
  * (`preventDefault` + `stopPropagation`) and returns true.
  *
  * If the anchor cannot be found, returns false WITHOUT touching the event so
@@ -138,15 +140,28 @@ export function redirectMouseDownToReconnectAnchor(
   event: RedirectableMouseDownEvent,
   edgeId: string,
 ): boolean {
+  const handleEl =
+    event.currentTarget instanceof Element ? event.currentTarget : null;
   const doc =
-    event.currentTarget instanceof Element
-      ? event.currentTarget.ownerDocument
-      : typeof document === 'undefined'
-        ? null
-        : document;
+    handleEl?.ownerDocument ??
+    (typeof document === 'undefined' ? null : document);
   if (!doc) return false;
 
-  const anchor = doc.querySelector(
+  // Scope the lookup to the handle's own canvas. The app mounts one
+  // (hidden) <FlowCanvas> per open tab and edge ids are only unique PER
+  // TAB (graphs loaded from example files carry fixed ids), so a
+  // document-wide query could match an identically-named edge in another
+  // tab's hidden ReactFlow instance — querySelector returns the FIRST
+  // match in DOM order, i.e. the OLDER tab's canvas. The ReactFlow root
+  // container carries the class "react-flow" (verified in @xyflow/react
+  // 12.10.1 dist/esm/index.js: the ReactFlow component renders
+  // `<div data-testid="rf__wrapper" ... className={cc(['react-flow',
+  // className, colorModeClassName])}>`), and every real Handle lives
+  // inside it. When the handle sits inside a canvas, ONLY that canvas is
+  // searched — an anchor is never borrowed from another canvas.
+  const scope: ParentNode = handleEl?.closest('.react-flow') ?? doc;
+
+  const anchor = scope.querySelector(
     `.react-flow__edge[data-id="${escapeCssString(edgeId)}"] .react-flow__edgeupdater-target`,
   );
   if (!anchor) return false;


### PR DESCRIPTION
## Problem

Users cannot pull an existing connection off a port with the mouse (confirmed by a real-mouse browser test). Expected ComfyUI-style behavior — which the red detach ring from #112 already signals — is that grabbing a CONNECTED input port drags the existing edge's endpoint off (React Flow reconnect: original edge unmounts, red ring shows via `uiStore.reconnectingHandle`, dropping on empty pane deletes the edge in `FlowCanvas.onReconnectEnd`).

Actual: the port dot (a `Handle` DOM element in the node layer) sits ABOVE React Flow's invisible reconnect anchor (`<circle class="react-flow__edgeupdater react-flow__edgeupdater-target" r=10>` in the edge SVG layer, which renders below nodes), so the mousedown always hits the Handle and starts a NEW connection instead; the anchor can never win the hit-test on its own. Dispatching a synthetic `mousedown` directly on the anchor circle was verified to drive the entire native reconnect flow perfectly.

## Fix: capture-phase redirect

Verified against the installed `@xyflow/react` 12.10.1 / `@xyflow/system` 0.0.75 sources (documented in `utils/reconnect.ts`):

- `Handle` starts mouse connections exclusively from its React bubble-phase `onMouseDown` (requires `button === 0`, then `XYHandle.onPointerDown`); `onTouchStart` covers touch only. An `onMouseDownCapture` prop on our own `<Handle>` reaches the DOM via the component's `...rest` spread and fires first; React's synthetic `stopPropagation()` also stops the NATIVE event at the React root, so the Handle's internal bubble handler never runs.
- The edge group is `<g class="react-flow__edge" data-id="<edgeId>">` (`data-id` confirmed in `EdgeWrapper`), and the anchor circle binds React `onMouseDown` (button 0 only) wired to the full reconnect lifecycle.

On CONNECTED data input handles (`BaseNode`) and exposed input handles (`PresetNode`), a plain left-button mousedown with no modifier keys is intercepted in the capture phase and re-dispatched onto the matching edge's target anchor; the original event is then suppressed. Everything downstream is the unmodified native reconnect lifecycle: `onReconnectStart` (red ring via `computeDetachedEndpoint`), live drag following the real mouse, drop-on-pane deletion in `onReconnectEnd`, drop-on-valid-handle rewire via `onReconnect`. A plain click without moving stays a no-op (React Flow only starts the reconnect after its drag threshold).

New helpers in `frontend/src/utils/reconnect.ts`:

- `findDetachableEdge(edges, nodeId, handleId)` — the LAST edge into that input wins (matches topmost render order), else null.
- `redirectMouseDownToReconnectAnchor(event, edgeId)` — locates `.react-flow__edge[data-id="<edgeId>"] .react-flow__edgeupdater-target` in the handle's own document, dispatches a left-button native `mousedown` carrying the original pointer coordinates, suppresses the original event, returns true; if the anchor is not found it returns false WITHOUT touching the event (graceful fallback to today's behavior).

Edges are read at event time via `useTabStore.getState()` (no per-node subscription, same imperative pattern as the existing `getEdges()` trigger check).

## Scope notes

- Modified drags (shift/ctrl/alt/meta) and non-left buttons keep the old start-a-new-connection behavior as an escape hatch.
- Output/source handles are untouched — dragging from an output intentionally fans out new connections.
- The hidden `__trigger` handle is untouched — it has `pointer-events: none` when inactive and nothing intercepts it today.
- `view` is intentionally omitted from the dispatched `MouseEvent`: nothing downstream reads `event.view` (`@xyflow/system` resolves the document from `event.target`), and jsdom's UIEvent init rejects window objects passed through vitest's copied globals (same reason `@testing-library/dom` omits it).

## Tests

- `reconnect.test.ts`: `findDetachableEdge` last-match/no-match/source-side cases; `redirectMouseDownToReconnectAnchor` against a DOM fixture matching the verified real edge DOM shape (coordinates forwarded, original suppressed, wrong-edge / source-only-anchor / missing-fixture return false untouched, CSS-hostile edge ids escaped, global-document fallback).
- `BaseNode.test.tsx`: connected input redirects to the anchor spy and suppresses default; unconnected input does not; ctrl-modified press does not; output handles never intercept.
- `PresetNode.test.tsx`: mirrored happy path for a connected exposed input.

`pnpm test`: 94 files, 1787 tests, all passing. `pnpm build`: clean (pre-existing chunk-size warning only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)