### PR TITLE
fix(ui): selection, log attribution, dialog i18n, persistence visibility

### DIFF
--- a/frontend/src/components/Canvas/FlowCanvas.test.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.test.tsx
@@ -686,6 +686,51 @@ describe('context menus', () => {
     // Node menu shows Rename/Duplicate/Delete (localized).
     expect(screen.getByText(useI18n.getState().t('contextMenu.rename'))).toBeTruthy();
     expect(screen.getByText(useI18n.getState().t('contextMenu.delete'))).toBeTruthy();
+    // Only one node is selected -- "Collapse to subgraph" needs 2+ (#167).
+    expect(screen.queryByText(useI18n.getState().t('contextMenu.collapseToSubgraph'))).toBeNull();
+  });
+
+  it('right-clicking a node inside a multi-selection keeps the selection, so Collapse to subgraph still renders (#167)', () => {
+    // Simulates a box-select of a+b (both `.selected`, as React Flow's own
+    // drag-select would leave them) followed by a right-click on a MEMBER of
+    // that selection (a) -- the universal editor convention is that this
+    // keeps the whole selection, not collapses it to just the clicked node.
+    setTab({
+      nodes: [
+        node('a', { selected: true }),
+        node('b', { selected: true }),
+        node('c', { selected: false }),
+      ],
+    });
+    renderCanvas();
+    act(() =>
+      captured.rf.onNodeContextMenu({ preventDefault: vi.fn(), clientX: 1, clientY: 1 } as any, { id: 'a' }),
+    );
+    expect(activeTab().selectedNodeId).toBe('a');
+    expect(activeTab().nodes.find((n) => n.id === 'a')!.selected).toBe(true);
+    expect(activeTab().nodes.find((n) => n.id === 'b')!.selected).toBe(true);
+    expect(activeTab().nodes.find((n) => n.id === 'c')!.selected).toBe(false);
+    // selectedCount stayed >= 2, so the collapse entry point survives.
+    expect(screen.getByText(useI18n.getState().t('contextMenu.collapseToSubgraph'))).toBeTruthy();
+  });
+
+  it('right-clicking a node OUTSIDE an existing selection still narrows to just that node (#167)', () => {
+    // The original reported bug: a is selected from an earlier click, b is
+    // right-clicked. b is not part of any multi-selection, so the rewrite
+    // must still run -- this is what makes Delete-after-dismiss correct.
+    setTab({
+      nodes: [
+        node('a', { selected: true }),
+        node('b', { selected: false }),
+      ],
+    });
+    renderCanvas();
+    act(() =>
+      captured.rf.onNodeContextMenu({ preventDefault: vi.fn(), clientX: 1, clientY: 1 } as any, { id: 'b' }),
+    );
+    expect(activeTab().nodes.find((n) => n.id === 'a')!.selected).toBe(false);
+    expect(activeTab().nodes.find((n) => n.id === 'b')!.selected).toBe(true);
+    expect(screen.queryByText(useI18n.getState().t('contextMenu.collapseToSubgraph'))).toBeNull();
   });
 
   it('renders the note menu variant for note nodes', () => {

--- a/frontend/src/components/Canvas/FlowCanvas.test.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.test.tsx
@@ -553,6 +553,42 @@ describe('click handlers', () => {
     expect(activeTab().selectedNodeId).toBeNull();
   });
 
+  it('shift+click that removes a node from a 3-member selection leaves the other two selected (#167 follow-up)', () => {
+    // React Flow applies a shift-click's own selection effect to `.selected`
+    // via its own onNodesChange dispatch BEFORE onNodeClick fires (verified
+    // against the installed @xyflow/react source) -- so a shift-click that
+    // REMOVES `a` from an {a,b,c} selection has already left `b` and `c`
+    // selected and `a` not by the time onNodeClick runs. This starts from
+    // that already-updated state and asserts onNodeClick does not fight it.
+    setTab({
+      nodes: [
+        node('a', { selected: false }),
+        node('b', { selected: true }),
+        node('c', { selected: true }),
+      ],
+    });
+    renderCanvas();
+    act(() => captured.rf.onNodeClick({} as any, { id: 'a' }));
+    expect(activeTab().nodes.find((n) => n.id === 'a')!.selected).toBe(false);
+    expect(activeTab().nodes.find((n) => n.id === 'b')!.selected).toBe(true);
+    expect(activeTab().nodes.find((n) => n.id === 'c')!.selected).toBe(true);
+  });
+
+  it('shift+click that adds a node to a selection leaves the group selected (#167 follow-up)', () => {
+    // Companion case: React Flow has already added `c` to the {a,b}
+    // selection before onNodeClick fires.
+    setTab({
+      nodes: [
+        node('a', { selected: true }),
+        node('b', { selected: true }),
+        node('c', { selected: true }),
+      ],
+    });
+    renderCanvas();
+    act(() => captured.rf.onNodeClick({} as any, { id: 'c' }));
+    expect(activeTab().nodes.every((n) => n.selected)).toBe(true);
+  });
+
   it('opens a data tooltip on edge click when a summary exists', () => {
     setTab({
       nodes: [node('a', { data: { label: 'A', type: 'Linear', params: {}, definition: makeDef() } }), node('b')],

--- a/frontend/src/components/Canvas/FlowCanvas.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.tsx
@@ -114,6 +114,7 @@ export function FlowCanvas({ tabId }: { tabId?: string } = {}) {
   const onEdgesChange = useTabStore((s) => s.onEdgesChange);
   const storeOnConnect = useTabStore((s) => s.onConnect);
   const setSelectedNodeId = useTabStore((s) => s.setSelectedNodeId);
+  const selectNodeExclusively = useTabStore((s) => s.selectNodeExclusively);
   const deleteNode = useTabStore((s) => s.deleteNode);
   const duplicateNode = useTabStore((s) => s.duplicateNode);
   const renameNode = useTabStore((s) => s.renameNode);
@@ -541,12 +542,12 @@ export function FlowCanvas({ tabId }: { tabId?: string } = {}) {
   }, []);
 
   const handlePaneClick = useCallback(() => {
-    setSelectedNodeId(null);
+    selectNodeExclusively(null);
     setContextMenu(null);
     setPaneMenu(null);
     setEdgeTooltip(null);
     // quickSearch is closed by QuickNodeSearch's own outside-click handler
-  }, [setSelectedNodeId]);
+  }, [selectNodeExclusively]);
 
   const handlePaneContextMenu = useCallback(
     (event: MouseEvent | React.MouseEvent) => {
@@ -560,10 +561,10 @@ export function FlowCanvas({ tabId }: { tabId?: string } = {}) {
   const handleNodeContextMenu = useCallback(
     (event: React.MouseEvent, node: { id: string }) => {
       event.preventDefault();
-      setSelectedNodeId(node.id);
+      selectNodeExclusively(node.id);
       setContextMenu({ nodeId: node.id, x: event.clientX, y: event.clientY });
     },
-    [setSelectedNodeId]
+    [selectNodeExclusively]
   );
 
   const handleRename = useCallback(

--- a/frontend/src/components/CustomNodeManager/CustomNodeManager.test.tsx
+++ b/frontend/src/components/CustomNodeManager/CustomNodeManager.test.tsx
@@ -125,6 +125,19 @@ describe('CustomNodeManager', () => {
     expect(useNodeDefStore.getState().reload).toHaveBeenCalled();
   });
 
+  it('passes a translated confirmText for the delete confirmation, not a raw literal (#160)', async () => {
+    useI18n.setState({ locale: 'zh-TW' });
+    mockedRest.listCustomNodes.mockResolvedValue([customNode({ filename: 'a.py' })]);
+    render(<CustomNodeManager onClose={vi.fn()} />);
+    // The row's own delete button is already translated -- find it by its
+    // zh-TW text, the same string the confirm dialog's button should use.
+    fireEvent.click(await screen.findByText('刪除'));
+    await waitFor(() => {
+      expect(useDialogStore.getState().active).not.toBeNull();
+    });
+    expect(useDialogStore.getState().active?.confirmText).toBe('刪除');
+  });
+
   it('deleting a node does nothing when the confirmation is cancelled', async () => {
     mockedRest.listCustomNodes.mockResolvedValue([customNode({ filename: 'a.py' })]);
     render(<CustomNodeManager onClose={vi.fn()} />);

--- a/frontend/src/components/CustomNodeManager/CustomNodeManager.tsx
+++ b/frontend/src/components/CustomNodeManager/CustomNodeManager.tsx
@@ -49,7 +49,7 @@ export function CustomNodeManager({ onClose }: CustomNodeManagerProps) {
   const handleDelete = useCallback(async (filename: string) => {
     const ok = await confirm({
       title: t('customNodes.delete.confirm', { name: filename }),
-      confirmText: 'Delete',
+      confirmText: t('customNodes.delete'),
       variant: 'danger',
     });
     if (!ok) return;

--- a/frontend/src/components/ResultsPanel/ResultsPanel.test.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.test.tsx
@@ -117,6 +117,23 @@ describe('ResultsPanel — log tab basics', () => {
     expect(screen.queryByText('bad shape')).not.toBeInTheDocument();
   });
 
+  it('clicking the node id badge selects that node exclusively (#167 follow-up)', () => {
+    // This panel is not the canvas -- React Flow's own click handling never
+    // runs for it -- so the badge needs the `.selected`-syncing action
+    // (selectNodeExclusively), not the plain-click one.
+    useTabStore.getState().setNodes([
+      { id: 'abcdef1234567890', type: 'baseNode', position: { x: 0, y: 0 }, selected: false, data: { label: 'N', type: 'N', params: {} } },
+      { id: 'other', type: 'baseNode', position: { x: 0, y: 0 }, selected: true, data: { label: 'O', type: 'O', params: {} } },
+    ] as any);
+    seedLogs([makeLog({ message: 'info msg', type: 'info', nodeId: 'abcdef1234567890' })]);
+    render(<ResultsPanel />);
+    fireEvent.click(screen.getByText('abcdef12'));
+    const tab = useTabStore.getState().tabs.find((tt) => tt.id === useTabStore.getState().activeTabId)!;
+    expect(tab.selectedNodeId).toBe('abcdef1234567890');
+    expect(tab.nodes.find((n) => n.id === 'abcdef1234567890')!.selected).toBe(true);
+    expect(tab.nodes.find((n) => n.id === 'other')!.selected).toBe(false);
+  });
+
   // #125: one ResultsPanel now serves every canvas tab (only the active tab's
   // surface is mounted, and it is not remounted on a switch), so local state
   // that indexes INTO the active tab's data has to be reset by hand.

--- a/frontend/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.tsx
@@ -77,7 +77,10 @@ export function ResultsPanel() {
   const bottomRef = useRef<HTMLDivElement>(null);
   const { t } = useI18n();
 
-  const setSelectedNodeId = useTabStore((s) => s.setSelectedNodeId);
+  // "Click to highlight" is a programmatic selection (this panel is not the
+  // canvas, so React Flow's own click handling never runs for it) -- needs
+  // the `.selected`-syncing action, not the plain-click one (#167 follow-up).
+  const selectNodeExclusively = useTabStore((s) => s.selectNodeExclusively);
 
   // The badge counts RUNNING/QUEUED runs, app-wide — the one fact a user who
   // has never opened the tab needs from it. `activeCount` is seeded by the
@@ -391,7 +394,7 @@ export function ResultsPanel() {
                         title={t('results.clickToHighlight')}
                         onClick={(e) => {
                           e.stopPropagation();
-                          setSelectedNodeId(entry.nodeId!);
+                          selectNodeExclusively(entry.nodeId!);
                         }}
                       >
                         {String(entry.nodeId).slice(0, 8)}

--- a/frontend/src/components/shared/DialogContainer.test.tsx
+++ b/frontend/src/components/shared/DialogContainer.test.tsx
@@ -3,10 +3,12 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { DialogContainer } from './DialogContainer';
 import { useDialogStore } from '../../store/dialogStore';
 import { confirm, prompt } from '../../utils/dialog';
+import { useI18n } from '../../i18n';
 
 describe('DialogContainer', () => {
   beforeEach(() => {
     useDialogStore.setState({ active: null, resolve: null });
+    useI18n.setState({ locale: 'en' });
   });
 
   afterEach(() => {
@@ -120,5 +122,29 @@ describe('DialogContainer', () => {
     fireEvent.change(input, { target: { value: 'fine' } });
     fireEvent.click(screen.getByText('OK'));
     await expect(p).resolves.toBe('fine');
+  });
+
+  // ── Locale-aware fallback labels (#160) ─────────────────────────────────
+  // cancelText is passed by no production caller at all, and confirmText's
+  // English fallback ('OK' / 'Confirm') was a raw literal -- both used to
+  // reach a zh-TW user unchanged.
+
+  it('shows the zh-TW cancel and confirm labels on a confirm dialog with no override (#160)', async () => {
+    useI18n.setState({ locale: 'zh-TW' });
+    render(<DialogContainer />);
+    confirm({ title: 'X' });
+    expect(await screen.findByText('取消')).toBeTruthy();
+    expect(await screen.findByText('確認')).toBeTruthy();
+    // Never the raw English fallback for a zh-TW user.
+    expect(screen.queryByText('Cancel')).toBeNull();
+    expect(screen.queryByText('Confirm')).toBeNull();
+  });
+
+  it('shows the zh-TW OK label on a prompt dialog with no override (#160)', async () => {
+    useI18n.setState({ locale: 'zh-TW' });
+    render(<DialogContainer />);
+    prompt({ title: 'X' });
+    expect(await screen.findByText('確定')).toBeTruthy();
+    expect(screen.queryByText('OK')).toBeNull();
   });
 });

--- a/frontend/src/components/shared/DialogContainer.tsx
+++ b/frontend/src/components/shared/DialogContainer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useDialogStore } from '../../store/dialogStore';
+import { useI18n } from '../../i18n';
 import styles from './DialogContainer.module.css';
 
 /**
@@ -20,6 +21,7 @@ import styles from './DialogContainer.module.css';
 export function DialogContainer() {
   const active = useDialogStore((s) => s.active);
   const close = useDialogStore((s) => s.close);
+  const { t } = useI18n();
 
   const [inputValue, setInputValue] = useState('');
   const [validationError, setValidationError] = useState<string | null>(null);
@@ -61,9 +63,9 @@ export function DialogContainer() {
   if (!active) return null;
 
   const variant = active.kind === 'confirm' ? active.variant ?? 'info' : 'info';
-  const cancelText = active.cancelText ?? 'Cancel';
+  const cancelText = active.cancelText ?? t('dialog.cancel');
   const confirmText =
-    active.confirmText ?? (active.kind === 'prompt' ? 'OK' : 'Confirm');
+    active.confirmText ?? (active.kind === 'prompt' ? t('dialog.ok') : t('dialog.confirm'));
 
   function handleConfirm() {
     // Unreachable: the component returns null above when !active, so this

--- a/frontend/src/hooks/useGraphExecution.test.ts
+++ b/frontend/src/hooks/useGraphExecution.test.ts
@@ -305,6 +305,26 @@ describe('useGraphExecution - node_status handler', () => {
     expect(log.message).toBe('Node abcdefgh completed');
   });
 
+  it('labels a background tab log from its own nodes, not the active tab (#163)', () => {
+    // t1 (active, from beforeEach) and t2 (background) each have a node
+    // sharing the id 'n1' but carrying a DIFFERENT label -- a wrong-tab
+    // lookup would silently "succeed" by resolving t1's label instead of
+    // t2's own, rather than failing loudly.
+    const t2 = makeTab('t2', {
+      nodes: [{ id: 'n1', data: { label: 'Background Node' } }],
+      edges: [],
+    });
+    setTabs([tabById('t1'), t2], 't1');
+    renderHook(() => useGraphExecution());
+
+    act(() => {
+      (t2.ws as FakeWs).emit('node_status', { node_id: 'n1', status: 'completed' });
+    });
+
+    const log = tabById('t2').logs.find((l: any) => l.message.includes('completed'));
+    expect(log.message).toBe('Node Background Node completed');
+  });
+
   it('routes structured text / image / tensor_summary outputs (#117)', () => {
     const ws = tabById('t1').ws as FakeWs;
     renderHook(() => useGraphExecution());

--- a/frontend/src/hooks/useGraphExecution.ts
+++ b/frontend/src/hooks/useGraphExecution.ts
@@ -136,9 +136,12 @@ export function useGraphExecution() {
 
         // Suppress running/cached chatter — only surface terminal transitions.
         if (data.status !== 'running' && data.status !== 'cached') {
-          const currentTab = store.tabs.find((t) => t.id === store.activeTabId);
+          // This event's OWN tab (captured above), not whichever tab is on
+          // screen -- a background tab's run must label its log from its
+          // own nodes, never the active tab's (#163).
+          const eventTab = store.tabs.find((t) => t.id === tabId);
           const nodeLabel =
-            currentTab?.nodes.find((n) => n.id === data.node_id)?.data?.label ??
+            eventTab?.nodes.find((n) => n.id === data.node_id)?.data?.label ??
             String(data.node_id).slice(0, 8);
 
           store.addTabLog(tabId, {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -566,6 +566,11 @@ const en = {
   'persistence.quotaError': 'Could not save tabs — browser storage is full.',
   'persistence.storageUnavailable':
     'Browser storage is not working — the tabs shown may be out of date, and new changes may not be saved. Export anything you need before closing this tab.',
+  // #164: the write-side counterpart to storageUnavailable above. A save
+  // still succeeded here (on the smaller fallback tier), so this is a
+  // warning about reduced headroom going forward, not a data-loss notice.
+  'persistence.downgraded':
+    'Browser storage dropped to a smaller fallback — large graphs may stop saving.',
 
   // Shared Confirm/Prompt dialog (#160): generic fallback button labels for
   // whichever call site does not override cancelText/confirmText. Every

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -567,6 +567,14 @@ const en = {
   'persistence.storageUnavailable':
     'Browser storage is not working — the tabs shown may be out of date, and new changes may not be saved. Export anything you need before closing this tab.',
 
+  // Shared Confirm/Prompt dialog (#160): generic fallback button labels for
+  // whichever call site does not override cancelText/confirmText. Every
+  // real dialog in the app used to fall through to a hardcoded English
+  // literal here regardless of locale.
+  'dialog.cancel': 'Cancel',
+  'dialog.ok': 'OK',
+  'dialog.confirm': 'Confirm',
+
   // Per-project tab scoping (ID10): header badge + cross-project save refusal.
   'project.badge.title': 'Active project directory',
   'project.save.crossProjectRefused': 'This graph belongs to another project ({origin}) and cannot be saved into the open project.',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -552,6 +552,11 @@ const zhTW: Record<TranslationKey, string> = {
   'persistence.storageUnavailable':
     '瀏覽器儲存空間無法運作 — 畫面上的分頁可能不是最新的，新的變更也可能不會被儲存。關閉這個分頁前，請先把需要的東西匯出。',
 
+  // Shared Confirm/Prompt dialog (#160): generic fallback button labels
+  'dialog.cancel': '取消',
+  'dialog.ok': '確定',
+  'dialog.confirm': '確認',
+
   // 專案範圍的分頁持久化（ID10）：標題徽章 + 跨專案儲存拒絕
   'project.badge.title': '目前的專案目錄',
   'project.save.crossProjectRefused': '此圖屬於另一個專案（{origin}），無法儲存到目前開啟的專案。',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -551,6 +551,8 @@ const zhTW: Record<TranslationKey, string> = {
   'persistence.quotaError': '無法儲存分頁 — 瀏覽器儲存空間已滿。',
   'persistence.storageUnavailable':
     '瀏覽器儲存空間無法運作 — 畫面上的分頁可能不是最新的，新的變更也可能不會被儲存。關閉這個分頁前，請先把需要的東西匯出。',
+  'persistence.downgraded':
+    '瀏覽器儲存空間已降級為容量較小的備援方案 — 較大的圖可能會無法儲存。',
 
   // Shared Confirm/Prompt dialog (#160): generic fallback button labels
   'dialog.cancel': '取消',

--- a/frontend/src/store/tabStore.idb.test.ts
+++ b/frontend/src/store/tabStore.idb.test.ts
@@ -296,6 +296,44 @@ describe('tab autosave - IndexedDB is the write target', () => {
     expect(toasts[0].message.length).toBeGreaterThan(0);
     setItem.mockRestore();
   });
+
+  it('warns at most once per session for the downgrade, even once the 60s throttle window has passed (#164)', async () => {
+    // saveTabs retries IndexedDB on EVERY autosave, so a persistently broken
+    // database re-enters the downgrade catch indefinitely -- unlike
+    // quotaError (which only fires when the fallback write ALSO fails).
+    // warnPersistence's own throttle is 60s, and error toasts never
+    // auto-dismiss, so relying on the throttle alone would leave one new
+    // undismissed toast piling up every minute for the rest of the session.
+    // The downgrade is a one-time state transition, so it must latch at
+    // exactly one toast for the whole session, not just per 60s window.
+    const { store, idb, toast } = await loadStore();
+    vi.stubGlobal('indexedDB', {
+      open: () => {
+        const request: Record<string, unknown> = { error: new Error('gone') };
+        queueMicrotask(() => (request.onerror as (() => void) | undefined)?.());
+        return request;
+      },
+    });
+    idb._resetIdbForTests();
+
+    store.useTabStore.getState().addTab('First');
+    await vi.waitFor(() => {
+      expect(toast.useToastStore.getState().toasts).toHaveLength(1);
+    });
+
+    // Simulate the 60s throttle window having fully elapsed before the next
+    // autosave retries against the still-broken database -- if the ONLY
+    // guard were warnPersistence's throttle, this would toast a second time.
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 61_000);
+    store.useTabStore.getState().addTab('Second');
+    await vi.waitFor(() => {
+      const raw = JSON.parse(localStorage.getItem(LEGACY_KEY)!);
+      expect(raw.tabs.some((t: { name: string }) => t.name === 'Second')).toBe(true);
+    });
+    nowSpy.mockRestore();
+
+    expect(toast.useToastStore.getState().toasts).toHaveLength(1);
+  });
 });
 
 describe('tab autosave - hydration failure is surfaced', () => {

--- a/frontend/src/store/tabStore.idb.test.ts
+++ b/frontend/src/store/tabStore.idb.test.ts
@@ -25,13 +25,15 @@ async function loadStore(): Promise<{
   store: TabStoreModule;
   idb: typeof import('../utils/idb');
   persistence: typeof import('./tabPersistence');
+  toast: typeof import('./toastStore');
 }> {
   vi.resetModules();
   const idb = await import('../utils/idb');
   const persistence = await import('./tabPersistence');
+  const toast = await import('./toastStore');
   const store = await import('./tabStore');
   await store.whenTabsHydrated();
-  return { store, idb, persistence };
+  return { store, idb, persistence, toast };
 }
 
 function legacyBlob(tabs: Array<Record<string, unknown>>, activeTabId: string) {
@@ -265,8 +267,8 @@ describe('tab autosave - IndexedDB is the write target', () => {
     expect(JSON.stringify(snapshot)).not.toContain('sk-must-not-persist');
   });
 
-  it('falls back to localStorage when the IndexedDB write fails', async () => {
-    const { store, idb } = await loadStore();
+  it('falls back to localStorage and toasts once when the IndexedDB write fails (#164)', async () => {
+    const { store, idb, toast } = await loadStore();
     const setItem = vi.spyOn(Storage.prototype, 'setItem');
     // Keep `idbAvailable()` true (so the IndexedDB branch is taken) while
     // every actual open fails -- a database revoked mid-session.
@@ -285,6 +287,13 @@ describe('tab autosave - IndexedDB is the write target', () => {
     });
     const raw = localStorage.getItem(LEGACY_KEY)!;
     expect(JSON.parse(raw).tabs.some((t: { name: string }) => t.name === 'Fallback')).toBe(true);
+    // The downgrade from IndexedDB to localStorage must not be silent: it
+    // drops the storage ceiling from generous to the 5MB localStorage cap
+    // with no notice otherwise (#164).
+    const toasts = toast.useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].type).toBe('error');
+    expect(toasts[0].message.length).toBeGreaterThan(0);
     setItem.mockRestore();
   });
 });

--- a/frontend/src/store/tabStore.idb.test.ts
+++ b/frontend/src/store/tabStore.idb.test.ts
@@ -324,13 +324,22 @@ describe('tab autosave - IndexedDB is the write target', () => {
     // Simulate the 60s throttle window having fully elapsed before the next
     // autosave retries against the still-broken database -- if the ONLY
     // guard were warnPersistence's throttle, this would toast a second time.
+    //
+    // try/finally, not a bare mockRestore() after the await: if the
+    // assertion inside vi.waitFor never becomes true, waitFor throws and a
+    // bare mockRestore() on the next line would never run, leaving Date.now
+    // mocked for every later test in this file -- a failure that would look
+    // nothing like its real cause.
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 61_000);
-    store.useTabStore.getState().addTab('Second');
-    await vi.waitFor(() => {
-      const raw = JSON.parse(localStorage.getItem(LEGACY_KEY)!);
-      expect(raw.tabs.some((t: { name: string }) => t.name === 'Second')).toBe(true);
-    });
-    nowSpy.mockRestore();
+    try {
+      store.useTabStore.getState().addTab('Second');
+      await vi.waitFor(() => {
+        const raw = JSON.parse(localStorage.getItem(LEGACY_KEY)!);
+        expect(raw.tabs.some((t: { name: string }) => t.name === 'Second')).toBe(true);
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
 
     expect(toast.useToastStore.getState().toasts).toHaveLength(1);
   });

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -695,6 +695,29 @@ describe('selection and modals', () => {
     expect(activeTab().selectedNodeId).toBeNull();
   });
 
+  it('setSelectedNodeId also selects the target node in React Flow, deselecting the rest (#167)', () => {
+    // Mirrors the context-menu path (FlowCanvas#handleNodeContextMenu): n1
+    // carries a stale `.selected` from an earlier plain click, then n2 is
+    // right-clicked. `selectedNodeId` and `.selected` must agree afterwards
+    // or React Flow's Delete key removes the wrong node.
+    store().setNodes([
+      { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, selected: true, data: { label: 'A', type: 'A', params: {} } },
+      { id: 'n2', type: 'baseNode', position: { x: 0, y: 0 }, selected: false, data: { label: 'B', type: 'B', params: {} } },
+    ] as any);
+    store().setSelectedNodeId('n2');
+    const nodes = activeTab().nodes;
+    expect(nodes.find((n) => n.id === 'n1')!.selected).toBe(false);
+    expect(nodes.find((n) => n.id === 'n2')!.selected).toBe(true);
+  });
+
+  it('setSelectedNodeId(null) deselects every node', () => {
+    store().setNodes([
+      { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, selected: true, data: { label: 'A', type: 'A', params: {} } },
+    ] as any);
+    store().setSelectedNodeId(null);
+    expect(activeTab().nodes[0].selected).toBe(false);
+  });
+
   it('open/close preset modal', () => {
     store().openPresetModal('p1');
     expect(activeTab().presetModalNodeId).toBe('p1');
@@ -1231,6 +1254,61 @@ describe('onNodesChange', () => {
     expect(activeTab().nodeDetailNodeId).toBeNull();
     expect(activeTab().nodeDetailTab).toBeNull();
     expect(activeTab().nodeDetailPort).toBeNull();
+  });
+
+  // ── selection desync between the store and React Flow (#167) ─────────────
+
+  it('openNodeDetail also selects the target node in React Flow, deselecting the rest (#167)', () => {
+    store().setNodes([
+      { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, selected: true, data: { label: 'A', type: 'A', params: {} } },
+      { id: 'n2', type: 'baseNode', position: { x: 0, y: 0 }, selected: false, data: { label: 'B', type: 'B', params: {} } },
+    ] as any);
+    // Mirrors NodeDetailModal's arrow-key `goTo`, which calls openNodeDetail
+    // with no target while walking from n1 to n2.
+    store().openNodeDetail('n2');
+    const nodes = activeTab().nodes;
+    expect(nodes.find((n) => n.id === 'n1')!.selected).toBe(false);
+    expect(nodes.find((n) => n.id === 'n2')!.selected).toBe(true);
+  });
+
+  it('lets a Delete-key removal target the node the modal is showing, not a stale click (#167)', () => {
+    store().setNodes([
+      { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, selected: true, data: { label: 'A', type: 'A', params: {} } },
+      { id: 'n2', type: 'baseNode', position: { x: 0, y: 0 }, selected: false, data: { label: 'B', type: 'B', params: {} } },
+    ] as any);
+    // Arrow-navigate the open detail modal from n1 to n2.
+    store().openNodeDetail('n2');
+    // React Flow's `deleteKeyCode` removes whatever node(s) it currently
+    // considers `.selected` -- simulate exactly that straight into the
+    // reducer, the same way the real Delete key does.
+    const toRemove = activeTab().nodes.filter((n) => n.selected).map((n) => n.id);
+    store().onNodesChange(toRemove.map((id) => ({ id, type: 'remove' as const })));
+    const remainingIds = activeTab().nodes.map((n) => n.id);
+    expect(remainingIds).not.toContain('n2');
+    expect(remainingIds).toContain('n1');
+  });
+
+  it('clears selectedNodeId when the selected node is removed here', () => {
+    // React Flow's Delete key never calls `deleteNode` -- it emits a `remove`
+    // change straight into this reducer -- so `selectedNodeId` has to be
+    // cleared here too, the same way `nodeDetailNodeId` already is above, or
+    // it is left naming a node that no longer exists.
+    store().setNodes([
+      { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'A', type: 'A', params: {} } },
+    ] as any);
+    store().setSelectedNodeId('n1');
+    store().onNodesChange([{ id: 'n1', type: 'remove' }]);
+    expect(activeTab().selectedNodeId).toBeNull();
+  });
+
+  it('leaves selectedNodeId alone when a different node is removed', () => {
+    store().setNodes([
+      { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'A', type: 'A', params: {} } },
+      { id: 'n2', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'B', type: 'B', params: {} } },
+    ] as any);
+    store().setSelectedNodeId('n1');
+    store().onNodesChange([{ id: 'n2', type: 'remove' }]);
+    expect(activeTab().selectedNodeId).toBe('n1');
   });
 
   it('recalculates a bound note offset when the note itself is dragged', () => {

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -695,7 +695,44 @@ describe('selection and modals', () => {
     expect(activeTab().selectedNodeId).toBeNull();
   });
 
-  it('setSelectedNodeId also selects the target node in React Flow, deselecting the rest (#167)', () => {
+  it('setSelectedNodeId does not touch .selected -- React Flow already has, for every click (#167 follow-up)', () => {
+    // The plain-click path (FlowCanvas#handleNodeClick). By the time this
+    // runs, React Flow has already applied the click's own selection effect
+    // to `.selected` via its own dispatch -- re-deriving it here would fight
+    // that (and, for a shift+click removal specifically, get it backwards;
+    // see the "shift+click that removes..." test below).
+    store().setNodes([
+      { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, selected: false, data: { label: 'A', type: 'A', params: {} } },
+      { id: 'n2', type: 'baseNode', position: { x: 0, y: 0 }, selected: true, data: { label: 'B', type: 'B', params: {} } },
+    ] as any);
+    store().setSelectedNodeId('n1');
+    expect(activeTab().selectedNodeId).toBe('n1');
+    // .selected is exactly as it was before this call -- untouched.
+    expect(activeTab().nodes.find((n) => n.id === 'n1')!.selected).toBe(false);
+    expect(activeTab().nodes.find((n) => n.id === 'n2')!.selected).toBe(true);
+  });
+
+  it('shift+click that removes a node from a selection does not re-select it (#167 follow-up)', () => {
+    // The regression this branch introduced and this test guards against:
+    // {a, c} selected, user shift+clicks a to remove it. React Flow's own
+    // dispatch (verified against the installed @xyflow/react source)
+    // synchronously sets a.selected=false BEFORE onNodeClick -- and
+    // therefore setSelectedNodeId -- ever runs. At that point `a` looks
+    // identical (from the nodes array alone) to a stale click landing
+    // outside the current selection, which is exactly the shape
+    // selectNodeExclusively exists to correct for a right-click. Using that
+    // syncing action here would re-select `a` and deselect `c` -- the
+    // opposite of what the user just did.
+    store().setNodes([
+      { id: 'a', type: 'baseNode', position: { x: 0, y: 0 }, selected: false, data: { label: 'A', type: 'A', params: {} } },
+      { id: 'c', type: 'baseNode', position: { x: 0, y: 0 }, selected: true, data: { label: 'C', type: 'C', params: {} } },
+    ] as any);
+    store().setSelectedNodeId('a');
+    expect(activeTab().nodes.find((n) => n.id === 'a')!.selected).toBe(false);
+    expect(activeTab().nodes.find((n) => n.id === 'c')!.selected).toBe(true);
+  });
+
+  it('selectNodeExclusively selects the target node in React Flow, deselecting the rest (#167)', () => {
     // Mirrors the context-menu path (FlowCanvas#handleNodeContextMenu): n1
     // carries a stale `.selected` from an earlier plain click, then n2 is
     // right-clicked. `selectedNodeId` and `.selected` must agree afterwards
@@ -704,17 +741,17 @@ describe('selection and modals', () => {
       { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, selected: true, data: { label: 'A', type: 'A', params: {} } },
       { id: 'n2', type: 'baseNode', position: { x: 0, y: 0 }, selected: false, data: { label: 'B', type: 'B', params: {} } },
     ] as any);
-    store().setSelectedNodeId('n2');
+    store().selectNodeExclusively('n2');
     const nodes = activeTab().nodes;
     expect(nodes.find((n) => n.id === 'n1')!.selected).toBe(false);
     expect(nodes.find((n) => n.id === 'n2')!.selected).toBe(true);
   });
 
-  it('setSelectedNodeId(null) deselects every node', () => {
+  it('selectNodeExclusively(null) deselects every node', () => {
     store().setNodes([
       { id: 'n1', type: 'baseNode', position: { x: 0, y: 0 }, selected: true, data: { label: 'A', type: 'A', params: {} } },
     ] as any);
-    store().setSelectedNodeId(null);
+    store().selectNodeExclusively(null);
     expect(activeTab().nodes[0].selected).toBe(false);
   });
 

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -340,6 +340,7 @@ interface TabStoreState {
   updateNodeParams: (nodeId: string, params: Record<string, any>) => void;
   updatePresetInternalParam: (nodeId: string, internalNodeId: string, paramName: string, value: any) => void;
   setSelectedNodeId: (id: string | null) => void;
+  selectNodeExclusively: (id: string | null) => void;
   openPresetModal: (id: string) => void;
   closePresetModal: () => void;
   openSubgraphModal: (id: string) => void;
@@ -493,38 +494,30 @@ function updateTab(tabs: TabState[], tabId: string, updater: (tab: TabState) => 
 
 /**
  * Point React Flow's own per-node `.selected` flag at exactly `id`,
- * deselecting every other node (#167) -- UNLESS `id` already names a member
- * of an existing multi-selection (two or more `.selected` nodes), in which
- * case the whole selection is left alone.
+ * deselecting every other node -- UNLESS `id` already names a member of an
+ * existing multi-selection (two or more `.selected` nodes), in which case
+ * the whole selection is left alone (#167).
  *
- * `selectedNodeId` and `.selected` used to be two independent sources of
- * truth for "which node is selected". A plain click kept them in sync only
- * by accident -- React Flow selects the clicked node itself, and the click
- * handler separately calls `setSelectedNodeId` -- but a programmatic
- * selection (the detail modal's arrow keys, a right-click) wrote only the
- * store field. `deleteKeyCode` removes whatever React Flow's `.selected`
- * says, so the two paths disagreeing meant Delete could remove a different
- * node than the one on screen. Routing the two interactive selection paths
- * (`setSelectedNodeId`, `openNodeDetail`) through this makes them agree with
- * `.selected` by construction.
+ * Used by the two PROGRAMMATIC selection paths, the ones React Flow itself
+ * has no opinion about: `selectNodeExclusively` (a right-click, the
+ * ResultsPanel's "click to highlight", or any other store-driven "make this
+ * the selection") and `openNodeDetail` (the detail modal's arrow keys). That
+ * makes `selectedNodeId` and `.selected` agree by construction on those two
+ * paths. Deliberately NOT used by `setSelectedNodeId` (the plain-click
+ * path) -- see its own comment for why running this on a click would be
+ * actively wrong, not just redundant.
  *
  * The multi-selection exception exists because `.selected` is not only the
  * Delete-key target -- it is the app's OWN multi-selection, read by four
  * bulk operations (`collapseSelectionToSubgraph`, `toggleBypassForSelection`,
  * selection-scoped auto-layout, `copySelectedNodes`). Without it, right-
- * clicking a node inside a box-selection (`handleNodeContextMenu` calls
- * `setSelectedNodeId`, and React Flow does not touch `.selected` on a right-
- * click) collapsed the selection down to that one node before the context
- * menu could read it -- which silently removed `NodeContextMenu`'s only
- * entry point to "Collapse to subgraph" (#198) whenever it was opened via
- * right-click. A lone selected node, or a target outside the current
- * selection, still narrows normally -- so the modal's arrow-key target and a
- * right-clicked non-member are unaffected, which is what fixed #167 in the
- * first place. Shift+click accumulation is also unaffected: React Flow
- * applies it to `.selected` via its own `onNodesChange` dispatch before
- * `onNodeClick` (and therefore `setSelectedNodeId`) ever runs, so by the
- * time this function sees the array, the new member is already `.selected`
- * and the multi-selection guard above keeps it that way.
+ * clicking a node inside a box-selection collapsed the selection down to
+ * that one node before the context menu could read it -- which silently
+ * removed `NodeContextMenu`'s only entry point to "Collapse to subgraph"
+ * (#198) whenever it was opened via right-click. A lone selected node, or a
+ * target outside the current selection, still narrows normally -- so the
+ * modal's arrow-key target and a right-clicked non-member are unaffected,
+ * which is what fixed #167 in the first place.
  */
 function selectOnlyNode(nodes: Node<NodeData>[], id: string | null): Node<NodeData>[] {
   if (id !== null) {
@@ -1614,7 +1607,38 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
       })),
     }),
 
+  // The plain-click path (FlowCanvas#handleNodeClick) ONLY. Deliberately
+  // does NOT sync `.selected` -- contrast `selectNodeExclusively` below.
+  //
+  // React Flow already applies every click's FULL selection effect to
+  // `.selected`, via its own `onNodesChange` dispatch, before `onNodeClick`
+  // (and therefore this action) ever runs -- verified against the installed
+  // `@xyflow/react` source for all three cases: a plain click (replaces the
+  // selection), a shift+click that ADDS to one, and a shift+click that
+  // REMOVES a member from one.
+  //
+  // Re-deriving `.selected` from just `id` here would fight that -- and for
+  // a shift+click REMOVAL specifically, it would get it backwards rather
+  // than merely redundant: the node the user just removed is, by the time
+  // this runs, the one node in the array that is NOT `.selected`, which is
+  // indistinguishable from "a stale click landed on a node outside the
+  // current selection" (the exact shape `selectNodeExclusively` exists to
+  // correct for a right-click). `selectOnlyNode` cannot tell those two
+  // apart from the nodes array alone, so it would re-select the node the
+  // user just removed and deselect the rest -- the opposite of the click
+  // (#167 follow-up). Staying raw for every click side-steps the ambiguity
+  // entirely: a click's own selection effect is never touched twice.
   setSelectedNodeId: (id) =>
+    set({ tabs: updateTab(get().tabs, get().activeTabId, () => ({ selectedNodeId: id })) }),
+
+  // Right-click, the ResultsPanel's "click to highlight", the pane-click
+  // clear, and anything else that is NOT a plain click and so gets no help
+  // from React Flow's own selection handling (#167). Goes through
+  // `selectOnlyNode` so `.selected` agrees with `selectedNodeId` by
+  // construction -- see that helper's comment for the multi-selection
+  // exception, and `setSelectedNodeId` above for why the click path is a
+  // separate action rather than sharing this one.
+  selectNodeExclusively: (id) =>
     set({
       tabs: updateTab(get().tabs, get().activeTabId, (tab) => ({
         selectedNodeId: id,

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -493,7 +493,9 @@ function updateTab(tabs: TabState[], tabId: string, updater: (tab: TabState) => 
 
 /**
  * Point React Flow's own per-node `.selected` flag at exactly `id`,
- * deselecting every other node (#167).
+ * deselecting every other node (#167) -- UNLESS `id` already names a member
+ * of an existing multi-selection (two or more `.selected` nodes), in which
+ * case the whole selection is left alone.
  *
  * `selectedNodeId` and `.selected` used to be two independent sources of
  * truth for "which node is selected". A plain click kept them in sync only
@@ -502,13 +504,36 @@ function updateTab(tabs: TabState[], tabId: string, updater: (tab: TabState) => 
  * selection (the detail modal's arrow keys, a right-click) wrote only the
  * store field. `deleteKeyCode` removes whatever React Flow's `.selected`
  * says, so the two paths disagreeing meant Delete could remove a different
- * node than the one on screen. Routing every store-driven selection through
- * this makes them the same selection by construction.
+ * node than the one on screen. Routing the two interactive selection paths
+ * (`setSelectedNodeId`, `openNodeDetail`) through this makes them agree with
+ * `.selected` by construction.
+ *
+ * The multi-selection exception exists because `.selected` is not only the
+ * Delete-key target -- it is the app's OWN multi-selection, read by four
+ * bulk operations (`collapseSelectionToSubgraph`, `toggleBypassForSelection`,
+ * selection-scoped auto-layout, `copySelectedNodes`). Without it, right-
+ * clicking a node inside a box-selection (`handleNodeContextMenu` calls
+ * `setSelectedNodeId`, and React Flow does not touch `.selected` on a right-
+ * click) collapsed the selection down to that one node before the context
+ * menu could read it -- which silently removed `NodeContextMenu`'s only
+ * entry point to "Collapse to subgraph" (#198) whenever it was opened via
+ * right-click. A lone selected node, or a target outside the current
+ * selection, still narrows normally -- so the modal's arrow-key target and a
+ * right-clicked non-member are unaffected, which is what fixed #167 in the
+ * first place. Shift+click accumulation is also unaffected: React Flow
+ * applies it to `.selected` via its own `onNodesChange` dispatch before
+ * `onNodeClick` (and therefore `setSelectedNodeId`) ever runs, so by the
+ * time this function sees the array, the new member is already `.selected`
+ * and the multi-selection guard above keeps it that way.
  */
 function selectOnlyNode(nodes: Node<NodeData>[], id: string | null): Node<NodeData>[] {
+  if (id !== null) {
+    const selected = nodes.filter((n) => n.selected);
+    if (selected.length >= 2 && selected.some((n) => n.id === id)) return nodes;
+  }
   return nodes.map((n) => {
-    const selected = n.id === id;
-    return n.selected === selected ? n : { ...n, selected };
+    const isTarget = n.id === id;
+    return n.selected === isTarget ? n : { ...n, selected: isTarget };
   });
 }
 

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -1134,6 +1134,14 @@ function saveTabs(tabs: TabState[], activeTabId: string) {
       // storage). Autosave is a promise to the user, so fall back to the
       // tier that may still work rather than dropping the save.
       saveTabsToLocalStorage(records, activeTabId);
+      // The fallback above is silent by design (it has its own quotaError
+      // notice for when IT fails), but the DOWNGRADE itself must not be
+      // (#164): the user just quietly lost the generous IndexedDB ceiling
+      // for the 5MB localStorage one, with nothing said about it until a
+      // future save fails for real. A distinct key from quotaError /
+      // storageUnavailable, so a read failure and a write failure never
+      // suppress each other's warning.
+      warnPersistence('persistence.downgraded');
     });
 }
 

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -1144,6 +1144,19 @@ function saveTabsToLocalStorage(records: PersistedTab[], activeTabId: string) {
 // durability bookkeeping in `tabPersistence` assumes it sees them in order.
 let _idbWriteChain: Promise<void> = Promise.resolve();
 
+// #164 follow-up: `saveTabs` retries IndexedDB on EVERY autosave, so a
+// persistently broken database re-enters the catch below indefinitely --
+// unlike `persistence.quotaError`, which only fires when the fallback write
+// ALSO fails, and so is rare. `warnPersistence`'s own throttle is 60s, and
+// error toasts never auto-dismiss, so the throttle alone would leave one new
+// undismissed toast piling up every minute for the rest of the session. The
+// downgrade is a one-time state transition, not a recurring event, so this
+// latches it to one toast for the session regardless of how long the
+// database stays broken -- deliberately never reset, even if a later save
+// happens to succeed (a flaky database earns one warning, not a fresh one
+// every time it flickers).
+let _downgradeWarned = false;
+
 function saveTabs(tabs: TabState[], activeTabId: string) {
   const records = persistedTabsFor(tabs);
   if (!idbAvailable()) {
@@ -1165,8 +1178,13 @@ function saveTabs(tabs: TabState[], activeTabId: string) {
       // for the 5MB localStorage one, with nothing said about it until a
       // future save fails for real. A distinct key from quotaError /
       // storageUnavailable, so a read failure and a write failure never
-      // suppress each other's warning.
-      warnPersistence('persistence.downgraded');
+      // suppress each other's warning. Latched (see `_downgradeWarned`)
+      // rather than left to warnPersistence's 60s throttle alone, or a
+      // database that stays broken would re-toast every minute forever.
+      if (!_downgradeWarned) {
+        _downgradeWarned = true;
+        warnPersistence('persistence.downgraded');
+      }
     });
 }
 

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -492,6 +492,27 @@ function updateTab(tabs: TabState[], tabId: string, updater: (tab: TabState) => 
 }
 
 /**
+ * Point React Flow's own per-node `.selected` flag at exactly `id`,
+ * deselecting every other node (#167).
+ *
+ * `selectedNodeId` and `.selected` used to be two independent sources of
+ * truth for "which node is selected". A plain click kept them in sync only
+ * by accident -- React Flow selects the clicked node itself, and the click
+ * handler separately calls `setSelectedNodeId` -- but a programmatic
+ * selection (the detail modal's arrow keys, a right-click) wrote only the
+ * store field. `deleteKeyCode` removes whatever React Flow's `.selected`
+ * says, so the two paths disagreeing meant Delete could remove a different
+ * node than the one on screen. Routing every store-driven selection through
+ * this makes them the same selection by construction.
+ */
+function selectOnlyNode(nodes: Node<NodeData>[], id: string | null): Node<NodeData>[] {
+  return nodes.map((n) => {
+    const selected = n.id === id;
+    return n.selected === selected ? n : { ...n, selected };
+  });
+}
+
+/**
  * Land a block of foreign nodes plus the definitions they name (core#137).
  *
  * Shared by paste and template insert, which are the same operation with
@@ -1353,7 +1374,15 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
         // points at a node that no longer exists — harmless while it renders
         // nothing, but an undo that restores the node would pop the modal
         // back open on its own.
+        //
+        // `selectedNodeId` gets the same treatment (#167): it is the other
+        // half of the same desync the Delete key exposed, just read instead
+        // of written. Left stale, it would name a node that no longer
+        // exists to every reader of the field (bypass/copy fallbacks,
+        // future callers) even though React Flow itself has no opinion left
+        // — nothing is `.selected` once its node is gone.
         let nodeDetailNodeId = tab.nodeDetailNodeId;
+        let selectedNodeId = tab.selectedNodeId;
         if (hasRemove) {
           const removedIds = new Set(
             changes.filter((c) => c.type === 'remove').map((c) => c.id)
@@ -1366,9 +1395,12 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
           if (nodeDetailNodeId !== null && removedIds.has(nodeDetailNodeId)) {
             nodeDetailNodeId = null;
           }
+          if (selectedNodeId !== null && removedIds.has(selectedNodeId)) {
+            selectedNodeId = null;
+          }
         }
 
-        return { nodes: updatedNodes, nodeDetailNodeId };
+        return { nodes: updatedNodes, nodeDetailNodeId, selectedNodeId };
       }),
     });
   },
@@ -1532,7 +1564,12 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
     }),
 
   setSelectedNodeId: (id) =>
-    set({ tabs: updateTab(get().tabs, get().activeTabId, () => ({ selectedNodeId: id })) }),
+    set({
+      tabs: updateTab(get().tabs, get().activeTabId, (tab) => ({
+        selectedNodeId: id,
+        nodes: selectOnlyNode(tab.nodes, id),
+      })),
+    }),
 
   openPresetModal: (id) =>
     set({ tabs: updateTab(get().tabs, get().activeTabId, () => ({ presetModalNodeId: id })) }),
@@ -1560,6 +1597,7 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
       tabs: updateTab(get().tabs, get().activeTabId, (tab) => ({
         nodeDetailNodeId: id,
         selectedNodeId: id,
+        nodes: selectOnlyNode(tab.nodes, id),
         nodeDetailTab: target?.tab ?? null,
         nodeDetailPort: target?.port ?? null,
         nodeDetailRequest: tab.nodeDetailRequest + 1,


### PR DESCRIPTION
Second of three Wave 6 Sprint 1 PRs (execution order: #211). Four unrelated UI defects, batched because each is small. Commits are separated per defect.

Closes #167. Closes #163. Closes #160. Closes #164.

## #167 — Delete removed the last-clicked node, not the one on screen

The app had two sources of truth for "which node is selected": the store's `selectedNodeId`, and React Flow's own per-node `selected` flag. React Flow's Delete key acts on the second; several app paths wrote only the first. So arrow-navigating to the fifth node in the detail modal and pressing Delete removed whatever you had clicked last, and right-clicking a node then pressing Delete removed a stale selection.

The fix splits the intent instead of papering over it. `setSelectedNodeId` stays raw — the plain-click path, where React Flow has already selected the node and the store agreeing is enough. A new `selectNodeExclusively` narrows the canvas selection and is used where nothing else does it: right-click, pane-click, and the ResultsPanel badge. `openNodeDetail` keeps narrowing, since arrow-navigation moves the modal without any click.

Right-clicking a node that is already part of a multi-selection deliberately does **not** narrow it — that would have made "collapse selection into a subgraph" unreachable, since the menu gates that item on two or more nodes being selected.

Also fixed here: the `onNodesChange` reducer already cleared `nodeDetailNodeId` when its node was removed, but never `selectedNodeId`, so after any Delete the store pointed at a node that no longer existed.

## #163 — execution log labelled a background tab's nodes with the active tab's names

`useGraphExecution` wrote each log line into the event's own tab, then resolved the node's display name from `activeTabId`. Run a graph, switch tabs, and its log filled with names borrowed from whatever was on screen. One-line fix; the event's tab id was already in scope.

## #160 — dialog buttons were hardcoded English

`DialogContainer` fell back to the literals `Cancel`, `OK` and `Confirm`. `confirmText` is passed by every production caller, but `cancelText` is passed by none — so every dialog in the app showed an English "Cancel" regardless of locale. Now translated through a new `dialog.*` namespace in both locale files. A raw `'Delete'` literal in `CustomNodeManager` went the same way.

## #164 — the IndexedDB downgrade was silent

When a mid-session IndexedDB write failed, the app fell back to localStorage and said nothing, so the 5MB ceiling came back unannounced and the user found out much later when a save failed. It now surfaces a notice. The notice is latched to fire once: the write is retried on every autosave, so without a latch a persistently broken database would produce one permanent, undismissable toast per minute for the rest of the session.

## Verification

- `pnpm test` 2885 passed across 137 files; `pnpm build` green.
- TDD throughout, and each failing-first test was independently confirmed to fail against the unmodified code rather than passing either way.
- Real-browser e2e against a freshly built dist, on a server verified to be the right install and to post-date the build: the detail-modal Delete removes the node the modal is showing (the headline bug), right-click then Delete removes the right-clicked node, dialog buttons read 取消 / Cancel in the respective locales, a background tab's execution log names only its own nodes, and no CodefyUI console errors appear.

### One limitation, stated plainly

Two acceptance criteria — right-clicking inside a live multi-selection, and shift+clicking to remove one node from it — could **not** be verified in a real browser. Browser automation cannot reach a React Flow multi-selection at all: the library tracks modifier state through its own `document` keydown listener keyed on `event.code`, while the automation dispatches modifiers only as a bit on the synthesized mouse event, so no standalone Shift keydown ever arrives. A real user pressing Shift generates exactly that event; the tooling cannot.

Those two paths are covered by unit tests instead, including a genuine `FlowCanvas` → `NodeContextMenu` integration test that exercises the real context-menu chain (that component is not mocked in the test file) and asserts the collapse item still renders after a right-click inside a selection.

Noticed while investigating, not touched here: `FlowCanvas` sets `multiSelectionKeyCode="Shift"` while `selectionKeyCode` also defaults to `"Shift"`, so both are bound to the same key. That is a real double-booking, but there is no evidence it misbehaves — no real Shift signal reached the app during testing — so it is recorded as something worth a human glance rather than claimed as a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166FJAiynQ4Ei891qJgFYyo
