### PR TITLE
feat(run-service): RunService core + REST API; runs detached from WebSocket lifetime

### DIFF
--- a/backend/app/api/routes_runs.py
+++ b/backend/app/api/routes_runs.py
@@ -39,14 +39,33 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
 
-from ..core.run_service import RunService, RunServiceUnavailable, RunSubmitError
-from ..core.run_store import STATUS_QUEUED, EventRecord, MetricRecord, RunRecord
+from ..core.run_service import (
+    RunService,
+    RunServiceUnavailable,
+    RunSubmitError,
+    json_size,
+)
+from ..core.run_store import (
+    RUN_STATUSES,
+    STATUS_QUEUED,
+    EventRecord,
+    MetricRecord,
+    RunRecord,
+)
 
 router = APIRouter(prefix="/api/runs", tags=["runs"])
 
 #: Upper bound for one queue-position sweep. A queue deeper than this is
 #: #123's problem, not a reason to scan the whole table on every poll.
 _QUEUE_SCAN_LIMIT = 1000
+
+#: Byte budget for ONE /events response. The per-event cap
+#: (RUN_EVENT_PAYLOAD_CAP_BYTES) bounds a single payload; this bounds the
+#: page, so ``limit`` cannot multiply the two into a response nobody asked
+#: for. A short page is already normal — the cursor says where to resume —
+#: so stopping early costs the client one extra round trip and nothing else.
+#: Far above any honest page (ordinary events are a couple of KB).
+_EVENTS_RESPONSE_CAP_BYTES = 4 * 1024 * 1024
 
 _CSV_COLUMNS = ("run_id", "node_id", "name", "step", "value", "ts")
 
@@ -107,6 +126,25 @@ def _event_payload(event: EventRecord) -> dict[str, Any]:
             "payload": event.payload, "ts": event.ts}
 
 
+def _bounded_events(events: list[EventRecord]) -> list[dict[str, Any]]:
+    """Serialise events up to the response byte budget, in cursor order.
+
+    Always yields at least one event so an oversized single event can never
+    wedge a follower's cursor. Costs one size measurement per event on the
+    read path; /events is polled far less often than events are produced,
+    and the alternative — trusting ``limit`` alone — makes the response size
+    a product of two independently-configured numbers.
+    """
+    out: list[dict[str, Any]] = []
+    total = 0
+    for event in events:
+        total += json_size(event.payload)
+        if out and total > _EVENTS_RESPONSE_CAP_BYTES:
+            break
+        out.append(_event_payload(event))
+    return out
+
+
 async def _require_run(service: RunService, run_id: str) -> RunRecord:
     record = await service.store.get_run(run_id)
     if record is None:
@@ -146,12 +184,21 @@ async def list_runs(
     walking every page.
     """
     service = _get_service(request)
-    try:
-        records = await service.store.list_runs(status=status, limit=limit,
-                                                offset=offset)
-        total = await service.store.count_runs(status=status)
-    except ValueError as exc:            # unknown status in the filter
-        raise HTTPException(status_code=400, detail=str(exc))
+    # Validate the CLIENT's input here rather than catching ValueError off
+    # the store call: the store raises the same exception type for a corrupt
+    # `options` column, and blaming the caller with a 400 for the server's
+    # own bad row would send whoever debugs it in exactly the wrong
+    # direction. A corrupt row now surfaces as the 500 it is.
+    if status is not None:
+        unknown = sorted(set(status) - RUN_STATUSES)
+        if unknown:
+            raise HTTPException(
+                status_code=400,
+                detail=f"unknown run status {unknown}; expected one of "
+                       f"{sorted(RUN_STATUSES)}")
+    records = await service.store.list_runs(status=status, limit=limit,
+                                            offset=offset)
+    total = await service.store.count_runs(status=status)
     positions = await _queue_positions(service, records)
     return {
         "runs": [
@@ -213,6 +260,10 @@ async def get_run_events(
     comes first, so a finished run answers immediately regardless of
     ``wait``. The returned ``cursor`` is where to resume, and never moves
     backwards on an empty page.
+
+    A page can come back SHORTER than ``limit`` even when more events exist:
+    the response also has a byte budget. Resume from ``cursor`` — which is
+    what a follower does anyway — and the next page continues.
     """
     service = _get_service(request)
     record = await _require_run(service, run_id)
@@ -221,12 +272,16 @@ async def get_run_events(
     if wait > 0:
         # The status may well have changed while we were parked.
         record = await service.store.get_run(run_id) or record
+    page = _bounded_events(events)
     return {
         "run_id": run_id,
         "status": record.status,
         "active": service.is_active(run_id),
-        "events": [_event_payload(event) for event in events],
-        "cursor": events[-1].cursor if events else cursor,
+        "events": page,
+        # The cursor tracks what was actually RETURNED, not what was read:
+        # a byte-budgeted short page must not tell a follower to skip the
+        # events it did not receive.
+        "cursor": page[-1]["cursor"] if page else cursor,
     }
 
 

--- a/backend/app/api/routes_runs.py
+++ b/backend/app/api/routes_runs.py
@@ -1,0 +1,292 @@
+"""REST surface for server-owned graph runs (#120).
+
+Six endpoints over ``RunService`` + ``RunStore``; no execution logic lives
+here. The point of the surface is that a run's lifetime is no longer tied to
+any connection: submit from one client, close it, and query status, events
+and metrics from another.
+
+    POST /api/runs                       submit  -> {run_id, status}
+    GET  /api/runs                       list (newest first, + queue position)
+    GET  /api/runs/{id}                  one row + last event cursor
+    POST /api/runs/{id}/cancel           cooperative stop
+    GET  /api/runs/{id}/events           replay after a cursor, optional long poll
+    GET  /api/runs/{id}/metrics          series as JSON or CSV
+
+Auth follows the house rule in ``main.py`` exactly: ``auth_guard`` requires
+the session token for the two mutating routes (POST), reads are open like
+every other GET in the app. This router is deliberately NOT added to
+``_AUTH_EXEMPT_PREFIXES`` — the exemption exists for ``/api/apps`` and
+``/api/keys``, which carry per-route dependencies instead; a run route
+gaining an exemption without one would silently drop authentication (which
+is what ``test_auth_drift.py`` guards for those two, and what
+``test_api_runs.test_runs_routes_are_not_under_an_auth_exempt_prefix``
+guards here).
+
+Errors: 400 for a malformed submit or an unknown status filter, 404 for an
+unknown run, 503 when the service is not on ``app.state`` (the
+``routes_execution_outputs._get_store`` precedent — the lifespan does not
+run under httpx's ASGITransport).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import asdict
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+from ..core.run_service import RunService, RunServiceUnavailable, RunSubmitError
+from ..core.run_store import STATUS_QUEUED, EventRecord, MetricRecord, RunRecord
+
+router = APIRouter(prefix="/api/runs", tags=["runs"])
+
+#: Upper bound for one queue-position sweep. A queue deeper than this is
+#: #123's problem, not a reason to scan the whole table on every poll.
+_QUEUE_SCAN_LIMIT = 1000
+
+_CSV_COLUMNS = ("run_id", "node_id", "name", "step", "value", "ts")
+
+
+def _get_service(request: Request) -> RunService:
+    service = getattr(request.app.state, "run_service", None)
+    if service is None:
+        raise HTTPException(status_code=503,
+                            detail="run service not initialised")
+    return service
+
+
+class SubmitRunRequest(BaseModel):
+    """``{graph, options, name}``.
+
+    ``graph`` is typed only as an object here; its shape is checked by
+    ``normalize_graph`` so the envelope rules live in ONE place next to the
+    service that enforces them, and pydantic never has to mirror them.
+    """
+
+    graph: dict[str, Any]
+    options: Any = None
+    name: str | None = None
+
+
+async def _queue_positions(service: RunService,
+                           records: list[RunRecord]) -> dict[str, int]:
+    """1-based position of each QUEUED run, oldest first.
+
+    Costs one extra query, and only when a queued row is actually present —
+    which today is never (every submit starts immediately). The field exists
+    from day one anyway so #123 can fill the queue without changing the
+    response shape out from under a client.
+    """
+    if not any(record.status == STATUS_QUEUED for record in records):
+        return {}
+    queued = await service.store.list_runs(status=STATUS_QUEUED,
+                                           limit=_QUEUE_SCAN_LIMIT)
+    # list_runs is newest-first; a queue is served oldest-first.
+    return {record.id: index
+            for index, record in enumerate(reversed(queued), start=1)}
+
+
+def _run_payload(record: RunRecord, *, queue_position: int | None,
+                 active: bool, last_cursor: int | None = None) -> dict[str, Any]:
+    payload = asdict(record)
+    payload["queue_position"] = queue_position
+    payload["active"] = active
+    if last_cursor is not None:
+        payload["last_cursor"] = last_cursor
+    return payload
+
+
+def _event_payload(event: EventRecord) -> dict[str, Any]:
+    # ``run_id`` is dropped: it is already on the envelope, and repeating it
+    # on every event is pure weight on a replay of thousands.
+    return {"cursor": event.cursor, "type": event.type,
+            "payload": event.payload, "ts": event.ts}
+
+
+async def _require_run(service: RunService, run_id: str) -> RunRecord:
+    record = await service.store.get_run(run_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"run '{run_id}' not found")
+    return record
+
+
+@router.post("")
+async def submit_run(body: SubmitRunRequest, request: Request):
+    """Persist and start a run. Returns as soon as it is scheduled.
+
+    Deliberately does NOT wait for the run: that is the entire point of the
+    endpoint. Progress is read back through ``/events`` (long-pollable) and
+    the row itself.
+    """
+    service = _get_service(request)
+    try:
+        result = await service.submit(body.graph, options=body.options,
+                                      name=body.name)
+    except RunSubmitError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except RunServiceUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc))
+    return {"run_id": result.run_id, "status": result.status}
+
+
+@router.get("")
+async def list_runs(
+    request: Request,
+    status: list[str] | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    """Newest first. ``?status=`` repeats (``?status=queued&status=running``).
+
+    ``total`` is the unpaged count so a table can size itself without
+    walking every page.
+    """
+    service = _get_service(request)
+    try:
+        records = await service.store.list_runs(status=status, limit=limit,
+                                                offset=offset)
+        total = await service.store.count_runs(status=status)
+    except ValueError as exc:            # unknown status in the filter
+        raise HTTPException(status_code=400, detail=str(exc))
+    positions = await _queue_positions(service, records)
+    return {
+        "runs": [
+            _run_payload(record,
+                         queue_position=positions.get(record.id),
+                         active=service.is_active(record.id))
+            for record in records
+        ],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@router.get("/{run_id}")
+async def get_run(run_id: str, request: Request):
+    """One row plus ``last_cursor`` — where an event follower should start."""
+    service = _get_service(request)
+    record = await _require_run(service, run_id)
+    positions = await _queue_positions(service, [record])
+    return _run_payload(
+        record,
+        queue_position=positions.get(record.id),
+        active=service.is_active(run_id),
+        last_cursor=await service.store.latest_cursor(run_id),
+    )
+
+
+@router.post("/{run_id}/cancel")
+async def cancel_run(run_id: str, request: Request):
+    """Ask a run to stop; cooperative, so ``status`` may still say running.
+
+    ``cancelled`` reports whether the request did anything: False for a run
+    that had already finished. Both are 200 — asking twice is not an error,
+    and a cancel that raced a completion is normal (the user hits Stop as
+    the last epoch lands).
+    """
+    service = _get_service(request)
+    outcome = await service.cancel(run_id)
+    if outcome is None:
+        raise HTTPException(status_code=404, detail=f"run '{run_id}' not found")
+    return {"run_id": outcome.run_id, "status": outcome.status,
+            "cancelled": outcome.cancelled}
+
+
+@router.get("/{run_id}/events")
+async def get_run_events(
+    run_id: str,
+    request: Request,
+    cursor: int = Query(default=0, ge=0),
+    wait: float = Query(default=0.0, ge=0.0, le=60.0),
+    limit: int = Query(default=500, ge=1, le=2000),
+):
+    """Events strictly after *cursor*, oldest first.
+
+    ``wait`` seconds of long polling when the tail is empty: the request
+    sleeps on an in-process wake-up (never a retry loop) and returns the
+    moment an event lands, the run ends, or the deadline passes — whichever
+    comes first, so a finished run answers immediately regardless of
+    ``wait``. The returned ``cursor`` is where to resume, and never moves
+    backwards on an empty page.
+    """
+    service = _get_service(request)
+    record = await _require_run(service, run_id)
+    events = await service.wait_for_events(run_id, after_cursor=cursor,
+                                           limit=limit, wait=wait)
+    if wait > 0:
+        # The status may well have changed while we were parked.
+        record = await service.store.get_run(run_id) or record
+    return {
+        "run_id": run_id,
+        "status": record.status,
+        "active": service.is_active(run_id),
+        "events": [_event_payload(event) for event in events],
+        "cursor": events[-1].cursor if events else cursor,
+    }
+
+
+def _metrics_csv(run_id: str, metrics: list[MetricRecord]) -> str:
+    buffer = io.StringIO(newline="")
+    # Explicit lineterminator: csv defaults to \r\n, and the module's own
+    # newline="" contract means that would survive verbatim into the body.
+    writer = csv.writer(buffer, lineterminator="\n")
+    writer.writerow(_CSV_COLUMNS)
+    for point in metrics:
+        writer.writerow([
+            point.run_id, point.node_id or "", point.name, point.step,
+            # A non-finite value is stored as NULL (a diverged loss); an
+            # EMPTY cell is what every spreadsheet reads as a gap, whereas
+            # "None" would read as text and poison the column's type.
+            "" if point.value is None else point.value,
+            point.ts,
+        ])
+    return buffer.getvalue()
+
+
+def _csv_filename(run_id: str) -> str:
+    """A filename that cannot break out of the header.
+
+    Run ids are our own uuid4 hex, but this endpoint's id comes off the URL,
+    so the value is whitelisted rather than trusted.
+    """
+    safe = "".join(c for c in run_id if c.isalnum() or c in "-_")[:64]
+    return f"run-{safe}-metrics.csv" if safe else "run-metrics.csv"
+
+
+@router.get("/{run_id}/metrics")
+async def get_run_metrics(
+    run_id: str,
+    request: Request,
+    name: str | None = Query(default=None),
+    format: str = Query(default="json", pattern="^(json|csv)$"),
+):
+    """Recorded scalar series, ordered ``(name, step)`` — chart order.
+
+    ``format=csv`` returns a download for spreadsheet/pandas use; the JSON
+    form additionally lists every series name so a legend can be built
+    without scanning the points.
+    """
+    service = _get_service(request)
+    await _require_run(service, run_id)
+    metrics = await service.store.get_metrics(run_id, name=name)
+    if format == "csv":
+        return Response(
+            content=_metrics_csv(run_id, metrics),
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition":
+                     f'attachment; filename="{_csv_filename(run_id)}"'},
+        )
+    return {
+        "run_id": run_id,
+        "names": await service.store.list_metric_names(run_id),
+        "metrics": [
+            {"node_id": point.node_id, "name": point.name, "step": point.step,
+             "value": point.value, "ts": point.ts}
+            for point in metrics
+        ],
+    }

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -51,14 +51,33 @@ class Settings(BaseSettings):
     MAX_IMAGE_PIXELS: int = 25_000_000  # per-image decode budget (Decision H2)
     RUN_IO_CAP_BYTES: int = 64 * 1024   # per-field runs.inputs_json/outputs_json cap
     RUNS_RETENTION_DAYS: int = 0        # 0 = keep forever (default); >0 prunes loudly
-    # ── Run Service retention (#120) ───────────────────────────────────
+    # ── Run Service retention + limits (#120) ──────────────────────────
     # Keep-last-N over the exec_runs table (graph runs), applied at startup
     # and after every run reaches a terminal state. Independent of
     # RUNS_RETENTION_DAYS above, which is age-based and covers the
     # unrelated publish `runs` table. Active runs are never deleted and
     # still occupy slots, so this is a straightforward cap on the table.
-    # A negative value disables it entirely (keep forever).
+    #
+    # MIND THE INVERTED ZERO, it is deliberate and not a typo: for the
+    # age-based knob above, 0 means "no cutoff" -> keep forever; for this
+    # count-based one, 0 is a real count -> keep zero finished runs, i.e.
+    # delete them all. Disabling THIS one takes a NEGATIVE value. Two
+    # different policies over two different tables; neither borrows the
+    # other's sentinel.
     RUN_RETENTION_KEEP_LAST: int = 200
+    # Per-event ceiling on what exec_run_events stores (and fans out).
+    # Retention counts runs, not bytes, so without this one graph emitting
+    # base64 PNGs on every node -- or a training payload carrying a
+    # per-batch array that grows each epoch -- can put hundreds of MB into
+    # the database for a single run, with record_outputs OFF. Over-cap
+    # output entries are replaced by an elision marker that keeps
+    # output_kind and port so a UI still knows something was there. 128 KB
+    # is twice the publish path's RUN_IO_CAP_BYTES because a node_status
+    # payload is a whole node's summary (several ports, each embedding up
+    # to 256 values) rather than one API field; measured honest payloads
+    # sit well under 20 KB, so the headroom means elision only ever fires
+    # on genuinely unbounded content. <= 0 disables the cap.
+    RUN_EVENT_PAYLOAD_CAP_BYTES: int = 128 * 1024
     # Comma-separated extra Host-whitelist entries, e.g.
     # "192.168.1.20:8000,mybox:8000". A str, not list[str]: pydantic list
     # env vars demand JSON-in-env quote hell; split in init_allowed_hosts.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -51,6 +51,14 @@ class Settings(BaseSettings):
     MAX_IMAGE_PIXELS: int = 25_000_000  # per-image decode budget (Decision H2)
     RUN_IO_CAP_BYTES: int = 64 * 1024   # per-field runs.inputs_json/outputs_json cap
     RUNS_RETENTION_DAYS: int = 0        # 0 = keep forever (default); >0 prunes loudly
+    # ── Run Service retention (#120) ───────────────────────────────────
+    # Keep-last-N over the exec_runs table (graph runs), applied at startup
+    # and after every run reaches a terminal state. Independent of
+    # RUNS_RETENTION_DAYS above, which is age-based and covers the
+    # unrelated publish `runs` table. Active runs are never deleted and
+    # still occupy slots, so this is a straightforward cap on the table.
+    # A negative value disables it entirely (keep forever).
+    RUN_RETENTION_KEEP_LAST: int = 200
     # Comma-separated extra Host-whitelist entries, e.g.
     # "192.168.1.20:8000,mybox:8000". A str, not list[str]: pydantic list
     # env vars demand JSON-in-env quote hell; split in init_allowed_hosts.

--- a/backend/app/core/run_service.py
+++ b/backend/app/core/run_service.py
@@ -44,7 +44,9 @@ two id shapes for one run is how outputs stop being findable.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import re
 import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -66,6 +68,7 @@ from .run_store import (
     EventRecord,
     MetricPoint,
     RunStore,
+    json_safe,
 )
 
 logger = logging.getLogger(__name__)
@@ -104,7 +107,18 @@ OPTION_KEYS = frozenset({"device", "seed", "record_outputs", "lane"})
 #: a label carried through to ``exec_runs.options`` unchanged.
 DEFAULT_LANE = "queued"
 MAX_LANE_LENGTH = 64
+MAX_NAME_LENGTH = 64
 MAX_SEED = 2 ** 32 - 1
+
+#: The device vocabulary ``resolve_device`` actually understands. Validated
+#: as a VALUE, not just a key: strict option keys exist to stop a typo from
+#: silently running forty minutes on the wrong device, and ``{"device":
+#: "cudda"}`` defeats that entirely if only the key is checked — it sails
+#: through, hits ``resolve_device``'s unknown-value branch, and degrades to
+#: CPU with nothing but a log line. ``auto`` is accepted because the canvas
+#: device selector emits it; note that ``resolve_device`` currently maps it
+#: to CPU (pre-existing behaviour, deliberately not changed here).
+DEVICE_PATTERN = re.compile(r"^(cpu|auto|cuda(:\d+)?|mps(:\d+)?)$")
 
 #: Progress-payload keys that describe the LOOP, not a measurement. Turning
 #: ``epoch`` into a series named "epoch" whose value equals its own step is
@@ -115,6 +129,11 @@ NON_METRIC_KEYS = frozenset({"event", "step", "epoch", "total_epochs",
 #: Flush thresholds for the metric batcher (see ``_flush_metrics``).
 METRIC_FLUSH_MAX_POINTS = 64
 METRIC_FLUSH_INTERVAL_S = 0.5
+
+#: Default per-event payload ceiling; overridden from
+#: ``settings.RUN_EVENT_PAYLOAD_CAP_BYTES`` in the lifespan. See
+#: ``cap_event_payload`` for what "over cap" does.
+EVENT_PAYLOAD_CAP_BYTES = 128 * 1024
 
 #: How long ``shutdown`` lets a run stop cooperatively before hard-cancelling.
 DEFAULT_SHUTDOWN_GRACE_S = 5.0
@@ -183,6 +202,11 @@ def normalize_options(raw: Any) -> dict[str, Any]:
     device = raw.get("device", "cpu")
     if not isinstance(device, str) or not device.strip():
         raise RunSubmitError("device must be a non-empty string")
+    device = device.strip().lower()
+    if DEVICE_PATTERN.match(device) is None:
+        raise RunSubmitError(
+            f"unknown device {device!r}; expected cpu, auto, cuda, cuda:N, "
+            "mps or mps:N")
 
     seed = raw.get("seed")
     if seed is not None:
@@ -203,11 +227,31 @@ def normalize_options(raw: Any) -> dict[str, Any]:
         raise RunSubmitError(f"lane must be at most {MAX_LANE_LENGTH} chars")
 
     return {
-        "device": device.strip().lower(),
+        "device": device,
         "seed": seed,
         "record_outputs": record_outputs,
         "lane": lane.strip(),
     }
+
+
+def normalize_name(raw: Any) -> str | None:
+    """Validate the optional run label. Bounded like ``lane``.
+
+    A run name is display text on a list row, not a document: an unbounded
+    one would be stored on every row and re-sent on every poll of the Runs
+    panel. Blank (or whitespace-only) means unnamed, stored as SQL NULL
+    rather than an empty string nobody can tell apart from "not set".
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise RunSubmitError(f"name must be a string, got {type(raw).__name__}")
+    name = raw.strip()
+    if not name:
+        return None
+    if len(name) > MAX_NAME_LENGTH:
+        raise RunSubmitError(f"name must be at most {MAX_NAME_LENGTH} chars")
+    return name
 
 
 def normalize_graph(raw: Any) -> dict[str, Any]:
@@ -238,6 +282,94 @@ def normalize_graph(raw: Any) -> dict[str, Any]:
     if not isinstance(presets, list):
         raise RunSubmitError("graph.presets must be a list")
     return {"nodes": nodes, "edges": edges, "presets": presets}
+
+
+def json_size(value: Any) -> int:
+    """Bytes this value would occupy as a stored JSON column.
+
+    Matches ``run_store._dumps``' encoding (compact separators, the default
+    ``ensure_ascii=True``), so the number is the real storage cost and not
+    an estimate. ``ensure_ascii`` also means every character encodes to one
+    byte, which is why ``len`` of the string is the byte count with no
+    encode step. ``default=str`` keeps MEASURING from ever raising on
+    something exotic — a sizer that throws would fail the run it was only
+    trying to bound.
+    """
+    try:
+        return len(json.dumps(value, separators=(",", ":"), default=str))
+    except (TypeError, ValueError, RecursionError):  # pragma: no cover
+        return 0
+
+
+def _elide_entry(entry: Any, budget_bytes: int) -> Any:
+    """Replace one over-budget output entry with a placeholder.
+
+    ``output_kind`` and ``port`` survive so a UI can render "image, elided"
+    in the right slot rather than a hole. The payload key (``image``,
+    ``tensor_summary``, …) is DROPPED rather than stuffed with a marker
+    object: a consumer that reads ``entry["text"]`` expecting a string must
+    not silently receive a dict instead. ``"elided" in entry`` is the check.
+    """
+    if not isinstance(entry, dict):
+        return entry
+    size = json_size(entry)
+    if size <= budget_bytes:
+        return entry
+    elided: dict[str, Any] = {"output_kind": entry.get("output_kind"),
+                              "elided": True, "bytes": size,
+                              "cap_bytes": budget_bytes}
+    if "port" in entry:
+        elided["port"] = entry["port"]
+    return elided
+
+
+def cap_event_payload(payload: Any, *, cap_bytes: int) -> Any:
+    """Bound one event payload before it becomes a durable row.
+
+    Retention counts RUNS, not bytes. Nothing else stops a graph whose nodes
+    emit base64 PNGs (#117 image entries are the full image) from writing
+    hundreds of megabytes of ``exec_run_events`` for a single run — with
+    ``record_outputs`` off, because this path is the live status stream, not
+    the output capture. Same for a training payload whose per-batch array
+    grows every epoch.
+
+    Three steps, cheapest first:
+
+    1. Measure once. Under cap — the overwhelmingly common case, an ordinary
+       ``node_status`` is a couple of KB — and the payload is returned
+       untouched, having cost exactly one ``json.dumps``.
+    2. Over cap, elide the output entries that are pulling more than their
+       equal share of the budget. Equal share, rather than the whole cap,
+       so a payload made of several medium entries degrades entry by entry
+       instead of collapsing wholesale.
+    3. Still over — nothing left to trim, e.g. a single enormous ``error``
+       string — and the payload collapses to a marker that keeps the
+       identifying keys. Losing the body beats refusing the event.
+
+    ``cap_bytes <= 0`` disables the whole thing.
+    """
+    if cap_bytes <= 0 or payload is None:
+        return payload
+    size = json_size(payload)
+    if size <= cap_bytes:
+        return payload
+
+    entries = payload.get("outputs") if isinstance(payload, dict) else None
+    if isinstance(entries, list) and entries:
+        budget = max(1, cap_bytes // len(entries))
+        payload = {**payload,
+                   "outputs": [_elide_entry(e, budget) for e in entries]}
+        size = json_size(payload)
+        if size <= cap_bytes:
+            return payload
+
+    marker: dict[str, Any] = {"elided": True, "bytes": size,
+                              "cap_bytes": cap_bytes}
+    if isinstance(payload, dict):
+        for key in ("node_id", "status", "run_id", "reason"):
+            if key in payload:
+                marker[key] = payload[key]
+    return marker
 
 
 def scalar_metrics(
@@ -395,8 +527,14 @@ class _ActiveRun:
     #: away). Set BEFORE the context flag so the unwinding task can tell the
     #: two apart — they are different facts about why a run stopped.
     stop_reason: str | None = None
+    #: True once the OUTCOME is decided — set on entry to ``_finalize``,
+    #: before any of its awaits. A cancel arriving after this cannot change
+    #: anything, so it must not claim it did.
+    terminating: bool = False
     #: True once the terminal event is durable. Long pollers stop waiting on
     #: this, not on registry removal, which happens a few statements later.
+    #: Strictly after ``terminating``: between the two the closing event is
+    #: still being written, and a poller should keep waiting for it.
     finished: bool = False
     pending_metrics: list[MetricPoint] = field(default_factory=list)
     last_metric_step: int = 0
@@ -438,6 +576,7 @@ class RunService:
         *,
         output_store: RunOutputStore | None = None,
         retention_keep_last: int | None = None,
+        event_payload_cap_bytes: int = EVENT_PAYLOAD_CAP_BYTES,
         shutdown_grace_s: float = DEFAULT_SHUTDOWN_GRACE_S,
         subscriber_queue_size: int = DEFAULT_SUBSCRIBER_QUEUE_SIZE,
         metric_flush_max_points: int = METRIC_FLUSH_MAX_POINTS,
@@ -446,6 +585,7 @@ class RunService:
         self.store = store
         self._output_store = output_store
         self._retention_keep_last = retention_keep_last
+        self._event_payload_cap_bytes = event_payload_cap_bytes
         self._shutdown_grace_s = shutdown_grace_s
         self._subscriber_queue_size = subscriber_queue_size
         self._metric_flush_max_points = metric_flush_max_points
@@ -494,11 +634,12 @@ class RunService:
             raise RunServiceUnavailable("run service is shutting down")
         normalized_graph = normalize_graph(graph)
         normalized_options = normalize_options(options)
+        normalized_name = normalize_name(name)
 
         record = await self.store.create_run(
             graph_snapshot=normalized_graph,
             options=normalized_options,
-            name=name,
+            name=normalized_name,
             status=STATUS_QUEUED,
         )
         # ── #123 inserts scheduling HERE ─────────────────────────────────
@@ -521,7 +662,19 @@ class RunService:
         The reported status is therefore a promise the task fulfils on its
         first step; a client that reads the row in that microsecond sees
         ``queued``, which is simply true.
+
+        The shutdown re-check is not redundant with ``submit``'s. That one
+        happens before ``create_run`` awaits (provenance capture can shell
+        out to git), and ``shutdown`` snapshots the registry at any await —
+        so a submit parked in that window would resume here and register a
+        task nobody drains, with ``main.py`` closing the database underneath
+        it. Refusing here leaves the durable ``queued`` row for startup
+        recovery, exactly like a cancelled submit.
         """
+        if self._shutting_down:
+            raise RunServiceUnavailable(
+                "run service began shutting down while the run was being "
+                "persisted; it stays queued and will be retired at startup")
         context = ExecutionContext(
             execution_id=run_id,
             device=resolve_device(options.get("device")),
@@ -553,11 +706,13 @@ class RunService:
     ) -> None:
         """The server-owned task. Nothing outside this module awaits it.
 
-        A hard ``Task.cancel`` (shutdown's last resort) is BaseException and
-        therefore skips every ``except`` below AND the finalizer, leaving the
-        row ``running`` for the next boot's recovery to retire. That is
-        deliberate: a forcibly-killed run must not write a tidy terminal
-        status it cannot vouch for. Everything else — including a broken
+        A hard ``Task.cancel`` (shutdown's last resort) is BaseException, so
+        it skips every ``except`` below and with them ``_finalize`` — the
+        row stays ``running`` for the next boot's recovery to retire, which
+        is deliberate: a forcibly-killed run must not write a tidy terminal
+        status it cannot vouch for. The ``finally`` still runs (that is what
+        closes subscriptions and deregisters the run); only the terminal
+        bookkeeping is skipped. Everything else — including a broken
         database — is caught, because an unretrieved task exception is a
         silent death nobody would ever see.
         """
@@ -638,7 +793,13 @@ class RunService:
         row (so an event-log follower never sees a finished row with no
         closing frame), and ``finished`` set before the row write so a long
         poller woken by the terminal event does not go back to sleep.
+
+        ``terminating`` is set FIRST, before any await: from here the
+        outcome is decided, and a cancel that arrives during the metric
+        flush must not report that it cancelled a run about to file
+        ``succeeded``.
         """
+        active.terminating = True
         await self._flush_metrics(active, force=True)
         if status == STATUS_SUCCEEDED:
             await self._emit(active.run_id, EVENT_RUN_COMPLETED, None)
@@ -707,10 +868,25 @@ class RunService:
         an append cancelled AFTER its COMMIT leaves a durable event whose
         cursor is lost here, which is safe precisely because every consumer
         re-reads the tail from the store rather than trusting this return.
+
+        Subscribers receive EXACTLY the object that was stored — sanitised
+        (``json_safe``: no NaN/Infinity, which are CPython tokens that
+        ``JSON.parse`` rejects, and which would otherwise reach #121's
+        WebSocket) and capped (``cap_event_payload``). The tempting
+        alternative — store the capped copy, push the full one, since
+        subscribers are in-process — is rejected because it would break the
+        drop-tolerance contract: a subscriber is told that when it lags it
+        may re-read the tail from the store "and lose nothing". If the live
+        copy carried more than the stored one, a lagging consumer would
+        silently get a DIFFERENT payload, so a UI would show an image live
+        and a placeholder after any hiccup. One payload, one truth; #121 can
+        revisit the split deliberately if it ever needs the full frame.
         """
         stamp = utc_now_iso()
+        stored = cap_event_payload(json_safe(payload),
+                                   cap_bytes=self._event_payload_cap_bytes)
         try:
-            cursor = await self.store.append_event(run_id, event_type, payload,
+            cursor = await self.store.append_event(run_id, event_type, stored,
                                                    ts=stamp)
         except asyncio.CancelledError:
             raise
@@ -720,7 +896,7 @@ class RunService:
             self._wake(run_id)
             return None
         record = EventRecord(run_id=run_id, cursor=cursor, type=event_type,
-                             payload=payload, ts=stamp)
+                             payload=stored, ts=stamp)
         self._fan_out(run_id, record)
         return record
 
@@ -862,13 +1038,15 @@ class RunService:
         orphan) is retired directly through the guarded ``mark_finished``, so
         a cancel racing a start cannot rewrite a run that is already going.
 
-        The ``finished`` check is what keeps the answer truthful in the
-        window between a run writing its terminal row and being removed from
-        the registry: a registry hit alone would report "cancelled: true" for
-        a run that had already succeeded.
+        The ``terminating`` check is what keeps the answer truthful once a
+        run's outcome is decided but it is still in the registry — from the
+        first line of ``_finalize`` (before the metric flush and the
+        terminal event, both of which await) until the task deregisters
+        itself. A registry hit alone would report "cancelled: true" for a
+        run that is on its way to filing ``succeeded``.
         """
         active = self._runs.get(run_id)
-        if active is not None and not active.finished:
+        if active is not None and not active.terminating:
             if active.stop_reason is None:
                 active.stop_reason = STOP_REASON_CANCELLED
             active.context.cancel()

--- a/backend/app/core/run_service.py
+++ b/backend/app/core/run_service.py
@@ -1,0 +1,971 @@
+"""Server-owned graph runs — the Run Service (#120).
+
+A run used to live inside the WebSocket handler: ``ws_execution.py`` created
+the ``asyncio.Task``, and it cancelled that task on ``WebSocketDisconnect``.
+Closing the browser tab killed a training job. Submitting a second graph on
+the same socket killed the first. Both are properties of *where the task was
+owned*, not of the engine — ``graph_engine.execute_graph`` is already a
+perfectly reusable coroutine.
+
+This module owns the task instead. The service is a plain object (no
+FastAPI, no HTTP — the ``db.py``/``api_contract.py`` precedent), constructed
+once in the lifespan and reachable at ``app.state.run_service``. Its
+responsibilities, and nothing else:
+
+- **submit** — persist the run (``RunStore``), then start it. Between those
+  two steps is the seam #123's FIFO queue slots into; in THIS issue every
+  submitted run starts immediately.
+- **observe** — every engine callback is appended to ``exec_run_events`` and
+  fanned out to live subscribers; scalar progress values are batched into
+  ``exec_run_metrics``.
+- **cancel** — cooperative, via the ``ExecutionContext`` flag (never
+  ``Task.cancel``; see ``cancel``).
+- **survive** — startup recovery retires rows a dead process left
+  ``running``; shutdown drains in-flight tasks BEFORE the database closes.
+
+Layering
+--------
+``core`` never imports ``api``… with one deliberate, function-local
+exception: the #117 output-entry builders currently live in
+``api/ws_execution.py``. They are imported lazily in ``_progress_bridge``
+rather than duplicated, because a second copy of that logic is exactly the
+drift #117 removed. #121 rewrites the WS handler on top of this service and
+should move those two helpers into ``core`` at that point.
+
+Ids
+---
+ONE id per run: ``RunStore``'s ``uuid4().hex``. It is the ``exec_runs.id``,
+the ``ExecutionContext.execution_id``, and the ``run_id`` handed to
+``execute_graph`` (so ``RunOutputStore`` entries key off the same string).
+``ExecutionContext``'s own ``str(uuid4())`` default is never used here —
+two id shapes for one run is how outputs stop being findable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Callable, NamedTuple
+
+from ..config import settings
+from .db import utc_now_iso
+from .device_utils import resolve_device
+from .execution_context import CancellationError, ExecutionContext
+from .graph_engine import GraphValidationError, build_preset_fallback, execute_graph
+from .run_output_store import RunOutputStore
+from .run_store import (
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_INTERRUPTED,
+    STATUS_QUEUED,
+    STATUS_RUNNING,
+    STATUS_SUCCEEDED,
+    EventRecord,
+    MetricPoint,
+    RunStore,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── event vocabulary ──────────────────────────────────────────────────────
+#
+# Deliberately the WebSocket message types, verbatim. The durable event log
+# exists to be replayed onto that wire (#121: attach to a running run and
+# catch up), so a 1:1 mapping means the bridge is
+# ``{"type": event.type, **(event.payload or {})}`` and there is no second
+# vocabulary to keep in sync. The ``type`` key itself is NOT stored in the
+# payload — the column already carries it.
+EVENT_RUN_STARTED = "execution_start"
+EVENT_NODE_STATUS = "node_status"
+EVENT_RUN_COMPLETED = "execution_complete"
+EVENT_RUN_FAILED = "execution_error"
+EVENT_RUN_STOPPED = "execution_stopped"
+
+#: ``execution_stopped`` payload discriminator. The WS protocol has one
+#: "stopped" frame; the run ROW distinguishes cancelled from interrupted,
+#: and this key carries the same fact into the replay log.
+STOP_REASON_CANCELLED = "cancelled"
+STOP_REASON_INTERRUPTED = "interrupted"
+
+# ── submit options ────────────────────────────────────────────────────────
+
+#: The complete option vocabulary. Unknown keys are REJECTED rather than
+#: ignored: ``{"devcie": "cuda"}`` silently running on CPU for forty minutes
+#: is the failure mode this closes. Extending the set is a one-line additive
+#: change — #121 (canvas flags: verbose/backward/graph_id) and #123 (queue
+#: priority) will each do exactly that, deliberately.
+OPTION_KEYS = frozenset({"device", "seed", "record_outputs", "lane"})
+
+#: Default lane. Named for #123's queue; no queue exists yet, so today it is
+#: a label carried through to ``exec_runs.options`` unchanged.
+DEFAULT_LANE = "queued"
+MAX_LANE_LENGTH = 64
+MAX_SEED = 2 ** 32 - 1
+
+#: Progress-payload keys that describe the LOOP, not a measurement. Turning
+#: ``epoch`` into a series named "epoch" whose value equals its own step is
+#: noise; ``total_epochs`` is a constant repeated once per point.
+NON_METRIC_KEYS = frozenset({"event", "step", "epoch", "total_epochs",
+                             "start_epoch"})
+
+#: Flush thresholds for the metric batcher (see ``_flush_metrics``).
+METRIC_FLUSH_MAX_POINTS = 64
+METRIC_FLUSH_INTERVAL_S = 0.5
+
+#: How long ``shutdown`` lets a run stop cooperatively before hard-cancelling.
+DEFAULT_SHUTDOWN_GRACE_S = 5.0
+
+#: Per-subscriber queue depth. Overflow drops (see ``RunSubscription``).
+DEFAULT_SUBSCRIBER_QUEUE_SIZE = 256
+
+
+class RunSubmitError(ValueError):
+    """Malformed submit envelope or options. REST maps this to 400."""
+
+
+class RunServiceUnavailable(RuntimeError):
+    """The service cannot take work right now. REST maps this to 503.
+
+    Distinct from a bare ``RuntimeError`` on purpose: "the server is
+    shutting down, retry" and "something inside broke" are different answers
+    and must not share a status code.
+    """
+
+
+class SubmitResult(NamedTuple):
+    """What ``submit`` hands back: the id, and where the run actually is.
+
+    ``status`` is ``running`` today. It is not hardcoded at the call site
+    because #123's queue will legitimately return ``queued`` from the same
+    call, and a client that reads this field keeps working.
+    """
+
+    run_id: str
+    status: str
+
+
+class CancelOutcome(NamedTuple):
+    """Result of a cancel request. ``cancelled`` is False for a no-op."""
+
+    run_id: str
+    status: str
+    cancelled: bool
+
+
+def normalize_options(raw: Any) -> dict[str, Any]:
+    """Validate the submit options and fill in defaults.
+
+    Strict on purpose (see ``OPTION_KEYS``). Returns a NEW dict with every
+    key present, so ``exec_runs.options`` always records the full effective
+    configuration rather than "whatever the client happened to send" — a
+    stored run has to be readable years later without knowing which defaults
+    were in force at submit time.
+
+    ``device`` is normalised (trimmed, lowercased) but NOT availability-
+    checked here: that resolution happens at start time via
+    ``resolve_device`` and lands in ``exec_runs.queue_key``, so the row keeps
+    both what was asked for and what was used.
+    """
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, dict):
+        raise RunSubmitError(
+            f"options must be an object, got {type(raw).__name__}")
+    unknown = sorted(set(raw) - OPTION_KEYS)
+    if unknown:
+        raise RunSubmitError(
+            f"unknown option(s) {unknown}; supported: {sorted(OPTION_KEYS)}")
+
+    device = raw.get("device", "cpu")
+    if not isinstance(device, str) or not device.strip():
+        raise RunSubmitError("device must be a non-empty string")
+
+    seed = raw.get("seed")
+    if seed is not None:
+        # bool is an int subclass; True is not a seed.
+        if isinstance(seed, bool) or not isinstance(seed, int):
+            raise RunSubmitError("seed must be an integer or null")
+        if not 0 <= seed <= MAX_SEED:
+            raise RunSubmitError(f"seed must be between 0 and {MAX_SEED}")
+
+    record_outputs = raw.get("record_outputs", False)
+    if not isinstance(record_outputs, bool):
+        raise RunSubmitError("record_outputs must be true or false")
+
+    lane = raw.get("lane", DEFAULT_LANE)
+    if not isinstance(lane, str) or not lane.strip():
+        raise RunSubmitError("lane must be a non-empty string")
+    if len(lane) > MAX_LANE_LENGTH:
+        raise RunSubmitError(f"lane must be at most {MAX_LANE_LENGTH} chars")
+
+    return {
+        "device": device.strip().lower(),
+        "seed": seed,
+        "record_outputs": record_outputs,
+        "lane": lane.strip(),
+    }
+
+
+def normalize_graph(raw: Any) -> dict[str, Any]:
+    """Validate the submit ENVELOPE only — never the graph's semantics.
+
+    Structural validation (unknown node types, missing entry points, cycles)
+    stays where it already lives: ``prepare_executable_graph``, inside the
+    run. Duplicating it here would mean two validators drifting apart, and
+    would make ``POST /api/runs`` reject things the engine accepts. A graph
+    that cannot execute becomes a ``failed`` run with the engine's own error
+    on the row, which is a far more useful artifact than a 400.
+    """
+    if not isinstance(raw, dict):
+        raise RunSubmitError(
+            "graph must be an object with 'nodes' and 'edges'")
+    nodes = raw.get("nodes")
+    # Absent means "none of these"; anything else is checked, never coerced.
+    # ``raw.get(k) or []`` would quietly accept a malformed ``"edges": {}``
+    # as an empty edge list because an empty dict is falsy.
+    edges = [] if raw.get("edges") is None else raw["edges"]
+    presets = [] if raw.get("presets") is None else raw["presets"]
+    if not isinstance(nodes, list):
+        raise RunSubmitError("graph.nodes must be a list")
+    if not nodes:
+        raise RunSubmitError("graph.nodes is empty")
+    if not isinstance(edges, list):
+        raise RunSubmitError("graph.edges must be a list")
+    if not isinstance(presets, list):
+        raise RunSubmitError("graph.presets must be a list")
+    return {"nodes": nodes, "edges": edges, "presets": presets}
+
+
+def scalar_metrics(
+    payload: Any, *, node_id: str | None, step: int,
+) -> list[MetricPoint]:
+    """Extract chartable scalars from one progress payload.
+
+    Every finite top-level number that is not a loop descriptor becomes a
+    point of a series named after its key. Booleans are excluded (a flag is
+    not a measurement), as are strings, lists and nested objects — a
+    ``losses`` array is per-batch detail that belongs in the event payload,
+    not as one row per element in the metrics table.
+    """
+    if not isinstance(payload, dict):
+        return []
+    points: list[MetricPoint] = []
+    for key, value in payload.items():
+        if key in NON_METRIC_KEYS or isinstance(value, bool):
+            continue
+        if not isinstance(value, (int, float)):
+            continue
+        points.append(MetricPoint(name=key, value=float(value), step=step,
+                                  node_id=node_id))
+    return points
+
+
+def metric_step(payload: Any, *, fallback: int) -> int:
+    """The step a progress payload belongs to.
+
+    ``step`` wins over ``epoch``; both beat the caller's running counter, so
+    a producer that reports nothing still gets a monotonic x-axis instead of
+    every point piling up on step 0.
+    """
+    if isinstance(payload, dict):
+        for key in ("step", "epoch"):
+            value = payload.get(key)
+            if isinstance(value, bool):
+                continue
+            if isinstance(value, int):
+                return value
+            if isinstance(value, float) and value.is_integer():
+                return int(value)
+    return fallback
+
+
+def apply_seed(seed: int | None) -> None:
+    """Seed the RNGs a run might touch. Best effort, PROCESS-GLOBAL.
+
+    Deliberately honest about its limits: ``torch.manual_seed`` and friends
+    set global state, so two concurrent runs with different seeds do NOT get
+    independent streams — the second submit reseeds the first run's
+    generator mid-flight. Reproducibility here means "run this one alone and
+    get the same numbers", which is what a stored ``seed`` is worth today.
+    Per-run generator isolation is a node-level change, not a service one.
+    """
+    if seed is None:
+        return
+    import random
+
+    random.seed(seed)
+    try:
+        import numpy as np
+
+        np.random.seed(seed)
+    except Exception:  # pragma: no cover - numpy always present in practice
+        logger.debug("numpy seeding skipped", exc_info=True)
+    try:
+        import torch
+
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+    except Exception:  # pragma: no cover - torch always present in practice
+        logger.debug("torch seeding skipped", exc_info=True)
+
+
+# ── in-process fan-out ────────────────────────────────────────────────────
+
+
+class _Broadcast:
+    """Edge-triggered wake-up for long pollers. No busy waiting anywhere.
+
+    ``asyncio.Event`` is level-triggered and single-shot; a shared one would
+    have to be cleared, and whoever clears it races everyone who has not
+    woken yet. Instead each ``notify`` SETS the current event and installs a
+    fresh one for the next generation. A waiter captures the event object
+    BEFORE it reads the store, so a notification that lands during that read
+    still wakes it — the classic lost-wakeup window is closed by ordering,
+    not by a timeout.
+
+    Not an ``asyncio.Condition``: a Condition makes every waiter contend for
+    one lock just to be told to go read sqlite, and its ``wait()`` reacquires
+    that lock before returning, serialising the wake-ups.
+    """
+
+    __slots__ = ("_event",)
+
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+
+    def waiter(self) -> asyncio.Event:
+        """The generation to wait on. Capture it before checking the store."""
+        return self._event
+
+    def notify(self) -> None:
+        event, self._event = self._event, asyncio.Event()
+        event.set()
+
+
+# eq=False: a subscription is a live handle, not a value. Identity equality
+# (and therefore identity hashing) is what lets it live in the per-run
+# subscriber set; the dataclass default would generate __eq__ and set
+# __hash__ to None, making it unhashable.
+@dataclass(eq=False)
+class RunSubscription:
+    """A live feed of one run's events, for in-process push consumers (#121).
+
+    Drop-tolerant BY DESIGN. The queue is bounded and a full queue drops the
+    new event rather than applying backpressure — a stalled consumer must
+    never be able to slow down or deadlock the run that is feeding it. The
+    durable log is the source of truth: a consumer that sees ``take_dropped()
+    > 0`` re-reads the tail from ``RunStore.get_events`` starting at its last
+    cursor and loses nothing. ``None`` on the queue is the end-of-run
+    sentinel; ``closed`` says the same thing for a consumer that never drains.
+    """
+
+    run_id: str
+    queue: "asyncio.Queue[EventRecord | None]"
+    closed: bool = False
+    _dropped: int = 0
+
+    def offer(self, event: "EventRecord | None") -> None:
+        try:
+            self.queue.put_nowait(event)
+        except asyncio.QueueFull:
+            self._dropped += 1
+
+    def take_dropped(self) -> int:
+        """How many events were dropped since the last call; resets to 0."""
+        dropped, self._dropped = self._dropped, 0
+        return dropped
+
+
+@dataclass(eq=False)
+class _ActiveRun:
+    """Everything the service holds for one in-flight run."""
+
+    run_id: str
+    context: ExecutionContext
+    signal: _Broadcast
+    record_outputs: bool = False
+    task: "asyncio.Task[None] | None" = None
+    subscribers: set[RunSubscription] = field(default_factory=set)
+    #: "cancelled" (a user asked) or "interrupted" (the server is going
+    #: away). Set BEFORE the context flag so the unwinding task can tell the
+    #: two apart — they are different facts about why a run stopped.
+    stop_reason: str | None = None
+    #: True once the terminal event is durable. Long pollers stop waiting on
+    #: this, not on registry removal, which happens a few statements later.
+    finished: bool = False
+    pending_metrics: list[MetricPoint] = field(default_factory=list)
+    last_metric_step: int = 0
+    last_flush_monotonic: float = field(default_factory=time.monotonic)
+
+    def close(self) -> None:
+        """End every subscription and wake every poller. Sync — never fails."""
+        self.finished = True
+        for subscription in list(self.subscribers):
+            subscription.offer(None)
+            subscription.closed = True
+        self.subscribers.clear()
+        self.signal.notify()
+
+
+def _output_entry_builders() -> tuple[Callable[..., Any], Callable[..., Any]]:
+    """The #117 output-entry helpers, imported lazily (see module docstring)."""
+    from ..api.ws_execution import build_node_output_entries, declared_image_ports
+
+    return build_node_output_entries, declared_image_ports
+
+
+# ── the service ───────────────────────────────────────────────────────────
+
+
+class RunService:
+    """Owns every server-side run: registry, tasks, events, lifecycle.
+
+    One instance per process, held on ``app.state.run_service``. Everything
+    it touches concurrently lives on the event loop (plain dict/set mutation
+    with no ``await`` in between), so it needs no lock of its own; the only
+    shared resource with real contention is the database, and ``Database.run``
+    already serialises that.
+    """
+
+    def __init__(
+        self,
+        store: RunStore,
+        *,
+        output_store: RunOutputStore | None = None,
+        retention_keep_last: int | None = None,
+        shutdown_grace_s: float = DEFAULT_SHUTDOWN_GRACE_S,
+        subscriber_queue_size: int = DEFAULT_SUBSCRIBER_QUEUE_SIZE,
+        metric_flush_max_points: int = METRIC_FLUSH_MAX_POINTS,
+        metric_flush_interval_s: float = METRIC_FLUSH_INTERVAL_S,
+    ) -> None:
+        self.store = store
+        self._output_store = output_store
+        self._retention_keep_last = retention_keep_last
+        self._shutdown_grace_s = shutdown_grace_s
+        self._subscriber_queue_size = subscriber_queue_size
+        self._metric_flush_max_points = metric_flush_max_points
+        self._metric_flush_interval_s = metric_flush_interval_s
+        self._runs: dict[str, _ActiveRun] = {}
+        self._shutting_down = False
+
+    # ── introspection ─────────────────────────────────────────────────────
+
+    def active_run_ids(self) -> list[str]:
+        """Runs THIS process is driving, submit order."""
+        return list(self._runs)
+
+    def is_active(self, run_id: str) -> bool:
+        return run_id in self._runs
+
+    def execution_id(self, run_id: str) -> str | None:
+        """The ``ExecutionContext.execution_id`` of a live run (== its id)."""
+        active = self._runs.get(run_id)
+        return None if active is None else active.context.execution_id
+
+    # ── submit ────────────────────────────────────────────────────────────
+
+    async def submit(
+        self,
+        graph: Any,
+        *,
+        options: Any = None,
+        name: str | None = None,
+    ) -> SubmitResult:
+        """Persist a run, then start it. Raises ``RunSubmitError`` on input.
+
+        The two halves are separate on purpose. ``create_run`` makes the run
+        exist and queryable before anything can execute, so a crash between
+        the two leaves a row that startup recovery retires honestly instead
+        of losing the submission entirely.
+
+        **The #123 seam is between them.** A queue implementation stops
+        calling ``_start`` here and calls it from its scheduler; the only
+        extra work is re-reading the graph with
+        ``store.get_graph_snapshot(run_id)``, since a deferred start cannot
+        rely on the submitting request still being in memory. Nothing else in
+        this module assumes immediacy.
+        """
+        if self._shutting_down:
+            raise RunServiceUnavailable("run service is shutting down")
+        normalized_graph = normalize_graph(graph)
+        normalized_options = normalize_options(options)
+
+        record = await self.store.create_run(
+            graph_snapshot=normalized_graph,
+            options=normalized_options,
+            name=name,
+            status=STATUS_QUEUED,
+        )
+        # ── #123 inserts scheduling HERE ─────────────────────────────────
+        return self._start(record.id, normalized_graph, normalized_options)
+
+    def _start(
+        self, run_id: str, graph: dict[str, Any], options: dict[str, Any],
+    ) -> SubmitResult:
+        """Register the run and hand it to its own task. SYNCHRONOUS.
+
+        Not a coroutine, and that is the load-bearing property: there is no
+        ``await`` anywhere between putting the run in the registry and
+        creating the task that owns it, so no cancellation of the SUBMITTING
+        coroutine can land in the middle and strand a registry entry that
+        nothing will ever finish. Everything that needs the database
+        (``mark_running``, the start event) happens inside the task, where a
+        cancellation is the RUN's cancellation and unwinds through the normal
+        terminal path.
+
+        The reported status is therefore a promise the task fulfils on its
+        first step; a client that reads the row in that microsecond sees
+        ``queued``, which is simply true.
+        """
+        context = ExecutionContext(
+            execution_id=run_id,
+            device=resolve_device(options.get("device")),
+            max_workers=settings.MAX_PARALLEL_NODES,
+            # A server-owned run is an isolated, reproducible unit: its
+            # stored graph_snapshot + options must fully describe what ran.
+            # Inheriting live nn.Module weights from a previous run would
+            # make that description a lie, and two concurrent runs of the
+            # same graph would train one shared module. The canvas's
+            # keep-training workflow keeps working over the WS path; #121
+            # re-introduces it here as an explicit option.
+            weights_persistent=False,
+            node_state_store=None,
+        )
+        active = _ActiveRun(
+            run_id=run_id, context=context, signal=_Broadcast(),
+            record_outputs=bool(options.get("record_outputs")),
+        )
+        self._runs[run_id] = active
+        active.task = asyncio.create_task(
+            self._drive(active, graph, options), name=f"run:{run_id}")
+        return SubmitResult(run_id=run_id, status=STATUS_RUNNING)
+
+    # ── the run task ──────────────────────────────────────────────────────
+
+    async def _drive(
+        self, active: _ActiveRun, graph: dict[str, Any],
+        options: dict[str, Any],
+    ) -> None:
+        """The server-owned task. Nothing outside this module awaits it.
+
+        A hard ``Task.cancel`` (shutdown's last resort) is BaseException and
+        therefore skips every ``except`` below AND the finalizer, leaving the
+        row ``running`` for the next boot's recovery to retire. That is
+        deliberate: a forcibly-killed run must not write a tidy terminal
+        status it cannot vouch for. Everything else — including a broken
+        database — is caught, because an unretrieved task exception is a
+        silent death nobody would ever see.
+        """
+        run_id = active.run_id
+        try:
+            if not await self._begin(active):
+                return
+            status, error = await self._execute(active, graph, options)
+            await self._finalize(active, status, error)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("run %s: unhandled error in the run task", run_id)
+        finally:
+            active.close()
+            self._runs.pop(run_id, None)
+
+    async def _begin(self, active: _ActiveRun) -> bool:
+        """Claim the row and announce the run. False means "do not run".
+
+        The only way this fails is the row not existing any more — deleted
+        out from under a submission — in which case there is nothing left to
+        write events or a status to.
+        """
+        started = await self.store.mark_running(
+            active.run_id, queue_key=active.context.device)
+        if not started:
+            logger.warning("run %s vanished before it could start",
+                           active.run_id)
+            return False
+        await self._emit(active.run_id, EVENT_RUN_STARTED,
+                         {"run_id": active.run_id})
+        return True
+
+    async def _execute(
+        self, active: _ActiveRun, graph: dict[str, Any],
+        options: dict[str, Any],
+    ) -> tuple[str, str | None]:
+        """Run the graph and classify the outcome. Never raises but cancel."""
+        try:
+            apply_seed(options.get("seed"))
+            await execute_graph(
+                graph["nodes"],
+                graph["edges"],
+                on_progress=self._progress_bridge(active, graph["nodes"]),
+                context=active.context,
+                # No ExecutionCache: nothing is re-executed within a run, and
+                # sharing one ACROSS runs would serve a later run stale
+                # tensors under a matching key.
+                cache=None,
+                run_id=active.run_id,
+                output_store=self._output_store,
+                record_outputs=active.record_outputs,
+                preset_fallback=build_preset_fallback(graph["presets"]),
+            )
+            return STATUS_SUCCEEDED, None
+        except CancellationError:
+            # Why it stopped is a different fact from that it stopped: a user
+            # pressing Stop is `cancelled`, the server going away is
+            # `interrupted`. The engine raises the same exception for both.
+            return ((STATUS_INTERRUPTED
+                     if active.stop_reason == STOP_REASON_INTERRUPTED
+                     else STATUS_CANCELLED), None)
+        except GraphValidationError as exc:
+            return STATUS_FAILED, str(exc)
+        except Exception as exc:
+            logger.warning("run %s failed: %s", active.run_id, exc,
+                           exc_info=True)
+            return STATUS_FAILED, str(exc)
+
+    async def _finalize(
+        self, active: _ActiveRun, status: str, error: str | None,
+    ) -> None:
+        """Terminal bookkeeping, in the one order that stays consistent.
+
+        Metrics before the terminal event (so a reader that stops at the
+        terminal event has the full series), the terminal event before the
+        row (so an event-log follower never sees a finished row with no
+        closing frame), and ``finished`` set before the row write so a long
+        poller woken by the terminal event does not go back to sleep.
+        """
+        await self._flush_metrics(active, force=True)
+        if status == STATUS_SUCCEEDED:
+            await self._emit(active.run_id, EVENT_RUN_COMPLETED, None)
+        elif status == STATUS_FAILED:
+            await self._emit(active.run_id, EVENT_RUN_FAILED,
+                             {"error": error or "run failed"})
+        else:
+            reason = (STOP_REASON_INTERRUPTED if status == STATUS_INTERRUPTED
+                      else STOP_REASON_CANCELLED)
+            await self._emit(active.run_id, EVENT_RUN_STOPPED,
+                             {"reason": reason})
+        active.finished = True
+
+        # mark_finished guards on the ACTIVE statuses and reports whether it
+        # landed, which is how a cancel racing a completion is resolved
+        # (#119): the loser simply did not write, instead of a succeeded run
+        # being filed forever as cancelled by a late writer.
+        landed = await self.store.mark_finished(active.run_id, status,
+                                                error=error)
+        if not landed:
+            logger.info(
+                "run %s was already terminal when %s was reported",
+                active.run_id, status)
+        await self.prune_retention()
+
+    def _progress_bridge(
+        self, active: _ActiveRun, nodes: list[dict[str, Any]],
+    ) -> Callable[[str, str, dict[str, Any] | None], Any]:
+        """Build the engine's ``on_progress`` callback for one run.
+
+        The message body is byte-for-byte what ``ws_execution`` puts on the
+        wire minus its ``type`` key — see the event-vocabulary block above.
+        """
+        build_entries, declared_image_ports = _output_entry_builders()
+        image_ports = declared_image_ports(nodes)
+
+        async def on_progress(
+            node_id: str, status: str, result: dict[str, Any] | None,
+        ) -> None:
+            message: dict[str, Any] = {"node_id": node_id, "status": status}
+            if result and status == "error":
+                message["error"] = result.get("error", "")
+            entries = build_entries(status, result, image_ports.get(node_id, ()))
+            if entries:
+                message["outputs"] = entries
+            await self._emit(active.run_id, EVENT_NODE_STATUS, message)
+            if status == "progress":
+                self._collect_metrics(active, node_id, result)
+                await self._flush_metrics(active)
+
+        return on_progress
+
+    # ── events ────────────────────────────────────────────────────────────
+
+    async def _emit(
+        self, run_id: str, event_type: str, payload: Any,
+    ) -> EventRecord | None:
+        """Append one event durably, then hand it to live subscribers.
+
+        Persist-then-fan-out, never the reverse: the store is the source of
+        truth and a subscriber must not learn of an event that failed to
+        land. A failed append is logged and swallowed — the event log is
+        observability, and losing a progress row must not fail the run that
+        was only trying to describe itself. ``CancelledError`` is re-raised
+        untouched (it is the run stopping, not a logging problem); note that
+        an append cancelled AFTER its COMMIT leaves a durable event whose
+        cursor is lost here, which is safe precisely because every consumer
+        re-reads the tail from the store rather than trusting this return.
+        """
+        stamp = utc_now_iso()
+        try:
+            cursor = await self.store.append_event(run_id, event_type, payload,
+                                                   ts=stamp)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("run %s: could not append %s event", run_id,
+                           event_type, exc_info=True)
+            self._wake(run_id)
+            return None
+        record = EventRecord(run_id=run_id, cursor=cursor, type=event_type,
+                             payload=payload, ts=stamp)
+        self._fan_out(run_id, record)
+        return record
+
+    def _fan_out(self, run_id: str, record: EventRecord) -> None:
+        active = self._runs.get(run_id)
+        if active is None:
+            return
+        for subscription in list(active.subscribers):
+            subscription.offer(record)
+        active.signal.notify()
+
+    def _wake(self, run_id: str) -> None:
+        active = self._runs.get(run_id)
+        if active is not None:
+            active.signal.notify()
+
+    @asynccontextmanager
+    async def subscribe(
+        self, run_id: str, *, maxsize: int | None = None,
+    ) -> AsyncIterator[RunSubscription]:
+        """Live event feed for an in-process consumer (#121's WS bridge).
+
+        A run that is already finished yields an immediately-closed
+        subscription: there is nothing left to push, and the consumer should
+        replay from ``RunStore.get_events``. Always used as a context manager
+        so a dropped consumer cannot leak a queue onto a long-lived run.
+
+        *maxsize* overrides the queue depth; ``0`` means unbounded, as
+        ``asyncio.Queue`` defines it. (``maxsize or default`` would have
+        quietly turned that request into the bounded default.)
+        """
+        depth = self._subscriber_queue_size if maxsize is None else maxsize
+        subscription = RunSubscription(run_id=run_id,
+                                       queue=asyncio.Queue(depth))
+        active = self._runs.get(run_id)
+        if active is None or active.finished:
+            subscription.closed = True
+            yield subscription
+            return
+        active.subscribers.add(subscription)
+        try:
+            yield subscription
+        finally:
+            active.subscribers.discard(subscription)
+
+    async def wait_for_events(
+        self,
+        run_id: str,
+        *,
+        after_cursor: int = 0,
+        limit: int = 500,
+        wait: float = 0.0,
+    ) -> list[EventRecord]:
+        """Events after *after_cursor*, optionally long-polling for the next.
+
+        The wake-up is edge-triggered (``_Broadcast``) — there is no sleep
+        loop and no polling interval anywhere in this function. Order is
+        load-bearing: the generation is captured BEFORE the store read, so an
+        event that lands during the read still satisfies the wait instead of
+        being missed until the next one.
+
+        Returns as soon as anything is available, and immediately (possibly
+        empty) once the run is finished or unknown — a long poll on a dead
+        run must never hang for its full timeout.
+        """
+        deadline = time.monotonic() + max(wait, 0.0)
+        while True:
+            active = self._runs.get(run_id)
+            waiter = None if active is None or active.finished \
+                else active.signal.waiter()
+            events = await self.store.get_events(
+                run_id, after_cursor=after_cursor, limit=limit)
+            if events or waiter is None:
+                return events
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return []
+            try:
+                await asyncio.wait_for(waiter.wait(), remaining)
+            except asyncio.TimeoutError:
+                return []
+
+    # ── metrics ───────────────────────────────────────────────────────────
+
+    def _collect_metrics(
+        self, active: _ActiveRun, node_id: str, payload: Any,
+    ) -> None:
+        step = metric_step(payload, fallback=active.last_metric_step + 1)
+        active.last_metric_step = step
+        active.pending_metrics.extend(
+            scalar_metrics(payload, node_id=node_id, step=step))
+
+    async def _flush_metrics(
+        self, active: _ActiveRun, *, force: bool = False,
+    ) -> int:
+        """Write buffered points in ONE transaction (``log_metrics``).
+
+        Never one row per point: a training loop emits several series per
+        epoch and per-point inserts would mean a transaction (and an fsync)
+        each. The buffer drains when it is big enough OR when it has been
+        sitting for ``metric_flush_interval_s`` — the second rule is what
+        keeps a live chart current on a slow producer, checked on the emit
+        path so no timer task is needed. ``force`` drains it at terminal.
+        """
+        if not active.pending_metrics:
+            return 0
+        now = time.monotonic()
+        if (not force
+                and len(active.pending_metrics) < self._metric_flush_max_points
+                and now - active.last_flush_monotonic
+                < self._metric_flush_interval_s):
+            return 0
+        batch, active.pending_metrics = active.pending_metrics, []
+        active.last_flush_monotonic = now
+        try:
+            return await self.store.log_metrics(active.run_id, batch)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("run %s: metric flush failed (%d point(s) lost)",
+                           active.run_id, len(batch), exc_info=True)
+            return 0
+
+    # ── cancel ────────────────────────────────────────────────────────────
+
+    async def cancel(self, run_id: str) -> CancelOutcome | None:
+        """Ask a run to stop. ``None`` when the run does not exist.
+
+        COOPERATIVE, never ``Task.cancel``: the ``ExecutionContext`` flag is
+        set and the engine unwinds at its next checkpoint (between nodes and
+        between levels). A node already executing in a worker thread runs to
+        completion first — a training node with a 90-second epoch stops after
+        that epoch, not mid-backward — because there is no safe way to
+        interrupt arbitrary third-party node code, and killing the task
+        outright is what leaves half-written rows and wedged CUDA state.
+        Cancellation is therefore ACKNOWLEDGED here and OBSERVED on the row.
+
+        A run that never started (a ``queued`` row — #123's lane, or an
+        orphan) is retired directly through the guarded ``mark_finished``, so
+        a cancel racing a start cannot rewrite a run that is already going.
+
+        The ``finished`` check is what keeps the answer truthful in the
+        window between a run writing its terminal row and being removed from
+        the registry: a registry hit alone would report "cancelled: true" for
+        a run that had already succeeded.
+        """
+        active = self._runs.get(run_id)
+        if active is not None and not active.finished:
+            if active.stop_reason is None:
+                active.stop_reason = STOP_REASON_CANCELLED
+            active.context.cancel()
+            return CancelOutcome(run_id=run_id, status=STATUS_RUNNING,
+                                 cancelled=True)
+
+        record = await self.store.get_run(run_id)
+        if record is None:
+            return None
+        if record.status == STATUS_QUEUED:
+            landed = await self.store.mark_finished(
+                run_id, STATUS_CANCELLED, expected=(STATUS_QUEUED,))
+            if landed:
+                return CancelOutcome(run_id=run_id, status=STATUS_CANCELLED,
+                                     cancelled=True)
+            record = await self.store.get_run(run_id) or record
+        return CancelOutcome(run_id=run_id, status=record.status,
+                             cancelled=False)
+
+    # ── lifecycle ─────────────────────────────────────────────────────────
+
+    async def recover_interrupted(self) -> int:
+        """Retire rows a dead process left active. STARTUP ONLY.
+
+        Nothing resumes a ``running`` row after a restart, so leaving one
+        claiming to be alive is both a lie to the user and an unbounded
+        metrics leak: retention never deletes an active run, so an
+        abandoned one would keep its events and metrics forever. This is why
+        it must run BEFORE ``prune_retention``.
+
+        Guarded rather than merely documented — calling it while this process
+        has live runs would mark those very runs interrupted underneath
+        themselves.
+        """
+        if self._runs:
+            raise RuntimeError(
+                "recover_interrupted is a startup call; "
+                f"{len(self._runs)} active run(s) are in flight")
+        count = await self.store.interrupt_active_runs()
+        if count:
+            logger.warning(
+                "marked %d run(s) interrupted (they did not survive a "
+                "restart)", count)
+        return count
+
+    async def prune_retention(self) -> int:
+        """Apply the keep-last-N retention policy. ``None`` disables it."""
+        keep_last = self._retention_keep_last
+        if keep_last is None or keep_last < 0:
+            return 0
+        deleted = await self.store.prune(keep_last=keep_last)
+        if deleted:
+            logger.info(
+                "run retention: removed %d finished run(s), keeping the "
+                "newest %d", deleted, keep_last)
+        return deleted
+
+    async def shutdown(self) -> None:
+        """Stop every run and DRAIN its task. Must complete before db.close().
+
+        The #119 carry-forward this closes: ``Database.close`` races any
+        merely-slow ``db.run`` that is still in flight, and the run tasks are
+        the only thing in the process that issues database work nobody is
+        awaiting. Every one of them is awaited to completion here, so by the
+        time this returns there is no worker thread left holding the
+        connection.
+
+        Two phases, in this order:
+
+        1. Cooperative. The stop reason is ``interrupted`` (the server is
+           going away, the user did not ask), so the tasks write an honest
+           terminal row on their way out.
+        2. Hard, after ``shutdown_grace_s``. ``Task.cancel`` on whatever is
+           still stuck in a long node; those rows stay ``running`` and the
+           next boot's ``recover_interrupted`` retires them. The cancelled
+           tasks are still awaited — cancelling is not draining.
+        """
+        self._shutting_down = True
+        active = list(self._runs.values())
+        for entry in active:
+            # First reason wins: a run the user already cancelled is filed as
+            # cancelled even if the server goes down before it unwinds. Their
+            # intent is the more specific fact, and it came first.
+            if entry.stop_reason is None:
+                entry.stop_reason = STOP_REASON_INTERRUPTED
+            entry.context.cancel()
+        tasks = [entry.task for entry in active if entry.task is not None]
+        if not tasks:
+            return
+        logger.info("shutdown: draining %d in-flight run(s)", len(tasks))
+        _done, pending = await asyncio.wait(tasks,
+                                            timeout=self._shutdown_grace_s)
+        if pending:
+            logger.warning(
+                "shutdown: %d run(s) did not stop within %.1fs; cancelling "
+                "(they will be marked interrupted on the next start)",
+                len(pending), self._shutdown_grace_s)
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -104,6 +104,15 @@ def _json_safe(value: Any) -> Any:
     return value
 
 
+#: Public alias. ``run_service`` fans an event out to in-process subscribers
+#: as well as storing it, and the two copies MUST agree — a NaN that reaches
+#: a subscriber but not the stored row would put a bare ``NaN`` token (a
+#: CPython extension, not JSON) on the WebSocket, where ``JSON.parse``
+#: rejects it. Exported rather than reimplemented so the sanitisation stays
+#: defined exactly once, by the module that owns what "storable" means.
+json_safe = _json_safe
+
+
 def _dumps(value: Any) -> str:
     """Compact JSON for a storage column. Always valid JSON.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,6 +49,7 @@ from .api import (
     routes_plugin_frontend,
     routes_plugins,
     routes_presets,
+    routes_runs,
     routes_system,
     ws_execution,
 )
@@ -77,6 +78,8 @@ from .core.plugin_loader import (
 )
 from .core.preset_registry import preset_registry
 from .core.run_output_store import RunOutputStore
+from .core.run_service import RunService
+from .core.run_store import RunStore
 
 logger = logging.getLogger(__name__)
 
@@ -301,7 +304,30 @@ async def lifespan(app: FastAPI):
     # on app delete.
     app.state.app_locks = {}
 
+    # ── Run Service (#120): server-owned graph runs ────────────────────
+    # Owns its own asyncio.Tasks, so it must be created after the DB and
+    # drained before it closes (see the shutdown block below).
+    run_service = RunService(
+        RunStore(db),
+        output_store=app.state.run_output_store,
+        retention_keep_last=settings.RUN_RETENTION_KEEP_LAST,
+    )
+    app.state.run_service = run_service
+    # Order matters. Recovery FIRST: nothing resumes a `running` row after a
+    # restart, and retention never deletes an active run — so an abandoned
+    # one would keep its events and metrics forever. Retiring it is what
+    # makes it prunable in the very next call. Both steps log their own
+    # counts when they do anything.
+    await run_service.recover_interrupted()
+    await run_service.prune_retention()
+
     yield
+
+    # Drain in-flight runs BEFORE the handle goes away. Their tasks are the
+    # only database work in the process that nobody is awaiting, and
+    # `Database.close` would otherwise race a run's final writes (#119).
+    await run_service.shutdown()
+    app.state.run_service = None
 
     # Release the SQLite handle so `cdui stop` on Windows frees the DB and
     # its WAL sidecar files (spec Section 13, Windows file locking).
@@ -396,6 +422,7 @@ app.include_router(routes_models.router)
 app.include_router(routes_images.router)
 app.include_router(routes_execution_outputs.router)
 app.include_router(routes_execution_state.router)
+app.include_router(routes_runs.router)
 app.include_router(routes_system.router)
 app.include_router(routes_llm.router)
 app.include_router(routes_apps.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -311,6 +311,7 @@ async def lifespan(app: FastAPI):
         RunStore(db),
         output_store=app.state.run_output_store,
         retention_keep_last=settings.RUN_RETENTION_KEEP_LAST,
+        event_payload_cap_bytes=settings.RUN_EVENT_PAYLOAD_CAP_BYTES,
     )
     app.state.run_service = run_service
     # Order matters. Recovery FIRST: nothing resumes a `running` row after a

--- a/backend/tests/test_api_runs.py
+++ b/backend/tests/test_api_runs.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import csv
 import io
+import json
 import time
 from typing import Any
 
@@ -28,7 +29,14 @@ from httpx import ASGITransport, AsyncClient
 from app.config import settings
 from app.core.auth import TOKEN_HEADER, session_token
 from app.core.db import Database
-from app.core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+from app.core.node_base import (
+    MEDIA_IMAGE,
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
 from app.core.node_registry import registry
 from app.core.run_service import RunService
 from app.core.run_store import RunProvenance, RunStore
@@ -86,12 +94,46 @@ class _ApiMetricsNode(BaseNode):
         return {"value": inputs.get("value")}
 
 
+class _ApiImageNode(BaseNode):
+    NODE_NAME = "_ApiImage"
+    CATEGORY = "Test"
+    DESCRIPTION = "Emits a declared base64 image"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="value", data_type=DataType.ANY),
+            PortDefinition(name="image", data_type=DataType.ANY,
+                           media=MEDIA_IMAGE),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [ParamDefinition(name="size", param_type=ParamType.INT,
+                                default=64)]
+
+    def execute(self, inputs: dict[str, Any],
+                params: dict[str, Any]) -> dict[str, Any]:
+        return {"value": inputs.get("value"),
+                "image": "A" * int(params.get("size", 64))}
+
+
+_TEST_NODES = {
+    "_ApiSlow": _ApiSlowNode,
+    "_ApiMetrics": _ApiMetricsNode,
+    "_ApiImage": _ApiImageNode,
+}
+
+
 @pytest.fixture(autouse=True)
 def _register_test_nodes():
-    registry._nodes["_ApiSlow"] = _ApiSlowNode
-    registry._nodes["_ApiMetrics"] = _ApiMetricsNode
+    registry._nodes.update(_TEST_NODES)
     yield
-    for name in ("_ApiSlow", "_ApiMetrics"):
+    for name in _TEST_NODES:
         registry._nodes.pop(name, None)
 
 
@@ -268,9 +310,11 @@ async def test_submit_records_normalized_options(client):
 @pytest.mark.parametrize("payload,expected", [
     ({"graph": {"nodes": []}}, 400),
     ({"graph": {"edges": []}}, 400),
-    ({"graph": _graph(), "options": {"devcie": "cuda"}}, 400),
+    ({"graph": _graph(), "options": {"devcie": "cuda"}}, 400),   # bad key
+    ({"graph": _graph(), "options": {"device": "cudda"}}, 400),  # bad value
     ({"graph": _graph(), "options": {"seed": -5}}, 400),
     ({"graph": _graph(), "options": "nope"}, 400),
+    ({"graph": _graph(), "name": "x" * 65}, 400),
     ({"options": {}}, 422),                       # graph is required
     ({"graph": "not-an-object"}, 422),
 ])
@@ -296,13 +340,22 @@ async def test_submit_during_shutdown_is_503(client, run_app):
 
 
 async def test_endpoints_503_without_a_wired_service():
+    # Restore whatever was on app.state: the module-level app is shared with
+    # every other test module, so a test that strips it must put it back
+    # even when the assertions fail.
+    saved = {name: getattr(app.state, name)
+             for name in ("db", "run_service") if hasattr(app.state, name)}
     for attribute in ("db", "run_service"):
         if hasattr(app.state, attribute):
             delattr(app.state, attribute)
-    async with _new_client() as http:
-        assert (await http.get("/api/runs")).status_code == 503
-        assert (await http.post(
-            "/api/runs", json={"graph": _graph()})).status_code == 503
+    try:
+        async with _new_client() as http:
+            assert (await http.get("/api/runs")).status_code == 503
+            assert (await http.post(
+                "/api/runs", json={"graph": _graph()})).status_code == 503
+    finally:
+        for name, value in saved.items():
+            setattr(app.state, name, value)
 
 
 # ── list / get ────────────────────────────────────────────────────────────
@@ -447,6 +500,55 @@ async def test_events_long_poll_wakes_on_the_next_event(client):
     assert later.json()["events"], "timed out instead of waking"
     assert elapsed < 9.0, "woke on the timeout, not on the event"
     await _poll_until_terminal(client, run_id)
+
+
+async def test_oversized_image_events_are_served_elided(client):
+    """The DB never stores the blob, so the API never serves it."""
+    run_id = (await client.post("/api/runs", json={
+        "graph": _graph("_ApiImage", {"size": 200_000})})).json()["run_id"]
+    await _poll_until_terminal(client, run_id)
+
+    body = (await client.get(f"/api/runs/{run_id}/events")).json()
+    images = [entry
+              for event in body["events"] if event["type"] == "node_status"
+              for entry in (event["payload"].get("outputs") or [])
+              if entry.get("output_kind") == "image"]
+    assert images, "the declared image port produced no entry at all"
+    assert images[0]["elided"] is True
+    assert images[0]["port"] == "image"        # placeholder still placeable
+    assert images[0]["bytes"] > 200_000
+    assert len(response_text := json.dumps(body)) < 200_000, response_text[:200]
+
+
+async def test_events_response_is_byte_bounded(client, monkeypatch):
+    """`limit` alone must not multiply into an unbounded response body.
+
+    A short page is normal — the cursor says where to resume — so the whole
+    log is still reachable, one bounded page at a time, with no gaps.
+    """
+    from app.api import routes_runs
+
+    monkeypatch.setattr(routes_runs, "_EVENTS_RESPONSE_CAP_BYTES", 400)
+    run_id = (await client.post("/api/runs", json={
+        "graph": _graph("_ApiImage", {"size": 300})})).json()["run_id"]
+    await _poll_until_terminal(client, run_id)
+
+    seen: list[dict[str, Any]] = []
+    cursor = 0
+    for _ in range(50):
+        page = (await client.get(
+            f"/api/runs/{run_id}/events?cursor={cursor}&limit=2000")).json()
+        if not page["events"]:
+            break
+        assert len(page["events"]) < 8, "the byte budget did not bound the page"
+        # The cursor tracks what was RETURNED, so resuming skips nothing.
+        assert page["cursor"] == page["events"][-1]["cursor"]
+        seen.extend(page["events"])
+        cursor = page["cursor"]
+
+    assert len(seen) >= 8, "the run should have produced more than one page"
+    assert [event["cursor"] for event in seen] == list(range(1, len(seen) + 1))
+    assert seen[-1]["type"] == "execution_complete"
 
 
 async def test_events_reject_an_out_of_range_wait(client):

--- a/backend/tests/test_api_runs.py
+++ b/backend/tests/test_api_runs.py
@@ -1,0 +1,527 @@
+"""Tests for /api/runs — the Run Service REST surface (#120).
+
+The three acceptance criteria of the issue are stated here at the level a
+user actually meets them (HTTP), on top of the service-level versions in
+test_run_service.py:
+
+1. Submit, kill the submitting client, the run still completes and stays
+   fully queryable.
+2. Two concurrent submits do not cancel each other.
+3. A row left ``running`` by a dead process reads ``interrupted``.
+
+Plus the parts of the contract only the HTTP layer has: cursor pagination,
+long-poll semantics, CSV metrics export, auth, and the 503 when the service
+is not wired up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+import time
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import settings
+from app.core.auth import TOKEN_HEADER, session_token
+from app.core.db import Database
+from app.core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+from app.core.node_registry import registry
+from app.core.run_service import RunService
+from app.core.run_store import RunProvenance, RunStore
+from app.main import app
+
+BASE_URL = f"http://127.0.0.1:{settings.PORT}"
+
+
+# ── test nodes (duplicated so test modules stay independent) ─────────────
+
+
+class _ApiSlowNode(BaseNode):
+    NODE_NAME = "_ApiSlow"
+    CATEGORY = "Test"
+    DESCRIPTION = "Sleeps, then passes through"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [ParamDefinition(name="seconds", param_type=ParamType.FLOAT,
+                                default=0.3)]
+
+    def execute(self, inputs: dict[str, Any],
+                params: dict[str, Any]) -> dict[str, Any]:
+        time.sleep(float(params.get("seconds", 0.3)))
+        return {"value": inputs.get("value")}
+
+
+class _ApiMetricsNode(BaseNode):
+    NODE_NAME = "_ApiMetrics"
+    CATEGORY = "Test"
+    DESCRIPTION = "Emits epoch progress events"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any],
+                progress_callback=None) -> dict[str, Any]:
+        for epoch in (1, 2):
+            if progress_callback:
+                progress_callback({"event": "epoch", "epoch": epoch,
+                                   "loss": 1.0 / epoch, "note": "text,with,commas"})
+        return {"value": inputs.get("value")}
+
+
+@pytest.fixture(autouse=True)
+def _register_test_nodes():
+    registry._nodes["_ApiSlow"] = _ApiSlowNode
+    registry._nodes["_ApiMetrics"] = _ApiMetricsNode
+    yield
+    for name in ("_ApiSlow", "_ApiMetrics"):
+        registry._nodes.pop(name, None)
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def run_app(tmp_path):
+    """Per-test Database + RunService on app.state, torn down in the REAL order.
+
+    Teardown mirrors the lifespan exactly — drain the service, THEN close the
+    database — so every test in this module also exercises the shutdown
+    ordering that keeps a run's last writes from racing ``db.close()``.
+    """
+    database = Database(tmp_path / "codefyui.db")
+    database.connect()
+    store = RunStore(database)
+    service = RunService(store, shutdown_grace_s=5.0)
+    app.state.db = database
+    app.state.run_service = service
+    try:
+        yield service
+    finally:
+        await service.shutdown()
+        database.close()
+        for attribute in ("db", "run_service"):
+            if hasattr(app.state, attribute):
+                delattr(app.state, attribute)
+
+
+@pytest.fixture
+async def client(run_app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url=BASE_URL,
+        headers={TOKEN_HEADER: session_token()},
+    ) as http:
+        yield http
+
+
+def _new_client() -> AsyncClient:
+    """A SEPARATE connection to the same app — a different browser tab."""
+    return AsyncClient(
+        transport=ASGITransport(app=app), base_url=BASE_URL,
+        headers={TOKEN_HEADER: session_token()},
+    )
+
+
+def _graph(middle_type: str | None = None,
+           params: dict[str, Any] | None = None) -> dict[str, Any]:
+    nodes = [
+        {"id": "start", "type": "Start", "data": {"params": {}}},
+        {"id": "src", "type": "_TestSource", "data": {"params": {"val": "hi"}}},
+        {"id": "print", "type": "Print", "data": {"params": {"label": "out"}}},
+    ]
+    edges = [
+        {"id": "et", "source": "start", "target": "src",
+         "sourceHandle": "trigger", "type": "trigger"},
+    ]
+    if middle_type is None:
+        edges.append({"id": "e1", "source": "src", "target": "print",
+                      "sourceHandle": "value", "targetHandle": "value"})
+    else:
+        nodes.insert(2, {"id": "mid", "type": middle_type,
+                         "data": {"params": params or {}}})
+        edges.append({"id": "e1", "source": "src", "target": "mid",
+                      "sourceHandle": "value", "targetHandle": "value"})
+        edges.append({"id": "e2", "source": "mid", "target": "print",
+                      "sourceHandle": "value", "targetHandle": "value"})
+    return {"nodes": nodes, "edges": edges}
+
+
+async def _poll_until_terminal(http: AsyncClient, run_id: str,
+                               timeout: float = 15.0) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = await http.get(f"/api/runs/{run_id}")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        if body["finished_at"] is not None:
+            return body
+        await asyncio.sleep(0.02)
+    raise AssertionError(f"run {run_id} did not finish within {timeout}s")
+
+
+# ── acceptance criterion 1 ────────────────────────────────────────────────
+
+
+async def test_run_completes_after_the_submitting_client_is_killed(run_app):
+    """Submit, close the client mid-run, then query everything from a new one."""
+    submitter = _new_client()
+    response = await submitter.post("/api/runs", json={
+        "graph": _graph("_ApiSlow", {"seconds": 0.4}),
+        "options": {"record_outputs": True},
+        "name": "detached",
+    })
+    assert response.status_code == 200, response.text
+    body = response.json()
+    run_id = body["run_id"]
+    assert body["status"] == "running"
+
+    # The client goes away while the run is still in flight.
+    await submitter.aclose()
+    assert run_app.is_active(run_id), "run was already over; test proves nothing"
+
+    async with _new_client() as watcher:
+        record = await _poll_until_terminal(watcher, run_id)
+        assert record["status"] == "succeeded"
+        assert record["error"] is None
+        assert record["name"] == "detached"
+
+        events = (await watcher.get(f"/api/runs/{run_id}/events")).json()
+        types = [event["type"] for event in events["events"]]
+        assert types[0] == "execution_start"
+        assert types[-1] == "execution_complete"
+        assert events["cursor"] == events["events"][-1]["cursor"]
+        assert events["status"] == "succeeded"
+
+        metrics = (await watcher.get(f"/api/runs/{run_id}/metrics")).json()
+        assert metrics["run_id"] == run_id
+        assert metrics["names"] == []
+
+
+# ── acceptance criterion 2 ────────────────────────────────────────────────
+
+
+async def test_two_concurrent_submits_do_not_cancel_each_other(client):
+    first, second = await asyncio.gather(
+        client.post("/api/runs",
+                    json={"graph": _graph("_ApiSlow", {"seconds": 0.3})}),
+        client.post("/api/runs",
+                    json={"graph": _graph("_ApiSlow", {"seconds": 0.05})}),
+    )
+    ids = [first.json()["run_id"], second.json()["run_id"]]
+    assert ids[0] != ids[1]
+
+    records = await asyncio.gather(*(
+        _poll_until_terminal(client, run_id) for run_id in ids))
+    assert [record["status"] for record in records] == ["succeeded", "succeeded"]
+
+
+# ── acceptance criterion 3 ────────────────────────────────────────────────
+
+
+async def test_restart_shows_interrupted_not_running(client, run_app):
+    """A row from a process that died mid-run must never read ``running``."""
+    orphan = await run_app.store.create_run(
+        graph_snapshot=_graph(), options={}, provenance=RunProvenance())
+    await run_app.store.mark_running(orphan.id)
+    assert (await client.get(f"/api/runs/{orphan.id}")).json()["status"] == "running"
+
+    # The process restarts: a fresh service over the same database.
+    reborn = RunService(run_app.store)
+    assert await reborn.recover_interrupted() == 1
+
+    body = (await client.get(f"/api/runs/{orphan.id}")).json()
+    assert body["status"] == "interrupted"
+    assert body["finished_at"] is not None
+    assert body["active"] is False
+
+
+# ── submit ────────────────────────────────────────────────────────────────
+
+
+async def test_submit_records_normalized_options(client):
+    response = await client.post("/api/runs", json={
+        "graph": _graph(), "options": {"seed": 3, "lane": "gpu"}})
+    run_id = response.json()["run_id"]
+    record = await _poll_until_terminal(client, run_id)
+    assert record["options"] == {"device": "cpu", "seed": 3,
+                                 "record_outputs": False, "lane": "gpu"}
+    assert record["queue_key"] == "cpu"
+
+
+@pytest.mark.parametrize("payload,expected", [
+    ({"graph": {"nodes": []}}, 400),
+    ({"graph": {"edges": []}}, 400),
+    ({"graph": _graph(), "options": {"devcie": "cuda"}}, 400),
+    ({"graph": _graph(), "options": {"seed": -5}}, 400),
+    ({"graph": _graph(), "options": "nope"}, 400),
+    ({"options": {}}, 422),                       # graph is required
+    ({"graph": "not-an-object"}, 422),
+])
+async def test_submit_rejects_bad_input(client, payload, expected):
+    response = await client.post("/api/runs", json=payload)
+    assert response.status_code == expected, response.text
+
+
+async def test_submit_requires_the_session_token(run_app):
+    async with AsyncClient(transport=ASGITransport(app=app),
+                           base_url=BASE_URL) as anonymous:
+        response = await anonymous.post("/api/runs", json={"graph": _graph()})
+        assert response.status_code == 403
+        cancel = await anonymous.post("/api/runs/whatever/cancel")
+        assert cancel.status_code == 403
+
+
+async def test_submit_during_shutdown_is_503(client, run_app):
+    await run_app.shutdown()
+    response = await client.post("/api/runs", json={"graph": _graph()})
+    assert response.status_code == 503
+    assert "shutting down" in response.json()["detail"]
+
+
+async def test_endpoints_503_without_a_wired_service():
+    for attribute in ("db", "run_service"):
+        if hasattr(app.state, attribute):
+            delattr(app.state, attribute)
+    async with _new_client() as http:
+        assert (await http.get("/api/runs")).status_code == 503
+        assert (await http.post(
+            "/api/runs", json={"graph": _graph()})).status_code == 503
+
+
+# ── list / get ────────────────────────────────────────────────────────────
+
+
+async def test_list_is_newest_first_and_filterable(client):
+    ids = []
+    for _ in range(3):
+        response = await client.post("/api/runs", json={"graph": _graph()})
+        run_id = response.json()["run_id"]
+        await _poll_until_terminal(client, run_id)
+        ids.append(run_id)
+
+    body = (await client.get("/api/runs")).json()
+    assert body["total"] == 3
+    assert body["limit"] == 50 and body["offset"] == 0
+    assert [run["id"] for run in body["runs"]] == list(reversed(ids))
+    # queue_position is part of the contract from day one; nothing queues yet.
+    assert all(run["queue_position"] is None for run in body["runs"])
+
+    succeeded = (await client.get("/api/runs?status=succeeded")).json()
+    assert succeeded["total"] == 3
+    empty = (await client.get("/api/runs?status=failed")).json()
+    assert empty["runs"] == [] and empty["total"] == 0
+    paged = (await client.get("/api/runs?limit=1&offset=1")).json()
+    assert [run["id"] for run in paged["runs"]] == [ids[1]]
+    assert paged["total"] == 3
+
+
+async def test_list_reports_queue_position_for_queued_rows(client, run_app):
+    """The field is computed, not hardcoded null — #123 inherits it working."""
+    first = await run_app.store.create_run(graph_snapshot=_graph(), options={},
+                                           provenance=RunProvenance())
+    second = await run_app.store.create_run(graph_snapshot=_graph(), options={},
+                                            provenance=RunProvenance())
+    body = (await client.get("/api/runs?status=queued")).json()
+    positions = {run["id"]: run["queue_position"] for run in body["runs"]}
+    assert positions == {first.id: 1, second.id: 2}
+
+
+async def test_list_rejects_an_unknown_status(client):
+    assert (await client.get("/api/runs?status=nope")).status_code == 400
+
+
+async def test_get_run_reports_the_event_cursor(client):
+    run_id = (await client.post("/api/runs",
+                                json={"graph": _graph()})).json()["run_id"]
+    record = await _poll_until_terminal(client, run_id)
+    events = (await client.get(f"/api/runs/{run_id}/events")).json()
+    assert record["last_cursor"] == events["events"][-1]["cursor"]
+    assert record["active"] is False
+    assert "graph_snapshot" not in record       # never on a list/detail row
+
+
+async def test_get_unknown_run_is_404(client):
+    for path in ("", "/events", "/metrics"):
+        response = await client.get(f"/api/runs/nope{path}")
+        assert response.status_code == 404, path
+
+
+# ── cancel ────────────────────────────────────────────────────────────────
+
+
+async def test_cancel_stops_a_running_run(client):
+    run_id = (await client.post("/api/runs", json={
+        "graph": _graph("_ApiSlow", {"seconds": 0.4})})).json()["run_id"]
+    response = await client.post(f"/api/runs/{run_id}/cancel")
+    assert response.status_code == 200
+    assert response.json() == {"run_id": run_id, "status": "running",
+                               "cancelled": True}
+
+    record = await _poll_until_terminal(client, run_id)
+    assert record["status"] == "cancelled"
+    events = (await client.get(f"/api/runs/{run_id}/events")).json()
+    assert events["events"][-1]["type"] == "execution_stopped"
+    assert events["events"][-1]["payload"] == {"reason": "cancelled"}
+
+
+async def test_cancel_of_a_finished_run_is_a_no_op(client):
+    run_id = (await client.post("/api/runs",
+                                json={"graph": _graph()})).json()["run_id"]
+    await _poll_until_terminal(client, run_id)
+    response = await client.post(f"/api/runs/{run_id}/cancel")
+    assert response.status_code == 200
+    assert response.json() == {"run_id": run_id, "status": "succeeded",
+                               "cancelled": False}
+
+
+async def test_cancel_unknown_run_is_404(client):
+    assert (await client.post("/api/runs/nope/cancel")).status_code == 404
+
+
+# ── events ────────────────────────────────────────────────────────────────
+
+
+async def test_events_paginate_by_cursor(client):
+    run_id = (await client.post("/api/runs",
+                                json={"graph": _graph()})).json()["run_id"]
+    await _poll_until_terminal(client, run_id)
+
+    everything = (await client.get(f"/api/runs/{run_id}/events")).json()
+    cursors = [event["cursor"] for event in everything["events"]]
+    assert cursors == list(range(1, len(cursors) + 1))
+
+    tail = (await client.get(
+        f"/api/runs/{run_id}/events?cursor={cursors[1]}")).json()
+    assert [event["cursor"] for event in tail["events"]] == cursors[2:]
+
+    exhausted = (await client.get(
+        f"/api/runs/{run_id}/events?cursor={cursors[-1]}")).json()
+    assert exhausted["events"] == []
+    assert exhausted["cursor"] == cursors[-1]   # cursor never goes backwards
+
+    capped = (await client.get(f"/api/runs/{run_id}/events?limit=2")).json()
+    assert len(capped["events"]) == 2
+
+
+async def test_events_long_poll_returns_immediately_on_a_dead_run(client):
+    run_id = (await client.post("/api/runs",
+                                json={"graph": _graph()})).json()["run_id"]
+    await _poll_until_terminal(client, run_id)
+    last = (await client.get(f"/api/runs/{run_id}/events")).json()["cursor"]
+
+    started = time.monotonic()
+    response = await client.get(
+        f"/api/runs/{run_id}/events?cursor={last}&wait=5")
+    assert response.status_code == 200
+    assert response.json()["events"] == []
+    assert time.monotonic() - started < 2.0, "long poll hung on a finished run"
+
+
+async def test_events_long_poll_wakes_on_the_next_event(client):
+    run_id = (await client.post("/api/runs", json={
+        "graph": _graph("_ApiSlow", {"seconds": 0.3})})).json()["run_id"]
+    first = (await client.get(f"/api/runs/{run_id}/events?wait=5")).json()
+    assert first["events"], "no events at all"
+
+    started = time.monotonic()
+    later = await client.get(
+        f"/api/runs/{run_id}/events?cursor={first['cursor']}&wait=10")
+    elapsed = time.monotonic() - started
+    assert later.json()["events"], "timed out instead of waking"
+    assert elapsed < 9.0, "woke on the timeout, not on the event"
+    await _poll_until_terminal(client, run_id)
+
+
+async def test_events_reject_an_out_of_range_wait(client):
+    run_id = (await client.post("/api/runs",
+                                json={"graph": _graph()})).json()["run_id"]
+    await _poll_until_terminal(client, run_id)
+    assert (await client.get(
+        f"/api/runs/{run_id}/events?wait=600")).status_code == 422
+    assert (await client.get(
+        f"/api/runs/{run_id}/events?cursor=-1")).status_code == 422
+
+
+# ── metrics ───────────────────────────────────────────────────────────────
+
+
+async def test_metrics_json_and_name_filter(client):
+    run_id = (await client.post("/api/runs", json={
+        "graph": _graph("_ApiMetrics")})).json()["run_id"]
+    await _poll_until_terminal(client, run_id)
+
+    body = (await client.get(f"/api/runs/{run_id}/metrics")).json()
+    assert body["names"] == ["loss"]            # "note" is a string, not a series
+    assert [(point["step"], point["value"]) for point in body["metrics"]] == [
+        (1, 1.0), (2, 0.5)]
+    assert body["metrics"][0]["node_id"] == "mid"
+
+    filtered = (await client.get(
+        f"/api/runs/{run_id}/metrics?name=loss")).json()
+    assert len(filtered["metrics"]) == 2
+    assert (await client.get(
+        f"/api/runs/{run_id}/metrics?name=nope")).json()["metrics"] == []
+
+
+async def test_metrics_csv_export(client):
+    run_id = (await client.post("/api/runs", json={
+        "graph": _graph("_ApiMetrics")})).json()["run_id"]
+    await _poll_until_terminal(client, run_id)
+
+    response = await client.get(f"/api/runs/{run_id}/metrics?format=csv")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert run_id in response.headers["content-disposition"]
+
+    rows = list(csv.reader(io.StringIO(response.text)))
+    assert rows[0] == ["run_id", "node_id", "name", "step", "value", "ts"]
+    assert len(rows) == 3
+    assert [row[2] for row in rows[1:]] == ["loss", "loss"]
+    assert [row[3] for row in rows[1:]] == ["1", "2"]
+    assert float(rows[1][4]) == 1.0
+
+
+async def test_metrics_reject_an_unknown_format(client):
+    run_id = (await client.post("/api/runs",
+                                json={"graph": _graph()})).json()["run_id"]
+    await _poll_until_terminal(client, run_id)
+    assert (await client.get(
+        f"/api/runs/{run_id}/metrics?format=xml")).status_code == 422
+
+
+# ── openapi / auth-surface sanity ─────────────────────────────────────────
+
+
+def test_runs_routes_are_not_under_an_auth_exempt_prefix():
+    """/api/runs relies on auth_guard, so it must NOT be prefix-exempt —
+    otherwise its mutating routes would sail through with no auth at all."""
+    from app.main import _prefix_exempt
+
+    for path in ("/api/runs", "/api/runs/abc", "/api/runs/abc/cancel"):
+        assert not _prefix_exempt(path), path
+
+
+def test_runs_routes_appear_in_the_openapi_document():
+    paths = app.openapi()["paths"]
+    assert "/api/runs" in paths
+    assert "/api/runs/{run_id}" in paths
+    assert "/api/runs/{run_id}/cancel" in paths
+    assert "/api/runs/{run_id}/events" in paths
+    assert "/api/runs/{run_id}/metrics" in paths

--- a/backend/tests/test_run_service.py
+++ b/backend/tests/test_run_service.py
@@ -24,7 +24,14 @@ from typing import Any
 import pytest
 
 from app.core.db import Database
-from app.core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+from app.core.node_base import (
+    MEDIA_IMAGE,
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
 from app.core.node_registry import registry
 from app.core.run_service import (
     EVENT_NODE_STATUS,
@@ -37,6 +44,9 @@ from app.core.run_service import (
     RunService,
     RunServiceUnavailable,
     RunSubmitError,
+    cap_event_payload,
+    json_size,
+    normalize_name,
     normalize_options,
 )
 from app.core.run_store import (
@@ -115,6 +125,59 @@ class _RunMetricsNode(BaseNode):
         return {"value": inputs.get("value")}
 
 
+class _RunNanNode(BaseNode):
+    """Emits a diverged (NaN) scalar — the JSON-token hazard."""
+
+    NODE_NAME = "_RunNan"
+    CATEGORY = "Test"
+    DESCRIPTION = "Emits a NaN progress scalar"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any],
+                progress_callback=None) -> dict[str, Any]:
+        if progress_callback:
+            progress_callback({"event": "epoch", "epoch": 1,
+                               "loss": float("nan")})
+        return {"value": inputs.get("value")}
+
+
+class _RunImageNode(BaseNode):
+    """DECLARES an image port and returns a base64 blob of a given size."""
+
+    NODE_NAME = "_RunImage"
+    CATEGORY = "Test"
+    DESCRIPTION = "Emits a declared base64 image"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="value", data_type=DataType.ANY),
+            PortDefinition(name="image", data_type=DataType.ANY,
+                           media=MEDIA_IMAGE),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [ParamDefinition(name="size", param_type=ParamType.INT,
+                                default=64)]
+
+    def execute(self, inputs: dict[str, Any],
+                params: dict[str, Any]) -> dict[str, Any]:
+        return {"value": inputs.get("value"),
+                "image": "A" * int(params.get("size", 64))}
+
+
 class _RunBoomNode(BaseNode):
     """Raises — drives the failed-run path."""
 
@@ -135,13 +198,20 @@ class _RunBoomNode(BaseNode):
         raise RuntimeError("boom: intentional run-service test failure")
 
 
+_TEST_NODES = {
+    "_RunSlow": _RunSlowNode,
+    "_RunMetrics": _RunMetricsNode,
+    "_RunNan": _RunNanNode,
+    "_RunImage": _RunImageNode,
+    "_RunBoom": _RunBoomNode,
+}
+
+
 @pytest.fixture(autouse=True)
 def _register_test_nodes():
-    registry._nodes["_RunSlow"] = _RunSlowNode
-    registry._nodes["_RunMetrics"] = _RunMetricsNode
-    registry._nodes["_RunBoom"] = _RunBoomNode
+    registry._nodes.update(_TEST_NODES)
     yield
-    for name in ("_RunSlow", "_RunMetrics", "_RunBoom"):
+    for name in _TEST_NODES:
         registry._nodes.pop(name, None)
 
 
@@ -371,8 +441,18 @@ def test_options_accept_every_documented_key():
     }) == {"device": "cuda", "seed": 7, "record_outputs": True, "lane": "gpu"}
 
 
+@pytest.mark.parametrize("device", ["cpu", "auto", "cuda", "cuda:1", "mps",
+                                    "mps:0", " CUDA:0 "])
+def test_options_accept_the_known_device_vocabulary(device):
+    assert normalize_options({"device": device})["device"] == device.strip().lower()
+
+
 @pytest.mark.parametrize("bad", [
-    {"devcie": "cpu"},              # typo -> loud, not silently ignored
+    {"devcie": "cpu"},              # key typo -> loud, not silently ignored
+    {"device": "cudda"},            # VALUE typo -> equally loud
+    {"device": "gpu"},
+    {"device": "cuda:"},
+    {"device": "cuda:x"},
     {"device": 3},
     {"device": ""},
     {"seed": -1},
@@ -387,6 +467,16 @@ def test_options_accept_every_documented_key():
 def test_options_reject_bad_input(bad):
     with pytest.raises(RunSubmitError):
         normalize_options(bad)
+
+
+def test_name_is_normalized_and_bounded():
+    assert normalize_name(None) is None
+    assert normalize_name("   ") is None          # blank means unnamed
+    assert normalize_name("  sweep 3 ") == "sweep 3"
+    assert normalize_name("x" * 64) == "x" * 64
+    for bad in ("x" * 65, 7):
+        with pytest.raises(RunSubmitError):
+            normalize_name(bad)
 
 
 async def test_submit_rejects_a_malformed_graph(service):
@@ -566,6 +656,107 @@ async def test_long_poll_wakes_on_the_next_event(store, service):
     await _await_terminal(store, submitted.run_id)
 
 
+# ── event payload bounds ──────────────────────────────────────────────────
+
+
+def test_cap_leaves_ordinary_payloads_untouched():
+    payload = {"node_id": "n", "status": "completed", "outputs": [
+        {"output_kind": "text", "text": "hello"},
+        {"output_kind": "tensor_summary", "tensor_summary": {"v": [1, 2, 3]}},
+    ]}
+    assert cap_event_payload(payload, cap_bytes=64 * 1024) is payload
+    assert cap_event_payload(payload, cap_bytes=0) is payload      # disabled
+
+
+def test_cap_elides_an_oversized_entry_but_keeps_its_identity():
+    big = {"output_kind": "image", "port": "image",
+           "image": {"format": "png", "encoding": "base64", "data": "A" * 5000}}
+    small = {"output_kind": "text", "text": "kept"}
+    capped = cap_event_payload(
+        {"node_id": "n", "status": "completed", "outputs": [big, small]},
+        cap_bytes=2000)
+
+    assert json_size(capped) <= 2000
+    elided, intact = capped["outputs"]
+    # Enough identity survives for a UI to draw a placeholder in the right
+    # slot, and nothing pretends to still be an image payload.
+    assert elided["output_kind"] == "image" and elided["port"] == "image"
+    assert elided["elided"] is True and elided["bytes"] > 5000
+    assert "image" not in elided
+    assert intact == small                       # the small one is untouched
+    assert capped["node_id"] == "n"              # envelope survives
+
+
+def test_cap_falls_back_to_a_marker_when_there_is_nothing_to_trim():
+    capped = cap_event_payload({"error": "x" * 5000, "run_id": "r"},
+                               cap_bytes=500)
+    assert capped["elided"] is True
+    assert capped["run_id"] == "r"               # identity kept
+    assert "error" not in capped
+    assert json_size(capped) <= 500
+
+
+async def test_an_oversized_image_event_is_stored_elided(store):
+    svc = RunService(store, event_payload_cap_bytes=2000)
+    try:
+        submitted = await svc.submit(_graph("_RunImage",
+                                            params={"size": 20000}))
+        await _await_terminal(store, submitted.run_id)
+        events = await store.get_events(submitted.run_id)
+        images = [entry
+                  for event in events if event.type == EVENT_NODE_STATUS
+                  for entry in (event.payload.get("outputs") or [])
+                  if entry.get("output_kind") == "image"]
+        assert images, "the declared image port produced no entry at all"
+        assert all(entry.get("elided") is True for entry in images)
+        assert all(json_size(event.payload) <= 2000 for event in events)
+    finally:
+        await svc.shutdown()
+
+
+async def test_a_small_image_event_is_stored_intact(store, service):
+    submitted = await service.submit(_graph("_RunImage", params={"size": 64}))
+    await _await_terminal(store, submitted.run_id)
+    events = await store.get_events(submitted.run_id)
+    images = [entry
+              for event in events if event.type == EVENT_NODE_STATUS
+              for entry in (event.payload.get("outputs") or [])
+              if entry.get("output_kind") == "image"]
+    assert len(images) == 1
+    assert images[0]["image"]["data"] == "A" * 64
+    assert "elided" not in images[0]
+
+
+async def test_non_finite_scalars_never_reach_a_subscriber(store, service):
+    """A NaN on the wire is a token JSON.parse rejects — it must not fan out."""
+    submitted = await service.submit(_graph("_RunNan"))
+    received: list[Any] = []
+    async with service.subscribe(submitted.run_id) as subscription:
+        while True:
+            event = await asyncio.wait_for(subscription.queue.get(), timeout=10)
+            if event is None:
+                break
+            received.append(event)
+
+    progress = [entry
+                for event in received if event.type == EVENT_NODE_STATUS
+                for entry in (event.payload.get("outputs") or [])
+                if entry.get("output_kind") == "progress"]
+    assert progress, "no progress event was fanned out"
+    assert progress[0]["progress"]["loss"] is None
+
+    # And the stored copy says exactly the same thing.
+    stored = [entry
+              for event in await store.get_events(submitted.run_id)
+              for entry in ((event.payload or {}).get("outputs") or [])
+              if entry.get("output_kind") == "progress"]
+    assert stored[0]["progress"]["loss"] is None
+    # The METRIC still records the point at its step, as a NULL value, so a
+    # chart shows the break where the training diverged.
+    points = await store.get_metrics(submitted.run_id, name="loss")
+    assert [(p.step, p.value) for p in points] == [(1, None)]
+
+
 # ── metrics ───────────────────────────────────────────────────────────────
 
 
@@ -708,6 +899,67 @@ async def test_submit_is_refused_after_shutdown(store):
     await svc.shutdown()
     with pytest.raises(RunServiceUnavailable, match="shutting down"):
         await svc.submit(_graph())
+
+
+async def test_submit_racing_shutdown_cannot_escape_the_drain(
+    store, monkeypatch,
+):
+    """A submit parked in create_run when shutdown starts must be refused.
+
+    Otherwise it resumes AFTER shutdown snapshotted the registry, registers
+    a task nobody drains, and the lifespan closes the database underneath it
+    — precisely the race this whole issue exists to close.
+    """
+    svc = RunService(store)
+    reached_db = asyncio.Event()
+    release = asyncio.Event()
+    original = RunStore.create_run
+
+    async def stalling_create(self, **kwargs):
+        record = await original(self, **kwargs)
+        reached_db.set()
+        await release.wait()
+        return record
+
+    monkeypatch.setattr(RunStore, "create_run", stalling_create)
+    task = asyncio.create_task(svc.submit(_graph()))
+    await asyncio.wait_for(reached_db.wait(), timeout=5)
+
+    await svc.shutdown()                 # snapshots a registry without it
+    release.set()
+    with pytest.raises(RunServiceUnavailable):
+        await task
+
+    assert svc.active_run_ids() == []
+    rows = await store.list_runs()
+    assert [row.status for row in rows] == ["queued"]
+    assert await svc.recover_interrupted() == 1
+
+
+async def test_cancel_during_finalize_does_not_claim_a_cancel(
+    store, service, monkeypatch,
+):
+    """Once the outcome is decided, a cancel must not report that it won."""
+    in_finalize = asyncio.Event()
+    release = asyncio.Event()
+    original = RunService._flush_metrics
+
+    async def stalling_flush(self, active, *, force=False):
+        if force:                        # the terminal flush, once per run
+            in_finalize.set()
+            await release.wait()
+        return await original(self, active, force=force)
+
+    monkeypatch.setattr(RunService, "_flush_metrics", stalling_flush)
+    submitted = await service.submit(_graph())
+    await asyncio.wait_for(in_finalize.wait(), timeout=10)
+
+    outcome = await service.cancel(submitted.run_id)
+    assert outcome is not None and outcome.cancelled is False
+
+    release.set()
+    record = await _await_terminal(store, submitted.run_id)
+    assert record.status == STATUS_SUCCEEDED
 
 
 async def test_a_cancelled_submit_never_strands_a_registry_entry(

--- a/backend/tests/test_run_service.py
+++ b/backend/tests/test_run_service.py
@@ -1,0 +1,749 @@
+"""Tests for app.core.run_service — the server-owned run lifecycle (#120).
+
+Five concerns, in order:
+
+1. The three acceptance criteria of the issue: a run outlives whatever
+   submitted it; two concurrent runs are independent; a restart retires
+   ``running`` rows instead of leaving zombies.
+2. Options normalization (the submit contract's only strict surface).
+3. Event persistence + fan-out: every engine callback reaches
+   ``exec_run_events`` AND any live subscriber, drop-tolerantly.
+4. Metrics: scalars off progress payloads, batched.
+5. Lifecycle plumbing: cancel semantics, retention, shutdown drain.
+
+The graphs here are deliberately tiny — Start -> source -> Print — because
+none of this is testing the engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from app.core.db import Database
+from app.core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+from app.core.node_registry import registry
+from app.core.run_service import (
+    EVENT_NODE_STATUS,
+    EVENT_RUN_COMPLETED,
+    EVENT_RUN_FAILED,
+    EVENT_RUN_STARTED,
+    EVENT_RUN_STOPPED,
+    STOP_REASON_CANCELLED,
+    STOP_REASON_INTERRUPTED,
+    RunService,
+    RunServiceUnavailable,
+    RunSubmitError,
+    normalize_options,
+)
+from app.core.run_store import (
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_INTERRUPTED,
+    STATUS_RUNNING,
+    STATUS_SUCCEEDED,
+    RunProvenance,
+    RunStore,
+)
+
+# ── test nodes ────────────────────────────────────────────────────────────
+
+
+class _RunSlowNode(BaseNode):
+    """Blocks the worker thread for ``seconds`` — the cancel/shutdown probe."""
+
+    NODE_NAME = "_RunSlow"
+    CATEGORY = "Test"
+    DESCRIPTION = "Sleeps, then passes through"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [ParamDefinition(name="seconds", param_type=ParamType.FLOAT,
+                                default=0.3)]
+
+    def execute(self, inputs: dict[str, Any],
+                params: dict[str, Any]) -> dict[str, Any]:
+        time.sleep(float(params.get("seconds", 0.3)))
+        return {"value": inputs.get("value")}
+
+
+class _RunMetricsNode(BaseNode):
+    """Emits progress payloads shaped like the training loop's epochs."""
+
+    NODE_NAME = "_RunMetrics"
+    CATEGORY = "Test"
+    DESCRIPTION = "Emits epoch progress events"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [ParamDefinition(name="epochs", param_type=ParamType.INT,
+                                default=3)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any],
+                progress_callback=None) -> dict[str, Any]:
+        epochs = int(params.get("epochs", 3))
+        for epoch in range(1, epochs + 1):
+            if progress_callback:
+                progress_callback({
+                    "event": "epoch",
+                    "epoch": epoch,
+                    "total_epochs": epochs,
+                    "loss": 1.0 / epoch,
+                    "accuracy": 0.5 + epoch / 100,
+                    "label": "not-a-metric",
+                    "converged": False,
+                })
+        return {"value": inputs.get("value")}
+
+
+class _RunBoomNode(BaseNode):
+    """Raises — drives the failed-run path."""
+
+    NODE_NAME = "_RunBoom"
+    CATEGORY = "Test"
+    DESCRIPTION = "Raises RuntimeError"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    def execute(self, inputs: dict[str, Any],
+                params: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("boom: intentional run-service test failure")
+
+
+@pytest.fixture(autouse=True)
+def _register_test_nodes():
+    registry._nodes["_RunSlow"] = _RunSlowNode
+    registry._nodes["_RunMetrics"] = _RunMetricsNode
+    registry._nodes["_RunBoom"] = _RunBoomNode
+    yield
+    for name in ("_RunSlow", "_RunMetrics", "_RunBoom"):
+        registry._nodes.pop(name, None)
+
+
+# ── fixtures / helpers ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = Database(tmp_path / "codefyui.db")
+    database.connect()
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+@pytest.fixture
+def store(db):
+    return RunStore(db)
+
+
+@pytest.fixture
+async def service(store):
+    svc = RunService(store, shutdown_grace_s=2.0)
+    try:
+        yield svc
+    finally:
+        await svc.shutdown()
+
+
+def _graph(middle_type: str = "_TestSource", *,
+           params: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Start -> <middle> -> Print, with a passthrough source in front.
+
+    ``_TestSource`` has no inputs, so it doubles as the value producer for
+    middles that take one.
+    """
+    nodes = [
+        {"id": "start", "type": "Start", "data": {"params": {}}},
+        {"id": "src", "type": "_TestSource", "data": {"params": {"val": "hi"}}},
+        {"id": "print", "type": "Print", "data": {"params": {"label": "out"}}},
+    ]
+    edges = [
+        {"id": "et", "source": "start", "target": "src",
+         "sourceHandle": "trigger", "type": "trigger"},
+    ]
+    if middle_type == "_TestSource":
+        edges.append({"id": "e1", "source": "src", "target": "print",
+                      "sourceHandle": "value", "targetHandle": "value"})
+    else:
+        nodes.insert(2, {"id": "mid", "type": middle_type,
+                         "data": {"params": params or {}}})
+        edges.append({"id": "e1", "source": "src", "target": "mid",
+                      "sourceHandle": "value", "targetHandle": "value"})
+        edges.append({"id": "e2", "source": "mid", "target": "print",
+                      "sourceHandle": "value", "targetHandle": "value"})
+    return {"nodes": nodes, "edges": edges}
+
+
+async def _await_terminal(store: RunStore, run_id: str, *,
+                          timeout: float = 15.0):
+    """Poll the STORE (never the in-process registry) until the row is done."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        record = await store.get_run(run_id)
+        assert record is not None, f"run {run_id} vanished"
+        if record.finished_at is not None:
+            return record
+        await asyncio.sleep(0.02)
+    raise AssertionError(f"run {run_id} did not finish within {timeout}s")
+
+
+# ── acceptance criterion 1: the run outlives its submitter ────────────────
+
+
+async def test_run_survives_the_submitter_going_away(store, service):
+    """Submit, drop every reference the caller held, run still completes.
+
+    The REST-level version of this (kill the HTTP client) lives in
+    test_api_runs.py; this is the service-level guarantee it rests on:
+    nothing about the run's lifetime is tied to the submitting coroutine.
+    """
+    submitted = await service.submit(_graph())
+    run_id = submitted.run_id
+    assert submitted.status == STATUS_RUNNING
+
+    # Simulate the submitter disappearing: the task that called submit()
+    # ends here and holds nothing. Only the service owns the run.
+    del submitted
+
+    record = await _await_terminal(store, run_id)
+    assert record.status == STATUS_SUCCEEDED
+    assert record.error is None
+    assert record.started_at is not None
+
+    events = await store.get_events(run_id)
+    assert [e.type for e in events][0] == EVENT_RUN_STARTED
+    assert [e.type for e in events][-1] == EVENT_RUN_COMPLETED
+    assert [e.cursor for e in events] == list(range(1, len(events) + 1))
+
+
+async def test_submitting_task_cancellation_does_not_kill_the_run(store, service):
+    """Cancelling the CALLER after submit() must not touch the run.
+
+    This is the exact failure mode of the WS handler (a disconnect cancels
+    the graph task); the run service owns the task itself.
+    """
+    holder: dict[str, str] = {}
+
+    async def submitter() -> None:
+        result = await service.submit(_graph("_RunSlow", params={"seconds": 0.2}))
+        holder["run_id"] = result.run_id
+        await asyncio.sleep(30)  # still "connected" when we cancel it
+
+    task = asyncio.create_task(submitter())
+    while "run_id" not in holder:
+        await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    record = await _await_terminal(store, holder["run_id"])
+    assert record.status == STATUS_SUCCEEDED
+
+
+# ── acceptance criterion 2: concurrent runs are independent ───────────────
+
+
+async def test_two_concurrent_runs_do_not_cancel_each_other(store, service):
+    """Regression vs ws_execution.py:171-175 (a second execute killed the first)."""
+    first, second = await asyncio.gather(
+        service.submit(_graph("_RunSlow", params={"seconds": 0.25})),
+        service.submit(_graph("_RunSlow", params={"seconds": 0.05})),
+    )
+    assert first.run_id != second.run_id
+
+    records = await asyncio.gather(
+        _await_terminal(store, first.run_id),
+        _await_terminal(store, second.run_id),
+    )
+    assert [r.status for r in records] == [STATUS_SUCCEEDED, STATUS_SUCCEEDED]
+
+    # Event logs are per run and neither is empty or cross-contaminated.
+    for record in records:
+        events = await store.get_events(record.id)
+        assert {e.run_id for e in events} == {record.id}
+        assert events[-1].type == EVENT_RUN_COMPLETED
+
+
+async def test_cancelling_one_run_leaves_the_other_alone(store, service):
+    victim = await service.submit(_graph("_RunSlow", params={"seconds": 0.4}))
+    survivor = await service.submit(_graph("_RunSlow", params={"seconds": 0.4}))
+
+    outcome = await service.cancel(victim.run_id)
+    assert outcome is not None and outcome.cancelled is True
+
+    dead = await _await_terminal(store, victim.run_id)
+    alive = await _await_terminal(store, survivor.run_id)
+    assert dead.status == STATUS_CANCELLED
+    assert alive.status == STATUS_SUCCEEDED
+
+
+# ── acceptance criterion 3: restart honesty ───────────────────────────────
+
+
+async def test_restart_marks_running_rows_interrupted(store):
+    """A row left ``running`` by a crashed process is retired at startup."""
+    orphan = await store.create_run(graph_snapshot=_graph(), options={},
+                                    provenance=RunProvenance())
+    await store.mark_running(orphan.id)
+    assert (await store.get_run(orphan.id)).status == STATUS_RUNNING
+
+    # A brand-new process comes up over the same database.
+    fresh = RunService(store)
+    interrupted = await fresh.recover_interrupted()
+    assert interrupted == 1
+
+    row = await store.get_run(orphan.id)
+    assert row.status == STATUS_INTERRUPTED
+    assert row.finished_at is not None
+    # Idempotent: a second boot finds nothing left to retire.
+    assert await fresh.recover_interrupted() == 0
+
+
+async def test_recovery_refuses_to_run_with_live_runs(store, service):
+    """Recovery is a STARTUP call; running it mid-flight would falsify rows."""
+    await service.submit(_graph("_RunSlow", params={"seconds": 0.2}))
+    with pytest.raises(RuntimeError, match="active run"):
+        await service.recover_interrupted()
+
+
+async def test_recovery_runs_before_retention(store, tmp_path):
+    """Interrupted rows become prunable — the ordering that bounds metrics.
+
+    An orphaned ``running`` row is never eligible for retention (active runs
+    are live state). Recovery first, prune second, is what lets an
+    abandoned run's metrics/events actually go away.
+    """
+    orphan = await store.create_run(graph_snapshot=_graph(), options={},
+                                    provenance=RunProvenance())
+    await store.mark_running(orphan.id)
+    await store.log_metric(orphan.id, "loss", 1.0, 1)
+
+    svc = RunService(store, retention_keep_last=0)
+    # Prune alone cannot touch it while it still claims to be running.
+    assert await svc.prune_retention() == 0
+    assert await svc.recover_interrupted() == 1
+    assert await svc.prune_retention() == 1
+    assert await store.get_run(orphan.id) is None
+    assert await store.get_metrics(orphan.id) == []
+
+
+# ── options normalization ─────────────────────────────────────────────────
+
+
+def test_options_defaults():
+    assert normalize_options(None) == {
+        "device": "cpu", "seed": None, "record_outputs": False,
+        "lane": "queued",
+    }
+    assert normalize_options({}) == normalize_options(None)
+
+
+def test_options_accept_every_documented_key():
+    assert normalize_options({
+        "device": " CUDA ", "seed": 7, "record_outputs": True, "lane": "gpu",
+    }) == {"device": "cuda", "seed": 7, "record_outputs": True, "lane": "gpu"}
+
+
+@pytest.mark.parametrize("bad", [
+    {"devcie": "cpu"},              # typo -> loud, not silently ignored
+    {"device": 3},
+    {"device": ""},
+    {"seed": -1},
+    {"seed": 2 ** 32},
+    {"seed": "abc"},
+    {"seed": True},                 # a bool is not a seed
+    {"lane": ""},
+    {"lane": "x" * 65},
+    {"record_outputs": "yes"},
+    ["not", "a", "dict"],
+])
+def test_options_reject_bad_input(bad):
+    with pytest.raises(RunSubmitError):
+        normalize_options(bad)
+
+
+async def test_submit_rejects_a_malformed_graph(service):
+    for bad in (None, [], {"edges": []}, {"nodes": {}}, {"nodes": []},
+                {"nodes": [{"id": "a"}], "edges": {}}):
+        with pytest.raises(RunSubmitError):
+            await service.submit(bad)
+
+
+async def test_submit_persists_normalized_options_and_snapshot(store, service):
+    graph = _graph()
+    submitted = await service.submit(graph, options={"seed": 11}, name="demo")
+    await _await_terminal(store, submitted.run_id)
+
+    record = await store.get_run(submitted.run_id)
+    assert record.name == "demo"
+    assert record.options == {"device": "cpu", "seed": 11,
+                              "record_outputs": False, "lane": "queued"}
+    # queue_key carries the RESOLVED device (mark_running's contract).
+    assert record.queue_key == "cpu"
+    snapshot = await store.get_graph_snapshot(submitted.run_id)
+    assert [n["id"] for n in snapshot["nodes"]] == [n["id"] for n in graph["nodes"]]
+    assert snapshot["presets"] == []
+
+
+async def test_run_id_is_also_the_execution_id(store, service):
+    """One id format: RunStore's uuid4().hex, reused as the execution id."""
+    submitted = await service.submit(_graph("_RunSlow", params={"seconds": 0.2}))
+    active = service.active_run_ids()
+    assert active == [submitted.run_id]
+    assert service.execution_id(submitted.run_id) == submitted.run_id
+    assert len(submitted.run_id) == 32 and "-" not in submitted.run_id
+    await _await_terminal(store, submitted.run_id)
+
+
+# ── events: persistence + fan-out ─────────────────────────────────────────
+
+
+async def test_every_callback_lands_in_the_event_log(store, service):
+    submitted = await service.submit(_graph())
+    await _await_terminal(store, submitted.run_id)
+
+    events = await store.get_events(submitted.run_id)
+    types = [e.type for e in events]
+    assert types[0] == EVENT_RUN_STARTED
+    assert types[-1] == EVENT_RUN_COMPLETED
+    assert types.count(EVENT_NODE_STATUS) >= 4  # running+completed per node
+
+    statuses = {(e.payload["node_id"], e.payload["status"])
+                for e in events if e.type == EVENT_NODE_STATUS}
+    assert ("print", "running") in statuses
+    assert ("print", "completed") in statuses
+
+    # #117 structured outputs ride along, not a re-sniffed heuristic.
+    completed = [e for e in events if e.type == EVENT_NODE_STATUS
+                 and e.payload["status"] == "completed"
+                 and e.payload["node_id"] == "print"][0]
+    kinds = {entry["output_kind"] for entry in completed.payload["outputs"]}
+    assert kinds == {"text", "tensor_summary"}
+
+
+async def test_failure_is_recorded_on_the_row_and_in_the_log(store, service):
+    submitted = await service.submit(_graph("_RunBoom"))
+    record = await _await_terminal(store, submitted.run_id)
+
+    assert record.status == STATUS_FAILED
+    assert "boom" in record.error
+    events = await store.get_events(submitted.run_id)
+    assert events[-1].type == EVENT_RUN_FAILED
+    assert "boom" in events[-1].payload["error"]
+
+
+async def test_cancel_records_a_stop_reason(store, service):
+    submitted = await service.submit(_graph("_RunSlow", params={"seconds": 0.3}))
+    await service.cancel(submitted.run_id)
+    record = await _await_terminal(store, submitted.run_id)
+
+    assert record.status == STATUS_CANCELLED
+    events = await store.get_events(submitted.run_id)
+    assert events[-1].type == EVENT_RUN_STOPPED
+    assert events[-1].payload == {"reason": STOP_REASON_CANCELLED}
+
+
+async def test_cancel_is_honest_about_unknown_and_finished_runs(store, service):
+    assert await service.cancel("no-such-run") is None
+
+    submitted = await service.submit(_graph())
+    await _await_terminal(store, submitted.run_id)
+    outcome = await service.cancel(submitted.run_id)
+    assert outcome is not None
+    assert outcome.cancelled is False
+    assert outcome.status == STATUS_SUCCEEDED
+
+
+async def test_cancel_of_a_never_started_run_uses_the_guarded_write(store, service):
+    """A queued row (the #123 lane) is retired directly, race-guarded."""
+    queued = await store.create_run(graph_snapshot=_graph(), options={},
+                                    provenance=RunProvenance())
+    outcome = await service.cancel(queued.id)
+    assert outcome.cancelled is True
+    assert outcome.status == STATUS_CANCELLED
+    assert (await store.get_run(queued.id)).status == STATUS_CANCELLED
+    # Second cancel is a no-op, not a status rewrite.
+    again = await service.cancel(queued.id)
+    assert again.cancelled is False
+    assert (await store.get_run(queued.id)).status == STATUS_CANCELLED
+
+
+async def test_subscribers_see_events_live(store, service):
+    submitted = await service.submit(_graph("_RunSlow", params={"seconds": 0.2}))
+    seen: list[str] = []
+    async with service.subscribe(submitted.run_id) as subscription:
+        while True:
+            event = await asyncio.wait_for(subscription.queue.get(), timeout=10)
+            if event is None:          # sentinel: the run is over
+                break
+            seen.append(event.type)
+    assert EVENT_NODE_STATUS in seen
+    assert seen[-1] == EVENT_RUN_COMPLETED
+    assert subscription.closed is True
+
+
+async def test_subscriber_backpressure_drops_instead_of_stalling(store, service):
+    """A slow subscriber must never block the run; it re-reads the tail."""
+    submitted = await service.submit(_graph())
+    async with service.subscribe(submitted.run_id, maxsize=1) as subscription:
+        record = await _await_terminal(store, submitted.run_id)
+        assert record.status == STATUS_SUCCEEDED
+        assert subscription.take_dropped() > 0
+        assert subscription.take_dropped() == 0     # counter resets
+        # Drop-tolerance contract: the store still holds every event.
+        events = await store.get_events(submitted.run_id)
+        assert events[-1].type == EVENT_RUN_COMPLETED
+
+
+async def test_subscribe_to_a_finished_run_yields_a_closed_subscription(store, service):
+    submitted = await service.submit(_graph())
+    await _await_terminal(store, submitted.run_id)
+    async with service.subscribe(submitted.run_id) as subscription:
+        assert subscription.closed is True
+
+
+async def test_wait_for_events_paginates_by_cursor(store, service):
+    submitted = await service.submit(_graph())
+    await _await_terminal(store, submitted.run_id)
+
+    everything = await service.wait_for_events(submitted.run_id)
+    assert len(everything) >= 5
+    tail = await service.wait_for_events(submitted.run_id,
+                                         after_cursor=everything[1].cursor)
+    assert [e.cursor for e in tail] == [e.cursor for e in everything[2:]]
+    assert await service.wait_for_events(
+        submitted.run_id, after_cursor=everything[-1].cursor) == []
+
+
+async def test_long_poll_returns_immediately_for_a_finished_run(store, service):
+    submitted = await service.submit(_graph())
+    events = await _await_terminal(store, submitted.run_id) and \
+        await store.get_events(submitted.run_id)
+    started = time.monotonic()
+    assert await service.wait_for_events(
+        submitted.run_id, after_cursor=events[-1].cursor, wait=5.0) == []
+    assert time.monotonic() - started < 2.0, "long poll hung on a dead run"
+
+
+async def test_long_poll_wakes_on_the_next_event(store, service):
+    submitted = await service.submit(_graph("_RunSlow", params={"seconds": 0.3}))
+    first = await service.wait_for_events(submitted.run_id, wait=5.0)
+    assert first, "no events at all"
+
+    started = time.monotonic()
+    later = await service.wait_for_events(
+        submitted.run_id, after_cursor=first[-1].cursor, wait=10.0)
+    elapsed = time.monotonic() - started
+    assert later, "long poll timed out instead of waking"
+    assert elapsed < 9.0, "woke on the timeout, not on the event"
+    await _await_terminal(store, submitted.run_id)
+
+
+# ── metrics ───────────────────────────────────────────────────────────────
+
+
+async def test_progress_scalars_land_in_exec_run_metrics(store, service):
+    submitted = await service.submit(_graph("_RunMetrics",
+                                            params={"epochs": 3}))
+    await _await_terminal(store, submitted.run_id)
+
+    names = await store.list_metric_names(submitted.run_id)
+    assert names == ["accuracy", "loss"]     # label/converged are not metrics
+    loss = await store.get_metrics(submitted.run_id, name="loss")
+    assert [p.step for p in loss] == [1, 2, 3]
+    assert loss[0].value == pytest.approx(1.0)
+    assert loss[2].value == pytest.approx(1 / 3)
+    assert {p.node_id for p in loss} == {"mid"}
+    # Structural keys never become series.
+    assert "epoch" not in names and "total_epochs" not in names
+
+
+async def test_metrics_are_written_in_batches(store, service, monkeypatch):
+    """One transaction per flush, never one per point (#119 carry-forward)."""
+    calls: list[int] = []
+    original = RunStore.log_metrics
+
+    async def counting(self, run_id, points):
+        batch = list(points)
+        calls.append(len(batch))
+        return await original(self, run_id, batch)
+
+    monkeypatch.setattr(RunStore, "log_metrics", counting)
+    monkeypatch.setattr(RunStore, "log_metric", None, raising=False)
+
+    submitted = await service.submit(_graph("_RunMetrics",
+                                            params={"epochs": 6}))
+    await _await_terminal(store, submitted.run_id)
+
+    assert calls, "no metric flush happened at all"
+    assert sum(calls) == 12          # 6 epochs x {loss, accuracy}
+    assert max(calls) > 1, "points were flushed one at a time"
+
+
+# ── retention + shutdown ──────────────────────────────────────────────────
+
+
+async def test_retention_prunes_after_each_terminal_run(store):
+    svc = RunService(store, retention_keep_last=2)
+    try:
+        ids = []
+        for _ in range(4):
+            submitted = await svc.submit(_graph())
+            await _await_terminal(store, submitted.run_id)
+            ids.append(submitted.run_id)
+        # The prune is the last step of the finishing task, which can still
+        # be a tick behind the row write _await_terminal watches for.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            remaining = {r.id for r in await store.list_runs()}
+            if len(remaining) <= 2:
+                break
+            await asyncio.sleep(0.02)
+        assert remaining == set(ids[-2:])
+    finally:
+        await svc.shutdown()
+
+
+async def test_retention_is_off_when_keep_last_is_none(store):
+    svc = RunService(store, retention_keep_last=None)
+    try:
+        for _ in range(3):
+            submitted = await svc.submit(_graph())
+            await _await_terminal(store, submitted.run_id)
+        assert len(await store.list_runs()) == 3
+        assert await svc.prune_retention() == 0
+    finally:
+        await svc.shutdown()
+
+
+async def test_shutdown_drains_runs_before_the_database_closes(db, store):
+    """The #119 carry-forward: no DB work may be in flight at db.close().
+
+    A run stopped by shutdown is ``interrupted`` (the server went away), not
+    ``cancelled`` (a user asked) — the two are different facts.
+    """
+    svc = RunService(store, shutdown_grace_s=10.0)
+    submitted = await svc.submit(_graph("_RunSlow", params={"seconds": 0.3}))
+    await asyncio.sleep(0.05)
+
+    await svc.shutdown()
+    assert svc.active_run_ids() == []
+
+    # Everything settled BEFORE this point: closing now must not orphan a
+    # write, and the row must already be terminal.
+    record = await store.get_run(submitted.run_id)
+    assert record.status == STATUS_INTERRUPTED
+    assert record.finished_at is not None
+    events = await store.get_events(submitted.run_id)
+    assert events[-1].type == EVENT_RUN_STOPPED
+    assert events[-1].payload == {"reason": STOP_REASON_INTERRUPTED}
+    db.close()
+
+
+async def test_shutdown_keeps_an_earlier_cancel_reason(db, store):
+    """Cancel then shut down: the user's intent came first and stands."""
+    svc = RunService(store, shutdown_grace_s=10.0)
+    submitted = await svc.submit(_graph("_RunSlow", params={"seconds": 0.3}))
+    await asyncio.sleep(0.05)
+    await svc.cancel(submitted.run_id)
+    await svc.shutdown()
+
+    record = await store.get_run(submitted.run_id)
+    assert record.status == STATUS_CANCELLED
+    events = await store.get_events(submitted.run_id)
+    assert events[-1].payload == {"reason": STOP_REASON_CANCELLED}
+    db.close()
+
+
+async def test_shutdown_hard_cancels_after_the_grace_period(db, store):
+    """A run that ignores the flag is force-cancelled; the row stays honest.
+
+    With no terminal write, the row is still ``running`` — which the NEXT
+    startup's recovery converts to ``interrupted``. That is the design: a
+    lie is never written, and the truth arrives one boot later.
+    """
+    svc = RunService(store, shutdown_grace_s=0.05)
+    submitted = await svc.submit(_graph("_RunSlow", params={"seconds": 1.5}))
+    await asyncio.sleep(0.05)
+    await svc.shutdown()
+
+    assert svc.active_run_ids() == []
+    record = await store.get_run(submitted.run_id)
+    assert record.status in (STATUS_RUNNING, STATUS_INTERRUPTED)
+    if record.status == STATUS_RUNNING:
+        assert await svc.recover_interrupted() == 1
+        assert (await store.get_run(submitted.run_id)).status == STATUS_INTERRUPTED
+    db.close()
+
+
+async def test_submit_is_refused_after_shutdown(store):
+    svc = RunService(store)
+    await svc.shutdown()
+    with pytest.raises(RunServiceUnavailable, match="shutting down"):
+        await svc.submit(_graph())
+
+
+async def test_a_cancelled_submit_never_strands_a_registry_entry(
+    store, service, monkeypatch,
+):
+    """Cancel the submitter mid-``create_run``: nothing may be half-owned.
+
+    The other half of this invariant needs no test because it is structural:
+    ``_start`` is synchronous, so there is no await between registering a run
+    and creating the task that owns it, and no cancellation can land there.
+    This covers the window that DOES exist — the persist — where the honest
+    outcome is a durable ``queued`` row that startup recovery retires.
+    """
+    reached_db = asyncio.Event()
+    original = RunStore.create_run
+
+    async def stalling_create(self, **kwargs):
+        record = await original(self, **kwargs)
+        reached_db.set()
+        await asyncio.sleep(30)          # the submitter is parked here
+        return record
+
+    monkeypatch.setattr(RunStore, "create_run", stalling_create)
+    task = asyncio.create_task(service.submit(_graph()))
+    await asyncio.wait_for(reached_db.wait(), timeout=5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert service.active_run_ids() == []
+    rows = await store.list_runs()
+    assert [row.status for row in rows] == ["queued"]
+    assert await service.recover_interrupted() == 1
+
+
+async def test_shutdown_is_idempotent(store, service):
+    await service.shutdown()
+    await service.shutdown()
+    assert service.active_run_ids() == []


### PR DESCRIPTION
## Summary

A run used to live inside the WebSocket handler: `ws_execution.py` created the `asyncio.Task` and cancelled it on `WebSocketDisconnect`, so closing a browser tab killed a training job, and a second `execute` on the same socket killed the first (`ws_execution.py:171-175`). Both are properties of **where the task was owned**, not of the engine — `graph_engine.execute_graph` was already a reusable coroutine.

`RunService` (`backend/app/core/run_service.py`) owns it instead, and `routes_runs.py` puts it on REST. `ws_execution.py` is untouched in this PR; rewriting it on top of this service is #121, which is why the durable event log deliberately uses the WebSocket message types verbatim.

## API

| Method | Path | Notes |
| --- | --- | --- |
| POST | `/api/runs` | `{graph, options, name}` -> `{run_id, status}`. Returns as soon as the run is scheduled; 400 on a malformed envelope/options, 503 while shutting down. Session token required (`auth_guard`). |
| GET | `/api/runs` | `?status=` (repeatable), `?limit=` (1-500), `?offset=`. Newest first; each row carries `queue_position` (null today) and `active`. `total` is the unpaged count. 400 on an unknown status. |
| GET | `/api/runs/{id}` | The row plus `last_cursor` — where an event follower starts. No `graph_snapshot` (a list must not deserialize a megabyte per row). |
| POST | `/api/runs/{id}/cancel` | `{run_id, status, cancelled}`. 200 either way: asking twice is not an error. Session token required. |
| GET | `/api/runs/{id}/events` | `?cursor=N&wait=0-60&limit=1-2000`. Events strictly after `N`; optional long poll. |
| GET | `/api/runs/{id}/metrics` | `?name=&format=json\|csv`. CSV is a download with `run_id,node_id,name,step,value,ts`. |

Auth follows `main.py`'s house rule exactly — `auth_guard` requires the session token on the two mutating routes, reads are open like every other GET. The router is deliberately **not** added to `_AUTH_EXEMPT_PREFIXES`; a test pins that, because an exemption without a per-route dependency would silently drop authentication.

## Design notes

**Ownership / cancellation window.** `submit` persists the run, then calls `_start`, which is **synchronous**. That is load-bearing: there is no `await` between putting the run in the registry and creating the task that owns it, so no cancellation of the submitting request can land in the middle and strand a registry entry nothing will ever finish. Everything needing the database (`mark_running`, the start event) happens inside the task, where a cancellation is the *run's* cancellation and unwinds through the normal terminal path. The one window that does exist — a cancel during `create_run` — leaves a durable `queued` row that startup recovery retires; there is a test for it.

**#123 seam.** Between `create_run` and `_start`. A queue stops calling `_start` from `submit` and calls it from its scheduler, re-reading the graph with `store.get_graph_snapshot(run_id)`. Nothing else in the module assumes immediacy, and `SubmitResult.status` already exists so a queued answer needs no shape change. No queue is implemented here — every submitted run starts immediately.

**Event vocabulary = the WS wire types.** `execution_start` / `node_status` / `execution_complete` / `execution_error` / `execution_stopped`, with the `type` key kept out of the payload because the column carries it. #121's bridge is then `{"type": event.type, **(event.payload or {})}` with no second vocabulary to keep in sync. `execution_stopped` carries `{"reason": "cancelled"|"interrupted"}` — the run row is authoritative, the payload carries the same fact into replay.

**Fan-out.** Persist first, then push: a subscriber must never learn of an event that failed to land. Per-run bounded `asyncio.Queue`s drop on overflow rather than applying backpressure (a stalled consumer must not be able to slow a run); the consumer sees `take_dropped() > 0` and re-reads the tail from the store, which is always the source of truth. That is also why an `append_event` cancelled after COMMIT — cursor lost, event durable — is safe here: nothing trusts the return value as the only record.

**Long-poll wake-up.** No busy polling and no sleep interval. A `_Broadcast` object hands out an `asyncio.Event` generation; `notify()` sets the current one and installs a fresh one. `wait_for_events` captures the generation **before** reading the store, so an event landing during that read still satisfies the wait — the lost-wakeup window is closed by ordering, not a timeout. Not an `asyncio.Condition`: that makes every waiter contend for one lock just to be told to go read sqlite. A finished or unknown run returns immediately regardless of `wait`.

**Metrics.** Every finite top-level number in a `progress` payload that is not a loop descriptor (`event`/`step`/`epoch`/`total_epochs`/`start_epoch`) becomes a point; booleans, strings and arrays are excluded. Points buffer and flush through the batched `log_metrics` when the buffer is large enough **or** has been sitting `0.5s` — the second rule keeps a live chart current on a slow producer without a timer task. Never one insert per row.

**Lifecycle ordering (`main.py`).**

- *Startup*: DB connect -> `RunService` -> `recover_interrupted()` -> `prune_retention()`. Recovery must come first: retention never deletes an active run, so an abandoned `running` row would keep its events and metrics forever. Retiring it is exactly what makes it prunable, which is what bounds the metrics growth flagged in #119.
- *Shutdown*: `run_service.shutdown()` -> **then** `db.close()`. Runs are stopped cooperatively (reason `interrupted`, so they write an honest terminal row), and after `shutdown_grace_s` whatever is still stuck in a long node is hard-cancelled — but every task is still **awaited**, because cancelling is not draining. This closes the #119 carry-forward: the run tasks were the only database work in the process that nobody awaited, and `Database.close` would otherwise race a run's final writes. A hard-cancelled run leaves its row `running` on purpose; the next boot's recovery converts it. A lie is never written; the truth arrives one boot later.

**Cancel semantics (P1-07).** Cooperative — the `ExecutionContext` flag, never `Task.cancel`. A node already executing in a worker thread runs to completion first (a 90-second epoch stops after that epoch), because there is no safe way to interrupt arbitrary node code and killing the task is what leaves half-written rows and wedged CUDA state. Cancellation is acknowledged by the endpoint and observed on the row. A never-started run is retired through `mark_finished`'s guarded write, so a cancel racing a completion cannot rewrite the winner — the #119 carry-forward, used rather than last-writer-wins.

**Id format (decision).** ONE id per run: `RunStore`'s `uuid4().hex`. It is `exec_runs.id`, the `ExecutionContext.execution_id`, and the `run_id` handed to `execute_graph`, so `RunOutputStore` entries key off the same string. `ExecutionContext`'s own `str(uuid4())` default is never used — two id shapes for one run is how captured outputs stop being findable.

**Run isolation (deliberate difference from the canvas).** Service runs get `weights_persistent=False` and no `NodeStateStore`, and no `ExecutionCache`. A server-owned run is a durable, reproducible unit whose stored `graph_snapshot` + `options` must fully describe what ran; inheriting live `nn.Module` weights would make that a lie, and two concurrent runs of the same graph would train one shared module. The canvas's keep-training workflow is unaffected (it still goes over the WS path); #121 re-introduces it here as an explicit option.

**Strict options.** `device` / `seed` / `record_outputs` / `lane` only; unknown keys are **rejected**, because `{"devcie": "cuda"}` silently running on CPU for forty minutes is the failure mode worth closing. The stored dict is always complete, so a run is readable years later without knowing which defaults were in force. `lane` defaults to `"queued"` per the brief. Extending the set is additive — #121 (verbose/backward/graph_id) and #123 (priority) will each do it deliberately. Graph *semantics* are not pre-validated: an unrunnable graph becomes a `failed` run carrying the engine's own error, which is a more useful artifact than a 400 and avoids a second validator drifting from `prepare_executable_graph`.

**Layering.** `core` never imports `api`, with one function-local exception: #117's output-entry builders live in `api/ws_execution.py` and are imported lazily rather than duplicated — a second copy is exactly the drift #117 removed. #121 should move both helpers into `core` when it rewrites that handler.

## Test evidence

`backend/tests/test_run_service.py` (44) + `backend/tests/test_api_runs.py` (31), both stated at the level the criteria live:

- **Submit, kill the client, the run completes** — service level (drop every reference; cancel the submitting task and assert the run still succeeds) and HTTP level (close the `AsyncClient` mid-run, assert the run was still in flight when it died, then query status/events/metrics from a fresh client).
- **Two concurrent runs do not cancel each other** — both succeed with separate, uncontaminated event logs; plus cancelling one leaves the other alone.
- **Restart marks running rows interrupted** — idempotent, guarded against being called with live runs, and pinned to run *before* retention (a `running` orphan is unprunable; recovery is what frees its metrics).

Plus: options normalization (11 rejection cases), envelope rejection, id-format, every callback landing in the log with #117 `outputs`, failure/cancel/stop-reason recording, subscriber liveness and drop-tolerance, cursor pagination, long poll returning fast on a dead run and waking on the next event, batched metric writes, retention after each terminal run, shutdown drain vs hard-cancel, cancel-then-shutdown keeping the user's reason, CSV export, auth, 503s, and OpenAPI presence.

```
backend/tests: 2126 passed, 14 skipped in 89.87s
```

(baseline before this branch: 2051 passed; +75 new). Syntax verified under CPython 3.10 (the CI floor) as well as 3.11.

## Follow-ups, deliberately not here

- `ws_execution.py` is untouched — #121 owns rewriting it onto this service (and moving the #117 helpers into `core`).
- No queue and no concurrency cap: unbounded simultaneous runs is #123's to bound.
- No docs page for the new endpoints yet.

Closes #120

---
Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 1 (commit `caa2cbd`)

Two Important findings plus eight strengtheners, all fixed on this branch. Full suite **2150 passed, 14 skipped** (+24 tests); CI green on 3.10/3.11/3.12.

**Submit could escape the shutdown drain.** The `_shutting_down` guard ran at `submit` entry, then `create_run` awaited (provenance capture can shell out to `git`) — so a submit parked in that window resumed after `shutdown()` had already snapshotted the registry, registered a task nobody drained, and `main.py` closed the database underneath it. `_start` now re-checks; because it is synchronous the check is atomic with respect to shutdown, and the durable `queued` row is left to startup recovery exactly like the cancelled-submit path.

**Event payloads were persisted uncapped**, and #117 image entries carry the full base64 PNG — so one graph emitting images per node could write hundreds of MB of `exec_run_events` for a single run, with `record_outputs` **off**, because this path is the live status stream rather than output capture. Retention counts runs, not bytes, so nothing else bounded it. `cap_event_payload` now measures once (one `json.dumps`; an ordinary event returns untouched), elides output entries over their equal share of the budget while keeping `output_kind` and `port` so a UI can still place a placeholder, and falls back to a marker keeping the identifying keys. `CODEFYUI_RUN_EVENT_PAYLOAD_CAP_BYTES` defaults to **128 KB** — twice the publish path's `RUN_IO_CAP_BYTES`, because a `node_status` payload is a whole node's summary (several ports, each embedding up to 256 values) rather than one API field, and measured honest payloads sit under ~20 KB, so elision only ever fires on genuinely unbounded content. `/events` also gained a response byte budget so `limit` cannot multiply into an unbounded body; the returned `cursor` tracks what was *returned*, so a short page skips nothing.

**Fan-out split:** subscribers receive *exactly* the stored object — sanitized and capped. Pushing the full payload while storing the capped one would break the drop-tolerance contract: a lagging consumer is told it may re-read the tail "and lose nothing", which would stop being true, and a UI would show an image live and a placeholder after any hiccup. One payload, one truth; #121 can revisit deliberately.

Also: a `terminating` flag set on entry to `_finalize` closes the other end of the cancel-truthfulness window (a cancel during the terminal metric flush no longer claims it cancelled a run about to file `succeeded`); the device **value** is validated against the vocabulary `resolve_device` knows, since strict keys existed precisely to stop `{"device": "cudda"}` running forty minutes on CPU; `name` is bounded like `lane`; the list endpoint pre-validates the status filter so a corrupt row's `ValueError` is no longer blamed on the client with a 400; `config.py` reconciles the inverted zero semantics of the two retention knobs; `_drive`'s docstring no longer claims the `finally` is skipped on a hard cancel (only `_finalize` is); `run_store.json_safe` is exported and applied in `_emit` so a NaN can never reach #121's WebSocket as a bare `NaN` token; and the 503 test restores `app.state` in a `finally`.

Deferred by review, not addressed here: a write-behind buffer for the per-event transaction on the hot progress path (rides #121/#122), and prune cadence.
