### PR TITLE
feat(training): per-epoch val_accuracy + a monitor for early stopping

### DIFF
--- a/backend/app/nodes/training/evaluate_model_node.py
+++ b/backend/app/nodes/training/evaluate_model_node.py
@@ -194,9 +194,12 @@ class EvaluateModelNode(BaseNode):
             # accuracy.
             result.update(interrupted_result(batch=stopped_at_batch))
         elif context is not None:
-            # Defensively coerced like batch_size above: params arrive
-            # already INT-typed in the normal editor/API path, but a
-            # hand-built graph.json or CLI invocation is not guaranteed to.
-            step = int(params.get("step", 1))
+            # Defensively coerced AND clamped to the param's own min_value
+            # (0) -- like batch_size above, which is coerced and clamped
+            # to ITS min_value (1). Params arrive already int-typed and
+            # in-range in the normal editor/API path, but a hand-built
+            # graph.json or CLI invocation is not guaranteed to respect
+            # either.
+            step = max(0, int(params.get("step", 1)))
             context.log_metric("eval_accuracy", accuracy, step)
         return result

--- a/backend/app/nodes/training/evaluate_model_node.py
+++ b/backend/app/nodes/training/evaluate_model_node.py
@@ -85,6 +85,20 @@ class EvaluateModelNode(BaseNode):
                 options=list(PRECISIONS),
                 advanced=True,
             ),
+            ParamDefinition(
+                name="step",
+                param_type=ParamType.INT,
+                default=1,
+                min_value=0,
+                description=(
+                    "Step value the eval_accuracy metric is logged under. "
+                    "Several EvaluateModel nodes in one graph (e.g. a "
+                    "before/after fine-tuning comparison) need different "
+                    "steps or they overwrite each other's point on the "
+                    "chart."
+                ),
+                advanced=True,
+            ),
         ]
 
     def execute(
@@ -180,5 +194,9 @@ class EvaluateModelNode(BaseNode):
             # accuracy.
             result.update(interrupted_result(batch=stopped_at_batch))
         elif context is not None:
-            context.log_metric("eval_accuracy", accuracy, 1)
+            # Defensively coerced like batch_size above: params arrive
+            # already INT-typed in the normal editor/API path, but a
+            # hand-built graph.json or CLI invocation is not guaranteed to.
+            step = int(params.get("step", 1))
+            context.log_metric("eval_accuracy", accuracy, step)
         return result

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -489,7 +489,11 @@ class TrainingLoopNode(BaseNode):
                 description=(
                     "Mixed precision. bf16 roughly halves activation memory "
                     "on Ampere and newer with no other change; fp16 does the "
-                    "same on older cards and adds a loss scaler. A device "
+                    "same on older cards and adds a loss scaler. val_accuracy "
+                    "floats at this same precision rather than being forced "
+                    "to fp32, so it stays comparable with val_loss -- but a "
+                    "lower-precision logit can flip an argmax on a near-tie "
+                    "and shift the reported accuracy slightly. A device "
                     "that cannot honour the choice falls back to fp32 and "
                     "says so."
                 ),
@@ -786,27 +790,51 @@ class TrainingLoopNode(BaseNode):
         # further back to avg_train_loss via the pre-existing rule just
         # below when there is no val_dataloader at all. Resolved once, here
         # -- not per epoch -- so the warning (if any) is logged once.
+        #
+        # A THIRD reason joins the two above: `monitor` itself might not be
+        # one of the two values the param declares at all. The editor never
+        # sends anything else, but a hand-built graph.json or CLI
+        # invocation is not guaranteed to -- and a typo ("accuracy" instead
+        # of "val_accuracy") must not silently monitor loss with no signal,
+        # the same way the other two reasons are not silent.
         monitor_is_accuracy = monitor == "val_accuracy"
         monitor_fallback_reason: str | None = None
-        if patience > 0 and monitor_is_accuracy and val_dataloader is None:
-            monitor_fallback_reason = "no val_dataloader is wired"
-        elif patience > 0 and monitor_is_accuracy and not is_classification_loss:
-            monitor_fallback_reason = (
-                "loss_fn is not a classification loss (CrossEntropyLoss "
-                "or NLLLoss)"
-            )
+        if patience > 0:
+            if monitor not in ("val_loss", "val_accuracy"):
+                monitor_fallback_reason = (
+                    f"{monitor!r} is not a recognised monitor value "
+                    "(expected 'val_loss' or 'val_accuracy')"
+                )
+            elif monitor_is_accuracy and val_dataloader is None:
+                monitor_fallback_reason = "no val_dataloader is wired"
+            elif monitor_is_accuracy and not is_classification_loss:
+                monitor_fallback_reason = (
+                    "loss_fn is not a classification loss (CrossEntropyLoss "
+                    "or NLLLoss)"
+                )
         if monitor_fallback_reason is not None:
             logger.warning(
-                "monitor=val_accuracy was requested for early stopping, "
-                "but %s, so there is no val_accuracy series to watch. "
+                "monitor=%r was requested for early stopping, but %s. "
                 "Falling back to monitor=val_loss.",
-                monitor_fallback_reason,
+                monitor, monitor_fallback_reason,
             )
             monitor_is_accuracy = False
         best_monitor_value = float("-inf") if monitor_is_accuracy else float("inf")
         best_epoch = 0
         best_state_dict = None
         patience_counter = 0
+        # Set True the epoch early stopping actually breaks the loop on.
+        # NOT derived from best_state_dict/patience_counter at exit time
+        # (which is what metrics["stopped_early"] used to do): the
+        # monitor=val_accuracy degenerate path below can leave
+        # best_state_dict at None on every epoch (nothing ever counts as
+        # an improvement when there is nothing to compare), which made
+        # that derivation silently say False for a run that plainly did
+        # stop early.
+        early_stopping_triggered = False
+        # Logged once, the first epoch it happens, not every epoch of a
+        # persistently-empty val_dataloader.
+        monitor_value_missing_warned = False
 
         # Where a stop landed: the 0-based index of the batch that never ran,
         # and which loop it was in. None until someone presses Stop.
@@ -1099,8 +1127,18 @@ class TrainingLoopNode(BaseNode):
                 # monitor_value can only be None here if monitor_is_accuracy
                 # but this SPECIFIC epoch produced no accuracy points (e.g.
                 # an empty val_dataloader) despite the run-level gates
-                # passing -- treated as "no improvement" rather than
-                # crashing on a None comparison.
+                # passing. Loud, like the two run-level fallbacks above:
+                # silently spending patience on a comparison that never
+                # happened would be the same mistake in a smaller dose.
+                if (monitor_is_accuracy and monitor_value is None
+                        and not monitor_value_missing_warned):
+                    logger.warning(
+                        "monitor=val_accuracy but epoch %d produced no "
+                        "val_accuracy points (e.g. an empty val_dataloader); "
+                        "treating it as no improvement for early stopping.",
+                        epoch + 1,
+                    )
+                    monitor_value_missing_warned = True
                 improved = monitor_value is not None and (
                     monitor_value > best_monitor_value if monitor_is_accuracy
                     else monitor_value < best_monitor_value
@@ -1115,6 +1153,7 @@ class TrainingLoopNode(BaseNode):
 
                 if patience_counter >= patience:
                     stopped_early = True
+                    early_stopping_triggered = True
 
             logger.info(
                 "Epoch %d/%d - Train Loss: %.4f%s%s",
@@ -1237,7 +1276,15 @@ class TrainingLoopNode(BaseNode):
             "total_epochs_run": len(epoch_losses),
             "start_epoch": start_epoch,
             "last_epoch": completed_epochs,
-            "stopped_early": best_state_dict is not None and patience_counter >= patience,
+            # #202 review: was `best_state_dict is not None and
+            # patience_counter >= patience`, an indirect proxy that
+            # silently read False whenever best_state_dict never got set
+            # -- which the monitor=val_accuracy degenerate path (an empty
+            # val_dataloader; see early_stopping_triggered's own comment)
+            # made newly possible even though the loop DID exit early.
+            # early_stopping_triggered is set at the exact point the break
+            # actually happens, so it cannot drift from what the loop did.
+            "stopped_early": early_stopping_triggered,
             "lr_history": lr_history,
             "interrupted": stopped_at is not None,
             # How much training actually happened, and whether the budget is

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -372,7 +372,10 @@ class TrainingLoopNode(BaseNode):
     the only two in this repo's loss map whose targets are integer class
     indices against ``[B, C]`` logits, which is the shape ``argmax(dim=1)``
     assumes). A regression or BCE run therefore never gets a val_accuracy
-    series.
+    series. ``monitor`` (default ``val_loss``) can point early stopping at
+    it instead; requesting ``val_accuracy`` without either gate above
+    holding falls back to ``val_loss`` with a warning rather than
+    comparing against a value that was never computed.
     """
 
     NODE_NAME = "TrainingLoop"
@@ -444,8 +447,23 @@ class TrainingLoopNode(BaseNode):
                 name="early_stopping_patience",
                 param_type=ParamType.INT,
                 default=0,
-                description="Stop if val loss doesn't improve for N epochs (0 = disabled)",
+                description="Stop if the monitored metric doesn't improve for N epochs (0 = disabled)",
                 min_value=0,
+            ),
+            ParamDefinition(
+                name="monitor",
+                param_type=ParamType.SELECT,
+                default="val_loss",
+                description=(
+                    "Metric early stopping watches. val_loss: lower is "
+                    "better (the default). val_accuracy: higher is "
+                    "better -- only recorded for a classification loss "
+                    "(CrossEntropyLoss/NLLLoss) with a val_dataloader "
+                    "wired; falls back to val_loss with a warning when "
+                    "neither holds, rather than watching a value that "
+                    "was never computed."
+                ),
+                options=["val_loss", "val_accuracy"],
             ),
             ParamDefinition(
                 name="grad_clip_norm",
@@ -650,6 +668,7 @@ class TrainingLoopNode(BaseNode):
         epochs = params.get("epochs", 5)
         device = resolve_node_device(params.get("device"), context)
         patience = params.get("early_stopping_patience", 0)
+        monitor = params.get("monitor", "val_loss")
         grad_clip = params.get("grad_clip_norm", 0.0)
         batch_metrics = bool(params.get("batch_metrics", False))
         max_steps = int(params.get("max_steps", 0) or 0)
@@ -752,8 +771,39 @@ class TrainingLoopNode(BaseNode):
         val_epoch_accuracies: list[float] = []
         lr_history: list[float] = []
 
-        # Early stopping state
-        best_val_loss = float("inf")
+        # Early stopping state.
+        #
+        # `monitor` picks which scalar is watched: val_loss (lower is
+        # better, the default -- unchanged from before this param existed)
+        # or val_accuracy (higher is better). val_accuracy only exists when
+        # BOTH gates above hold (a val_dataloader is wired AND loss_fn is
+        # classification -- see is_classification_loss); asking to monitor
+        # it without either means there is no series to watch. This
+        # codebase's convention for an unusable request is to degrade with
+        # a loud warning rather than fail the run (precision falling back
+        # to fp32, a scheduler replay that cannot proceed, ...), so the
+        # same rule applies here: fall back to val_loss, which itself falls
+        # further back to avg_train_loss via the pre-existing rule just
+        # below when there is no val_dataloader at all. Resolved once, here
+        # -- not per epoch -- so the warning (if any) is logged once.
+        monitor_is_accuracy = monitor == "val_accuracy"
+        monitor_fallback_reason: str | None = None
+        if patience > 0 and monitor_is_accuracy and val_dataloader is None:
+            monitor_fallback_reason = "no val_dataloader is wired"
+        elif patience > 0 and monitor_is_accuracy and not is_classification_loss:
+            monitor_fallback_reason = (
+                "loss_fn is not a classification loss (CrossEntropyLoss "
+                "or NLLLoss)"
+            )
+        if monitor_fallback_reason is not None:
+            logger.warning(
+                "monitor=val_accuracy was requested for early stopping, "
+                "but %s, so there is no val_accuracy series to watch. "
+                "Falling back to monitor=val_loss.",
+                monitor_fallback_reason,
+            )
+            monitor_is_accuracy = False
+        best_monitor_value = float("-inf") if monitor_is_accuracy else float("inf")
         best_epoch = 0
         best_state_dict = None
         patience_counter = 0
@@ -1042,9 +1092,21 @@ class TrainingLoopNode(BaseNode):
             # ── Early stopping check ──
             stopped_early = False
             if patience > 0:
-                monitor_loss = avg_val_loss if avg_val_loss is not None else avg_train_loss
-                if monitor_loss < best_val_loss:
-                    best_val_loss = monitor_loss
+                if monitor_is_accuracy:
+                    monitor_value = avg_val_accuracy
+                else:
+                    monitor_value = avg_val_loss if avg_val_loss is not None else avg_train_loss
+                # monitor_value can only be None here if monitor_is_accuracy
+                # but this SPECIFIC epoch produced no accuracy points (e.g.
+                # an empty val_dataloader) despite the run-level gates
+                # passing -- treated as "no improvement" rather than
+                # crashing on a None comparison.
+                improved = monitor_value is not None and (
+                    monitor_value > best_monitor_value if monitor_is_accuracy
+                    else monitor_value < best_monitor_value
+                )
+                if improved:
+                    best_monitor_value = monitor_value
                     best_epoch = epoch + 1
                     best_state_dict = {k: v.clone() for k, v in model.state_dict().items()}
                     patience_counter = 0
@@ -1193,6 +1255,13 @@ class TrainingLoopNode(BaseNode):
         }
         if policy.fell_back:
             metrics["precision_requested"] = policy.requested
+        if patience > 0:
+            # Only meaningful when early stopping actually ran -- with
+            # patience=0, monitor is not consulted at all, so reporting it
+            # would imply a comparison that never happened.
+            metrics["monitor"] = "val_accuracy" if monitor_is_accuracy else "val_loss"
+            if monitor_fallback_reason is not None:
+                metrics["monitor_requested"] = monitor
         # ``tensorboard_logdir`` is added by ``execute`` after the writer is
         # closed and registered, which happens in a ``finally`` outside this
         # method so a run that raises still gets its artifact row.

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -729,6 +729,7 @@ class TrainingLoopNode(BaseNode):
 
         epoch_losses: list[float] = []
         val_epoch_losses: list[float] = []
+        val_epoch_accuracies: list[float] = []
         lr_history: list[float] = []
 
         # Early stopping state
@@ -923,10 +924,13 @@ class TrainingLoopNode(BaseNode):
 
             # ── Validation phase ──
             avg_val_loss = None
+            avg_val_accuracy = None
             if val_dataloader is not None:
                 model.eval()
                 val_running_loss = 0.0
                 val_batch_count = 0
+                val_correct = 0
+                val_total = 0
 
                 with torch.no_grad():
                     for batch_index, batch_data in enumerate(val_dataloader):
@@ -958,6 +962,22 @@ class TrainingLoopNode(BaseNode):
                                 loss = loss_fn(outputs)
                         val_running_loss += loss.item()
                         val_batch_count += 1
+
+                        # Accuracy from this SAME forward pass -- no second
+                        # model call. Same argmax-vs-label comparison as
+                        # EvaluateModel (evaluate_model_node.py:163-165),
+                        # deliberately at whatever precision ``outputs`` was
+                        # already produced at (the policy above) rather than
+                        # forced to fp32: the val_loss next to it is not
+                        # fp32-forced either, and the two must stay
+                        # comparable (see the ``precision`` param
+                        # description for the consequence -- a lower-
+                        # precision logit can flip an argmax on a near-tie).
+                        if targets is not None:
+                            pred = outputs.argmax(dim=1)
+                            val_correct += int((pred == targets).sum().item())
+                            val_total += int(targets.numel())
+
                         throttle.emit({
                             "event": EVENT_BATCH,
                             "epoch": epoch + 1,
@@ -976,6 +996,9 @@ class TrainingLoopNode(BaseNode):
 
                 avg_val_loss = val_running_loss / max(val_batch_count, 1)
                 val_epoch_losses.append(avg_val_loss)
+                if val_total > 0:
+                    avg_val_accuracy = val_correct / val_total
+                    val_epoch_accuracies.append(avg_val_accuracy)
 
             # ── LR Scheduler step ──
             if lr_scheduler is not None:
@@ -1024,6 +1047,8 @@ class TrainingLoopNode(BaseNode):
             record_metric("train_loss", avg_train_loss, epoch + 1)
             if avg_val_loss is not None:
                 record_metric("val_loss", avg_val_loss, epoch + 1)
+            if avg_val_accuracy is not None:
+                record_metric("val_accuracy", avg_val_accuracy, epoch + 1)
             record_metric("lr", current_lr, epoch + 1)
             if patience > 0:
                 record_metric("patience_counter", patience_counter,
@@ -1042,6 +1067,8 @@ class TrainingLoopNode(BaseNode):
                 if avg_val_loss is not None:
                     progress_data["val_loss"] = round(avg_val_loss, 6)
                     progress_data["val_losses"] = [round(l, 6) for l in val_epoch_losses]
+                if avg_val_accuracy is not None:
+                    progress_data["val_accuracy"] = round(avg_val_accuracy, 6)
                 if patience > 0:
                     progress_data["patience_counter"] = patience_counter
                     progress_data["best_epoch"] = best_epoch
@@ -1115,6 +1142,7 @@ class TrainingLoopNode(BaseNode):
         metrics = {
             "final_train_loss": epoch_losses[-1] if epoch_losses else 0.0,
             "final_val_loss": val_epoch_losses[-1] if val_epoch_losses else None,
+            "final_val_accuracy": val_epoch_accuracies[-1] if val_epoch_accuracies else None,
             "best_epoch": best_epoch if patience > 0 else completed_epochs,
             "total_epochs_run": len(epoch_losses),
             "start_epoch": start_epoch,

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -365,6 +365,14 @@ class TrainingLoopNode(BaseNode):
     to INFER from the epoch progress payload was called ``loss``; it is
     ``train_loss`` now, which is the same number under a name that lines up
     with ``val_loss``.
+
+    **val_accuracy (#202).** Recorded alongside ``val_loss``, under the same
+    gate (a validation loader must be wired) plus one more: ``loss_fn`` must
+    be a classification loss (``nn.CrossEntropyLoss`` or ``nn.NLLLoss`` --
+    the only two in this repo's loss map whose targets are integer class
+    indices against ``[B, C]`` logits, which is the shape ``argmax(dim=1)``
+    assumes). A regression or BCE run therefore never gets a val_accuracy
+    series.
     """
 
     NODE_NAME = "TrainingLoop"
@@ -606,6 +614,7 @@ class TrainingLoopNode(BaseNode):
         tb_writer: Any = None,
     ) -> dict[str, Any]:
         import torch
+        import torch.nn as nn
 
         from ...core.amp import AmpPolicy
         from ...core.device_utils import resolve_node_device, to_device
@@ -623,6 +632,17 @@ class TrainingLoopNode(BaseNode):
         dataloader = inputs["dataloader"]
         optimizer = inputs["optimizer"]
         loss_fn = inputs["loss_fn"]
+        # CrossEntropyLoss / NLLLoss are the only two losses in this repo's
+        # map (loss_node.py's LOSS_TYPES) whose targets are integer class
+        # indices against [B, C] logits -- the shape argmax(dim=1) assumes.
+        # Every other loss (BCE*, the regression losses) is not
+        # argmax-shaped, so val_accuracy is only ever computed, recorded,
+        # or monitored by early stopping when this holds. Getting this
+        # wrong in the permissive direction -- e.g. admitting
+        # BCEWithLogitsLoss -- either crashes on a shape mismatch or
+        # silently broadcasts into a meaningless number, which is worse
+        # than not shipping the feature at all.
+        is_classification_loss = isinstance(loss_fn, (nn.CrossEntropyLoss, nn.NLLLoss))
         val_dataloader = inputs.get("val_dataloader")
         lr_scheduler = inputs.get("lr_scheduler")
         start_epoch = _coerce_start_epoch(inputs.get("start_epoch"))
@@ -973,7 +993,15 @@ class TrainingLoopNode(BaseNode):
                         # comparable (see the ``precision`` param
                         # description for the consequence -- a lower-
                         # precision logit can flip an argmax on a near-tie).
-                        if targets is not None:
+                        #
+                        # Classification-only: see is_classification_loss
+                        # above. A regression/BCE loss's outputs are not
+                        # [B, C] class logits, so argmax(dim=1) over them is
+                        # not "the predicted class" -- it is a shape that
+                        # happens to run (or, for a [B, 1] regression head,
+                        # a broadcasted comparison that happens NOT to
+                        # crash) and a number with no meaning either way.
+                        if is_classification_loss and targets is not None:
                             pred = outputs.argmax(dim=1)
                             val_correct += int((pred == targets).sum().item())
                             val_total += int(targets.numel())
@@ -996,7 +1024,7 @@ class TrainingLoopNode(BaseNode):
 
                 avg_val_loss = val_running_loss / max(val_batch_count, 1)
                 val_epoch_losses.append(avg_val_loss)
-                if val_total > 0:
+                if is_classification_loss and val_total > 0:
                     avg_val_accuracy = val_correct / val_total
                     val_epoch_accuracies.append(avg_val_accuracy)
 

--- a/backend/tests/test_cancellation.py
+++ b/backend/tests/test_cancellation.py
@@ -769,6 +769,9 @@ def test_batch_metrics_are_opt_in():
 
 
 def test_validation_loss_is_logged_when_present():
+    """#202: val_accuracy joins val_loss in this list -- this scenario is a
+    classifier (CrossEntropyLoss) with a val_dataloader wired, exactly
+    val_accuracy's gate, so it is expected here too."""
     ctx = ExecutionContext()
     model = _fresh_model()
     TrainingLoopNode().execute(
@@ -781,8 +784,8 @@ def test_validation_loss_is_logged_when_present():
     )
     points = ctx.outbox.drain()[0]
     assert [(p.name, p.step) for p in points] == [
-        ("train_loss", 1), ("val_loss", 1), ("lr", 1),
-        ("train_loss", 2), ("val_loss", 2), ("lr", 2),
+        ("train_loss", 1), ("val_loss", 1), ("val_accuracy", 1), ("lr", 1),
+        ("train_loss", 2), ("val_loss", 2), ("val_accuracy", 2), ("lr", 2),
     ]
 
 
@@ -794,7 +797,10 @@ def test_every_previously_inferred_series_is_still_logged():
     any more. Everything ``scalar_metrics`` used to take from that payload —
     ``lr`` and, under early stopping, ``patience_counter`` and
     ``best_epoch`` — therefore has to be logged by hand. ``loss`` is the one
-    deliberate change: it is ``train_loss`` now.
+    deliberate change: it is ``train_loss`` now. #202 adds a second:
+    ``val_accuracy`` is now in the epoch payload too (this scenario is a
+    classifier with a val_dataloader, its gate), and is likewise logged
+    explicitly.
     """
     model = _fresh_model()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
@@ -820,8 +826,8 @@ def test_every_previously_inferred_series_is_still_logged():
         for payload in payloads if payload.get("event") == "epoch"
         for point in scalar_metrics(payload, node_id=None, step=1)
     }
-    assert inferable == {"loss", "val_loss", "lr", "patience_counter",
-                         "best_epoch"}
+    assert inferable == {"loss", "val_loss", "val_accuracy", "lr",
+                         "patience_counter", "best_epoch"}
     assert logged == (inferable - {"loss"}) | {"train_loss"}
 
 

--- a/backend/tests/test_evaluate_model_node.py
+++ b/backend/tests/test_evaluate_model_node.py
@@ -259,3 +259,20 @@ def test_two_evaluate_model_nodes_with_different_steps_do_not_collide():
         {"step": 2}, context=ctx)
     steps = [step for name, _, step in ctx.metrics if name == "eval_accuracy"]
     assert steps == [1, 2]
+
+
+# ── #202 review fix (Minor 5) ────────────────────────────────────────
+
+
+def test_step_is_clamped_to_its_own_declared_min_value_of_0():
+    """The in-code comment claims step is "coerced and clamped ... like
+    batch_size above" (which does max(1, int(...))); step's own
+    ParamDefinition declares min_value=0. A hand-built graph.json
+    bypassing the editor's bounds must not reach a negative step -- the
+    comment's claim must be true, not just fixed prose."""
+    ctx = _RecordingContext()
+    EvaluateModelNode().execute(
+        {"model": _fresh_model(), "dataset": _dataset()},
+        {"step": -5}, context=ctx)
+    steps = [step for name, _, step in ctx.metrics if name == "eval_accuracy"]
+    assert steps == [0]

--- a/backend/tests/test_evaluate_model_node.py
+++ b/backend/tests/test_evaluate_model_node.py
@@ -208,3 +208,54 @@ def test_precision_bf16_runs_the_forward_pass_in_bf16_but_keeps_params_fp32():
         {"device": "cpu", "precision": "bf16"})
     assert probe.seen_dtype == torch.bfloat16
     assert probe.linear.weight.dtype == torch.float32
+
+
+# ── 1d (#202): step, so several EvaluateModel nodes in one graph don't
+# overwrite each other's point on the eval_accuracy chart ──────────────
+
+
+class _RecordingContext:
+    """Collects log_metric calls; should_stop always False. Mirrors the
+    stub of the same name in test_training_loop_node.py."""
+
+    def __init__(self):
+        self.current_node_id = "eval"
+        self.metrics: list[tuple[str, float, int]] = []
+
+    def should_stop(self):
+        return False
+
+    def log_metric(self, name, value, step, node_id=None):
+        self.metrics.append((name, value, step))
+
+    def can_record_artifacts(self):
+        return False
+
+
+def test_step_param_defaults_to_1_matching_the_prior_hardcoded_behaviour():
+    p = next(p for p in EvaluateModelNode.define_params() if p.name == "step")
+    assert p.default == 1
+
+
+def test_eval_accuracy_is_logged_at_the_default_step_1():
+    """Regression pin: leaving `step` unset must behave exactly like the
+    previous hardcoded `context.log_metric("eval_accuracy", accuracy, 1)`."""
+    ctx = _RecordingContext()
+    result = EvaluateModelNode().execute(
+        {"model": _fresh_model(), "dataset": _dataset()}, {}, context=ctx)
+    assert ctx.metrics == [("eval_accuracy", result["accuracy"], 1)]
+
+
+def test_two_evaluate_model_nodes_with_different_steps_do_not_collide():
+    """Acceptance: several EvaluateModel nodes in one graph no longer
+    overwrite each other -- e.g. a before/after-fine-tuning comparison,
+    each logged at its own step on the shared eval_accuracy series."""
+    ctx = _RecordingContext()
+    EvaluateModelNode().execute(
+        {"model": _fresh_model(), "dataset": _dataset()},
+        {"step": 1}, context=ctx)
+    EvaluateModelNode().execute(
+        {"model": _fresh_model(), "dataset": _dataset()},
+        {"step": 2}, context=ctx)
+    steps = [step for name, _, step in ctx.metrics if name == "eval_accuracy"]
+    assert steps == [1, 2]

--- a/backend/tests/test_training_loop_node.py
+++ b/backend/tests/test_training_loop_node.py
@@ -482,30 +482,57 @@ class _ScriptedValLoss(nn.CrossEntropyLoss):
 
 def test_monitor_val_accuracy_stops_at_a_different_epoch_than_val_loss():
     """Acceptance: monitor=val_accuracy stops on the accuracy plateau
-    rather than the loss turn.
+    rather than the loss turn. Also the durable guard on early stopping's
+    direction for accuracy (higher-is-better) -- see the note below on
+    why the accuracy trajectory is 0.5 / 0.75 / 0.25, not a tie.
 
     Loss and accuracy are scripted independently (see the two helper
-    classes above) so the two curves deliberately DISAGREE about which
-    epoch is best: loss improves through epoch 2 then turns worse at
-    epoch 3; accuracy ties at epoch 2 (no improvement under a strict
-    threshold) then improves at epoch 3. With early_stopping_patience=1,
-    each monitor stops at ITS OWN plateau, not the other's -- proving
-    monitor genuinely changes which epoch ends the run, not just which
-    number gets logged.
+    classes above) so the two curves DISAGREE about which epoch is best:
+    loss improves through epoch 1->2 then turns worse at epoch 2->3 (a
+    short, 2-entry script is enough since monitor=val_loss's own patience
+    is spent by epoch 2); accuracy improves for two epochs then drops at
+    epoch 3. With early_stopping_patience=1, each monitor stops at ITS
+    OWN, genuinely different point.
+
+    Review note (this trajectory replaces an earlier 0.5/0.5/1.0 one):
+    accuracy's direction (higher is better) is baked into exactly two
+    spots -- best_monitor_value initialised to float("-inf"), and
+    compared with ``>``. A trajectory with a TIE at epoch 2 (0.5, 0.5,
+    ...) cannot catch a bug that flips BOTH of those consistently
+    (equivalent to comparing the same numbers with float("inf") and
+    ``<``) -- a tie is "no improvement" under EITHER direction, so a
+    consistently-inverted rule stops at exactly the same epoch as the
+    correct one and the assertions pass either way. 0.5 -> 0.75 has no
+    such blind spot: 0.75 is an improvement over 0.5 under "higher is
+    better" but NOT under a consistently-inverted "lower is better", so
+    the two rules diverge starting at epoch 2 and land on different
+    (stop epoch, best_epoch) pairs -- verified by hand: correct
+    (higher-is-better) stops at epoch 3 with best_epoch=2; a
+    consistently-inverted rule on these same three numbers stops at
+    epoch 2 with best_epoch=1. Asserting best_epoch, not just where the
+    run stopped, is what makes the guard real -- two runs can stop at
+    the same epoch count while disagreeing about which epoch was best.
     """
     val_targets = torch.tensor([0, 1, 0, 1])
     val_X = torch.randn(4, 4)
-    # 2/4 correct (rows 0, 2); tied between epoch 1 and 2.
+    # 2/4 correct (rows 0, 2).
     acc_50 = torch.tensor([[1., -1.], [1., -1.], [1., -1.], [1., -1.]])
-    # 4/4 correct; only at epoch 3.
-    acc_100 = torch.tensor([[1., -1.], [-1., 1.], [1., -1.], [-1., 1.]])
+    # 3/4 correct (rows 0, 1, 2) -- an improvement over acc_50.
+    acc_75 = torch.tensor([[1., -1.], [-1., 1.], [1., -1.], [1., -1.]])
+    # 1/4 correct (row 2 only) -- a drop from acc_75.
+    acc_25 = torch.tensor([[-1., 1.], [1., -1.], [1., -1.], [1., -1.]])
 
     def _run(monitor):
         torch.manual_seed(0)
         val_loader = torch.utils.data.DataLoader(
             torch.utils.data.TensorDataset(val_X, val_targets), batch_size=4)
-        model = _ScriptedEvalModel([acc_50, acc_50, acc_100])
-        loss_fn = _ScriptedValLoss([2.0, 1.0, 1.5])  # improves, improves, turns
+        model = _ScriptedEvalModel([acc_50, acc_75, acc_25])
+        # Only the first two values are ever read by the val_loss run
+        # (its own patience is spent by epoch 2); the third is padding so
+        # the val_accuracy run -- which reads the SAME loss script every
+        # epoch regardless of which series it monitors -- does not run
+        # off the end of the list at its epoch 3.
+        loss_fn = _ScriptedValLoss([2.0, 3.0, 3.0])  # improves, then worse
         train_loader = _make_loader(_make_dataset(n=2), batch_size=2)
         optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
         return TrainingLoopNode().execute(
@@ -520,15 +547,17 @@ def test_monitor_val_accuracy_stops_at_a_different_epoch_than_val_loss():
     by_loss = _run("val_loss")
     by_accuracy = _run("val_accuracy")
 
-    # Loss: ep1=2.0 (best, first), ep2=1.0 (improves, new best),
-    # ep3=1.5 (worse -> patience_counter=1 >= patience=1 -> stop after ep3).
-    assert by_loss["metrics"]["total_epochs_run"] == 3
-    assert by_loss["metrics"]["best_epoch"] == 2
+    # Loss: ep1=2.0 (best, first), ep2=3.0 (worse ->
+    # patience_counter=1 >= patience=1 -> stop after ep2).
+    assert by_loss["metrics"]["total_epochs_run"] == 2
+    assert by_loss["metrics"]["best_epoch"] == 1
 
-    # Accuracy: ep1=0.5 (best, first), ep2=0.5 (TIE, not a strict
-    # improvement -> patience_counter=1 >= patience=1 -> stop after ep2).
-    assert by_accuracy["metrics"]["total_epochs_run"] == 2
-    assert by_accuracy["metrics"]["best_epoch"] == 1
+    # Accuracy: ep1=0.5 (best, first), ep2=0.75 (improves, new best),
+    # ep3=0.25 (worse -> patience_counter=1 >= patience=1 -> stop after
+    # ep3). Genuinely different from by_loss above (3 epochs vs 2,
+    # best_epoch 2 vs 1) -- monitor changed which epoch ended the run.
+    assert by_accuracy["metrics"]["total_epochs_run"] == 3
+    assert by_accuracy["metrics"]["best_epoch"] == 2
 
 
 def test_monitor_val_accuracy_falls_back_to_val_loss_with_no_val_dataloader(caplog):

--- a/backend/tests/test_training_loop_node.py
+++ b/backend/tests/test_training_loop_node.py
@@ -618,3 +618,63 @@ def test_monitor_key_absent_from_metrics_when_early_stopping_is_off():
     metrics should not claim a value was monitored when none was."""
     result = _train({"epochs": 2, "monitor": "val_accuracy"})
     assert "monitor" not in result["metrics"]
+
+
+# ── #202 review fixes ────────────────────────────────────────────────
+
+
+def test_precision_param_documents_the_val_accuracy_consequence():
+    """Important 1: the in-loop validation-accuracy comment says "see the
+    precision param description for the consequence -- a lower-precision
+    logit can flip an argmax on a near-tie". That text must actually
+    exist in this node's precision description (the brief required it,
+    the way EvaluateModel.precision's description already states it) or
+    the comment points at nothing."""
+    p = next(p for p in TrainingLoopNode.define_params() if p.name == "precision")
+    assert "argmax" in p.description
+    assert "val_accuracy" in p.description
+
+
+def test_monitor_val_accuracy_with_an_empty_val_dataloader_warns_and_reports_stopped_early_honestly(caplog):
+    """Minor 3: the run-level gates pass (classification loss, a
+    val_dataloader IS wired) but the loader itself yields zero batches,
+    so avg_val_accuracy is None every epoch. Two things must not happen
+    silently: patience being spent on a comparison that never ran, and
+    metrics["stopped_early"] claiming False when the loop plainly broke
+    early (patience=2, epochs=5 requested, only 2 ever run)."""
+    torch.manual_seed(0)
+    model = nn.Linear(4, 2)
+    train_loader = _make_loader(_make_dataset(n=4), batch_size=2)
+    empty_val_loader = _make_loader(_make_dataset(n=0), batch_size=4)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    with caplog.at_level(logging.WARNING, logger="app.nodes.training.training_loop_node"):
+        result = TrainingLoopNode().execute(
+            {
+                "model": model, "dataloader": train_loader, "optimizer": optimizer,
+                "loss_fn": nn.CrossEntropyLoss(), "val_dataloader": empty_val_loader,
+            },
+            {"epochs": 5, "device": "cpu", "early_stopping_patience": 2,
+             "monitor": "val_accuracy"},
+        )
+
+    assert result["metrics"]["total_epochs_run"] == 2
+    assert result["metrics"]["stopped_early"] is True
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("val_accuracy" in m and "epoch" in m.lower() for m in messages), messages
+
+
+def test_monitor_with_an_unrecognised_value_falls_back_to_val_loss_with_a_warning(caplog):
+    """Minor 4: a hand-built graph.json with a typo'd or out-of-vocabulary
+    monitor value (e.g. "accuracy" instead of "val_accuracy") must not be
+    silently swallowed as val_loss with no signal -- loud, like the other
+    two fallback reasons."""
+    with caplog.at_level(logging.WARNING, logger="app.nodes.training.training_loop_node"):
+        result = _train({
+            "epochs": 2, "early_stopping_patience": 1, "monitor": "accuracy",
+        })
+
+    assert result["metrics"]["monitor"] == "val_loss"
+    assert result["metrics"]["monitor_requested"] == "accuracy"
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("accuracy" in m and "recognised" in m for m in messages), messages

--- a/backend/tests/test_training_loop_node.py
+++ b/backend/tests/test_training_loop_node.py
@@ -228,3 +228,65 @@ def test_defaults_leave_the_loop_unchanged():
     assert result["losses"].shape == (3,)
     assert result["metrics"]["total_steps"] == 12
     assert result["metrics"]["stopped_at_max_steps"] is False
+
+
+# ── val_accuracy per epoch (#202, 1a) ───────────────────────────────────
+#
+# Gated exactly like val_loss: present only when a val_dataloader is
+# wired. The classification-only gate (1b) is proven separately, below.
+
+
+def _classification_scenario(n_train=8, n_val=4, in_features=4, out_classes=2):
+    torch.manual_seed(0)
+    model = nn.Linear(in_features, out_classes)
+    train_loader = _make_loader(
+        _make_dataset(n=n_train, in_features=in_features, out_classes=out_classes),
+        batch_size=2,
+    )
+    val_loader = _make_loader(
+        _make_dataset(n=n_val, in_features=in_features, out_classes=out_classes),
+        batch_size=n_val,
+    )
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+    return model, train_loader, val_loader, optimizer
+
+
+def test_classification_run_with_val_dataloader_records_val_accuracy_per_epoch():
+    """Acceptance: a classifier run with a val_dataloader plots
+    val_accuracy against epoch -- one point per epoch, in [0, 1]."""
+    model, train_loader, val_loader, optimizer = _classification_scenario()
+    ctx = _RecordingContext()
+    TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": train_loader,
+            "optimizer": optimizer,
+            "loss_fn": nn.CrossEntropyLoss(),
+            "val_dataloader": val_loader,
+        },
+        {"epochs": 3, "device": "cpu"},
+        context=ctx,
+    )
+    acc_points = [(step, value) for name, value, step in ctx.metrics
+                  if name == "val_accuracy"]
+    assert [step for step, _ in acc_points] == [1, 2, 3]
+    assert all(0.0 <= value <= 1.0 for _, value in acc_points)
+
+
+def test_no_val_dataloader_records_no_val_accuracy_and_does_not_crash():
+    """Acceptance: a run with no val_dataloader emits no accuracy series
+    and does not crash."""
+    model = nn.Linear(4, 2)
+    ctx = _RecordingContext()
+    result = TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": _make_loader(_make_dataset()),
+            "optimizer": torch.optim.SGD(model.parameters(), lr=0.01),
+            "loss_fn": nn.CrossEntropyLoss(),
+        },
+        {"epochs": 2, "device": "cpu"},
+        context=ctx,
+    )
+    assert result["metrics"]["total_epochs_run"] == 2
+    assert not [m for m in ctx.metrics if m[0] == "val_accuracy"]

--- a/backend/tests/test_training_loop_node.py
+++ b/backend/tests/test_training_loop_node.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import torch
 import torch.nn as nn
 
@@ -381,3 +383,209 @@ def test_nll_loss_with_val_dataloader_records_val_accuracy():
     )
     names = {name for name, _, _ in ctx.metrics}
     assert "val_accuracy" in names
+
+
+# ── monitor: early stopping can watch val_accuracy (#202, 1c) ──────────
+
+
+def test_monitor_param_defaults_to_val_loss_with_both_options():
+    """default val_loss to preserve current behaviour."""
+    p = next(p for p in TrainingLoopNode.define_params() if p.name == "monitor")
+    assert p.default == "val_loss"
+    assert p.options == ["val_loss", "val_accuracy"]
+
+
+def test_monitor_omitted_behaves_exactly_like_val_loss():
+    """Regression guard for "default val_loss to preserve current
+    behaviour": leaving the new param unset must produce bit-identical
+    results to spelling it out."""
+    def _run(with_monitor_key):
+        torch.manual_seed(0)
+        model = nn.Linear(4, 2)
+        loader = _make_loader(_make_dataset(n=8), batch_size=2)
+        val_loader = _make_loader(_make_dataset(n=4), batch_size=4)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+        params = {"epochs": 6, "device": "cpu", "early_stopping_patience": 2}
+        if with_monitor_key:
+            params["monitor"] = "val_loss"
+        return TrainingLoopNode().execute(
+            {
+                "model": model, "dataloader": loader, "optimizer": optimizer,
+                "loss_fn": nn.CrossEntropyLoss(), "val_dataloader": val_loader,
+            },
+            params,
+        )
+
+    omitted = _run(False)
+    explicit = _run(True)
+    assert omitted["metrics"]["total_epochs_run"] == explicit["metrics"]["total_epochs_run"]
+    assert omitted["metrics"]["best_epoch"] == explicit["metrics"]["best_epoch"]
+    assert torch.equal(omitted["losses"], explicit["losses"])
+
+
+class _ScriptedEvalModel(nn.Module):
+    """A model whose EVAL-mode forward pass returns pre-scripted logits --
+    one script entry consumed per validation call -- so a test can pin an
+    exact, independently-controlled accuracy trajectory across epochs.
+    TRAIN-mode forward passes are a real, differentiable Linear op (so the
+    training phase runs and backward() has something to do) and never
+    touch the script. Keyed off ``self.training``, which model.train() /
+    model.eval() genuinely toggle for a model (unlike for a loss module --
+    see _ScriptedValLoss below)."""
+
+    def __init__(self, eval_logits: list[torch.Tensor], in_features=4, out_classes=2):
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_classes)
+        self._eval_logits = eval_logits
+        self._eval_index = 0
+
+    def forward(self, x):
+        if self.training:
+            return self.linear(x)
+        logits = self._eval_logits[self._eval_index]
+        self._eval_index += 1
+        return logits
+
+
+class _ScriptedValLoss(nn.CrossEntropyLoss):
+    """A CrossEntropyLoss whose VALUE is scripted per validation call,
+    decoupled from the actual logits/targets, so a test can pin an exact
+    loss trajectory independent of the accuracy trajectory (itself driven
+    by _ScriptedEvalModel's real, independently-chosen logits).
+    isinstance(this, nn.CrossEntropyLoss) is True, so the 1b classification
+    gate still admits it.
+
+    ``loss_fn.train()``/``.eval()`` are never called by TrainingLoop --
+    only ``model.train()``/``.eval()`` are -- so ``self.training`` cannot
+    be used to tell a train call from a val call here. Instead this counts
+    calls: with exactly one train batch and one val batch per epoch (the
+    scenario below), calls alternate train, val, train, val, ... starting
+    with train, so val calls are the odd-indexed ones.
+    """
+
+    def __init__(self, eval_losses: list[float]):
+        super().__init__()
+        self._eval_losses = eval_losses
+        self._call = 0
+        self._eval_index = 0
+
+    def forward(self, outputs, targets):
+        real = super().forward(outputs, targets)
+        is_val_call = self._call % 2 == 1
+        self._call += 1
+        if is_val_call:
+            value = self._eval_losses[self._eval_index]
+            self._eval_index += 1
+            return real * 0 + value
+        return real
+
+
+def test_monitor_val_accuracy_stops_at_a_different_epoch_than_val_loss():
+    """Acceptance: monitor=val_accuracy stops on the accuracy plateau
+    rather than the loss turn.
+
+    Loss and accuracy are scripted independently (see the two helper
+    classes above) so the two curves deliberately DISAGREE about which
+    epoch is best: loss improves through epoch 2 then turns worse at
+    epoch 3; accuracy ties at epoch 2 (no improvement under a strict
+    threshold) then improves at epoch 3. With early_stopping_patience=1,
+    each monitor stops at ITS OWN plateau, not the other's -- proving
+    monitor genuinely changes which epoch ends the run, not just which
+    number gets logged.
+    """
+    val_targets = torch.tensor([0, 1, 0, 1])
+    val_X = torch.randn(4, 4)
+    # 2/4 correct (rows 0, 2); tied between epoch 1 and 2.
+    acc_50 = torch.tensor([[1., -1.], [1., -1.], [1., -1.], [1., -1.]])
+    # 4/4 correct; only at epoch 3.
+    acc_100 = torch.tensor([[1., -1.], [-1., 1.], [1., -1.], [-1., 1.]])
+
+    def _run(monitor):
+        torch.manual_seed(0)
+        val_loader = torch.utils.data.DataLoader(
+            torch.utils.data.TensorDataset(val_X, val_targets), batch_size=4)
+        model = _ScriptedEvalModel([acc_50, acc_50, acc_100])
+        loss_fn = _ScriptedValLoss([2.0, 1.0, 1.5])  # improves, improves, turns
+        train_loader = _make_loader(_make_dataset(n=2), batch_size=2)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+        return TrainingLoopNode().execute(
+            {
+                "model": model, "dataloader": train_loader, "optimizer": optimizer,
+                "loss_fn": loss_fn, "val_dataloader": val_loader,
+            },
+            {"epochs": 5, "device": "cpu", "early_stopping_patience": 1,
+             "monitor": monitor},
+        )
+
+    by_loss = _run("val_loss")
+    by_accuracy = _run("val_accuracy")
+
+    # Loss: ep1=2.0 (best, first), ep2=1.0 (improves, new best),
+    # ep3=1.5 (worse -> patience_counter=1 >= patience=1 -> stop after ep3).
+    assert by_loss["metrics"]["total_epochs_run"] == 3
+    assert by_loss["metrics"]["best_epoch"] == 2
+
+    # Accuracy: ep1=0.5 (best, first), ep2=0.5 (TIE, not a strict
+    # improvement -> patience_counter=1 >= patience=1 -> stop after ep2).
+    assert by_accuracy["metrics"]["total_epochs_run"] == 2
+    assert by_accuracy["metrics"]["best_epoch"] == 1
+
+
+def test_monitor_val_accuracy_falls_back_to_val_loss_with_no_val_dataloader(caplog):
+    """Degenerate case 1: no val_dataloader means there is no val_accuracy
+    series (1a's gate) to monitor. Falls back to val_loss -- which, with
+    no val_dataloader either, is itself the pre-existing avg_train_loss
+    fallback -- so the run completes normally rather than crashing or
+    silently comparing against a value that was never computed."""
+    with caplog.at_level(logging.WARNING, logger="app.nodes.training.training_loop_node"):
+        result = _train({
+            "epochs": 3, "early_stopping_patience": 5, "monitor": "val_accuracy",
+        })
+
+    assert result["metrics"]["total_epochs_run"] == 3
+    assert result["metrics"]["monitor"] == "val_loss"
+    assert result["metrics"]["monitor_requested"] == "val_accuracy"
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("val_accuracy" in m and "val_dataloader" in m for m in messages), messages
+
+
+def test_monitor_val_accuracy_falls_back_to_val_loss_for_a_regression_loss(caplog):
+    """Degenerate case 2: a regression loss never produces val_accuracy
+    (1b's gate), so monitor=val_accuracy falls back to val_loss here too,
+    even though a val_dataloader IS wired."""
+    torch.manual_seed(0)
+    model = nn.Linear(4, 1)
+    train_loader = _make_loader(_make_regression_dataset(n=8))
+    val_loader = _make_loader(_make_regression_dataset(n=4), batch_size=4)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    with caplog.at_level(logging.WARNING, logger="app.nodes.training.training_loop_node"):
+        res = TrainingLoopNode().execute(
+            {
+                "model": model, "dataloader": train_loader, "optimizer": optimizer,
+                "loss_fn": nn.MSELoss(), "val_dataloader": val_loader,
+            },
+            {"epochs": 3, "device": "cpu", "early_stopping_patience": 5,
+             "monitor": "val_accuracy"},
+        )
+
+    assert res["metrics"]["total_epochs_run"] == 3
+    assert res["metrics"]["monitor"] == "val_loss"
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("classification" in m.lower() for m in messages), messages
+
+
+def test_monitor_val_loss_reports_no_requested_key_when_not_falling_back():
+    """metrics["monitor_requested"] only appears when a fallback actually
+    happened -- an ordinary val_loss run has nothing to report a
+    discrepancy about."""
+    result = _train({"epochs": 2, "early_stopping_patience": 1})
+    assert result["metrics"]["monitor"] == "val_loss"
+    assert "monitor_requested" not in result["metrics"]
+
+
+def test_monitor_key_absent_from_metrics_when_early_stopping_is_off():
+    """monitor is meaningless when patience=0 (early stopping disabled);
+    metrics should not claim a value was monitored when none was."""
+    result = _train({"epochs": 2, "monitor": "val_accuracy"})
+    assert "monitor" not in result["metrics"]

--- a/backend/tests/test_training_loop_node.py
+++ b/backend/tests/test_training_loop_node.py
@@ -15,6 +15,15 @@ def _make_dataset(n=8, in_features=4, out_classes=2):
     return torch.utils.data.TensorDataset(X, y)
 
 
+def _make_regression_dataset(n=8, in_features=4, out_features=1):
+    """Tiny regression dataset: float targets shaped like the model's
+    output, so MSELoss compares like-shaped tensors rather than silently
+    broadcasting a [B] target against a [B, out_features] prediction."""
+    X = torch.randn(n, in_features)
+    y = torch.randn(n, out_features)
+    return torch.utils.data.TensorDataset(X, y)
+
+
 def _make_loader(dataset, batch_size=4):
     return torch.utils.data.DataLoader(dataset, batch_size=batch_size)
 
@@ -290,3 +299,85 @@ def test_no_val_dataloader_records_no_val_accuracy_and_does_not_crash():
     )
     assert result["metrics"]["total_epochs_run"] == 2
     assert not [m for m in ctx.metrics if m[0] == "val_accuracy"]
+
+
+# ── classification-only gate (#202, 1b) ─────────────────────────────────
+#
+# Getting this wrong in the permissive direction (emitting an "accuracy"
+# for a regression run) is worse than not shipping the feature: it is a
+# meaningless number presented with authority.
+
+
+def test_regression_loss_with_val_dataloader_records_no_val_accuracy():
+    """Acceptance: a regression run emits no accuracy series at all --
+    even though its val_dataloader means the validation loop (and
+    val_loss) still runs normally."""
+    torch.manual_seed(0)
+    model = nn.Linear(4, 1)
+    train_loader = _make_loader(_make_regression_dataset(n=8))
+    val_loader = _make_loader(_make_regression_dataset(n=4), batch_size=4)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    ctx = _RecordingContext()
+    TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": train_loader,
+            "optimizer": optimizer,
+            "loss_fn": nn.MSELoss(),
+            "val_dataloader": val_loader,
+        },
+        {"epochs": 2, "device": "cpu"},
+        context=ctx,
+    )
+    names = {name for name, _, _ in ctx.metrics}
+    assert "val_loss" in names
+    assert "val_accuracy" not in names
+
+
+def test_bce_loss_with_val_dataloader_records_no_val_accuracy():
+    """BCEWithLogitsLoss is binary/multi-label, not argmax-shaped over
+    dim=1 the way CrossEntropyLoss/NLLLoss are -- also excluded."""
+    torch.manual_seed(0)
+    model = nn.Linear(4, 3)
+    train_loader = _make_loader(_make_regression_dataset(n=8, out_features=3))
+    val_loader = _make_loader(_make_regression_dataset(n=4, out_features=3), batch_size=4)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    ctx = _RecordingContext()
+    TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": train_loader,
+            "optimizer": optimizer,
+            "loss_fn": nn.BCEWithLogitsLoss(),
+            "val_dataloader": val_loader,
+        },
+        {"epochs": 1, "device": "cpu"},
+        context=ctx,
+    )
+    names = {name for name, _, _ in ctx.metrics}
+    assert "val_accuracy" not in names
+
+
+def test_nll_loss_with_val_dataloader_records_val_accuracy():
+    """NLLLoss is the other classification loss the gate must admit --
+    log-probabilities against integer class indices, same argmax(dim=1)
+    shape as CrossEntropyLoss."""
+    torch.manual_seed(0)
+    model = nn.Sequential(nn.Linear(4, 2), nn.LogSoftmax(dim=1))
+    train_loader = _make_loader(_make_dataset(n=8))
+    val_loader = _make_loader(_make_dataset(n=4), batch_size=4)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    ctx = _RecordingContext()
+    TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": train_loader,
+            "optimizer": optimizer,
+            "loss_fn": nn.NLLLoss(),
+            "val_dataloader": val_loader,
+        },
+        {"epochs": 1, "device": "cpu"},
+        context=ctx,
+    )
+    names = {name for name, _, _ in ctx.metrics}
+    assert "val_accuracy" in names

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -490,6 +490,7 @@ const zhTW: NodeTranslations = {
       batch_size: '評估時每批跑幾筆（不影響結果，只影響速度/記憶體）。',
       device: '評估裝置',
       precision: '前向傳播用的混合精度。bf16 在 Ampere 以後的顯卡上可以把 activation 記憶體用量大約減半，其他都不用改；fp16 則是給更舊的顯卡用的。不論選哪一種，參數都維持 fp32；但降精度的前向傳播仍可能讓量出來的準確率有些微變動（精度較低的 logit 在接近平手時可能讓 argmax 換邊），所以要回報的準確率應該用 fp32 這個數字。裝置做不到的話會自動退回 fp32 並記錄下來。',
+      step: 'eval_accuracy 這個指標記錄時使用的 step 值。同一張圖裡有多個 EvaluateModel 節點時（例如微調前後的比較），需要各自設定不同的 step，否則會在圖表上互相覆蓋。',
     },
   },
   BackwardOnce: {

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -476,7 +476,7 @@ const zhTW: NodeTranslations = {
       monitor: '早停監控的指標。val_loss：越低越好（預設）。val_accuracy：越高越好，僅在使用分類損失函數（CrossEntropyLoss/NLLLoss）且有接上 val_dataloader 時才會記錄；兩者缺一就會退回 val_loss 並記錄警告，而不是去監控一個從未被算出來的數值。',
       grad_clip_norm: '最大梯度範數裁剪（0 = 停用）',
       batch_metrics: '同時把每一批的損失記錄成 train_loss_batch 這條序列（預設關閉：每批一列資料量相當可觀）',
-      precision: '混合精度。bf16 在 Ampere 以後的顯卡上可以把 activation 記憶體用量大約減半，其他都不用改；fp16 則是給更舊的顯卡用的，會額外搭配 loss scaler。裝置做不到的話會自動退回 fp32 並記錄下來。',
+      precision: '混合精度。bf16 在 Ampere 以後的顯卡上可以把 activation 記憶體用量大約減半，其他都不用改；fp16 則是給更舊的顯卡用的，會額外搭配 loss scaler。val_accuracy 會用跟這個相同的精度計算（不會強制轉成 fp32），才能跟 val_loss 維持可比較性——但精度較低的 logit 在接近平手時可能讓 argmax 換邊，讓量出來的準確率有些微變動。裝置做不到的話會自動退回 fp32 並記錄下來。',
       accumulate_steps: '累積這麼多批之後才做一次優化器更新，同時把每一批的損失除以同一個數字。batch_size 8 搭配 4，梯度會等同於 batch_size 32，但記憶體裡同時只放 8 筆（1 = 關閉）。',
       max_steps: '總共跑滿這麼多次優化器更新後就停止，不論 epochs 設定為何。算的是優化器更新次數而不是批次數，所以不管 accumulate_steps 設多少意思都一樣（0 = 不限制）',
       log_interval: '開啟批次指標時，每 N 批記錄一次。長時間執行時調高可以讓圖表稀疏一點。',

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -472,7 +472,8 @@ const zhTW: NodeTranslations = {
     params: {
       epochs: '訓練 epoch 數量',
       device: '訓練裝置',
-      early_stopping_patience: '驗證損失未改善 N 個 epoch 後停止（0 = 停用）',
+      early_stopping_patience: '監控的指標未改善 N 個 epoch 後停止（0 = 停用）',
+      monitor: '早停監控的指標。val_loss：越低越好（預設）。val_accuracy：越高越好，僅在使用分類損失函數（CrossEntropyLoss/NLLLoss）且有接上 val_dataloader 時才會記錄；兩者缺一就會退回 val_loss 並記錄警告，而不是去監控一個從未被算出來的數值。',
       grad_clip_norm: '最大梯度範數裁剪（0 = 停用）',
       batch_metrics: '同時把每一批的損失記錄成 train_loss_batch 這條序列（預設關閉：每批一列資料量相當可觀）',
       precision: '混合精度。bf16 在 Ampere 以後的顯卡上可以把 activation 記憶體用量大約減半，其他都不用改；fp16 則是給更舊的顯卡用的，會額外搭配 loss scaler。裝置做不到的話會自動退回 fp32 並記錄下來。',


### PR DESCRIPTION
First of two Wave 6 Sprint 2 PRs (execution order: #211). Periodic checkpointing (#203, #149, #156) follows separately.

Closes #202.

## What was missing

`TrainingLoop` recorded six metric series — `train_loss`, `val_loss`, `lr`, `patience_counter`, `best_epoch`, and `train_loss_batch` — and none of them was accuracy. `EvaluateModel` wrote one point, `eval_accuracy` at a hardcoded step 1.

So accuracy had no curve. For a classifier that is the plot people actually read: it is where you see the schedule land and where overfitting begins. Validation loss is a proxy, not a substitute — the two routinely diverge late in training, which is the region a cosine schedule spends most of its time in.

It also made early stopping weaker than it looked, since `early_stopping_patience` watched loss: a run whose accuracy is still climbing while its loss has turned is stopped at the wrong epoch.

## What changed

- **`val_accuracy` is recorded per epoch**, computed inside the existing validation loop. `outputs` and `targets` are already in scope right after the loss call, so this is an `argmax` and a counter — **no second forward pass**.
- **Only for classification.** Gated on `isinstance(loss_fn, (nn.CrossEntropyLoss, nn.NLLLoss))` — the only two losses in this repo's loss map whose targets are integer class indices against `[B, C]` logits. `BCEWithLogitsLoss`/`BCELoss` are binary or multi-label and are not argmax-shaped; the regression losses obviously are not. An accuracy number computed against regression targets would be a meaningless number presented with authority, so the gate fails conservatively: a wrapped or custom criterion gets no accuracy series rather than a wrong one.
- **`monitor` on early stopping** (`val_loss` / `val_accuracy`, default `val_loss` so existing graphs are unchanged). Selecting accuracy flips the comparison direction at both places it was baked in.
- **`step` on `EvaluateModel`**, so a before/after comparison in one graph stops overwriting its own point.

### Precision, stated rather than hidden

`val_accuracy` floats at the selected precision rather than being forced to fp32, so it stays comparable with `val_loss` — the two share one autocast policy deliberately. The consequence is now in the `precision` description in both locales: a lower-precision logit can flip an `argmax` on a near-tie and shift the reported accuracy slightly, so fp32 is the number to report.

### Every fallback is loud

Three ways `monitor=val_accuracy` cannot be honoured — no `val_dataloader`, a regression loss, or an unrecognised value in a hand-edited graph — each log a warning and surface `metrics["monitor_requested"]` alongside `metrics["monitor"]`, which reports what was *actually* monitored. Nothing silently watches a value that was never computed.

Also fixed here: `metrics["stopped_early"]` used to report `False` on a run that had in fact broken out of the epoch loop early.

## Out of scope, deliberately

`ReduceLROnPlateau` is still fed loss unconditionally, and `LRSchedulerNode` never exposes `mode`, so it is hardwired to torch's default `"min"`. That is a real gap and a separate one; widening this diff to cover it would have mixed two decisions.

## Verification

- Full backend suite: **3734 passed, 14 skipped, 0 failed.** `tsc -b` clean.
- TDD throughout, with each failing-first test confirmed to fail against unmodified code rather than passing either way.
- Real-browser e2e on a freshly built dist, on a server verified to be this worktree's own install: `monitor` renders as a two-option dropdown defaulting to `val_loss`, `step` renders behind the Advanced disclosure at 1, and all three descriptions read correctly in both locales with no cross-language leakage.

### The review catch worth recording

The first version of the direction test did not guard direction. Its trajectory was accuracy 0.5 / 0.5 / 1.0 with `patience=1`, and under a *consistently* inverted rule — `float("inf")` init **and** `<` comparison, both flipped together — it produced an identical stop epoch and an identical `best_epoch`. It caught one-sided inversions only, which is the easy half. The trajectory is now 0.5 / 0.75 / 0.25: the correct rule runs three epochs and selects the second, an inverted rule stops after two and selects the first, and the test asserts both numbers. Verified by mutation.

## Note for the maintainer

Browser automation cannot perform a true OS-level HTML5 drag, so nodes were added during e2e by dispatching synthetic `DragEvent`s. That produced two console `TypeError`s (`Cannot read properties of null (reading 'document')`) which correlate exactly with those synthetic dispatches and did not recur during any other interaction. A manually-constructed `DragEvent` leaves `event.view` null where a real drag populates it, so this reads as a test-harness artifact in pre-existing drag-and-drop code untouched by this PR — but it could not be conclusively ruled out with this tooling. Filed separately rather than left in a report; a real mouse drag of any node is the one-look check that settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166FJAiynQ4Ei891qJgFYyo
