### PR TITLE
fix(ui): per-node auto-layout gate in the layer editor

### DIFF
--- a/frontend/src/components/SubgraphEditor/graphSerialization.test.ts
+++ b/frontend/src/components/SubgraphEditor/graphSerialization.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import type { Node, Edge } from '@xyflow/react';
 import {
@@ -477,8 +478,8 @@ describe('graphToFlow', () => {
     expect(res.nodes[1].position).toEqual({ x: 30, y: 40 });
   });
 
-  it('treats a node at x=0 but y!=0 as already positioned (needsLayout=false)', () => {
-    // Exercises the `n.position.y === 0` half of the origin check short-circuiting.
+  it('treats a node at x=0 but y!=0 as already positioned, and leaves it alone', () => {
+    // Exercises the `n.position.y === 0` half of the per-node origin check.
     const res = graphToFlow(
       JSON.stringify({
         version: 2,
@@ -489,9 +490,52 @@ describe('graphToFlow', () => {
         edges: [{ id: 'e', source: 'a', target: 'b' }],
       }),
     );
-    // a has y!=0 so the `every(... x===0 && y===0)` is false -> no relayout.
+    // a has y!=0 so it already counts as positioned -> untouched.
     expect(res.nodes[0].position).toEqual({ x: 0, y: 5 });
-    expect(res.nodes[1].position).toEqual({ x: 0, y: 0 });
+    // b sits exactly at the origin, which the origin-check treats as "no real
+    // position" (same ambiguity the gate has always had). The gate is now
+    // per-node ("some" node needs layout, not "every" node), so b still gets
+    // laid out even though its sibling a is already positioned -- it must NOT
+    // stay frozen at the literal origin.
+    expect(res.nodes[1].position).not.toEqual({ x: 0, y: 0 });
+  });
+
+  it('lays out unpositioned nodes while preserving an explicitly-positioned sibling (mixed case, #207)', () => {
+    // Regression for the actual bug: give ONE node of a position-less chain a
+    // real position and, under the old whole-spec `every(...)` gate, ALL other
+    // nodes fell through to the `position ?? {x:0,y:0}` default and stacked on
+    // top of each other at the origin -- indistinguishable from data loss. The
+    // fix makes the gate per-node: b/c/d still lack a position and must be laid
+    // out by dagre, while a's explicit coordinates must survive untouched.
+    const res = graphToFlow(
+      JSON.stringify({
+        version: 2,
+        nodes: [
+          { id: 'a', type: 'Conv2d', position: { x: 999, y: 999 } },
+          { id: 'b', type: 'Conv2d' },
+          { id: 'c', type: 'Conv2d' },
+          { id: 'd', type: 'Conv2d' },
+        ],
+        edges: [
+          { id: 'e1', source: 'a', target: 'b' },
+          { id: 'e2', source: 'b', target: 'c' },
+          { id: 'e3', source: 'c', target: 'd' },
+        ],
+      }),
+    );
+    const byId = Object.fromEntries(res.nodes.map((n) => [n.id, n]));
+
+    // The explicitly-positioned node keeps its EXACT coordinates.
+    expect(byId.a.position).toEqual({ x: 999, y: 999 });
+
+    // The unpositioned nodes are laid out by topology, not stacked at the origin.
+    const rest = ['b', 'c', 'd'].map((id) => byId[id].position);
+    for (const p of rest) {
+      expect(p).not.toEqual({ x: 0, y: 0 });
+    }
+    // ...and distinctly from one another (a real dagre layout, not one shared point).
+    const restKeys = rest.map((p) => `${p.x},${p.y}`);
+    expect(new Set(restKeys).size).toBe(rest.length);
   });
 
   it('auto-layout keeps a short chain in a single column', () => {
@@ -602,6 +646,78 @@ describe('graphToFlow', () => {
     expect(xOf('n4')).toBeGreaterThan(Math.max(xOf('n1'), xOf('n7')) + 60);
     // Outside the skip, head and tail share the base column band.
     expect(Math.abs(xOf('n0') - xOf('n11'))).toBeLessThan(1);
+  });
+});
+
+// ── graphToFlow: real shipped examples (regression, #207 item 1) ───────────
+//
+// DQN-Atari-RL, PPO-Robotics-RL and ResNet18-CIFAR10-Baseline all ship their
+// `layers` param as a fully position-less GraphSpec, relying entirely on the
+// auto-layout path to be pleasant to open. The per-node gate must not change
+// behaviour for this case: when EVERY node lacks a position, layout must run
+// exactly as it did before the fix (a spec where every node has a position,
+// the opposite end of the spectrum, is already covered under `graphToFlow`
+// above by "does NOT auto-layout when nodes already have non-origin
+// positions").
+
+/**
+ * Extract the embedded `layers` GraphSpec JSON from a shipped example's
+ * top-level graph.json, the same way `convertWorkflowToGraphSpec`'s caller
+ * detects a SequentialModel node -- by the shape of its params, not a
+ * hardcoded node id (DQN/PPO use `seq-model`, ResNet18 uses `model`).
+ */
+function loadRealLayersSpec(relativePath: string): string {
+  let raw: string;
+  try {
+    raw = readFileSync(relativePath, 'utf8');
+  } catch {
+    throw new Error(
+      `${relativePath} is missing. If the example moved, repoint this test rather than deleting it.`,
+    );
+  }
+  const graph = JSON.parse(raw) as { nodes: Array<{ data?: { params?: Record<string, unknown> } }> };
+  const seqNode = graph.nodes.find((n) => typeof n.data?.params?.layers === 'string');
+  if (!seqNode) {
+    throw new Error(`${relativePath}: no node with a string 'layers' param found`);
+  }
+  return seqNode.data!.params!.layers as string;
+}
+
+describe.each([
+  { name: 'DQN-Atari-RL', path: '../examples/Model_Architecture/DQN-Atari-RL/graph.json' },
+  { name: 'PPO-Robotics-RL', path: '../examples/Model_Architecture/PPO-Robotics-RL/graph.json' },
+  {
+    name: 'ResNet18-CIFAR10-Baseline',
+    path: '../examples/Usage_Example/ResNet18-CIFAR10-Baseline/graph.json',
+    // The largest position-less spec in the repo (#206) -- the file most
+    // likely to trip the whole-spec gate, and why this fix is worth doing now.
+    expectedNodeCount: 70,
+  },
+])('graphToFlow on the real $name layer spec', ({ path, expectedNodeCount }) => {
+  it('lays it out exactly as it does today (fully position-less spec, no regression)', () => {
+    const layersJson = loadRealLayersSpec(path);
+    const parsed: GraphSpec = JSON.parse(layersJson);
+
+    // Sanity: confirms these fixtures are actually the position-less specs
+    // the fix targets, so this test would catch it if that ever changed.
+    expect(parsed.nodes.every((n) => !n.position)).toBe(true);
+    if (expectedNodeCount !== undefined) {
+      expect(parsed.nodes.length).toBe(expectedNodeCount);
+    }
+
+    const res = graphToFlow(layersJson);
+
+    // Nothing dropped or duplicated.
+    expect(res.nodes).toHaveLength(parsed.nodes.length);
+    // Every node actually received a finite position.
+    for (const n of res.nodes) {
+      expect(Number.isFinite(n.position.x)).toBe(true);
+      expect(Number.isFinite(n.position.y)).toBe(true);
+    }
+    // Real layout happened: nodes are spread out, not all stacked together
+    // (the exact failure mode of the bug this fixes).
+    const positions = res.nodes.map((n) => `${n.position.x},${n.position.y}`);
+    expect(new Set(positions).size).toBeGreaterThan(1);
   });
 });
 

--- a/frontend/src/components/SubgraphEditor/graphSerialization.test.ts
+++ b/frontend/src/components/SubgraphEditor/graphSerialization.test.ts
@@ -538,6 +538,19 @@ describe('graphToFlow', () => {
     expect(new Set(restKeys).size).toBe(rest.length);
   });
 
+  it('a single unpositioned node is still exempt from layout (length>1 guard unchanged by every->some)', () => {
+    // On record for this task specifically: the every->some change only
+    // matters once there are >= 2 nodes to disagree about. A one-node spec
+    // never reaches `needsPosition` at all -- `spec.nodes.length > 1` short-
+    // circuits `needsLayout` to false regardless -- so it must fall through
+    // to the plain `position ?? {x:0,y:0}` default exactly as before.
+    const res = graphToFlow(
+      JSON.stringify({ version: 2, nodes: [{ id: 'solo', type: 'Conv2d' }], edges: [] }),
+    );
+    expect(res.nodes).toHaveLength(1);
+    expect(res.nodes[0].position).toEqual({ x: 0, y: 0 });
+  });
+
   it('auto-layout keeps a short chain in a single column', () => {
     // 5-node chain with no skips: the valley pass is a no-op, so dagre's
     // single-column TB layout comes through untouched.
@@ -684,16 +697,34 @@ function loadRealLayersSpec(relativePath: string): string {
 }
 
 describe.each([
-  { name: 'DQN-Atari-RL', path: '../examples/Model_Architecture/DQN-Atari-RL/graph.json' },
-  { name: 'PPO-Robotics-RL', path: '../examples/Model_Architecture/PPO-Robotics-RL/graph.json' },
+  {
+    name: 'DQN-Atari-RL',
+    path: '../examples/Model_Architecture/DQN-Atari-RL/graph.json',
+    expectedNodeCount: 12,
+    // Pinned by running the fixed code once and reading off its own output
+    // (`convertWorkflowToGraphSpec`-style specs always start with the
+    // synthesized Input node and end with the synthesized Output node, so
+    // "first"/"last" by array index are exactly those two boundary nodes).
+    expectedFirst: { id: 'in', position: { x: 0, y: 0 } },
+    expectedLast: { id: 'out', position: { x: 0, y: 1100 } },
+  },
+  {
+    name: 'PPO-Robotics-RL',
+    path: '../examples/Model_Architecture/PPO-Robotics-RL/graph.json',
+    expectedNodeCount: 7,
+    expectedFirst: { id: 'in', position: { x: 0, y: 0 } },
+    expectedLast: { id: 'out', position: { x: 0, y: 600 } },
+  },
   {
     name: 'ResNet18-CIFAR10-Baseline',
     path: '../examples/Usage_Example/ResNet18-CIFAR10-Baseline/graph.json',
     // The largest position-less spec in the repo (#206) -- the file most
     // likely to trip the whole-spec gate, and why this fix is worth doing now.
     expectedNodeCount: 70,
+    expectedFirst: { id: 'in', position: { x: 94, y: 0 } },
+    expectedLast: { id: 'out', position: { x: 94, y: 5166 } },
   },
-])('graphToFlow on the real $name layer spec', ({ path, expectedNodeCount }) => {
+])('graphToFlow on the real $name layer spec', ({ path, expectedNodeCount, expectedFirst, expectedLast }) => {
   it('lays it out exactly as it does today (fully position-less spec, no regression)', () => {
     const layersJson = loadRealLayersSpec(path);
     const parsed: GraphSpec = JSON.parse(layersJson);
@@ -701,9 +732,7 @@ describe.each([
     // Sanity: confirms these fixtures are actually the position-less specs
     // the fix targets, so this test would catch it if that ever changed.
     expect(parsed.nodes.every((n) => !n.position)).toBe(true);
-    if (expectedNodeCount !== undefined) {
-      expect(parsed.nodes.length).toBe(expectedNodeCount);
-    }
+    expect(parsed.nodes.length).toBe(expectedNodeCount);
 
     const res = graphToFlow(layersJson);
 
@@ -718,6 +747,17 @@ describe.each([
     // (the exact failure mode of the bug this fixes).
     const positions = res.nodes.map((n) => `${n.position.x},${n.position.y}`);
     expect(new Set(positions).size).toBeGreaterThan(1);
+
+    // Pinned, not just well-formed: exact coordinates for the synthesized
+    // Input (first) and Output (last) node, so a future change to
+    // `assignPositionsFromTopology`, `applyValleyPass`, or the layout config
+    // (nodesep/ranksep/thresholds) is actually caught here, not just gross
+    // degeneracy (everything dropped, everything stacked at one point).
+    expect({ id: res.nodes[0].id, position: res.nodes[0].position }).toEqual(expectedFirst);
+    expect({
+      id: res.nodes[res.nodes.length - 1].id,
+      position: res.nodes[res.nodes.length - 1].position,
+    }).toEqual(expectedLast);
   });
 });
 

--- a/frontend/src/components/SubgraphEditor/graphSerialization.ts
+++ b/frontend/src/components/SubgraphEditor/graphSerialization.ts
@@ -323,8 +323,21 @@ function topoSort(
 }
 
 /**
- * Use dagre to assign positions when loading a graph without saved positions.
- * Uses default dimensions since nodes haven't been rendered yet.
+ * True when a node has no real position of its own: either the field is
+ * absent, or it sits at the exact literal origin (the placeholder every node
+ * falls back to when a spec omits `position` -- see `graphToFlow`'s mapping
+ * below). Shared by the whole-spec gate and `assignPositionsFromTopology` so
+ * the two always agree on which nodes need laying out.
+ */
+function needsPosition(n: GraphSpec['nodes'][number]): boolean {
+  return !n.position || (n.position.x === 0 && n.position.y === 0);
+}
+
+/**
+ * Use dagre to assign positions to the nodes of `spec` that lack one, leaving
+ * any already-positioned node's coordinates untouched. Uses default
+ * dimensions for every node (including already-positioned ones, which still
+ * take part in the topology) since nodes haven't been rendered yet.
  */
 function assignPositionsFromTopology(spec: GraphSpec): void {
   // Only ever called when needsLayout is true, which requires spec.nodes.length > 1.
@@ -372,6 +385,9 @@ function assignPositionsFromTopology(spec: GraphSpec): void {
     skipPredicate: (e) => !isTriggerEdge(e),
   });
   for (const n of spec.nodes) {
+    // Preserve nodes that already have a real position -- only the ones that
+    // triggered needsLayout in the first place get the computed coordinates.
+    if (!needsPosition(n)) continue;
     const p = wrapped.get(n.id);
     // applyValleyPass returns an entry for every input id, so `p` is always
     // defined (the falsy branch is unreachable).
@@ -462,9 +478,11 @@ export function graphToFlow(json: string): { nodes: Node<LayerNodeData>[]; edges
     return emptyGraph();
   }
 
-  // Auto-assign positions when nodes lack them (all at origin or missing)
-  const needsLayout = spec.nodes.length > 1 &&
-    spec.nodes.every((n) => !n.position || (n.position.x === 0 && n.position.y === 0));
+  // Auto-assign positions when ANY node lacks one (at origin or missing).
+  // Per-node, not whole-spec: one already-positioned node must not block
+  // layout for the rest, or they all fall through to the shared `{x:0,y:0}`
+  // default below and land stacked on top of each other.
+  const needsLayout = spec.nodes.length > 1 && spec.nodes.some(needsPosition);
   if (needsLayout) {
     assignPositionsFromTopology(spec);
   }


### PR DESCRIPTION
Third of three Wave 6 Sprint 1 PRs (execution order: #211).

Closes item 1 of #207. That issue stays open for item 2 (a `Start` node id inconsistent in one example), which is deliberately untouched — see below.

## What was wrong

The layer editor opens a node's `layers` parameter as its own mini-canvas, and specs that ship without coordinates get dagre auto-layout, which is what makes them pleasant to open. But the gate was all-or-nothing:

```ts
const needsLayout = spec.nodes.length > 1 &&
  spec.nodes.every((n) => !n.position || (n.position.x === 0 && n.position.y === 0));
```

Give **one** node of a position-less spec a position and `needsLayout` flips to false. Every other node then falls through to `position: n.position ?? { x: 0, y: 0 }` and they all land on top of each other at the origin. It reads as data loss, not as a layout bug.

Worth fixing now because #206 shipped the largest position-less spec in the repo — ResNet-18's 70 layers — making it the file most likely to trip it.

## What changed

Both halves, not just the gate. A shared `needsPosition` predicate now drives two things: the gate runs layout whenever **any** node lacks a position, and `assignPositionsFromTopology` skips nodes that already have one. Changing only the gate would have satisfied the condition while still overwriting the user's explicit coordinates.

The `spec.nodes.length > 1` guard is unchanged.

The predicate's doc comment names the origin-ambiguity it inherits from the old code — a node legitimately at `{x: 0, y: 0}` is indistinguishable from an unpositioned one. That behaviour is preserved deliberately rather than silently carried forward, and there is a test for it.

## Verification

- `pnpm test` 2872 passed across 137 files; `pnpm build` green. Both from one fresh `pnpm install --frozen-lockfile`, back to back, same `node_modules`.
- TDD: the mixed-case test was confirmed to fail against the unmodified code (nodes stacked at the origin), then pass.
- **Regression protection for the three shipped examples that rely on the auto-layout path** (`DQN-Atari-RL`, `PPO-Robotics-RL`, `ResNet18-CIFAR10-Baseline`): exact first- and last-node coordinates and node counts are now pinned, and the pins were confirmed to actually fail under a temporary layout-config perturbation before being reverted.
- Real-browser e2e on a freshly built dist, on a server verified to be the worktree's own install: all three examples open as clean laid-out graphs — 12/12, 7/7 and 70/70 nodes at distinct positions, zero stacking, measured from the DOM rather than eyeballed. The mixed case was then constructed live in the inspector: a node pinned at `{x: 999, y: 999}` kept those exact coordinates while its three position-less siblings were laid out into their own column instead of stacking. No CodefyUI console errors.

### Honest limitation of the new pins

`DQN-Atari-RL` and `PPO-Robotics-RL` are pure linear chains, and for that topology three of the four pinned values per fixture (`first.x`, `first.y`, `last.x`) are structurally forced by the coordinate math regardless of layout config — only `last.y` carries real discriminating power. `ResNet18-CIFAR10-Baseline` branches, so its pins are genuinely sensitive on both axes. All three clear the "not just gross degeneracy" bar, but a future maintainer should know the chain fixtures' protection rests on one coordinate rather than four.

Separately: `applyValleyPass` acts on interior ranks, so first/last pins are unlikely to catch a regression in it. That mechanism's real coverage is the pre-existing synthetic skip-connection test, which is untouched here.

### Deliberately not done

Item 2 of #207 — one example's `Start` node id is `start` where the other 29 use `start-1` — stays open. That example's `graph.json` is byte-identical to the `graph_snapshot` recorded for the two runs behind the published 95.48% result, and that correspondence is the provenance evidence for the number. Renaming a node id to match a convention would break it for no functional gain. Worth folding in the next time the example is re-measured, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166FJAiynQ4Ei891qJgFYyo
