### PR TITLE
test(training): make the log_metric overflow test deterministic

### DIFF
--- a/backend/tests/test_log_metric.py
+++ b/backend/tests/test_log_metric.py
@@ -331,25 +331,74 @@ async def test_logging_never_blocks_the_worker_thread():
 
 @pytest.mark.asyncio
 async def test_overflow_reports_a_dropped_count_and_keeps_the_run_healthy():
-    """Drop-oldest under a tiny queue, surfaced as a DroppedSignal."""
+    """Drop-oldest under a tiny queue, surfaced as a DroppedSignal.
+
+    The overflow is FORCED, not raced for (#171). Every drain in the engine
+    goes through one delivery lock, so a consumer that parks inside its first
+    dispatch holds that lock and nothing can empty the queue while the node
+    floods it. The previous version logged 40 points and trusted the pump to
+    fall behind; on an idle CI runner it kept up and dropped nothing, which
+    is a flaky test rather than a passing contract.
+    """
     from app.core.execution_context import DroppedSignal
 
+    capacity, total = 4, 40
+    loop = asyncio.get_running_loop()
+    consumer_parked = threading.Event()   # loop → node: no drain can happen
+    burst_queued = asyncio.Event()        # node → loop: the flood is queued
+    observed: dict[str, bool] = {}
+
+    class _FloodingLogger(_MetricLoggerNode):
+        """Waits until the consumer is provably stuck, THEN overruns it."""
+
+        NODE_NAME = "_FloodingLogger"
+
+        def execute(self, inputs, params, progress_callback=None, *, context=None):
+            # One point to wake the pump, which parks in the consumer below.
+            context.log_metric("train_loss", 1.0, 1)
+            observed["parked"] = consumer_parked.wait(timeout=5.0)
+            for step in range(2, int(params.get("count", 5)) + 1):
+                context.log_metric("train_loss", 1.0 / step, step)
+            loop.call_soon_threadsafe(burst_queued.set)
+            return {"value": "flooded"}
+
     signals: list[object] = []
-    context = ExecutionContext(outbox=EventOutbox(capacity=4))
-    nodes, edges = _graph(count=40)
 
-    outputs = await execute_graph(nodes, edges, context=context,
-                                  on_signal=signals.append)
+    async def gated_consumer(signal):
+        signals.append(signal)
+        if consumer_parked.is_set():
+            return
+        consumer_parked.set()
+        # Still inside the engine's delivery lock, so every later drain waits
+        # here — the node's remaining points have nowhere to go but out.
+        await asyncio.wait_for(burst_queued.wait(), timeout=5.0)
 
+    context = ExecutionContext(outbox=EventOutbox(capacity=capacity))
+    nodes, edges = _graph(count=total)
+    nodes[1]["type"] = "_FloodingLogger"
+    registry._nodes["_FloodingLogger"] = _FloodingLogger
+    try:
+        outputs = await execute_graph(nodes, edges, context=context,
+                                      on_signal=gated_consumer)
+    finally:
+        registry._nodes.pop("_FloodingLogger", None)
+
+    assert observed.get("parked"), "the consumer never parked; nothing was held"
     assert outputs["logger"]["value"], "the run completed regardless"
+
     metrics = [s for s in signals if isinstance(s, MetricSignal)]
-    dropped = sum(s.count for s in signals if isinstance(s, DroppedSignal))
-    assert dropped > 0, "a capacity-4 queue must have shed 40 points"
-    assert len(metrics) + dropped == 40, (
+    # Point 1 was delivered on its own; of the other 39 only the last
+    # `capacity` can survive, so the shed count is exact rather than "> 0".
+    expected_dropped = total - 1 - capacity
+    assert [s.count for s in signals if isinstance(s, DroppedSignal)] == [
+        expected_dropped
+    ], "one stalled drain, one drop-count covering everything it missed"
+    assert len(metrics) + expected_dropped == total, (
         "every point is either delivered or accounted for as dropped"
     )
     # The tail survives: what a chart needs most is where the run got to.
-    assert metrics[-1].step == 40
+    assert [s.step for s in metrics] == [
+        1, *range(total - capacity + 1, total + 1)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The race

`test_overflow_reports_a_dropped_count_and_keeps_the_run_healthy` asserted that a
capacity-4 outbox *must* shed 40 points. Whether it does is pure scheduling luck:

- the producer is the node, logging from its executor thread;
- the consumer is the engine's loop-side pump, which drains whenever the loop is idle —
  and while the node runs in the executor, the loop is *very* idle.

On a loaded machine the pump falls behind and points get dropped. On an idle CI runner
it keeps up, `dropped == 0`, and the test fails. It failed twice on the 3.11 job for #169
while passing 5/5 locally.

## The gate

Force the overflow instead of hoping for it.

Every drain in the engine funnels through one `asyncio.Lock` — `_pump`, the inline drain
after a node's future, and the final flush all go through `_deliver`. So a consumer that
parks inside its *first* dispatch holds that lock and provably prevents the queue from
being emptied by anyone.

The node now:

1. logs one point, which wakes the pump;
2. waits (`threading.Event`) for the consumer to confirm it has parked;
3. floods the remaining 39 points into a queue nobody can drain;
4. releases the gate via `loop.call_soon_threadsafe`.

## Stronger, not just stabler

The arithmetic is now exact, so the assertions got tighter rather than looser:

| before | after |
| --- | --- |
| `dropped > 0` | `[s.count for s in drops] == [35]` — one stalled drain, one exact count |
| `metrics[-1].step == 40` | full surviving list `[1, 37, 38, 39, 40]` — drop-oldest, pinned |

The capacity bound, drop-oldest semantics, the `DroppedSignal` report and the run
completing healthily are all still covered, and the `parked` flag asserts the gate
actually engaged so the test can't quietly go back to racing.

## Verification

- `backend/tests/test_log_metric.py` — 16 passed.
- The single test, 10 consecutive runs — 10/10 green.
- Mutation check: flipping the expected count to 36 fails with `assert [35] == [36]`,
  confirming the assertion is load-bearing and the count really is deterministic.
- `test_log_metric.py` + `test_graph_engine.py` + `test_run_service.py` — 160 passed.

**No production code touched** — the diff is one test file.

Closes #171

---
Generated with [Claude Code](https://claude.com/claude-code)
