### PR TITLE
feat(training): periodic checkpointing so a killed server does not lose the whole run

### DIFF
--- a/backend/app/core/checkpoints.py
+++ b/backend/app/core/checkpoints.py
@@ -25,11 +25,32 @@ key                          contents
 ``epoch``                    int, the epoch the checkpoint was taken at
 ``model_state_dict``         ``model.state_dict()``
 ``optimizer_state_dict``     ``optimizer.state_dict()``
+``initial_lrs``              list[float], one per param group (#149)
 ``losses``                   optional tensor of per-epoch training losses
 ``scheduler_state_dict``     optional ``lr_scheduler.state_dict()`` (#118)
 ``scheduler_class``          optional class name guarding the restore (#118)
 ``scaler_state_dict``        optional ``GradScaler.state_dict()`` (#135)
 ===========================  ============================================
+
+**Honest base_lrs (#149).** ``LRScheduler.__init__`` stamps
+``group.setdefault("initial_lr", group["lr"])`` onto each optimizer param
+group at CONSTRUCTION time, and ``Optimizer.load_state_dict`` happens to
+carry that key through a round trip -- verified against the installed torch
+2.11.0+cu128: ``update_group`` replaces each LIVE param group with the
+SAVED group's dict wholesale (only ``params``/``param_names`` are patched in
+from the live side), so a saved dict that already has ``initial_lr`` keeps
+it, accidentally, with no code anywhere naming the guarantee. That accident
+stops applying the moment a checkpoint's own ``optimizer_state_dict`` does
+NOT carry the key -- which happens whenever the optimizer being saved never
+had ANY scheduler constructed over it -- and a scheduler built fresh on the
+resumed optimizer then stamps ``initial_lr`` from whatever the CURRENT
+(possibly already-decayed) ``lr`` is, silently treating it as the run's
+starting point. ``initial_lrs`` makes the guarantee explicit instead of
+inherited: captured here at save time, restored onto
+``optimizer.param_groups[i]["initial_lr"]`` by ``CheckpointLoaderNode``
+before anything downstream can construct a scheduler, so a fresh schedule
+always starts from the honest original regardless of what the accidental
+mechanism would or would not have preserved.
 
 ``scaler_state_dict`` is present only for an fp16 run, and holds five plain
 scalars (``scale``, ``growth_factor``, ``backoff_factor``,
@@ -50,26 +71,39 @@ file. An interrupt checkpoint is an ordinary checkpoint that happens to have
 been written by the engine, so ``CheckpointLoader`` needs no special case
 and a user can resume from it exactly as from a hand-placed one. Where it
 came from is recorded on the ``exec_run_artifacts`` row instead, which is
-the layer that owns run history.
+the layer that owns run history. The periodic path (#203, below) makes the
+identical choice for the identical reason.
 
-No row, no file (#122)
-----------------------
+No row, no file (#122, #203)
+----------------------------
 That last sentence is a constraint, not a description. The artifact ROW is
-the only index of an interrupt checkpoint: nothing scans
-``MODELS_DIR/interrupted/``, no retention pass sweeps it, and the filename
-is readable but not enumerable by any consumer. So a run with nowhere to
-put the row must not write the file either -- it would be an orphan that
-grows a model-sized hole in the user's disk on every timeout, forever.
+the only index of an interrupt or periodic checkpoint: nothing scans
+``MODELS_DIR/interrupted/`` or ``MODELS_DIR/periodic/`` directly, and the
+filename is readable but not enumerable by any consumer. So a run with
+nowhere to put the row must not write the file either -- it would be an
+orphan that grows a model-sized hole in the user's disk on every timeout,
+forever.
 
 The runs that have nowhere: the REST contract runner
 (``routes_graph_run.execute_contract_run``, which passes no ``on_signal``
 and cancels its context on timeout), the exported Python script, and any
-bare ``execute_graph``. ``loop_control.save_interrupt_checkpoint`` asks
-``context.can_record_artifacts()`` and declines. The alternative -- write
-the file and log the path -- was rejected: a path in a log line that the
-user has to find and clean up by hand is not a feature, and the interactive
-and queued lanes (which DO record rows) are where interruption actually
-happens.
+bare ``execute_graph``. ``loop_control.save_interrupt_checkpoint`` and
+``save_periodic_checkpoint`` both ask ``context.can_record_artifacts()``
+and decline. The alternative -- write the file and log the path -- was
+rejected: a path in a log line that the user has to find and clean up by
+hand is not a feature, and the interactive and queued lanes (which DO
+record rows) are where interruption and long training both actually
+happen.
+
+Retention (#156) is the other half of the invariant: the row is only a
+reliable index for as long as SOMETHING deletes the file when the row goes.
+``RunStore.prune`` does, for ``checkpoint``-kind artifacts, via
+:func:`unlink_checkpoint` -- see that function and ``RunStore.prune``'s own
+docstring for why the delete has to happen inside the same transaction as
+the row read. Retention only ever reaches a run once it is terminal AND has
+aged out of the keep-last-N window, so it does not, and structurally cannot,
+bound how many periodic checkpoints a single STILL-RUNNING job accumulates
+-- see ``TrainingLoopNode``'s ``checkpoint_every`` docs for that trade-off.
 
 Durability
 ----------
@@ -104,6 +138,15 @@ logger = logging.getLogger(__name__)
 
 #: Sub-directory of ``MODELS_DIR`` for checkpoints nobody asked for by name.
 INTERRUPT_DIRNAME = "interrupted"
+
+#: Sub-directory of ``MODELS_DIR`` for checkpoints a HEALTHY run writes on
+#: its own schedule (``TrainingLoop.checkpoint_every``, #203) rather than
+#: because anything went wrong. Kept apart from ``INTERRUPT_DIRNAME``: a
+#: file under "interrupted" for a run that is training normally would
+#: mislead anyone browsing MODELS_DIR by hand, even though both directories
+#: follow the identical no-row-no-file discipline and the identical
+#: path-safety rules.
+PERIODIC_DIRNAME = "periodic"
 
 #: Cap on each path component built from a run/node id. Long enough to stay
 #: recognisable, short enough that a deep MODELS_DIR plus two components
@@ -158,6 +201,21 @@ def interrupt_checkpoint_path(
     return settings.MODELS_DIR / INTERRUPT_DIRNAME / name
 
 
+def periodic_checkpoint_path(run_id: str, node_id: str, *, epoch: int) -> Path:
+    """Where a periodic (#203) checkpoint for *epoch* goes.
+
+    Named like :func:`interrupt_checkpoint_path` minus the batch component:
+    a periodic checkpoint is only ever taken at a clean epoch boundary (see
+    ``loop_control.save_periodic_checkpoint``), so there is no mid-epoch
+    position to record. One file per checkpoint event rather than one
+    overwritten file per run -- retention (``RunStore.prune``,
+    :func:`unlink_checkpoint`) is what bounds the count once a run's row
+    ages out, not this function.
+    """
+    name = f"{_safe_part(run_id)}-{_safe_part(node_id)}-e{int(epoch)}.pt"
+    return settings.MODELS_DIR / PERIODIC_DIRNAME / name
+
+
 def build_checkpoint(
     model: Any,
     optimizer: Any,
@@ -180,6 +238,17 @@ def build_checkpoint(
         "epoch": epoch,
         "model_state_dict": model.state_dict(),
         "optimizer_state_dict": optimizer.state_dict(),
+        # #149: captured explicitly, mirroring LRScheduler.__init__'s own
+        # ``setdefault("initial_lr", lr)`` -- see the "Honest base_lrs"
+        # section above for why this must not be left to
+        # Optimizer.load_state_dict's accidental dict-merge behaviour.
+        # Unconditional (unlike the optional keys below): every optimizer
+        # has param_groups, so there is always something honest to record,
+        # even when it just equals the current lr because nothing has
+        # decayed it yet.
+        "initial_lrs": [
+            g.get("initial_lr", g["lr"]) for g in optimizer.param_groups
+        ],
     }
     if losses is not None:
         checkpoint["losses"] = losses
@@ -273,3 +342,42 @@ def write_checkpoint(
         target, epoch, checkpoint.get("scheduler_class", "none"),
     )
     return target
+
+
+def unlink_checkpoint(path: str | Path) -> bool:
+    """Best-effort delete of a checkpoint file whose only row is gone (#156).
+
+    Called from retention (``RunStore.prune``), which runs unattended --
+    after every run finishes and at every server startup -- and must never
+    fail a whole prune over one file. A locked handle, a path some earlier
+    prune already removed (the SELECT-then-DELETE inside one transaction
+    that ``RunStore.prune`` uses makes that the only realistic case, but a
+    hand-deleted file is just as possible) or a permissions error are all
+    logged and swallowed. Never raises.
+
+    Only removes a path that resolves inside the project data directory --
+    the same rule :func:`resolve_checkpoint_path` enforces on write. An
+    artifact's ``kind`` is an open vocabulary (see ``run_store``'s
+    ``ARTIFACT_KIND_*`` comment), so a row mislabelled ``checkpoint`` by
+    something outside this module's own writers must not turn an automatic
+    sweep into a delete of an arbitrary file.
+
+    Returns True when a file was actually removed.
+    """
+    try:
+        resolved = resolve_checkpoint_path(path)
+    except ValueError:
+        logger.warning(
+            "retention: not deleting artifact path %r -- it resolves "
+            "outside the project data directory", str(path),
+        )
+        return False
+    try:
+        resolved.unlink()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        logger.warning("retention: could not delete checkpoint file %s",
+                       resolved, exc_info=True)
+        return False
+    return True

--- a/backend/app/core/checkpoints.py
+++ b/backend/app/core/checkpoints.py
@@ -32,6 +32,16 @@ key                          contents
 ``scaler_state_dict``        optional ``GradScaler.state_dict()`` (#135)
 ===========================  ============================================
 
+``losses`` covers only the epochs the WRITING CALL ran, matching
+``TrainingLoopNode``'s own "arrays are per call" rule -- the interrupt and
+periodic paths both pass their node's own ``epoch_losses`` as it stands at
+the moment they fire, never the whole history back to epoch 0. A chained
+resume (checkpoint -> resume -> checkpoint again, the realistic
+long-running-job shape) therefore has each LEG's checkpoint carry only
+that leg's own losses; ``epoch`` (always absolute) is what stays accurate
+across the whole chain, not the ``losses`` tensor. Pre-existing for the
+interrupt path; #203 makes it fire routinely rather than only on a stop.
+
 **Honest base_lrs (#149).** ``LRScheduler.__init__`` stamps
 ``group.setdefault("initial_lr", group["lr"])`` onto each optimizer param
 group at CONSTRUCTION time, and ``Optimizer.load_state_dict`` happens to
@@ -39,18 +49,39 @@ carry that key through a round trip -- verified against the installed torch
 2.11.0+cu128: ``update_group`` replaces each LIVE param group with the
 SAVED group's dict wholesale (only ``params``/``param_names`` are patched in
 from the live side), so a saved dict that already has ``initial_lr`` keeps
-it, accidentally, with no code anywhere naming the guarantee. That accident
-stops applying the moment a checkpoint's own ``optimizer_state_dict`` does
-NOT carry the key -- which happens whenever the optimizer being saved never
-had ANY scheduler constructed over it -- and a scheduler built fresh on the
-resumed optimizer then stamps ``initial_lr`` from whatever the CURRENT
-(possibly already-decayed) ``lr`` is, silently treating it as the run's
-starting point. ``initial_lrs`` makes the guarantee explicit instead of
-inherited: captured here at save time, restored onto
-``optimizer.param_groups[i]["initial_lr"]`` by ``CheckpointLoaderNode``
-before anything downstream can construct a scheduler, so a fresh schedule
-always starts from the honest original regardless of what the accidental
-mechanism would or would not have preserved.
+it, accidentally, with no code anywhere naming the guarantee.
+
+**This is a defensive invariant, not a fix for a reachable bug.**
+``initial_lrs`` is derived from ``g.get("initial_lr", g["lr"]) for g in
+optimizer.param_groups`` -- the SAME ``optimizer.param_groups`` that
+``optimizer.state_dict()`` ALSO reads, in the same dict literal, with
+nothing mutating them in between. So for any checkpoint this module can
+actually produce, ``initial_lrs`` and whatever
+``optimizer_state_dict["param_groups"][i].get("initial_lr", lr)`` would
+independently reconstruct are mathematically the same value -- proven,
+not merely tested: when the live group carries ``initial_lr``, both read
+it; when it does not, both fall back to the SAME current ``lr``. There is
+no code path, resume chain or ``update_group`` replacement that makes them
+disagree, because "the live optimizer at save time" is the one and only
+source both draw from. A checkpoint whose optimizer never had a scheduler
+attached has no OTHER, richer truth for either field to recover -- nothing
+in this process ever knew a different number.
+
+What this key buys instead: CodefyUI's own behaviour no longer *depends*
+on ``optimizer.state_dict()``/``load_state_dict()`` choosing to carry
+``initial_lr`` through -- it is read from ``optimizer.param_groups``
+directly and restored explicitly by ``CheckpointLoaderNode``, before
+anything downstream can construct a scheduler. If a future torch release
+(or a plugin's custom ``Optimizer`` subclass) ever stops serialising extra
+param-group keys, or a scheduler ever stops using ``initial_lr`` as its
+name for this, CodefyUI's own contract keeps holding -- what breaks is
+visible as a difference in THIS key, not as a silent, no-diff LR
+corruption discovered by comparing loss curves. See
+``test_initial_lr_is_captured_from_the_live_optimizer_not_its_state_dict``
+in ``test_training_resume.py`` for what actually exercises this: it
+simulates exactly that kind of divergence (a ``state_dict()`` that drops
+the key while the live object keeps it) because no REAL torch behaviour
+today produces one.
 
 ``scaler_state_dict`` is present only for an fp16 run, and holds five plain
 scalars (``scale``, ``growth_factor``, ``backoff_factor``,
@@ -239,13 +270,15 @@ def build_checkpoint(
         "model_state_dict": model.state_dict(),
         "optimizer_state_dict": optimizer.state_dict(),
         # #149: captured explicitly, mirroring LRScheduler.__init__'s own
-        # ``setdefault("initial_lr", lr)`` -- see the "Honest base_lrs"
-        # section above for why this must not be left to
-        # Optimizer.load_state_dict's accidental dict-merge behaviour.
-        # Unconditional (unlike the optional keys below): every optimizer
-        # has param_groups, so there is always something honest to record,
-        # even when it just equals the current lr because nothing has
-        # decayed it yet.
+        # ``setdefault("initial_lr", lr)`` -- a DEFENSIVE invariant, not a
+        # fix for a reachable divergence: this reads the same live
+        # optimizer.param_groups that optimizer.state_dict() (above) also
+        # reads, so the two can never disagree for any checkpoint this
+        # function can actually produce. See the "Honest base_lrs" section
+        # above for what it protects against instead. Unconditional (unlike
+        # the optional keys below): every optimizer has param_groups, so
+        # there is always something honest to record, even when it just
+        # equals the current lr because nothing has decayed it yet.
         "initial_lrs": [
             g.get("initial_lr", g["lr"]) for g in optimizer.param_groups
         ],

--- a/backend/app/core/loop_control.py
+++ b/backend/app/core/loop_control.py
@@ -19,8 +19,10 @@ kept in one place so ``TrainingLoop``, ``DiffusionTrainingLoop``,
     The same write-and-register, for a HEALTHY run checkpointing on its own
     schedule (#203) rather than because it is stopping. The one thing the
     interrupt path does not cover: a server process dying outright (SIGKILL,
-    OOM kill, power loss, a restart) never reaches the interrupt path either,
-    because that only runs on the way out of a node that decided to return.
+    an OOM kill, a restart) never reaches the interrupt path either, because
+    that only runs on the way out of a node that decided to return. NOT
+    power loss -- neither path fsyncs, so that is a separate, unfixed gap;
+    see ``core.checkpoints``'s "Durability" section.
 
 ``interrupted_result``
     Build the ``__interrupted__`` marker the engine turns into an
@@ -302,12 +304,19 @@ def save_periodic_checkpoint(
     Everything else in this stack survives a browser disconnect, a tab
     close, the submitting process exiting, or a cooperative Stop click (see
     :func:`save_interrupt_checkpoint`). The one thing none of that covers is
-    the SERVER PROCESS itself: a SIGKILL, an OOM kill, a power loss or a
-    server restart never reach the interrupt path either, because that only
-    runs on the way OUT of a node that has already decided to return partial
-    results. ``TrainingLoop.checkpoint_every`` is what closes that gap --
-    called after every Nth completed epoch, so at most N epochs are ever
-    unrecoverable, whatever kills the process.
+    the SERVER PROCESS itself: a SIGKILL, an OOM kill or a server restart
+    never reach the interrupt path either, because that only runs on the
+    way OUT of a node that has already decided to return partial results.
+    ``TrainingLoop.checkpoint_every`` is what closes that gap -- called
+    after every Nth completed epoch, so at most N epochs are ever
+    unrecoverable for any of those three.
+
+    **Not power loss.** ``write_checkpoint`` deliberately skips fsync (see
+    ``core.checkpoints``'s "Durability" section), so ``os.replace`` can make
+    a new filename visible before its content is durably on disk. A process
+    death survives because the OS -- and its page cache -- keeps running;
+    power loss does not. This function does not change that trade-off, only
+    who benefits from it.
 
     Same gating, same failure posture and the same ``epoch``/``batch``
     conventions as :func:`save_interrupt_checkpoint` -- see that function's
@@ -321,19 +330,27 @@ def save_periodic_checkpoint(
     not stop, and a checkpoint list that claimed otherwise would be actively
     misleading.
 
-    **Not queued last.** Unlike the interrupt path, this fires mid-loop --
-    by definition, since "periodic" means more epochs (and their own
-    progress/metric signals) follow. ``ArtifactSignal``'s tail-safety
-    obligation ("queue an ArtifactSignal LAST... a future producer that
-    wants to log an artifact mid-loop has to solve this first") is
-    therefore not fully discharged here: under sustained backpressure on the
-    outbox's consumer, a burst of later signals could in principle evict
-    this one before it is delivered, which would leave the FILE written
-    with no row. The outbox wakes its pump on every ``put`` rather than
-    polling, so this needs the consumer itself to be stalled for a long
-    stretch while training keeps producing signals -- not a routine
-    condition -- and is accepted here rather than solved, which would mean
-    restructuring ``EventOutbox`` well beyond what this feature needs.
+    **Two distinct ways a file can outlive its row, both recoverable by
+    hand and neither blocking.** First, the ALWAYS-PRESENT one: the file is
+    durable the moment ``write_checkpoint`` returns, but the row exists
+    only once the outbox delivers this call's ``ArtifactSignal`` AND
+    ``RunStore.add_artifact`` commits -- a gap of milliseconds, but on
+    EVERY periodic checkpoint, not only under load. A process death in that
+    window leaves a file with no row, same as any other signal race in this
+    engine. Second, **not queued last**: unlike the interrupt path, this
+    fires mid-loop -- by definition, since "periodic" means more epochs
+    (and their own progress/metric signals) follow. ``ArtifactSignal``'s
+    tail-safety obligation ("queue an ArtifactSignal LAST... a future
+    producer that wants to log an artifact mid-loop has to solve this
+    first") is therefore not fully discharged here: under SUSTAINED
+    backpressure on the outbox's consumer, a burst of later signals could
+    in principle evict this one before it is delivered. The outbox wakes
+    its pump on every ``put`` rather than polling, so this second case
+    needs the consumer itself to be stalled for a long stretch while
+    training keeps producing signals -- not a routine condition -- unlike
+    the first, which is a plain race present on every call. Both are
+    accepted here rather than solved, which would mean restructuring
+    ``EventOutbox`` well beyond what this feature needs.
     """
     if context is None:
         return None
@@ -353,6 +370,14 @@ def save_periodic_checkpoint(
 
     from .checkpoints import periodic_checkpoint_path, write_checkpoint
 
+    # Timed and sized so the cost is VISIBLE rather than merely accepted:
+    # this write runs synchronously on the training thread, once every
+    # checkpoint_every epochs, for as long as the run is active -- disk I/O
+    # and, on a CUDA run, a device-to-host copy of the whole model and
+    # optimizer state. Neither number changes what this function does; both
+    # exist so a slow MODELS_DIR or a surprising per-run total shows up in
+    # the log instead of only as "training feels slower than it used to".
+    started = time.monotonic()
     try:
         target = periodic_checkpoint_path(run_id, resolved_node_id, epoch=epoch)
         write_checkpoint(
@@ -367,6 +392,7 @@ def save_periodic_checkpoint(
             resolved_node_id, run_id, epoch, exc_info=True,
         )
         return None
+    elapsed = time.monotonic() - started
 
     log_artifact = getattr(context, "log_artifact", None)
     if callable(log_artifact):
@@ -376,8 +402,17 @@ def save_periodic_checkpoint(
             {"reason": "periodic", "epoch": int(epoch)},
             resolved_node_id,
         )
+
+    try:
+        size_mb = target.stat().st_size / (1024 * 1024)
+        size_note = f"{size_mb:.1f} MB"
+    except OSError:  # noqa: BLE001 - the checkpoint is already written; a
+        # stat() failure here must not turn a successful write into a
+        # reported failure, only a log line missing one number.
+        size_note = "size unknown"
     logger.info(
-        "Periodic checkpoint for node %s written to %s (epoch=%d)",
-        resolved_node_id, target, epoch,
+        "Periodic checkpoint for node %s written to %s in %.2fs (%s, "
+        "epoch=%d)",
+        resolved_node_id, target, elapsed, size_note, epoch,
     )
     return str(target)

--- a/backend/app/core/loop_control.py
+++ b/backend/app/core/loop_control.py
@@ -15,6 +15,13 @@ kept in one place so ``TrainingLoop``, ``DiffusionTrainingLoop``,
     Write the partial training state where ``CheckpointLoader`` can find it
     and register it on the run.
 
+``save_periodic_checkpoint``
+    The same write-and-register, for a HEALTHY run checkpointing on its own
+    schedule (#203) rather than because it is stopping. The one thing the
+    interrupt path does not cover: a server process dying outright (SIGKILL,
+    OOM kill, power loss, a restart) never reaches the interrupt path either,
+    because that only runs on the way out of a node that decided to return.
+
 ``interrupted_result``
     Build the ``__interrupted__`` marker the engine turns into an
     ``interrupted`` node status.
@@ -275,5 +282,102 @@ def save_interrupt_checkpoint(
     logger.info(
         "Interrupt checkpoint for node %s written to %s (epoch=%d, batch=%d)",
         resolved_node_id, target, epoch, batch,
+    )
+    return str(target)
+
+
+def save_periodic_checkpoint(
+    context: Any,
+    model: Any,
+    optimizer: Any,
+    *,
+    epoch: int,
+    losses: Any = None,
+    lr_scheduler: Any = None,
+    scaler_state: Any = None,
+    node_id: str | None = None,
+) -> str | None:
+    """Persist a HEALTHY run's progress on its own schedule (#203). Never raises.
+
+    Everything else in this stack survives a browser disconnect, a tab
+    close, the submitting process exiting, or a cooperative Stop click (see
+    :func:`save_interrupt_checkpoint`). The one thing none of that covers is
+    the SERVER PROCESS itself: a SIGKILL, an OOM kill, a power loss or a
+    server restart never reach the interrupt path either, because that only
+    runs on the way OUT of a node that has already decided to return partial
+    results. ``TrainingLoop.checkpoint_every`` is what closes that gap --
+    called after every Nth completed epoch, so at most N epochs are ever
+    unrecoverable, whatever kills the process.
+
+    Same gating, same failure posture and the same ``epoch``/``batch``
+    conventions as :func:`save_interrupt_checkpoint` -- see that function's
+    docstring for the full reasoning, all of which applies here unchanged.
+    The differences are narrow: the file goes under
+    ``MODELS_DIR/periodic/`` rather than ``MODELS_DIR/interrupted/`` (see
+    ``core.checkpoints``' ``PERIODIC_DIRNAME`` for why the two stay apart),
+    there is no ``batch`` to record because a periodic checkpoint is only
+    ever taken at a clean epoch boundary, and the artifact ``meta`` says
+    ``"reason": "periodic"`` rather than ``"interrupted"`` -- the run did
+    not stop, and a checkpoint list that claimed otherwise would be actively
+    misleading.
+
+    **Not queued last.** Unlike the interrupt path, this fires mid-loop --
+    by definition, since "periodic" means more epochs (and their own
+    progress/metric signals) follow. ``ArtifactSignal``'s tail-safety
+    obligation ("queue an ArtifactSignal LAST... a future producer that
+    wants to log an artifact mid-loop has to solve this first") is
+    therefore not fully discharged here: under sustained backpressure on the
+    outbox's consumer, a burst of later signals could in principle evict
+    this one before it is delivered, which would leave the FILE written
+    with no row. The outbox wakes its pump on every ``put`` rather than
+    polling, so this needs the consumer itself to be stalled for a long
+    stretch while training keeps producing signals -- not a routine
+    condition -- and is accepted here rather than solved, which would mean
+    restructuring ``EventOutbox`` well beyond what this feature needs.
+    """
+    if context is None:
+        return None
+
+    resolved_node_id = node_id or getattr(context, "current_node_id", "") or "node"
+    run_id = getattr(context, "execution_id", "") or "run"
+
+    can_record = getattr(context, "can_record_artifacts", None)
+    if not (callable(can_record) and can_record()):
+        logger.info(
+            "Node %s reached a periodic checkpoint, but this run records no "
+            "artifacts, so it was skipped -- the file would have had no row "
+            "referencing it and nothing would ever clean it up.",
+            resolved_node_id,
+        )
+        return None
+
+    from .checkpoints import periodic_checkpoint_path, write_checkpoint
+
+    try:
+        target = periodic_checkpoint_path(run_id, resolved_node_id, epoch=epoch)
+        write_checkpoint(
+            target, model, optimizer, epoch=epoch, losses=losses,
+            lr_scheduler=lr_scheduler, scaler_state=scaler_state,
+            resolve=False,
+        )
+    except Exception:  # noqa: BLE001 - a checkpoint must not take the run down
+        logger.warning(
+            "could not write the periodic checkpoint for node %s of run %s "
+            "at epoch %d; training continues",
+            resolved_node_id, run_id, epoch, exc_info=True,
+        )
+        return None
+
+    log_artifact = getattr(context, "log_artifact", None)
+    if callable(log_artifact):
+        log_artifact(
+            "checkpoint",
+            str(target),
+            {"reason": "periodic", "epoch": int(epoch)},
+            resolved_node_id,
+        )
+    logger.info(
+        "Periodic checkpoint for node %s written to %s (epoch=%d)",
+        resolved_node_id, target, epoch,
     )
     return str(target)

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -1010,10 +1010,35 @@ class RunStore:
         runs, so a run that becomes eligible between two separate calls to
         this method can never be seen by one call's SELECT and removed by
         another's DELETE -- which would silently orphan its file exactly as
-        before. The unlink itself happens AFTER the commit, and is
-        best-effort (see :func:`core.checkpoints.unlink_checkpoint`): a
-        locked handle or a file some earlier prune already removed must
-        never turn a successful prune into a failed one.
+        before. The unlink itself happens AFTER the commit, off the event
+        loop (``asyncio.to_thread``, matching ``main.py``'s own
+        ``db.connect`` dispatch): this runs after every run finishes and at
+        server startup, on the loop also serving WebSockets and HTTP, and
+        ``Path.resolve()`` plus a delete for what can be hundreds of paths
+        -- the first prune after a fresh deploy, or any prune after
+        lowering ``RUN_RETENTION_KEEP_LAST`` -- is not free, especially
+        against a network or cloud-synced ``MODELS_DIR``. Best-effort (see
+        :func:`core.checkpoints.unlink_checkpoint`): a locked handle or a
+        file some earlier prune already removed must never turn a
+        successful prune into a failed one. Every path actually removed is
+        logged at INFO -- the only audit trail this irreversible,
+        unattended delete leaves.
+
+        **Runs left ``interrupted`` keep their checkpoint files.** Startup
+        orders ``recover_interrupted()`` before this call specifically so
+        an abandoned ``running`` row becomes "prunable in the very next
+        call" (see ``main.py``) -- which means a server that died MID-RUN,
+        restarted, and is running this very prune pass on ITS OWN startup
+        would otherwise delete the periodic checkpoint the user needs to
+        resume the run this feature exists to protect, on the same startup
+        where they'd want to. At the default ``RUN_RETENTION_KEEP_LAST``
+        this is rare (a freshly-interrupted run is the newest thing in the
+        table), but ``keep_last=0`` is a real, documented configuration
+        (``config.py``'s "inverted zero") where it is not. Rows still go on
+        the normal schedule -- only the FILE survives, under its ordinary
+        readable name, recoverable by hand exactly as it was before this
+        method unlinked anything at all. ``succeeded``/``failed``/
+        ``cancelled`` runs are unaffected.
 
         Scoped to ``kind == "checkpoint"`` only. Other artifact kinds
         (``export``, ``image``, a plugin's own) are an open vocabulary this
@@ -1033,11 +1058,16 @@ class RunStore:
 
         def _prune(conn: sqlite3.Connection) -> tuple[int, list[str]]:
             with transaction(conn):
+                # Excludes STATUS_INTERRUPTED so its checkpoint file is
+                # never collected for unlinking -- see the docstring's
+                # "Runs left interrupted" section. The row itself is NOT
+                # exempted: it still goes with the ordinary DELETE below.
                 doomed_paths = [
                     row["path"] for row in conn.execute(
                         "SELECT path FROM exec_run_artifacts WHERE kind = ? "
-                        f"AND run_id IN (SELECT id FROM exec_runs WHERE {where_clause})",
-                        (ARTIFACT_KIND_CHECKPOINT, *params),
+                        "AND run_id IN (SELECT id FROM exec_runs WHERE "
+                        f"{where_clause} AND status != ?)",
+                        (ARTIFACT_KIND_CHECKPOINT, *params, STATUS_INTERRUPTED),
                     ).fetchall()
                 ]
                 deleted = conn.execute(
@@ -1049,10 +1079,23 @@ class RunStore:
         if doomed_paths:
             from .checkpoints import unlink_checkpoint
 
-            removed = sum(1 for path in doomed_paths if unlink_checkpoint(path))
-            logger.info(
-                "run retention: removed %d checkpoint file(s) belonging to "
-                "pruned runs (%d already gone or could not be removed)",
-                removed, len(doomed_paths) - removed,
-            )
+            def _unlink_all(paths: list[str]) -> list[str]:
+                """Blocking; dispatched off the event loop below. Returns
+                the paths actually removed, for the audit log."""
+                return [path for path in paths if unlink_checkpoint(path)]
+
+            removed_paths = await asyncio.to_thread(_unlink_all, doomed_paths)
+            if removed_paths:
+                logger.info(
+                    "run retention: removed %d checkpoint file(s) "
+                    "belonging to pruned runs: %s",
+                    len(removed_paths), ", ".join(removed_paths),
+                )
+            missing = len(doomed_paths) - len(removed_paths)
+            if missing:
+                logger.info(
+                    "run retention: %d checkpoint file(s) were already "
+                    "gone or could not be removed (see prior warnings, if "
+                    "any, for which)", missing,
+                )
         return deleted

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import math
 import sqlite3
 from dataclasses import dataclass
@@ -52,6 +53,8 @@ from ..config import settings
 from .db import Database, transaction, utc_now_iso
 from .plugin_loader import is_enabled, load_lockfile
 from .project import git_provenance
+
+logger = logging.getLogger(__name__)
 
 # ── status vocabulary ─────────────────────────────────────────────────────
 #
@@ -989,20 +992,67 @@ class RunStore:
         everything". Age-based retention (the publish table's
         ``Database.prune_runs`` model) can be added alongside this later;
         the two are independent policies over different tables.
+
+        **Checkpoint files go with their row (#156).** Unlike
+        :meth:`delete_run` (an explicit, one-run, human-driven action that
+        deliberately leaves artifact files on disk -- see that method's
+        docstring), this is an UNATTENDED sweep that runs after every run
+        finishes and at every server startup, specifically to bound
+        resource usage automatically. A ``checkpoint``-kind artifact's row
+        is the ONLY index of its file (the "No row, no file" section of
+        ``core.checkpoints``), so leaving the file behind here would defeat
+        the entire point of retention: every prune would leak a
+        model-sized orphan, growing without bound, forever.
+
+        The doomed checkpoint paths are read INSIDE the same transaction as
+        the DELETE, using the identical WHERE clause: ``BEGIN IMMEDIATE``
+        (see ``transaction``) takes the write lock before the SELECT even
+        runs, so a run that becomes eligible between two separate calls to
+        this method can never be seen by one call's SELECT and removed by
+        another's DELETE -- which would silently orphan its file exactly as
+        before. The unlink itself happens AFTER the commit, and is
+        best-effort (see :func:`core.checkpoints.unlink_checkpoint`): a
+        locked handle or a file some earlier prune already removed must
+        never turn a successful prune into a failed one.
+
+        Scoped to ``kind == "checkpoint"`` only. Other artifact kinds
+        (``export``, ``image``, a plugin's own) are an open vocabulary this
+        store does not otherwise own the lifecycle of, and at least one
+        (``tensorboard``) is a DIRECTORY, not a file -- widening this beyond
+        checkpoints is a deliberately separate decision.
         """
         if keep_last < 0:
             raise ValueError(f"keep_last must be >= 0, got {keep_last}")
         active = tuple(sorted(ACTIVE_STATUSES))
+        where_clause = (
+            "status NOT IN "
+            f"({','.join('?' * len(active))}) AND rowid NOT IN "
+            "(SELECT rowid FROM exec_runs ORDER BY created_at DESC, rowid DESC LIMIT ?)"
+        )
         params = (*active, keep_last)
 
-        def _prune(conn: sqlite3.Connection) -> int:
+        def _prune(conn: sqlite3.Connection) -> tuple[int, list[str]]:
             with transaction(conn):
-                return conn.execute(
-                    "DELETE FROM exec_runs WHERE status NOT IN "
-                    f"({','.join('?' * len(active))}) AND rowid NOT IN "
-                    "(SELECT rowid FROM exec_runs "
-                    "ORDER BY created_at DESC, rowid DESC LIMIT ?)",
-                    params,
+                doomed_paths = [
+                    row["path"] for row in conn.execute(
+                        "SELECT path FROM exec_run_artifacts WHERE kind = ? "
+                        f"AND run_id IN (SELECT id FROM exec_runs WHERE {where_clause})",
+                        (ARTIFACT_KIND_CHECKPOINT, *params),
+                    ).fetchall()
+                ]
+                deleted = conn.execute(
+                    f"DELETE FROM exec_runs WHERE {where_clause}", params,
                 ).rowcount
+                return deleted, doomed_paths
 
-        return await self.db.run(_prune)
+        deleted, doomed_paths = await self.db.run(_prune)
+        if doomed_paths:
+            from .checkpoints import unlink_checkpoint
+
+            removed = sum(1 for path in doomed_paths if unlink_checkpoint(path))
+            logger.info(
+                "run retention: removed %d checkpoint file(s) belonging to "
+                "pruned runs (%d already gone or could not be removed)",
+                removed, len(doomed_paths) - removed,
+            )
+        return deleted

--- a/backend/app/nodes/io/checkpoint_node.py
+++ b/backend/app/nodes/io/checkpoint_node.py
@@ -188,6 +188,30 @@ class CheckpointLoaderNode(BaseNode):
                 if isinstance(v, torch.Tensor):
                     state[k] = to_device(v, device)
 
+        # Honest base_lrs (#149). Restored explicitly and unconditionally --
+        # not only when a scheduler is wired into THIS node -- because the
+        # optimizer this returns may feed a scheduler built downstream in
+        # the graph instead. Optimizer.load_state_dict's own dict-merge
+        # (verified against the installed torch: `update_group` replaces
+        # each live param group with the SAVED group's dict wholesale)
+        # already carries `initial_lr` through by accident whenever the
+        # checkpoint's own optimizer_state_dict happens to have it; this
+        # makes that guarantee explicit instead of inherited, so it also
+        # holds for a checkpoint whose optimizer never had a scheduler
+        # attached at save time. See the "Honest base_lrs" section of
+        # core.checkpoints for the full reasoning. Done BEFORE the scheduler
+        # section below on purpose -- "before any scheduler is constructed".
+        initial_lrs = checkpoint.get("initial_lrs")
+        if initial_lrs is not None:
+            if len(initial_lrs) != len(optimizer.param_groups):
+                logger.warning(
+                    "Checkpoint %s holds %d initial_lr value(s) but the "
+                    "optimizer has %d param group(s); restoring only the "
+                    "overlap.", p, len(initial_lrs), len(optimizer.param_groups),
+                )
+            for param_group, initial_lr in zip(optimizer.param_groups, initial_lrs):
+                param_group["initial_lr"] = initial_lr
+
         # LR schedule (#118). Restored AFTER the optimizer on purpose: the
         # optimizer state dict carries the learning rate that was live when the
         # checkpoint was taken, and ``LRScheduler.load_state_dict`` does not

--- a/backend/app/nodes/io/checkpoint_node.py
+++ b/backend/app/nodes/io/checkpoint_node.py
@@ -188,19 +188,24 @@ class CheckpointLoaderNode(BaseNode):
                 if isinstance(v, torch.Tensor):
                     state[k] = to_device(v, device)
 
-        # Honest base_lrs (#149). Restored explicitly and unconditionally --
-        # not only when a scheduler is wired into THIS node -- because the
-        # optimizer this returns may feed a scheduler built downstream in
-        # the graph instead. Optimizer.load_state_dict's own dict-merge
-        # (verified against the installed torch: `update_group` replaces
-        # each live param group with the SAVED group's dict wholesale)
-        # already carries `initial_lr` through by accident whenever the
-        # checkpoint's own optimizer_state_dict happens to have it; this
-        # makes that guarantee explicit instead of inherited, so it also
-        # holds for a checkpoint whose optimizer never had a scheduler
-        # attached at save time. See the "Honest base_lrs" section of
-        # core.checkpoints for the full reasoning. Done BEFORE the scheduler
-        # section below on purpose -- "before any scheduler is constructed".
+        # Honest base_lrs (#149) -- a DEFENSIVE invariant, not a fix for a
+        # reachable divergence: `initial_lrs` is derived, at save time, from
+        # the same live optimizer.param_groups that optimizer_state_dict
+        # also serialises, so for any checkpoint this codebase can actually
+        # produce the two never disagree, and restoring this key is
+        # provably a no-op against today's torch (verified against the
+        # installed 2.11.0+cu128: `update_group` replaces each live param
+        # group with the SAVED group's dict wholesale, which already
+        # carries `initial_lr` through whenever the checkpoint has it).
+        # What this DOES buy: CodefyUI's own contract no longer depends on
+        # optimizer.state_dict()/load_state_dict() choosing to carry that
+        # key through -- it is read from param_groups directly and
+        # restored explicitly, so a future torch (or a plugin's custom
+        # Optimizer) that stops doing so surfaces as a visible difference
+        # here rather than a silent LR corruption. See the "Honest
+        # base_lrs" section of core.checkpoints for the full reasoning.
+        # Done BEFORE the scheduler section below on purpose -- "before any
+        # scheduler is constructed".
         initial_lrs = checkpoint.get("initial_lrs")
         if initial_lrs is not None:
             if len(initial_lrs) != len(optimizer.param_groups):

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Any
 
 from ...core.amp import PRECISIONS
@@ -338,23 +339,37 @@ class TrainingLoopNode(BaseNode):
     **Periodic checkpointing (#203).** ``should_stop()`` and the interrupt
     checkpoint above cover every way a RUN can end early -- a Stop click, a
     cancelled browser tab, the submitting process exiting. None of them
-    cover the SERVER PROCESS dying outright (SIGKILL, an OOM kill, power
-    loss, a restart): that path never reaches the interrupt checkpoint,
-    because it only runs on the way OUT of a node that has already decided
-    to return. ``checkpoint_every`` (epochs, ``0`` = disabled, matching
-    ``early_stopping_patience``'s own convention and every other opt-in knob
-    on this node) closes that gap: every Nth COMPLETE epoch, on a run that
-    is training normally, an ordinary checkpoint is written under
-    ``MODELS_DIR/periodic/`` and registered exactly like the interrupt
-    checkpoint (an ``exec_run_artifacts`` row of kind ``checkpoint``, same
+    cover the SERVER PROCESS dying outright (SIGKILL, an OOM kill, a
+    restart): that path never reaches the interrupt checkpoint, because it
+    only runs on the way OUT of a node that has already decided to return.
+    (NOT power loss -- ``write_checkpoint`` deliberately skips fsync, so a
+    rename can be visible with unflushed content; a process death survives
+    because the OS and its page cache do, a power cut does not. See
+    ``core.checkpoints``'s "Durability" section.) ``checkpoint_every``
+    (epochs, ``0`` = disabled, matching ``early_stopping_patience``'s own
+    convention and every other opt-in knob on this node) closes the
+    process-death gap: every Nth COMPLETE epoch, on a run that is training
+    normally, an ordinary checkpoint is written under ``MODELS_DIR/periodic/``
+    and registered exactly like the interrupt checkpoint (an
+    ``exec_run_artifacts`` row of kind ``checkpoint``, same
     ``can_record_artifacts()`` gating, same atomic write). Resuming from one
     needs no new concepts -- the same ``CheckpointLoader.epoch ->
-    start_epoch`` wiring. Retention (``RunStore.prune``) is what bounds the
-    file count once a run's row ages out of the keep-last-N window; it
-    cannot reach a still-active run, so a very frequent ``checkpoint_every``
-    on a very long run legitimately accumulates one file per event until
-    then -- see ``core.checkpoints``' "No row, no file" section for the
-    full reasoning.
+    start_epoch`` wiring.
+
+    Cost is real and NOT bounded while the run is active: each checkpoint is
+    written synchronously on the training thread and costs roughly model
+    size plus optimizer state (often several times the model's own size) --
+    a 200-epoch ResNet-18 at ``checkpoint_every=1`` is on the order of
+    18 GB before the run ends. Retention (``RunStore.prune``) is what
+    bounds the file count, but only once a run's row ages out of the
+    keep-last-N window, which structurally cannot happen while the run is
+    still running -- see ``core.checkpoints``' "No row, no file" section.
+    Each write's duration and this run's cumulative periodic-checkpoint
+    bytes are logged (INFO), so the cost is visible rather than only felt
+    as "training got slower". A run left ``interrupted`` -- including by a
+    server restart retiring an abandoned one -- keeps its periodic
+    checkpoint files even once retention removes its row; see
+    ``RunStore.prune``'s docstring for why.
 
     **Fitting a bigger run on one card (#135).** Two independent levers,
     both off by default:
@@ -469,7 +484,13 @@ class TrainingLoopNode(BaseNode):
                     "server crash loses at most N epochs instead of the "
                     "whole run. Independent of CheckpointSaver and resumes "
                     "the same way: wire CheckpointLoader.epoch to "
-                    "start_epoch (0 = disabled)"
+                    "start_epoch. Each checkpoint is roughly model size "
+                    "plus optimizer state (often several times the "
+                    "model's own size), written synchronously on the "
+                    "training thread; a low N on a large model over a "
+                    "long run can use many GB before the run ends, since "
+                    "nothing bounds this while the run is still active "
+                    "(0 = disabled)"
                 ),
                 min_value=0,
             ),
@@ -766,6 +787,13 @@ class TrainingLoopNode(BaseNode):
         epoch_losses: list[float] = []
         val_epoch_losses: list[float] = []
         lr_history: list[float] = []
+
+        # #203: running total of what checkpoint_every has written so far
+        # THIS call, logged alongside each new periodic checkpoint. Not a
+        # limit -- retention (RunStore.prune) cannot reach a still-active
+        # run, so nothing here bounds it; this only makes the cost visible.
+        # See checkpoint_every's own description for the size/cost warning.
+        periodic_checkpoint_bytes = 0
 
         # Early stopping state
         best_val_loss = float("inf")
@@ -1102,13 +1130,28 @@ class TrainingLoopNode(BaseNode):
             # should_stop exits below so the run's very last epoch is
             # covered too when it happens to land on a multiple.
             if checkpoint_every and (epoch + 1) % checkpoint_every == 0:
-                save_periodic_checkpoint(
+                periodic_path = save_periodic_checkpoint(
                     context, model, optimizer,
                     epoch=epoch + 1,
                     losses=torch.tensor(epoch_losses, dtype=torch.float32),
                     lr_scheduler=lr_scheduler,
                     scaler_state=policy.state_dict(),
                 )
+                # Cumulative, not per-call: retention cannot reach a
+                # still-active run (see the class docstring's "Periodic
+                # checkpointing" section), so this total can only grow for
+                # as long as the run keeps training -- exactly the cost
+                # checkpoint_every's own description warns about.
+                if periodic_path is not None:
+                    try:
+                        periodic_checkpoint_bytes += Path(periodic_path).stat().st_size
+                        logger.info(
+                            "checkpoint_every: %.1f MB written to periodic "
+                            "checkpoints so far this run",
+                            periodic_checkpoint_bytes / (1024 * 1024),
+                        )
+                    except OSError:
+                        pass  # already logged by save_periodic_checkpoint itself
 
             if stopped_early:
                 logger.info("Early stopping triggered at epoch %d (best epoch: %d)", epoch + 1, best_epoch)

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -335,6 +335,27 @@ class TrainingLoopNode(BaseNode):
     ``val_losses`` one entry shorter than ``losses``, because that epoch's
     training finished and its validation did not.
 
+    **Periodic checkpointing (#203).** ``should_stop()`` and the interrupt
+    checkpoint above cover every way a RUN can end early -- a Stop click, a
+    cancelled browser tab, the submitting process exiting. None of them
+    cover the SERVER PROCESS dying outright (SIGKILL, an OOM kill, power
+    loss, a restart): that path never reaches the interrupt checkpoint,
+    because it only runs on the way OUT of a node that has already decided
+    to return. ``checkpoint_every`` (epochs, ``0`` = disabled, matching
+    ``early_stopping_patience``'s own convention and every other opt-in knob
+    on this node) closes that gap: every Nth COMPLETE epoch, on a run that
+    is training normally, an ordinary checkpoint is written under
+    ``MODELS_DIR/periodic/`` and registered exactly like the interrupt
+    checkpoint (an ``exec_run_artifacts`` row of kind ``checkpoint``, same
+    ``can_record_artifacts()`` gating, same atomic write). Resuming from one
+    needs no new concepts -- the same ``CheckpointLoader.epoch ->
+    start_epoch`` wiring. Retention (``RunStore.prune``) is what bounds the
+    file count once a run's row ages out of the keep-last-N window; it
+    cannot reach a still-active run, so a very frequent ``checkpoint_every``
+    on a very long run legitimately accumulates one file per event until
+    then -- see ``core.checkpoints``' "No row, no file" section for the
+    full reasoning.
+
     **Fitting a bigger run on one card (#135).** Two independent levers,
     both off by default:
 
@@ -437,6 +458,19 @@ class TrainingLoopNode(BaseNode):
                 param_type=ParamType.INT,
                 default=0,
                 description="Stop if val loss doesn't improve for N epochs (0 = disabled)",
+                min_value=0,
+            ),
+            ParamDefinition(
+                name="checkpoint_every",
+                param_type=ParamType.INT,
+                default=0,
+                description=(
+                    "Save a checkpoint every N completed epochs, so a "
+                    "server crash loses at most N epochs instead of the "
+                    "whole run. Independent of CheckpointSaver and resumes "
+                    "the same way: wire CheckpointLoader.epoch to "
+                    "start_epoch (0 = disabled)"
+                ),
                 min_value=0,
             ),
             ParamDefinition(
@@ -615,6 +649,7 @@ class TrainingLoopNode(BaseNode):
             interrupted_result,
             loader_length,
             save_interrupt_checkpoint,
+            save_periodic_checkpoint,
             stop_checker,
         )
         from ...core.seeding import apply_determinism
@@ -630,6 +665,7 @@ class TrainingLoopNode(BaseNode):
         epochs = params.get("epochs", 5)
         device = resolve_node_device(params.get("device"), context)
         patience = params.get("early_stopping_patience", 0)
+        checkpoint_every = int(params.get("checkpoint_every", 0) or 0)
         grad_clip = params.get("grad_clip_norm", 0.0)
         batch_metrics = bool(params.get("batch_metrics", False))
         max_steps = int(params.get("max_steps", 0) or 0)
@@ -1052,6 +1088,27 @@ class TrainingLoopNode(BaseNode):
                     # run's payload is byte-for-byte what it was before #118.
                     progress_data["start_epoch"] = start_epoch
                 progress_callback(progress_data)
+
+            # #203: a periodic checkpoint, taken on a HEALTHY run so the
+            # server process itself -- the one failure nothing else in this
+            # stack survives -- is no longer a single point of failure for
+            # hours of completed epochs. Keyed off the ABSOLUTE epoch
+            # number, so a resumed run keeps hitting the same multiples it
+            # would have hit uninterrupted, exactly like every other
+            # epoch-indexed decision in this loop. Placed AFTER the epoch is
+            # fully banked (loss, LR, early-stopping bookkeeping, progress)
+            # so the checkpoint's own `epoch`/`losses` line up with what was
+            # just reported, and BEFORE the early-stopping/step-budget/
+            # should_stop exits below so the run's very last epoch is
+            # covered too when it happens to land on a multiple.
+            if checkpoint_every and (epoch + 1) % checkpoint_every == 0:
+                save_periodic_checkpoint(
+                    context, model, optimizer,
+                    epoch=epoch + 1,
+                    losses=torch.tensor(epoch_losses, dtype=torch.float32),
+                    lr_scheduler=lr_scheduler,
+                    scaler_state=policy.state_dict(),
+                )
 
             if stopped_early:
                 logger.info("Early stopping triggered at epoch %d (best epoch: %d)", epoch + 1, best_epoch)

--- a/backend/tests/test_checkpoint_node.py
+++ b/backend/tests/test_checkpoint_node.py
@@ -167,7 +167,10 @@ def test_scheduler_state_roundtrip(sched_type):
 
 
 def test_checkpoint_omits_scheduler_key_when_none_wired():
-    """The key is additive: an unwired scheduler leaves the payload as it was."""
+    """The scheduler keys are additive: an unwired scheduler leaves the rest
+    of the payload as it was. ``initial_lrs`` (#149) is NOT one of the
+    optional keys -- every optimizer has param_groups, so there is always
+    something honest to record there, unconditionally."""
     settings.MODELS_DIR.mkdir(parents=True, exist_ok=True)
     target = "_ckpt_no_sched.pt"
     try:
@@ -177,7 +180,8 @@ def test_checkpoint_omits_scheduler_key_when_none_wired():
             {"path": target, "epoch": 1},
         )
         raw = torch.load(settings.MODELS_DIR / target, map_location="cpu", weights_only=True)
-        assert set(raw) == {"epoch", "model_state_dict", "optimizer_state_dict"}
+        assert set(raw) == {"epoch", "model_state_dict", "optimizer_state_dict",
+                            "initial_lrs"}
     finally:
         (settings.MODELS_DIR / target).unlink(missing_ok=True)
 

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -1088,6 +1088,36 @@ async def test_prune_rejects_a_negative_keep_last(store):
 # the new writer.
 
 
+async def test_prune_keeps_the_checkpoint_file_of_an_interrupted_run(
+    store, db, tmp_path, monkeypatch,
+):
+    """A run left ``interrupted`` -- including by ``recover_interrupted()``
+    retiring an abandoned ``running`` row on server startup, immediately
+    before this same prune pass -- keeps its checkpoint file even once its
+    row is gone. Startup orders recovery before retention specifically so
+    an abandoned row becomes prunable "in the very next call" (main.py);
+    without this exemption, a server that died mid-run could destroy the
+    very checkpoint #203 exists to let it resume, on its own restart, at
+    keep_last=0 (config.py's "inverted zero" -- a real, documented
+    configuration, not a hypothetical one)."""
+    models = tmp_path / "models"
+    models.mkdir()
+    monkeypatch.setattr(settings, "MODELS_DIR", models)
+
+    run = await _make_run(store)
+    checkpoint_file = models / "crash_recovery.pt"
+    checkpoint_file.write_bytes(b"the run's only path back")
+    await store.add_artifact(run.id, "checkpoint", str(checkpoint_file))
+    await store.mark_finished(run.id, "interrupted")
+
+    assert await store.prune(keep_last=0) == 1
+    assert await store.get_run(run.id) is None, "the row still goes"
+    assert checkpoint_file.exists(), (
+        "an interrupted run's checkpoint file must survive its own row "
+        "being pruned -- it is the recovery point the feature exists for"
+    )
+
+
 async def test_prune_deletes_the_checkpoint_files_of_pruned_runs(
     store, db, tmp_path, monkeypatch,
 ):

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -20,6 +20,7 @@ import sqlite3
 
 import pytest
 
+from app.config import settings
 from app.core.db import Database
 from app.core.migrations import MIGRATION_001, MIGRATION_002, MIGRATIONS
 from app.core.run_store import (
@@ -1075,6 +1076,100 @@ async def test_prune_never_deletes_queued_or_running_runs(store):
 async def test_prune_rejects_a_negative_keep_last(store):
     with pytest.raises(ValueError, match="keep_last"):
         await store.prune(keep_last=-1)
+
+
+# ── 6b. retention unlinks checkpoint files (#156) ────────────────────────
+#
+# RunStore.prune deletes artifact ROWS via ON DELETE CASCADE but, before
+# this fix, never unlinked the .pt file the row pointed to -- so today's
+# row-based retention silently creates an orphan checkpoint file every time
+# it runs. #203's checkpoint_every makes that multiply (one file per
+# periodic checkpoint event), so the fix has to cover the sweep, not just
+# the new writer.
+
+
+async def test_prune_deletes_the_checkpoint_files_of_pruned_runs(
+    store, db, tmp_path, monkeypatch,
+):
+    models = tmp_path / "models"
+    models.mkdir()
+    monkeypatch.setattr(settings, "MODELS_DIR", models)
+
+    old_run = await _make_run(store)
+    old_file = models / "old.pt"
+    old_file.write_bytes(b"old checkpoint")
+    await store.add_artifact(old_run.id, "checkpoint", str(old_file))
+    await store.mark_finished(old_run.id, "succeeded")
+
+    kept_run = await _make_run(store)
+    kept_file = models / "kept.pt"
+    kept_file.write_bytes(b"kept checkpoint")
+    await store.add_artifact(kept_run.id, "checkpoint", str(kept_file))
+    await store.mark_finished(kept_run.id, "succeeded")
+
+    assert await store.prune(keep_last=1) == 1
+    assert not old_file.exists(), "the pruned run's checkpoint file leaked"
+    assert kept_file.exists(), "the KEPT run's checkpoint file must survive"
+
+
+async def test_prune_tolerates_a_checkpoint_file_already_gone(
+    store, db, tmp_path, monkeypatch,
+):
+    """A file removed by hand (or an earlier, interrupted prune) must not
+    turn a successful prune into a failed one."""
+    models = tmp_path / "models"
+    models.mkdir()
+    monkeypatch.setattr(settings, "MODELS_DIR", models)
+
+    run = await _make_run(store)
+    missing = models / "already_gone.pt"
+    await store.add_artifact(run.id, "checkpoint", str(missing))
+    await store.mark_finished(run.id, "succeeded")
+    assert not missing.exists()
+
+    assert await store.prune(keep_last=0) == 1  # must not raise
+
+
+async def test_prune_does_not_touch_a_non_checkpoint_artifact_file(
+    store, db, tmp_path, monkeypatch,
+):
+    """Scoped to kind='checkpoint' -- an export/image/etc. artifact of a
+    pruned run keeps its file. Only the checkpoint lifecycle is owned here;
+    see the report for why widening this was left out of scope."""
+    models = tmp_path / "models"
+    models.mkdir()
+    monkeypatch.setattr(settings, "MODELS_DIR", models)
+
+    run = await _make_run(store)
+    exported = models / "export.py"
+    exported.write_text("# exported script")
+    await store.add_artifact(run.id, "export", str(exported))
+    await store.mark_finished(run.id, "succeeded")
+
+    assert await store.prune(keep_last=0) == 1
+    assert exported.exists(), "only checkpoint-kind artifacts are cleaned up"
+
+
+async def test_prune_refuses_to_delete_a_checkpoint_path_outside_the_data_dir(
+    store, db, tmp_path, monkeypatch,
+):
+    """Defense in depth: the SAME path-safety rule ``write_checkpoint``
+    enforces on write also guards the delete, so a row whose path was not
+    produced by this module's own writers cannot become an arbitrary file
+    deletion."""
+    models = tmp_path / "data" / "models"
+    models.mkdir(parents=True)
+    monkeypatch.setattr(settings, "MODELS_DIR", models)
+
+    outside = tmp_path / "outside.pt"
+    outside.write_bytes(b"not a checkpoint this store owns")
+
+    run = await _make_run(store)
+    await store.add_artifact(run.id, "checkpoint", str(outside))
+    await store.mark_finished(run.id, "succeeded")
+
+    assert await store.prune(keep_last=0) == 1
+    assert outside.exists(), "a path outside the data directory must survive"
 
 
 async def test_publish_retention_does_not_touch_exec_runs(store, db):

--- a/backend/tests/test_training_resume.py
+++ b/backend/tests/test_training_resume.py
@@ -17,6 +17,8 @@ two paths are numerically comparable.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 import torch
 import torch.nn as nn
@@ -767,3 +769,256 @@ def test_training_on_cuda_moves_reused_optimizer_state() -> None:
     assert all(
         s["momentum_buffer"].device.type == "cuda" for s in optimizer.state.values()
     )
+
+
+# ---------------------------------------------------------------------------
+# #149: honest base_lrs -- initial_lr survives a resume explicitly, not by
+# accident of Optimizer.load_state_dict's dict-merge behaviour.
+# ---------------------------------------------------------------------------
+#
+# LRScheduler.__init__ does ``group.setdefault("initial_lr", group["lr"])``
+# and Optimizer.load_state_dict's ``update_group`` replaces each live param
+# group with the SAVED group's dict wholesale (verified against the
+# installed torch 2.11.0+cu128 -- see ``core.checkpoints``'s module
+# docstring). So a checkpoint whose OWN ``optimizer_state_dict`` happens to
+# carry ``initial_lr`` already survives a round trip with no fix at all --
+# that is "the case torch already handles" and proves nothing about #149.
+#
+# The bug is specifically about a checkpoint whose optimizer_state_dict does
+# NOT carry ``initial_lr`` (its optimizer object never had ANY scheduler
+# constructed over it at save time -- state_dict() only ever contains the
+# key if something stamped it) while its ``lr`` is not a value a
+# freshly-built scheduler should treat as the schedule's start. That shape
+# is real: e.g. an optimizer whose live param_groups DID carry a meaningful
+# ``initial_lr`` gets it silently replaced -- not merged -- the moment
+# ``load_state_dict`` restores from ANY checkpoint whose own saved dict
+# lacks the key, because ``update_group`` returns the saved group wholesale
+# (only ``params``/``param_names`` are patched in from the live side).
+
+
+def test_checkpoint_captures_initial_lr_explicitly(ckpt_path: str) -> None:
+    """The SAVE side: ``initial_lrs`` prefers the scheduler's true origin.
+
+    Not yet about resuming -- just that the key exists and, once a scheduler
+    has decayed the live lr, holds the ORIGINAL rather than the current
+    value. (This specific checkpoint's ``optimizer_state_dict`` also happens
+    to carry ``initial_lr`` by accident, same as it does today -- the crux
+    test below is the one that isolates the explicit key from that
+    accident.)
+    """
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    scheduler = _scheduler("StepLR", optimizer)  # step_size=2, gamma=0.5
+    for _ in range(2):
+        optimizer.step()
+        scheduler.step()
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(0.05), (
+        "the decay must actually have happened, or this test proves nothing"
+    )
+
+    CheckpointSaverNode().execute(
+        {"model": model, "optimizer": optimizer},
+        {"path": ckpt_path, "epoch": 1},
+    )
+    raw = torch.load(settings.MODELS_DIR / ckpt_path, map_location="cpu",
+                     weights_only=True)
+    assert raw["initial_lrs"] == pytest.approx([0.1])
+
+
+def test_loader_restores_initial_lr_even_when_the_optimizer_state_lacks_it(
+    ckpt_path: str,
+) -> None:
+    """#149's crux: the LOAD side must not depend on torch's accident.
+
+    This checkpoint is built to isolate the explicit ``initial_lrs`` key
+    from the accidental carrier: its ``optimizer_state_dict.param_groups``
+    has NO ``initial_lr`` (asserted below, so this test fails loudly rather
+    than silently if ``write_checkpoint``'s payload shape ever changes)
+    while the top-level ``initial_lrs`` key -- the one #149 adds -- says the
+    honest original. A loader that only trusted
+    ``optimizer.load_state_dict``'s own dict-merge would leave a freshly
+    built scheduler treating the CURRENT, decayed lr as its starting point,
+    which is exactly the bug the issue reports.
+
+    Hand-editing the saved payload (rather than deriving this shape from a
+    longer chain of real resumes) follows the same precedent as
+    ``test_old_format_checkpoint_without_scheduler_key_still_loads`` above:
+    it is the loader's CONTRACT under test, not a specific history.
+    """
+    from app.core import checkpoints
+
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    optimizer.param_groups[0]["lr"] = 0.025  # "current", already decayed
+    target = checkpoints.write_checkpoint(ckpt_path, model, optimizer, epoch=4)
+    raw = torch.load(target, map_location="cpu", weights_only=True)
+    assert "initial_lr" not in raw["optimizer_state_dict"]["param_groups"][0], (
+        "this checkpoint must NOT carry the accidental carrier, or the test "
+        "below would pass even without the #149 fix"
+    )
+    raw["initial_lrs"] = [0.1]  # the explicit, honestly-known truth
+    torch.save(raw, target)
+
+    resumed_model = _model()
+    resumed_opt = _optimizer("sgd_momentum", resumed_model)
+    restored = CheckpointLoaderNode().execute(
+        {"model": resumed_model, "optimizer": resumed_opt},
+        {"path": ckpt_path, "device": "cpu"},
+    )
+    restored_opt = restored["optimizer"]
+    assert restored_opt.param_groups[0]["lr"] == pytest.approx(0.025), (
+        "the resumed lr itself must still be the checkpoint's current value"
+    )
+    assert restored_opt.param_groups[0]["initial_lr"] == pytest.approx(0.1)
+
+    # The crux: a scheduler built AFTER the resume -- as a graph that wires
+    # a fresh LRScheduler node from CheckpointLoader's own optimizer output
+    # would -- must see the TRUE original, not the decayed value it resumed
+    # at.
+    fresh_scheduler = torch.optim.lr_scheduler.StepLR(restored_opt, step_size=1)
+    assert fresh_scheduler.base_lrs == pytest.approx([0.1])
+
+
+# ---------------------------------------------------------------------------
+# #203: periodic checkpointing -- TrainingLoop.checkpoint_every
+# ---------------------------------------------------------------------------
+#
+# A server crash mid-run survives nothing today: CheckpointSaver only fires
+# after TrainingLoop returns (never, if the process dies first) and the
+# interrupt checkpoint only fires on a COOPERATIVE stop (never, on a
+# SIGKILL/OOM-kill/power-loss/server-restart). checkpoint_every makes a
+# HEALTHY run write an ordinary checkpoint -- same core.checkpoints
+# machinery, same exec_run_artifacts row discipline as the interrupt path --
+# every N completed epochs, so at most N epochs are ever at risk.
+
+
+def _recording_context(**kwargs):
+    """A context that records artifacts, as a real interactive/queued run
+    does. Mirrors test_cancellation.py's helper of the same shape."""
+    from app.core.execution_context import ExecutionContext
+
+    return ExecutionContext(signals_recorded=True, **kwargs)
+
+
+@pytest.fixture
+def periodic_dir(tmp_path, monkeypatch):
+    """Point MODELS_DIR at a per-test directory; yield its periodic folder.
+
+    Isolated rather than the shared real MODELS_DIR (unlike ``ckpt_path``
+    above) because these tests assert exact file COUNTS and NAMES, which a
+    directory other tests also write into cannot support.
+    """
+    from app.core.checkpoints import PERIODIC_DIRNAME
+
+    models = tmp_path / "data" / "models"
+    models.mkdir(parents=True)
+    monkeypatch.setattr(settings, "MODELS_DIR", models)
+    return models / PERIODIC_DIRNAME
+
+
+def _checkpoint_signals(ctx):
+    signals, _dropped = ctx.outbox.drain()
+    return [s for s in signals if getattr(s, "kind", None) == "checkpoint"]
+
+
+def test_checkpoint_every_defaults_to_off(periodic_dir):
+    """0 = disabled, and 0 is the default -- matching every sibling knob on
+    this node (early_stopping_patience, grad_clip_norm, max_steps)."""
+    ctx = _recording_context()
+    model = _model()
+    TrainingLoopNode().execute(
+        {"model": model, "dataloader": _loader(),
+         "optimizer": _optimizer("sgd_momentum", model),
+         "loss_fn": nn.CrossEntropyLoss()},
+        {"epochs": 4, "device": "cpu"},  # checkpoint_every omitted
+        context=ctx,
+    )
+    assert not periodic_dir.exists(), "nothing should be written by default"
+    assert _checkpoint_signals(ctx) == []
+
+
+def test_checkpoint_every_writes_a_file_and_row_at_each_multiple(periodic_dir):
+    """Fires on the ABSOLUTE epoch number, at every multiple -- one distinct
+    file and one exec_run_artifacts row per event, exactly like the
+    interrupt path's own artifact discipline."""
+    ctx = _recording_context()
+    model = _model()
+    TrainingLoopNode().execute(
+        {"model": model, "dataloader": _loader(),
+         "optimizer": _optimizer("sgd_momentum", model),
+         "loss_fn": nn.CrossEntropyLoss()},
+        {"epochs": 5, "checkpoint_every": 2, "device": "cpu"},
+        context=ctx,
+    )
+    # epochs=5 at every-2 fires at absolute epoch 2 and 4 (not 5: 5 % 2 != 0)
+    files = sorted(p.name for p in periodic_dir.iterdir())
+    assert len(files) == 2, files
+
+    artifacts = _checkpoint_signals(ctx)
+    assert [a.meta.get("epoch") for a in artifacts] == [2, 4]
+    assert all(a.meta.get("reason") == "periodic" for a in artifacts)
+    assert all(a.kind == "checkpoint" for a in artifacts)
+    # The row IS the file: every artifact path this run logged exists.
+    assert {Path(a.path).name for a in artifacts} == set(files)
+
+
+def test_checkpoint_every_declines_when_the_run_records_no_artifacts(periodic_dir):
+    """The same "no row, no file" rule as the interrupt path (#122): a run
+    with nowhere durable to put the row must not write the file either."""
+    from app.core.execution_context import ExecutionContext
+
+    ctx = ExecutionContext()  # signals_recorded defaults to False
+    assert ctx.can_record_artifacts() is False
+    model = _model()
+    TrainingLoopNode().execute(
+        {"model": model, "dataloader": _loader(),
+         "optimizer": _optimizer("sgd_momentum", model),
+         "loss_fn": nn.CrossEntropyLoss()},
+        {"epochs": 3, "checkpoint_every": 1, "device": "cpu"},
+        context=ctx,
+    )
+    assert not periodic_dir.exists() or list(periodic_dir.iterdir()) == [], (
+        "a run that cannot record artifacts still wrote a periodic checkpoint"
+    )
+
+
+def test_resume_from_a_periodic_checkpoint_matches_the_straight_run(periodic_dir):
+    """The #203 acceptance criterion: kill-and-resume through the ordinary
+    CheckpointLoader -> start_epoch wiring, with no new concepts -- a
+    periodic checkpoint resumes exactly like a hand-placed one."""
+    loader = _loader()
+    straight_model = _model()
+    straight = _train(
+        straight_model, _optimizer("sgd_momentum", straight_model), loader,
+        {"epochs": TOTAL_EPOCHS},
+    )
+
+    ctx = _recording_context()
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    TrainingLoopNode().execute(
+        {"model": model, "dataloader": loader, "optimizer": optimizer,
+         "loss_fn": nn.CrossEntropyLoss()},
+        {"epochs": SPLIT_EPOCH, "checkpoint_every": SPLIT_EPOCH, "device": "cpu"},
+        context=ctx,
+    )
+    artifacts = _checkpoint_signals(ctx)
+    assert len(artifacts) == 1
+    checkpoint_path = artifacts[0].path
+
+    resumed_model = _model()
+    restored = CheckpointLoaderNode().execute(
+        {"model": resumed_model, "optimizer": _optimizer("sgd_momentum", resumed_model)},
+        {"path": checkpoint_path, "device": "cpu"},
+    )
+    assert restored["epoch"] == SPLIT_EPOCH
+    second = _train(
+        restored["model"], restored["optimizer"], loader,
+        {"epochs": TOTAL_EPOCHS}, start_epoch=restored["epoch"],
+    )
+
+    assert second["metrics"]["total_epochs_run"] == TOTAL_EPOCHS - SPLIT_EPOCH
+    assert second["losses"].tolist() == pytest.approx(
+        straight["losses"][SPLIT_EPOCH:].tolist(), rel=1e-5, abs=1e-7
+    )
+    _assert_same_weights(straight["model"], second["model"])

--- a/backend/tests/test_training_resume.py
+++ b/backend/tests/test_training_resume.py
@@ -772,39 +772,42 @@ def test_training_on_cuda_moves_reused_optimizer_state() -> None:
 
 
 # ---------------------------------------------------------------------------
-# #149: honest base_lrs -- initial_lr survives a resume explicitly, not by
-# accident of Optimizer.load_state_dict's dict-merge behaviour.
-# ---------------------------------------------------------------------------
+# #149: honest base_lrs -- a DEFENSIVE invariant, not a fix for a reachable
+# bug. Verified directly (see task-2-report.md): build_checkpoint derives
+# ``initial_lrs`` from ``g.get("initial_lr", g["lr"]) for g in
+# optimizer.param_groups`` -- the SAME live param_groups that
+# ``optimizer.state_dict()`` (called in the same dict literal, nothing
+# mutating in between) also reads. For any checkpoint this module can
+# actually produce, the two are therefore mathematically identical, and
+# restoring ``initial_lrs`` in CheckpointLoaderNode is a provable no-op
+# against the installed torch 2.11.0+cu128 -- ``Optimizer.load_state_dict``'s
+# ``update_group`` already carries a saved ``initial_lr`` through by
+# accident whenever the checkpoint's own dict has it, and when it does not,
+# a freshly built scheduler's own ``setdefault("initial_lr", lr)`` lands on
+# the identical number this key would have restored.
 #
-# LRScheduler.__init__ does ``group.setdefault("initial_lr", group["lr"])``
-# and Optimizer.load_state_dict's ``update_group`` replaces each live param
-# group with the SAVED group's dict wholesale (verified against the
-# installed torch 2.11.0+cu128 -- see ``core.checkpoints``'s module
-# docstring). So a checkpoint whose OWN ``optimizer_state_dict`` happens to
-# carry ``initial_lr`` already survives a round trip with no fix at all --
-# that is "the case torch already handles" and proves nothing about #149.
-#
-# The bug is specifically about a checkpoint whose optimizer_state_dict does
-# NOT carry ``initial_lr`` (its optimizer object never had ANY scheduler
-# constructed over it at save time -- state_dict() only ever contains the
-# key if something stamped it) while its ``lr`` is not a value a
-# freshly-built scheduler should treat as the schedule's start. That shape
-# is real: e.g. an optimizer whose live param_groups DID carry a meaningful
-# ``initial_lr`` gets it silently replaced -- not merged -- the moment
-# ``load_state_dict`` restores from ANY checkpoint whose own saved dict
-# lacks the key, because ``update_group`` returns the saved group wholesale
-# (only ``params``/``param_names`` are patched in from the live side).
+# What the key buys instead: CodefyUI's OWN contract stops depending on
+# ``optimizer.state_dict()``/``load_state_dict()`` choosing to carry
+# ``initial_lr`` through -- it is read from ``optimizer.param_groups``
+# directly and restored explicitly. The test below proves that decoupling
+# is real by constructing the one situation where it would matter: a
+# ``state_dict()`` that does NOT serialise ``initial_lr`` while the live
+# object still carries it. No real torch behaviour produces that today
+# (confirmed empirically -- see the report); it stands in for "a future
+# torch change, or a plugin's custom Optimizer subclass, alters what gets
+# serialised."
 
 
 def test_checkpoint_captures_initial_lr_explicitly(ckpt_path: str) -> None:
     """The SAVE side: ``initial_lrs`` prefers the scheduler's true origin.
 
-    Not yet about resuming -- just that the key exists and, once a scheduler
-    has decayed the live lr, holds the ORIGINAL rather than the current
-    value. (This specific checkpoint's ``optimizer_state_dict`` also happens
-    to carry ``initial_lr`` by accident, same as it does today -- the crux
-    test below is the one that isolates the explicit key from that
-    accident.)
+    Just that the key exists and, once a scheduler has decayed the live lr,
+    holds the ORIGINAL rather than the current value -- using ordinary
+    torch behaviour throughout, so (as the section note above explains)
+    this checkpoint's ``optimizer_state_dict`` also happens to carry
+    ``initial_lr`` by the same accident. That is expected, not a gap: this
+    test pins the CAPTURE logic's own correctness, independent of whether
+    anything downstream needed it.
     """
     model = _model()
     optimizer = _optimizer("sgd_momentum", model)
@@ -825,39 +828,59 @@ def test_checkpoint_captures_initial_lr_explicitly(ckpt_path: str) -> None:
     assert raw["initial_lrs"] == pytest.approx([0.1])
 
 
-def test_loader_restores_initial_lr_even_when_the_optimizer_state_lacks_it(
+def test_initial_lr_is_captured_from_the_live_optimizer_not_its_state_dict(
     ckpt_path: str,
 ) -> None:
-    """#149's crux: the LOAD side must not depend on torch's accident.
+    """The one real divergence the defensive framing protects against.
 
-    This checkpoint is built to isolate the explicit ``initial_lrs`` key
-    from the accidental carrier: its ``optimizer_state_dict.param_groups``
-    has NO ``initial_lr`` (asserted below, so this test fails loudly rather
-    than silently if ``write_checkpoint``'s payload shape ever changes)
-    while the top-level ``initial_lrs`` key -- the one #149 adds -- says the
-    honest original. A loader that only trusted
-    ``optimizer.load_state_dict``'s own dict-merge would leave a freshly
-    built scheduler treating the CURRENT, decayed lr as its starting point,
-    which is exactly the bug the issue reports.
-
-    Hand-editing the saved payload (rather than deriving this shape from a
-    longer chain of real resumes) follows the same precedent as
-    ``test_old_format_checkpoint_without_scheduler_key_still_loads`` above:
-    it is the loader's CONTRACT under test, not a specific history.
+    ``optimizer.state_dict`` is patched to drop ``initial_lr`` from what it
+    serialises -- standing in for a torch (or custom-optimizer) behaviour
+    change -- while leaving it on the LIVE ``param_groups`` untouched.
+    ``build_checkpoint`` must still capture the truth (it reads
+    ``param_groups`` directly, not through the crippled ``state_dict()``),
+    and ``CheckpointLoaderNode`` must still restore it from ``initial_lrs``
+    even though ``optimizer_state_dict`` -- the ordinary carrier -- lacks
+    it. This is the shape of test the brief asked for ("fails on the
+    history-dependent path specifically"); this codebase does not have a
+    real history that produces it, so the test manufactures the one
+    dependency the code takes on torch's serialisation choices, rather than
+    hand-editing a value no writer would ever produce.
     """
+    from unittest import mock
+
     from app.core import checkpoints
 
     model = _model()
     optimizer = _optimizer("sgd_momentum", model)
-    optimizer.param_groups[0]["lr"] = 0.025  # "current", already decayed
-    target = checkpoints.write_checkpoint(ckpt_path, model, optimizer, epoch=4)
+    scheduler = _scheduler("StepLR", optimizer)  # step_size=2, gamma=0.5
+    for _ in range(2):
+        optimizer.step()
+        scheduler.step()
+    assert optimizer.param_groups[0]["initial_lr"] == pytest.approx(0.1)
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(0.05)
+
+    real_state_dict = optimizer.state_dict
+
+    def _stripped_state_dict():
+        state = real_state_dict()
+        for group in state["param_groups"]:
+            group.pop("initial_lr", None)
+        return state
+
+    with mock.patch.object(optimizer, "state_dict",
+                           side_effect=_stripped_state_dict):
+        target = checkpoints.write_checkpoint(
+            ckpt_path, model, optimizer, epoch=4)
+
     raw = torch.load(target, map_location="cpu", weights_only=True)
     assert "initial_lr" not in raw["optimizer_state_dict"]["param_groups"][0], (
-        "this checkpoint must NOT carry the accidental carrier, or the test "
-        "below would pass even without the #149 fix"
+        "the patched state_dict() must actually have dropped the key, or "
+        "this test is not exercising the simulated divergence"
     )
-    raw["initial_lrs"] = [0.1]  # the explicit, honestly-known truth
-    torch.save(raw, target)
+    assert raw["initial_lrs"] == pytest.approx([0.1]), (
+        "captured from the LIVE param_groups, independent of what the "
+        "(crippled) state_dict() serialised"
+    )
 
     resumed_model = _model()
     resumed_opt = _optimizer("sgd_momentum", resumed_model)
@@ -866,15 +889,11 @@ def test_loader_restores_initial_lr_even_when_the_optimizer_state_lacks_it(
         {"path": ckpt_path, "device": "cpu"},
     )
     restored_opt = restored["optimizer"]
-    assert restored_opt.param_groups[0]["lr"] == pytest.approx(0.025), (
+    assert restored_opt.param_groups[0]["lr"] == pytest.approx(0.05), (
         "the resumed lr itself must still be the checkpoint's current value"
     )
     assert restored_opt.param_groups[0]["initial_lr"] == pytest.approx(0.1)
 
-    # The crux: a scheduler built AFTER the resume -- as a graph that wires
-    # a fresh LRScheduler node from CheckpointLoader's own optimizer output
-    # would -- must see the TRUE original, not the decayed value it resumed
-    # at.
     fresh_scheduler = torch.optim.lr_scheduler.StepLR(restored_opt, step_size=1)
     assert fresh_scheduler.base_lrs == pytest.approx([0.1])
 
@@ -886,10 +905,22 @@ def test_loader_restores_initial_lr_even_when_the_optimizer_state_lacks_it(
 # A server crash mid-run survives nothing today: CheckpointSaver only fires
 # after TrainingLoop returns (never, if the process dies first) and the
 # interrupt checkpoint only fires on a COOPERATIVE stop (never, on a
-# SIGKILL/OOM-kill/power-loss/server-restart). checkpoint_every makes a
-# HEALTHY run write an ordinary checkpoint -- same core.checkpoints
-# machinery, same exec_run_artifacts row discipline as the interrupt path --
-# every N completed epochs, so at most N epochs are ever at risk.
+# SIGKILL/OOM-kill/server-restart -- NOT power loss either; see
+# save_periodic_checkpoint's docstring). checkpoint_every makes a HEALTHY
+# run write an ordinary checkpoint -- same core.checkpoints machinery, same
+# exec_run_artifacts row discipline as the interrupt path -- every N
+# completed epochs, so at most N epochs are ever at risk.
+#
+# The tested boundary below is the QUEUE (ctx.outbox.drain()), not an
+# actual exec_run_artifacts ROW -- the same boundary
+# test_cancellation.py's own interrupt-checkpoint tests use, for the same
+# reason: proving the queue -> row mapping itself (ArtifactSignal ->
+# RunService._record_artifact -> RunStore.add_artifact) is generic and
+# already covered once, for every producer, by
+# test_run_service.py::test_log_artifact_registers_a_row_and_announces_it.
+# save_periodic_checkpoint calls the identical context.log_artifact(...)
+# API that test exercises, so re-proving the row lands here would just
+# duplicate that coverage under a different producer.
 
 
 def _recording_context(**kwargs):
@@ -917,7 +948,14 @@ def periodic_dir(tmp_path, monkeypatch):
 
 
 def _checkpoint_signals(ctx):
-    signals, _dropped = ctx.outbox.drain()
+    """Drain and filter to ``checkpoint`` signals -- and assert none of them
+    were EVICTED first. The outbox is drop-oldest under load (see
+    ``save_periodic_checkpoint``'s "always-present" orphan-window note); an
+    evicted checkpoint signal is a file with no row, which every test using
+    this helper is otherwise implicitly assuming did not happen. One line,
+    so that assumption is checked rather than merely made."""
+    signals, dropped = ctx.outbox.drain()
+    assert dropped == 0, f"{dropped} signal(s) evicted before delivery"
     return [s for s in signals if getattr(s, "kind", None) == "checkpoint"]
 
 
@@ -960,6 +998,35 @@ def test_checkpoint_every_writes_a_file_and_row_at_each_multiple(periodic_dir):
     assert all(a.kind == "checkpoint" for a in artifacts)
     # The row IS the file: every artifact path this run logged exists.
     assert {Path(a.path).name for a in artifacts} == set(files)
+
+
+def test_checkpoint_every_uses_absolute_epochs_on_a_resumed_run(periodic_dir):
+    """The discriminating case a fully-successful, never-resumed run cannot
+    exercise: ``start_epoch`` combined with ``checkpoint_every`` must
+    produce ABSOLUTE epoch numbers, not epochs-completed-THIS-CALL.
+
+    epochs=6, checkpoint_every=2, start_epoch=2 runs absolute epochs
+    3,4,5,6 (call-relative 1,2,3,4). The correct, absolute-indexed
+    implementation fires at absolute 4 and 6. A regression that counted
+    epochs completed in THIS call instead (an easy mistake given this
+    file's own "arrays are per call" / "epochs are absolute" distinction)
+    would report [2, 4] -- call-relative counts mistaken for epoch
+    numbers -- which also happens to be the wrong SET of firing points,
+    not just a mislabelling: this pins both where periodic checkpoints
+    land AND what they call themselves, in the realistic crash -> resume
+    -> crash again scenario #203 exists for.
+    """
+    ctx = _recording_context()
+    model = _model()
+    TrainingLoopNode().execute(
+        {"model": model, "dataloader": _loader(),
+         "optimizer": _optimizer("sgd_momentum", model),
+         "loss_fn": nn.CrossEntropyLoss(), "start_epoch": 2},
+        {"epochs": 6, "checkpoint_every": 2, "device": "cpu"},
+        context=ctx,
+    )
+    artifacts = _checkpoint_signals(ctx)
+    assert [a.meta.get("epoch") for a in artifacts] == [4, 6]
 
 
 def test_checkpoint_every_declines_when_the_run_records_no_artifacts(periodic_dir):

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -473,6 +473,7 @@ const zhTW: NodeTranslations = {
       epochs: '訓練 epoch 數量',
       device: '訓練裝置',
       early_stopping_patience: '驗證損失未改善 N 個 epoch 後停止（0 = 停用）',
+      checkpoint_every: '每 N 個完整 epoch 存一次檢查點，讓伺服器當機時最多只損失 N 個 epoch，而不是整次執行。與 CheckpointSaver 互相獨立，恢復方式也相同：把 CheckpointLoader.epoch 接到 start_epoch（0 = 停用）',
       grad_clip_norm: '最大梯度範數裁剪（0 = 停用）',
       batch_metrics: '同時把每一批的損失記錄成 train_loss_batch 這條序列（預設關閉：每批一列資料量相當可觀）',
       precision: '混合精度。bf16 在 Ampere 以後的顯卡上可以把 activation 記憶體用量大約減半，其他都不用改；fp16 則是給更舊的顯卡用的，會額外搭配 loss scaler。裝置做不到的話會自動退回 fp32 並記錄下來。',

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -473,7 +473,7 @@ const zhTW: NodeTranslations = {
       epochs: '訓練 epoch 數量',
       device: '訓練裝置',
       early_stopping_patience: '驗證損失未改善 N 個 epoch 後停止（0 = 停用）',
-      checkpoint_every: '每 N 個完整 epoch 存一次檢查點，讓伺服器當機時最多只損失 N 個 epoch，而不是整次執行。與 CheckpointSaver 互相獨立，恢復方式也相同：把 CheckpointLoader.epoch 接到 start_epoch（0 = 停用）',
+      checkpoint_every: '每 N 個完整 epoch 存一次檢查點，讓伺服器當機時最多只損失 N 個 epoch，而不是整次執行。與 CheckpointSaver 互相獨立，恢復方式也相同：把 CheckpointLoader.epoch 接到 start_epoch。每個檢查點大小大約是模型加上優化器狀態（常常是模型本身的好幾倍），而且是在訓練執行緒上同步寫入；大模型搭配偏低的 N、跑很長的訓練，執行完之前可能會用掉好幾 GB 磁碟空間，因為執行中的任務目前沒有機制限制這件事（0 = 停用）',
       grad_clip_norm: '最大梯度範數裁剪（0 = 停用）',
       batch_metrics: '同時把每一批的損失記錄成 train_loss_batch 這條序列（預設關閉：每批一列資料量相當可觀）',
       precision: '混合精度。bf16 在 Ampere 以後的顯卡上可以把 activation 記憶體用量大約減半，其他都不用改；fp16 則是給更舊的顯卡用的，會額外搭配 loss scaler。裝置做不到的話會自動退回 fp32 並記錄下來。',


### PR DESCRIPTION
Wave 6 Sprint 2, second of two. The first (per-epoch `val_accuracy`) merged as #218; this branch has `main` merged in and the epoch-loop conflict resolved.

Closes #203. Closes #156.

**#149 is deliberately NOT closed by this PR** — see below. Please leave it open.

## Why #203 matters

This is not hypothetical. From the issue: a server process died 13 minutes into a 22-minute run and **all 101 completed epochs were unrecoverable** — not degraded, gone. The run row was marked `interrupted` and the artifacts list came back empty.

Checkpoints were written at exactly two moments, and neither survived an abrupt death. `CheckpointSaver` is a graph node, so it fires *after* `TrainingLoop` returns — a run that never returns never saves. The interrupt checkpoint is on the cooperative stop path, which requires the process to still be alive and running the loop; a SIGKILL, an OOM kill or a server restart never reaches it.

Everything else in the stack is already built for long jobs: runs survive browser disconnects, tab closes and the submitting process exiting. The one thing not survivable was the server process itself — which, for a job measured in hours, is the failure most likely to actually happen.

## What changed

- **`checkpoint_every` on `TrainingLoop`** (epochs, `0` = off, not advanced). It follows `save_interrupt_checkpoint` rather than `CheckpointSaver`: the latter's `execute()` has no `context` parameter and therefore never registers an artifact row, so reusing it would have produced files no retention pass can ever reclaim — the orphan pattern the "no row, no file" rule exists to prevent.
- **Retention now unlinks the file, not just the row** (#156). `RunStore.prune` deleted artifact rows via cascade and left the `.pt` on disk, so row-based retention was already manufacturing orphans on every sweep. The unlink re-validates the path before deleting and runs off the event loop.
- **Checkpoints of `interrupted` runs are exempt from the sweep.** Recovery runs before retention at startup, so on a box configured to keep zero finished runs, a crash-restart would otherwise have deleted the very checkpoint the user restarted to resume from. The row still goes; the file stays.
- Write duration and cumulative bytes are logged, and the parameter's own description states the disk cost in both locales.

## Why #149 stays open

The change is in this branch — `initial_lrs` is captured in `build_checkpoint` and restored in `CheckpointLoader` before any scheduler is constructed — but **it does not fix a reachable bug**, and it should not close the issue.

`Optimizer.state_dict()` packs every param-group key, including `initial_lr`, and `build_checkpoint` derives `initial_lrs` from the *same* `param_groups` objects in the *same* dict literal. The two cannot disagree for any checkpoint this codebase can emit. Review established that by probing the installed torch directly; the implementer then independently re-derived it, reconstructed the scenario its original reasoning had rested on, and confirmed the fix does not rescue it either.

So the code ships as what it actually is: **a defensive invariant**, stated as such in the docstrings. It decouples our contract from `state_dict()`/`load_state_dict()` serialization choices, so a future torch change surfaces as a behaviour difference rather than silent LR corruption. That is worth having. It is not #149.

The crux test was replaced accordingly — it now manufactures the divergence through the real write path with a mocked `state_dict()`, which genuinely discriminates implementations on the save side, rather than hand-editing a saved payload to a value no writer produces.

## Verification

- Full backend suite after the merge: **3753 passed, 14 skipped, 0 failed.**
- Every fix has failing-first evidence. The retention exemption was proved by reverting the guard and watching the new test fail; the chained-resume test was proved by injecting the call-relative-epoch regression and watching only that test catch it.
- Real-browser check on a freshly built dist: `checkpoint_every` renders as a number input defaulting to 0, outside the Advanced disclosure, with the disk-cost warning present in both locales and no cross-language leakage. No console errors.

### The merge

`main` gained #218 (per-epoch `val_accuracy`, a `monitor` param, `stopped_early` corrections) which edits the same epoch-loop tail. Two real conflicts, both there. Review audited the resolution by hunk arithmetic — every old-side count equals its context lines, so the merge is **pure insertion with zero deletions** and no #218 line was altered or shadowed — then read the composed loop: the periodic checkpoint fires *before* the early-stopping break, so a final epoch landing on a multiple is still captured, and a mid-epoch stop breaks before the loss append, so a partial epoch can never trigger one.

## Known gaps, disclosed rather than found later

- **Nothing bounds disk cost while a run is alive.** At `checkpoint_every=1` a 200-epoch ResNet-18 writes roughly 18 GB. Retention structurally cannot reach a still-active run. In-run rotation was considered and rejected: there is no per-artifact delete anywhere in `RunStore`, and `log_artifact` is fire-and-forget, so rotation-by-deletion would leave rows pointing at nothing. Review accepted the rejection of *that* mechanism while noting a single stable path per (run, node) would give keep-last-1 with no retract needed — worth revisiting, not blocking.
- **Two orphan windows**, both failing in the recoverable direction (readable filename; no row means retention never touches it): the always-present gap between `os.replace` and the row commit, and a backpressure/eviction case. Both documented in the code.
- **Not power loss.** `write_checkpoint` does `torch.save` + `os.replace` with no fsync, so the claim is process death — SIGKILL, OOM, restart — not an unflushed rename surviving a power cut. Three docstrings that overstated this were corrected.

Also filed during review: **#224**, because retention now deletes files keyed off an open-vocabulary `kind` column while guarded by a rule written for writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166FJAiynQ4Ei891qJgFYyo
