### PR TITLE
feat(stats): first-party statistics node pack with chart display kind

### DIFF
--- a/backend/app/core/node_base.py
+++ b/backend/app/core/node_base.py
@@ -48,6 +48,21 @@ class ParamType(str, Enum):
 # declare a new kind rather than overload this one.
 MEDIA_IMAGE = "image"
 
+# ``MEDIA_CHART`` contract (#130): the port's value is a JSON-safe chart
+# *spec* — a dict the client renders with its own plotting components, so the
+# picture is crisp, themed and hoverable instead of a server-rendered PNG.
+#
+#   {"kind": "bar" | "line" | "scatter" | "heatmap",   # required
+#    "title": str, "x_label": str, "y_label": str,     # optional captions
+#    ...payload keys for that kind}
+#
+# Every number in the spec must be finite: the run store serialises events
+# with ``allow_nan=False``, so a NaN would be rewritten to ``null`` and the
+# renderer would draw a hole. Producers substitute a real value (usually 0.0)
+# and say so in the caption. See ``plugins/stats/README.md`` for the per-kind
+# payload keys.
+MEDIA_CHART = "chart"
+
 
 @dataclass
 class PortDefinition:

--- a/backend/app/core/output_entries.py
+++ b/backend/app/core/output_entries.py
@@ -22,25 +22,26 @@ produces no output entries at all; the builders belong to the run, not to
 one transport.
 
 Pure functions over plain dicts, with exactly one dependency on live server
-state: :func:`declared_image_ports` asks the node registry what a node
+state: :func:`declared_media_ports` asks the node registry what a node
 declares. Nothing here touches a socket, a request or a database.
 """
 
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from ..config import settings
-from .node_base import MEDIA_IMAGE
+from .node_base import MEDIA_CHART, MEDIA_IMAGE
 from .node_registry import registry
 
 logger = logging.getLogger(__name__)
 
 OUTPUT_KIND_TEXT = "text"
 OUTPUT_KIND_IMAGE = "image"
+OUTPUT_KIND_CHART = "chart"
 OUTPUT_KIND_PROGRESS = "progress"
 OUTPUT_KIND_TENSOR_SUMMARY = "tensor_summary"
 
@@ -144,15 +145,22 @@ def _summarize_outputs(result: dict[str, Any]) -> dict[str, Any]:
     return summary
 
 
-def declared_image_ports(nodes: list[Any]) -> dict[str, list[str]]:
-    """Map ``node id -> output ports the node DECLARES as image media``.
+def declared_media_ports(nodes: list[Any]) -> dict[str, dict[str, list[str]]]:
+    """Map ``node id -> {media kind -> output ports declaring it}``.
 
     Resolved from the registry once per run, so the hot progress path only
     does a dict lookup. Nodes the registry does not know (presets, typos)
     and malformed entries are silently skipped: an unresolvable node simply
     has no declared media, which is the safe answer.
+
+    The media kind is whatever string the port declared — this function does
+    not know the vocabulary and never filters on it. That is what makes the
+    "a node pack can add its own kind without a core release" promise in the
+    module docstring true rather than aspirational (#130): a third-party pack
+    declaring ``media="waveform"`` reaches the wire as
+    ``{"output_kind": "waveform", ...}`` with no change here.
     """
-    ports: dict[str, list[str]] = {}
+    ports: dict[str, dict[str, list[str]]] = {}
     if not isinstance(nodes, list):
         return ports
     for node in nodes:
@@ -171,23 +179,58 @@ def declared_image_ports(nodes: list[Any]) -> dict[str, list[str]]:
         except Exception:  # pragma: no cover - defensive: bad third-party node
             logger.debug("define_outputs_dynamic failed for %s", node_type, exc_info=True)
             continue
-        declared = [p.name for p in definitions if getattr(p, "media", None) == MEDIA_IMAGE]
+        declared: dict[str, list[str]] = {}
+        for port in definitions:
+            kind = getattr(port, "media", None)
+            if isinstance(kind, str) and kind:
+                declared.setdefault(kind, []).append(port.name)
         if declared:
             ports[node_id] = declared
     return ports
 
 
+def _image_payload(value: Any) -> dict[str, Any] | None:
+    """Wrap a MEDIA_IMAGE port value in its container, or skip it."""
+    if not isinstance(value, str) or not value:
+        return None
+    # MEDIA_IMAGE's contract (see node_base): base64 PNG.
+    return {"format": "png", "encoding": "base64", "data": value}
+
+
+def _object_payload(value: Any) -> dict[str, Any] | None:
+    """Default envelope: ship a JSON-object port value through untouched.
+
+    Used by MEDIA_CHART and by any kind core has never heard of. A value that
+    is not a non-empty dict is skipped rather than shipped, so a declared port
+    that produced nothing this run is silently absent instead of arriving as
+    an empty picture — the same rule the image branch has always used.
+    """
+    if not isinstance(value, dict) or not value:
+        return None
+    return value
+
+
+#: Per-kind envelope builders. A kind absent from this map falls back to
+#: :func:`_object_payload`, which is why adding a kind needs no entry here
+#: unless its payload needs a container the node's raw value does not have.
+_MEDIA_PAYLOADS: dict[str, Callable[[Any], dict[str, Any] | None]] = {
+    MEDIA_IMAGE: _image_payload,
+    MEDIA_CHART: _object_payload,
+}
+
+
 def build_node_output_entries(
     status: str,
     result: dict[str, Any] | None,
-    image_ports: Sequence[str] = (),
+    media_ports: Mapping[str, Sequence[str]] | None = None,
 ) -> list[dict[str, Any]]:
     """Build the typed ``outputs`` list for one ``node_status`` message.
 
-    ``image_ports`` are the output port names this node *declared* as image
-    media (see :func:`declared_image_ports`). Values on any other port stay
-    plain data no matter what they look like -- there is deliberately no
-    length or character-class inspection anywhere in this function.
+    ``media_ports`` maps a media kind to the output port names this node
+    *declared* for it (see :func:`declared_media_ports`). Values on any other
+    port stay plain data no matter what they look like -- there is
+    deliberately no length or character-class inspection anywhere in this
+    function.
     """
     if not result:
         return []
@@ -207,24 +250,15 @@ def build_node_output_entries(
             {"output_kind": OUTPUT_KIND_TEXT, OUTPUT_KIND_TEXT: str(result["__log__"])}
         )
 
-    # Declared image ports. A declared port that produced nothing this run is
-    # skipped rather than announced as an empty image.
-    for port in image_ports:
-        value = result.get(port)
-        if not isinstance(value, str) or not value:
-            continue
-        entries.append(
-            {
-                "output_kind": OUTPUT_KIND_IMAGE,
-                "port": port,
-                OUTPUT_KIND_IMAGE: {
-                    # MEDIA_IMAGE's contract (see node_base): base64 PNG.
-                    "format": "png",
-                    "encoding": "base64",
-                    "data": value,
-                },
-            }
-        )
+    # Declared media ports, kind by kind. A declared port that produced
+    # nothing this run is skipped rather than announced as an empty payload.
+    for kind, port_names in (media_ports or {}).items():
+        envelope = _MEDIA_PAYLOADS.get(kind, _object_payload)
+        for port in port_names:
+            payload = envelope(result.get(port))
+            if payload is None:
+                continue
+            entries.append({"output_kind": kind, "port": port, kind: payload})
 
     # Per-port summaries for edge inspection. Emitted on "cached" too so the
     # edge tooltip and Inspector still populate when a node is served from

--- a/backend/app/core/output_entries.py
+++ b/backend/app/core/output_entries.py
@@ -218,6 +218,18 @@ _MEDIA_PAYLOADS: dict[str, Callable[[Any], dict[str, Any] | None]] = {
     MEDIA_CHART: _object_payload,
 }
 
+#: Keys an entry dict already uses for its own bookkeeping. Since an entry
+#: stores its payload under a key NAMED BY THE KIND, a third-party pack
+#: declaring ``media="port"`` would overwrite the port name, and one declaring
+#: ``media="elided"`` would forge the marker ``run_store`` writes when a
+#: payload exceeds the size cap — making an intact entry read as truncated, or
+#: vice versa. Refused rather than silently renamed: a kind that collides is a
+#: bug in the declaring pack, and quietly serving it under another name would
+#: hide that from its author.
+_RESERVED_ENTRY_KEYS = frozenset(
+    {"output_kind", "port", "elided", "bytes", "cap_bytes"}
+)
+
 
 def build_node_output_entries(
     status: str,
@@ -234,6 +246,16 @@ def build_node_output_entries(
     """
     if not result:
         return []
+
+    # A Sequence here is the pre-#130 signature (a bare list of image ports).
+    # Left unguarded, iterating a string yields its characters and a list
+    # yields port names used as media kinds -- either way the caller gets
+    # plausible-looking nonsense instead of an error.
+    if media_ports is not None and not isinstance(media_ports, Mapping):
+        raise TypeError(
+            "media_ports must be a mapping of media kind -> port names, e.g. "
+            f"{{'image': ['plot']}}; got {type(media_ports).__name__}"
+        )
 
     # A "progress" status carries a live training event, nothing else.
     if status == "progress":
@@ -253,6 +275,13 @@ def build_node_output_entries(
     # Declared media ports, kind by kind. A declared port that produced
     # nothing this run is skipped rather than announced as an empty payload.
     for kind, port_names in (media_ports or {}).items():
+        if kind in _RESERVED_ENTRY_KEYS:
+            logger.warning(
+                "skipping media kind %r: it collides with a reserved entry key "
+                "(%s). Rename the kind in the declaring node pack.",
+                kind, ", ".join(sorted(_RESERVED_ENTRY_KEYS)),
+            )
+            continue
         envelope = _MEDIA_PAYLOADS.get(kind, _object_payload)
         for port in port_names:
             payload = envelope(result.get(port))

--- a/backend/app/core/run_service.py
+++ b/backend/app/core/run_service.py
@@ -119,7 +119,7 @@ from .execution_context import (
 )
 from .graph_engine import GraphValidationError, build_preset_fallback, execute_graph
 from .node_state_store import NodeStateStore
-from .output_entries import build_node_output_entries, declared_image_ports
+from .output_entries import build_node_output_entries, declared_media_ports
 from .run_output_store import RunOutputStore
 from .run_store import (
     STATUS_CANCELLED,
@@ -1722,7 +1722,7 @@ class RunService:
         The message body is byte-for-byte what ``ws_execution`` puts on the
         wire minus its ``type`` key — see the event-vocabulary block above.
         """
-        image_ports = declared_image_ports(nodes)
+        media_ports = declared_media_ports(nodes)
 
         async def on_progress(
             node_id: str, status: str, result: dict[str, Any] | None,
@@ -1731,7 +1731,7 @@ class RunService:
             if result and status == "error":
                 message["error"] = result.get("error", "")
             entries = build_node_output_entries(
-                status, result, image_ports.get(node_id, ()))
+                status, result, media_ports.get(node_id))
             if entries:
                 message["outputs"] = entries
             await self._emit(active.run_id, EVENT_NODE_STATUS, message)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -38,11 +38,16 @@ settings.DB_PATH = Path(tempfile.mkdtemp(prefix="codefyui-test-db-")) / "codefyu
 # ASGITransport doesn't always go through it).
 init_allowed_hosts(settings.HOST, settings.PORT)
 
-# Register the in-repo chapter plugin packs in the synthetic `cdui_plugins`
-# namespace AT CONFTEST IMPORT TIME, before any test_*.py module is collected.
-# Tests for Edu nodes import them from `cdui_plugins.{foundations,deep,rl}.nodes.*`
-# — those imports happen during pytest's collection pass, which runs after conftest
-# is imported, so the namespace must exist by then.
+# In-repo plugin packs the test suite loads. One tuple, three consumers (the
+# namespace install below and the two registry-discovery paths further down):
+# a pack missing from any one of them fails in a different, confusing way —
+# an ImportError at collection, or a node type the graph engine cannot find.
+_BUILTIN_TEST_PACKS = ("foundations", "deep", "rl", "stats")
+
+# Register those packs in the synthetic `cdui_plugins` namespace AT CONFTEST
+# IMPORT TIME, before any test_*.py module is collected. Pack node tests import
+# from `cdui_plugins.<pack>.nodes.*` during pytest's collection pass, which runs
+# after conftest is imported, so the namespace must exist by then.
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 purge_all_plugin_modules()
 install_plugin_finder(
@@ -51,12 +56,37 @@ install_plugin_finder(
     lockfile={
         "schema": 1,
         "plugins": {
-            "foundations": {"source_kind": "builtin", "source": "foundations"},
-            "deep": {"source_kind": "builtin", "source": "deep"},
-            "rl": {"source_kind": "builtin", "source": "rl"},
+            pack: {"source_kind": "builtin", "source": pack}
+            for pack in _BUILTIN_TEST_PACKS
         },
     },
 )
+
+
+def _discover_builtin_packs() -> None:
+    """Register every in-repo pack's nodes into the global registry.
+
+    ``force_reload`` is left off deliberately: re-registering hands back the
+    same class objects, so a test holding an ``is`` comparison against one
+    still passes.
+    """
+    for plugin_id in _BUILTIN_TEST_PACKS:
+        plugin_nodes = _REPO_ROOT / "plugins" / plugin_id / "nodes"
+        if plugin_nodes.exists():
+            registry.discover(plugin_nodes, f"cdui_plugins.{plugin_id}.nodes")
+
+
+def _packs_missing_from_registry() -> bool:
+    """True when a pack this suite needs has no nodes registered.
+
+    ``rediscover_all`` — which ``POST /api/plugins/reload`` runs — rebuilds the
+    registry from the machine's REAL lockfile, not from the synthetic one this
+    file installs. A pack that is not installed on the developer's machine (or
+    on CI, where the lockfile is empty) is therefore silently dropped, and
+    every later test that resolves a node BY TYPE gets "Unknown node type".
+    """
+    registered = {key.split(":", 1)[0] for key in registry._nodes if ":" in key}
+    return any(pack not in registered for pack in _BUILTIN_TEST_PACKS)
 
 
 @pytest.fixture(autouse=True)
@@ -99,11 +129,7 @@ def registry_with_nodes() -> NodeRegistry:
     if len(registry.nodes) == 0:
         registry.discover(settings.NODES_DIR, "app.nodes")
         registry.discover(settings.CUSTOM_NODES_DIR, "app.custom_nodes")
-        # Plugin nodes — the three direction packs (foundations / deep / rl).
-        for plugin_id in ("foundations", "deep", "rl"):
-            plugin_nodes = _REPO_ROOT / "plugins" / plugin_id / "nodes"
-            if plugin_nodes.exists():
-                registry.discover(plugin_nodes, f"cdui_plugins.{plugin_id}.nodes")
+        _discover_builtin_packs()
         preset_registry.discover(settings.PRESETS_DIR, registry)
     registry._nodes["_TestSource"] = _TestSourceNode
     return registry
@@ -117,6 +143,13 @@ def _ensure_registry_intact(registry_with_nodes):
     clears every registry entry, including the manually-injected
     ``_TestSource`` synthetic node and the built-ins. Without this safety net,
     ws-execution tests that follow such a test see "Unknown node type".
+
+    The plugin packs are checked separately from the built-ins because a
+    reload does not lose them the same way: it re-registers the built-ins from
+    ``NODES_DIR`` and then the packs from the real lockfile, so ``Start`` comes
+    back while an uninstalled pack does not. Testing only for ``Start`` made
+    the suite pass or fail on collection order — a pack test sorting before
+    ``test_plugin_api`` was fine, one sorting after was not.
     """
     if "_TestSource" not in registry._nodes:
         registry._nodes["_TestSource"] = _TestSourceNode
@@ -124,11 +157,9 @@ def _ensure_registry_intact(registry_with_nodes):
         # Wholesale rebuild — registry was nuked by an earlier reload.
         registry.discover(settings.NODES_DIR, "app.nodes")
         registry.discover(settings.CUSTOM_NODES_DIR, "app.custom_nodes")
-        for plugin_id in ("foundations", "deep", "rl"):
-            plugin_nodes = _REPO_ROOT / "plugins" / plugin_id / "nodes"
-            if plugin_nodes.exists():
-                registry.discover(plugin_nodes, f"cdui_plugins.{plugin_id}.nodes")
         registry._nodes["_TestSource"] = _TestSourceNode
+    if _packs_missing_from_registry():
+        _discover_builtin_packs()
     yield
 
 

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -622,10 +622,12 @@ from app.core.output_entries import (  # noqa: E402
     OUTPUT_KIND_PROGRESS,
     OUTPUT_KIND_TENSOR_SUMMARY,
     OUTPUT_KIND_TEXT,
+    OUTPUT_KIND_CHART,
     build_node_output_entries,
-    declared_image_ports,
+    declared_media_ports,
 )
 from app.core.node_base import (  # noqa: E402
+    MEDIA_CHART,
     MEDIA_IMAGE,
     BaseNode,
     DataType,
@@ -678,17 +680,17 @@ def test_port_definition_media_defaults_to_none():
     )
 
 
-def test_declared_image_ports_lists_only_declared_ports(plot_like_node_type):
-    ports = declared_image_ports([
+def test_declared_media_ports_lists_only_declared_ports(plot_like_node_type):
+    ports = declared_media_ports([
         {"id": "a", "type": plot_like_node_type, "data": {"params": {}}},
         {"id": "b", "type": "Print", "data": {"params": {}}},
     ])
-    # Only the node that declares media=image is listed, and only that port.
-    assert ports == {"a": ["image"]}
+    # Only the node that declares media is listed, and only that port.
+    assert ports == {"a": {MEDIA_IMAGE: ["image"]}}
 
 
-def test_declared_image_ports_ignores_unknown_and_malformed_nodes():
-    ports = declared_image_ports([
+def test_declared_media_ports_ignores_unknown_and_malformed_nodes():
+    ports = declared_media_ports([
         {"id": "x", "type": "NoSuchNodeType"},
         {"id": "y"},              # no type
         {"type": "Print"},        # no id
@@ -698,14 +700,99 @@ def test_declared_image_ports_ignores_unknown_and_malformed_nodes():
     assert ports == {}
 
 
+def test_declared_media_ports_keys_on_whatever_kind_the_port_declared(
+    monkeypatch, registry_with_nodes,
+):
+    """The open-vocabulary promise, exercised by a kind core does not know.
+
+    #117 documented that a node pack could add its own kind without a core
+    release, but the resolver only ever looked for MEDIA_IMAGE — so until #130
+    a new kind never reached the wire. Nothing here mentions "image" or
+    "chart": a port declaring "waveform" must arrive as a waveform entry.
+    """
+    class _MultiMediaNode(BaseNode):
+        NODE_NAME = "_ContractMultiMedia"
+        CATEGORY = "Test"
+
+        @classmethod
+        def define_inputs(cls) -> list[PortDefinition]:
+            return []
+
+        @classmethod
+        def define_outputs(cls) -> list[PortDefinition]:
+            return [
+                PortDefinition(name="pic", data_type=DataType.STRING, media=MEDIA_IMAGE),
+                PortDefinition(name="plot", data_type=DataType.ANY, media=MEDIA_CHART),
+                PortDefinition(name="sound", data_type=DataType.ANY, media="waveform"),
+                PortDefinition(name="plain", data_type=DataType.ANY),
+            ]
+
+        def execute(self, inputs, params, progress_callback=None, *, context=None):
+            return {}
+
+    monkeypatch.setitem(
+        registry_with_nodes._nodes, _MultiMediaNode.NODE_NAME, _MultiMediaNode
+    )
+    declared = declared_media_ports(
+        [{"id": "n", "type": _MultiMediaNode.NODE_NAME, "data": {"params": {}}}]
+    )
+    assert declared == {"n": {
+        MEDIA_IMAGE: ["pic"], MEDIA_CHART: ["plot"], "waveform": ["sound"],
+    }}
+
+    entries = build_node_output_entries(
+        "completed",
+        {"sound": {"hz": 440}, "plain": {"not": "media"}},
+        declared["n"],
+    )
+    waveform = next(e for e in entries if e["output_kind"] == "waveform")
+    assert waveform == {"output_kind": "waveform", "port": "sound", "waveform": {"hz": 440}}
+    assert "plain" not in _kinds(entries)
+
+
+def test_build_output_entries_declared_chart_port_ships_the_spec_verbatim():
+    spec = {"kind": "heatmap", "matrix": [[0.0, 1.0], [1.0, 0.0]], "title": "cm"}
+    entries = build_node_output_entries(
+        "completed", {"chart": spec}, {MEDIA_CHART: ["chart"]}
+    )
+    assert _kinds(entries) == [OUTPUT_KIND_CHART, OUTPUT_KIND_TENSOR_SUMMARY]
+    chart = entries[0]
+    assert chart["port"] == "chart"
+    # Unlike an image, a chart spec needs no container — it IS the payload.
+    assert chart[OUTPUT_KIND_CHART] == spec
+
+
+@pytest.mark.parametrize("value", [None, "", {}, "a string", 42, [1, 2]])
+def test_build_output_entries_chart_port_without_a_spec_is_skipped(value):
+    entries = build_node_output_entries(
+        "completed", {"chart": value}, {MEDIA_CHART: ["chart"]}
+    )
+    assert _kinds(entries) == [OUTPUT_KIND_TENSOR_SUMMARY]
+
+
+def test_build_output_entries_emits_one_entry_per_declared_kind():
+    entries = build_node_output_entries(
+        "completed",
+        {"image": _tiny_png_base64(), "chart": {"kind": "bar", "bars": []},
+         "__log__": "done"},
+        {MEDIA_IMAGE: ["image"], MEDIA_CHART: ["chart"]},
+    )
+    assert _kinds(entries) == [
+        OUTPUT_KIND_TEXT,
+        OUTPUT_KIND_IMAGE,
+        OUTPUT_KIND_CHART,
+        OUTPUT_KIND_TENSOR_SUMMARY,
+    ]
+
+
 def test_build_output_entries_progress_carries_the_event():
     event = {"event": "epoch", "epoch": 1, "total_epochs": 3, "loss": 0.5}
-    entries = build_node_output_entries("progress", event, ())
+    entries = build_node_output_entries("progress", event)
     assert entries == [{"output_kind": OUTPUT_KIND_PROGRESS, "progress": event}]
 
 
 def test_build_output_entries_text_comes_from_the_log_channel():
-    entries = build_node_output_entries("completed", {"value": 1, "__log__": "hi"}, ())
+    entries = build_node_output_entries("completed", {"value": 1, "__log__": "hi"})
     assert _kinds(entries) == [OUTPUT_KIND_TEXT, OUTPUT_KIND_TENSOR_SUMMARY]
     assert entries[0]["text"] == "hi"
     # Dunder keys never leak into the summary.
@@ -714,7 +801,7 @@ def test_build_output_entries_text_comes_from_the_log_channel():
 
 def test_build_output_entries_declared_image_port_produces_an_image_entry():
     b64 = _tiny_png_base64()
-    entries = build_node_output_entries("completed", {"image": b64}, ["image"])
+    entries = build_node_output_entries("completed", {"image": b64}, {MEDIA_IMAGE: ["image"]})
     assert _kinds(entries) == [OUTPUT_KIND_IMAGE, OUTPUT_KIND_TENSOR_SUMMARY]
     img = entries[0]
     assert img["port"] == "image"
@@ -743,7 +830,7 @@ def test_build_output_entries_long_alphanumeric_text_is_never_an_image(long_text
     # Exactly the shape the pre-#117 sniff claimed was a base64 PNG.
     assert len(long_text) == 500 and long_text[:20].isalnum()
 
-    entries = build_node_output_entries("completed", {"answer": long_text}, ())
+    entries = build_node_output_entries("completed", {"answer": long_text})
     assert OUTPUT_KIND_IMAGE not in _kinds(entries)
     summary = entries[0][OUTPUT_KIND_TENSOR_SUMMARY]
     assert summary["answer"]["type"] == "string"
@@ -752,41 +839,42 @@ def test_build_output_entries_long_alphanumeric_text_is_never_an_image(long_text
 def test_build_output_entries_undeclared_port_never_becomes_an_image():
     # Even a genuinely base64-looking value stays plain data without a
     # declaration — declaring is the node's job, not the transport's.
-    entries = build_node_output_entries("completed", {"blob": _tiny_png_base64()}, ())
+    entries = build_node_output_entries("completed", {"blob": _tiny_png_base64()})
     assert _kinds(entries) == [OUTPUT_KIND_TENSOR_SUMMARY]
 
 
 def test_build_output_entries_declared_port_with_no_value_is_skipped():
-    entries = build_node_output_entries("completed", {"image": ""}, ["image"])
+    entries = build_node_output_entries("completed", {"image": ""}, {MEDIA_IMAGE: ["image"]})
     assert _kinds(entries) == [OUTPUT_KIND_TENSOR_SUMMARY]
-    entries = build_node_output_entries("completed", {"other": "x"}, ["image"])
+    entries = build_node_output_entries("completed", {"other": "x"}, {MEDIA_IMAGE: ["image"]})
     assert _kinds(entries) == [OUTPUT_KIND_TENSOR_SUMMARY]
-    entries = build_node_output_entries("completed", {"image": 42}, ["image"])
+    entries = build_node_output_entries("completed", {"image": 42}, {MEDIA_IMAGE: ["image"]})
     assert _kinds(entries) == [OUTPUT_KIND_TENSOR_SUMMARY]
 
 
 def test_build_output_entries_cached_status_matches_completed():
     result = {"image": _tiny_png_base64(), "__log__": "from cache"}
-    assert _kinds(build_node_output_entries("cached", result, ["image"])) == _kinds(
-        build_node_output_entries("completed", result, ["image"])
+    assert _kinds(build_node_output_entries("cached", result, {MEDIA_IMAGE: ["image"]})) == _kinds(
+        build_node_output_entries("completed", result, {MEDIA_IMAGE: ["image"]})
     )
 
 
 def test_build_output_entries_non_terminal_statuses_are_empty():
     for status in ("running", "skipped", "error"):
-        assert build_node_output_entries(status, {"value": 1}, ["image"]) == []
-    assert build_node_output_entries("completed", None, ["image"]) == []
-    assert build_node_output_entries("progress", None, ()) == []
+        assert build_node_output_entries(status, {"value": 1}, {MEDIA_IMAGE: ["image"]}) == []
+    assert build_node_output_entries("completed", None, {MEDIA_IMAGE: ["image"]}) == []
+    assert build_node_output_entries("progress", None) == []
 
 
 def test_every_output_entry_stores_its_payload_under_the_matching_key():
     result = {"image": _tiny_png_base64(), "__log__": "hi", "value": 1}
-    entries = build_node_output_entries("completed", result, ["image"])
-    entries += build_node_output_entries("progress", {"event": "epoch"}, ())
+    entries = build_node_output_entries("completed", result, {MEDIA_IMAGE: ["image"]})
+    entries += build_node_output_entries("progress", {"event": "epoch"})
     for entry in entries:
         assert entry["output_kind"] in {
             OUTPUT_KIND_TEXT,
             OUTPUT_KIND_IMAGE,
+            OUTPUT_KIND_CHART,
             OUTPUT_KIND_PROGRESS,
             OUTPUT_KIND_TENSOR_SUMMARY,
         }

--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -770,6 +770,33 @@ def test_build_output_entries_chart_port_without_a_spec_is_skipped(value):
     assert _kinds(entries) == [OUTPUT_KIND_TENSOR_SUMMARY]
 
 
+@pytest.mark.parametrize("reserved", ["output_kind", "port", "elided", "bytes", "cap_bytes"])
+def test_build_output_entries_refuses_a_kind_that_collides_with_a_reserved_key(reserved):
+    """A payload is stored under a key NAMED BY THE KIND.
+
+    So ``media="port"`` would overwrite the port name and ``media="elided"``
+    would forge the marker run_service writes when a payload exceeds the size
+    cap — making an intact entry read as truncated. Refused, not renamed: a
+    collision is a bug in the declaring pack and must surface to its author.
+    """
+    entries = build_node_output_entries(
+        "completed", {"p": {"a": 1}}, {reserved: ["p"]},
+    )
+    assert _kinds(entries) == [OUTPUT_KIND_TENSOR_SUMMARY]
+
+
+def test_build_output_entries_rejects_the_pre_130_sequence_signature():
+    """A bare list was the old third argument.
+
+    Left unguarded it iterates as media kinds (and a string iterates as
+    characters), so an out-of-repo caller would get plausible nonsense rather
+    than an error.
+    """
+    for legacy in (["image"], "image", ("image",)):
+        with pytest.raises(TypeError, match="mapping of media kind"):
+            build_node_output_entries("completed", {"image": "x"}, legacy)
+
+
 def test_build_output_entries_emits_one_entry_per_declared_kind():
     entries = build_node_output_entries(
         "completed",

--- a/backend/tests/test_stats_confusion_matrix_node.py
+++ b/backend/tests/test_stats_confusion_matrix_node.py
@@ -98,6 +98,17 @@ def test_a_class_missing_from_class_names_is_ignored_and_reported():
     assert "1 sample(s) ignored" in result["chart"]["note"]
 
 
+def test_an_ignored_sample_notice_does_not_erase_the_downsampling_notice():
+    """Both notices must survive together — see the histogram twin of this test."""
+    classes = [str(i) for i in range(80)]          # over MAX_HEATMAP_SIDE (64)
+    labels = classes + ["off-the-list"]
+    result = _run(labels, labels, {"class_names": ",".join(classes)})
+
+    note = result["chart"]["note"]
+    assert "showing the first 64x64 of 80x80 cells" in note
+    assert "1 sample(s) ignored" in note
+
+
 def test_integer_class_indices_sort_numerically_not_lexicographically():
     """Sorted as strings, class 10 would land before class 2."""
     labels = [str(v) for v in (2, 10, 2, 10)]

--- a/backend/tests/test_stats_confusion_matrix_node.py
+++ b/backend/tests/test_stats_confusion_matrix_node.py
@@ -1,0 +1,189 @@
+"""Stats-ConfusionMatrix: sklearn parity across every normalize mode.
+
+scikit-learn is already a backend dependency (the classical-ML nodes use it)
+and its `confusion_matrix` is the definition everyone compares against, so it
+is the reference here — including its 0/0 -> 0 resolution, which is the part a
+hand-written implementation usually gets wrong.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+import torch
+from sklearn.metrics import confusion_matrix
+
+from cdui_plugins.stats.nodes.stats_confusion_matrix_node import (
+    StatsConfusionMatrixNode,
+)
+
+TRUE = ["cat", "cat", "dog", "dog", "dog", "bird", "bird"]
+PRED = ["cat", "dog", "dog", "dog", "cat", "bird", "cat"]
+
+
+def _run(predictions, labels, params=None):
+    return StatsConfusionMatrixNode().execute(
+        {"predictions": predictions, "labels": labels}, params or {}
+    )
+
+
+def test_node_metadata():
+    assert StatsConfusionMatrixNode.NODE_NAME == "Stats-ConfusionMatrix"
+    outputs = StatsConfusionMatrixNode.define_outputs()
+    assert [p.name for p in outputs] == [
+        "matrix", "columns", "row_labels", "accuracy", "chart",
+    ]
+    assert next(p for p in outputs if p.name == "chart").media == "chart"
+
+
+@pytest.mark.parametrize("normalize", ["none", "true", "pred", "all"])
+def test_every_normalize_mode_matches_sklearn(normalize):
+    result = _run(PRED, TRUE, {"normalize": normalize})
+    expected = confusion_matrix(
+        TRUE, PRED, normalize=None if normalize == "none" else normalize
+    )
+    assert result["matrix"].numpy() == pytest.approx(expected, rel=1e-6, abs=1e-9)
+
+
+def test_classes_are_sorted_and_label_both_axes_like_sklearn():
+    result = _run(PRED, TRUE)
+    assert result["columns"] == ["bird", "cat", "dog"]
+    assert result["row_labels"] == result["columns"]
+
+
+def test_rows_are_the_true_class_and_columns_the_prediction():
+    """The one orientation mistake that silently transposes every rate."""
+    result = _run(["dog"], ["cat"])
+    matrix = result["matrix"].numpy()
+    row = result["row_labels"].index("cat")
+    col = result["columns"].index("dog")
+    assert matrix[row, col] == 1.0
+    assert matrix[col, row] == 0.0
+
+
+def test_normalize_true_puts_recall_on_the_diagonal():
+    result = _run(PRED, TRUE, {"normalize": "true"})
+    matrix = result["matrix"].numpy()
+    # dog: 2 of 3 dogs predicted dog.
+    dog = result["row_labels"].index("dog")
+    assert matrix[dog, dog] == pytest.approx(2.0 / 3.0)
+    assert matrix.sum(axis=1) == pytest.approx(np.ones(3))
+
+
+def test_accuracy_is_the_diagonal_share_of_the_raw_counts():
+    result = _run(PRED, TRUE)
+    assert result["accuracy"] == pytest.approx(4.0 / 7.0)
+
+
+def test_accuracy_ignores_the_normalize_setting():
+    """Normalizing changes the picture, not how often the model was right."""
+    plain = _run(PRED, TRUE)["accuracy"]
+    for mode in ("true", "pred", "all"):
+        assert _run(PRED, TRUE, {"normalize": mode})["accuracy"] == pytest.approx(plain)
+
+
+def test_explicit_class_names_fix_the_order_and_keep_absent_classes():
+    result = _run(["a", "a"], ["a", "b"], {"class_names": "b, a, z"})
+    assert result["columns"] == ["b", "a", "z"]
+    assert result["matrix"].shape == (3, 3)
+    # `z` never appears, so its row and column are all zeros — not dropped.
+    assert result["matrix"].numpy()[2].tolist() == [0.0, 0.0, 0.0]
+
+
+def test_a_class_missing_from_class_names_is_ignored_and_reported():
+    result = _run(["a", "zzz"], ["a", "a"], {"class_names": "a"})
+    assert result["matrix"].numpy().tolist() == [[1.0]]
+    assert "1 sample(s) ignored" in result["chart"]["note"]
+
+
+def test_integer_class_indices_sort_numerically_not_lexicographically():
+    """Sorted as strings, class 10 would land before class 2."""
+    labels = [str(v) for v in (2, 10, 2, 10)]
+    result = _run(labels, labels)
+    assert result["columns"] == ["2", "10"]
+
+
+def test_tensor_class_indices_line_up_with_string_labels():
+    """An argmax gives floats; CSVReader gives strings. They must still match."""
+    result = _run(torch.tensor([0.0, 1.0, 1.0]), ["0", "1", "1"])
+    assert result["accuracy"] == pytest.approx(1.0)
+    assert result["columns"] == ["0", "1"]
+
+
+def test_a_2d_score_matrix_is_reduced_by_argmax():
+    scores = torch.tensor([[0.9, 0.1], [0.2, 0.8], [0.7, 0.3]])
+    result = _run(scores, ["0", "1", "1"])
+    assert result["accuracy"] == pytest.approx(2.0 / 3.0)
+
+
+def test_chart_is_a_heatmap_labelled_true_versus_predicted():
+    chart = _run(PRED, TRUE)["chart"]
+    assert chart["kind"] == "heatmap"
+    assert (chart["x_label"], chart["y_label"]) == ("predicted", "true")
+    assert chart["row_labels"] == ["bird", "cat", "dog"]
+    assert chart["matrix"] == confusion_matrix(TRUE, PRED).tolist()
+
+
+def test_normalized_charts_are_pinned_to_zero_one_and_raw_ones_are_not():
+    normalized = _run(PRED, TRUE, {"normalize": "true"})["chart"]
+    assert (normalized["vmin"], normalized["vmax"]) == (0.0, 1.0)
+    raw = _run(PRED, TRUE)["chart"]
+    assert raw["vmin"] == 0.0 and raw["vmax"] == 2.0
+
+
+def test_chart_payload_is_json_safe_when_a_class_has_no_samples():
+    """0/0 must land on 0, as sklearn's nan_to_num does — NaN is not JSON."""
+    result = _run(["a", "a"], ["a", "a"], {"class_names": "a,b", "normalize": "true"})
+    assert result["matrix"].numpy().tolist() == [[1.0, 0.0], [0.0, 0.0]]
+    expected = confusion_matrix(["a", "a"], ["a", "a"], labels=["a", "b"],
+                                normalize="true")
+    assert result["matrix"].numpy() == pytest.approx(expected)
+    json.dumps(result["chart"], allow_nan=False)
+
+
+# ── boundaries ───────────────────────────────────────────────────────────────
+
+def test_a_perfect_classifier_is_purely_diagonal():
+    result = _run(TRUE, TRUE)
+    matrix = result["matrix"].numpy()
+    assert result["accuracy"] == pytest.approx(1.0)
+    assert (matrix - np.diag(np.diag(matrix)) == 0).all()
+
+
+def test_a_single_class_produces_a_one_by_one_matrix():
+    result = _run(["a"], ["a"])
+    assert result["matrix"].numpy().tolist() == [[1.0]]
+
+
+def test_mismatched_lengths_are_rejected():
+    with pytest.raises(ValueError, match="must be per-sample and aligned"):
+        _run(["a", "b"], ["a"])
+
+
+def test_empty_inputs_without_class_names_are_rejected():
+    with pytest.raises(ValueError, match="no classes to report"):
+        _run([], [])
+
+
+def test_empty_inputs_with_class_names_give_an_all_zero_matrix():
+    result = _run([], [], {"class_names": "a,b"})
+    assert result["matrix"].numpy().tolist() == [[0.0, 0.0], [0.0, 0.0]]
+    assert result["accuracy"] == 0.0
+
+
+def test_unknown_normalize_is_rejected():
+    with pytest.raises(ValueError, match="unknown normalize"):
+        _run(PRED, TRUE, {"normalize": "row"})
+
+
+def test_missing_inputs_are_clear_errors():
+    with pytest.raises(ValueError, match="requires a `predictions` input"):
+        StatsConfusionMatrixNode().execute({"labels": ["a"]}, {})
+    with pytest.raises(ValueError, match="requires a `labels` input"):
+        StatsConfusionMatrixNode().execute({"predictions": ["a"]}, {})
+
+
+def test_output_is_float32():
+    assert _run(PRED, TRUE)["matrix"].dtype == torch.float32

--- a/backend/tests/test_stats_correlation_node.py
+++ b/backend/tests/test_stats_correlation_node.py
@@ -1,0 +1,176 @@
+"""Stats-Correlation: pandas parity for pearson and spearman, and NaN policy.
+
+pandas is the reference here for the same reason as in the describe tests: it
+implements pairwise-complete correlation and average-rank Spearman
+independently, so agreeing with it is evidence, whereas re-deriving the same
+formula next to the node would not be.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from cdui_plugins.stats.nodes.stats_correlation_node import (
+    StatsCorrelationNode,
+    average_ranks,
+)
+
+
+def _run(table, params=None, columns=None):
+    inputs = {"table": table}
+    if columns is not None:
+        inputs["columns"] = columns
+    return StatsCorrelationNode().execute(inputs, params or {})
+
+
+@pytest.fixture(scope="module")
+def frame() -> pd.DataFrame:
+    rng = np.random.default_rng(11)
+    a = rng.normal(size=60)
+    return pd.DataFrame({
+        "a": a,
+        "b": 2.0 * a + rng.normal(scale=0.3, size=60),   # strongly linear
+        "c": rng.normal(size=60),                         # unrelated
+        "d": np.exp(a),                                   # monotonic, not linear
+    })
+
+
+def test_node_metadata():
+    assert StatsCorrelationNode.NODE_NAME == "Stats-Correlation"
+    outputs = StatsCorrelationNode.define_outputs()
+    assert [p.name for p in outputs] == ["matrix", "columns", "row_labels", "chart"]
+    assert next(p for p in outputs if p.name == "chart").media == "chart"
+
+
+def test_pearson_matches_pandas(frame):
+    result = _run(torch.tensor(frame.to_numpy()), columns=list(frame.columns))
+    expected = frame.corr(method="pearson").to_numpy()
+    assert result["matrix"].numpy() == pytest.approx(expected, rel=1e-5, abs=1e-6)
+    assert result["columns"] == list(frame.columns)
+    assert result["row_labels"] == result["columns"]
+
+
+def test_spearman_matches_pandas(frame):
+    result = _run(torch.tensor(frame.to_numpy()), {"method": "spearman"},
+                  columns=list(frame.columns))
+    expected = frame.corr(method="spearman").to_numpy()
+    assert result["matrix"].numpy() == pytest.approx(expected, rel=1e-5, abs=1e-6)
+
+
+def test_spearman_sees_a_monotonic_relationship_pearson_understates(frame):
+    """exp(a) vs a is a perfect rank correlation but an imperfect linear one."""
+    pearson = _run(torch.tensor(frame.to_numpy()))["matrix"].numpy()
+    spearman = _run(torch.tensor(frame.to_numpy()), {"method": "spearman"})["matrix"].numpy()
+    assert spearman[0, 3] == pytest.approx(1.0, abs=1e-6)
+    assert pearson[0, 3] < 0.95
+
+
+def test_the_diagonal_is_one_and_the_matrix_is_symmetric(frame):
+    matrix = _run(torch.tensor(frame.to_numpy()))["matrix"].numpy()
+    assert np.diag(matrix) == pytest.approx(np.ones(4))
+    assert matrix == pytest.approx(matrix.T)
+
+
+def test_nan_is_dropped_pairwise_by_default_like_pandas():
+    frame = pd.DataFrame({
+        "a": [1.0, 2.0, 3.0, 4.0, 5.0],
+        "b": [2.0, 4.0, 6.0, 8.0, 10.0],
+        "c": [1.0, float("nan"), 2.0, 9.0, 4.0],
+    })
+    matrix = _run(torch.tensor(frame.to_numpy()))["matrix"].numpy()
+    expected = frame.corr().to_numpy()
+
+    # The hole in `c` must not touch the a-b cell.
+    assert matrix[0, 1] == pytest.approx(1.0)
+    assert matrix == pytest.approx(expected, rel=1e-5, abs=1e-6)
+
+
+def test_drop_nan_off_lets_nan_propagate_like_numpy():
+    table = torch.tensor([[1.0, 1.0], [2.0, float("nan")], [3.0, 5.0]])
+    matrix = _run(table, {"drop_nan": False})["matrix"].numpy()
+    assert matrix[0, 0] == pytest.approx(1.0)
+    assert math.isnan(matrix[0, 1])
+    assert math.isnan(matrix[1, 1])
+
+
+def test_drop_nan_off_also_propagates_through_spearman():
+    """Ranking a NaN would give it a finite rank and invent a correlation."""
+    table = torch.tensor([[1.0, 1.0], [2.0, float("nan")], [3.0, 5.0]])
+    matrix = _run(table, {"method": "spearman", "drop_nan": False})["matrix"].numpy()
+    assert math.isnan(matrix[0, 1])
+
+
+def test_chart_is_a_heatmap_pinned_to_the_diverging_range():
+    result = _run(torch.tensor([[1.0, 1.0], [2.0, 2.0], [3.0, 3.1]]))
+    chart = result["chart"]
+    assert chart["kind"] == "heatmap"
+    assert chart["colormap"] == "RdBu"
+    # Never the data's own extent: a weak matrix must not look like a strong one.
+    assert (chart["vmin"], chart["vmax"]) == (-1.0, 1.0)
+    assert chart["row_labels"] == chart["col_labels"] == result["columns"]
+
+
+def test_chart_payload_is_json_safe_even_with_undefined_cells():
+    table = torch.tensor([[1.0, 5.0], [2.0, 5.0], [3.0, 5.0]])  # constant column
+    chart = _run(table)["chart"]
+    json.dumps(chart, allow_nan=False)
+
+
+# ── average_ranks ────────────────────────────────────────────────────────────
+
+def test_average_ranks_assigns_shared_ranks_to_ties():
+    assert average_ranks(np.array([10.0, 20.0, 20.0, 40.0])).tolist() == [
+        1.0, 2.5, 2.5, 4.0,
+    ]
+
+
+def test_average_ranks_handles_an_all_equal_vector():
+    assert average_ranks(np.array([5.0, 5.0, 5.0])).tolist() == [2.0, 2.0, 2.0]
+
+
+def test_average_ranks_of_an_empty_vector_is_empty():
+    assert average_ranks(np.array([])).tolist() == []
+
+
+# ── boundaries ───────────────────────────────────────────────────────────────
+
+def test_a_constant_column_has_no_defined_correlation():
+    matrix = _run(torch.tensor([[1.0, 7.0], [2.0, 7.0], [3.0, 7.0]]))["matrix"].numpy()
+    assert matrix[0, 0] == pytest.approx(1.0)
+    assert math.isnan(matrix[0, 1])
+    assert math.isnan(matrix[1, 1])
+
+
+def test_a_single_row_has_too_few_pairs():
+    matrix = _run(torch.tensor([[1.0, 2.0]]))["matrix"].numpy()
+    assert np.isnan(matrix).all()
+
+
+def test_a_single_column_is_a_one_by_one_matrix():
+    result = _run(torch.tensor([[1.0], [2.0], [3.0]]))
+    assert result["matrix"].shape == (1, 1)
+    assert result["matrix"].tolist() == [[pytest.approx(1.0)]]
+
+
+def test_column_names_default_when_none_are_connected():
+    assert _run(torch.zeros((3, 2)))["columns"] == ["c0", "c1"]
+
+
+def test_unknown_method_is_rejected():
+    with pytest.raises(ValueError, match="unknown method"):
+        _run(torch.zeros((3, 2)), {"method": "kendall"})
+
+
+def test_missing_table_input_is_a_clear_error():
+    with pytest.raises(ValueError, match="requires a `table` input"):
+        StatsCorrelationNode().execute({}, {})
+
+
+def test_output_is_float32():
+    assert _run(torch.zeros((3, 2)))["matrix"].dtype == torch.float32

--- a/backend/tests/test_stats_correlation_node.py
+++ b/backend/tests/test_stats_correlation_node.py
@@ -99,6 +99,41 @@ def test_drop_nan_off_lets_nan_propagate_like_numpy():
     assert math.isnan(matrix[1, 1])
 
 
+def test_spearman_with_pairwise_nan_drop_matches_pandas():
+    """The intersection of the two subtlest semantics.
+
+    Ranking happens AFTER the pairwise mask, so each pair is ranked within its
+    own surviving rows — rank the full column first and a hole in one column
+    shifts every rank in the other. pandas does the former; the columns below
+    carry non-overlapping holes and ties, so the two orders disagree.
+    """
+    frame = pd.DataFrame({
+        "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+        "b": [7.0, float("nan"), 5.0, 5.0, 3.0, 2.0, 1.0],
+        "c": [2.0, 2.0, float("nan"), 4.0, float("nan"), 9.0, 3.0],
+    })
+    result = _run(torch.tensor(frame.to_numpy()), {"method": "spearman"},
+                  columns=list(frame.columns))
+    expected = frame.corr(method="spearman").to_numpy()
+
+    assert result["matrix"].numpy() == pytest.approx(expected, rel=1e-5, abs=1e-6)
+    # Guard the guard: a wrong implementation would have to miss by more than
+    # the tolerance, so check the reference itself is not degenerate.
+    assert abs(expected[0, 2]) < 0.999
+
+
+def test_pearson_with_pairwise_nan_drop_matches_pandas_on_the_same_frame():
+    frame = pd.DataFrame({
+        "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+        "b": [7.0, float("nan"), 5.0, 5.0, 3.0, 2.0, 1.0],
+        "c": [2.0, 2.0, float("nan"), 4.0, float("nan"), 9.0, 3.0],
+    })
+    result = _run(torch.tensor(frame.to_numpy()), columns=list(frame.columns))
+    assert result["matrix"].numpy() == pytest.approx(
+        frame.corr().to_numpy(), rel=1e-5, abs=1e-6
+    )
+
+
 def test_drop_nan_off_also_propagates_through_spearman():
     """Ranking a NaN would give it a finite rank and invent a correlation."""
     table = torch.tensor([[1.0, 1.0], [2.0, float("nan")], [3.0, 5.0]])

--- a/backend/tests/test_stats_describe_node.py
+++ b/backend/tests/test_stats_describe_node.py
@@ -1,0 +1,231 @@
+"""Stats-Describe: pandas `describe()` parity plus the axis / percentile knobs.
+
+pandas is a backend dependency already (CSVReader reads through it), but the
+stats pack itself never imports it — the pack is numpy + torch only. pandas
+appears here purely as the reference implementation, which is the point: a
+test that recomputed the statistics with the same numpy calls the node uses
+would pass no matter how wrong both were.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from cdui_plugins.stats.nodes.stats_describe_node import StatsDescribeNode
+
+IRIS_COLUMNS = [
+    "sepal length (cm)",
+    "sepal width (cm)",
+    "petal length (cm)",
+    "petal width (cm)",
+]
+
+
+def _run(table, params=None, columns=None):
+    inputs = {"table": table}
+    if columns is not None:
+        inputs["columns"] = columns
+    return StatsDescribeNode().execute(inputs, params or {})
+
+
+def _as_frame(result) -> pd.DataFrame:
+    """The node's output as a DataFrame indexed the way pandas indexes describe()."""
+    return pd.DataFrame(
+        result["table"].numpy(),
+        index=result["row_labels"],
+        columns=result["columns"],
+    )
+
+
+@pytest.fixture(scope="module")
+def iris() -> pd.DataFrame:
+    return pd.read_csv("data/samples/iris.csv")[IRIS_COLUMNS]
+
+
+def test_node_metadata():
+    assert StatsDescribeNode.NODE_NAME == "Stats-Describe"
+    assert StatsDescribeNode.CATEGORY == "Data"
+    assert [p.name for p in StatsDescribeNode.define_outputs()] == [
+        "table",
+        "columns",
+        "row_labels",
+    ]
+    assert StatsDescribeNode.cacheable is True
+
+
+def test_reproduces_pandas_describe_on_the_iris_fixture(iris):
+    """The acceptance criterion: every cell matches pandas on a real CSV."""
+    result = _run(torch.tensor(iris.to_numpy(), dtype=torch.float32),
+                  columns=IRIS_COLUMNS)
+    expected = iris.describe()
+
+    assert result["row_labels"] == list(expected.index)
+    assert result["columns"] == list(expected.columns)
+
+    got = _as_frame(result)
+    for stat in expected.index:
+        for column in expected.columns:
+            assert got.loc[stat, column] == pytest.approx(
+                expected.loc[stat, column], rel=1e-5
+            ), f"{stat} of {column!r}"
+
+
+def test_row_labels_and_order_match_pandas():
+    frame = pd.DataFrame({"a": [1.0, 2.0, 3.0, 4.0]})
+    result = _run(torch.tensor(frame.to_numpy()), columns=["a"])
+    assert result["row_labels"] == ["count", "mean", "std", "min", "25%", "50%", "75%", "max"]
+    assert result["row_labels"] == list(frame.describe().index)
+
+
+def test_custom_percentiles_report_exactly_what_was_asked_for():
+    """No implicit median.
+
+    pandas <=2.x appended 0.5 to any percentile list and 3.0 stopped; the CI
+    matrix spans both (3.10 gets pandas 2.x, 3.11+ gets 3.x). The node follows
+    the surviving rule, so this asserts the labels itself and only borrows
+    pandas for the VALUES of the percentiles both versions agree on.
+    """
+    frame = pd.DataFrame({"a": [float(v) for v in range(1, 21)]})
+    result = _run(torch.tensor(frame.to_numpy()), {"percentiles": "10,90"}, columns=["a"])
+
+    assert result["row_labels"] == ["count", "mean", "std", "min", "10%", "90%", "max"]
+
+    expected = frame.describe(percentiles=[0.1, 0.9])
+    got = _as_frame(result)
+    for stat in result["row_labels"]:
+        assert got.loc[stat, "a"] == pytest.approx(expected.loc[stat, "a"], rel=1e-6), stat
+
+
+def test_percentiles_are_sorted_and_deduplicated():
+    result = _run(torch.arange(10, dtype=torch.float32).reshape(-1, 1),
+                  {"percentiles": "75,25,25,50"})
+    assert result["row_labels"] == ["count", "mean", "std", "min", "25%", "50%", "75%", "max"]
+
+
+def test_std_is_the_sample_std_not_the_population_one():
+    result = _run(torch.tensor([[1.0], [2.0], [3.0], [4.0]]))
+    got = _as_frame(result)
+    # ddof=1 => sqrt(5/3) = 1.29099; the population std would be 1.11803.
+    assert got.loc["std", "c0"] == pytest.approx(math.sqrt(5.0 / 3.0), rel=1e-6)
+
+
+# Arithmetic on an inf legitimately raises "invalid value encountered" inside
+# BOTH numpy and pandas (inf - inf); that is the behaviour under test, not a
+# defect, and the warning would otherwise be the suite's only noise.
+@pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning")
+def test_nan_is_missing_and_inf_is_a_value_like_pandas():
+    frame = pd.DataFrame({"holes": [1.0, float("nan"), 3.0], "big": [1.0, 2.0, float("inf")]})
+    result = _run(torch.tensor(frame.to_numpy()), columns=list(frame.columns))
+    expected = frame.describe()
+    got = _as_frame(result)
+
+    assert got.loc["count", "holes"] == 2.0 == expected.loc["count", "holes"]
+    assert got.loc["mean", "holes"] == pytest.approx(2.0)
+    # An inf is data, so it counts and it poisons the mean — in both libraries.
+    assert got.loc["count", "big"] == 3.0 == expected.loc["count", "big"]
+    assert math.isinf(got.loc["mean", "big"]) and math.isinf(expected.loc["mean", "big"])
+
+
+def test_axis_rows_describes_each_row():
+    result = _run(torch.tensor([[1.0, 3.0], [10.0, 20.0]]), {"axis": "rows"})
+    got = _as_frame(result)
+    assert result["columns"] == ["r0", "r1"]
+    assert got.loc["mean", "r0"] == pytest.approx(2.0)
+    assert got.loc["mean", "r1"] == pytest.approx(15.0)
+
+
+def test_axis_all_describes_the_whole_table_as_one_series():
+    result = _run(torch.tensor([[1.0, 2.0], [3.0, 4.0]]), {"axis": "all"})
+    got = _as_frame(result)
+    assert result["columns"] == ["all"]
+    assert got.loc["count", "all"] == 4.0
+    assert got.loc["mean", "all"] == pytest.approx(2.5)
+
+
+def test_a_1d_vector_is_treated_as_one_column():
+    result = _run(torch.tensor([1.0, 2.0, 3.0]))
+    assert result["columns"] == ["c0"]
+    assert _as_frame(result).loc["mean", "c0"] == pytest.approx(2.0)
+
+
+def test_missing_column_names_are_generated_and_extra_ones_trimmed():
+    table = torch.zeros((2, 3))
+    assert _run(table)["columns"] == ["c0", "c1", "c2"]
+    assert _run(table, columns=["a"])["columns"] == ["a", "c1", "c2"]
+    assert _run(table, columns=["a", "b", "c", "d"])["columns"] == ["a", "b", "c"]
+
+
+def test_duplicate_column_names_are_disambiguated():
+    assert _run(torch.zeros((2, 3)), columns=["a", "a", "a"])["columns"] == [
+        "a", "a#1", "a#2",
+    ]
+
+
+# ── boundaries ───────────────────────────────────────────────────────────────
+
+def test_an_all_nan_column_reports_count_zero_and_nan_statistics():
+    result = _run(torch.tensor([[float("nan")], [float("nan")]]))
+    got = _as_frame(result)
+    assert got.loc["count", "c0"] == 0.0
+    for stat in ("mean", "std", "min", "50%", "max"):
+        assert math.isnan(got.loc[stat, "c0"]), stat
+
+
+def test_a_single_row_has_no_sample_std():
+    result = _run(torch.tensor([[7.0]]))
+    got = _as_frame(result)
+    assert got.loc["count", "c0"] == 1.0
+    assert got.loc["mean", "c0"] == pytest.approx(7.0)
+    # ddof=1 with one observation is undefined — pandas says NaN, so do we.
+    assert math.isnan(got.loc["std", "c0"])
+    assert math.isnan(pd.DataFrame({"a": [7.0]}).describe().loc["std", "a"])
+
+
+def test_zero_rows_produce_an_empty_but_well_formed_table():
+    result = _run(torch.zeros((0, 2)))
+    assert result["columns"] == ["c0", "c1"]
+    assert result["table"].shape == (8, 2)
+    assert result["table"][0].tolist() == [0.0, 0.0]  # count
+
+
+def test_a_list_of_lists_is_accepted_like_a_tensor():
+    result = _run([[1.0, 2.0], [3.0, 4.0]])
+    assert _as_frame(result).loc["mean", "c0"] == pytest.approx(2.0)
+
+
+def test_missing_table_input_is_a_clear_error():
+    with pytest.raises(ValueError, match="requires a `table` input"):
+        StatsDescribeNode().execute({}, {})
+
+
+def test_a_3d_tensor_is_rejected_by_shape_not_silently_flattened():
+    with pytest.raises(ValueError, match="2D"):
+        _run(torch.zeros((2, 3, 4)))
+
+
+def test_unknown_axis_is_rejected():
+    with pytest.raises(ValueError, match="unknown axis"):
+        _run(torch.zeros((2, 2)), {"axis": "diagonal"})
+
+
+@pytest.mark.parametrize("bad", ["abc", "25,abc", "-1", "101"])
+def test_invalid_percentiles_are_rejected(bad):
+    with pytest.raises(ValueError, match="percentiles"):
+        _run(torch.zeros((3, 1)), {"percentiles": bad})
+
+
+def test_the_output_table_is_float32_like_every_other_table_in_the_repo():
+    assert _run(torch.zeros((3, 1)))["table"].dtype == torch.float32
+
+
+def test_output_is_a_valid_input_for_a_second_describe():
+    """The table contract round-trips: describe(describe(x)) is well-formed."""
+    first = _run(torch.tensor(np.arange(12, dtype=np.float32).reshape(4, 3)))
+    second = _run(first["table"], columns=first["columns"])
+    assert second["columns"] == first["columns"]
+    assert second["table"].shape[1] == 3

--- a/backend/tests/test_stats_group_by_aggregate_node.py
+++ b/backend/tests/test_stats_group_by_aggregate_node.py
@@ -1,0 +1,220 @@
+"""Stats-GroupByAggregate: pandas groupby parity, both grouping sources."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from cdui_plugins.stats.nodes.stats_group_by_aggregate_node import (
+    StatsGroupByAggregateNode,
+)
+
+IRIS_COLUMNS = [
+    "sepal length (cm)",
+    "sepal width (cm)",
+    "petal length (cm)",
+    "petal width (cm)",
+]
+
+
+def _run(table, params=None, columns=None, keys=None):
+    inputs = {"table": table}
+    if columns is not None:
+        inputs["columns"] = columns
+    if keys is not None:
+        inputs["keys"] = keys
+    return StatsGroupByAggregateNode().execute(inputs, params or {})
+
+
+@pytest.fixture(scope="module")
+def iris() -> pd.DataFrame:
+    return pd.read_csv("data/samples/iris.csv")
+
+
+def test_node_metadata():
+    assert StatsGroupByAggregateNode.NODE_NAME == "Stats-GroupByAggregate"
+    assert [p.name for p in StatsGroupByAggregateNode.define_outputs()] == [
+        "table", "columns", "row_labels", "counts",
+    ]
+
+
+@pytest.mark.parametrize("agg", ["mean", "sum", "count", "min", "max", "std"])
+def test_every_aggregate_matches_pandas_groupby_on_iris(iris, agg):
+    """The CSV -> GroupBy demo shape, checked against pandas for each aggregate."""
+    result = _run(
+        torch.tensor(iris[IRIS_COLUMNS].to_numpy(), dtype=torch.float32),
+        {"agg": agg},
+        columns=IRIS_COLUMNS,
+        keys=[str(v) for v in iris["species"].tolist()],
+    )
+    expected = iris.groupby("species")[IRIS_COLUMNS].agg(agg)
+
+    assert result["row_labels"] == list(expected.index)
+    assert result["columns"] == [f"{c} [{agg}]" for c in IRIS_COLUMNS]
+    assert result["table"].numpy() == pytest.approx(expected.to_numpy(), rel=1e-5)
+
+
+def test_group_counts_are_the_row_counts(iris):
+    result = _run(
+        torch.tensor(iris[IRIS_COLUMNS].to_numpy(), dtype=torch.float32),
+        columns=IRIS_COLUMNS,
+        keys=[str(v) for v in iris["species"].tolist()],
+    )
+    expected = iris.groupby("species").size()
+    assert result["counts"].tolist() == pytest.approx(expected.to_numpy())
+
+
+def test_groups_come_back_in_sorted_order_like_pandas():
+    result = _run(
+        torch.tensor([[1.0], [2.0], [3.0]]),
+        keys=["zebra", "apple", "mango"],
+    )
+    assert result["row_labels"] == ["apple", "mango", "zebra"]
+    assert result["table"].tolist() == [[2.0], [3.0], [1.0]]
+
+
+def test_group_by_a_table_column_by_name():
+    table = torch.tensor([[1.0, 10.0], [1.0, 20.0], [2.0, 30.0]])
+    result = _run(table, {"group_by": "key"}, columns=["key", "value"])
+    assert result["row_labels"] == ["1", "2"]
+    assert result["columns"] == ["value [mean]"]
+    assert result["table"].tolist() == [[15.0], [30.0]]
+
+
+def test_group_by_a_table_column_by_index():
+    table = torch.tensor([[1.0, 10.0], [1.0, 20.0], [2.0, 30.0]])
+    result = _run(table, {"group_by": "0"})
+    assert result["table"].tolist() == [[15.0], [30.0]]
+
+
+def test_group_by_several_columns_makes_a_compound_key():
+    table = torch.tensor([
+        [1.0, 1.0, 5.0],
+        [1.0, 2.0, 7.0],
+        [1.0, 1.0, 9.0],
+    ])
+    result = _run(table, {"group_by": "0,1"}, columns=["a", "b", "v"])
+    assert result["row_labels"] == ["1|1", "1|2"]
+    assert result["table"].tolist() == [[7.0], [7.0]]
+
+
+def test_numeric_group_keys_sort_numerically_not_as_text():
+    """Sorting the rendered labels would put 10 before 2."""
+    table = torch.tensor([[10.0, 1.0], [2.0, 2.0]])
+    result = _run(table, {"group_by": "0"})
+    assert result["row_labels"] == ["2", "10"]
+
+
+def test_group_by_param_wins_over_a_connected_keys_input():
+    table = torch.tensor([[1.0, 10.0], [2.0, 20.0]])
+    result = _run(table, {"group_by": "0"}, keys=["same", "same"])
+    assert result["row_labels"] == ["1", "2"]
+
+
+def test_agg_overrides_apply_per_column_and_show_in_the_names():
+    table = torch.tensor([[1.0, 10.0], [3.0, 20.0]])
+    result = _run(
+        table, {"agg": "mean", "agg_overrides": "b=max"}, columns=["a", "b"],
+        keys=["g", "g"],
+    )
+    assert result["columns"] == ["a [mean]", "b [max]"]
+    assert result["table"].tolist() == [[2.0, 20.0]]
+
+
+def test_std_is_the_sample_std_like_pandas():
+    result = _run(torch.tensor([[1.0], [2.0], [3.0], [4.0]]),
+                  {"agg": "std"}, keys=["g"] * 4)
+    expected = pd.DataFrame({"g": ["g"] * 4, "v": [1.0, 2.0, 3.0, 4.0]}).groupby("g").std()
+    assert result["table"].tolist()[0][0] == pytest.approx(expected.iloc[0, 0], rel=1e-6)
+
+
+def test_nan_is_skipped_per_column_like_pandas():
+    frame = pd.DataFrame({"g": ["a", "a", "a"], "v": [1.0, float("nan"), 3.0]})
+    result = _run(torch.tensor([[1.0], [float("nan")], [3.0]]), keys=list(frame["g"]))
+    assert result["table"].tolist() == [[pytest.approx(2.0)]]
+    assert result["table"].tolist()[0][0] == pytest.approx(
+        frame.groupby("g").mean().iloc[0, 0]
+    )
+
+
+def test_count_counts_present_values_while_counts_counts_rows():
+    result = _run(
+        torch.tensor([[1.0], [float("nan")], [3.0]]), {"agg": "count"}, keys=["g"] * 3
+    )
+    assert result["table"].tolist() == [[2.0]]   # two present values
+    assert result["counts"].tolist() == [3.0]    # three rows in the group
+
+
+# ── boundaries ───────────────────────────────────────────────────────────────
+
+def test_an_all_nan_group_sums_to_zero_and_averages_to_nan_like_pandas():
+    frame = pd.DataFrame({"g": ["a", "a"], "v": [float("nan")] * 2})
+    table = torch.tensor([[float("nan")], [float("nan")]])
+
+    summed = _run(table, {"agg": "sum"}, keys=["a", "a"])["table"].tolist()[0][0]
+    assert summed == 0.0 == frame.groupby("g").sum().iloc[0, 0]
+
+    averaged = _run(table, {"agg": "mean"}, keys=["a", "a"])["table"].tolist()[0][0]
+    assert math.isnan(averaged)
+    assert math.isnan(frame.groupby("g").mean().iloc[0, 0])
+
+
+def test_a_one_row_group_has_no_sample_std():
+    result = _run(torch.tensor([[5.0]]), {"agg": "std"}, keys=["only"])
+    assert math.isnan(result["table"].tolist()[0][0])
+
+
+def test_every_row_in_its_own_group_is_the_identity():
+    table = torch.tensor([[1.0], [2.0], [3.0]])
+    result = _run(table, keys=["a", "b", "c"])
+    assert result["table"].tolist() == [[1.0], [2.0], [3.0]]
+    assert result["counts"].tolist() == [1.0, 1.0, 1.0]
+
+
+def test_no_keys_and_no_group_by_is_a_clear_error():
+    with pytest.raises(ValueError, match="nothing to group by"):
+        _run(torch.zeros((2, 2)))
+
+
+def test_misaligned_keys_are_rejected():
+    with pytest.raises(ValueError, match="must be aligned"):
+        _run(torch.zeros((3, 1)), keys=["a", "b"])
+
+
+def test_grouping_by_every_column_leaves_nothing_to_aggregate():
+    with pytest.raises(ValueError, match="nothing left to aggregate"):
+        _run(torch.zeros((2, 1)), {"group_by": "0"})
+
+
+@pytest.mark.parametrize(
+    "params, message",
+    [
+        ({"agg": "median"}, "unknown agg"),
+        ({"agg_overrides": "a"}, "not a 'column=agg' pair"),
+        ({"agg_overrides": "a=median"}, "unknown aggregate"),
+        ({"agg_overrides": "nope=max"}, "unknown column"),
+        ({"group_by": "nope"}, "unknown column"),
+        ({"group_by": "9"}, "out of range"),
+    ],
+)
+def test_invalid_params_are_rejected(params, message):
+    with pytest.raises(ValueError, match=message):
+        _run(torch.zeros((2, 2)), params, columns=["a", "b"], keys=["g", "g"])
+
+
+def test_output_is_float32():
+    result = _run(torch.zeros((2, 1)), keys=["g", "g"])
+    assert result["table"].dtype == torch.float32
+    assert result["counts"].dtype == torch.float32
+
+
+def test_output_feeds_straight_into_a_table_view_contract():
+    """[groups, columns] + names + row labels — the pack's table contract."""
+    result = _run(torch.tensor(np.arange(6.0).reshape(3, 2)), keys=["a", "b", "a"])
+    assert result["table"].shape == (2, 2)
+    assert len(result["columns"]) == result["table"].shape[1]
+    assert len(result["row_labels"]) == result["table"].shape[0]

--- a/backend/tests/test_stats_histogram_node.py
+++ b/backend/tests/test_stats_histogram_node.py
@@ -65,6 +65,23 @@ def test_non_finite_values_are_dropped_and_counted():
     assert "non-finite" in result["chart"]["note"]
 
 
+def test_a_dropped_value_notice_does_not_erase_the_downsampling_notice():
+    """Both notices must survive together.
+
+    Assigning `chart["note"] = ...` after bar_chart has already recorded its
+    cap notice deletes it, so a 500-bin histogram would disclose the excluded
+    NaNs and silently hide that only 200 of its 500 bars are drawn — exactly
+    the truncation lie the caps exist to prevent.
+    """
+    values = list(range(500)) + [float("nan")] * 7
+    result = _run(torch.tensor(values, dtype=torch.float64), {"bins": 500})
+
+    note = result["chart"]["note"]
+    assert "showing the first 200 of 500 bars" in note
+    assert "7 non-finite value(s) excluded" in note
+    assert len(result["chart"]["bars"]) == 200
+
+
 def test_chart_payload_is_a_bar_chart_with_one_bar_per_bin():
     result = _run(torch.tensor([1.0, 2.0, 3.0, 4.0]), {"bins": 4, "title": "Widths"})
     chart = result["chart"]

--- a/backend/tests/test_stats_histogram_node.py
+++ b/backend/tests/test_stats_histogram_node.py
@@ -1,0 +1,134 @@
+"""Stats-Histogram: numpy parity, range modes, density, and the chart payload."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+import torch
+
+from cdui_plugins.stats.nodes.stats_histogram_node import StatsHistogramNode
+
+
+def _run(tensor, params=None):
+    return StatsHistogramNode().execute({"tensor": tensor}, params or {})
+
+
+def test_node_metadata():
+    assert StatsHistogramNode.NODE_NAME == "Stats-Histogram"
+    outputs = StatsHistogramNode.define_outputs()
+    assert [p.name for p in outputs] == [
+        "table", "columns", "row_labels", "chart", "dropped",
+    ]
+    chart = next(p for p in outputs if p.name == "chart")
+    assert chart.media == "chart", "the chart port must declare its media kind"
+
+
+def test_counts_and_edges_match_numpy_histogram():
+    data = np.random.default_rng(7).normal(size=500)
+    result = _run(torch.tensor(data), {"bins": 12})
+
+    counts, edges = np.histogram(data, bins=12)
+    table = result["table"].numpy()
+    assert table[:, 0] == pytest.approx(edges[:-1], rel=1e-5)
+    assert table[:, 1] == pytest.approx(edges[1:], rel=1e-5)
+    assert table[:, 2].tolist() == pytest.approx(counts.astype(float))
+    assert result["columns"] == ["bin_start", "bin_end", "count"]
+
+
+def test_density_matches_numpy_and_renames_the_column():
+    data = np.random.default_rng(3).normal(size=400)
+    result = _run(torch.tensor(data), {"bins": 8, "density": True})
+
+    density, _edges = np.histogram(data, bins=8, density=True)
+    assert result["table"].numpy()[:, 2] == pytest.approx(density, rel=1e-5)
+    assert result["columns"][2] == "density"
+
+
+def test_manual_range_pins_the_edges_regardless_of_the_data():
+    result = _run(
+        torch.tensor([0.4, 0.5, 0.6]),
+        {"bins": 4, "range_mode": "manual", "range_min": 0.0, "range_max": 1.0},
+    )
+    table = result["table"].numpy()
+    assert table[0, 0] == pytest.approx(0.0)
+    assert table[-1, 1] == pytest.approx(1.0)
+    assert table[:, 2].tolist() == pytest.approx([0.0, 1.0, 2.0, 0.0])
+
+
+def test_non_finite_values_are_dropped_and_counted():
+    data = torch.tensor([1.0, 2.0, float("nan"), float("inf"), -float("inf"), 3.0])
+    result = _run(data, {"bins": 2})
+    assert result["dropped"] == 3
+    assert result["table"].numpy()[:, 2].sum() == pytest.approx(3.0)
+    assert "non-finite" in result["chart"]["note"]
+
+
+def test_chart_payload_is_a_bar_chart_with_one_bar_per_bin():
+    result = _run(torch.tensor([1.0, 2.0, 3.0, 4.0]), {"bins": 4, "title": "Widths"})
+    chart = result["chart"]
+    assert chart["kind"] == "bar"
+    assert chart["title"] == "Widths"
+    assert len(chart["bars"]) == 4
+    assert chart["bars"][0]["label"] == result["row_labels"][0]
+
+
+def test_chart_payload_is_json_safe():
+    """The run store serialises events with allow_nan=False."""
+    chart = _run(torch.tensor([1.0, float("nan"), 3.0]), {"bins": 3})["chart"]
+    encoded = json.dumps(chart, allow_nan=False)
+    assert "NaN" not in encoded and "Infinity" not in encoded
+
+
+def test_row_labels_read_as_half_open_intervals():
+    labels = _run(torch.tensor([0.0, 1.0]), {"bins": 2})["row_labels"]
+    assert labels == ["[0, 0.5)", "[0.5, 1)"]
+
+
+# ── boundaries ───────────────────────────────────────────────────────────────
+
+def test_a_single_bin_holds_everything():
+    result = _run(torch.tensor([1.0, 2.0, 3.0]), {"bins": 1})
+    assert result["table"].numpy()[:, 2].tolist() == pytest.approx([3.0])
+
+
+def test_constant_data_still_produces_a_usable_range():
+    """numpy widens a zero-width auto range to +-0.5; the node inherits that."""
+    result = _run(torch.tensor([5.0, 5.0, 5.0]), {"bins": 2})
+    table = result["table"].numpy()
+    assert table[0, 0] < table[-1, 1]
+    assert table[:, 2].sum() == pytest.approx(3.0)
+
+
+def test_an_empty_tensor_produces_empty_bins_not_an_exception():
+    """numpy cannot autodetect a range from nothing — the node substitutes 0..1."""
+    result = _run(torch.zeros(0), {"bins": 4})
+    assert result["dropped"] == 0
+    assert result["table"].numpy()[:, 2].tolist() == [0.0, 0.0, 0.0, 0.0]
+    assert result["chart"]["bars"][0]["value"] == 0.0
+
+
+def test_an_all_nan_tensor_behaves_like_an_empty_one():
+    result = _run(torch.tensor([float("nan")] * 3), {"bins": 2})
+    assert result["dropped"] == 3
+    assert result["table"].numpy()[:, 2].sum() == 0.0
+
+
+@pytest.mark.parametrize(
+    "params, message",
+    [
+        ({"bins": 0}, "at least 1"),
+        ({"range_mode": "sideways"}, "unknown range_mode"),
+        ({"range_mode": "manual", "range_min": 1.0, "range_max": 1.0}, "range_min < range_max"),
+        ({"range_mode": "manual", "range_min": 2.0, "range_max": 1.0}, "range_min < range_max"),
+    ],
+)
+def test_invalid_params_are_rejected(params, message):
+    with pytest.raises(ValueError, match=message):
+        _run(torch.tensor([1.0, 2.0]), params)
+
+
+def test_a_2d_tensor_is_flattened():
+    result = _run(torch.tensor([[1.0, 2.0], [3.0, 4.0]]), {"bins": 2})
+    assert result["table"].numpy()[:, 2].sum() == pytest.approx(4.0)

--- a/backend/tests/test_stats_pack.py
+++ b/backend/tests/test_stats_pack.py
@@ -1,0 +1,311 @@
+"""The stats pack as a PACK: catalog entry, install, hot-reload, security gate.
+
+Node behaviour lives in the per-node ``test_stats_*_node.py`` files. What is
+asserted here is everything that only matters because this ships as a
+first-party plugin rather than as built-in nodes — the acceptance criteria of
+issue #130, in the order the issue lists them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+from textwrap import dedent
+
+import pandas as pd
+import plugins as plugin_cli
+import pytest
+
+from app.core import plugin_loader
+from app.core.graph_engine import execute_graph
+from app.core.node_registry import NodeRegistry
+from app.core.output_entries import build_node_output_entries, declared_media_ports
+from app.core.plugin_validator import validate_python_source
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PACK_DIR = _REPO_ROOT / "plugins" / "stats"
+_EXAMPLES = _PACK_DIR / "examples" / "Stats"
+
+NODE_NAMES = [
+    "Stats-ChartView",
+    "Stats-ConfusionMatrix",
+    "Stats-Correlation",
+    "Stats-Describe",
+    "Stats-GroupByAggregate",
+    "Stats-Histogram",
+    "Stats-Percentile",
+    "Stats-TableView",
+]
+
+
+def _pack_sources() -> list[Path]:
+    return sorted(
+        p for p in _PACK_DIR.rglob("*.py") if "__pycache__" not in p.parts
+    )
+
+
+@pytest.fixture
+def isolated_lockfile(tmp_path, monkeypatch):
+    """Redirect the lockfile to a temp dir and stub the server hot-reload.
+
+    Same shape as the fixture in ``test_plugin_cli.py``: CLI tests must never
+    touch real user data or expect a running server.
+    """
+    target = tmp_path / "plugins"
+    target.mkdir()
+    monkeypatch.setattr(plugin_loader, "plugins_user_root", lambda: target)
+    monkeypatch.setattr(plugin_cli, "_backend_reload", lambda: False)
+    return target
+
+
+def _install(**overrides) -> int:
+    args = argparse.Namespace(
+        source=["stats"], force=False, no_confirm=True, trust_author=False,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return plugin_cli.cmd_install(args)
+
+
+# ── the catalog entry ────────────────────────────────────────────────────────
+
+def test_the_pack_is_in_the_first_party_catalog():
+    """Without this, `cdui plugin install stats` parses `stats` as a GitHub repo."""
+    entry = plugin_cli.load_catalog()["plugins"]["stats"]
+    assert entry["kind"] == "builtin"
+    assert entry["path"] == "plugins/stats"
+    assert entry["name"] and entry["description"]
+
+
+def test_the_catalog_name_resolves_as_a_catalog_source_not_a_repo():
+    assert plugin_cli.parse_source("stats")[:2] == ("catalog", "stats")
+
+
+def test_the_manifest_validates():
+    manifest = plugin_cli.read_manifest(_PACK_DIR)
+    plugin_cli.validate_manifest(manifest)
+    assert manifest["plugin"]["id"] == "stats"
+    assert manifest["plugin"]["schema_version"] == 1
+    assert manifest["content"]["nodes_dir"] == "nodes"
+    assert manifest["content"]["examples_dir"] == "examples"
+
+
+# ── acceptance: install exposes all eight nodes, and reload works ────────────
+
+def test_install_records_a_builtin_lockfile_entry(isolated_lockfile):
+    assert _install() == 0
+
+    entry = plugin_loader.load_lockfile()["plugins"]["stats"]
+    assert entry["source_kind"] == "builtin"
+    assert entry["enabled"] is True
+    assert entry["trusted_modules"] == []
+    assert entry["manifest"]["id"] == "stats"
+
+
+def test_installing_twice_needs_force(isolated_lockfile):
+    assert _install() == 0
+    assert _install() != 0
+    assert _install(force=True) == 0
+
+
+def test_an_installed_pack_exposes_all_eight_nodes(isolated_lockfile):
+    assert _install() == 0
+
+    pairs = plugin_loader.install_plugin_finder(
+        plugin_loader.plugins_builtin_root(),
+        plugin_loader.plugins_user_root(),
+        plugin_loader.load_lockfile(),
+    )
+    nodes_dir, package = next(p for p in pairs if p[1].endswith("stats.nodes"))
+
+    registry = NodeRegistry()
+    assert registry.discover(nodes_dir, package) == 8
+    assert sorted(registry.nodes) == [f"stats:{name}" for name in NODE_NAMES]
+
+
+def test_hot_reload_re_registers_every_node(isolated_lockfile):
+    """`cdui plugin reload` rediscovers with force_reload — twice must be stable."""
+    assert _install() == 0
+    nodes_dir = _PACK_DIR / "nodes"
+    package = "cdui_plugins.stats.nodes"
+
+    registry = NodeRegistry()
+    assert registry.discover(nodes_dir, package, force_reload=True) == 8
+    registry.clear()
+    assert registry.discover(nodes_dir, package, force_reload=True) == 8
+    assert sorted(registry.nodes) == [f"stats:{name}" for name in NODE_NAMES]
+
+
+def test_node_types_are_namespaced_so_saved_graphs_are_unambiguous(
+    registry_with_nodes,
+):
+    for name in NODE_NAMES:
+        assert registry_with_nodes.get(f"stats:{name}") is not None
+
+
+def test_the_helper_module_contributes_no_nodes():
+    """`_stats_core` is shared code, not a node — it must not register anything."""
+    registry = NodeRegistry()
+    registry.discover(_PACK_DIR / "nodes", "cdui_plugins.stats.nodes")
+    assert len(registry.nodes) == len(NODE_NAMES)
+
+
+# ── acceptance: the AST gate passes with zero [security] overrides ──────────
+
+def test_the_manifest_declares_no_security_overrides():
+    """The whole point of the pack: the default policy is workable for stats."""
+    manifest = plugin_cli.read_manifest(_PACK_DIR)
+    assert "security" not in manifest
+    assert manifest.get("security", {}).get("allowed_modules", []) == []
+
+
+@pytest.mark.parametrize(
+    "source", _pack_sources(), ids=[p.name for p in _pack_sources()]
+)
+def test_every_source_file_passes_the_ast_validator(source):
+    validate_python_source(source.read_bytes(), source.name, allowed_modules=None)
+
+
+def test_the_whole_pack_passes_the_directory_gate_a_github_install_would_run():
+    plugin_cli.validate_plugin_dir(_PACK_DIR, [])
+
+
+def test_the_pack_imports_no_pandas_at_runtime():
+    """pandas is the tests' reference implementation, never the pack's dependency."""
+    for source in _pack_sources():
+        text = source.read_text(encoding="utf-8")
+        assert "import pandas" not in text, source
+        assert "\nimport sklearn" not in text, source
+
+
+def test_a_pack_file_that_broke_the_rules_would_be_caught(tmp_path):
+    """Guards the guard: the parametrised test above must be able to fail."""
+    offender = tmp_path / "bad_node.py"
+    offender.write_text(dedent("""
+        import os
+        VALUE = os.environ
+    """), encoding="utf-8")
+    with pytest.raises(plugin_cli.PluginValidationError):
+        validate_python_source(offender.read_bytes(), offender.name)
+
+
+# ── acceptance: the chart kind reaches the wire ─────────────────────────────
+
+def test_chart_ports_are_declared_as_media_and_ride_the_output_channel(
+    registry_with_nodes,
+):
+    nodes = [{"id": "cm", "type": "stats:Stats-ConfusionMatrix", "data": {"params": {}}}]
+    declared = declared_media_ports(nodes)
+    assert declared == {"cm": {"chart": ["chart"]}}
+
+    entries = build_node_output_entries(
+        "completed",
+        {"matrix": [[1.0]], "chart": {"kind": "heatmap", "matrix": [[1.0]]}},
+        declared["cm"],
+    )
+    chart = next(e for e in entries if e["output_kind"] == "chart")
+    assert chart["port"] == "chart"
+    assert chart["chart"]["kind"] == "heatmap"
+
+
+def test_every_chart_producing_node_declares_the_media_kind(registry_with_nodes):
+    producers = [
+        "Stats-Histogram", "Stats-Correlation", "Stats-ConfusionMatrix",
+        "Stats-ChartView",
+    ]
+    for name in producers:
+        cls = registry_with_nodes.get(f"stats:{name}")
+        chart = next(p for p in cls.define_outputs() if p.name == "chart")
+        assert chart.media == "chart", name
+
+
+# ── acceptance: the demo graphs run, and reproduce pandas ───────────────────
+
+def _run_graph(name: str) -> dict:
+    payload = json.loads((_EXAMPLES / name / "graph.json").read_text(encoding="utf-8"))
+    backend_dir = Path(__file__).resolve().parents[1]
+    previous = Path.cwd()
+    os.chdir(backend_dir)
+    try:
+        return asyncio.run(
+            execute_graph(payload["nodes"], payload["edges"], error_mode="fail_fast")
+        )
+    finally:
+        os.chdir(previous)
+
+
+def test_the_pack_ships_the_demo_graphs():
+    shipped = sorted(p.parent.name for p in _EXAMPLES.rglob("graph.json"))
+    assert shipped == [
+        "Confusion-Matrix-Heatmap", "Iris-Describe-Table", "Iris-GroupBy-Chart",
+    ]
+
+
+def test_the_describe_demo_reproduces_pandas_describe_end_to_end():
+    """The headline acceptance criterion, through the real graph engine.
+
+    Not a call to the node with hand-made inputs: the CSV is read by CSVReader,
+    the columns travel the LIST port, and the numbers are read back out of the
+    text Stats-TableView rendered — so a break anywhere along that chain fails
+    here.
+    """
+    results = _run_graph("Iris-Describe-Table")
+
+    frame = pd.read_csv(Path(__file__).resolve().parents[1] / "data/samples/iris.csv")
+    expected = frame.select_dtypes("number").describe()
+
+    described = results["describe"]
+    assert described["columns"] == list(expected.columns)
+    assert described["row_labels"] == list(expected.index)
+    assert described["table"].numpy() == pytest.approx(
+        expected.to_numpy(), rel=1e-5
+    )
+
+    # ...and the view actually rendered it, headers, statistic names and all.
+    lines = results["view"]["text"].splitlines()
+    assert lines[0] == "Iris - describe()"
+    for column in expected.columns:
+        assert column in lines[1]
+    assert [line.split()[0] for line in lines[2:]] == list(expected.index)
+
+
+def test_the_groupby_demo_charts_one_bar_per_species():
+    results = _run_graph("Iris-GroupBy-Chart")
+
+    assert results["group"]["row_labels"] == ["setosa", "versicolor", "virginica"]
+    chart = results["chart"]["chart"]
+    assert chart["kind"] == "bar"
+    assert [b["label"] for b in chart["bars"]] == [
+        "setosa", "versicolor", "virginica",
+    ]
+
+    frame = pd.read_csv(Path(__file__).resolve().parents[1] / "data/samples/iris.csv")
+    expected = frame.groupby("species")["petal length (cm)"].mean()
+    assert [b["value"] for b in chart["bars"]] == pytest.approx(
+        expected.to_numpy(), rel=1e-5
+    )
+
+
+def test_the_confusion_matrix_demo_produces_a_heatmap_payload():
+    results = _run_graph("Confusion-Matrix-Heatmap")
+
+    chart = results["cm"]["chart"]
+    assert chart["kind"] == "heatmap"
+    assert chart["row_labels"] == ["setosa", "versicolor", "virginica"]
+    assert (chart["x_label"], chart["y_label"]) == ("predicted", "true")
+
+    # 45 held-out samples, all accounted for, and the tree is at least sane.
+    assert sum(sum(row) for row in chart["matrix"]) == 45
+    assert results["cm"]["accuracy"] > 0.8
+
+
+def test_every_demo_chart_payload_survives_the_run_stores_json_encoder():
+    """Events are serialised with allow_nan=False; a NaN would break the socket."""
+    for name in ("Iris-GroupBy-Chart", "Confusion-Matrix-Heatmap"):
+        results = _run_graph(name)
+        for node in results.values():
+            if isinstance(node, dict) and isinstance(node.get("chart"), dict):
+                json.dumps(node["chart"], allow_nan=False)

--- a/backend/tests/test_stats_pack.py
+++ b/backend/tests/test_stats_pack.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import os
 import shutil
+import sys
 from pathlib import Path
 from textwrap import dedent
 
@@ -144,56 +145,79 @@ def test_rediscovery_does_not_duplicate_or_drop_nodes(isolated_lockfile):
     assert sorted(registry.nodes) == [f"stats:{name}" for name in NODE_NAMES]
 
 
-def test_hot_reload_picks_up_an_edit_to_a_node_file(tmp_path, monkeypatch):
+def test_hot_reload_picks_up_an_edit_to_a_node_file(tmp_path):
     """The acceptance criterion, exercised the way a plugin author lives it.
 
-    Copies the pack to a temp dir, runs a node, EDITS the source, reloads
-    through ``rediscover_all`` — the same call ``POST /api/plugins/reload``
-    makes — and re-runs. Discovering a pristine pack twice would pass even if
-    reload could not pick up a change, which is the only thing anyone actually
-    wants from it.
+    Copies the pack to a temp dir, runs a node, EDITS the source, reloads, and
+    re-runs. Discovering a pristine pack twice would pass even if reload could
+    not see a change, which is the only thing anyone wants from it.
+
+    The reload here is exactly what ``rediscover_all`` does — the function
+    behind ``POST /api/plugins/reload`` — for a plugin:
+    ``install_plugin_finder`` then ``discover(force_reload=True)``. There is no
+    ``purge_plugin_modules`` call because production does not make one:
+    ``force_reload`` re-imports through ``importlib.reload``, which re-reads
+    the file, and that is sufficient on its own.
+
+    The copy is installed under a DIFFERENT plugin id. ``conftest`` binds
+    ``cdui_plugins.stats`` to the real in-repo pack for the whole session, so
+    reusing that id would silently rebind a session-wide namespace to a temp
+    directory — a global-state mutation that also forces a purge the real
+    reload path never needs. A fresh id keeps the test honest and inert.
     """
+    plugin_id = "statscopy"
     user_root = tmp_path / "userdata" / "plugins"
-    pack = user_root / "stats"
+    pack = user_root / plugin_id
     shutil.copytree(_PACK_DIR, pack)
-    monkeypatch.setattr(plugin_loader, "plugins_user_root", lambda: user_root)
-
-    lockfile = {
-        "schema": 1,
-        "plugins": {"stats": {"source_kind": "user", "source": "stats", "enabled": True}},
-    }
-    monkeypatch.setattr(plugin_loader, "load_lockfile", lambda: lockfile)
-
-    registry = NodeRegistry()
-
-    def reload_pack() -> None:
-        plugin_loader.purge_plugin_modules("stats")
-        plugin_loader.install_plugin_finder(
-            plugin_loader.plugins_builtin_root(), user_root, lockfile
-        )
-        registry.clear()
-        registry.discover(pack / "nodes", "cdui_plugins.stats.nodes", force_reload=True)
-
-    reload_pack()
-    describe = registry.get("stats:Stats-Describe")
-    before = describe().execute({"table": torch.zeros((3, 1))}, {})
-    assert before["row_labels"][0] == "count"
-
-    # The edit: rename the first statistic. Small, but only a genuine re-import
-    # of the changed file can make it visible.
-    source = pack / "nodes" / "stats_describe_node.py"
-    source.write_text(
-        source.read_text(encoding="utf-8").replace(
-            '["count", "mean", "std", "min"]', '["N_ROWS", "mean", "std", "min"]'
-        ),
+    manifest = pack / "cdui.plugin.toml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8").replace('id              = "stats"',
+                                                     f'id              = "{plugin_id}"'),
         encoding="utf-8",
     )
 
-    reload_pack()
-    after = registry.get("stats:Stats-Describe")
-    assert after is not describe, "reload must hand back a freshly imported class"
-    assert after().execute({"table": torch.zeros((3, 1))}, {})["row_labels"][0] == "N_ROWS"
-    assert len(registry.nodes) == 8, "an edit must not duplicate or drop nodes"
+    lockfile = {
+        "schema": 1,
+        "plugins": {plugin_id: {"source_kind": "user", "enabled": True}},
+    }
+    registry = NodeRegistry()
+    package = f"cdui_plugins.{plugin_id}.nodes"
+
+    def reload_pack() -> int:
+        """The plugin half of rediscover_all, verbatim."""
+        pairs = plugin_loader.install_plugin_finder(
+            plugin_loader.plugins_builtin_root(), user_root, lockfile
+        )
+        registry.clear()
+        return sum(
+            registry.discover(nodes_dir, pkg, force_reload=True)
+            for nodes_dir, pkg in pairs
+        )
+
+    try:
+        assert reload_pack() == 8
+        describe = registry.get(f"{plugin_id}:Stats-Describe")
+        assert describe().execute({"table": torch.zeros((3, 1))}, {})["row_labels"][0] == "count"
+
+        # The edit: rename the first statistic. Small, but only a genuine
+        # re-read of the changed file can make it visible.
+        source = pack / "nodes" / "stats_describe_node.py"
+        source.write_text(
+            source.read_text(encoding="utf-8").replace(
+                '["count", "mean", "std", "min"]', '["N_ROWS", "mean", "std", "min"]'
+            ),
+            encoding="utf-8",
+        )
+
+        assert reload_pack() == 8, "an edit must not duplicate or drop nodes"
+        after = registry.get(f"{plugin_id}:Stats-Describe")
+        assert after is not describe, "reload must hand back a freshly imported class"
+        assert after().execute({"table": torch.zeros((3, 1))}, {})["row_labels"][0] == "N_ROWS"
+    finally:
+        # The only global state this test created. The real `stats` namespace
+        # conftest installed is untouched either way.
+        plugin_loader.purge_plugin_modules(plugin_id)
+        sys.modules.pop(f"cdui_plugins.{plugin_id}", None)
 
 
 def test_node_types_are_namespaced_so_saved_graphs_are_unambiguous(

--- a/backend/tests/test_stats_pack.py
+++ b/backend/tests/test_stats_pack.py
@@ -12,12 +12,14 @@ import argparse
 import asyncio
 import json
 import os
+import shutil
 from pathlib import Path
 from textwrap import dedent
 
 import pandas as pd
 import plugins as plugin_cli
 import pytest
+import torch
 
 from app.core import plugin_loader
 from app.core.graph_engine import execute_graph
@@ -42,9 +44,12 @@ NODE_NAMES = [
 
 
 def _pack_sources() -> list[Path]:
-    return sorted(
-        p for p in _PACK_DIR.rglob("*.py") if "__pycache__" not in p.parts
-    )
+    found = sorted(p for p in _PACK_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+    # A parametrize over an empty list collects zero tests and reports success,
+    # so a moved or renamed pack directory would turn the security gate into a
+    # no-op that still shows green. Fail at import instead.
+    assert found, f"no Python sources found under {_PACK_DIR} — the AST gate would be a no-op"
+    return found
 
 
 @pytest.fixture
@@ -126,8 +131,8 @@ def test_an_installed_pack_exposes_all_eight_nodes(isolated_lockfile):
     assert sorted(registry.nodes) == [f"stats:{name}" for name in NODE_NAMES]
 
 
-def test_hot_reload_re_registers_every_node(isolated_lockfile):
-    """`cdui plugin reload` rediscovers with force_reload — twice must be stable."""
+def test_rediscovery_does_not_duplicate_or_drop_nodes(isolated_lockfile):
+    """Discovering twice is stable — no duplicate keys, no losses."""
     assert _install() == 0
     nodes_dir = _PACK_DIR / "nodes"
     package = "cdui_plugins.stats.nodes"
@@ -137,6 +142,58 @@ def test_hot_reload_re_registers_every_node(isolated_lockfile):
     registry.clear()
     assert registry.discover(nodes_dir, package, force_reload=True) == 8
     assert sorted(registry.nodes) == [f"stats:{name}" for name in NODE_NAMES]
+
+
+def test_hot_reload_picks_up_an_edit_to_a_node_file(tmp_path, monkeypatch):
+    """The acceptance criterion, exercised the way a plugin author lives it.
+
+    Copies the pack to a temp dir, runs a node, EDITS the source, reloads
+    through ``rediscover_all`` — the same call ``POST /api/plugins/reload``
+    makes — and re-runs. Discovering a pristine pack twice would pass even if
+    reload could not pick up a change, which is the only thing anyone actually
+    wants from it.
+    """
+    user_root = tmp_path / "userdata" / "plugins"
+    pack = user_root / "stats"
+    shutil.copytree(_PACK_DIR, pack)
+    monkeypatch.setattr(plugin_loader, "plugins_user_root", lambda: user_root)
+
+    lockfile = {
+        "schema": 1,
+        "plugins": {"stats": {"source_kind": "user", "source": "stats", "enabled": True}},
+    }
+    monkeypatch.setattr(plugin_loader, "load_lockfile", lambda: lockfile)
+
+    registry = NodeRegistry()
+
+    def reload_pack() -> None:
+        plugin_loader.purge_plugin_modules("stats")
+        plugin_loader.install_plugin_finder(
+            plugin_loader.plugins_builtin_root(), user_root, lockfile
+        )
+        registry.clear()
+        registry.discover(pack / "nodes", "cdui_plugins.stats.nodes", force_reload=True)
+
+    reload_pack()
+    describe = registry.get("stats:Stats-Describe")
+    before = describe().execute({"table": torch.zeros((3, 1))}, {})
+    assert before["row_labels"][0] == "count"
+
+    # The edit: rename the first statistic. Small, but only a genuine re-import
+    # of the changed file can make it visible.
+    source = pack / "nodes" / "stats_describe_node.py"
+    source.write_text(
+        source.read_text(encoding="utf-8").replace(
+            '["count", "mean", "std", "min"]', '["N_ROWS", "mean", "std", "min"]'
+        ),
+        encoding="utf-8",
+    )
+
+    reload_pack()
+    after = registry.get("stats:Stats-Describe")
+    assert after is not describe, "reload must hand back a freshly imported class"
+    assert after().execute({"table": torch.zeros((3, 1))}, {})["row_labels"][0] == "N_ROWS"
+    assert len(registry.nodes) == 8, "an edit must not duplicate or drop nodes"
 
 
 def test_node_types_are_namespaced_so_saved_graphs_are_unambiguous(

--- a/backend/tests/test_stats_percentile_node.py
+++ b/backend/tests/test_stats_percentile_node.py
@@ -1,0 +1,118 @@
+"""Stats-Percentile: numpy parity for each axis, and NaN-skipping semantics."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from cdui_plugins.stats.nodes.stats_percentile_node import StatsPercentileNode
+
+
+def _run(tensor, params=None, columns=None):
+    inputs = {"tensor": tensor}
+    if columns is not None:
+        inputs["columns"] = columns
+    return StatsPercentileNode().execute(inputs, params or {})
+
+
+def test_node_metadata():
+    assert StatsPercentileNode.NODE_NAME == "Stats-Percentile"
+    assert [p.name for p in StatsPercentileNode.define_outputs()] == [
+        "percentiles",
+        "columns",
+        "row_labels",
+    ]
+
+
+def test_axis_all_matches_numpy_percentile():
+    data = np.array([3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0])
+    result = _run(torch.tensor(data), {"q": "10,50,90"})
+
+    assert result["row_labels"] == ["10%", "50%", "90%"]
+    assert result["columns"] == ["all"]
+    assert result["percentiles"].shape == (3,)
+    expected = np.percentile(data, [10, 50, 90])
+    assert result["percentiles"].tolist() == pytest.approx(expected, rel=1e-6)
+
+
+def test_axis_columns_matches_numpy_per_column():
+    data = np.arange(24, dtype=np.float64).reshape(8, 3)
+    result = _run(
+        torch.tensor(data), {"q": "25,75", "axis": "columns"}, columns=["a", "b", "c"]
+    )
+
+    assert result["columns"] == ["a", "b", "c"]
+    assert result["percentiles"].shape == (2, 3)
+    expected = np.percentile(data, [25, 75], axis=0)
+    assert result["percentiles"].numpy() == pytest.approx(expected, rel=1e-6)
+
+
+def test_axis_rows_matches_numpy_per_row():
+    data = np.arange(12, dtype=np.float64).reshape(3, 4)
+    result = _run(torch.tensor(data), {"q": "50", "axis": "rows"})
+
+    assert result["columns"] == ["r0", "r1", "r2"]
+    expected = np.percentile(data, [50], axis=1)
+    assert result["percentiles"].numpy() == pytest.approx(expected, rel=1e-6)
+
+
+def test_interpolation_is_linear_not_nearest():
+    # Median of [1, 2, 3, 4] is 2.5 under linear interpolation, 2 or 3 under
+    # a nearest-rank rule — the single clearest way to tell them apart.
+    result = _run(torch.tensor([1.0, 2.0, 3.0, 4.0]), {"q": "50"})
+    assert result["percentiles"].tolist() == pytest.approx([2.5])
+
+
+def test_nan_is_skipped_matching_nanpercentile_not_percentile():
+    data = np.array([1.0, float("nan"), 3.0, 5.0])
+    result = _run(torch.tensor(data), {"q": "50"})
+
+    assert result["percentiles"].tolist() == pytest.approx(
+        [float(np.nanpercentile(data, 50))]
+    )
+    # np.percentile itself would propagate the NaN; the node deliberately does not.
+    assert math.isnan(float(np.percentile(data, 50)))
+
+
+def test_percentiles_are_sorted_and_deduplicated():
+    result = _run(torch.arange(10, dtype=torch.float32), {"q": "90,10,10"})
+    assert result["row_labels"] == ["10%", "90%"]
+
+
+def test_fractional_percentiles_keep_their_label():
+    result = _run(torch.arange(1000, dtype=torch.float32), {"q": "2.5,99.9"})
+    assert result["row_labels"] == ["2.5%", "99.9%"]
+
+
+# ── boundaries ───────────────────────────────────────────────────────────────
+
+def test_an_all_nan_series_reports_nan_without_warning():
+    result = _run(torch.tensor([float("nan"), float("nan")]), {"q": "50"})
+    assert math.isnan(result["percentiles"].tolist()[0])
+
+
+def test_a_single_value_is_its_own_every_percentile():
+    result = _run(torch.tensor([7.0]), {"q": "0,50,100"})
+    assert result["percentiles"].tolist() == pytest.approx([7.0, 7.0, 7.0])
+
+
+def test_empty_q_is_rejected_rather_than_returning_an_empty_tensor():
+    with pytest.raises(ValueError, match="`q` is empty"):
+        _run(torch.zeros(4), {"q": " "})
+
+
+def test_unknown_axis_is_rejected():
+    with pytest.raises(ValueError, match="unknown axis"):
+        _run(torch.zeros(4), {"axis": "sideways"})
+
+
+def test_missing_input_is_a_clear_error():
+    with pytest.raises(ValueError, match="requires a `tensor` input"):
+        StatsPercentileNode().execute({}, {})
+
+
+def test_output_is_float32():
+    assert _run(torch.zeros(4))["percentiles"].dtype == torch.float32

--- a/backend/tests/test_stats_views_node.py
+++ b/backend/tests/test_stats_views_node.py
@@ -1,0 +1,259 @@
+"""Stats-TableView and Stats-ChartView — the pack's two display nodes."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+
+from cdui_plugins.stats.nodes.stats_chart_view_node import (
+    StatsChartViewNode,
+    convert_chart,
+)
+from cdui_plugins.stats.nodes.stats_table_view_node import StatsTableViewNode
+
+
+def _table_view(table, params=None, **inputs):
+    return StatsTableViewNode().execute({"table": table, **inputs}, params or {})
+
+
+def _chart_view(params=None, **inputs):
+    return StatsChartViewNode().execute(dict(inputs), params or {})
+
+
+# ── Stats-TableView ──────────────────────────────────────────────────────────
+
+def test_table_view_metadata():
+    assert StatsTableViewNode.NODE_NAME == "Stats-TableView"
+    assert [p.name for p in StatsTableViewNode.define_outputs()] == ["text"]
+
+
+def test_table_view_emits_the_log_key_so_it_renders_as_a_text_entry():
+    """`__log__` is what the #117 output_kind channel turns into a text entry."""
+    result = _table_view(torch.tensor([[1.0]]))
+    assert result["__log__"] == result["text"]
+
+
+def test_table_view_renders_headers_row_labels_and_aligned_values():
+    result = _table_view(
+        torch.tensor([[1.0, 22.5], [333.0, 4.0]]),
+        columns=["a", "bb"],
+        row_labels=["first", "second"],
+    )
+    lines = result["text"].splitlines()
+    assert lines[0].split() == ["a", "bb"]
+    assert lines[1].split() == ["first", "1", "22.5000"]
+    assert lines[2].split() == ["second", "333", "4"]
+    # Right-aligned on the widest cell, so the numbers form a column.
+    assert len(lines[1]) == len(lines[2])
+
+
+def test_table_view_prints_integers_without_a_decimal_tail():
+    assert "150" in _table_view(torch.tensor([[150.0]]))["text"]
+    assert "150.0000" not in _table_view(torch.tensor([[150.0]]))["text"]
+
+
+def test_table_view_honours_precision():
+    text = _table_view(torch.tensor([[1.23456]]), {"precision": 2})["text"]
+    assert "1.23" in text and "1.2346" not in text
+
+
+def test_table_view_truncates_and_says_how_many_rows_it_left_out():
+    text = _table_view(torch.zeros((10, 1)), {"max_rows": 3})["text"]
+    assert "... 7 more row(s) of 10" in text
+    assert len(text.splitlines()) == 5  # header + 3 rows + the notice
+
+
+def test_max_rows_zero_shows_every_row():
+    text = _table_view(torch.zeros((10, 1)), {"max_rows": 0})["text"]
+    assert "more row(s)" not in text
+    assert len(text.splitlines()) == 11
+
+
+def test_table_view_title_is_printed_above_the_table():
+    text = _table_view(torch.tensor([[1.0]]), {"title": "Summary"})["text"]
+    assert text.splitlines()[0] == "Summary"
+
+
+def test_table_view_generates_missing_labels():
+    text = _table_view(torch.zeros((2, 2)))["text"]
+    assert "c0" in text and "c1" in text
+    assert text.splitlines()[1].startswith("0")
+
+
+def test_table_view_renders_nan_and_inf_readably():
+    text = _table_view(torch.tensor([[float("nan"), float("inf"), -float("inf")]]))["text"]
+    assert "NaN" in text and "inf" in text and "-inf" in text
+
+
+def test_table_view_rejects_a_missing_table():
+    with pytest.raises(ValueError, match="requires a `table` input"):
+        StatsTableViewNode().execute({}, {})
+
+
+# ── Stats-ChartView ──────────────────────────────────────────────────────────
+
+def test_chart_view_metadata():
+    assert StatsChartViewNode.NODE_NAME == "Stats-ChartView"
+    outputs = StatsChartViewNode.define_outputs()
+    assert [p.name for p in outputs] == ["chart"]
+    assert outputs[0].media == "chart", "the output must declare the chart media kind"
+
+
+def test_chart_view_passes_a_payload_through_unchanged_on_auto():
+    payload = {"kind": "heatmap", "matrix": [[1.0]], "title": "T"}
+    assert _chart_view(chart=payload)["chart"] == payload
+
+
+def test_chart_view_retitles_without_touching_the_data():
+    payload = {"kind": "bar", "bars": [{"label": "a", "value": 1.0}], "title": "old"}
+    result = _chart_view({"title": "new"}, chart=payload)["chart"]
+    assert result["title"] == "new"
+    assert result["bars"] == payload["bars"]
+    assert payload["title"] == "old", "the incoming payload must not be mutated"
+
+
+def test_chart_view_charts_a_table_with_row_labels_as_bars():
+    """The CSV -> GroupBy -> Chart demo shape."""
+    result = _chart_view(
+        table=torch.tensor([[1.0], [2.0], [3.0]]),
+        columns=["petal"],
+        row_labels=["setosa", "versicolor", "virginica"],
+    )["chart"]
+    assert result["kind"] == "bar"
+    assert [b["label"] for b in result["bars"]] == ["setosa", "versicolor", "virginica"]
+    assert [b["value"] for b in result["bars"]] == [1.0, 2.0, 3.0]
+
+
+def test_chart_view_charts_a_table_without_row_labels_as_lines():
+    result = _chart_view(table=torch.tensor([[1.0, 4.0], [2.0, 5.0]]))["chart"]
+    assert result["kind"] == "line"
+    assert [s["name"] for s in result["series"]] == ["c0", "c1"]
+    assert result["series"][0]["points"] == [[0.0, 1.0], [1.0, 2.0]]
+
+
+def test_a_multi_column_bar_chart_says_which_column_it_drew():
+    result = _chart_view(
+        {"kind": "bar"},
+        table=torch.tensor([[1.0, 2.0]]),
+        columns=["a", "b"],
+        row_labels=["g"],
+    )["chart"]
+    assert result["bars"][0]["value"] == 1.0
+    assert "'a'" in result["note"]
+
+
+def test_columns_filter_picks_the_charted_column():
+    result = _chart_view(
+        {"kind": "bar", "columns_filter": "b"},
+        table=torch.tensor([[1.0, 2.0]]),
+        columns=["a", "b"],
+        row_labels=["g"],
+    )["chart"]
+    assert result["bars"][0]["value"] == 2.0
+    assert "note" not in result
+
+
+def test_scatter_from_a_table_uses_the_first_two_columns():
+    result = _chart_view(
+        {"kind": "scatter"},
+        table=torch.tensor([[1.0, 10.0], [2.0, 20.0]]),
+        columns=["x", "y"],
+    )["chart"]
+    assert result["kind"] == "scatter"
+    assert result["points"] == [
+        {"x": 1.0, "y": 10.0, "label": "0"},
+        {"x": 2.0, "y": 20.0, "label": "1"},
+    ]
+    assert (result["x_label"], result["y_label"]) == ("x", "y")
+
+
+def test_heatmap_from_a_table_keeps_both_axes_labelled():
+    result = _chart_view(
+        {"kind": "heatmap"},
+        table=torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+        columns=["p", "q"],
+        row_labels=["u", "v"],
+    )["chart"]
+    assert result["matrix"] == [[1.0, 2.0], [3.0, 4.0]]
+    assert result["row_labels"] == ["u", "v"]
+    assert result["col_labels"] == ["p", "q"]
+
+
+def test_chart_view_rejects_a_scatter_of_one_column():
+    with pytest.raises(ValueError, match="needs two columns"):
+        _chart_view({"kind": "scatter"}, table=torch.tensor([[1.0], [2.0]]))
+
+
+def test_chart_view_needs_one_of_its_two_inputs():
+    with pytest.raises(ValueError, match="connect either a `chart` payload or a `table`"):
+        _chart_view()
+
+
+def test_a_dict_that_is_not_a_chart_payload_is_rejected():
+    with pytest.raises(ValueError, match="carries no `kind`"):
+        _chart_view(chart={"bars": []})
+
+
+def test_unknown_kind_is_rejected():
+    with pytest.raises(ValueError, match="unknown kind"):
+        _chart_view({"kind": "pie"}, table=torch.zeros((2, 2)))
+
+
+def test_unknown_columns_filter_is_rejected():
+    with pytest.raises(ValueError, match="unknown column"):
+        _chart_view({"columns_filter": "nope"}, table=torch.zeros((2, 1)))
+
+
+# ── convert_chart ────────────────────────────────────────────────────────────
+
+BARS = {"kind": "bar", "title": "T", "bars": [
+    {"label": "a", "value": 1.0}, {"label": "b", "value": 2.0},
+]}
+
+
+def test_converting_to_the_same_kind_is_a_no_op():
+    assert convert_chart(BARS, "bar") is BARS
+
+
+def test_bars_become_a_single_line_series_indexed_by_position():
+    line = convert_chart(BARS, "line")
+    assert line["kind"] == "line"
+    assert line["series"][0]["points"] == [[0.0, 1.0], [1.0, 2.0]]
+    assert line["title"] == "T"
+
+
+def test_bars_become_scatter_points_keeping_their_labels():
+    scatter = convert_chart(BARS, "scatter")
+    assert scatter["kind"] == "scatter"
+    assert [p["label"] for p in scatter["points"]] == ["a", "b"]
+
+
+def test_a_line_becomes_bars_labelled_by_x():
+    line = {"kind": "line", "series": [{"name": "s", "points": [[3.0, 9.0]]}]}
+    bars = convert_chart(line, "bar")
+    assert bars["bars"] == [{"label": "s", "value": 9.0}]
+
+
+def test_a_heatmap_refuses_to_become_a_bar_chart_and_says_so():
+    heatmap = {"kind": "heatmap", "matrix": [[1.0]]}
+    result = convert_chart(heatmap, "bar")
+    assert result["kind"] == "heatmap"
+    assert "cannot redraw" in result["note"]
+
+
+def test_nothing_can_become_a_heatmap():
+    result = convert_chart(BARS, "heatmap")
+    assert result["kind"] == "bar"
+    assert "cannot redraw" in result["note"]
+
+
+def test_an_existing_note_survives_a_conversion():
+    noted = dict(BARS, note="sampled")
+    assert convert_chart(noted, "line")["note"].startswith("sampled")
+
+
+def test_every_produced_spec_is_json_safe():
+    for kind in ("bar", "line", "scatter"):
+        json.dumps(convert_chart(BARS, kind), allow_nan=False)

--- a/docs/docs/advanced/custom-nodes.md
+++ b/docs/docs/advanced/custom-nodes.md
@@ -75,6 +75,33 @@ def define_outputs(cls):
 
 Declaring is mandatory — nothing inspects your values to work out what they are. An undeclared port stays plain data no matter how much it looks like an image, which is what keeps a long text output (an LLM answer, a token dump) from being rendered as a broken picture.
 
+## Drawing a chart in the results panel
+
+`media=MEDIA_CHART` is the same mechanism for plots. The port's value is a JSON **chart spec** — a plain dict — which the editor draws with its own SVG components, so the picture is themed, hoverable, and sharp at any zoom instead of a fixed-size PNG:
+
+```python
+from app.core.node_base import MEDIA_CHART, BaseNode, DataType, PortDefinition
+
+@classmethod
+def define_outputs(cls):
+    return [
+        PortDefinition(name="chart", data_type=DataType.ANY, media=MEDIA_CHART),
+    ]
+
+def execute(self, inputs, params, progress_callback=None, *, context=None):
+    return {"chart": {
+        "kind": "bar",                       # bar | line | scatter | heatmap
+        "title": "Mean petal length by species",
+        "bars": [{"label": "setosa", "value": 1.462}],
+    }}
+```
+
+Every number in a spec must be a finite, plain Python `float` or `int`: run events are serialised with `allow_nan=False`, and a `numpy.float32` is not JSON-serialisable at all. Keep specs small — a `node_status` payload over 128 KB is replaced by an elision marker. The full per-kind payload reference lives in the [stats pack's README](https://github.com/CodefyUI/CodefyUI/blob/main/plugins/stats/README.md), which is the reference implementation.
+
+### Your own media kind
+
+Neither kind is special-cased. The resolver keys on whatever string a port declares, and any port value that is a non-empty dict is shipped through untouched, so a pack declaring `media="waveform"` already arrives in the browser as `{"output_kind": "waveform", ...}`. Only *rendering* it needs a frontend change; an editor that does not know a kind ignores it rather than breaking.
+
 :::tip
 Need to package existing nodes rather than write new behavior? Use a **[preset](./presets)**. Want to share nodes with others as an installable bundle? Build a **[plugin pack](./plugins)**.
 :::

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -24,6 +24,9 @@ cdui plugin uninstall deep
 | `foundations` | I1 Data Representation · I2 Classical ML | Edu-ColumnStats, Edu-KNN, Edu-LinearRegression, Edu-LogisticRegression, Edu-TokenEmbedding, Edu-FFN |
 | `deep` | I3 Vision · I4 Sequences | Edu-CrossAttention, Edu-ResBlock, Edu-SelfAttention, Edu-MultiHeadAttention, Edu-Patchify |
 | `rl` | I5 Reinforcement Learning | Edu-PolicyGradient |
+| `stats` | — (any dataset) | Stats-Describe, Stats-GroupByAggregate, Stats-Histogram, Stats-Percentile, Stats-Correlation, Stats-ConfusionMatrix, Stats-TableView, Stats-ChartView |
+
+`stats` is the odd one out: not a textbook companion but a working reference for third-party pack authors. It is pure numpy + torch, passes the AST security gate with **no `[security]` overrides**, and its [README](https://github.com/CodefyUI/CodefyUI/blob/main/plugins/stats/README.md) is the normative write-up of the two contracts a data pack needs — how a table travels between ports, and how a `chart` output is declared and drawn.
 
 Each Edu node decomposes a single lesson concept into a chain of named steps that the [Teaching Inspector](/usage/teaching-inspector) renders one row at a time — `Edu-ColumnStats` shows the population-std formula as `sum → divide → deviations² → variance → sqrt`; `Edu-PolicyGradient` exposes `softmax → gather → log → baseline → loss`; `Edu-Patchify` makes `unfold → permute → flatten` visible. Switch on **Verbose mode** in the Settings popover to capture them.
 

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -19,7 +19,7 @@ cdui plugin uninstall deep
 
 ## What's available
 
-| Pack | Hands-on modules | Edu nodes |
+| Pack | Hands-on modules | Nodes |
 |------|------------------|-----------|
 | `foundations` | I1 Data Representation · I2 Classical ML | Edu-ColumnStats, Edu-KNN, Edu-LinearRegression, Edu-LogisticRegression, Edu-TokenEmbedding, Edu-FFN |
 | `deep` | I3 Vision · I4 Sequences | Edu-CrossAttention, Edu-ResBlock, Edu-SelfAttention, Edu-MultiHeadAttention, Edu-Patchify |

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/custom-nodes.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/custom-nodes.md
@@ -75,6 +75,33 @@ def define_outputs(cls):
 
 宣告是**必要的**——系統不會去檢查你的值長什麼樣子來猜它是不是圖片。沒有宣告的連接埠，不論多像圖片都仍然是一般資料。正是這一點，讓長文字輸出（LLM 的回答、token 傾印）不會被當成圖片、渲染成一張壞掉的圖。
 
+## 在執行結果面板畫圖表
+
+`media=MEDIA_CHART` 是同一套機制，用來畫圖表。連接埠的值是一份 JSON **圖表規格**（一個普通的 dict），由編輯器用自己的 SVG 元件繪製，因此圖表會套用主題、可以滑鼠停留查看數值，而且放大也不會糊掉——這些都是固定尺寸的 PNG 做不到的：
+
+```python
+from app.core.node_base import MEDIA_CHART, BaseNode, DataType, PortDefinition
+
+@classmethod
+def define_outputs(cls):
+    return [
+        PortDefinition(name="chart", data_type=DataType.ANY, media=MEDIA_CHART),
+    ]
+
+def execute(self, inputs, params, progress_callback=None, *, context=None):
+    return {"chart": {
+        "kind": "bar",                       # bar | line | scatter | heatmap
+        "title": "各品種的平均花瓣長度",
+        "bars": [{"label": "setosa", "value": 1.462}],
+    }}
+```
+
+規格裡的每個數字都必須是有限的、原生的 Python `float` 或 `int`：執行事件是以 `allow_nan=False` 序列化的，而 `numpy.float32` 根本無法被 JSON 序列化。規格也要小——`node_status` 訊息超過 128 KB 就會整份被省略標記取代。各種 `kind` 的完整欄位參考，請見 [stats 外掛包的 README](https://github.com/CodefyUI/CodefyUI/blob/main/plugins/stats/README.md)，那就是本機制的參考實作。
+
+### 自訂你自己的媒體種類
+
+這兩種 media 都沒有被特別寫死。解析器只認連接埠宣告的那個字串，而且只要連接埠的值是非空的 dict 就會原封不動送出。因此一個外掛包宣告 `media="waveform"`，瀏覽器端就已經會收到 `{"output_kind": "waveform", ...}`；只有*繪製*它才需要改前端。遇到不認識的種類時，編輯器會直接忽略，而不是壞掉。
+
 :::tip
 需要封裝既有節點而不是撰寫新行為嗎？使用**[預設模組](./presets)**。想以可安裝的套件與他人分享節點嗎？建立一個**[外掛包](./plugins)**。
 :::

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -24,6 +24,9 @@ cdui plugin uninstall deep
 | `foundations` | I1 Data Representation · I2 Classical ML | Edu-ColumnStats、Edu-KNN、Edu-LinearRegression、Edu-LogisticRegression、Edu-TokenEmbedding、Edu-FFN |
 | `deep` | I3 Vision · I4 Sequences | Edu-CrossAttention、Edu-ResBlock、Edu-SelfAttention、Edu-MultiHeadAttention、Edu-Patchify |
 | `rl` | I5 Reinforcement Learning | Edu-PolicyGradient |
+| `stats` | —（任何資料集） | Stats-Describe, Stats-GroupByAggregate, Stats-Histogram, Stats-Percentile, Stats-Correlation, Stats-ConfusionMatrix, Stats-TableView, Stats-ChartView |
+
+`stats` 是這裡的例外：它不是教科書的配套，而是給第三方外掛作者的實作範例。它只用 numpy 與 torch，通過 AST 安全檢查且**不需要任何 `[security]` 例外**；它的 [README](https://github.com/CodefyUI/CodefyUI/blob/main/plugins/stats/README.md) 正式記載了資料類外掛需要的兩份契約——表格如何在連接埠之間傳遞，以及 `chart` 輸出如何宣告與繪製。
 
 每個 Edu 節點都把單一課程概念分解成一連串具名步驟，由 [Teaching Inspector](/usage/teaching-inspector) 一次渲染一列——`Edu-ColumnStats` 將母體標準差公式呈現為 `sum → divide → deviations² → variance → sqrt`；`Edu-PolicyGradient` 暴露 `softmax → gather → log → baseline → loss`；`Edu-Patchify` 讓 `unfold → permute → flatten` 變得可見。在 Settings popover 中開啟 **Verbose mode** 即可擷取它們。
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -19,12 +19,12 @@ cdui plugin uninstall deep
 
 ## 有哪些可用的外掛包
 
-| 外掛包 | 動手實作模組 | Edu 節點 |
+| 外掛包 | 動手實作模組 | 節點 |
 |------|------------------|-----------|
 | `foundations` | I1 Data Representation · I2 Classical ML | Edu-ColumnStats、Edu-KNN、Edu-LinearRegression、Edu-LogisticRegression、Edu-TokenEmbedding、Edu-FFN |
 | `deep` | I3 Vision · I4 Sequences | Edu-CrossAttention、Edu-ResBlock、Edu-SelfAttention、Edu-MultiHeadAttention、Edu-Patchify |
 | `rl` | I5 Reinforcement Learning | Edu-PolicyGradient |
-| `stats` | —（任何資料集） | Stats-Describe, Stats-GroupByAggregate, Stats-Histogram, Stats-Percentile, Stats-Correlation, Stats-ConfusionMatrix, Stats-TableView, Stats-ChartView |
+| `stats` | —（任何資料集） | Stats-Describe、Stats-GroupByAggregate、Stats-Histogram、Stats-Percentile、Stats-Correlation、Stats-ConfusionMatrix、Stats-TableView、Stats-ChartView |
 
 `stats` 是這裡的例外：它不是教科書的配套，而是給第三方外掛作者的實作範例。它只用 numpy 與 torch，通過 AST 安全檢查且**不需要任何 `[security]` 例外**；它的 [README](https://github.com/CodefyUI/CodefyUI/blob/main/plugins/stats/README.md) 正式記載了資料類外掛需要的兩份契約——表格如何在連接埠之間傳遞，以及 `chart` 輸出如何宣告與繪製。
 

--- a/frontend/src/components/NodeDetailModal/CapturesTab.tsx
+++ b/frontend/src/components/NodeDetailModal/CapturesTab.tsx
@@ -4,8 +4,13 @@ import type { OutputSummary } from '../../types';
 import { PortGroup } from '../InspectorPanel/PortGroup';
 import { resolveSingleNodePorts, usePortFetches } from '../InspectorPanel/portCaptures';
 import { getPortColor } from '../../utils';
+import { useTabStore, type LogEntry } from '../../store/tabStore';
+import { ChartView } from '../shared/ChartView';
 import type { NodeDetailTabContext } from './tabs';
 import styles from './NodeDetailModal.module.css';
+
+/** Stable empty reference — a fresh `[]` from a zustand selector re-renders forever. */
+const NO_LOGS: LogEntry[] = [];
 
 /**
  * Condense one streamed port summary into a single readable line —
@@ -51,6 +56,21 @@ export function CapturesTab({
 
   const fetches = usePortFetches(ctx.runId, ports);
 
+  // Charts this node emitted during the run (#130). They arrive on the
+  // node_status stream rather than through the captures API, so they are read
+  // from the tab's log rather than fetched — which also means they survive
+  // with Record outputs off, when the port fetches below have nothing to show.
+  const logs = useTabStore(
+    (s) => s.tabs.find((t) => t.id === s.activeTabId)?.logs ?? NO_LOGS,
+  );
+  const charts = useMemo(
+    () =>
+      kind === 'output'
+        ? logs.filter((e) => e.kind === 'chart' && e.nodeId === ctx.nodeId && e.chart?.kind)
+        : [],
+    [kind, logs, ctx.nodeId],
+  );
+
   const title =
     kind === 'input'
       ? t('nodeDetail.inputs.title', { count: ports.length })
@@ -58,9 +78,21 @@ export function CapturesTab({
   const emptyText =
     kind === 'input' ? t('nodeDetail.inputs.empty') : t('nodeDetail.outputs.empty');
 
+  const chartBlock = charts.length > 0 && (
+    <div className={styles.chartBlock}>
+      <div className={styles.chartBlockTitle}>
+        {t('nodeDetail.captures.charts', { count: charts.length })}
+      </div>
+      {charts.map((entry, i) => (
+        <ChartView key={`${entry.timestamp}-${i}`} chart={entry.chart!} width={380} />
+      ))}
+    </div>
+  );
+
   if (ctx.runId === null) {
     return (
       <div className={styles.tabBody}>
+        {chartBlock}
         <div className={styles.emptyState}>
           <div className={styles.emptyIcon}>▶</div>
           <div>{t('nodeDetail.captures.notRun')}</div>
@@ -96,6 +128,7 @@ export function CapturesTab({
 
   return (
     <div className={styles.tabBody}>
+      {chartBlock}
       {!ctx.recordOutputs && (
         <div className={styles.warnHint}>{t('nodeDetail.captures.recordingOff')}</div>
       )}

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.module.css
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.module.css
@@ -376,6 +376,26 @@
   padding-top: 10px;
 }
 
+/* Charts a node emitted this run (#130), above its captured port values. */
+.chartBlock {
+  display: flex;
+  flex-direction: column;
+  /* Hug the chart instead of stretching to the panel width — a flex column
+     stretches its children by default, which left the plot stranded against
+     the right edge of a full-width card. */
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.chartBlockTitle {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  color: #64748b;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .summaryTitle {
   font-size: 0.6875rem;
   font-weight: 700;

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
@@ -1340,6 +1340,101 @@ describe('NodeDetailModal — capture parity with InspectorPanel', () => {
 
 // ── Tab registry (container contract for #129 / #131) ────────────────────────
 
+// ── #130: charts a node emitted, on its Outputs tab ──────────────────────────
+// A chart rides the node_status stream rather than the captures API, so the
+// tab reads it from the tab's log. That is also why it shows with Record
+// outputs off, when the port fetches below it have nothing.
+
+describe('NodeDetailModal — chart outputs (#130)', () => {
+  function chartLog(nodeId: string, chart: Record<string, unknown>) {
+    return {
+      timestamp: 1_700_000_000_000,
+      nodeId,
+      message: '',
+      type: 'info' as const,
+      kind: 'chart' as const,
+      chart: chart as any,
+    };
+  }
+
+  const CONFUSION = {
+    kind: 'heatmap',
+    title: 'Confusion matrix',
+    matrix: [[13, 0], [1, 12]],
+    row_labels: ['setosa', 'versicolor'],
+    col_labels: ['setosa', 'versicolor'],
+    vmin: 0,
+    vmax: 13,
+  };
+
+  it('renders a confusion matrix as a heatmap on the Outputs tab', async () => {
+    seedTab({
+      nodes: [node('n1', { definition: outputsDef(['matrix']) })],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [chartLog('n1', CONFUSION)],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+
+    expect(screen.getByText('Charts (1)')).toBeInTheDocument();
+    // The modal renders through a portal, so query the document, not the root.
+    expect(document.querySelector('[data-chart-kind="heatmap"]')).toBeInTheDocument();
+    expect(document.querySelectorAll('rect[data-i]')).toHaveLength(4);
+    expect(screen.getByText('Confusion matrix')).toBeInTheDocument();
+    // The captured ports still render underneath.
+    await waitFor(() => expect(screen.getByText('shape [2, 2]')).toBeInTheDocument());
+  });
+
+  it('shows only the charts belonging to the node being inspected', () => {
+    seedTab({
+      nodes: [node('n1'), node('n2')],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [
+        chartLog('n1', { kind: 'bar', title: 'Mine', bars: [] }),
+        chartLog('n2', { kind: 'bar', title: 'Someone else', bars: [] }),
+      ],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+
+    expect(screen.getByText('Mine')).toBeInTheDocument();
+    expect(screen.queryByText('Someone else')).toBeNull();
+  });
+
+  it('keeps charts off the Inputs tab', () => {
+    seedTab({
+      nodes: [node('n1')],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [chartLog('n1', CONFUSION)],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Inputs' }));
+    expect(screen.queryByText('Charts (1)')).toBeNull();
+  });
+
+  it('shows the chart before a run has captured anything', () => {
+    seedTab({
+      nodes: [node('n1')],
+      nodeDetailNodeId: 'n1',
+      lastRunId: null,
+      logs: [chartLog('n1', CONFUSION)],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+    expect(document.querySelector('[data-chart-kind="heatmap"]')).toBeInTheDocument();
+  });
+
+  it('renders no chart block when the node emitted none', () => {
+    seedTab({ nodes: [node('n1')], nodeDetailNodeId: 'n1', lastRunId: 'run1', logs: [] });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+    expect(screen.queryByText(/^Charts \(/)).toBeNull();
+  });
+});
+
 describe('NodeDetailModal — tab registry', () => {
   function ctx(over: Partial<NodeDetailTabContext> = {}): NodeDetailTabContext {
     const n = node('n1');

--- a/frontend/src/components/ResultsPanel/ResultsPanel.module.css
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.module.css
@@ -218,6 +218,14 @@
   margin-bottom: 2px;
 }
 
+/* Chart output entry (#130). The card brings its own frame, so this only has
+   to keep it from stretching the log row. */
+.logChart {
+  margin-top: 2px;
+  margin-bottom: 2px;
+  max-width: 100%;
+}
+
 /* Log message text */
 .logMessage {
   font-size: 0.8125rem;

--- a/frontend/src/components/ResultsPanel/ResultsPanel.test.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.test.tsx
@@ -529,6 +529,72 @@ describe('ResultsPanel — structured output kinds (#117)', () => {
   });
 });
 
+// ── #130: chart output entries ───────────────────────────────────────────
+// A node declaring `media=MEDIA_CHART` ships a JSON spec, and the panel draws
+// it with the app's own SVG plots rather than showing a server-rendered PNG.
+
+describe('ResultsPanel — chart output entries (#130)', () => {
+  function chartLog(chart: Record<string, unknown>): LogEntry {
+    return makeLog({ message: '', kind: 'chart', chart: chart as any });
+  }
+
+  it('draws a kind="chart" entry in the log', () => {
+    seedLogs([
+      chartLog({
+        kind: 'bar',
+        title: 'Mean petal length',
+        bars: [{ label: 'setosa', value: 1.46 }],
+      }),
+    ]);
+    const { container } = render(<ResultsPanel />);
+    expect(screen.getByText('Mean petal length')).toBeInTheDocument();
+    expect(container.querySelector('[data-chart-kind="bar"]')).toBeInTheDocument();
+    expect(container.querySelector('rect[data-label="setosa"]')).toBeInTheDocument();
+  });
+
+  it('renders a confusion matrix as a heatmap with its class labels', () => {
+    seedLogs([
+      chartLog({
+        kind: 'heatmap',
+        title: 'Confusion matrix',
+        matrix: [[13, 0], [1, 12]],
+        row_labels: ['setosa', 'versicolor'],
+        col_labels: ['setosa', 'versicolor'],
+        vmin: 0,
+        vmax: 13,
+      }),
+    ]);
+    const { container } = render(<ResultsPanel />);
+    expect(container.querySelector('[data-chart-kind="heatmap"]')).toBeInTheDocument();
+    expect(container.querySelectorAll('rect[data-i]')).toHaveLength(4);
+    expect(screen.getAllByText('setosa').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows a chart entry alongside the text a node emitted with it', () => {
+    seedLogs([
+      makeLog({ message: 'rendered table', kind: 'text' }),
+      chartLog({ kind: 'bar', bars: [{ label: 'a', value: 1 }] }),
+    ]);
+    const { container } = render(<ResultsPanel />);
+    expect(screen.getByText('rendered table')).toBeInTheDocument();
+    expect(container.querySelector('[data-chart-kind="bar"]')).toBeInTheDocument();
+  });
+
+  it('ignores a kind="chart" entry with no spec and falls back to the message', () => {
+    seedLogs([makeLog({ message: 'no payload', kind: 'chart' })]);
+    const { container } = render(<ResultsPanel />);
+    expect(container.querySelector('[data-chart-kind]')).not.toBeInTheDocument();
+    expect(screen.getByText('no payload')).toBeInTheDocument();
+  });
+
+  it('counts chart entries in the log tab badge like any other entry', () => {
+    seedLogs([chartLog({ kind: 'bar', bars: [] }), chartLog({ kind: 'bar', bars: [] })]);
+    render(<ResultsPanel />);
+    const logTabBtn = screen.getByText(t('results.title')).closest('button')!;
+    expect(within(logTabBtn).getByText('2')).toBeInTheDocument();
+  });
+});
+
 // ── #124: the Runs tab ───────────────────────────────────────────────────
 
 describe('ResultsPanel — Runs tab', () => {

--- a/frontend/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../../i18n';
 import { friendlyError } from '../../utils/errorMessages';
 import { LossChart } from './LossChart';
 import { RunsPanel } from './RunsPanel';
+import { ChartView } from '../shared/ChartView';
 import styles from './ResultsPanel.module.css';
 
 const MIN_HEIGHT = 80;
@@ -357,7 +358,9 @@ export function ResultsPanel() {
                         {String(entry.nodeId).slice(0, 8)}
                       </span>
                     )}
-                    {entry.kind === 'image' && entry.image?.data ? (
+                    {entry.kind === 'chart' && entry.chart?.kind ? (
+                      <ChartView chart={entry.chart} className={styles.logChart} />
+                    ) : entry.kind === 'image' && entry.image?.data ? (
                       <img
                         src={`data:image/${entry.image.format};base64,${entry.image.data}`}
                         alt="output"

--- a/frontend/src/components/shared/ChartView.module.css
+++ b/frontend/src/components/shared/ChartView.module.css
@@ -1,0 +1,58 @@
+/* Matches the shared-plot wrapper used by HistogramPlot and ScatterPlot, so a
+   chart output entry sits in the panel like every other plot in the app. */
+.wrapper {
+  display: inline-block;
+  max-width: 100%;
+  padding: 8px 10px 10px;
+  background: #161616;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+}
+
+.title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #ccc;
+  margin-bottom: 2px;
+}
+
+.note {
+  font-size: 10px;
+  font-style: italic;
+  color: #6b7280;
+  margin-bottom: 4px;
+}
+
+/* Wide charts scroll inside the card rather than widening the panel. */
+.body {
+  overflow-x: auto;
+  max-width: 100%;
+  /* Keep the plot against the card's leading edge; HeatmapPlot's own grid
+     otherwise centres itself in whatever width it is handed. */
+  display: flex;
+  justify-content: flex-start;
+}
+
+.axes {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 4px;
+  font-size: 9px;
+  color: #6b7280;
+}
+
+.axisY {
+  font-style: italic;
+}
+
+.axisX {
+  margin-left: auto;
+}
+
+.unknown {
+  padding: 12px 8px;
+  font-size: 11px;
+  font-style: italic;
+  color: #6b7280;
+}

--- a/frontend/src/components/shared/ChartView.test.tsx
+++ b/frontend/src/components/shared/ChartView.test.tsx
@@ -133,9 +133,43 @@ describe('ChartView', () => {
     ).toBeInTheDocument();
   });
 
-  it('treats a heatmap with no matrix as an unknown kind rather than an empty box', () => {
-    render(<ChartView chart={{ kind: 'heatmap' }} />);
-    expect(screen.getByText(/needs a newer editor/)).toBeInTheDocument();
+  // A known kind with a missing payload is a producer bug, not an old editor.
+  // Telling the reader to upgrade would send them to the wrong place.
+  it.each([
+    ['heatmap', { kind: 'heatmap' }],
+    ['bar', { kind: 'bar' }],
+    ['line', { kind: 'line' }],
+    ['scatter', { kind: 'scatter' }],
+  ])('reports a %s missing its payload as malformed, not as too new', (kind, chart) => {
+    render(<ChartView chart={chart as LogChartPayload} />);
+    expect(
+      screen.getByText(`This ${kind} chart arrived without its data`),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/needs a newer editor/)).toBeNull();
+  });
+
+  it('draws an empty-but-present payload rather than calling it malformed', () => {
+    // `bars: []` is a real answer ("nothing in range"), unlike a missing key.
+    render(<ChartView chart={{ kind: 'bar', bars: [] }} />);
+    expect(screen.queryByText(/arrived without its data/)).toBeNull();
+  });
+
+  it('captions the y axis of a line chart', () => {
+    // LossChart draws x itself but has no y caption, so the footer must carry
+    // it — otherwise every line chart silently loses its unit.
+    render(
+      <ChartView
+        chart={{
+          kind: 'line',
+          series: [{ name: 's', points: [[0, 1]] }],
+          x_label: 'step',
+          y_label: 'loss',
+        }}
+      />,
+    );
+    expect(screen.getByText('loss')).toBeInTheDocument();
+    // x is not repeated: LossChart already prints it under its own axis.
+    expect(screen.getAllByText('step')).toHaveLength(1);
   });
 
   it('renders an empty bar chart without crashing', () => {

--- a/frontend/src/components/shared/ChartView.test.tsx
+++ b/frontend/src/components/shared/ChartView.test.tsx
@@ -172,6 +172,20 @@ describe('ChartView', () => {
     expect(screen.getAllByText('step')).toHaveLength(1);
   });
 
+  it('omits the axis footer entirely when it would be empty', () => {
+    // A line chart with only x_label has nothing to put there, since x is
+    // suppressed — the row must not render as a bare strip of padding.
+    const { container } = render(
+      <ChartView
+        chart={{ kind: 'line', series: [{ name: 's', points: [[0, 1]] }], x_label: 'step' }}
+      />,
+    );
+    const footer = [...container.querySelectorAll('div')].find(
+      (d) => d.className.includes('axes'),
+    );
+    expect(footer).toBeUndefined();
+  });
+
   it('renders an empty bar chart without crashing', () => {
     const { container } = render(<ChartView chart={{ kind: 'bar', bars: [] }} />);
     expect(kindOf(container)).toBe('bar');

--- a/frontend/src/components/shared/ChartView.test.tsx
+++ b/frontend/src/components/shared/ChartView.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ChartView } from './ChartView';
+import { useI18n } from '../../i18n';
+import type { LogChartPayload } from '../../store/tabStore';
+
+beforeEach(() => {
+  useI18n.setState({ locale: 'en' });
+});
+
+const BAR: LogChartPayload = {
+  kind: 'bar',
+  title: 'Mean petal length by species',
+  x_label: 'species',
+  y_label: 'cm',
+  bars: [
+    { label: 'setosa', value: 1.46 },
+    { label: 'versicolor', value: 4.26 },
+    { label: 'virginica', value: 5.55 },
+  ],
+};
+
+function kindOf(container: HTMLElement): string | null {
+  return container.querySelector('[data-chart-kind]')?.getAttribute('data-chart-kind') ?? null;
+}
+
+describe('ChartView', () => {
+  it('renders a bar spec through the histogram plot, one bar per entry', () => {
+    const { container } = render(<ChartView chart={BAR} />);
+    expect(kindOf(container)).toBe('bar');
+    const bars = [...container.querySelectorAll('rect[data-count]')];
+    expect(bars.map((r) => r.getAttribute('data-label'))).toEqual([
+      'setosa',
+      'versicolor',
+      'virginica',
+    ]);
+    expect(bars.map((r) => r.getAttribute('data-count'))).toEqual(['1.46', '4.26', '5.55']);
+  });
+
+  it('shows the title, the axis captions and a note', () => {
+    render(<ChartView chart={{ ...BAR, note: '2 values excluded' }} />);
+    expect(screen.getByText('Mean petal length by species')).toBeInTheDocument();
+    expect(screen.getByText('2 values excluded')).toBeInTheDocument();
+    expect(screen.getByText('species')).toBeInTheDocument();
+    expect(screen.getByText('cm')).toBeInTheDocument();
+  });
+
+  it('renders a line spec as a polyline per series', () => {
+    const { container } = render(
+      <ChartView
+        chart={{
+          kind: 'line',
+          series: [
+            { name: 'a', points: [[0, 1], [1, 2]] },
+            { name: 'b', points: [[0, 3], [1, 4]] },
+          ],
+        }}
+      />,
+    );
+    expect(kindOf(container)).toBe('line');
+    expect(container.querySelectorAll('polyline')).toHaveLength(2);
+    expect(screen.getByText('a')).toBeInTheDocument();
+  });
+
+  it('names an unnamed line series so its colour and key stay stable', () => {
+    render(<ChartView chart={{ kind: 'line', series: [{ name: '', points: [[0, 1]] }] }} />);
+    expect(screen.getByText('series 1')).toBeInTheDocument();
+  });
+
+  it('renders a scatter spec as one dot per point', () => {
+    const { container } = render(
+      <ChartView
+        chart={{
+          kind: 'scatter',
+          points: [
+            { x: 1, y: 2, label: 'p' },
+            { x: 3, y: 4, label: 'q' },
+          ],
+        }}
+      />,
+    );
+    expect(kindOf(container)).toBe('scatter');
+    expect(container.querySelectorAll('circle').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders a heatmap spec as a cell grid with both axes labelled', () => {
+    const { container } = render(
+      <ChartView
+        chart={{
+          kind: 'heatmap',
+          matrix: [[13, 0], [1, 12]],
+          row_labels: ['setosa', 'versicolor'],
+          col_labels: ['setosa', 'versicolor'],
+          vmin: 0,
+          vmax: 13,
+        }}
+      />,
+    );
+    expect(kindOf(container)).toBe('heatmap');
+    expect(container.querySelectorAll('rect[data-i]')).toHaveLength(4);
+    expect(screen.getAllByText('setosa').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('colours a heatmap against the spec range, not a hard-coded 0..1', () => {
+    // Without `vmax`, every count above 1 would clamp to full brightness and
+    // a 13-vs-1 confusion would look like a 13-vs-13 one.
+    const { container } = render(
+      <ChartView
+        chart={{ kind: 'heatmap', matrix: [[13, 1]], vmin: 0, vmax: 13 }}
+      />,
+    );
+    const cells = [...container.querySelectorAll('rect[data-i]')];
+    expect(cells[0].getAttribute('data-color-t')).toBe('1.000');
+    expect(Number(cells[1].getAttribute('data-color-t'))).toBeCloseTo(1 / 13, 3);
+  });
+
+  it('does not stripe a lower-triangular heatmap as causally masked', () => {
+    // A confusion matrix is often zero above the diagonal by accident, which
+    // the attention-oriented default would report as a mask that never was.
+    const { container } = render(
+      <ChartView chart={{ kind: 'heatmap', matrix: [[1, 0], [1, 1]], vmin: 0, vmax: 1 }} />,
+    );
+    const masked = [...container.querySelectorAll('rect[data-masked="true"]')];
+    expect(masked).toHaveLength(0);
+  });
+
+  // ── boundaries ────────────────────────────────────────────────────────────
+
+  it('says so, rather than throwing, when the kind postdates the editor', () => {
+    render(<ChartView chart={{ kind: 'sankey' }} />);
+    expect(
+      screen.getByText('This chart kind (sankey) needs a newer editor'),
+    ).toBeInTheDocument();
+  });
+
+  it('treats a heatmap with no matrix as an unknown kind rather than an empty box', () => {
+    render(<ChartView chart={{ kind: 'heatmap' }} />);
+    expect(screen.getByText(/needs a newer editor/)).toBeInTheDocument();
+  });
+
+  it('renders an empty bar chart without crashing', () => {
+    const { container } = render(<ChartView chart={{ kind: 'bar', bars: [] }} />);
+    expect(kindOf(container)).toBe('bar');
+    expect(screen.getByText('no distribution')).toBeInTheDocument();
+  });
+
+  it('localizes its own strings', () => {
+    useI18n.setState({ locale: 'zh-TW' });
+    render(<ChartView chart={{ kind: 'sankey' }} />);
+    expect(screen.getByText(/需要更新版的編輯器/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/shared/ChartView.tsx
+++ b/frontend/src/components/shared/ChartView.tsx
@@ -59,8 +59,26 @@ export function ChartView({ chart, width = 420, height = 180, className }: Chart
     [chart.points],
   );
 
+  // A kind this build knows, whose spec is missing the payload that kind needs
+  // (a heatmap with no `matrix`), is a different failure from a kind that
+  // postdates the editor — and saying "needs a newer editor" about it sends
+  // the reader to upgrade instead of to the node that produced it.
+  const KNOWN: string[] = ['bar', 'line', 'scatter', 'heatmap'];
+  const malformed =
+    KNOWN.includes(chart.kind) &&
+    ((chart.kind === 'bar' && !chart.bars) ||
+      (chart.kind === 'line' && !chart.series) ||
+      (chart.kind === 'scatter' && !chart.points) ||
+      (chart.kind === 'heatmap' && !chart.matrix?.length));
+
   let body: React.ReactNode;
-  if (chart.kind === 'bar') {
+  if (malformed) {
+    body = (
+      <div className={styles.unknown}>
+        {t('chart.malformed', { kind: chart.kind })}
+      </div>
+    );
+  } else if (chart.kind === 'bar') {
     body = (
       <HistogramPlot
         bars={bars}
@@ -71,7 +89,12 @@ export function ChartView({ chart, width = 420, height = 180, className }: Chart
       />
     );
   } else if (chart.kind === 'line') {
-    body = <LossChart series={series} height={height} xLabel={chart.x_label ?? 'x'} />;
+    // LossChart draws the x caption itself but has no y caption, so the
+    // footer below carries y_label for this kind too — dropping it silently
+    // lost the unit on every line chart.
+    body = (
+      <LossChart series={series} height={height} xLabel={chart.x_label ?? 'x'} />
+    );
   } else if (chart.kind === 'scatter') {
     body = (
       <ScatterPlot
@@ -83,11 +106,11 @@ export function ChartView({ chart, width = 420, height = 180, className }: Chart
         showLabels={points.length <= 12}
       />
     );
-  } else if (chart.kind === 'heatmap' && chart.matrix?.length) {
+  } else if (chart.kind === 'heatmap') {
     const side = Math.min(width, height + 80);
     body = (
       <HeatmapPlot
-        data={chart.matrix}
+        data={chart.matrix as number[][]}
         rowLabels={chart.row_labels}
         colLabels={chart.col_labels}
         panelWidth={side}
@@ -110,10 +133,14 @@ export function ChartView({ chart, width = 420, height = 180, className }: Chart
       {chart.title && <div className={styles.title}>{chart.title}</div>}
       {chart.note && <div className={styles.note}>{chart.note}</div>}
       <div className={styles.body}>{body}</div>
-      {(chart.x_label || chart.y_label) && chart.kind !== 'line' && (
+      {(chart.x_label || chart.y_label) && (
         <div className={styles.axes}>
           {chart.y_label && <span className={styles.axisY}>{chart.y_label}</span>}
-          {chart.x_label && <span className={styles.axisX}>{chart.x_label}</span>}
+          {/* LossChart already prints x under its own axis, so showing it
+              again here would caption the same axis twice. */}
+          {chart.x_label && chart.kind !== 'line' && (
+            <span className={styles.axisX}>{chart.x_label}</span>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/shared/ChartView.tsx
+++ b/frontend/src/components/shared/ChartView.tsx
@@ -1,0 +1,121 @@
+import { useMemo } from 'react';
+import { useI18n } from '../../i18n';
+import type { LogChartPayload } from '../../store/tabStore';
+import { HistogramPlot, type HistogramBar } from './HistogramPlot';
+import { ScatterPlot, type ScatterPoint } from './ScatterPlot';
+import { HeatmapPlot, type HeatmapColormap } from './HeatmapPlot';
+import { LossChart, type ChartSeries } from '../ResultsPanel/LossChart';
+import styles from './ChartView.module.css';
+
+const COLORMAPS: HeatmapColormap[] = ['viridis', 'blues', 'RdBu'];
+
+function isColormap(value: string | undefined): value is HeatmapColormap {
+  return COLORMAPS.includes(value as HeatmapColormap);
+}
+
+interface ChartViewProps {
+  chart: LogChartPayload;
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+/**
+ * Renders a backend `chart` output entry (#130).
+ *
+ * Deliberately NOT a fifth plotting component: it dispatches a chart spec to
+ * the four the app already has, so a bar chart from a node looks exactly like
+ * the port-statistics histogram and a line chart exactly like the loss curve.
+ * A spec whose `kind` is unknown renders as a caption rather than as an error
+ * or an empty box — the backend's kinds are open strings, so an editor will
+ * meet one it predates, and saying so is the honest outcome.
+ */
+export function ChartView({ chart, width = 420, height = 180, className }: ChartViewProps) {
+  const { t } = useI18n();
+
+  const bars: HistogramBar[] = useMemo(
+    () => (chart.bars ?? []).map((bar) => ({ label: bar.label, count: bar.value })),
+    [chart.bars],
+  );
+
+  const series: ChartSeries[] = useMemo(
+    () =>
+      (chart.series ?? []).map((line, i) => ({
+        // An unnamed series still needs a stable key and a stable colour.
+        name: line.name || `${t('chart.series')} ${i + 1}`,
+        points: line.points.map(([x, y]) => ({ x, y })),
+      })),
+    [chart.series, t],
+  );
+
+  const points: ScatterPoint[] = useMemo(
+    () =>
+      (chart.points ?? []).map((point) => ({
+        x: point.x,
+        y: point.y,
+        label: point.label,
+        cluster: point.cluster,
+      })),
+    [chart.points],
+  );
+
+  let body: React.ReactNode;
+  if (chart.kind === 'bar') {
+    body = (
+      <HistogramPlot
+        bars={bars}
+        variant="categorical"
+        width={width}
+        height={height}
+        ariaLabel={chart.title || t('chart.bar')}
+      />
+    );
+  } else if (chart.kind === 'line') {
+    body = <LossChart series={series} height={height} xLabel={chart.x_label ?? 'x'} />;
+  } else if (chart.kind === 'scatter') {
+    body = (
+      <ScatterPlot
+        points={points}
+        width={width}
+        height={height}
+        // Labels on every dot turn a few hundred points into a smear; the
+        // hover tooltip already names the one under the pointer.
+        showLabels={points.length <= 12}
+      />
+    );
+  } else if (chart.kind === 'heatmap' && chart.matrix?.length) {
+    const side = Math.min(width, height + 80);
+    body = (
+      <HeatmapPlot
+        data={chart.matrix}
+        rowLabels={chart.row_labels}
+        colLabels={chart.col_labels}
+        panelWidth={side}
+        panelHeight={side}
+        colormap={isColormap(chart.colormap) ? chart.colormap : 'viridis'}
+        // A confusion matrix is often lower-triangular by accident; the
+        // causal-mask stripes would then claim a masking that never happened.
+        detectCausalMask={false}
+        valueRange={[chart.vmin ?? 0, chart.vmax ?? 1]}
+      />
+    );
+  } else {
+    body = (
+      <div className={styles.unknown}>{t('chart.unknownKind', { kind: chart.kind })}</div>
+    );
+  }
+
+  return (
+    <div className={`${styles.wrapper} ${className ?? ''}`} data-chart-kind={chart.kind}>
+      {chart.title && <div className={styles.title}>{chart.title}</div>}
+      {chart.note && <div className={styles.note}>{chart.note}</div>}
+      <div className={styles.body}>{body}</div>
+      {(chart.x_label || chart.y_label) && chart.kind !== 'line' && (
+        <div className={styles.axes}>
+          {chart.y_label && <span className={styles.axisY}>{chart.y_label}</span>}
+          {chart.x_label && <span className={styles.axisX}>{chart.x_label}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/shared/ChartView.tsx
+++ b/frontend/src/components/shared/ChartView.tsx
@@ -128,19 +128,22 @@ export function ChartView({ chart, width = 420, height = 180, className }: Chart
     );
   }
 
+  const showY = Boolean(chart.y_label);
+  const showX = Boolean(chart.x_label) && chart.kind !== 'line';
+
   return (
     <div className={`${styles.wrapper} ${className ?? ''}`} data-chart-kind={chart.kind}>
       {chart.title && <div className={styles.title}>{chart.title}</div>}
       {chart.note && <div className={styles.note}>{chart.note}</div>}
       <div className={styles.body}>{body}</div>
-      {(chart.x_label || chart.y_label) && (
+      {/* LossChart already prints x under its own axis, so repeating it here
+          would caption the same axis twice — which means a line chart with
+          only an x_label has nothing to show, and the row must not render at
+          all rather than as an empty strip of padding. */}
+      {(showY || showX) && (
         <div className={styles.axes}>
-          {chart.y_label && <span className={styles.axisY}>{chart.y_label}</span>}
-          {/* LossChart already prints x under its own axis, so showing it
-              again here would caption the same axis twice. */}
-          {chart.x_label && chart.kind !== 'line' && (
-            <span className={styles.axisX}>{chart.x_label}</span>
-          )}
+          {showY && <span className={styles.axisY}>{chart.y_label}</span>}
+          {showX && <span className={styles.axisX}>{chart.x_label}</span>}
         </div>
       )}
     </div>

--- a/frontend/src/components/shared/HeatmapPlot.test.tsx
+++ b/frontend/src/components/shared/HeatmapPlot.test.tsx
@@ -363,4 +363,54 @@ describe('HeatmapPlot', () => {
     const cell00 = container.querySelector('rect[data-i="0"][data-j="0"]');
     expect(cell00?.getAttribute('data-color-t')).toBe('0.000');
   });
+
+  // ── valueRange (#130) ─────────────────────────────────────────────────────
+  // Attention weights are already in [0, 1]; a confusion matrix of counts is
+  // not, and clamping it there would paint every non-zero cell full brightness.
+
+  function colorT(container: HTMLElement, i: number, j: number): string | null {
+    return container
+      .querySelector(`rect[data-i="${i}"][data-j="${j}"]`)
+      ?.getAttribute('data-color-t') ?? null;
+  }
+
+  it('clamps to 0..1 when no valueRange is given (the attention default)', () => {
+    const { container } = render(<HeatmapPlot data={[[13, 1]]} />);
+    expect(colorT(container, 0, 0)).toBe('1.000');
+    expect(colorT(container, 0, 1)).toBe('1.000');
+  });
+
+  it('stretches the ramp across valueRange instead', () => {
+    const { container } = render(<HeatmapPlot data={[[13, 1]]} valueRange={[0, 13]} />);
+    expect(colorT(container, 0, 0)).toBe('1.000');
+    expect(Number(colorT(container, 0, 1))).toBeCloseTo(1 / 13, 3);
+  });
+
+  it('maps a diverging range so zero lands mid-ramp', () => {
+    const { container } = render(
+      <HeatmapPlot data={[[-1, 0, 1]]} valueRange={[-1, 1]} />,
+    );
+    expect(colorT(container, 0, 0)).toBe('0.000');
+    expect(colorT(container, 0, 1)).toBe('0.500');
+    expect(colorT(container, 0, 2)).toBe('1.000');
+  });
+
+  it('clamps values outside the declared range rather than overflowing', () => {
+    const { container } = render(<HeatmapPlot data={[[-5, 99]]} valueRange={[0, 10]} />);
+    expect(colorT(container, 0, 0)).toBe('0.000');
+    expect(colorT(container, 0, 1)).toBe('1.000');
+  });
+
+  it('renders a degenerate range mid-ramp, not fully bright', () => {
+    const { container } = render(<HeatmapPlot data={[[7, 7]]} valueRange={[7, 7]} />);
+    expect(colorT(container, 0, 0)).toBe('0.500');
+  });
+
+  it('lets normalizePerRow win over valueRange', () => {
+    const { container } = render(
+      <HeatmapPlot data={[[2, 4]]} valueRange={[0, 100]} normalizePerRow />,
+    );
+    // Per-row min-max stretch: the row's own max reaches the top of the ramp.
+    expect(colorT(container, 0, 1)).toBe('1.000');
+  });
 });

--- a/frontend/src/components/shared/HeatmapPlot.tsx
+++ b/frontend/src/components/shared/HeatmapPlot.tsx
@@ -28,6 +28,14 @@ interface HeatmapPlotProps {
    * the raw weight.
    */
   normalizePerRow?: boolean;
+  /**
+   * `[min, max]` the colour ramp spans. Defaults to `[0, 1]`, which is right
+   * for attention weights — the only data this component saw before #130 —
+   * and wrong for everything else: a confusion matrix of counts would render
+   * every non-zero cell at full brightness. Tooltips keep showing the RAW
+   * value, so pinning the scale never changes what the numbers say.
+   */
+  valueRange?: [number, number];
 }
 
 interface HoverCell {
@@ -119,6 +127,7 @@ interface SinglePanelProps {
   causalMasked: boolean;
   headIndex?: number;
   normalizePerRow: boolean;
+  valueRange?: [number, number];
   onHover: (cell: HoverCell | null) => void;
 }
 
@@ -132,6 +141,7 @@ function SinglePanel({
   causalMasked,
   headIndex,
   normalizePerRow,
+  valueRange,
   onHover,
 }: SinglePanelProps) {
   const n = matrix.length;
@@ -277,6 +287,11 @@ function SinglePanel({
                   ? Math.max(0, Math.min(1, (v - min) / range))
                   : 0.5; // truly-uniform row — neutral signal, no peak
               }
+            } else if (valueRange) {
+              const [lo, hi] = valueRange;
+              // A degenerate range (every cell equal) has no gradient to
+              // show; mid-ramp reads as "uniform", not as "all maximal".
+              colorT = hi > lo ? Math.max(0, Math.min(1, (v - lo) / (hi - lo))) : 0.5;
             } else {
               colorT = Math.max(0, Math.min(1, v));
             }
@@ -362,6 +377,7 @@ export function HeatmapPlot({
   className,
   onExpand,
   normalizePerRow = false,
+  valueRange,
 }: HeatmapPlotProps) {
   const [hover, setHover] = useState<HoverCell | null>(null);
 
@@ -421,6 +437,7 @@ export function HeatmapPlot({
             causalMasked={p.causalMasked}
             headIndex={p.head}
             normalizePerRow={normalizePerRow}
+            valueRange={valueRange}
             onHover={setHover}
           />
         ))}

--- a/frontend/src/hooks/useGraphExecution.test.ts
+++ b/frontend/src/hooks/useGraphExecution.test.ts
@@ -403,7 +403,8 @@ describe('useGraphExecution - node_status handler', () => {
         outputs: [
           null,
           'nonsense',
-          { output_kind: 'chart', chart: { series: [] } }, // a future kind
+          { output_kind: 'waveform', waveform: { hz: 440 } }, // a future kind
+          { output_kind: 'chart', chart: { series: [] } }, // chart with no kind
           { output_kind: 'image' }, // no payload
           { output_kind: 'text', text: '' }, // empty text
         ],
@@ -412,6 +413,66 @@ describe('useGraphExecution - node_status handler', () => {
     const tab = tabById('t1');
     expect(tab.logs.some((l: any) => l.kind === 'image')).toBe(false);
     expect(tab.logs.some((l: any) => l.kind === 'text')).toBe(false);
+    expect(tab.logs.some((l: any) => l.kind === 'chart')).toBe(false);
+  });
+
+  // ── Chart output entries (#130) ────────────────────────────────────────
+  it('turns a chart output into a chart log entry carrying its spec', () => {
+    const ws = tabById('t1').ws as FakeWs;
+    const spec = {
+      kind: 'heatmap',
+      title: 'Confusion matrix',
+      matrix: [[1, 0], [0, 1]],
+      row_labels: ['a', 'b'],
+      col_labels: ['a', 'b'],
+      vmin: 0,
+      vmax: 1,
+    };
+    renderHook(() => useGraphExecution());
+    act(() => {
+      ws.emit('node_status', {
+        node_id: 'n1',
+        status: 'completed',
+        outputs: [{ output_kind: 'chart', port: 'chart', chart: spec }],
+      });
+    });
+    const entry = tabById('t1').logs.find((l: any) => l.kind === 'chart');
+    expect(entry.nodeId).toBe('n1');
+    expect(entry.chart).toEqual({ ...spec, port: 'chart' });
+  });
+
+  it('appends one entry per chart when a node emits several', () => {
+    const ws = tabById('t1').ws as FakeWs;
+    renderHook(() => useGraphExecution());
+    act(() => {
+      ws.emit('node_status', {
+        node_id: 'n1',
+        status: 'completed',
+        outputs: [
+          { output_kind: 'chart', port: 'a', chart: { kind: 'bar', bars: [] } },
+          { output_kind: 'chart', port: 'b', chart: { kind: 'line', series: [] } },
+        ],
+      });
+    });
+    const charts = tabById('t1').logs.filter((l: any) => l.kind === 'chart');
+    expect(charts.map((l: any) => l.chart.kind)).toEqual(['bar', 'line']);
+  });
+
+  it('keeps a chart alongside the text a node emits with it', () => {
+    const ws = tabById('t1').ws as FakeWs;
+    renderHook(() => useGraphExecution());
+    act(() => {
+      ws.emit('node_status', {
+        node_id: 'n1',
+        status: 'completed',
+        outputs: [
+          { output_kind: 'text', text: 'rendered table' },
+          { output_kind: 'chart', chart: { kind: 'bar', bars: [] } },
+        ],
+      });
+    });
+    const kinds = tabById('t1').logs.map((l: any) => l.kind).filter(Boolean);
+    expect(kinds).toEqual(['text', 'chart']);
   });
 
   // ── Deprecated flat fields (remove one release after #117) ──────────────

--- a/frontend/src/hooks/useGraphExecution.ts
+++ b/frontend/src/hooks/useGraphExecution.ts
@@ -190,6 +190,20 @@ export function useGraphExecution() {
           });
         }
 
+        // #130: a chart entry carries a spec the client draws itself. No
+        // legacy fallback — the kind postdates the flat-field era entirely.
+        for (const entry of ofKind('chart')) {
+          const payload = entry.chart;
+          if (!payload?.kind) continue;
+          store.addTabLog(tabId, {
+            nodeId: data.node_id,
+            message: '',
+            kind: 'chart',
+            chart: { ...payload, ...(entry.port ? { port: entry.port } : {}) },
+            type: 'info',
+          });
+        }
+
         const summary = firstOf('tensor_summary')?.tensor_summary ?? legacy.output_summary;
         if (summary) {
           store.setTabOutputSummary(tabId, data.node_id, summary);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -664,6 +664,7 @@ const en = {
   'chart.bar': 'Bar chart',
   'chart.series': 'series',
   'chart.unknownKind': 'This chart kind ({kind}) needs a newer editor',
+  'chart.malformed': 'This {kind} chart arrived without its data',
   'nodeDetail.captures.charts': 'Charts ({count})',
 } as const;
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -659,6 +659,12 @@ const en = {
   // Shared plots
   'plot.noDistribution': 'no distribution',
   'plot.peak': 'peak {count}',
+
+  // Chart output entries (#130)
+  'chart.bar': 'Bar chart',
+  'chart.series': 'series',
+  'chart.unknownKind': 'This chart kind ({kind}) needs a newer editor',
+  'nodeDetail.captures.charts': 'Charts ({count})',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -656,6 +656,12 @@ const zhTW: Record<TranslationKey, string> = {
   // Shared plots
   'plot.noDistribution': '沒有分佈資料',
   'plot.peak': '最高 {count}',
+
+  // Chart output entries (#130)
+  'chart.bar': '長條圖',
+  'chart.series': '數列',
+  'chart.unknownKind': '這種圖表類型（{kind}）需要更新版的編輯器',
+  'nodeDetail.captures.charts': '圖表（{count}）',
 };
 
 export default zhTW;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -661,6 +661,7 @@ const zhTW: Record<TranslationKey, string> = {
   'chart.bar': '長條圖',
   'chart.series': '數列',
   'chart.unknownKind': '這種圖表類型（{kind}）需要更新版的編輯器',
+  'chart.malformed': '這張 {kind} 圖表沒有帶資料',
   'nodeDetail.captures.charts': '圖表（{count}）',
 };
 

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -21,7 +21,7 @@ import { useProjectStore } from './projectStore';
  * render, so a later node pack can add its own kind; unknown kinds are
  * ignored by the panel rather than rendered wrong.
  */
-export type LogKind = 'text' | 'image' | 'progress';
+export type LogKind = 'text' | 'image' | 'progress' | 'chart';
 
 /** Base64 media payload of a `kind: 'image'` entry. */
 export interface LogImagePayload {
@@ -30,6 +30,44 @@ export interface LogImagePayload {
   encoding: string;
   data: string;
   /** Output port the image came from, when the backend named one. */
+  port?: string;
+}
+
+/**
+ * Chart spec of a `kind: 'chart'` entry (#130) — the payload a port declaring
+ * `media=MEDIA_CHART` produced, verbatim.
+ *
+ * Deliberately NOT a discriminated union over `kind`: the backend's kinds are
+ * open strings, so a pack can ship a fifth one, and a union would make that
+ * payload unrepresentable rather than merely unrendered. `ChartView` switches
+ * on `kind` and renders nothing for one it does not know.
+ *
+ * Every number here is finite by the producer's contract — run events are
+ * serialised with `allow_nan=False`, so a NaN would already have become
+ * `null` upstream. See `plugins/stats/README.md`.
+ */
+export interface LogChartPayload {
+  kind: string;
+  title?: string;
+  x_label?: string;
+  y_label?: string;
+  /** Downsampling / substitution notice, shown under the title. */
+  note?: string;
+  /** `kind: 'bar'` */
+  bars?: { label: string; value: number }[];
+  /** `kind: 'line'` — each series' points are `[x, y]` pairs. */
+  series?: { name: string; points: [number, number][] }[];
+  /** `kind: 'scatter'` */
+  points?: { x: number; y: number; label?: string; cluster?: number }[];
+  /** `kind: 'heatmap'` */
+  matrix?: number[][];
+  row_labels?: string[];
+  col_labels?: string[];
+  /** Colour-scale bounds — the scale to read against, not the data's extent. */
+  vmin?: number;
+  vmax?: number;
+  colormap?: string;
+  /** Output port the chart came from, when the backend named one. */
   port?: string;
 }
 
@@ -49,6 +87,8 @@ export interface LogEntry {
   image?: LogImagePayload;
   /** Set when `kind === 'progress'` — the raw progress event. */
   progress?: Record<string, any>;
+  /** Set when `kind === 'chart'` (#130) — the spec to draw. */
+  chart?: LogChartPayload;
 }
 
 interface UndoSnapshot {

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -56,6 +56,7 @@ export const EXAMPLE_CATEGORY_COLORS: Record<string, string> = {
   Transformer: '#26C6DA',
   RNN: '#5C6BC0',
   RL: '#EF5350',
+  Stats: '#7E57C2',
 };
 
 export const EXAMPLE_CATEGORY_FALLBACK = '#FF9800';

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -22,6 +22,13 @@
       "path": "plugins/deep",
       "chapters": ["C3", "C4", "C6"]
     },
+    "stats": {
+      "name": "Stats — 描述統計與圖表",
+      "description": "Descriptive statistics as single nodes instead of hand-wired tensor ops: Stats-Describe (pandas-compatible describe table), Stats-GroupByAggregate (mean/sum/count/min/max/std per group), Stats-Histogram, Stats-Percentile, Stats-Correlation (pearson / spearman, pairwise NaN drop), Stats-ConfusionMatrix (normalize none/true/pred/all), plus Stats-TableView and Stats-ChartView which render bar / line / scatter / heatmap charts in the Results panel. Pure numpy + torch.",
+      "kind": "builtin",
+      "path": "plugins/stats",
+      "tags": ["statistics", "chart", "table", "eda", "confusion-matrix"]
+    },
     "rl": {
       "name": "Reinforcement Learning — 強化學習",
       "description": "Reinforcement-learning teaching nodes for hands-on module I5: Edu-PolicyGradient, Edu-PPOClip, Edu-GRPO, Edu-PreferenceLoss. Each RL update is exposed as softmax → gather → baseline → ratio → clip → loss.",

--- a/plugins/stats/README.md
+++ b/plugins/stats/README.md
@@ -7,22 +7,152 @@ each, instead of hand-wiring `Mean` / `Reduce` / `Softmax` every time.
 cdui plugin install stats
 ```
 
-| Node | In → Out | Params |
-|---|---|---|
-| `Stats-Describe` | table → table | `axis`, `percentiles` |
-| `Stats-GroupByAggregate` | table, keys → table | `group_by`, `agg`, `agg_overrides` |
-| `Stats-Histogram` | tensor → table + chart | `bins`, `range_mode`, `range_min`, `range_max`, `density`, `title` |
-| `Stats-Percentile` | tensor → tensor | `q`, `axis` |
-| `Stats-Correlation` | table → matrix + chart | `method`, `drop_nan`, `title` |
-| `Stats-ConfusionMatrix` | predictions, labels → matrix + chart | `normalize`, `class_names`, `title` |
-| `Stats-TableView` | table → display | `max_rows`, `precision`, `title` |
-| `Stats-ChartView` | chart *or* table → display | `kind`, `title`, `columns_filter` |
+Every node is pure, cacheable and computes on CPU with numpy. The pack imports
+**numpy and torch only** — no pandas, no scikit-learn at runtime — and passes
+CodefyUI's AST security gate with **no `[security]` overrides**, which is the
+point: the default plugin policy is workable for real statistics code.
 
-Every node is pure and cacheable, computes on CPU with numpy, and returns
-`float32` tensors. The pack imports **numpy and torch only** — no pandas, no
-scikit-learn at runtime — and passes CodefyUI's AST security gate with **no
-`[security]` overrides**, which is the point: the default plugin policy is
-workable for real statistics code.
+## Node reference
+
+Ports marked *(opt)* are optional. Every `table` / `matrix` output is a
+`float32` 2D `TENSOR`; see [the table contract](#the-table-contract) for the
+companion list ports. The two display nodes are the exceptions — `TableView`
+returns a `STRING` and `ChartView` returns a spec `dict`.
+
+### `Stats-Describe`
+
+| | |
+|---|---|
+| **In** | `table` TENSOR · `columns` LIST *(opt)* |
+| **Out** | `table` TENSOR `[statistics, columns]` · `columns` LIST · `row_labels` LIST |
+
+`row_labels` are pandas' names: `count`, `mean`, `std`, `min`, the requested
+percentiles, `max`.
+
+| Param | Type | Default | Values |
+|---|---|---|---|
+| `axis` | select | **`columns`** | `columns`, `rows`, `all` |
+| `percentiles` | string | `25,50,75` | comma-separated, 0–100 |
+
+### `Stats-GroupByAggregate`
+
+| | |
+|---|---|
+| **In** | `table` TENSOR · `columns` LIST *(opt)* · `keys` LIST *(opt)* |
+| **Out** | `table` TENSOR `[groups, columns]` · `columns` LIST · `row_labels` LIST *(group keys)* · `counts` TENSOR `[groups]` |
+
+`counts` is each group's **row** count. An `agg` of `count` instead gives the
+number of *present* (non-NaN) values per column, so the two differ wherever
+there are holes. Output column names carry the aggregate applied — `petal
+length (cm) [mean]`.
+
+| Param | Type | Default | Values |
+|---|---|---|---|
+| `group_by` | string | `""` *(use `keys`)* | comma-separated column names or indices |
+| `agg` | select | `mean` | `mean`, `sum`, `count`, `min`, `max`, `std` |
+| `agg_overrides` | string | `""` | `col=agg` pairs, comma-separated |
+
+### `Stats-Histogram`
+
+| | |
+|---|---|
+| **In** | `tensor` TENSOR |
+| **Out** | `table` TENSOR `[bins, 3]` · `columns` LIST · `row_labels` LIST *(bin intervals)* · `chart` ANY *(`media=chart`)* · `dropped` SCALAR |
+
+`columns` is `["bin_start", "bin_end", "count"]`, or `"density"` when `density`
+is on. `dropped` counts the non-finite values excluded before binning.
+
+| Param | Type | Default | Values |
+|---|---|---|---|
+| `bins` | int | `20` | 1–1000 |
+| `range_mode` | select | `auto` | `auto`, `manual` |
+| `range_min` | float | `0.0` | *(manual only)* |
+| `range_max` | float | `1.0` | *(manual only)* |
+| `density` | bool | `false` | |
+| `title` | string | `Histogram` | |
+
+### `Stats-Percentile`
+
+| | |
+|---|---|
+| **In** | `tensor` TENSOR · `columns` LIST *(opt)* |
+| **Out** | `percentiles` TENSOR · `columns` LIST · `row_labels` LIST *(`25%`, `50%`, …)* |
+
+`percentiles` is 1D `[q]` for `axis = all`, else 2D `[q, series]`.
+
+| Param | Type | Default | Values |
+|---|---|---|---|
+| `q` | string | `50` | comma-separated, 0–100 |
+| `axis` | select | **`all`** | `all`, `columns`, `rows` |
+
+> **The two `axis` params differ.** `Stats-Describe` defaults to `columns`
+> (describe each column, as pandas does) and lists `columns, rows, all`.
+> `Stats-Percentile` defaults to `all` (reduce everything to one number per q)
+> and lists `all, columns, rows`. Same name, different default, different order
+> in the dropdown.
+
+### `Stats-Correlation`
+
+| | |
+|---|---|
+| **In** | `table` TENSOR · `columns` LIST *(opt)* |
+| **Out** | `matrix` TENSOR `[columns, columns]` · `columns` LIST · `row_labels` LIST *(same names)* · `chart` ANY *(`media=chart`)* |
+
+| Param | Type | Default | Values |
+|---|---|---|---|
+| `method` | select | `pearson` | `pearson`, `spearman` |
+| `drop_nan` | bool | `true` | pairwise-complete, as pandas' `corr` |
+| `title` | string | `Correlation` | |
+
+### `Stats-ConfusionMatrix`
+
+| | |
+|---|---|
+| **In** | `predictions` ANY · `labels` ANY |
+| **Out** | `matrix` TENSOR `[classes, classes]` · `columns` LIST *(predicted)* · `row_labels` LIST *(true)* · `accuracy` SCALAR · `chart` ANY *(`media=chart`)* |
+
+Each input takes a list of labels, a 1D tensor of class indices, or a 2D
+`[samples, classes]` score matrix (row argmax). `accuracy` is the diagonal's
+share of the **raw counts**, so it does not move when `normalize` does.
+
+| Param | Type | Default | Values |
+|---|---|---|---|
+| `normalize` | select | `none` | `none`, `true` *(row → recall)*, `pred` *(column → precision)*, `all` |
+| `class_names` | string | `""` *(every class seen, sorted)* | comma-separated |
+| `title` | string | `Confusion matrix` | |
+
+### `Stats-TableView`
+
+| | |
+|---|---|
+| **In** | `table` TENSOR · `columns` LIST *(opt)* · `row_labels` LIST *(opt)* |
+| **Out** | `text` STRING — the rendered table, **not** a tensor |
+
+Also emits the reserved `__log__` key, which the `output_kind` channel turns
+into a `text` entry, so the table appears in the Results panel.
+
+| Param | Type | Default | Values |
+|---|---|---|---|
+| `max_rows` | int | `20` | 0–1000; `0` means every row |
+| `precision` | int | `4` | 0–12 |
+| `title` | string | `""` | |
+
+### `Stats-ChartView`
+
+| | |
+|---|---|
+| **In** | `chart` ANY *(opt)* · `table` TENSOR *(opt)* · `columns` LIST *(opt)* · `row_labels` LIST *(opt)* |
+| **Out** | `chart` ANY *(`media=chart`)* — a spec **dict**, not a tensor |
+
+Connect either a `chart` payload from another Stats node or a `table`. With
+`kind = auto` a table becomes a bar chart when `row_labels` are present (the
+rows are categories) and a line chart otherwise.
+
+| Param | Type | Default | Values |
+|---|---|---|---|
+| `kind` | select | `auto` | `auto`, `bar`, `line`, `scatter`, `heatmap` |
+| `title` | string | `""` *(keep the payload's)* | |
+| `columns_filter` | string | `""` *(all columns)* | comma-separated names or indices |
 
 ## Examples
 
@@ -54,10 +184,18 @@ and there is no `TABLE`, `DATAFRAME` or `RECORD`. A table therefore travels as
 | `row_labels` | `LIST` | one name per row, in row order (optional) |
 | `keys` / `labels` | `LIST` | one categorical value per row (optional) |
 
-This is what `CSVReader` and `SyntheticDataset` already emit (`tensor` +
-`labels` + `columns`) and what `ColumnSelector`, `RowSelector`, `FilterRows`
-and `Edu-ColumnStats` already accept. This pack produces and consumes exactly
-that shape, so `CSVReader → Stats-Describe` needs no adapter.
+**Who speaks it in core today:**
+
+- **Produce** `tensor` + `labels` + `columns`: `CSVReader` and
+  `SyntheticDataset`. Those are the only two.
+- **Consume the column-name list:** `ColumnSelector` (`columns`, optional) —
+  the only one. It emits no `columns` of its own, so the names stop there.
+- **Consume the per-row categorical list:** `TrainTestSplit`, `Accuracy`, the
+  classifier nodes (`y_train`), `ScatterPlot2D`, `EmbeddingScatter`.
+- **`RowSelector`** takes a `labels` LIST, but those are **row** labels — the
+  row-axis analogue of `row_labels` below, not column names. It is the closest
+  core precedent for the row-name port this pack adds.
+- `Edu-ColumnStats` takes a bare 2D `TENSOR` and no list port at all.
 
 ### Rules
 
@@ -68,11 +206,10 @@ that shape, so `CSVReader → Stats-Describe` needs no adapter.
 2. **`columns` is `list[str]`, positionally aligned with the columns.** Emit
    strings; when consuming, re-cast with `str()` — `CSVReader` forwards raw
    pandas labels, which are usually but not always strings.
-3. **`columns` is optional and often absent.** Any transform node in core
-   drops it (`ColumnSelector` has no `columns` output at all), so a table
-   arriving from mid-graph usually has no names. Generate `c0`, `c1`, … rather
-   than failing. These nodes do, and they disambiguate duplicates as `a`,
-   `a#1`, `a#2`.
+3. **`columns` is optional and often absent.** `ColumnSelector` consumes the
+   names and emits none, so a table arriving from mid-graph usually has no
+   names at all. Generate `c0`, `c1`, … rather than failing. These nodes do,
+   and they disambiguate duplicates as `a`, `a#1`, `a#2`.
 4. **A short or over-long `columns` list is not an error.** Pad with generated
    names, trim the excess.
 5. **NaN means missing; ±Inf is a value.** This is pandas' rule, and it is what
@@ -142,10 +279,12 @@ picture is themed, hoverable and sharp at any zoom.
   "row_labels": ["setosa", "versicolor"],
   "col_labels": ["setosa", "versicolor"],
   "vmin": 0, "vmax": 13,
-  "colormap": "viridis" | "blues" | "RdBu",
-  "value_format": "0.00"
+  "colormap": "viridis" | "blues" | "RdBu"
 }
 ```
+
+Those are the only keys the renderer reads. Anything else travels to the
+browser untouched and is ignored — do not add a field expecting an effect.
 
 ### Rules
 
@@ -154,18 +293,33 @@ picture is themed, hoverable and sharp at any zoom.
    to `null` and drawn as a hole — and a `np.float32` is not JSON-serialisable
    at all (only `np.float64` subclasses Python `float`, so it slips past the
    run store's `json_safe`). Substitute a real value and say so in `note`.
-2. **Keep the spec small.** A `node_status` payload over
-   `RUN_EVENT_PAYLOAD_CAP_BYTES` (128 KB) is replaced wholesale by an elision
-   marker. This pack caps at 200 bars, 8 series × 2000 points, 2000 scatter
-   points and a 64×64 heatmap, downsampling with a `note` rather than
-   truncating silently.
-3. **`vmin`/`vmax` are the colour scale, not the data range.** A correlation
+2. **Keep the spec small — budget about 64 KB, not 128 KB.** When a
+   `node_status` payload exceeds `RUN_EVENT_PAYLOAD_CAP_BYTES` (128 KB) the
+   run service degrades it in three stages: first each output entry gets a
+   share of the cap (`cap ÷ number of entries`) and any entry over its share
+   becomes an `{"elided": true, ...}` marker keeping `output_kind` and `port`
+   but **dropping the payload**; then long strings are truncated; only if it is
+   still too big does the whole payload collapse to one marker. A chart node
+   emits at least a `chart` entry and a `tensor_summary` sibling, so the
+   realistic share for one chart is **half the cap**. This pack caps at 200
+   bars, 8 series × 2000 points, 2000 scatter points and a 64×64 heatmap.
+3. **Never assign `note` directly.** Use `add_note()` from `_stats_core`. A
+   builder may already have recorded a downsampling notice, and overwriting it
+   turns a disclosed truncation into a silent one — a 500-bin histogram of data
+   containing NaN would report the excluded values and quietly lose "showing
+   the first 200 of 500 bars".
+4. **`vmin`/`vmax` are the colour scale, not the data range.** A correlation
    heatmap pins −1…1 so a weak matrix cannot masquerade as a strong one; a raw
    confusion matrix uses its own maximum.
-4. **An unknown `kind` renders as nothing, not as an error.** The frontend
-   ignores kinds it does not know, exactly as it ignores unknown
-   `output_kind`s — so adding a fifth kind is a frontend change, and old
-   editors keep working against a new backend.
+5. **A spec the editor cannot draw degrades to a caption, never to an error.**
+   Three distinct cases, and they say different things:
+   - an **unknown `output_kind`** (a media kind this editor predates) is
+     dropped by the WebSocket handler and never reaches the log at all;
+   - an **unknown chart `kind`** renders "This chart kind (`x`) needs a newer
+     editor" — the reader should upgrade;
+   - a **known kind missing its payload** (a `heatmap` with no `matrix`)
+     renders "This heatmap chart arrived without its data" — the reader should
+     look at the node that produced it, not at their editor version.
 
 ### Adding your own media kind
 
@@ -174,3 +328,12 @@ whatever string a port declares, and any port whose value is a non-empty dict
 is shipped through untouched. A pack declaring `media="waveform"` reaches the
 browser as `{"output_kind": "waveform", ...}` with no core change; only
 rendering it needs one.
+
+Two constraints on the kind string. It must not collide with the keys an entry
+uses for its own bookkeeping — `output_kind`, `port`, `elided`, `bytes`,
+`cap_bytes` — because the payload is stored under a key *named by the kind*, so
+a `media="elided"` port would forge the truncation marker. Colliding kinds are
+refused with a logged warning rather than quietly renamed, so the mistake
+surfaces to the pack author. And the payload must be a non-empty `dict`;
+anything else is skipped, which is how a declared port that produced nothing
+this run stays absent instead of arriving empty.

--- a/plugins/stats/README.md
+++ b/plugins/stats/README.md
@@ -1,0 +1,176 @@
+# Stats — descriptive statistics and charts
+
+Eight nodes that answer the ordinary questions about a dataset in one node
+each, instead of hand-wiring `Mean` / `Reduce` / `Softmax` every time.
+
+```bash
+cdui plugin install stats
+```
+
+| Node | In → Out | Params |
+|---|---|---|
+| `Stats-Describe` | table → table | `axis`, `percentiles` |
+| `Stats-GroupByAggregate` | table, keys → table | `group_by`, `agg`, `agg_overrides` |
+| `Stats-Histogram` | tensor → table + chart | `bins`, `range_mode`, `range_min`, `range_max`, `density`, `title` |
+| `Stats-Percentile` | tensor → tensor | `q`, `axis` |
+| `Stats-Correlation` | table → matrix + chart | `method`, `drop_nan`, `title` |
+| `Stats-ConfusionMatrix` | predictions, labels → matrix + chart | `normalize`, `class_names`, `title` |
+| `Stats-TableView` | table → display | `max_rows`, `precision`, `title` |
+| `Stats-ChartView` | chart *or* table → display | `kind`, `title`, `columns_filter` |
+
+Every node is pure and cacheable, computes on CPU with numpy, and returns
+`float32` tensors. The pack imports **numpy and torch only** — no pandas, no
+scikit-learn at runtime — and passes CodefyUI's AST security gate with **no
+`[security]` overrides**, which is the point: the default plugin policy is
+workable for real statistics code.
+
+## Examples
+
+`examples/Stats/` ships three graphs, reachable from the Examples gallery:
+
+- **Iris describe()** — `CSVReader → Stats-Describe → Stats-TableView`.
+- **Group by species, then chart it** — `CSVReader → Stats-GroupByAggregate → Stats-ChartView`.
+- **Confusion matrix as a heatmap** — decision tree on held-out iris → `Stats-ConfusionMatrix`.
+
+---
+
+## The table contract
+
+Third-party packs that want to interoperate with these nodes should read this
+section. It documents what CodefyUI **actually** does, which is not quite what
+the phrase "a table" suggests.
+
+### There is no `TABLE` port type
+
+`DataType` in `backend/app/core/node_base.py` is a closed `Enum`
+(`TENSOR`, `LIST`, `SCALAR`, `STRING`, `ANY`, …). A plugin cannot add a member,
+and there is no `TABLE`, `DATAFRAME` or `RECORD`. A table therefore travels as
+**several ports that agree with each other**, not as one value:
+
+| Port | Type | Meaning |
+|---|---|---|
+| `table` | `TENSOR` | 2D `[rows, columns]`, numeric |
+| `columns` | `LIST` | one name per column, in column order |
+| `row_labels` | `LIST` | one name per row, in row order (optional) |
+| `keys` / `labels` | `LIST` | one categorical value per row (optional) |
+
+This is what `CSVReader` and `SyntheticDataset` already emit (`tensor` +
+`labels` + `columns`) and what `ColumnSelector`, `RowSelector`, `FilterRows`
+and `Edu-ColumnStats` already accept. This pack produces and consumes exactly
+that shape, so `CSVReader → Stats-Describe` needs no adapter.
+
+### Rules
+
+1. **Values are numeric and 2D.** `float32` on output; any numeric dtype
+   accepted on input. A 1D input is read as a single column. Non-numeric data
+   never enters `table` — it rides a `LIST` port instead. That is why
+   `CSVReader` sends the species column to `labels` rather than to `tensor`.
+2. **`columns` is `list[str]`, positionally aligned with the columns.** Emit
+   strings; when consuming, re-cast with `str()` — `CSVReader` forwards raw
+   pandas labels, which are usually but not always strings.
+3. **`columns` is optional and often absent.** Any transform node in core
+   drops it (`ColumnSelector` has no `columns` output at all), so a table
+   arriving from mid-graph usually has no names. Generate `c0`, `c1`, … rather
+   than failing. These nodes do, and they disambiguate duplicates as `a`,
+   `a#1`, `a#2`.
+4. **A short or over-long `columns` list is not an error.** Pad with generated
+   names, trim the excess.
+5. **NaN means missing; ±Inf is a value.** This is pandas' rule, and it is what
+   makes `Stats-Describe` reproduce `DataFrame.describe()` exactly: `count`
+   ignores NaN but counts Inf, so a column holding an Inf has an Inf mean.
+   There is no separate mask port and no sentinel value.
+6. **`row_labels` is this pack's addition.** No core node round-trips row
+   names, which is why a `describe()` table would otherwise print without
+   telling you which row is the median. Every node here that produces a table
+   emits it; every node that consumes one treats it as optional.
+
+### What a columnar dict is (and is not)
+
+`backend/app/core/port_stats.py` accepts a columnar dict —
+`{"age": [30, 40], "city": ["taipei", "tainan"]}` — and so the Node Detail
+Modal's **Stats** tab can summarise one. That is an *inspection* shape, not a
+transport contract:
+
+- it is not a declared port type, so nothing type-checks it;
+- on the WebSocket and the outputs REST API it degrades to a truncated
+  `repr()` string, because neither serialiser has a branch for it;
+- it is only recognised when **every** value is a `list`/`tuple` — including
+  length-1 columns.
+
+Do not build a pipeline on it. Use the split table above.
+
+---
+
+## The chart contract
+
+`Stats-Histogram`, `Stats-Correlation`, `Stats-ConfusionMatrix` and
+`Stats-ChartView` all declare `media=MEDIA_CHART` on their `chart` output:
+
+```python
+from app.core.node_base import MEDIA_CHART, DataType, PortDefinition
+
+PortDefinition(name="chart", data_type=DataType.ANY, media=MEDIA_CHART)
+```
+
+The value is a plain dict — a **chart spec** — which rides the structured
+`output_kind` channel to the browser as
+`{"output_kind": "chart", "port": "chart", "chart": {...}}` and is drawn by
+the editor's own SVG components. Nothing is rendered server-side, so the
+picture is themed, hoverable and sharp at any zoom.
+
+### Spec shape
+
+```jsonc
+{
+  "kind": "bar" | "line" | "scatter" | "heatmap",   // required
+  "title": "Mean petal length by species",
+  "x_label": "species",
+  "y_label": "cm",
+  "note": "12 non-finite value(s) excluded",        // shown under the title
+
+  // kind: "bar"
+  "bars": [{ "label": "setosa", "value": 1.462 }],
+
+  // kind: "line"
+  "series": [{ "name": "loss", "points": [[0, 1.2], [1, 0.8]] }],
+
+  // kind: "scatter"
+  "points": [{ "x": 1.0, "y": 2.0, "label": "a", "cluster": 0 }],
+
+  // kind: "heatmap"
+  "matrix": [[13, 0], [1, 12]],
+  "row_labels": ["setosa", "versicolor"],
+  "col_labels": ["setosa", "versicolor"],
+  "vmin": 0, "vmax": 13,
+  "colormap": "viridis" | "blues" | "RdBu",
+  "value_format": "0.00"
+}
+```
+
+### Rules
+
+1. **Every number must be a finite, plain Python `float` or `int`.** Run
+   events are serialised with `allow_nan=False`, so a NaN would be rewritten
+   to `null` and drawn as a hole — and a `np.float32` is not JSON-serialisable
+   at all (only `np.float64` subclasses Python `float`, so it slips past the
+   run store's `json_safe`). Substitute a real value and say so in `note`.
+2. **Keep the spec small.** A `node_status` payload over
+   `RUN_EVENT_PAYLOAD_CAP_BYTES` (128 KB) is replaced wholesale by an elision
+   marker. This pack caps at 200 bars, 8 series × 2000 points, 2000 scatter
+   points and a 64×64 heatmap, downsampling with a `note` rather than
+   truncating silently.
+3. **`vmin`/`vmax` are the colour scale, not the data range.** A correlation
+   heatmap pins −1…1 so a weak matrix cannot masquerade as a strong one; a raw
+   confusion matrix uses its own maximum.
+4. **An unknown `kind` renders as nothing, not as an error.** The frontend
+   ignores kinds it does not know, exactly as it ignores unknown
+   `output_kind`s — so adding a fifth kind is a frontend change, and old
+   editors keep working against a new backend.
+
+### Adding your own media kind
+
+`MEDIA_CHART` is not special-cased in core. `declared_media_ports()` keys on
+whatever string a port declares, and any port whose value is a non-empty dict
+is shipped through untouched. A pack declaring `media="waveform"` reaches the
+browser as `{"output_kind": "waveform", ...}` with no core change; only
+rendering it needs one.

--- a/plugins/stats/cdui.plugin.toml
+++ b/plugins/stats/cdui.plugin.toml
@@ -1,0 +1,11 @@
+[plugin]
+id              = "stats"
+name            = "Stats — 描述統計與圖表"
+version         = "0.1.0"
+description     = "Descriptive statistics as single nodes: Describe, GroupByAggregate, Histogram, Percentile, Correlation and ConfusionMatrix, plus TableView / ChartView display nodes that render bar, line, scatter and heatmap charts client-side. Pure numpy/torch — no pandas at runtime, no security overrides."
+schema_version  = 1
+requires_codefyui = ">=1.4.0"
+
+[content]
+nodes_dir    = "nodes"
+examples_dir = "examples"

--- a/plugins/stats/examples/Stats/Confusion-Matrix-Heatmap/graph.json
+++ b/plugins/stats/examples/Stats/Confusion-Matrix-Heatmap/graph.json
@@ -1,0 +1,80 @@
+{
+  "name": "Confusion matrix as a heatmap",
+  "description": "Trains a shallow decision tree on 70% of iris, predicts the held-out 30%, and feeds those predictions plus the true labels to Stats-ConfusionMatrix. The matrix arrives as a labelled heatmap in the Results panel and in the node's detail view, so a confusion between versicolor and virginica is a bright off-diagonal cell rather than a number to hunt for. Switch `normalize` to `true` to read per-class recall straight off the diagonal.",
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "Start",
+      "position": { "x": -260, "y": 60 },
+      "data": { "params": {} }
+    },
+    {
+      "id": "csv",
+      "type": "CSVReader",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "params": {
+          "path": "data/samples/iris.csv",
+          "target_column": "species",
+          "include_columns": "",
+          "skip_header": true
+        }
+      }
+    },
+    {
+      "id": "split",
+      "type": "TrainTestSplit",
+      "position": { "x": 300, "y": 0 },
+      "data": {
+        "params": { "test_size": 0.3, "seed": 42, "stratify": true }
+      }
+    },
+    {
+      "id": "tree",
+      "type": "DecisionTreeClassifier",
+      "position": { "x": 600, "y": 0 },
+      "data": {
+        "params": { "max_depth": 3, "criterion": "gini", "random_state": 42 }
+      }
+    },
+    {
+      "id": "cm",
+      "type": "stats:Stats-ConfusionMatrix",
+      "position": { "x": 900, "y": 0 },
+      "data": {
+        "params": {
+          "normalize": "none",
+          "class_names": "",
+          "title": "Iris - decision tree, held-out 30%"
+        }
+      }
+    },
+    {
+      "id": "view",
+      "type": "stats:Stats-TableView",
+      "position": { "x": 1220, "y": 120 },
+      "data": {
+        "params": { "max_rows": 10, "precision": 0, "title": "Counts (rows = true, columns = predicted)" }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "trig",
+      "source": "start-1",
+      "target": "csv",
+      "sourceHandle": "trigger",
+      "type": "trigger"
+    },
+    { "id": "s_f", "source": "csv", "target": "split", "sourceHandle": "tensor", "targetHandle": "features" },
+    { "id": "s_l", "source": "csv", "target": "split", "sourceHandle": "labels", "targetHandle": "labels" },
+    { "id": "t_x", "source": "split", "target": "tree", "sourceHandle": "x_train", "targetHandle": "x_train" },
+    { "id": "t_y", "source": "split", "target": "tree", "sourceHandle": "y_train", "targetHandle": "y_train" },
+    { "id": "t_q", "source": "split", "target": "tree", "sourceHandle": "x_test", "targetHandle": "x_query" },
+    { "id": "m_p", "source": "tree", "target": "cm", "sourceHandle": "predictions", "targetHandle": "predictions" },
+    { "id": "m_l", "source": "split", "target": "cm", "sourceHandle": "y_test", "targetHandle": "labels" },
+    { "id": "v_t", "source": "cm", "target": "view", "sourceHandle": "matrix", "targetHandle": "table" },
+    { "id": "v_c", "source": "cm", "target": "view", "sourceHandle": "columns", "targetHandle": "columns" },
+    { "id": "v_r", "source": "cm", "target": "view", "sourceHandle": "row_labels", "targetHandle": "row_labels" }
+  ]
+}

--- a/plugins/stats/examples/Stats/Iris-Describe-Table/graph.json
+++ b/plugins/stats/examples/Stats/Iris-Describe-Table/graph.json
@@ -1,0 +1,62 @@
+{
+  "name": "Iris describe(): the whole table in one node",
+  "description": "Reads the bundled iris.csv and hands it to Stats-Describe, which reproduces pandas' describe() — count, mean, std, min, 25/50/75%, max for every numeric column. Stats-TableView prints the result in the Results panel with its statistic names down the side. This is the shortest path from a CSV to knowing what is in it.",
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "Start",
+      "position": { "x": -260, "y": 40 },
+      "data": { "params": {} }
+    },
+    {
+      "id": "csv",
+      "type": "CSVReader",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "params": {
+          "path": "data/samples/iris.csv",
+          "target_column": "species",
+          "include_columns": "",
+          "skip_header": true
+        }
+      }
+    },
+    {
+      "id": "describe",
+      "type": "stats:Stats-Describe",
+      "position": { "x": 320, "y": 0 },
+      "data": {
+        "params": {
+          "axis": "columns",
+          "percentiles": "25,50,75"
+        }
+      }
+    },
+    {
+      "id": "view",
+      "type": "stats:Stats-TableView",
+      "position": { "x": 640, "y": 0 },
+      "data": {
+        "params": {
+          "max_rows": 20,
+          "precision": 4,
+          "title": "Iris - describe()"
+        }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "trig",
+      "source": "start-1",
+      "target": "csv",
+      "sourceHandle": "trigger",
+      "type": "trigger"
+    },
+    { "id": "e_t", "source": "csv", "target": "describe", "sourceHandle": "tensor", "targetHandle": "table" },
+    { "id": "e_c", "source": "csv", "target": "describe", "sourceHandle": "columns", "targetHandle": "columns" },
+    { "id": "v_t", "source": "describe", "target": "view", "sourceHandle": "table", "targetHandle": "table" },
+    { "id": "v_c", "source": "describe", "target": "view", "sourceHandle": "columns", "targetHandle": "columns" },
+    { "id": "v_r", "source": "describe", "target": "view", "sourceHandle": "row_labels", "targetHandle": "row_labels" }
+  ]
+}

--- a/plugins/stats/examples/Stats/Iris-GroupBy-Chart/graph.json
+++ b/plugins/stats/examples/Stats/Iris-GroupBy-Chart/graph.json
@@ -1,0 +1,79 @@
+{
+  "name": "Group by species, then chart it",
+  "description": "CSV -> GroupBy -> Chart. The species column becomes the grouping key (CSVReader's `labels` output is exactly the per-row label list Stats-GroupByAggregate wants), every numeric column is averaged per species, and Stats-ChartView draws the mean petal length as a bar per species. The same grouped table is printed as text alongside, so the chart and the numbers agree in front of you.",
+  "nodes": [
+    {
+      "id": "start-1",
+      "type": "Start",
+      "position": { "x": -260, "y": 60 },
+      "data": { "params": {} }
+    },
+    {
+      "id": "csv",
+      "type": "CSVReader",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "params": {
+          "path": "data/samples/iris.csv",
+          "target_column": "species",
+          "include_columns": "",
+          "skip_header": true
+        }
+      }
+    },
+    {
+      "id": "group",
+      "type": "stats:Stats-GroupByAggregate",
+      "position": { "x": 320, "y": 0 },
+      "data": {
+        "params": {
+          "group_by": "",
+          "agg": "mean",
+          "agg_overrides": ""
+        }
+      }
+    },
+    {
+      "id": "chart",
+      "type": "stats:Stats-ChartView",
+      "position": { "x": 660, "y": -80 },
+      "data": {
+        "params": {
+          "kind": "bar",
+          "title": "Mean petal length by species",
+          "columns_filter": "petal length (cm) [mean]"
+        }
+      }
+    },
+    {
+      "id": "view",
+      "type": "stats:Stats-TableView",
+      "position": { "x": 660, "y": 140 },
+      "data": {
+        "params": {
+          "max_rows": 10,
+          "precision": 3,
+          "title": "Per-species means"
+        }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "trig",
+      "source": "start-1",
+      "target": "csv",
+      "sourceHandle": "trigger",
+      "type": "trigger"
+    },
+    { "id": "g_t", "source": "csv", "target": "group", "sourceHandle": "tensor", "targetHandle": "table" },
+    { "id": "g_c", "source": "csv", "target": "group", "sourceHandle": "columns", "targetHandle": "columns" },
+    { "id": "g_k", "source": "csv", "target": "group", "sourceHandle": "labels", "targetHandle": "keys" },
+    { "id": "c_t", "source": "group", "target": "chart", "sourceHandle": "table", "targetHandle": "table" },
+    { "id": "c_c", "source": "group", "target": "chart", "sourceHandle": "columns", "targetHandle": "columns" },
+    { "id": "c_r", "source": "group", "target": "chart", "sourceHandle": "row_labels", "targetHandle": "row_labels" },
+    { "id": "v_t", "source": "group", "target": "view", "sourceHandle": "table", "targetHandle": "table" },
+    { "id": "v_c", "source": "group", "target": "view", "sourceHandle": "columns", "targetHandle": "columns" },
+    { "id": "v_r", "source": "group", "target": "view", "sourceHandle": "row_labels", "targetHandle": "row_labels" }
+  ]
+}

--- a/plugins/stats/nodes/_stats_core.py
+++ b/plugins/stats/nodes/_stats_core.py
@@ -1,0 +1,498 @@
+"""Shared plumbing for the stats pack: the table contract and chart specs.
+
+Two contracts live here, and both are normative for the pack — see
+``plugins/stats/README.md`` for the third-party-facing version.
+
+**The table contract.** CodefyUI has no ``TABLE`` port type (``DataType`` is a
+closed Enum in core). What ``CSVReader`` and ``SyntheticDataset`` actually
+emit, and what ``ColumnSelector`` / ``RowSelector`` / ``Edu-ColumnStats``
+actually accept, is a *split table*: a 2D numeric ``TENSOR`` carrying the
+values plus a parallel ``LIST`` of column names. This pack produces and
+consumes exactly that, and additionally carries a ``row_labels`` LIST — the
+one thing no core node round-trips, and the reason a ``describe()`` table is
+readable at all.
+
+**Missing values.** NaN means missing; ±Inf is a value. That is pandas' rule
+(``count()`` ignores NaN but counts Inf, so a column holding an Inf has an Inf
+mean), and matching it is what makes the parity test in
+``backend/tests/test_stats_describe_node.py`` meaningful. Every reduction here
+is written against an explicit ``~isnan`` mask rather than ``np.nanmean`` and
+friends, because those warn on an all-NaN column and this code runs on engine
+worker threads, where ``warnings.catch_warnings`` is process-global and so not
+safe to use.
+
+**Chart specs.** ``MEDIA_CHART`` payloads must be JSON-safe *and* small: the
+run store serialises events with ``allow_nan=False`` and elides any payload
+over ``RUN_EVENT_PAYLOAD_CAP_BYTES`` (128 KB). So every number goes through
+:func:`_num`, which returns a plain finite Python ``float`` — a ``np.float32``
+is not JSON-serialisable, and the run store's ``json_safe`` does not catch it
+either, since only ``np.float64`` subclasses Python ``float``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+import torch
+
+# ── chart payload caps ───────────────────────────────────────────────────────
+# Sized so a spec stays well under RUN_EVENT_PAYLOAD_CAP_BYTES (128 KB) even
+# with long labels. Past these the producer downsamples and says so in the
+# spec's ``note``, which the renderer prints under the title: silently drawing
+# the first N points would be a lie about the data.
+MAX_BARS = 200
+MAX_SERIES = 8
+MAX_POINTS_PER_SERIES = 2000
+MAX_SCATTER_POINTS = 2000
+MAX_HEATMAP_SIDE = 64
+
+#: Chart kinds the frontend renderer knows. Extending this list means teaching
+#: ``frontend/src/components/shared/ChartView.tsx`` a new branch.
+CHART_KINDS = ("bar", "line", "scatter", "heatmap")
+
+#: Aggregations ``Stats-GroupByAggregate`` understands.
+AGGREGATIONS = ("mean", "sum", "count", "min", "max", "std")
+
+
+# ── table coercion ───────────────────────────────────────────────────────────
+
+def as_matrix(value: Any, *, node: str, port: str = "table") -> np.ndarray:
+    """Coerce a table port value to a 2D float64 numpy array.
+
+    float64 rather than the float32 of the tensor convention: every statistic
+    is computed here and only the *result* goes back out as float32, so
+    accumulating a 150-row mean does not lose digits the parity test would
+    then blame on the algorithm. A 1D input becomes a single column, which is
+    what lets ``Stats-Describe`` sit directly on a vector.
+    """
+    if value is None:
+        raise ValueError(f"{node} requires a `{port}` input.")
+    if isinstance(value, torch.Tensor):
+        arr = value.detach().cpu().to(torch.float64).numpy()
+    else:
+        try:
+            arr = np.asarray(value, dtype=np.float64)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{node}: `{port}` must be numeric; got {type(value).__name__}, "
+                f"which numpy could not read as numbers ({exc})."
+            ) from exc
+    if arr.ndim == 1:
+        arr = arr.reshape(-1, 1)
+    if arr.ndim != 2:
+        raise ValueError(
+            f"{node} expects a 2D [rows, columns] table on `{port}`; "
+            f"got shape {tuple(arr.shape)}."
+        )
+    return arr
+
+
+def as_vector(value: Any, *, node: str, port: str = "tensor") -> np.ndarray:
+    """Coerce a port value to a flat float64 numpy array."""
+    if value is None:
+        raise ValueError(f"{node} requires a `{port}` input.")
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu().to(torch.float64).numpy().reshape(-1)
+    try:
+        return np.asarray(value, dtype=np.float64).reshape(-1)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{node}: `{port}` must be numeric; got {type(value).__name__} ({exc})."
+        ) from exc
+
+
+def to_tensor(arr: np.ndarray) -> torch.Tensor:
+    """Hand a computed array back as float32, the pack's output dtype.
+
+    ``ascontiguousarray`` because ``torch.from_numpy`` refuses a negative
+    stride, which is exactly what a reversed or transposed view hands it.
+    """
+    return torch.from_numpy(np.ascontiguousarray(arr, dtype=np.float32))
+
+
+def resolve_columns(names: Any, n_cols: int, *, prefix: str = "c") -> list[str]:
+    """Column names for a table, padded or trimmed to ``n_cols``.
+
+    A missing or short ``columns`` input is not an error: it is the normal
+    state downstream of a ``ColumnSelector``, which drops the metadata it was
+    given. Generated names carry the column index, so a graph that later
+    reconnects the real names does not silently renumber anything.
+
+    Duplicates are disambiguated with a ``#n`` suffix rather than letting the
+    first one win — a duplicate name makes a rendered table unreadable and an
+    ``agg_overrides`` lookup ambiguous.
+    """
+    resolved = [str(c) for c in names] if isinstance(names, (list, tuple)) else []
+    if len(resolved) > n_cols:
+        resolved = resolved[:n_cols]
+    resolved.extend(f"{prefix}{i}" for i in range(len(resolved), n_cols))
+    seen: dict[str, int] = {}
+    unique: list[str] = []
+    for name in resolved:
+        if name in seen:
+            seen[name] += 1
+            unique.append(f"{name}#{seen[name]}")
+        else:
+            seen[name] = 0
+            unique.append(name)
+    return unique
+
+
+def as_labels(value: Any, *, node: str, port: str) -> list[str]:
+    """Read a per-row label list from a LIST port or a 1D/2D tensor.
+
+    Accepts what real graphs produce: ``CSVReader.labels`` (already strings), a
+    class-index tensor from an ``argmax``, or a one-hot / logit matrix (row
+    argmax is taken, which is what a classifier's raw output is). Everything
+    becomes ``str`` because a confusion matrix is indexed by class *name*.
+    """
+    if value is None:
+        raise ValueError(f"{node} requires a `{port}` input.")
+    if isinstance(value, torch.Tensor):
+        work = value.detach().cpu()
+        if work.ndim >= 2 and work.shape[-1] > 1:
+            work = work.argmax(dim=-1)
+        flat = work.reshape(-1).tolist()
+        return [_label_of(v) for v in flat]
+    if isinstance(value, np.ndarray):
+        work_np = value
+        if work_np.ndim >= 2 and work_np.shape[-1] > 1:
+            work_np = work_np.argmax(axis=-1)
+        return [_label_of(v) for v in work_np.reshape(-1).tolist()]
+    if isinstance(value, (list, tuple)):
+        return [_label_of(v) for v in value]
+    raise ValueError(
+        f"{node}: `{port}` must be a list of labels or a tensor of class "
+        f"indices; got {type(value).__name__}."
+    )
+
+
+def _label_of(value: Any) -> str:
+    """Stringify one class label, keeping integral floats readable.
+
+    A class-index tensor arrives as float (``2.0``), and ``"2.0"`` would not
+    match the ``"2"`` a sibling list-of-strings port carries for the same
+    class. Collapsing integral floats is what lets predictions and ground
+    truth come from different node types.
+    """
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def parse_names(raw: Any) -> list[str]:
+    """Split a comma-separated STRING param into trimmed, non-empty names."""
+    if raw is None:
+        return []
+    return [part.strip() for part in str(raw).split(",") if part.strip()]
+
+
+def parse_percentiles(raw: Any, *, node: str, param: str) -> list[float]:
+    """Parse a comma-separated percentile list, in percent (0-100).
+
+    Percent rather than pandas' fractions because the value is typed into a
+    text box: ``25,50,75`` is unambiguous where ``0.25,0.5,0.75`` invites
+    someone to write ``50`` and get the 50th of a percent.
+    """
+    values: list[float] = []
+    for part in parse_names(raw):
+        try:
+            q = float(part)
+        except ValueError as exc:
+            raise ValueError(
+                f"{node}: `{param}` entry {part!r} is not a number "
+                f"(expected percentages such as '25,50,75')."
+            ) from exc
+        if not 0.0 <= q <= 100.0:
+            raise ValueError(
+                f"{node}: `{param}` entry {q:g} is outside 0-100."
+            )
+        values.append(q)
+    return values
+
+
+def _number_param(params: Any, name: str, default: Any, node: str, cast: Any) -> Any:
+    """Read a numeric param without the ``or default`` falsy-zero trap.
+
+    ``int(params.get("bins", 20) or 20)`` reads fine and silently turns a
+    deliberate ``0`` into ``20``, so an out-of-range value the node means to
+    reject never reaches the check. Only ``None`` and ``""`` — a cleared
+    widget — fall back to the default here.
+    """
+    raw = params.get(name, default)
+    if raw is None or raw == "":
+        return cast(default)
+    try:
+        return cast(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{node}: `{name}` must be a number; got {raw!r} ({exc})."
+        ) from exc
+
+
+def int_param(params: Any, name: str, default: int, *, node: str) -> int:
+    return _number_param(params, name, default, node, int)
+
+
+def float_param(params: Any, name: str, default: float, *, node: str) -> float:
+    return _number_param(params, name, default, node, float)
+
+
+def format_percentile(q: float) -> str:
+    """pandas' label for a percentile: ``25%``, ``2.5%``, ``99.9%``."""
+    text = f"{q:g}"
+    return f"{text}%"
+
+
+# ── NaN-aware reductions (NaN is missing, ±Inf is a value) ───────────────────
+
+def present(column: np.ndarray) -> np.ndarray:
+    """The non-missing entries of one column."""
+    return column[~np.isnan(column)]
+
+
+def mean_of(values: np.ndarray) -> float:
+    return float(values.mean()) if values.size else float("nan")
+
+
+def std_of(values: np.ndarray, ddof: int = 1) -> float:
+    """Sample std by default — pandas' ``describe`` uses ddof=1."""
+    if values.size <= ddof:
+        return float("nan")
+    return float(values.std(ddof=ddof))
+
+
+def min_of(values: np.ndarray) -> float:
+    return float(values.min()) if values.size else float("nan")
+
+
+def max_of(values: np.ndarray) -> float:
+    return float(values.max()) if values.size else float("nan")
+
+
+def percentile_of(values: np.ndarray, q: float) -> float:
+    """Linear-interpolated percentile — numpy's and pandas' shared default."""
+    if not values.size:
+        return float("nan")
+    return float(np.percentile(values, q))
+
+
+# ── chart specs ──────────────────────────────────────────────────────────────
+
+def _num(value: Any) -> float:
+    """A plain, finite Python float — the only numeric type a spec may carry."""
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return out if np.isfinite(out) else 0.0
+
+
+def _base(kind: str, title: str, x_label: str, y_label: str) -> dict[str, Any]:
+    spec: dict[str, Any] = {"kind": kind, "title": str(title)}
+    if x_label:
+        spec["x_label"] = str(x_label)
+    if y_label:
+        spec["y_label"] = str(y_label)
+    return spec
+
+
+def _note(spec: dict[str, Any], text: str) -> None:
+    """Record a downsampling / substitution notice on the spec."""
+    existing = spec.get("note")
+    spec["note"] = f"{existing} {text}".strip() if existing else text
+
+
+def bar_chart(
+    labels: Sequence[Any],
+    values: Sequence[Any],
+    *,
+    title: str = "",
+    x_label: str = "",
+    y_label: str = "",
+) -> dict[str, Any]:
+    """A categorical bar chart: one labelled bar per value."""
+    spec = _base("bar", title, x_label, y_label)
+    pairs = list(zip([str(label) for label in labels], [_num(v) for v in values]))
+    if len(pairs) > MAX_BARS:
+        _note(spec, f"showing the first {MAX_BARS} of {len(pairs)} bars")
+        pairs = pairs[:MAX_BARS]
+    spec["bars"] = [{"label": label, "value": value} for label, value in pairs]
+    return spec
+
+
+def line_chart(
+    series: Sequence[tuple[str, Sequence[Any], Sequence[Any]]],
+    *,
+    title: str = "",
+    x_label: str = "",
+    y_label: str = "",
+) -> dict[str, Any]:
+    """One or more named lines, each given as ``(name, xs, ys)``.
+
+    Points with a non-finite x or y are dropped rather than pinned to 0: a
+    gap in a curve is honest, a spike to the origin is not.
+    """
+    spec = _base("line", title, x_label, y_label)
+    kept = list(series)
+    if len(kept) > MAX_SERIES:
+        _note(spec, f"showing {MAX_SERIES} of {len(kept)} series")
+        kept = kept[:MAX_SERIES]
+    out: list[dict[str, Any]] = []
+    for name, xs, ys in kept:
+        points = [
+            [float(x), float(y)]
+            for x, y in zip(xs, ys)
+            if np.isfinite(float(x)) and np.isfinite(float(y))
+        ]
+        if len(points) > MAX_POINTS_PER_SERIES:
+            step = (len(points) + MAX_POINTS_PER_SERIES - 1) // MAX_POINTS_PER_SERIES
+            _note(spec, f"series sampled every {step} points")
+            points = points[::step]
+        out.append({"name": str(name), "points": points})
+    spec["series"] = out
+    return spec
+
+
+def scatter_chart(
+    xs: Sequence[Any],
+    ys: Sequence[Any],
+    *,
+    labels: Sequence[Any] | None = None,
+    clusters: Sequence[Any] | None = None,
+    title: str = "",
+    x_label: str = "",
+    y_label: str = "",
+) -> dict[str, Any]:
+    """A point cloud. Non-finite points are dropped, as in :func:`line_chart`."""
+    spec = _base("scatter", title, x_label, y_label)
+    points: list[dict[str, Any]] = []
+    for i, (x, y) in enumerate(zip(xs, ys)):
+        fx, fy = float(x), float(y)
+        if not (np.isfinite(fx) and np.isfinite(fy)):
+            continue
+        point: dict[str, Any] = {"x": fx, "y": fy}
+        if labels is not None and i < len(labels):
+            point["label"] = str(labels[i])
+        if clusters is not None and i < len(clusters):
+            point["cluster"] = int(clusters[i])
+        points.append(point)
+    if len(points) > MAX_SCATTER_POINTS:
+        step = (len(points) + MAX_SCATTER_POINTS - 1) // MAX_SCATTER_POINTS
+        _note(spec, f"sampled every {step} of {len(points)} points")
+        points = points[::step]
+    spec["points"] = points
+    return spec
+
+
+def heatmap_chart(
+    matrix: np.ndarray,
+    *,
+    row_labels: Sequence[str] | None = None,
+    col_labels: Sequence[str] | None = None,
+    colormap: str = "viridis",
+    title: str = "",
+    x_label: str = "",
+    y_label: str = "",
+    value_format: str = "",
+    vmin: float | None = None,
+    vmax: float | None = None,
+) -> dict[str, Any]:
+    """A labelled matrix with an explicit value range for colour scaling.
+
+    ``vmin``/``vmax`` travel with the spec because the renderer must colour a
+    raw count matrix (0..N) and a row-normalised one (0..1) on the same
+    component without inventing a scale of its own. They default to the data's
+    own extent; pass them to pin a scale the data does not reach — a
+    correlation matrix is read against a fixed -1..1 whether or not this
+    particular one contains a -1.
+    """
+    spec = _base("heatmap", title, x_label, y_label)
+    work = np.asarray(matrix, dtype=np.float64)
+    if work.ndim != 2:
+        raise ValueError(
+            f"heatmap needs a 2D matrix; got shape {tuple(work.shape)}."
+        )
+    rows = list(row_labels or [])
+    cols = list(col_labels or [])
+    if work.shape[0] > MAX_HEATMAP_SIDE or work.shape[1] > MAX_HEATMAP_SIDE:
+        _note(
+            spec,
+            f"showing the first {MAX_HEATMAP_SIDE}x{MAX_HEATMAP_SIDE} of "
+            f"{work.shape[0]}x{work.shape[1]} cells",
+        )
+        work = work[:MAX_HEATMAP_SIDE, :MAX_HEATMAP_SIDE]
+        rows = rows[:MAX_HEATMAP_SIDE]
+        cols = cols[:MAX_HEATMAP_SIDE]
+    finite = work[np.isfinite(work)]
+    if finite.size < work.size:
+        _note(spec, "non-finite cells drawn as 0")
+    spec["matrix"] = [[_num(v) for v in row] for row in work.tolist()]
+    spec["row_labels"] = [str(r) for r in rows]
+    spec["col_labels"] = [str(c) for c in cols]
+    spec["vmin"] = vmin if vmin is not None else (
+        float(finite.min()) if finite.size else 0.0
+    )
+    spec["vmax"] = vmax if vmax is not None else (
+        float(finite.max()) if finite.size else 1.0
+    )
+    spec["colormap"] = colormap
+    if value_format:
+        spec["value_format"] = value_format
+    return spec
+
+
+# ── text rendering ───────────────────────────────────────────────────────────
+
+def format_number(value: float, precision: int) -> str:
+    """One cell of a rendered table. NaN prints as the pandas-ish ``NaN``."""
+    if np.isnan(value):
+        return "NaN"
+    if np.isinf(value):
+        return "inf" if value > 0 else "-inf"
+    if float(value).is_integer() and abs(value) < 1e15:
+        return str(int(value))
+    return f"{value:.{precision}f}"
+
+
+def format_text_table(
+    matrix: np.ndarray,
+    columns: Sequence[str],
+    row_labels: Sequence[str],
+    *,
+    max_rows: int,
+    precision: int,
+) -> str:
+    """Render a table as fixed-width text for the Results log.
+
+    Columns are right-aligned on their widest cell, which is what makes a
+    column of numbers scannable; the row-label gutter is left-aligned.
+    """
+    rows = matrix.shape[0]
+    shown = rows if max_rows <= 0 else min(rows, max_rows)
+    labels = [str(r) for r in row_labels[:shown]]
+    labels.extend(str(i) for i in range(len(labels), shown))
+    gutter = max([len(label) for label in labels] + [0])
+
+    cells: list[list[str]] = []
+    for r in range(shown):
+        cells.append([format_number(float(v), precision) for v in matrix[r]])
+
+    widths = []
+    for c, name in enumerate(columns):
+        widest = max([len(row[c]) for row in cells] + [len(str(name))])
+        widths.append(widest)
+
+    lines = [
+        " ".join([" " * gutter] + [str(n).rjust(w) for n, w in zip(columns, widths)])
+    ]
+    for label, row in zip(labels, cells):
+        lines.append(
+            " ".join([label.ljust(gutter)] + [v.rjust(w) for v, w in zip(row, widths)])
+        )
+    if shown < rows:
+        lines.append(f"... {rows - shown} more row(s) of {rows}")
+    return "\n".join(lines)

--- a/plugins/stats/nodes/_stats_core.py
+++ b/plugins/stats/nodes/_stats_core.py
@@ -4,13 +4,15 @@ Two contracts live here, and both are normative for the pack — see
 ``plugins/stats/README.md`` for the third-party-facing version.
 
 **The table contract.** CodefyUI has no ``TABLE`` port type (``DataType`` is a
-closed Enum in core). What ``CSVReader`` and ``SyntheticDataset`` actually
-emit, and what ``ColumnSelector`` / ``RowSelector`` / ``Edu-ColumnStats``
-actually accept, is a *split table*: a 2D numeric ``TENSOR`` carrying the
-values plus a parallel ``LIST`` of column names. This pack produces and
-consumes exactly that, and additionally carries a ``row_labels`` LIST — the
-one thing no core node round-trips, and the reason a ``describe()`` table is
-readable at all.
+closed Enum in core). What ``CSVReader`` and ``SyntheticDataset`` emit is a
+*split table*: a 2D numeric ``TENSOR`` plus a parallel ``LIST`` of column
+names (plus a per-row ``labels`` LIST for the categorical column).
+``ColumnSelector`` is the only core node that reads the column-name list back.
+This pack produces and consumes that shape, and additionally carries a
+``row_labels`` LIST — no core node round-trips row names, which is why a
+``describe()`` table would otherwise print without saying which row is the
+median. ``RowSelector.labels`` is the nearest core precedent: a row-axis
+label list, not column names.
 
 **Missing values.** NaN means missing; ±Inf is a value. That is pandas' rule
 (``count()`` ignores NaN but counts Inf, so a column holding an Inf has an Inf
@@ -300,8 +302,16 @@ def _base(kind: str, title: str, x_label: str, y_label: str) -> dict[str, Any]:
     return spec
 
 
-def _note(spec: dict[str, Any], text: str) -> None:
-    """Record a downsampling / substitution notice on the spec."""
+def add_note(spec: dict[str, Any], text: str) -> None:
+    """Append a downsampling / substitution notice to *spec*, keeping any earlier one.
+
+    Public because producers add notices of their own AFTER a builder has
+    returned, and assigning ``spec["note"]`` there silently deletes the
+    builder's. That is the exact truncation lie the caps above exist to
+    prevent: a 500-bin histogram of data containing NaN would report the
+    excluded values and quietly drop "showing the first 200 of 500 bars".
+    Never assign ``note`` directly; always come through here.
+    """
     existing = spec.get("note")
     spec["note"] = f"{existing} {text}".strip() if existing else text
 
@@ -318,7 +328,7 @@ def bar_chart(
     spec = _base("bar", title, x_label, y_label)
     pairs = list(zip([str(label) for label in labels], [_num(v) for v in values]))
     if len(pairs) > MAX_BARS:
-        _note(spec, f"showing the first {MAX_BARS} of {len(pairs)} bars")
+        add_note(spec, f"showing the first {MAX_BARS} of {len(pairs)} bars")
         pairs = pairs[:MAX_BARS]
     spec["bars"] = [{"label": label, "value": value} for label, value in pairs]
     return spec
@@ -339,7 +349,7 @@ def line_chart(
     spec = _base("line", title, x_label, y_label)
     kept = list(series)
     if len(kept) > MAX_SERIES:
-        _note(spec, f"showing {MAX_SERIES} of {len(kept)} series")
+        add_note(spec, f"showing {MAX_SERIES} of {len(kept)} series")
         kept = kept[:MAX_SERIES]
     out: list[dict[str, Any]] = []
     for name, xs, ys in kept:
@@ -350,7 +360,7 @@ def line_chart(
         ]
         if len(points) > MAX_POINTS_PER_SERIES:
             step = (len(points) + MAX_POINTS_PER_SERIES - 1) // MAX_POINTS_PER_SERIES
-            _note(spec, f"series sampled every {step} points")
+            add_note(spec, f"series sampled every {step} points")
             points = points[::step]
         out.append({"name": str(name), "points": points})
     spec["series"] = out
@@ -382,7 +392,7 @@ def scatter_chart(
         points.append(point)
     if len(points) > MAX_SCATTER_POINTS:
         step = (len(points) + MAX_SCATTER_POINTS - 1) // MAX_SCATTER_POINTS
-        _note(spec, f"sampled every {step} of {len(points)} points")
+        add_note(spec, f"sampled every {step} of {len(points)} points")
         points = points[::step]
     spec["points"] = points
     return spec
@@ -397,7 +407,6 @@ def heatmap_chart(
     title: str = "",
     x_label: str = "",
     y_label: str = "",
-    value_format: str = "",
     vmin: float | None = None,
     vmax: float | None = None,
 ) -> dict[str, Any]:
@@ -419,7 +428,7 @@ def heatmap_chart(
     rows = list(row_labels or [])
     cols = list(col_labels or [])
     if work.shape[0] > MAX_HEATMAP_SIDE or work.shape[1] > MAX_HEATMAP_SIDE:
-        _note(
+        add_note(
             spec,
             f"showing the first {MAX_HEATMAP_SIDE}x{MAX_HEATMAP_SIDE} of "
             f"{work.shape[0]}x{work.shape[1]} cells",
@@ -429,19 +438,20 @@ def heatmap_chart(
         cols = cols[:MAX_HEATMAP_SIDE]
     finite = work[np.isfinite(work)]
     if finite.size < work.size:
-        _note(spec, "non-finite cells drawn as 0")
+        add_note(spec, "non-finite cells drawn as 0")
     spec["matrix"] = [[_num(v) for v in row] for row in work.tolist()]
     spec["row_labels"] = [str(r) for r in rows]
     spec["col_labels"] = [str(c) for c in cols]
-    spec["vmin"] = vmin if vmin is not None else (
-        float(finite.min()) if finite.size else 0.0
+    # Through _num like every other number in a spec: this is the function a
+    # third party copies, so it has to obey Rule 1 of the chart contract even
+    # when the caller hands it an inf bound.
+    spec["vmin"] = _num(vmin) if vmin is not None else (
+        _num(finite.min()) if finite.size else 0.0
     )
-    spec["vmax"] = vmax if vmax is not None else (
-        float(finite.max()) if finite.size else 1.0
+    spec["vmax"] = _num(vmax) if vmax is not None else (
+        _num(finite.max()) if finite.size else 1.0
     )
     spec["colormap"] = colormap
-    if value_format:
-        spec["value_format"] = value_format
     return spec
 
 

--- a/plugins/stats/nodes/stats_chart_view_node.py
+++ b/plugins/stats/nodes/stats_chart_view_node.py
@@ -1,0 +1,303 @@
+"""StatsChartViewNode — render a chart payload, or a plain table, as a chart.
+
+Declares ``media=MEDIA_CHART`` on its output, so the spec rides the #117
+``output_kind`` channel to the browser and is drawn by the app's own SVG
+plotting components — crisp, themed and hoverable, rather than a
+server-rendered PNG.
+
+It takes either input:
+
+* a ``chart`` spec from ``Stats-Histogram`` / ``Stats-Correlation`` /
+  ``Stats-ConfusionMatrix``, to retitle or redraw as a different kind; or
+* a ``table`` (plus the usual ``columns`` / ``row_labels``), so the required
+  "CSV -> GroupBy -> Chart" shape needs no chart-payload adapter node in
+  between. Anything producing the pack's table contract can be charted.
+
+``kind`` conversions are best-effort and never fatal: a heatmap asked to
+become a bar chart stays a heatmap and says so in the chart's note, because
+there is no honest way to flatten a matrix into bars and a failed run would
+lose the picture entirely.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.node_base import (
+    MEDIA_CHART,
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+from ._stats_core import (
+    CHART_KINDS,
+    as_matrix,
+    bar_chart,
+    heatmap_chart,
+    line_chart,
+    parse_names,
+    resolve_columns,
+    scatter_chart,
+)
+
+_KINDS = ("auto",) + CHART_KINDS
+
+
+def _points_of(spec: dict[str, Any]) -> list[tuple[float, float, str]]:
+    """Flatten whatever a spec carries into (x, y, label) triples."""
+    if "bars" in spec:
+        return [
+            (float(i), float(bar.get("value", 0.0)), str(bar.get("label", i)))
+            for i, bar in enumerate(spec["bars"])
+        ]
+    if "series" in spec:
+        out: list[tuple[float, float, str]] = []
+        for series in spec["series"]:
+            name = str(series.get("name", ""))
+            for x, y in series.get("points", []):
+                out.append((float(x), float(y), name))
+        return out
+    if "points" in spec:
+        return [
+            (float(p.get("x", 0.0)), float(p.get("y", 0.0)), str(p.get("label", "")))
+            for p in spec["points"]
+        ]
+    return []
+
+
+def convert_chart(spec: dict[str, Any], kind: str) -> dict[str, Any]:
+    """Redraw ``spec`` as ``kind``, or hand it back untouched with a note."""
+    current = str(spec.get("kind", ""))
+    if kind == current:
+        return spec
+
+    title = str(spec.get("title", ""))
+    x_label = str(spec.get("x_label", ""))
+    y_label = str(spec.get("y_label", ""))
+
+    # A matrix has no faithful 1D reading, and nothing 1D can be made into a
+    # matrix, so those two directions are the ones that refuse.
+    if current == "heatmap" or kind == "heatmap":
+        out = dict(spec)
+        note = f"cannot redraw a {current} chart as {kind}; showing it as {current}"
+        out["note"] = f"{spec['note']} {note}".strip() if spec.get("note") else note
+        return out
+
+    triples = _points_of(spec)
+    if kind == "bar":
+        converted = bar_chart(
+            [label or f"{x:g}" for x, _y, label in triples],
+            [y for _x, y, _label in triples],
+            title=title, x_label=x_label, y_label=y_label,
+        )
+    elif kind == "line":
+        converted = line_chart(
+            [("", [x for x, _y, _l in triples], [y for _x, y, _l in triples])],
+            title=title, x_label=x_label, y_label=y_label,
+        )
+    else:
+        converted = scatter_chart(
+            [x for x, _y, _l in triples],
+            [y for _x, y, _l in triples],
+            labels=[label for _x, _y, label in triples],
+            title=title, x_label=x_label, y_label=y_label,
+        )
+    if spec.get("note"):
+        converted["note"] = (
+            f"{spec['note']} {converted.get('note', '')}".strip()
+        )
+    return converted
+
+
+class StatsChartViewNode(BaseNode):
+    NODE_NAME = "Stats-ChartView"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "Draw a chart in the Results panel: bar, line, scatter or heatmap. "
+        "Takes a chart payload from another Stats node, or any table plus its "
+        "column names and row labels."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="chart",
+                data_type=DataType.ANY,
+                description="Chart payload from Stats-Histogram / Correlation / ConfusionMatrix.",
+                optional=True,
+            ),
+            PortDefinition(
+                name="table",
+                data_type=DataType.TENSOR,
+                description="A table to chart, when no `chart` payload is connected.",
+                optional=True,
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Optional column names for `table`.",
+                optional=True,
+            ),
+            PortDefinition(
+                name="row_labels",
+                data_type=DataType.LIST,
+                description="Optional row labels for `table` — the category axis of a bar chart.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="chart",
+                data_type=DataType.ANY,
+                description="The rendered chart spec (also drawn in the Results panel).",
+                media=MEDIA_CHART,
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="kind",
+                param_type=ParamType.SELECT,
+                default="auto",
+                options=list(_KINDS),
+                description=(
+                    "`auto` keeps a payload's own kind, and picks bar or line for a "
+                    "table depending on whether it has row labels."
+                ),
+            ),
+            ParamDefinition(
+                name="title",
+                param_type=ParamType.STRING,
+                default="",
+                description="Chart title. Empty keeps the incoming payload's title.",
+            ),
+            ParamDefinition(
+                name="columns_filter",
+                param_type=ParamType.STRING,
+                default="",
+                description=(
+                    "Which table columns to chart, by name or index, comma-separated. "
+                    "Empty charts them all. A scatter uses the first two."
+                ),
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        kind = str(params.get("kind", "auto") or "auto")
+        if kind not in _KINDS:
+            raise ValueError(
+                f"{self.NODE_NAME}: unknown kind {kind!r}; expected one of {list(_KINDS)}."
+            )
+        title = str(params.get("title", "") or "").strip()
+
+        payload = inputs.get("chart")
+        if isinstance(payload, dict) and payload:
+            if "kind" not in payload:
+                raise ValueError(
+                    f"{self.NODE_NAME}: the `chart` input is a dict but carries no "
+                    "`kind` — it is not a chart payload."
+                )
+            spec = dict(payload) if kind == "auto" else convert_chart(dict(payload), kind)
+        elif inputs.get("table") is not None:
+            spec = self._chart_from_table(inputs, params, kind, title)
+        else:
+            raise ValueError(
+                f"{self.NODE_NAME}: connect either a `chart` payload or a `table`."
+            )
+
+        if title:
+            spec["title"] = title
+        return {"chart": spec}
+
+    def _chart_from_table(
+        self, inputs: dict[str, Any], params: dict[str, Any], kind: str, title: str
+    ) -> dict[str, Any]:
+        table = as_matrix(inputs.get("table"), node=self.NODE_NAME)
+        names = resolve_columns(inputs.get("columns"), table.shape[1])
+        raw_rows = inputs.get("row_labels")
+        row_labels = (
+            [str(r) for r in raw_rows] if isinstance(raw_rows, (list, tuple)) else []
+        )
+
+        selection = [
+            self._resolve_column(token, names)
+            for token in parse_names(params.get("columns_filter"))
+        ] or list(range(len(names)))
+
+        if kind == "auto":
+            # Row labels mean the rows are categories, and categories are bars.
+            # Without them the row index is a continuous axis, so: a line.
+            kind = "bar" if row_labels else "line"
+
+        labels = list(row_labels) or [str(i) for i in range(table.shape[0])]
+
+        if kind == "heatmap":
+            return heatmap_chart(
+                table[:, selection],
+                row_labels=labels,
+                col_labels=[names[c] for c in selection],
+                title=title,
+            )
+        if kind == "scatter":
+            if len(selection) < 2:
+                raise ValueError(
+                    f"{self.NODE_NAME}: a scatter needs two columns for x and y; "
+                    f"only {len(selection)} selected."
+                )
+            x, y = selection[0], selection[1]
+            return scatter_chart(
+                table[:, x], table[:, y], labels=labels,
+                title=title, x_label=names[x], y_label=names[y],
+            )
+        if kind == "line":
+            return line_chart(
+                [
+                    (names[c], list(range(table.shape[0])), table[:, c])
+                    for c in selection
+                ],
+                title=title, x_label="row", y_label="value",
+            )
+        column = selection[0]
+        spec = bar_chart(
+            labels, table[:, column],
+            title=title, x_label="group", y_label=names[column],
+        )
+        if len(selection) > 1:
+            spec["note"] = (
+                f"charting {names[column]!r}; a bar chart shows one column — set "
+                "columns_filter to pick another"
+            )
+        return spec
+
+    def _resolve_column(self, token: str, names: list[str]) -> int:
+        if token in names:
+            return names.index(token)
+        try:
+            index = int(token)
+        except ValueError:
+            raise ValueError(
+                f"{self.NODE_NAME}: `columns_filter` names unknown column "
+                f"{token!r}; the table has {names}."
+            ) from None
+        if not 0 <= index < len(names):
+            raise ValueError(
+                f"{self.NODE_NAME}: `columns_filter` index {index} is out of range "
+                f"for a table with {len(names)} column(s)."
+            )
+        return index

--- a/plugins/stats/nodes/stats_chart_view_node.py
+++ b/plugins/stats/nodes/stats_chart_view_node.py
@@ -34,6 +34,7 @@ from app.core.node_base import (
 
 from ._stats_core import (
     CHART_KINDS,
+    add_note,
     as_matrix,
     bar_chart,
     heatmap_chart,
@@ -82,8 +83,9 @@ def convert_chart(spec: dict[str, Any], kind: str) -> dict[str, Any]:
     # matrix, so those two directions are the ones that refuse.
     if current == "heatmap" or kind == "heatmap":
         out = dict(spec)
-        note = f"cannot redraw a {current} chart as {kind}; showing it as {current}"
-        out["note"] = f"{spec['note']} {note}".strip() if spec.get("note") else note
+        add_note(
+            out, f"cannot redraw a {current} chart as {kind}; showing it as {current}"
+        )
         return out
 
     triples = _points_of(spec)
@@ -106,9 +108,11 @@ def convert_chart(spec: dict[str, Any], kind: str) -> dict[str, Any]:
             title=title, x_label=x_label, y_label=y_label,
         )
     if spec.get("note"):
-        converted["note"] = (
-            f"{spec['note']} {converted.get('note', '')}".strip()
-        )
+        # The source's notice comes FIRST, then whatever the rebuild added.
+        carried = converted.pop("note", "")
+        add_note(converted, str(spec["note"]))
+        if carried:
+            add_note(converted, carried)
     return converted
 
 
@@ -279,9 +283,10 @@ class StatsChartViewNode(BaseNode):
             title=title, x_label="group", y_label=names[column],
         )
         if len(selection) > 1:
-            spec["note"] = (
+            add_note(
+                spec,
                 f"charting {names[column]!r}; a bar chart shows one column — set "
-                "columns_filter to pick another"
+                "columns_filter to pick another",
             )
         return spec
 

--- a/plugins/stats/nodes/stats_confusion_matrix_node.py
+++ b/plugins/stats/nodes/stats_confusion_matrix_node.py
@@ -1,0 +1,245 @@
+"""StatsConfusionMatrixNode — true-vs-predicted counts, and the heatmap of them.
+
+Matches ``sklearn.metrics.confusion_matrix``: rows are the true class, columns
+the predicted one, classes sort ascending unless named explicitly, and
+``normalize`` takes the same four values with the same meanings —
+
+===========  ================================================================
+``none``     raw counts
+``true``     each row divided by its own total: per-class recall on the diagonal
+``pred``     each column divided by its own total: per-class precision
+``all``      divided by the grand total: the joint distribution
+===========  ================================================================
+
+A row (or column) that sums to zero would make that division 0/0. sklearn
+resolves it with ``np.nan_to_num``, so an absent class reads as a band of
+zeros rather than a band of NaN, and this node does the same — which also
+keeps the chart payload JSON-safe.
+
+Predictions and labels may each arrive as a list of strings (``CSVReader``'s
+``labels``), a 1D tensor of class indices (an ``argmax``), or a 2D tensor of
+logits / one-hots, whose row argmax is taken. Everything is compared as a
+string, so an integer-coded prediction still lines up with a string label of
+the same class.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from app.core.node_base import (
+    MEDIA_CHART,
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+from ._stats_core import as_labels, heatmap_chart, parse_names, to_tensor
+
+_NORMALIZE = ("none", "true", "pred", "all")
+
+
+def _sorted_classes(labels: list[str]) -> list[str]:
+    """sklearn's class order: sorted, numerically where the labels are numbers.
+
+    Plain lexicographic sorting puts class 10 before class 2, which silently
+    permutes the rows of any matrix built over integer-coded classes.
+    """
+    unique = sorted(set(labels))
+    try:
+        return sorted(unique, key=float)
+    except ValueError:
+        return unique
+
+
+class StatsConfusionMatrixNode(BaseNode):
+    NODE_NAME = "Stats-ConfusionMatrix"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "Confusion matrix of predictions against true labels — rows are the "
+        "true class, columns the predicted one. Normalize by true row "
+        "(recall), predicted column (precision) or the grand total. Renders as "
+        "a heatmap in the Results panel and the node's detail view."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="predictions",
+                data_type=DataType.ANY,
+                description=(
+                    "Predicted class per sample: a list of labels, a 1D tensor of "
+                    "class indices, or a 2D [samples, classes] score matrix."
+                ),
+            ),
+            PortDefinition(
+                name="labels",
+                data_type=DataType.ANY,
+                description="True class per sample, in the same forms as `predictions`.",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="matrix",
+                data_type=DataType.TENSOR,
+                description="float32 [classes, classes]; rows true, columns predicted.",
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Predicted-class names, matching the matrix columns.",
+            ),
+            PortDefinition(
+                name="row_labels",
+                data_type=DataType.LIST,
+                description="True-class names, matching the matrix rows.",
+            ),
+            PortDefinition(
+                name="accuracy",
+                data_type=DataType.SCALAR,
+                description="Fraction of samples on the diagonal, from the raw counts.",
+            ),
+            PortDefinition(
+                name="chart",
+                data_type=DataType.ANY,
+                description="Heatmap spec for Stats-ChartView; also rendered directly.",
+                media=MEDIA_CHART,
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="normalize",
+                param_type=ParamType.SELECT,
+                default="none",
+                options=list(_NORMALIZE),
+                description=(
+                    "`none` counts; `true` divides each row (recall on the "
+                    "diagonal); `pred` divides each column (precision); `all` "
+                    "divides by the total."
+                ),
+            ),
+            ParamDefinition(
+                name="class_names",
+                param_type=ParamType.STRING,
+                default="",
+                description=(
+                    "Comma-separated class order. Empty means every class seen in "
+                    "either input, sorted. Naming classes explicitly also keeps a "
+                    "class with no samples in the matrix."
+                ),
+            ),
+            ParamDefinition(
+                name="title",
+                param_type=ParamType.STRING,
+                default="Confusion matrix",
+                description="Chart title.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        predictions = as_labels(
+            inputs.get("predictions"), node=self.NODE_NAME, port="predictions"
+        )
+        truth = as_labels(inputs.get("labels"), node=self.NODE_NAME, port="labels")
+        if len(predictions) != len(truth):
+            raise ValueError(
+                f"{self.NODE_NAME}: `predictions` has {len(predictions)} entries but "
+                f"`labels` has {len(truth)} — they must be per-sample and aligned."
+            )
+
+        normalize = str(params.get("normalize", "none") or "none")
+        if normalize not in _NORMALIZE:
+            raise ValueError(
+                f"{self.NODE_NAME}: unknown normalize {normalize!r}; "
+                f"expected one of {list(_NORMALIZE)}."
+            )
+
+        named = parse_names(params.get("class_names", ""))
+        classes = named or _sorted_classes(truth + predictions)
+        if not classes:
+            raise ValueError(
+                f"{self.NODE_NAME}: no classes to report — both inputs are empty "
+                "and no class_names were given."
+            )
+        index = {name: i for i, name in enumerate(classes)}
+
+        counts = np.zeros((len(classes), len(classes)), dtype=np.float64)
+        ignored = 0
+        for actual, predicted in zip(truth, predictions):
+            row = index.get(actual)
+            col = index.get(predicted)
+            if row is None or col is None:
+                # Only reachable with an explicit class_names list that omits a
+                # class present in the data. Counting it into some other cell
+                # would corrupt every rate derived from the matrix.
+                ignored += 1
+                continue
+            counts[row, col] += 1.0
+
+        total = float(counts.sum())
+        accuracy = float(np.trace(counts) / total) if total else 0.0
+
+        matrix = counts
+        if normalize == "true":
+            matrix = _divide(counts, counts.sum(axis=1, keepdims=True))
+        elif normalize == "pred":
+            matrix = _divide(counts, counts.sum(axis=0, keepdims=True))
+        elif normalize == "all":
+            matrix = _divide(counts, np.array([[total]]))
+
+        chart = heatmap_chart(
+            matrix,
+            row_labels=classes,
+            col_labels=classes,
+            colormap="blues",
+            title=str(params.get("title", "Confusion matrix") or "Confusion matrix"),
+            x_label="predicted",
+            y_label="true",
+            value_format="0" if normalize == "none" else "0.00",
+            vmin=0.0,
+            vmax=None if normalize == "none" else 1.0,
+        )
+        if ignored:
+            chart["note"] = (
+                f"{ignored} sample(s) ignored — their class is not in class_names"
+            )
+
+        return {
+            "matrix": to_tensor(matrix),
+            "columns": list(classes),
+            "row_labels": list(classes),
+            "accuracy": accuracy,
+            "chart": chart,
+        }
+
+
+def _divide(counts: np.ndarray, denominator: np.ndarray) -> np.ndarray:
+    """Normalise, resolving 0/0 to 0 the way sklearn's nan_to_num does.
+
+    ``np.divide`` with a ``where`` mask leaves the untouched cells at whatever
+    ``out`` was initialised to, so starting from zeros gives exactly sklearn's
+    answer without ever evaluating the invalid division (and so without the
+    RuntimeWarning that would come with it).
+    """
+    out = np.zeros_like(counts)
+    denom = np.broadcast_to(denominator, counts.shape)
+    np.divide(counts, denom, out=out, where=denom != 0)
+    return out

--- a/plugins/stats/nodes/stats_confusion_matrix_node.py
+++ b/plugins/stats/nodes/stats_confusion_matrix_node.py
@@ -38,7 +38,7 @@ from app.core.node_base import (
     PortDefinition,
 )
 
-from ._stats_core import as_labels, heatmap_chart, parse_names, to_tensor
+from ._stats_core import add_note, as_labels, heatmap_chart, parse_names, to_tensor
 
 _NORMALIZE = ("none", "true", "pred", "all")
 
@@ -213,13 +213,16 @@ class StatsConfusionMatrixNode(BaseNode):
             title=str(params.get("title", "Confusion matrix") or "Confusion matrix"),
             x_label="predicted",
             y_label="true",
-            value_format="0" if normalize == "none" else "0.00",
             vmin=0.0,
             vmax=None if normalize == "none" else 1.0,
         )
         if ignored:
-            chart["note"] = (
-                f"{ignored} sample(s) ignored — their class is not in class_names"
+            # add_note, never `chart["note"] = ...`: heatmap_chart may already
+            # have recorded a downsampling notice, and overwriting it would
+            # hide the truncation the cap exists to disclose.
+            add_note(
+                chart,
+                f"{ignored} sample(s) ignored — their class is not in class_names",
             )
 
         return {

--- a/plugins/stats/nodes/stats_correlation_node.py
+++ b/plugins/stats/nodes/stats_correlation_node.py
@@ -1,0 +1,221 @@
+"""StatsCorrelationNode — a Pearson or Spearman correlation matrix, plus a heatmap.
+
+Matches ``pandas.DataFrame.corr`` on both counts:
+
+* **Pairwise NaN handling.** With ``drop_nan`` on (the default, and pandas'
+  default) each cell is computed from the rows where *both* of its columns are
+  present, so one hole in column C does not shrink the A-B correlation. Turn it
+  off to let NaN propagate the way ``numpy.corrcoef`` does.
+* **Spearman is Pearson on ranks**, with tied values sharing their average
+  rank — the same definition ``scipy.stats.rankdata(method="average")`` uses.
+
+The heatmap is pinned to a -1..1 diverging scale rather than the data's own
+extent: a matrix whose strongest off-diagonal correlation is 0.3 must not look
+like one full of perfect correlations.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from app.core.node_base import (
+    MEDIA_CHART,
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+from ._stats_core import as_matrix, heatmap_chart, resolve_columns, to_tensor
+
+_METHODS = ("pearson", "spearman")
+
+#: Below this many complete pairs a correlation is not defined (a single point
+#: has no spread, so the denominator is zero).
+_MIN_PAIRS = 2
+
+
+def average_ranks(values: np.ndarray) -> np.ndarray:
+    """Rank ``values`` ascending, ties sharing their average rank.
+
+    Hand-rolled rather than pulled from scipy: the pack is numpy + torch only,
+    and this is the one scipy function it would otherwise need.
+    """
+    n = values.size
+    if n == 0:
+        return values.astype(np.float64)
+    # mergesort => stable, so equal values keep input order and the tie scan
+    # below walks contiguous runs.
+    order = np.argsort(values, kind="mergesort")
+    ranks = np.empty(n, dtype=np.float64)
+    ordered = values[order]
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and ordered[j + 1] == ordered[i]:
+            j += 1
+        # Ranks are 1-based, so the run [i..j] averages to (i+1 + j+1) / 2.
+        ranks[order[i:j + 1]] = (i + j + 2) / 2.0
+        i = j + 1
+    return ranks
+
+
+def _pearson(x: np.ndarray, y: np.ndarray) -> float:
+    """Pearson r for two equal-length, already-cleaned vectors."""
+    if x.size < _MIN_PAIRS:
+        return float("nan")
+    xc = x - x.mean()
+    yc = y - y.mean()
+    denom = float(np.sqrt(float(xc @ xc) * float(yc @ yc)))
+    if denom == 0.0:
+        # A constant column has no variance, so no correlation is defined.
+        return float("nan")
+    return float(float(xc @ yc) / denom)
+
+
+class StatsCorrelationNode(BaseNode):
+    NODE_NAME = "Stats-Correlation"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "Correlation matrix across a table's columns, Pearson or Spearman. "
+        "NaN is handled pairwise by default, so one gap does not shrink every "
+        "other pair. Outputs the matrix plus a -1..1 heatmap."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="table",
+                data_type=DataType.TENSOR,
+                description="2D [rows, columns] table to correlate column-wise.",
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Optional column names, in table order.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="matrix",
+                data_type=DataType.TENSOR,
+                description="float32 [columns, columns] correlation matrix.",
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Column names, matching both axes of the matrix.",
+            ),
+            PortDefinition(
+                name="row_labels",
+                data_type=DataType.LIST,
+                description="Same names as `columns` — the matrix is symmetric.",
+            ),
+            PortDefinition(
+                name="chart",
+                data_type=DataType.ANY,
+                description="Heatmap spec for Stats-ChartView; also rendered directly.",
+                media=MEDIA_CHART,
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="method",
+                param_type=ParamType.SELECT,
+                default="pearson",
+                options=list(_METHODS),
+                description=(
+                    "`pearson` measures a linear relationship; `spearman` ranks "
+                    "first, so it catches any monotonic one and shrugs off outliers."
+                ),
+            ),
+            ParamDefinition(
+                name="drop_nan",
+                param_type=ParamType.BOOL,
+                default=True,
+                description=(
+                    "Compute each pair from the rows where both columns are present "
+                    "(pandas' default). Off lets NaN propagate into the result."
+                ),
+            ),
+            ParamDefinition(
+                name="title",
+                param_type=ParamType.STRING,
+                default="Correlation",
+                description="Chart title.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        table = as_matrix(inputs.get("table"), node=self.NODE_NAME)
+        names = resolve_columns(inputs.get("columns"), table.shape[1])
+
+        method = str(params.get("method", "pearson") or "pearson")
+        if method not in _METHODS:
+            raise ValueError(
+                f"{self.NODE_NAME}: unknown method {method!r}; "
+                f"expected one of {list(_METHODS)}."
+            )
+        drop_nan = bool(params.get("drop_nan", True))
+
+        n_cols = table.shape[1]
+        matrix = np.full((n_cols, n_cols), float("nan"), dtype=np.float64)
+        missing = np.isnan(table)
+
+        for i in range(n_cols):
+            for j in range(i, n_cols):
+                if drop_nan:
+                    keep = ~(missing[:, i] | missing[:, j])
+                    x = table[keep, i]
+                    y = table[keep, j]
+                else:
+                    x = table[:, i]
+                    y = table[:, j]
+                if method == "spearman" and not (
+                    np.isnan(x).any() or np.isnan(y).any()
+                ):
+                    x = average_ranks(x)
+                    y = average_ranks(y)
+                # A NaN left in place here is deliberate: ranking would give
+                # it a finite rank and turn "undefined" into a number, so with
+                # drop_nan off Spearman propagates exactly as Pearson does.
+                r = _pearson(x, y)
+                matrix[i, j] = r
+                matrix[j, i] = r
+
+        chart = heatmap_chart(
+            matrix,
+            row_labels=names,
+            col_labels=names,
+            colormap="RdBu",
+            title=str(params.get("title", "Correlation") or "Correlation"),
+            value_format="0.00",
+            # Read against a fixed diverging scale, never the data's own extent.
+            vmin=-1.0,
+            vmax=1.0,
+        )
+
+        return {
+            "matrix": to_tensor(matrix),
+            "columns": list(names),
+            "row_labels": list(names),
+            "chart": chart,
+        }

--- a/plugins/stats/nodes/stats_correlation_node.py
+++ b/plugins/stats/nodes/stats_correlation_node.py
@@ -207,7 +207,6 @@ class StatsCorrelationNode(BaseNode):
             col_labels=names,
             colormap="RdBu",
             title=str(params.get("title", "Correlation") or "Correlation"),
-            value_format="0.00",
             # Read against a fixed diverging scale, never the data's own extent.
             vmin=-1.0,
             vmax=1.0,

--- a/plugins/stats/nodes/stats_describe_node.py
+++ b/plugins/stats/nodes/stats_describe_node.py
@@ -1,0 +1,170 @@
+"""StatsDescribeNode — the one-node answer to "what is in this data?".
+
+Reproduces ``pandas.DataFrame.describe()`` on the numeric half of a table:
+count, mean, sample std (ddof=1), min, the requested percentiles, and max —
+in that order and with pandas' row labels, so a reader who knows the pandas
+output can read this one without a legend.
+
+**NaN is missing, ±Inf is a value** — pandas' rule, pinned against the real
+library in ``backend/tests/test_stats_describe_node.py``: ``count`` is the
+non-NaN count, and a column holding an ``inf`` has an ``inf`` mean.
+
+The node reports exactly the percentiles it was asked for, sorted and
+de-duplicated. pandas ≤2.x silently appended the median to any percentile
+list; pandas 3.0 removed that (it was deprecated in 2.2), and since the CI
+matrix spans both — 3.10 resolves pandas 2.x, 3.11+ resolves 3.x — matching
+the old behaviour would make this node's output depend on which pandas
+happened to be installed next to it. It follows the surviving rule.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+from ._stats_core import (
+    as_matrix,
+    format_percentile,
+    max_of,
+    mean_of,
+    min_of,
+    parse_percentiles,
+    percentile_of,
+    present,
+    resolve_columns,
+    std_of,
+    to_tensor,
+)
+
+_AXES = ("columns", "rows", "all")
+
+
+class StatsDescribeNode(BaseNode):
+    NODE_NAME = "Stats-Describe"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "Descriptive statistics for every column of a table: count, mean, std, "
+        "min, percentiles and max, laid out exactly like pandas' describe(). "
+        "Set `axis` to describe rows instead, or the table as a whole."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="table",
+                data_type=DataType.TENSOR,
+                description="2D [rows, columns] table, or a 1D vector treated as one column.",
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Optional column names, in table order (e.g. CSVReader's `columns`).",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="table",
+                data_type=DataType.TENSOR,
+                description="[statistics, columns] float32 table of the computed statistics.",
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Column names of the output table (the described columns).",
+            ),
+            PortDefinition(
+                name="row_labels",
+                data_type=DataType.LIST,
+                description="Statistic names: count, mean, std, min, <percentiles>, max.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="axis",
+                param_type=ParamType.SELECT,
+                default="columns",
+                options=list(_AXES),
+                description=(
+                    "`columns` describes each column (the pandas default), `rows` "
+                    "describes each row, `all` describes every value as one series."
+                ),
+            ),
+            ParamDefinition(
+                name="percentiles",
+                param_type=ParamType.STRING,
+                default="25,50,75",
+                description=(
+                    "Comma-separated percentiles in 0-100. Reported exactly as "
+                    "asked, sorted and de-duplicated."
+                ),
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        table = as_matrix(inputs.get("table"), node=self.NODE_NAME)
+
+        axis = str(params.get("axis", "columns") or "columns")
+        if axis not in _AXES:
+            raise ValueError(
+                f"{self.NODE_NAME}: unknown axis {axis!r}; expected one of {list(_AXES)}."
+            )
+
+        quantiles = sorted(set(parse_percentiles(
+            params.get("percentiles", "25,50,75"),
+            node=self.NODE_NAME,
+            param="percentiles",
+        )))
+
+        if axis == "columns":
+            work = table
+            names = resolve_columns(inputs.get("columns"), table.shape[1])
+        elif axis == "rows":
+            work = table.T
+            names = [f"r{i}" for i in range(table.shape[0])]
+        else:
+            work = table.reshape(-1, 1)
+            names = ["all"]
+
+        row_labels = (
+            ["count", "mean", "std", "min"]
+            + [format_percentile(q) for q in quantiles]
+            + ["max"]
+        )
+
+        out = np.empty((len(row_labels), work.shape[1]), dtype=np.float64)
+        for c in range(work.shape[1]):
+            values = present(work[:, c])
+            stats = [float(values.size), mean_of(values), std_of(values), min_of(values)]
+            stats.extend(percentile_of(values, q) for q in quantiles)
+            stats.append(max_of(values))
+            out[:, c] = stats
+
+        return {
+            "table": to_tensor(out),
+            "columns": list(names),
+            "row_labels": row_labels,
+        }

--- a/plugins/stats/nodes/stats_group_by_aggregate_node.py
+++ b/plugins/stats/nodes/stats_group_by_aggregate_node.py
@@ -1,0 +1,273 @@
+"""StatsGroupByAggregateNode — one row per group, one aggregate per column.
+
+Two ways to say what a group is, because CodefyUI tables carry their
+categorical column *beside* the numeric matrix rather than inside it:
+
+* connect ``keys`` — a per-row label list, which is exactly what
+  ``CSVReader``'s ``labels`` output is; or
+* set ``group_by`` to one or more of the table's own columns, by name or by
+  index, for data that is already numerically coded.
+
+``group_by`` wins when both are given, so a graph that leaves a ``keys`` edge
+connected while experimenting with a column grouping gets the thing it just
+typed rather than the thing it forgot to unplug.
+
+Aggregates follow pandas' ``groupby`` semantics: NaN is skipped, ``count`` is
+the number of *present* values in that column and group (which is why the
+separate ``counts`` output carries the group's row count), and ``std`` is the
+sample std, ddof=1.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+from ._stats_core import (
+    AGGREGATIONS,
+    as_matrix,
+    max_of,
+    mean_of,
+    min_of,
+    parse_names,
+    present,
+    resolve_columns,
+    std_of,
+    to_tensor,
+)
+
+
+def _aggregate(values: np.ndarray, how: str) -> float:
+    present_values = present(values)
+    if how == "count":
+        return float(present_values.size)
+    if how == "sum":
+        # pandas sums an all-NaN group to 0.0, not NaN.
+        return float(present_values.sum()) if present_values.size else 0.0
+    if how == "mean":
+        return mean_of(present_values)
+    if how == "min":
+        return min_of(present_values)
+    if how == "max":
+        return max_of(present_values)
+    return std_of(present_values)
+
+
+class StatsGroupByAggregateNode(BaseNode):
+    NODE_NAME = "Stats-GroupByAggregate"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "Collapse a table to one row per group. Group by a per-row label list "
+        "on `keys` (e.g. CSVReader's labels) or by the table's own columns via "
+        "`group_by`, then aggregate every remaining column with mean / sum / "
+        "count / min / max / std."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="table",
+                data_type=DataType.TENSOR,
+                description="2D [rows, columns] table of values to aggregate.",
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Optional column names, in table order.",
+                optional=True,
+            ),
+            PortDefinition(
+                name="keys",
+                data_type=DataType.LIST,
+                description=(
+                    "Optional per-row group label, one entry per table row "
+                    "(e.g. CSVReader's `labels`)."
+                ),
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="table",
+                data_type=DataType.TENSOR,
+                description="float32 [groups, aggregated columns].",
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Aggregated column names, each suffixed with its aggregate.",
+            ),
+            PortDefinition(
+                name="row_labels",
+                data_type=DataType.LIST,
+                description="One group key per row, in output order.",
+            ),
+            PortDefinition(
+                name="counts",
+                data_type=DataType.TENSOR,
+                description="float32 [groups] — how many table rows fell in each group.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="group_by",
+                param_type=ParamType.STRING,
+                default="",
+                description=(
+                    "Comma-separated column names or indices to group by. Those "
+                    "columns leave the value set. Empty means group by the `keys` input."
+                ),
+            ),
+            ParamDefinition(
+                name="agg",
+                param_type=ParamType.SELECT,
+                default="mean",
+                options=list(AGGREGATIONS),
+                description="Aggregate applied to every value column.",
+            ),
+            ParamDefinition(
+                name="agg_overrides",
+                param_type=ParamType.STRING,
+                default="",
+                description=(
+                    "Per-column exceptions as 'column=agg' pairs, comma-separated — "
+                    "e.g. 'price=max, qty=sum'."
+                ),
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        table = as_matrix(inputs.get("table"), node=self.NODE_NAME)
+        names = resolve_columns(inputs.get("columns"), table.shape[1])
+
+        default_agg = str(params.get("agg", "mean") or "mean")
+        if default_agg not in AGGREGATIONS:
+            raise ValueError(
+                f"{self.NODE_NAME}: unknown agg {default_agg!r}; "
+                f"expected one of {list(AGGREGATIONS)}."
+            )
+        overrides = self._parse_overrides(params.get("agg_overrides", ""), names)
+
+        group_by = parse_names(params.get("group_by", ""))
+        if group_by:
+            key_columns = [self._resolve_column(token, names) for token in group_by]
+            value_columns = [c for c in range(len(names)) if c not in set(key_columns)]
+            keys = [
+                tuple(float(table[r, c]) for c in key_columns)
+                for r in range(table.shape[0])
+            ]
+            labels = ["|".join(f"{v:g}" for v in key) for key in keys]
+        else:
+            raw_keys = inputs.get("keys")
+            if not isinstance(raw_keys, (list, tuple)):
+                raise ValueError(
+                    f"{self.NODE_NAME}: nothing to group by — connect a per-row "
+                    "`keys` list or set the `group_by` param to one of the table's "
+                    "columns."
+                )
+            if len(raw_keys) != table.shape[0]:
+                raise ValueError(
+                    f"{self.NODE_NAME}: `keys` has {len(raw_keys)} entries but the "
+                    f"table has {table.shape[0]} rows — they must be aligned."
+                )
+            labels = [str(k) for k in raw_keys]
+            keys = [(label,) for label in labels]
+            value_columns = list(range(len(names)))
+
+        if not value_columns:
+            raise ValueError(
+                f"{self.NODE_NAME}: every column is a grouping column, so there is "
+                "nothing left to aggregate."
+            )
+
+        # Ordered by key so a re-run of the same graph produces the same rows.
+        # Sorting the tuples, not the rendered labels, keeps numeric groups in
+        # numeric order (10 after 2, not before it).
+        members: dict[Any, list[int]] = {}
+        label_of: dict[Any, str] = {}
+        for row, (key, label) in enumerate(zip(keys, labels)):
+            members.setdefault(key, []).append(row)
+            label_of.setdefault(key, label)
+        ordered = sorted(members)
+
+        out = np.empty((len(ordered), len(value_columns)), dtype=np.float64)
+        counts = np.empty(len(ordered), dtype=np.float64)
+        for r, key in enumerate(ordered):
+            rows = members[key]
+            counts[r] = float(len(rows))
+            for c, column in enumerate(value_columns):
+                how = overrides.get(names[column], default_agg)
+                out[r, c] = _aggregate(table[rows, column], how)
+
+        return {
+            "table": to_tensor(out),
+            "columns": [
+                f"{names[c]} [{overrides.get(names[c], default_agg)}]"
+                for c in value_columns
+            ],
+            "row_labels": [label_of[key] for key in ordered],
+            "counts": to_tensor(counts),
+        }
+
+    def _parse_overrides(self, raw: Any, names: list[str]) -> dict[str, str]:
+        overrides: dict[str, str] = {}
+        for pair in parse_names(raw):
+            column, sep, how = pair.partition("=")
+            column, how = column.strip(), how.strip()
+            if not sep or not column or not how:
+                raise ValueError(
+                    f"{self.NODE_NAME}: `agg_overrides` entry {pair!r} is not a "
+                    "'column=agg' pair."
+                )
+            if how not in AGGREGATIONS:
+                raise ValueError(
+                    f"{self.NODE_NAME}: `agg_overrides` names unknown aggregate "
+                    f"{how!r}; expected one of {list(AGGREGATIONS)}."
+                )
+            if column not in names:
+                raise ValueError(
+                    f"{self.NODE_NAME}: `agg_overrides` names unknown column "
+                    f"{column!r}; the table has {names}."
+                )
+            overrides[column] = how
+        return overrides
+
+    def _resolve_column(self, token: str, names: list[str]) -> int:
+        if token in names:
+            return names.index(token)
+        try:
+            index = int(token)
+        except ValueError:
+            raise ValueError(
+                f"{self.NODE_NAME}: `group_by` names unknown column {token!r}; "
+                f"the table has {names}."
+            ) from None
+        if not 0 <= index < len(names):
+            raise ValueError(
+                f"{self.NODE_NAME}: `group_by` index {index} is out of range for a "
+                f"table with {len(names)} column(s)."
+            )
+        return index

--- a/plugins/stats/nodes/stats_histogram_node.py
+++ b/plugins/stats/nodes/stats_histogram_node.py
@@ -1,0 +1,206 @@
+"""StatsHistogramNode — bin a tensor and hand back both a table and a chart.
+
+Wraps ``numpy.histogram`` with the two knobs that matter in practice: a fixed
+range (so two runs are comparable frame to frame) and ``density`` (so a
+histogram of 10 000 samples is comparable with one of 100).
+
+Non-finite values are dropped before binning and counted in ``dropped``.
+numpy would otherwise refuse the auto range outright — "autodetected range of
+[nan, nan] is not finite" — and, given an explicit range, would silently drop
+them anyway because every comparison against a NaN is False. Reporting the
+number is the difference between a quiet lie and a fact the reader can check.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from app.core.node_base import (
+    MEDIA_CHART,
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+from ._stats_core import as_vector, bar_chart, float_param, int_param, to_tensor
+
+_RANGE_MODES = ("auto", "manual")
+
+
+class StatsHistogramNode(BaseNode):
+    NODE_NAME = "Stats-Histogram"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "Bin a tensor into a histogram. Outputs a [bins, 3] table of "
+        "(bin_start, bin_end, count) plus a bar chart that renders in the "
+        "Results panel. Set `density` for a probability density instead of counts."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor",
+                data_type=DataType.TENSOR,
+                description="Values to bin. Any shape; flattened first.",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="table",
+                data_type=DataType.TENSOR,
+                description="float32 [bins, 3]: bin_start, bin_end, count (or density).",
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="['bin_start', 'bin_end', 'count'] — or 'density'.",
+            ),
+            PortDefinition(
+                name="row_labels",
+                data_type=DataType.LIST,
+                description="One '[lo, hi)' label per bin.",
+            ),
+            PortDefinition(
+                name="chart",
+                data_type=DataType.ANY,
+                description="Bar-chart spec for Stats-ChartView; also rendered directly.",
+                media=MEDIA_CHART,
+            ),
+            PortDefinition(
+                name="dropped",
+                data_type=DataType.SCALAR,
+                description="How many non-finite values (NaN / ±Inf) were excluded.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="bins",
+                param_type=ParamType.INT,
+                default=20,
+                min_value=1,
+                max_value=1000,
+                description="Number of equal-width bins.",
+            ),
+            ParamDefinition(
+                name="range_mode",
+                param_type=ParamType.SELECT,
+                default="auto",
+                options=list(_RANGE_MODES),
+                description=(
+                    "`auto` spans the data's own min..max; `manual` pins the range "
+                    "so successive runs are comparable."
+                ),
+            ),
+            ParamDefinition(
+                name="range_min",
+                param_type=ParamType.FLOAT,
+                default=0.0,
+                description="Low edge of the first bin (manual range only).",
+                visible_when={"range_mode": "manual"},
+            ),
+            ParamDefinition(
+                name="range_max",
+                param_type=ParamType.FLOAT,
+                default=1.0,
+                description="High edge of the last bin (manual range only).",
+                visible_when={"range_mode": "manual"},
+            ),
+            ParamDefinition(
+                name="density",
+                param_type=ParamType.BOOL,
+                default=False,
+                description=(
+                    "Report a probability density (bin areas sum to 1) instead of "
+                    "raw counts."
+                ),
+            ),
+            ParamDefinition(
+                name="title",
+                param_type=ParamType.STRING,
+                default="Histogram",
+                description="Chart title.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        values = as_vector(inputs.get("tensor"), node=self.NODE_NAME, port="tensor")
+        finite = values[np.isfinite(values)]
+        dropped = int(values.size - finite.size)
+
+        bins = int_param(params, "bins", 20, node=self.NODE_NAME)
+        if bins < 1:
+            raise ValueError(f"{self.NODE_NAME}: `bins` must be at least 1; got {bins}.")
+
+        density = bool(params.get("density", False))
+        mode = str(params.get("range_mode", "auto") or "auto")
+        if mode not in _RANGE_MODES:
+            raise ValueError(
+                f"{self.NODE_NAME}: unknown range_mode {mode!r}; "
+                f"expected one of {list(_RANGE_MODES)}."
+            )
+
+        if mode == "manual":
+            lo = float_param(params, "range_min", 0.0, node=self.NODE_NAME)
+            hi = float_param(params, "range_max", 1.0, node=self.NODE_NAME)
+            if not (np.isfinite(lo) and np.isfinite(hi)) or hi <= lo:
+                raise ValueError(
+                    f"{self.NODE_NAME}: manual range needs finite range_min < range_max; "
+                    f"got [{lo}, {hi}]."
+                )
+            span = (lo, hi)
+        elif finite.size == 0:
+            # numpy cannot autodetect a range from nothing. A unit range keeps
+            # the output well-formed (all-zero counts) instead of raising on a
+            # graph whose upstream simply produced no data yet.
+            span = (0.0, 1.0)
+        else:
+            span = None
+
+        if span is None:
+            counts, edges = np.histogram(finite, bins=bins, density=density)
+        else:
+            counts, edges = np.histogram(
+                finite, bins=bins, range=span, density=density
+            )
+
+        value_name = "density" if density else "count"
+        table = np.stack(
+            [edges[:-1], edges[1:], counts.astype(np.float64)], axis=1
+        )
+        labels = [f"[{edges[i]:g}, {edges[i + 1]:g})" for i in range(len(counts))]
+
+        chart = bar_chart(
+            labels,
+            counts,
+            title=str(params.get("title", "Histogram") or "Histogram"),
+            x_label="bin",
+            y_label=value_name,
+        )
+        if dropped:
+            chart["note"] = f"{dropped} non-finite value(s) excluded"
+
+        return {
+            "table": to_tensor(table),
+            "columns": ["bin_start", "bin_end", value_name],
+            "row_labels": labels,
+            "chart": chart,
+            "dropped": dropped,
+        }

--- a/plugins/stats/nodes/stats_histogram_node.py
+++ b/plugins/stats/nodes/stats_histogram_node.py
@@ -26,7 +26,14 @@ from app.core.node_base import (
     PortDefinition,
 )
 
-from ._stats_core import as_vector, bar_chart, float_param, int_param, to_tensor
+from ._stats_core import (
+    add_note,
+    as_vector,
+    bar_chart,
+    float_param,
+    int_param,
+    to_tensor,
+)
 
 _RANGE_MODES = ("auto", "manual")
 
@@ -195,7 +202,10 @@ class StatsHistogramNode(BaseNode):
             y_label=value_name,
         )
         if dropped:
-            chart["note"] = f"{dropped} non-finite value(s) excluded"
+            # add_note, never `chart["note"] = ...`: bar_chart may already have
+            # recorded a downsampling notice, and overwriting it would hide the
+            # truncation the cap exists to disclose.
+            add_note(chart, f"{dropped} non-finite value(s) excluded")
 
         return {
             "table": to_tensor(table),

--- a/plugins/stats/nodes/stats_percentile_node.py
+++ b/plugins/stats/nodes/stats_percentile_node.py
@@ -1,0 +1,155 @@
+"""StatsPercentileNode — the q-th percentile of a tensor, along a chosen axis.
+
+Linear interpolation between order statistics, which is numpy's and pandas'
+shared default, so a value from this node lines up with ``np.percentile`` and
+``DataFrame.quantile`` on the same data.
+
+NaN is skipped per series, as everywhere in this pack. That is deliberately
+*not* what ``np.percentile`` does — it propagates NaN across the whole
+reduction — and matches ``np.nanpercentile`` instead, minus the RuntimeWarning
+that one raises on an all-NaN slice.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+from ._stats_core import (
+    as_matrix,
+    format_percentile,
+    parse_percentiles,
+    percentile_of,
+    present,
+    resolve_columns,
+    to_tensor,
+)
+
+_AXES = ("all", "columns", "rows")
+
+
+class StatsPercentileNode(BaseNode):
+    NODE_NAME = "Stats-Percentile"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "Percentiles of a tensor: one row per requested q. `all` reduces the "
+        "whole tensor to a 1D result, `columns` gives a percentile per column, "
+        "`rows` per row. NaN is skipped; interpolation is linear."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="tensor",
+                data_type=DataType.TENSOR,
+                description="Values to take percentiles of. 1D or 2D [rows, columns].",
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Optional column names, used when `axis` is `columns`.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="percentiles",
+                data_type=DataType.TENSOR,
+                description=(
+                    "float32 [q] for axis `all`, otherwise [q, series] "
+                    "(one column per described column or row)."
+                ),
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Series names of the result, in result order.",
+            ),
+            PortDefinition(
+                name="row_labels",
+                data_type=DataType.LIST,
+                description="One label per requested percentile, e.g. 25%, 50%, 75%.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="q",
+                param_type=ParamType.STRING,
+                default="50",
+                description="Comma-separated percentiles in 0-100, e.g. '5,50,95'.",
+            ),
+            ParamDefinition(
+                name="axis",
+                param_type=ParamType.SELECT,
+                default="all",
+                options=list(_AXES),
+                description=(
+                    "`all` reduces every value to one number per q; `columns` "
+                    "reduces down each column; `rows` reduces across each row."
+                ),
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        table = as_matrix(inputs.get("tensor"), node=self.NODE_NAME, port="tensor")
+
+        axis = str(params.get("axis", "all") or "all")
+        if axis not in _AXES:
+            raise ValueError(
+                f"{self.NODE_NAME}: unknown axis {axis!r}; expected one of {list(_AXES)}."
+            )
+
+        quantiles = sorted(set(parse_percentiles(
+            params.get("q", "50"), node=self.NODE_NAME, param="q",
+        )))
+        if not quantiles:
+            raise ValueError(
+                f"{self.NODE_NAME}: `q` is empty — give at least one percentile, e.g. '50'."
+            )
+
+        if axis == "columns":
+            work = table
+            names = resolve_columns(inputs.get("columns"), table.shape[1])
+        elif axis == "rows":
+            work = table.T
+            names = [f"r{i}" for i in range(table.shape[0])]
+        else:
+            work = table.reshape(-1, 1)
+            names = ["all"]
+
+        out = np.empty((len(quantiles), work.shape[1]), dtype=np.float64)
+        for c in range(work.shape[1]):
+            values = present(work[:, c])
+            out[:, c] = [percentile_of(values, q) for q in quantiles]
+
+        # `all` collapses to the 1D tensor the name promises; the axis forms
+        # keep the [q, series] table shape so they feed TableView directly.
+        result = out.reshape(-1) if axis == "all" else out
+        return {
+            "percentiles": to_tensor(result),
+            "columns": list(names),
+            "row_labels": [format_percentile(q) for q in quantiles],
+        }

--- a/plugins/stats/nodes/stats_table_view_node.py
+++ b/plugins/stats/nodes/stats_table_view_node.py
@@ -1,0 +1,124 @@
+"""StatsTableViewNode — render a table as fixed-width text in the Results log.
+
+The terminal end of a stats chain. It emits the reserved ``__log__`` key,
+which the ``output_kind`` channel turns into a ``text`` entry (#117), so the
+rendered table appears in the Results panel with no new frontend surface at
+all — and also hands the same string back on a ``text`` port for anything
+downstream that wants it.
+
+Rows past ``max_rows`` are dropped with a trailing "... N more row(s)" line
+rather than silently, because a table that stops without saying so reads as
+the whole answer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+from ._stats_core import as_matrix, format_text_table, int_param, resolve_columns
+
+
+class StatsTableViewNode(BaseNode):
+    NODE_NAME = "Stats-TableView"
+    CATEGORY = "Data"
+    DESCRIPTION = (
+        "Show a table in the Results panel as aligned text, with its column "
+        "names and row labels. Caps the output at `max_rows` and says how many "
+        "rows it left out."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="table",
+                data_type=DataType.TENSOR,
+                description="2D [rows, columns] table to render.",
+            ),
+            PortDefinition(
+                name="columns",
+                data_type=DataType.LIST,
+                description="Optional column names, in table order.",
+                optional=True,
+            ),
+            PortDefinition(
+                name="row_labels",
+                data_type=DataType.LIST,
+                description="Optional row names — e.g. Stats-Describe's statistic names.",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="text",
+                data_type=DataType.STRING,
+                description="The rendered table, as it appears in the Results panel.",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="max_rows",
+                param_type=ParamType.INT,
+                default=20,
+                min_value=0,
+                max_value=1000,
+                description="Rows to show before truncating. 0 means every row.",
+            ),
+            ParamDefinition(
+                name="precision",
+                param_type=ParamType.INT,
+                default=4,
+                min_value=0,
+                max_value=12,
+                description="Decimal places for non-integer values.",
+            ),
+            ParamDefinition(
+                name="title",
+                param_type=ParamType.STRING,
+                default="",
+                description="Optional heading printed above the table.",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        table = as_matrix(inputs.get("table"), node=self.NODE_NAME)
+        names = resolve_columns(inputs.get("columns"), table.shape[1])
+        raw_rows = inputs.get("row_labels")
+        row_labels = (
+            [str(r) for r in raw_rows] if isinstance(raw_rows, (list, tuple)) else []
+        )
+
+        rendered = format_text_table(
+            table,
+            names,
+            row_labels,
+            max_rows=int_param(params, "max_rows", 20, node=self.NODE_NAME),
+            precision=int_param(params, "precision", 4, node=self.NODE_NAME),
+        )
+        title = str(params.get("title", "") or "").strip()
+        text = f"{title}\n{rendered}" if title else rendered
+
+        # `__log__` is the reserved key the output_kind channel reads as a
+        # `text` entry; `text` is the same string as ordinary port data.
+        return {"text": text, "__log__": text}


### PR DESCRIPTION
## Summary

Statistics as one-node answers, shipped as a first-party plugin pack at `plugins/stats/` — deliberately built against the public plugin API instead of as built-in nodes, so the API gets eaten rather than described.

Along the way this closes a gap #117 left open: kinds were documented as "plain strings so a later node pack can add its own without a core release", but the resolver only ever looked for `MEDIA_IMAGE`, so a new kind never actually reached the wire. It does now.

## Nodes

All pure, cacheable, CPU-only, numpy + torch.

| Node | In → Out | Params |
|---|---|---|
| `Stats-Describe` | table → table | `axis`, `percentiles` |
| `Stats-GroupByAggregate` | table, keys → table | `group_by`, `agg`, `agg_overrides` |
| `Stats-Histogram` | tensor → table + chart | `bins`, `range_mode`, `range_min`, `range_max`, `density`, `title` |
| `Stats-Percentile` | tensor → tensor | `q`, `axis` |
| `Stats-Correlation` | table → matrix + chart | `method`, `drop_nan`, `title` |
| `Stats-ConfusionMatrix` | predictions, labels → matrix + chart | `normalize`, `class_names`, `title` |
| `Stats-TableView` | table → display | `max_rows`, `precision`, `title` |
| `Stats-ChartView` | chart *or* table → display | `kind`, `title`, `columns_filter` |

Numeric behaviour is pinned against pandas (`describe` / `corr` / `groupby`), numpy (`percentile` / `histogram`) and sklearn (`confusion_matrix`). The pack imports none of them at runtime — a test that re-derived the same numpy call the node uses would pass however wrong both were, so the references are the point.

Three example graphs ship in `examples/Stats/` and appear in the gallery under a **Stats** section.

## The `chart` output kind

`declared_media_ports()` replaces `declared_image_ports()` and keys on **whatever string a port declared**, with any non-empty dict payload shipped through untouched. A third-party pack declaring `media="waveform"` now arrives in the browser as `{"output_kind": "waveform", ...}` with no core change; only *rendering* it needs one. `test_api_contract.py` exercises exactly that, with a kind core has never heard of.

`MEDIA_CHART` rides that path as a JSON spec:

```jsonc
{ "kind": "bar" | "line" | "scatter" | "heatmap",
  "title": "...", "x_label": "...", "y_label": "...", "note": "...",
  "bars": [{"label": "setosa", "value": 1.462}],          // bar
  "series": [{"name": "loss", "points": [[0, 1.2]]}],      // line
  "points": [{"x": 1, "y": 2, "label": "a"}],              // scatter
  "matrix": [[13, 0]], "row_labels": [], "col_labels": [], // heatmap
  "vmin": 0, "vmax": 13, "colormap": "viridis|blues|RdBu" }
```

The new `ChartView` is a dispatcher, not a fifth plotting component: it hands specs to the existing `HistogramPlot` / `LossChart` / `ScatterPlot` / `HeatmapPlot`, so a chart from a node looks exactly like the port-statistics histogram and the loss curve already do. An unknown `kind` renders a caption rather than an error or an empty box — the vocabulary is open, so an editor *will* meet one it predates.

Rendered on both required surfaces: the Results-panel log, and the Node Detail Modal's Outputs tab (read from the log, not the captures API, so a chart shows even with Record outputs off).

Two constraints are load-bearing and documented: every number must be a **finite plain Python float** (events serialise with `allow_nan=False`, and a `np.float32` is not JSON-serialisable *and* slips past the run store's `json_safe`, since only `np.float64` subclasses `float`); and specs must stay under `RUN_EVENT_PAYLOAD_CAP_BYTES`, so the pack caps at 200 bars / 8×2000 line points / 2000 scatter points / 64×64 cells and downsamples with a visible `note` rather than truncating silently.

## The table contract

The issue assumed a columnar-dict convention "already used by CSVReader/ColumnSelector". Verifying it found otherwise, and the README documents what is actually true:

- **There is no `TABLE` port type.** `DataType` is a closed Enum; a plugin cannot add one.
- What `CSVReader` and `SyntheticDataset` emit — and `ColumnSelector` / `RowSelector` / `FilterRows` / `Edu-ColumnStats` accept — is a **split table**: a 2D numeric `TENSOR` plus a parallel `LIST` of column names, with an optional per-row `LIST` for the categorical column. The pack produces and consumes exactly that, so `CSVReader → Stats-Describe` needs no adapter.
- It adds `row_labels`, which no core node round-trips — the reason a `describe()` table is readable at all.
- **NaN is missing, ±Inf is a value** (pandas' rule; it is what makes the parity hold).
- The columnar dict that `port_stats.py` accepts is an *inspection* shape only: undeclared, `repr()`-truncated on both the WS and the outputs API, and recognised only when every value is a list. The README says not to build a pipeline on it.

## Incidental fixes

- **`HeatmapPlot` hard-assumed data in `[0, 1]`** — an attention-only assumption. A confusion matrix of counts rendered every non-zero cell at full brightness, so a 13-vs-1 confusion looked like 13-vs-13. New optional `valueRange` scales the ramp; tooltips still show raw values.
- **`conftest`'s registry guard only checked for `Start`.** `rediscover_all` (what `POST /api/plugins/reload` runs) rebuilds from the machine's *real* lockfile, so a pack not installed there stayed dropped for every later test — and `Start` came back, so the guard never fired. The suite passed or failed on collection order; a pack test sorting before `test_plugin_api` was fine, one sorting after was not.
- `params.get("bins", 20) or 20` silently turned a deliberate `bins=0` into `20`, so the out-of-range check never saw it. Replaced with an `int_param` / `float_param` helper that only falls back on `None`/`""`.

One deliberate spec deviation: `Stats-Describe` reports **exactly** the percentiles asked for. pandas ≤2.x appended the median to any percentile list and 3.0 removed it (deprecated in 2.2). The CI matrix spans both — 3.10 resolves pandas 2.x, 3.11+ resolves 3.x — so matching the old rule would make the node's output depend on which pandas sat next to it.

## Test evidence

**Backend** — `2645 passed, 13 skipped`, of which **197 are the new pack suites**, plus new chart-kind cases in `test_api_contract.py` and 3 auto-discovered example graphs. Per-node numeric parity suites (`test_stats_{describe,percentile,histogram,correlation,confusion_matrix,group_by_aggregate,views}_node.py`), a pack suite (`test_stats_pack.py`, 30 tests: catalog entry, `cdui plugin install` lockfile entry, force-reinstall, hot-reload stability, all-8-nodes exposure, the AST gate over every source file *plus* a guard-the-guard case, "no pandas at runtime", and the three demo graphs executed end to end). `test_chapter_examples.py` picks up the new graphs automatically.

**Frontend** — `117 files, 2437 passed` (+31), `tsc -b` clean, `pnpm build` clean. New `ChartView.test.tsx` (16), plus additions to `HeatmapPlot`, `ResultsPanel`, `NodeDetailModal` and `useGraphExecution` suites.

**Browser e2e** (Chrome, `cdui start` against a fresh `pnpm build`):
- `cdui plugin install stats` → all 8 nodes in `GET /api/nodes` and in the palette.
- All three examples listed in the gallery under **Stats**.
- Confusion-matrix demo run end to end → heatmap rendered in the Results log **and** in the Node Detail Modal's Outputs tab (`圖表（1）`), diagonal `15 / 14 / 15` with the single off-diagonal error faintly tinted — the `vmax` scaling doing its job.
- GroupBy demo run → bar chart with `setosa 1.462 / versicolor 4.26 / virginica 5.552`, matching `iris.groupby('species')['petal length (cm)'].mean()` exactly.
- Console clean (only a MetaMask extension warning).

A cosmetic fix landed from that pass: the chart card stretched to the panel width, stranding the plot against the right edge.

Closes #130

---
Generated with [Claude Code](https://claude.com/claude-code)
