### PR TITLE
feat(run-service): SQLite schema + RunStore DAO for runs, metrics, events, artifacts

### DIFF
--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -51,6 +51,9 @@ def transaction(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
     except ``BaseException`` / ``ROLLBACK`` / re-raise) is already the house
     idiom in ``routes_apps.py`` and ``_apply_migrations``; this is the same
     thing factored out for the modules that need it in several places.
+    Those two existing call sites are deliberately left inline — rewriting
+    shipped transaction code is not worth the risk in an unrelated change,
+    so the two forms coexist until something else has to touch them.
 
     IMMEDIATE, not the default DEFERRED: the write lock is taken up front,
     so a read-then-write inside the block (``SELECT MAX(...) + 1`` then
@@ -138,12 +141,45 @@ class Database:
         THE seam: every route-level DB operation goes through here (one
         sync fn, one ``to_thread``, one lock — Decision A2). Multi-statement
         transactions live INSIDE ``fn`` with explicit BEGIN/COMMIT/ROLLBACK.
+
+        Cancelling the caller does NOT abandon the worker
+        --------------------------------------------------
+        ``asyncio.to_thread`` cancellation cancels the *awaiter*, never the
+        thread — a running sqlite3 statement cannot be interrupted. A bare
+        ``await asyncio.to_thread(...)`` would therefore unwind the
+        ``async with`` and RELEASE THE LOCK while ``fn`` was still executing
+        on the shared connection, so the next caller would land in the
+        middle of someone else's transaction: its writes silently swallowed
+        by that transaction's ROLLBACK, swept into its COMMIT, or refused
+        with "cannot start a transaction within a transaction".
+
+        So the cancellation is absorbed (``shield``) and re-raised only once
+        the thread has finished and the transaction is settled. The loop
+        handles repeated cancellation — during shutdown a task can be
+        cancelled more than once, and every one of those must be held until
+        the connection is quiet. ``shield`` ALONE is not enough: the outer
+        await still raises immediately and the lock still goes early.
+
+        The cost is bounded: cancelling a DB call now takes as long as the
+        statement in flight, which ``PRAGMA busy_timeout=5000`` caps.
         """
         async with self._lock:
             conn = self._conn
             if conn is None:
                 raise RuntimeError("Database is not connected")
-            return await asyncio.to_thread(fn, conn)
+            worker = asyncio.ensure_future(asyncio.to_thread(fn, conn))
+            cancellation: BaseException | None = None
+            while not worker.done():
+                try:
+                    await asyncio.shield(worker)
+                except asyncio.CancelledError as exc:
+                    if not worker.done():
+                        cancellation = exc   # ours, not the worker's
+                except BaseException:
+                    pass                     # worker.result() re-raises below
+            if cancellation is not None:
+                raise cancellation
+            return worker.result()
 
     async def prune_runs(self, retention_days: int, *, force: bool = False) -> int:
         """Delete runs older than ``retention_days`` days; 0 disables.

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -20,9 +20,10 @@ import asyncio
 import logging
 import sqlite3
 import time
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Callable, TypeVar
+from typing import Callable, Iterator, TypeVar
 
 from .migrations import MIGRATIONS, iter_statements
 
@@ -40,6 +41,38 @@ def utc_now_iso() -> str:
     the runs ``before=`` cursor) is lexicographically correct.
     """
     return datetime.now(timezone.utc).strftime(_TIMESTAMP_FORMAT)
+
+
+@contextmanager
+def transaction(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
+    """``BEGIN IMMEDIATE`` … ``COMMIT``, rolling back on any exception.
+
+    The inline form of this (``BEGIN IMMEDIATE`` / try / ``COMMIT`` /
+    except ``BaseException`` / ``ROLLBACK`` / re-raise) is already the house
+    idiom in ``routes_apps.py`` and ``_apply_migrations``; this is the same
+    thing factored out for the modules that need it in several places.
+
+    IMMEDIATE, not the default DEFERRED: the write lock is taken up front,
+    so a read-then-write inside the block (``SELECT MAX(...) + 1`` then
+    ``INSERT``) cannot interleave with another writer. DEFERRED would
+    upgrade the lock only at the INSERT, leaving the read stale.
+
+    Only usable because ``Database.connect`` passes ``isolation_level=None``
+    — sqlite3's default would emit its own implicit BEGIN and de-atomize
+    this.
+    """
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        yield conn
+        conn.execute("COMMIT")
+    except BaseException:
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            # A failed COMMIT can already have rolled the transaction back;
+            # never let that mask the original error on its way out.
+            pass
+        raise
 
 
 class Database:

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -17,6 +17,8 @@ Decision A2 contract, verbatim:
 from __future__ import annotations
 
 import asyncio
+import contextvars
+import functools
 import logging
 import sqlite3
 import time
@@ -160,24 +162,49 @@ class Database:
         the connection is quiet. ``shield`` ALONE is not enough: the outer
         await still raises immediately and the lock still goes early.
 
-        The cost is bounded: cancelling a DB call now takes as long as the
-        statement in flight, which ``PRAGMA busy_timeout=5000`` caps.
+        The worker is a bare Future, not a Task, and that is load-bearing
+        rather than stylistic. ``asyncio``'s shutdown sweep cancels every
+        entry of ``asyncio.all_tasks()``; ``asyncio.to_thread`` is a
+        coroutine, so scheduling it produces a Task that the sweep would
+        cancel DIRECTLY — flipping ``done()`` to True while the thread is
+        still mid-transaction, which walks straight back into the bug above
+        through a second door. ``run_in_executor`` returns a Future, which
+        is not in ``all_tasks()``; nothing else holds a reference to it, so
+        the only cancellable thing left is our own shield. (Verified: under
+        a blanket cancel the Task reports cancelled and the Future does
+        not.) ``copy_context`` keeps the contextvar propagation that
+        ``to_thread`` gave us for free.
+
+        The delay is bounded by how long ``fn`` runs. Note that
+        ``PRAGMA busy_timeout=5000`` does NOT cap that: it caps how long a
+        statement waits for a lock held by ANOTHER connection, not how long
+        one takes to execute. A large DELETE takes as long as it takes.
         """
         async with self._lock:
             conn = self._conn
             if conn is None:
                 raise RuntimeError("Database is not connected")
-            worker = asyncio.ensure_future(asyncio.to_thread(fn, conn))
+            ctx = contextvars.copy_context()
+            worker = asyncio.get_running_loop().run_in_executor(
+                None, functools.partial(ctx.run, fn, conn))
             cancellation: BaseException | None = None
             while not worker.done():
                 try:
                     await asyncio.shield(worker)
                 except asyncio.CancelledError as exc:
-                    if not worker.done():
-                        cancellation = exc   # ours, not the worker's
+                    cancellation = exc       # ours: the worker is unreachable
                 except BaseException:
-                    pass                     # worker.result() re-raises below
+                    break                    # worker failed; re-raised below
             if cancellation is not None:
+                if not worker.cancelled():
+                    # Retrieve any worker error before raising the
+                    # cancellation instead, so Future.__del__ never routes
+                    # it to the loop's exception handler ("Future exception
+                    # was never retrieved") at a later GC. Belt and braces:
+                    # shield's own _inner_done_callback already calls
+                    # inner.exception() when the outer was cancelled, so
+                    # this only matters if the shield ever goes away.
+                    worker.exception()
                 raise cancellation
             return worker.result()
 

--- a/backend/app/core/migrations.py
+++ b/backend/app/core/migrations.py
@@ -1,8 +1,11 @@
-"""Stage-2 SQLite schema migrations.
+"""SQLite schema migrations.
 
 ``MIGRATIONS[i]`` moves ``PRAGMA user_version`` from ``i`` to ``i + 1``.
 Append-only: NEVER edit a shipped migration — add a new list entry.
 Timestamps are ISO-8601 UTC TEXT (``app.core.db.utc_now_iso``).
+
+001/002 are the Stage-2 publish subsystem; 003 is the Run Service store
+(see the naming-decision block above ``MIGRATION_003``).
 """
 
 from __future__ import annotations
@@ -66,7 +69,118 @@ ALTER TABLE app_versions ADD COLUMN git_commit TEXT;
 ALTER TABLE app_versions ADD COLUMN git_dirty INTEGER;
 """
 
-MIGRATIONS: list[str] = [MIGRATION_001, MIGRATION_002]
+# ── Migration 003: Run Service storage ─────────────────────────────────────
+#
+# NAMING DECISION (issue #119, acceptance criterion 3) — why ``exec_runs``
+# and not ``runs``:
+#
+# ``runs`` (MIGRATION_001) is already taken, and it is a DIFFERENT concept.
+# It is the *published-app invocation* history: every row REQUIRES an
+# ``app_id`` (NOT NULL, FK CASCADE to ``apps``) plus a ``version``, its
+# status vocabulary is the two-valued ``"ok" | "error"`` REST envelope
+# result, and it stores request/response I/O (``inputs_json`` /
+# ``outputs_json``, capped at ``settings.RUN_IO_CAP_BYTES``). Editor and
+# CLI graph executions have no row there at all.
+#
+# What this migration adds is the *graph execution* run: no app, a six-state
+# lifecycle (queued/running/succeeded/failed/cancelled/interrupted), a graph
+# snapshot instead of request I/O, and child tables for metrics, a replay
+# event log and artifacts.
+#
+# Options considered:
+#   (a) Reuse ``runs``. Rejected: it would mean relaxing ``app_id`` to
+#       nullable, overloading one ``status`` column with two disjoint
+#       vocabularies, and rebuilding a SHIPPED table (SQLite cannot drop a
+#       NOT NULL constraint in place) — a destructive migration of live
+#       user data to save one word of naming.
+#   (b) Migrate ``runs`` into the new tables. Rejected for the same reason
+#       plus a lossy mapping: publish rows carry per-field I/O and API-key
+#       attribution that have no home in the execution schema.
+#   (c) Namespace the new tables ``exec_*``. CHOSEN. Purely additive: 001
+#       and 002 are untouched, existing publish history keeps working
+#       byte-for-byte, and the prefix reads correctly at every call site
+#       (``exec_run_events`` is unambiguous next to ``runs``).
+#
+# Consequence to remember: ``Database.prune_runs`` is the *publish* table's
+# retention (``DELETE FROM runs``); ``RunStore.prune`` is this one's. They
+# are deliberately separate policies and never touch each other's rows.
+#
+# Schema notes:
+# - ``status`` carries NO SQL CHECK constraint: SQLite cannot ALTER one away
+#   later, and the queue/sweep work may add lifecycle states. The closed
+#   vocabulary is enforced in ``app.core.run_store`` (RUN_STATUSES), which
+#   is the only writer.
+# - Child tables use a plain ``INTEGER PRIMARY KEY`` (rowid alias) rather
+#   than AUTOINCREMENT: no ``sqlite_sequence`` write per insert, which
+#   matters for the high-frequency metric path, and nothing references a
+#   metric/event row by id so rowid reuse after a delete is harmless.
+# - Everything is additive-friendly: the sweep work adds ``sweep_id`` with a
+#   bare ``ALTER TABLE exec_runs ADD COLUMN``.
+MIGRATION_003 = """
+CREATE TABLE exec_runs (
+  id             TEXT PRIMARY KEY,       -- uuid4().hex, like runs.run_id
+  name           TEXT,                   -- user-facing label. NULL = unnamed
+  graph_snapshot TEXT NOT NULL,          -- JSON. immutable copy of the submitted graph
+  options        TEXT NOT NULL,          -- JSON {device, seed, record_outputs, lane}
+  status         TEXT NOT NULL,          -- queued|running|succeeded|failed|cancelled|interrupted
+  error          TEXT,                   -- failure summary. NULL unless status = failed
+  queue_key      TEXT,                   -- resolved device, e.g. cpu / cuda:0. NULL until scheduled
+  created_at     TEXT NOT NULL,          -- submit time. the list + retention ordering key
+  started_at     TEXT,                   -- NULL while queued
+  finished_at    TEXT,                   -- NULL until terminal
+  git_commit     TEXT,                   -- project provenance. NULL = unknown, never guessed
+  git_dirty      INTEGER,                -- 0/1/NULL, same tri-state as app_versions.git_dirty
+  plugin_pins    TEXT                    -- JSON {plugin_id: {source_kind, source, ref, sha, version}}
+);
+-- ASC, deliberately, even though every read is newest-first. The list
+-- order is (created_at DESC, rowid DESC), and sqlite serves that by
+-- scanning an ASC index BACKWARDS -- entries are stored (created_at ASC,
+-- rowid ASC), so reversed they are exactly (created_at DESC, rowid DESC).
+-- A DESC index stores (created_at DESC, rowid ASC): the tie-break points
+-- the wrong way, so sqlite falls back to a full scan plus a temp b-tree
+-- sort (verified with EXPLAIN QUERY PLAN both ways). Do not "fix" these
+-- to DESC.
+CREATE INDEX idx_exec_runs_created        ON exec_runs(created_at);
+CREATE INDEX idx_exec_runs_status_created ON exec_runs(status, created_at);
+
+CREATE TABLE exec_run_metrics (
+  id      INTEGER PRIMARY KEY,
+  run_id  TEXT NOT NULL REFERENCES exec_runs(id) ON DELETE CASCADE,
+  node_id TEXT,                          -- emitting node. NULL for run-level scalars
+  name    TEXT NOT NULL,                 -- series name, e.g. train_loss
+  step    INTEGER NOT NULL,              -- epoch or batch index, series-defined
+  value   REAL NOT NULL,
+  ts      TEXT NOT NULL
+);
+-- Serves both chart reads: one series (run_id, name -> ordered steps) and
+-- the series list (DISTINCT name uses the same index prefix).
+CREATE INDEX idx_exec_run_metrics_series ON exec_run_metrics(run_id, name, step);
+
+CREATE TABLE exec_run_events (
+  id      INTEGER PRIMARY KEY,
+  run_id  TEXT NOT NULL REFERENCES exec_runs(id) ON DELETE CASCADE,
+  cursor  INTEGER NOT NULL,              -- 1-based, gapless, monotonic within a run
+  type    TEXT NOT NULL,                 -- open vocabulary. the WS message type
+  payload TEXT,                          -- JSON. NULL when the type needs no body
+  ts      TEXT NOT NULL,
+  -- UNIQUE, not a plain index: it is the (run_id, cursor) replay index AND
+  -- the backstop that turns a lost cursor update into a loud IntegrityError
+  -- instead of two events silently sharing a cursor.
+  UNIQUE (run_id, cursor)
+);
+
+CREATE TABLE exec_run_artifacts (
+  id         INTEGER PRIMARY KEY,
+  run_id     TEXT NOT NULL REFERENCES exec_runs(id) ON DELETE CASCADE,
+  kind       TEXT NOT NULL,              -- checkpoint|export|image. open vocabulary
+  path       TEXT NOT NULL,              -- as written by the node, under the data root
+  meta       TEXT,                       -- JSON, e.g. {epoch, batch} for an interrupt checkpoint
+  created_at TEXT NOT NULL
+);
+CREATE INDEX idx_exec_run_artifacts_run ON exec_run_artifacts(run_id, created_at);
+"""
+
+MIGRATIONS: list[str] = [MIGRATION_001, MIGRATION_002, MIGRATION_003]
 
 
 def _is_comment_only(statement: str) -> bool:

--- a/backend/app/core/migrations.py
+++ b/backend/app/core/migrations.py
@@ -149,7 +149,14 @@ CREATE TABLE exec_run_metrics (
   node_id TEXT,                          -- emitting node. NULL for run-level scalars
   name    TEXT NOT NULL,                 -- series name, e.g. train_loss
   step    INTEGER NOT NULL,              -- epoch or batch index, series-defined
-  value   REAL NOT NULL,
+  -- Nullable on purpose. sqlite has no NaN: the driver binds one as NULL,
+  -- so NOT NULL here would reject a diverged loss with a constraint error
+  -- naming a column the caller never set -- and, because the metric flush
+  -- is one all-or-nothing transaction, would discard the whole batch of
+  -- good points around it. run_store normalises every non-finite value
+  -- (NaN, +/-inf) to NULL and reads it back as None, which is also the
+  -- only JSON-representable answer for the chart consumers.
+  value   REAL,
   ts      TEXT NOT NULL
 );
 -- Serves both chart reads: one series (run_id, name -> ordered steps) and

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -1,0 +1,750 @@
+"""Persistence for graph-execution runs — the Run Service store (#119).
+
+Storage only. No scheduling, no engine calls, no HTTP: this module owns the
+``exec_runs`` / ``exec_run_metrics`` / ``exec_run_events`` /
+``exec_run_artifacts`` tables created by ``migrations.MIGRATION_003`` and
+nothing else. The naming decision behind the ``exec_`` prefix (there is an
+unrelated, already-shipped ``runs`` table for published-app invocations)
+lives in the comment block above ``MIGRATION_003``.
+
+Not to be confused with ``run_output_store.RunOutputStore``, which is the
+in-memory LRU of captured node outputs and is lost on restart. This one is
+the durable half.
+
+House-style note: the publish subsystem keeps its SQL inline in the route
+handlers. A shared DAO is used here instead because five separate consumers
+(run service, WS attach/replay, the metric logger, the Runs panel API and
+sweeps) read and write the same rows, and a lifecycle spread across five
+modules is exactly how status vocabularies drift apart.
+
+Every method goes through ``Database.run`` — one sync function, one worker
+thread, one shared ``asyncio.Lock``, one connection. See ``append_event``
+for why that plus ``BEGIN IMMEDIATE`` is what makes the event cursor safe.
+
+Rows in, rows out
+-----------------
+Reads return frozen dataclasses, not ``sqlite3.Row``: the row objects are
+tied to the connection's lifetime and would leak the storage layer into
+five consumers. ``dataclasses.asdict`` covers the REST-serialisation side.
+``RunRecord`` deliberately omits ``graph_snapshot`` — a run list must not
+deserialize a megabyte of graph per row on every poll of the Runs panel;
+fetch it explicitly with ``get_graph_snapshot``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, NamedTuple, Sequence
+from uuid import uuid4
+
+from ..config import settings
+from .db import Database, transaction, utc_now_iso
+from .plugin_loader import is_enabled, load_lockfile
+from .project import git_provenance
+
+# ── status vocabulary ─────────────────────────────────────────────────────
+#
+# The canonical definition, and the only enforcement point: the schema
+# deliberately carries no CHECK constraint (SQLite cannot ALTER one away and
+# the queue/sweep work may add states), so validation happens here, on the
+# one module that writes the column.
+#
+# Distinct from the per-NODE status vocabulary on the WebSocket
+# (running/completed/cached/skipped/error/progress) and from the publish
+# envelope's two-valued ok/error — do not cross-map them by accident.
+STATUS_QUEUED = "queued"
+STATUS_RUNNING = "running"
+STATUS_SUCCEEDED = "succeeded"
+STATUS_FAILED = "failed"
+STATUS_CANCELLED = "cancelled"
+STATUS_INTERRUPTED = "interrupted"
+
+#: Not yet finished; cannot survive a server restart.
+ACTIVE_STATUSES: frozenset[str] = frozenset({STATUS_QUEUED, STATUS_RUNNING})
+#: Finished, one way or another. Only these are eligible for retention.
+TERMINAL_STATUSES: frozenset[str] = frozenset({
+    STATUS_SUCCEEDED, STATUS_FAILED, STATUS_CANCELLED, STATUS_INTERRUPTED,
+})
+RUN_STATUSES: frozenset[str] = ACTIVE_STATUSES | TERMINAL_STATUSES
+
+# Known artifact kinds. Open vocabulary on purpose (a node pack may register
+# its own); listed for discoverability, never validated.
+ARTIFACT_KIND_CHECKPOINT = "checkpoint"
+ARTIFACT_KIND_EXPORT = "export"
+ARTIFACT_KIND_IMAGE = "image"
+
+_RUN_COLUMNS = (
+    "id, name, options, status, error, queue_key, created_at, started_at, "
+    "finished_at, git_commit, git_dirty, plugin_pins"
+)
+_METRIC_COLUMNS = "run_id, node_id, name, step, value, ts"
+_EVENT_COLUMNS = "run_id, cursor, type, payload, ts"
+_ARTIFACT_COLUMNS = "id, run_id, kind, path, meta, created_at"
+
+
+def _dumps(value: Any) -> str:
+    """Compact JSON for a storage column.
+
+    ``separators`` trims the whitespace sqlite would otherwise store for
+    every graph snapshot and event payload. ``ensure_ascii`` stays at its
+    default: escaping keeps a lone surrogate (legal in a JSON string that
+    arrived over the wire) from raising ``UnicodeEncodeError`` on insert,
+    and the round-trip is byte-identical either way.
+    """
+    return json.dumps(value, separators=(",", ":"))
+
+
+def _loads(raw: str | None) -> Any:
+    return None if raw is None else json.loads(raw)
+
+
+def _tri_state(value: int | None) -> bool | None:
+    """SQLite 0/1/NULL -> False/True/None (NULL means *unknown*, not False)."""
+    return None if value is None else bool(value)
+
+
+# ── records ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    """One ``exec_runs`` row, minus ``graph_snapshot`` (see module docstring)."""
+
+    id: str
+    name: str | None
+    options: dict[str, Any]
+    status: str
+    error: str | None
+    queue_key: str | None
+    created_at: str
+    started_at: str | None
+    finished_at: str | None
+    git_commit: str | None
+    git_dirty: bool | None
+    plugin_pins: dict[str, Any] | None
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "RunRecord":
+        return cls(
+            id=row["id"],
+            name=row["name"],
+            options=_loads(row["options"]) or {},
+            status=row["status"],
+            error=row["error"],
+            queue_key=row["queue_key"],
+            created_at=row["created_at"],
+            started_at=row["started_at"],
+            finished_at=row["finished_at"],
+            git_commit=row["git_commit"],
+            git_dirty=_tri_state(row["git_dirty"]),
+            plugin_pins=_loads(row["plugin_pins"]),
+        )
+
+
+@dataclass(frozen=True)
+class MetricRecord:
+    """One stored point of a named series. The read side of ``MetricPoint``."""
+
+    run_id: str
+    node_id: str | None
+    name: str
+    step: int
+    value: float
+    ts: str
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "MetricRecord":
+        return cls(run_id=row["run_id"], node_id=row["node_id"],
+                   name=row["name"], step=row["step"], value=row["value"],
+                   ts=row["ts"])
+
+
+class MetricPoint(NamedTuple):
+    """The write side: one point to append, before the store stamps it.
+
+    Separate from ``MetricRecord`` so the high-frequency producer can build
+    a flush batch without inventing a ``run_id``/``ts`` per point.
+    """
+
+    name: str
+    value: float
+    step: int
+    node_id: str | None = None
+    ts: str | None = None
+
+
+@dataclass(frozen=True)
+class EventRecord:
+    """One entry of a run's replay log, addressed by its per-run cursor."""
+
+    run_id: str
+    cursor: int
+    type: str
+    payload: Any
+    ts: str
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "EventRecord":
+        return cls(run_id=row["run_id"], cursor=row["cursor"],
+                   type=row["type"], payload=_loads(row["payload"]),
+                   ts=row["ts"])
+
+
+@dataclass(frozen=True)
+class ArtifactRecord:
+    """A file a run produced: checkpoint, export, image."""
+
+    id: int
+    run_id: str
+    kind: str
+    path: str
+    meta: Any
+    created_at: str
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "ArtifactRecord":
+        return cls(id=row["id"], run_id=row["run_id"], kind=row["kind"],
+                   path=row["path"], meta=_loads(row["meta"]),
+                   created_at=row["created_at"])
+
+
+@dataclass(frozen=True)
+class RunProvenance:
+    """What the workspace looked like when a run was submitted.
+
+    All three fields are tri-state: ``None`` means *not known*, and is
+    stored as SQL NULL rather than guessed — the same rule
+    ``app_versions.git_commit`` follows.
+    """
+
+    git_commit: str | None = None
+    git_dirty: bool | None = None
+    plugin_pins: dict[str, dict[str, Any]] | None = None
+
+    @classmethod
+    def capture(cls, project_dir: Path | str | None = None) -> "RunProvenance":
+        """Snapshot the current workspace. Blocking — call in a thread.
+
+        Runs two ``git`` subprocesses (via ``project.git_provenance``) and
+        reads the plugin lockfile, so ``create_run`` dispatches it through
+        ``asyncio.to_thread`` rather than calling it on the event loop.
+
+        *project_dir* defaults to ``settings.PROJECT_DIR``. Outside project
+        mode that is ``None`` and git is skipped entirely: the server's own
+        checkout is not the user's project, so reporting its commit would be
+        a lie, and spawning git per run to learn nothing is pure cost.
+        """
+        directory = project_dir if project_dir is not None \
+            else settings.PROJECT_DIR
+        commit: str | None = None
+        dirty: bool | None = None
+        if directory is not None:
+            commit, dirty = git_provenance(Path(directory))
+        return cls(git_commit=commit, git_dirty=dirty,
+                   plugin_pins=_capture_plugin_pins())
+
+
+def _capture_plugin_pins() -> dict[str, dict[str, Any]]:
+    """Which plugins were active for this run, from the install lockfile.
+
+    Related to but deliberately different from ``cdui project freeze``:
+    freeze emits only what can be re-installed (github pins with a sha) and
+    skips builtin/local entries. A run snapshot answers "what was loaded",
+    so builtin and local packs are included with whatever identity they
+    have. Disabled entries are skipped — they were not loaded.
+
+    Never raises: ``load_lockfile`` already degrades a missing or corrupt
+    file to an empty lockfile, and a malformed entry is skipped rather than
+    failing the run that was only trying to describe itself.
+    """
+    plugins = load_lockfile().get("plugins")
+    if not isinstance(plugins, dict):
+        return {}
+    pins: dict[str, dict[str, Any]] = {}
+    for plugin_id, entry in plugins.items():
+        if not isinstance(entry, dict) or not is_enabled(entry):
+            continue
+        manifest = entry.get("manifest")
+        pins[str(plugin_id)] = {
+            "source_kind": str(entry.get("source_kind") or ""),
+            "source": str(entry.get("source") or ""),
+            "ref": str(entry.get("ref") or ""),
+            "sha": str(entry.get("sha") or ""),
+            "version": (manifest.get("version")
+                        if isinstance(manifest, dict) else None),
+        }
+    return pins
+
+
+# ── the store ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunStore:
+    """Typed CRUD over the four ``exec_*`` tables.
+
+    Holds no state of its own beyond the ``Database`` it was handed, so it
+    is safe to construct per request or once on ``app.state``.
+    """
+
+    db: Database
+
+    # ── runs ──────────────────────────────────────────────────────────────
+
+    async def create_run(
+        self,
+        *,
+        graph_snapshot: dict[str, Any],
+        options: dict[str, Any] | None = None,
+        name: str | None = None,
+        status: str = STATUS_QUEUED,
+        queue_key: str | None = None,
+        run_id: str | None = None,
+        provenance: RunProvenance | None = None,
+    ) -> RunRecord:
+        """Insert a run and return its row.
+
+        *run_id* defaults to a fresh ``uuid4().hex`` (the shape the publish
+        ``runs.run_id`` and the WS envelope already use). Passing one is for
+        callers that minted the id earlier — a duplicate raises
+        ``sqlite3.IntegrityError`` rather than overwriting.
+
+        *provenance* defaults to a fresh ``RunProvenance.capture()`` in a
+        worker thread. Pass an explicit one (even an empty
+        ``RunProvenance()``) to skip the git/lockfile work.
+        """
+        if status not in RUN_STATUSES:
+            raise ValueError(
+                f"unknown run status {status!r}; expected one of "
+                f"{sorted(RUN_STATUSES)}")
+        if provenance is None:
+            provenance = await asyncio.to_thread(RunProvenance.capture)
+
+        record = RunRecord(
+            id=run_id or uuid4().hex,
+            name=name,
+            options=options if options is not None else {},
+            status=status,
+            error=None,
+            queue_key=queue_key,
+            created_at=utc_now_iso(),
+            started_at=None,
+            finished_at=None,
+            git_commit=provenance.git_commit,
+            git_dirty=provenance.git_dirty,
+            plugin_pins=provenance.plugin_pins,
+        )
+        params = (
+            record.id, record.name, _dumps(graph_snapshot),
+            _dumps(record.options), record.status, record.queue_key,
+            record.created_at, record.git_commit,
+            None if record.git_dirty is None else int(record.git_dirty),
+            None if record.plugin_pins is None else _dumps(record.plugin_pins),
+        )
+
+        def _insert(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                "INSERT INTO exec_runs (id, name, graph_snapshot, options, "
+                "status, queue_key, created_at, git_commit, git_dirty, "
+                "plugin_pins) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params,
+            )
+
+        await self.db.run(_insert)
+        return record
+
+    async def get_run(self, run_id: str) -> RunRecord | None:
+        def _select(conn: sqlite3.Connection) -> sqlite3.Row | None:
+            return conn.execute(
+                f"SELECT {_RUN_COLUMNS} FROM exec_runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()
+
+        row = await self.db.run(_select)
+        return None if row is None else RunRecord.from_row(row)
+
+    async def get_graph_snapshot(self, run_id: str) -> dict[str, Any] | None:
+        """The submitted graph, fetched on demand (not part of ``RunRecord``)."""
+        def _select(conn: sqlite3.Connection) -> str | None:
+            row = conn.execute(
+                "SELECT graph_snapshot FROM exec_runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()
+            return None if row is None else row["graph_snapshot"]
+
+        raw = await self.db.run(_select)
+        return None if raw is None else json.loads(raw)
+
+    async def list_runs(
+        self,
+        *,
+        status: str | Sequence[str] | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[RunRecord]:
+        """Newest first. Ties break on insertion order, never scan order.
+
+        *status* accepts one status or several (the Runs panel asks for
+        ``queued|running`` on mount). An unknown status raises rather than
+        quietly returning nothing; an EMPTY sequence is the honest empty
+        filter and returns nothing (``IN ()`` is not valid SQL).
+        """
+        where, params = "", []
+        if status is not None:
+            wanted = (status,) if isinstance(status, str) else tuple(status)
+            if not wanted:
+                return []
+            unknown = sorted(set(wanted) - RUN_STATUSES)
+            if unknown:
+                raise ValueError(
+                    f"unknown run status {unknown}; expected one of "
+                    f"{sorted(RUN_STATUSES)}")
+            where = f" WHERE status IN ({','.join('?' * len(wanted))})"
+            params = list(wanted)
+        params += [limit, offset]
+
+        def _select(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+            return conn.execute(
+                f"SELECT {_RUN_COLUMNS} FROM exec_runs{where} "
+                "ORDER BY created_at DESC, rowid DESC LIMIT ? OFFSET ?",
+                params,
+            ).fetchall()
+
+        return [RunRecord.from_row(r) for r in await self.db.run(_select)]
+
+    async def mark_running(
+        self, run_id: str, *, queue_key: str | None = None,
+    ) -> bool:
+        """Move a run to ``running``. False when no such run exists.
+
+        ``started_at`` is written once (COALESCE): a re-mark — a resumed or
+        retried run — must not erase when the work actually began. A
+        *queue_key* of None likewise leaves any previously resolved device
+        in place.
+        """
+        stamp = utc_now_iso()
+
+        def _update(conn: sqlite3.Connection) -> int:
+            return conn.execute(
+                "UPDATE exec_runs SET status = ?, "
+                "started_at = COALESCE(started_at, ?), "
+                "queue_key = COALESCE(?, queue_key) WHERE id = ?",
+                (STATUS_RUNNING, stamp, queue_key, run_id),
+            ).rowcount
+
+        return await self.db.run(_update) > 0
+
+    async def mark_finished(
+        self, run_id: str, status: str, *, error: str | None = None,
+    ) -> bool:
+        """Move a run to a terminal status and stamp ``finished_at``.
+
+        *error* is written as given, including None — the finishing caller
+        holds the authoritative outcome. ``started_at`` is left alone, so a
+        queued run cancelled before it ever ran keeps a NULL there.
+        """
+        if status not in TERMINAL_STATUSES:
+            raise ValueError(
+                f"{status!r} is not a terminal status; expected one of "
+                f"{sorted(TERMINAL_STATUSES)}")
+        stamp = utc_now_iso()
+
+        def _update(conn: sqlite3.Connection) -> int:
+            return conn.execute(
+                "UPDATE exec_runs SET status = ?, error = ?, finished_at = ? "
+                "WHERE id = ?",
+                (status, error, stamp, run_id),
+            ).rowcount
+
+        return await self.db.run(_update) > 0
+
+    async def interrupt_active_runs(
+        self, *, statuses: Sequence[str] = tuple(sorted(ACTIVE_STATUSES)),
+    ) -> int:
+        """Crash recovery: retire rows no process is driving any more.
+
+        Call once at startup. Both active states are covered by default —
+        nothing resumes a ``running`` row after a restart, and a ``queued``
+        row would otherwise wait forever on a scheduler that lost its queue.
+        Narrow it with *statuses* if a caller can genuinely re-adopt one.
+        Idempotent: a second call finds nothing.
+        """
+        wanted = tuple(statuses)
+        if not wanted:
+            return 0
+        unknown = sorted(set(wanted) - RUN_STATUSES)
+        if unknown:
+            raise ValueError(f"unknown run status {unknown}")
+        stamp = utc_now_iso()
+
+        def _update(conn: sqlite3.Connection) -> int:
+            return conn.execute(
+                "UPDATE exec_runs SET status = ?, finished_at = ? "
+                f"WHERE status IN ({','.join('?' * len(wanted))})",
+                (STATUS_INTERRUPTED, stamp, *wanted),
+            ).rowcount
+
+        return await self.db.run(_update)
+
+    # ── events ────────────────────────────────────────────────────────────
+
+    async def append_event(
+        self,
+        run_id: str,
+        event_type: str,
+        payload: Any = None,
+        *,
+        ts: str | None = None,
+    ) -> int:
+        """Append to a run's replay log; return the cursor it landed on.
+
+        Cursors are per run, 1-based, gapless and strictly increasing, which
+        is what lets a re-attaching client say "everything after N" and get
+        back exactly the events it missed, once each.
+
+        Why that holds under concurrent writers
+        ---------------------------------------
+        Allocating a cursor is a read-modify-write (``MAX(cursor) + 1`` then
+        INSERT), the classic lost-update shape. Three things stack:
+
+        1. In-process serialisation. Every call funnels through
+           ``Database.run``, which holds ONE ``asyncio.Lock`` for the whole
+           ``asyncio.to_thread`` hop onto ONE connection. Two coroutines
+           physically cannot interleave their statements, no matter how many
+           are gathered — this is the property the concurrency test pins.
+        2. Cross-connection serialisation. ``BEGIN IMMEDIATE`` takes the
+           write lock BEFORE the SELECT, so even a second connection on the
+           same file (another process, a future pool) cannot commit between
+           this read and this write. DEFERRED would not: it would upgrade
+           the lock only at the INSERT, having already read a stale MAX.
+        3. A constraint backstop. ``UNIQUE (run_id, cursor)`` means that if
+           1 and 2 were ever both defeated, the loser raises
+           ``IntegrityError`` — a failed append, never two events silently
+           sharing a cursor and a replay that skips one of them.
+
+        *payload* is any JSON-serialisable value; None stores SQL NULL.
+        Pass *ts* when the caller needs the exact stamp it will fan out to
+        subscribers, otherwise the store stamps it.
+        """
+        stamp = ts or utc_now_iso()
+        encoded = None if payload is None else _dumps(payload)
+
+        def _append(conn: sqlite3.Connection) -> int:
+            with transaction(conn):
+                cursor = conn.execute(
+                    "SELECT COALESCE(MAX(cursor), 0) + 1 FROM exec_run_events "
+                    "WHERE run_id = ?", (run_id,),
+                ).fetchone()[0]
+                conn.execute(
+                    "INSERT INTO exec_run_events (run_id, cursor, type, "
+                    "payload, ts) VALUES (?, ?, ?, ?, ?)",
+                    (run_id, cursor, event_type, encoded, stamp),
+                )
+                return cursor
+
+        return await self.db.run(_append)
+
+    async def get_events(
+        self, run_id: str, *, after_cursor: int = 0, limit: int | None = None,
+    ) -> list[EventRecord]:
+        """Replay in cursor order, strictly after *after_cursor*.
+
+        ``after_cursor=0`` is the whole log (cursors start at 1), which is
+        what a fresh attach asks for.
+        """
+        sql = (f"SELECT {_EVENT_COLUMNS} FROM exec_run_events "
+               "WHERE run_id = ? AND cursor > ? ORDER BY cursor")
+        params: list[Any] = [run_id, after_cursor]
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+
+        def _select(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+            return conn.execute(sql, params).fetchall()
+
+        return [EventRecord.from_row(r) for r in await self.db.run(_select)]
+
+    async def latest_cursor(self, run_id: str) -> int:
+        """Highest cursor issued for *run_id*; 0 when it has no events.
+
+        Because cursors are gapless this doubles as the event count.
+        """
+        def _select(conn: sqlite3.Connection) -> int:
+            return conn.execute(
+                "SELECT COALESCE(MAX(cursor), 0) FROM exec_run_events "
+                "WHERE run_id = ?", (run_id,),
+            ).fetchone()[0]
+
+        return await self.db.run(_select)
+
+    # ── metrics ───────────────────────────────────────────────────────────
+
+    async def log_metric(
+        self,
+        run_id: str,
+        name: str,
+        value: float,
+        step: int,
+        *,
+        node_id: str | None = None,
+        ts: str | None = None,
+    ) -> None:
+        """Append one point. Prefer ``log_metrics`` for anything in a loop."""
+        await self.log_metrics(
+            run_id, [MetricPoint(name, value, step, node_id, ts)])
+
+    async def log_metrics(
+        self, run_id: str, points: Iterable[MetricPoint],
+    ) -> int:
+        """Append a batch in ONE transaction; return how many landed.
+
+        The training-loop consumer flushes bursts, and per-point
+        transactions would mean one fsync each. All-or-nothing on purpose: a
+        bad point rolls the whole flush back rather than leaving a partial
+        one behind for a chart to interpolate through.
+        """
+        rows = [
+            (run_id, p.node_id, p.name, p.step, p.value, p.ts or utc_now_iso())
+            for p in points
+        ]
+        if not rows:
+            return 0
+
+        def _insert(conn: sqlite3.Connection) -> int:
+            with transaction(conn):
+                conn.executemany(
+                    "INSERT INTO exec_run_metrics (run_id, node_id, name, "
+                    "step, value, ts) VALUES (?, ?, ?, ?, ?, ?)",
+                    rows,
+                )
+                return len(rows)
+
+        return await self.db.run(_insert)
+
+    async def get_metrics(
+        self,
+        run_id: str,
+        *,
+        name: str | None = None,
+        after_step: int | None = None,
+        limit: int | None = None,
+    ) -> list[MetricRecord]:
+        """Points ordered ``(name, step)`` — chart order, and index order."""
+        sql = (f"SELECT {_METRIC_COLUMNS} FROM exec_run_metrics "
+               "WHERE run_id = ?")
+        params: list[Any] = [run_id]
+        if name is not None:
+            sql += " AND name = ?"
+            params.append(name)
+        if after_step is not None:
+            sql += " AND step > ?"
+            params.append(after_step)
+        sql += " ORDER BY name, step, id"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+
+        def _select(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+            return conn.execute(sql, params).fetchall()
+
+        return [MetricRecord.from_row(r) for r in await self.db.run(_select)]
+
+    async def list_metric_names(self, run_id: str) -> list[str]:
+        """Distinct series names for a run — the chart legend."""
+        def _select(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+            return conn.execute(
+                "SELECT DISTINCT name FROM exec_run_metrics "
+                "WHERE run_id = ? ORDER BY name", (run_id,),
+            ).fetchall()
+
+        return [r["name"] for r in await self.db.run(_select)]
+
+    # ── artifacts ─────────────────────────────────────────────────────────
+
+    async def add_artifact(
+        self, run_id: str, kind: str, path: str, *, meta: Any = None,
+    ) -> ArtifactRecord:
+        """Register a file a run produced. *kind* is an open vocabulary."""
+        created_at = utc_now_iso()
+        encoded = None if meta is None else _dumps(meta)
+
+        def _insert(conn: sqlite3.Connection) -> int:
+            return conn.execute(
+                "INSERT INTO exec_run_artifacts (run_id, kind, path, meta, "
+                "created_at) VALUES (?, ?, ?, ?, ?)",
+                (run_id, kind, path, encoded, created_at),
+            ).lastrowid
+
+        artifact_id = await self.db.run(_insert)
+        return ArtifactRecord(id=artifact_id, run_id=run_id, kind=kind,
+                              path=path, meta=meta, created_at=created_at)
+
+    async def list_artifacts(
+        self, run_id: str, *, kind: str | None = None,
+    ) -> list[ArtifactRecord]:
+        sql = (f"SELECT {_ARTIFACT_COLUMNS} FROM exec_run_artifacts "
+               "WHERE run_id = ?")
+        params: list[Any] = [run_id]
+        if kind is not None:
+            sql += " AND kind = ?"
+            params.append(kind)
+        sql += " ORDER BY created_at, id"
+
+        def _select(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+            return conn.execute(sql, params).fetchall()
+
+        return [ArtifactRecord.from_row(r) for r in await self.db.run(_select)]
+
+    # ── retention ─────────────────────────────────────────────────────────
+
+    async def delete_run(self, run_id: str) -> bool:
+        """Delete one run. Metrics, events and artifacts cascade with it.
+
+        The cascade is the schema's (``ON DELETE CASCADE`` +
+        ``PRAGMA foreign_keys=ON`` from ``Database.connect``), not a manual
+        three-table sweep that a future table would silently escape.
+        Artifact FILES are left on disk — this store never owned them.
+        """
+        def _delete(conn: sqlite3.Connection) -> int:
+            return conn.execute(
+                "DELETE FROM exec_runs WHERE id = ?", (run_id,)).rowcount
+
+        return await self.db.run(_delete) > 0
+
+    async def prune(self, *, keep_last: int) -> int:
+        """Keep the *keep_last* newest runs, delete the older ones.
+
+        Returns how many rows went (children cascade). Two rules:
+
+        - Active runs are never deleted. A queued or running row is live
+          state, not history; retention that could delete one would be a
+          scheduler bug generator.
+        - Active runs still occupy slots in the keep window, so *keep_last*
+          stays a straightforward cap on the table rather than a moving
+          target that depends on how many runs happen to be in flight.
+
+        ``keep_last=0`` therefore means "drop all finished runs", not "drop
+        everything". Age-based retention (the publish table's
+        ``Database.prune_runs`` model) can be added alongside this later;
+        the two are independent policies over different tables.
+        """
+        if keep_last < 0:
+            raise ValueError(f"keep_last must be >= 0, got {keep_last}")
+        active = tuple(sorted(ACTIVE_STATUSES))
+        params = (*active, keep_last)
+
+        def _prune(conn: sqlite3.Connection) -> int:
+            with transaction(conn):
+                return conn.execute(
+                    "DELETE FROM exec_runs WHERE status NOT IN "
+                    f"({','.join('?' * len(active))}) AND rowid NOT IN "
+                    "(SELECT rowid FROM exec_runs "
+                    "ORDER BY created_at DESC, rowid DESC LIMIT ?)",
+                    params,
+                ).rowcount
+
+        return await self.db.run(_prune)

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -369,10 +369,17 @@ class RunStore:
         if provenance is None:
             provenance = await asyncio.to_thread(RunProvenance.capture)
 
+        # Sanitize ONCE, up front, and build both the row and the returned
+        # record from the same copy. Storing _dumps(raw) while returning the
+        # caller's raw dict would make create_run(...).options differ from
+        # get_run(...).options for a non-finite value — and the returned
+        # record is what a REST layer serialises straight into its response,
+        # which would put a NaN token back on the wire. Copying also stops
+        # the record from aliasing a dict the caller can still mutate.
         record = RunRecord(
             id=run_id or uuid4().hex,
             name=name,
-            options=options if options is not None else {},
+            options=_json_safe(options) if options is not None else {},
             status=status,
             error=None,
             queue_key=queue_key,
@@ -381,7 +388,7 @@ class RunStore:
             finished_at=None,
             git_commit=provenance.git_commit,
             git_dirty=provenance.git_dirty,
-            plugin_pins=provenance.plugin_pins,
+            plugin_pins=_json_safe(provenance.plugin_pins),
         )
         params = (
             record.id, record.name, _dumps(graph_snapshot),
@@ -413,7 +420,15 @@ class RunStore:
         return None if row is None else RunRecord.from_row(row)
 
     async def get_graph_snapshot(self, run_id: str) -> dict[str, Any] | None:
-        """The submitted graph, fetched on demand (not part of ``RunRecord``)."""
+        """The submitted graph, fetched on demand (not part of ``RunRecord``).
+
+        JSON-normalised, not byte-preserved: the graph round-trips through
+        ``json.dumps``/``loads``, so key order and formatting are not the
+        submitted bytes, tuples come back as lists, and a non-finite float
+        comes back as null. Unlike ``app_versions.graph_json``, which stores
+        the exact saved-file bytes, this is a re-execution input, not a
+        signable artifact.
+        """
         def _select(conn: sqlite3.Connection) -> str | None:
             row = conn.execute(
                 "SELECT graph_snapshot FROM exec_runs WHERE id = ?",
@@ -518,9 +533,28 @@ class RunStore:
         return await self.db.run(_update) > 0
 
     async def mark_finished(
-        self, run_id: str, status: str, *, error: str | None = None,
+        self,
+        run_id: str,
+        status: str,
+        *,
+        error: str | None = None,
+        expected: Sequence[str] = tuple(sorted(ACTIVE_STATUSES)),
     ) -> bool:
-        """Move a run to a terminal status and stamp ``finished_at``.
+        """Move an ACTIVE run to a terminal status and stamp ``finished_at``.
+
+        Returns True only if the transition actually happened. It does not
+        happen when the run does not exist, or when its status is not in
+        *expected* — which by default means a run that already finished.
+        That guard is the point: a cancel racing a completion is normal
+        (the user hits Stop as the last epoch lands), and without it the
+        late writer wins and a succeeded run is filed forever as cancelled.
+        The same rule already protects ``interrupt_active_runs``.
+
+        A caller that genuinely means to overwrite a terminal row — a
+        correction, a re-classification — passes *expected* explicitly.
+        Distinguishing "no such run" from "already finished" needs a
+        ``get_run``; this returns one boolean on purpose, because both mean
+        "your write did not land".
 
         *error* is written as given, including None — the finishing caller
         holds the authoritative outcome. ``started_at`` is left alone, so a
@@ -530,13 +564,21 @@ class RunStore:
             raise ValueError(
                 f"{status!r} is not a terminal status; expected one of "
                 f"{sorted(TERMINAL_STATUSES)}")
+        allowed = tuple(expected)
+        if not allowed:
+            return False
+        unknown = sorted(set(allowed) - RUN_STATUSES)
+        if unknown:
+            raise ValueError(
+                f"unknown run status {unknown}; expected a subset of "
+                f"{sorted(RUN_STATUSES)}")
         stamp = utc_now_iso()
 
         def _update(conn: sqlite3.Connection) -> int:
             return conn.execute(
                 "UPDATE exec_runs SET status = ?, error = ?, finished_at = ? "
-                "WHERE id = ?",
-                (status, error, stamp, run_id),
+                f"WHERE id = ? AND status IN ({','.join('?' * len(allowed))})",
+                (status, error, stamp, run_id, *allowed),
             ).rowcount
 
         return await self.db.run(_update) > 0
@@ -626,8 +668,12 @@ class RunStore:
         attempt may already be in the log.
 
         *payload* is any JSON-serialisable value; None stores SQL NULL.
-        Pass *ts* when the caller needs the exact stamp it will fan out to
-        subscribers, otherwise the store stamps it.
+        Note that an omitted payload and an explicit JSON ``null`` are
+        therefore INDISTINGUISHABLE on read — both come back as None. An
+        event type that needs to tell those apart must wrap the value
+        (``{"value": None}``) rather than pass it bare. Pass *ts* when the
+        caller needs the exact stamp it will fan out to subscribers,
+        otherwise the store stamps it.
         """
         stamp = ts or utc_now_iso()
         encoded = None if payload is None else _dumps(payload)
@@ -784,8 +830,13 @@ class RunStore:
     async def add_artifact(
         self, run_id: str, kind: str, path: str, *, meta: Any = None,
     ) -> ArtifactRecord:
-        """Register a file a run produced. *kind* is an open vocabulary."""
+        """Register a file a run produced. *kind* is an open vocabulary.
+
+        *meta* is sanitized once and both stored and returned from that
+        copy, so the returned record always equals what a re-read gives.
+        """
         created_at = utc_now_iso()
+        meta = _json_safe(meta)
         encoded = None if meta is None else _dumps(meta)
 
         def _insert(conn: sqlite3.Connection) -> int:

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -21,6 +21,12 @@ Every method goes through ``Database.run`` — one sync function, one worker
 thread, one shared ``asyncio.Lock``, one connection. See ``append_event``
 for why that plus ``BEGIN IMMEDIATE`` is what makes the event cursor safe.
 
+Each method is individually atomic; they do NOT compose. Two calls are two
+transactions, and calling one from inside another's ``fn(conn)`` closure
+deadlocks on the non-reentrant lock. When a caller needs several writes to
+land together, that belongs in a new method with one ``Database.run`` —
+``log_metrics`` is the existing example (a whole flush, one transaction).
+
 Rows in, rows out
 -----------------
 Reads return frozen dataclasses, not ``sqlite3.Row``: the row objects are
@@ -35,6 +41,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
@@ -86,16 +93,40 @@ _EVENT_COLUMNS = "run_id, cursor, type, payload, ts"
 _ARTIFACT_COLUMNS = "id, run_id, kind, path, meta, created_at"
 
 
+def _json_safe(value: Any) -> Any:
+    """Replace every non-finite float with None, recursively."""
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return value
+
+
 def _dumps(value: Any) -> str:
-    """Compact JSON for a storage column.
+    """Compact JSON for a storage column. Always valid JSON.
 
     ``separators`` trims the whitespace sqlite would otherwise store for
     every graph snapshot and event payload. ``ensure_ascii`` stays at its
     default: escaping keeps a lone surrogate (legal in a JSON string that
     arrived over the wire) from raising ``UnicodeEncodeError`` on insert,
     and the round-trip is byte-identical either way.
+
+    ``allow_nan=False`` is the load-bearing one. Python's default emits the
+    bare tokens ``NaN`` / ``Infinity``, which are a CPython extension and
+    NOT JSON — ``JSON.parse`` throws on them. A stored event payload is
+    replayed verbatim to a browser on attach, so a diverged ``loss`` in a
+    progress payload would otherwise poison the whole replay, remotely and
+    long after the fact. The strict attempt runs first (no cost when the
+    data is clean); only when it trips do we walk the structure and replace
+    the offenders with null. Dropping the value beats dropping the event.
     """
-    return json.dumps(value, separators=(",", ":"))
+    try:
+        return json.dumps(value, separators=(",", ":"), allow_nan=False)
+    except ValueError:
+        return json.dumps(_json_safe(value), separators=(",", ":"),
+                          allow_nan=False)
 
 
 def _loads(raw: str | None) -> Any:
@@ -129,10 +160,17 @@ class RunRecord:
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "RunRecord":
+        # `or {}` would quietly turn a corrupt 0 / "" / [] into a plausible
+        # empty options dict; an explicit type check keeps damage loud.
+        options = _loads(row["options"])
+        if not isinstance(options, dict):
+            raise ValueError(
+                f"exec_runs.options for run {row['id']!r} is "
+                f"{type(options).__name__}, expected a JSON object")
         return cls(
             id=row["id"],
             name=row["name"],
-            options=_loads(row["options"]) or {},
+            options=options,
             status=row["status"],
             error=row["error"],
             queue_key=row["queue_key"],
@@ -147,13 +185,20 @@ class RunRecord:
 
 @dataclass(frozen=True)
 class MetricRecord:
-    """One stored point of a named series. The read side of ``MetricPoint``."""
+    """One stored point of a named series. The read side of ``MetricPoint``.
+
+    ``value`` is None when the producer logged a non-finite number — a
+    diverged ``train_loss`` is NaN, and neither sqlite nor JSON can carry
+    NaN or +/-inf. The point is still recorded at its step so a chart shows
+    a break exactly where the training went bad, instead of the series
+    silently ending there.
+    """
 
     run_id: str
     node_id: str | None
     name: str
     step: int
-    value: float
+    value: float | None
     ts: str
 
     @classmethod
@@ -392,19 +437,14 @@ class RunStore:
         ``queued|running`` on mount). An unknown status raises rather than
         quietly returning nothing; an EMPTY sequence is the honest empty
         filter and returns nothing (``IN ()`` is not valid SQL).
+
+        A single-status filter is fully index-ordered; a multi-status one
+        merges two index ranges and pays a sort. That is accepted — the
+        query exists to find the handful of runs still in flight.
         """
-        where, params = "", []
-        if status is not None:
-            wanted = (status,) if isinstance(status, str) else tuple(status)
-            if not wanted:
-                return []
-            unknown = sorted(set(wanted) - RUN_STATUSES)
-            if unknown:
-                raise ValueError(
-                    f"unknown run status {unknown}; expected one of "
-                    f"{sorted(RUN_STATUSES)}")
-            where = f" WHERE status IN ({','.join('?' * len(wanted))})"
-            params = list(wanted)
+        where, params = self._status_filter(status)
+        if where is None:
+            return []
         params += [limit, offset]
 
         def _select(conn: sqlite3.Connection) -> list[sqlite3.Row]:
@@ -415,6 +455,45 @@ class RunStore:
             ).fetchall()
 
         return [RunRecord.from_row(r) for r in await self.db.run(_select)]
+
+    async def count_runs(
+        self, *, status: str | Sequence[str] | None = None,
+    ) -> int:
+        """Total matching runs, ignoring limit/offset.
+
+        The paging companion to ``list_runs``: a table cannot render
+        "1-50 of 213" or size a scrollbar from a page alone.
+        """
+        where, params = self._status_filter(status)
+        if where is None:
+            return 0
+
+        def _count(conn: sqlite3.Connection) -> int:
+            return conn.execute(
+                f"SELECT COUNT(*) FROM exec_runs{where}", params).fetchone()[0]
+
+        return await self.db.run(_count)
+
+    @staticmethod
+    def _status_filter(
+        status: str | Sequence[str] | None,
+    ) -> tuple[str | None, list[Any]]:
+        """(WHERE fragment, params) for a status filter.
+
+        Returns ``(None, [])`` for an explicitly EMPTY filter — ``IN ()`` is
+        not valid SQL, so callers short-circuit to an empty result instead.
+        """
+        if status is None:
+            return "", []
+        wanted = (status,) if isinstance(status, str) else tuple(status)
+        if not wanted:
+            return None, []
+        unknown = sorted(set(wanted) - RUN_STATUSES)
+        if unknown:
+            raise ValueError(
+                f"unknown run status {unknown}; expected one of "
+                f"{sorted(RUN_STATUSES)}")
+        return f" WHERE status IN ({','.join('?' * len(wanted))})", list(wanted)
 
     async def mark_running(
         self, run_id: str, *, queue_key: str | None = None,
@@ -472,13 +551,20 @@ class RunStore:
         row would otherwise wait forever on a scheduler that lost its queue.
         Narrow it with *statuses* if a caller can genuinely re-adopt one.
         Idempotent: a second call finds nothing.
+
+        *statuses* is validated against ACTIVE_STATUSES, not the full
+        vocabulary: this rewrites ``status`` AND ``finished_at``, so letting
+        a terminal state through would let a startup call silently falsify
+        completed history.
         """
         wanted = tuple(statuses)
         if not wanted:
             return 0
-        unknown = sorted(set(wanted) - RUN_STATUSES)
+        unknown = sorted(set(wanted) - ACTIVE_STATUSES)
         if unknown:
-            raise ValueError(f"unknown run status {unknown}")
+            raise ValueError(
+                f"{unknown} is not an active status; expected a subset of "
+                f"{sorted(ACTIVE_STATUSES)}")
         stamp = utc_now_iso()
 
         def _update(conn: sqlite3.Connection) -> int:
@@ -513,18 +599,31 @@ class RunStore:
 
         1. In-process serialisation. Every call funnels through
            ``Database.run``, which holds ONE ``asyncio.Lock`` for the whole
-           ``asyncio.to_thread`` hop onto ONE connection. Two coroutines
-           physically cannot interleave their statements, no matter how many
-           are gathered — this is the property the concurrency test pins.
+           ``asyncio.to_thread`` hop onto ONE connection — including when
+           the caller is CANCELLED mid-call, which is the case that used to
+           hand the connection over with a transaction still open (see
+           ``Database.run``). Gathered coroutines cannot interleave their
+           statements. ``test_cursors_are_gapless_and_monotonic_under_
+           concurrent_writers`` pins this layer, plus the cursor-to-caller
+           mapping; note it CANNOT detect a missing transaction, because
+           the lock alone already serialises the 100 writers.
         2. Cross-connection serialisation. ``BEGIN IMMEDIATE`` takes the
            write lock BEFORE the SELECT, so even a second connection on the
            same file (another process, a future pool) cannot commit between
            this read and this write. DEFERRED would not: it would upgrade
            the lock only at the INSERT, having already read a stale MAX.
+           Pinned by ``test_append_event_reads_and_writes_in_one_immediate_
+           transaction`` here and by
+           ``test_transaction_takes_the_write_lock_up_front`` in test_db.
         3. A constraint backstop. ``UNIQUE (run_id, cursor)`` means that if
            1 and 2 were ever both defeated, the loser raises
            ``IntegrityError`` — a failed append, never two events silently
            sharing a cursor and a replay that skips one of them.
+
+        Not covered: an append whose caller is cancelled after the COMMIT
+        still leaves a durable event, and the cursor is lost with the
+        raise. A producer that retries must expect that its previous
+        attempt may already be in the log.
 
         *payload* is any JSON-serialisable value; None stores SQL NULL.
         Pass *ts* when the caller needs the exact stamp it will fan out to
@@ -606,9 +705,17 @@ class RunStore:
         transactions would mean one fsync each. All-or-nothing on purpose: a
         bad point rolls the whole flush back rather than leaving a partial
         one behind for a chart to interpolate through.
+
+        A non-finite value (NaN from a diverged loss, +/-inf) is stored as
+        NULL and reads back as ``MetricRecord.value is None``. It must not
+        be an error: all-or-nothing means one NaN would otherwise discard
+        every good point flushed alongside it, at exactly the moment the
+        user most needs to see the chart.
         """
         rows = [
-            (run_id, p.node_id, p.name, p.step, p.value, p.ts or utc_now_iso())
+            (run_id, p.node_id, p.name, p.step,
+             p.value if math.isfinite(p.value) else None,
+             p.ts or utc_now_iso())
             for p in points
         ]
         if not rows:
@@ -616,12 +723,11 @@ class RunStore:
 
         def _insert(conn: sqlite3.Connection) -> int:
             with transaction(conn):
-                conn.executemany(
+                return conn.executemany(
                     "INSERT INTO exec_run_metrics (run_id, node_id, name, "
                     "step, value, ts) VALUES (?, ?, ?, ?, ?, ?)",
                     rows,
-                )
-                return len(rows)
+                ).rowcount
 
         return await self.db.run(_insert)
 
@@ -633,7 +739,17 @@ class RunStore:
         after_step: int | None = None,
         limit: int | None = None,
     ) -> list[MetricRecord]:
-        """Points ordered ``(name, step)`` — chart order, and index order."""
+        """Points ordered ``(name, step)`` — chart order, and index order.
+
+        *limit* requires *name*. The ordering groups by series, so a raw row
+        cap over several interleaved series would return the whole
+        alphabetically-first one and NOTHING of the rest, with no signal
+        that anything was dropped. Cap a series, not a run.
+        """
+        if limit is not None and name is None:
+            raise ValueError(
+                "limit requires name: capping across series would silently "
+                "drop whole series (order is name, step)")
         sql = (f"SELECT {_METRIC_COLUMNS} FROM exec_run_metrics "
                "WHERE run_id = ?")
         params: list[Any] = [run_id]
@@ -673,11 +789,14 @@ class RunStore:
         encoded = None if meta is None else _dumps(meta)
 
         def _insert(conn: sqlite3.Connection) -> int:
-            return conn.execute(
+            cur = conn.execute(
                 "INSERT INTO exec_run_artifacts (run_id, kind, path, meta, "
                 "created_at) VALUES (?, ?, ?, ?, ?)",
                 (run_id, kind, path, encoded, created_at),
-            ).lastrowid
+            )
+            # lastrowid is Optional in the driver's typing; after a
+            # successful single-row INSERT it is always the new rowid.
+            return int(cur.lastrowid or 0)
 
         artifact_id = await self.db.run(_insert)
         return ArtifactRecord(id=artifact_id, run_id=run_id, kind=kind,

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -9,8 +9,10 @@ WAL / busy_timeout / foreign_keys pragmas.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sqlite3
+import threading
 
 import pytest
 
@@ -248,6 +250,55 @@ async def test_run_seam_executes_and_returns(tmp_path):
 
         assert await db.run(_count) == 1
     finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelling_run_waits_for_the_worker_thread(tmp_path):
+    # A cancelled db.run must NOT release the lock while its fn is still
+    # executing: the abandoned thread would keep driving BEGIN/COMMIT on the
+    # SHARED connection, and the next caller's write would be swallowed by
+    # someone else's ROLLBACK, swept into their COMMIT, or refused with
+    # "cannot start a transaction within a transaction".
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    inside = threading.Event()
+    release = threading.Event()
+
+    def _slow(conn: sqlite3.Connection) -> None:
+        with transaction(conn):
+            conn.execute(
+                "INSERT INTO api_keys (name, prefix, token_hash, created_at) "
+                "VALUES ('slow', 'p', ?, ?)", ("a" * 64, utc_now_iso()))
+            inside.set()
+            release.wait(10)
+
+    try:
+        task = asyncio.create_task(db.run(_slow))
+        await asyncio.to_thread(inside.wait, 10)   # thread is mid-transaction
+        task.cancel()
+        await asyncio.sleep(0.05)                  # let cancellation settle
+        assert db._lock.locked()                   # lock NOT handed over yet
+        assert not task.done()
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert db._conn.in_transaction is False
+
+        # The next caller gets a quiet connection and its write survives.
+        def _next(conn: sqlite3.Connection) -> int:
+            with transaction(conn):
+                conn.execute(
+                    "INSERT INTO api_keys (name, prefix, token_hash, "
+                    "created_at) VALUES ('next', 'p', ?, ?)",
+                    ("b" * 64, utc_now_iso()))
+            return conn.execute(
+                "SELECT COUNT(*) FROM api_keys").fetchone()[0]
+
+        assert await db.run(_next) == 2
+    finally:
+        release.set()
         db.close()
 
 

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -10,6 +10,7 @@ WAL / busy_timeout / foreign_keys pragmas.
 from __future__ import annotations
 
 import asyncio
+import gc
 import logging
 import sqlite3
 import threading
@@ -297,6 +298,89 @@ async def test_cancelling_run_waits_for_the_worker_thread(tmp_path):
                 "SELECT COUNT(*) FROM api_keys").fetchone()[0]
 
         assert await db.run(_next) == 2
+    finally:
+        release.set()
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_sweep_cannot_cancel_the_worker(tmp_path):
+    # asyncio's teardown cancels EVERY entry of all_tasks(). If the worker
+    # were a Task (what ensure_future(to_thread(...)) builds) the sweep
+    # would cancel it directly: done() flips True while the thread is still
+    # mid-transaction and the lock goes early -- the same bug as above
+    # through a second door. run_in_executor hands back a Future, which the
+    # sweep cannot see.
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    inside = threading.Event()
+    release = threading.Event()
+
+    def _slow(conn: sqlite3.Connection) -> None:
+        with transaction(conn):
+            conn.execute(
+                "INSERT INTO api_keys (name, prefix, token_hash, created_at) "
+                "VALUES ('slow', 'p', ?, ?)", ("a" * 64, utc_now_iso()))
+            inside.set()
+            release.wait(10)
+
+    try:
+        task = asyncio.create_task(db.run(_slow))
+        await asyncio.to_thread(inside.wait, 10)
+
+        current = asyncio.current_task()
+        for pending in asyncio.all_tasks():
+            if pending is not current:
+                pending.cancel()
+        await asyncio.sleep(0.05)
+        assert db._lock.locked()          # connection still private
+        assert db._conn.in_transaction    # ...and the thread still owns it
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert db._conn.in_transaction is False
+        assert await db.run(lambda c: c.execute(
+            "SELECT COUNT(*) FROM api_keys").fetchone()[0]) == 1
+    finally:
+        release.set()
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_run_does_not_leak_an_unretrieved_exception(
+        tmp_path, caplog):
+    # End-to-end guard on the fn-raises-AND-caller-cancelled path: the lock
+    # comes back, CancelledError wins over the worker's error, and asyncio
+    # logs nothing. Honest about its own reach: this passes with or without
+    # Database.run's explicit worker.exception(), because shield's
+    # _inner_done_callback already retrieves the inner exception when the
+    # outer was cancelled. It is the OBSERVABLE that is pinned here (no
+    # "never retrieved" noise, whatever the mechanism), so a refactor that
+    # drops the shield and forgets the retrieval is caught.
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    inside = threading.Event()
+    release = threading.Event()
+
+    def _boom(conn: sqlite3.Connection) -> None:
+        inside.set()
+        release.wait(10)
+        raise sqlite3.OperationalError("worker blew up")
+
+    try:
+        with caplog.at_level(logging.ERROR, logger="asyncio"):
+            task = asyncio.create_task(db.run(_boom))
+            await asyncio.to_thread(inside.wait, 10)
+            task.cancel()
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert db._lock.locked() is False
+            del task
+            gc.collect()
+            await asyncio.sleep(0)      # let any handler callback land
+        assert "never retrieved" not in caplog.text
     finally:
         release.set()
         db.close()

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -14,7 +14,7 @@ import sqlite3
 
 import pytest
 
-from app.core.db import Database, utc_now_iso
+from app.core.db import Database, transaction, utc_now_iso
 from app.core.migrations import MIGRATIONS, iter_statements
 
 
@@ -23,13 +23,19 @@ def test_connect_migrates_empty_file(tmp_path):
     db.connect()
     try:
         assert db._conn.execute("PRAGMA user_version").fetchone()[0] \
-            == len(MIGRATIONS) == 2
+            == len(MIGRATIONS) == 3
         names = {
             r[0] for r in db._conn.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table'"
             ).fetchall()
         }
+        # Publish (001/002) plus the Run Service store (003). The literal
+        # count above is a deliberate tripwire: adding a migration should
+        # make someone extend this set too. Per-table schema assertions
+        # live with each subsystem (test_provenance / test_run_store).
         assert {"apps", "app_versions", "api_keys", "runs"} <= names
+        assert {"exec_runs", "exec_run_metrics", "exec_run_events",
+                "exec_run_artifacts"} <= names
     finally:
         db.close()
 
@@ -85,6 +91,67 @@ def test_failed_migration_rolls_back_atomically(tmp_path, monkeypatch):
         assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
     finally:
         conn.close()
+
+
+# ── transaction() ────────────────────────────────────────────────────────
+
+
+def test_transaction_commits_on_success(tmp_path):
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    try:
+        with transaction(db._conn) as conn:
+            conn.execute(
+                "INSERT INTO api_keys (name, prefix, token_hash, created_at) "
+                "VALUES ('t', 'cdui_a', ?, ?)", ("h" * 64, utc_now_iso()))
+        assert db._conn.in_transaction is False   # no dangling transaction
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM api_keys").fetchone()[0] == 1
+    finally:
+        db.close()
+
+
+def test_transaction_rolls_back_every_statement_on_failure(tmp_path):
+    # The multi-statement guarantee: the first INSERT must not survive a
+    # failure in the second (this is exactly what RunStore's batched metric
+    # flush and cursor allocation rely on).
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            with transaction(db._conn) as conn:
+                conn.execute(
+                    "INSERT INTO api_keys (name, prefix, token_hash, "
+                    "created_at) VALUES ('a', 'p', ?, ?)",
+                    ("h" * 64, utc_now_iso()))
+                conn.execute(
+                    "INSERT INTO api_keys (name, prefix, token_hash, "
+                    "created_at) VALUES ('b', 'p', ?, ?)",   # duplicate hash
+                    ("h" * 64, utc_now_iso()))
+        assert db._conn.in_transaction is False   # no dangling transaction
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM api_keys").fetchone()[0] == 0
+    finally:
+        db.close()
+
+
+def test_transaction_takes_the_write_lock_up_front(tmp_path):
+    # IMMEDIATE, not DEFERRED: the lock must be held before the block's
+    # first read, which is what makes a read-then-write cursor allocation
+    # safe against a second connection.
+    db = Database(tmp_path / "codefyui.db")
+    db.connect()
+    other = sqlite3.connect(str(tmp_path / "codefyui.db"),
+                            isolation_level=None)
+    other.execute("PRAGMA busy_timeout=0")
+    try:
+        with transaction(db._conn) as conn:
+            conn.execute("SELECT COUNT(*) FROM api_keys").fetchone()
+            with pytest.raises(sqlite3.OperationalError, match="locked|busy"):
+                other.execute("BEGIN IMMEDIATE")
+    finally:
+        other.close()
+        db.close()
 
 
 def test_iter_statements_handles_comments_and_multistatement():

--- a/backend/tests/test_provenance.py
+++ b/backend/tests/test_provenance.py
@@ -44,16 +44,20 @@ def _user_version(db: Database) -> int:
 
 
 def test_migration_002_columns_and_idempotent(tmp_path):
+    # Fully-migrated head, not the literal 2: later migrations (003+) belong
+    # to other subsystems and must not make this provenance test a liar.
+    from app.core.migrations import MIGRATIONS
+
     db = Database(tmp_path / "p.db")
     db.connect()
-    assert _user_version(db) == 2
+    assert _user_version(db) == len(MIGRATIONS)
     cols = _table_columns(db, "app_versions")
     assert "git_commit" in cols and "git_dirty" in cols
     db.close()
     # Re-connecting an already-migrated DB is a no-op (user_version gate).
     db2 = Database(tmp_path / "p.db")
     db2.connect()
-    assert _user_version(db2) == 2
+    assert _user_version(db2) == len(MIGRATIONS)
     db2.close()
 
 

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -256,6 +256,24 @@ def test_event_replay_and_cursor_allocation_are_index_served(db):
         assert "TEMP B-TREE" not in plan
 
 
+def test_metric_reads_are_index_served(db):
+    """The chart queries, in the exact form get_metrics/list_metric_names
+    emit. `ORDER BY name, step, id` is chosen to match the index; a future
+    reorder to `ts` or `step, name` would still be correct but would sort
+    the whole series on every poll of a live run."""
+    for sql, params in (
+        ("SELECT run_id, node_id, name, step, value, ts FROM exec_run_metrics "
+         "WHERE run_id = ? AND name = ? ORDER BY name, step, id", ("r", "a")),
+        ("SELECT DISTINCT name FROM exec_run_metrics WHERE run_id = ? "
+         "ORDER BY name", ("r",)),
+    ):
+        plan = " ".join(r["detail"] for r in db._conn.execute(
+            "EXPLAIN QUERY PLAN " + sql, params).fetchall())
+        assert "idx_exec_run_metrics_series" in plan
+        assert "SCAN exec_run_metrics" not in plan
+        assert "TEMP B-TREE" not in plan
+
+
 def test_status_vocabulary_is_not_pinned_in_sql(db):
     """No CHECK constraint on `status`: SQLite cannot ALTER one away, and
     the queue/sweep issues may add lifecycle states. Enforcement is the
@@ -415,6 +433,39 @@ async def test_cancelling_a_queued_run_leaves_started_at_null(store):
     cancelled = await store.get_run(run.id)
     assert cancelled.started_at is None
     assert cancelled.finished_at is not None
+
+
+async def test_a_late_cancel_cannot_rewrite_a_finished_run(store):
+    """The Stop-button race: the user hits cancel as the last epoch lands.
+
+    Without a precondition the late writer wins and a run that actually
+    succeeded is filed forever as cancelled -- with a finished_at from the
+    wrong moment.
+    """
+    run = await _make_run(store)
+    await store.mark_running(run.id)
+    assert await store.mark_finished(run.id, "succeeded") is True
+    settled = await store.get_run(run.id)
+
+    assert await store.mark_finished(run.id, "cancelled") is False
+    unchanged = await store.get_run(run.id)
+    assert unchanged.status == "succeeded"
+    assert unchanged.finished_at == settled.finished_at
+    assert unchanged.error is None
+
+
+async def test_mark_finished_can_be_forced_with_an_explicit_expected(store):
+    run = await _make_run(store)
+    await store.mark_finished(run.id, "succeeded")
+    assert await store.mark_finished(
+        run.id, "failed", error="found later",
+        expected=["succeeded"]) is True
+    fixed = await store.get_run(run.id)
+    assert (fixed.status, fixed.error) == ("failed", "found later")
+
+    assert await store.mark_finished(run.id, "failed", expected=[]) is False
+    with pytest.raises(ValueError, match="status"):
+        await store.mark_finished(run.id, "failed", expected=["nope"])
 
 
 async def test_mark_finished_rejects_a_non_terminal_status(store):
@@ -726,6 +777,34 @@ async def test_artifact_meta_and_options_are_also_json_safe(store):
     assert art.id > 0
 
 
+async def test_returned_records_equal_what_a_reread_gives(store):
+    """The RETURN VALUE must be sanitized too, not just the stored row.
+
+    #120 serialises the record it got back straight into its response, so
+    a create_run(...) that still held the caller's raw NaN would put the
+    non-JSON token back on the wire that this store just removed.
+    """
+    created = await store.create_run(
+        graph_snapshot={}, options={"lr": float("nan"), "epochs": 3},
+        provenance=RunProvenance())
+    assert created.options == {"lr": None, "epochs": 3}
+    assert created == await store.get_run(created.id)
+
+    art = await store.add_artifact(created.id, "checkpoint", "c.pt",
+                                   meta={"loss": float("-inf"), "epoch": 1})
+    assert art.meta == {"loss": None, "epoch": 1}
+    assert art == (await store.list_artifacts(created.id))[0]
+
+
+async def test_create_run_does_not_alias_the_callers_dict(store):
+    options = {"device": "cpu"}
+    created = await store.create_run(graph_snapshot={}, options=options,
+                                     provenance=RunProvenance())
+    options["device"] = "cuda"          # caller keeps using its own dict
+    assert created.options == {"device": "cpu"}
+    assert (await store.get_run(created.id)).options == {"device": "cpu"}
+
+
 # ── 5. artifacts ──────────────────────────────────────────────────────────
 
 
@@ -890,17 +969,15 @@ async def test_provenance_skips_git_outside_project_mode(store, monkeypatch):
     assert run.plugin_pins == {}
 
 
-def test_capture_uses_the_real_git_helper_and_the_project_dir():
+def test_capture_binds_the_real_git_helper():
     """Wiring check without spawning git.
 
     Asserting `capture(x) == git_provenance(x)` against the live checkout
     would be both tautological and flaky: `dirty` is whatever the working
     tree looks like at that instant, so anything writing into the repo
-    between the two calls reddens the test. Prove the binding by identity,
-    and prove the argument with a spy.
+    between the two calls reddens the test. Prove the binding by identity;
+    the companion test below proves the argument.
     """
-    from pathlib import Path
-
     from app.core import project, run_store
 
     assert run_store.git_provenance is project.git_provenance

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -15,6 +15,7 @@ Four concerns, in order:
 from __future__ import annotations
 
 import asyncio
+import json
 import sqlite3
 
 import pytest
@@ -217,6 +218,29 @@ def test_the_run_list_order_is_served_by_an_index(db):
     ).fetchall())
     assert "idx_exec_runs_created" in plan
     assert "TEMP B-TREE" not in plan
+
+
+def test_status_filtered_list_order_is_index_served_for_one_status(db):
+    """...and honestly is NOT for several.
+
+    A multi-value IN merges two index ranges, which cannot preserve a
+    global created_at order, so sqlite sorts. Accepted: that query exists
+    to find the handful of runs still in flight. Asserted rather than left
+    implicit so the ASC-index rationale does not overclaim.
+    """
+    def _plan(marks: str, params: tuple) -> str:
+        return " ".join(r["detail"] for r in db._conn.execute(
+            f"EXPLAIN QUERY PLAN SELECT id FROM exec_runs WHERE status IN "
+            f"({marks}) ORDER BY created_at DESC, rowid DESC LIMIT ?", params,
+        ).fetchall())
+
+    one = _plan("?", ("queued", 1))
+    assert "idx_exec_runs_status_created" in one
+    assert "TEMP B-TREE" not in one
+
+    two = _plan("?,?", ("queued", "running", 1))
+    assert "idx_exec_runs_status_created" in two
+    assert "TEMP B-TREE" in two          # documented, accepted trade-off
 
 
 def test_event_replay_and_cursor_allocation_are_index_served(db):
@@ -430,6 +454,31 @@ async def test_interrupt_active_runs_can_be_narrowed_to_running(store):
         await store.interrupt_active_runs(statuses=["nope"])
 
 
+async def test_interrupt_active_runs_refuses_to_rewrite_finished_history(store):
+    # It rewrites status AND finished_at, so a terminal status must not be
+    # reachable through the statuses= escape hatch.
+    done = await _make_run(store)
+    await store.mark_finished(done.id, "succeeded")
+    with pytest.raises(ValueError, match="not an active status"):
+        await store.interrupt_active_runs(statuses=["succeeded"])
+    assert (await store.get_run(done.id)).status == "succeeded"
+
+
+async def test_count_runs_ignores_paging(store):
+    for _ in range(3):
+        await _make_run(store)
+    running = await _make_run(store)
+    await store.mark_running(running.id)
+
+    assert await store.count_runs() == 4
+    assert await store.count_runs(status="queued") == 3
+    assert await store.count_runs(status=["queued", "running"]) == 4
+    assert await store.count_runs(status=[]) == 0
+    assert len(await store.list_runs(limit=2)) == 2      # paging unaffected
+    with pytest.raises(ValueError, match="status"):
+        await store.count_runs(status="bogus")
+
+
 def test_status_constants_partition_the_vocabulary():
     assert ACTIVE_STATUSES | TERMINAL_STATUSES == RUN_STATUSES
     assert not (ACTIVE_STATUSES & TERMINAL_STATUSES)
@@ -462,6 +511,31 @@ async def test_cursors_are_gapless_and_monotonic_under_concurrent_writers(store)
     by_cursor = {e.cursor: e.payload["i"] for e in events}
     for i, cursor in enumerate(cursors):
         assert by_cursor[cursor] == i
+
+
+async def test_append_event_reads_and_writes_in_one_immediate_transaction(
+        store, db):
+    """Layer 2 of the cursor argument, which the gather test cannot see.
+
+    The gather test is serialised by Database.run's lock before any SQL
+    runs, so it passes even with no transaction at all. What actually
+    protects the read-modify-write from a SECOND connection is that the
+    SELECT and the INSERT sit inside one BEGIN IMMEDIATE -- assert exactly
+    that statement order.
+    """
+    run = await _make_run(store)
+    statements: list[str] = []
+    db._conn.set_trace_callback(statements.append)
+    try:
+        await store.append_event(run.id, "log", {"i": 1})
+    finally:
+        db._conn.set_trace_callback(None)
+
+    trimmed = [" ".join(s.split()).upper() for s in statements]
+    assert trimmed[0].startswith("BEGIN IMMEDIATE")   # not DEFERRED, not absent
+    assert trimmed[-1].startswith("COMMIT")
+    body = " ".join(trimmed)
+    assert body.index("MAX(CURSOR)") < body.index("INSERT INTO")
 
 
 async def test_cursors_are_independent_per_run(store):
@@ -596,6 +670,60 @@ async def test_list_metric_names_is_sorted_and_deduped(store):
 async def test_metric_for_an_unknown_run_is_rejected(store):
     with pytest.raises(sqlite3.IntegrityError):
         await store.log_metric("ghost", "train_loss", 1.0, 0)
+
+
+async def test_a_diverged_loss_is_stored_as_none_not_an_error(store):
+    # sqlite binds NaN as NULL, so a NOT NULL column would reject it with a
+    # constraint error -- and because the flush is all-or-nothing, would
+    # discard every good point around it. A diverged loss is the single
+    # thing a user most wants to SEE on the chart.
+    run = await _make_run(store)
+    points = [MetricPoint("train_loss", 0.5, 0),
+              MetricPoint("train_loss", float("nan"), 1),
+              MetricPoint("train_loss", float("inf"), 2),
+              MetricPoint("train_loss", float("-inf"), 3),
+              MetricPoint("train_loss", 0.25, 4)]
+    assert await store.log_metrics(run.id, points) == 5
+    series = await store.get_metrics(run.id, name="train_loss")
+    assert [m.step for m in series] == [0, 1, 2, 3, 4]
+    assert [m.value for m in series] == [0.5, None, None, None, 0.25]
+
+
+async def test_get_metrics_limit_requires_a_name(store):
+    run = await _make_run(store)
+    await store.log_metrics(run.id, [MetricPoint("a", 1.0, 0),
+                                     MetricPoint("b", 1.0, 0)])
+    with pytest.raises(ValueError, match="limit requires name"):
+        await store.get_metrics(run.id, limit=1)
+
+
+async def test_event_payloads_never_store_non_json_tokens(store):
+    # json.dumps defaults to allow_nan=True and emits the bare tokens NaN /
+    # Infinity, which JSON.parse throws on -- and the WS attach path replays
+    # stored payloads verbatim to a browser.
+    run = await _make_run(store)
+    await store.append_event(run.id, "progress", {
+        "loss": float("nan"), "lr": float("inf"),
+        "losses": [1.0, float("-inf")], "epoch": 3})
+    raw = await store.db.run(lambda conn: conn.execute(
+        "SELECT payload FROM exec_run_events WHERE run_id = ?",
+        (run.id,)).fetchone()[0])
+    assert "NaN" not in raw and "Infinity" not in raw
+    assert json.loads(raw) == {"loss": None, "lr": None,
+                               "losses": [1.0, None], "epoch": 3}
+    assert (await store.get_events(run.id))[0].payload["epoch"] == 3
+
+
+async def test_artifact_meta_and_options_are_also_json_safe(store):
+    run = await store.create_run(graph_snapshot={"t": [float("nan")]},
+                                 options={"lr": float("inf")},
+                                 provenance=RunProvenance())
+    assert (await store.get_run(run.id)).options == {"lr": None}
+    assert await store.get_graph_snapshot(run.id) == {"t": [None]}
+    art = await store.add_artifact(run.id, "checkpoint", "c.pt",
+                                   meta={"loss": float("nan")})
+    assert (await store.list_artifacts(run.id))[0].meta == {"loss": None}
+    assert art.id > 0
 
 
 # ── 5. artifacts ──────────────────────────────────────────────────────────
@@ -762,26 +890,56 @@ async def test_provenance_skips_git_outside_project_mode(store, monkeypatch):
     assert run.plugin_pins == {}
 
 
-def test_provenance_capture_delegates_to_the_real_git_helper(tmp_path):
-    """Wiring check against the unpatched project.git_provenance, asserted
-    as equality so it holds in a git checkout AND in a source tarball."""
+def test_capture_uses_the_real_git_helper_and_the_project_dir():
+    """Wiring check without spawning git.
+
+    Asserting `capture(x) == git_provenance(x)` against the live checkout
+    would be both tautological and flaky: `dirty` is whatever the working
+    tree looks like at that instant, so anything writing into the repo
+    between the two calls reddens the test. Prove the binding by identity,
+    and prove the argument with a spy.
+    """
     from pathlib import Path
 
-    from app.core.project import git_provenance
+    from app.core import project, run_store
 
-    for directory in (Path(__file__).resolve().parents[2], tmp_path):
-        captured = RunProvenance.capture(directory)
-        assert (captured.git_commit, captured.git_dirty) == \
-            git_provenance(directory)
+    assert run_store.git_provenance is project.git_provenance
 
 
-def test_provenance_capture_tolerates_a_corrupt_lockfile(monkeypatch, tmp_path):
+def test_capture_passes_the_project_dir_as_a_path(monkeypatch):
+    seen: list[object] = []
+    monkeypatch.setattr("app.core.run_store.git_provenance",
+                        lambda d: (seen.append(d) or ("a" * 40, False)))
+    monkeypatch.setattr("app.core.run_store.load_lockfile",
+                        lambda: {"schema": 1, "plugins": {}})
+    monkeypatch.setattr("app.core.run_store.settings.PROJECT_DIR",
+                        r"C:\projects\demo")
+
+    from pathlib import Path
+    assert RunProvenance.capture().git_commit == "a" * 40
+    assert seen == [Path(r"C:\projects\demo")]     # str coerced to Path
+
+    seen.clear()
+    RunProvenance.capture(Path("/explicit"))       # explicit beats settings
+    assert seen == [Path("/explicit")]
+
+
+@pytest.fixture
+def no_git(monkeypatch):
+    """Keep the plugin-pin tests off real `git` subprocesses."""
+    monkeypatch.setattr("app.core.run_store.git_provenance",
+                        lambda d: (None, None))
+
+
+def test_provenance_capture_tolerates_a_corrupt_lockfile(
+        monkeypatch, tmp_path, no_git):
     monkeypatch.setattr("app.core.run_store.load_lockfile",
                         lambda: {"schema": 1, "plugins": "not-a-dict"})
     assert RunProvenance.capture(tmp_path).plugin_pins == {}
 
 
-def test_provenance_capture_skips_disabled_plugins(monkeypatch, tmp_path):
+def test_provenance_capture_skips_disabled_plugins(
+        monkeypatch, tmp_path, no_git):
     monkeypatch.setattr("app.core.run_store.load_lockfile", lambda: {
         "schema": 1,
         "plugins": {

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -1,0 +1,807 @@
+"""Tests for app.core.run_store + migration 003 (Run Service storage, #119).
+
+Four concerns, in order:
+
+1. Migration 003 applies cleanly on a FRESH database and as an in-place
+   UPGRADE of the shipped v2 schema, without touching the publish
+   subsystem's own (unrelated) ``runs`` table.
+2. Typed CRUD round-trips for runs / metrics / events / artifacts.
+3. THE hard requirement: ``append_event`` hands out a per-run cursor that
+   is gapless AND monotonic under concurrent asyncio writers, and every
+   caller gets back the cursor its own event actually landed on.
+4. Retention (``prune``/``delete_run``) and provenance capture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+import pytest
+
+from app.core.db import Database
+from app.core.migrations import MIGRATION_001, MIGRATION_002, MIGRATIONS
+from app.core.run_store import (
+    ACTIVE_STATUSES,
+    ARTIFACT_KIND_CHECKPOINT,
+    ARTIFACT_KIND_EXPORT,
+    ARTIFACT_KIND_IMAGE,
+    RUN_STATUSES,
+    TERMINAL_STATUSES,
+    MetricPoint,
+    RunProvenance,
+    RunRecord,
+    RunStore,
+)
+
+EXEC_TABLES = {
+    "exec_runs",
+    "exec_run_metrics",
+    "exec_run_events",
+    "exec_run_artifacts",
+}
+
+GRAPH = {
+    "name": "demo",
+    "nodes": [
+        {"id": "a", "type": "Start", "position": {"x": 0, "y": 0},
+         "data": {"params": {}}},
+    ],
+    "edges": [],
+}
+OPTIONS = {"device": "cpu", "seed": 7, "record_outputs": True,
+           "lane": "queued"}
+
+
+# ── fixtures / helpers ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = Database(tmp_path / "codefyui.db")
+    database.connect()
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+@pytest.fixture
+def store(db):
+    return RunStore(db)
+
+
+def _tables(database: Database) -> set[str]:
+    return {r[0] for r in database._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()}
+
+
+def _index_names(database: Database) -> set[str]:
+    return {r[0] for r in database._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'index' "
+        "AND name IS NOT NULL").fetchall()}
+
+
+def _columns(database: Database, table: str) -> list[str]:
+    return [r["name"] for r in database._conn.execute(
+        f"PRAGMA table_info({table})").fetchall()]
+
+
+def _user_version(database: Database) -> int:
+    return database._conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+def _indexed_columns(database: Database, table: str) -> set[tuple[str, ...]]:
+    """Column tuples of every index on *table* (name-independent shape check)."""
+    out: set[tuple[str, ...]] = set()
+    for row in database._conn.execute(f"PRAGMA index_list({table})").fetchall():
+        cols = database._conn.execute(
+            f"PRAGMA index_info({row['name']})").fetchall()
+        out.add(tuple(c["name"] for c in cols))
+    return out
+
+
+async def _make_run(store: RunStore, **kwargs) -> RunRecord:
+    kwargs.setdefault("graph_snapshot", GRAPH)
+    kwargs.setdefault("options", OPTIONS)
+    kwargs.setdefault("provenance", RunProvenance())
+    return await store.create_run(**kwargs)
+
+
+# ── 1. migrations ─────────────────────────────────────────────────────────
+
+
+def test_fresh_install_creates_the_four_exec_tables(db):
+    assert _user_version(db) == len(MIGRATIONS) == 3
+    assert EXEC_TABLES <= _tables(db)
+
+
+def test_fresh_install_keeps_the_publish_tables_untouched(db):
+    # The naming decision under test: `exec_runs` is a NEW namespace, so the
+    # Stage-2 publish tables -- including its own, unrelated `runs` table --
+    # must survive migration 003 byte-for-byte.
+    assert {"apps", "app_versions", "api_keys", "runs"} <= _tables(db)
+    assert _columns(db, "runs") == [
+        "run_id", "app_id", "version", "api_key_id", "status", "error_code",
+        "error_message", "error_node_id", "device", "total_s",
+        "node_timings_json", "inputs_json", "outputs_json", "created_at",
+    ]
+
+
+def test_exec_runs_has_the_full_column_list(db):
+    assert _columns(db, "exec_runs") == [
+        "id", "name", "graph_snapshot", "options", "status", "error",
+        "queue_key", "created_at", "started_at", "finished_at",
+        "git_commit", "git_dirty", "plugin_pins",
+    ]
+
+
+def test_child_tables_have_the_specified_columns(db):
+    assert _columns(db, "exec_run_metrics") == [
+        "id", "run_id", "node_id", "name", "step", "value", "ts"]
+    assert _columns(db, "exec_run_events") == [
+        "id", "run_id", "cursor", "type", "payload", "ts"]
+    assert _columns(db, "exec_run_artifacts") == [
+        "id", "run_id", "kind", "path", "meta", "created_at"]
+
+
+def test_required_indexes_exist(db):
+    assert ("run_id", "name", "step") in _indexed_columns(db, "exec_run_metrics")
+    assert ("run_id", "cursor") in _indexed_columns(db, "exec_run_events")
+    assert ("run_id",) in {t[:1] for t in _indexed_columns(db, "exec_run_artifacts")}
+    names = _index_names(db)
+    assert "idx_exec_runs_created" in names
+    assert "idx_exec_runs_status_created" in names
+
+
+def test_upgrade_from_shipped_v2_db_preserves_publish_data(tmp_path, monkeypatch):
+    """In-place upgrade of a real v2 DB with rows in it (test_provenance.py
+    pattern): user_version 2 -> 3, new tables appear, old rows survive."""
+    from app.core import db as dbmod
+
+    monkeypatch.setattr(dbmod, "MIGRATIONS", [MIGRATION_001, MIGRATION_002])
+    old = Database(tmp_path / "u.db")
+    old.connect()
+    assert _user_version(old) == 2
+    assert not (EXEC_TABLES & _tables(old))
+    now = "2026-01-01T00:00:00.000000Z"
+    old._conn.execute(
+        "INSERT INTO apps (id, slug, graph_name, active_version, record_io, "
+        "created_at, updated_at) VALUES (1, 'legacy', 'g', 1, 1, ?, ?)",
+        (now, now),
+    )
+    old._conn.execute(
+        "INSERT INTO runs (run_id, app_id, version, api_key_id, status, "
+        "created_at) VALUES ('legacy-invoke', 1, 1, NULL, 'ok', ?)", (now,),
+    )
+    old.close()
+
+    monkeypatch.setattr(dbmod, "MIGRATIONS", list(MIGRATIONS))
+    new = Database(tmp_path / "u.db")
+    new.connect()
+    try:
+        assert _user_version(new) == 3
+        assert EXEC_TABLES <= _tables(new)
+        row = new._conn.execute(
+            "SELECT status, created_at FROM runs WHERE run_id = 'legacy-invoke'"
+        ).fetchone()
+        assert row["status"] == "ok"            # publish history intact
+        assert row["created_at"] == now
+        assert new._conn.execute(
+            "SELECT COUNT(*) FROM exec_runs").fetchone()[0] == 0
+    finally:
+        new.close()
+
+
+def test_reconnecting_a_v3_db_is_a_noop(tmp_path):
+    first = Database(tmp_path / "idem.db")
+    first.connect()
+    first.close()
+    second = Database(tmp_path / "idem.db")
+    second.connect()          # must not raise "table already exists"
+    try:
+        assert _user_version(second) == len(MIGRATIONS)
+        assert EXEC_TABLES <= _tables(second)
+    finally:
+        second.close()
+
+
+def test_the_run_list_order_is_served_by_an_index(db):
+    """Guards the ASC-index choice in migration 003. `created_at DESC,
+    rowid DESC` is satisfied by scanning an ASC index backwards; flipping
+    the index to DESC silently degrades every Runs-panel poll to a full
+    scan plus a sort, which no functional test would notice."""
+    plan = " ".join(r["detail"] for r in db._conn.execute(
+        "EXPLAIN QUERY PLAN SELECT id FROM exec_runs "
+        "ORDER BY created_at DESC, rowid DESC LIMIT ? OFFSET ?", (1, 0),
+    ).fetchall())
+    assert "idx_exec_runs_created" in plan
+    assert "TEMP B-TREE" not in plan
+
+
+def test_event_replay_and_cursor_allocation_are_index_served(db):
+    for sql, params in (
+        ("SELECT cursor FROM exec_run_events WHERE run_id = ? AND cursor > ? "
+         "ORDER BY cursor", ("r", 0)),
+        ("SELECT COALESCE(MAX(cursor), 0) + 1 FROM exec_run_events "
+         "WHERE run_id = ?", ("r",)),
+    ):
+        plan = " ".join(r["detail"] for r in db._conn.execute(
+            "EXPLAIN QUERY PLAN " + sql, params).fetchall())
+        assert "SCAN exec_run_events" not in plan   # never a full scan
+        assert "TEMP B-TREE" not in plan
+
+
+def test_status_vocabulary_is_not_pinned_in_sql(db):
+    """No CHECK constraint on `status`: SQLite cannot ALTER one away, and
+    the queue/sweep issues may add lifecycle states. Enforcement is the
+    DAO's frozenset instead (asserted by the create/finish tests)."""
+    ddl = db._conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'exec_runs'").fetchone()[0]
+    assert "CHECK" not in ddl.upper()
+
+
+def test_schema_stays_additive_for_the_sweep_column(db):
+    """#140 will add `sweep_id` -- prove a plain ALTER TABLE ADD COLUMN is
+    enough (no table rebuild, no data migration)."""
+    db._conn.execute("ALTER TABLE exec_runs ADD COLUMN sweep_id TEXT")
+    assert "sweep_id" in _columns(db, "exec_runs")
+
+
+# ── 2. run CRUD ───────────────────────────────────────────────────────────
+
+
+async def test_create_and_get_run_round_trip(store):
+    created = await _make_run(store, name="mnist", queue_key="cpu")
+    assert created.status == "queued"
+    assert created.name == "mnist"
+    assert created.queue_key == "cpu"
+    assert created.options == OPTIONS
+    assert created.started_at is None and created.finished_at is None
+    assert created.error is None
+    assert len(created.id) == 32           # uuid4().hex, like publish runs
+
+    fetched = await store.get_run(created.id)
+    assert fetched == created
+
+
+async def test_graph_snapshot_is_fetched_separately_from_the_row(store):
+    # RunRecord deliberately omits the (potentially megabyte) snapshot so
+    # list_runs() stays cheap for the Runs panel's polling.
+    run = await _make_run(store)
+    assert not hasattr(run, "graph_snapshot")
+    assert await store.get_graph_snapshot(run.id) == GRAPH
+    assert await store.get_graph_snapshot("nope") is None
+
+
+async def test_get_run_returns_none_for_unknown_id(store):
+    assert await store.get_run("does-not-exist") is None
+
+
+async def test_create_run_defaults_options_to_empty_dict(store):
+    run = await store.create_run(graph_snapshot=GRAPH,
+                                 provenance=RunProvenance())
+    assert run.options == {}
+    assert (await store.get_run(run.id)).options == {}
+
+
+async def test_create_run_accepts_an_explicit_run_id(store):
+    run = await _make_run(store, run_id="fixed-id")
+    assert run.id == "fixed-id"
+    assert (await store.get_run("fixed-id")) == run
+
+
+async def test_create_run_rejects_an_unknown_status(store):
+    with pytest.raises(ValueError, match="status"):
+        await _make_run(store, status="wat")
+
+
+async def test_create_run_accepts_an_already_running_status(store):
+    # A caller that starts work immediately should not have to insert
+    # `queued` first and correct it a microsecond later.
+    run = await _make_run(store, status="running")
+    assert (await store.get_run(run.id)).status == "running"
+
+
+async def test_duplicate_run_id_is_rejected_loudly(store):
+    await _make_run(store, run_id="dup")
+    with pytest.raises(sqlite3.IntegrityError):
+        await _make_run(store, run_id="dup")
+
+
+async def test_non_ascii_graph_and_options_survive_the_round_trip(store):
+    graph = {"name": "中文圖", "nodes": [], "edges": []}
+    run = await store.create_run(
+        graph_snapshot=graph, options={"note": "訓練"},
+        name="實驗 1", provenance=RunProvenance())
+    assert await store.get_graph_snapshot(run.id) == graph
+    reread = await store.get_run(run.id)
+    assert reread.name == "實驗 1"
+    assert reread.options == {"note": "訓練"}
+
+
+async def test_list_runs_is_newest_first_and_filters_by_status(store):
+    a = await _make_run(store, name="a")
+    b = await _make_run(store, name="b")
+    c = await _make_run(store, name="c")
+    await store.mark_running(b.id)
+    await store.mark_finished(c.id, "succeeded")
+
+    assert [r.id for r in await store.list_runs()] == [c.id, b.id, a.id]
+    assert [r.id for r in await store.list_runs(status="running")] == [b.id]
+    assert [r.id for r in await store.list_runs(
+        status=["queued", "running"])] == [b.id, a.id]
+    assert [r.id for r in await store.list_runs(limit=2)] == [c.id, b.id]
+    assert [r.id for r in await store.list_runs(limit=2, offset=2)] == [a.id]
+
+
+async def test_list_runs_rejects_an_unknown_status_filter(store):
+    with pytest.raises(ValueError, match="status"):
+        await store.list_runs(status="finished")
+
+
+async def test_list_runs_with_an_empty_status_filter_returns_nothing(store):
+    # `IN ()` is a syntax error, so the empty filter must short-circuit
+    # rather than reach sqlite.
+    await _make_run(store)
+    assert await store.list_runs(status=[]) == []
+
+
+async def test_list_runs_ties_break_on_insertion_order(store, monkeypatch):
+    # Same created_at for every row -> ordering must still be deterministic
+    # (newest inserted first), never sqlite's arbitrary scan order.
+    monkeypatch.setattr("app.core.run_store.utc_now_iso",
+                        lambda: "2026-01-01T00:00:00.000000Z")
+    ids = [(await _make_run(store)).id for _ in range(5)]
+    assert [r.id for r in await store.list_runs()] == list(reversed(ids))
+
+
+async def test_mark_running_sets_status_and_started_at(store):
+    run = await _make_run(store)
+    assert await store.mark_running(run.id, queue_key="cuda:0") is True
+    updated = await store.get_run(run.id)
+    assert updated.status == "running"
+    assert updated.started_at is not None
+    assert updated.queue_key == "cuda:0"
+    assert updated.finished_at is None
+
+
+async def test_mark_running_keeps_the_first_started_at(store):
+    run = await _make_run(store)
+    await store.mark_running(run.id)
+    first = (await store.get_run(run.id)).started_at
+    await store.mark_running(run.id)
+    assert (await store.get_run(run.id)).started_at == first
+
+
+async def test_mark_finished_records_terminal_status_and_error(store):
+    run = await _make_run(store)
+    await store.mark_running(run.id)
+    assert await store.mark_finished(run.id, "failed", error="boom") is True
+    done = await store.get_run(run.id)
+    assert done.status == "failed"
+    assert done.error == "boom"
+    assert done.finished_at is not None
+
+
+async def test_cancelling_a_queued_run_leaves_started_at_null(store):
+    # Dequeue-cancel: the run never ran, so it must not claim a start time.
+    run = await _make_run(store)
+    await store.mark_finished(run.id, "cancelled")
+    cancelled = await store.get_run(run.id)
+    assert cancelled.started_at is None
+    assert cancelled.finished_at is not None
+
+
+async def test_mark_finished_rejects_a_non_terminal_status(store):
+    run = await _make_run(store)
+    with pytest.raises(ValueError, match="terminal"):
+        await store.mark_finished(run.id, "running")
+
+
+async def test_mark_helpers_return_false_for_unknown_runs(store):
+    assert await store.mark_running("ghost") is False
+    assert await store.mark_finished("ghost", "succeeded") is False
+
+
+async def test_interrupt_active_runs_clears_zombie_states(store):
+    queued = await _make_run(store)
+    running = await _make_run(store)
+    finished = await _make_run(store)
+    await store.mark_running(running.id)
+    await store.mark_finished(finished.id, "succeeded")
+
+    assert await store.interrupt_active_runs() == 2
+    assert (await store.get_run(running.id)).status == "interrupted"
+    assert (await store.get_run(queued.id)).status == "interrupted"
+    assert (await store.get_run(finished.id)).status == "succeeded"
+    assert (await store.get_run(running.id)).finished_at is not None
+    assert await store.interrupt_active_runs() == 0   # idempotent
+
+
+async def test_interrupt_active_runs_can_be_narrowed_to_running(store):
+    queued = await _make_run(store)
+    running = await _make_run(store)
+    await store.mark_running(running.id)
+    assert await store.interrupt_active_runs(statuses=["running"]) == 1
+    assert (await store.get_run(queued.id)).status == "queued"
+    assert await store.interrupt_active_runs(statuses=[]) == 0
+    with pytest.raises(ValueError, match="status"):
+        await store.interrupt_active_runs(statuses=["nope"])
+
+
+def test_status_constants_partition_the_vocabulary():
+    assert ACTIVE_STATUSES | TERMINAL_STATUSES == RUN_STATUSES
+    assert not (ACTIVE_STATUSES & TERMINAL_STATUSES)
+    assert RUN_STATUSES == {"queued", "running", "succeeded", "failed",
+                            "cancelled", "interrupted"}
+
+
+# ── 3. events: the gapless cursor ─────────────────────────────────────────
+
+
+async def test_append_event_returns_a_one_based_cursor(store):
+    run = await _make_run(store)
+    assert await store.append_event(run.id, "execution_start") == 1
+    assert await store.append_event(run.id, "node_status", {"n": "a"}) == 2
+
+
+async def test_cursors_are_gapless_and_monotonic_under_concurrent_writers(store):
+    """THE acceptance criterion. 100 coroutines append at once; every
+    caller must get a distinct cursor, the set must be exactly 1..100,
+    and the payload stored at cursor C must be the one whose caller was
+    handed C (no cross-assignment)."""
+    run = await _make_run(store)
+    cursors = await asyncio.gather(*(
+        store.append_event(run.id, "log", {"i": i}) for i in range(100)
+    ))
+    assert sorted(cursors) == list(range(1, 101))
+
+    events = await store.get_events(run.id)
+    assert [e.cursor for e in events] == list(range(1, 101))
+    by_cursor = {e.cursor: e.payload["i"] for e in events}
+    for i, cursor in enumerate(cursors):
+        assert by_cursor[cursor] == i
+
+
+async def test_cursors_are_independent_per_run(store):
+    a = await _make_run(store)
+    b = await _make_run(store)
+    interleaved = await asyncio.gather(*(
+        store.append_event(run.id, "log", {"i": i})
+        for i in range(20) for run in (a, b)
+    ))
+    assert sorted(interleaved) == sorted(list(range(1, 21)) * 2)
+    assert await store.latest_cursor(a.id) == 20
+    assert await store.latest_cursor(b.id) == 20
+
+
+async def test_latest_cursor_is_zero_before_any_event(store):
+    run = await _make_run(store)
+    assert await store.latest_cursor(run.id) == 0
+    assert await store.latest_cursor("ghost") == 0
+
+
+async def test_get_events_replays_after_a_cursor_without_gaps_or_dupes(store):
+    run = await _make_run(store)
+    for i in range(10):
+        await store.append_event(run.id, "log", {"i": i})
+    tail = await store.get_events(run.id, after_cursor=6)
+    assert [e.cursor for e in tail] == [7, 8, 9, 10]
+    assert [e.payload["i"] for e in tail] == [6, 7, 8, 9]
+    assert await store.get_events(run.id, after_cursor=10) == []
+
+    page = await store.get_events(run.id, after_cursor=0, limit=3)
+    assert [e.cursor for e in page] == [1, 2, 3]
+
+
+async def test_event_record_carries_type_payload_and_timestamp(store):
+    run = await _make_run(store)
+    await store.append_event(run.id, "node_status",
+                             {"node_id": "a", "status": "running"},
+                             ts="2026-01-01T00:00:00.000000Z")
+    event = (await store.get_events(run.id))[0]
+    assert event.run_id == run.id
+    assert event.type == "node_status"
+    assert event.payload == {"node_id": "a", "status": "running"}
+    assert event.ts == "2026-01-01T00:00:00.000000Z"
+
+
+async def test_event_payload_may_be_omitted(store):
+    run = await _make_run(store)
+    await store.append_event(run.id, "execution_complete")
+    assert (await store.get_events(run.id))[0].payload is None
+
+
+async def test_append_event_for_an_unknown_run_is_rejected(store):
+    with pytest.raises(sqlite3.IntegrityError):
+        await store.append_event("ghost", "log")
+
+
+def test_duplicate_cursor_is_rejected_by_the_unique_constraint(db):
+    """Backstop for the serialized-writer argument: even if a second
+    connection ever bypassed Database.run's lock, a lost update would
+    raise instead of silently duplicating a cursor."""
+    now = "2026-01-01T00:00:00.000000Z"
+    db._conn.execute(
+        "INSERT INTO exec_runs (id, graph_snapshot, options, status, "
+        "created_at) VALUES ('r', '{}', '{}', 'running', ?)", (now,))
+    db._conn.execute(
+        "INSERT INTO exec_run_events (run_id, cursor, type, ts) "
+        "VALUES ('r', 1, 'log', ?)", (now,))
+    with pytest.raises(sqlite3.IntegrityError):
+        db._conn.execute(
+            "INSERT INTO exec_run_events (run_id, cursor, type, ts) "
+            "VALUES ('r', 1, 'log', ?)", (now,))
+
+
+# ── 4. metrics ────────────────────────────────────────────────────────────
+
+
+async def test_log_metric_round_trip(store):
+    run = await _make_run(store)
+    await store.log_metric(run.id, "train_loss", 0.5, 1, node_id="loop")
+    metric = (await store.get_metrics(run.id))[0]
+    assert metric.run_id == run.id
+    assert metric.name == "train_loss"
+    assert metric.value == pytest.approx(0.5)
+    assert metric.step == 1
+    assert metric.node_id == "loop"
+    assert metric.ts
+
+
+async def test_get_metrics_filters_by_name_and_orders_by_step(store):
+    run = await _make_run(store)
+    for step in (3, 1, 2):
+        await store.log_metric(run.id, "train_loss", step / 10, step)
+        await store.log_metric(run.id, "val_loss", step, step)
+    series = await store.get_metrics(run.id, name="train_loss")
+    assert [m.step for m in series] == [1, 2, 3]
+    assert [m.value for m in series] == pytest.approx([0.1, 0.2, 0.3])
+    assert len(await store.get_metrics(run.id)) == 6
+    assert [m.step for m in await store.get_metrics(
+        run.id, name="val_loss", after_step=1)] == [2, 3]
+    assert [m.step for m in await store.get_metrics(
+        run.id, name="train_loss", limit=2)] == [1, 2]
+
+
+async def test_log_metrics_batch_inserts_every_point(store):
+    run = await _make_run(store)
+    points = [MetricPoint("train_loss", 1.0 / (s + 1), s) for s in range(50)]
+    assert await store.log_metrics(run.id, points) == 50
+    assert len(await store.get_metrics(run.id, name="train_loss")) == 50
+    assert await store.log_metrics(run.id, []) == 0
+
+
+async def test_log_metrics_batch_is_atomic(store):
+    """One bad point rolls the whole batch back -- the high-frequency
+    consumer never leaves a half-written flush behind."""
+    run = await _make_run(store)
+    points = [MetricPoint("ok", 1.0, 0), MetricPoint("bad", 1.0, None)]
+    with pytest.raises(sqlite3.IntegrityError):
+        await store.log_metrics(run.id, points)
+    assert await store.get_metrics(run.id) == []
+
+
+async def test_list_metric_names_is_sorted_and_deduped(store):
+    run = await _make_run(store)
+    await store.log_metrics(run.id, [
+        MetricPoint("val_loss", 1.0, 0), MetricPoint("train_loss", 2.0, 0),
+        MetricPoint("train_loss", 1.5, 1),
+    ])
+    assert await store.list_metric_names(run.id) == ["train_loss", "val_loss"]
+    assert await store.list_metric_names("ghost") == []
+
+
+async def test_metric_for_an_unknown_run_is_rejected(store):
+    with pytest.raises(sqlite3.IntegrityError):
+        await store.log_metric("ghost", "train_loss", 1.0, 0)
+
+
+# ── 5. artifacts ──────────────────────────────────────────────────────────
+
+
+def test_artifact_kind_constants_are_the_documented_literals():
+    assert (ARTIFACT_KIND_CHECKPOINT, ARTIFACT_KIND_EXPORT,
+            ARTIFACT_KIND_IMAGE) == ("checkpoint", "export", "image")
+
+
+async def test_add_and_list_artifacts(store):
+    run = await _make_run(store)
+    art = await store.add_artifact(
+        run.id, ARTIFACT_KIND_CHECKPOINT, "models/interrupt.pt",
+        meta={"epoch": 3, "batch": 12})
+    assert art.id > 0
+    assert art.kind == "checkpoint"
+    assert art.path == "models/interrupt.pt"
+    assert art.meta == {"epoch": 3, "batch": 12}
+    assert art.created_at
+
+    listed = await store.list_artifacts(run.id)
+    assert listed == [art]
+
+
+async def test_list_artifacts_filters_by_kind(store):
+    run = await _make_run(store)
+    await store.add_artifact(run.id, "checkpoint", "a.pt")
+    await store.add_artifact(run.id, "image", "b.png")
+    assert [a.path for a in await store.list_artifacts(run.id, kind="image")] \
+        == ["b.png"]
+    assert len(await store.list_artifacts(run.id)) == 2
+    assert await store.list_artifacts("ghost") == []
+
+
+async def test_artifact_meta_defaults_to_none(store):
+    run = await _make_run(store)
+    art = await store.add_artifact(run.id, "export", "out.py")
+    assert art.meta is None
+
+
+async def test_artifact_for_an_unknown_run_is_rejected(store):
+    with pytest.raises(sqlite3.IntegrityError):
+        await store.add_artifact("ghost", "checkpoint", "a.pt")
+
+
+# ── 6. retention ──────────────────────────────────────────────────────────
+
+
+async def _child_counts(database: Database, run_id: str) -> tuple[int, int, int]:
+    def _count(conn: sqlite3.Connection) -> tuple[int, int, int]:
+        return tuple(
+            conn.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE run_id = ?", (run_id,)
+            ).fetchone()[0]
+            for table in ("exec_run_metrics", "exec_run_events",
+                          "exec_run_artifacts")
+        )
+    return await database.run(_count)
+
+
+async def _populate(store: RunStore, run: RunRecord) -> None:
+    await store.log_metric(run.id, "train_loss", 1.0, 0)
+    await store.append_event(run.id, "execution_start")
+    await store.add_artifact(run.id, "checkpoint", "c.pt")
+
+
+async def test_delete_run_cascades_to_children(store, db):
+    run = await _make_run(store)
+    await _populate(store, run)
+    assert await _child_counts(db, run.id) == (1, 1, 1)
+
+    assert await store.delete_run(run.id) is True
+    assert await store.get_run(run.id) is None
+    assert await _child_counts(db, run.id) == (0, 0, 0)
+    assert await store.delete_run(run.id) is False
+
+
+async def test_prune_keeps_the_newest_n_and_cascades(store, db):
+    runs = []
+    for _ in range(5):
+        run = await _make_run(store)
+        await _populate(store, run)
+        await store.mark_finished(run.id, "succeeded")
+        runs.append(run)
+
+    assert await store.prune(keep_last=2) == 3
+    remaining = {r.id for r in await store.list_runs()}
+    assert remaining == {runs[3].id, runs[4].id}
+    assert await _child_counts(db, runs[0].id) == (0, 0, 0)
+    assert await _child_counts(db, runs[4].id) == (1, 1, 1)
+    assert await store.prune(keep_last=2) == 0      # nothing left to drop
+
+
+async def test_prune_never_deletes_queued_or_running_runs(store):
+    old_active = await _make_run(store, name="active")
+    await store.mark_running(old_active.id)
+    old_queued = await _make_run(store, name="queued")
+    for _ in range(3):
+        done = await _make_run(store)
+        await store.mark_finished(done.id, "succeeded")
+
+    assert await store.prune(keep_last=0) == 3
+    survivors = {r.name for r in await store.list_runs()}
+    assert survivors == {"active", "queued"}
+
+
+async def test_prune_rejects_a_negative_keep_last(store):
+    with pytest.raises(ValueError, match="keep_last"):
+        await store.prune(keep_last=-1)
+
+
+async def test_publish_retention_does_not_touch_exec_runs(store, db):
+    """Database.prune_runs targets the publish `runs` table only -- the two
+    same-named concepts must never prune each other."""
+    run = await _make_run(store)
+    await store.mark_finished(run.id, "succeeded")
+    db._conn.execute(
+        "UPDATE exec_runs SET created_at = '2000-01-01T00:00:00.000000Z'")
+    assert await db.prune_runs(1, force=True) == 0
+    assert await store.get_run(run.id) is not None
+
+
+# ── 7. provenance ─────────────────────────────────────────────────────────
+
+
+async def test_create_run_persists_captured_provenance(store, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.run_store.git_provenance", lambda d: ("a" * 40, True))
+    monkeypatch.setattr(
+        "app.core.run_store.load_lockfile",
+        lambda: {"schema": 1, "plugins": {
+            "demo": {"source_kind": "github_url", "source": "o/r",
+                     "ref": "v1", "sha": "b" * 40, "enabled": True,
+                     "manifest": {"version": "0.2.0"}}}})
+    monkeypatch.setattr("app.core.run_store.settings.PROJECT_DIR",
+                        "/some/project")
+
+    run = await store.create_run(graph_snapshot=GRAPH)
+    assert run.git_commit == "a" * 40
+    assert run.git_dirty is True
+    assert run.plugin_pins == {"demo": {
+        "source_kind": "github_url", "source": "o/r", "ref": "v1",
+        "sha": "b" * 40, "version": "0.2.0"}}
+
+    reread = await store.get_run(run.id)
+    assert reread.git_commit == run.git_commit
+    assert reread.git_dirty is True                  # INTEGER 1 -> True
+    assert reread.plugin_pins == run.plugin_pins
+
+
+async def test_provenance_skips_git_outside_project_mode(store, monkeypatch):
+    called: list[object] = []
+    monkeypatch.setattr("app.core.run_store.git_provenance",
+                        lambda d: called.append(d) or ("x", False))
+    monkeypatch.setattr("app.core.run_store.load_lockfile",
+                        lambda: {"schema": 1, "plugins": {}})
+    monkeypatch.setattr("app.core.run_store.settings.PROJECT_DIR", None)
+
+    run = await store.create_run(graph_snapshot=GRAPH)
+    assert called == []                    # no subprocess in non-project mode
+    assert run.git_commit is None
+    assert run.git_dirty is None
+    assert run.plugin_pins == {}
+
+
+def test_provenance_capture_delegates_to_the_real_git_helper(tmp_path):
+    """Wiring check against the unpatched project.git_provenance, asserted
+    as equality so it holds in a git checkout AND in a source tarball."""
+    from pathlib import Path
+
+    from app.core.project import git_provenance
+
+    for directory in (Path(__file__).resolve().parents[2], tmp_path):
+        captured = RunProvenance.capture(directory)
+        assert (captured.git_commit, captured.git_dirty) == \
+            git_provenance(directory)
+
+
+def test_provenance_capture_tolerates_a_corrupt_lockfile(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.core.run_store.load_lockfile",
+                        lambda: {"schema": 1, "plugins": "not-a-dict"})
+    assert RunProvenance.capture(tmp_path).plugin_pins == {}
+
+
+def test_provenance_capture_skips_disabled_plugins(monkeypatch, tmp_path):
+    monkeypatch.setattr("app.core.run_store.load_lockfile", lambda: {
+        "schema": 1,
+        "plugins": {
+            "on": {"source_kind": "builtin", "source": "on"},
+            "off": {"source_kind": "builtin", "source": "off",
+                    "enabled": False},
+        },
+    })
+    pins = RunProvenance.capture(tmp_path).plugin_pins
+    assert set(pins) == {"on"}
+    assert pins["on"] == {"source_kind": "builtin", "source": "on",
+                          "ref": "", "sha": "", "version": None}
+
+
+async def test_explicit_provenance_overrides_capture(store, monkeypatch):
+    monkeypatch.setattr("app.core.run_store.git_provenance",
+                        lambda d: pytest.fail("capture must be skipped"))
+    run = await store.create_run(
+        graph_snapshot=GRAPH,
+        provenance=RunProvenance(git_commit="c" * 40, git_dirty=False,
+                                 plugin_pins={}))
+    assert run.git_commit == "c" * 40
+    assert (await store.get_run(run.id)).git_dirty is False


### PR DESCRIPTION
## Summary

Storage-only first stone for the Run Service: migration 003 adds four tables for graph-execution runs, and a new `RunStore` DAO (`backend/app/core/run_store.py`) gives the follow-up issues typed CRUD, an atomic per-run event cursor, and retention helpers. No service logic, no REST routes, no wiring into `app.state` — those are #120.

## Schema (migration 003)

| Table | Shape |
|---|---|
| `exec_runs` | `id` (uuid4 hex PK), `name`, `graph_snapshot` (JSON), `options` (JSON), `status`, `error`, `queue_key`, `created_at`, `started_at`, `finished_at`, `git_commit`, `git_dirty`, `plugin_pins` (JSON). Indexes `(created_at)`, `(status, created_at)`. |
| `exec_run_metrics` | `id`, `run_id` FK CASCADE, `node_id`, `name`, `step`, `value` (nullable -- see below), `ts`. Index `(run_id, name, step)`. |
| `exec_run_events` | `id`, `run_id` FK CASCADE, `cursor`, `type`, `payload` (JSON), `ts`. **`UNIQUE (run_id, cursor)`** — the replay index and the cursor backstop in one. |
| `exec_run_artifacts` | `id`, `run_id` FK CASCADE, `kind`, `path`, `meta` (JSON), `created_at`. Index `(run_id, created_at)`. |

Two schema choices worth flagging:

- **No `CHECK` on `status`.** SQLite cannot ALTER a CHECK away, and the queue/sweep work may add lifecycle states. The closed vocabulary lives in `run_store.RUN_STATUSES`, which is the only writer. Everything stays additive: #140 adds `sweep_id` with a bare `ALTER TABLE ADD COLUMN` (there is a test for exactly that).
- **The two `exec_runs` indexes are ASC, deliberately**, even though every read is newest-first. The list order is `created_at DESC, rowid DESC`, and sqlite serves that by scanning an ASC index *backwards*. A DESC index stores `(created_at DESC, rowid ASC)` — the tie-break points the wrong way, so the planner falls back to a full scan plus a temp b-tree. Verified with `EXPLAIN QUERY PLAN` both ways, and pinned by a test that asserts the plan contains no `TEMP B-TREE`.

## Naming decision: `exec_runs`, not `runs`

`runs` was already taken by the publish subsystem, and it is a different concept: every row REQUIRES an `app_id` (NOT NULL, FK CASCADE) plus a `version`, its status vocabulary is the two-valued `"ok" | "error"` REST envelope result, and it stores capped request/response I/O. Editor and CLI graph executions have no row there at all.

- Reusing `runs` would mean relaxing `app_id` to nullable, overloading one `status` column with two disjoint vocabularies, and rebuilding a **shipped** table (SQLite cannot drop NOT NULL in place) — a destructive migration of live user data to save one word.
- Migrating `runs` into the new tables is lossy: publish rows carry per-field I/O and API-key attribution with no home in the execution schema.
- Namespacing as `exec_*` is purely additive. 001/002 untouched, publish history keeps working byte-for-byte.

Consequence recorded in the migration comment: `Database.prune_runs` is the *publish* table's retention; `RunStore.prune` is this one's. They are separate policies and never touch each other's rows — there is a test asserting exactly that.

The full rationale lives in the comment block above `MIGRATION_003` (acceptance criterion 3).

## Atomicity: why the event cursor is gapless

Allocating a cursor is a read-modify-write (`MAX(cursor) + 1`, then INSERT) — the classic lost-update shape. Three things stack:

1. **In-process serialisation.** Every call funnels through `Database.run`, which holds ONE `asyncio.Lock` across the whole `asyncio.to_thread` hop onto ONE connection. Gathered coroutines physically cannot interleave their statements.
2. **Cross-connection serialisation.** `BEGIN IMMEDIATE` takes the write lock *before* the SELECT, so a second connection on the same file cannot commit between this read and this write. DEFERRED would upgrade the lock only at the INSERT, having already read a stale MAX. New `db.transaction()` contextmanager (the factored-out form of the idiom already in `routes_apps.py` and `_apply_migrations`), with a test proving the lock is held up front.
3. **Constraint backstop.** `UNIQUE (run_id, cursor)`: if 1 and 2 were ever both defeated, the loser raises `IntegrityError` — a failed append, never two events silently sharing a cursor and a replay that skips one.

Layer 1 covers cancellation too, which it did not originally — see the second commit below.

**Mutation checks, so the tests are not passing trivially.** Against the obvious alternative implementation (allocate in one `Database.run`, insert in another, i.e. release the lock in between), 100 gathered appends:

```
real : 100 ok / 0 IntegrityError, 100 distinct cursors, exactly 1..100 = True, rows stored = 100
naive:   1 ok / 99 IntegrityError,  1 distinct cursor,  exactly 1..100 = False, rows stored = 1
```

Stated honestly: the 100-way gather test pins layer 1 and the cursor-to-caller mapping, but it **cannot** detect a missing transaction, because `Database.run`'s lock already serialises the writers before any SQL runs. Layer 2 is pinned separately — `test_append_event_reads_and_writes_in_one_immediate_transaction` traces the actual statement sequence (`BEGIN IMMEDIATE` -> `SELECT MAX(cursor)` -> `INSERT` -> `COMMIT`), and `test_transaction_takes_the_write_lock_up_front` proves a second connection is refused while the block is open. The `append_event` docstring now says exactly this rather than overclaiming.

## DAO surface

`RunStore(db)` — runs: `create_run` / `get_run` / `get_graph_snapshot` / `list_runs` / `mark_running` / `mark_finished` / `interrupt_active_runs`. Events: `append_event` -> cursor / `get_events(after_cursor=)` / `latest_cursor`. Metrics: `log_metric` / `log_metrics` (batched, one transaction) / `get_metrics` / `list_metric_names`. Artifacts: `add_artifact` / `list_artifacts`. Retention: `delete_run` / `prune(keep_last=N)`.

Designed against the named consumers: `RunRecord` deliberately omits `graph_snapshot` so the Runs panel's polling does not deserialize a megabyte of graph per row (fetch it with `get_graph_snapshot`); `log_metrics` takes a batch so the training loop's queue consumer gets one transaction per flush; `prune` never deletes a `queued`/`running` row; `interrupt_active_runs` covers both active states for crash recovery. Provenance (`git_provenance` + the plugin lockfile) is captured in a worker thread and skipped entirely outside project mode.

## Test evidence

New `backend/tests/test_run_store.py` (78 tests) plus 6 new `transaction()` / cancellation tests in `test_db.py`.

```
backend\.venv\Scripts\python.exe -m pytest tests -q
2052 passed, 13 skipped, 16 warnings in 85.38s

# Python 3.10 floor venv
backend\.venv310\Scripts\python.exe -m pytest tests -q
2051 passed, 14 skipped, 10 warnings in 66.72s
```

`tests/test_run_store.py` was also run 8 times in a row (0 failures) to rule out ordering/timestamp-tie flakiness. Note the two suites must be run sequentially: an unrelated pre-existing test (`test_image_batch_reader_node.py::test_reads_batch_of_images`) writes to a fixed `backend/data/` path instead of `tmp_path`, so two concurrent pytest processes delete each other's fixture.

TDD: the test module was written first and failed with `ModuleNotFoundError: No module named 'app.core.run_store'`. Adding migration 003 then tripped the two existing migration-count assertions (`test_db.py::test_connect_migrates_empty_file`, `test_provenance.py::test_migration_002_columns_and_idempotent`), both updated — the first keeps a literal count as a deliberate tripwire and now also asserts the four new tables; the second moves to `len(MIGRATIONS)` so later migrations from other subsystems cannot make a provenance test lie.

Covered: fresh-install and in-place-upgrade-from-a-populated-v2-DB migrations, the full column lists, index shape, CRUD round-trips (including non-ASCII graph/options), lifecycle transitions, gapless cursors under `asyncio.gather` of 100 with per-caller payload attribution, per-run cursor independence, replay-after-cursor, batched-metric atomicity, cascade deletes, prune semantics, and provenance capture. Also green on the Python 3.10 floor venv.

## Second commit: fixes from an adversarial review of the first

Two real defects and a set of API traps, each fixed with a test.

**`Database.run` released its lock when the awaiting task was cancelled** (`cc1d7bd`). `asyncio.to_thread` cancellation cancels the *awaiter*, never the thread, so the `async with` unwound and handed the shared connection to the next caller while the abandoned worker was still driving `BEGIN`/`COMMIT` on it — the next caller's write swallowed by that transaction's ROLLBACK, swept into its COMMIT, or refused with "cannot start a transaction within a transaction". Now the cancellation is absorbed and re-raised only once the worker has finished and the connection is quiet, with a loop covering repeated cancellation during shutdown. Note `shield()` **alone** does not fix this: the outer await still raises immediately and the lock still goes early.

This is pre-existing (`ws_execution.py` already calls `task.cancel()` on the execution task), but this PR is what makes multi-statement transactions routine on that connection, so it is fixed here rather than deferred. Reintroducing the bug makes the new test crash the interpreter — the abandoned thread races `Database.close()` — so the guard is real, and it also closes the second hazard I had planned to only document.

**A diverged loss destroyed the whole metric flush.** SQLite has no NaN; the driver binds one as NULL, so `value REAL NOT NULL` rejected it with a constraint error naming a column the caller never set — and because a flush is one all-or-nothing transaction, one NaN discarded every good point around it, exactly when the user most needs the chart. `value` is now nullable, non-finite values (NaN, ±inf) normalise to NULL, and `MetricRecord.value` is `float | None`, so a chart breaks at the right step instead of the series silently ending.

**Stored JSON could not be parsed by a browser.** `json.dumps` defaults to `allow_nan=True` and emits the bare tokens `NaN` / `Infinity`, which are a CPython extension — `JSON.parse` throws. Event payloads are replayed verbatim on attach, so a diverged `loss` in a progress payload would have poisoned a whole replay remotely and long after the fact. `_dumps` now uses `allow_nan=False`, falling back to a sanitising pass only when the strict attempt trips (clean data pays nothing).

Also: `interrupt_active_runs` validates against `ACTIVE_STATUSES` rather than the whole vocabulary (it rewrites `status` *and* `finished_at`, so a terminal state reaching it would falsify completed history); `get_metrics` rejects `limit` without `name` (the ordering groups by series, so a raw row cap returned the whole alphabetically-first series and none of the rest, silently); `RunRecord.from_row` raises instead of `or {}` so corrupt data is loud; new `count_runs()` for the panel's paging, sharing one `_status_filter` helper with `list_runs` so the two cannot drift. Two tests were corrected rather than added to: the provenance test compared the real git helper against itself over the live checkout (tautological, and flaky because `dirty` flips if anything writes to the repo mid-test), and the index-plan test left the ASC rationale overclaiming for multi-status filters.

## Third commit: coordinator review

**Sanitize-on-return gap.** `create_run` / `add_artifact` stored `_dumps(raw)` but built the *returned* record from the caller's raw dict, so `create_run(...).options` could still be `{"lr": inf}` while `get_run()` gave `{"lr": None}` — and the returned record is what a REST layer serialises straight into its response, putting the non-JSON token back on the wire that the previous commit removed. Both now sanitize once and build the row and the record from the same copy (which also stops the record aliasing a dict the caller can mutate). Tests assert the return value, not only the re-read.

**The `Database.run` guarantee had a second door — and the previous commit opened it.** `ensure_future(asyncio.to_thread(...))` builds a **Task**, and asyncio's shutdown sweep cancels every entry of `all_tasks()`; a swept worker reports `done()` while its thread is still mid-transaction, so the lock released early. Measured both candidates rather than guessing:

```
ensure_future(to_thread): type=Task   in all_tasks=True   after blanket cancel -> done=True  cancelled=True
run_in_executor         : type=Future in all_tasks=False  after blanket cancel -> done=False cancelled=False
```

Fixed at the root instead of narrowing the docstring: the worker is now the `run_in_executor` Future (plus `copy_context()` to keep the contextvar propagation `to_thread` gave for free), which the sweep cannot see and nothing else references. Smaller than the `threading.Event`-in-a-`finally` alternative and with no deadlock surface. Reintroducing the Task makes the new test crash the interpreter.

**`mark_finished` had no precondition**, so a cancel landing after completion silently rewrote `succeeded` -> `cancelled` with a `finished_at` from the wrong moment — the ordinary Stop-button race. It now transitions only from an active status by default, returns whether the write landed, and takes an explicit `expected=` for deliberate corrections.

Plus: corrected the `busy_timeout` claim (it caps waiting on another connection's lock, not statement duration); documented that `graph_snapshot` is JSON-normalised rather than byte-preserved (unlike `app_versions.graph_json`) and that an omitted event payload is indistinguishable from an explicit JSON `null`; pinned the metric-series query plans the way the runs-list and events plans already were.

One honest downgrade: I wrote a `worker.exception()` retrieval and a test for it, then mutation-checked the test — it passes either way, because `asyncio.shield`'s `_inner_done_callback` already retrieves the inner exception when the outer was cancelled. I kept the defensive call but rewrote the comment and test docstring to say so, rather than leave a test claiming to verify a line it cannot see.

Closes #119

---
Generated with [Claude Code](https://claude.com/claude-code)
