### PR TITLE
feat(stats): server-side sampled port statistics + Stats tab

### DIFF
--- a/backend/app/api/routes_execution_outputs.py
+++ b/backend/app/api/routes_execution_outputs.py
@@ -2,17 +2,34 @@
 
 Complements the WebSocket stream by letting the frontend lazily fetch
 full tensor values (or their slices) for the Teaching Inspector panel.
+
+The ``/stats`` route is the counterpart for data too big to fetch: it
+summarises a value server-side (see ``core.port_stats``) so the answer to
+"what does this data look like" costs a kilobyte instead of two gigabytes.
 """
 
 from __future__ import annotations
 
+import asyncio
+import functools
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
+from ..config import settings
+from ..core.port_stats import PortStatsCache, compute_port_stats
 from ..core.run_output_store import RunOutputStore
 
 router = APIRouter(prefix="/api/execution/outputs", tags=["execution-outputs"])
+
+#: Ceiling on stat computations running at once. The Stats tab asks for every
+#: port of a node in parallel, and each one is real CPU work over a real
+#: tensor, so the default executor's ~32 threads would let a few clicks
+#: saturate the machine the graph is training on. An executor rather than an
+#: ``asyncio.Semaphore`` because executors are not bound to an event loop —
+#: the test transport runs each test on its own.
+_STATS_EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="port-stats")
 
 
 def _get_store(request: Request) -> RunOutputStore:
@@ -20,6 +37,29 @@ def _get_store(request: Request) -> RunOutputStore:
     if store is None:
         raise HTTPException(status_code=503, detail="run_output_store not initialised")
     return store
+
+
+def _get_stats_cache(request: Request) -> PortStatsCache:
+    """The app-wide stats LRU, created on first use if the lifespan didn't.
+
+    ``main.lifespan`` installs one for the real server. The fallback is for
+    the test transport, which never runs the lifespan (see
+    ``tests/conftest.py``) — and a cache is an optimisation, so a missing one
+    is worth creating rather than 503-ing over.
+    """
+    cache = getattr(request.app.state, "port_stats_cache", None)
+    if cache is None:
+        cache = PortStatsCache(max_bytes=settings.STATS_CACHE_MAX_BYTES)
+        request.app.state.port_stats_cache = cache
+    return cache
+
+
+def _not_captured(what: str) -> str:
+    """404 detail that names the switch the user probably left off."""
+    return (
+        f"{what}. Turn on Record outputs (the Rec toggle in the toolbar) and "
+        "re-run the graph to capture port data."
+    )
 
 
 def _parse_slice(slice_str: str) -> tuple[Any, ...] | None:
@@ -291,6 +331,58 @@ async def get_grad_index(run_id: str, node_id: str, request: Request):
             })
             seen.add(port)
     return entries
+
+
+@router.get("/{run_id}/{node_id}/{port}/stats")
+async def get_output_stats(run_id: str, node_id: str, port: str, request: Request):
+    """Summary statistics for one captured port, computed server-side.
+
+    Never proportional to the input: a tensor comes back as a fixed set of
+    scalars plus a 64-bin histogram (or, for label tensors, up to 64 value
+    counts), which is a kilobyte or two whatever the tensor weighs.
+
+    The compute runs on a worker thread. A 2 GB tensor takes about a second of
+    real CPU work, and doing that on the event loop would stall every open
+    WebSocket — including the run that produced the tensor.
+    """
+    store = _get_store(request)
+    if not await store.has_run(run_id):
+        raise HTTPException(
+            status_code=404,
+            detail=_not_captured(f"run '{run_id}' has no captured outputs"),
+        )
+    slot = await store.get_with_version(run_id, node_id, port)
+    if slot is None or slot[0] is None:
+        raise HTTPException(
+            status_code=404,
+            detail=_not_captured(
+                f"nothing captured for '{node_id}.{port}' in run '{run_id}'"
+            ),
+        )
+    value, version = slot
+
+    cache = _get_stats_cache(request)
+    # The store's write serial is part of the KEY. A node inside a loop
+    # overwrites one port several times in a run, and the replacement can
+    # land on the freed storage of the value before it — same address, same
+    # shape, same dtype — so anything derived from the object itself would
+    # happily answer for a tensor that no longer exists.
+    key = (run_id, node_id, port, version)
+    payload = cache.get(key)
+    if payload is None:
+        loop = asyncio.get_running_loop()
+        stats = await loop.run_in_executor(
+            _STATS_EXECUTOR,
+            functools.partial(
+                compute_port_stats,
+                value,
+                sample_threshold=settings.STATS_SAMPLE_THRESHOLD,
+                sample_size=settings.STATS_SAMPLE_SIZE,
+            ),
+        )
+        payload = {"run_id": run_id, "node_id": node_id, "port": port, **stats}
+        cache.put(key, payload)
+    return payload
 
 
 @router.get("/{run_id}/{node_id}/{port}")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -120,6 +120,32 @@ class Settings(BaseSettings):
     # env vars demand JSON-in-env quote hell; split in init_allowed_hosts.
     EXTRA_ALLOWED_HOSTS: str = ""
 
+    # ── Port statistics (#129) ─────────────────────────────────────────
+    # GET /api/execution/outputs/{run}/{node}/{port}/stats summarises a
+    # captured value instead of shipping it. Above this element count the
+    # DISTRIBUTION stats (mean/std/quantiles/histogram) are computed from a
+    # deterministic seeded sample and the response is marked
+    # `"sampled": true`. Note what this does NOT cover: count, min, max,
+    # nan_count, inf_count, zero_frac and integer class balance stay exact
+    # at every size, because they are O(n) reductions with no sort — and a
+    # sampled NaN count is not an answer anybody can debug with.
+    #
+    # 4M is a measured number, not a round one: quantiles need a sort, and
+    # torch.sort runs ~0.18us/element (0.7s at 4M, 3s at 16M, 9s at 50M),
+    # while torch.quantile refuses inputs over 16.7M outright. So 4M is the
+    # largest tensor this can summarise EXACTLY while still feeling like a
+    # click. Raising it buys exactness and pays in seconds, linearly.
+    STATS_SAMPLE_THRESHOLD: int = 4_000_000
+    # Elements in that sample. 1M sorts in ~0.17s and pins a quantile to
+    # about 0.1% in probability space — far finer than a 64-bar histogram
+    # can draw, so the chart is never the thing the sample limits.
+    STATS_SAMPLE_SIZE: int = 1_000_000
+    # Byte budget for the computed-stats LRU. BYTES, not entries: one payload
+    # ranges from ~1.5 KB (a 64-bin histogram) to ~50 KB (a wide tabular
+    # summary), so an entry count would be a limit in name only. 8 MB holds
+    # hundreds of ports; a run's worth of inspection never approaches it.
+    STATS_CACHE_MAX_BYTES: int = 8 * 1024 * 1024
+
     NODES_DIR: Path = Path(__file__).parent / "nodes"
     CUSTOM_NODES_DIR: Path = Path(__file__).parent / "custom_nodes"
     GRAPHS_DIR: Path = Path(__file__).parent.parent / "data" / "graphs"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -131,19 +131,26 @@ class Settings(BaseSettings):
     # sampled NaN count is not an answer anybody can debug with.
     #
     # 4M is a measured number, not a round one: quantiles need a sort, and
-    # torch.sort runs ~0.18us/element (0.7s at 4M, 3s at 16M, 9s at 50M),
-    # while torch.quantile refuses inputs over 16.7M outright. So 4M is the
-    # largest tensor this can summarise EXACTLY while still feeling like a
-    # click. Raising it buys exactness and pays in seconds, linearly.
+    # torch.sort runs ~0.18us/element (0.7s at 4M, 3s at 16M, 9s at 50M). So
+    # 4M is the largest tensor this can summarise EXACTLY while still feeling
+    # like a click. Raising it buys exactness and pays in seconds, linearly.
+    # (torch.quantile additionally refuses inputs over 16.7M, but that is a
+    # corroborating observation, not the binding constraint — this module
+    # sorts and interpolates itself precisely so it is not bound by it.)
     STATS_SAMPLE_THRESHOLD: int = 4_000_000
     # Elements in that sample. 1M sorts in ~0.17s and pins a quantile to
     # about 0.1% in probability space — far finer than a 64-bar histogram
     # can draw, so the chart is never the thing the sample limits.
     STATS_SAMPLE_SIZE: int = 1_000_000
     # Byte budget for the computed-stats LRU. BYTES, not entries: one payload
-    # ranges from ~1.5 KB (a 64-bin histogram) to ~50 KB (a wide tabular
+    # ranges from ~2 KB (a 64-bin histogram) to ~50 KB (a wide tabular
     # summary), so an entry count would be a limit in name only. 8 MB holds
     # hundreds of ports; a run's worth of inspection never approaches it.
+    #
+    # Measured as SERIALIZED size, which is what the response costs and what
+    # #135 will bound everywhere. Resident size is some multiple of it —
+    # Python dicts, str keys and boxed floats run roughly 5-10x — so read this
+    # as a cap on payload volume, not as an RSS guarantee.
     STATS_CACHE_MAX_BYTES: int = 8 * 1024 * 1024
 
     NODES_DIR: Path = Path(__file__).parent / "nodes"

--- a/backend/app/core/port_stats.py
+++ b/backend/app/core/port_stats.py
@@ -318,7 +318,11 @@ def _narrow_for_sampling(t: Any, target: int, seed: int) -> Any:
     Drawn with ``randint`` rather than ``randperm`` because the axis can be
     long: a permutation of 500M rows is a 4 GB allocation to pick four of them.
     ``unique`` sorts and de-duplicates, so the survivors stay in order and no
-    slice is counted twice.
+    slice is counted twice — which does mean the count can come out below
+    ``keep`` when the draw collides. Deterministic for a seed, and harmless:
+    this only sizes the pool, and ``_seeded_sample`` then draws exactly
+    ``sample_size`` elements from it with replacement, so the reported
+    ``sample_size`` is unaffected.
     """
     import torch
 
@@ -733,13 +737,10 @@ def _tabular_stats(
     *,
     max_rows: int,
 ) -> dict[str, Any]:
-    # ``max_rows`` is a budget over the whole TABLE, not per column. The column
-    # walk is interpreted Python, so a 64-column table at 200k rows each would
-    # be 12.8M dict operations — seconds of wall clock for a summary that is
-    # supposed to be instant. Spreading the budget keeps the cost flat in the
-    # column count, with a floor so a very wide table still sees enough rows
-    # per column for its top-k to mean something.
-    per_column = max(1000, max_rows // max(1, len(columns))) if columns else max_rows
+    # The same budget `_as_columns` already sliced to. Shared through the
+    # helper rather than restated here, so the number of cells actually
+    # scanned and the number reported as `sample_size` cannot drift apart.
+    per_column = _row_budget(len(columns), max_rows)
     sampled = rows > per_column
     return {
         "kind": "tabular",

--- a/backend/app/core/port_stats.py
+++ b/backend/app/core/port_stats.py
@@ -1,0 +1,832 @@
+"""Summary statistics for one captured port value, computed where the data is.
+
+Why this module exists
+----------------------
+``/api/execution/outputs/{run}/{node}/{port}`` ships VALUES. That is the right
+answer for a [2, 3] tensor and the wrong one for a 2 GB activation: the only
+honest way to answer "what does this data look like" at that scale is to
+summarise it on the server and send back a couple of kilobytes. This module is
+that summary, and nothing here ever returns a payload proportional to the input.
+
+What is exact and what is not
+-----------------------------
+The split is deliberate, because the stats people debug with are not the stats
+that are expensive:
+
+* ALWAYS EXACT, at any size — ``count``, ``min``, ``max``, ``nan_count``,
+  ``inf_count``, ``zero_frac``, and integer class balance. These are O(n)
+  reductions with no sort, so there is no reason to approximate them, and a
+  *sampled* NaN count is close to useless: "3 NaNs in a 1M sample" is not an
+  answer anybody can act on, whereas "3 NaNs, exactly" is.
+* SAMPLED above ``sample_threshold`` — ``mean``, ``std``, the quantiles and the
+  histogram. These describe a distribution, and a distribution is exactly the
+  thing a sample estimates well.
+
+The sample is drawn with a seeded CPU generator, so the same tensor and the
+same seed give byte-identical output — a cached stat and a recomputed one can
+never disagree.
+
+Why the threshold is 4M and not something rounder
+-------------------------------------------------
+Quantiles need a sort, and ``torch.sort`` costs ~0.18 µs/element (measured on
+a 16-thread CPU): 0.7 s at 4M, 3 s at 16M, 9 s at 50M. ``torch.quantile``
+refuses inputs over 16.7M outright. 4M is therefore the largest tensor this
+can summarise exactly while still feeling like a click rather than a job.
+
+An earlier draft kept the threshold at 50M and estimated quantiles above 4M by
+inverting a 16384-bin histogram — O(n), no sort. That is more accurate than
+sampling on well-behaved data and catastrophically worse on the data this
+endpoint exists to debug: bin width is set by the full range, so one diverged
+value at 1e6 in a standard-normal tensor moved the reported median from 0.0012
+to 25.3. A 1M-element sample put it at 0.0023. Outliers are the whole reason
+someone opens this panel, so the estimator that breaks on them is the wrong
+one, and sampling took its place along with ~45 lines of it.
+
+Mean and std ride the same working set as the quantiles; ``min``/``max`` do
+not, so an outlier is always visible in the stat table even when the
+distribution around it was sampled.
+
+JSON safety
+-----------
+Every float goes through :func:`_num`, which turns NaN/±Inf into ``None``. That
+is the convention ``run_store.json_safe`` established in #119, and it is
+load-bearing rather than cosmetic: Starlette renders responses with
+``allow_nan=False``, so one leaked NaN is a 500, and NaN-laden tensors are
+precisely what this endpoint exists to describe.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import threading
+from collections import OrderedDict
+from typing import Any, Iterator
+
+# ── tunables that are not worth a config knob ────────────────────────────────
+
+#: Bars in the returned histogram. 64 reads well at inspector width and keeps
+#: the payload around 1.5 KB.
+HISTOGRAM_BINS = 64
+
+#: An integer tensor with at most this many distinct values is a label tensor,
+#: and a label tensor wants class balance rather than a histogram.
+CLASS_BALANCE_MAX = 64
+
+#: Rows in a tabular column's ``top`` list.
+TOP_K = 10
+
+#: Elements per chunk in the full-tensor passes. Bounds the temporaries those
+#: passes allocate (a bool mask, an int64 cast) to ~64 MB for any tensor that
+#: has an axis to split on — see :func:`_split_axis` for the one shape that
+#: does not, a single element.
+CHUNK_ELEMENTS = 8_000_000
+
+#: Ceiling on the ``torch.unique`` fallback that catches label tensors whose
+#: values are few but far apart. Above this the fallback is skipped rather
+#: than approximated: a sort of the whole tensor is exactly the cost this
+#: module is built to avoid, and a *guessed* class balance is worse than none.
+UNIQUE_EXACT_MAX = 1_000_000
+
+#: Columns described in a tabular payload, and rows scanned per column.
+DEFAULT_TABULAR_MAX_COLUMNS = 64
+DEFAULT_TABULAR_MAX_ROWS = 200_000
+
+QUANTILE_LEVELS: tuple[tuple[str, float], ...] = (
+    ("p1", 0.01),
+    ("p5", 0.05),
+    ("p25", 0.25),
+    ("p50", 0.50),
+    ("p75", 0.75),
+    ("p95", 0.95),
+    ("p99", 0.99),
+)
+
+
+# ── number formatting ────────────────────────────────────────────────────────
+
+
+def _num(value: Any) -> float | None:
+    """The value as a plain float, or None when it is not finite.
+
+    None rather than NaN/±Inf is the whole point (see the JSON-safety note in
+    the module docstring): an all-NaN tensor has no mean, and saying so with
+    ``null`` beats emitting a token the encoder refuses.
+
+    Deliberately NOT rounded. An earlier version trimmed to six significant
+    figures for compactness, which flattened an int64 tensor near 1e15 into a
+    single repeated value and collapsed all 65 edges of a narrow range at a
+    large magnitude (1e6 to 1e6+0.5) onto one number — the payload lying about
+    the data to save a few hundred bytes. Python emits the shortest string
+    that round-trips, so ``0.1`` still costs three characters; only the values
+    that genuinely need the digits pay for them, and the frontend rounds for
+    display anyway.
+    """
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if math.isfinite(f) else None
+
+
+# ── tensor helpers ───────────────────────────────────────────────────────────
+
+
+def _split_axis(t: Any) -> int | None:
+    """First dimension with more than one element, or None if there is none.
+
+    NOT hard-coded to dim 0. A single-sample activation permuted to
+    channels-last — ``x.permute(0, 2, 3, 1)`` on ``[1, C, H, W]`` — is
+    non-contiguous with ``shape[0] == 1``, which is both the commonest thing
+    anyone inspects and the one shape a dim-0 split cannot cut.
+    """
+    for dim in range(t.dim()):
+        if t.shape[dim] > 1:
+            return dim
+    return None
+
+
+def _iter_chunks(t: Any, chunk_elements: int = CHUNK_ELEMENTS) -> Iterator[Any]:
+    """Walk `t` in pieces of roughly `chunk_elements` elements.
+
+    A contiguous tensor is walked through a free 1-D view. A non-contiguous one
+    is walked in slices along {@link _split_axis} instead, because flattening it
+    would copy the whole thing — the exact allocation the chunking exists to
+    avoid. A tensor with no splittable axis is a single element; it is yielded
+    whole because there is nothing to cut.
+    """
+    if t.numel() == 0:
+        return
+    if t.is_contiguous():
+        flat = t.reshape(-1)
+        for start in range(0, flat.numel(), chunk_elements):
+            yield flat[start : start + chunk_elements]
+        return
+    axis = _split_axis(t)
+    if axis is None:
+        yield t
+        return
+    length = t.shape[axis]
+    per_slice = max(1, t.numel() // length)
+    step = max(1, chunk_elements // per_slice)
+    for start in range(0, length, step):
+        yield t.narrow(axis, start, min(step, length - start))
+
+
+def _dtype_kind(t: Any) -> str:
+    """One of ``float`` / ``int`` / ``bool`` / ``other`` (complex, quantized).
+
+    A non-strided layout (sparse, nested) also lands in ``other``: every pass
+    below calls ``is_contiguous`` or ``amin``, and those raise rather than
+    answer for a tensor that is not a dense buffer.
+    """
+    import torch
+
+    if t.layout != torch.strided:
+        return "other"
+    if t.dtype == torch.bool:
+        return "bool"
+    if t.is_floating_point():
+        return "float"
+    if t.is_complex():
+        return "other"
+    try:
+        # Integral dtypes are the ones that survive an int64 cast unchanged.
+        # Asking this way (rather than listing dtypes) keeps future int types
+        # working, and quantized dtypes fall out as "other" because they raise.
+        torch.zeros(1, dtype=t.dtype).to(torch.int64)
+    except (RuntimeError, TypeError):
+        return "other"
+    return "int"
+
+
+class _Scan:
+    """Result of the single full-tensor pass."""
+
+    __slots__ = ("nan", "inf", "zero", "lo", "hi", "finite")
+
+    def __init__(self) -> None:
+        self.nan = 0
+        self.inf = 0
+        self.zero = 0
+        self.lo: float | int | None = None
+        self.hi: float | int | None = None
+        self.finite = 0
+
+
+def _scan_tensor(t: Any, kind: str) -> _Scan:
+    """One pass over every element: health counts plus the finite extremes.
+
+    NaN and Inf are excluded from min/max — a diverged tensor whose max reads
+    ``inf`` tells you nothing about the values you still have.
+    """
+    import torch
+
+    out = _Scan()
+    lo_t = None
+    hi_t = None
+    for chunk in _iter_chunks(t):
+        n = chunk.numel()
+        if kind == "float":
+            nan_mask = torch.isnan(chunk)
+            inf_mask = torch.isinf(chunk)
+            n_nan = int(nan_mask.sum())
+            n_inf = int(inf_mask.sum())
+            out.nan += n_nan
+            out.inf += n_inf
+            out.finite += n - n_nan - n_inf
+            if n_nan or n_inf:
+                good = ~(nan_mask | inf_mask)
+                if not bool(good.any()):
+                    continue
+                # `where` rather than a boolean index: masked selection would
+                # allocate a second copy of the chunk's surviving elements.
+                c_lo = torch.where(good, chunk, torch.inf).amin()
+                c_hi = torch.where(good, chunk, -torch.inf).amax()
+            else:
+                c_lo = chunk.amin()
+                c_hi = chunk.amax()
+        else:
+            out.finite += n
+            c_lo = chunk.amin()
+            c_hi = chunk.amax()
+        lo_t = c_lo if lo_t is None else torch.minimum(lo_t, c_lo)
+        hi_t = c_hi if hi_t is None else torch.maximum(hi_t, c_hi)
+        out.zero += int((chunk == 0).sum())
+
+    if lo_t is not None:
+        if kind == "int":
+            out.lo = int(lo_t)
+            out.hi = int(hi_t)
+        elif kind == "bool":
+            out.lo = int(bool(lo_t))
+            out.hi = int(bool(hi_t))
+        else:
+            out.lo = float(lo_t)
+            out.hi = float(hi_t)
+    return out
+
+
+def _flat_view(t: Any) -> Any:
+    """1-D view of `t`, copying only when the layout leaves no choice."""
+    try:
+        return t.view(-1)
+    except RuntimeError:
+        return t.reshape(-1)
+
+
+def _narrow_for_sampling(t: Any, target: int) -> Any:
+    """Pre-thin a non-contiguous tensor before flattening it.
+
+    Flattening a non-contiguous 2 GB tensor copies 2 GB, which is exactly the
+    allocation a sampled path must not make. Striding along {@link _split_axis}
+    first is a view, so only the survivors get copied.
+    """
+    if t.is_contiguous() or t.numel() <= target * 4:
+        return t
+    axis = _split_axis(t)
+    if axis is None:
+        return t
+    length = t.shape[axis]
+    per_slice = max(1, t.numel() // length)
+    keep = max(1, -(-target * 4 // per_slice))
+    if keep >= length:
+        return t
+    step = max(1, length // keep)
+    return t[(slice(None),) * axis + (slice(None, None, step),)]
+
+
+def _seeded_sample(flat: Any, size: int, seed: int) -> Any:
+    """`size` elements drawn uniformly (with replacement) from `flat`.
+
+    The index draw happens on CPU whatever device the data is on, so a CUDA
+    tensor and its CPU copy sample the same positions.
+    """
+    import torch
+
+    generator = torch.Generator()
+    generator.manual_seed(seed)
+    idx = torch.randint(0, flat.numel(), (size,), generator=generator, dtype=torch.long)
+    if flat.device.type != "cpu":
+        idx = idx.to(flat.device)
+    return flat.index_select(0, idx)
+
+
+def _finite_only(x: Any, kind: str) -> Any:
+    """Drop NaN/Inf. Returns `x` untouched when there is nothing to drop."""
+    import torch
+
+    if kind != "float":
+        return x
+    mask = torch.isfinite(x)
+    if bool(mask.all()):
+        return x
+    return x[mask]
+
+
+def _quantiles_by_sort(work: Any, levels=QUANTILE_LEVELS) -> dict[str, float | None]:
+    """Exact quantiles, linearly interpolated — ``numpy.quantile`` semantics."""
+    import torch
+
+    ordered, _ = torch.sort(work.to(torch.float64))
+    n = ordered.numel()
+    out: dict[str, float | None] = {}
+    for name, q in levels:
+        pos = q * (n - 1)
+        low = int(math.floor(pos))
+        high = min(low + 1, n - 1)
+        frac = pos - low
+        value = float(ordered[low]) * (1.0 - frac) + float(ordered[high]) * frac
+        out[name] = _num(value)
+    return out
+
+
+def _histogram_counts(work: Any, bins: int, lo: float, hi: float) -> Any:
+    """``torch.histc`` over `work`, cast to something histc accepts."""
+    import torch
+
+    if work.dtype not in (torch.float32, torch.float64):
+        work = work.to(torch.float32)
+    return torch.histc(work, bins=bins, min=lo, max=hi).to(torch.int64)
+
+
+def _exact_value_counts(t: Any, lo: int, span: int) -> list[dict[str, Any]]:
+    """Exact per-value counts over EVERY element, via a chunked bincount.
+
+    O(n) with no sort, so class balance stays exact even for a tensor whose
+    distribution had to be sampled — which matters, because "is my training set
+    balanced" is not a question anybody wants answered approximately.
+    """
+    import torch
+
+    total = None
+    for chunk in _iter_chunks(t):
+        shifted = chunk.reshape(-1).to(torch.int64) - lo
+        counts = torch.bincount(shifted, minlength=span)
+        total = counts if total is None else total + counts
+    if total is None:
+        return []
+    return [
+        {"value": lo + i, "count": int(c)}
+        for i, c in enumerate(total.tolist())
+        if c > 0
+    ]
+
+
+# ── the tensor branch ────────────────────────────────────────────────────────
+
+
+def _tensor_stats(
+    value: Any,
+    *,
+    sample_threshold: int,
+    sample_size: int,
+    seed: int,
+) -> dict[str, Any]:
+    import torch
+
+    t = value.detach()
+    numel = t.numel()
+    kind = _dtype_kind(t)
+
+    stats: dict[str, Any] = {
+        "kind": "tensor",
+        "shape": list(t.shape),
+        "dtype": str(t.dtype),
+        "device": str(t.device),
+        "count": numel,
+        "sampled": False,
+        "sample_size": None,
+        "mean": None,
+        "std": None,
+        "min": None,
+        "max": None,
+        "quantiles": {},
+        "nan_count": 0,
+        "inf_count": 0,
+        "zero_frac": None,
+        "histogram": None,
+        "value_counts": None,
+    }
+
+    if numel == 0:
+        stats["zero_frac"] = 0.0
+        return stats
+    if kind == "other":
+        # Complex / quantized: the shape and dtype are still worth showing, but
+        # every stat below assumes a total order that these dtypes do not have.
+        return stats
+
+    scan = _scan_tensor(t, kind)
+    stats["nan_count"] = scan.nan
+    stats["inf_count"] = scan.inf
+    stats["zero_frac"] = _num(scan.zero / numel)
+    stats["min"] = _num(scan.lo) if kind == "float" else scan.lo
+    stats["max"] = _num(scan.hi) if kind == "float" else scan.hi
+
+    if scan.finite == 0 or scan.lo is None:
+        # Everything is NaN/Inf. Reporting `mean: null` beats reporting NaN,
+        # and the counts above already say what happened.
+        return stats
+
+    # ── the working set: what the distribution stats actually read ──────────
+    sampled = numel > sample_threshold
+    if sampled:
+        narrowed = _narrow_for_sampling(t, sample_size)
+        work = _seeded_sample(_flat_view(narrowed), sample_size, seed)
+    else:
+        work = _flat_view(t)
+    if work.device.type != "cpu":
+        work = work.to("cpu")
+    work = _finite_only(work, kind)
+
+    if work.numel() == 0:
+        # A sample that happened to land entirely on NaNs.
+        stats["sampled"] = sampled
+        stats["sample_size"] = 0 if sampled else None
+        return stats
+
+    stats["sampled"] = sampled
+    stats["sample_size"] = work.numel() if sampled else None
+
+    # float64 for integers, not float32: a mantissa of 24 bits silently
+    # rounds anything past 2^24, and an int64 tensor around 1e15 would report
+    # a mean sitting outside the p25-p75 spread printed beside it.
+    if work.dtype == torch.float64:
+        work_f = work
+    else:
+        work_f = work.to(torch.float64 if kind == "int" else torch.float32)
+    var, mean = torch.var_mean(work_f, correction=0)
+    stats["mean"] = _num(mean)
+    # Population std (ddof=0), matching `numpy.std` rather than torch's own
+    # default of Bessel-corrected — this module checks itself against numpy.
+    stats["std"] = _num(math.sqrt(max(float(var), 0.0)))
+
+    lo = float(scan.lo)
+    hi = float(scan.hi)
+    stats["quantiles"] = (
+        _quantiles_by_sort(work_f)
+        if hi > lo
+        else {name: _num(lo) for name, _ in QUANTILE_LEVELS}
+    )
+
+    # ── class balance, or a histogram ──────────────────────────────────────
+    if kind in ("int", "bool"):
+        span = int(scan.hi) - int(scan.lo) + 1
+        if 1 <= span <= CLASS_BALANCE_MAX:
+            counts = _exact_value_counts(t, int(scan.lo), span)
+        elif not sampled and work.numel() <= UNIQUE_EXACT_MAX:
+            # Few distinct values, far apart — labels carrying their original
+            # ids rather than 0..C-1. Only taken when `work` IS the whole
+            # tensor, so these counts are exact like the bincount ones; a
+            # sampled class balance would be a guess wearing a count's clothes.
+            unique, unique_counts = torch.unique(work, return_counts=True)
+            counts = (
+                [
+                    {"value": int(v), "count": int(c)}
+                    for v, c in zip(unique.tolist(), unique_counts.tolist())
+                ]
+                if unique.numel() <= CLASS_BALANCE_MAX
+                else []
+            )
+        else:
+            counts = []
+        if counts:
+            if kind == "bool":
+                counts = [{"value": bool(e["value"]), "count": e["count"]} for e in counts]
+            stats["value_counts"] = counts
+            return stats
+
+    if hi > lo:
+        counts = _histogram_counts(work_f, HISTOGRAM_BINS, lo, hi)
+        width = (hi - lo) / HISTOGRAM_BINS
+        stats["histogram"] = {
+            "bins": HISTOGRAM_BINS,
+            "edges": [_num(lo + i * width) for i in range(HISTOGRAM_BINS + 1)],
+            "counts": [int(c) for c in counts.tolist()],
+        }
+    else:
+        # One value, one bar. A 64-bin histogram of a constant is 63 lies.
+        stats["histogram"] = {
+            "bins": 1,
+            "edges": [_num(lo), _num(hi)],
+            "counts": [int(work.numel())],
+        }
+    return stats
+
+
+# ── the tabular branch ───────────────────────────────────────────────────────
+
+
+def _is_missing(v: Any) -> bool:
+    return v is None or (isinstance(v, float) and not math.isfinite(v))
+
+
+def _column_stats(name: str, values: list[Any], max_rows: int) -> dict[str, Any]:
+    """count / unique / top-k / missing for one column, plus numeric moments.
+
+    ``unique`` and ``top`` are computed from a plain ``dict`` counter rather
+    than a set-plus-sort, so one walk answers both. Unhashable cell values
+    (a list in a cell) are counted by their repr — a stat is better than a
+    crash, and the repr is what the UI would show anyway.
+    """
+    scanned = values if len(values) <= max_rows else values[:max_rows]
+    counter: dict[Any, int] = {}
+    missing = 0
+    numeric: list[float] = []
+    all_numeric = True
+    saw_bool = False
+    saw_float = False
+    saw_int = False
+    saw_str = False
+
+    for v in scanned:
+        if _is_missing(v):
+            missing += 1
+            continue
+        if isinstance(v, bool):
+            saw_bool = True
+            numeric.append(float(v))
+        elif isinstance(v, int):
+            saw_int = True
+            numeric.append(float(v))
+        elif isinstance(v, float):
+            saw_float = True
+            numeric.append(v)
+        else:
+            all_numeric = False
+            if isinstance(v, str):
+                saw_str = True
+        try:
+            counter[v] = counter.get(v, 0) + 1
+        except TypeError:
+            key = repr(v)
+            counter[key] = counter.get(key, 0) + 1
+
+    if saw_bool and not (saw_int or saw_float or saw_str):
+        dtype = "bool"
+    elif all_numeric and saw_float:
+        dtype = "float"
+    elif all_numeric and saw_int:
+        dtype = "int"
+    elif saw_str and all(isinstance(k, str) for k in counter):
+        dtype = "str"
+    elif not counter:
+        dtype = "empty"
+    else:
+        dtype = "mixed"
+
+    top = sorted(counter.items(), key=lambda kv: (-kv[1], str(kv[0])))[:TOP_K]
+    column: dict[str, Any] = {
+        "name": name,
+        "dtype": dtype,
+        "count": len(scanned) - missing,
+        "missing": missing,
+        "unique": len(counter),
+        "top": [
+            {"value": v if isinstance(v, (str, int, float, bool)) else str(v),
+             "count": c}
+            for v, c in top
+        ],
+        "mean": None,
+        "min": None,
+        "max": None,
+    }
+    if all_numeric and numeric:
+        mean = sum(numeric) / len(numeric)
+        column["mean"] = _num(mean)
+        column["min"] = _num(min(numeric))
+        column["max"] = _num(max(numeric))
+    return column
+
+
+def _as_columns(
+    value: Any, *, max_rows: int, max_columns: int
+) -> tuple[list[tuple[str, list[Any]]], int, int] | None:
+    """Normalise a tabular-ish value into ``([(name, cells)], rows, columns)``.
+
+    Three shapes are recognised, all of them things a node in this repo
+    actually emits: a columnar dict (``{"age": [...], "city": [...]}``), a list
+    of record dicts, and a flat list of primitives (``CSVReader.labels``), which
+    becomes a single column so class balance over string labels works.
+
+    The caps are applied HERE, at the slice, not downstream where the summary
+    is computed. A 10M-row CSV transposed in full is over a gigabyte of list
+    slots and ten seconds on the GIL — spent building rows nobody then reads.
+    The returned row and column counts are still the true ones; only the cells
+    handed on are cut.
+    """
+    if isinstance(value, dict):
+        if not value:
+            return [], 0, 0
+        columns: list[tuple[str, list[Any]]] = []
+        rows = 0
+        # Distinct dict keys can share a `str()` (1 and "1"). Left alone they
+        # become two columns with one name and a duplicate React key.
+        names: list[str] = []
+        seen: set[str] = set()
+        for key, cells in value.items():
+            if not isinstance(cells, (list, tuple)):
+                return None
+            rows = max(rows, len(cells))
+            name = str(key)
+            if name in seen:
+                continue
+            seen.add(name)
+            names.append(name)
+            if len(columns) < max_columns:
+                columns.append((name, list(cells[:max_rows])))
+        return columns, rows, len(names)
+
+    if isinstance(value, (list, tuple)):
+        if len(value) == 0:
+            return [], 0, 0
+        head = value[:max_rows]
+        if all(isinstance(row, dict) for row in head):
+            record_names: list[str] = []
+            seen_names: set[str] = set()
+            for row in head:
+                for key in row:
+                    if str(key) not in seen_names:
+                        seen_names.add(str(key))
+                        record_names.append(str(key))
+            kept = record_names[:max_columns]
+            columns = [(name, [row.get(name) for row in head]) for name in kept]
+            return columns, len(value), len(record_names)
+        primitive = (str, int, float, bool, type(None))
+        if all(isinstance(x, primitive) for x in head):
+            return [("values", list(head))], len(value), 1
+    return None
+
+
+def _tabular_stats(
+    columns: list[tuple[str, list[Any]]],
+    rows: int,
+    column_count: int,
+    *,
+    max_rows: int,
+) -> dict[str, Any]:
+    # ``max_rows`` is a budget over the whole TABLE, not per column. The column
+    # walk is interpreted Python, so a 64-column table at 200k rows each would
+    # be 12.8M dict operations — seconds of wall clock for a summary that is
+    # supposed to be instant. Spreading the budget keeps the cost flat in the
+    # column count, with a floor so a very wide table still sees enough rows
+    # per column for its top-k to mean something.
+    per_column = max(1000, max_rows // max(1, len(columns))) if columns else max_rows
+    sampled = rows > per_column
+    return {
+        "kind": "tabular",
+        "rows": rows,
+        "column_count": column_count,
+        "columns_truncated": column_count > len(columns),
+        "sampled": sampled,
+        "sample_size": min(rows, per_column) if sampled else None,
+        "columns": [_column_stats(name, cells, per_column) for name, cells in columns],
+    }
+
+
+# ── entry point ──────────────────────────────────────────────────────────────
+
+
+def compute_port_stats(
+    value: Any,
+    *,
+    sample_threshold: int | None = None,
+    sample_size: int | None = None,
+    tabular_max_rows: int | None = None,
+    tabular_max_columns: int | None = None,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Summarise one captured port value.
+
+    The returned dict is JSON-safe by construction and bounded in size: a
+    64-bin histogram or at most ``CLASS_BALANCE_MAX`` value counts for a
+    tensor, at most ``tabular_max_columns`` column summaries for a table.
+
+    Every limit is a parameter rather than a settings read so tests can drive
+    the branches with small inputs. The route fills the two that users have a
+    reason to tune (``sample_threshold``, ``sample_size``) from ``settings``;
+    the tabular caps have no knob because nothing has needed one.
+    """
+    from ..config import settings
+
+    if sample_threshold is None:
+        sample_threshold = settings.STATS_SAMPLE_THRESHOLD
+    if sample_size is None:
+        sample_size = settings.STATS_SAMPLE_SIZE
+    if tabular_max_rows is None:
+        tabular_max_rows = DEFAULT_TABULAR_MAX_ROWS
+    if tabular_max_columns is None:
+        tabular_max_columns = DEFAULT_TABULAR_MAX_COLUMNS
+
+    try:
+        import torch
+
+        if isinstance(value, torch.Tensor):
+            return _tensor_stats(
+                value,
+                sample_threshold=max(1, sample_threshold),
+                sample_size=max(1, sample_size),
+                seed=seed,
+            )
+        if isinstance(value, torch.nn.Module):
+            return {"kind": "unsupported", "type": type(value).__name__}
+    except ImportError:  # pragma: no cover - torch is a hard dependency here
+        pass
+
+    max_rows = max(1, tabular_max_rows)
+    max_columns = max(1, tabular_max_columns)
+    shaped = _as_columns(value, max_rows=max_rows, max_columns=max_columns)
+    if shaped is not None:
+        columns, rows, column_count = shaped
+        return _tabular_stats(columns, rows, column_count, max_rows=max_rows)
+
+    return {"kind": "unsupported", "type": type(value).__name__}
+
+
+# ── cache ────────────────────────────────────────────────────────────────────
+
+
+def payload_bytes(payload: Any) -> int:
+    """Serialized size of a stats payload, in bytes.
+
+    Mirrors ``run_service.json_size`` deliberately rather than importing it:
+    that module pulls in RunService and the whole database layer, and this one
+    is meant to stay a leaf. ``ensure_ascii`` defaults to True, so ``len`` is a
+    byte count.
+    """
+    try:
+        return len(json.dumps(payload, separators=(",", ":"), default=str))
+    except (TypeError, ValueError, RecursionError):  # pragma: no cover
+        return 0
+
+
+class PortStatsCache:
+    """A bytes-bounded LRU for computed stat payloads.
+
+    Bounded by BYTES, not by entry count. An entry-count bound would be a
+    guess dressed as a limit here: a 64-bin histogram is ~1.5 KB and a wide
+    tabular summary is ~50 KB, so "200 entries" means anywhere from 300 KB to
+    10 MB depending on what the user happened to inspect.
+
+    Guarded by a ``threading.Lock`` rather than an ``asyncio.Lock`` because
+    the compute that fills it runs in a worker thread.
+    """
+
+    def __init__(self, max_bytes: int) -> None:
+        self._max_bytes = max_bytes
+        self._entries: OrderedDict[tuple, tuple[Any, int]] = OrderedDict()
+        self._total = 0
+        self._lock = threading.Lock()
+        self.hits = 0
+        self.misses = 0
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+    @property
+    def total_bytes(self) -> int:
+        with self._lock:
+            return self._total
+
+    @property
+    def max_bytes(self) -> int:
+        return self._max_bytes
+
+    def get(self, key: tuple) -> Any | None:
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                self.misses += 1
+                return None
+            self._entries.move_to_end(key)
+            self.hits += 1
+            return entry[0]
+
+    def put(self, key: tuple, payload: Any) -> None:
+        size = payload_bytes(payload)
+        with self._lock:
+            if size > self._max_bytes:
+                # Caching it would evict everything else and still not fit.
+                self._drop(key)
+                return
+            self._drop(key)
+            self._entries[key] = (payload, size)
+            self._total += size
+            while self._total > self._max_bytes and self._entries:
+                _, (_, evicted) = self._entries.popitem(last=False)
+                self._total -= evicted
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+            self._total = 0
+
+    def _drop(self, key: tuple) -> None:
+        """Remove `key` if present. Caller holds the lock."""
+        old = self._entries.pop(key, None)
+        if old is not None:
+            self._total -= old[1]

--- a/backend/app/core/port_stats.py
+++ b/backend/app/core/port_stats.py
@@ -29,9 +29,11 @@ never disagree.
 Why the threshold is 4M and not something rounder
 -------------------------------------------------
 Quantiles need a sort, and ``torch.sort`` costs ~0.18 µs/element (measured on
-a 16-thread CPU): 0.7 s at 4M, 3 s at 16M, 9 s at 50M. ``torch.quantile``
-refuses inputs over 16.7M outright. 4M is therefore the largest tensor this
-can summarise exactly while still feeling like a click rather than a job.
+a 16-thread CPU): 0.7 s at 4M, 3 s at 16M, 9 s at 50M. 4M is therefore the
+largest tensor this can summarise exactly while still feeling like a click
+rather than a job. (``torch.quantile`` also refuses inputs over 16.7M, which
+is why :func:`_quantiles_by_sort` interpolates by hand rather than calling it
+— corroborating evidence for the number, not the reason for it.)
 
 An earlier draft kept the threshold at 50M and estimated quantiles above 4M by
 inverting a 16384-bin histogram — O(n), no sort. That is more accurate than
@@ -77,10 +79,22 @@ CLASS_BALANCE_MAX = 64
 TOP_K = 10
 
 #: Elements per chunk in the full-tensor passes. Bounds the temporaries those
-#: passes allocate (a bool mask, an int64 cast) to ~64 MB for any tensor that
-#: has an axis to split on — see :func:`_split_axis` for the one shape that
-#: does not, a single element.
+#: passes allocate (a bool mask, an int64 cast) to ~64 MB. When one slice of
+#: the first splittable axis is itself over budget, :func:`_iter_chunks`
+#: recurses onto the next axis, so the only shape that exceeds this is a
+#: single element with no axis to split at all.
 CHUNK_ELEMENTS = 8_000_000
+
+#: Rows scanned when working out which columns a list-of-records has. Bounded
+#: separately from the cell budget because discovering names is itself a
+#: Python loop over every key of every row; a column that first appears after
+#: this many records is not described.
+RECORD_NAME_PROBE_ROWS = 1_000
+
+#: Cap on one ``top`` value's rendered length. A text column can hold whole
+#: paragraphs, and ten of those across sixty columns is the difference between
+#: a 2 KB payload and a 600 KB one.
+TOP_VALUE_MAX_CHARS = 120
 
 #: Ceiling on the ``torch.unique`` fallback that catches label tensors whose
 #: values are few but far apart. Above this the fallback is skipped rather
@@ -172,7 +186,17 @@ def _iter_chunks(t: Any, chunk_elements: int = CHUNK_ELEMENTS) -> Iterator[Any]:
     per_slice = max(1, t.numel() // length)
     step = max(1, chunk_elements // per_slice)
     for start in range(0, length, step):
-        yield t.narrow(axis, start, min(step, length - start))
+        piece = t.narrow(axis, start, min(step, length - start))
+        if piece.numel() > chunk_elements and piece.shape[axis] == 1:
+            # One slice of this axis is already over budget — a `[1, 3, 16384,
+            # 16384]` image batch splits into three 268M-element pieces, and
+            # `_scan_tensor` would then build a bool mask over each. Hand the
+            # piece back to the next splittable axis. Terminating: this branch
+            # only runs once `step` has collapsed to a single slice, so every
+            # recursion retires one axis.
+            yield from _iter_chunks(piece, chunk_elements)
+        else:
+            yield piece
 
 
 def _dtype_kind(t: Any) -> str:
@@ -277,13 +301,27 @@ def _flat_view(t: Any) -> Any:
         return t.reshape(-1)
 
 
-def _narrow_for_sampling(t: Any, target: int) -> Any:
+def _narrow_for_sampling(t: Any, target: int, seed: int) -> Any:
     """Pre-thin a non-contiguous tensor before flattening it.
 
     Flattening a non-contiguous 2 GB tensor copies 2 GB, which is exactly the
-    allocation a sampled path must not make. Striding along {@link _split_axis}
-    first is a view, so only the survivors get copied.
+    allocation a sampled path must not make. Keeping a subset of slices along
+    {@link _split_axis} first means only the survivors get copied.
+
+    The slices are CHOSEN AT RANDOM, not strided. An earlier version kept every
+    n-th slice, which on a ``[1, 64, 1024, 1024]`` activation meant channels
+    0, 16, 32 and 48 and nothing else — a systematically selected quarter of
+    the data reported under ``"sampled": true``, which reads as an unbiased
+    draw. Any axis that carries structure (channel, class, time) would have
+    been summarised from whichever slices the stride happened to land on.
+
+    Drawn with ``randint`` rather than ``randperm`` because the axis can be
+    long: a permutation of 500M rows is a 4 GB allocation to pick four of them.
+    ``unique`` sorts and de-duplicates, so the survivors stay in order and no
+    slice is counted twice.
     """
+    import torch
+
     if t.is_contiguous() or t.numel() <= target * 4:
         return t
     axis = _split_axis(t)
@@ -294,8 +332,12 @@ def _narrow_for_sampling(t: Any, target: int) -> Any:
     keep = max(1, -(-target * 4 // per_slice))
     if keep >= length:
         return t
-    step = max(1, length // keep)
-    return t[(slice(None),) * axis + (slice(None, None, step),)]
+    generator = torch.Generator()
+    generator.manual_seed(seed)
+    picks = torch.unique(
+        torch.randint(0, length, (keep,), generator=generator, dtype=torch.long)
+    )
+    return t.index_select(axis, picks.to(t.device))
 
 
 def _seeded_sample(flat: Any, size: int, seed: int) -> Any:
@@ -434,7 +476,7 @@ def _tensor_stats(
     # ── the working set: what the distribution stats actually read ──────────
     sampled = numel > sample_threshold
     if sampled:
-        narrowed = _narrow_for_sampling(t, sample_size)
+        narrowed = _narrow_for_sampling(t, sample_size, seed)
         work = _seeded_sample(_flat_view(narrowed), sample_size, seed)
     else:
         work = _flat_view(t)
@@ -524,6 +566,16 @@ def _is_missing(v: Any) -> bool:
     return v is None or (isinstance(v, float) and not math.isfinite(v))
 
 
+def _top_value(v: Any) -> str | int | float | bool:
+    """One `top` entry, with long text cut to a length a table can show."""
+    if isinstance(v, (int, float, bool)):
+        return v
+    text = v if isinstance(v, str) else str(v)
+    if len(text) <= TOP_VALUE_MAX_CHARS:
+        return text
+    return text[:TOP_VALUE_MAX_CHARS] + "..."
+
+
 def _column_stats(name: str, values: list[Any], max_rows: int) -> dict[str, Any]:
     """count / unique / top-k / missing for one column, plus numeric moments.
 
@@ -585,11 +637,7 @@ def _column_stats(name: str, values: list[Any], max_rows: int) -> dict[str, Any]
         "count": len(scanned) - missing,
         "missing": missing,
         "unique": len(counter),
-        "top": [
-            {"value": v if isinstance(v, (str, int, float, bool)) else str(v),
-             "count": c}
-            for v, c in top
-        ],
+        "top": [{"value": _top_value(v), "count": c} for v, c in top],
         "mean": None,
         "min": None,
         "max": None,
@@ -600,6 +648,18 @@ def _column_stats(name: str, values: list[Any], max_rows: int) -> dict[str, Any]
         column["min"] = _num(min(numeric))
         column["max"] = _num(max(numeric))
     return column
+
+
+def _row_budget(columns: int, max_rows: int) -> int:
+    """Rows to scan PER COLUMN, given a budget over the whole table.
+
+    The column walk is interpreted Python, so a 64-column table at 200k rows
+    each would be 12.8M dict operations - seconds of wall clock for a summary
+    that is supposed to be instant. Spreading the budget keeps the cost flat in
+    the column count, with a floor so a very wide table still sees enough rows
+    per column for its top-k to mean something.
+    """
+    return max(1000, max_rows // max(1, columns)) if columns else max_rows
 
 
 def _as_columns(
@@ -621,10 +681,10 @@ def _as_columns(
     if isinstance(value, dict):
         if not value:
             return [], 0, 0
-        columns: list[tuple[str, list[Any]]] = []
         rows = 0
         # Distinct dict keys can share a `str()` (1 and "1"). Left alone they
         # become two columns with one name and a duplicate React key.
+        keep: list[tuple[str, Any]] = []
         names: list[str] = []
         seen: set[str] = set()
         for key, cells in value.items():
@@ -636,28 +696,33 @@ def _as_columns(
                 continue
             seen.add(name)
             names.append(name)
-            if len(columns) < max_columns:
-                columns.append((name, list(cells[:max_rows])))
+            if len(keep) < max_columns:
+                keep.append((name, cells))
+        budget = _row_budget(len(keep), max_rows)
+        columns = [(name, list(cells[:budget])) for name, cells in keep]
         return columns, rows, len(names)
 
     if isinstance(value, (list, tuple)):
         if len(value) == 0:
             return [], 0, 0
-        head = value[:max_rows]
-        if all(isinstance(row, dict) for row in head):
+        probe = value[:RECORD_NAME_PROBE_ROWS]
+        if all(isinstance(row, dict) for row in probe):
             record_names: list[str] = []
             seen_names: set[str] = set()
-            for row in head:
+            for row in probe:
                 for key in row:
                     if str(key) not in seen_names:
                         seen_names.add(str(key))
                         record_names.append(str(key))
             kept = record_names[:max_columns]
+            budget = _row_budget(len(kept), max_rows)
+            head = value[:budget]
             columns = [(name, [row.get(name) for row in head]) for name in kept]
             return columns, len(value), len(record_names)
         primitive = (str, int, float, bool, type(None))
-        if all(isinstance(x, primitive) for x in head):
-            return [("values", list(head))], len(value), 1
+        if all(isinstance(x, primitive) for x in probe):
+            budget = _row_budget(1, max_rows)
+            return [("values", list(value[:budget]))], len(value), 1
     return None
 
 

--- a/backend/app/core/run_output_store.py
+++ b/backend/app/core/run_output_store.py
@@ -20,8 +20,12 @@ from typing import Any
 class RunOutputStore:
     def __init__(self, max_runs: int = 20) -> None:
         self._max_runs = max_runs
-        self._store: dict[str, dict[str, dict[str, Any]]] = {}
+        # Each slot holds ``(value, write_serial)``. See ``get_with_version``
+        # for why the serial exists; ``get`` unwraps it, so every caller that
+        # only wants the value is unaffected.
+        self._store: dict[str, dict[str, dict[str, tuple[Any, int]]]] = {}
         self._order: deque[str] = deque()
+        self._writes = 0
         self._lock = asyncio.Lock()
 
     async def put(self, run_id: str, node_id: str, port: str, value: Any) -> None:
@@ -35,9 +39,27 @@ class RunOutputStore:
             nodes = self._store[run_id]
             if node_id not in nodes:
                 nodes[node_id] = {}
-            nodes[node_id][port] = value
+            self._writes += 1
+            nodes[node_id][port] = (value, self._writes)
 
     async def get(self, run_id: str, node_id: str, port: str) -> Any | None:
+        async with self._lock:
+            slot = self._store.get(run_id, {}).get(node_id, {}).get(port)
+            return None if slot is None else slot[0]
+
+    async def get_with_version(
+        self, run_id: str, node_id: str, port: str
+    ) -> tuple[Any, int] | None:
+        """The value plus the write serial that produced it, or None.
+
+        The serial is what makes it safe to memoise anything DERIVED from a
+        captured value (see ``port_stats``). Object identity is not: a node
+        inside a loop overwrites one port several times in a run, and torch's
+        caching allocator hands the freed block straight to the replacement —
+        so the new tensor can carry the old one's ``data_ptr``, ``shape`` and
+        ``dtype`` and be indistinguishable from it. The serial only ever goes
+        up, so a cache keyed on it cannot answer for a value that is gone.
+        """
         async with self._lock:
             return self._store.get(run_id, {}).get(node_id, {}).get(port)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -68,6 +68,7 @@ from .core.db import Database
 from .core.logging_config import setup_logging
 from .core.node_registry import registry
 from .core.node_state_store import NodeStateStore
+from .core.port_stats import PortStatsCache
 from .core import plugin_loader
 from .core.plugin_loader import (
     MANIFEST_FILENAME,
@@ -284,6 +285,13 @@ async def lifespan(app: FastAPI):
 
     # In-memory store for captured per-run node outputs (Teaching Inspector)
     app.state.run_output_store = RunOutputStore(max_runs=20)
+
+    # Memoised /stats payloads for those captures (#129). Bounded by BYTES —
+    # a stat payload ranges from ~1.5 KB to ~50 KB, so an entry count would
+    # be a limit in name only.
+    app.state.port_stats_cache = PortStatsCache(
+        max_bytes=settings.STATS_CACHE_MAX_BYTES
+    )
 
     # Persistent ``nn.Module`` instances per (graph, node, structure-hash).
     # Lifetime: server process. Survives Run clicks; lost on restart.

--- a/backend/tests/test_port_stats.py
+++ b/backend/tests/test_port_stats.py
@@ -146,6 +146,18 @@ def test_all_nan_tensor_reports_none_rather_than_nan():
     _assert_json_safe(stats)
 
 
+def test_inf_only_tensor_reports_none_rather_than_inf():
+    t = torch.tensor([float("inf"), -float("inf"), float("inf")])
+    stats = compute_port_stats(t)
+    assert stats["inf_count"] == 3
+    assert stats["nan_count"] == 0
+    assert stats["min"] is None
+    assert stats["max"] is None
+    assert stats["mean"] is None
+    assert stats["histogram"] is None
+    _assert_json_safe(stats)
+
+
 def test_empty_tensor_is_described_not_crashed():
     stats = compute_port_stats(torch.zeros(0))
     assert stats["kind"] == "tensor"
@@ -231,12 +243,54 @@ def test_a_single_sample_activation_is_still_chunked_and_thinned():
     assert max(c.numel() for c in chunks) <= 40 * 40 * 64
     assert sum(c.numel() for c in chunks) == t.numel()
 
-    thinned = _narrow_for_sampling(t, 1000)
+    thinned = _narrow_for_sampling(t, 1000, 0)
     assert thinned.numel() < t.numel()
 
     stats = compute_port_stats(t, sample_threshold=1000, sample_size=512)
     assert stats["count"] == t.numel()
     assert stats["sampled"] is True
+
+
+def test_thinning_a_structured_axis_does_not_pick_a_stride():
+    """A fixed stride would summarise whichever slices it happened to land on.
+
+    Row i is drawn from N(i, 1), so the split axis carries all the signal. The
+    old ``t[::step]`` kept rows 0, 16, 32, 48 of 64 and reported their mean —
+    a systematically chosen quarter of the data under ``"sampled": true``.
+    """
+    rows = 64
+    t = torch.stack([torch.randn(4096) + i for i in range(rows)]).t()
+    assert not t.is_contiguous()
+    true_mean = (rows - 1) / 2  # 31.5
+
+    stats = compute_port_stats(t, sample_threshold=1000, sample_size=4096)
+    assert stats["sampled"] is True
+    assert stats["mean"] == pytest.approx(true_mean, abs=3.0)
+
+
+def test_thinning_stays_deterministic_under_a_seed():
+    t = torch.stack([torch.randn(2048) + i for i in range(64)]).t()
+    a = compute_port_stats(t, sample_threshold=1000, sample_size=2048, seed=7)
+    b = compute_port_stats(t, sample_threshold=1000, sample_size=2048, seed=7)
+    assert a == b
+
+
+def test_one_oversized_slice_recurses_onto_the_next_axis():
+    """A single slice bigger than the budget used to be yielded whole.
+
+    ``[1, 3, H, W]`` splits on the channel axis into three slices; each is far
+    over budget, and ``_scan_tensor`` then builds a bool mask over the whole
+    thing. The chunker has to keep going.
+    """
+    from app.core.port_stats import _iter_chunks
+
+    t = torch.zeros(1, 3, 1024, 1024).permute(0, 2, 3, 1)
+    assert not t.is_contiguous()
+
+    budget = 100_000
+    chunks = list(_iter_chunks(t, chunk_elements=budget))
+    assert sum(c.numel() for c in chunks) == t.numel()
+    assert max(c.numel() for c in chunks) <= budget
 
 
 def test_sampling_handles_non_contiguous_tensors():
@@ -377,6 +431,21 @@ def test_wide_integer_tensor_uses_a_histogram():
     assert sum(stats["histogram"]["counts"]) == CLASS_BALANCE_MAX * 4
 
 
+def test_exactly_sixty_four_distinct_values_is_still_class_balance():
+    t = torch.arange(CLASS_BALANCE_MAX, dtype=torch.int64)
+    stats = compute_port_stats(t)
+    assert stats["value_counts"] is not None
+    assert len(stats["value_counts"]) == CLASS_BALANCE_MAX
+    assert stats["histogram"] is None
+
+
+def test_sixty_five_distinct_values_tips_over_to_a_histogram():
+    t = torch.arange(CLASS_BALANCE_MAX + 1, dtype=torch.int64)
+    stats = compute_port_stats(t)
+    assert stats["value_counts"] is None
+    assert stats["histogram"] is not None
+
+
 def test_negative_integer_labels():
     t = torch.tensor([-1, -1, 0, 1], dtype=torch.int64)
     stats = compute_port_stats(t)
@@ -483,20 +552,58 @@ def test_row_cap_applies_before_the_table_is_materialised():
     Transposing a ten-million-row CSV in full costs a gigabyte of list slots
     and seconds on the GIL, all to build rows the summary then discards.
     """
-    from app.core.port_stats import _as_columns
+    from app.core.port_stats import _as_columns, _row_budget
 
     records = [{"a": i, "b": i} for i in range(50_000)]
-    columns, rows, column_count = _as_columns(records, max_rows=100, max_columns=8)
+    columns, rows, column_count = _as_columns(records, max_rows=8000, max_columns=8)
     assert rows == 50_000  # the reported total stays honest
     assert column_count == 2
-    assert all(len(cells) == 100 for _, cells in columns)
+    assert all(len(cells) == _row_budget(2, 8000) for _, cells in columns)
 
     columnar = {f"c{i}": list(range(50_000)) for i in range(20)}
-    columns, rows, column_count = _as_columns(columnar, max_rows=100, max_columns=4)
+    columns, rows, column_count = _as_columns(columnar, max_rows=8000, max_columns=4)
     assert rows == 50_000
     assert column_count == 20
     assert len(columns) == 4
-    assert all(len(cells) == 100 for _, cells in columns)
+    assert all(len(cells) == _row_budget(4, 8000) for _, cells in columns)
+
+
+def test_the_row_budget_is_applied_before_the_transpose_not_after():
+    """The old order built every column at the whole-table budget, then cut.
+
+    Counted through a list subclass, because "we sliced early" is only
+    observable as cells never read. 64 columns x 200k rows is 12.8M reads to
+    produce cells the summary then throws away.
+    """
+    from app.core.port_stats import _as_columns
+
+    reads = 0
+
+    class CountingDict(dict):
+        def get(self, key, default=None):  # noqa: A003 - dict API
+            nonlocal reads
+            reads += 1
+            return super().get(key, default)
+
+    records = [CountingDict({f"c{i}": 1 for i in range(64)}) for _ in range(20_000)]
+    columns, rows, column_count = _as_columns(records, max_rows=64_000, max_columns=64)
+
+    assert rows == 20_000
+    assert column_count == 64
+    # Budget is 64_000 // 64 = 1000 rows per column, over 64 columns.
+    assert reads == 64 * 1000
+    assert all(len(cells) == 1000 for _, cells in columns)
+
+
+def test_long_top_values_are_truncated():
+    from app.core.port_stats import TOP_VALUE_MAX_CHARS
+
+    essay = "x" * 5000
+    stats = compute_port_stats({"notes": [essay, essay, "short"]})
+    top = stats["columns"][0]["top"]
+    assert len(top[0]["value"]) <= TOP_VALUE_MAX_CHARS + 3
+    assert top[0]["value"].endswith("...")
+    assert len(_assert_json_safe(stats)) < 2000
 
 
 def test_duplicate_stringified_keys_collapse_to_one_column():

--- a/backend/tests/test_port_stats.py
+++ b/backend/tests/test_port_stats.py
@@ -251,46 +251,83 @@ def test_a_single_sample_activation_is_still_chunked_and_thinned():
     assert stats["sampled"] is True
 
 
-def test_thinning_a_structured_axis_does_not_pick_a_stride():
-    """A fixed stride would summarise whichever slices it happened to land on.
+def _periodic_axis_tensor(rows: int = 64, cols: int = 4096, period: int = 16):
+    """Non-contiguous, with periodic structure ON the axis thinning splits.
 
-    Row i is drawn from N(i, 1), so the split axis carries all the signal. The
-    old ``t[::step]`` kept rows 0, 16, 32, 48 of 64 and reported their mean —
-    a systematically chosen quarter of the data under ``"sampled": true``.
+    Row ``i`` is entirely ``1.0`` when ``i % period == 0`` and ``0.0``
+    otherwise, so the true mean is ``1 / period``. Built transposed so
+    :func:`_split_axis` picks the 64-long structured axis rather than the long
+    featureless one - get that backwards and a stride looks unbiased, because
+    it is then striding across the axis that carries no signal.
     """
-    rows = 64
-    t = torch.stack([torch.randn(4096) + i for i in range(rows)]).t()
-    assert not t.is_contiguous()
-    true_mean = (rows - 1) / 2  # 31.5
+    per_row = [1.0 if i % period == 0 else 0.0 for i in range(rows)]
+    base = torch.stack([torch.full((cols,), v) for v in per_row], dim=1)
+    return base.t()
 
-    stats = compute_port_stats(t, sample_threshold=1000, sample_size=4096)
-    assert stats["sampled"] is True
-    assert stats["mean"] == pytest.approx(true_mean, abs=3.0)
+
+def test_thinning_a_structured_axis_does_not_pick_a_stride():
+    """A fixed stride reports whichever slices it happens to land on.
+
+    The old ``t[::step]`` kept 4 of 64 rows at a step of 16 - every one of them
+    a spike row - and reported a mean of 1.0 for data whose mean is 0.0625,
+    under ``"sampled": true``. Aliasing is the failure a stride has and a draw
+    does not, which is why this fixture is periodic rather than a ramp: a
+    stride estimates a ramp perfectly well, so a ramp proves nothing.
+    """
+    from app.core.port_stats import _split_axis
+
+    t = _periodic_axis_tensor()
+    assert not t.is_contiguous()
+    assert _split_axis(t) == 0, "the structured axis must be the split axis"
+    assert t.mean().item() == pytest.approx(1 / 16)
+
+    for seed in range(6):
+        stats = compute_port_stats(
+            t, sample_threshold=1000, sample_size=4096, seed=seed
+        )
+        assert stats["sampled"] is True
+        # The stride returns exactly 1.0 for every seed; a draw of 4 rows from
+        # 64 lands on all four spikes with probability ~1.5e-5.
+        assert stats["mean"] < 0.5, f"seed {seed} looks strided: {stats['mean']}"
 
 
 def test_thinning_stays_deterministic_under_a_seed():
-    t = torch.stack([torch.randn(2048) + i for i in range(64)]).t()
+    t = _periodic_axis_tensor(cols=2048)
     a = compute_port_stats(t, sample_threshold=1000, sample_size=2048, seed=7)
     b = compute_port_stats(t, sample_threshold=1000, sample_size=2048, seed=7)
     assert a == b
 
 
-def test_one_oversized_slice_recurses_onto_the_next_axis():
-    """A single slice bigger than the budget used to be yielded whole.
+@pytest.mark.parametrize(
+    "make, budget",
+    [
+        # Split axis is the 3-long channel dim, so one slice is 40k elements
+        # against a 10k budget - the pre-fix chunker yielded it whole.
+        (lambda: torch.zeros(1, 3, 200, 400)[:, :, :, ::2], 10_000),
+        # Still over budget after the first recursion, so it has to go again.
+        (lambda: torch.zeros(1, 3, 4, 20_000)[:, :, :, ::2], 1_000),
+    ],
+    ids=["one-oversized-slice", "two-level-recursion"],
+)
+def test_an_oversized_slice_recurses_onto_the_next_axis(make, budget):
+    """A slice bigger than the budget used to be yielded whole.
 
-    ``[1, 3, H, W]`` splits on the channel axis into three slices; each is far
-    over budget, and ``_scan_tensor`` then builds a bool mask over the whole
-    thing. The chunker has to keep going.
+    ``step`` clamps to 1 once a single slice already exceeds the budget, and
+    the pre-fix chunker then handed that slice on - ``_scan_tensor`` would
+    build a bool mask over all of it, which is the allocation chunking exists
+    to prevent. Measured pre-fix: 40k-element chunks against both budgets.
     """
     from app.core.port_stats import _iter_chunks
 
-    t = torch.zeros(1, 3, 1024, 1024).permute(0, 2, 3, 1)
+    t = make()
     assert not t.is_contiguous()
 
-    budget = 100_000
     chunks = list(_iter_chunks(t, chunk_elements=budget))
-    assert sum(c.numel() for c in chunks) == t.numel()
     assert max(c.numel() for c in chunks) <= budget
+    # Nothing skipped or double-counted, however deep the recursion went.
+    assert sum(c.numel() for c in chunks) == t.numel()
+    assert len(chunks) >= t.numel() // budget
+
 
 
 def test_sampling_handles_non_contiguous_tensors():

--- a/backend/tests/test_port_stats.py
+++ b/backend/tests/test_port_stats.py
@@ -1,0 +1,674 @@
+"""Unit tests for ``app.core.port_stats`` — the summary-statistics compute.
+
+The reference for every numeric assertion is numpy, computed over the same
+values, because "is this number right" must not be answered by the code under
+test. Where the module deliberately deviates from a naive numpy call (NaN and
+Inf are excluded from mean/std/quantiles rather than poisoning them) the test
+builds the filtered array explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from app.core.port_stats import (
+    CLASS_BALANCE_MAX,
+    HISTOGRAM_BINS,
+    PortStatsCache,
+    compute_port_stats,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _q(a: np.ndarray, p: float) -> float:
+    return float(np.quantile(a, p))
+
+
+def _assert_json_safe(payload: dict) -> str:
+    """Round-trip through the same encoder Starlette's JSONResponse uses."""
+    return json.dumps(payload, separators=(",", ":"), allow_nan=False)
+
+
+# ── tensor branch: exactness against numpy ───────────────────────────────────
+
+
+#: Stats are emitted as plain float64 (``port_stats._num`` does not round), so
+#: the only slack needed against numpy is torch's own accumulation order.
+ROUNDING_REL = 1e-12
+
+
+def test_float_tensor_matches_numpy_reference():
+    a = np.linspace(-3.5, 7.25, 501, dtype=np.float64)
+    stats = compute_port_stats(torch.from_numpy(a.copy()))
+
+    assert stats["kind"] == "tensor"
+    assert stats["sampled"] is False
+    assert stats["sample_size"] is None
+    assert stats["shape"] == [501]
+    assert stats["dtype"] == "torch.float64"
+    assert stats["device"] == "cpu"
+    assert stats["count"] == 501
+
+    assert stats["mean"] == pytest.approx(float(np.mean(a)), rel=ROUNDING_REL)
+    assert stats["std"] == pytest.approx(float(np.std(a)), rel=ROUNDING_REL)
+    assert stats["min"] == pytest.approx(float(np.min(a)), rel=ROUNDING_REL)
+    assert stats["max"] == pytest.approx(float(np.max(a)), rel=ROUNDING_REL)
+
+    for name, p in (
+        ("p1", 0.01),
+        ("p5", 0.05),
+        ("p25", 0.25),
+        ("p50", 0.5),
+        ("p75", 0.75),
+        ("p95", 0.95),
+        ("p99", 0.99),
+    ):
+        assert stats["quantiles"][name] == pytest.approx(_q(a, p), rel=ROUNDING_REL)
+
+    assert stats["nan_count"] == 0
+    assert stats["inf_count"] == 0
+    assert stats["zero_frac"] == pytest.approx(0.0)
+
+
+def test_multi_dim_tensor_reports_full_shape_and_flattened_count():
+    t = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+    stats = compute_port_stats(t)
+    assert stats["shape"] == [2, 3, 4]
+    assert stats["count"] == 24
+    assert stats["min"] == pytest.approx(0.0)
+    assert stats["max"] == pytest.approx(23.0)
+
+
+def test_histogram_shape_and_totals():
+    a = np.random.default_rng(7).normal(size=5000)
+    stats = compute_port_stats(torch.from_numpy(a))
+
+    hist = stats["histogram"]
+    assert stats["value_counts"] is None
+    assert hist["bins"] == HISTOGRAM_BINS
+    assert len(hist["edges"]) == HISTOGRAM_BINS + 1
+    assert len(hist["counts"]) == HISTOGRAM_BINS
+    assert sum(hist["counts"]) == 5000
+    assert hist["edges"][0] == pytest.approx(float(a.min()), rel=ROUNDING_REL)
+    assert hist["edges"][-1] == pytest.approx(float(a.max()), rel=ROUNDING_REL)
+
+
+def test_constant_tensor_collapses_to_one_bin():
+    stats = compute_port_stats(torch.full((100,), 2.5))
+    assert stats["min"] == pytest.approx(2.5)
+    assert stats["max"] == pytest.approx(2.5)
+    assert stats["std"] == pytest.approx(0.0)
+    hist = stats["histogram"]
+    assert hist["bins"] == 1
+    assert hist["counts"] == [100]
+
+
+def test_zero_fraction_counts_exact_zeros():
+    t = torch.tensor([0.0, 0.0, 1.0, -1.0])
+    stats = compute_port_stats(t)
+    assert stats["zero_frac"] == pytest.approx(0.5)
+
+
+# ── NaN / Inf: the headline debugging stat ───────────────────────────────────
+
+
+def test_nan_and_inf_are_counted_and_excluded_from_moments():
+    raw = [1.0, 2.0, float("nan"), float("inf"), -float("inf"), 3.0, float("nan")]
+    stats = compute_port_stats(torch.tensor(raw, dtype=torch.float64))
+    finite = np.array([1.0, 2.0, 3.0])
+
+    assert stats["nan_count"] == 2
+    assert stats["inf_count"] == 2
+    assert stats["count"] == 7
+    assert stats["mean"] == pytest.approx(float(np.mean(finite)))
+    assert stats["std"] == pytest.approx(float(np.std(finite)))
+    assert stats["min"] == pytest.approx(1.0)
+    assert stats["max"] == pytest.approx(3.0)
+    _assert_json_safe(stats)
+
+
+def test_all_nan_tensor_reports_none_rather_than_nan():
+    stats = compute_port_stats(torch.full((16,), float("nan")))
+    assert stats["nan_count"] == 16
+    assert stats["mean"] is None
+    assert stats["std"] is None
+    assert stats["min"] is None
+    assert stats["max"] is None
+    assert stats["histogram"] is None
+    assert stats["quantiles"] == {}
+    _assert_json_safe(stats)
+
+
+def test_empty_tensor_is_described_not_crashed():
+    stats = compute_port_stats(torch.zeros(0))
+    assert stats["kind"] == "tensor"
+    assert stats["count"] == 0
+    assert stats["mean"] is None
+    assert stats["histogram"] is None
+    _assert_json_safe(stats)
+
+
+def test_zero_dim_tensor():
+    stats = compute_port_stats(torch.tensor(4.5))
+    assert stats["shape"] == []
+    assert stats["count"] == 1
+    assert stats["mean"] == pytest.approx(4.5)
+
+
+def test_tensor_requiring_grad_is_detached():
+    t = torch.ones(4, requires_grad=True) * 2
+    stats = compute_port_stats(t)
+    assert stats["mean"] == pytest.approx(2.0)
+
+
+# ── sampling ─────────────────────────────────────────────────────────────────
+
+
+def test_threshold_switches_to_sampled_mode():
+    t = torch.arange(5000, dtype=torch.float32)
+
+    exact = compute_port_stats(t, sample_threshold=10_000, sample_size=500)
+    assert exact["sampled"] is False
+    assert exact["sample_size"] is None
+
+    sampled = compute_port_stats(t, sample_threshold=1000, sample_size=500)
+    assert sampled["sampled"] is True
+    assert sampled["sample_size"] == 500
+    # count stays the TRUE element count; only the distribution is sampled.
+    assert sampled["count"] == 5000
+
+
+def test_same_seed_gives_the_same_sample():
+    t = torch.randn(20_000)
+    a = compute_port_stats(t, sample_threshold=100, sample_size=256, seed=99)
+    b = compute_port_stats(t, sample_threshold=100, sample_size=256, seed=99)
+    assert a == b
+
+
+def test_different_seed_gives_a_different_sample():
+    t = torch.randn(20_000)
+    a = compute_port_stats(t, sample_threshold=100, sample_size=256, seed=1)
+    b = compute_port_stats(t, sample_threshold=100, sample_size=256, seed=2)
+    assert a["mean"] != b["mean"]
+
+
+def test_sampled_min_max_and_nan_counts_stay_exact():
+    """Sampling degrades the distribution, never the outlier/health counts."""
+    t = torch.zeros(10_000)
+    t[4321] = 999.0
+    t[8765] = float("nan")
+
+    stats = compute_port_stats(t, sample_threshold=100, sample_size=128)
+    assert stats["sampled"] is True
+    assert stats["max"] == pytest.approx(999.0)
+    assert stats["min"] == pytest.approx(0.0)
+    assert stats["nan_count"] == 1
+
+
+def test_a_single_sample_activation_is_still_chunked_and_thinned():
+    """`shape[0] == 1` is the commonest thing anyone inspects.
+
+    A `[1, C, H, W]` activation permuted to channels-last is non-contiguous
+    with a leading dim of 1. Splitting on dim 0 cannot cut it, so both the
+    chunked scan and the pre-sampling thin have to look for the first axis
+    that actually has length.
+    """
+    from app.core.port_stats import _iter_chunks, _narrow_for_sampling, _split_axis
+
+    t = torch.randn(1, 64, 40, 40).permute(0, 2, 3, 1)
+    assert not t.is_contiguous()
+    assert _split_axis(t) == 1
+
+    chunks = list(_iter_chunks(t, chunk_elements=10_000))
+    assert len(chunks) > 1
+    assert max(c.numel() for c in chunks) <= 40 * 40 * 64
+    assert sum(c.numel() for c in chunks) == t.numel()
+
+    thinned = _narrow_for_sampling(t, 1000)
+    assert thinned.numel() < t.numel()
+
+    stats = compute_port_stats(t, sample_threshold=1000, sample_size=512)
+    assert stats["count"] == t.numel()
+    assert stats["sampled"] is True
+
+
+def test_sampling_handles_non_contiguous_tensors():
+    t = torch.randn(400, 50).t()  # non-contiguous view
+    assert not t.is_contiguous()
+    stats = compute_port_stats(t, sample_threshold=100, sample_size=256)
+    assert stats["sampled"] is True
+    assert stats["count"] == 20_000
+    assert stats["mean"] is not None
+
+
+def test_sampled_quantiles_track_the_exact_ones():
+    """A sample must describe the same distribution the full sort does."""
+    a = np.random.default_rng(3).normal(size=200_000)
+    t = torch.from_numpy(a)
+
+    exact = compute_port_stats(t)
+    sampled = compute_port_stats(t, sample_threshold=1000, sample_size=50_000)
+
+    assert exact["sampled"] is False
+    assert sampled["sampled"] is True
+    for name in ("p5", "p25", "p50", "p75", "p95"):
+        assert sampled["quantiles"][name] == pytest.approx(
+            exact["quantiles"][name], abs=0.05
+        )
+
+
+def test_a_lone_outlier_does_not_move_the_median():
+    """The regression that killed the histogram-based quantile estimator.
+
+    A diverged value is the normal reason to open this panel, so an estimator
+    whose resolution is set by the full range is the wrong one.
+    """
+    a = np.random.default_rng(11).normal(size=300_000)
+    a[123] = 1e6
+    stats = compute_port_stats(torch.from_numpy(a), sample_threshold=1000, sample_size=50_000)
+
+    assert stats["max"] == pytest.approx(1e6)  # the outlier is still visible
+    assert abs(stats["quantiles"]["p50"]) < 0.05
+    assert stats["quantiles"]["p99"] == pytest.approx(2.33, abs=0.1)
+
+
+# ── integer / class-balance branch ───────────────────────────────────────────
+
+
+def test_integer_labels_switch_to_class_balance():
+    t = torch.tensor([0, 1, 1, 2, 2, 2], dtype=torch.int64)
+    stats = compute_port_stats(t)
+
+    assert stats["histogram"] is None
+    assert stats["value_counts"] == [
+        {"value": 0, "count": 1},
+        {"value": 1, "count": 2},
+        {"value": 2, "count": 3},
+    ]
+    assert stats["nan_count"] == 0
+    assert stats["inf_count"] == 0
+
+
+def test_class_balance_counts_stay_exact_when_sampled():
+    t = torch.tensor([0] * 900 + [1] * 100, dtype=torch.int64)
+    stats = compute_port_stats(t, sample_threshold=10, sample_size=32)
+    assert stats["sampled"] is True
+    assert stats["value_counts"] == [
+        {"value": 0, "count": 900},
+        {"value": 1, "count": 100},
+    ]
+
+
+def test_bool_tensor_class_balance():
+    t = torch.tensor([True, False, True, True])
+    stats = compute_port_stats(t)
+    assert stats["value_counts"] == [
+        {"value": False, "count": 1},
+        {"value": True, "count": 3},
+    ]
+
+
+def test_sparse_integer_values_still_class_balance():
+    """Few distinct values, wide range — the span test misses, unique catches."""
+    t = torch.tensor([0, 5000, 5000, 0, 5000], dtype=torch.int32)
+    stats = compute_port_stats(t)
+    assert stats["value_counts"] == [
+        {"value": 0, "count": 2},
+        {"value": 5000, "count": 3},
+    ]
+
+
+def test_sparse_integer_class_balance_is_dropped_rather_than_estimated():
+    """A class balance that cannot be exact must not be shipped as one.
+
+    The span test only catches labels numbered 0..C-1. For labels that are few
+    but far apart, the fallback reads the whole tensor — so once the tensor is
+    sampled there is no honest count to report and the payload falls back to a
+    histogram instead of quoting a scaled-down guess.
+    """
+    t = torch.tensor([0, 5000] * 5000, dtype=torch.int64)
+
+    exact = compute_port_stats(t)
+    assert exact["value_counts"] == [
+        {"value": 0, "count": 5000},
+        {"value": 5000, "count": 5000},
+    ]
+
+    sampled = compute_port_stats(t, sample_threshold=100, sample_size=256)
+    assert sampled["sampled"] is True
+    assert sampled["value_counts"] is None
+    assert sampled["histogram"] is not None
+
+
+def test_class_balance_over_a_contiguous_span_survives_sampling():
+    """Labels numbered 0..C-1 still get exact counts — bincount needs no sort."""
+    t = torch.tensor([0] * 700 + [1] * 200 + [2] * 100, dtype=torch.int64)
+    stats = compute_port_stats(t, sample_threshold=100, sample_size=64)
+    assert stats["sampled"] is True
+    assert stats["value_counts"] == [
+        {"value": 0, "count": 700},
+        {"value": 1, "count": 200},
+        {"value": 2, "count": 100},
+    ]
+
+
+def test_large_integers_keep_their_precision():
+    """float32 has 24 mantissa bits; an int64 near 1e15 would round flat."""
+    base = 10**15
+    t = torch.tensor([base, base + 1, base + 2, base + 3], dtype=torch.int64)
+    stats = compute_port_stats(t)
+    assert stats["mean"] == pytest.approx(base + 1.5, rel=1e-15)
+    # The mean must not land outside the spread printed next to it.
+    assert stats["quantiles"]["p25"] <= stats["mean"] <= stats["quantiles"]["p75"]
+
+
+def test_wide_integer_tensor_uses_a_histogram():
+    t = torch.arange(CLASS_BALANCE_MAX * 4, dtype=torch.int64)
+    stats = compute_port_stats(t)
+    assert stats["value_counts"] is None
+    assert stats["histogram"]["bins"] == HISTOGRAM_BINS
+    assert sum(stats["histogram"]["counts"]) == CLASS_BALANCE_MAX * 4
+
+
+def test_negative_integer_labels():
+    t = torch.tensor([-1, -1, 0, 1], dtype=torch.int64)
+    stats = compute_port_stats(t)
+    assert stats["value_counts"] == [
+        {"value": -1, "count": 2},
+        {"value": 0, "count": 1},
+        {"value": 1, "count": 1},
+    ]
+
+
+# ── tabular branch ───────────────────────────────────────────────────────────
+
+
+def test_columnar_dict_per_column_stats():
+    value = {
+        "age": [30, 40, 40, None],
+        "city": ["taipei", "tainan", "taipei", "taipei"],
+    }
+    stats = compute_port_stats(value)
+
+    assert stats["kind"] == "tabular"
+    assert stats["rows"] == 4
+    by_name = {c["name"]: c for c in stats["columns"]}
+
+    age = by_name["age"]
+    assert age["dtype"] == "int"
+    assert age["count"] == 3
+    assert age["missing"] == 1
+    assert age["unique"] == 2
+    assert age["min"] == pytest.approx(30.0)
+    assert age["max"] == pytest.approx(40.0)
+    assert age["mean"] == pytest.approx(110 / 3)
+
+    city = by_name["city"]
+    assert city["dtype"] == "str"
+    assert city["missing"] == 0
+    assert city["unique"] == 2
+    assert city["top"][0] == {"value": "taipei", "count": 3}
+    assert city["mean"] is None
+
+
+def test_records_list_is_transposed_to_columns():
+    value = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}, {"a": 3}]
+    stats = compute_port_stats(value)
+    assert stats["kind"] == "tabular"
+    assert stats["rows"] == 3
+    by_name = {c["name"]: c for c in stats["columns"]}
+    assert by_name["a"]["count"] == 3
+    # The third record has no "b" at all — that is a missing value, not a row.
+    assert by_name["b"]["count"] == 2
+    assert by_name["b"]["missing"] == 1
+
+
+def test_plain_list_becomes_one_column():
+    value = ["setosa"] * 3 + ["virginica"]
+    stats = compute_port_stats(value)
+    assert stats["kind"] == "tabular"
+    assert stats["rows"] == 4
+    assert len(stats["columns"]) == 1
+    col = stats["columns"][0]
+    assert col["unique"] == 2
+    assert col["top"] == [
+        {"value": "setosa", "count": 3},
+        {"value": "virginica", "count": 1},
+    ]
+
+
+def test_float_nan_in_a_column_counts_as_missing():
+    stats = compute_port_stats({"x": [1.0, float("nan"), 3.0]})
+    col = stats["columns"][0]
+    assert col["missing"] == 1
+    assert col["count"] == 2
+    assert col["mean"] == pytest.approx(2.0)
+    _assert_json_safe(stats)
+
+
+def test_top_k_is_bounded_and_ordered():
+    stats = compute_port_stats({"x": [str(i % 40) for i in range(400)]})
+    col = stats["columns"][0]
+    assert col["unique"] == 40
+    assert len(col["top"]) <= 10
+    counts = [entry["count"] for entry in col["top"]]
+    assert counts == sorted(counts, reverse=True)
+
+
+def test_empty_list_is_tabular_with_no_rows():
+    stats = compute_port_stats([])
+    assert stats["kind"] == "tabular"
+    assert stats["rows"] == 0
+    assert stats["columns"] == []
+
+
+def test_wide_table_truncates_columns():
+    value = {f"c{i}": [1, 2] for i in range(400)}
+    stats = compute_port_stats(value)
+    assert stats["columns_truncated"] is True
+    assert stats["column_count"] == 400
+    assert len(stats["columns"]) < 400
+
+
+def test_row_cap_applies_before_the_table_is_materialised():
+    """The cap has to bound the ALLOCATION, not just the analysis.
+
+    Transposing a ten-million-row CSV in full costs a gigabyte of list slots
+    and seconds on the GIL, all to build rows the summary then discards.
+    """
+    from app.core.port_stats import _as_columns
+
+    records = [{"a": i, "b": i} for i in range(50_000)]
+    columns, rows, column_count = _as_columns(records, max_rows=100, max_columns=8)
+    assert rows == 50_000  # the reported total stays honest
+    assert column_count == 2
+    assert all(len(cells) == 100 for _, cells in columns)
+
+    columnar = {f"c{i}": list(range(50_000)) for i in range(20)}
+    columns, rows, column_count = _as_columns(columnar, max_rows=100, max_columns=4)
+    assert rows == 50_000
+    assert column_count == 20
+    assert len(columns) == 4
+    assert all(len(cells) == 100 for _, cells in columns)
+
+
+def test_duplicate_stringified_keys_collapse_to_one_column():
+    stats = compute_port_stats({1: [1, 2], "1": [3, 4]})
+    names = [c["name"] for c in stats["columns"]]
+    assert names == ["1"]
+    assert stats["column_count"] == 1
+
+
+def test_long_table_samples_rows():
+    value = {"x": list(range(50_000))}
+    stats = compute_port_stats(value, tabular_max_rows=1000)
+    assert stats["rows"] == 50_000
+    assert stats["sampled"] is True
+    assert stats["sample_size"] == 1000
+    assert stats["columns"][0]["count"] == 1000
+
+
+def test_row_budget_is_shared_across_columns():
+    """The scan is interpreted Python — its cost must not scale with width."""
+    narrow = compute_port_stats(
+        {"a": list(range(40_000))}, tabular_max_rows=20_000, tabular_max_columns=8
+    )
+    wide = compute_port_stats(
+        {f"c{i}": list(range(40_000)) for i in range(8)},
+        tabular_max_rows=20_000,
+        tabular_max_columns=8,
+    )
+    assert narrow["columns"][0]["count"] == 20_000
+    # Same budget, eight columns -> an eighth of the rows each.
+    assert wide["columns"][0]["count"] == 2500
+    assert all(c["count"] == 2500 for c in wide["columns"])
+
+
+# ── unsupported values ───────────────────────────────────────────────────────
+
+
+def test_module_value_is_reported_as_unsupported():
+    stats = compute_port_stats(torch.nn.Linear(2, 2))
+    assert stats["kind"] == "unsupported"
+    assert stats["type"] == "Linear"
+
+
+def test_scalar_value_is_reported_as_unsupported():
+    stats = compute_port_stats(3)
+    assert stats["kind"] == "unsupported"
+    assert stats["type"] == "int"
+
+
+def test_complex_tensor_reports_metadata_only():
+    stats = compute_port_stats(torch.ones(4, dtype=torch.complex64))
+    assert stats["kind"] == "tensor"
+    assert stats["shape"] == [4]
+    assert stats["mean"] is None
+    assert stats["histogram"] is None
+
+
+def test_list_of_tensors_is_unsupported():
+    stats = compute_port_stats([torch.ones(2), torch.ones(2)])
+    assert stats["kind"] == "unsupported"
+
+
+def test_sparse_tensor_reports_metadata_without_crashing():
+    """Every pass here assumes a dense buffer; a sparse one must not 500."""
+    # `to_sparse` rather than `sparse_coo_tensor`: the latter warns that it is
+    # skipping invariant checks, and this suite keeps its output clean.
+    sparse = torch.tensor([[0.0, 3.0], [4.0, 0.0]]).to_sparse()
+    stats = compute_port_stats(sparse)
+    assert stats["kind"] == "tensor"
+    assert stats["shape"] == [2, 2]
+    assert stats["mean"] is None
+
+
+def test_half_precision_tensor_with_nans():
+    t = torch.tensor([1.0, 2.0, float("nan")], dtype=torch.float16)
+    stats = compute_port_stats(t)
+    assert stats["nan_count"] == 1
+    assert stats["mean"] == pytest.approx(1.5, rel=1e-3)
+    assert stats["max"] == pytest.approx(2.0, rel=1e-3)
+
+
+# ── payload budget ───────────────────────────────────────────────────────────
+
+
+def test_payload_is_small_for_a_large_tensor():
+    t = torch.randn(2_000_000)
+    stats = compute_port_stats(t, sample_threshold=1_000_000, sample_size=100_000)
+    assert stats["sampled"] is True
+    assert len(_assert_json_safe(stats)) < 100_000
+
+
+# ── bytes-bounded cache ──────────────────────────────────────────────────────
+
+
+def _payload(n: int) -> dict:
+    """A payload whose serialized size grows with n."""
+    return {"blob": "x" * n}
+
+
+def test_cache_returns_the_stored_payload():
+    cache = PortStatsCache(max_bytes=10_000)
+    cache.put(("r", "n", "p"), _payload(10))
+    assert cache.get(("r", "n", "p")) == _payload(10)
+    assert cache.hits == 1
+    assert cache.misses == 0
+
+
+def test_cache_miss_counts():
+    cache = PortStatsCache(max_bytes=10_000)
+    assert cache.get(("r", "n", "p")) is None
+    assert cache.misses == 1
+
+
+def test_cache_evicts_by_bytes_not_by_count():
+    cache = PortStatsCache(max_bytes=1000)
+    for i in range(20):
+        cache.put(("r", "n", str(i)), _payload(200))
+
+    assert cache.total_bytes <= 1000
+    # 20 entries of ~215 bytes each cannot all fit in 1000 bytes.
+    assert len(cache) < 20
+    assert cache.get(("r", "n", "0")) is None
+    assert cache.get(("r", "n", "19")) is not None
+
+
+def test_cache_evicts_least_recently_used_first():
+    # Two ~211-byte payloads fit, three do not.
+    cache = PortStatsCache(max_bytes=500)
+    cache.put(("a",), _payload(200))
+    cache.put(("b",), _payload(200))
+    cache.get(("a",))  # "a" is now the most recent
+    cache.put(("c",), _payload(200))
+
+    assert cache.get(("b",)) is None
+    assert cache.get(("a",)) is not None
+    assert cache.get(("c",)) is not None
+
+
+def test_cache_refuses_an_entry_larger_than_the_budget():
+    cache = PortStatsCache(max_bytes=100)
+    cache.put(("big",), _payload(5000))
+    assert cache.get(("big",)) is None
+    assert cache.total_bytes == 0
+
+
+def test_cache_replacing_a_key_updates_the_byte_total():
+    cache = PortStatsCache(max_bytes=10_000)
+    cache.put(("k",), _payload(100))
+    first = cache.total_bytes
+    cache.put(("k",), _payload(500))
+    assert len(cache) == 1
+    assert cache.total_bytes > first
+
+
+def test_cache_clear_resets_bytes():
+    cache = PortStatsCache(max_bytes=10_000)
+    cache.put(("k",), _payload(100))
+    cache.clear()
+    assert len(cache) == 0
+    assert cache.total_bytes == 0
+
+
+def test_cache_is_disabled_by_a_zero_budget():
+    cache = PortStatsCache(max_bytes=0)
+    cache.put(("k",), _payload(1))
+    assert cache.get(("k",)) is None
+
+
+def test_no_stat_is_a_bare_nan():
+    """Every float in the payload must survive ``allow_nan=False``."""
+    t = torch.tensor([float("nan"), float("inf"), 0.0, 1.0])
+    stats = compute_port_stats(t)
+    text = _assert_json_safe(stats)
+    assert "NaN" not in text and "Infinity" not in text
+    assert math.isfinite(stats["zero_frac"])

--- a/backend/tests/test_routes_execution_outputs.py
+++ b/backend/tests/test_routes_execution_outputs.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 
+from app.core.port_stats import PortStatsCache
 from app.core.run_output_store import RunOutputStore
 from app.main import app
 
@@ -223,3 +224,187 @@ async def test_string_output(test_client):
     body = resp.json()
     assert body["type"] == "string"
     assert body["value"] == "hello"
+
+
+# ── /stats (#129) ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _fresh_stats_cache():
+    """A per-test stats LRU, so hit/miss counters start at zero."""
+    app.state.port_stats_cache = PortStatsCache(max_bytes=1024 * 1024)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_stats_for_a_tensor(test_client):
+    store = app.state.run_output_store
+    await store.put("r1", "n1", "out", torch.arange(100, dtype=torch.float32))
+
+    resp = await test_client.get("/api/execution/outputs/r1/n1/out/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_id"] == "r1"
+    assert body["node_id"] == "n1"
+    assert body["port"] == "out"
+    assert body["kind"] == "tensor"
+    assert body["shape"] == [100]
+    assert body["dtype"] == "torch.float32"
+    assert body["count"] == 100
+    assert body["sampled"] is False
+    assert body["mean"] == pytest.approx(49.5)
+    assert body["quantiles"]["p50"] == pytest.approx(49.5)
+    assert body["histogram"]["bins"] == 64
+    assert sum(body["histogram"]["counts"]) == 100
+
+
+@pytest.mark.asyncio
+async def test_stats_for_integer_labels_returns_class_balance(test_client):
+    store = app.state.run_output_store
+    labels = torch.tensor([0] * 7 + [1] * 3, dtype=torch.int64)
+    await store.put("r1", "n1", "labels", labels)
+
+    resp = await test_client.get("/api/execution/outputs/r1/n1/labels/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["histogram"] is None
+    assert body["value_counts"] == [
+        {"value": 0, "count": 7},
+        {"value": 1, "count": 3},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stats_survives_a_nan_tensor(test_client):
+    """The whole point of the endpoint: a diverged tensor must not 500.
+
+    Starlette renders with ``allow_nan=False``, so a leaked NaN would be a
+    broken response rather than a bad number.
+    """
+    store = app.state.run_output_store
+    t = torch.tensor([float("nan"), float("inf"), 1.0, 2.0])
+    await store.put("r1", "n1", "out", t)
+
+    resp = await test_client.get("/api/execution/outputs/r1/n1/out/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["nan_count"] == 1
+    assert body["inf_count"] == 1
+    assert body["mean"] == pytest.approx(1.5)
+    assert "NaN" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_stats_for_a_label_list(test_client):
+    store = app.state.run_output_store
+    await store.put("r1", "n1", "labels", ["a", "b", "a"])
+
+    resp = await test_client.get("/api/execution/outputs/r1/n1/labels/stats")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["kind"] == "tabular"
+    assert body["rows"] == 3
+    assert body["columns"][0]["unique"] == 2
+
+
+@pytest.mark.asyncio
+async def test_stats_for_an_unsupported_value(test_client):
+    store = app.state.run_output_store
+    await store.put("r1", "n1", "model", torch.nn.Linear(2, 2))
+
+    resp = await test_client.get("/api/execution/outputs/r1/n1/model/stats")
+    assert resp.status_code == 200
+    assert resp.json()["kind"] == "unsupported"
+
+
+@pytest.mark.asyncio
+async def test_stats_unknown_run_404s_with_a_record_hint(test_client):
+    resp = await test_client.get("/api/execution/outputs/ghost/n1/out/stats")
+    assert resp.status_code == 404
+    assert "Record outputs" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_stats_unknown_port_404s_with_a_record_hint(test_client):
+    store = app.state.run_output_store
+    await store.put("r1", "n1", "out", torch.ones(2))
+
+    resp = await test_client.get("/api/execution/outputs/r1/n1/missing/stats")
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert "n1.missing" in detail
+    assert "Record outputs" in detail
+
+
+@pytest.mark.asyncio
+async def test_stats_are_cached_per_port(test_client):
+    store = app.state.run_output_store
+    await store.put("r1", "n1", "out", torch.ones(64))
+
+    first = await test_client.get("/api/execution/outputs/r1/n1/out/stats")
+    second = await test_client.get("/api/execution/outputs/r1/n1/out/stats")
+
+    assert first.json() == second.json()
+    cache = app.state.port_stats_cache
+    assert cache.hits == 1
+    assert cache.misses == 1
+
+
+@pytest.mark.asyncio
+async def test_replacing_a_value_does_not_serve_the_stale_stat(test_client):
+    """A node inside a loop rewrites one port during a single run.
+
+    Deliberately looped, and deliberately dropping every reference to the
+    previous tensor before building the next: torch's caching allocator then
+    reuses the freed block, so iteration N gets iteration N-2's address with
+    the same shape and dtype. Any cache keyed on the object rather than on the
+    store's write serial answers with the older tensor's mean here — two
+    iterations alone never collide, so a two-step test proves nothing.
+    """
+    store = app.state.run_output_store
+    for i in range(6):
+        await store.put("r1", "n1", "out", torch.full((512, 512), float(i)))
+        resp = await test_client.get("/api/execution/outputs/r1/n1/out/stats")
+        assert resp.status_code == 200
+        assert resp.json()["mean"] == pytest.approx(float(i)), f"stale at i={i}"
+
+
+@pytest.mark.asyncio
+async def test_stats_sample_above_the_threshold(test_client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "STATS_SAMPLE_THRESHOLD", 100)
+    monkeypatch.setattr(settings, "STATS_SAMPLE_SIZE", 50)
+
+    store = app.state.run_output_store
+    await store.put("r1", "n1", "out", torch.arange(1000, dtype=torch.float32))
+
+    resp = await test_client.get("/api/execution/outputs/r1/n1/out/stats")
+    body = resp.json()
+    assert body["sampled"] is True
+    assert body["sample_size"] == 50
+    assert body["count"] == 1000
+    # Exact at any size — sampling never touches the extremes.
+    assert body["min"] == pytest.approx(0.0)
+    assert body["max"] == pytest.approx(999.0)
+
+
+@pytest.mark.asyncio
+async def test_stats_payload_stays_small(test_client):
+    store = app.state.run_output_store
+    await store.put("r1", "n1", "out", torch.randn(200_000))
+
+    resp = await test_client.get("/api/execution/outputs/r1/n1/out/stats")
+    assert resp.status_code == 200
+    assert len(resp.content) < 100_000
+
+
+@pytest.mark.asyncio
+async def test_stats_route_does_not_shadow_the_value_route(test_client):
+    """A port literally named 'stats' still serves its value, not statistics."""
+    store = app.state.run_output_store
+    await store.put("r1", "n1", "stats", torch.ones(2))
+
+    resp = await test_client.get("/api/execution/outputs/r1/n1/stats")
+    assert resp.status_code == 200
+    assert resp.json()["type"] == "tensor"

--- a/backend/tests/test_run_output_store.py
+++ b/backend/tests/test_run_output_store.py
@@ -116,3 +116,76 @@ async def test_clear():
     await store.clear()
     assert await store.list_runs() == []
     assert await store.has_run("r1") is False
+
+
+# ── write serials (#129) ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_with_version_returns_value_and_serial():
+    store = RunOutputStore()
+    await store.put("r1", "n1", "p", "first")
+    slot = await store.get_with_version("r1", "n1", "p")
+    assert slot is not None
+    value, version = slot
+    assert value == "first"
+    assert version > 0
+
+
+@pytest.mark.asyncio
+async def test_get_with_version_is_none_for_a_missing_port():
+    store = RunOutputStore()
+    await store.put("r1", "n1", "p", 1)
+    assert await store.get_with_version("r1", "n1", "other") is None
+    assert await store.get_with_version("r1", "other", "p") is None
+    assert await store.get_with_version("other", "n1", "p") is None
+
+
+@pytest.mark.asyncio
+async def test_overwriting_a_port_bumps_its_serial():
+    store = RunOutputStore()
+    await store.put("r1", "n1", "p", "first")
+    first = (await store.get_with_version("r1", "n1", "p"))[1]
+    await store.put("r1", "n1", "p", "second")
+    second = (await store.get_with_version("r1", "n1", "p"))[1]
+    assert second > first
+    assert await store.get("r1", "n1", "p") == "second"
+
+
+@pytest.mark.asyncio
+async def test_serials_are_unique_across_ports_and_runs():
+    store = RunOutputStore()
+    await store.put("r1", "n1", "a", 1)
+    await store.put("r1", "n1", "b", 2)
+    await store.put("r2", "n1", "a", 3)
+    versions = [
+        (await store.get_with_version(*key))[1]
+        for key in (("r1", "n1", "a"), ("r1", "n1", "b"), ("r2", "n1", "a"))
+    ]
+    assert len(set(versions)) == 3
+
+
+@pytest.mark.asyncio
+async def test_serial_distinguishes_tensors_that_reuse_one_allocation():
+    """The reason the serial exists rather than a fingerprint of the value.
+
+    torch's caching allocator hands a freed block straight to the next tensor
+    of the same shape, so a replacement can carry the previous tensor's
+    ``data_ptr``, ``shape`` and ``dtype`` and be indistinguishable from it.
+    """
+    import torch
+
+    store = RunOutputStore()
+    seen_versions = set()
+    seen_pointers = set()
+    for i in range(6):
+        await store.put("r1", "n1", "out", torch.full((512, 512), float(i)))
+        value, version = await store.get_with_version("r1", "n1", "out")
+        seen_versions.add(version)
+        seen_pointers.add(value.data_ptr())
+        assert float(value[0][0]) == float(i)
+
+    assert len(seen_versions) == 6
+    # If this ever stops holding, the allocator changed — the serial is still
+    # correct, this assertion just no longer demonstrates why it is needed.
+    assert len(seen_pointers) < 6

--- a/frontend/src/api/executionOutputs.ts
+++ b/frontend/src/api/executionOutputs.ts
@@ -116,3 +116,96 @@ export async function fetchGradIndex(
   if (!res.ok) throw new Error(`fetchGradIndex failed: ${await readDetail(res)}`);
   return res.json();
 }
+
+// ── Port statistics (#129) ───────────────────────────────────────────────────
+
+/** A fixed-bin histogram: `bins` counts between `bins + 1` edges. */
+export interface StatsHistogram {
+  bins: number;
+  edges: number[];
+  counts: number[];
+}
+
+/** One class in an integer tensor's class balance. */
+export interface StatsValueCount {
+  value: number | boolean;
+  count: number;
+}
+
+/** Per-column summary for a tabular value (columnar dict, records, or list). */
+export interface StatsColumn {
+  name: string;
+  dtype: 'int' | 'float' | 'str' | 'bool' | 'mixed' | 'empty';
+  count: number;
+  missing: number;
+  unique: number;
+  top: { value: string | number | boolean; count: number }[];
+  mean: number | null;
+  min: number | null;
+  max: number | null;
+}
+
+/**
+ * What `GET /api/execution/outputs/{run}/{node}/{port}/stats` returns.
+ *
+ * Every numeric field is `null` rather than NaN when the statistic is
+ * undefined — an all-NaN tensor has no mean, and the server says so with
+ * `null` instead of a token no JSON parser accepts.
+ *
+ * `sampled` covers the DISTRIBUTION only. `count`, `min`, `max`, `nan_count`,
+ * `inf_count`, `zero_frac` and `value_counts` are exact at any size.
+ */
+export interface PortStats {
+  run_id: string;
+  node_id: string;
+  port: string;
+  kind: 'tensor' | 'tabular' | 'unsupported';
+  sampled?: boolean;
+  sample_size?: number | null;
+
+  // kind === 'tensor'
+  shape?: number[];
+  dtype?: string;
+  device?: string;
+  count?: number;
+  mean?: number | null;
+  std?: number | null;
+  min?: number | null;
+  max?: number | null;
+  quantiles?: Record<string, number | null>;
+  nan_count?: number;
+  inf_count?: number;
+  zero_frac?: number | null;
+  histogram?: StatsHistogram | null;
+  value_counts?: StatsValueCount[] | null;
+
+  // kind === 'tabular'
+  rows?: number;
+  column_count?: number;
+  columns_truncated?: boolean;
+  columns?: StatsColumn[];
+
+  // kind === 'unsupported'
+  type?: string;
+}
+
+/** 404 from the stats endpoint — carries the server's "turn on Rec" hint. */
+export class StatsNotCapturedError extends Error {
+  constructor(detail: string) {
+    super(detail);
+    this.name = 'StatsNotCapturedError';
+  }
+}
+
+export async function fetchPortStats(
+  runId: string,
+  nodeId: string,
+  port: string,
+  opts: { signal?: AbortSignal } = {},
+): Promise<PortStats> {
+  const url = `${BASE_URL}/${encodeURIComponent(runId)}/${encodeURIComponent(nodeId)}/${encodeURIComponent(port)}/stats`;
+  const res = await fetch(url, { signal: opts.signal });
+  if (res.status === 404) throw new StatsNotCapturedError(await readDetail(res));
+  if (!res.ok) throw new Error(`fetchPortStats failed: ${await readDetail(res)}`);
+  return res.json();
+}

--- a/frontend/src/api/executionOutputs.ts
+++ b/frontend/src/api/executionOutputs.ts
@@ -122,7 +122,8 @@ export async function fetchGradIndex(
 /** A fixed-bin histogram: `bins` counts between `bins + 1` edges. */
 export interface StatsHistogram {
   bins: number;
-  edges: number[];
+  /** Nullable like every other float here — a non-finite edge reports `null`. */
+  edges: (number | null)[];
   counts: number[];
 }
 

--- a/frontend/src/components/Canvas/EdgeDataTooltip.test.tsx
+++ b/frontend/src/components/Canvas/EdgeDataTooltip.test.tsx
@@ -7,7 +7,11 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function renderTooltip(summary: OutputSummary, onClose = vi.fn()) {
+function renderTooltip(
+  summary: OutputSummary,
+  onClose = vi.fn(),
+  onViewStats?: () => void,
+) {
   const utils = render(
     <EdgeDataTooltip
       x={100}
@@ -17,6 +21,7 @@ function renderTooltip(summary: OutputSummary, onClose = vi.fn()) {
       portName="out"
       summary={summary}
       onClose={onClose}
+      onViewStats={onViewStats}
     />,
   );
   return { ...utils, onClose };
@@ -120,6 +125,28 @@ describe('EdgeDataTooltip', () => {
     unmount();
     fireEvent.keyDown(document, { key: 'Escape' });
     fireEvent.mouseDown(document.body);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  // ── "View stats" (#129) ───────────────────────────────────────────────────
+
+  it('offers no stats link when no handler is supplied (nothing has run)', () => {
+    renderTooltip({ type: 'Tensor' });
+    expect(screen.queryByRole('button', { name: /View stats/ })).toBeNull();
+  });
+
+  it('calls onViewStats when the link is clicked', () => {
+    const onViewStats = vi.fn();
+    renderTooltip({ type: 'Tensor' }, vi.fn(), onViewStats);
+    fireEvent.click(screen.getByRole('button', { name: /View stats/ }));
+    expect(onViewStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close the tooltip just because the link was pressed', () => {
+    // mousedown inside must stay inert — the click handler owns what happens
+    // next, and a close racing it would unmount before the click landed.
+    const { onClose } = renderTooltip({ type: 'Tensor' }, vi.fn(), vi.fn());
+    fireEvent.mouseDown(screen.getByRole('button', { name: /View stats/ }));
     expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/Canvas/EdgeDataTooltip.tsx
+++ b/frontend/src/components/Canvas/EdgeDataTooltip.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { OutputSummary } from '../../types';
+import { useI18n } from '../../i18n';
 import styles from '../ResultsPanel/ResultsPanel.module.css';
 
 interface EdgeDataTooltipProps {
@@ -10,6 +11,11 @@ interface EdgeDataTooltipProps {
   portName: string;
   summary: OutputSummary;
   onClose: () => void;
+  /**
+   * Open the full statistics for the value on this edge (#129). Omitted when
+   * nothing has run, since there would be no captured value to summarise.
+   */
+  onViewStats?: () => void;
 }
 
 function formatSummary(summary: OutputSummary) {
@@ -50,8 +56,18 @@ function formatSummary(summary: OutputSummary) {
   return rows;
 }
 
-export function EdgeDataTooltip({ x, y, sourceLabel, targetLabel, portName, summary, onClose }: EdgeDataTooltipProps) {
+export function EdgeDataTooltip({
+  x,
+  y,
+  sourceLabel,
+  targetLabel,
+  portName,
+  summary,
+  onClose,
+  onViewStats,
+}: EdgeDataTooltipProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const { t } = useI18n();
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -87,6 +103,15 @@ export function EdgeDataTooltip({ x, y, sourceLabel, targetLabel, portName, summ
           <span className={styles.edgeTooltipValue}>{row.value}</span>
         </div>
       ))}
+      {onViewStats && (
+        // The summary above is whatever the run streamed — a shape, a dtype,
+        // maybe a min/max. This is the way to the real distribution, computed
+        // on the server, so the ANSWER is a kilobyte whatever the tensor
+        // weighs (the computing still costs the server real time).
+        <button type="button" className={styles.edgeTooltipLink} onClick={onViewStats}>
+          {t('edge.viewStats')} &rarr;
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Canvas/FlowCanvas.test.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.test.tsx
@@ -94,7 +94,14 @@ function node(id: string, over: Partial<Node<NodeData>> = {}): Node<NodeData> {
   } as Node<NodeData>;
 }
 
-function setTab(partial: Partial<{ nodes: Node<NodeData>[]; edges: Edge[]; outputSummaries: any }>) {
+function setTab(
+  partial: Partial<{
+    nodes: Node<NodeData>[];
+    edges: Edge[];
+    outputSummaries: any;
+    lastRunId: string | null;
+  }>,
+) {
   useTabStore.setState((s) => ({
     tabs: s.tabs.map((t) =>
       t.id === TAB_ID ? { ...t, ...partial } : t,
@@ -566,6 +573,49 @@ describe('click handlers', () => {
       fireEvent.keyDown(document, { key: 'Escape' });
     });
     expect(screen.queryByText('Type')).toBeNull();
+  });
+
+  // ── "View stats" (#129) ───────────────────────────────────────────────────
+
+  it('offers no stats link on an edge tooltip before anything has run', () => {
+    setTab({
+      nodes: [node('a'), node('b')],
+      edges: [{ id: 'e1', source: 'a', target: 'b', sourceHandle: 'out' }],
+      outputSummaries: { a: { out: { type: 'Tensor', shape: [2] } } },
+      lastRunId: null,
+    });
+    renderCanvas();
+    act(() =>
+      captured.rf.onEdgeClick({ clientX: 10, clientY: 10 } as any, {
+        id: 'e1', source: 'a', target: 'b', sourceHandle: 'out',
+      }),
+    );
+    expect(screen.queryByRole('button', { name: /View stats/ })).toBeNull();
+  });
+
+  it('opens the consumer node on the Stats tab, pointed at the edge port', () => {
+    setTab({
+      nodes: [node('a'), node('b')],
+      edges: [{ id: 'e1', source: 'a', target: 'b', sourceHandle: 'out' }],
+      outputSummaries: { a: { out: { type: 'Tensor', shape: [2] } } },
+      lastRunId: 'run1',
+    });
+    renderCanvas();
+    act(() =>
+      captured.rf.onEdgeClick({ clientX: 10, clientY: 10 } as any, {
+        id: 'e1', source: 'a', target: 'b', sourceHandle: 'out',
+      }),
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /View stats/ }));
+    });
+    expect(activeTab().nodeDetailNodeId).toBe('b');
+    expect(activeTab().nodeDetailTab).toBe('stats');
+    // The port is named by its PRODUCER, which is how the Stats tab resolves
+    // it back to the capture the run actually stored.
+    expect(activeTab().nodeDetailPort).toBe('a::out');
+    // The tooltip gets out of the way once it has handed over.
+    expect(screen.queryByRole('button', { name: /View stats/ })).toBeNull();
   });
 
   it('uses id-slice fallbacks for labels when nodes are missing/unlabeled', () => {

--- a/frontend/src/components/Canvas/FlowCanvas.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.tsx
@@ -251,6 +251,11 @@ export function FlowCanvas({ tabId }: { tabId?: string } = {}) {
     x: number; y: number;
     sourceLabel: string; targetLabel: string;
     portName: string; summary: OutputSummary;
+    // Where the value on this edge comes from and where it lands. "View
+    // stats" opens the CONSUMER's modal, because the port reads there as the
+    // input it is — and the Stats tab resolves an input back to the producing
+    // node's capture, so it is the same numbers either way (#129).
+    sourceId: string; targetId: string;
   } | null>(null);
 
   const outputSummaries = useTabStore((s) => {
@@ -483,6 +488,8 @@ export function FlowCanvas({ tabId }: { tabId?: string } = {}) {
         targetLabel: targetNode?.data.label ?? edge.target.slice(0, 8),
         portName: sourceHandle,
         summary: nodeSummaries[sourceHandle],
+        sourceId,
+        targetId: edge.target,
       });
     },
     [outputSummaries, activeTab.nodes]
@@ -666,6 +673,18 @@ export function FlowCanvas({ tabId }: { tabId?: string } = {}) {
           portName={edgeTooltip.portName}
           summary={edgeTooltip.summary}
           onClose={() => setEdgeTooltip(null)}
+          onViewStats={
+            // No run, no capture, nothing to summarise — so no link either.
+            activeTab.lastRunId
+              ? () => {
+                  openNodeDetail(edgeTooltip.targetId, {
+                    tab: 'stats',
+                    port: `${edgeTooltip.sourceId}::${edgeTooltip.portName}`,
+                  });
+                  setEdgeTooltip(null);
+                }
+              : undefined
+          }
         />
       )}
 

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
@@ -930,6 +930,47 @@ describe('NodeDetailModal — tabs', () => {
     );
   });
 
+  it('honours a SECOND deep link into the node already on screen', () => {
+    // Following "View stats" from another edge into the same consumer changes
+    // neither the node id nor the requested tab — only the request nonce.
+    seedTab({ nodes: [node('n1'), node('n2')] });
+    act(() => {
+      useTabStore.getState().openNodeDetail('n1', { tab: 'stats', port: 'a::x' });
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Docs' }));
+    expect(screen.getByRole('tab', { name: 'Docs' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    act(() => {
+      useTabStore.getState().openNodeDetail('n1', { tab: 'stats', port: 'b::y' });
+    });
+    expect(screen.getByRole('tab', { name: 'Stats' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(activeTab().nodeDetailPort).toBe('b::y');
+  });
+
+  it('mounts straight onto the deep-linked tab, never Inputs first', () => {
+    // A one-commit-late correction still mounts the Inputs tab, and the Inputs
+    // tab fetches every port before it is thrown away.
+    seedTab({
+      nodes: [node('n1')],
+      nodeDetailNodeId: 'n1',
+      nodeDetailTab: 'docs',
+      lastRunId: 'run1',
+    });
+    render(<NodeDetailModal />);
+    expect(screen.getByRole('tab', { name: 'Docs' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(mockOutput).not.toHaveBeenCalled();
+  });
+
   it('hands the requested port to every tab as focusPort', () => {
     const seen: (string | null)[] = [];
     registerNodeDetailTab({

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
@@ -888,13 +888,13 @@ describe('NodeDetailModal — tabs', () => {
     expect(mockGradIndex).toHaveBeenCalledWith('run1', 'n1');
   });
 
-  it('renders the Stats placeholder that P3-14 will replace', () => {
-    seedTab({ nodes: [node('n1')], nodeDetailNodeId: 'n1' });
+  it('shows the Stats tab pre-run empty state before anything has run', () => {
+    seedTab({ nodes: [node('n1')], nodeDetailNodeId: 'n1', lastRunId: null });
     render(<NodeDetailModal />);
     fireEvent.click(screen.getByRole('tab', { name: 'Stats' }));
     expect(screen.getByText('Node statistics')).toBeInTheDocument();
     expect(
-      screen.getByText('Timing, memory and parameter counts arrive here in a later release.'),
+      screen.getByText('Run the graph with Rec on to capture this node’s values'),
     ).toBeInTheDocument();
   });
 
@@ -906,6 +906,51 @@ describe('NodeDetailModal — tabs', () => {
 
     fireEvent.click(screen.getByLabelText('Next node'));
     expect(screen.getByRole('tab', { name: 'Inputs' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  // ── deep link from the edge tooltip (#129) ─────────────────────────────────
+
+  it('opens on the tab the caller asked for', () => {
+    seedTab({ nodes: [node('n1')], nodeDetailNodeId: 'n1', nodeDetailTab: 'stats' });
+    render(<NodeDetailModal />);
+    expect(screen.getByRole('tab', { name: 'Stats' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  it('lets the user leave the deep-linked tab without being dragged back', () => {
+    seedTab({ nodes: [node('n1')], nodeDetailNodeId: 'n1', nodeDetailTab: 'stats' });
+    const { rerender } = render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Docs' }));
+    rerender(<NodeDetailModal />);
+    expect(screen.getByRole('tab', { name: 'Docs' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  it('hands the requested port to every tab as focusPort', () => {
+    const seen: (string | null)[] = [];
+    registerNodeDetailTab({
+      id: 'probe',
+      labelKey: 'nodeDetail.tabs.docs',
+      order: 1,
+      render: (c) => {
+        seen.push(c.focusPort);
+        return <div data-testid="probe" />;
+      },
+    });
+    seedTab({
+      nodes: [node('n1')],
+      nodeDetailNodeId: 'n1',
+      nodeDetailTab: 'probe',
+      nodeDetailPort: 'src::out',
+    });
+    render(<NodeDetailModal />);
+    expect(screen.getByTestId('probe')).toBeInTheDocument();
+    expect(seen).toContain('src::out');
+    unregisterNodeDetailTab('probe');
   });
 
   it('falls back to the first tab when the selected one disappears', () => {
@@ -1248,6 +1293,7 @@ describe('NodeDetailModal — tab registry', () => {
       edges: [],
       recordOutputs: true,
       outputSummaries: {},
+      focusPort: null,
       ...over,
     };
   }

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
@@ -955,10 +955,13 @@ describe('NodeDetailModal — tabs', () => {
   });
 
   it('mounts straight onto the deep-linked tab, never Inputs first', () => {
-    // A one-commit-late correction still mounts the Inputs tab, and the Inputs
-    // tab fetches every port before it is thrown away.
+    // A one-commit-late correction still MOUNTS the Inputs tab, and the Inputs
+    // tab fetches every connected port before being thrown away. The node
+    // therefore needs a real wired input — with no edges `usePortFetches`
+    // bails on an empty port set and the assertion below proves nothing.
     seedTab({
-      nodes: [node('n1')],
+      nodes: [node('src'), node('n1')],
+      edges: [edge('e1', 'src', 'n1')],
       nodeDetailNodeId: 'n1',
       nodeDetailTab: 'docs',
       lastRunId: 'run1',
@@ -969,6 +972,20 @@ describe('NodeDetailModal — tabs', () => {
       'true',
     );
     expect(mockOutput).not.toHaveBeenCalled();
+  });
+
+  it('the previous test is not vacuous: Inputs first DOES fetch', () => {
+    // Guards the guard. Same fixture, no deep link, so the modal opens on
+    // Inputs and the wired port is fetched — which is exactly what mounting
+    // Inputs before correcting to Docs would have done.
+    seedTab({
+      nodes: [node('src'), node('n1')],
+      edges: [edge('e1', 'src', 'n1')],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+    });
+    render(<NodeDetailModal />);
+    expect(mockOutput).toHaveBeenCalledWith('run1', 'src', 'out');
   });
 
   it('hands the requested port to every tab as focusPort', () => {

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.tsx
@@ -81,7 +81,12 @@ function NodeDetailModalBody({ nodeId }: { nodeId: string }) {
   const edges = activeTab.edges;
   const node = nodes.find((n) => n.id === nodeId) as Node<NodeData> | undefined;
 
-  const [activeTabId, setActiveTabId] = useState('inputs');
+  // Seeded from the request rather than defaulted to 'inputs' and corrected by
+  // the effect below: a deep-linked Stats tab that mounts one commit late
+  // mounts the Inputs tab first, and the Inputs tab fetches.
+  const [activeTabId, setActiveTabId] = useState(
+    () => activeTab.nodeDetailTab ?? 'inputs',
+  );
   const [draftName, setDraftName] = useState<string | null>(null);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const nameInputRef = useRef<HTMLInputElement | null>(null);
@@ -110,16 +115,21 @@ function NodeDetailModalBody({ nodeId }: { nodeId: string }) {
   // node's draft over the new node's header.
   //
   // `requestedTab` is the deep link from `openNodeDetail(id, { tab })` (#129).
-  // Listing it as a dependency is what makes a SECOND deep link land while
-  // the modal is already open on that node — following "View stats" from
-  // another edge into the same consumer changes nothing else the effect
-  // watches. It does not fight a manual tab switch, because clicking a tab
-  // changes local state and leaves the store's request alone.
+  // The effect keys on the request NONCE, not on the tab id: following "View
+  // stats" from a second edge into the consumer already on screen changes
+  // neither the node nor the requested tab, so an effect watching only those
+  // would decide nothing had happened and strand the user on whatever tab
+  // they had moved to. It still does not fight a manual tab switch, because
+  // clicking a tab changes local state and leaves the store's request alone.
   const requestedTab = activeTab.nodeDetailTab;
+  const requestNonce = activeTab.nodeDetailRequest;
   useEffect(() => {
     setDraftName(null);
     setActiveTabId(requestedTab ?? 'inputs');
-  }, [nodeId, requestedTab]);
+    // `requestedTab` is read, not watched — the nonce already changes on every
+    // open, and listing both would re-run twice for one request.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeId, requestNonce]);
 
   // Take focus so the key handling below has somewhere to sit and the page
   // behind the backdrop cannot be tabbed into blind — then hand it back to

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.tsx
@@ -108,10 +108,18 @@ function NodeDetailModalBody({ nodeId }: { nodeId: string }) {
 
   // Leaving the name editor open across a node change would show the previous
   // node's draft over the new node's header.
+  //
+  // `requestedTab` is the deep link from `openNodeDetail(id, { tab })` (#129).
+  // Listing it as a dependency is what makes a SECOND deep link land while
+  // the modal is already open on that node — following "View stats" from
+  // another edge into the same consumer changes nothing else the effect
+  // watches. It does not fight a manual tab switch, because clicking a tab
+  // changes local state and leaves the store's request alone.
+  const requestedTab = activeTab.nodeDetailTab;
   useEffect(() => {
     setDraftName(null);
-    setActiveTabId('inputs');
-  }, [nodeId]);
+    setActiveTabId(requestedTab ?? 'inputs');
+  }, [nodeId, requestedTab]);
 
   // Take focus so the key handling below has somewhere to sit and the page
   // behind the backdrop cannot be tabbed into blind — then hand it back to
@@ -184,6 +192,7 @@ function NodeDetailModalBody({ nodeId }: { nodeId: string }) {
     edges,
     recordOutputs: activeTab.recordOutputs,
     outputSummaries: activeTab.outputSummaries,
+    focusPort: activeTab.nodeDetailPort,
   };
 
   const tabs = getNodeDetailTabs(ctx);

--- a/frontend/src/components/NodeDetailModal/StatsTab.module.css
+++ b/frontend/src/components/NodeDetailModal/StatsTab.module.css
@@ -1,0 +1,219 @@
+.group {
+  margin-bottom: 14px;
+}
+
+.groupTitle {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin-bottom: 6px;
+}
+
+.portBlock {
+  border: 1px solid #232323;
+  border-radius: 6px;
+  background: #131313;
+  padding: 8px 10px 10px;
+  margin-bottom: 8px;
+}
+
+/* The port an edge tooltip pointed at. A ring rather than a background so the
+   block still reads as one of the list, just the one you asked for. */
+.portFocused {
+  border-color: #0e7490;
+  box-shadow: 0 0 0 1px rgba(103, 232, 249, 0.35);
+}
+
+.portHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.portDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.portName {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: #e5e7eb;
+}
+
+.sampledChip {
+  margin-left: auto;
+  font-size: 9px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid #b45309;
+  color: #fbbf24;
+  white-space: nowrap;
+}
+
+/* ── health strip ─────────────────────────────────────────────────────── */
+
+.healthRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.healthBadge {
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: #1b1b1b;
+  border: 1px solid #2a2a2a;
+  color: #9ca3af;
+}
+
+.healthBadge b {
+  color: #d1d5db;
+  font-weight: 600;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+.healthAlert {
+  border-color: #b91c1c;
+  background: rgba(185, 28, 28, 0.16);
+  color: #fca5a5;
+}
+
+.healthAlert b {
+  color: #fecaca;
+}
+
+/* ── stat grid ────────────────────────────────────────────────────────── */
+
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
+  gap: 4px 10px;
+}
+
+.statCell,
+.quantileCell {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.statLabel {
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6b7280;
+}
+
+.statValue {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: #e5e7eb;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── quantiles + charts ───────────────────────────────────────────────── */
+
+.blockTitle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin: 10px 0 4px;
+}
+
+.quantileRow {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.chartBlock {
+  margin-top: 4px;
+}
+
+.quantileBlock {
+  min-width: 0;
+}
+
+/* ── tabular ──────────────────────────────────────────────────────────── */
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+
+.table th {
+  text-align: left;
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #6b7280;
+  font-weight: 500;
+  padding: 3px 8px 3px 0;
+  border-bottom: 1px solid #262626;
+  white-space: nowrap;
+}
+
+.table td {
+  padding: 3px 8px 3px 0;
+  border-bottom: 1px solid #1c1c1c;
+  color: #d1d5db;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  white-space: nowrap;
+}
+
+.colName {
+  color: #e5e7eb;
+}
+
+.colType {
+  color: #67e8f9;
+}
+
+.colMissing {
+  color: #fbbf24;
+}
+
+.colTop {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── misc ─────────────────────────────────────────────────────────────── */
+
+.muted {
+  font-size: 11px;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.note {
+  font-size: 10px;
+  color: #9ca3af;
+  margin-bottom: 6px;
+}
+
+.error {
+  font-size: 11px;
+  color: #fca5a5;
+  line-height: 1.5;
+}

--- a/frontend/src/components/NodeDetailModal/StatsTab.test.tsx
+++ b/frontend/src/components/NodeDetailModal/StatsTab.test.tsx
@@ -351,7 +351,9 @@ describe('StatsTab', () => {
     ).toBeInTheDocument();
   });
 
-  it("surfaces the server's not-captured hint", async () => {
+  it('localizes the not-captured hint instead of echoing the server', async () => {
+    // The server detail is English by construction; the one error whose cause
+    // is known exactly gets the translated wording.
     mockStats.mockRejectedValue(
       new StatsNotCapturedError(
         "nothing captured for 'n1.out' in run 'run1'. Turn on Record outputs (the Rec toggle in the toolbar) and re-run the graph to capture port data.",
@@ -359,14 +361,33 @@ describe('StatsTab', () => {
     );
     render(<StatsTab ctx={ctx()} />);
     await waitFor(() =>
-      expect(screen.getAllByText(/Turn on Record outputs/).length).toBe(2),
+      expect(
+        screen.getAllByText('Nothing captured for this port — re-run with Rec on'),
+      ).toHaveLength(2),
     );
+    expect(screen.queryByText(/Rec toggle in the toolbar/)).toBeNull();
   });
 
   it('reports an unexpected failure without blanking the tab', async () => {
     mockStats.mockRejectedValue(new Error('boom'));
     render(<StatsTab ctx={ctx()} />);
     await waitFor(() => expect(screen.getAllByText('boom').length).toBe(2));
+  });
+
+  it('aborts the previous round when the port set changes', async () => {
+    const signals: AbortSignal[] = [];
+    mockStats.mockImplementation(async (_r, _n, _p, opts) => {
+      if (opts?.signal) signals.push(opts.signal);
+      return tensorStats();
+    });
+    const { rerender } = render(<StatsTab ctx={ctx()} />);
+    await waitFor(() => expect(signals.length).toBe(2));
+
+    // Dropping the edge drops the input port, so the set changes.
+    rerender(<StatsTab ctx={ctx({ edges: [] })} />);
+    await waitFor(() => expect(signals.length).toBeGreaterThan(2));
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[signals.length - 1].aborted).toBe(false);
   });
 
   it('aborts in-flight requests when the tab unmounts', async () => {

--- a/frontend/src/components/NodeDetailModal/StatsTab.test.tsx
+++ b/frontend/src/components/NodeDetailModal/StatsTab.test.tsx
@@ -1,0 +1,431 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import type { Edge, Node } from '@xyflow/react';
+import type { NodeData, NodeDefinition } from '../../types';
+
+vi.mock('../../api/executionOutputs', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../api/executionOutputs')>();
+  return { ...actual, fetchPortStats: vi.fn() };
+});
+
+import {
+  fetchPortStats,
+  StatsNotCapturedError,
+  type PortStats,
+} from '../../api/executionOutputs';
+import { StatsTab, formatStat } from './StatsTab';
+import type { NodeDetailTabContext } from './tabs';
+
+const mockStats = vi.mocked(fetchPortStats);
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const definition = (outputs: string[]): NodeDefinition =>
+  ({
+    node_name: 'Demo',
+    category: 'Utility',
+    description: '',
+    params: [],
+    inputs: [{ name: 'x', data_type: 'TENSOR' }],
+    outputs: outputs.map((name) => ({ name, data_type: 'TENSOR' })),
+  }) as unknown as NodeDefinition;
+
+const node = (id: string, outputs: string[] = ['out']): Node<NodeData> =>
+  ({
+    id,
+    type: 'baseNode',
+    position: { x: 0, y: 0 },
+    data: { type: 'Demo', label: id, params: {}, definition: definition(outputs) },
+  }) as Node<NodeData>;
+
+function ctx(overrides: Partial<NodeDetailTabContext> = {}): NodeDetailTabContext {
+  const nodes = [node('src'), node('n1')];
+  const edges: Edge[] = [
+    { id: 'e1', source: 'src', target: 'n1', sourceHandle: 'out', targetHandle: 'x' },
+  ];
+  return {
+    nodeId: 'n1',
+    node: nodes[1],
+    runId: 'run1',
+    nodes,
+    edges,
+    recordOutputs: true,
+    outputSummaries: {},
+    focusPort: null,
+    ...overrides,
+  };
+}
+
+const tensorStats = (overrides: Partial<PortStats> = {}): PortStats => ({
+  run_id: 'run1',
+  node_id: 'n1',
+  port: 'out',
+  kind: 'tensor',
+  sampled: false,
+  sample_size: null,
+  shape: [2, 3],
+  dtype: 'torch.float32',
+  device: 'cpu',
+  count: 6,
+  mean: 0.5,
+  std: 1.25,
+  min: -2,
+  max: 3,
+  quantiles: { p1: -1.9, p5: -1.5, p25: -0.5, p50: 0.4, p75: 1.5, p95: 2.5, p99: 2.9 },
+  nan_count: 0,
+  inf_count: 0,
+  zero_frac: 0.125,
+  histogram: {
+    bins: 4,
+    edges: [-2, -0.75, 0.5, 1.75, 3],
+    counts: [1, 2, 2, 1],
+  },
+  value_counts: null,
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockStats.mockReset();
+  mockStats.mockResolvedValue(tensorStats());
+});
+
+// ── rendering ────────────────────────────────────────────────────────────────
+
+describe('StatsTab', () => {
+  it('fetches stats for every input and output port of the node', async () => {
+    render(<StatsTab ctx={ctx()} />);
+    await waitFor(() => expect(mockStats).toHaveBeenCalledTimes(2));
+    // Input side is keyed by the UPSTREAM node — that is where the value was
+    // captured, and it is what makes the edge tooltip's link resolve.
+    expect(mockStats).toHaveBeenCalledWith('run1', 'src', 'out', expect.anything());
+    expect(mockStats).toHaveBeenCalledWith('run1', 'n1', 'out', expect.anything());
+  });
+
+  it('renders the tensor stat table from the response', async () => {
+    render(<StatsTab ctx={ctx()} />);
+    await waitFor(() => expect(screen.getAllByText('Shape').length).toBe(2));
+    const block = screen.getByTestId('stats-port-n1-out');
+    expect(within(block).getByText('[2, 3]')).toBeInTheDocument();
+    expect(within(block).getByText('torch.float32')).toBeInTheDocument();
+    expect(within(block).getByText('cpu')).toBeInTheDocument();
+    expect(within(block).getByText('0.5')).toBeInTheDocument();
+    expect(within(block).getByText('1.25')).toBeInTheDocument();
+  });
+
+  it('renders the quantile row', async () => {
+    render(<StatsTab ctx={ctx()} />);
+    await waitFor(() => expect(screen.getAllByText('p50').length).toBe(2));
+    const block = screen.getByTestId('stats-port-n1-out');
+    expect(within(block).getByText('p1')).toBeInTheDocument();
+    expect(within(block).getByText('p99')).toBeInTheDocument();
+    expect(within(block).getByText('0.4')).toBeInTheDocument();
+  });
+
+  it('draws a histogram bar per bin', async () => {
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-n1-out');
+    await waitFor(() =>
+      expect(within(block).getByLabelText('Distribution')).toBeInTheDocument(),
+    );
+    const chart = within(block).getByLabelText('Distribution');
+    expect(chart.querySelectorAll('rect[data-count]')).toHaveLength(4);
+  });
+
+  // ── NaN / Inf prominence ───────────────────────────────────────────────────
+
+  it('shows NaN and Inf counts for a clean tensor without alarm styling', async () => {
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-n1-out');
+    const nan = within(block).getByTestId('stat-nan');
+    expect(nan).toHaveTextContent('NaN 0');
+    expect(nan.className).not.toMatch(/healthAlert/);
+  });
+
+  it('flags a tensor that contains NaNs', async () => {
+    mockStats.mockResolvedValue(tensorStats({ nan_count: 12, inf_count: 3 }));
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-n1-out');
+    await waitFor(() =>
+      expect(within(block).getByTestId('stat-nan')).toHaveTextContent('NaN 12'),
+    );
+    expect(within(block).getByTestId('stat-nan').className).toMatch(/healthAlert/);
+    expect(within(block).getByTestId('stat-inf').className).toMatch(/healthAlert/);
+  });
+
+  it('renders null statistics as an em dash rather than NaN', async () => {
+    mockStats.mockResolvedValue(
+      tensorStats({
+        mean: null,
+        std: null,
+        min: null,
+        max: null,
+        quantiles: {},
+        histogram: null,
+        nan_count: 6,
+      }),
+    );
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-n1-out');
+    await waitFor(() =>
+      expect(within(block).getAllByText('—').length).toBeGreaterThanOrEqual(4),
+    );
+    // "NaN" appears exactly once, as the health badge's LABEL — never as the
+    // rendered value of a statistic.
+    expect(within(block).getByTestId('stat-nan')).toHaveTextContent('NaN 6');
+    expect(block.textContent?.match(/NaN/g)).toHaveLength(1);
+  });
+
+  // ── sampling ───────────────────────────────────────────────────────────────
+
+  it('marks a sampled port and explains what stayed exact', async () => {
+    mockStats.mockResolvedValue(
+      tensorStats({ sampled: true, sample_size: 1_000_000, count: 500_000_000 }),
+    );
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-n1-out');
+    const chip = await within(block).findByText(/sampled/);
+    expect(chip).toHaveTextContent((1_000_000).toLocaleString());
+    expect(chip.title).toMatch(/exact/);
+    // The true element count survives sampling.
+    expect(within(block).getByText((500_000_000).toLocaleString())).toBeInTheDocument();
+  });
+
+  // ── class balance ──────────────────────────────────────────────────────────
+
+  it('renders a class-balance chart instead of a histogram for label tensors', async () => {
+    mockStats.mockResolvedValue(
+      tensorStats({
+        dtype: 'torch.int64',
+        histogram: null,
+        value_counts: [
+          { value: 0, count: 900 },
+          { value: 1, count: 100 },
+        ],
+      }),
+    );
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-n1-out');
+    await waitFor(() =>
+      expect(within(block).getByLabelText('Class balance')).toBeInTheDocument(),
+    );
+    expect(within(block).queryByLabelText('Distribution')).toBeNull();
+    const bars = within(block)
+      .getByLabelText('Class balance')
+      .querySelectorAll('rect[data-count]');
+    expect(bars).toHaveLength(2);
+    expect(bars[0].getAttribute('data-label')).toContain('900');
+  });
+
+  it('renders boolean class balance labels', async () => {
+    mockStats.mockResolvedValue(
+      tensorStats({
+        dtype: 'torch.bool',
+        histogram: null,
+        value_counts: [
+          { value: false, count: 3 },
+          { value: true, count: 1 },
+        ],
+      }),
+    );
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-n1-out');
+    await waitFor(() => expect(within(block).getByLabelText('Class balance')).toBeTruthy());
+    const bars = within(block)
+      .getByLabelText('Class balance')
+      .querySelectorAll('rect[data-count]');
+    expect(bars[0].getAttribute('data-label')).toContain('false');
+  });
+
+  // ── tabular ────────────────────────────────────────────────────────────────
+
+  it('renders a per-column table for a tabular value', async () => {
+    mockStats.mockResolvedValue({
+      run_id: 'run1',
+      node_id: 'n1',
+      port: 'out',
+      kind: 'tabular',
+      rows: 150,
+      column_count: 2,
+      columns_truncated: false,
+      sampled: false,
+      sample_size: null,
+      columns: [
+        {
+          name: 'petal_width',
+          dtype: 'float',
+          count: 148,
+          missing: 2,
+          unique: 22,
+          top: [{ value: 0.2, count: 29 }],
+          mean: 1.2,
+          min: 0.1,
+          max: 2.5,
+        },
+        {
+          name: 'species',
+          dtype: 'str',
+          count: 150,
+          missing: 0,
+          unique: 3,
+          top: [{ value: 'setosa', count: 50 }],
+          mean: null,
+          min: null,
+          max: null,
+        },
+      ],
+    });
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-n1-out');
+    await waitFor(() => expect(within(block).getByText('petal_width')).toBeInTheDocument());
+    expect(within(block).getByText('species')).toBeInTheDocument();
+    expect(within(block).getByText('setosa (50)')).toBeInTheDocument();
+    // Row and column totals sit in the badge strip above the table.
+    expect(within(block).getByText('Rows').parentElement).toHaveTextContent('Rows 150');
+    expect(within(block).getByText('Columns').parentElement).toHaveTextContent(
+      'Columns 2',
+    );
+    // A column with missing cells calls them out.
+    expect(within(block).getByText('2', { selector: 'td' })).toBeInTheDocument();
+  });
+
+  it('notes when a wide table had its columns truncated', async () => {
+    mockStats.mockResolvedValue({
+      run_id: 'run1',
+      node_id: 'n1',
+      port: 'out',
+      kind: 'tabular',
+      rows: 2,
+      column_count: 400,
+      columns_truncated: true,
+      columns: [
+        {
+          name: 'c0',
+          dtype: 'int',
+          count: 2,
+          missing: 0,
+          unique: 2,
+          top: [],
+          mean: 1.5,
+          min: 1,
+          max: 2,
+        },
+      ],
+    });
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-n1-out');
+    await waitFor(() =>
+      expect(within(block).getByText('Showing 1 of 400 columns')).toBeInTheDocument(),
+    );
+  });
+
+  it('says so plainly for a value type with no statistics', async () => {
+    mockStats.mockResolvedValue({
+      run_id: 'run1',
+      node_id: 'n1',
+      port: 'out',
+      kind: 'unsupported',
+      type: 'Linear',
+    });
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-n1-out');
+    await waitFor(() =>
+      expect(
+        within(block).getByText('No statistics for this value type (Linear)'),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  // ── states ─────────────────────────────────────────────────────────────────
+
+  it('shows the pre-run empty state and fetches nothing without a run', () => {
+    render(<StatsTab ctx={ctx({ runId: null })} />);
+    expect(screen.getByText('Node statistics')).toBeInTheDocument();
+    expect(mockStats).not.toHaveBeenCalled();
+  });
+
+  it("warns when Record outputs is off", async () => {
+    render(<StatsTab ctx={ctx({ recordOutputs: false })} />);
+    expect(
+      screen.getByText('Record outputs is off — re-run with Rec on to capture values'),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces the server's not-captured hint", async () => {
+    mockStats.mockRejectedValue(
+      new StatsNotCapturedError(
+        "nothing captured for 'n1.out' in run 'run1'. Turn on Record outputs (the Rec toggle in the toolbar) and re-run the graph to capture port data.",
+      ),
+    );
+    render(<StatsTab ctx={ctx()} />);
+    await waitFor(() =>
+      expect(screen.getAllByText(/Turn on Record outputs/).length).toBe(2),
+    );
+  });
+
+  it('reports an unexpected failure without blanking the tab', async () => {
+    mockStats.mockRejectedValue(new Error('boom'));
+    render(<StatsTab ctx={ctx()} />);
+    await waitFor(() => expect(screen.getAllByText('boom').length).toBe(2));
+  });
+
+  it('aborts in-flight requests when the tab unmounts', async () => {
+    let captured: AbortSignal | undefined;
+    mockStats.mockImplementation(async (_r, _n, _p, opts) => {
+      captured = opts?.signal;
+      return tensorStats();
+    });
+    const { unmount } = render(<StatsTab ctx={ctx()} />);
+    await waitFor(() => expect(captured).toBeDefined());
+    expect(captured!.aborted).toBe(false);
+    unmount();
+    expect(captured!.aborted).toBe(true);
+  });
+
+  // ── focus port (the edge tooltip's destination) ────────────────────────────
+
+  it('rings the port the edge tooltip pointed at', async () => {
+    render(<StatsTab ctx={ctx({ focusPort: 'src::out' })} />);
+    const focused = await screen.findByTestId('stats-port-src-out');
+    const other = screen.getByTestId('stats-port-n1-out');
+    expect(focused.className).toMatch(/portFocused/);
+    expect(other.className).not.toMatch(/portFocused/);
+  });
+
+  it('rings nothing when the modal was opened without a port', async () => {
+    render(<StatsTab ctx={ctx()} />);
+    const block = await screen.findByTestId('stats-port-src-out');
+    expect(block.className).not.toMatch(/portFocused/);
+  });
+
+  it('tells the user when a node has no connected inputs', async () => {
+    render(<StatsTab ctx={ctx({ edges: [] })} />);
+    expect(screen.getByText('No inputs connected')).toBeInTheDocument();
+  });
+});
+
+// ── the number formatter ─────────────────────────────────────────────────────
+
+describe('formatStat', () => {
+  it('renders an em dash for a statistic that does not exist', () => {
+    expect(formatStat(null)).toBe('—');
+    expect(formatStat(undefined)).toBe('—');
+    expect(formatStat(NaN)).toBe('—');
+  });
+
+  it('keeps integers plain', () => {
+    expect(formatStat(0)).toBe('0');
+    expect(formatStat(-42)).toBe('-42');
+  });
+
+  it('trims trailing zeros off a decimal', () => {
+    expect(formatStat(0.5)).toBe('0.5');
+    expect(formatStat(1.25)).toBe('1.25');
+  });
+
+  it('falls back to exponent notation at the extremes', () => {
+    // A vanishing gradient must not round to a flat zero.
+    expect(formatStat(3.7e-9)).toBe('3.700e-9');
+    expect(formatStat(1.5e12)).toBe('1.500e+12');
+  });
+});

--- a/frontend/src/components/NodeDetailModal/StatsTab.tsx
+++ b/frontend/src/components/NodeDetailModal/StatsTab.tsx
@@ -1,23 +1,447 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  fetchPortStats,
+  StatsNotCapturedError,
+  type PortStats,
+  type StatsColumn,
+} from '../../api/executionOutputs';
 import { useI18n } from '../../i18n';
-import styles from './NodeDetailModal.module.css';
+import { keyOf, type PortTarget } from '../InspectorPanel/PortGroup';
+import { resolveSingleNodePorts } from '../InspectorPanel/portCaptures';
+import { HistogramPlot, type HistogramBar } from '../shared/HistogramPlot';
+import { getPortColor } from '../../utils';
+import type { NodeDetailTabContext } from './tabs';
+import modal from './NodeDetailModal.module.css';
+import styles from './StatsTab.module.css';
+
+interface StatsFetchState {
+  loading: boolean;
+  error: string | null;
+  data: PortStats | null;
+}
+
+type StatsMap = Record<string, StatsFetchState>;
 
 /**
- * Placeholder for the per-node statistics tab.
+ * Load `/stats` for every port of one node.
  *
- * The tab exists now so the modal ships its full shape and the slot is
- * reserved; P3-14 replaces this body by registering a `stats` spec over the
- * built-in one (see `registerNodeDetailTab`). Nothing else in the modal needs
- * to change when it does.
+ * Mirrors `usePortFetches`, with one difference that matters: the in-flight
+ * requests are tied to an `AbortController` and cancelled on unmount or port
+ * change (#124). Stats are the one capture read that can cost the server a
+ * second of CPU per port, so a user arrowing through ten nodes must not leave
+ * ten abandoned computations queued behind the one they are looking at.
  */
-export function StatsTab() {
-  const { t } = useI18n();
+export function usePortStats(
+  runId: string | null,
+  ports: readonly PortTarget[],
+): StatsMap {
+  const [stats, setStats] = useState<StatsMap>({});
+
+  const portsRef = useRef(ports);
+  portsRef.current = ports;
+  const portsKey = ports.map((p) => keyOf(p.nodeId, p.port)).join('|');
+
+  useEffect(() => {
+    if (!runId) return;
+    const all = portsRef.current;
+    if (all.length === 0) return;
+    const controller = new AbortController();
+
+    const pending: StatsMap = {};
+    for (const p of all) {
+      pending[keyOf(p.nodeId, p.port)] = { loading: true, error: null, data: null };
+    }
+    setStats((prev) => ({ ...prev, ...pending }));
+
+    void Promise.all(
+      all.map(async (p) => {
+        const key = keyOf(p.nodeId, p.port);
+        try {
+          const data = await fetchPortStats(runId, p.nodeId, p.port, {
+            signal: controller.signal,
+          });
+          if (controller.signal.aborted) return;
+          setStats((prev) => ({ ...prev, [key]: { loading: false, error: null, data } }));
+        } catch (e) {
+          // An abort is this component going away, not a failure to report.
+          if (controller.signal.aborted) return;
+          const message =
+            e instanceof StatsNotCapturedError ? e.message : (e as Error).message;
+          setStats((prev) => ({
+            ...prev,
+            [key]: { loading: false, error: message, data: null },
+          }));
+        }
+      }),
+    );
+
+    return () => controller.abort();
+  }, [runId, portsKey]);
+
+  return stats;
+}
+
+/** Drop trailing zeros only from something that actually has a decimal point. */
+function trimZeros(text: string): string {
+  return text.includes('.') && !text.includes('e')
+    ? text.replace(/0+$/, '').replace(/\.$/, '')
+    : text;
+}
+
+/** Compact display for one statistic. Undefined statistics read as an em dash. */
+export function formatStat(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '—';
+  if (!Number.isFinite(value)) return '—';
+  if (Number.isInteger(value) && Math.abs(value) < 1e9) return String(value);
+  const magnitude = Math.abs(value);
+  if (magnitude !== 0 && (magnitude < 1e-4 || magnitude >= 1e9)) {
+    return value.toExponential(3);
+  }
+  return trimZeros(value.toPrecision(6));
+}
+
+function formatCount(value: number | null | undefined): string {
+  return value === null || value === undefined ? '—' : value.toLocaleString();
+}
+
+function StatCell({ label, value }: { label: string; value: string }) {
   return (
-    <div className={styles.tabBody}>
-      <div className={styles.emptyState}>
-        <div className={styles.emptyIcon}>~</div>
-        <div>{t('nodeDetail.stats.title')}</div>
-        <div className={styles.emptyHint}>{t('nodeDetail.stats.placeholder')}</div>
+    <div className={styles.statCell}>
+      <span className={styles.statLabel}>{label}</span>
+      <span className={styles.statValue}>{value}</span>
+    </div>
+  );
+}
+
+/**
+ * NaN / Inf / zero counts, on their own line above everything else.
+ *
+ * Position is the feature: "are there NaNs in this tensor" is the question
+ * that brings people to a stats panel in the first place, and an answer
+ * buried in row seven of a grid is an answer nobody reads. A non-zero NaN or
+ * Inf count also flips the badge to the alert style, so the panel looks
+ * different from across the room.
+ */
+function HealthRow({ stats }: { stats: PortStats }) {
+  const { t } = useI18n();
+  const nan = stats.nan_count ?? 0;
+  const inf = stats.inf_count ?? 0;
+  const zeroFrac = stats.zero_frac;
+  return (
+    <div className={styles.healthRow}>
+      <span
+        className={`${styles.healthBadge} ${nan > 0 ? styles.healthAlert : ''}`}
+        data-testid="stat-nan"
+      >
+        {t('nodeDetail.stats.nan')} <b>{formatCount(nan)}</b>
+      </span>
+      <span
+        className={`${styles.healthBadge} ${inf > 0 ? styles.healthAlert : ''}`}
+        data-testid="stat-inf"
+      >
+        {t('nodeDetail.stats.inf')} <b>{formatCount(inf)}</b>
+      </span>
+      {zeroFrac !== null && zeroFrac !== undefined && (
+        <span className={styles.healthBadge}>
+          {t('nodeDetail.stats.zeros')} <b>{(zeroFrac * 100).toFixed(1)}%</b>
+        </span>
+      )}
+    </div>
+  );
+}
+
+function TensorStats({ stats }: { stats: PortStats }) {
+  const { t } = useI18n();
+  const quantiles = stats.quantiles ?? {};
+  const quantileNames = ['p1', 'p5', 'p25', 'p50', 'p75', 'p95', 'p99'];
+
+  const bars: HistogramBar[] = useMemo(() => {
+    if (stats.value_counts?.length) {
+      return stats.value_counts.map((entry) => ({
+        label: `${String(entry.value)} · ${entry.count.toLocaleString()}`,
+        count: entry.count,
+      }));
+    }
+    const hist = stats.histogram;
+    if (!hist) return [];
+    return hist.counts.map((count, i) => ({
+      label: `[${formatStat(hist.edges[i])}, ${formatStat(hist.edges[i + 1])})`,
+      count,
+    }));
+  }, [stats.value_counts, stats.histogram]);
+
+  const isClassBalance = Boolean(stats.value_counts?.length);
+
+  return (
+    <>
+      <HealthRow stats={stats} />
+
+      <div className={styles.statGrid}>
+        <StatCell
+          label={t('nodeDetail.stats.shape')}
+          value={stats.shape ? `[${stats.shape.join(', ')}]` : '—'}
+        />
+        <StatCell label={t('nodeDetail.stats.dtype')} value={stats.dtype ?? '—'} />
+        <StatCell label={t('nodeDetail.stats.device')} value={stats.device ?? '—'} />
+        <StatCell label={t('nodeDetail.stats.count')} value={formatCount(stats.count)} />
+        <StatCell label={t('nodeDetail.stats.mean')} value={formatStat(stats.mean)} />
+        <StatCell label={t('nodeDetail.stats.std')} value={formatStat(stats.std)} />
+        <StatCell label={t('nodeDetail.stats.min')} value={formatStat(stats.min)} />
+        <StatCell label={t('nodeDetail.stats.max')} value={formatStat(stats.max)} />
       </div>
+
+      {quantileNames.some((name) => quantiles[name] !== undefined) && (
+        <div className={styles.quantileBlock}>
+          <div className={styles.blockTitle}>{t('nodeDetail.stats.quantiles')}</div>
+          <div className={styles.quantileRow}>
+            {quantileNames.map((name) => (
+              <div key={name} className={styles.quantileCell}>
+                <span className={styles.statLabel}>{name}</span>
+                <span className={styles.statValue}>{formatStat(quantiles[name])}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {bars.length > 0 && (
+        <div className={styles.chartBlock}>
+          <div className={styles.blockTitle}>
+            {isClassBalance
+              ? t('nodeDetail.stats.classBalance')
+              : t('nodeDetail.stats.distribution')}
+          </div>
+          <HistogramPlot
+            bars={bars}
+            variant={isClassBalance ? 'categorical' : 'continuous'}
+            axisMin={isClassBalance ? undefined : formatStat(stats.min)}
+            axisMax={isClassBalance ? undefined : formatStat(stats.max)}
+            ariaLabel={
+              isClassBalance
+                ? t('nodeDetail.stats.classBalance')
+                : t('nodeDetail.stats.distribution')
+            }
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+function ColumnRow({ column }: { column: StatsColumn }) {
+  const top = column.top
+    .slice(0, 3)
+    .map((entry) => `${String(entry.value)} (${entry.count})`)
+    .join(', ');
+  return (
+    <tr>
+      <td className={styles.colName}>{column.name}</td>
+      <td className={styles.colType}>{column.dtype}</td>
+      <td>{formatCount(column.count)}</td>
+      <td className={column.missing > 0 ? styles.colMissing : undefined}>
+        {formatCount(column.missing)}
+      </td>
+      <td>{formatCount(column.unique)}</td>
+      <td className={styles.colTop} title={top}>
+        {top || '—'}
+      </td>
+      <td>
+        {column.mean == null
+          ? '—'
+          : `${formatStat(column.mean)} (${formatStat(column.min)} … ${formatStat(column.max)})`}
+      </td>
+    </tr>
+  );
+}
+
+function TabularStats({ stats }: { stats: PortStats }) {
+  const { t } = useI18n();
+  const columns = stats.columns ?? [];
+  return (
+    <>
+      <div className={styles.healthRow}>
+        <span className={styles.healthBadge}>
+          {t('nodeDetail.stats.rows')} <b>{formatCount(stats.rows)}</b>
+        </span>
+        <span className={styles.healthBadge}>
+          {t('nodeDetail.stats.columns')} <b>{formatCount(stats.column_count)}</b>
+        </span>
+      </div>
+      {stats.columns_truncated && (
+        <div className={styles.note}>
+          {t('nodeDetail.stats.columnsTruncated', {
+            shown: columns.length,
+            total: stats.column_count ?? columns.length,
+          })}
+        </div>
+      )}
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>{t('nodeDetail.stats.column')}</th>
+              <th>{t('nodeDetail.stats.dtype')}</th>
+              <th>{t('nodeDetail.stats.count')}</th>
+              <th>{t('nodeDetail.stats.missing')}</th>
+              <th>{t('nodeDetail.stats.unique')}</th>
+              <th>{t('nodeDetail.stats.top')}</th>
+              <th>{t('nodeDetail.stats.mean')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {columns.map((column, index) => (
+              <ColumnRow key={`${column.name}::${index}`} column={column} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+function PortStatsBlock({
+  port,
+  state,
+  focused,
+}: {
+  port: PortTarget;
+  state: StatsFetchState | undefined;
+  focused: boolean;
+}) {
+  const { t } = useI18n();
+  const ref = useRef<HTMLElement | null>(null);
+  const stats = state?.data;
+
+  // The edge tooltip's "View stats" lands here — bring the port it named into
+  // view rather than leaving the user to find it in the list.
+  // `state?.data` is in the deps because the block is a one-line header until
+  // the fetch lands and a full stat panel afterwards — scrolling only on mount
+  // aims at the wrong height and leaves the port off screen.
+  useEffect(() => {
+    if (focused) ref.current?.scrollIntoView({ block: 'nearest' });
+  }, [focused, state?.data]);
+
+  return (
+    <section
+      ref={ref}
+      className={`${styles.portBlock} ${focused ? styles.portFocused : ''}`}
+      data-testid={`stats-port-${port.nodeId}-${port.port}`}
+    >
+      <header className={styles.portHeader}>
+        {port.dataType && (
+          <span
+            className={styles.portDot}
+            style={{ background: getPortColor(port.dataType) }}
+          />
+        )}
+        <span className={styles.portName}>{port.displayName ?? port.port}</span>
+        {stats?.sampled && (
+          <span className={styles.sampledChip} title={t('nodeDetail.stats.sampledNote')}>
+            {t('nodeDetail.stats.sampled', {
+              size: (stats.sample_size ?? 0).toLocaleString(),
+            })}
+          </span>
+        )}
+      </header>
+
+      {state?.loading && <div className={styles.muted}>{t('nodeDetail.stats.loading')}</div>}
+      {state?.error && <div className={styles.error}>{state.error}</div>}
+      {stats?.kind === 'tensor' && <TensorStats stats={stats} />}
+      {stats?.kind === 'tabular' && <TabularStats stats={stats} />}
+      {stats?.kind === 'unsupported' && (
+        <div className={styles.muted}>
+          {t('nodeDetail.stats.unsupported', { type: stats.type ?? '?' })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PortStatsGroup({
+  title,
+  ports,
+  stats,
+  focusPort,
+  emptyText,
+}: {
+  title: string;
+  ports: PortTarget[];
+  stats: StatsMap;
+  focusPort: string | null;
+  emptyText: string;
+}) {
+  return (
+    <div className={styles.group}>
+      <div className={styles.groupTitle}>{title}</div>
+      {ports.length === 0 ? (
+        <div className={styles.muted}>{emptyText}</div>
+      ) : (
+        ports.map((port) => (
+          <PortStatsBlock
+            key={keyOf(port.nodeId, port.port)}
+            port={port}
+            state={stats[keyOf(port.nodeId, port.port)]}
+            focused={focusPort === keyOf(port.nodeId, port.port)}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+/**
+ * Server-computed statistics for every port of one node (#129).
+ *
+ * Nothing here downloads a tensor. Each port is summarised by
+ * `/api/execution/outputs/{run}/{node}/{port}/stats`, which returns a couple
+ * of kilobytes whatever the value weighs — so this tab costs the same for a
+ * [2, 3] tensor and for a 2 GB activation.
+ *
+ * Ports come from the Inspector's own `resolveSingleNodePorts`, the same
+ * resolution the Inputs and Outputs tabs use, which is why a port named on an
+ * edge tooltip is findable here under the node that consumes it.
+ */
+export function StatsTab({ ctx }: { ctx: NodeDetailTabContext }) {
+  const { t } = useI18n();
+
+  const { inputs, outputs } = useMemo(
+    () => resolveSingleNodePorts(ctx.nodeId, ctx.nodes, ctx.edges),
+    [ctx.nodeId, ctx.nodes, ctx.edges],
+  );
+  const allPorts = useMemo(() => [...inputs, ...outputs], [inputs, outputs]);
+  const stats = usePortStats(ctx.runId, allPorts);
+
+  if (ctx.runId === null) {
+    return (
+      <div className={modal.tabBody}>
+        <div className={modal.emptyState}>
+          <div className={modal.emptyIcon}>~</div>
+          <div>{t('nodeDetail.stats.title')}</div>
+          <div className={modal.emptyHint}>{t('nodeDetail.captures.notRunHint')}</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={modal.tabBody}>
+      {!ctx.recordOutputs && (
+        <div className={modal.warnHint}>{t('nodeDetail.captures.recordingOff')}</div>
+      )}
+      <PortStatsGroup
+        title={t('nodeDetail.inputs.title', { count: inputs.length })}
+        ports={inputs}
+        stats={stats}
+        focusPort={ctx.focusPort}
+        emptyText={t('nodeDetail.inputs.empty')}
+      />
+      <PortStatsGroup
+        title={t('nodeDetail.outputs.title', { count: outputs.length })}
+        ports={outputs}
+        stats={stats}
+        focusPort={ctx.focusPort}
+        emptyText={t('nodeDetail.outputs.empty')}
+      />
     </div>
   );
 }

--- a/frontend/src/components/NodeDetailModal/StatsTab.tsx
+++ b/frontend/src/components/NodeDetailModal/StatsTab.tsx
@@ -16,6 +16,7 @@ import styles from './StatsTab.module.css';
 
 interface StatsFetchState {
   loading: boolean;
+  /** Localized message, or null. */
   error: string | null;
   data: PortStats | null;
 }
@@ -36,6 +37,12 @@ export function usePortStats(
   ports: readonly PortTarget[],
 ): StatsMap {
   const [stats, setStats] = useState<StatsMap>({});
+  // The server's 404 detail carries the Record-outputs hint in English. It is
+  // the one error here whose cause we know exactly, so it gets the localized
+  // wording rather than a raw server string in the middle of a zh-TW panel.
+  const { t } = useI18n();
+  const tRef = useRef(t);
+  tRef.current = t;
 
   const portsRef = useRef(ports);
   portsRef.current = ports;
@@ -66,7 +73,9 @@ export function usePortStats(
           // An abort is this component going away, not a failure to report.
           if (controller.signal.aborted) return;
           const message =
-            e instanceof StatsNotCapturedError ? e.message : (e as Error).message;
+            e instanceof StatsNotCapturedError
+              ? tRef.current('nodeDetail.stats.notCaptured')
+              : (e as Error).message;
           setStats((prev) => ({
             ...prev,
             [key]: { loading: false, error: message, data: null },

--- a/frontend/src/components/NodeDetailModal/tabs.tsx
+++ b/frontend/src/components/NodeDetailModal/tabs.tsx
@@ -28,6 +28,12 @@ export interface NodeDetailTabContext {
   recordOutputs: boolean;
   /** Per-node, per-port summaries streamed during the last run. */
   outputSummaries: Record<string, Record<string, OutputSummary>>;
+  /**
+   * A specific port the modal was opened *about*, as `nodeId::port` — set when
+   * the edge tooltip's "View stats" link opened it, null otherwise. A tab that
+   * lists many ports scrolls to this one and rings it (#129).
+   */
+  focusPort: string | null;
 }
 
 export interface NodeDetailTabSpec {
@@ -97,7 +103,7 @@ export const BUILTIN_NODE_DETAIL_TABS: readonly NodeDetailTabSpec[] = [
     id: 'stats',
     labelKey: 'nodeDetail.tabs.stats',
     order: 50,
-    render: () => <StatsTab />,
+    render: (ctx) => <StatsTab key={`${ctx.runId}:${ctx.nodeId}`} ctx={ctx} />,
   },
   {
     id: 'docs',
@@ -114,9 +120,14 @@ const extraTabs = new Map<string, NodeDetailTabSpec>();
  * Add a tab to the Node Detail Modal, or replace a built-in one.
  *
  * Registering an id that already exists as a built-in REPLACES it while
- * keeping its slot — which is how P3-14 turns the placeholder `stats` tab into
- * a real one without touching this file, and how a code-editor tab lands next
- * to the others. Registering a new id inserts it by `order`.
+ * keeping its slot — which is how a code-editor tab lands next to the others,
+ * and how a plugin swaps one out. Registering a new id inserts it by `order`.
+ *
+ * (#129 filled the `stats` placeholder in the array above rather than through
+ * here: `StatsTab` is imported BY this module, so registering from it would
+ * make the two files circular, and the alternative — a side-effect-only module
+ * imported at the app root — would leave the tab unregistered in every test
+ * that renders the modal without the app. Third-party code still uses this.)
  *
  * Call at module scope from the feature's own module; the modal reads the
  * registry on every render, so a tab registered before the modal opens is

--- a/frontend/src/components/ResultsPanel/ResultsPanel.module.css
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.module.css
@@ -457,6 +457,28 @@
   text-align: right;
 }
 
+/* "View stats →" (#129) — the way from a streamed summary to the real
+   server-computed distribution. */
+.edgeTooltipLink {
+  display: block;
+  width: 100%;
+  margin-top: 8px;
+  padding: 4px 0 0;
+  border: none;
+  border-top: 1px solid #3a3a3a;
+  background: none;
+  color: #67e8f9;
+  font-size: 0.75rem;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.edgeTooltipLink:hover {
+  color: #a5f3fc;
+  text-decoration: underline;
+}
+
 /* Training summary stats */
 .trainingSummary {
   display: flex;

--- a/frontend/src/components/shared/HistogramPlot.module.css
+++ b/frontend/src/components/shared/HistogramPlot.module.css
@@ -1,0 +1,78 @@
+.wrapper {
+  position: relative;
+  background: #161616;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+  padding: 6px 6px 4px;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.svg {
+  display: block;
+  overflow: visible;
+}
+
+.bar {
+  fill: #0e7490;
+  transition: fill 0.12s ease;
+}
+
+.barActive {
+  fill: #67e8f9;
+}
+
+.baseline {
+  stroke: #2a2a2a;
+  stroke-width: 1;
+}
+
+.axisRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 4px;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 9px;
+  color: #666;
+}
+
+.axisPeak {
+  color: #4b5563;
+}
+
+.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #161616;
+  border: 1px dashed #2a2a2a;
+  border-radius: 4px;
+  color: #666;
+  font-size: 11px;
+  font-style: italic;
+}
+
+.tooltip {
+  position: fixed;
+  z-index: 10000;
+  background: #0a0f17;
+  border: 1px solid #1f2937;
+  border-radius: 6px;
+  padding: 5px 9px;
+  font-size: 11px;
+  color: #eee;
+  pointer-events: none;
+  box-shadow: 0 12px 28px -8px rgba(0, 0, 0, 0.7);
+}
+
+.tooltipLabel {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  color: #9ca3af;
+}
+
+.tooltipCount {
+  margin-top: 2px;
+  font-weight: 600;
+}

--- a/frontend/src/components/shared/HistogramPlot.test.tsx
+++ b/frontend/src/components/shared/HistogramPlot.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { HistogramPlot, type HistogramBar } from './HistogramPlot';
+
+const bars: HistogramBar[] = [
+  { label: '[0, 1)', count: 4 },
+  { label: '[1, 2)', count: 0 },
+  { label: '[2, 3)', count: 8 },
+];
+
+function barRects(container: HTMLElement): SVGRectElement[] {
+  return [...container.querySelectorAll<SVGRectElement>('rect[data-count]')];
+}
+
+describe('HistogramPlot', () => {
+  it('renders one bar per non-empty bin', () => {
+    const { container } = render(<HistogramPlot bars={bars} ariaLabel="Distribution" />);
+    const rects = barRects(container);
+    expect(rects).toHaveLength(2);
+    expect(rects.map((r) => r.getAttribute('data-count'))).toEqual(['4', '8']);
+  });
+
+  it('scales bar height against the tallest bin', () => {
+    const { container } = render(<HistogramPlot bars={bars} height={100} />);
+    const [small, tall] = barRects(container);
+    expect(Number(tall.getAttribute('height'))).toBe(100);
+    expect(Number(small.getAttribute('height'))).toBeCloseTo(50);
+  });
+
+  it('keeps a tiny bin visible instead of rounding it away', () => {
+    const { container } = render(
+      <HistogramPlot bars={[{ label: 'a', count: 1 }, { label: 'b', count: 100000 }]} height={100} />,
+    );
+    const [tiny] = barRects(container);
+    expect(Number(tiny.getAttribute('height'))).toBeGreaterThanOrEqual(1.5);
+  });
+
+  it('renders an empty-state instead of an empty chart', () => {
+    render(<HistogramPlot bars={[]} />);
+    expect(screen.getByText('no distribution')).toBeInTheDocument();
+    expect(document.querySelector('rect[data-count]')).toBeNull();
+  });
+
+  it('shows the axis captions and the peak count when given', () => {
+    render(<HistogramPlot bars={bars} axisMin="-2" axisMax="3" />);
+    expect(screen.getByText('-2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('peak 8')).toBeInTheDocument();
+  });
+
+  it('omits the axis row entirely when no captions are supplied', () => {
+    render(<HistogramPlot bars={bars} />);
+    expect(screen.queryByText(/^peak/)).toBeNull();
+  });
+
+  it('opens a tooltip on hover and drops it on leave', () => {
+    const { container } = render(<HistogramPlot bars={bars} />);
+    // The hover target is the full-height transparent rect, not the bar.
+    const targets = container.querySelectorAll('rect[fill="transparent"]');
+    fireEvent.mouseEnter(targets[2]);
+    expect(screen.getByText('[2, 3)')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(container.querySelector('svg') as SVGSVGElement);
+    expect(screen.queryByText('[2, 3)')).toBeNull();
+  });
+
+  it('follows the pointer while it moves across a bin', () => {
+    const { container } = render(<HistogramPlot bars={bars} />);
+    const targets = container.querySelectorAll('rect[fill="transparent"]');
+    fireEvent.mouseEnter(targets[0], { clientX: 10, clientY: 10 });
+    fireEvent.mouseMove(targets[0], { clientX: 80, clientY: 60 });
+    const tooltip = screen.getByText('[0, 1)').parentElement as HTMLElement;
+    expect(tooltip.style.left).toBe('92px');
+    expect(tooltip.style.top).toBe('72px');
+  });
+
+  it('gaps categorical bars and butts continuous ones together', () => {
+    const { container: continuous } = render(
+      <HistogramPlot bars={bars} width={300} variant="continuous" />,
+    );
+    const { container: categorical } = render(
+      <HistogramPlot bars={bars} width={300} variant="categorical" />,
+    );
+    const continuousWidth = Number(barRects(continuous)[0].getAttribute('width'));
+    const categoricalWidth = Number(barRects(categorical)[0].getAttribute('width'));
+    expect(continuousWidth).toBe(100);
+    expect(categoricalWidth).toBeLessThan(continuousWidth);
+  });
+
+  it('exposes the accessible name on the plot', () => {
+    render(<HistogramPlot bars={bars} ariaLabel="Class balance" />);
+    expect(screen.getByLabelText('Class balance')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/shared/HistogramPlot.test.tsx
+++ b/frontend/src/components/shared/HistogramPlot.test.tsx
@@ -92,4 +92,43 @@ describe('HistogramPlot', () => {
     render(<HistogramPlot bars={bars} ariaLabel="Class balance" />);
     expect(screen.getByLabelText('Class balance')).toBeInTheDocument();
   });
+
+  // ── boundaries ────────────────────────────────────────────────────────────
+
+  it('draws no bars when every bin is empty, and does not divide by zero', () => {
+    const empty = [
+      { label: 'a', count: 0 },
+      { label: 'b', count: 0 },
+    ];
+    const { container } = render(<HistogramPlot bars={empty} axisMin="0" axisMax="1" />);
+    expect(barRects(container)).toHaveLength(0);
+    // An all-zero histogram is a real answer (an all-NaN slice), not an error.
+    expect(screen.queryByText('no distribution')).toBeNull();
+    expect(screen.getByText('peak 0')).toBeInTheDocument();
+  });
+
+  it('renders the degenerate single-bin histogram of a constant tensor', () => {
+    const { container } = render(
+      <HistogramPlot bars={[{ label: '[2.5, 2.5]', count: 100 }]} height={80} />,
+    );
+    const rects = barRects(container);
+    expect(rects).toHaveLength(1);
+    expect(Number(rects[0].getAttribute('height'))).toBe(80);
+  });
+
+  it('drops the tooltip when the bars change out from under it', () => {
+    const { container, rerender } = render(<HistogramPlot bars={bars} />);
+    fireEvent.mouseEnter(container.querySelectorAll('rect[fill="transparent"]')[2]);
+    expect(screen.getByText('[2, 3)')).toBeInTheDocument();
+
+    // A refetch can swap a 64-bin histogram for a 2-bar class balance.
+    rerender(<HistogramPlot bars={[{ label: 'only', count: 1 }]} />);
+    expect(screen.queryByText('[2, 3)')).toBeNull();
+  });
+
+  it('localizes its own strings', () => {
+    // The repo's plots were previously the one place hard-coded English lived.
+    render(<HistogramPlot bars={[]} />);
+    expect(screen.getByText('no distribution')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/shared/HistogramPlot.tsx
+++ b/frontend/src/components/shared/HistogramPlot.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './HistogramPlot.module.css';
+
+/** One bar. `x0`/`x1` are the bin edges for a continuous histogram. */
+export interface HistogramBar {
+  label: string;
+  count: number;
+  x0?: number;
+  x1?: number;
+}
+
+interface HistogramPlotProps {
+  bars: HistogramBar[];
+  width?: number;
+  height?: number;
+  /**
+   * Categorical bars get a gap between them and their own tick label;
+   * continuous bins sit flush so the shape of the distribution reads as one
+   * curve rather than 64 separate things.
+   */
+  variant?: 'continuous' | 'categorical';
+  /** Axis captions under the left and right ends of the plot. */
+  axisMin?: string;
+  axisMax?: string;
+  className?: string;
+  /** Accessible name; also the SVG's `aria-label`. */
+  ariaLabel?: string;
+}
+
+interface HoverState {
+  index: number;
+  screenX: number;
+  screenY: number;
+}
+
+/**
+ * Pure-SVG bar chart for a distribution: either a fixed-bin histogram or a
+ * class-balance chart.
+ *
+ * Same shape as `ScatterPlot` on purpose — stateless with respect to data, no
+ * chart library, hover tooltip through a portal so an `overflow: hidden`
+ * ancestor cannot clip it. The two components are the repo's plotting
+ * convention and a third one would be a third thing to keep in sync.
+ */
+export function HistogramPlot({
+  bars,
+  width = 420,
+  height = 140,
+  variant = 'continuous',
+  axisMin,
+  axisMax,
+  className,
+  ariaLabel,
+}: HistogramPlotProps) {
+  const [hover, setHover] = useState<HoverState | null>(null);
+
+  const { rects, maxCount } = useMemo(() => {
+    if (bars.length === 0) return { rects: [], maxCount: 0 };
+    const maxCount = Math.max(...bars.map((b) => b.count));
+    const gap = variant === 'categorical' ? Math.min(4, 240 / bars.length) : 0;
+    const slot = width / bars.length;
+    const barWidth = Math.max(1, slot - gap);
+    const rects = bars.map((bar, i) => {
+      // A non-empty bin always gets a visible sliver: a bar rounded to zero
+      // pixels reads as "no data here", which is the opposite of the truth.
+      const scaled = maxCount > 0 ? (bar.count / maxCount) * height : 0;
+      const h = bar.count > 0 ? Math.max(1.5, scaled) : 0;
+      return { bar, i, x: i * slot + gap / 2, w: barWidth, h, y: height - h };
+    });
+    return { rects, maxCount };
+  }, [bars, width, height, variant]);
+
+  if (bars.length === 0) {
+    return (
+      <div className={`${styles.empty} ${className ?? ''}`} style={{ width, height }}>
+        <span>no distribution</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${styles.wrapper} ${className ?? ''}`}>
+      <svg
+        width={width}
+        height={height}
+        className={styles.svg}
+        role="img"
+        aria-label={ariaLabel}
+        onMouseLeave={() => setHover(null)}
+      >
+        {rects.map(({ bar, i, x, w, h, y }) => (
+          <g key={i}>
+            {/* A full-height transparent target: hovering a one-pixel bar in
+                the tail is otherwise a game of skill. */}
+            <rect
+              x={x}
+              y={0}
+              width={w}
+              height={height}
+              fill="transparent"
+              onMouseEnter={(e) => setHover({ index: i, screenX: e.clientX, screenY: e.clientY })}
+              onMouseMove={(e) => setHover({ index: i, screenX: e.clientX, screenY: e.clientY })}
+            />
+            {bar.count > 0 && (
+              <rect
+                className={`${styles.bar} ${hover?.index === i ? styles.barActive : ''}`}
+                x={x}
+                y={y}
+                width={w}
+                height={h}
+                data-count={bar.count}
+                data-label={bar.label}
+                pointerEvents="none"
+              />
+            )}
+          </g>
+        ))}
+        <line x1={0} y1={height - 0.5} x2={width} y2={height - 0.5} className={styles.baseline} />
+      </svg>
+
+      {(axisMin !== undefined || axisMax !== undefined) && (
+        <div className={styles.axisRow} style={{ width }}>
+          <span>{axisMin}</span>
+          <span className={styles.axisPeak}>peak {maxCount.toLocaleString()}</span>
+          <span>{axisMax}</span>
+        </div>
+      )}
+
+      {/* Indexed defensively: a refetch can swap a 64-bin histogram for a
+          2-bar class balance while the pointer is still down on bin 40. */}
+      {hover && bars[hover.index] &&
+        createPortal(
+          <div
+            className={styles.tooltip}
+            style={{ left: hover.screenX + 12, top: hover.screenY + 12 }}
+          >
+            <div className={styles.tooltipLabel}>{bars[hover.index].label}</div>
+            <div className={styles.tooltipCount}>
+              {bars[hover.index].count.toLocaleString()}
+            </div>
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/frontend/src/components/shared/HistogramPlot.tsx
+++ b/frontend/src/components/shared/HistogramPlot.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useI18n } from '../../i18n';
 import styles from './HistogramPlot.module.css';
 
 /** One bar. `x0`/`x1` are the bin edges for a continuous histogram. */
@@ -53,6 +54,7 @@ export function HistogramPlot({
   className,
   ariaLabel,
 }: HistogramPlotProps) {
+  const { t } = useI18n();
   const [hover, setHover] = useState<HoverState | null>(null);
 
   const { rects, maxCount } = useMemo(() => {
@@ -74,7 +76,7 @@ export function HistogramPlot({
   if (bars.length === 0) {
     return (
       <div className={`${styles.empty} ${className ?? ''}`} style={{ width, height }}>
-        <span>no distribution</span>
+        <span>{t('plot.noDistribution')}</span>
       </div>
     );
   }
@@ -122,7 +124,9 @@ export function HistogramPlot({
       {(axisMin !== undefined || axisMax !== undefined) && (
         <div className={styles.axisRow} style={{ width }}>
           <span>{axisMin}</span>
-          <span className={styles.axisPeak}>peak {maxCount.toLocaleString()}</span>
+          <span className={styles.axisPeak}>
+            {t('plot.peak', { count: maxCount.toLocaleString() })}
+          </span>
           <span>{axisMax}</span>
         </div>
       )}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -641,6 +641,7 @@ const en = {
   'nodeDetail.stats.top': 'Most common',
   'nodeDetail.stats.columnsTruncated': 'Showing {shown} of {total} columns',
   'nodeDetail.stats.unsupported': 'No statistics for this value type ({type})',
+  'nodeDetail.stats.notCaptured': 'Nothing captured for this port — re-run with Rec on',
   'nodeDetail.docs.description': 'Description',
   'nodeDetail.docs.noDescription': 'This node ships no description.',
   'nodeDetail.docs.params': 'Parameters',
@@ -654,6 +655,10 @@ const en = {
 
   // Edge data tooltip
   'edge.viewStats': 'View stats',
+
+  // Shared plots
+  'plot.noDistribution': 'no distribution',
+  'plot.peak': 'peak {count}',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -615,7 +615,32 @@ const en = {
   'nodeDetail.captures.summaryTitle': 'Shapes from the last run',
   'nodeDetail.captures.noSummary': 'Nothing recorded for this node yet',
   'nodeDetail.stats.title': 'Node statistics',
-  'nodeDetail.stats.placeholder': 'Timing, memory and parameter counts arrive here in a later release.',
+  'nodeDetail.stats.loading': 'Computing…',
+  'nodeDetail.stats.shape': 'Shape',
+  'nodeDetail.stats.dtype': 'Dtype',
+  'nodeDetail.stats.device': 'Device',
+  'nodeDetail.stats.count': 'Count',
+  'nodeDetail.stats.mean': 'Mean',
+  'nodeDetail.stats.std': 'Std',
+  'nodeDetail.stats.min': 'Min',
+  'nodeDetail.stats.max': 'Max',
+  'nodeDetail.stats.nan': 'NaN',
+  'nodeDetail.stats.inf': 'Inf',
+  'nodeDetail.stats.zeros': 'Zeros',
+  'nodeDetail.stats.quantiles': 'Quantiles',
+  'nodeDetail.stats.distribution': 'Distribution',
+  'nodeDetail.stats.classBalance': 'Class balance',
+  'nodeDetail.stats.sampled': 'sampled {size}',
+  'nodeDetail.stats.sampledNote':
+    'Mean, std, quantiles and the histogram come from a sample of this size. Count, min, max, NaN/Inf counts and class balance are exact.',
+  'nodeDetail.stats.rows': 'Rows',
+  'nodeDetail.stats.columns': 'Columns',
+  'nodeDetail.stats.column': 'Column',
+  'nodeDetail.stats.missing': 'Missing',
+  'nodeDetail.stats.unique': 'Unique',
+  'nodeDetail.stats.top': 'Most common',
+  'nodeDetail.stats.columnsTruncated': 'Showing {shown} of {total} columns',
+  'nodeDetail.stats.unsupported': 'No statistics for this value type ({type})',
   'nodeDetail.docs.description': 'Description',
   'nodeDetail.docs.noDescription': 'This node ships no description.',
   'nodeDetail.docs.params': 'Parameters',
@@ -626,6 +651,9 @@ const en = {
   'nodeDetail.docs.default': 'default',
   'nodeDetail.docs.options': 'options',
   'nodeDetail.docs.range': 'range',
+
+  // Edge data tooltip
+  'edge.viewStats': 'View stats',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -612,7 +612,32 @@ const zhTW: Record<TranslationKey, string> = {
   'nodeDetail.captures.summaryTitle': '上一次執行的形狀',
   'nodeDetail.captures.noSummary': '這個節點還沒有任何紀錄',
   'nodeDetail.stats.title': '節點統計',
-  'nodeDetail.stats.placeholder': '執行時間、記憶體與參數量會在後續版本加進這裡。',
+  'nodeDetail.stats.loading': '計算中…',
+  'nodeDetail.stats.shape': '形狀',
+  'nodeDetail.stats.dtype': '資料型別',
+  'nodeDetail.stats.device': '裝置',
+  'nodeDetail.stats.count': '元素數',
+  'nodeDetail.stats.mean': '平均',
+  'nodeDetail.stats.std': '標準差',
+  'nodeDetail.stats.min': '最小值',
+  'nodeDetail.stats.max': '最大值',
+  'nodeDetail.stats.nan': 'NaN',
+  'nodeDetail.stats.inf': 'Inf',
+  'nodeDetail.stats.zeros': '零值',
+  'nodeDetail.stats.quantiles': '分位數',
+  'nodeDetail.stats.distribution': '分佈',
+  'nodeDetail.stats.classBalance': '類別分佈',
+  'nodeDetail.stats.sampled': '取樣 {size}',
+  'nodeDetail.stats.sampledNote':
+    '平均、標準差、分位數與直方圖來自這個大小的取樣；元素數、最小值、最大值、NaN/Inf 數量與類別分佈則是精確值。',
+  'nodeDetail.stats.rows': '列數',
+  'nodeDetail.stats.columns': '欄數',
+  'nodeDetail.stats.column': '欄位',
+  'nodeDetail.stats.missing': '缺失',
+  'nodeDetail.stats.unique': '相異值',
+  'nodeDetail.stats.top': '最常出現',
+  'nodeDetail.stats.columnsTruncated': '顯示 {total} 欄中的 {shown} 欄',
+  'nodeDetail.stats.unsupported': '此資料型別（{type}）沒有可用的統計',
   'nodeDetail.docs.description': '說明',
   'nodeDetail.docs.noDescription': '這個節點沒有附說明文字。',
   'nodeDetail.docs.params': '參數',
@@ -623,6 +648,9 @@ const zhTW: Record<TranslationKey, string> = {
   'nodeDetail.docs.default': '預設值',
   'nodeDetail.docs.options': '選項',
   'nodeDetail.docs.range': '範圍',
+
+  // Edge data tooltip
+  'edge.viewStats': '查看統計',
 };
 
 export default zhTW;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -638,6 +638,7 @@ const zhTW: Record<TranslationKey, string> = {
   'nodeDetail.stats.top': '最常出現',
   'nodeDetail.stats.columnsTruncated': '顯示 {total} 欄中的 {shown} 欄',
   'nodeDetail.stats.unsupported': '此資料型別（{type}）沒有可用的統計',
+  'nodeDetail.stats.notCaptured': '這個連接埠沒有擷取到資料 — 開啟 Rec 後重新執行',
   'nodeDetail.docs.description': '說明',
   'nodeDetail.docs.noDescription': '這個節點沒有附說明文字。',
   'nodeDetail.docs.params': '參數',
@@ -651,6 +652,10 @@ const zhTW: Record<TranslationKey, string> = {
 
   // Edge data tooltip
   'edge.viewStats': '查看統計',
+
+  // Shared plots
+  'plot.noDistribution': '沒有分佈資料',
+  'plot.peak': '最高 {count}',
 };
 
 export default zhTW;

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -984,6 +984,36 @@ describe('onNodesChange', () => {
     expect(activeTab().nodeDetailNodeId).toBe('n1');
   });
 
+  // ── deep-linking a tab and a port (#129) ──────────────────────────────────
+
+  it('opens the detail modal with no tab or port requested by default', () => {
+    store().openNodeDetail('n1');
+    expect(activeTab().nodeDetailTab).toBeNull();
+    expect(activeTab().nodeDetailPort).toBeNull();
+  });
+
+  it('records the requested tab and port when one is given', () => {
+    store().openNodeDetail('n1', { tab: 'stats', port: 'src::out' });
+    expect(activeTab().nodeDetailNodeId).toBe('n1');
+    expect(activeTab().nodeDetailTab).toBe('stats');
+    expect(activeTab().nodeDetailPort).toBe('src::out');
+  });
+
+  it('clears a previous deep link when the modal is opened plainly', () => {
+    store().openNodeDetail('n1', { tab: 'stats', port: 'src::out' });
+    store().openNodeDetail('n2');
+    expect(activeTab().nodeDetailTab).toBeNull();
+    expect(activeTab().nodeDetailPort).toBeNull();
+  });
+
+  it('clears the deep link on close', () => {
+    store().openNodeDetail('n1', { tab: 'stats', port: 'src::out' });
+    store().closeNodeDetail();
+    expect(activeTab().nodeDetailNodeId).toBeNull();
+    expect(activeTab().nodeDetailTab).toBeNull();
+    expect(activeTab().nodeDetailPort).toBeNull();
+  });
+
   it('recalculates a bound note offset when the note itself is dragged', () => {
     store().setNodes([
       { id: 'comp', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'C', type: 'C', params: {} } },

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -1006,6 +1006,17 @@ describe('onNodesChange', () => {
     expect(activeTab().nodeDetailPort).toBeNull();
   });
 
+  it('bumps the request nonce on every open, target or not', () => {
+    const start = activeTab().nodeDetailRequest;
+    store().openNodeDetail('n1', { tab: 'stats', port: 'src::out' });
+    const first = activeTab().nodeDetailRequest;
+    expect(first).toBeGreaterThan(start);
+
+    // Same node, same tab: only the nonce says anything happened.
+    store().openNodeDetail('n1', { tab: 'stats', port: 'other::out' });
+    expect(activeTab().nodeDetailRequest).toBeGreaterThan(first);
+  });
+
   it('clears the deep link on close', () => {
     store().openNodeDetail('n1', { tab: 'stats', port: 'src::out' });
     store().closeNodeDetail();

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -102,6 +102,17 @@ export interface TabState {
    * rather than on top of a modal the user has no memory of opening.
    */
   nodeDetailNodeId: string | null;
+  /**
+   * Tab id the detail modal should open on, or null for its default (#129).
+   * Set by the edge tooltip's "View stats" link; every other entry point
+   * writes null, so a deep link never becomes sticky.
+   */
+  nodeDetailTab: string | null;
+  /**
+   * Port the modal was opened *about*, as `nodeId::port`, or null. Handed to
+   * every tab so a list-of-ports tab can scroll to the one that was asked for.
+   */
+  nodeDetailPort: string | null;
   // undo/redo
   undoStack: UndoSnapshot[];
   redoStack: UndoSnapshot[];
@@ -149,6 +160,8 @@ function createTabState(id: string, name: string): TabState {
     presetModalNodeId: null,
     subgraphModalNodeId: null,
     nodeDetailNodeId: null,
+    nodeDetailTab: null,
+    nodeDetailPort: null,
     undoStack: [],
     redoStack: [],
     dirtyNodeIds: new Set(),
@@ -206,7 +219,7 @@ interface TabStoreState {
   closePresetModal: () => void;
   openSubgraphModal: (id: string) => void;
   closeSubgraphModal: () => void;
-  openNodeDetail: (id: string) => void;
+  openNodeDetail: (id: string, target?: { tab?: string; port?: string }) => void;
   closeNodeDetail: () => void;
   updateSubgraphLayers: (nodeId: string, layersJson: string) => void;
   setNodeExecutionStatus: (nodeId: string, status: NodeData['executionStatus'], error?: string) => void;
@@ -1043,16 +1056,28 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
   // arrows) therefore leaves the canvas, the config panel and the Inspector
   // pointing at the same node the modal is showing — which is what makes
   // stepping through a graph with the arrow keys read as a walkthrough.
-  openNodeDetail: (id) =>
+  // `target` deep-links a tab and a port (#129: the edge tooltip's "View
+  // stats"). Both are written unconditionally — an omitted target CLEARS
+  // them, so opening a node normally after following a deep link lands on the
+  // default tab rather than wherever the link went.
+  openNodeDetail: (id, target) =>
     set({
       tabs: updateTab(get().tabs, get().activeTabId, () => ({
         nodeDetailNodeId: id,
         selectedNodeId: id,
+        nodeDetailTab: target?.tab ?? null,
+        nodeDetailPort: target?.port ?? null,
       })),
     }),
 
   closeNodeDetail: () =>
-    set({ tabs: updateTab(get().tabs, get().activeTabId, () => ({ nodeDetailNodeId: null })) }),
+    set({
+      tabs: updateTab(get().tabs, get().activeTabId, () => ({
+        nodeDetailNodeId: null,
+        nodeDetailTab: null,
+        nodeDetailPort: null,
+      })),
+    }),
 
   updateSubgraphLayers: (nodeId, layersJson) =>
     set({

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -113,6 +113,15 @@ export interface TabState {
    * every tab so a list-of-ports tab can scroll to the one that was asked for.
    */
   nodeDetailPort: string | null;
+  /**
+   * Bumped on every `openNodeDetail` call. The modal watches it so a SECOND
+   * deep link into the node it is already showing still lands: following
+   * "View stats" from another edge into the same consumer changes neither the
+   * node id nor the requested tab, and an effect keyed on those alone would
+   * see nothing happen and leave the user on whatever tab they had wandered
+   * to (#129).
+   */
+  nodeDetailRequest: number;
   // undo/redo
   undoStack: UndoSnapshot[];
   redoStack: UndoSnapshot[];
@@ -162,6 +171,7 @@ function createTabState(id: string, name: string): TabState {
     nodeDetailNodeId: null,
     nodeDetailTab: null,
     nodeDetailPort: null,
+    nodeDetailRequest: 0,
     undoStack: [],
     redoStack: [],
     dirtyNodeIds: new Set(),
@@ -1062,11 +1072,12 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
   // default tab rather than wherever the link went.
   openNodeDetail: (id, target) =>
     set({
-      tabs: updateTab(get().tabs, get().activeTabId, () => ({
+      tabs: updateTab(get().tabs, get().activeTabId, (tab) => ({
         nodeDetailNodeId: id,
         selectedNodeId: id,
         nodeDetailTab: target?.tab ?? null,
         nodeDetailPort: target?.port ?? null,
+        nodeDetailRequest: tab.nodeDetailRequest + 1,
       })),
     }),
 


### PR DESCRIPTION
## Summary

Answers "what does this data look like" without shipping the data. A new endpoint summarises a captured port server-side, and a real Stats tab in the Node Detail Modal renders it — so inspecting a 2 GB activation costs the same couple of kilobytes as inspecting a `[2, 3]` tensor.

- **`GET /api/execution/outputs/{run_id}/{node_id}/{port}/stats`** — shape/dtype/device/count, mean/std/min/max, seven quantiles, NaN/Inf/zero counts, and a 64-bin histogram (or class balance for label tensors). Tabular values get per-column count/unique/top-k/missing.
- **Stats tab** (fills the #127 placeholder) — a health strip, a stat grid, quantiles and an SVG distribution chart per port, for the node's inputs *and* outputs.
- **`View stats →`** on the edge data tooltip — opens the consuming node's Stats tab with the edge's port ringed and scrolled into view.

Works identically for interactive canvas runs and Run Service runs: since #121 both mint one `RunStore` uuid and write to the same `RunOutputStore`, so the endpoint needs no lane awareness.

## What the endpoint returns

| Field | Tensor | Notes |
| --- | --- | --- |
| `shape` `dtype` `device` `count` | yes | `count` is always the true element count |
| `mean` `std` | yes | over finite values; `null` when none |
| `min` `max` | yes | **exact at any size**, finite values only |
| `quantiles` | p1 p5 p25 p50 p75 p95 p99 | sorted, linearly interpolated — `numpy.quantile` semantics |
| `nan_count` `inf_count` `zero_frac` | yes | **exact at any size** — one chunked pass over everything |
| `histogram` | `{bins, edges[65], counts[64]}` | `null` in class-balance mode |
| `value_counts` | `[{value, count}]` | integer/bool with <=64 distinct values; **exact counts, or absent** |
| `sampled` `sample_size` | yes | covers `mean`/`std`/quantiles/histogram only |

Tabular (`kind: "tabular"`) returns `rows`, `column_count`, `columns_truncated` and per-column `dtype/count/missing/unique/top/mean/min/max`. Three shapes are recognised, all of which nodes in this repo actually emit: a columnar dict (`Normalize.stats`), a list of record dicts, and a flat list of primitives (`CSVReader.labels`, so class balance over string labels works). Anything else is `kind: "unsupported"` with its type name — a plain statement, not an error.

## Sampling design

The split is between stats that are expensive and stats people debug with, and they are not the same stats:

- **Always exact, at any size** — `count`, `min`, `max`, `nan_count`, `inf_count`, `zero_frac`, and integer class balance. All O(n) reductions with no sort, computed in one chunked pass over the full tensor with bounded temporaries, so a CUDA tensor cannot OOM on a bool mask. A *sampled* NaN count is close to useless: "3 NaNs in a 1M sample" is not something anyone can act on.
- **Sampled above `STATS_SAMPLE_THRESHOLD`** — `mean`, `std`, quantiles, histogram. `STATS_SAMPLE_SIZE` (1M) elements drawn by `index_select` with a seeded **CPU** generator, so the same tensor and seed give byte-identical output whatever device it lives on, and a cached stat can never disagree with a recomputed one.

**The threshold defaults to 4M, not the 50M the issue suggested, and that is the one deliberate deviation here.** Quantiles need a sort; `torch.sort` measures ~0.18 µs/element on this machine (0.7 s at 4M, 3 s at 16M, 9 s at 50M) and `torch.quantile` refuses inputs over 16.7M outright. 4M is the largest tensor that can be summarised *exactly* while still feeling like a click.

The first draft did keep 50M, and estimated quantiles above 4M by inverting a 16384-bin histogram — O(n), no sort, error bounded by one bin width. Review measurement killed it: bin width is set by the full range, so one diverged value at `1e6` in a standard-normal tensor moved the reported median from **0.0012 to 25.3**, while a 1M sample put it at 0.0023. Outliers are the entire reason someone opens this panel, so the estimator that breaks on them was the wrong one. It went, along with ~45 lines, a payload field and a UI marker.

`min`/`max` never ride the sample, so an outlier stays visible in the stat table even when the distribution around it was estimated.

Two more sampling details worth a look:

- Non-contiguous tensors are pre-thinned before flattening (flattening a non-contiguous 2 GB tensor copies 2 GB), and both the thin and the chunked scan split on **the first axis with length > 1** rather than dim 0. `[1, C, H, W]` permuted to channels-last is the commonest thing anyone inspects and the one shape a dim-0 split cannot cut — review measured 20.7 s and 402 MB of peak overhead for a 40M-element case that now takes **0.38 s**.
- Class balance for labels numbered `0..C-1` is an exact chunked `bincount`, no sort. For labels that are few but far apart the fallback reads the whole tensor, so once the tensor is sampled the payload **drops `value_counts` and shows a histogram instead** rather than quoting a scaled-down guess in a field named `count`.

## Cache bounds

`PortStatsCache` is bounded by **bytes** from day one, not by entry count (gap #5 / #135). An entry count would be a limit in name only here: one payload runs from ~0.7 KB to ~50 KB, so "200 entries" means anywhere from 140 KB to 10 MB. Default `STATS_CACHE_MAX_BYTES` = 8 MB; entries larger than the whole budget are refused rather than evicting everything else to not fit. `OrderedDict` + `move_to_end`, guarded by a `threading.Lock` because the compute that fills it runs off the event loop.

**The cache key carries `RunOutputStore`'s write serial**, which is new in this PR (`get_with_version`). `(run_id, node_id, port)` is not unique — a node inside a loop writes one port several times per run — and the first attempt at fixing that fingerprinted the tensor's `data_ptr` + shape + dtype. Review demonstrated that this fails: torch's caching allocator hands the freed block straight to the replacement, so iteration 2 gets iteration 0's address with an identical shape and **served iteration 0's mean**. A monotonic serial cannot collide. The regression test loops six times and drops each reference before building the next, because two iterations alone never collide and a two-step test proves nothing.

Stat computation runs on a dedicated `ThreadPoolExecutor(max_workers=4)` — off the event loop, since a 2 GB tensor is a second of real CPU and stalling the loop would stall every open WebSocket including the run that produced the tensor; and capped, since the Stats tab asks for every port of a node at once and the default executor's ~32 threads would let a few clicks saturate the machine.

## Test evidence

**Backend** — `2427 passed, 13 skipped`, 16 warnings, all pre-existing and none from the new modules. 54 new tests in `test_port_stats.py`, 13 in `test_routes_execution_outputs.py`, 5 in `test_run_output_store.py`. Every numeric assertion is checked against a numpy reference; the rest cover sampling determinism (same seed -> identical payload), the threshold switch, a lone outlier not moving the median, class balance dropped rather than estimated, int64 precision near 1e15, the `shape[0] == 1` split axis, tabular caps applied at the slice, bytes-bounded eviction and LRU order, and `json.dumps(..., allow_nan=False)` round-tripping a NaN/Inf tensor.

**Frontend** — `2397 passed` (116 files), `tsc -b` and `pnpm build` clean. New `StatsTab.test.tsx` (25) and `HistogramPlot.test.tsx` (10) drive every branch off mocked responses, including abort-on-unmount.

**Measured against the acceptance criteria**, 500M-element (2 GB) float32 tensor with one NaN and one Inf planted in it:

```
2GB float32 (500M elem)            1.104s   payload 2045B   sampled=true  size=1000000  nan=1 inf=1
200M int64 labels                  0.538s   payload  652B   exact class balance
40M channels-last, shape[0]==1     0.380s   payload 2233B   (20.7s before the split-axis fix)
20M float32                        0.213s   payload 2043B   sampled
3M  float32                        0.537s   payload 2097B   exact
```

Also exercised manually on CUDA (RTX 4080): float tensor with NaN/Inf, integer class balance summing exactly to 2M, the sampled path with exact min/max, and a non-contiguous transposed CUDA tensor. The index draw happens on a CPU generator, so device does not change the sample.

**Browser e2e** (Chrome, built dist, Tabular Iris Pipeline example): ran the graph, opened Normalize -> Stats and saw the input tensor `[150, 4]` with its histogram, the z-scored output at mean 2.4e-7 / std 1, and `Normalize.stats` rendered through the tabular branch. Clicked the `CSVReader -> TrainTestSplit (labels)` edge, followed the View stats link, and landed on TrainTestSplit's Stats tab with `CSVReader.labels` ringed, reading `setosa (50), versicolor (50), virginica (50)`. Arrowing to the next node cleared the deep link back to Inputs. No console errors.

## Notes for review

- The `stats` placeholder is filled **in `BUILTIN_NODE_DETAIL_TABS`** rather than through `registerNodeDetailTab`, which the placeholder's docstring had anticipated. `tabs.tsx` imports `StatsTab`, so registering from `StatsTab.tsx` would make the two modules circular; the alternative — a side-effect-only module imported at the app root — would leave the tab unregistered in every test that renders the modal without the app. The registry contract is unchanged and still what plugins and later tabs use; the reasoning is recorded next to `registerNodeDetailTab`.
- `NodeDetailTabContext` gains `focusPort` (additive, as its docstring allows). `RunOutputStore` gains `get_with_version`; `get` is unchanged for every existing caller.
- Stats are emitted as plain float64 rather than rounded. Six significant figures flattened an int64 tensor near 1e15 into one repeated value and collapsed all 65 histogram edges of a narrow range at a large magnitude onto the same number — the payload lying about the data to save a few hundred bytes. Python emits the shortest round-tripping string, so ordinary values still cost what they did; the frontend rounds for display.
- **Found, not fixed:** the existing `GET .../{port}` value route serialises `tensor.tolist()` and raw `float(min/max/mean)` with no NaN guard, so fetching a diverged tensor through the Inputs/Outputs tabs renders NaN into a response Starlette encodes with `allow_nan=False` -> 500. Same exposure in `backward_pass.grad_health`. Out of scope here (the new route is NaN-safe by construction) but worth its own issue.

Closes #129

---
Generated with [Claude Code](https://claude.com/claude-code)
