### PR TITLE
fix(training): checkpoint resume restores optimizer state, epoch offset, and LR schedule

### DIFF
--- a/backend/app/nodes/io/checkpoint_node.py
+++ b/backend/app/nodes/io/checkpoint_node.py
@@ -112,6 +112,16 @@ class CheckpointSaverNode(BaseNode):
             # #118: without this the LR schedule restarts from scratch on
             # resume. The class name is stored alongside so the loader can
             # refuse to splice a StepLR state into a CosineAnnealingLR.
+            #
+            # The port is DataType.ANY, so anything at all can be wired into
+            # it. Say what is wrong before writing the file rather than
+            # crashing half way through serialization.
+            if not hasattr(lr_scheduler, "state_dict"):
+                raise ValueError(
+                    f"The lr_scheduler input is a {type(lr_scheduler).__name__}, "
+                    "which has no state_dict(); connect an LRScheduler node's "
+                    "'scheduler' output (or a CheckpointLoader's) to this port."
+                )
             checkpoint["scheduler_state_dict"] = lr_scheduler.state_dict()
             checkpoint["scheduler_class"] = type(lr_scheduler).__name__
 

--- a/backend/app/nodes/io/checkpoint_node.py
+++ b/backend/app/nodes/io/checkpoint_node.py
@@ -1,3 +1,30 @@
+"""Save / load a full training checkpoint.
+
+Checkpoint payload format
+-------------------------
+A checkpoint is a plain dict written with ``torch.save`` and read back with
+``torch.load(..., weights_only=True)``. Every key is optional on read; the
+loader must degrade gracefully when one is missing so that checkpoints written
+by an older CodefyUI keep working.
+
+===========================  ============================================
+key                          contents
+===========================  ============================================
+``epoch``                    int, the epoch the checkpoint was taken at
+``model_state_dict``         ``model.state_dict()``
+``optimizer_state_dict``     ``optimizer.state_dict()``
+``losses``                   optional tensor of per-epoch training losses
+``scheduler_state_dict``     optional ``lr_scheduler.state_dict()`` (#118)
+``scheduler_class``          optional class name guarding the restore (#118)
+===========================  ============================================
+
+**The format is append-only.** New keys are added with ``.get()`` on the read
+side and never made mandatory, so a newer loader reads an older checkpoint and
+an older loader ignores what it does not know. Everything stored must survive
+``weights_only=True`` unpickling, i.e. tensors and plain Python containers --
+no arbitrary objects.
+"""
+
 import logging
 from typing import Any
 
@@ -9,7 +36,7 @@ logger = logging.getLogger(__name__)
 class CheckpointSaverNode(BaseNode):
     NODE_NAME = "CheckpointSaver"
     CATEGORY = "IO"
-    DESCRIPTION = "Save a full training checkpoint (model + optimizer + epoch + loss) for resuming training later"
+    DESCRIPTION = "Save a full training checkpoint (model + optimizer + LR schedule + epoch + loss) for resuming training later"
 
     @classmethod
     def define_inputs(cls) -> list[PortDefinition]:
@@ -17,6 +44,12 @@ class CheckpointSaverNode(BaseNode):
             PortDefinition(name="model", data_type=DataType.MODEL, description="Trained model"),
             PortDefinition(name="optimizer", data_type=DataType.OPTIMIZER, description="Optimizer state"),
             PortDefinition(name="losses", data_type=DataType.TENSOR, description="Loss history", optional=True),
+            PortDefinition(
+                name="lr_scheduler",
+                data_type=DataType.ANY,
+                description="LR scheduler whose position in the schedule to store",
+                optional=True,
+            ),
         ]
 
     @classmethod
@@ -52,6 +85,7 @@ class CheckpointSaverNode(BaseNode):
         model = inputs["model"]
         optimizer = inputs["optimizer"]
         losses = inputs.get("losses")
+        lr_scheduler = inputs.get("lr_scheduler")
         path = params.get("path", "checkpoint.pt")
         epoch = params.get("epoch", 0)
 
@@ -74,9 +108,18 @@ class CheckpointSaverNode(BaseNode):
         }
         if losses is not None:
             checkpoint["losses"] = losses
+        if lr_scheduler is not None:
+            # #118: without this the LR schedule restarts from scratch on
+            # resume. The class name is stored alongside so the loader can
+            # refuse to splice a StepLR state into a CosineAnnealingLR.
+            checkpoint["scheduler_state_dict"] = lr_scheduler.state_dict()
+            checkpoint["scheduler_class"] = type(lr_scheduler).__name__
 
         torch.save(checkpoint, str(p))
-        logger.info("Saved checkpoint to %s (epoch=%d)", p, epoch)
+        logger.info(
+            "Saved checkpoint to %s (epoch=%d, scheduler=%s)",
+            p, epoch, checkpoint.get("scheduler_class", "none"),
+        )
 
         return {"path": str(p), "model": model}
 
@@ -84,7 +127,7 @@ class CheckpointSaverNode(BaseNode):
 class CheckpointLoaderNode(BaseNode):
     NODE_NAME = "CheckpointLoader"
     CATEGORY = "IO"
-    DESCRIPTION = "Load a training checkpoint to resume training (restores model + optimizer + epoch)"
+    DESCRIPTION = "Load a training checkpoint to resume training (restores model + optimizer + LR schedule + epoch)"
 
     # The cache key hashes `path`, never the checkpoint behind it. Saving a
     # newer checkpoint to the same path between runs is the whole point of
@@ -96,6 +139,12 @@ class CheckpointLoaderNode(BaseNode):
         return [
             PortDefinition(name="model", data_type=DataType.MODEL, description="Model architecture to load weights into"),
             PortDefinition(name="optimizer", data_type=DataType.OPTIMIZER, description="Optimizer to restore state into"),
+            PortDefinition(
+                name="lr_scheduler",
+                data_type=DataType.ANY,
+                description="LR scheduler to restore its position in the schedule into",
+                optional=True,
+            ),
         ]
 
     @classmethod
@@ -103,8 +152,9 @@ class CheckpointLoaderNode(BaseNode):
         return [
             PortDefinition(name="model", data_type=DataType.MODEL, description="Model with restored weights"),
             PortDefinition(name="optimizer", data_type=DataType.OPTIMIZER, description="Optimizer with restored state"),
-            PortDefinition(name="epoch", data_type=DataType.SCALAR, description="Epoch number from checkpoint"),
+            PortDefinition(name="epoch", data_type=DataType.SCALAR, description="Epoch number from checkpoint (wire to TrainingLoop.start_epoch)"),
             PortDefinition(name="losses", data_type=DataType.TENSOR, description="Loss history from checkpoint"),
+            PortDefinition(name="lr_scheduler", data_type=DataType.ANY, description="LR scheduler with restored state (None if none was wired in)"),
         ]
 
     @classmethod
@@ -135,6 +185,7 @@ class CheckpointLoaderNode(BaseNode):
 
         model = inputs["model"]
         optimizer = inputs["optimizer"]
+        lr_scheduler = inputs.get("lr_scheduler")
         path = params.get("path", "checkpoint.pt")
         device = resolve_node_device(params.get("device"), context)
 
@@ -171,6 +222,42 @@ class CheckpointLoaderNode(BaseNode):
                 if isinstance(v, torch.Tensor):
                     state[k] = to_device(v, device)
 
+        # LR schedule (#118). Restored AFTER the optimizer on purpose: the
+        # optimizer state dict carries the learning rate that was live when the
+        # checkpoint was taken, and ``LRScheduler.load_state_dict`` does not
+        # touch ``param_groups``, so this order leaves both consistent.
+        #
+        # Every branch below is a no-op-with-a-log rather than an error, so a
+        # checkpoint written before this key existed still loads (and so does a
+        # newer checkpoint read by a graph that has no scheduler wired in).
+        scheduler_state = checkpoint.get("scheduler_state_dict")
+        if lr_scheduler is not None and scheduler_state is not None:
+            saved_class = checkpoint.get("scheduler_class")
+            live_class = type(lr_scheduler).__name__
+            if saved_class and saved_class != live_class:
+                logger.warning(
+                    "Checkpoint holds %s state but a %s is wired in; leaving the "
+                    "scheduler untouched rather than restoring incompatible state.",
+                    saved_class, live_class,
+                )
+            else:
+                lr_scheduler.load_state_dict(scheduler_state)
+                logger.info(
+                    "Restored %s at last_epoch=%s",
+                    live_class, getattr(lr_scheduler, "last_epoch", "?"),
+                )
+        elif lr_scheduler is not None:
+            logger.info(
+                "Checkpoint %s holds no scheduler state (written before it was "
+                "recorded); the LR schedule will be fast-forwarded from start_epoch "
+                "instead.", p,
+            )
+        elif scheduler_state is not None:
+            logger.info(
+                "Checkpoint %s holds scheduler state but no scheduler is wired into "
+                "this loader; it will be ignored.", p,
+            )
+
         epoch = checkpoint.get("epoch", 0)
         losses = checkpoint.get("losses", torch.tensor([]))
 
@@ -181,4 +268,5 @@ class CheckpointLoaderNode(BaseNode):
             "optimizer": optimizer,
             "epoch": epoch,
             "losses": losses,
+            "lr_scheduler": lr_scheduler,
         }

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -147,9 +147,9 @@ def _prepare_optimizer(optimizer: Any, model: Any) -> tuple[Any, str]:
     accepted = set(inspect.signature(optimizer_cls.__init__).parameters)
     optimizer_kwargs = {k: v for k, v in optimizer.defaults.items() if k in accepted}
     logger.warning(
-        "Optimizer %s tracks %d parameters but the model has %d; it was built for a "
-        "different model, so a fresh one is being constructed and any optimizer "
-        "state is discarded.",
+        "Optimizer %s tracks %d parameter tensors that do not match the model's %d "
+        "in count or shape, so it was built for a different model: constructing a "
+        "fresh one and discarding any optimizer state.",
         optimizer_cls.__name__, len(tracked), len(model_params),
     )
     return optimizer_cls(model.parameters(), **optimizer_kwargs), "rebuilt"

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -147,10 +147,12 @@ def _prepare_optimizer(optimizer: Any, model: Any) -> tuple[Any, str]:
     accepted = set(inspect.signature(optimizer_cls.__init__).parameters)
     optimizer_kwargs = {k: v for k, v in optimizer.defaults.items() if k in accepted}
     logger.warning(
-        "Optimizer %s tracks %d parameter tensors that do not match the model's %d "
-        "in count or shape, so it was built for a different model: constructing a "
-        "fresh one and discarding any optimizer state.",
-        optimizer_cls.__name__, len(tracked), len(model_params),
+        "Optimizer %s tracks %d parameter tensors that do not line up with the "
+        "model's %d (count or shape), so its state cannot be re-keyed onto this "
+        "model. Constructing a fresh %s over model.parameters() and discarding any "
+        "optimizer state. Note this also widens a deliberately partial optimizer "
+        "(e.g. one built over an unfrozen head only) to every parameter.",
+        optimizer_cls.__name__, len(tracked), len(model_params), optimizer_cls.__name__,
     )
     return optimizer_cls(model.parameters(), **optimizer_kwargs), "rebuilt"
 
@@ -180,8 +182,11 @@ def _fast_forward_scheduler(lr_scheduler: Any, optimizer: Any, start_epoch: int)
 
     Returns True when the scheduler was advanced. ``ReduceLROnPlateau`` is
     metric-driven and cannot be replayed without the original loss history, so
-    it is left alone with a warning.
+    it is left alone with a warning. A scheduler that raises mid-replay is
+    likewise left where it is with a warning: an unusable schedule must not
+    take the training run down with it.
     """
+    import re
     import warnings
 
     import torch.optim.lr_scheduler as sched_module
@@ -203,11 +208,31 @@ def _fast_forward_scheduler(lr_scheduler: Any, optimizer: Any, start_epoch: int)
             group["lr"] = base_lr
 
     with warnings.catch_warnings():
-        # The first replayed step() precedes any optimizer.step() on this
-        # scheduler instance, which torch warns about. Here it is expected.
-        warnings.simplefilter("ignore", UserWarning)
-        for _ in range(start_epoch):
-            lr_scheduler.step()
+        # The replay calls step() before this scheduler instance has seen an
+        # optimizer.step(), which torch warns about twice over. Both are
+        # expected here and only here -- suppress those two messages by name
+        # rather than every UserWarning the schedule might legitimately raise
+        # (OneCycleLR's "stepped past total_steps", say).
+        for prefix in (
+            "Detected call of `lr_scheduler.step()` before `optimizer.step()`",
+            "Seems like `optimizer.step()` has been overridden",
+        ):
+            warnings.filterwarnings(
+                "ignore", message=re.escape(prefix), category=UserWarning
+            )
+        for completed in range(start_epoch):
+            try:
+                lr_scheduler.step()
+            except Exception:  # noqa: BLE001 - a broken schedule must not fail the run
+                logger.warning(
+                    "%s raised while replaying epoch %d of %d; leaving it at "
+                    "last_epoch=%s and training on. Wire the scheduler through "
+                    "CheckpointSaver/CheckpointLoader to restore it exactly.",
+                    type(lr_scheduler).__name__, completed + 1, start_epoch,
+                    getattr(lr_scheduler, "last_epoch", "?"),
+                    exc_info=True,
+                )
+                return False
     return True
 
 
@@ -246,8 +271,22 @@ def _prepare_scheduler(
         else:
             logger.info("Re-pointed %s at the optimizer being trained", name)
 
-    if getattr(lr_scheduler, "last_epoch", 0) > 0:
-        logger.info("%s resumes at last_epoch=%d (restored state)", name, lr_scheduler.last_epoch)
+    last_epoch = getattr(lr_scheduler, "last_epoch", 0)
+    if last_epoch > 0:
+        if last_epoch != start_epoch:
+            # The desync this issue exists to eliminate: the schedule and the
+            # epoch counter disagree about where the run is. Trust the
+            # scheduler's own state (it is the only faithful record for a
+            # metric-driven or hand-built schedule) but say so loudly.
+            logger.warning(
+                "%s is at last_epoch=%d but training resumes at epoch %d. The "
+                "learning rate will follow the scheduler, not start_epoch. This "
+                "usually means the checkpoint's scheduler state and its epoch were "
+                "written at different times.",
+                name, last_epoch, start_epoch,
+            )
+        else:
+            logger.info("%s resumes at last_epoch=%d (restored state)", name, last_epoch)
     elif start_epoch > 0 and _fast_forward_scheduler(lr_scheduler, optimizer, start_epoch):
         logger.info("Fast-forwarded %s to last_epoch=%d", name, lr_scheduler.last_epoch)
 
@@ -255,6 +294,26 @@ def _prepare_scheduler(
 
 
 class TrainingLoopNode(BaseNode):
+    """Train a model, optionally resuming a previous run.
+
+    **Indexing basis (#118).** Two things are counted differently and the
+    difference is deliberate:
+
+    * *Epoch numbers are absolute* -- they index the whole training run, not
+      this call. ``epochs`` is the absolute target, the loop runs
+      ``range(start_epoch, epochs)``, and the epoch numbers in the log lines,
+      the ``epoch`` field of progress events and ``metrics["best_epoch"]`` are
+      all the absolute one. Resuming at 2 with ``epochs=4`` reports "3/4" and
+      "4/4".
+    * *Arrays are per call* -- the ``losses`` and ``val_losses`` outputs, the
+      ``losses`` field of progress events and ``metrics["lr_history"]`` cover
+      only the epochs **this** call ran. A resumed leg's ``losses`` therefore
+      holds the remaining epochs alone, not the whole history; the earlier
+      epochs live in the checkpoint's ``losses``. Map array index to absolute
+      epoch with ``metrics["start_epoch"]``, which progress events also carry
+      as ``start_epoch`` whenever it is non-zero.
+    """
+
     NODE_NAME = "TrainingLoop"
     CATEGORY = "Training"
     DESCRIPTION = (

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -6,6 +6,254 @@ from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, Po
 logger = logging.getLogger(__name__)
 
 
+def _coerce_start_epoch(value: Any) -> int:
+    """Read an epoch index off the ``start_epoch`` SCALAR port.
+
+    ``CheckpointLoader.epoch`` hands back whatever was stored in the
+    checkpoint, which is normally a plain ``int`` but may be a 0-dim tensor
+    (older checkpoints written by hand) or a float. Anything unusable degrades
+    to 0 -- "start from the beginning" -- with a warning, never an exception.
+    """
+    if value is None:
+        return 0
+    if hasattr(value, "item") and not isinstance(value, (int, float, bool)):
+        try:
+            value = value.item()
+        except Exception:  # noqa: BLE001 - any odd object means "no offset"
+            logger.warning("start_epoch %r is not readable as a number; starting from 0", value)
+            return 0
+    try:
+        epoch = int(value)
+    except (TypeError, ValueError):
+        logger.warning("start_epoch %r is not a number; starting from 0", value)
+        return 0
+    if epoch < 0:
+        logger.warning("start_epoch %d is negative; starting from 0", epoch)
+        return 0
+    return epoch
+
+
+def _tracked_params(optimizer: Any) -> list[Any]:
+    """Every parameter the optimizer currently owns, in param-group order."""
+    return [p for group in optimizer.param_groups for p in group["params"]]
+
+
+def _sync_optimizer_state_device(optimizer: Any) -> None:
+    """Move stranded optimizer state onto the device of its parameter.
+
+    ``model.to(device)`` swaps each ``Parameter``'s storage in place but leaves
+    the optimizer's momentum / moment buffers wherever they were, which blows
+    up on the first ``optimizer.step()`` with a device mismatch. The repair is
+    a ``state_dict()`` round-trip rather than a manual ``.to()`` sweep, because
+    ``Optimizer.load_state_dict`` applies torch's own per-key device policy --
+    notably it keeps the 0-dim ``step`` counter on the CPU for non-fused,
+    non-capturable optimizers, which a blanket ``.to(device)`` would break.
+
+    The scan deliberately ignores 0-dim tensors for the same reason: those are
+    the scalar step counters that are *supposed* to stay on the CPU.
+    """
+    import torch
+
+    stranded = any(
+        isinstance(value, torch.Tensor)
+        and value.dim() > 0
+        and value.device != param.device
+        for param, state in optimizer.state.items()
+        # A state dict loaded with unmatched parameter ids leaves plain ints as
+        # keys; those carry no device to compare against.
+        if isinstance(param, torch.Tensor)
+        for value in state.values()
+    )
+    if stranded:
+        optimizer.load_state_dict(optimizer.state_dict())
+
+
+def _prepare_optimizer(optimizer: Any, model: Any) -> tuple[Any, str]:
+    """Bind ``optimizer`` to ``model``'s current parameters, keeping its state.
+
+    #118: this used to unconditionally rebuild the optimizer from
+    ``type(optimizer)(model.parameters(), **optimizer.defaults)``, which threw
+    away exactly the state a resume needs (Adam's ``exp_avg``/``exp_avg_sq``
+    and step count, SGD's momentum buffer). The rebuild existed to re-bind the
+    optimizer to parameters that ``model.to(device)`` had replaced -- a much
+    smaller problem than the one it caused.
+
+    The resume rule, in order:
+
+    ``reused``
+        Every parameter the optimizer tracks *is* (object identity) the
+        corresponding parameter of the model, in order. The optimizer is used
+        untouched, so all of its state survives. Only stranded state tensors
+        are moved (see :func:`_sync_optimizer_state_device`).
+
+    ``rebound``
+        The optimizer tracks a different set of parameter *objects* but a
+        structurally identical one (same count, same shapes, same dtypes) --
+        e.g. a torch build where a device move allocates fresh ``Parameter``
+        objects, or a graph that feeds a differently-constructed instance of
+        the same architecture. Each group's ``params`` list is re-pointed at
+        the model's parameters positionally and the optimizer's own
+        ``state_dict()`` is loaded straight back, which is how torch re-keys
+        per-parameter state onto new parameter objects. Hyperparameters,
+        including per-group overrides, are preserved.
+
+    ``rebuilt``
+        The optimizer belongs to a *different* model (different parameter
+        count or shapes), so its state is meaningless here. A fresh optimizer
+        of the same class is constructed over ``model.parameters()`` and a
+        warning is logged.
+
+    Note that the check is on the *parameters*, not on the module object:
+    ``nn.Module.to()`` mutates in place and returns ``self``, so the module is
+    always the same object after a device move while its parameters may or may
+    not be, depending on the torch version. Comparing parameters is the check
+    that actually detects a stale binding.
+    """
+    model_params = list(model.parameters())
+    tracked = _tracked_params(optimizer)
+
+    if len(tracked) == len(model_params) and all(
+        a is b for a, b in zip(tracked, model_params)
+    ):
+        _sync_optimizer_state_device(optimizer)
+        return optimizer, "reused"
+
+    structurally_same = len(tracked) == len(model_params) and all(
+        a.shape == b.shape and a.dtype == b.dtype
+        for a, b in zip(tracked, model_params)
+    )
+    if structurally_same:
+        saved = optimizer.state_dict()
+        offset = 0
+        for group in optimizer.param_groups:
+            count = len(group["params"])
+            group["params"] = model_params[offset:offset + count]
+            offset += count
+        # Re-keys `state` from positional ids onto the parameters just bound,
+        # and casts each state tensor to that parameter's device/dtype.
+        optimizer.load_state_dict(saved)
+        return optimizer, "rebound"
+
+    # Filter ``defaults`` to keys the constructor actually accepts. PyTorch
+    # 2.11 added ``decoupled_weight_decay`` to Adam's defaults, but AdamW
+    # (an Adam subclass) re-routes that internally and rejects it as a
+    # public kwarg -- a naive ``**defaults`` round-trip raises
+    # ``AdamW.__init__() got an unexpected keyword argument
+    # 'decoupled_weight_decay'``. Filtering by signature keeps the rebuild
+    # robust against future upstream churn.
+    import inspect
+
+    optimizer_cls = type(optimizer)
+    accepted = set(inspect.signature(optimizer_cls.__init__).parameters)
+    optimizer_kwargs = {k: v for k, v in optimizer.defaults.items() if k in accepted}
+    logger.warning(
+        "Optimizer %s tracks %d parameters but the model has %d; it was built for a "
+        "different model, so a fresh one is being constructed and any optimizer "
+        "state is discarded.",
+        optimizer_cls.__name__, len(tracked), len(model_params),
+    )
+    return optimizer_cls(model.parameters(), **optimizer_kwargs), "rebuilt"
+
+
+def _fast_forward_scheduler(lr_scheduler: Any, optimizer: Any, start_epoch: int) -> bool:
+    """Advance a never-stepped scheduler to where epoch ``start_epoch`` begins.
+
+    #118 asked for ``last_epoch=start_epoch - 1`` at construction time. The
+    observable end state here is the same (``last_epoch == start_epoch``) but
+    the mechanism is a replay of ``start_epoch`` ``step()`` calls from the
+    scheduler's ``base_lrs``, because reconstructing is measurably wrong:
+
+    * ``StepLR``/``ExponentialLR``/``CosineAnnealingLR`` derive the next LR
+      from the optimizer's **current** ``lr``, and on a resume that value has
+      already been overwritten with the decayed LR out of the checkpoint. A
+      ``last_epoch=k`` rebuild therefore decays an already-decayed LR (with
+      lr0=0.1, gamma=0.1, step_size=2 and start_epoch=2 it yields 0.001 where
+      the straight run is at 0.01).
+    * a rebuild leaves ``_step_count == 1``, which the issue explicitly calls
+      out as the thing that must not be dropped, and which changes
+      ``CosineAnnealingLR``'s closed-form/recursive branch.
+    * a rebuild has to guess constructor kwargs out of ``state_dict()``, which
+      does not round-trip for every scheduler type.
+
+    The replay performs exactly the same float operations in the same order as
+    the straight run, so the resumed LR trajectory is bit-identical to it.
+
+    Returns True when the scheduler was advanced. ``ReduceLROnPlateau`` is
+    metric-driven and cannot be replayed without the original loss history, so
+    it is left alone with a warning.
+    """
+    import warnings
+
+    import torch.optim.lr_scheduler as sched_module
+
+    if isinstance(lr_scheduler, sched_module.ReduceLROnPlateau):
+        logger.warning(
+            "ReduceLROnPlateau is driven by the validation metric and cannot be "
+            "replayed from start_epoch=%d. Wire the scheduler through "
+            "CheckpointSaver/CheckpointLoader to restore its state exactly.",
+            start_epoch,
+        )
+        return False
+
+    base_lrs = getattr(lr_scheduler, "base_lrs", None)
+    if base_lrs and len(base_lrs) == len(optimizer.param_groups):
+        # Replay from the schedule's own starting point, not from whatever LR
+        # the restored optimizer state left in the param groups.
+        for group, base_lr in zip(optimizer.param_groups, base_lrs):
+            group["lr"] = base_lr
+
+    with warnings.catch_warnings():
+        # The first replayed step() precedes any optimizer.step() on this
+        # scheduler instance, which torch warns about. Here it is expected.
+        warnings.simplefilter("ignore", UserWarning)
+        for _ in range(start_epoch):
+            lr_scheduler.step()
+    return True
+
+
+def _prepare_scheduler(
+    lr_scheduler: Any, optimizer: Any, start_epoch: int, optimizer_mode: str
+) -> Any:
+    """Attach the scheduler to ``optimizer`` and position it at ``start_epoch``.
+
+    Three situations, in order of preference:
+
+    1. the scheduler already carries restored state (``last_epoch > 0``, which
+       is what ``CheckpointLoader`` produces when the checkpoint holds a
+       ``scheduler_state_dict``) -- it is left exactly as it is, which is the
+       only way to resume a ``ReduceLROnPlateau`` or a hand-built schedule
+       faithfully;
+    2. the scheduler is fresh and ``start_epoch > 0`` -- it is fast-forwarded
+       (see :func:`_fast_forward_scheduler`);
+    3. neither -- nothing to do.
+
+    Independently of the above, a scheduler pointing at a *replaced* optimizer
+    is re-pointed at the live one. Re-pointing rather than reconstructing keeps
+    ``last_epoch``/``_step_count``/``base_lrs`` and works for scheduler types
+    whose constructor arguments cannot be recovered from ``state_dict()``.
+    """
+    if lr_scheduler is None:
+        return None
+
+    name = type(lr_scheduler).__name__
+    if getattr(lr_scheduler, "optimizer", optimizer) is not optimizer:
+        lr_scheduler.optimizer = optimizer
+        if optimizer_mode == "rebuilt":
+            logger.warning(
+                "The optimizer had to be rebuilt, so %s is now driving an optimizer "
+                "it was not created for; its schedule may not line up.", name,
+            )
+        else:
+            logger.info("Re-pointed %s at the optimizer being trained", name)
+
+    if getattr(lr_scheduler, "last_epoch", 0) > 0:
+        logger.info("%s resumes at last_epoch=%d (restored state)", name, lr_scheduler.last_epoch)
+    elif start_epoch > 0 and _fast_forward_scheduler(lr_scheduler, optimizer, start_epoch):
+        logger.info("Fast-forwarded %s to last_epoch=%d", name, lr_scheduler.last_epoch)
+
+    return lr_scheduler
+
+
 class TrainingLoopNode(BaseNode):
     NODE_NAME = "TrainingLoop"
     CATEGORY = "Training"
@@ -23,6 +271,15 @@ class TrainingLoopNode(BaseNode):
             PortDefinition(name="loss_fn", data_type=DataType.LOSS_FN, description="Loss function"),
             PortDefinition(name="val_dataloader", data_type=DataType.DATALOADER, description="Validation data loader", optional=True),
             PortDefinition(name="lr_scheduler", data_type=DataType.ANY, description="Learning rate scheduler", optional=True),
+            PortDefinition(
+                name="start_epoch",
+                data_type=DataType.SCALAR,
+                description=(
+                    "Resume from this epoch (0-based). Wire CheckpointLoader.epoch here; "
+                    "the loop then runs epochs start_epoch..epochs-1"
+                ),
+                optional=True,
+            ),
         ]
 
     @classmethod
@@ -79,6 +336,7 @@ class TrainingLoopNode(BaseNode):
         loss_fn = inputs["loss_fn"]
         val_dataloader = inputs.get("val_dataloader")
         lr_scheduler = inputs.get("lr_scheduler")
+        start_epoch = _coerce_start_epoch(inputs.get("start_epoch"))
 
         epochs = params.get("epochs", 5)
         device = resolve_node_device(params.get("device"), context)
@@ -88,43 +346,16 @@ class TrainingLoopNode(BaseNode):
         model = to_device(model, device)
         loss_fn = to_device(loss_fn, device)
 
-        # Recreate the optimizer so its param list, momentum buffers and state are
-        # freshly bound to the moved model parameters. The Optimizer node runs before
-        # TrainingLoop with the model still on CPU, so any optimizer created there
-        # holds stale references / state. Preserving the original class + defaults
-        # keeps the user's choices (Adam/SGD/..., lr, weight_decay, etc.) intact.
-        #
-        # Filter ``defaults`` to keys the constructor actually accepts. PyTorch
-        # 2.11 added ``decoupled_weight_decay`` to Adam's defaults, but AdamW
-        # (an Adam subclass) re-routes that internally and rejects it as a
-        # public kwarg — a naive ``**defaults`` round-trip raises
-        # ``AdamW.__init__() got an unexpected keyword argument 'decoupled_weight_decay'``.
-        # Filtering by signature keeps the rebind robust against future
-        # upstream churn.
-        import inspect
-        optimizer_cls = type(optimizer)
-        accepted = set(inspect.signature(optimizer_cls.__init__).parameters)
-        optimizer_kwargs = {
-            k: v for k, v in optimizer.defaults.items() if k in accepted
-        }
-        optimizer = optimizer_cls(model.parameters(), **optimizer_kwargs)
+        # #118: keep the incoming optimizer (and therefore its state) whenever
+        # it is usable for this model -- see _prepare_optimizer for the rule.
+        optimizer, optimizer_mode = _prepare_optimizer(optimizer, model)
+        lr_scheduler = _prepare_scheduler(lr_scheduler, optimizer, start_epoch, optimizer_mode)
 
-        # If an LR scheduler was passed in, rebind it to the new optimizer using
-        # the same class and non-optimizer init arguments.
-        if lr_scheduler is not None:
-            scheduler_cls = type(lr_scheduler)
-            # Only keep primitive/scalar state to re-init the scheduler cleanly
-            scheduler_init_kwargs: dict[str, Any] = {}
-            for key, value in lr_scheduler.state_dict().items():
-                if key in ("base_lrs", "_last_lr", "last_epoch", "_step_count", "verbose", "_get_lr_called_within_step"):
-                    continue
-                if isinstance(value, (int, float, str, bool, list, tuple)):
-                    scheduler_init_kwargs[key] = value
-            try:
-                lr_scheduler = scheduler_cls(optimizer, **scheduler_init_kwargs)
-            except TypeError:
-                # Couldn't reconstruct — fall back to manual optimizer attachment.
-                lr_scheduler.optimizer = optimizer
+        if start_epoch >= epochs:
+            logger.warning(
+                "start_epoch=%d is at or past epochs=%d; no epoch will run.",
+                start_epoch, epochs,
+            )
 
         # Training config for frontend display
         param_count = sum(p.numel() for p in model.parameters())
@@ -137,6 +368,7 @@ class TrainingLoopNode(BaseNode):
             "lr": optimizer.param_groups[0].get("lr", "N/A"),
             "loss_fn": loss_fn.__class__.__name__,
             "epochs": epochs,
+            "start_epoch": start_epoch,
             "device": device,
             "batch_size": getattr(dataloader, "batch_size", "N/A"),
             "early_stopping": patience > 0,
@@ -159,7 +391,11 @@ class TrainingLoopNode(BaseNode):
         best_state_dict = None
         patience_counter = 0
 
-        for epoch in range(epochs):
+        # ``epoch`` is the ABSOLUTE epoch index for the whole training run, not
+        # an offset into this call: a resume at start_epoch=2 with epochs=4 runs
+        # epochs 2 and 3, and every epoch number it reports (logs, progress
+        # events, best_epoch) is that absolute number.
+        for epoch in range(start_epoch, epochs):
             # ── Training phase ──
             model.train()
             running_loss = 0.0
@@ -273,6 +509,12 @@ class TrainingLoopNode(BaseNode):
                 if patience > 0:
                     progress_data["patience_counter"] = patience_counter
                     progress_data["best_epoch"] = best_epoch
+                if start_epoch > 0:
+                    # ``losses`` only covers the epochs THIS call ran, so a
+                    # consumer plotting it against absolute epochs needs the
+                    # offset. Omitted entirely when there is none, so a normal
+                    # run's payload is byte-for-byte what it was before #118.
+                    progress_data["start_epoch"] = start_epoch
                 progress_callback(progress_data)
 
             if stopped_early:
@@ -287,11 +529,15 @@ class TrainingLoopNode(BaseNode):
         losses_tensor = torch.tensor(epoch_losses, dtype=torch.float32)
         val_losses_tensor = torch.tensor(val_epoch_losses, dtype=torch.float32) if val_epoch_losses else torch.tensor([], dtype=torch.float32)
 
+        # Epoch numbers are absolute; counts are for this call only.
+        # ``best_epoch`` keeps its pre-#118 value when start_epoch is 0.
         metrics = {
             "final_train_loss": epoch_losses[-1] if epoch_losses else 0.0,
             "final_val_loss": val_epoch_losses[-1] if val_epoch_losses else None,
-            "best_epoch": best_epoch if patience > 0 else len(epoch_losses),
+            "best_epoch": best_epoch if patience > 0 else start_epoch + len(epoch_losses),
             "total_epochs_run": len(epoch_losses),
+            "start_epoch": start_epoch,
+            "last_epoch": start_epoch + len(epoch_losses),
             "stopped_early": best_state_dict is not None and patience_counter >= patience,
             "lr_history": lr_history,
         }

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -210,9 +210,10 @@ def _fast_forward_scheduler(lr_scheduler: Any, optimizer: Any, start_epoch: int)
     with warnings.catch_warnings():
         # The replay calls step() before this scheduler instance has seen an
         # optimizer.step(), which torch warns about twice over. Both are
-        # expected here and only here -- suppress those two messages by name
-        # rather than every UserWarning the schedule might legitimately raise
-        # (OneCycleLR's "stepped past total_steps", say).
+        # expected here and only here -- so suppress those two messages by
+        # name. A blanket UserWarning filter would also swallow whatever the
+        # schedule itself (or a plugin's custom scheduler) has to say, which
+        # the user needs to see.
         for prefix in (
             "Detected call of `lr_scheduler.step()` before `optimizer.step()`",
             "Seems like `optimizer.step()` has been overridden",

--- a/backend/tests/test_checkpoint_node.py
+++ b/backend/tests/test_checkpoint_node.py
@@ -72,3 +72,106 @@ def test_load_missing_checkpoint_raises():
             {"model": model, "optimizer": opt},
             {"path": "_does_not_exist.pt", "device": "cpu"},
         )
+
+
+# --- scheduler state in the payload (#118) --------------------------------
+
+
+def _advanced_scheduler(opt, steps=3):
+    """A StepLR that has already walked ``steps`` epochs of its schedule."""
+    sched = torch.optim.lr_scheduler.StepLR(opt, step_size=2, gamma=0.5)
+    for _ in range(steps):
+        opt.step()
+        sched.step()
+    return sched
+
+
+def test_scheduler_state_roundtrip():
+    settings.MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    target = "_ckpt_sched.pt"
+    try:
+        model, opt = _model_and_opt()
+        sched = _advanced_scheduler(opt)
+
+        CheckpointSaverNode().execute(
+            {"model": model, "optimizer": opt, "lr_scheduler": sched},
+            {"path": target, "epoch": 3},
+        )
+        raw = torch.load(settings.MODELS_DIR / target, map_location="cpu", weights_only=True)
+        assert raw["scheduler_class"] == "StepLR"
+        assert raw["scheduler_state_dict"]["last_epoch"] == 3
+
+        new_model, new_opt = _model_and_opt()
+        new_sched = torch.optim.lr_scheduler.StepLR(new_opt, step_size=2, gamma=0.5)
+        res = CheckpointLoaderNode().execute(
+            {"model": new_model, "optimizer": new_opt, "lr_scheduler": new_sched},
+            {"path": target, "device": "cpu"},
+        )
+
+        assert res["lr_scheduler"] is new_sched
+        assert new_sched.last_epoch == sched.last_epoch
+        assert new_sched._step_count == sched._step_count
+        assert new_sched.base_lrs == sched.base_lrs
+        assert new_sched.get_last_lr() == sched.get_last_lr()
+    finally:
+        (settings.MODELS_DIR / target).unlink(missing_ok=True)
+
+
+def test_checkpoint_omits_scheduler_key_when_none_wired():
+    """The key is additive: an unwired scheduler leaves the payload as it was."""
+    settings.MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    target = "_ckpt_no_sched.pt"
+    try:
+        model, opt = _model_and_opt()
+        CheckpointSaverNode().execute(
+            {"model": model, "optimizer": opt},
+            {"path": target, "epoch": 1},
+        )
+        raw = torch.load(settings.MODELS_DIR / target, map_location="cpu", weights_only=True)
+        assert set(raw) == {"epoch", "model_state_dict", "optimizer_state_dict"}
+    finally:
+        (settings.MODELS_DIR / target).unlink(missing_ok=True)
+
+
+def test_loader_refuses_scheduler_state_from_a_different_class():
+    """StepLR state spliced into a CosineAnnealingLR would corrupt it."""
+    settings.MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    target = "_ckpt_sched_mismatch.pt"
+    try:
+        model, opt = _model_and_opt()
+        CheckpointSaverNode().execute(
+            {"model": model, "optimizer": opt, "lr_scheduler": _advanced_scheduler(opt)},
+            {"path": target, "epoch": 3},
+        )
+
+        new_model, new_opt = _model_and_opt()
+        other = torch.optim.lr_scheduler.CosineAnnealingLR(new_opt, T_max=10)
+        CheckpointLoaderNode().execute(
+            {"model": new_model, "optimizer": new_opt, "lr_scheduler": other},
+            {"path": target, "device": "cpu"},
+        )
+
+        assert other.last_epoch == 0
+        assert not hasattr(other, "step_size")
+    finally:
+        (settings.MODELS_DIR / target).unlink(missing_ok=True)
+
+
+def test_loader_reports_no_scheduler_when_none_wired():
+    settings.MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    target = "_ckpt_sched_unused.pt"
+    try:
+        model, opt = _model_and_opt()
+        CheckpointSaverNode().execute(
+            {"model": model, "optimizer": opt, "lr_scheduler": _advanced_scheduler(opt)},
+            {"path": target, "epoch": 3},
+        )
+        new_model, new_opt = _model_and_opt()
+        res = CheckpointLoaderNode().execute(
+            {"model": new_model, "optimizer": new_opt},
+            {"path": target, "device": "cpu"},
+        )
+        assert res["lr_scheduler"] is None
+        assert res["epoch"] == 3
+    finally:
+        (settings.MODELS_DIR / target).unlink(missing_ok=True)

--- a/backend/tests/test_checkpoint_node.py
+++ b/backend/tests/test_checkpoint_node.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 
 from app.config import settings
 from app.nodes.io.checkpoint_node import CheckpointLoaderNode, CheckpointSaverNode
+from app.nodes.training.lr_scheduler_node import LRSchedulerNode
 
 
 def _model_and_opt():
@@ -77,42 +78,90 @@ def test_load_missing_checkpoint_raises():
 # --- scheduler state in the payload (#118) --------------------------------
 
 
-def _advanced_scheduler(opt, steps=3):
-    """A StepLR that has already walked ``steps`` epochs of its schedule."""
-    sched = torch.optim.lr_scheduler.StepLR(opt, step_size=2, gamma=0.5)
-    for _ in range(steps):
+# Every scheduler LRSchedulerNode can build, read off the node itself so a
+# newly supported type is covered the moment it is added to the SELECT.
+SCHEDULER_TYPES = next(
+    p.options for p in LRSchedulerNode.define_params() if p.name == "type"
+)
+
+# Enough to satisfy every branch of LRSchedulerNode.execute() at once.
+SCHEDULER_PARAMS = {
+    "step_size": 2, "gamma": 0.5, "T_max": 10, "max_lr": 0.1, "total_steps": 20,
+}
+
+
+def _build_scheduler(sched_type, opt):
+    return LRSchedulerNode().execute(
+        {"optimizer": opt}, {"type": sched_type, **SCHEDULER_PARAMS}
+    )["scheduler"]
+
+
+def _advance(sched, opt, steps=3):
+    """Walk ``steps`` epochs so the stored state is not the initial one."""
+    plateau = isinstance(sched, torch.optim.lr_scheduler.ReduceLROnPlateau)
+    for i in range(steps):
         opt.step()
-        sched.step()
+        # ReduceLROnPlateau is metric-driven; feed a worsening metric so its
+        # bad-epoch counter moves and the state is genuinely non-trivial.
+        sched.step(1.0 + i) if plateau else sched.step()
     return sched
 
 
-def test_scheduler_state_roundtrip():
+def _advanced_scheduler(opt, steps=3):
+    """A StepLR that has already walked ``steps`` epochs of its schedule."""
+    return _advance(_build_scheduler("StepLR", opt), opt, steps)
+
+
+@pytest.mark.parametrize("sched_type", SCHEDULER_TYPES)
+def test_scheduler_state_roundtrip(sched_type):
+    """Every supported scheduler must survive save + ``weights_only=True`` load.
+
+    This is not only about the schedule. ``CheckpointLoader`` reads the whole
+    file with ``weights_only=True``, so a scheduler state dict holding a type
+    outside torch's unpickler allowlist would raise ``UnpicklingError`` and
+    take the **model weights** down with it. The saver therefore has to store
+    something the loader can always read back, for every type the
+    ``LRScheduler`` node is able to produce -- and torch has changed what those
+    state dicts contain between releases (this repo pins only ``torch>=2.0``,
+    so CI resolves whatever is newest).
+
+    The type to watch is ``MultiStepLR.milestones``, which is a
+    ``collections.Counter`` rather than a plain dict. torch allowlists it on
+    2.11 and 2.12; a release that stopped doing so, or a new scheduler holding
+    something more exotic, would fail here rather than in a user's resume.
+    """
     settings.MODELS_DIR.mkdir(parents=True, exist_ok=True)
-    target = "_ckpt_sched.pt"
+    target = f"_ckpt_sched_{sched_type}.pt"
     try:
         model, opt = _model_and_opt()
-        sched = _advanced_scheduler(opt)
+        sched = _advance(_build_scheduler(sched_type, opt), opt)
 
         CheckpointSaverNode().execute(
             {"model": model, "optimizer": opt, "lr_scheduler": sched},
             {"path": target, "epoch": 3},
         )
+
+        # The whole payload, not just the scheduler key: an unreadable
+        # scheduler state loses the model too.
         raw = torch.load(settings.MODELS_DIR / target, map_location="cpu", weights_only=True)
-        assert raw["scheduler_class"] == "StepLR"
-        assert raw["scheduler_state_dict"]["last_epoch"] == 3
+        assert raw["scheduler_class"] == type(sched).__name__
+        assert set(raw["scheduler_state_dict"]) == set(sched.state_dict())
+        assert raw["model_state_dict"].keys() == model.state_dict().keys()
 
         new_model, new_opt = _model_and_opt()
-        new_sched = torch.optim.lr_scheduler.StepLR(new_opt, step_size=2, gamma=0.5)
+        new_sched = _build_scheduler(sched_type, new_opt)
         res = CheckpointLoaderNode().execute(
             {"model": new_model, "optimizer": new_opt, "lr_scheduler": new_sched},
             {"path": target, "device": "cpu"},
         )
 
         assert res["lr_scheduler"] is new_sched
+        assert new_sched.state_dict() == sched.state_dict()
         assert new_sched.last_epoch == sched.last_epoch
-        assert new_sched._step_count == sched._step_count
-        assert new_sched.base_lrs == sched.base_lrs
-        assert new_sched.get_last_lr() == sched.get_last_lr()
+        if hasattr(sched, "_step_count"):
+            assert new_sched._step_count == sched._step_count
+        if hasattr(sched, "get_last_lr"):
+            assert new_sched.get_last_lr() == sched.get_last_lr()
     finally:
         (settings.MODELS_DIR / target).unlink(missing_ok=True)
 
@@ -153,6 +202,24 @@ def test_loader_refuses_scheduler_state_from_a_different_class():
 
         assert other.last_epoch == 0
         assert not hasattr(other, "step_size")
+    finally:
+        (settings.MODELS_DIR / target).unlink(missing_ok=True)
+
+
+def test_saver_rejects_a_non_scheduler_on_the_lr_scheduler_port():
+    """The port is ANY, so a mis-wire must fail with a readable message."""
+    settings.MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    target = "_ckpt_bad_sched.pt"
+    try:
+        model, opt = _model_and_opt()
+        with pytest.raises(ValueError, match="no state_dict"):
+            CheckpointSaverNode().execute(
+                {"model": model, "optimizer": opt, "lr_scheduler": torch.tensor([1.0])},
+                {"path": target, "epoch": 1},
+            )
+        assert not (settings.MODELS_DIR / target).exists(), (
+            "the failure must happen before anything is written"
+        )
     finally:
         (settings.MODELS_DIR / target).unlink(missing_ok=True)
 

--- a/backend/tests/test_training_resume.py
+++ b/backend/tests/test_training_resume.py
@@ -45,9 +45,14 @@ TOL = dict(rtol=1e-5, atol=1e-7)
 
 @pytest.fixture
 def ckpt_path(request):
-    """A unique checkpoint filename under MODELS_DIR, removed afterwards."""
+    """A per-test checkpoint filename under MODELS_DIR, removed afterwards.
+
+    Derived from the test id rather than a random suffix so parametrized cases
+    never collide and a file left behind by a hard crash is traceable.
+    """
     settings.MODELS_DIR.mkdir(parents=True, exist_ok=True)
-    name = f"_resume_{abs(hash(request.node.nodeid)) % (10**10)}.pt"
+    stem = "".join(c if c.isalnum() else "_" for c in request.node.name)
+    name = f"_resume_{stem}.pt"
     yield name
     (settings.MODELS_DIR / name).unlink(missing_ok=True)
 

--- a/backend/tests/test_training_resume.py
+++ b/backend/tests/test_training_resume.py
@@ -1,0 +1,603 @@
+"""Resume-from-checkpoint tests for #118.
+
+Before #118 a "resume" only restored *weights*: ``TrainingLoopNode`` threw the
+incoming optimizer away and built a fresh one, so Adam moments / SGD momentum
+buffers / step counts were lost, the epoch counter restarted at 0, and the LR
+schedule was reset. The tests here pin the three properties a real resume has
+to have:
+
+* training 4 epochs straight == training 2, checkpointing, restoring and
+  training 2 more (Adam **and** SGD+momentum),
+* the learning rate at absolute epoch N is the same on both paths,
+* a checkpoint written by the pre-#118 format (no scheduler key) still loads.
+
+Everything runs on CPU with fixed seeds and ``shuffle=False`` loaders so the
+two paths are numerically comparable.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from app.config import settings
+from app.nodes.io.checkpoint_node import CheckpointLoaderNode, CheckpointSaverNode
+from app.nodes.training.training_loop_node import (
+    TrainingLoopNode,
+    _sync_optimizer_state_device,
+)
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA not available"
+)
+
+IN_FEATURES = 4
+OUT_CLASSES = 3
+TOTAL_EPOCHS = 4
+SPLIT_EPOCH = 2
+
+# The two paths perform the same float ops in the same order, so they agree to
+# well within float32 noise; the tolerance only absorbs platform-level FMA
+# differences, not algorithmic drift.
+TOL = dict(rtol=1e-5, atol=1e-7)
+
+
+@pytest.fixture
+def ckpt_path(request):
+    """A unique checkpoint filename under MODELS_DIR, removed afterwards."""
+    settings.MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    name = f"_resume_{abs(hash(request.node.nodeid)) % (10**10)}.pt"
+    yield name
+    (settings.MODELS_DIR / name).unlink(missing_ok=True)
+
+
+def _loader(n: int = 24, batch_size: int = 6):
+    """A fixed dataset in a fixed order -- no shuffling, no per-run RNG draw."""
+    gen = torch.Generator().manual_seed(1234)
+    x = torch.randn(n, IN_FEATURES, generator=gen)
+    y = torch.randint(0, OUT_CLASSES, (n,), generator=gen)
+    dataset = torch.utils.data.TensorDataset(x, y)
+    return torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=False)
+
+
+def _model() -> nn.Module:
+    torch.manual_seed(7)
+    return nn.Linear(IN_FEATURES, OUT_CLASSES)
+
+
+def _optimizer(kind: str, model: nn.Module):
+    if kind == "adam":
+        return torch.optim.Adam(model.parameters(), lr=0.05)
+    if kind == "sgd_momentum":
+        return torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+    raise AssertionError(f"unknown optimizer kind {kind!r}")
+
+
+def _train(model, optimizer, loader, params, **inputs):
+    return TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": loader,
+            "optimizer": optimizer,
+            "loss_fn": nn.CrossEntropyLoss(),
+            **inputs,
+        },
+        {"device": "cpu", **params},
+    )
+
+
+def _assert_same_weights(left: nn.Module, right: nn.Module) -> None:
+    left_sd, right_sd = left.state_dict(), right.state_dict()
+    assert left_sd.keys() == right_sd.keys()
+    for key in left_sd:
+        assert torch.allclose(left_sd[key], right_sd[key], **TOL), (
+            f"parameter {key!r} diverged between the straight and resumed runs"
+        )
+
+
+@pytest.mark.parametrize("optimizer_kind", ["adam", "sgd_momentum"])
+def test_resume_matches_straight_run(optimizer_kind: str, ckpt_path: str) -> None:
+    """4 epochs straight == 2 epochs + checkpoint + restore + 2 epochs.
+
+    This is the headline #118 regression. It fails before the fix for both
+    optimizers because the resumed leg starts from empty optimizer state:
+    Adam restarts its bias correction and SGD restarts its momentum buffer.
+    """
+    loader = _loader()
+
+    straight_model = _model()
+    straight_opt = _optimizer(optimizer_kind, straight_model)
+    straight = _train(straight_model, straight_opt, loader, {"epochs": TOTAL_EPOCHS})
+
+    # ---- leg 1: train SPLIT_EPOCH epochs, then checkpoint --------------
+    model = _model()
+    optimizer = _optimizer(optimizer_kind, model)
+    first = _train(model, optimizer, loader, {"epochs": SPLIT_EPOCH})
+    CheckpointSaverNode().execute(
+        {"model": first["model"], "optimizer": optimizer, "losses": first["losses"]},
+        {"path": ckpt_path, "epoch": SPLIT_EPOCH},
+    )
+
+    # ---- leg 2: fresh objects, restore, train the remaining epochs -----
+    resumed_model = _model()
+    resumed_opt = _optimizer(optimizer_kind, resumed_model)
+    restored = CheckpointLoaderNode().execute(
+        {"model": resumed_model, "optimizer": resumed_opt},
+        {"path": ckpt_path, "device": "cpu"},
+    )
+    assert restored["epoch"] == SPLIT_EPOCH
+    second = _train(
+        restored["model"], restored["optimizer"], loader,
+        {"epochs": TOTAL_EPOCHS - SPLIT_EPOCH},
+    )
+
+    straight_tail = straight["losses"][SPLIT_EPOCH:].tolist()
+    assert second["losses"].tolist() == pytest.approx(straight_tail, rel=1e-5, abs=1e-7)
+    _assert_same_weights(straight["model"], second["model"])
+
+
+@pytest.mark.parametrize("optimizer_kind", ["adam", "sgd_momentum"])
+def test_resume_through_start_epoch_port(optimizer_kind: str, ckpt_path: str) -> None:
+    """The same equivalence through the wiring a user actually builds.
+
+    ``CheckpointLoader.epoch`` goes into ``TrainingLoop.start_epoch`` and the
+    ``epochs`` param keeps its absolute meaning, so the resumed node runs only
+    the epochs that are left instead of another full ``epochs`` of them.
+    """
+    loader = _loader()
+
+    straight_model = _model()
+    straight = _train(
+        straight_model, _optimizer(optimizer_kind, straight_model), loader,
+        {"epochs": TOTAL_EPOCHS},
+    )
+
+    model = _model()
+    optimizer = _optimizer(optimizer_kind, model)
+    first = _train(model, optimizer, loader, {"epochs": SPLIT_EPOCH})
+    CheckpointSaverNode().execute(
+        {"model": first["model"], "optimizer": optimizer},
+        {"path": ckpt_path, "epoch": SPLIT_EPOCH},
+    )
+
+    resumed_model = _model()
+    restored = CheckpointLoaderNode().execute(
+        {"model": resumed_model, "optimizer": _optimizer(optimizer_kind, resumed_model)},
+        {"path": ckpt_path, "device": "cpu"},
+    )
+    second = _train(
+        restored["model"], restored["optimizer"], loader,
+        {"epochs": TOTAL_EPOCHS},
+        start_epoch=restored["epoch"],
+    )
+
+    assert second["metrics"]["total_epochs_run"] == TOTAL_EPOCHS - SPLIT_EPOCH
+    assert second["metrics"]["start_epoch"] == SPLIT_EPOCH
+    assert second["metrics"]["last_epoch"] == TOTAL_EPOCHS
+    assert second["losses"].tolist() == pytest.approx(
+        straight["losses"][SPLIT_EPOCH:].tolist(), rel=1e-5, abs=1e-7
+    )
+    _assert_same_weights(straight["model"], second["model"])
+
+
+def test_optimizer_state_survives_the_training_loop() -> None:
+    """The optimizer handed to the node is the one that gets trained.
+
+    Before #118 the node built its own optimizer internally, so the object a
+    downstream ``CheckpointSaver`` sees still had empty ``state`` -- the save
+    side of a resume was broken as well as the load side.
+    """
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    assert optimizer.state == {}
+
+    result = _train(model, optimizer, _loader(), {"epochs": 1})
+
+    assert result["model"] is model
+    assert optimizer.state, "the incoming optimizer accumulated no state"
+    buffers = [s["momentum_buffer"] for s in optimizer.state.values()]
+    assert all(b is not None and b.abs().sum() > 0 for b in buffers)
+    saved = optimizer.state_dict()
+    assert saved["state"], "optimizer.state_dict() would checkpoint nothing"
+
+
+def test_start_epoch_makes_progress_events_absolute() -> None:
+    """Progress events, logs and metrics count epochs from start_epoch."""
+    model = _model()
+    events: list[dict] = []
+    TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": _loader(),
+            "optimizer": _optimizer("adam", model),
+            "loss_fn": nn.CrossEntropyLoss(),
+            "start_epoch": 3,
+        },
+        {"epochs": 5, "device": "cpu"},
+        progress_callback=events.append,
+    )
+
+    epochs = [e for e in events if e.get("event") == "epoch"]
+    assert [e["epoch"] for e in epochs] == [4, 5]
+    assert all(e["total_epochs"] == 5 for e in epochs)
+    assert all(e["start_epoch"] == 3 for e in epochs)
+
+    config = next(e for e in events if e.get("event") == "config")
+    assert config["config"]["start_epoch"] == 3
+    assert config["config"]["epochs"] == 5
+
+
+def test_progress_payload_unchanged_without_start_epoch() -> None:
+    """A non-resumed run emits exactly the keys it emitted before #118."""
+    model = _model()
+    events: list[dict] = []
+    TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": _loader(),
+            "optimizer": _optimizer("adam", model),
+            "loss_fn": nn.CrossEntropyLoss(),
+        },
+        {"epochs": 2, "device": "cpu"},
+        progress_callback=events.append,
+    )
+    epochs = [e for e in events if e.get("event") == "epoch"]
+    assert [e["epoch"] for e in epochs] == [1, 2]
+    assert all("start_epoch" not in e for e in epochs)
+
+
+def test_start_epoch_at_or_past_total_runs_nothing() -> None:
+    """Resuming a finished run is a no-op, not a crash."""
+    model = _model()
+    before = {k: v.clone() for k, v in model.state_dict().items()}
+    result = _train(
+        model, _optimizer("adam", model), _loader(), {"epochs": 3}, start_epoch=3,
+    )
+    assert result["losses"].numel() == 0
+    assert result["metrics"]["total_epochs_run"] == 0
+    for key, value in before.items():
+        assert torch.equal(value, result["model"].state_dict()[key])
+
+
+def test_start_epoch_accepts_tensor_and_rejects_garbage() -> None:
+    """The SCALAR port takes whatever a checkpoint stored; junk means 0."""
+    for value, expected in [
+        (torch.tensor(2), 2),
+        (2.0, 2),
+        (-5, 0),
+        (None, 0),
+        ("not-a-number", 0),
+    ]:
+        model = _model()
+        result = _train(
+            model, _optimizer("adam", model), _loader(), {"epochs": 3},
+            start_epoch=value,
+        )
+        assert result["metrics"]["start_epoch"] == expected, f"start_epoch={value!r}"
+
+
+def test_optimizer_is_rebound_when_parameters_are_replaced() -> None:
+    """A structurally identical model gets the optimizer's state re-keyed.
+
+    This is the ``rebound`` branch of the resume rule: different parameter
+    *objects*, same shapes. The momentum buffers have to survive and to end up
+    attached to the new parameters.
+    """
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    _train(model, optimizer, _loader(), {"epochs": 1})
+    buffers_before = [
+        s["momentum_buffer"].clone() for s in optimizer.state.values()
+    ]
+
+    replacement = _model()
+    replacement.load_state_dict(model.state_dict())
+    assert all(a is not b for a, b in zip(model.parameters(), replacement.parameters()))
+
+    _train(replacement, optimizer, _loader(), {"epochs": 1})
+
+    assert set(optimizer.state) == set(replacement.parameters())
+    assert len(optimizer.state) == len(buffers_before)
+    assert all(
+        s["momentum_buffer"] is not None for s in optimizer.state.values()
+    )
+    # State carried over rather than restarting from zero.
+    assert any(
+        not torch.equal(before, s["momentum_buffer"])
+        for before, s in zip(buffers_before, optimizer.state.values())
+    )
+
+
+def test_optimizer_is_rebuilt_for_a_different_model() -> None:
+    """The ``rebuilt`` branch: an optimizer from another architecture."""
+    other = nn.Linear(IN_FEATURES, OUT_CLASSES + 5)
+    optimizer = torch.optim.SGD(other.parameters(), lr=0.1, momentum=0.9)
+    optimizer.state[next(other.parameters())] = {
+        "momentum_buffer": torch.ones(OUT_CLASSES + 5, IN_FEATURES)
+    }
+
+    model = _model()
+    result = _train(model, optimizer, _loader(), {"epochs": 1})
+
+    assert result["losses"].shape == (1,)
+    # The stale state did not leak into this run's optimizer.
+    assert all(p.shape[0] == OUT_CLASSES for p in model.parameters() if p.dim() == 2)
+
+
+# ---------------------------------------------------------------------------
+# LR schedule continuation
+# ---------------------------------------------------------------------------
+
+SCHED_EPOCHS = 6
+SCHED_SPLIT = 3
+
+
+def _scheduler(kind: str, optimizer):
+    import torch.optim.lr_scheduler as sched_module
+
+    if kind == "StepLR":
+        return sched_module.StepLR(optimizer, step_size=2, gamma=0.5)
+    if kind == "CosineAnnealingLR":
+        return sched_module.CosineAnnealingLR(optimizer, T_max=SCHED_EPOCHS)
+    raise AssertionError(f"unknown scheduler kind {kind!r}")
+
+
+def _straight_lr_run(kind: str, loader):
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    return _train(
+        model, optimizer, loader, {"epochs": SCHED_EPOCHS},
+        lr_scheduler=_scheduler(kind, optimizer),
+    )
+
+
+@pytest.mark.parametrize("scheduler_kind", ["StepLR", "CosineAnnealingLR"])
+def test_scheduler_continues_from_checkpointed_state(
+    scheduler_kind: str, ckpt_path: str
+) -> None:
+    """LR at absolute epoch N is the same straight-through and after a resume.
+
+    The scheduler travels through the checkpoint, which is the exact path:
+    ``last_epoch``/``_step_count``/``base_lrs`` are all restored verbatim.
+    """
+    loader = _loader()
+    straight = _straight_lr_run(scheduler_kind, loader)
+
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    scheduler = _scheduler(scheduler_kind, optimizer)
+    first = _train(
+        model, optimizer, loader, {"epochs": SCHED_SPLIT}, lr_scheduler=scheduler,
+    )
+    CheckpointSaverNode().execute(
+        {"model": first["model"], "optimizer": optimizer, "lr_scheduler": scheduler},
+        {"path": ckpt_path, "epoch": SCHED_SPLIT},
+    )
+
+    resumed_model = _model()
+    resumed_opt = _optimizer("sgd_momentum", resumed_model)
+    resumed_sched = _scheduler(scheduler_kind, resumed_opt)
+    restored = CheckpointLoaderNode().execute(
+        {"model": resumed_model, "optimizer": resumed_opt, "lr_scheduler": resumed_sched},
+        {"path": ckpt_path, "device": "cpu"},
+    )
+    assert restored["lr_scheduler"] is resumed_sched
+    assert resumed_sched.last_epoch == SCHED_SPLIT
+
+    second = _train(
+        restored["model"], restored["optimizer"], loader, {"epochs": SCHED_EPOCHS},
+        lr_scheduler=restored["lr_scheduler"], start_epoch=restored["epoch"],
+    )
+
+    assert second["metrics"]["lr_history"] == pytest.approx(
+        straight["metrics"]["lr_history"][SCHED_SPLIT:], rel=1e-9
+    )
+    assert second["losses"].tolist() == pytest.approx(
+        straight["losses"][SCHED_SPLIT:].tolist(), rel=1e-5, abs=1e-7
+    )
+    _assert_same_weights(straight["model"], second["model"])
+
+
+@pytest.mark.parametrize("scheduler_kind", ["StepLR", "CosineAnnealingLR"])
+def test_scheduler_fast_forwards_when_checkpoint_has_no_scheduler_state(
+    scheduler_kind: str, ckpt_path: str
+) -> None:
+    """Fallback path: only ``start_epoch`` is known, no saved scheduler state.
+
+    The scheduler is rebuilt by the graph (as ``LRScheduler`` would) over the
+    optimizer at its original LR and then fast-forwarded, which has to land on
+    the same LR the straight run is using at that epoch.
+    """
+    loader = _loader()
+    straight = _straight_lr_run(scheduler_kind, loader)
+
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    first = _train(
+        model, optimizer, loader, {"epochs": SCHED_SPLIT},
+        lr_scheduler=_scheduler(scheduler_kind, optimizer),
+    )
+    # Deliberately NOT passing lr_scheduler -- a pre-#118 style checkpoint.
+    CheckpointSaverNode().execute(
+        {"model": first["model"], "optimizer": optimizer},
+        {"path": ckpt_path, "epoch": SCHED_SPLIT},
+    )
+
+    resumed_model = _model()
+    resumed_opt = _optimizer("sgd_momentum", resumed_model)
+    # Built before the checkpoint is loaded, so base_lrs are the run's original
+    # LRs -- that is the ordering the graph produces (LRScheduler consumes the
+    # Optimizer node's output) and what the fast-forward documents it needs.
+    resumed_sched = _scheduler(scheduler_kind, resumed_opt)
+    restored = CheckpointLoaderNode().execute(
+        {"model": resumed_model, "optimizer": resumed_opt, "lr_scheduler": resumed_sched},
+        {"path": ckpt_path, "device": "cpu"},
+    )
+    assert resumed_sched.last_epoch == 0, "nothing should have restored the schedule"
+
+    second = _train(
+        restored["model"], restored["optimizer"], loader, {"epochs": SCHED_EPOCHS},
+        lr_scheduler=resumed_sched, start_epoch=restored["epoch"],
+    )
+
+    assert resumed_sched._step_count == 1 + SCHED_EPOCHS, (
+        "_step_count must keep counting through the resume, not restart"
+    )
+    assert second["metrics"]["lr_history"] == pytest.approx(
+        straight["metrics"]["lr_history"][SCHED_SPLIT:], rel=1e-9
+    )
+    assert second["losses"].tolist() == pytest.approx(
+        straight["losses"][SCHED_SPLIT:].tolist(), rel=1e-5, abs=1e-7
+    )
+
+
+def test_reduce_lr_on_plateau_is_left_alone_by_the_fast_forward() -> None:
+    """A metric-driven schedule cannot be replayed; it must not be mangled."""
+    import torch.optim.lr_scheduler as sched_module
+
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    scheduler = sched_module.ReduceLROnPlateau(optimizer, factor=0.5, patience=0)
+
+    result = _train(
+        model, optimizer, _loader(), {"epochs": 4},
+        lr_scheduler=scheduler, start_epoch=2,
+    )
+
+    assert result["metrics"]["total_epochs_run"] == 2
+    assert optimizer.param_groups[0]["lr"] > 0
+
+
+def test_old_format_checkpoint_without_scheduler_key_still_loads(ckpt_path: str) -> None:
+    """A checkpoint written before #118 has no scheduler key at all."""
+    settings.MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    legacy = {
+        "epoch": SPLIT_EPOCH,
+        "model_state_dict": model.state_dict(),
+        "optimizer_state_dict": optimizer.state_dict(),
+    }
+    torch.save(legacy, str(settings.MODELS_DIR / ckpt_path))
+
+    target_model = _model()
+    target_opt = _optimizer("sgd_momentum", target_model)
+    scheduler = _scheduler("StepLR", target_opt)
+
+    restored = CheckpointLoaderNode().execute(
+        {"model": target_model, "optimizer": target_opt, "lr_scheduler": scheduler},
+        {"path": ckpt_path, "device": "cpu"},
+    )
+
+    assert restored["epoch"] == SPLIT_EPOCH
+    assert restored["lr_scheduler"] is scheduler
+    assert scheduler.last_epoch == 0, "an absent key must not disturb the scheduler"
+    assert restored["losses"].numel() == 0
+
+    # ...and the same file still loads for a graph with no scheduler wired in.
+    plain_model = _model()
+    plain = CheckpointLoaderNode().execute(
+        {"model": plain_model, "optimizer": _optimizer("sgd_momentum", plain_model)},
+        {"path": ckpt_path, "device": "cpu"},
+    )
+    assert plain["epoch"] == SPLIT_EPOCH
+    assert plain["lr_scheduler"] is None
+
+
+# ---------------------------------------------------------------------------
+# Keeping the optimizer means keeping its state on the right device
+# ---------------------------------------------------------------------------
+
+
+def test_state_device_sync_is_a_no_op_when_nothing_moved() -> None:
+    """Aligned state must not be rebuilt -- the sync only repairs mismatches."""
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    _train(model, optimizer, _loader(), {"epochs": 1})
+    buffers = {p: s["momentum_buffer"] for p, s in optimizer.state.items()}
+
+    _sync_optimizer_state_device(optimizer)
+
+    assert {p: s["momentum_buffer"] for p, s in optimizer.state.items()} == buffers
+
+
+def test_resume_graph_is_wireable() -> None:
+    """The new ports type-check through the real graph validator.
+
+    Calling ``execute()`` directly cannot catch a port that no user could
+    actually connect, so build the resume graph the editor would produce --
+    ``CheckpointLoader.epoch -> TrainingLoop.start_epoch`` (SCALAR) and the
+    scheduler round trip (ANY) -- and run it past ``validate_graph``.
+    Structural only: graphs containing ``TrainingLoop``/``DataLoader`` are not
+    executed in the suite (see test_builtin_examples.py).
+    """
+    from app.core.graph_engine import validate_graph
+
+    nodes = [
+        {"id": "start", "type": "Start", "data": {"params": {}}},
+        {"id": "data", "type": "SyntheticShapes", "data": {"params": {}}},
+        {"id": "loader", "type": "DataLoader", "data": {"params": {"batch_size": 8}}},
+        {"id": "model", "type": "SequentialModel", "data": {"params": {}}},
+        {"id": "opt", "type": "Optimizer", "data": {"params": {"type": "Adam"}}},
+        {"id": "sched", "type": "LRScheduler", "data": {"params": {"type": "StepLR"}}},
+        {"id": "loss", "type": "Loss", "data": {"params": {}}},
+        {"id": "load", "type": "CheckpointLoader", "data": {"params": {"path": "run.pt"}}},
+        {"id": "train", "type": "TrainingLoop", "data": {"params": {"epochs": 4}}},
+        {"id": "save", "type": "CheckpointSaver", "data": {"params": {"path": "run.pt", "epoch": 4}}},
+    ]
+
+    def edge(source, source_handle, target, target_handle):
+        return {
+            "id": f"{source}.{source_handle}->{target}.{target_handle}",
+            "source": source, "sourceHandle": source_handle,
+            "target": target, "targetHandle": target_handle,
+        }
+
+    edges = [
+        {"id": "t1", "source": "start", "target": "data", "sourceHandle": "trigger", "type": "trigger"},
+        {"id": "t2", "source": "start", "target": "model", "sourceHandle": "trigger", "type": "trigger"},
+        {"id": "t3", "source": "start", "target": "loss", "sourceHandle": "trigger", "type": "trigger"},
+        edge("data", "dataset", "loader", "dataset"),
+        edge("model", "model", "opt", "model"),
+        edge("model", "model", "load", "model"),
+        edge("opt", "optimizer", "sched", "optimizer"),
+        edge("opt", "optimizer", "load", "optimizer"),
+        edge("sched", "scheduler", "load", "lr_scheduler"),
+        edge("load", "model", "train", "model"),
+        edge("load", "optimizer", "train", "optimizer"),
+        edge("load", "lr_scheduler", "train", "lr_scheduler"),
+        edge("load", "epoch", "train", "start_epoch"),
+        edge("loader", "dataloader", "train", "dataloader"),
+        edge("loss", "loss_fn", "train", "loss_fn"),
+        edge("train", "model", "save", "model"),
+        edge("load", "optimizer", "save", "optimizer"),
+        edge("load", "lr_scheduler", "save", "lr_scheduler"),
+    ]
+
+    assert validate_graph(nodes, edges) == []
+
+
+@requires_cuda
+def test_training_on_cuda_moves_reused_optimizer_state() -> None:
+    """Reusing the optimizer must not strand its buffers on the old device.
+
+    ``model.to("cuda")`` swaps each parameter's storage but leaves the
+    optimizer's momentum buffers on the CPU, so a naive "keep the optimizer"
+    would blow up on the first step with a device mismatch.
+    """
+    loader = _loader()
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    _train(model.cpu(), optimizer, loader, {"epochs": 1, "device": "cpu"})
+    assert all(
+        s["momentum_buffer"].device.type == "cpu" for s in optimizer.state.values()
+    )
+
+    result = _train(model, optimizer, loader, {"epochs": 1, "device": "cuda"})
+
+    assert result["losses"].shape == (1,)
+    assert all(p.device.type == "cuda" for p in result["model"].parameters())
+    assert all(
+        s["momentum_buffer"].device.type == "cuda" for s in optimizer.state.values()
+    )

--- a/backend/tests/test_training_resume.py
+++ b/backend/tests/test_training_resume.py
@@ -25,6 +25,8 @@ from app.config import settings
 from app.nodes.io.checkpoint_node import CheckpointLoaderNode, CheckpointSaverNode
 from app.nodes.training.training_loop_node import (
     TrainingLoopNode,
+    _fast_forward_scheduler,
+    _prepare_optimizer,
     _sync_optimizer_state_device,
 )
 
@@ -282,36 +284,99 @@ def test_start_epoch_accepts_tensor_and_rejects_garbage() -> None:
         assert result["metrics"]["start_epoch"] == expected, f"start_epoch={value!r}"
 
 
-def test_optimizer_is_rebound_when_parameters_are_replaced() -> None:
-    """A structurally identical model gets the optimizer's state re-keyed.
+def test_prepare_optimizer_picks_the_documented_branch() -> None:
+    """The resume rule itself, asserted on the mode it reports.
 
-    This is the ``rebound`` branch of the resume rule: different parameter
-    *objects*, same shapes. The momentum buffers have to survive and to end up
-    attached to the new parameters.
+    The end-to-end tests below can look similar whichever branch ran, so pin
+    the decision directly: same parameter objects -> ``reused``, structurally
+    identical replacements -> ``rebound``, anything else -> ``rebuilt``.
     """
     model = _model()
     optimizer = _optimizer("sgd_momentum", model)
+
+    assert _prepare_optimizer(optimizer, model) == (optimizer, "reused")
+
+    replacement = _model()
+    rebound, mode = _prepare_optimizer(optimizer, replacement)
+    assert mode == "rebound"
+    assert rebound is optimizer, "rebinding must not swap the optimizer object"
+    tracked = [p for g in rebound.param_groups for p in g["params"]]
+    assert all(a is b for a, b in zip(tracked, replacement.parameters()))
+
+    other = nn.Linear(IN_FEATURES, OUT_CLASSES + 5)
+    stale = _optimizer("sgd_momentum", other)
+    fresh, mode = _prepare_optimizer(stale, model)
+    assert mode == "rebuilt"
+    assert fresh is not stale
+    assert type(fresh) is type(stale)
+    tracked = [p for g in fresh.param_groups for p in g["params"]]
+    assert all(a is b for a, b in zip(tracked, model.parameters()))
+
+
+# Which per-parameter state key proves the optimizer continued rather than
+# restarted, for each optimizer under test.
+_STATE_KEY = {"adam": "exp_avg", "sgd_momentum": "momentum_buffer"}
+
+
+@pytest.mark.parametrize("optimizer_kind", ["adam", "sgd_momentum"])
+def test_optimizer_is_rebound_when_parameters_are_replaced(optimizer_kind: str) -> None:
+    """A structurally identical model gets the optimizer's state re-keyed.
+
+    The ``rebound`` branch end to end: different parameter *objects*, same
+    shapes. Adam's moments and SGD's momentum buffer both have to survive and
+    end up attached to the new parameters.
+    """
+    key = _STATE_KEY[optimizer_kind]
+    model = _model()
+    optimizer = _optimizer(optimizer_kind, model)
     _train(model, optimizer, _loader(), {"epochs": 1})
-    buffers_before = [
-        s["momentum_buffer"].clone() for s in optimizer.state.values()
-    ]
+    before = [s[key].clone() for s in optimizer.state.values()]
+    assert before and all(b.abs().sum() > 0 for b in before)
 
     replacement = _model()
     replacement.load_state_dict(model.state_dict())
     assert all(a is not b for a, b in zip(model.parameters(), replacement.parameters()))
 
-    _train(replacement, optimizer, _loader(), {"epochs": 1})
+    result = _train(replacement, optimizer, _loader(), {"epochs": 1})
 
+    assert result["model"] is replacement
+    # Keyed on the NEW parameter objects: the groups were re-bound. A rebuild
+    # would have left this optimizer's state sitting on the old parameters.
     assert set(optimizer.state) == set(replacement.parameters())
-    assert len(optimizer.state) == len(buffers_before)
-    assert all(
-        s["momentum_buffer"] is not None for s in optimizer.state.values()
+    after = [s[key] for s in optimizer.state.values()]
+    assert len(after) == len(before)
+    assert all(a is not None for a in after)
+    # State continued rather than restarting from zero.
+    assert any(not torch.equal(b, a) for b, a in zip(before, after))
+
+
+def test_rebind_preserves_per_group_hyperparameters() -> None:
+    """Multi-group optimizers keep their per-group overrides and split."""
+    model = _model()
+    weight, bias = list(model.parameters())
+    optimizer = torch.optim.SGD(
+        [
+            {"params": [weight], "lr": 0.05},
+            {"params": [bias], "lr": 0.2, "momentum": 0.5},
+        ],
+        lr=0.1,
+        momentum=0.9,
     )
-    # State carried over rather than restarting from zero.
-    assert any(
-        not torch.equal(before, s["momentum_buffer"])
-        for before, s in zip(buffers_before, optimizer.state.values())
-    )
+    model(torch.zeros(2, IN_FEATURES)).sum().backward()
+    optimizer.step()
+    assert len(optimizer.state) == 2
+
+    replacement = _model()
+    rebound, mode = _prepare_optimizer(optimizer, replacement)
+
+    assert mode == "rebound"
+    assert [g["lr"] for g in rebound.param_groups] == [0.05, 0.2]
+    assert [g["momentum"] for g in rebound.param_groups] == [0.9, 0.5]
+    assert [len(g["params"]) for g in rebound.param_groups] == [1, 1]
+    new_weight, new_bias = list(replacement.parameters())
+    assert rebound.param_groups[0]["params"][0] is new_weight
+    assert rebound.param_groups[1]["params"][0] is new_bias
+    assert set(rebound.state) == {new_weight, new_bias}
 
 
 def test_optimizer_is_rebuilt_for_a_different_model() -> None:
@@ -455,6 +520,102 @@ def test_scheduler_fast_forwards_when_checkpoint_has_no_scheduler_state(
     assert second["losses"].tolist() == pytest.approx(
         straight["losses"][SCHED_SPLIT:].tolist(), rel=1e-5, abs=1e-7
     )
+
+
+def test_scheduler_ahead_of_start_epoch_warns_and_keeps_its_own_position(caplog) -> None:
+    """A schedule/epoch desync is exactly what this issue removes -- say so."""
+    import logging
+
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    scheduler = _scheduler("StepLR", optimizer)
+    for _ in range(5):
+        optimizer.step()
+        scheduler.step()
+    assert scheduler.last_epoch == 5
+
+    with caplog.at_level(logging.WARNING, logger="app.nodes.training.training_loop_node"):
+        _train(
+            model, optimizer, _loader(), {"epochs": 4},
+            lr_scheduler=scheduler, start_epoch=2,
+        )
+
+    warnings_seen = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("last_epoch=5" in m and "epoch 2" in m for m in warnings_seen), warnings_seen
+    # The scheduler kept its own position rather than being rewound.
+    assert scheduler.last_epoch == 5 + 2
+
+
+def test_replay_failure_degrades_instead_of_failing_the_run(caplog) -> None:
+    """A schedule that cannot be replayed must not take the training run down.
+
+    The failure is injected rather than borrowed from a real scheduler
+    (``OneCycleLR`` raises once stepped past ``total_steps``) because a real
+    one keeps raising from inside the epoch loop too. That in-loop step is
+    unguarded on purpose -- a schedule failing during actual training is a
+    genuine misconfiguration and predates #118 -- so borrowing it would test
+    something other than the replay.
+    """
+    import logging
+
+    class _BrittleStepLR(torch.optim.lr_scheduler.StepLR):
+        """Raises for its next ``_pending_failures`` steps, then behaves.
+
+        Defaults to 0 so the ``_initial_step()`` inside ``__init__`` is not
+        the one that trips; the test arms it afterwards.
+        """
+
+        _pending_failures = 0
+
+        def step(self, *args, **kwargs):
+            if self._pending_failures > 0:
+                self._pending_failures -= 1
+                raise RuntimeError("this schedule cannot be replayed")
+            return super().step(*args, **kwargs)
+
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    scheduler = _BrittleStepLR(optimizer, step_size=2, gamma=0.5)
+    scheduler._pending_failures = 1
+
+    with caplog.at_level(logging.WARNING, logger="app.nodes.training.training_loop_node"):
+        result = _train(
+            model, optimizer, _loader(), {"epochs": 5},
+            lr_scheduler=scheduler, start_epoch=3,
+        )
+
+    assert result["metrics"]["total_epochs_run"] == 2, "training carried on regardless"
+    assert result["metrics"]["start_epoch"] == 3
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("replaying epoch 1 of 3" in m for m in messages), messages
+
+
+@pytest.mark.filterwarnings("ignore:custom schedule notice")
+def test_replay_only_suppresses_the_step_order_warnings() -> None:
+    """The suppression is by message, so a real schedule warning still lands.
+
+    The marker only silences the copy this scheduler emits while being
+    *constructed*, which is outside the block under test; the recorder below
+    still sees the one raised during the replay.
+    """
+    import warnings as warnings_mod
+
+    class _NoisyStepLR(torch.optim.lr_scheduler.StepLR):
+        def get_lr(self):
+            warnings_mod.warn("custom schedule notice", UserWarning)
+            return super().get_lr()
+
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    scheduler = _NoisyStepLR(optimizer, step_size=2, gamma=0.5)
+
+    with warnings_mod.catch_warnings(record=True) as seen:
+        warnings_mod.simplefilter("always")
+        assert _fast_forward_scheduler(scheduler, optimizer, 2) is True
+
+    messages = [str(w.message) for w in seen]
+    assert any("custom schedule notice" in m for m in messages), messages
+    assert not any("lr_scheduler.step()" in m for m in messages), messages
 
 
 def test_reduce_lr_on_plateau_is_left_alone_by_the_fast_forward() -> None:

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -459,14 +459,14 @@ const zhTW: NodeTranslations = {
     },
   },
   CheckpointSaver: {
-    description: '儲存完整訓練檢查點（模型 + 優化器 + epoch + 損失值），用於稍後恢復訓練',
+    description: '儲存完整訓練檢查點（模型 + 優化器 + 學習率排程 + epoch + 損失值），用於稍後恢復訓練',
     params: {
       path: '輸出檢查點檔案路徑',
       epoch: '要儲存在檢查點中的當前 epoch 數',
     },
   },
   CheckpointLoader: {
-    description: '載入訓練檢查點以恢復訓練（恢復模型 + 優化器 + epoch）',
+    description: '載入訓練檢查點以恢復訓練（恢復模型 + 優化器 + 學習率排程 + epoch）',
     params: {
       path: '檢查點檔案路徑',
       device: '載入的目標裝置',


### PR DESCRIPTION
## Summary

`TrainingLoop` rebuilt the incoming optimizer on every run
(`optimizer_cls(model.parameters(), **defaults)`), so a "resume" only ever
restored **weights**. Adam's moments, SGD's momentum buffers and the step
counts were thrown away, the loop always ran `range(epochs)` from 0, and the
LR scheduler was reconstructed with `last_epoch` / `_step_count` dropped.

The rebuild also broke the **save** side: a `CheckpointSaver` downstream of
`TrainingLoop` sees the optimizer object the graph created, and that object
never got trained, so every checkpoint was written with an empty
`optimizer_state_dict`. Both halves are fixed here.

## The resume-semantics rule (spec item 1)

Whether the incoming optimizer is reused, re-bound or rebuilt is decided by
comparing **parameters**, not the module object. `nn.Module.to()` mutates in
place and returns `self`, so "the model object differs" is never true after a
device move; whether the *parameters* are still the ones the optimizer tracks
is the check that actually detects a stale binding (and it is torch-version
independent -- 2.11 preserves `Parameter` identity across a CPU->CUDA move,
older builds do not).

| branch | condition | behaviour |
|---|---|---|
| `reused` | every tracked param **is** the model's param, in order | optimizer used untouched; all state survives |
| `rebound` | same count/shapes/dtypes, different objects | each group's `params` re-pointed positionally, then `optimizer.load_state_dict(optimizer.state_dict())` re-keys the state onto them; hyperparameters and per-group overrides preserved |
| `rebuilt` | different param count or shapes | optimizer belongs to another model, so its state is meaningless: fresh instance of the same class over `model.parameters()`, logged as a warning |

Stranded state (buffers left on the old device by a `model.to(device)`) is
repaired with a `state_dict()` round-trip rather than a manual `.to()` sweep,
because `Optimizer.load_state_dict` applies torch's own per-key device policy
-- notably keeping the 0-dim `step` counter on the CPU, which a blanket
`.to(device)` would break.

## The rest

- **Epoch offset (item 2).** New optional `start_epoch: SCALAR` input on
  `TrainingLoop`, fed from `CheckpointLoader.epoch`. The loop is
  `range(start_epoch, epochs)`, so `epochs` keeps its absolute meaning, and
  every epoch number reported (log lines, `epoch` in progress events,
  `best_epoch`) is the absolute one. `metrics` gains `start_epoch` /
  `last_epoch`; progress events gain `start_epoch` **only when it is non-zero**,
  so a normal run's payload is unchanged.
- **Schedule continuation (item 3).** A scheduler that already carries
  restored state (`last_epoch > 0`) is left exactly as it is. A fresh one with
  `start_epoch > 0` is fast-forwarded to `last_epoch == start_epoch`.
  The issue asked for `last_epoch=start_epoch-1` at construction; the end
  state is the same but the mechanism is a **replay of `start_epoch` `step()`
  calls from `base_lrs`**, because rebuilding is measurably wrong:
  `StepLR`/`ExponentialLR`/`CosineAnnealingLR` derive the next LR from the
  optimizer's *current* `lr`, which on resume is already the decayed value out
  of the checkpoint. Measured with lr0=0.1, gamma=0.1, step_size=2,
  start_epoch=2: rebuild gives **0.001**, the straight run is at **0.01**, the
  replay gives **0.01**. A rebuild also leaves `_step_count == 1` -- the exact
  thing the issue says must not be dropped -- and has to guess constructor
  kwargs out of `state_dict()`. `ReduceLROnPlateau` is metric-driven and cannot
  be replayed, so it is skipped with a warning pointing at the checkpoint route.
- **Payload (item 4).** `CheckpointSaver`/`CheckpointLoader` gain an optional
  `lr_scheduler` port (the loader also exposes it as an output so it can be
  wired onward), and the checkpoint gains `scheduler_state_dict` plus
  `scheduler_class`. The class name lets the loader refuse to splice `StepLR`
  state into a `CosineAnnealingLR`. Both keys are read with `.get()`. The
  format is documented as append-only in the module docstring, ready for the
  interrupt checkpoints of #122 and the `GradScaler` state of #135.

## Test evidence

New `backend/tests/test_training_resume.py` (20 tests) + 4 added to
`test_checkpoint_node.py`.

TDD: the equivalence test was written first and fails on `main` for both
optimizers --

```
FAILED test_resume_matches_straight_run[adam]
FAILED test_resume_matches_straight_run[sgd_momentum]
  Max absolute difference: 0.05325734615325928
  Index | Obtained           | Expected
  0     | 0.8764177560806274 | 0.8546229600906372
  1     | 0.8253013491630554 | 0.7720440030097961
```

and the LR test shows the schedule restarting rather than continuing
(obtained `[0.1, 0.1, ... ]` over 6 epochs where 3 epochs from `0.05` were
expected). Against the whole pre-fix tree, 15 of the 17 tests written at that
point failed; the 2 that passed are the ones that deliberately pin *unchanged*
behaviour. All pass after the fix.

Acceptance criteria:

- **Equivalence** -- 4 epochs straight vs 2 + checkpoint + restore + 2, for
  Adam and SGD+momentum, on losses *and* final weights, both directly and
  through the `start_epoch` port. Tolerance `rel=1e-5, abs=1e-7`; the two paths
  run identical float ops in identical order, so the tolerance only absorbs
  platform FMA differences.
- **LR continuation** -- `lr_history` after resume equals the straight run's
  tail, parametrized over `StepLR` and `CosineAnnealingLR`, both via
  checkpointed scheduler state and via the `start_epoch` fast-forward
  (`rel=1e-9`), plus `_step_count` continuity.
- **Backward compatibility** -- a checkpoint written by hand in the pre-#118
  format loads with a scheduler wired in (untouched) and with none wired in.

Also covered: absolute progress/config payloads, unchanged payload without
`start_epoch`, `start_epoch` past `epochs`, tensor/float/negative/garbage
coercion, the `rebound` and `rebuilt` branches, a `validate_graph` check that
the whole resume graph is wireable in the editor
(`CheckpointLoader.epoch -> TrainingLoop.start_epoch`), and a CUDA-gated test
that reusing the optimizer does not strand its buffers on the CPU (verified to
fail with `Expected all tensors to be on the same device` when the sync is
removed; skips on CPU-only CI).

Suites: backend `1955 passed, 13 skipped` on Python 3.11, and the new/adjacent
files also green on the 3.10 floor venv. Frontend `94 files / 1804 tests`
passed and `tsc -b` clean (one zh-TW node description updated to match the
changed English one). No new warnings -- the suite is clean under
`-W error::UserWarning`.

Closes #118

---
Generated with [Claude Code](https://claude.com/claude-code)
