### PR TITLE
chore: bump versions to 2.0.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefyui-backend"
-version = "1.4.2"
+version = "2.0.0"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
 requires-python = ">=3.10"
 # PEP 639 SPDX license expression (bare string). The previous PEP 621

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "codefyui-backend"
-version = "1.4.2"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codefyui-frontend",
   "private": true,
-  "version": "1.4.2",
+  "version": "2.0.0",
   "license": "AGPL-3.0-only",
   "packageManager": "pnpm@9.15.0",
   "type": "module",


### PR DESCRIPTION
Cuts the 2.0.0 release.

31 commits since 1.4.2 turned CodefyUI from a canvas that runs graphs into a training platform:

- **Durable run service** — SQLite-backed runs detached from the WebSocket lifetime, per-device FIFO queue, `cdui run` CLI, Runs panel with live curves and re-attach (#150, #152, #153, #154, #158, #159)
- **UI/UX foundation** — NodePalette v2, Node Detail Modal, template gallery, Subgraph v1, circuit-board edges, rAF-batched updates + IndexedDB autosave (#161, #165, #166, #168, #198, #208, #111-#115)
- **Statistics toolchain** — sampled port statistics + Stats tab, first-party statistics node pack, PythonScript node with AST gating (#169, #173, #176)
- **Plugin platform** — Plugin API v3 (dock panels, toolbar buttons, run events, runs facade) on a tiered AST validation policy with declared capabilities (#180, #184)
- **Training depth** — AMP, gradient accumulation, `cuda:N`, OOM handling, run seeds, checkpoint resume, augmentation nodes, TensorBoard logging (#147, #188, #191, #195)
- **Validation milestone** — ResNet-18 / CIFAR-10 at 95.48%, built fully in the GUI, bitwise reproducible (#206)

No breaking API changes. The major bump marks the scope of the release, not a compatibility break.

## Changes

Three version fields only: `backend/pyproject.toml`, `backend/uv.lock`, `frontend/package.json`.

## Verification

- CI on this PR (Backend Tests / Frontend Build Check)
- Release notes go on the annotated tag; `release-build.yml` reads them into the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166FJAiynQ4Ei891qJgFYyo