### PR TITLE
feat(ui): template gallery modal + node bypass with engine pass-through

### DIFF
--- a/backend/app/core/codegen.py
+++ b/backend/app/core/codegen.py
@@ -25,6 +25,7 @@ import copy
 import keyword
 import math
 import re
+from collections import deque
 from typing import Any
 
 from .api_contract import (
@@ -34,8 +35,10 @@ from .api_contract import (
     derive_contract,
 )
 from .graph_engine import (
+    BypassLink,
     build_preset_fallback,
     prepare_executable_graph,
+    resolve_bypass,
     topological_sort,
 )
 from .secret_params import scrub_graph_secrets
@@ -616,6 +619,92 @@ def generate_python(
 
     raw_by_id = {node.get("id"): node for node in nodes}
 
+    # ── Bypassed nodes (core#128) ────────────────────────────────────────
+    #
+    # `prepare_executable_graph` already removed them, so the script would
+    # simply never mention them.  Resolving the RAW graph a second time here
+    # is purely so the export SHOWS what was muted and what each of its
+    # outputs stood in for -- a commented-out assignment, sitting immediately
+    # above the first node that consumes the pass-through.
+    #
+    # It re-resolves rather than reusing the executable pass because the
+    # resolution is internal to that call; the only cost is a second port
+    # lookup per bypassed node, and the only divergence is a bypassed node fed
+    # by a PRESET (whose expanded internals the raw graph does not have), which
+    # simply has no local variable to name -- handled below.
+    bypass = resolve_bypass(nodes, edges)
+    kept_ids = {kept.get("id") for kept in bypass.nodes}
+    # Graph order, so the emitted comments are deterministic.
+    bypassed_ids = [
+        node.get("id")
+        for node in nodes
+        if node.get("id") is not None and node.get("id") not in kept_ids
+    ]
+    bypassed_id_set = set(bypassed_ids)
+    links_by_node: dict[str, list[BypassLink]] = {}
+    for link in bypass.links:
+        links_by_node.setdefault(link.node_id, []).append(link)
+
+    raw_downstream: dict[str, list[str]] = {}
+    for edge in edges:
+        if edge.get("type", "data") == "data":
+            raw_downstream.setdefault(edge["source"], []).append(edge["target"])
+
+    def _bypass_anchor(node_id: str) -> str | None:
+        """Earliest emitted node that consumes this bypass, through chains."""
+        best: str | None = None
+        seen = {node_id}
+        queue = deque([node_id])
+        while queue:
+            for target in raw_downstream.get(queue.popleft(), []):
+                if target in seen:
+                    continue
+                seen.add(target)
+                if target in bypassed_id_set:
+                    queue.append(target)
+                elif target in seq_by_id and (
+                    best is None or seq_by_id[target] < seq_by_id[best]
+                ):
+                    best = target
+        return best
+
+    def _bypass_lines(node_id: str) -> list[str]:
+        node_type = str((raw_by_id.get(node_id) or {}).get("type", ""))
+        lines = [
+            f"# BYPASSED node {_literal(node_id)} ({_literal(node_type)}) -- "
+            "not executed; its inputs pass straight through:"
+        ]
+        node_links = links_by_node.get(node_id, [])
+        if not node_links:
+            lines.append("#     (nothing was wired through it)")
+            return lines
+        stand_in = _slug(node_id, "node")
+        for link in node_links:
+            source_local = local_names.get(link.source)
+            rhs = (
+                f"_port({source_local}, {_literal(link.source_handle)})"
+                if source_local is not None
+                else (
+                    f"output {_literal(link.source_handle)} of node "
+                    f"{_literal(link.source)}"
+                )
+            )
+            lines.append(
+                f"#     {stand_in}[{_literal(link.output)}] = {rhs}"
+                f"  # via input {_literal(link.input)}"
+            )
+        return lines
+
+    # node_id -> comment block emitted just before it inside its flow body.
+    bypass_comments: dict[str, list[str]] = {}
+    orphan_bypass_lines: list[str] = []
+    for node_id in bypassed_ids:
+        anchor = _bypass_anchor(node_id)
+        if anchor is None:
+            orphan_bypass_lines.extend(_bypass_lines(node_id))
+        else:
+            bypass_comments.setdefault(anchor, []).extend(_bypass_lines(node_id))
+
     def _preset_origin(node_id: str) -> str | None:
         preset_id = internal_to_preset.get(node_id)
         if preset_id is None:
@@ -684,6 +773,8 @@ def generate_python(
         lines = [f"def flow_{index}(ctx, results, provided):"]
         lines.append(f"    {ascii(_flow_summary(member_ids))}")
         for member in member_ids:
+            for comment in bypass_comments.get(member, ()):
+                lines.append(f"    {comment}")
             node = node_by_id[member]
             kwargs: list[str] = []
             if node.get("type") == GRAPH_INPUT_TYPE:
@@ -750,6 +841,10 @@ def generate_python(
 
     banner = "# " + "=" * 28 + " Node functions " + "=" * 28
     node_sections: list[str] = [banner + "\n"]
+    # Bypassed nodes nothing downstream consumes have no flow member to sit
+    # above, so they are recorded here rather than dropped without trace.
+    if orphan_bypass_lines:
+        node_sections.append("\n".join(orphan_bypass_lines) + "\n")
     for index, member_ids in enumerate(flows, start=1):
         header = _comment_text(_flow_summary(member_ids))
         node_sections.append(f"# ---- Flow {index}: {header} ----\n")

--- a/backend/app/core/codegen.py
+++ b/backend/app/core/codegen.py
@@ -676,7 +676,10 @@ def generate_python(
         ]
         node_links = links_by_node.get(node_id, [])
         if not node_links:
-            lines.append("#     (nothing was wired through it)")
+            # A pass-through is only ever resolved for an output something
+            # downstream reads, so an empty link list means nothing consumed
+            # this node -- it says nothing about what was wired INTO it.
+            lines.append("#     (nothing downstream consumed it)")
             return lines
         stand_in = _slug(node_id, "node")
         for link in node_links:

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -210,6 +210,11 @@ class BypassResolution:
     edges: list[dict]
     errors: list[str] = field(default_factory=list)
     links: list[BypassLink] = field(default_factory=list)
+    #: ``(target_id, target_handle) -> bypassed node id`` for every edge the
+    #: resolution DROPPED because the bypass had nothing to forward. Lets the
+    #: resulting "Missing required input" name the mute that caused it, rather
+    #: than pointing at a port the user never touched.
+    dropped: dict[tuple[str, str], str] = field(default_factory=dict)
 
 
 def resolve_bypass(nodes: list[dict], edges: list[dict]) -> BypassResolution:
@@ -217,7 +222,14 @@ def resolve_bypass(nodes: list[dict], edges: list[dict]) -> BypassResolution:
 
     Port matching rule (ComfyUI's, spelled out): for output port ``o``, the
     forwarded input is the FIRST declared input ``i`` with
-    ``is_compatible(i.data_type, o.data_type)``. Then:
+    ``is_compatible(i.data_type, o.data_type)``.
+
+    ``is_compatible`` is deliberately WIDER than the issue's literal "same
+    DataType": it is the very predicate the edge validator uses, so an input
+    the bypass forwards can only produce an edge validation would already have
+    accepted (ANY absorbs everything; IMAGE flows into TENSOR). Requiring
+    strict equality would refuse pass-throughs the graph could legally have
+    been wired with in the first place. Then:
 
     * matched input is wired  -> every edge leaving ``o`` is re-pointed at
       whatever fed ``i`` (recursively, so chains of bypassed nodes collapse);
@@ -240,19 +252,37 @@ def resolve_bypass(nodes: list[dict], edges: list[dict]) -> BypassResolution:
     errors: list[str] = []
     links: list[BypassLink] = []
 
-    # Two kinds of bypassed node are left in place rather than resolved:
+    # Imported lazily: api_contract imports find_entry_points from THIS module,
+    # so a top-level import would close a cycle. One source of truth beats
+    # re-spelling the two type names here.
+    from .api_contract import GRAPH_INPUT_TYPE, GRAPH_OUTPUT_TYPE
+
+    # Three kinds of bypassed node are left in place rather than resolved:
     #
     #  - a preset instance, whose ports come from the preset definition and
     #    whose body is expanded elsewhere. Refused loudly (the canvas does not
     #    offer bypass on presets; a hand-edited file might).
+    #  - a GraphInput / GraphOutput, which declares the graph's I/O CONTRACT.
+    #    `derive_contract` and `check_wiring` scan the raw graph, so silently
+    #    deleting one here would leave a published app advertising an output
+    #    the run cannot produce. GraphOutput is the sharp case: it declares no
+    #    output ports at all, so nothing would ever call `_forward` on it and
+    #    no pass-through error would fire. Refused for the same reason presets
+    #    are — bypass has no meaning for a node that IS the signature.
     #  - an unregistered node type, whose ports cannot be read at all. Left
     #    alone so the caller reports "Unknown node type", which is the real
     #    problem, instead of a confusing pass-through complaint.
+    contract_types = (GRAPH_INPUT_TYPE, GRAPH_OUTPUT_TYPE)
     active: dict[str, dict] = {}
     for node_id, node in bypassed.items():
         node_type = str(node.get("type", ""))
         if node_type.startswith("preset:"):
             errors.append(f"Bypass is not supported on preset node {node_id}")
+        elif node_type in contract_types:
+            errors.append(
+                f"Bypass is not supported on {node_type} node {node_id}: it "
+                "declares the graph's I/O contract"
+            )
         elif registry.get(node_type) is not None:
             active[node_id] = node
         # else: unregistered type — left in place on purpose (see above).
@@ -290,10 +320,14 @@ def resolve_bypass(nodes: list[dict], edges: list[dict]) -> BypassResolution:
     def _forward(node_id: str, out_port: str) -> tuple[str, str] | None:
         """The (source, handle) a bypassed output forwards, or None.
 
-        The memo is seeded with ``None`` BEFORE recursing, which is also the
-        cycle guard: bypassed nodes wired in a loop re-enter, short-circuit to
-        ``None``, and leave the cycle itself for validate_graph to report.
-        It is what keeps the error below to one line per port, too.
+        The memo is seeded with ``None`` BEFORE recursing, which doubles as
+        the cycle guard: bypassed nodes wired in a ring re-enter, short-circuit
+        to ``None``, and the recursion terminates. Note that validate_graph
+        will NOT go on to report that cycle — the nodes forming it no longer
+        exist by then. Every edge leaving the ring is simply dropped, so what
+        the user sees is a missing input on whatever consumed it, attributed
+        to the mute via ``dropped`` below. Seeding also keeps the
+        no-compatible-input error to one line per port.
         """
         key = (node_id, out_port)
         if key in resolved:
@@ -303,7 +337,10 @@ def resolve_bypass(nodes: list[dict], edges: list[dict]) -> BypassResolution:
         inputs, outputs = _ports(node_id)
         output = next((p for p in outputs if p.name == out_port), None)
         if output is None:
-            return None  # unknown handle; edge validation reports it
+            # An edge naming a source handle this node does not declare. Edge
+            # validation will never see it either (the node and the edge are
+            # both about to go), so it lands as a missing input downstream.
+            return None
 
         match = next(
             (p for p in inputs if is_compatible(p.data_type, output.data_type)),
@@ -363,6 +400,7 @@ def resolve_bypass(nodes: list[dict], edges: list[dict]) -> BypassResolution:
         return out
 
     new_edges: list[dict] = []
+    dropped: dict[tuple[str, str], str] = {}
     for edge in edges:
         edge_type = edge.get("type", "data")
         source, target = edge["source"], edge["target"]
@@ -384,6 +422,9 @@ def resolve_bypass(nodes: list[dict], edges: list[dict]) -> BypassResolution:
                 continue  # a bypassed node emits nothing, triggers included
             forwarded = _forward(source, edge.get("sourceHandle", ""))
             if forwarded is None:
+                # Nothing to carry across. Remember who caused it so the
+                # missing input this creates can name the mute.
+                dropped[(target, edge.get("targetHandle", ""))] = source
                 continue
             rewired = dict(edge)
             rewired["source"], rewired["sourceHandle"] = forwarded
@@ -393,7 +434,7 @@ def resolve_bypass(nodes: list[dict], edges: list[dict]) -> BypassResolution:
         new_edges.append(edge)
 
     new_nodes = [n for n in nodes if n["id"] not in active]
-    return BypassResolution(new_nodes, new_edges, errors, links)
+    return BypassResolution(new_nodes, new_edges, errors, links, dropped)
 
 
 def validate_graph(
@@ -451,8 +492,16 @@ def validate_graph(
         node_cls = registry.get(node["type"])
         for inp in node_cls.define_inputs():
             if not inp.optional and (node["id"], inp.name) not in connected_inputs:
+                # A port left unconnected BY A BYPASS reads as the user's own
+                # wiring mistake unless the message says otherwise (core#128).
+                cause = resolution.dropped.get((node["id"], inp.name))
                 errors.append(
                     f"Missing required input '{inp.name}' on node {node['id']} ({node['type']})"
+                    + (
+                        f" (input dropped because '{cause}' is bypassed)"
+                        if cause
+                        else ""
+                    )
                 )
 
     # 3. Parameter range validation (skip preset nodes)

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import traceback
 from collections import defaultdict, deque
+from dataclasses import dataclass, field
 from typing import Any, Callable
 
 from ..config import settings
@@ -151,6 +152,250 @@ def expand_presets(
     return expanded_nodes, expanded_edges, internal_to_preset
 
 
+# ── Bypass / mute (core#128) ─────────────────────────────────────────────
+#
+# A node the user has bypassed on the canvas carries ``data.bypassed = True``.
+# It is not executed; instead every one of its output ports forwards the value
+# that arrived on the first type-compatible input port, so downstream nodes see
+# the graph as if the bypassed node were not there. This mirrors ComfyUI's
+# Ctrl+B, and — like ComfyUI — the match is made on the node's own DECLARED
+# port types, positionally, first match wins.
+#
+# Resolution happens once, structurally: `resolve_bypass` removes the node and
+# rewires its outgoing edges to whatever fed the matched input. Everything
+# downstream of that (reachability, validation, topological order, the Python
+# exporter) therefore needs no bypass awareness at all — it simply never sees
+# the node.
+
+BYPASS_KEY = "bypassed"
+
+
+def _is_bypassed(node: dict) -> bool:
+    data = node.get("data")
+    return bool(data.get(BYPASS_KEY)) if isinstance(data, dict) else False
+
+
+def _type_name(data_type: Any) -> str:
+    """Readable port type for an error message, enum or bare string."""
+    return str(getattr(data_type, "value", data_type))
+
+
+@dataclass(frozen=True)
+class BypassLink:
+    """One resolved pass-through: ``node_id.output`` came from ``source``.
+
+    ``source`` is the nearest NON-bypassed producer, so a chain of bypassed
+    nodes collapses to the value's real origin. Collected for the Python
+    exporter, which comments each bypass with the assignment it stands in for.
+    """
+
+    node_id: str
+    node_type: str
+    output: str
+    input: str
+    source: str
+    source_handle: str
+
+
+@dataclass
+class BypassResolution:
+    """Result of :func:`resolve_bypass` — a graph with no bypassed nodes left.
+
+    ``nodes``/``edges`` are the SAME objects that went in when the graph has
+    no bypassed node, so the overwhelmingly common case costs one scan and no
+    allocation.
+    """
+
+    nodes: list[dict]
+    edges: list[dict]
+    errors: list[str] = field(default_factory=list)
+    links: list[BypassLink] = field(default_factory=list)
+
+
+def resolve_bypass(nodes: list[dict], edges: list[dict]) -> BypassResolution:
+    """Remove bypassed nodes, forwarding each output from a matching input.
+
+    Port matching rule (ComfyUI's, spelled out): for output port ``o``, the
+    forwarded input is the FIRST declared input ``i`` with
+    ``is_compatible(i.data_type, o.data_type)``. Then:
+
+    * matched input is wired  -> every edge leaving ``o`` is re-pointed at
+      whatever fed ``i`` (recursively, so chains of bypassed nodes collapse);
+    * matched input is empty  -> the edges leaving ``o`` are dropped, and the
+      downstream node reports the missing input like any unconnected port;
+    * no compatible input     -> an error naming the incompatibility, because
+      silently dropping the edge would hide a wiring mistake.
+
+    Incoming TRIGGER edges are re-pointed at the first non-bypassed node the
+    bypassed one feeds, so bypassing an entry point does not silently leave
+    the graph with none.
+
+    Never raises. Callers decide what an error means: ``validate_graph``
+    reports it, ``prepare_executable_graph`` refuses to run.
+    """
+    bypassed = {n["id"]: n for n in nodes if _is_bypassed(n)}
+    if not bypassed:
+        return BypassResolution(nodes, edges)
+
+    errors: list[str] = []
+    links: list[BypassLink] = []
+
+    # Two kinds of bypassed node are left in place rather than resolved:
+    #
+    #  - a preset instance, whose ports come from the preset definition and
+    #    whose body is expanded elsewhere. Refused loudly (the canvas does not
+    #    offer bypass on presets; a hand-edited file might).
+    #  - an unregistered node type, whose ports cannot be read at all. Left
+    #    alone so the caller reports "Unknown node type", which is the real
+    #    problem, instead of a confusing pass-through complaint.
+    active: dict[str, dict] = {}
+    for node_id, node in bypassed.items():
+        node_type = str(node.get("type", ""))
+        if node_type.startswith("preset:"):
+            errors.append(f"Bypass is not supported on preset node {node_id}")
+        elif registry.get(node_type) is not None:
+            active[node_id] = node
+        # else: unregistered type — left in place on purpose (see above).
+    if not active:
+        return BypassResolution(nodes, edges, errors)
+
+    # Last edge into a handle wins, matching how the engine builds a node's
+    # inputs dict (later writes to `inputs[tgt_handle]` overwrite earlier ones).
+    incoming: dict[tuple[str, str], tuple[str, str]] = {}
+    data_out: dict[str, list[str]] = defaultdict(list)
+    for edge in edges:
+        if edge.get("type", "data") != "data":
+            continue
+        incoming[(edge["target"], edge.get("targetHandle", ""))] = (
+            edge["source"],
+            edge.get("sourceHandle", ""),
+        )
+        data_out[edge["source"]].append(edge["target"])
+
+    ports: dict[str, tuple[list, list]] = {}
+
+    def _ports(node_id: str) -> tuple[list, list]:
+        if node_id not in ports:
+            node = active[node_id]
+            node_cls = registry.get(node["type"])
+            params = node.get("data", {}).get("params", {})
+            ports[node_id] = (
+                node_cls.define_inputs(),
+                node_cls.define_outputs_dynamic(params),
+            )
+        return ports[node_id]
+
+    resolved: dict[tuple[str, str], tuple[str, str] | None] = {}
+
+    def _forward(node_id: str, out_port: str) -> tuple[str, str] | None:
+        """The (source, handle) a bypassed output forwards, or None.
+
+        The memo is seeded with ``None`` BEFORE recursing, which is also the
+        cycle guard: bypassed nodes wired in a loop re-enter, short-circuit to
+        ``None``, and leave the cycle itself for validate_graph to report.
+        It is what keeps the error below to one line per port, too.
+        """
+        key = (node_id, out_port)
+        if key in resolved:
+            return resolved[key]
+        resolved[key] = None  # provisional
+
+        inputs, outputs = _ports(node_id)
+        output = next((p for p in outputs if p.name == out_port), None)
+        if output is None:
+            return None  # unknown handle; edge validation reports it
+
+        match = next(
+            (p for p in inputs if is_compatible(p.data_type, output.data_type)),
+            None,
+        )
+        if match is None:
+            declared = ", ".join(
+                f"{p.name} ({_type_name(p.data_type)})" for p in inputs
+            )
+            errors.append(
+                f"Bypassed node {node_id} ({active[node_id].get('type', '')}): "
+                f"output '{out_port}' ({_type_name(output.data_type)}) has no "
+                f"type-compatible input to forward "
+                f"(inputs: {declared or 'none'})"
+            )
+            return None
+
+        upstream = incoming.get((node_id, match.name))
+        if upstream is None:
+            return None  # nothing wired in; downstream input stays unconnected
+
+        source, handle = upstream
+        if source in active:
+            upstream = _forward(source, handle)
+            if upstream is None:
+                return None
+            source, handle = upstream
+
+        resolved[key] = (source, handle)
+        links.append(
+            BypassLink(
+                node_id=node_id,
+                node_type=str(active[node_id].get("type", "")),
+                output=out_port,
+                input=match.name,
+                source=source,
+                source_handle=handle,
+            )
+        )
+        return resolved[key]
+
+    def _trigger_targets(node_id: str) -> list[str]:
+        """First non-bypassed nodes downstream, in breadth-first edge order."""
+        out: list[str] = []
+        seen = {node_id}
+        queue = deque([node_id])
+        while queue:
+            current = queue.popleft()
+            for nxt in data_out.get(current, []):
+                if nxt in seen:
+                    continue
+                seen.add(nxt)
+                if nxt in active:
+                    queue.append(nxt)
+                else:
+                    out.append(nxt)
+        return out
+
+    new_edges: list[dict] = []
+    for edge in edges:
+        edge_type = edge.get("type", "data")
+        source, target = edge["source"], edge["target"]
+
+        if target in active:
+            # Consumed by the pass-through map — except a trigger, which is a
+            # marker rather than a value and moves on to what the node fed.
+            if edge_type == "trigger":
+                for index, downstream in enumerate(_trigger_targets(target)):
+                    moved = dict(edge)
+                    moved["target"] = downstream
+                    if "id" in moved:
+                        moved["id"] = f"{moved['id']}:bypass:{index}"
+                    new_edges.append(moved)
+            continue
+
+        if source in active:
+            if edge_type == "trigger":
+                continue  # a bypassed node emits nothing, triggers included
+            forwarded = _forward(source, edge.get("sourceHandle", ""))
+            if forwarded is None:
+                continue
+            rewired = dict(edge)
+            rewired["source"], rewired["sourceHandle"] = forwarded
+            new_edges.append(rewired)
+            continue
+
+        new_edges.append(edge)
+
+    new_nodes = [n for n in nodes if n["id"] not in active]
+    return BypassResolution(new_nodes, new_edges, errors, links)
+
+
 def validate_graph(
     nodes: list[dict],
     edges: list[dict],
@@ -161,8 +406,15 @@ def validate_graph(
     ``preset_fallback`` (ID6) lets a graph-embedded preset (one the
     server's registry does not know) validate as present -- see
     ``build_preset_fallback``.
+
+    Bypassed nodes (core#128) are resolved away first, so every check below
+    runs against the graph that would actually execute: a node whose only
+    upstream is bypassed is checked against what the bypass forwards, not
+    against the node the user muted.
     """
-    errors: list[str] = []
+    resolution = resolve_bypass(nodes, edges)
+    errors: list[str] = list(resolution.errors)
+    nodes, edges = resolution.nodes, resolution.edges
     node_map = {n["id"]: n for n in nodes}
 
     # --- Node-level validation (standalone, before edge checks) ---
@@ -473,12 +725,27 @@ def prepare_executable_graph(
     *,
     preset_fallback: dict | None = None,
 ) -> tuple[list[dict], list[dict], dict[str, str]]:
-    """Expand presets, prune draft components, and validate runtime input.
+    """Expand presets, resolve bypass, prune drafts, and validate.
 
     This is the structural preflight used immediately before execution. It is
     also safe for callers such as Python export that need the exact same preset
     grouping and draft-pruning semantics without actually running any nodes.
     """
+
+    # Presets expand into a sub-graph whose ports come from the preset
+    # definition rather than a node class, so the pass-through rule has nothing
+    # to match on. Refuse before expansion, where the preset node still exists
+    # to be named.
+    bypassed_presets = [
+        node["id"]
+        for node in nodes
+        if _is_bypassed(node) and str(node.get("type", "")).startswith("preset:")
+    ]
+    if bypassed_presets:
+        raise GraphValidationError(
+            "Bypass is not supported on preset node(s): "
+            + ", ".join(sorted(bypassed_presets))
+        )
 
     internal_to_preset: dict[str, str] = {}
     expanded_nodes, expanded_edges = nodes, edges
@@ -500,6 +767,14 @@ def prepare_executable_graph(
         for node in expanded_nodes
     ):
         raise GraphValidationError("Preset nesting exceeds the maximum depth of 10")
+
+    # Bypass BEFORE reachability: a bypassed node is not part of the graph, so
+    # what is reachable, what the topological order is, and what the exporter
+    # emits are all decided on the graph the user actually asked to run.
+    bypass = resolve_bypass(expanded_nodes, expanded_edges)
+    if bypass.errors:
+        raise GraphValidationError("; ".join(bypass.errors))
+    expanded_nodes, expanded_edges = bypass.nodes, bypass.edges
 
     entry_ids = find_entry_points(expanded_nodes, expanded_edges)
     if not entry_ids:

--- a/backend/tests/test_api_graph.py
+++ b/backend/tests/test_api_graph.py
@@ -394,3 +394,43 @@ async def test_save_and_load_roundtrips_segment_groups(
         {"id": "g1", "headNodeId": "a", "tailNodeId": "b"},
         {"id": "g2", "headNodeId": "c", "tailNodeId": "d"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_save_and_load_roundtrips_the_bypass_flag(
+    test_client, tmp_path, monkeypatch,
+):
+    """core#128: a muted node stays muted across save/load.
+
+    `NodeData.data` is a free-form dict, so this is really a guard against a
+    future schema tightening quietly dropping the flag.
+    """
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    graph = {
+        "name": "bypass-graph",
+        "nodes": [
+            {
+                "id": "drop",
+                "type": "Dropout",
+                "position": {"x": 0, "y": 0},
+                "data": {"params": {"p": 0.25}, "bypassed": True},
+            },
+            {
+                "id": "flat",
+                "type": "Flatten",
+                "position": {"x": 0, "y": 0},
+                "data": {"params": {}},
+            },
+        ],
+        "edges": [],
+    }
+    resp = await test_client.post("/api/graph/save", json=graph)
+    assert resp.status_code == 200
+
+    resp = await test_client.get("/api/graph/load/bypass-graph")
+    assert resp.status_code == 200
+    loaded = {n["id"]: n for n in resp.json()["nodes"]}
+    assert loaded["drop"]["data"]["bypassed"] is True
+    assert loaded["drop"]["data"]["params"]["p"] == 0.25
+    # An untouched node gains no flag.
+    assert "bypassed" not in loaded["flat"]["data"]

--- a/backend/tests/test_codegen.py
+++ b/backend/tests/test_codegen.py
@@ -1462,4 +1462,6 @@ def test_export_notes_a_bypassed_node_that_leads_nowhere():
     script = generate_python(nodes, edges, name="leaf")
     _compile_check(script)
     assert "# BYPASSED node 'drop' ('Dropout')" in script
-    assert "#     (nothing was wired through it)" in script
+    # Its input IS still wired (TensorCreate -> drop); what is missing is a
+    # consumer, and the note has to say that and not the opposite.
+    assert "#     (nothing downstream consumed it)" in script

--- a/backend/tests/test_codegen.py
+++ b/backend/tests/test_codegen.py
@@ -1357,3 +1357,109 @@ async def test_export_endpoint_validates_graph(test_client):
     }
     response = await test_client.post("/api/graph/export", json=bad)
     assert response.status_code == 400
+
+
+# ── Bypass in the exported script (core#128) ─────────────────────────────
+
+
+def _bypass_export_graph(bypass: bool = True) -> tuple[list[dict], list[dict]]:
+    """Start -> TensorCreate -> Dropout(bypassed?) -> Print."""
+    dropout: dict = {
+        "id": "drop",
+        "type": "Dropout",
+        "position": {"x": 0, "y": 0},
+        "data": {"params": {"p": 0.5}},
+    }
+    if bypass:
+        dropout["data"]["bypassed"] = True
+    nodes = [
+        {"id": "s1", "type": "Start", "position": {"x": 0, "y": 0}, "data": {"params": {}}},
+        {
+            "id": "make",
+            "type": "TensorCreate",
+            "position": {"x": 0, "y": 0},
+            "data": {"params": {"shape": "2,2", "fill": "ones"}},
+        },
+        dropout,
+        {
+            "id": "out",
+            "type": "Print",
+            "position": {"x": 0, "y": 0},
+            "data": {"params": {"label": "tail"}},
+        },
+    ]
+    edges = [
+        {"id": "t1", "source": "s1", "target": "make", "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+        {"id": "d1", "source": "make", "target": "drop", "sourceHandle": "tensor", "targetHandle": "tensor", "type": "data"},
+        {"id": "d2", "source": "drop", "target": "out", "sourceHandle": "tensor", "targetHandle": "value", "type": "data"},
+    ]
+    return nodes, edges
+
+
+def test_export_omits_a_bypassed_node_and_wires_the_pass_through():
+    from app.core.codegen import generate_python
+
+    script = generate_python(*_bypass_export_graph(), name="bypassed")
+    _compile_check(script)
+
+    emitted = _node_functions(script)
+    assert "drop" not in {node_id for _, node_id, _ in emitted}
+    assert {node_id for _, node_id, _ in emitted} == {"s1", "make", "out"}
+
+    # Print is called with the tensor TensorCreate produced, not via Dropout.
+    make_local = next(name for name, nid, _ in emitted if nid == "make")
+    assert make_local  # sanity: the source node did get a function
+    assert "_port(make, 'tensor')" in script
+
+    # ...and the export says so, in a commented-out pass-through assignment.
+    assert "# BYPASSED node 'drop' ('Dropout')" in script
+    assert "#     drop['tensor'] = _port(make, 'tensor')" in script
+
+
+def test_export_keeps_a_bypassed_node_when_the_flag_is_off():
+    from app.core.codegen import generate_python
+
+    script = generate_python(*_bypass_export_graph(bypass=False), name="plain")
+    _compile_check(script)
+
+    assert "drop" in {node_id for _, node_id, _ in _node_functions(script)}
+    assert "BYPASSED" not in script
+
+
+def test_export_refuses_a_bypass_with_no_compatible_input():
+    from app.core.codegen import generate_python
+    from app.core.graph_engine import GraphValidationError
+
+    nodes = [
+        {"id": "s1", "type": "Start", "position": {"x": 0, "y": 0}, "data": {"params": {}}},
+        {"id": "ds", "type": "Dataset", "position": {"x": 0, "y": 0}, "data": {"params": {}}},
+        {
+            "id": "dl",
+            "type": "DataLoader",
+            "position": {"x": 0, "y": 0},
+            "data": {"params": {}, "bypassed": True},
+        },
+        {"id": "loop", "type": "TrainingLoop", "position": {"x": 0, "y": 0}, "data": {"params": {}}},
+    ]
+    edges = [
+        {"id": "t1", "source": "s1", "target": "ds", "sourceHandle": "trigger", "targetHandle": "", "type": "trigger"},
+        {"id": "d1", "source": "ds", "target": "dl", "sourceHandle": "dataset", "targetHandle": "dataset", "type": "data"},
+        {"id": "d2", "source": "dl", "target": "loop", "sourceHandle": "dataloader", "targetHandle": "dataloader", "type": "data"},
+    ]
+    with pytest.raises(GraphValidationError, match="no type-compatible input"):
+        generate_python(nodes, edges, name="broken")
+
+
+def test_export_notes_a_bypassed_node_that_leads_nowhere():
+    """A muted leaf has no consumer to sit above, so it gets its own note."""
+    from app.core.codegen import generate_python
+
+    nodes, edges = _bypass_export_graph()
+    # Drop the Dropout -> Print edge: nothing consumes the bypass any more.
+    edges = [e for e in edges if e["id"] != "d2"]
+    nodes = [n for n in nodes if n["id"] != "out"]
+
+    script = generate_python(nodes, edges, name="leaf")
+    _compile_check(script)
+    assert "# BYPASSED node 'drop' ('Dropout')" in script
+    assert "#     (nothing was wired through it)" in script

--- a/backend/tests/test_graph_engine.py
+++ b/backend/tests/test_graph_engine.py
@@ -696,3 +696,175 @@ def test_bypass_records_the_pass_through_links_it_applied():
     assert (link.node_id, link.node_type) == ("drop", "Dropout")
     assert (link.output, link.input) == ("tensor", "tensor")
     assert (link.source, link.source_handle) == ("make", "tensor")
+
+
+def test_bypass_is_refused_on_the_graph_io_contract_nodes():
+    """GraphInput/GraphOutput ARE the signature; muting one cannot be silent.
+
+    GraphOutput is the sharp case: it declares no output ports, so nothing
+    would ever ask what it forwards and no pass-through error would fire --
+    it would simply vanish, leaving a published contract advertising an
+    output the run cannot produce.
+    """
+    from app.core.graph_engine import prepare_executable_graph, resolve_bypass
+
+    nodes = [
+        _start_node(),
+        _node("make", "TensorCreate", shape="2,2", fill="ones"),
+        _bypassed(_node("out", "GraphOutput", name="result")),
+    ]
+    edges = [
+        _trigger("et", "start", "make"),
+        _data_edge("e1", "make", "tensor", "out", "value"),
+    ]
+
+    assert any(
+        "Bypass is not supported on GraphOutput node out" in e
+        for e in validate_graph(nodes, edges)
+    )
+    # Refused means LEFT IN PLACE: the contract layer still sees the node.
+    assert "out" in {n["id"] for n in resolve_bypass(nodes, edges).nodes}
+
+    with pytest.raises(GraphValidationError, match="not supported on GraphOutput"):
+        prepare_executable_graph(nodes, edges)
+
+
+def test_bypass_is_refused_on_a_graph_input_node():
+    from app.core.graph_engine import prepare_executable_graph
+
+    nodes = [
+        _start_node(),
+        _bypassed(_node("in", "GraphInput", name="x", type="string")),
+        _node("show", "Print", label="tail"),
+    ]
+    edges = [
+        _trigger("et", "start", "in"),
+        _data_edge("e1", "in", "value", "show", "value"),
+    ]
+    assert any(
+        "Bypass is not supported on GraphInput node in" in e
+        for e in validate_graph(nodes, edges)
+    )
+    with pytest.raises(GraphValidationError, match="not supported on GraphInput"):
+        prepare_executable_graph(nodes, edges)
+
+
+def test_bypass_forwards_the_first_matching_input_of_several():
+    """Lerp takes tensor_a, tensor_b, alpha and emits one TENSOR.
+
+    All three inputs are equally compatible, so this pins WHICH one
+    positional first-match picks: the earliest declared, tensor_a.
+    """
+    from app.core.graph_engine import resolve_bypass
+
+    nodes = [
+        _start_node(),
+        _node("a", "TensorCreate", shape="2,2", fill="ones"),
+        _node("b", "TensorCreate", shape="2,2", fill="zeros"),
+        _bypassed(_node("mix", "Lerp", alpha=0.5)),
+        _node("out", "Print", label="tail"),
+    ]
+    edges = [
+        _trigger("et", "start", "a"),
+        _data_edge("e1", "a", "tensor", "mix", "tensor_a"),
+        _data_edge("e2", "b", "tensor", "mix", "tensor_b"),
+        _data_edge("e3", "mix", "tensor", "out", "value"),
+    ]
+    resolution = resolve_bypass(nodes, edges)
+
+    assert resolution.errors == []
+    assert [(link.input, link.source) for link in resolution.links] == [("tensor_a", "a")]
+    rewired = [e for e in resolution.edges if e["target"] == "out"]
+    assert (rewired[0]["source"], rewired[0]["sourceHandle"]) == ("a", "tensor")
+
+
+def test_bypass_resolves_each_output_of_a_multi_output_node_by_type():
+    """TrainTestSplit emits x_train/x_test (TENSOR) and y_train/y_test (LIST).
+
+    Each output picks the first input its OWN type is compatible with, so the
+    two consumed here resolve to different inputs -- and to different source
+    ports of the same upstream node.
+    """
+    from app.core.graph_engine import resolve_bypass
+
+    nodes = [
+        _start_node(),
+        _node("csv", "CSVReader", path="data/samples/iris.csv", target_column="species"),
+        _bypassed(_node("split", "TrainTestSplit")),
+        _node("o1", "Print", label="a"),
+        _node("o2", "Print", label="b"),
+    ]
+    edges = [
+        _trigger("et", "start", "csv"),
+        _data_edge("e1", "csv", "tensor", "split", "features"),
+        _data_edge("e2", "csv", "labels", "split", "labels"),
+        _data_edge("e3", "split", "x_train", "o1", "value"),
+        _data_edge("e4", "split", "y_test", "o2", "value"),
+    ]
+    resolution = resolve_bypass(nodes, edges)
+
+    assert resolution.errors == []
+    assert sorted(
+        (link.output, link.input, link.source_handle) for link in resolution.links
+    ) == [
+        ("x_train", "features", "tensor"),
+        ("y_test", "labels", "labels"),
+    ]
+
+
+def test_bypass_matching_is_wider_than_equality_when_a_port_is_any():
+    """Switch: selector (SCALAR), input_0..3 (ANY) -> output (ANY).
+
+    ``is_compatible`` -- the edge validator's own predicate -- accepts SCALAR
+    into ANY, so positional first-match takes `selector`, not `input_0`.
+    Surprising at a glance and deliberately pinned: the rule is positional
+    over a WIDE compatibility test, exactly as ComfyUI's is, and a strict
+    same-DataType rule would refuse pass-throughs the graph could legally
+    have been wired with.
+    """
+    from app.core.graph_engine import resolve_bypass
+
+    nodes = [
+        _start_node(),
+        _node("sel", "TensorCreate", shape="1", fill="ones"),
+        _node("a", "TensorCreate", shape="2,2", fill="ones"),
+        _bypassed(_node("sw", "Switch")),
+        _node("out", "Print", label="tail"),
+    ]
+    edges = [
+        _trigger("et", "start", "sel"),
+        _data_edge("e1", "sel", "tensor", "sw", "selector"),
+        _data_edge("e2", "a", "tensor", "sw", "input_0"),
+        _data_edge("e3", "sw", "output", "out", "value"),
+    ]
+    resolution = resolve_bypass(nodes, edges)
+
+    assert resolution.errors == []
+    assert [(link.input, link.source) for link in resolution.links] == [("selector", "sel")]
+
+
+def test_a_missing_input_caused_by_a_bypass_names_the_bypass():
+    """Otherwise the error reads as a port the user forgot to wire."""
+    nodes = [
+        _start_node(),
+        _bypassed(_node("drop", "Dropout", p=0.5)),
+        _node("out", "Print", label="tail"),
+    ]
+    edges = [
+        _trigger("et", "start", "drop"),
+        _data_edge("e1", "drop", "tensor", "out", "value"),
+    ]
+    errors = validate_graph(nodes, edges)
+    assert any(
+        "Missing required input 'value' on node out" in e
+        and "input dropped because 'drop' is bypassed" in e
+        for e in errors
+    ), errors
+
+
+def test_an_ordinary_missing_input_carries_no_bypass_attribution():
+    nodes = [_start_node(), _node("out", "Print", label="tail")]
+    edges = [_trigger("et", "start", "out")]
+    errors = validate_graph(nodes, edges)
+    assert any("Missing required input 'value' on node out" in e for e in errors)
+    assert not any("is bypassed" in e for e in errors), errors

--- a/backend/tests/test_graph_engine.py
+++ b/backend/tests/test_graph_engine.py
@@ -465,3 +465,234 @@ async def test_execute_graph_skips_draft_components():
     results = await execute_graph(nodes, edges)
     assert "live" in results
     assert "draft" not in results
+
+
+# ── Bypass / mute (core#128) ─────────────────────────────────────────────
+#
+# A bypassed node is removed from the executable graph and each of its
+# outputs forwards the first type-compatible input, ComfyUI-style. The tests
+# below cover the shapes that matter: a straight chain, a fan-out, a chain of
+# two bypassed nodes, and the failure modes (no compatible input, nothing
+# wired into the matched input).
+
+
+def _bypassed(node):
+    """Mark a node dict as bypassed, mirroring what the canvas serializes."""
+    node.setdefault("data", {})["bypassed"] = True
+    return node
+
+
+def _node(nid, ntype, **params):
+    return {"id": nid, "type": ntype, "data": {"params": params}}
+
+
+def _data_edge(eid, src, src_handle, tgt, tgt_handle):
+    return {
+        "id": eid,
+        "source": src,
+        "target": tgt,
+        "sourceHandle": src_handle,
+        "targetHandle": tgt_handle,
+        "type": "data",
+    }
+
+
+def _chain_with_bypassed_dropout(bypass=True):
+    """Start -> TensorCreate -> Dropout(bypassed?) -> Print."""
+    dropout = _node("drop", "Dropout", p=0.5)
+    if bypass:
+        _bypassed(dropout)
+    nodes = [
+        _start_node(),
+        _node("make", "TensorCreate", shape="2,2", fill="ones"),
+        dropout,
+        _node("out", "Print", label="tail"),
+    ]
+    edges = [
+        _trigger("et", "start", "make"),
+        _data_edge("e1", "make", "tensor", "drop", "tensor"),
+        _data_edge("e2", "drop", "tensor", "out", "value"),
+    ]
+    return nodes, edges
+
+
+def test_bypass_removes_the_node_and_rewires_downstream():
+    from app.core.graph_engine import prepare_executable_graph
+
+    nodes, edges = _chain_with_bypassed_dropout()
+    exec_nodes, exec_edges, _ = prepare_executable_graph(nodes, edges)
+
+    assert "drop" not in {n["id"] for n in exec_nodes}
+    rewired = [e for e in exec_edges if e["target"] == "out"]
+    assert len(rewired) == 1
+    assert rewired[0]["source"] == "make"
+    assert rewired[0]["sourceHandle"] == "tensor"
+    assert rewired[0]["targetHandle"] == "value"
+
+
+def test_bypass_leaves_a_clean_graph_untouched_by_identity():
+    """No bypassed node -> the very same list objects come back out."""
+    from app.core.graph_engine import resolve_bypass
+
+    nodes, edges = _chain_with_bypassed_dropout(bypass=False)
+    resolution = resolve_bypass(nodes, edges)
+    assert resolution.nodes is nodes
+    assert resolution.edges is edges
+    assert resolution.errors == []
+
+
+@pytest.mark.asyncio
+async def test_bypassed_mid_chain_node_runs_as_if_absent():
+    nodes, edges = _chain_with_bypassed_dropout()
+    results = await execute_graph(nodes, edges)
+
+    assert "drop" not in results
+    # Pass-through is by reference: Print received exactly what TensorCreate
+    # produced, with no Dropout in between.
+    assert results["out"]["value"] is results["make"]["tensor"]
+
+
+@pytest.mark.asyncio
+async def test_un_bypassing_restores_the_node():
+    nodes, edges = _chain_with_bypassed_dropout(bypass=False)
+    results = await execute_graph(nodes, edges)
+
+    assert "drop" in results
+    assert results["out"]["value"] is not results["make"]["tensor"]
+
+
+@pytest.mark.asyncio
+async def test_bypass_fans_out_to_every_consumer():
+    nodes, edges = _chain_with_bypassed_dropout()
+    nodes.append(_node("out2", "Print", label="second"))
+    edges.append(_data_edge("e3", "drop", "tensor", "out2", "value"))
+
+    results = await execute_graph(nodes, edges)
+    assert results["out"]["value"] is results["make"]["tensor"]
+    assert results["out2"]["value"] is results["make"]["tensor"]
+
+
+@pytest.mark.asyncio
+async def test_a_chain_of_bypassed_nodes_resolves_to_the_original_source():
+    nodes = [
+        _start_node(),
+        _node("make", "TensorCreate", shape="2,2", fill="ones"),
+        _bypassed(_node("d1", "Dropout", p=0.5)),
+        _bypassed(_node("d2", "Dropout", p=0.5)),
+        _node("out", "Print", label="tail"),
+    ]
+    edges = [
+        _trigger("et", "start", "make"),
+        _data_edge("e1", "make", "tensor", "d1", "tensor"),
+        _data_edge("e2", "d1", "tensor", "d2", "tensor"),
+        _data_edge("e3", "d2", "tensor", "out", "value"),
+    ]
+    results = await execute_graph(nodes, edges)
+
+    assert "d1" not in results and "d2" not in results
+    assert results["out"]["value"] is results["make"]["tensor"]
+
+
+def test_bypass_with_no_type_compatible_input_is_a_validation_error():
+    """DataLoader takes DATASET and emits DATALOADER -- nothing to forward."""
+    from app.core.graph_engine import prepare_executable_graph
+
+    nodes = [
+        _start_node(),
+        _node("ds", "Dataset"),
+        _bypassed(_node("dl", "DataLoader")),
+        _node("loop", "TrainingLoop"),
+    ]
+    edges = [
+        _trigger("et", "start", "ds"),
+        _data_edge("e1", "ds", "dataset", "dl", "dataset"),
+        _data_edge("e2", "dl", "dataloader", "loop", "dataloader"),
+    ]
+
+    errors = validate_graph(nodes, edges)
+    assert any(
+        "dl" in e and "no type-compatible input" in e and "dataloader" in e
+        for e in errors
+    ), errors
+
+    with pytest.raises(GraphValidationError, match="no type-compatible input"):
+        prepare_executable_graph(nodes, edges)
+
+
+def test_bypass_whose_matched_input_is_unconnected_leaves_downstream_unwired():
+    """Nothing flows into the bypassed node, so its consumer loses its input."""
+    nodes = [
+        _start_node(),
+        _bypassed(_node("drop", "Dropout", p=0.5)),
+        _node("out", "Print", label="tail"),
+    ]
+    edges = [
+        _trigger("et", "start", "drop"),
+        _data_edge("e1", "drop", "tensor", "out", "value"),
+    ]
+    errors = validate_graph(nodes, edges)
+    assert any("Missing required input 'value'" in e and "out" in e for e in errors), errors
+
+
+def test_bypassing_a_trigger_target_repoints_the_trigger_downstream():
+    """A bypassed entry point hands its trigger to what it fed."""
+    from app.core.graph_engine import find_entry_points, resolve_bypass
+
+    nodes = [
+        _start_node(),
+        _bypassed(_node("drop", "Dropout", p=0.5)),
+        _node("out", "Print", label="tail"),
+    ]
+    edges = [
+        _trigger("et", "start", "drop"),
+        _data_edge("e1", "drop", "tensor", "out", "value"),
+    ]
+    resolution = resolve_bypass(nodes, edges)
+
+    triggers = [e for e in resolution.edges if e.get("type") == "trigger"]
+    assert [e["target"] for e in triggers] == ["out"]
+    assert find_entry_points(resolution.nodes, resolution.edges) == ["out"]
+
+
+def test_bypass_is_refused_on_a_preset_node():
+    from app.core.graph_engine import prepare_executable_graph
+
+    nodes = [
+        _start_node(),
+        _bypassed({"id": "p1", "type": "preset:Whatever", "data": {"params": {}}}),
+    ]
+    edges = [_trigger("et", "start", "p1")]
+
+    assert any("not supported on preset node" in e for e in validate_graph(nodes, edges))
+    with pytest.raises(GraphValidationError, match="not supported on preset node"):
+        prepare_executable_graph(nodes, edges)
+
+
+def test_bypass_on_an_unknown_node_type_reports_the_unknown_type():
+    """The real problem is the missing node class, not the pass-through."""
+    nodes = [
+        _start_node(),
+        _bypassed(_node("ghost", "NotARealNode")),
+        _node("out", "Print", label="tail"),
+    ]
+    edges = [
+        _trigger("et", "start", "ghost"),
+        _data_edge("e1", "ghost", "value", "out", "value"),
+    ]
+    errors = validate_graph(nodes, edges)
+    assert any("Unknown node type: NotARealNode" in e for e in errors), errors
+    assert not any("no type-compatible input" in e for e in errors), errors
+
+
+def test_bypass_records_the_pass_through_links_it_applied():
+    """The link list is what the Python exporter comments the bypass with."""
+    from app.core.graph_engine import resolve_bypass
+
+    nodes, edges = _chain_with_bypassed_dropout()
+    resolution = resolve_bypass(nodes, edges)
+
+    assert len(resolution.links) == 1
+    link = resolution.links[0]
+    assert (link.node_id, link.node_type) == ("drop", "Dropout")
+    assert (link.output, link.input) == ("tensor", "tensor")
+    assert (link.source, link.source_handle) == ("make", "tensor")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { ResultsPanel } from './components/ResultsPanel/ResultsPanel';
 import { PresetConfigModal } from './components/PresetModal/PresetConfigModal';
 import { SubgraphEditorModal } from './components/SubgraphEditor/SubgraphEditorModal';
 import { NodeDetailModal } from './components/NodeDetailModal/NodeDetailModal';
+import { TemplateGalleryModal } from './components/TemplateGallery/TemplateGalleryModal';
 import { ToastContainer } from './components/shared/Toast';
 import { ShortcutsModal } from './components/shared/ShortcutsModal';
 import { DialogContainer } from './components/shared/DialogContainer';
@@ -135,6 +136,7 @@ function App() {
       <PresetConfigModal />
       <SubgraphEditorModal />
       <NodeDetailModal />
+      <TemplateGalleryModal />
       <ToastContainer />
       <ShortcutsModal />
       <DialogContainer />

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -469,8 +469,12 @@ export interface ExampleSummary {
    * Where the example ships from: `builtin`, or `plugin:<id>` for one a
    * plugin pack contributed. The gallery (core#128) shows it so an example
    * can be traced back to the pack that has to stay installed for it to work.
+   *
+   * Optional because this type describes what arrives over the wire, not a
+   * guarantee: a frontend built from source can meet an older prebuilt
+   * backend. Every consumer already treats a missing value as "built-in".
    */
-  source: string;
+  source?: string;
 }
 
 export async function listExamples(): Promise<ExampleSummary[]> {

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -465,6 +465,12 @@ export interface ExampleSummary {
   path: string;
   node_count: number;
   edge_count: number;
+  /**
+   * Where the example ships from: `builtin`, or `plugin:<id>` for one a
+   * plugin pack contributed. The gallery (core#128) shows it so an example
+   * can be traced back to the pack that has to stay installed for it to work.
+   */
+  source: string;
 }
 
 export async function listExamples(): Promise<ExampleSummary[]> {

--- a/frontend/src/components/Canvas/EmptyCanvasOverlay.module.css
+++ b/frontend/src/components/Canvas/EmptyCanvasOverlay.module.css
@@ -32,7 +32,25 @@
 .subtitle {
   font-size: 0.875rem;
   color: #444;
+  margin-bottom: 14px;
+}
+
+/* Entry into the full gallery modal (core#128). */
+.browseButton {
   margin-bottom: 24px;
+  padding: 6px 16px;
+  background: rgba(6, 182, 212, 0.1);
+  border: 1px solid #0e7490;
+  border-radius: 6px;
+  color: #22d3ee;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.browseButton:hover {
+  background: rgba(6, 182, 212, 0.22);
 }
 
 /* Quick-start preset card grid */

--- a/frontend/src/components/Canvas/EmptyCanvasOverlay.test.tsx
+++ b/frontend/src/components/Canvas/EmptyCanvasOverlay.test.tsx
@@ -38,8 +38,21 @@ function ex(overrides: Partial<ExampleSummary> = {}): ExampleSummary {
     path: '/examples/foo.json',
     node_count: 3,
     edge_count: 2,
+    source: 'builtin',
     ...overrides,
   };
+}
+
+/**
+ * Names of the example cards in DOM order. Filtered by class rather than
+ * taken from every button, because the overlay also carries the
+ * browse-the-gallery button (core#128), which is not a card.
+ */
+function cardNames(): (string | null | undefined)[] {
+  return screen
+    .getAllByRole('button')
+    .filter((b) => b.className.includes('presetCard'))
+    .map((b) => b.querySelector('span')?.textContent);
 }
 
 describe('EmptyCanvasOverlay', () => {
@@ -137,10 +150,7 @@ describe('EmptyCanvasOverlay', () => {
     // Global card order: pinned trio first (in pinned order, not list order),
     // then Advanced (LLM before leftover Usage_Example), then plugin, then
     // architectures last.
-    const names = screen
-      .getAllByRole('button')
-      .map((b) => b.querySelector('span')?.textContent);
-    expect(names).toEqual([
+    expect(cardNames()).toEqual([
       'Train CNN',
       'Inference CNN',
       'Api Fn',
@@ -163,10 +173,7 @@ describe('EmptyCanvasOverlay', () => {
     ]);
     render(<EmptyCanvasOverlay />);
     await waitFor(() => expect(screen.getByText('Analogy')).toBeInTheDocument());
-    const names = screen
-      .getAllByRole('button')
-      .map((b) => b.querySelector('span')?.textContent);
-    expect(names).toEqual(['Analogy', 'Forward', 'ToySampling', 'MiniUNet', 'Iris']);
+    expect(cardNames()).toEqual(['Analogy', 'Forward', 'ToySampling', 'MiniUNet', 'Iris']);
   });
 
   it('renders unknown categories in the plugin section with the fallback badge colour', async () => {

--- a/frontend/src/components/Canvas/EmptyCanvasOverlay.tsx
+++ b/frontend/src/components/Canvas/EmptyCanvasOverlay.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useI18n, type TranslationKey } from '../../i18n';
 import { openExample } from '../../utils/openExample';
+import { useUIStore } from '../../store/uiStore';
 import { listExamples } from '../../api/rest';
 import type { ExampleSummary } from '../../api/rest';
 import { EXAMPLE_CATEGORY_COLORS, EXAMPLE_CATEGORY_FALLBACK } from '../../styles/theme';
@@ -156,6 +157,18 @@ export function EmptyCanvasOverlay() {
       <div className={styles.inner}>
         <div className={styles.title}>{t('empty.title')}</div>
         <div className={styles.subtitle}>{t('empty.subtitle')}</div>
+
+        {/* The curated sections below stay the fast path; this is the way to
+            the full, searchable list — the same modal the toolbar and the
+            sidebar's Templates tab open (core#128). */}
+        <button
+          type="button"
+          className={styles.browseButton}
+          onClick={() => useUIStore.getState().openTemplateGallery()}
+          title={t('gallery.open.title')}
+        >
+          {t('gallery.browse')}
+        </button>
 
         {loading && (
           <div className={styles.hint}>{t('empty.loading')}</div>

--- a/frontend/src/components/ContextMenu/NodeContextMenu.test.tsx
+++ b/frontend/src/components/ContextMenu/NodeContextMenu.test.tsx
@@ -318,3 +318,79 @@ describe('useNoteContextMenuItems', () => {
     expect(colorItems.every((i) => i.color === '#999')).toBe(true);
   });
 });
+
+
+// ── Bypass entry (core#128) ──────────────────────────────────────────────
+
+/** Put a single node on the active tab and return its id. */
+function seedNode(id: string, over: Partial<Node<NodeData>> = {}) {
+  const tabId = useTabStore.getState().activeTabId;
+  useTabStore.setState({
+    tabs: useTabStore.getState().tabs.map((t) =>
+      t.id === tabId
+        ? {
+            ...t,
+            nodes: [
+              {
+                id,
+                type: 'baseNode',
+                position: { x: 0, y: 0 },
+                data: { label: id, type: 'Dropout', params: {} },
+                ...over,
+              } as Node<NodeData>,
+            ],
+          }
+        : t,
+    ),
+  });
+  return id;
+}
+
+describe('useNodeContextMenuItems — bypass', () => {
+  const callbacks = {
+    onDelete: vi.fn(),
+    onRename: vi.fn(),
+    onDuplicate: vi.fn(),
+    onOpenDetails: vi.fn(),
+  };
+
+  it('offers Bypass on an ordinary node and forwards to the store', () => {
+    seedNode('n1');
+    const spy = vi.spyOn(useTabStore.getState(), 'toggleNodeBypass');
+    const { result } = renderHook(() => useNodeContextMenuItems('n1', callbacks));
+
+    expect(result.current.map((i) => i.label)).toEqual([
+      'Open details',
+      'Rename',
+      'Duplicate',
+      'Bypass',
+      'Delete',
+    ]);
+    result.current[3].action();
+    expect(spy).toHaveBeenCalledWith('n1');
+  });
+
+  it('offers the inverse label once the node is muted', () => {
+    seedNode('n1', { data: { label: 'n1', type: 'Dropout', params: {}, bypassed: true } });
+    const { result } = renderHook(() => useNodeContextMenuItems('n1', callbacks));
+    const item = result.current.find((i) => i.label === 'Remove Bypass');
+    expect(item).toBeTruthy();
+    expect(item!.color).toBe('#22d3ee');
+  });
+
+  it('omits the entry for node kinds bypass does not apply to', () => {
+    for (const type of ['noteNode', 'start', 'presetNode']) {
+      seedNode('n1', { type });
+      const { result } = renderHook(() => useNodeContextMenuItems('n1', callbacks));
+      expect(result.current.map((i) => i.label)).toEqual([
+        'Open details',
+        'Rename',
+        'Duplicate',
+        'Delete',
+      ]);
+      // Duplicate keeps the divider that would otherwise sit under Bypass, so
+      // Delete stays visually separated either way.
+      expect(result.current[2].dividerAfter).toBe(true);
+    }
+  });
+});

--- a/frontend/src/components/ContextMenu/NodeContextMenu.test.tsx
+++ b/frontend/src/components/ContextMenu/NodeContextMenu.test.tsx
@@ -393,4 +393,21 @@ describe('useNodeContextMenuItems — bypass', () => {
       expect(result.current[2].dividerAfter).toBe(true);
     }
   });
+
+  it('omits the entry for the graph I/O contract nodes (core#128 review)', () => {
+    // GraphInput/GraphOutput render as ordinary baseNode cards, so the
+    // component-type check cannot see them — the real node type can. Muting
+    // one would leave a published contract advertising an input or output
+    // the run cannot honour, which the backend refuses outright.
+    for (const graphType of ['GraphInput', 'GraphOutput']) {
+      seedNode('n1', { data: { label: 'n1', type: graphType, params: {} } });
+      const { result } = renderHook(() => useNodeContextMenuItems('n1', callbacks));
+      expect(result.current.map((i) => i.label)).toEqual([
+        'Open details',
+        'Rename',
+        'Duplicate',
+        'Delete',
+      ]);
+    }
+  });
 });

--- a/frontend/src/components/ContextMenu/NodeContextMenu.tsx
+++ b/frontend/src/components/ContextMenu/NodeContextMenu.tsx
@@ -1,5 +1,6 @@
 import { useI18n } from '../../i18n';
 import { useTabStore } from '../../store/tabStore';
+import { isBypassable } from '../../utils';
 import styles from './NodeContextMenu.module.css';
 
 export interface ContextMenuPosition {
@@ -71,6 +72,13 @@ export function useNodeContextMenuItems(
   },
 ) {
   const { t } = useI18n();
+  const toggleNodeBypass = useTabStore((s) => s.toggleNodeBypass);
+  const node = useTabStore((s) => {
+    const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
+    return tab?.nodes.find((n) => n.id === nodeId);
+  });
+  const bypassable = isBypassable(node);
+  const bypassed = node?.data.bypassed === true;
 
   return [
     // First, and divided off from the edit actions: it is the only entry that
@@ -81,7 +89,19 @@ export function useNodeContextMenuItems(
       dividerAfter: true,
     },
     { label: t('contextMenu.rename'), action: () => callbacks.onRename(nodeId), dividerAfter: false },
-    { label: t('contextMenu.duplicate'), action: () => callbacks.onDuplicate(nodeId), dividerAfter: true },
+    { label: t('contextMenu.duplicate'), action: () => callbacks.onDuplicate(nodeId), dividerAfter: !bypassable },
+    // Bypass (core#128) sits with the edit actions, not next to Delete: it
+    // changes what runs, it does not remove anything. Absent entirely for the
+    // node kinds bypass does not apply to (notes, Start, presets) rather than
+    // shown greyed out — an entry that can never do anything is noise.
+    ...(bypassable
+      ? [{
+          label: bypassed ? t('contextMenu.unbypass') : t('contextMenu.bypass'),
+          action: () => toggleNodeBypass(nodeId),
+          color: bypassed ? '#22d3ee' : undefined,
+          dividerAfter: true,
+        }]
+      : []),
     { label: t('contextMenu.delete'), action: () => callbacks.onDelete(nodeId), color: '#F44336' },
   ];
 }

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.module.css
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.module.css
@@ -174,6 +174,20 @@
   letter-spacing: 0.06em;
 }
 
+/* Bypassed / muted (core#128). Amber rather than red: muting is deliberate,
+   not a failure — the same reading `interrupted` gets in the status palette. */
+.bypassChip {
+  font-size: 0.625rem;
+  border: 1px solid #ff8f00;
+  color: #ff8f00;
+  border-radius: 9px;
+  padding: 0 6px;
+  line-height: 1.5;
+  white-space: nowrap;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
 /* Shown only while the name editor is open, so the commit/cancel keys are
    discoverable without a tooltip. */
 .renameHint {

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
@@ -487,6 +487,21 @@ describe('NodeDetailModal — header', () => {
     expect(screen.getByText('PRESET')).toBeInTheDocument();
   });
 
+  it('flags a bypassed node, which the canvas card underneath cannot (core#128)', () => {
+    seedTab({
+      nodes: [node('n1', { data: { bypassed: true } })],
+      nodeDetailNodeId: 'n1',
+    });
+    render(<NodeDetailModal />);
+    expect(screen.getByText('BYPASS')).toBeInTheDocument();
+  });
+
+  it('carries no bypass chip for an ordinary node', () => {
+    seedTab({ nodes: [node('n1')], nodeDetailNodeId: 'n1' });
+    render(<NodeDetailModal />);
+    expect(screen.queryByText('BYPASS')).toBeNull();
+  });
+
   it('surfaces the commit/cancel keys only while the name editor is open', () => {
     seedTab({ nodes: [node('n1', { label: 'Old' })], nodeDetailNodeId: 'n1' });
     render(<NodeDetailModal />);

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.tsx
@@ -279,6 +279,14 @@ function NodeDetailModalBody({ nodeId }: { nodeId: string }) {
                   {t('preset.badge')}
                 </span>
               )}
+              {/* core#128: the canvas card is greyed out and struck through,
+                  but the modal covers it — without this chip the params on
+                  screen would read as though they still affect a run. */}
+              {node.data.bypassed && (
+                <span className={styles.bypassChip} title={t('node.bypassed.title')}>
+                  {t('node.bypassed')}
+                </span>
+              )}
               <span className={styles.statusChip} style={{ color: statusColor, borderColor: statusColor }}>
                 {t(`status.${status}` as const)}
               </span>

--- a/frontend/src/components/Nodes/BaseNode.module.css
+++ b/frontend/src/components/Nodes/BaseNode.module.css
@@ -11,6 +11,42 @@
   transition: border-color 0.2s, box-shadow 0.2s;
 }
 
+/* ── Bypassed / muted (core#128) ──
+   Faded and struck through so a muted node reads as "still here, not running"
+   at a glance, without being mistaken for a disabled control: the card stays
+   fully clickable, because selecting it is how you un-mute it. The opacity
+   sits on the card only — handles keep their own so edges into and out of a
+   bypassed node stay grabbable. */
+.bypassed {
+  opacity: 0.45;
+  filter: grayscale(0.7);
+}
+
+.bypassed .headerLabel {
+  text-decoration: line-through;
+  text-decoration-thickness: 1.5px;
+}
+
+.bypassed .portLabel {
+  text-decoration: line-through;
+}
+
+.bypassed .portHandle {
+  opacity: 1 !important;
+}
+
+.bypassBadge {
+  font-size: 0.5625rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.45);
+  color: #ffffff;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 /* ── Hover tooltip ── */
 .tooltip {
   position: absolute;

--- a/frontend/src/components/Nodes/BaseNode.test.tsx
+++ b/frontend/src/components/Nodes/BaseNode.test.tsx
@@ -824,3 +824,42 @@ describe('BaseNode detach drag redirect', () => {
 afterEach(() => {
   vi.restoreAllMocks();
 });
+
+
+// ── Bypass visuals (core#128) ────────────────────────────────────────────
+
+describe('BaseNode bypass', () => {
+  beforeEach(resetStores);
+
+  it('renders no bypass marker on an ordinary node', () => {
+    const { container } = renderBody(baseData());
+    expect(screen.queryByText('BYPASS')).toBeNull();
+    expect(container.querySelector('[data-bypassed]')).toBeNull();
+  });
+
+  it('dims, strikes through and badges a bypassed node', () => {
+    const { container } = renderBody(baseData({ bypassed: true }));
+
+    const badge = screen.getByText('BYPASS');
+    expect(badge).toBeInTheDocument();
+    expect(badge.getAttribute('title')).toBe(
+      'Bypassed: this node is skipped and passes its input straight through',
+    );
+
+    // The card carries the dim/strike-through class, and says so in the DOM
+    // so a test (or a screenshot diff) does not have to match on a hashed
+    // CSS-module name.
+    const card = container.querySelector('[data-bypassed="true"]');
+    expect(card).not.toBeNull();
+    expect(card!.className).toMatch(/bypassed/);
+  });
+
+  it('keeps the label and ports of a bypassed node on screen', () => {
+    renderBody(baseData({ bypassed: true }));
+    // Muting hides nothing: the node is still readable and still selectable,
+    // which is how it gets un-muted.
+    expect(screen.getByText('My Linear')).toBeInTheDocument();
+    expect(screen.getByText('in')).toBeInTheDocument();
+    expect(screen.getByText('out')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Nodes/BaseNode.tsx
+++ b/frontend/src/components/Nodes/BaseNode.tsx
@@ -49,6 +49,9 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
 
   const isSequentialModel = data.type === 'SequentialModel';
   const isDraggingTrigger = draggingSourceType === 'TRIGGER';
+  // core#128: muted in place. The card stays fully interactive (you have to
+  // be able to select it to un-mute it) — only its look says "skipped".
+  const isBypassed = data.bypassed === true;
 
   // True when this exact handle is the originally-connected endpoint of an
   // in-progress edge-reconnect drag; it shows a red "detaching" ring warning
@@ -175,7 +178,8 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
       onDoubleClick={handleDoubleClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      className={`${styles.node}${isTriggerTarget ? ` ${styles.entryPoint}` : ''}${isDraggingTrigger ? ` ${styles.triggerDropTarget}` : ''}`}
+      className={`${styles.node}${isTriggerTarget ? ` ${styles.entryPoint}` : ''}${isDraggingTrigger ? ` ${styles.triggerDropTarget}` : ''}${isBypassed ? ` ${styles.bypassed}` : ''}`}
+      data-bypassed={isBypassed || undefined}
       style={{
         '--border-color': borderColor,
         boxShadow: selected
@@ -210,6 +214,11 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
         <span className={styles.headerLabel}>
           {data.label}
         </span>
+        {isBypassed && (
+          <span className={styles.bypassBadge} title={t('node.bypassed.title')}>
+            {t('node.bypassed')}
+          </span>
+        )}
         <span className={styles.headerCategory}>
           {category}
         </span>

--- a/frontend/src/components/Sidebar/TemplatesTab.module.css
+++ b/frontend/src/components/Sidebar/TemplatesTab.module.css
@@ -41,3 +41,26 @@
   color: #555;
   margin-top: 3px;
 }
+
+/* ── Footer: the way into the full gallery modal (core#128) ── */
+.browseButton {
+  display: block;
+  width: 100%;
+  padding: 5px 8px;
+  background: rgba(6, 182, 212, 0.1);
+  border: 1px solid #0e7490;
+  border-radius: 4px;
+  color: #22d3ee;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.browseButton:hover {
+  background: rgba(6, 182, 212, 0.22);
+}
+
+.footerHint {
+  margin-top: 5px;
+}

--- a/frontend/src/components/Sidebar/TemplatesTab.test.tsx
+++ b/frontend/src/components/Sidebar/TemplatesTab.test.tsx
@@ -26,6 +26,7 @@ function ex(overrides: Partial<ExampleSummary> = {}): ExampleSummary {
     path: 'Usage_Example/Foo',
     node_count: 3,
     edge_count: 2,
+    source: 'builtin',
     ...overrides,
   };
 }

--- a/frontend/src/components/Sidebar/TemplatesTab.tsx
+++ b/frontend/src/components/Sidebar/TemplatesTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { listExamples, type ExampleSummary } from '../../api/rest';
 import { openExample } from '../../utils/openExample';
+import { useUIStore } from '../../store/uiStore';
 import { useI18n } from '../../i18n';
 import { EXAMPLE_CATEGORY_COLORS, EXAMPLE_CATEGORY_FALLBACK } from '../../styles/theme';
 import { RefreshIcon } from '../shared/Icons';
@@ -73,9 +74,11 @@ function ExampleItem({ example }: { example: ExampleSummary }) {
  * `GET /api/examples/list` (#126).
  *
  * Deliberately thumbnail-less: this is the always-available list view, and the
- * richer gallery is the empty-canvas overlay's job (and, later, #128's modal —
- * which should call the same `openExample` helper this does, so an example
- * opens the same way from every surface).
+ * richer gallery is the empty-canvas overlay's job — and core#128's modal,
+ * which the footer button below opens. Both call the same `openExample`
+ * helper this does, so an example opens the same way from every surface, and
+ * both group by category through `groupExamplesByCategory` (exported for
+ * exactly that reason) so the two never drift out of order.
  *
  * Examples are fetched per mount rather than cached in a store: the sidebar
  * only mounts this tab while it is the selected one, and the list changes
@@ -172,7 +175,17 @@ export function TemplatesTab() {
         )}
       </div>
 
-      <div className={styles.footer}>{t('templates.hint')}</div>
+      <div className={styles.footer}>
+        <button
+          type="button"
+          className={tabStyles.browseButton}
+          onClick={() => useUIStore.getState().openTemplateGallery()}
+          title={t('gallery.open.title')}
+        >
+          {t('gallery.browse')}
+        </button>
+        <div className={tabStyles.footerHint}>{t('templates.hint')}</div>
+      </div>
     </>
   );
 }

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.module.css
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.module.css
@@ -1,0 +1,384 @@
+/* TemplateGalleryModal.module.css — the always-reachable example browser
+   (core#128). Same Crafted-dark surface as the node detail modal (#127):
+   layered gradient panel, teal accent, monospace meta. */
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.68);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 3vh 3vw;
+}
+
+.modal {
+  width: 84vw;
+  max-width: 1180px;
+  height: 82vh;
+  min-width: 320px;
+  background: linear-gradient(180deg, #0e1520 0%, #0a0f17 100%);
+  border: 1px solid #1f2937;
+  border-radius: 10px;
+  box-shadow:
+    0 30px 70px -20px rgba(0, 0, 0, 0.8),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  outline: none;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────────── */
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  flex-shrink: 0;
+  background: rgba(10, 15, 23, 0.72);
+  border-bottom: 2px solid #06b6d4;
+}
+
+.titleBlock {
+  min-width: 0;
+}
+
+.title {
+  color: #e5e7eb;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.subtitle {
+  color: #64748b;
+  font-size: 0.6875rem;
+  margin-top: 2px;
+}
+
+.search {
+  margin-left: auto;
+  width: 240px;
+  max-width: 40%;
+  padding: 5px 9px;
+  background: #0a0f17;
+  border: 1px solid #334155;
+  border-radius: 5px;
+  color: #e5e7eb;
+  font-size: 0.8125rem;
+  outline: none;
+}
+
+.search:focus {
+  border-color: #06b6d4;
+}
+
+.closeBtn {
+  background: transparent;
+  border: 1px solid #334155;
+  color: #cbd5e1;
+  width: 26px;
+  height: 26px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  flex-shrink: 0;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.closeBtn:hover {
+  background: rgba(244, 67, 54, 0.14);
+  border-color: #f44336;
+  color: #ff7b72;
+}
+
+/* ── Body: card grid left, detail right ─────────────────────────────────── */
+
+.body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.grid {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 14px 16px 20px;
+}
+
+.stateMessage {
+  color: #64748b;
+  font-size: 0.8125rem;
+  padding: 28px 4px;
+  text-align: center;
+}
+
+.errorText {
+  color: #f44336;
+  margin-bottom: 10px;
+}
+
+.retryBtn {
+  font-size: 0.75rem;
+  padding: 4px 10px;
+  background: #1f2937;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  color: #cbd5e1;
+  cursor: pointer;
+}
+
+.retryBtn:hover {
+  border-color: #06b6d4;
+  color: #22d3ee;
+}
+
+.section {
+  margin-bottom: 18px;
+}
+
+.sectionTitle {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 0 8px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sectionDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.sectionCount {
+  color: #64748b;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 10px;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+  padding: 10px 12px;
+  text-align: left;
+  background: #131b26;
+  border: 1px solid #1f2937;
+  border-radius: 7px;
+  cursor: pointer;
+  color: inherit;
+  transition: border-color 0.12s, background 0.12s, box-shadow 0.12s;
+}
+
+.card:hover {
+  background: #16202d;
+  border-color: #334155;
+}
+
+.cardActive {
+  border-color: #06b6d4;
+  box-shadow: 0 0 0 1px rgba(6, 182, 212, 0.35);
+}
+
+.cardName {
+  color: #e5e7eb;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cardDesc {
+  color: #64748b;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  /* Two lines, then ellipsis — the detail pane carries the full text. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2em;
+}
+
+.cardFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.cardChip {
+  font-size: 0.5625rem;
+  border: 1px solid;
+  border-radius: 9px;
+  padding: 0 6px;
+  line-height: 1.6;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cardCount {
+  color: #475569;
+  font-size: 0.625rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: nowrap;
+}
+
+/* ── Detail pane ────────────────────────────────────────────────────────── */
+
+.detail {
+  width: 290px;
+  flex-shrink: 0;
+  border-left: 1px solid #1f2937;
+  background: rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+  padding: 16px 16px 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* The scrolling half. Keeping the overflow here rather than on `.detail`
+   is what pins the action buttons: however long the description, they stay
+   at the bottom of the pane instead of being pushed below the fold. */
+.detailScroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.detailEmpty {
+  color: #64748b;
+  font-size: 0.8125rem;
+}
+
+.detailName {
+  color: #e5e7eb;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.3;
+  word-break: break-word;
+}
+
+.detailMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  margin-top: 6px;
+  color: #64748b;
+  font-size: 0.6875rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.detailSource {
+  margin-top: 6px;
+  color: #475569;
+  font-size: 0.6875rem;
+}
+
+.detailDesc {
+  margin: 12px 0 0;
+  color: #94a3b8;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  word-break: break-word;
+}
+
+.detailActions {
+  flex-shrink: 0;
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid #1f2937;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.primaryBtn,
+.secondaryBtn {
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.primaryBtn {
+  background: rgba(6, 182, 212, 0.16);
+  border: 1px solid #06b6d4;
+  color: #22d3ee;
+}
+
+.primaryBtn:hover:not(:disabled) {
+  background: rgba(6, 182, 212, 0.28);
+}
+
+.secondaryBtn {
+  background: transparent;
+  border: 1px solid #334155;
+  color: #cbd5e1;
+}
+
+.secondaryBtn:hover:not(:disabled) {
+  border-color: #06b6d4;
+  color: #22d3ee;
+}
+
+.primaryBtn:disabled,
+.secondaryBtn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.detailHint {
+  color: #64748b;
+  font-size: 0.625rem;
+  line-height: 1.5;
+}
+
+/* Narrow viewports: the detail pane drops below the grid rather than
+   squeezing the cards to one column of unreadable width. */
+@media (max-width: 860px) {
+  .body {
+    flex-direction: column;
+  }
+
+  .detail {
+    width: auto;
+    border-left: none;
+    border-top: 1px solid #1f2937;
+    max-height: 42%;
+  }
+
+  .search {
+    width: 150px;
+  }
+}

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.test.tsx
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { TemplateGalleryModal, exampleSourceLabel } from './TemplateGalleryModal';
+import { useDialogStore } from '../../store/dialogStore';
 import { useNodeDefStore } from '../../store/nodeDefStore';
 import { useTabStore } from '../../store/tabStore';
 import { useToastStore } from '../../store/toastStore';
@@ -55,7 +56,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  useUIStore.setState({ templateGalleryOpen: false });
+  useUIStore.setState({ templateGalleryOpen: false, shortcutsModalOpen: false });
+  useDialogStore.setState({ active: null });
   vi.restoreAllMocks();
 });
 
@@ -189,9 +191,14 @@ describe('TemplateGalleryModal', () => {
 
     render(<TemplateGalleryModal />);
     await waitFor(() => expect(within(grid()).getByText('Template')).toBeInTheDocument());
-    fireEvent.doubleClick(within(grid()).getByText('Template'));
+    const card = within(grid()).getByText('Template');
+    // Two rapid double-clicks: the second must not start a second load, or
+    // the user gets two tabs (and one of them after the modal has closed).
+    fireEvent.doubleClick(card);
+    fireEvent.doubleClick(card);
 
     await waitFor(() => expect(store().tabs).toHaveLength(2));
+    expect(mockedRest.loadExample).toHaveBeenCalledTimes(1);
     expect(mockedRest.loadExample).toHaveBeenCalledWith('u/1');
   });
 
@@ -222,6 +229,28 @@ describe('TemplateGalleryModal', () => {
   it('closes on Escape', async () => {
     render(<TemplateGalleryModal />);
     await screen.findByText('No examples available');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useUIStore.getState().templateGalleryOpen).toBe(false);
+  });
+
+  it('leaves Escape alone while something is stacked above it', async () => {
+    render(<TemplateGalleryModal />);
+    await screen.findByText('No examples available');
+
+    // The shortcuts modal (`?`) renders over whatever is showing and has no
+    // Escape handler of its own — closing the gallery underneath it would
+    // dismiss the surface the user is NOT looking at.
+    useUIStore.setState({ shortcutsModalOpen: true });
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useUIStore.getState().templateGalleryOpen).toBe(true);
+    useUIStore.setState({ shortcutsModalOpen: false });
+
+    // Same for a confirm/prompt dialog.
+    useDialogStore.setState({ active: { kind: 'confirm', title: 'x' } as never });
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useUIStore.getState().templateGalleryOpen).toBe(true);
+    useDialogStore.setState({ active: null });
+
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(useUIStore.getState().templateGalleryOpen).toBe(false);
   });

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.test.tsx
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.test.tsx
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { TemplateGalleryModal, exampleSourceLabel } from './TemplateGalleryModal';
+import { useNodeDefStore } from '../../store/nodeDefStore';
+import { useTabStore } from '../../store/tabStore';
+import { useToastStore } from '../../store/toastStore';
+import { useUIStore } from '../../store/uiStore';
+import { useI18n } from '../../i18n';
+import * as rest from '../../api/rest';
+import type { ExampleSummary } from '../../api/rest';
+
+// Only the two network calls are stubbed. `openExampleInNewTab` and
+// `insertExample` run for real against the real tab store, so the two actions
+// are exercised end to end rather than asserted as "a function was called".
+vi.mock('../../api/rest', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/rest')>();
+  return { ...actual, listExamples: vi.fn(), loadExample: vi.fn() };
+});
+
+const mockedRest = vi.mocked(rest);
+const store = () => useTabStore.getState();
+const activeTab = () => useTabStore.getState().getActiveTab();
+
+function ex(overrides: Partial<ExampleSummary> = {}): ExampleSummary {
+  return {
+    name: 'Example',
+    description: 'short desc',
+    category: 'Usage_Example',
+    path: 'Usage_Example/Foo',
+    node_count: 3,
+    edge_count: 2,
+    source: 'builtin',
+    ...overrides,
+  };
+}
+
+function raw(id: string) {
+  return { id, type: 'Dropout', position: { x: 0, y: 0 }, data: { params: {} } };
+}
+
+/** The card list. Scoped because the detail pane repeats the chosen name. */
+const grid = () => screen.getByRole('region', { name: 'Template list' });
+const detail = () => screen.getByRole('complementary', { name: 'Template details' });
+
+beforeEach(() => {
+  useI18n.setState({ locale: 'en' });
+  useNodeDefStore.setState({ definitions: [], presets: [] });
+  useToastStore.setState({ toasts: [] });
+  useUIStore.setState({ templateGalleryOpen: true });
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  useTabStore.getState().addTab('Tab 1');
+  mockedRest.listExamples.mockReset();
+  mockedRest.loadExample.mockReset();
+  mockedRest.listExamples.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  useUIStore.setState({ templateGalleryOpen: false });
+  vi.restoreAllMocks();
+});
+
+describe('exampleSourceLabel', () => {
+  it('names the plugin pack, and nothing for a builtin', () => {
+    expect(exampleSourceLabel(ex({ source: 'plugin:c2' }))).toBe('c2');
+    expect(exampleSourceLabel(ex({ source: 'builtin' }))).toBeNull();
+  });
+});
+
+describe('TemplateGalleryModal', () => {
+  it('renders nothing while closed', () => {
+    useUIStore.setState({ templateGalleryOpen: false });
+    const { container } = render(<TemplateGalleryModal />);
+    expect(container.firstChild).toBeNull();
+    expect(mockedRest.listExamples).not.toHaveBeenCalled();
+  });
+
+  it('is reachable with a populated canvas and lists examples by category', async () => {
+    // The whole point of the modal: before it, a canvas with nodes on it had
+    // no way back to the examples at all.
+    store().setNodes([
+      { id: 'mine', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'A', type: 'K', params: {} } },
+    ] as never);
+    mockedRest.listExamples.mockResolvedValue([
+      ex({ name: 'ResNet', category: 'Model_Architecture', path: 'm/1' }),
+      ex({ name: 'Train CNN', category: 'Usage_Example', path: 'u/1', node_count: 7 }),
+    ]);
+
+    render(<TemplateGalleryModal />);
+    await screen.findByText('Train CNN');
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    // Category labels have their underscores replaced for display, and appear
+    // in the shared order (usage examples first, architectures last).
+    const listed = grid().textContent ?? '';
+    expect(listed.indexOf('Usage Example')).toBeLessThan(listed.indexOf('Model Architecture'));
+    expect(within(grid()).getByText('ResNet')).toBeInTheDocument();
+    // The canvas keeps its own graph while the gallery is up.
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['mine']);
+  });
+
+  it('shows the loading, empty, and error states', async () => {
+    render(<TemplateGalleryModal />);
+    expect(screen.getByText('Loading examples...')).toBeInTheDocument();
+    await screen.findByText('No examples available');
+  });
+
+  it('offers a retry after a failed list', async () => {
+    mockedRest.listExamples.mockRejectedValueOnce(new Error('server down'));
+    render(<TemplateGalleryModal />);
+    await screen.findByText('Failed to load examples: server down');
+
+    mockedRest.listExamples.mockResolvedValue([ex({ name: 'Back online' })]);
+    fireEvent.click(screen.getByText('Retry'));
+    await waitFor(() =>
+      expect(within(grid()).getByText('Back online')).toBeInTheDocument(),
+    );
+  });
+
+  it('filters by name, description, category and source pack', async () => {
+    mockedRest.listExamples.mockResolvedValue([
+      ex({ name: 'Train CNN', description: 'mnist digits', category: 'Usage_Example', path: 'u/1' }),
+      ex({ name: 'Sampler', description: 'toy denoiser', category: 'Diffusion', path: 'd/1', source: 'plugin:c4' }),
+    ]);
+    render(<TemplateGalleryModal />);
+    await waitFor(() => expect(within(grid()).getByText('Train CNN')).toBeInTheDocument());
+    const input = screen.getByPlaceholderText('Search templates...');
+
+    fireEvent.change(input, { target: { value: 'denoiser' } });
+    expect(within(grid()).getByText('Sampler')).toBeInTheDocument();
+    expect(within(grid()).queryByText('Train CNN')).toBeNull();
+
+    fireEvent.change(input, { target: { value: 'c4' } });
+    expect(within(grid()).getByText('Sampler')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: 'zzzz' } });
+    expect(screen.getByText('No matching examples')).toBeInTheDocument();
+  });
+
+  it('describes the first example until another is chosen', async () => {
+    mockedRest.listExamples.mockResolvedValue([
+      ex({ name: 'First', description: 'the first one', path: 'a', node_count: 4, edge_count: 3 }),
+      ex({ name: 'Second', description: 'the second one', path: 'b', source: 'plugin:c2' }),
+    ]);
+    render(<TemplateGalleryModal />);
+    await waitFor(() =>
+      expect(within(detail()).getByText('the first one')).toBeInTheDocument(),
+    );
+
+    expect(within(detail()).getByText('First')).toBeInTheDocument();
+    expect(within(detail()).getByText('4 nodes')).toBeInTheDocument();
+    expect(within(detail()).getByText('3 connections')).toBeInTheDocument();
+    expect(within(detail()).getByText('Built-in example')).toBeInTheDocument();
+
+    fireEvent.click(within(grid()).getByText('Second'));
+    expect(within(detail()).getByText('the second one')).toBeInTheDocument();
+    expect(within(detail()).getByText('From plugin pack "c2"')).toBeInTheDocument();
+  });
+
+  it('falls back to a placeholder for a template with no description', async () => {
+    mockedRest.listExamples.mockResolvedValue([ex({ name: 'Terse', description: '' })]);
+    render(<TemplateGalleryModal />);
+    await screen.findByText('This template ships no description.');
+    expect(within(grid()).getByText('Terse')).toBeInTheDocument();
+  });
+
+  it('opens the chosen template in a new tab, leaving the current graph alone', async () => {
+    store().setNodes([
+      { id: 'mine', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'A', type: 'K', params: {} } },
+    ] as never);
+    const firstTabId = store().activeTabId;
+    mockedRest.listExamples.mockResolvedValue([ex({ name: 'Template', path: 'u/1' })]);
+    mockedRest.loadExample.mockResolvedValue({ name: 'Template', nodes: [raw('a')], edges: [] });
+
+    render(<TemplateGalleryModal />);
+    await waitFor(() => expect(within(grid()).getByText('Template')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Open in new tab'));
+
+    await waitFor(() => expect(store().tabs).toHaveLength(2));
+    expect(mockedRest.loadExample).toHaveBeenCalledWith('u/1');
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['a']);
+    expect(store().getTab(firstTabId)!.nodes.map((n) => n.id)).toEqual(['mine']);
+    // The modal gets out of the way once it has done its job.
+    expect(useUIStore.getState().templateGalleryOpen).toBe(false);
+  });
+
+  it('double-clicking a card opens it in a new tab too', async () => {
+    mockedRest.listExamples.mockResolvedValue([ex({ name: 'Template', path: 'u/1' })]);
+    mockedRest.loadExample.mockResolvedValue({ nodes: [raw('a')], edges: [] });
+
+    render(<TemplateGalleryModal />);
+    await waitFor(() => expect(within(grid()).getByText('Template')).toBeInTheDocument());
+    fireEvent.doubleClick(within(grid()).getByText('Template'));
+
+    await waitFor(() => expect(store().tabs).toHaveLength(2));
+    expect(mockedRest.loadExample).toHaveBeenCalledWith('u/1');
+  });
+
+  it('inserts into the current canvas with remapped ids', async () => {
+    // Canvas and template share the id "a": inserting must not replace the
+    // user's node with the template's.
+    store().setNodes([
+      { id: 'a', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'MINE', type: 'K', params: {} } },
+    ] as never);
+    mockedRest.listExamples.mockResolvedValue([ex({ name: 'Template', path: 'u/1' })]);
+    mockedRest.loadExample.mockResolvedValue({
+      name: 'Template',
+      nodes: [raw('a'), raw('b')],
+      edges: [{ id: 'e1', source: 'a', target: 'b', sourceHandle: 'tensor', targetHandle: 'tensor' }],
+    });
+
+    render(<TemplateGalleryModal />);
+    await waitFor(() => expect(within(grid()).getByText('Template')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Insert into this canvas'));
+
+    await waitFor(() => expect(activeTab().nodes).toHaveLength(3));
+    expect(store().tabs).toHaveLength(1);
+    expect(activeTab().nodes.find((n) => n.id === 'a')!.data.label).toBe('MINE');
+    expect(new Set(activeTab().nodes.map((n) => n.id)).size).toBe(3);
+    expect(useUIStore.getState().templateGalleryOpen).toBe(false);
+  });
+
+  it('closes on Escape', async () => {
+    render(<TemplateGalleryModal />);
+    await screen.findByText('No examples available');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useUIStore.getState().templateGalleryOpen).toBe(false);
+  });
+
+  it('closes on a backdrop press but not on a press inside the surface', async () => {
+    render(<TemplateGalleryModal />);
+    await screen.findByText('No examples available');
+    const dialog = screen.getByRole('dialog');
+
+    fireEvent.mouseDown(dialog);
+    expect(useUIStore.getState().templateGalleryOpen).toBe(true);
+
+    fireEvent.mouseDown(dialog.parentElement!);
+    expect(useUIStore.getState().templateGalleryOpen).toBe(false);
+  });
+
+  it('closes on the close button', async () => {
+    render(<TemplateGalleryModal />);
+    await screen.findByText('No examples available');
+    fireEvent.click(screen.getByRole('button', { name: 'Close template gallery' }));
+    expect(useUIStore.getState().templateGalleryOpen).toBe(false);
+  });
+
+  it('says so when nothing is selectable', async () => {
+    render(<TemplateGalleryModal />);
+    await screen.findByText('No examples available');
+    expect(screen.getByText('Select a template to see what it contains')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.tsx
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.tsx
@@ -1,0 +1,296 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { listExamples, type ExampleSummary } from '../../api/rest';
+import { insertExample, openExampleInNewTab } from '../../utils/openExample';
+import { useUIStore } from '../../store/uiStore';
+import { useI18n } from '../../i18n';
+import { EXAMPLE_CATEGORY_COLORS, EXAMPLE_CATEGORY_FALLBACK } from '../../styles/theme';
+// The sidebar's Templates tab (#126) already owns the category order every
+// example surface is expected to share; importing it keeps the modal's grid
+// and the tab's list in the same sequence by construction rather than by
+// two copies of the same sort staying in step.
+import {
+  exampleCategoryLabel,
+  groupExamplesByCategory,
+} from '../Sidebar/TemplatesTab';
+import styles from './TemplateGalleryModal.module.css';
+
+/** Human-readable origin: a built-in example, or the pack that ships it. */
+export function exampleSourceLabel(example: ExampleSummary): string | null {
+  const source = example.source ?? '';
+  if (source.startsWith('plugin:')) return source.slice('plugin:'.length);
+  return null;
+}
+
+function matches(example: ExampleSummary, query: string): boolean {
+  return (
+    example.name.toLowerCase().includes(query) ||
+    example.description.toLowerCase().includes(query) ||
+    example.category.toLowerCase().includes(query) ||
+    (example.source ?? '').toLowerCase().includes(query)
+  );
+}
+
+/**
+ * The full example browser (core#128).
+ *
+ * Reachable at any time — toolbar, sidebar Templates tab, empty-canvas
+ * overlay — which is the whole point: before this, the ~30 shipped examples
+ * were visible only on an empty canvas, so the moment you had a graph they
+ * became unreachable.
+ *
+ * Two ways to take one: open it in a NEW tab (leaving the current graph
+ * alone), or insert it into the CURRENT canvas, which remaps every incoming
+ * id and drops the block clear of what is already there.
+ *
+ * Mounted once at the app root and driven by `uiStore.templateGalleryOpen`.
+ */
+export function TemplateGalleryModal() {
+  const open = useUIStore((s) => s.templateGalleryOpen);
+  if (!open) return null;
+  return <TemplateGalleryBody />;
+}
+
+function TemplateGalleryBody() {
+  const close = useUIStore((s) => s.closeTemplateGallery);
+  const { t } = useI18n();
+
+  const [examples, setExamples] = useState<ExampleSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [chosenPath, setChosenPath] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    listExamples()
+      .then(setExamples)
+      .catch((e: Error) => {
+        setExamples([]);
+        setError(e.message);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Take focus so Escape lands here and the page behind the backdrop cannot
+  // be tabbed into blind; hand it back on close, the way the node detail
+  // modal (#127) does.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const timer = setTimeout(() => surfaceRef.current?.focus(), 0);
+    return () => {
+      clearTimeout(timer);
+      if (previouslyFocused && previouslyFocused.isConnected) {
+        previouslyFocused.focus();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [close]);
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return q ? examples.filter((e) => matches(e, q)) : examples;
+  }, [examples, query]);
+
+  const groups = useMemo(() => groupExamplesByCategory(visible), [visible]);
+
+  // The detail pane always describes something as long as anything is
+  // listed: a search that filters the chosen example away falls back to the
+  // first remaining one rather than emptying the pane.
+  const chosen =
+    visible.find((e) => e.path === chosenPath) ?? visible[0] ?? null;
+
+  const take = useCallback(
+    async (run: () => Promise<boolean>) => {
+      setBusy(true);
+      try {
+        // Closing regardless of outcome: a failure has already surfaced its
+        // own toast, and leaving the modal up over it just hides the message.
+        await run();
+      } finally {
+        setBusy(false);
+        close();
+      }
+    },
+    [close],
+  );
+
+  const openInNewTab = useCallback(
+    (path: string) => void take(() => openExampleInNewTab(path)),
+    [take],
+  );
+
+  return createPortal(
+    <div
+      className={styles.backdrop}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+    >
+      <div
+        ref={surfaceRef}
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('gallery.title')}
+        tabIndex={-1}
+      >
+        <div className={styles.header}>
+          <div className={styles.titleBlock}>
+            <div className={styles.title}>{t('gallery.title')}</div>
+            <div className={styles.subtitle}>{t('gallery.subtitle')}</div>
+          </div>
+          <input
+            type="search"
+            className={styles.search}
+            placeholder={t('gallery.search')}
+            aria-label={t('gallery.search')}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <button
+            type="button"
+            className={styles.closeBtn}
+            onClick={close}
+            title={t('gallery.close')}
+            aria-label={t('gallery.close')}
+          >
+            &#215;
+          </button>
+        </div>
+
+        <div className={styles.body}>
+          {/* A named <section> so the card list is one addressable region,
+              distinct from the detail pane that repeats the chosen name. */}
+          <section className={styles.grid} aria-label={t('gallery.list')}>
+            {loading && <div className={styles.stateMessage}>{t('templates.loading')}</div>}
+
+            {!loading && error && (
+              <div className={styles.stateMessage}>
+                <div className={styles.errorText}>
+                  {t('templates.loadFail', { error })}
+                </div>
+                <button type="button" className={styles.retryBtn} onClick={load}>
+                  {t('palette.retry')}
+                </button>
+              </div>
+            )}
+
+            {!loading && !error && groups.length === 0 && (
+              <div className={styles.stateMessage}>
+                {query ? t('templates.noMatch') : t('templates.empty')}
+              </div>
+            )}
+
+            {!loading && !error &&
+              groups.map(({ category, items }) => {
+                const color =
+                  EXAMPLE_CATEGORY_COLORS[category] ?? EXAMPLE_CATEGORY_FALLBACK;
+                return (
+                  <section key={category} className={styles.section}>
+                    <h3 className={styles.sectionTitle} style={{ color }}>
+                      <span className={styles.sectionDot} style={{ background: color }} />
+                      {exampleCategoryLabel(category)}
+                      <span className={styles.sectionCount}>{items.length}</span>
+                    </h3>
+                    <div className={styles.cards}>
+                      {items.map((example) => (
+                        <button
+                          key={example.path}
+                          type="button"
+                          className={`${styles.card} ${
+                            chosen?.path === example.path ? styles.cardActive : ''
+                          }`}
+                          aria-pressed={chosen?.path === example.path}
+                          onClick={() => setChosenPath(example.path)}
+                          onDoubleClick={() => openInNewTab(example.path)}
+                        >
+                          <span className={styles.cardName}>{example.name}</span>
+                          <span className={styles.cardDesc}>{example.description}</span>
+                          <span className={styles.cardFooter}>
+                            <span
+                              className={styles.cardChip}
+                              style={{ color, borderColor: color }}
+                            >
+                              {exampleCategoryLabel(category)}
+                            </span>
+                            <span className={styles.cardCount}>
+                              {t('empty.nodeCount', { count: example.node_count })}
+                            </span>
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </section>
+                );
+              })}
+          </section>
+
+          <aside className={styles.detail} aria-label={t('gallery.detail')}>
+            {chosen === null ? (
+              <div className={styles.detailEmpty}>{t('gallery.detailEmpty')}</div>
+            ) : (
+              <>
+                {/* Only the prose scrolls. The actions below stay pinned, so a
+                    long description can never push "Open in new tab" out of
+                    reach on a short window. */}
+                <div className={styles.detailScroll}>
+                  <div className={styles.detailName}>{chosen.name}</div>
+                  <div className={styles.detailMeta}>
+                    <span>{exampleCategoryLabel(chosen.category)}</span>
+                    <span>{t('empty.nodeCount', { count: chosen.node_count })}</span>
+                    <span>{t('gallery.edgeCount', { count: chosen.edge_count })}</span>
+                  </div>
+                  <div className={styles.detailSource}>
+                    {exampleSourceLabel(chosen)
+                      ? t('gallery.sourcePlugin', { plugin: exampleSourceLabel(chosen)! })
+                      : t('gallery.sourceBuiltin')}
+                  </div>
+                  <p className={styles.detailDesc}>
+                    {chosen.description || t('gallery.noDescription')}
+                  </p>
+                </div>
+                <div className={styles.detailActions}>
+                  <button
+                    type="button"
+                    className={styles.primaryBtn}
+                    disabled={busy}
+                    onClick={() => openInNewTab(chosen.path)}
+                  >
+                    {t('gallery.openNewTab')}
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.secondaryBtn}
+                    disabled={busy}
+                    onClick={() => void take(() => insertExample(chosen.path))}
+                  >
+                    {t('gallery.insert')}
+                  </button>
+                  <div className={styles.detailHint}>{t('gallery.insertHint')}</div>
+                </div>
+              </>
+            )}
+          </aside>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.tsx
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { listExamples, type ExampleSummary } from '../../api/rest';
 import { insertExample, openExampleInNewTab } from '../../utils/openExample';
+import { useDialogStore } from '../../store/dialogStore';
 import { useUIStore } from '../../store/uiStore';
 import { useI18n } from '../../i18n';
 import { EXAMPLE_CATEGORY_COLORS, EXAMPLE_CATEGORY_FALLBACK } from '../../styles/theme';
@@ -79,9 +80,12 @@ function TemplateGalleryBody() {
     load();
   }, [load]);
 
-  // Take focus so Escape lands here and the page behind the backdrop cannot
-  // be tabbed into blind; hand it back on close, the way the node detail
-  // modal (#127) does.
+  // Move focus onto the surface so the keyboard starts inside the modal
+  // rather than wherever it was on the page behind, and hand it back on
+  // close — the way the node detail modal (#127) does. This is NOT a focus
+  // trap: Tab can still walk out into the page underneath. Left that way on
+  // purpose, so the two modals behave identically; trapping is worth doing,
+  // but as one change to both rather than a divergence here.
   useEffect(() => {
     const previouslyFocused = document.activeElement as HTMLElement | null;
     const timer = setTimeout(() => surfaceRef.current?.focus(), 0);
@@ -96,6 +100,13 @@ function TemplateGalleryBody() {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
+      // Something can sit ON TOP of the gallery — a confirm/prompt dialog, or
+      // the shortcuts modal, which `?` opens over whatever is showing and
+      // which has no Escape handler of its own. Closing the surface
+      // UNDERNEATH the one the user is looking at is the bug this guards.
+      // Same check `useKeyboardShortcuts` makes before answering Enter.
+      if (useDialogStore.getState().active !== null) return;
+      if (useUIStore.getState().shortcutsModalOpen) return;
       e.preventDefault();
       close();
     };
@@ -131,9 +142,15 @@ function TemplateGalleryBody() {
     [close],
   );
 
+  // `busy` gates this as well as the detail buttons: a double-click lands two
+  // events, and the second must not start a second load (two tabs, or a tab
+  // opened after the modal has already closed).
   const openInNewTab = useCallback(
-    (path: string) => void take(() => openExampleInNewTab(path)),
-    [take],
+    (path: string) => {
+      if (busy) return;
+      void take(() => openExampleInNewTab(path));
+    },
+    [busy, take],
   );
 
   return createPortal(

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -579,6 +579,13 @@ export function Toolbar() {
       {/* Node management */}
       <div className={styles.cluster}>
         <button type="button"
+          onClick={() => useUIStore.getState().openTemplateGallery()}
+          title={t('gallery.open.title')}
+          className={`${styles.ghost} ${styles.ghostMuted}`}
+        >
+          {t('gallery.open')}
+        </button>
+        <button type="button"
           onClick={handleReloadNodes}
           title={t('toolbar.reloadNodes.title')}
           className={`${styles.ghost} ${styles.ghostMuted}`}

--- a/frontend/src/components/shared/ShortcutsModal.test.tsx
+++ b/frontend/src/components/shared/ShortcutsModal.test.tsx
@@ -23,19 +23,27 @@ describe('ShortcutsModal', () => {
     useUIStore.setState({ shortcutsModalOpen: true });
     render(<ShortcutsModal />);
     expect(screen.getByText(useI18n.getState().t('shortcuts.title'))).toBeTruthy();
-    // 9 shortcut rows → 9 <kbd> elements.
-    expect(document.querySelectorAll('kbd').length).toBe(9);
+    // 11 shortcut rows → 11 <kbd> elements. (core#128 added the bypass row
+    // and the unconditional sidebar chord alongside the context-sensitive one.)
+    expect(document.querySelectorAll('kbd').length).toBe(11);
     // A platform-prefixed combo is present (Cmd+Z or Ctrl+Z).
     expect(screen.getByText(/(Cmd|Ctrl)\+Z$/)).toBeTruthy();
     expect(screen.getByText('Delete')).toBeTruthy();
     expect(screen.getByText('?')).toBeTruthy();
   });
 
-  it('lists the sidebar toggle (#126) with its platform modifier', () => {
+  it('spells out both halves of the context-sensitive mod+B (core#128)', () => {
     useUIStore.setState({ shortcutsModalOpen: true });
     render(<ShortcutsModal />);
-    expect(screen.getByText(/(Cmd|Ctrl)\+B$/)).toBeTruthy();
-    expect(screen.getByText(useI18n.getState().t('shortcuts.toggleSidebar'))).toBeTruthy();
+    const { t } = useI18n.getState();
+    // Two rows share the chord — bypass when a node is selected, sidebar
+    // otherwise — so the modal has to name both rather than pick one.
+    expect(screen.getAllByText(/(Cmd|Ctrl)\+B$/)).toHaveLength(2);
+    expect(screen.getByText(t('shortcuts.bypass'))).toBeTruthy();
+    expect(screen.getByText(t('shortcuts.toggleSidebar'))).toBeTruthy();
+    // ...plus the unconditional sidebar chord.
+    expect(screen.getByText(/(Cmd|Ctrl)\+Shift\+B$/)).toBeTruthy();
+    expect(screen.getByText(t('shortcuts.toggleSidebarAlways'))).toBeTruthy();
   });
 
   it('clicking the overlay toggles (closes) the modal', () => {

--- a/frontend/src/components/shared/ShortcutsModal.tsx
+++ b/frontend/src/components/shared/ShortcutsModal.tsx
@@ -17,7 +17,12 @@ export function ShortcutsModal() {
     { keys: `${mod}+C`, action: t('shortcuts.copy') },
     { keys: `${mod}+V`, action: t('shortcuts.paste') },
     { keys: 'Delete', action: t('shortcuts.delete') },
+    // Ctrl+B is context-sensitive (core#128), so both halves are listed —
+    // and the unconditional sidebar chord right after them, because a user
+    // who only ever wanted the sidebar needs to know it still exists.
+    { keys: `${mod}+B`, action: t('shortcuts.bypass') },
     { keys: `${mod}+B`, action: t('shortcuts.toggleSidebar') },
+    { keys: `${mod}+Shift+B`, action: t('shortcuts.toggleSidebarAlways') },
     { keys: t('shortcuts.doubleClickKey'), action: t('shortcuts.quickSearch') },
     { keys: '?', action: t('shortcuts.help') },
   ];

--- a/frontend/src/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.test.ts
@@ -18,6 +18,7 @@ let pasteNodes: ReturnType<typeof vi.fn>;
 let applyLayout: ReturnType<typeof vi.fn>;
 let toggleShortcutsModal: ReturnType<typeof vi.fn>;
 let toggleSidebarCollapsed: ReturnType<typeof vi.fn>;
+let toggleBypassForSelection: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   undo = vi.fn();
@@ -27,9 +28,14 @@ beforeEach(() => {
   applyLayout = vi.fn();
   toggleShortcutsModal = vi.fn();
   toggleSidebarCollapsed = vi.fn();
+  // Defaults to "nothing bypassable was selected", so mod+B falls through to
+  // the sidebar unless a test says otherwise (core#128).
+  toggleBypassForSelection = vi.fn().mockReturnValue(false);
 
   // Override only the actions exercised here; leave the rest of the store intact.
-  useTabStore.setState({ undo, redo, copySelectedNodes, pasteNodes, applyLayout } as any);
+  useTabStore.setState({
+    undo, redo, copySelectedNodes, pasteNodes, applyLayout, toggleBypassForSelection,
+  } as any);
   useUIStore.setState({
     toggleShortcutsModal,
     toggleSidebarCollapsed,
@@ -129,23 +135,49 @@ describe('useKeyboardShortcuts', () => {
     expect(saveActiveGraph).not.toHaveBeenCalled();
   });
 
-  it('Ctrl+B toggles the sidebar and prevents default', () => {
+  // ── mod+B, the contested chord (core#128) ──
+  //
+  // #126 gave Ctrl+B to the sidebar; ComfyUI users reach for it to bypass a
+  // node. It is now context-sensitive: bypass when the selection has one,
+  // sidebar when it does not, with Ctrl+Shift+B as the unconditional sidebar
+  // toggle. `toggleBypassForSelection`'s return value is the switch.
+
+  it('Ctrl+B toggles the sidebar when nothing bypassable is selected', () => {
     renderHook(() => useKeyboardShortcuts());
     const e = dispatchKey({ key: 'b', ctrlKey: true });
+    expect(toggleBypassForSelection).toHaveBeenCalledTimes(1);
     expect(toggleSidebarCollapsed).toHaveBeenCalledTimes(1);
     expect(e.defaultPrevented).toBe(true);
   });
 
-  it('Cmd+B (metaKey) also toggles the sidebar', () => {
+  it('Cmd+B (metaKey) behaves the same way', () => {
     renderHook(() => useKeyboardShortcuts());
     dispatchKey({ key: 'b', metaKey: true });
     expect(toggleSidebarCollapsed).toHaveBeenCalledTimes(1);
   });
 
-  it('Ctrl+Shift+B does not toggle the sidebar (shiftKey excluded)', () => {
+  it('Ctrl+B bypasses instead of touching the sidebar when a node is selected', () => {
+    toggleBypassForSelection.mockReturnValue(true);
     renderHook(() => useKeyboardShortcuts());
-    dispatchKey({ key: 'b', ctrlKey: true, shiftKey: true });
+    const e = dispatchKey({ key: 'b', ctrlKey: true });
+    expect(toggleBypassForSelection).toHaveBeenCalledTimes(1);
     expect(toggleSidebarCollapsed).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it('Ctrl+Shift+B always toggles the sidebar, selection or not', () => {
+    toggleBypassForSelection.mockReturnValue(true);
+    renderHook(() => useKeyboardShortcuts());
+    const e = dispatchKey({ key: 'b', ctrlKey: true, shiftKey: true });
+    expect(toggleSidebarCollapsed).toHaveBeenCalledTimes(1);
+    expect(toggleBypassForSelection).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it('Ctrl+Shift+B matches an uppercase key value too', () => {
+    renderHook(() => useKeyboardShortcuts());
+    dispatchKey({ key: 'B', ctrlKey: true, shiftKey: true });
+    expect(toggleSidebarCollapsed).toHaveBeenCalledTimes(1);
   });
 
   it('Ctrl+B is ignored while typing in an input', () => {

--- a/frontend/src/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.test.ts
@@ -180,6 +180,14 @@ describe('useKeyboardShortcuts', () => {
     expect(toggleSidebarCollapsed).toHaveBeenCalledTimes(1);
   });
 
+  it('plain Ctrl+B survives Caps Lock (uppercase key, shiftKey false)', () => {
+    toggleBypassForSelection.mockReturnValue(true);
+    renderHook(() => useKeyboardShortcuts());
+    dispatchKey({ key: 'B', ctrlKey: true });
+    expect(toggleBypassForSelection).toHaveBeenCalledTimes(1);
+    expect(toggleSidebarCollapsed).not.toHaveBeenCalled();
+  });
+
   it('Ctrl+B is ignored while typing in an input', () => {
     renderHook(() => useKeyboardShortcuts());
     const input = document.createElement('input');

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -70,10 +70,36 @@ export function useKeyboardShortcuts() {
         return;
       }
 
-      // Ctrl+B / Cmd+B — Collapse/expand the left sidebar to its icon rail
-      // (#126). Shift excluded so future Ctrl+Shift+B combinations stay free.
+      // Ctrl+Shift+B / Cmd+Shift+B — Collapse/expand the left sidebar,
+      // unconditionally. See the note on Ctrl+B below for why this exists.
+      if (mod && e.shiftKey && e.key.toLowerCase() === 'b') {
+        e.preventDefault();
+        useUIStore.getState().toggleSidebarCollapsed();
+        return;
+      }
+
+      // Ctrl+B / Cmd+B — CONTEXT-SENSITIVE (core#128).
+      //
+      // Two features want this chord. #126 gave it to the sidebar (VS Code's
+      // binding); ComfyUI — which is where anyone reaching for "mute this
+      // node" learned the gesture — gives it to bypass, and every graph
+      // editor this one is measured against agrees. Neither could simply be
+      // moved without breaking the muscle memory it was chosen for.
+      //
+      // Resolution: the selection decides. With a bypassable node selected
+      // the canvas has the keyboard's attention and Ctrl+B means bypass;
+      // with nothing selected there is no bypass to perform and it means the
+      // sidebar, exactly as before. `toggleBypassForSelection` returning
+      // false is what makes that fall-through total — a selection of only
+      // notes / Start / preset nodes lands on the sidebar rather than doing
+      // nothing at all.
+      //
+      // Ctrl+Shift+B (handled above) is the unconditional sidebar toggle, so
+      // there is always a chord that does the sidebar regardless of what is
+      // selected. Both are listed in the shortcuts modal.
       if (mod && !e.shiftKey && e.key === 'b') {
         e.preventDefault();
+        if (useTabStore.getState().toggleBypassForSelection()) return;
         useUIStore.getState().toggleSidebarCollapsed();
         return;
       }

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -97,7 +97,9 @@ export function useKeyboardShortcuts() {
       // Ctrl+Shift+B (handled above) is the unconditional sidebar toggle, so
       // there is always a chord that does the sidebar regardless of what is
       // selected. Both are listed in the shortcuts modal.
-      if (mod && !e.shiftKey && e.key === 'b') {
+      // `toLowerCase` because Caps Lock alone reports 'B' with shiftKey
+      // false — without it the chord silently stops working.
+      if (mod && !e.shiftKey && e.key.toLowerCase() === 'b') {
         e.preventDefault();
         if (useTabStore.getState().toggleBypassForSelection()) return;
         useUIStore.getState().toggleSidebarCollapsed();

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -101,6 +101,28 @@ const en = {
   'templates.noMatch': 'No matching examples',
   'templates.hint': 'Click an example to open it',
 
+  // Template gallery modal (core#128)
+  'gallery.open': 'Templates',
+  // Used where the word "Templates" is already on screen as a heading (the
+  // sidebar tab, the empty-canvas overlay), so the two never read as the same
+  // control.
+  'gallery.browse': 'Browse all templates',
+  'gallery.open.title': 'Browse every built-in and plugin example',
+  'gallery.title': 'Template Gallery',
+  'gallery.subtitle': 'Open one in a new tab, or insert it into this canvas',
+  'gallery.search': 'Search templates...',
+  'gallery.close': 'Close template gallery',
+  'gallery.list': 'Template list',
+  'gallery.detail': 'Template details',
+  'gallery.detailEmpty': 'Select a template to see what it contains',
+  'gallery.noDescription': 'This template ships no description.',
+  'gallery.edgeCount': '{count} connections',
+  'gallery.sourceBuiltin': 'Built-in example',
+  'gallery.sourcePlugin': 'From plugin pack "{plugin}"',
+  'gallery.openNewTab': 'Open in new tab',
+  'gallery.insert': 'Insert into this canvas',
+  'gallery.insertHint': 'Inserted nodes get fresh ids and are placed below your current graph, so nothing is overwritten. One undo removes them.',
+
   // Sidebar: Custom & Plugins tab (#126)
   'customTab.section.nodes': 'Custom Nodes',
   'customTab.section.plugins': 'Plugins',
@@ -128,6 +150,8 @@ const en = {
   'node.completed': 'Completed',
   'node.cached': 'Cached',
   'node.error': 'Error: {error}',
+  'node.bypassed': 'BYPASS',
+  'node.bypassed.title': 'Bypassed: this node is skipped and passes its input straight through',
 
   // Results Panel
   'results.title': 'Execution Log',
@@ -164,6 +188,8 @@ const en = {
   'contextMenu.rename.prompt': 'Enter a new name for this node:',
   'contextMenu.addTextNote': 'Add Text Note',
   'contextMenu.addImageNote': 'Add Image Note',
+  'contextMenu.bypass': 'Bypass',
+  'contextMenu.unbypass': 'Remove Bypass',
 
   // Notes
   'note.placeholder': 'Click to edit...',
@@ -274,7 +300,9 @@ const en = {
   'shortcuts.copy': 'Copy selected nodes',
   'shortcuts.paste': 'Paste nodes',
   'shortcuts.delete': 'Delete selected',
-  'shortcuts.toggleSidebar': 'Collapse / expand sidebar',
+  'shortcuts.bypass': 'Bypass / un-bypass the selected node(s)',
+  'shortcuts.toggleSidebar': 'Collapse / expand sidebar (when no node is selected)',
+  'shortcuts.toggleSidebarAlways': 'Collapse / expand sidebar (always)',
   'shortcuts.quickSearch': 'Quick node search',
   'shortcuts.help': 'Show this help',
   'shortcuts.doubleClickKey': 'Double-click',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -103,6 +103,25 @@ const zhTW: Record<TranslationKey, string> = {
   'templates.noMatch': '找不到符合的範例',
   'templates.hint': '點選範例即可開啟',
 
+  // 範例圖庫彈窗 (core#128)
+  'gallery.open': '範例圖庫',
+  'gallery.browse': '瀏覽全部範例',
+  'gallery.open.title': '瀏覽所有內建與外掛提供的範例',
+  'gallery.title': '範例圖庫',
+  'gallery.subtitle': '可以開在新分頁，或直接插入目前的畫布',
+  'gallery.search': '搜尋範例...',
+  'gallery.close': '關閉範例圖庫',
+  'gallery.list': '範例清單',
+  'gallery.detail': '範例詳情',
+  'gallery.detailEmpty': '選一個範例來看它的內容',
+  'gallery.noDescription': '這個範例沒有附說明文字。',
+  'gallery.edgeCount': '{count} 條連線',
+  'gallery.sourceBuiltin': '內建範例',
+  'gallery.sourcePlugin': '來自外掛套件「{plugin}」',
+  'gallery.openNewTab': '在新分頁開啟',
+  'gallery.insert': '插入目前畫布',
+  'gallery.insertHint': '插入的節點會拿到全新的 id，並放在目前圖表的下方，不會覆蓋既有內容。按一次復原就能整批移除。',
+
   // Sidebar: Custom & Plugins tab (#126)
   'customTab.section.nodes': '自訂節點',
   'customTab.section.plugins': '外掛',
@@ -130,6 +149,8 @@ const zhTW: Record<TranslationKey, string> = {
   'node.completed': '已完成',
   'node.cached': '已快取',
   'node.error': '錯誤：{error}',
+  'node.bypassed': '略過',
+  'node.bypassed.title': '已略過：這個節點不會執行，輸入會直接傳給下游',
 
   // Results Panel
   'results.title': '執行紀錄',
@@ -166,6 +187,8 @@ const zhTW: Record<TranslationKey, string> = {
   'contextMenu.rename.prompt': '請輸入節點的新名稱：',
   'contextMenu.addTextNote': '新增文字註記',
   'contextMenu.addImageNote': '新增圖片註記',
+  'contextMenu.bypass': '略過這個節點',
+  'contextMenu.unbypass': '取消略過',
 
   // Notes
   'note.placeholder': '點擊以編輯...',
@@ -276,7 +299,9 @@ const zhTW: Record<TranslationKey, string> = {
   'shortcuts.copy': '複製選取的節點',
   'shortcuts.paste': '貼上節點',
   'shortcuts.delete': '刪除選取項目',
-  'shortcuts.toggleSidebar': '收合／展開側邊欄',
+  'shortcuts.bypass': '略過／取消略過選取的節點',
+  'shortcuts.toggleSidebar': '收合／展開側邊欄（沒有選取節點時）',
+  'shortcuts.toggleSidebarAlways': '收合／展開側邊欄（永遠有效）',
   'shortcuts.quickSearch': '快速搜尋節點',
   'shortcuts.help': '顯示此說明',
   'shortcuts.doubleClickKey': '雙擊',

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -2229,3 +2229,63 @@ describe('insertGraph', () => {
     expect(inserted.data.error).toBeUndefined();
   });
 });
+
+
+describe('bypass — graph I/O contract nodes (core#128 review)', () => {
+  beforeEach(resetToSingleTab);
+
+  it('toggleNodeBypass refuses GraphInput and GraphOutput', () => {
+    store().setNodes([
+      bnode('gi', { data: { label: 'gi', type: 'GraphInput', params: {} } }),
+      bnode('go', { data: { label: 'go', type: 'GraphOutput', params: {} } }),
+    ]);
+    store().toggleNodeBypass('gi');
+    store().toggleNodeBypass('go');
+    expect(activeTab().nodes.every((n) => n.data.bypassed === undefined)).toBe(true);
+  });
+
+  it('toggleBypassForSelection skips them and falls through', () => {
+    store().setNodes([
+      bnode('go', { selected: true, data: { label: 'go', type: 'GraphOutput', params: {} } }),
+    ]);
+    // false is what lets Ctrl+B reach the sidebar instead of doing nothing.
+    expect(store().toggleBypassForSelection()).toBe(false);
+    expect(activeTab().nodes[0].data.bypassed).toBeUndefined();
+  });
+
+  it('still bypasses an ordinary node sharing the selection with a contract node', () => {
+    store().setNodes([
+      bnode('go', { selected: true, data: { label: 'go', type: 'GraphOutput', params: {} } }),
+      bnode('drop', { selected: true }),
+    ]);
+    expect(store().toggleBypassForSelection()).toBe(true);
+    const byId = Object.fromEntries(activeTab().nodes.map((n) => [n.id, n.data.bypassed]));
+    expect(byId).toEqual({ go: undefined, drop: true });
+  });
+});
+
+
+describe('insertGraph — viewport fit (core#128 review)', () => {
+  beforeEach(() => {
+    resetToSingleTab();
+    useUIStore.setState({ layoutFitRequest: null });
+  });
+
+  it('asks the canvas to fit the inserted block, not the whole graph', () => {
+    // Without this, a template dropped below a graph the user has panned
+    // away from lands entirely off-screen and the insert looks like a no-op.
+    store().setNodes([bnode('n1', { position: { x: 0, y: 0 } })]);
+    store().insertGraph([bnode('t1', { position: { x: 900, y: 900 } })], []);
+
+    const request = useUIStore.getState().layoutFitRequest;
+    expect(request).not.toBeNull();
+    const inserted = activeTab().nodes.find((n) => n.selected)!;
+    expect(request!.bounds.x).toBe(inserted.position.x);
+    expect(request!.bounds.y).toBe(inserted.position.y);
+  });
+
+  it('does not request a fit for an empty template', () => {
+    store().insertGraph([], []);
+    expect(useUIStore.getState().layoutFitRequest).toBeNull();
+  });
+});

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -1993,3 +1993,239 @@ describe('persistence (module reload)', () => {
     }
   });
 });
+
+
+// ── Bypass (core#128) ────────────────────────────────────────────────────────
+
+/** A canvas node, defaulting to the plain (bypassable) card type. */
+function bnode(id: string, over: Record<string, any> = {}) {
+  const { data, ...rest } = over;
+  return {
+    id,
+    type: 'baseNode',
+    position: { x: 0, y: 0 },
+    selected: false,
+    data: { label: id, type: 'Dropout', params: {}, ...data },
+    ...rest,
+  } as any;
+}
+
+describe('bypass', () => {
+  beforeEach(resetToSingleTab);
+
+  it('toggleNodeBypass flips the flag and back again', () => {
+    store().setNodes([bnode('n1')]);
+    store().toggleNodeBypass('n1');
+    expect(activeTab().nodes[0].data.bypassed).toBe(true);
+    store().toggleNodeBypass('n1');
+    expect(activeTab().nodes[0].data.bypassed).toBe(false);
+  });
+
+  it('toggleNodeBypass is one undo step', () => {
+    store().setNodes([bnode('n1')]);
+    store().toggleNodeBypass('n1');
+    store().undo();
+    expect(activeTab().nodes[0].data.bypassed).toBeUndefined();
+  });
+
+  it('toggleNodeBypass marks the node dirty so the next run redoes downstream', () => {
+    store().setNodes([bnode('n1')]);
+    store().setEdges([{ id: 'e1', source: 'n1', target: 'n2' }] as any);
+    store().toggleNodeBypass('n1');
+    // n1 itself is filtered out of the hint once muted; its consumer is not.
+    expect(store().getDirtyWithDownstream()).toEqual(['n2']);
+  });
+
+  it('toggleNodeBypass refuses notes, Start nodes and presets', () => {
+    store().setNodes([
+      bnode('note', { type: 'noteNode' }),
+      bnode('start', { type: 'start' }),
+      bnode('preset', { type: 'presetNode' }),
+    ]);
+    for (const id of ['note', 'start', 'preset']) store().toggleNodeBypass(id);
+    expect(activeTab().nodes.every((n) => n.data.bypassed === undefined)).toBe(true);
+  });
+
+  it('toggleNodeBypass ignores an id that is not on the canvas', () => {
+    store().setNodes([bnode('n1')]);
+    store().toggleNodeBypass('ghost');
+    expect(activeTab().nodes[0].data.bypassed).toBeUndefined();
+  });
+
+  it('toggleBypassForSelection mutes every selected node and reports true', () => {
+    store().setNodes([
+      bnode('n1', { selected: true }),
+      bnode('n2', { selected: true }),
+      bnode('n3'),
+    ]);
+    expect(store().toggleBypassForSelection()).toBe(true);
+    const byId = Object.fromEntries(activeTab().nodes.map((n) => [n.id, n.data.bypassed]));
+    expect(byId).toEqual({ n1: true, n2: true, n3: undefined });
+  });
+
+  it('toggleBypassForSelection makes a mixed selection uniformly bypassed', () => {
+    store().setNodes([
+      bnode('n1', { selected: true, data: { bypassed: true } }),
+      bnode('n2', { selected: true }),
+    ]);
+    store().toggleBypassForSelection();
+    expect(activeTab().nodes.map((n) => n.data.bypassed)).toEqual([true, true]);
+    // A second press now un-mutes the whole (uniform) selection.
+    store().toggleBypassForSelection();
+    expect(activeTab().nodes.map((n) => n.data.bypassed)).toEqual([false, false]);
+  });
+
+  it('toggleBypassForSelection falls back to selectedNodeId when nothing is flagged', () => {
+    store().setNodes([bnode('n1'), bnode('n2')]);
+    store().setSelectedNodeId('n2');
+    expect(store().toggleBypassForSelection()).toBe(true);
+    expect(activeTab().nodes.map((n) => n.data.bypassed)).toEqual([undefined, true]);
+  });
+
+  it('toggleBypassForSelection reports false with nothing selected', () => {
+    store().setNodes([bnode('n1')]);
+    expect(store().toggleBypassForSelection()).toBe(false);
+    expect(activeTab().nodes[0].data.bypassed).toBeUndefined();
+  });
+
+  it('toggleBypassForSelection reports false when only un-bypassable nodes are selected', () => {
+    store().setNodes([bnode('note', { type: 'noteNode', selected: true })]);
+    expect(store().toggleBypassForSelection()).toBe(false);
+  });
+
+  it('getSerializedGraph writes the flag only for muted nodes', () => {
+    store().setNodes([
+      bnode('n1', { data: { bypassed: true } }),
+      bnode('n2'),
+    ]);
+    const [muted, plain] = store().getSerializedGraph().nodes;
+    expect(muted.data.bypassed).toBe(true);
+    expect('bypassed' in plain.data).toBe(false);
+  });
+
+  it('getSerializedGraph drops the flag again once the node is un-muted', () => {
+    store().setNodes([bnode('n1', { data: { bypassed: true } })]);
+    store().toggleNodeBypass('n1');
+    expect('bypassed' in store().getSerializedGraph().nodes[0].data).toBe(false);
+  });
+
+  it('getDirtyWithDownstream propagates through a muted node but never names it', () => {
+    store().setNodes([
+      bnode('a'),
+      bnode('b', { data: { bypassed: true } }),
+      bnode('c'),
+    ]);
+    store().setEdges([
+      { id: 'e1', source: 'a', target: 'b' },
+      { id: 'e2', source: 'b', target: 'c' },
+    ] as any);
+    store().markDirty('a');
+    expect(store().getDirtyWithDownstream().sort()).toEqual(['a', 'c']);
+  });
+});
+
+// ── insertGraph (core#128 template insertion) ────────────────────────────────
+
+describe('insertGraph', () => {
+  beforeEach(resetToSingleTab);
+
+  it('is a no-op for an empty template', () => {
+    store().setNodes([bnode('n1')]);
+    store().insertGraph([], []);
+    expect(activeTab().nodes).toHaveLength(1);
+    expect(activeTab().undoStack).toHaveLength(0);
+  });
+
+  it('remaps ids so a template can never clobber an existing node', () => {
+    // Both graphs use the id "n1" — the exact collision a template saved by
+    // someone else routinely causes.
+    store().setNodes([bnode('n1', { data: { label: 'MINE' } })]);
+    store().insertGraph(
+      [bnode('n1', { data: { label: 'TEMPLATE' } }), bnode('n2')],
+      [{ id: 'e1', source: 'n1', target: 'n2' }] as any,
+    );
+
+    const tab = activeTab();
+    expect(tab.nodes).toHaveLength(3);
+    // The original survives untouched, under its own id.
+    expect(tab.nodes.find((n) => n.id === 'n1')!.data.label).toBe('MINE');
+    // Neither inserted node kept a template id.
+    const inserted = tab.nodes.filter((n) => n.selected);
+    expect(inserted).toHaveLength(2);
+    expect(inserted.map((n) => n.id)).not.toContain('n1');
+    expect(inserted.map((n) => n.id)).not.toContain('n2');
+    expect(new Set(tab.nodes.map((n) => n.id)).size).toBe(3);
+    // ...and the inserted edge follows the remap rather than pointing at the
+    // user's own "n1".
+    expect(tab.edges).toHaveLength(1);
+    const insertedIds = new Set(inserted.map((n) => n.id));
+    expect(insertedIds.has(tab.edges[0].source)).toBe(true);
+    expect(insertedIds.has(tab.edges[0].target)).toBe(true);
+    expect(tab.edges[0].id).not.toBe('e1');
+  });
+
+  it('places the template clear of the existing graph and selects only it', () => {
+    store().setNodes([bnode('n1', { position: { x: 10, y: 0 } })]);
+    store().insertGraph([bnode('t1', { position: { x: 500, y: 500 } })], []);
+
+    const tab = activeTab();
+    const [original, insertedNode] = tab.nodes;
+    expect(original.selected).toBe(false);
+    expect(insertedNode.selected).toBe(true);
+    // Left-aligned with the existing graph, below its lowest point.
+    expect(insertedNode.position.x).toBe(10);
+    expect(insertedNode.position.y).toBeGreaterThan(0);
+  });
+
+  it('drops a template into an empty canvas at its own coordinates', () => {
+    store().insertGraph([bnode('t1', { position: { x: 40, y: 60 } })], []);
+    expect(activeTab().nodes[0].position).toEqual({ x: 40, y: 60 });
+  });
+
+  it('undoes the whole insertion in one step', () => {
+    store().setNodes([bnode('n1')]);
+    store().insertGraph([bnode('t1'), bnode('t2')], [{ id: 'e1', source: 't1', target: 't2' }] as any);
+    expect(activeTab().nodes).toHaveLength(3);
+    store().undo();
+    expect(activeTab().nodes).toHaveLength(1);
+    expect(activeTab().edges).toHaveLength(0);
+  });
+
+  it('drops an edge whose endpoint the template did not ship', () => {
+    store().setNodes([bnode('n1')]);
+    store().insertGraph(
+      [bnode('t1')],
+      [{ id: 'e1', source: 't1', target: 'nowhere' }] as any,
+    );
+    expect(activeTab().edges).toHaveLength(0);
+  });
+
+  it('remaps a note binding inside the template and clears a dangling one', () => {
+    store().insertGraph(
+      [
+        bnode('t1'),
+        bnode('bound', { type: 'noteNode', data: { boundToNodeId: 't1', boundOffset: { x: 1, y: 2 } } }),
+        bnode('orphan', { type: 'noteNode', data: { boundToNodeId: 'gone', boundOffset: { x: 3, y: 4 } } }),
+      ],
+      [],
+    );
+    const tab = activeTab();
+    const t1 = tab.nodes[0];
+    const bound = tab.nodes[1];
+    const orphan = tab.nodes[2];
+    expect(bound.data.boundToNodeId).toBe(t1.id);
+    expect(bound.data.boundOffset).toEqual({ x: 1, y: 2 });
+    expect(orphan.data.boundToNodeId).toBeNull();
+    expect(orphan.data.boundOffset).toBeNull();
+  });
+
+  it('resets execution state on inserted nodes', () => {
+    store().insertGraph(
+      [bnode('t1', { data: { executionStatus: 'error', error: 'stale' } })],
+      [],
+    );
+    const inserted = activeTab().nodes[0];
+    expect(inserted.data.executionStatus).toBe('idle');
+    expect(inserted.data.error).toBeUndefined();
+  });
+});

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -1334,6 +1334,15 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
         edges: [...t.edges, ...newEdges],
       })),
     });
+
+    // The block is placed below the existing graph, which on a canvas the
+    // user has panned or zoomed into can be entirely off-screen — an insert
+    // that looks like it did nothing. Reuse auto-layout's one-shot fit
+    // request so the viewport lands on what just arrived.
+    const inserted = nodesBoundingBox(newNodes as Node[]);
+    if (inserted && inserted.width > 0 && inserted.height > 0) {
+      useUIStore.getState().requestLayoutFit(inserted);
+    }
   },
 
   // ── Note actions ──
@@ -1667,9 +1676,16 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
     // Bypassed nodes are dropped from the RESULT but not from the walk
     // (core#128). This list becomes the backend's `changed_nodes` — a
     // force-re-execute hint — and a bypassed node is never executed, so
-    // naming one says nothing. Dirtiness still travels THROUGH it to
-    // whatever consumes its pass-through, which is why the BFS above is
-    // unfiltered: bypassing a node is exactly what makes its consumers stale.
+    // naming one says nothing.
+    //
+    // `markDirty` upstream of this stays unconditional, and that is REQUIRED,
+    // not merely conservative: a param can change a bypassed node's own PORT
+    // SET (define_outputs_dynamic — Split's `chunks` is the live example), so
+    // editing a muted node's params can change which input each output
+    // forwards, and therefore what its consumers receive. Skipping the mark
+    // would leave those consumers on cached values computed from the old
+    // pass-through. Dirtiness travelling THROUGH the node is the same story,
+    // which is why the BFS above is unfiltered.
     const bypassed = new Set(
       tab.nodes.filter((n) => n.data.bypassed).map((n) => n.id),
     );

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { applyNodeChanges, applyEdgeChanges } from '@xyflow/react';
 import type { Node, Edge, NodeChange, EdgeChange, Connection } from '@xyflow/react';
-import { generateId, buildFlowNode } from '../utils';
+import { generateId, buildFlowNode, isBypassable } from '../utils';
 import { forgetViewport } from '../utils/viewportMemory';
 import { idbAvailable } from '../utils/idb';
 import { readSnapshot, writeSnapshot } from './tabPersistence';
@@ -222,6 +222,20 @@ interface TabStoreState {
   duplicateNode: (nodeId: string) => void;
   renameNode: (nodeId: string, newLabel: string) => void;
   applyLayout: (mode: LayoutMode) => void;
+  /** Toggle ComfyUI-style bypass on one node (core#128). */
+  toggleNodeBypass: (nodeId: string) => void;
+  /**
+   * Toggle bypass across the canvas selection. Returns false when nothing in
+   * the selection can be bypassed, which is what lets Ctrl+B fall through to
+   * the sidebar shortcut instead of doing nothing at all.
+   */
+  toggleBypassForSelection: () => boolean;
+  /**
+   * Merge a template's nodes/edges into the active tab (core#128).
+   * Paste-style: fresh ids, placed clear of what is already on the canvas,
+   * one undo step for the whole insertion.
+   */
+  insertGraph: (nodes: Node<NodeData>[], edges: Edge[]) => void;
 
   // note actions
   addNote: (kind: 'text' | 'image', position: { x: number; y: number }) => void;
@@ -307,6 +321,48 @@ function roundOffset(
 // Round an optional pixel dimension (note width/height), tolerating undefined.
 function roundDimension(v: number | undefined): number | undefined {
   return typeof v === 'number' ? Math.round(v) : v;
+}
+
+// ── Bypass (core#128) ──
+//
+// One patch builder for both entry points (single node, whole selection) so
+// the node write and the dirty marking always land in the SAME commit — two
+// separate `set` calls would re-render the canvas twice per keypress.
+function bypassPatch(
+  tab: TabState,
+  ids: ReadonlySet<string>,
+  bypassed: boolean,
+): Partial<TabState> {
+  const dirtyNodeIds = new Set(tab.dirtyNodeIds);
+  for (const id of ids) dirtyNodeIds.add(id);
+  return {
+    nodes: tab.nodes.map((n) =>
+      ids.has(n.id) ? { ...n, data: { ...n.data, bypassed } } : n,
+    ),
+    dirtyNodeIds,
+  };
+}
+
+/** Gap between the existing graph and an inserted template, in flow pixels. */
+const INSERT_GAP = 96;
+
+/**
+ * Where to drop an inserted template so it lands clear of the current graph:
+ * left-aligned with what is already there, one gap below its lowest node. The
+ * template keeps its own internal layout — only the whole block moves.
+ */
+function insertionOffset(
+  existing: Node<NodeData>[],
+  incoming: Node<NodeData>[],
+): { x: number; y: number } {
+  const target = nodesBoundingBox(existing as Node[]);
+  const source = nodesBoundingBox(incoming as Node[]);
+  // An empty canvas (or a template with nothing in it) needs no move at all.
+  if (!target || !source) return { x: 0, y: 0 };
+  return {
+    x: target.x - source.x,
+    y: target.y + target.height + INSERT_GAP - source.y,
+  };
 }
 
 // Replace every SECRET-typed param value with '' so secrets (e.g. an LLM API
@@ -1096,6 +1152,9 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
           ...(n.data.isPreset
             ? { internalParams: stripSecretInternalParams(n.data.internalParams, n.data.presetDefinition) }
             : {}),
+          // Written only when muted (core#128), so a graph nobody has
+          // bypassed anything in serializes byte-identically to before.
+          ...(n.data.bypassed ? { bypassed: true } : {}),
         },
       };
     });
@@ -1177,6 +1236,102 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
         nodes: tab.nodes.map((n) =>
           n.id === nodeId ? { ...n, data: { ...n.data, label: newLabel } } : n
         ),
+      })),
+    });
+  },
+
+  // ── Bypass (core#128) ──
+
+  toggleNodeBypass: (nodeId) => {
+    const tab = get().getActiveTab();
+    const node = tab.nodes.find((n) => n.id === nodeId);
+    if (!node || !isBypassable(node)) return;
+    get().pushUndoSnapshot();
+    set({
+      tabs: updateTab(get().tabs, get().activeTabId, (t) =>
+        bypassPatch(t, new Set([nodeId]), !node.data.bypassed),
+      ),
+    });
+  },
+
+  toggleBypassForSelection: () => {
+    const tab = get().getActiveTab();
+    // React Flow's own multi-selection first. A plain click sets BOTH
+    // `selected` and `selectedNodeId`, so the fallback only matters for
+    // selections made programmatically (a modal, a test, a plugin).
+    const marked = tab.nodes.filter((n) => n.selected);
+    const pool = marked.length > 0
+      ? marked
+      : tab.nodes.filter((n) => n.id === tab.selectedNodeId);
+    const targets = pool.filter(isBypassable);
+    if (targets.length === 0) return false;
+    // A mixed selection becomes uniform: mute everything unless all of it is
+    // already muted, in which case the whole selection comes back. Same rule
+    // ComfyUI applies, and it makes the shortcut its own inverse.
+    const bypassed = targets.some((n) => !n.data.bypassed);
+    const ids = new Set(targets.map((n) => n.id));
+    get().pushUndoSnapshot();
+    set({
+      tabs: updateTab(get().tabs, get().activeTabId, (t) =>
+        bypassPatch(t, ids, bypassed),
+      ),
+    });
+    return true;
+  },
+
+  // ── Template insertion (core#128) ──
+
+  insertGraph: (incomingNodes, incomingEdges) => {
+    if (incomingNodes.length === 0) return;
+    const tab = get().getActiveTab();
+    get().pushUndoSnapshot();
+
+    // Every incoming id is remapped, unconditionally. A template ships
+    // whatever ids its author saved ("node_1", "conv"), and two templates —
+    // or a template and the current graph — routinely collide; reusing an
+    // incoming id would silently replace the node already wearing it.
+    const idMap = new Map<string, string>();
+    for (const node of incomingNodes) idMap.set(node.id, generateId());
+
+    const offset = insertionOffset(tab.nodes, incomingNodes);
+
+    const newNodes: Node<NodeData>[] = incomingNodes.map((node) => {
+      const data: NodeData = { ...node.data, executionStatus: 'idle', error: undefined };
+      if (node.type === 'noteNode' && data.boundToNodeId) {
+        const remapped = idMap.get(data.boundToNodeId);
+        data.boundToNodeId = remapped ?? null;
+        if (!remapped) data.boundOffset = null;
+      }
+      return {
+        ...node,
+        id: idMap.get(node.id)!,
+        position: {
+          x: node.position.x + offset.x,
+          y: node.position.y + offset.y,
+        },
+        selected: true,
+        data,
+      };
+    });
+
+    const newEdges: Edge[] = incomingEdges
+      // An edge naming a node the template did not ship would dangle over the
+      // existing graph, so it is dropped rather than remapped to nothing.
+      .filter((e) => idMap.has(e.source) && idMap.has(e.target))
+      .map((e) => ({
+        ...e,
+        id: generateId(),
+        source: idMap.get(e.source)!,
+        target: idMap.get(e.target)!,
+      }));
+
+    // Selecting exactly what was inserted (and nothing else) is what makes
+    // "insert, then drag/lay-out the new block" work as one gesture — the
+    // same thing paste does.
+    set({
+      tabs: updateTab(get().tabs, get().activeTabId, (t) => ({
+        nodes: [...t.nodes.map((n) => ({ ...n, selected: false })), ...newNodes],
+        edges: [...t.edges, ...newEdges],
       })),
     });
   },
@@ -1509,7 +1664,16 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
         }
       }
     }
-    return [...result];
+    // Bypassed nodes are dropped from the RESULT but not from the walk
+    // (core#128). This list becomes the backend's `changed_nodes` — a
+    // force-re-execute hint — and a bypassed node is never executed, so
+    // naming one says nothing. Dirtiness still travels THROUGH it to
+    // whatever consumes its pass-through, which is why the BFS above is
+    // unfiltered: bypassing a node is exactly what makes its consumers stale.
+    const bypassed = new Set(
+      tab.nodes.filter((n) => n.data.bypassed).map((n) => n.id),
+    );
+    return [...result].filter((id) => !bypassed.has(id));
   },
 
   // ── Execution actions (active tab) ──

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -25,6 +25,14 @@ interface UIState {
   setCanvasPanning: (panning: boolean) => void;
   shortcutsModalOpen: boolean;
   toggleShortcutsModal: () => void;
+  /**
+   * Template gallery modal (core#128). Workspace-global like the rest of the
+   * panel state (#125) and deliberately NOT persisted — reopening the app on
+   * top of a modal nobody remembers opening is never what you want.
+   */
+  templateGalleryOpen: boolean;
+  openTemplateGallery: () => void;
+  closeTemplateGallery: () => void;
   draggingSourceType: string | null;
   setDraggingSourceType: (type: string | null) => void;
   /** Endpoint of the edge currently being detached during an edge-reconnect
@@ -137,6 +145,9 @@ export const useUIStore = create<UIState>((set) => ({
   setCanvasPanning: (panning) => set({ isCanvasPanning: panning }),
   shortcutsModalOpen: false,
   toggleShortcutsModal: () => set((state) => ({ shortcutsModalOpen: !state.shortcutsModalOpen })),
+  templateGalleryOpen: false,
+  openTemplateGallery: () => set({ templateGalleryOpen: true }),
+  closeTemplateGallery: () => set({ templateGalleryOpen: false }),
   draggingSourceType: null,
   setDraggingSourceType: (type) => set({ draggingSourceType: type }),
   reconnectingHandle: null,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -97,6 +97,13 @@ export interface NodeData {
   isPreset?: boolean;
   presetDefinition?: PresetDefinition;
   internalParams?: Record<string, Record<string, any>>;
+  /**
+   * ComfyUI-style bypass (core#128). A bypassed node is not executed: the
+   * engine removes it and forwards, per output port, the value that arrived
+   * on the first type-compatible input. Serialized with the graph, so a saved
+   * file remembers what was muted.
+   */
+  bypassed?: boolean;
   // Note-specific fields (present only when node.type === 'noteNode')
   noteKind?: 'text' | 'image';
   noteContent?: string;

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -83,7 +83,7 @@ export function resolveNodeComponentType(nodeType: string): string {
 }
 
 /**
- * xyflow component types that cannot be bypassed (core#128).
+ * xyflow COMPONENT types that cannot be bypassed (core#128).
  *
  * `noteNode` is an annotation with no execution to skip; `start` is the
  * trigger marker that defines an entry point (muting it would silently strip
@@ -93,9 +93,25 @@ export function resolveNodeComponentType(nodeType: string): string {
  */
 const NON_BYPASSABLE_NODE_TYPES = new Set(['noteNode', 'start', 'presetNode']);
 
+/**
+ * GRAPH node types that cannot be bypassed, checked against `data.type`.
+ *
+ * These two render as ordinary `baseNode` cards, so the component-type set
+ * above cannot see them. They declare the graph's I/O contract, which
+ * `derive_contract` / `check_wiring` read from the RAW graph — muting one
+ * would leave a published app advertising an input or output the run cannot
+ * honour. The backend refuses them for the same reason; this keeps the
+ * canvas from offering an action that can only end in a validation error.
+ */
+const NON_BYPASSABLE_GRAPH_TYPES = new Set(['GraphInput', 'GraphOutput']);
+
 /** Whether the bypass toggle applies to this canvas node. */
-export function isBypassable(node: { type?: string } | undefined | null): boolean {
-  return !!node && !NON_BYPASSABLE_NODE_TYPES.has(node.type ?? '');
+export function isBypassable(
+  node: { type?: string; data?: { type?: string } } | undefined | null,
+): boolean {
+  if (!node) return false;
+  if (NON_BYPASSABLE_NODE_TYPES.has(node.type ?? '')) return false;
+  return !NON_BYPASSABLE_GRAPH_TYPES.has(node.data?.type ?? '');
 }
 
 export const DATA_TYPE_COLORS: Record<string, string> = {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -82,6 +82,22 @@ export function resolveNodeComponentType(nodeType: string): string {
   return nodeType.includes(':') ? 'pluginNode' : 'baseNode';
 }
 
+/**
+ * xyflow component types that cannot be bypassed (core#128).
+ *
+ * `noteNode` is an annotation with no execution to skip; `start` is the
+ * trigger marker that defines an entry point (muting it would silently strip
+ * the graph's only entry); `presetNode` expands into a sub-graph whose ports
+ * come from the preset definition, so there is nothing for the engine's
+ * pass-through rule to match on — the backend refuses it explicitly.
+ */
+const NON_BYPASSABLE_NODE_TYPES = new Set(['noteNode', 'start', 'presetNode']);
+
+/** Whether the bypass toggle applies to this canvas node. */
+export function isBypassable(node: { type?: string } | undefined | null): boolean {
+  return !!node && !NON_BYPASSABLE_NODE_TYPES.has(node.type ?? '');
+}
+
 export const DATA_TYPE_COLORS: Record<string, string> = {
   TENSOR: '#4CAF50',
   MODEL: '#2196F3',
@@ -275,6 +291,9 @@ export function resolveSerializedNodes(
         params,
         definition: def ?? { node_name: nodeType, category: 'Utility', description: '', inputs: [], outputs: [], params: [] },
         executionStatus: 'idle' as const,
+        // Only set when muted, so a graph with no bypass carries no flag at
+        // all — the same asymmetry getSerializedGraph writes with (core#128).
+        ...(raw.data?.bypassed ? { bypassed: true } : {}),
       },
     };
   });

--- a/frontend/src/utils/openExample.test.ts
+++ b/frontend/src/utils/openExample.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { insertExample, openExample, openExampleInNewTab } from './openExample';
+import { useNodeDefStore } from '../store/nodeDefStore';
+import { useTabStore } from '../store/tabStore';
+import { useToastStore } from '../store/toastStore';
+import { useI18n } from '../i18n';
+import * as rest from '../api/rest';
+
+// Only the network call is stubbed: resolution, preset merging and the store
+// writes all run for real, which is the point — these three entry points are
+// supposed to differ ONLY in where the resolved graph lands.
+vi.mock('../api/rest', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/rest')>();
+  return { ...actual, loadExample: vi.fn() };
+});
+
+const mockedRest = vi.mocked(rest);
+const store = () => useTabStore.getState();
+const activeTab = () => useTabStore.getState().getActiveTab();
+
+/** A serialized example node, in the shape `/api/examples/load` returns. */
+function raw(id: string, over: Record<string, unknown> = {}) {
+  return { id, type: 'Dropout', position: { x: 0, y: 0 }, data: { params: {} }, ...over };
+}
+
+beforeEach(() => {
+  useI18n.setState({ locale: 'en' });
+  useNodeDefStore.setState({ definitions: [], presets: [] });
+  useToastStore.setState({ toasts: [] });
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  useTabStore.getState().addTab('Tab 1');
+  mockedRest.loadExample.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('openExample', () => {
+  it('replaces the active tab graph and mirrors the example name onto the tab', async () => {
+    mockedRest.loadExample.mockResolvedValue({
+      name: '  My Model  ',
+      nodes: [raw('a'), raw('b')],
+      edges: [{ id: 'e1', source: 'a', target: 'b', sourceHandle: 'tensor', targetHandle: 'tensor' }],
+    });
+
+    await expect(openExample('Usage_Example/Foo')).resolves.toBe(true);
+    expect(mockedRest.loadExample).toHaveBeenCalledWith('Usage_Example/Foo');
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['a', 'b']);
+    expect(activeTab().edges).toHaveLength(1);
+    expect(activeTab().name).toBe('My Model');
+  });
+
+  it('leaves the tab name alone when the example ships without one', async () => {
+    mockedRest.loadExample.mockResolvedValue({ nodes: [raw('a')], edges: [] });
+    await openExample('x');
+    expect(activeTab().name).toBe('Tab 1');
+  });
+
+  it('merges presets the running server has never seen', async () => {
+    const preset = { preset_name: 'Fresh', category: 'c', description: '', tags: [], nodes: [], edges: [], exposed_inputs: [], exposed_outputs: [], exposed_params: [] };
+    mockedRest.loadExample.mockResolvedValue({ nodes: [], edges: [], presets: [preset] });
+    await openExample('x');
+    expect(useNodeDefStore.getState().presets.map((p) => p.preset_name)).toEqual(['Fresh']);
+  });
+
+  it('toasts and leaves the graph alone when the load fails', async () => {
+    store().setNodes([{ id: 'keep', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'k', type: 'K', params: {} } }] as never);
+    mockedRest.loadExample.mockRejectedValue(new Error('nope'));
+
+    await expect(openExample('x')).resolves.toBe(false);
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['keep']);
+    expect(useToastStore.getState().toasts[0].message).toBe('Failed to load example');
+  });
+});
+
+describe('openExampleInNewTab', () => {
+  it('opens the example in a fresh tab, leaving the original untouched', async () => {
+    store().setNodes([{ id: 'keep', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'k', type: 'K', params: {} } }] as never);
+    const firstTabId = store().activeTabId;
+    mockedRest.loadExample.mockResolvedValue({ name: 'Template', nodes: [raw('a')], edges: [] });
+
+    await expect(openExampleInNewTab('x')).resolves.toBe(true);
+
+    expect(store().tabs).toHaveLength(2);
+    expect(store().activeTabId).not.toBe(firstTabId);
+    expect(activeTab().name).toBe('Template');
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['a']);
+    // The graph that was already open is exactly as it was.
+    expect(store().getTab(firstTabId)!.nodes.map((n) => n.id)).toEqual(['keep']);
+  });
+
+  it('does not leave an empty tab behind when the load fails', async () => {
+    mockedRest.loadExample.mockRejectedValue(new Error('nope'));
+    await expect(openExampleInNewTab('x')).resolves.toBe(false);
+    expect(store().tabs).toHaveLength(1);
+    expect(useToastStore.getState().toasts[0].message).toBe('Failed to load example');
+  });
+});
+
+describe('insertExample', () => {
+  it('merges into the current canvas without clobbering colliding ids', async () => {
+    // The canvas and the template both use "a" — the collision the id remap
+    // exists for.
+    store().setNodes([
+      { id: 'a', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'MINE', type: 'K', params: {} } },
+    ] as never);
+    mockedRest.loadExample.mockResolvedValue({
+      name: 'Template',
+      nodes: [raw('a'), raw('b')],
+      edges: [{ id: 'e1', source: 'a', target: 'b', sourceHandle: 'tensor', targetHandle: 'tensor' }],
+    });
+
+    await expect(insertExample('x')).resolves.toBe(true);
+
+    const tab = activeTab();
+    expect(tab.nodes).toHaveLength(3);
+    expect(tab.nodes.find((n) => n.id === 'a')!.data.label).toBe('MINE');
+    expect(new Set(tab.nodes.map((n) => n.id)).size).toBe(3);
+    // The inserted edge joins the two INSERTED nodes, not the user's own "a".
+    const insertedIds = new Set(tab.nodes.filter((n) => n.selected).map((n) => n.id));
+    expect(insertedIds.size).toBe(2);
+    expect(insertedIds.has(tab.edges[0].source)).toBe(true);
+    expect(insertedIds.has(tab.edges[0].target)).toBe(true);
+    // Inserting joins a graph rather than replacing it, so the tab keeps its
+    // own name.
+    expect(tab.name).toBe('Tab 1');
+  });
+
+  it('reports false for a template with no nodes', async () => {
+    mockedRest.loadExample.mockResolvedValue({ nodes: [], edges: [] });
+    await expect(insertExample('x')).resolves.toBe(false);
+    expect(activeTab().nodes).toHaveLength(0);
+  });
+
+  it('toasts and leaves the graph alone when the load fails', async () => {
+    store().setNodes([{ id: 'keep', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'k', type: 'K', params: {} } }] as never);
+    mockedRest.loadExample.mockRejectedValue(new Error('nope'));
+
+    await expect(insertExample('x')).resolves.toBe(false);
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['keep']);
+    expect(useToastStore.getState().toasts[0].message).toBe('Failed to load example');
+  });
+
+  it('round-trips a bypassed node from the example file onto the canvas', async () => {
+    mockedRest.loadExample.mockResolvedValue({
+      nodes: [raw('muted', { data: { params: {}, bypassed: true } }), raw('plain')],
+      edges: [],
+    });
+    await insertExample('x');
+    const [muted, plain] = activeTab().nodes;
+    expect(muted.data.bypassed).toBe(true);
+    expect(plain.data.bypassed).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/openExample.ts
+++ b/frontend/src/utils/openExample.ts
@@ -1,17 +1,78 @@
+import type { Edge, Node } from '@xyflow/react';
 import { loadExample } from '../api/rest';
 import { useNodeDefStore } from '../store/nodeDefStore';
 import { useTabStore } from '../store/tabStore';
 import { useToastStore } from '../store/toastStore';
 import { useI18n } from '../i18n';
+import type { NodeData } from '../types';
 import { resolveSerializedNodes, resolveSerializedEdges } from '.';
+
+/** A fetched example, resolved into live canvas nodes and edges. */
+interface ResolvedExample {
+  nodes: Node<NodeData>[];
+  edges: Edge[];
+  /** The example's own name, trimmed; null when it ships without one. */
+  name: string | null;
+}
+
+/**
+ * Fetch one example and turn it into canvas-ready nodes/edges.
+ *
+ * Every gallery surface goes through here, so an example resolves the same
+ * way whether it is opened, opened in a new tab, or inserted (core#128).
+ * Throws on a failed load; the three callers below each decide what that
+ * means for the graph in front of the user.
+ */
+async function fetchResolvedExample(path: string): Promise<ResolvedExample> {
+  const data = await loadExample(path);
+
+  const store = useNodeDefStore.getState();
+  // An example may ship presets the running server has never seen. Merge the
+  // unknown ones in by name so its nodes resolve, without clobbering the
+  // installed definitions of same-named presets.
+  const importedPresets = Array.isArray(data.presets) ? data.presets : [];
+  const mergedPresets = [...store.presets];
+  for (const p of importedPresets) {
+    if (!mergedPresets.some((ep) => ep.preset_name === p.preset_name)) {
+      mergedPresets.push(p);
+    }
+  }
+
+  const nodes = resolveSerializedNodes(data.nodes ?? [], store.definitions, mergedPresets);
+  const edges = resolveSerializedEdges(data.edges ?? [], nodes);
+  if (importedPresets.length > 0) {
+    useNodeDefStore.setState({ presets: mergedPresets });
+  }
+
+  const name =
+    typeof data.name === 'string' && data.name.trim() ? data.name.trim() : null;
+  return { nodes, edges, name };
+}
+
+/** Replace the active tab's graph with a resolved example. */
+function applyToActiveTab(example: ResolvedExample): void {
+  const tabs = useTabStore.getState();
+  tabs.setNodes(example.nodes);
+  tabs.setEdges(example.edges);
+  // Mirror the example name onto the active tab so saves, exports, and the
+  // script header all use a meaningful name out of the box.
+  if (example.name) {
+    tabs.renameTab(useTabStore.getState().activeTabId, example.name);
+  }
+}
+
+function reportLoadFailure(): false {
+  useToastStore.getState().addToast(useI18n.getState().t('empty.loadError'), 'error');
+  return false;
+}
 
 /**
  * Load a builtin/plugin example into the ACTIVE tab.
  *
  * Extracted from `EmptyCanvasOverlay` in #126 so the sidebar's Templates tab
  * opens an example exactly the way the empty-canvas gallery does — same
- * resolution, same preset merge, same tab rename, same error toast. Any future
- * gallery surface should call this rather than re-implement it.
+ * resolution, same preset merge, same tab rename, same error toast. The
+ * template gallery modal (core#128) calls it too.
  *
  * Stores are read through `getState()` instead of hooks because this is a
  * plain function called from an event handler, not a component.
@@ -20,43 +81,47 @@ import { resolveSerializedNodes, resolveSerializedEdges } from '.';
  * Returns whether the example was applied, for callers that want to react.
  */
 export async function openExample(path: string): Promise<boolean> {
-  const { t } = useI18n.getState();
   try {
-    const data = await loadExample(path);
-    const rawNodes = data.nodes ?? [];
-    const edges = data.edges ?? [];
-
-    const store = useNodeDefStore.getState();
-    // An example may ship presets the running server has never seen. Merge the
-    // unknown ones in by name so its nodes resolve, without clobbering the
-    // installed definitions of same-named presets.
-    const importedPresets = Array.isArray(data.presets) ? data.presets : [];
-    const mergedPresets = [...store.presets];
-    for (const p of importedPresets) {
-      if (!mergedPresets.some((ep) => ep.preset_name === p.preset_name)) {
-        mergedPresets.push(p);
-      }
-    }
-
-    const resolvedNodes = resolveSerializedNodes(rawNodes, store.definitions, mergedPresets);
-    const resolvedEdges = resolveSerializedEdges(edges, resolvedNodes);
-    const tabs = useTabStore.getState();
-    tabs.setNodes(resolvedNodes);
-    tabs.setEdges(resolvedEdges);
-
-    // Mirror the example name onto the active tab so saves, exports, and the
-    // script header all use a meaningful name out of the box.
-    const exampleName = typeof data.name === 'string' && data.name.trim() ? data.name.trim() : null;
-    if (exampleName) {
-      tabs.renameTab(useTabStore.getState().activeTabId, exampleName);
-    }
-
-    if (importedPresets.length > 0) {
-      useNodeDefStore.setState({ presets: mergedPresets });
-    }
+    applyToActiveTab(await fetchResolvedExample(path));
     return true;
   } catch {
-    useToastStore.getState().addToast(t('empty.loadError'), 'error');
-    return false;
+    return reportLoadFailure();
+  }
+}
+
+/**
+ * Open an example in a NEW tab, leaving the current graph untouched.
+ *
+ * The tab is created only after the fetch succeeds — a failed load must not
+ * leave an empty tab behind as the sole evidence that anything happened.
+ */
+export async function openExampleInNewTab(path: string): Promise<boolean> {
+  let example: ResolvedExample;
+  try {
+    example = await fetchResolvedExample(path);
+  } catch {
+    return reportLoadFailure();
+  }
+  useTabStore.getState().addTab();
+  applyToActiveTab(example);
+  return true;
+}
+
+/**
+ * Merge an example into the CURRENT canvas, paste-style (core#128).
+ *
+ * Ids are remapped and the block is placed clear of the existing graph by
+ * `insertGraph`, so inserting into a populated canvas can never clobber a
+ * node that is already there. Unlike `openExample` this does not rename the
+ * tab: the tab still holds the user's own graph, which the template joined.
+ */
+export async function insertExample(path: string): Promise<boolean> {
+  try {
+    const example = await fetchResolvedExample(path);
+    if (example.nodes.length === 0) return false;
+    useTabStore.getState().insertGraph(example.nodes, example.edges);
+    return true;
+  } catch {
+    return reportLoadFailure();
   }
 }


### PR DESCRIPTION
Two independent features from the issue: the template gallery modal (frontend only) and ComfyUI-style node bypass (frontend + engine semantics + Python export).

## Template gallery

The ~30 shipped examples were reachable only from `EmptyCanvasOverlay` — the moment you had a graph on screen, there was no way back to them. `TemplateGalleryModal` is the always-available browser:

- **Grid grouped by category**, reusing the sidebar Templates tab's `groupExamplesByCategory` so the two surfaces can never drift out of order (Usage Example first, Model Architecture last, everything else alphabetical).
- **Search** across name, description, category and source pack.
- **Detail pane**: description, node count, connection count, and the pack an example ships from (`Built-in example` / `From plugin pack "c2"`). `ExampleSummary.source` was already on the wire; it just was not in the TS type.
- **Actions**: *Open in new tab* (current graph untouched; the tab is created only after the fetch succeeds, so a failed load leaves nothing behind) and *Insert into this canvas*.

**Entry points**: toolbar button, sidebar Templates tab footer, and the empty-canvas overlay — which keeps its curated quick-start cards and gains a link into the full list. All four surfaces load an example through the same `utils/openExample` helpers.

### Insert semantics

`tabStore.insertGraph` is paste-style: **every** incoming id is remapped unconditionally, edges follow the remap (an edge naming a node the template did not ship is dropped rather than left dangling), note bindings are remapped or cleared, the block is placed left-aligned one gap below the existing graph's bounding box, it arrives selected (so "insert, then drag / lay out" is one gesture), and the whole insertion is a single undo step. Inserting does **not** rename the tab — the tab still holds the user's graph, which the template joined.

## Bypass / mute

`data.bypassed` on a node, toggled from the node context menu or the keyboard, serialized with the graph, drawn as a dimmed + struck-through card with a `BYPASS` badge (handles keep full opacity so edges through a muted node stay grabbable). The Node Detail Modal shows a matching chip, since the modal covers the card it belongs to.

Not offered on notes, `Start`, or preset nodes — the context-menu entry is absent rather than greyed out, and the backend refuses a bypassed preset explicitly.

### Engine semantics

`resolve_bypass` runs once, structurally, right after preset expansion and **before** reachability — so what is reachable, the topological order, validation and the exporter all operate on a graph the bypassed node is simply not part of. Nothing downstream needs bypass awareness.

| Situation | Result |
|---|---|
| Output `o` has a type-compatible input `i` (first match, on the node's own declared port types, `is_compatible(i, o)`) that is wired | Every edge leaving `o` is re-pointed at whatever fed `i` |
| The forwarded source is itself bypassed | Resolved recursively — a chain collapses to the real producer |
| Matched input `i` is unwired | Edges leaving `o` are dropped; the downstream node reports its missing input like any unconnected port |
| No input is type-compatible with `o` | Error naming the node, the output and its type, and the inputs it had to choose from |
| Bypassed node is a trigger target | The trigger moves to the first non-bypassed node it fed, so muting an entry point does not silently leave the graph with none |
| Bypassed nodes wired in a loop | Memo seeded before recursing doubles as the cycle guard; `validate_graph` still reports the cycle |
| Bypassed preset node | Refused: `Bypass is not supported on preset node <id>` |
| Bypassed node of an unknown type | Left in place, so the caller reports `Unknown node type` — the real problem |
| No bypassed node anywhere | The same list objects come back out; one scan, no allocation |

`validate_graph` reports the errors; `prepare_executable_graph` raises `GraphValidationError`. Both surface through the existing pre-flight, so the canvas shows them as ordinary validation toasts.

### Dirty tracking

Dirtiness propagates **through** a bypassed node (bypassing one is exactly what makes its consumers stale) but a bypassed id is filtered out of `getDirtyWithDownstream()`: that list becomes the backend's `changed_nodes` force-re-execute hint, and a node that never executes cannot be forced to.

### Python export

`prepare_executable_graph` already removes the node, so the script would simply never mention it. The exporter re-resolves the raw graph purely to *show* the mute — a commented-out pass-through assignment, sitting immediately above the first node that consumes it:

```python
def flow_1(ctx, results, provided):
    'Start -> TensorCreate -> Print'
    s1 = results['s1'] = n01_start(ctx)
    make = results['make'] = n02_tensorcreate(ctx)
    # BYPASSED node 'drop' ('Dropout') -- not executed; its inputs pass straight through:
    #     drop['tensor'] = _port(make, 'tensor')  # via input 'tensor'
    out = results['out'] = n03_print(
        ctx,
        value=_port(make, 'tensor'),
    )
```

A muted leaf nothing consumes gets its own note under the node-functions banner rather than vanishing without trace.

## The Ctrl+B conflict

The issue predates #126, which had already given `Ctrl/Cmd+B` to the sidebar collapse (VS Code's binding). ComfyUI — where anyone reaching for "mute this node" learned the gesture — gives it to bypass. Neither could be moved without breaking the muscle memory it was chosen for.

**Resolution: the selection decides.**

| Chord | With a bypassable node selected | With nothing bypassable selected |
|---|---|---|
| `Ctrl/Cmd+B` | Toggle bypass | Collapse / expand sidebar |
| `Ctrl/Cmd+Shift+B` | Collapse / expand sidebar | Collapse / expand sidebar |

`toggleBypassForSelection()` returns whether it did anything, which is what makes the fall-through total: a selection of only notes / `Start` / preset nodes lands on the sidebar rather than doing nothing at all. `Ctrl+Shift+B` was explicitly left free by #126's own comment and is now the unconditional sidebar toggle, so there is always a chord that reaches the sidebar regardless of selection. All three rows are spelled out in the shortcuts modal.

A mixed selection becomes uniform (mute everything unless all of it is already muted), so the shortcut is its own inverse.

## Test evidence

**Backend** — `2348 passed, 14 skipped`

- `test_graph_engine.py` (+12): chain, fan-out, chain-of-two-bypassed, un-bypass restores, pass-through is by reference (the consumer receives the exact object the producer made), incompatible-type error via both `validate_graph` and `prepare_executable_graph`, unwired matched input, trigger retarget, preset refusal, unknown-type deferral, identity fast path, recorded links.
- `test_codegen.py` (+4): the bypassed node's function is not emitted, the consumer wires straight from upstream, the comment is present, the flag off keeps the node, incompatible bypass raises, and the muted-leaf note.
- `test_api_graph.py` (+1): the flag round-trips through save/load.

**Frontend** — `114 files, 2342 passed` (+2 files, +56 tests), `tsc -b` clean, `pnpm build` clean

- `TemplateGalleryModal.test.tsx` (new, 15): reachable over a populated canvas, grouping order, loading/empty/error/retry, search across all four fields, detail-pane fallback selection and source labels, open-in-new-tab (original tab untouched), double-click, insert with id remap, three close paths.
- `openExample.test.ts` (new, 10): the three entry points share resolution and preset merging; no empty tab on a failed new-tab open; insert id remap; bypass flag round-trip from the example file.
- `tabStore.test.ts` (+22): bypass toggle/undo/dirty/refusals, selection toggle incl. mixed and fall-back-to-`selectedNodeId`, serialization asymmetry, dirty propagation through a muted node; `insertGraph` id remap, placement, single-step undo, dangling edge, note rebinding.
- `BaseNode.test.tsx` (+3), `NodeContextMenu.test.tsx` (+3), `NodeDetailModal.test.tsx` (+2), `useKeyboardShortcuts.test.ts` (rewritten mod+B block), `ShortcutsModal.test.tsx` (updated).

**Browser e2e** (Chrome, real backend, production build):

- Gallery opened over a populated 9-node canvas; search narrowed correctly; opened a 7-node template in a new tab.
- Inserted a second template into it: **7 to 13 nodes, all 7 original ids intact, 6 fresh UUIDs, zero duplicates**, placed clear of the existing graph. One `Ctrl+Z` removed all 6.
- Bypassed a mid-chain `Normalize` from the context menu; ran the graph — every other node completed, the muted one never ran. `Ctrl+B` on the selection un-muted it and left the sidebar alone; `Ctrl+B` with nothing selected collapsed the sidebar (298px to the 44px rail); `Ctrl+Shift+B` restored it with a node still selected.
- Bypassed the source `CSVReader` (no inputs at all) and pressed Run: five clear toasts, no run started, no crash —
  `Bypassed node csv (CSVReader): output 'tensor' (TENSOR) has no type-compatible input to forward (inputs: none)`.
- The flag survived a full page reload (IndexedDB round-trip). Console clean; the scratch tab was closed afterwards.

Closes #128

---
Generated with [Claude Code](https://claude.com/claude-code)
