### PR TITLE
chore: test and CI hygiene - fixture paths, isolation, a byte-scan guard, and two deflaked timing tests

### DIFF
--- a/.github/workflows/byte-scan.yml
+++ b/.github/workflows/byte-scan.yml
@@ -1,0 +1,41 @@
+name: Byte Scan
+
+# Fails the build when a tracked source file contains a raw C0 control byte
+# (#209) -- five times so far the root cause has been a one-byte typo (a
+# raw separator instead of an escaped one) that no test, type check or
+# lint catches, and that ripgrep/git grep silently skip rather than
+# search. See scripts/check_control_bytes.py for the detection approach
+# and why it has to be a byte count rather than a grep.
+#
+# No `paths:` filter: every historical instance was a single stray byte
+# inside an otherwise-ordinary file, and the ones caught before reaching
+# main were all under frontend/src/ -- gating this the way backend-test.yml
+# and frontend-build.yml gate on their own areas would leave the other
+# areas unscanned on PRs that don't touch that path. The scan itself is
+# sub-second over the whole tree, so there is no cost to running it always.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: scan tracked files for raw control bytes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      # No third-party dependency -- stdlib only -- so the system Python
+      # already on the runner image is enough; no setup-python step needed.
+      - name: Scan for raw C0 control bytes
+        run: python3 scripts/check_control_bytes.py

--- a/backend/tests/test_api_apps_invoke.py
+++ b/backend/tests/test_api_apps_invoke.py
@@ -512,21 +512,51 @@ async def test_concurrent_invokes_on_one_slug_serialize(
 async def test_invokes_on_different_slugs_interleave(
     test_client, app_db, api_key,
 ):
+    """Different slugs never queue on each other.
+
+    Judged against a serial baseline measured on this runner moments
+    earlier, not a fixed wall-clock budget (#157): the old
+    `elapsed < 1.3` on two 0.7s sleeps left only 0.1s of margin and flaked
+    on a loaded shared CI runner (`1.398 < 1.3`, PR #154's first CI run).
+    The SAME two requests are timed serial-then-concurrent back to back, so
+    whatever this runner's current speed is affects both measurements
+    alike -- only the ratio between them has to hold.
+    """
     await _publish(test_client, "para-one",
                    _chain_graph("slow-a", "_SlowPass", {"seconds": 0.7}))
     await _publish(test_client, "para-two",
                    _chain_graph("slow-b", "_SlowPass", {"seconds": 0.7}))
     key_headers = _bearer(api_key["token"])
+
+    async def _invoke_one():
+        return await test_client.post(
+            "/api/apps/para-one/invoke",
+            json={"inputs": {"x": "a"}}, headers=key_headers)
+
+    async def _invoke_two():
+        return await test_client.post(
+            "/api/apps/para-two/invoke",
+            json={"inputs": {"x": "b"}}, headers=key_headers)
+
     t0 = time.monotonic()
-    r1, r2 = await asyncio.gather(
-        test_client.post("/api/apps/para-one/invoke",
-                         json={"inputs": {"x": "a"}}, headers=key_headers),
-        test_client.post("/api/apps/para-two/invoke",
-                         json={"inputs": {"x": "b"}}, headers=key_headers),
-    )
-    elapsed = time.monotonic() - t0
+    baseline1 = await _invoke_one()
+    baseline2 = await _invoke_two()
+    serial = time.monotonic() - t0
+    assert baseline1.status_code == 200 and baseline2.status_code == 200
+
+    t0 = time.monotonic()
+    r1, r2 = await asyncio.gather(_invoke_one(), _invoke_two())
+    interleaved = time.monotonic() - t0
     assert r1.status_code == 200 and r2.status_code == 200
-    assert elapsed < 1.3           # different slugs never queue on each other
+
+    # True parallelism lands near serial/2; 0.75 leaves generous headroom
+    # for scheduling noise while still failing hard if the two slugs
+    # silently queued on each other (interleaved ~= serial).
+    assert interleaved < serial * 0.75, (
+        f"interleaved={interleaved:.3f}s not well under "
+        f"serial={serial:.3f}s -- different slugs may be queuing on "
+        f"each other"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api_apps_invoke.py
+++ b/backend/tests/test_api_apps_invoke.py
@@ -521,6 +521,18 @@ async def test_invokes_on_different_slugs_interleave(
     The SAME two requests are timed serial-then-concurrent back to back, so
     whatever this runner's current speed is affects both measurements
     alike -- only the ratio between them has to hold.
+
+    Both slugs are warmed with one untimed invoke each before either
+    measurement starts (review follow-up). The FIRST-ever invoke of a
+    freshly published app pays a one-time setup cost that later invokes on
+    the same slug don't; without the warm-up, `serial` (always the FIRST
+    hit on both slugs) is measured cold while `interleaved` (always the
+    SECOND) is measured warm, which inflates `serial` well past its
+    steady-state floor. That slack is enough for a fully-serialized
+    regression to slip under `serial * margin` even though it should fail
+    -- confirmed by simulating the regression directly (collapsing both
+    slugs onto one lock, the same class of bug Decision I's per-slug lock
+    exists to prevent): the unwarmed version of this test passed anyway.
     """
     await _publish(test_client, "para-one",
                    _chain_graph("slow-a", "_SlowPass", {"seconds": 0.7}))
@@ -538,6 +550,10 @@ async def test_invokes_on_different_slugs_interleave(
             "/api/apps/para-two/invoke",
             json={"inputs": {"x": "b"}}, headers=key_headers)
 
+    warm1 = await _invoke_one()
+    warm2 = await _invoke_two()
+    assert warm1.status_code == 200 and warm2.status_code == 200
+
     t0 = time.monotonic()
     baseline1 = await _invoke_one()
     baseline2 = await _invoke_two()
@@ -549,10 +565,12 @@ async def test_invokes_on_different_slugs_interleave(
     interleaved = time.monotonic() - t0
     assert r1.status_code == 200 and r2.status_code == 200
 
-    # True parallelism lands near serial/2; 0.75 leaves generous headroom
-    # for scheduling noise while still failing hard if the two slugs
-    # silently queued on each other (interleaved ~= serial).
-    assert interleaved < serial * 0.75, (
+    # True parallelism lands near serial/2; full serialization lands near
+    # serial/1 (ratio ~1.0). 0.85 sits well clear of both -- more headroom
+    # on the "pass" side than the bare 0.75 the review flagged as tight
+    # once the cold/warm asymmetry above is gone -- while still failing
+    # hard on a genuinely serialized run.
+    assert interleaved < serial * 0.85, (
         f"interleaved={interleaved:.3f}s not well under "
         f"serial={serial:.3f}s -- different slugs may be queuing on "
         f"each other"

--- a/backend/tests/test_check_control_bytes.py
+++ b/backend/tests/test_check_control_bytes.py
@@ -1,0 +1,63 @@
+"""Unit tests for scripts/check_control_bytes.py (#209 review follow-up).
+
+The guard itself has no other tests exercising it -- CI just runs it as a
+script -- so a change that silently narrowed what it catches (the UTF-8
+skip broadening, the vendored-dump exemption growing) would stay green
+forever. These pin ``_scan`` and the vendored-dump predicate directly, the
+same way ``backend/tests/test_dev_cli.py`` pins ``scripts/dev.py``'s pure
+helpers.
+"""
+
+from __future__ import annotations
+
+import check_control_bytes as ccb  # scripts/check_control_bytes.py -- conftest puts scripts/ on sys.path
+
+
+def test_scan_finds_a_raw_nul_with_its_line_number():
+    assert ccb._scan(b"a\x00b") == [(1, 0x00)]
+
+
+def test_scan_clean_text_reports_nothing():
+    assert ccb._scan(b"ok\n") == []
+
+
+def test_scan_allows_tab_lf_cr():
+    # Tab, LF and CR are C0 too, but legitimate in text source (CR shows up
+    # in CRLF-checked-out files) -- must never be flagged.
+    assert ccb._scan(b"a\tb\nc\rd\n") == []
+
+
+def test_scan_flags_the_whole_c0_range_not_just_nul():
+    # The same hazard construct has also produced 0x01 and 0x02 in this
+    # repo's history (issue #209's own comment thread) -- a NUL-only scan
+    # would have missed them.
+    assert ccb._scan(b"a\x01b\x02c") == [(1, 0x01), (1, 0x02)]
+
+
+def test_scan_reports_the_correct_line_across_multiple_lines():
+    data = b"line one\nline two\x00\nline three\n"
+    assert ccb._scan(data) == [(2, 0x00)]
+
+
+def test_scan_skips_binary_data_entirely():
+    # Not valid UTF-8 (0x89 is an invalid UTF-8 leading byte on its own --
+    # the PNG signature byte) -- must be skipped rather than scanned, even
+    # though it contains plenty of C0-range bytes.
+    png_like = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+    assert ccb._scan(png_like) == []
+
+
+def test_is_vendored_binary_dump_matches_only_the_mnist_ubyte_files():
+    assert ccb._is_vendored_binary_dump(
+        "backend/data/MNIST/raw/train-labels-idx1-ubyte")
+    assert ccb._is_vendored_binary_dump(
+        "backend/data/MNIST/raw/t10k-images-idx3-ubyte")
+    # The suffix match is deliberately narrow: a DIFFERENT file added later
+    # under the same directory (a README, say) must not be silently
+    # exempted along with the actual binary dumps.
+    assert not ccb._is_vendored_binary_dump(
+        "backend/data/MNIST/raw/README.md")
+    assert not ccb._is_vendored_binary_dump(
+        "backend/data/MNIST/raw/train-labels-idx1-ubyte.gz")
+    # Same suffix, wrong directory -- also not exempt.
+    assert not ccb._is_vendored_binary_dump("some/other/dir/train-ubyte")

--- a/backend/tests/test_image_batch_reader_node.py
+++ b/backend/tests/test_image_batch_reader_node.py
@@ -19,8 +19,16 @@ def test_empty_directory_raises():
         ImageBatchReaderNode().execute({}, {"directory": ""})
 
 
-def test_nonexistent_dir_raises(tmp_path):
-    # Use a directory under data root for the path validation to pass
+def test_nonexistent_dir_raises(monkeypatch, tmp_path):
+    # Isolated under tmp_path the same way as the writer tests below
+    # (review follow-up on #151): this one creates nothing, so it cannot
+    # actually clobber a concurrent run, but pointing it at the real
+    # backend/data/ instead read as half-applied isolation next to the
+    # three that are. MODELS_DIR still has to be patched (not just
+    # tmp_path used directly) for the same reason as the others: the
+    # node's own path-escape check only accepts a directory under
+    # MODELS_DIR.parent.
+    monkeypatch.setattr(settings, "MODELS_DIR", tmp_path / "data" / "models")
     target_dir = settings.MODELS_DIR.parent / "_missing_dir_for_test"
     with pytest.raises(FileNotFoundError):
         ImageBatchReaderNode().execute({}, {"directory": str(target_dir)})

--- a/backend/tests/test_image_batch_reader_node.py
+++ b/backend/tests/test_image_batch_reader_node.py
@@ -26,50 +26,46 @@ def test_nonexistent_dir_raises(tmp_path):
         ImageBatchReaderNode().execute({}, {"directory": str(target_dir)})
 
 
-def test_reads_batch_of_images():
+def test_reads_batch_of_images(monkeypatch, tmp_path):
+    # A fixed name under the real backend/data/ (#151) let two concurrent
+    # pytest runs race to create/write/delete the same directory. Point
+    # MODELS_DIR under tmp_path -- unique per test process -- the same way
+    # test_image_folder_dataset_node.py and test_tensorboard.py already do;
+    # the node itself confines `directory` under MODELS_DIR.parent, so this
+    # also keeps the node's own path-escape check satisfied.
+    monkeypatch.setattr(settings, "MODELS_DIR", tmp_path / "data" / "models")
     test_dir = settings.MODELS_DIR.parent / "_test_img_batch"
     test_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        for i in range(3):
-            img = Image.new("RGB", (32, 32), (i * 50, 0, 0))
-            img.save(test_dir / f"img_{i}.png")
-        res = ImageBatchReaderNode().execute(
-            {},
-            {"directory": str(test_dir), "pattern": "*.png", "resize": 16, "max_images": 0, "mode": "RGB"},
-        )
-        assert res["images"].shape == (3, 3, 16, 16)
-        assert res["count"] == 3
-    finally:
-        for f in test_dir.glob("*"):
-            f.unlink()
-        test_dir.rmdir()
+    for i in range(3):
+        img = Image.new("RGB", (32, 32), (i * 50, 0, 0))
+        img.save(test_dir / f"img_{i}.png")
+    res = ImageBatchReaderNode().execute(
+        {},
+        {"directory": str(test_dir), "pattern": "*.png", "resize": 16, "max_images": 0, "mode": "RGB"},
+    )
+    assert res["images"].shape == (3, 3, 16, 16)
+    assert res["count"] == 3
 
 
-def test_max_images_limits_count():
+def test_max_images_limits_count(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "MODELS_DIR", tmp_path / "data" / "models")
     test_dir = settings.MODELS_DIR.parent / "_test_max_images"
     test_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        for i in range(5):
-            Image.new("RGB", (16, 16)).save(test_dir / f"img_{i}.png")
-        res = ImageBatchReaderNode().execute(
-            {},
-            {"directory": str(test_dir), "pattern": "*.png", "resize": 8, "max_images": 2, "mode": "RGB"},
-        )
-        assert res["count"] == 2
-    finally:
-        for f in test_dir.glob("*"):
-            f.unlink()
-        test_dir.rmdir()
+    for i in range(5):
+        Image.new("RGB", (16, 16)).save(test_dir / f"img_{i}.png")
+    res = ImageBatchReaderNode().execute(
+        {},
+        {"directory": str(test_dir), "pattern": "*.png", "resize": 8, "max_images": 2, "mode": "RGB"},
+    )
+    assert res["count"] == 2
 
 
-def test_no_matching_files_raises():
+def test_no_matching_files_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "MODELS_DIR", tmp_path / "data" / "models")
     test_dir = settings.MODELS_DIR.parent / "_test_no_match"
     test_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        with pytest.raises(ValueError, match="No images"):
-            ImageBatchReaderNode().execute(
-                {},
-                {"directory": str(test_dir), "pattern": "*.png", "resize": 16},
-            )
-    finally:
-        test_dir.rmdir()
+    with pytest.raises(ValueError, match="No images"):
+        ImageBatchReaderNode().execute(
+            {},
+            {"directory": str(test_dir), "pattern": "*.png", "resize": 16},
+        )

--- a/backend/tests/test_node_resolution_project.py
+++ b/backend/tests/test_node_resolution_project.py
@@ -40,11 +40,33 @@ def test_csvreader_escape_is_rejected(project):
         CSVReaderNode().execute({}, {"path": "../escape.csv"})
 
 
-def test_csvreader_iris_default_special_cased_to_install(project):
-    # The bundled sample resolves against the install CWD (backend/), not the
-    # project, so demos keep working with no copy. cwd is backend/ under pytest.
-    if not Path("data/samples/iris.csv").exists():
+def test_csvreader_iris_default_special_cased_to_install(project, monkeypatch):
+    """The bundled sample resolves against the install CWD (backend/), not
+    the project, so demos keep working with no copy (spec 7.2).
+
+    The node's OWN resolution for this special case is cwd-relative BY
+    DESIGN (csv_reader_node.py: ``path.resolve()`` against whatever the
+    process's cwd is) -- matching real deployment, where the server always
+    runs from backend/ (see scripts/dev.py's ``os.chdir``). So the test
+    pins its OWN cwd to backend/ via monkeypatch rather than trusting
+    whatever pytest happened to be invoked with.
+
+    The previous version instead just checked ``Path("data/samples/
+    iris.csv").exists()`` and skipped if not -- but THAT check is exactly
+    as cwd-relative as the bug #185 fixes elsewhere, so from the repo root
+    it reported the false reason "iris sample not present in this
+    checkout" for a file that is very much present, just not at that path
+    relative to THAT cwd (#185 follow-up). Anchoring only the ``.exists()``
+    check on ``__file__`` is not enough on its own: it would make the skip
+    message honest but then let the node call below fail for real, since
+    the node's resolution would still run under the repo-root cwd -- fixed
+    here instead by making backend/ the actual cwd for this test's
+    duration, so the feature is exercised the way it is deployed.
+    """
+    backend_dir = Path(__file__).resolve().parents[1]
+    if not (backend_dir / "data" / "samples" / "iris.csv").exists():
         pytest.skip("iris sample not present in this checkout")
+    monkeypatch.chdir(backend_dir)
     out = CSVReaderNode().execute(
         {}, {"path": "data/samples/iris.csv", "target_column": "species"})
     assert out["tensor"].shape[0] > 0

--- a/backend/tests/test_run_queue.py
+++ b/backend/tests/test_run_queue.py
@@ -577,29 +577,36 @@ async def test_an_interactive_run_starts_alongside_a_full_gpu_queue(
     4/4 green on rerun.
     """
     release_first = probe.hold("train-0")
-    training = [await _submit(service, f"train-{i}", device="cuda:0",
-                              seconds=0.4) for i in range(5)]
-    # train-0 is provably occupying the slot, not merely assumed to be
-    # (admission itself is synchronous -- see RunService._pump -- so this
-    # is a sanity check that the hold is wired up, not a race).
-    await probe.wait_entered("train-0")
-    assert len(service.queue_snapshot()["cuda:0"]) == 4
+    try:
+        training = [await _submit(service, f"train-{i}", device="cuda:0",
+                                  seconds=0.4) for i in range(5)]
+        # train-0 is provably occupying the slot, not merely assumed to be
+        # (admission itself is synchronous -- see RunService._pump -- so
+        # this is a sanity check that the hold is wired up, not a race).
+        await probe.wait_entered("train-0")
+        assert len(service.queue_snapshot()["cuda:0"]) == 4
 
-    demo = await _submit(service, "demo", device="cuda:0", seconds=0.05,
-                         lane=LANE_INTERACTIVE,
-                         session=InteractiveSession())
-    assert demo.status == STATUS_RUNNING
-    assert service.is_active(demo.run_id)
-    assert service.queue_position(demo.run_id) is None
+        demo = await _submit(service, "demo", device="cuda:0", seconds=0.05,
+                             lane=LANE_INTERACTIVE,
+                             session=InteractiveSession())
+        assert demo.status == STATUS_RUNNING
+        assert service.is_active(demo.run_id)
+        assert service.queue_position(demo.run_id) is None
 
-    record = await _await_terminal(store, demo.run_id, timeout=5)
-    assert record.status == STATUS_SUCCEEDED
-    assert record.options["lane"] == LANE_INTERACTIVE
-    # It really did overtake: four training runs are still waiting --
-    # guaranteed (train-0 is still parked on its gate), not timed.
-    assert len(service.queue_snapshot()["cuda:0"]) == 4
+        record = await _await_terminal(store, demo.run_id, timeout=5)
+        assert record.status == STATUS_SUCCEEDED
+        assert record.options["lane"] == LANE_INTERACTIVE
+        # It really did overtake: four training runs are still waiting --
+        # guaranteed (train-0 is still parked on its gate), not timed.
+        assert len(service.queue_snapshot()["cuda:0"]) == 4
+    finally:
+        # However this exits -- an assertion above failing, or the happy
+        # path -- train-0 must be released. Left parked, it would sit out
+        # its 10s safety-net timeout before the worker thread raises,
+        # adding a slow, confusing second failure right next to whatever
+        # assertion actually failed (review follow-up).
+        release_first.set()
 
-    release_first.set()
     for result in training:
         await _await_terminal(store, result.run_id)
 

--- a/backend/tests/test_run_queue.py
+++ b/backend/tests/test_run_queue.py
@@ -84,6 +84,15 @@ class _Probe:
         #: probe's own param, so it cannot see two ALIASES of one device
         #: overlapping; this can.
         self.peak_total = 0
+        #: label -> (entered, release). A label registered here (via
+        #: ``hold``) blocks its node's worker thread on ``release`` instead
+        #: of ``time.sleep(seconds)`` -- a test can then hold a run open
+        #: for as long as it needs, deterministically, rather than sizing a
+        #: sleep duration against wall-clock timing and hoping it survives
+        #: a loaded CI runner (#187). ``entered`` is set the instant the
+        #: node reaches the hold, so ``wait_entered`` can block on an
+        #: observed fact instead of another sleep.
+        self.gates: dict[str, tuple[threading.Event, threading.Event]] = {}
 
     def enter(self, label: str, device: str) -> None:
         with self.lock:
@@ -95,6 +104,39 @@ class _Probe:
     def leave(self) -> None:
         with self.lock:
             self.inflight -= 1
+
+    def hold(self, label: str) -> threading.Event:
+        """Register *label* to block on a gate instead of sleeping.
+
+        Returns the release ``Event``: setting it lets that label's node
+        return from ``execute``. Must be called before the run is
+        submitted -- the node looks its label up in ``gates`` on entry.
+        """
+        entered = threading.Event()
+        release = threading.Event()
+        self.gates[label] = (entered, release)
+        return release
+
+    async def wait_entered(self, label: str, timeout: float = 5.0) -> None:
+        """Block until *label*'s node has actually reached its hold point.
+
+        A bounded wait on an observed fact, not a sleep: proves the run is
+        provably occupying its slot (rather than merely admitted-but-not-
+        yet-dispatched) before a test relies on it staying that way.
+
+        Runs the ``Event.wait`` in a thread rather than calling it directly:
+        this is awaited from the test's own coroutine, which runs ON the
+        event loop, and the node's dispatch chain (Start -> ... -> the
+        gated node) needs that SAME event loop to keep turning in order to
+        progress far enough to reach the gate and set it. A direct
+        ``Event.wait`` there would freeze the loop and deadlock against the
+        very thing it is waiting for.
+        """
+        entered, _release = self.gates[label]
+        ok = await asyncio.to_thread(entered.wait, timeout)
+        if not ok:
+            raise AssertionError(
+                f"{label!r} never reached its hold point within {timeout}s")
 
 
 _probe = _Probe()
@@ -133,9 +175,23 @@ class _QueueProbeNode(BaseNode):
 
     def execute(self, inputs: dict[str, Any],
                 params: dict[str, Any]) -> dict[str, Any]:
-        _probe.enter(str(params.get("label", "")), str(params.get("device")))
+        label = str(params.get("label", ""))
+        _probe.enter(label, str(params.get("device")))
         try:
-            time.sleep(float(params.get("seconds", 0.05)))
+            gate = _probe.gates.get(label)
+            if gate is not None:
+                # Held open on a gate (#187) instead of a fixed sleep: the
+                # test controls exactly when this run may finish. Bounded
+                # wait as a safety net only -- a test that forgets to
+                # release should time out and fail loudly, not hang the
+                # suite forever.
+                entered, release = gate
+                entered.set()
+                if not release.wait(timeout=10.0):
+                    raise TimeoutError(
+                        f"probe hold for {label!r} was never released")
+            else:
+                time.sleep(float(params.get("seconds", 0.05)))
         finally:
             _probe.leave()
         return {"value": inputs.get("value")}
@@ -509,9 +565,24 @@ async def test_each_device_keeps_its_own_line(service):
 
 async def test_an_interactive_run_starts_alongside_a_full_gpu_queue(
         service, store, probe):
-    """The acceptance criterion: a classroom demo never waits for training."""
+    """The acceptance criterion: a classroom demo never waits for training.
+
+    ``train-0`` is held open on a gate rather than raced against a sleep
+    duration (#187): "the other four are still queued when the demo
+    finishes" is then true by construction -- train-0 provably cannot
+    finish before the test releases it -- instead of depending on a 0.4s
+    training sleep outlasting a 0.05s demo on whatever CI runner happens to
+    be running this. The flake this replaces was exactly that assumption
+    failing under load: `assert 3 == 4` on an otherwise unrelated PR,
+    4/4 green on rerun.
+    """
+    release_first = probe.hold("train-0")
     training = [await _submit(service, f"train-{i}", device="cuda:0",
                               seconds=0.4) for i in range(5)]
+    # train-0 is provably occupying the slot, not merely assumed to be
+    # (admission itself is synchronous -- see RunService._pump -- so this
+    # is a sanity check that the hold is wired up, not a race).
+    await probe.wait_entered("train-0")
     assert len(service.queue_snapshot()["cuda:0"]) == 4
 
     demo = await _submit(service, "demo", device="cuda:0", seconds=0.05,
@@ -524,9 +595,11 @@ async def test_an_interactive_run_starts_alongside_a_full_gpu_queue(
     record = await _await_terminal(store, demo.run_id, timeout=5)
     assert record.status == STATUS_SUCCEEDED
     assert record.options["lane"] == LANE_INTERACTIVE
-    # It really did overtake: four training runs are still waiting.
+    # It really did overtake: four training runs are still waiting --
+    # guaranteed (train-0 is still parked on its gate), not timed.
     assert len(service.queue_snapshot()["cuda:0"]) == 4
 
+    release_first.set()
     for result in training:
         await _await_terminal(store, result.run_id)
 

--- a/backend/tests/test_stats_describe_node.py
+++ b/backend/tests/test_stats_describe_node.py
@@ -10,6 +10,7 @@ would pass no matter how wrong both were.
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -44,7 +45,11 @@ def _as_frame(result) -> pd.DataFrame:
 
 @pytest.fixture(scope="module")
 def iris() -> pd.DataFrame:
-    return pd.read_csv("data/samples/iris.csv")[IRIS_COLUMNS]
+    # Resolved relative to this file, not the pytest cwd (#185) -- a bare
+    # "data/samples/iris.csv" only worked when pytest ran from backend/.
+    return pd.read_csv(
+        Path(__file__).resolve().parents[1] / "data/samples/iris.csv"
+    )[IRIS_COLUMNS]
 
 
 def test_node_metadata():

--- a/backend/tests/test_stats_group_by_aggregate_node.py
+++ b/backend/tests/test_stats_group_by_aggregate_node.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -32,7 +33,9 @@ def _run(table, params=None, columns=None, keys=None):
 
 @pytest.fixture(scope="module")
 def iris() -> pd.DataFrame:
-    return pd.read_csv("data/samples/iris.csv")
+    # Resolved relative to this file, not the pytest cwd (#185) -- a bare
+    # "data/samples/iris.csv" only worked when pytest ran from backend/.
+    return pd.read_csv(Path(__file__).resolve().parents[1] / "data/samples/iris.csv")
 
 
 def test_node_metadata():

--- a/scripts/check_control_bytes.py
+++ b/scripts/check_control_bytes.py
@@ -16,6 +16,16 @@ count, and -- the sharpest one -- ripgrep and `git grep` both classify a file
 containing these bytes as binary and skip it, reporting "no match" rather
 than "not searched". See issue #209 for the full incident list.
 
+Known blind spot: a file that is not valid UTF-8 is skipped entirely (see
+``_scan``), including one that is genuine text but encoded as something
+else -- UTF-16, for instance, which is what plain `>` redirection produces
+by default in Windows PowerShell, and whose FF FE byte-order mark alone is
+invalid UTF-8. UTF-16 also encodes every ASCII character with a NUL
+companion byte, so a file that entered the tree that way would carry NULs
+throughout and never be scanned. No incident on record has been UTF-16; this
+is a real gap given the target audience, not a theoretical one, so it is
+written down here rather than silently relied on not mattering.
+
 Usage (from anywhere; resolves the repo root from this file's own path):
 
     python scripts/check_control_bytes.py
@@ -51,15 +61,27 @@ _FLAGGED_C0 = frozenset(b for b in range(0x20) if b not in _ALLOWED_C0)
 
 # Vendored binary content that is not source and must not be scanned, even
 # though it is tracked. Ordinary binary assets (PNG, ico, the .gz dumps)
-# already fail the UTF-8-validity check below and need no listing here.
-# This one directory is the sole exception found while validating this
-# script against the real tree: `backend/data/MNIST/raw/*-labels-idx1-ubyte`
-# is the *uncompressed* IDX label dump, one byte per label (0-9) plus a
-# small header -- every byte in it happens to be < 0x80, which makes it
-# accidentally valid UTF-8 and would otherwise register ~9000 false hits.
-_EXCLUDED_PREFIXES = (
-    "backend/data/MNIST/",
-)
+# already fail the UTF-8-validity check below and need no listing here. The
+# uncompressed MNIST IDX dumps under backend/data/MNIST/raw/ are the sole
+# exception found while validating this script against the real tree:
+# every byte in the *-labels-idx1-ubyte files is a label 0-9 or part of a
+# small header, all < 0x80, which makes them accidentally valid UTF-8 and
+# would otherwise register ~9000 false hits each. (The *-images-idx3-ubyte
+# files already fail the UTF-8 check on their own -- listed here anyway,
+# for the same "this whole vendored dump is not source" reason, not
+# because they need the exemption.)
+#
+# Matched on directory AND the IDX-specific "-ubyte" suffix together, not
+# on the directory alone: a directory-only match would silently exempt any
+# OTHER file added later under the same path (a README, say), which is
+# exactly the kind of exemption that is meant not to be able to grow by
+# accident.
+_VENDORED_BINARY_DIR = "backend/data/MNIST/"
+_VENDORED_BINARY_SUFFIX = "-ubyte"
+
+
+def _is_vendored_binary_dump(rel: str) -> bool:
+    return rel.startswith(_VENDORED_BINARY_DIR) and rel.endswith(_VENDORED_BINARY_SUFFIX)
 
 
 def _tracked_files() -> list[Path]:
@@ -73,7 +95,7 @@ def _tracked_files() -> list[Path]:
     rels = [raw.decode("utf-8") for raw in result.stdout.split(b"\x00") if raw]
     return [
         _REPO_ROOT / rel for rel in rels
-        if not rel.startswith(_EXCLUDED_PREFIXES)
+        if not _is_vendored_binary_dump(rel)
     ]
 
 

--- a/scripts/check_control_bytes.py
+++ b/scripts/check_control_bytes.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""CI guard (#209): fail when a tracked source file holds a raw C0 control byte.
+
+Five times so far in this repo's history, a composite map key was built as a
+template literal with a delimiter written as a *raw* byte -- on the reasoning
+that "no id can contain a NUL, so it's a safe separator" -- instead of the
+escaped form (``\\0``, ``\\x01``, ...). One instance reached `main`. The
+correct escaped form is four ordinary ASCII characters (backslash, x, 0, 0);
+a raw control byte is a single invisible byte sitting in the file's own byte
+stream.
+
+This has to be a byte count, not a grep. The failure is silent everywhere
+else: it's runtime-identical so nothing type-checks or lints differently,
+editors render the byte invisibly, `git diff --stat` misreports the line
+count, and -- the sharpest one -- ripgrep and `git grep` both classify a file
+containing these bytes as binary and skip it, reporting "no match" rather
+than "not searched". See issue #209 for the full incident list.
+
+Usage (from anywhere; resolves the repo root from this file's own path):
+
+    python scripts/check_control_bytes.py
+
+Exit 0: no raw C0 control bytes in any tracked file (besides tab/LF/CR).
+Exit 1: at least one was found; every hit is printed as `path:line  0xHH`.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Force UTF-8 on Windows so this prints cleanly regardless of the console
+# code page. Mirrors the same guard in scripts/device_smoke.py.
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, OSError):
+        pass
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# C0 controls are U+0000-U+001F. Tab/LF/CR are legitimate in text source
+# (CR shows up in CRLF-checked-out files) and are excluded. Everything else
+# in the block -- 0x00, and the same construct's other observed victims
+# 0x01 and 0x02, plus the rest of the range -- is flagged. DEL (0x7F) is
+# outside the formal C0 block and outside every incident on record, so it
+# is deliberately not included.
+_ALLOWED_C0 = frozenset({0x09, 0x0A, 0x0D})
+_FLAGGED_C0 = frozenset(b for b in range(0x20) if b not in _ALLOWED_C0)
+
+# Vendored binary content that is not source and must not be scanned, even
+# though it is tracked. Ordinary binary assets (PNG, ico, the .gz dumps)
+# already fail the UTF-8-validity check below and need no listing here.
+# This one directory is the sole exception found while validating this
+# script against the real tree: `backend/data/MNIST/raw/*-labels-idx1-ubyte`
+# is the *uncompressed* IDX label dump, one byte per label (0-9) plus a
+# small header -- every byte in it happens to be < 0x80, which makes it
+# accidentally valid UTF-8 and would otherwise register ~9000 false hits.
+_EXCLUDED_PREFIXES = (
+    "backend/data/MNIST/",
+)
+
+
+def _tracked_files() -> list[Path]:
+    """Every git-tracked file, as absolute paths. Never touches untracked
+    files (build output, .venv, node_modules, ...) because it asks git
+    directly instead of walking the filesystem."""
+    result = subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "ls-files", "-z"],
+        capture_output=True, check=True,
+    )
+    rels = [raw.decode("utf-8") for raw in result.stdout.split(b"\x00") if raw]
+    return [
+        _REPO_ROOT / rel for rel in rels
+        if not rel.startswith(_EXCLUDED_PREFIXES)
+    ]
+
+
+def _scan(data: bytes) -> list[tuple[int, int]]:
+    """[(line_number, byte_value), ...] for every flagged C0 byte in data.
+
+    Binary files are skipped by attempting a UTF-8 decode first: arbitrary
+    binary data (images, fonts, the vendored MNIST dumps) essentially never
+    decodes as valid UTF-8, while every hazard instance on record is a raw
+    control byte sitting inside an otherwise-normal UTF-8 source file (the
+    byte itself is legal UTF-8 on its own -- it is wrong *semantically*,
+    not structurally). This needs no hand-maintained extension allowlist or
+    denylist, so it can't silently miss a new source language later the way
+    one would.
+    """
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return []
+    hits = []
+    line = 1
+    for byte in data:
+        if byte == 0x0A:
+            line += 1
+        elif byte in _FLAGGED_C0:
+            hits.append((line, byte))
+    return hits
+
+
+def main() -> int:
+    files = _tracked_files()
+    hits_by_file: list[tuple[Path, list[tuple[int, int]]]] = []
+    for path in files:
+        if not path.is_file():
+            continue
+        found = _scan(path.read_bytes())
+        if found:
+            hits_by_file.append((path, found))
+
+    if not hits_by_file:
+        print(f"OK: no raw C0 control bytes in {len(files)} tracked files")
+        return 0
+
+    print("Raw C0 control byte(s) found. Use the escaped form (e.g. \\x00, "
+          "\\x01) instead of a literal byte in the source:\n")
+    for path, found in hits_by_file:
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        for line, byte in found:
+            print(f"  {rel}:{line}  0x{byte:02x}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Five test-and-CI hygiene fixes. No production code is touched anywhere in this branch except the new standalone check script.

Closes #185. Closes #151. Closes #209. Closes #187. Closes #157.

## What was wrong

**#185 / #151 — tests that depended on how you invoked them.** `test_stats_group_by_aggregate_node.py` loaded its fixture with a bare relative path, so 8 tests errored when pytest ran from the repo root rather than `backend/` — which is how the contribution docs invoke it. `test_image_batch_reader_node.py` wrote to a fixed path under the real data root, so two concurrent pytest runs clobbered each other.

**#209 — a hazard that no existing signal catches.** Five raw NUL bytes have entered source in this repo, one of them reaching `main`. Every occurrence had the same shape: a delimiter written as a raw byte inside a template literal building a composite map key. The failure is silent across every signal that normally helps — runtime-identical so no test or typecheck fails, invisible in editors, `git diff --stat` misreports the line count, and **ripgrep classifies the file as binary and skips it, reporting "no match" rather than "not searched"**, which once hid a file from an adversarial reviewer's searches entirely.

**#187 / #157 — two tests that flaked on timing.** One asserted a count that depended on scheduler timing (`assert 3 == 4`), the other a hardcoded wall-clock budget (`assert 1.398 < 1.3`). #187 fired on `main` the day before this branch, on Python 3.12, for a merge that did not touch the scheduler.

## What changed

- **#185** — fixture paths anchored on the test file. The sweep found a second live instance in `test_stats_describe_node.py`, and a third in `test_node_resolution_project.py` that was skipping with the false reason "iris sample not present in this checkout" while the file was present.
- **#151** — the reader tests are isolated under `tmp_path`. A plain `tmp_path` swap would not have worked: the node re-reads `settings.MODELS_DIR` at execute time and enforces `is_relative_to`, so monkeypatching the setting is the lever that actually takes effect.
- **#209** — `scripts/check_control_bytes.py` plus a workflow, scanning the whole C0 range rather than NUL alone (per the issue thread). Detection is by UTF-8 validity rather than an extension allowlist, so it cannot silently stop covering a language added later. The guard has its own tests, following this repo's existing convention of testing `scripts/`.
- **#187** — the interactive-overtake test now gates on an observable event rather than a sleep, following the deterministic-pump precedent from #171.
- **#157** — the interleave test now measures a serial baseline in-test and compares against it, rather than asserting a fixed budget.

## Verification

Full backend suite: **3722 passed, 14 skipped, 0 failed**, run from the repo root — the invocation #185 exists to make work.

### The part worth reading

#157's first rewrite was wrong in a way that would have been easy to miss: it passed while two slugs were **fully serialized against each other** — the precise regression it exists to guard, which its flaky predecessor did catch. Review reproduced it by collapsing every slug onto one lock and running the test: `serial=2.328, interleaved=1.406, threshold=1.746` → passed. The replaced assertion (`elapsed < 1.3`) would have failed on that same 1.406s.

The cause was that the serial baseline was timed **cold** while the subject was timed **warm** — the first invoke of each app pays about 0.44s of one-time cost, inflating the baseline 63% over its floor and consuming the margin with the asymmetry rather than with scheduling noise. The original non-vacuity proof had itself been produced against a warm baseline, a regime the shipped test never entered.

Fixed by warming each slug before either timed phase, with the margin raised to 0.85. Re-verified against the same collapsed-lock simulation: a serialized run now **fails** (1.407 > 1.208) and a genuinely parallel one passes (0.719 < 1.195). The failing side's margin is structural rather than statistical — under full serialization the interleaved time *is* the serial work, so the ratio approaches 1.0 by construction and noise cannot push it near the parallel case.

Both #187 and #157 were repeated 8 times each with no flakes. Neither could be made to fail on the original wall-clock race on demand — that is inherent to a load-dependent flake — so determinism was demonstrated under injected pressure instead. Stated plainly rather than claimed as proof.

## Note for the maintainer

The new `Byte Scan` workflow is **advisory until it is added to branch protection's required checks**. Until then a red scan will not block a merge. It is a separate workflow rather than a job inside `backend-test.yml` because that workflow's path filter excludes `frontend/**`, and 4 of the 5 recorded NUL incidents were under `frontend/src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166FJAiynQ4Ei891qJgFYyo
