### PR TITLE
feat(ui): a real design-token layer — contrast, type scale and density across all 54 modules

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,10 +7,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "node scripts/check-contrast.mjs && tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "contrast": "node scripts/check-contrast.mjs"
   },
   "dependencies": {
     "@codemirror/commands": "^6",

--- a/frontend/scripts/check-contrast.mjs
+++ b/frontend/scripts/check-contrast.mjs
@@ -218,13 +218,34 @@ for (const token of BADGE_PALETTES) {
   check(`${token} as text on --surface-panel`, contrast(t(token), t('--surface-panel')), 4.5);
 }
 
-/* 9. The accent wash is a translucent fill; check what it actually composites
-      to, not what its own rgba() claims. */
-const washAlpha = parseFloat(t('--accent-wash').match(/,\s*([\d.]+)\s*\)/)[1]);
-const washOnPanel = overlay(toRgb(t('--accent')), washAlpha, toRgb(t('--surface-panel')));
-const washHex = `#${washOnPanel.map((v) => Math.round(v).toString(16).padStart(2, '0')).join('')}`;
-check('--text-primary on --accent-wash over panel', contrast(t('--text-primary'), washHex), 4.5);
-check('--accent on --accent-wash over panel', contrast(t('--accent'), washHex), 4.5);
+/* 9. Washes are translucent fills. Check what they actually composite to over
+      the panel they land on, not what their own rgba() claims in isolation —
+      that is the mistake that made the old gallery badges look like 1:1 pairs.
+      Each wash is paired with the text colour that is drawn on it. */
+const WASHES = [
+  ['--accent-wash', '--accent'],
+  ['--success-wash', '--status-success'],
+  ['--danger-wash', '--status-error'],
+  ['--warning-wash', '--status-warning'],
+  ['--info-wash', '--status-info'],
+];
+for (const [wash, ink] of WASHES) {
+  const alpha = parseFloat(t(wash).match(/,\s*([\d.]+)\s*\)/)[1]);
+  const composited = overlay(toRgb(t(ink)), alpha, toRgb(t('--surface-panel')));
+  const hex = `#${composited.map((v) => Math.round(v).toString(16).padStart(2, '0')).join('')}`;
+  check(`--text-primary on ${wash} over panel`, contrast(t('--text-primary'), hex), 4.5);
+  check(`--text-secondary on ${wash} over panel`, contrast(t('--text-secondary'), hex), 4.5);
+  check(`${ink} on ${wash} over panel`, contrast(t(ink), hex), 4.5);
+}
+
+/* 10. Glows are box-shadows and must stay translucent. An opaque one reads as
+       a hard ring, not a glow — easy to introduce when swapping an rgba()
+       literal for a solid colour token. */
+for (const glow of ['--glow-running', '--glow-accent']) {
+  if (!/rgba\([^)]*,\s*0?\.\d+\s*\)/.test(t(glow))) {
+    failures.push(`${glow} must use a translucent rgba() colour, got: ${t(glow)}`);
+  }
+}
 
 /* ---------- report ---------- */
 

--- a/frontend/scripts/check-contrast.mjs
+++ b/frontend/scripts/check-contrast.mjs
@@ -152,9 +152,17 @@ for (const surface of ['--surface-app', '--surface-panel', '--surface-raised']) 
   check(`--border-strong on ${surface}`, contrast(t('--border-strong'), t(surface)), 3);
 }
 
-/* 5. Canvas wires are meaningful graphics, so 1.4.11 applies to them too. */
-for (const wire of ['--wire', '--wire-data', '--wire-active']) {
+/* 5. Canvas wires are meaningful graphics, so 1.4.11 applies to them too.
+      The trigger-flow green is the same kind of thing: it is what tells you an
+      edge carries execution order rather than data. */
+for (const wire of ['--wire', '--wire-data', '--wire-active', '--flow-trigger', '--flow-trigger-deep']) {
   check(`${wire} on --surface-canvas`, contrast(t(wire), t('--surface-canvas')), 3);
+}
+
+/* 5b. Preset nodes keep a filled gold header, so the ink on it is ordinary
+       text and needs the full AA bar against every stop of the gradient. */
+for (const stop of t('--preset-fill').match(/#[0-9a-f]{6}/gi) ?? []) {
+  check(`--preset-ink on preset gradient stop ${stop}`, contrast(t('--preset-ink'), stop), 4.5);
 }
 
 /* 6. Accent and status colours are used as text, so they need the text bar. */
@@ -198,7 +206,13 @@ if (!(NODE_HEADER_TINT > 0 && NODE_HEADER_TINT < 1)) {
 for (const cat of CATEGORIES) {
   const fill = mixHex(t('--surface-raised'), t(cat), NODE_HEADER_TINT);
   check(`node title on ${cat} header`, contrast(t('--text-primary'), fill), 4.5);
-  check(`${cat} label on its own header`, contrast(t(cat), fill), 3);
+  // The hue on its own tinted header is the accent bar / chip border — a
+  // graphic, so 3:1. It is deliberately NOT used as the label text: a hue on a
+  // tint of itself measured 3.50-4.16:1 and stays under 4.5 at every tint
+  // strength and every lift, so that pairing is unreadable by construction.
+  check(`${cat} accent bar on its own header`, contrast(t(cat), fill), 3);
+  // The label that sits on the tinted header is ordinary text.
+  check(`--text-muted label on ${cat} header`, contrast(t('--text-muted'), fill), 4.5);
   check(`${cat} as text on --surface-raised`, contrast(t(cat), t('--surface-raised')), 4.5);
 }
 
@@ -213,7 +227,8 @@ const BADGE_PALETTES = [...tokens.keys()].filter(
 );
 for (const token of BADGE_PALETTES) {
   const fill = mixHex(t('--surface-raised'), t(token), NODE_HEADER_TINT);
-  check(`${token} on its own badge tint`, contrast(t(token), fill), 3);
+  check(`${token} as a badge border on its own tint`, contrast(t(token), fill), 3);
+  check(`--text-muted label on ${token} badge`, contrast(t('--text-muted'), fill), 4.5);
   check(`${token} as text on --surface-raised`, contrast(t(token), t('--surface-raised')), 4.5);
   check(`${token} as text on --surface-panel`, contrast(t(token), t('--surface-panel')), 4.5);
 }
@@ -236,6 +251,12 @@ for (const [wash, ink] of WASHES) {
   check(`--text-primary on ${wash} over panel`, contrast(t('--text-primary'), hex), 4.5);
   check(`--text-secondary on ${wash} over panel`, contrast(t('--text-secondary'), hex), 4.5);
   check(`${ink} on ${wash} over panel`, contrast(t(ink), hex), 4.5);
+}
+
+/* 9b. Code editor. Comments and line numbers carry meaning in source, so they
+       are held to the text bar, not to a "decoration" bar. */
+for (const role of ['--code-text', '--code-comment', '--code-gutter']) {
+  check(`${role} on --surface-code`, contrast(t(role), t('--surface-code')), 4.5);
 }
 
 /* 10. Glows are box-shadows and must stay translucent. An opaque one reads as

--- a/frontend/scripts/check-contrast.mjs
+++ b/frontend/scripts/check-contrast.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Contrast gate for the design tokens.
+ *
+ * Parses `src/styles/tokens.css` and re-derives every colour relationship the
+ * token file claims, so the numbers in its comments cannot quietly rot. Run via
+ * `pnpm contrast`; CI runs it too.
+ *
+ * Deliberately reads the CSS rather than importing a duplicated JS copy of the
+ * palette — a checker with its own copy of the values proves only that the copy
+ * is self-consistent.
+ *
+ * Implements WCAG 2.1 exactly: sRGB linearisation (c <= 0.03928 ? c/12.92 :
+ * ((c+0.055)/1.055)^2.4), relative luminance L = 0.2126R + 0.7152G + 0.0722B,
+ * ratio = (Lighter + 0.05) / (Darker + 0.05). Sanity-checked below against the
+ * canonical #767676-on-white = 4.54:1 pair and black-on-white = 21:1.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const TOKENS = join(here, '..', 'src', 'styles', 'tokens.css');
+
+/* ---------- colour maths ---------- */
+
+const toRgb = (value) => {
+  const hex = value.trim().match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (hex) {
+    let h = hex[1];
+    if (h.length === 3) h = [...h].map((c) => c + c).join('');
+    return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+  }
+  const rgba = value.trim().match(/^rgba?\(([^)]+)\)$/i);
+  if (rgba) {
+    const parts = rgba[1].split(',').map((p) => parseFloat(p));
+    return parts.slice(0, 3);
+  }
+  throw new Error(`cannot parse colour: ${value}`);
+};
+
+const luminance = (rgb) => {
+  const [r, g, b] = rgb.map((v) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+const contrast = (a, b) => {
+  const la = luminance(toRgb(a));
+  const lb = luminance(toRgb(b));
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+};
+
+/** CIE L* — the right axis for judging whether two dark surfaces read as
+ *  separate planes. Contrast ratio compresses near black and would call a
+ *  1.03:1 pair "different". */
+const lstar = (colour) => {
+  const y = luminance(toRgb(colour));
+  return y <= 216 / 24389 ? (y * 24389) / 27 : Math.cbrt(y) * 116 - 16;
+};
+
+/** Alpha-composite `fg` over `bg`, both as rgb triples. */
+const overlay = (fg, alpha, bg) =>
+  fg.map((v, i) => v * alpha + bg[i] * (1 - alpha));
+
+const mixHex = (a, b, t) => {
+  const [ra, rb] = [toRgb(a), toRgb(b)];
+  const out = ra.map((v, i) => Math.round(v + (rb[i] - v) * t));
+  return `#${out.map((v) => v.toString(16).padStart(2, '0')).join('')}`;
+};
+
+/* ---------- self-test: prove the maths before trusting a verdict ---------- */
+
+const selfTests = [
+  ['#767676 on #ffffff', contrast('#767676', '#ffffff'), 4.54, 0.01],
+  ['#000000 on #ffffff', contrast('#000000', '#ffffff'), 21.0, 0.001],
+  ['#ffffff on #ffffff', contrast('#ffffff', '#ffffff'), 1.0, 0.001],
+];
+for (const [name, got, want, tol] of selfTests) {
+  if (Math.abs(got - want) > tol) {
+    console.error(`contrast maths is wrong: ${name} = ${got.toFixed(3)}, expected ${want}`);
+    process.exit(2);
+  }
+}
+
+/* ---------- read the tokens ---------- */
+
+const css = readFileSync(TOKENS, 'utf8');
+const tokens = new Map();
+for (const m of css.matchAll(/^\s*(--[\w-]+)\s*:\s*([^;]+);/gm)) {
+  tokens.set(m[1], m[2].trim());
+}
+const t = (name) => {
+  if (!tokens.has(name)) throw new Error(`token ${name} is not defined in tokens.css`);
+  return tokens.get(name);
+};
+
+const SURFACES = [
+  '--surface-canvas',
+  '--surface-app',
+  '--surface-panel',
+  '--surface-raised',
+  '--surface-input',
+  '--surface-hover',
+  '--surface-active',
+];
+const CATEGORIES = [...tokens.keys()].filter((k) => k.startsWith('--cat-'));
+
+const failures = [];
+let checked = 0;
+const check = (label, actual, min) => {
+  checked += 1;
+  if (actual < min) failures.push(`${label}: ${actual.toFixed(2)} (needs ${min})`);
+};
+
+/* 1. Every usable text tier must clear AA on every surface.
+      --text-disabled is exempt by design and is asserted separately. */
+for (const tier of ['--text-primary', '--text-secondary', '--text-muted']) {
+  for (const surface of SURFACES) {
+    check(`${tier} on ${surface}`, contrast(t(tier), t(surface)), 4.5);
+  }
+}
+
+/* 2. The disabled tier must actually look disabled — below AA on purpose —
+      while still being distinguishable from the background. Asserting the
+      upper bound stops someone "fixing" it into a fourth readable tier. */
+const disabledOnPanel = contrast(t('--text-disabled'), t('--surface-panel'));
+check('--text-disabled on --surface-panel (lower bound)', disabledOnPanel, 2.5);
+if (disabledOnPanel >= 4.5) {
+  failures.push(
+    `--text-disabled on --surface-panel: ${disabledOnPanel.toFixed(2)} — ` +
+      `that now passes AA, so it is no longer a disabled tier. Use --text-muted instead.`
+  );
+}
+
+/* 3. Surfaces must be far enough apart in L* to read as separate planes.
+      ~3 L* is the floor at which a step is perceptible on a dark screen. */
+for (let i = 1; i < SURFACES.length; i++) {
+  const step = lstar(t(SURFACES[i])) - lstar(t(SURFACES[i - 1]));
+  if (step < 3) {
+    failures.push(
+      `${SURFACES[i - 1]} -> ${SURFACES[i]}: only ${step.toFixed(1)} L* apart (needs 3)`
+    );
+  }
+}
+
+/* 4. WCAG 1.4.11 — control outlines against the surface behind the control. */
+for (const surface of ['--surface-app', '--surface-panel', '--surface-raised']) {
+  check(`--border-strong on ${surface}`, contrast(t('--border-strong'), t(surface)), 3);
+}
+
+/* 5. Canvas wires are meaningful graphics, so 1.4.11 applies to them too. */
+for (const wire of ['--wire', '--wire-data', '--wire-active']) {
+  check(`${wire} on --surface-canvas`, contrast(t(wire), t('--surface-canvas')), 3);
+}
+
+/* 6. Accent and status colours are used as text, so they need the text bar. */
+for (const colour of [
+  '--accent',
+  '--accent-deep',
+  '--status-success',
+  '--status-error',
+  '--status-warning',
+  '--status-info',
+  '--status-idle',
+  '--status-preset',
+]) {
+  for (const surface of ['--surface-panel', '--surface-raised', '--surface-canvas']) {
+    check(`${colour} on ${surface}`, contrast(t(colour), t(surface)), 4.5);
+  }
+}
+
+/* 7. Text inside a filled accent button. */
+check(
+  '--text-on-accent on --accent',
+  contrast(t('--text-on-accent'), t('--accent')),
+  4.5
+);
+check(
+  '--text-on-accent on --accent-deep',
+  contrast(t('--text-on-accent'), t('--accent-deep')),
+  4.5
+);
+
+/* 8. Node headers. The header fill is the category hue tinted into
+      --surface-raised at --node-header-tint; the title sits on that fill and
+      the hue itself is drawn on it as the category label. Both must hold for
+      all fourteen categories — the old design painted the raw hue as the fill
+      and #eee on top, which failed on twelve of them. The tint is read from
+      the CSS rather than restated here so it cannot drift. */
+const NODE_HEADER_TINT = parseFloat(t('--node-header-tint'));
+if (!(NODE_HEADER_TINT > 0 && NODE_HEADER_TINT < 1)) {
+  failures.push(`--node-header-tint must be between 0 and 1, got ${t('--node-header-tint')}`);
+}
+for (const cat of CATEGORIES) {
+  const fill = mixHex(t('--surface-raised'), t(cat), NODE_HEADER_TINT);
+  check(`node title on ${cat} header`, contrast(t('--text-primary'), fill), 4.5);
+  check(`${cat} label on its own header`, contrast(t(cat), fill), 3);
+  check(`${cat} as text on --surface-raised`, contrast(t(cat), t('--surface-raised')), 4.5);
+}
+
+/* 8b. The gallery-category, difficulty and run-status palettes are drawn the
+       same way — a hue on a tint of itself — so they get the same two checks.
+       These are what produced the 1:1-looking badges in the example gallery. */
+const BADGE_PALETTES = [...tokens.keys()].filter(
+  (k) =>
+    k.startsWith('--ex-') ||
+    k.startsWith('--difficulty-') ||
+    (k.startsWith('--status-') && k !== '--status-idle')
+);
+for (const token of BADGE_PALETTES) {
+  const fill = mixHex(t('--surface-raised'), t(token), NODE_HEADER_TINT);
+  check(`${token} on its own badge tint`, contrast(t(token), fill), 3);
+  check(`${token} as text on --surface-raised`, contrast(t(token), t('--surface-raised')), 4.5);
+  check(`${token} as text on --surface-panel`, contrast(t(token), t('--surface-panel')), 4.5);
+}
+
+/* 9. The accent wash is a translucent fill; check what it actually composites
+      to, not what its own rgba() claims. */
+const washAlpha = parseFloat(t('--accent-wash').match(/,\s*([\d.]+)\s*\)/)[1]);
+const washOnPanel = overlay(toRgb(t('--accent')), washAlpha, toRgb(t('--surface-panel')));
+const washHex = `#${washOnPanel.map((v) => Math.round(v).toString(16).padStart(2, '0')).join('')}`;
+check('--text-primary on --accent-wash over panel', contrast(t('--text-primary'), washHex), 4.5);
+check('--accent on --accent-wash over panel', contrast(t('--accent'), washHex), 4.5);
+
+/* ---------- report ---------- */
+
+if (failures.length) {
+  console.error(`\nContrast gate FAILED — ${failures.length} problem(s):\n`);
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error(
+    '\nEdit src/styles/tokens.css. Do not relax a threshold to make this pass;\n' +
+      'the thresholds are WCAG 2.1 AA (1.4.3 text, 1.4.11 non-text).\n'
+  );
+  process.exit(1);
+}
+
+console.log(`Contrast gate passed — ${checked} colour relationships verified across ${tokens.size} tokens.`);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,6 +2,8 @@
    CodefyUI Global Styles - Dark Theme
    ============================================================ */
 
+@import './styles/tokens.css';
+
 *,
 *::before,
 *::after {
@@ -11,8 +13,12 @@
 }
 
 html {
-  /* Responsive root font-size: scales with viewport, clamped for readability */
-  font-size: clamp(13.5px, 0.35vw + 11px, 18px);
+  /* Fixed root so every rem token in tokens.css renders at a predictable size.
+     App.tsx overrides this per the Small/Default/Large setting. This used to be
+     `clamp(13.5px, 0.35vw + 11px, 18px)`, which tied text size to window width
+     and made the smallest text shrink on exactly the laptop screens that could
+     least afford it. */
+  font-size: 16px;
 }
 
 html,
@@ -24,12 +30,12 @@ body,
 }
 
 body {
-  background-color: #121212;
-  color: #eeeeee;
+  background-color: var(--surface-app);
+  color: var(--text-secondary);
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
     Roboto, sans-serif;
-  font-size: 0.875rem;
-  line-height: 1.5;
+  font-size: var(--fs-md);
+  line-height: var(--lh-normal);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -13,12 +13,23 @@
 }
 
 html {
-  /* Fixed root so every rem token in tokens.css renders at a predictable size.
-     App.tsx overrides this per the Small/Default/Large setting. This used to be
-     `clamp(13.5px, 0.35vw + 11px, 18px)`, which tied text size to window width
-     and made the smallest text shrink on exactly the laptop screens that could
-     least afford it. */
-  font-size: 16px;
+  /* Root size for every rem token in tokens.css.
+
+     This was `clamp(13.5px, 0.35vw + 11px, 18px)`. The problem was never that
+     it scaled with the window — it was the 13.5px floor, which on a 1366px
+     laptop put the most-used size at 10.8px and, at the Small setting, put
+     0.625rem rules at 7.5px.
+
+     So the floor is raised to 16px, which is what makes the 14px body / 12px
+     secondary floors in tokens.css actually hold on a small screen, and the
+     ceiling to 19px so a large monitor gets more than the old 18px rather than
+     less. Between those it still tracks the window.
+
+     --font-scale is the Small/Default/Large control (App.tsx). It multiplies
+     rather than replacing, so the choice composes with the viewport instead of
+     overriding it — which is why Large is genuinely large on a big monitor. */
+  --font-scale: 1;
+  font-size: calc(clamp(16px, 0.35vw + 11px, 19px) * var(--font-scale));
 }
 
 html,
@@ -50,16 +61,16 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-  background: #1a1a1a;
+  background: var(--surface-raised);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #333;
+  background: var(--border-base);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #444;
+  background: var(--border-strong);
 }
 
 /* ============================================================
@@ -67,61 +78,61 @@ body {
    ============================================================ */
 
 .react-flow {
-  background: #0a0a0a;
+  background: var(--surface-canvas);
 }
 
 .react-flow__background {
-  background: #0a0a0a;
+  background: var(--surface-canvas);
 }
 
 .react-flow__edge-path {
-  stroke: #555;
+  stroke: var(--wire);
   stroke-width: 2;
 }
 
 .react-flow__edge.selected .react-flow__edge-path {
-  stroke: #888;
+  stroke: var(--wire-active);
   stroke-width: 2.5;
 }
 
 .react-flow__edge:hover .react-flow__edge-path {
-  stroke: #777;
+  stroke: var(--wire-data);
 }
 
 .react-flow__connection-path {
-  stroke: #888;
+  stroke: var(--wire-active);
   stroke-width: 2;
 }
 
 /* Controls — covers both v11 and v12 class names */
 .react-flow__controls,
 .react-flow__panel.react-flow__controls {
-  background: #1e1e1e !important;
-  border: 1px solid #333 !important;
-  border-radius: 6px !important;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4) !important;
+  background: var(--surface-raised) !important;
+  border: 1px solid var(--border-base) !important;
+  border-radius: var(--radius) !important;
+  box-shadow: var(--shadow) !important;
   overflow: hidden;
 }
 
 .react-flow__controls button,
 .react-flow__controls-button {
-  background: #1e1e1e !important;
+  background: var(--surface-raised) !important;
   border: none !important;
-  border-bottom: 1px solid #2a2a2a !important;
-  color: #aaa !important;
+  border-bottom: 1px solid var(--border-subtle) !important;
+  color: var(--text-muted) !important;
   width: 30px !important;
   height: 30px !important;
   display: flex !important;
   align-items: center !important;
   justify-content: center !important;
   cursor: pointer !important;
-  transition: background 0.15s, color 0.15s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .react-flow__controls button:hover,
 .react-flow__controls-button:hover {
-  background: #333 !important;
-  color: #fff !important;
+  background: var(--surface-hover) !important;
+  color: var(--text-primary) !important;
 }
 
 .react-flow__controls button:last-child,
@@ -143,20 +154,20 @@ body {
 
 /* MiniMap */
 .react-flow__minimap {
-  background: #1e1e1e;
-  border: 1px solid #333;
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
 }
 
 .react-flow__minimap-mask {
-  fill: rgba(0, 0, 0, 0.6);
+  fill: var(--surface-scrim);
 }
 
 /* Selection box */
 .react-flow__selection {
-  background: rgba(33, 150, 243, 0.05);
-  border: 1px solid rgba(33, 150, 243, 0.4);
+  background: var(--accent-wash);
+  border: 1px solid var(--accent-glow);
 }
 
 /* Node selection wrapper */
@@ -195,13 +206,13 @@ body {
 input:focus,
 select:focus,
 textarea:focus {
-  border-color: #2196F3 !important;
-  box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
+  border-color: var(--border-focus) !important;
+  box-shadow: var(--focus-ring);
   outline: none;
 }
 
 button:focus-visible {
-  outline: 2px solid #2196F3;
+  outline: 2px solid var(--border-focus);
   outline-offset: 2px;
 }
 
@@ -216,6 +227,13 @@ textarea {
   font-family: inherit;
 }
 
+/* Form controls do not inherit line-height from body — the UA stylesheet sets
+   `normal` on them. Left that way deliberately: every such control in this app
+   is single-line (icon buttons, chevrons, counts), so `normal` costs nothing,
+   and their height comes from the --h-control-* tokens rather than from
+   leading. Anything inside a control that can WRAP must set a line-height
+   itself; `--lh-snug` is the usual choice. */
+
 input[type='number'] {
   -moz-appearance: textfield;
 }
@@ -226,6 +244,6 @@ input[type='number']::-webkit-outer-spin-button {
 }
 
 select option {
-  background: #1e1e1e;
-  color: #ddd;
+  background: var(--surface-raised);
+  color: var(--text-secondary);
 }

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -7,11 +7,11 @@
 .root {
   width: 100vw;
   height: 100vh;
-  background: #121212; /* SURFACE.bg */
+  background: var(--surface-app);
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  color: #eeeeee; /* TEXT.primary */
+  color: var(--text-primary);
   font-family: Inter, system-ui, -apple-system, sans-serif;
 }
 
@@ -55,9 +55,8 @@
   flex-shrink: 0;
   display: flex;
   flex-direction: row;
-  background: #161616;
-  border-left: 1px solid #2a2a2a;
+  background: var(--surface-panel);
+  border-left: 1px solid var(--border-base);
   overflow: hidden;
   min-height: 0;
 }
-

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -205,40 +205,63 @@ describe('App', () => {
 
   // ── Font-size effect ────────────────────────────────────────────────────────
 
-  it('applies the small font size to the document element', () => {
+  it('applies the small font scale to the document element', () => {
+    // Small is a deliberate density trade for people who want more on screen,
+    // not an accessibility setting. It is applied as a multiplier so it
+    // composes with App.css's viewport clamp rather than replacing it.
     useUIStore.setState({ fontSize: 'small' });
     render(<App />);
-    expect(document.documentElement.style.fontSize).toBe('12px');
+    expect(
+      document.documentElement.style.getPropertyValue('--font-scale'),
+    ).toBe('0.92');
   });
 
-  it('applies the large font size to the document element', () => {
+  it('applies the large font scale to the document element', () => {
     useUIStore.setState({ fontSize: 'large' });
     render(<App />);
-    expect(document.documentElement.style.fontSize).toBe('20px');
+    expect(
+      document.documentElement.style.getPropertyValue('--font-scale'),
+    ).toBe('1.15');
   });
 
-  it('clears the inline font size for the default choice', () => {
-    // Seed a non-empty inline size first to prove the effect clears it.
-    document.documentElement.style.fontSize = '99px';
+  it('applies a neutral scale for the default choice', () => {
+    // The control used to write an absolute root px, where "default" cleared
+    // the inline style and fell through to a `clamp(13.5px, ...)` in App.css
+    // whose floor put the most-used size at 10.8px on a 1366px laptop. It is
+    // now a multiplier over a clamp floored at 16px, so default means "no
+    // adjustment" rather than "no value". Seed a different scale first to
+    // prove the effect overwrites it rather than leaving the seeded value.
+    document.documentElement.style.setProperty('--font-scale', '9');
     useUIStore.setState({ fontSize: 'default' });
     render(<App />);
-    expect(document.documentElement.style.fontSize).toBe('');
+    expect(
+      document.documentElement.style.getPropertyValue('--font-scale'),
+    ).toBe('1');
   });
 
-  it('falls back to clearing the inline size for an unknown font size value', () => {
-    document.documentElement.style.fontSize = '99px';
-    // Drive an out-of-range value to hit the `?? ''` fallback branch.
+  it('falls back to a neutral scale for an unknown font size value', () => {
+    document.documentElement.style.setProperty('--font-scale', '9');
+    // Drive an out-of-range value to hit the `?? '1'` fallback branch. It must
+    // land on 1, not on an empty string: an empty custom property would make
+    // the calc() in App.css invalid and collapse the root size.
     useUIStore.setState({ fontSize: 'weird' as never });
     render(<App />);
-    expect(document.documentElement.style.fontSize).toBe('');
+    expect(
+      document.documentElement.style.getPropertyValue('--font-scale'),
+    ).toBe('1');
   });
 
   it('reacts to font-size changes after mount', () => {
     const { rerender } = render(<App />);
-    expect(document.documentElement.style.fontSize).toBe('');
+    // beforeEach leaves fontSize at 'default', which applies a neutral scale.
+    expect(
+      document.documentElement.style.getPropertyValue('--font-scale'),
+    ).toBe('1');
     useUIStore.setState({ fontSize: 'large' });
     rerender(<App />);
-    expect(document.documentElement.style.fontSize).toBe('20px');
+    expect(
+      document.documentElement.style.getPropertyValue('--font-scale'),
+    ).toBe('1.15');
   });
 
   it('invokes the keyboard shortcuts hook on mount', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,23 +24,24 @@ import { useProjectStore } from './store/projectStore';
 import { useRunStore } from './store/runStore';
 import styles from './App.module.css';
 
-// Map the user's font-size choice onto the root element. Every size token in
-// `styles/tokens.css` is a rem, so this scales the whole app.
+// The user's font-size choice, as a multiplier on the root size. Every size
+// token in `styles/tokens.css` is a rem, so this scales the whole app.
 //
-// These used to be 12px / (unset) / 20px, where "unset" fell through to a
-// viewport-responsive `clamp(13.5px, 0.35vw + 11px, 18px)` in App.css. Two
-// problems with that: the root moved with the window, so the same UI rendered
-// at 15.8px root on a 1366px laptop and 18px on a 2560px monitor and no size
-// in the app was predictable; and at the Small setting a 0.625rem rule — of
-// which there were 38 — came out at 7.5px.
+// These used to be absolute pixel roots — 12px / (unset) / 20px — where the
+// unset "default" fell through to App.css's viewport clamp. Absolute values
+// fight the viewport instead of composing with it: a flat root that suits a
+// 1366px laptop makes a 2560px monitor render *smaller* than it did before,
+// which is the opposite of the point. A multiplier keeps the window-size
+// response and layers the preference on top.
 //
-// Fixed roots instead, with Default at the 16px browser standard. Small is a
-// deliberate density trade for people who want more on screen, not an
-// accessibility setting, and it still keeps body text at 13.1px.
-const FONT_SIZE_PX: Record<string, string> = {
-  small: '15px',
-  default: '16px',
-  large: '18px',
+// Small is a deliberate density trade for people who want more on screen, not
+// an accessibility setting. It is the one setting where the 12px secondary-text
+// floor in tokens.css does not hold — badge text lands near 10px on a small
+// window — which is the cost of asking for more on screen.
+const FONT_SCALE: Record<string, string> = {
+  small: '0.92',
+  default: '1',
+  large: '1.15',
 };
 
 function RightColumn() {
@@ -116,7 +117,10 @@ function App() {
   const fontSize = useUIStore((s) => s.fontSize);
 
   useEffect(() => {
-    document.documentElement.style.fontSize = FONT_SIZE_PX[fontSize] ?? '';
+    document.documentElement.style.setProperty(
+      '--font-scale',
+      FONT_SCALE[fontSize] ?? '1',
+    );
   }, [fontSize]);
 
   useEffect(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,14 +24,23 @@ import { useProjectStore } from './store/projectStore';
 import { useRunStore } from './store/runStore';
 import styles from './App.module.css';
 
-// Map user font-size choice to the documentElement. Setting an empty string
-// removes the inline style, letting App.css's responsive `clamp(...)` take over
-// (capped at 18px). Large jumps clearly above the clamp ceiling so the change
-// is actually visible.
+// Map the user's font-size choice onto the root element. Every size token in
+// `styles/tokens.css` is a rem, so this scales the whole app.
+//
+// These used to be 12px / (unset) / 20px, where "unset" fell through to a
+// viewport-responsive `clamp(13.5px, 0.35vw + 11px, 18px)` in App.css. Two
+// problems with that: the root moved with the window, so the same UI rendered
+// at 15.8px root on a 1366px laptop and 18px on a 2560px monitor and no size
+// in the app was predictable; and at the Small setting a 0.625rem rule — of
+// which there were 38 — came out at 7.5px.
+//
+// Fixed roots instead, with Default at the 16px browser standard. Small is a
+// deliberate density trade for people who want more on screen, not an
+// accessibility setting, and it still keeps body text at 13.1px.
 const FONT_SIZE_PX: Record<string, string> = {
-  small: '12px',
-  default: '',
-  large: '20px',
+  small: '15px',
+  default: '16px',
+  large: '18px',
 };
 
 function RightColumn() {

--- a/frontend/src/components/Canvas/EmptyCanvasOverlay.module.css
+++ b/frontend/src/components/Canvas/EmptyCanvasOverlay.module.css
@@ -18,114 +18,133 @@
   width: 90%;
   max-height: 90%;
   overflow-y: auto;
-  padding: 16px 20px;
+  padding: var(--sp-5) var(--sp-6);
   box-sizing: border-box;
 }
 
+/* The first thing a new user sees — a real heading, not faded placeholder
+   text. Was #555 at 1.25rem (2.66:1); now the primary text tier at the hero
+   size, which is what a deliberate empty state calls for. */
 .title {
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: #555;
-  margin-bottom: 6px;
+  font-size: var(--fs-3xl);
+  font-weight: var(--fw-bold);
+  line-height: var(--lh-snug);
+  color: var(--text-primary);
+  margin-bottom: var(--sp-4);
 }
 
 .subtitle {
-  font-size: 0.875rem;
-  color: #444;
-  margin-bottom: 14px;
+  font-size: var(--fs-lg);
+  line-height: var(--lh-normal);
+  color: var(--text-secondary);
+  margin-bottom: var(--sp-6);
 }
 
 /* Entry into the full gallery modal (core#128). */
 .browseButton {
-  margin-bottom: 24px;
-  padding: 6px 16px;
-  background: rgba(6, 182, 212, 0.1);
-  border: 1px solid #0e7490;
-  border-radius: 6px;
-  color: #22d3ee;
-  font-size: 0.8125rem;
-  font-weight: 600;
+  margin-bottom: var(--sp-7);
+  padding: var(--sp-3) var(--sp-5);
+  background: var(--accent-wash);
+  border: 1px solid var(--accent-dim);
+  border-radius: var(--radius);
+  color: var(--accent);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--transition-fast);
 }
 
 .browseButton:hover {
-  background: rgba(6, 182, 212, 0.22);
+  /* Stronger accent tint than --accent-wash for the hover state — no
+     "wash-strong" token exists yet, so this hand-tunes the accent hue's own
+     rgb() at a higher alpha rather than reusing the old, unrelated
+     accent-deep hue. See migration report. */
+  background: rgba(34, 211, 238, 0.22);
 }
 
 /* Quick-start preset card grid */
 .quickStartGrid {
   display: flex;
-  gap: 12px;
+  gap: var(--sp-4);
   justify-content: center;
   flex-wrap: wrap;
 }
 
 .section {
-  margin-bottom: 20px;
+  margin-bottom: var(--sp-6);
 }
 
 .sectionTitle {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: #888;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-snug);
+  color: var(--text-muted);
   text-align: left;
-  margin-bottom: 8px;
+  margin-bottom: var(--sp-3);
   letter-spacing: 0.02em;
 }
 
 /* Preset card base — hover effects (borderColor, boxShadow) applied via onMouseEnter/Leave inline */
 .presetCard {
-  background: #1e1e1e;
-  border: 1px solid #3a3a3a;
-  border-radius: 8px;
-  padding: 14px 18px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-4) var(--sp-5);
   cursor: pointer;
   width: 200px;
   text-align: left;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color var(--transition), box-shadow var(--transition);
 }
 
 .presetCardHeader {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 6px;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-3);
 }
 
 .presetCardName {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: #ddd;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-tight);
+  color: var(--text-secondary);
 }
 
 .presetCardDesc {
-  font-size: 0.6875rem;
-  color: #777;
-  line-height: 1.4;
-  margin-bottom: 8px;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  line-height: var(--lh-snug);
+  margin-bottom: var(--sp-3);
 }
 
 .presetCardFooter {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 /* Difficulty badge — bg and color are dynamic (DIFFICULTY_COLORS) — set inline */
 .difficultyBadge {
-  font-size: 0.625rem;
-  padding: 1px 5px;
-  border-radius: 3px;
-  font-weight: 600;
+  /* Hue on the border and in the fill tint (graphics, 3:1); the label is text
+     and takes the text tier. The old pattern was the hue as text on a 13%
+     alpha wash of itself, which measured 2.24:1. */
+  color: var(--text-muted);
+  border: 1px solid;
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
+  font-weight: var(--fw-semibold);
 }
 
 .nodeCount {
-  font-size: 0.625rem;
-  color: #555;
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
+  color: var(--text-muted);
 }
 
 .hint {
-  font-size: 0.75rem;
-  color: #444;
+  font-size: var(--fs-sm);
+  line-height: var(--lh-normal);
+  color: var(--text-secondary);
 }

--- a/frontend/src/components/Canvas/EmptyCanvasOverlay.test.tsx
+++ b/frontend/src/components/Canvas/EmptyCanvasOverlay.test.tsx
@@ -204,12 +204,22 @@ describe('EmptyCanvasOverlay', () => {
     render(<EmptyCanvasOverlay />);
     const card = (await screen.findByText('Hover Me')).closest('button') as HTMLButtonElement;
 
+    // Hover styling now writes the CSS custom property directly instead of
+    // a resolved literal (was '#D4A017' / '#3a3a3a'). jsdom does not
+    // evaluate var() references on `.style`, so the raw token string is
+    // what's reported here — and there's nothing to import instead: only
+    // the semantic data palettes are mirrored into theme.ts as TS
+    // constants (see theme.ts's file comment), not chrome tokens like
+    // --status-preset / --border-base.
     fireEvent.mouseEnter(card);
-    expect(card.style.borderColor).toBe('rgb(212, 160, 23)'); // #D4A017
-    expect(card.style.boxShadow).toBe('0 4px 16px rgba(212,160,23,0.15)');
+    expect(card.style.borderColor).toBe('var(--status-preset)');
+    // rgba(224,169,43,0.15) is --status-preset's own rgb() (#e0a92b) — no
+    // glow token is paired with it, so this stays a hand-tuned literal at
+    // the hue (see the component's own comment).
+    expect(card.style.boxShadow).toBe('0 4px 16px rgba(224, 169, 43, 0.15)');
 
     fireEvent.mouseLeave(card);
-    expect(card.style.borderColor).toBe('rgb(58, 58, 58)'); // #3a3a3a
+    expect(card.style.borderColor).toBe('var(--border-base)');
     expect(card.style.boxShadow).toBe('none');
   });
 

--- a/frontend/src/components/Canvas/EmptyCanvasOverlay.tsx
+++ b/frontend/src/components/Canvas/EmptyCanvasOverlay.tsx
@@ -4,7 +4,7 @@ import { openExample } from '../../utils/openExample';
 import { useUIStore } from '../../store/uiStore';
 import { listExamples } from '../../api/rest';
 import type { ExampleSummary } from '../../api/rest';
-import { EXAMPLE_CATEGORY_COLORS, EXAMPLE_CATEGORY_FALLBACK } from '../../styles/theme';
+import { EXAMPLE_CATEGORY_COLORS, EXAMPLE_CATEGORY_FALLBACK, SURFACE_RAISED, NODE_HEADER_TINT, mixColor } from '../../styles/theme';
 import styles from './EmptyCanvasOverlay.module.css';
 
 // Quick Start: pinned by path (paths are stable identifiers, robust to
@@ -101,11 +101,13 @@ function renderCard(
       onClick={() => onClick(example)}
       className={styles.presetCard}
       onMouseEnter={(e) => {
-        e.currentTarget.style.borderColor = '#D4A017';
-        e.currentTarget.style.boxShadow = '0 4px 16px rgba(212,160,23,0.15)';
+        e.currentTarget.style.borderColor = 'var(--status-preset)';
+        // rgb(224,169,43) is --status-preset's own rgb() — no glow token is
+        // paired with it, so this stays a hand-tuned literal at the hue.
+        e.currentTarget.style.boxShadow = '0 4px 16px rgba(224, 169, 43, 0.15)';
       }}
       onMouseLeave={(e) => {
-        e.currentTarget.style.borderColor = '#3a3a3a';
+        e.currentTarget.style.borderColor = 'var(--border-base)';
         e.currentTarget.style.boxShadow = 'none';
       }}
     >
@@ -120,7 +122,13 @@ function renderCard(
       <div className={styles.presetCardFooter}>
         <span
           className={styles.difficultyBadge}
-          style={{ background: `${catColor}22`, color: catColor }}
+          // Fill is the hue tinted into the card surface and the border carries
+          // the hue at full strength; the label takes the text tier. The old
+          // `${catColor}22` wash with the hue as text measured 2.24:1.
+          style={{
+            background: mixColor(SURFACE_RAISED, catColor, NODE_HEADER_TINT),
+            borderColor: catColor,
+          }}
         >
           {catLabel}
         </span>

--- a/frontend/src/components/Canvas/FlowCanvas.module.css
+++ b/frontend/src/components/Canvas/FlowCanvas.module.css
@@ -3,6 +3,6 @@
 .canvas {
   width: 100%;
   height: 100%;
-  background: #0a0a0a;
+  background: var(--surface-canvas);
   position: relative;
 }

--- a/frontend/src/components/Canvas/FlowCanvas.test.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { screen, fireEvent, act } from '@testing-library/react';
 import type { Node, Edge } from '@xyflow/react';
 import type { NodeData, NodeDefinition } from '../../types';
+import { CATEGORY_COLORS } from '../../styles/theme';
 
 // ── Capture everything <ReactFlow> receives ─────────────────────────────────
 // FlowCanvas wires ~20 handlers onto <ReactFlow>. jsdom can't drive real
@@ -178,13 +179,22 @@ describe('minimapNodeColor', () => {
   it('colors note / preset / known-category / unknown-category / missing-definition nodes', () => {
     renderCanvas();
     const color = captured.minimap.nodeColor as (n: any) => string;
+    // No note-category token exists in tokens.css (see minimapNodeColor's
+    // own comment) — kept literal, this is a decorative minimap dot.
     expect(color({ type: 'noteNode', data: {} })).toBe('#FFD700');
-    expect(color({ type: 'baseNode', data: { isPreset: true } })).toBe('#D4A017');
-    expect(color({ type: 'baseNode', data: { definition: { category: 'Training' } } })).toBe('#F44336');
-    // Unknown category falls back to the gray default.
-    expect(color({ type: 'baseNode', data: { definition: { category: 'Nonexistent' } } })).toBe('#607D8B');
+    // This is a plain function return, not a DOM style write, so there is
+    // no jsdom normalization involved — the raw CSS custom property string
+    // comes straight back.
+    expect(color({ type: 'baseNode', data: { isPreset: true } })).toBe('var(--status-preset)');
+    expect(color({ type: 'baseNode', data: { definition: { category: 'Training' } } })).toBe(
+      CATEGORY_COLORS.Training,
+    );
+    // Unknown category falls back to the (lifted-for-legibility) Utility hue.
+    expect(color({ type: 'baseNode', data: { definition: { category: 'Nonexistent' } } })).toBe(
+      CATEGORY_COLORS.Utility,
+    );
     // No definition -> category defaults to 'Utility'.
-    expect(color({ type: 'baseNode', data: {} })).toBe('#607D8B');
+    expect(color({ type: 'baseNode', data: {} })).toBe(CATEGORY_COLORS.Utility);
   });
 });
 

--- a/frontend/src/components/Canvas/FlowCanvas.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.tsx
@@ -99,11 +99,15 @@ const edgeTypes: EdgeTypes = {
 };
 
 const minimapNodeColor = (node: any) => {
+  // No note-category token exists in tokens.css (see migration report) —
+  // kept literal; this is a decorative minimap dot, not chrome text.
   if (node.type === 'noteNode') return '#FFD700';
   const data = node.data as any;
-  if (data?.isPreset) return '#D4A017';
+  if (data?.isPreset) return 'var(--status-preset)';
   const category = data?.definition?.category ?? 'Utility';
-  return CATEGORY_COLORS[category] ?? '#607D8B';
+  // Fallback used to be the raw, unlifted '#607D8B' — see the same fix in
+  // BaseNode.tsx's headerColor.
+  return CATEGORY_COLORS[category] ?? CATEGORY_COLORS.Utility;
 };
 
 
@@ -634,18 +638,18 @@ export function FlowCanvas({ tabId }: { tabId?: string } = {}) {
           proOptions={proOptions}
           deleteKeyCode="Delete"
           multiSelectionKeyCode="Shift"
-          style={{ background: '#0a0a0a' }}
+          style={{ background: 'var(--surface-canvas)' }}
           defaultEdgeOptions={{
             animated: false,
-            style: { stroke: '#555', strokeWidth: 2 },
+            style: { stroke: 'var(--wire)', strokeWidth: 2 },
           }}
-          connectionLineStyle={{ stroke: '#888', strokeWidth: 2 }}
+          connectionLineStyle={{ stroke: 'var(--wire-active)', strokeWidth: 2 }}
           zoomOnDoubleClick={false}
           snapToGrid={gridSnapEnabled}
           snapGrid={[24, 24]}
         >
           <Background
-            color="#2a2a2a"
+            color="var(--border-subtle)"
             variant={BackgroundVariant.Dots}
             gap={24}
             size={1.5}
@@ -658,8 +662,8 @@ export function FlowCanvas({ tabId }: { tabId?: string } = {}) {
             zoomable
             position="bottom-right"
             nodeColor={minimapNodeColor}
-            maskColor="rgba(0,0,0,0.7)"
-            style={{ background: '#1e1e1e' }}
+            maskColor="var(--surface-scrim)"
+            style={{ background: 'var(--surface-raised)' }}
           />
         </ReactFlow>
       </EdgeLaneProvider>

--- a/frontend/src/components/Canvas/QuickNodeSearch.module.css
+++ b/frontend/src/components/Canvas/QuickNodeSearch.module.css
@@ -1,63 +1,65 @@
 .panel {
   position: fixed;
   width: 280px;
-  background: #1a1a1a;
-  border: 1px solid #444;
-  border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-popover);
   z-index: 1000;
   overflow: hidden;
 }
 
 .input {
   width: 100%;
-  padding: 10px 12px;
-  background: #222;
+  padding: var(--sp-4);
+  background: var(--surface-input);
   border: none;
-  border-bottom: 1px solid #333;
-  color: #eee;
-  font-size: 0.875rem;
+  border-bottom: 1px solid var(--border-base);
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-tight);
   outline: none;
   box-sizing: border-box;
 }
 
 .input::placeholder {
-  color: #666;
+  color: var(--text-muted);
 }
 
 .list {
   max-height: 320px;
   overflow-y: auto;
-  padding: 4px 0;
+  padding: var(--sp-2) 0;
 }
 
 .empty {
-  padding: 16px 12px;
+  padding: var(--sp-5) var(--sp-4);
   text-align: center;
-  color: #555;
-  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-snug);
 }
 
 .item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--sp-3);
   width: 100%;
-  padding: 6px 12px;
+  padding: var(--sp-3) var(--sp-4);
   background: transparent;
   border: none;
   cursor: pointer;
   text-align: left;
   font-family: inherit;
-  transition: background 0.08s;
+  transition: background var(--transition-fast);
 }
 
 .item:hover {
-  background: #2a2a2a;
+  background: var(--surface-hover);
 }
 
 .itemSelected {
-  background: #2a2a2a;
+  background: var(--surface-hover);
 }
 
 .dot {
@@ -72,13 +74,14 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: var(--sp-1);
 }
 
 .itemName {
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: #ddd;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  line-height: var(--lh-tight);
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -86,26 +89,32 @@
 
 .presetBadge {
   display: inline-block;
-  font-size: 0.5625rem;
-  font-weight: 600;
-  color: #D4A017;
-  background: rgba(212, 160, 23, 0.15);
-  padding: 0 4px;
-  border-radius: 3px;
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-tight);
+  color: var(--status-preset);
+  background: rgba(224, 169, 43, 0.15);
+  padding: 0 var(--sp-2);
+  border-radius: var(--radius-sm);
   align-self: flex-start;
 }
 
 .itemDesc {
-  font-size: 0.6875rem;
-  color: #666;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .itemCategory {
-  font-size: 0.625rem;
-  font-weight: 600;
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-tight);
   flex-shrink: 0;
-  opacity: 0.8;
+  /* Same rule as BaseNode's .headerCategory: the label is text, so it takes
+     the text tier rather than the category hue. Was opacity: 0.8 over the
+     hue, which dimmed it below the AA margin. */
+  color: var(--text-muted);
 }

--- a/frontend/src/components/Canvas/QuickNodeSearch.test.tsx
+++ b/frontend/src/components/Canvas/QuickNodeSearch.test.tsx
@@ -142,8 +142,15 @@ describe('QuickNodeSearch', () => {
       <QuickNodeSearch screenPos={SCREEN} flowPos={FLOW} onClose={() => {}} />,
     );
     const categorySpan = getByText('Unknown');
-    // CATEGORY_COLORS has no 'Unknown' => '#607D8B' => rgb(96, 125, 139)
-    expect(categorySpan.style.color).toBe('rgb(96, 125, 139)');
+    // The label itself is no longer tinted: a hue drawn on a tint of itself
+    // cannot reach 4.5:1, so the label takes the shared text tier and the hue
+    // identifies the category through the dot instead.
+    expect(categorySpan.style.color).toBe('');
+    // CATEGORY_COLORS has no 'Unknown', so it falls back to the Utility hue
+    // every other unknown-category node uses -- not to a stale literal.
+    const dot = categorySpan.closest('button')?.querySelector('span');
+    expect(dot).toBeTruthy();
+    expect((dot as HTMLElement).style.background).toBe('rgb(128, 151, 162)');
   });
 
   it('boosts the Start node to the top when query is empty', () => {

--- a/frontend/src/components/Canvas/QuickNodeSearch.tsx
+++ b/frontend/src/components/Canvas/QuickNodeSearch.tsx
@@ -154,7 +154,7 @@ export function QuickNodeSearch({ screenPos, flowPos, onClose }: QuickNodeSearch
           const desc = r.kind === 'node'
             ? tn(r.def.node_name, 'description', r.def.description)
             : r.preset.description;
-          const color = CATEGORY_COLORS[category] ?? '#607D8B';
+          const color = CATEGORY_COLORS[category] ?? CATEGORY_COLORS.Utility;
 
           return (
             <button type="button"
@@ -169,7 +169,7 @@ export function QuickNodeSearch({ screenPos, flowPos, onClose }: QuickNodeSearch
                 {r.kind === 'preset' && <span className={styles.presetBadge}>{t('preset.badge')}</span>}
                 {desc && <span className={styles.itemDesc}>{desc}</span>}
               </div>
-              <span className={styles.itemCategory} style={{ color }}>{category}</span>
+              <span className={styles.itemCategory}>{category}</span>
             </button>
           );
         })}

--- a/frontend/src/components/Canvas/SmartDataEdge.overlap.test.tsx
+++ b/frontend/src/components/Canvas/SmartDataEdge.overlap.test.tsx
@@ -427,7 +427,7 @@ describe('trigger edges, on the real ResNet-18 / CIFAR-10 example', () => {
       </svg>,
     );
     const style = container.querySelector('path.react-flow__edge-path')?.getAttribute('style') ?? '';
-    expect(style).toContain('stroke: #22c55e');
+    expect(style).toContain('stroke: var(--flow-trigger)');
     expect(style).toContain('stroke-dasharray: 6 4');
   });
 });

--- a/frontend/src/components/Canvas/SubgraphBreadcrumb.module.css
+++ b/frontend/src/components/Canvas/SubgraphBreadcrumb.module.css
@@ -1,31 +1,32 @@
 .bar {
   position: absolute;
-  top: 8px;
+  top: var(--sp-3);
   left: 50%;
   transform: translateX(-50%);
   z-index: 6;
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--sp-1);
   max-width: 70%;
-  padding: 4px 8px;
-  border: 1px solid #333;
-  border-radius: 6px;
-  background: rgba(24, 24, 24, 0.94);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
-  font-size: 12px;
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-tight);
 }
 
 .segment {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--sp-1);
   min-width: 0;
 }
 
 .separator {
-  color: #555;
-  padding: 0 2px;
+  color: var(--text-muted);
+  padding: 0 var(--sp-1);
 }
 
 .crumb {
@@ -33,46 +34,49 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding: 2px 6px;
+  padding: var(--sp-1) var(--sp-3);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
-  color: #bbb;
-  font-size: 12px;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-tight);
   cursor: pointer;
 }
 
 .crumb:hover {
-  background: #262626;
-  color: #eee;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .current {
-  color: #2dd4bf;
+  color: var(--accent);
 }
 
 .input {
   width: 140px;
-  padding: 1px 5px;
-  border: 1px solid #2dd4bf;
-  border-radius: 4px;
-  background: #101010;
-  color: #eee;
-  font-size: 12px;
+  padding: var(--sp-1) var(--sp-2);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  color: var(--text-primary);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-tight);
 }
 
 .exit {
-  margin-left: 6px;
-  padding: 2px 8px;
-  border: 1px solid #3a3a3a;
-  border-radius: 4px;
-  background: #202020;
-  color: #ccc;
-  font-size: 11px;
+  margin-left: var(--sp-3);
+  padding: var(--sp-1) var(--sp-3);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
   cursor: pointer;
 }
 
 .exit:hover {
-  border-color: #2dd4bf;
-  color: #2dd4bf;
+  border-color: var(--accent);
+  color: var(--accent);
 }

--- a/frontend/src/components/Canvas/TriggerEdge.tsx
+++ b/frontend/src/components/Canvas/TriggerEdge.tsx
@@ -37,7 +37,7 @@ export function TriggerEdge(props: EdgeProps) {
       id={props.id}
       path={path}
       style={{
-        stroke: '#22c55e',
+        stroke: 'var(--flow-trigger)',
         strokeDasharray: '6 4',
         strokeWidth: 2,
       }}

--- a/frontend/src/components/ConfigPanel/NodeConfigPanel.module.css
+++ b/frontend/src/components/ConfigPanel/NodeConfigPanel.module.css
@@ -4,110 +4,110 @@
   width: 300px;
   flex: 1;
   min-height: 0;
-  background: #161616;
-  border-left: 1px solid #2a2a2a;
+  background: var(--surface-panel);
+  border-left: 1px solid var(--border-base);
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transition: opacity 0.2s ease;
+  transition: opacity var(--transition);
 }
 
 /* Panel header */
 .header {
-  padding: 12px 14px;
+  padding: var(--sp-4);
   flex-shrink: 0;
-  background: #1a1a1a;
+  background: var(--surface-raised);
   /* border-bottom color is dynamic (accentColor) — set as inline style */
 }
 
 .headerMeta {
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: #888;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-bold);
+  color: var(--text-muted);
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  margin-bottom: 4px;
+  margin-bottom: var(--sp-2);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .presetBadge {
-  font-size: 0.625rem;
-  background: rgba(212, 160, 23, 0.2);
-  color: #D4A017;
-  padding: 1px 5px;
-  border-radius: 3px;
-  font-weight: 600;
+  font-size: var(--fs-2xs);
+  background: var(--warning-wash);
+  color: var(--status-preset);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
+  font-weight: var(--fw-semibold);
 }
 
 .headerName {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #eee;
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
 }
 
 /* category label color is dynamic (accentColor) — set as inline style */
 .headerCategory {
-  font-size: 0.75rem;
-  margin-top: 2px;
+  font-size: var(--fs-sm);
+  margin-top: var(--sp-1);
 }
 
 .headerDescription {
-  font-size: 0.75rem;
-  color: #666;
-  margin-top: 6px;
-  line-height: 1.4;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  margin-top: var(--sp-3);
+  line-height: var(--lh-snug);
 }
 
 /* Scrollable content */
 .content {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 14px;
+  padding: var(--sp-4);
 }
 
 /* Section headers (PARAMETERS, PORTS, etc.) */
 .sectionHeader {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  color: #666;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  color: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin-bottom: 10px;
+  margin-bottom: var(--sp-4);
 }
 
 .sectionHeaderPorts {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  color: #666;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  color: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin-bottom: 8px;
+  margin-bottom: var(--sp-3);
 }
 
 .sectionHeaderExecution {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  color: #666;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  color: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin-bottom: 6px;
+  margin-bottom: var(--sp-3);
 }
 
 /* Port info rows */
 .portSubLabel {
-  font-size: 0.6875rem;
-  color: #555;
-  margin-bottom: 4px;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  margin-bottom: var(--sp-2);
 }
 
 .portRow {
-  font-size: 0.75rem;
-  color: #888;
-  padding: 2px 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  padding: var(--sp-2) 0;
   display: flex;
-  gap: 6px;
+  gap: var(--sp-3);
   align-items: center;
 }
 
@@ -116,50 +116,50 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #555;
+  background: var(--text-muted);
   flex-shrink: 0;
 }
 
 .portName {
-  color: #aaa;
+  color: var(--text-muted);
 }
 
 .portType {
-  color: #555;
-  font-size: 0.6875rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
 }
 
 .portOptional {
-  color: #444;
-  font-size: 0.625rem;
+  color: var(--text-muted);
+  font-size: var(--fs-2xs);
 }
 
 /* Preset configure section */
 .presetHint {
-  font-size: 0.75rem;
-  color: #888;
-  margin-bottom: 8px;
-  line-height: 1.4;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  margin-bottom: var(--sp-3);
+  line-height: var(--lh-snug);
 }
 
 .presetConfigureBtn {
   width: 100%;
-  padding: 8px 12px;
-  background: rgba(212, 160, 23, 0.15);
-  border: 1px solid #D4A017;
-  border-radius: 6px;
-  color: #D4A017;
-  font-size: 0.8125rem;
-  font-weight: 600;
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--warning-wash);
+  border: 1px solid var(--status-preset);
+  border-radius: var(--radius);
+  color: var(--status-preset);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
   cursor: pointer;
 }
 
 /* No-params placeholder */
 .noParams {
   text-align: center;
-  color: #444;
-  font-size: 0.8125rem;
-  padding-top: 20px;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
+  padding-top: var(--sp-6);
 }
 
 /* Param description / range hints now live in shared/NodeParamList.module.css,

--- a/frontend/src/components/ConfigPanel/NodeConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel/NodeConfigPanel.tsx
@@ -28,7 +28,7 @@ export function NodeConfigPanel() {
 
   const isPreset = selectedNode.data.isPreset;
   const category = def?.category ?? 'Utility';
-  const accentColor = isPreset ? '#D4A017' : (CATEGORY_COLORS[category] ?? '#607D8B');
+  const accentColor = isPreset ? 'var(--status-preset)' : (CATEGORY_COLORS[category] ?? 'var(--cat-utility)');
 
   return (
     <div
@@ -63,7 +63,7 @@ export function NodeConfigPanel() {
       <div className={styles.content}>
         {/* Preset: Configure button */}
         {isPreset && (
-          <div style={{ marginBottom: 16 }}>
+          <div style={{ marginBottom: 'var(--sp-5)' }}>
             <div className={styles.presetHint}>
               {t('preset.nodeCount', { count: selectedNode.data.presetDefinition?.nodes.length ?? 0 })}
             </div>
@@ -94,11 +94,11 @@ export function NodeConfigPanel() {
             PythonScript, ComposeTransform) lists what it actually has
             right now. */}
         {def && (liveInputs.length > 0 || liveOutputs.length > 0) && (
-          <div style={{ marginTop: 20 }}>
+          <div style={{ marginTop: 'var(--sp-6)' }}>
             <div className={styles.sectionHeaderPorts}>{t('config.ports')}</div>
 
             {liveInputs.length > 0 && (
-              <div style={{ marginBottom: 8 }}>
+              <div style={{ marginBottom: 'var(--sp-3)' }}>
                 <div className={styles.portSubLabel}>{t('config.inputs')}</div>
                 {liveInputs.map((inp) => (
                   <div key={inp.name} className={styles.portRow}>
@@ -130,38 +130,38 @@ export function NodeConfigPanel() {
 
         {/* Execution status */}
         {selectedNode.data.executionStatus && selectedNode.data.executionStatus !== 'idle' && (
-          <div style={{ marginTop: 20 }}>
+          <div style={{ marginTop: 'var(--sp-6)' }}>
             <div className={styles.sectionHeaderExecution}>{t('config.execution')}</div>
             <div
               style={{
-                padding: '6px 10px',
-                borderRadius: 4,
+                padding: 'var(--sp-3) var(--sp-4)',
+                borderRadius: 'var(--radius-sm)',
                 background:
                   selectedNode.data.executionStatus === 'error'
-                    ? 'rgba(244,67,54,0.1)'
+                    ? 'var(--danger-wash)'
                     : selectedNode.data.executionStatus === 'completed'
-                      ? 'rgba(76,175,80,0.1)'
+                      ? 'var(--success-wash)'
                       : selectedNode.data.executionStatus === 'cached'
-                        ? 'rgba(33,150,243,0.1)'
-                        : 'rgba(255,193,7,0.1)',
+                        ? 'var(--info-wash)'
+                        : 'var(--warning-wash)',
                 border: `1px solid ${
                   selectedNode.data.executionStatus === 'error'
-                    ? '#F44336'
+                    ? 'var(--status-error)'
                     : selectedNode.data.executionStatus === 'completed'
-                      ? '#4CAF50'
+                      ? 'var(--status-completed)'
                       : selectedNode.data.executionStatus === 'cached'
-                        ? '#2196F3'
-                        : '#FFC107'
+                        ? 'var(--status-cached)'
+                        : 'var(--status-running)'
                 }`,
-                fontSize: '0.75rem',
+                fontSize: 'var(--fs-sm)',
                 color:
                   selectedNode.data.executionStatus === 'error'
-                    ? '#F44336'
+                    ? 'var(--status-error)'
                     : selectedNode.data.executionStatus === 'completed'
-                      ? '#4CAF50'
+                      ? 'var(--status-completed)'
                       : selectedNode.data.executionStatus === 'cached'
-                        ? '#2196F3'
-                        : '#FFC107',
+                        ? 'var(--status-cached)'
+                        : 'var(--status-running)',
               }}
             >
               {selectedNode.data.executionStatus === 'error' && selectedNode.data.error

--- a/frontend/src/components/ConfigPanel/TensorGridEditor.module.css
+++ b/frontend/src/components/ConfigPanel/TensorGridEditor.module.css
@@ -1,46 +1,46 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .label {
-  font-size: 0.75rem;
-  color: #aaa;
-  font-weight: 500;
-  margin-bottom: 2px;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  font-weight: var(--fw-medium);
+  margin-bottom: var(--sp-1);
 }
 
 .hintDim {
-  font-size: 0.7rem;
-  color: #666;
-  background: #1a1a1a;
-  border: 1px dashed #2a2a2a;
-  padding: 6px 8px;
-  border-radius: 3px;
-  line-height: 1.4;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  background: var(--surface-raised);
+  border: 1px dashed var(--border-base);
+  padding: var(--sp-3);
+  border-radius: var(--radius-sm);
+  line-height: var(--lh-snug);
 }
 
 .hintDim code {
-  background: #222;
-  color: #aaa;
-  padding: 1px 4px;
-  border-radius: 2px;
-  font-size: 0.68rem;
+  background: var(--surface-input);
+  color: var(--text-muted);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-xs);
 }
 
 .hintWarn {
-  font-size: 0.7rem;
-  color: #f5a623;
-  background: rgba(245, 166, 35, 0.06);
-  border: 1px solid rgba(245, 166, 35, 0.3);
-  padding: 6px 8px;
-  border-radius: 3px;
-  line-height: 1.4;
+  font-size: var(--fs-xs);
+  color: var(--status-warning);
+  background: var(--warning-wash);
+  border: 1px solid var(--status-warning);
+  padding: var(--sp-3);
+  border-radius: var(--radius-sm);
+  line-height: var(--lh-snug);
 }
 
 .hintWarn code {
-  color: #f5a623;
+  color: var(--status-warning);
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
@@ -48,60 +48,60 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 4px;
+  gap: var(--sp-2);
 }
 
 .toolbarBtn {
-  background: #222;
-  border: 1px solid #333;
-  color: #ccc;
-  font-size: 0.68rem;
-  padding: 2px 8px;
-  border-radius: 3px;
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-sm);
   cursor: pointer;
 }
 
 .toolbarBtn:hover {
-  background: #2a2a2a;
-  border-color: #444;
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
 }
 
 .shapeBadge {
   margin-left: auto;
-  font-size: 0.65rem;
-  color: #888;
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
 .leadingRow {
   display: flex;
-  gap: 6px;
+  gap: var(--sp-3);
   flex-wrap: wrap;
 }
 
 .leadingLabel {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
-  font-size: 0.65rem;
-  color: #888;
+  gap: var(--sp-2);
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
 }
 
 .leadingSelect {
-  background: #222;
-  color: #ddd;
-  border: 1px solid #333;
-  font-size: 0.7rem;
-  padding: 1px 4px;
-  border-radius: 3px;
+  background: var(--surface-input);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-strong);
+  font-size: var(--fs-xs);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
 }
 
 .gridScroll {
   max-height: 220px;
   overflow: auto;
-  background: #0f0f0f;
-  border: 1px solid #262626;
-  border-radius: 4px;
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
 }
 
 .table {
@@ -111,16 +111,16 @@
 
 .cell {
   padding: 0;
-  border: 1px solid #1c1c1c;
+  border: 1px solid var(--border-subtle);
 }
 
 .cellInput {
   background: transparent;
   border: none;
-  color: #ddd;
-  font-size: 0.7rem;
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
   font-family: inherit;
-  padding: 3px 5px;
+  padding: var(--sp-2) var(--sp-2);
   width: 64px;
   text-align: right;
   outline: none;
@@ -134,6 +134,6 @@
 }
 
 .cellInput:focus {
-  background: #1c1c1c;
-  box-shadow: inset 0 0 0 1px rgba(255, 140, 0, 0.5);
+  background: var(--surface-panel);
+  box-shadow: inset 0 0 0 1px var(--border-focus);
 }

--- a/frontend/src/components/ContextMenu/NodeContextMenu.module.css
+++ b/frontend/src/components/ContextMenu/NodeContextMenu.module.css
@@ -10,33 +10,36 @@
 .menu {
   position: fixed;
   z-index: 1000;
-  background: #222;
-  border: 1px solid #444;
-  border-radius: 6px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
   min-width: 160px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+  box-shadow: var(--shadow-popover);
   overflow: hidden;
-  padding: 4px 0;
+  padding: var(--sp-2) 0;
 }
 
-/* Menu item base — color is dynamic (item.color) — set inline */
+/* Menu item base — color is dynamic (item.color) — set inline.
+   Padding is a single value: sp-4 all round lands the row at ~40px tall
+   (--h-control-lg), the guidance floor for menu rows. */
 .menuItem {
   display: block;
   width: 100%;
-  padding: 7px 14px;
+  padding: var(--sp-4);
   text-align: left;
   background: transparent;
   border: none;
-  font-size: 0.8125rem;
+  font-size: var(--fs-sm);
+  line-height: var(--lh-tight);
   cursor: pointer;
 }
 
 .menuItem:hover {
-  background: #2a2a2a;
+  background: var(--surface-hover);
 }
 
 .divider {
   height: 1px;
-  background: #333;
-  margin: 4px 0;
+  background: var(--border-base);
+  margin: var(--sp-2) 0;
 }

--- a/frontend/src/components/CustomNodeManager/CustomNodeManager.module.css
+++ b/frontend/src/components/CustomNodeManager/CustomNodeManager.module.css
@@ -1,7 +1,7 @@
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--surface-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -9,164 +9,167 @@
 }
 
 .modal {
-  background: #1a1a1a;
-  border: 1px solid #444;
-  border-radius: 10px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-xl);
   width: 480px;
   max-height: 70vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+  box-shadow: var(--shadow-lg);
 }
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 18px;
-  border-bottom: 1px solid #333;
+  padding: var(--sp-4) var(--sp-5);
+  border-bottom: 1px solid var(--border-base);
 }
 
 .title {
-  font-size: 1rem;
-  font-weight: 700;
-  color: #eee;
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-bold);
+  color: var(--text-primary);
   margin: 0;
 }
 
 .closeButton {
   background: none;
   border: none;
-  color: #666;
-  font-size: 1rem;
+  color: var(--text-muted);
+  font-size: var(--fs-lg);
   cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 4px;
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-sm);
 }
 
 .closeButton:hover {
-  background: #333;
-  color: #eee;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .error {
-  padding: 8px 18px;
-  background: rgba(244, 67, 54, 0.1);
-  color: #F44336;
-  font-size: 0.8125rem;
+  padding: var(--sp-3) var(--sp-5);
+  background: var(--danger-wash);
+  color: var(--status-error);
+  font-size: var(--fs-md);
 }
 
 .body {
   flex: 1;
   overflow-y: auto;
-  padding: 8px 0;
+  padding: var(--sp-3) 0;
 }
 
 .message {
-  padding: 24px 18px;
+  padding: var(--sp-7) var(--sp-5);
   text-align: center;
-  color: #666;
-  font-size: 0.875rem;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
 }
 
 .nodeRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 18px;
-  border-bottom: 1px solid #2a2a2a;
+  padding: var(--sp-4) var(--sp-5);
+  border-bottom: 1px solid var(--border-base);
 }
 
 .nodeRow:hover {
-  background: #222;
+  background: var(--surface-hover);
 }
 
 .nodeInfo {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--sp-1);
   min-width: 0;
   flex: 1;
 }
 
 .nodeFilename {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #ddd;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .nodeNames {
-  font-size: 0.75rem;
-  color: #888;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
 }
 
 .nodeActions {
   display: flex;
-  gap: 6px;
+  gap: var(--sp-3);
   flex-shrink: 0;
-  margin-left: 12px;
+  margin-left: var(--sp-4);
 }
 
 .toggleButton {
-  padding: 4px 10px;
-  border-radius: 4px;
+  padding: var(--sp-2) var(--sp-4);
+  border-radius: var(--radius-sm);
   border: 1px solid;
-  font-size: 0.6875rem;
-  font-weight: 600;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
   cursor: pointer;
   font-family: inherit;
 }
 
 .toggleOn {
-  color: #4CAF50;
-  border-color: #4CAF50;
-  background: rgba(76, 175, 80, 0.1);
+  color: var(--status-success);
+  border-color: var(--status-success);
+  background: var(--success-wash);
 }
 
 .toggleOff {
-  color: #888;
-  border-color: #555;
+  color: var(--text-muted);
+  border-color: var(--border-strong);
   background: transparent;
 }
 
 .deleteButton {
-  padding: 4px 10px;
-  border-radius: 4px;
-  border: 1px solid #555;
-  font-size: 0.6875rem;
-  font-weight: 600;
-  color: #F44336;
+  padding: var(--sp-2) var(--sp-4);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  color: var(--status-error);
   background: transparent;
   cursor: pointer;
   font-family: inherit;
 }
 
 .deleteButton:hover {
-  background: rgba(244, 67, 54, 0.1);
+  background: var(--danger-wash);
 }
 
 .footer {
-  padding: 12px 18px;
-  border-top: 1px solid #333;
+  padding: var(--sp-4) var(--sp-5);
+  border-top: 1px solid var(--border-base);
   display: flex;
   justify-content: flex-end;
 }
 
 .uploadButton {
-  padding: 6px 16px;
-  border-radius: 5px;
-  border: 1px solid #2196F3;
-  color: #2196F3;
-  background: rgba(33, 150, 243, 0.1);
-  font-size: 0.8125rem;
-  font-weight: 600;
+  padding: var(--sp-3) var(--sp-5);
+  border-radius: var(--radius);
+  border: 1px solid var(--status-info);
+  color: var(--status-info);
+  background: var(--info-wash);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
   cursor: pointer;
   font-family: inherit;
 }
 
 .uploadButton:hover {
-  background: rgba(33, 150, 243, 0.2);
+  /* rgb(106,169,255) mirrors --status-info; kept as a literal hover wash
+     since --info-wash's own alpha (0.14) is already used at rest above and
+     this hover state wants to read visibly stronger. */
+  background: rgba(106, 169, 255, 0.2);
 }

--- a/frontend/src/components/InspectorPanel/InspectorPanel.module.css
+++ b/frontend/src/components/InspectorPanel/InspectorPanel.module.css
@@ -4,8 +4,8 @@
   width: 360px;
   min-width: 36px;
   flex-shrink: 0;
-  background: #151515;
-  border-left: 1px solid #2a2a2a;
+  background: var(--surface-panel);
+  border-left: 1px solid var(--border-base);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -20,138 +20,142 @@
 
 .collapseBtn {
   position: absolute;
-  top: 8px;
-  right: 6px;
-  width: 22px;
-  height: 22px;
-  border: 1px solid #333;
-  background: #1a1a1a;
-  color: #aaa;
-  border-radius: 3px;
-  font-size: 0.7rem;
-  font-weight: 700;
+  top: var(--sp-3);
+  right: var(--sp-3);
+  width: var(--h-control-xs);
+  height: var(--h-control-xs);
+  border: 1px solid var(--border-strong);
+  background: var(--surface-raised);
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
   cursor: pointer;
   padding: 0;
   z-index: 2;
 }
 
 .collapseBtn:hover {
-  color: #eee;
-  border-color: #555;
-  background: #222;
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: var(--surface-hover);
 }
 
 .collapsedStub {
   writing-mode: vertical-rl;
   transform: rotate(180deg);
   text-align: center;
-  color: #888;
-  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
   letter-spacing: 0.12em;
-  padding-top: 36px;
+  padding-top: var(--sp-8);
   text-transform: uppercase;
   user-select: none;
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
 }
 
 .panel.collapsed .collapseBtn {
-  top: 6px;
+  top: var(--sp-3);
   right: 50%;
   transform: translateX(50%);
 }
 
 .panelHeader {
-  padding: 10px 14px;
-  background: #1a1a1a;
-  border-bottom: 2px solid rgba(6, 182, 212, 0.45);
+  padding: var(--sp-4);
+  background: var(--surface-raised);
+  border-bottom: 2px solid var(--accent-glow);
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--sp-1);
   flex-shrink: 0;
 }
 
 .panelTitle {
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: #06b6d4;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  color: var(--accent-deep);
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  line-height: var(--lh-tight);
 }
 
 .panelSubtitle {
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: #eee;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+  line-height: var(--lh-snug);
 }
 
 .segmentBadge {
-  font-size: 0.65rem;
-  font-weight: 700;
-  color: #021821;
-  background: rgba(6, 182, 212, 0.85);
-  padding: 2px 6px;
-  border-radius: 3px;
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-bold);
+  color: var(--text-on-accent);
+  background: var(--accent-deep);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-sm);
   letter-spacing: 0.08em;
   width: fit-content;
 }
 
 .segmentNames {
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: #eee;
-  margin-top: 2px;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+  margin-top: var(--sp-1);
+  line-height: var(--lh-snug);
 }
 
 .panelContent {
   flex: 1;
   overflow-y: auto;
-  padding: 10px 12px;
+  padding: var(--sp-4);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--sp-4);
 }
 
 .emptyState {
-  padding: 28px 18px;
+  padding: var(--sp-7) var(--sp-5);
   text-align: center;
-  color: #888;
-  font-size: 0.8125rem;
-  line-height: 1.5;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
+  line-height: var(--lh-normal);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: var(--sp-3);
 }
 
 .emptyIcon {
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  border: 2px dashed #333;
+  border: 2px dashed var(--border-base);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.4rem;
-  color: #666;
+  font-size: var(--fs-2xl);
+  color: var(--text-muted);
 }
 
 .emptyHint {
-  color: #666;
-  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-normal);
 }
 
 .portBlock {
-  background: #1e1e1e;
-  border: 1px solid #2a2a2a;
-  border-radius: 6px;
-  padding: 8px 10px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  padding: var(--sp-3) var(--sp-4);
 }
 
 .portHeader {
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: #888;
-  margin-bottom: 6px;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  color: var(--text-muted);
+  margin-bottom: var(--sp-3);
   letter-spacing: 0.05em;
 }
 
@@ -160,23 +164,23 @@
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  margin-right: 6px;
+  margin-right: var(--sp-3);
   vertical-align: middle;
 }
 
 .portError {
-  font-size: 0.7rem;
-  color: #f5a623;
-  background: rgba(245, 166, 35, 0.08);
-  padding: 4px 6px;
-  border-radius: 3px;
-  margin-bottom: 6px;
+  font-size: var(--fs-xs);
+  color: var(--status-warning);
+  background: var(--warning-wash);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--sp-3);
 }
 
 .diffMissing {
-  font-size: 0.75rem;
-  color: #555;
-  padding: 10px;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  padding: var(--sp-4);
 }
 
 /* ── TensorGridView ── */
@@ -184,93 +188,93 @@
 .tensorView {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--sp-2);
 }
 
 .tensorLabel {
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: #aaa;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  color: var(--text-muted);
   letter-spacing: 0.04em;
 }
 
 .tensorMeta {
-  font-size: 0.7rem;
-  color: #888;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   font-family: ui-monospace, SFMono-Regular, monospace;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .tensorShape {
-  color: #bbb;
+  color: var(--text-secondary);
 }
 
 .tensorDtype {
-  color: #777;
+  color: var(--text-muted);
 }
 
 .tensorStats {
-  color: #666;
+  color: var(--text-muted);
 }
 
 .tensorLeadingRow {
   display: flex;
-  gap: 6px;
+  gap: var(--sp-3);
   flex-wrap: wrap;
-  margin-top: 2px;
+  margin-top: var(--sp-1);
 }
 
 .tensorLeadingLabel {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
-  font-size: 0.65rem;
-  color: #888;
+  gap: var(--sp-2);
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
 }
 
 .tensorLeadingSelect {
-  background: #222;
-  color: #ddd;
-  border: 1px solid #333;
-  font-size: 0.7rem;
-  padding: 1px 4px;
-  border-radius: 3px;
+  background: var(--surface-input);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-strong);
+  font-size: var(--fs-xs);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
 }
 
 .tensorGridScroll {
   max-height: 300px;
   overflow: auto;
-  background: #0f0f0f;
-  border: 1px solid #262626;
-  border-radius: 4px;
-  margin-top: 2px;
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  margin-top: var(--sp-1);
 }
 
 .tensorTable {
   border-collapse: collapse;
   font-family: ui-monospace, SFMono-Regular, monospace;
-  font-size: 0.7rem;
+  font-size: var(--fs-xs);
 }
 
 .tensorCell {
-  padding: 3px 6px;
-  color: #ddd;
-  border: 1px solid #1c1c1c;
+  padding: var(--sp-2) var(--sp-3);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-subtle);
   text-align: right;
   min-width: 48px;
   white-space: nowrap;
 }
 
 .tensorScalar {
-  padding: 8px;
+  padding: var(--sp-3);
   font-family: ui-monospace, SFMono-Regular, monospace;
-  font-size: 0.85rem;
-  color: #ddd;
-  background: #0f0f0f;
-  border: 1px solid #262626;
-  border-radius: 4px;
+  font-size: var(--fs-md);
+  color: var(--text-secondary);
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
 }
 
 /* ── Port groups: stacked inputs then outputs (single-node and segment) ── */
@@ -278,21 +282,21 @@
 .portGroup {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .portGroupTitle {
-  font-size: 0.7rem;
-  font-weight: 700;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
   letter-spacing: 0.08em;
-  color: #06b6d4;
+  color: var(--accent-deep);
   text-transform: uppercase;
 }
 
 .portGroupEmpty {
-  font-size: 0.75rem;
-  color: #555;
-  padding: 6px 2px;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  padding: var(--sp-3) var(--sp-1);
 }
 
 /* The in→out flow divider between the two groups */
@@ -301,35 +305,35 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 3px;
-  padding: 2px 0;
+  gap: var(--sp-2);
+  padding: var(--sp-1) 0;
   user-select: none;
 }
 
 .flowLine {
   width: 1px;
   height: 8px;
-  background: #2a2a2a;
+  background: var(--border-base);
 }
 
 .flowArrow {
-  color: #06b6d4;
-  font-size: 1rem;
-  line-height: 1;
+  color: var(--accent-deep);
+  font-size: var(--fs-lg);
+  line-height: var(--lh-tight);
 }
 
 .shapeChip {
-  font-size: 0.7rem;
+  font-size: var(--fs-xs);
   font-family: ui-monospace, SFMono-Regular, monospace;
-  color: #22d3ee;
-  background: rgba(6, 182, 212, 0.09);
-  border: 1px solid #0e7490;
-  padding: 2px 8px;
-  border-radius: 3px;
+  color: var(--accent);
+  background: var(--accent-wash);
+  border: 1px solid var(--accent-dim);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-sm);
 }
 
 .portName {
-  color: #ddd;
+  color: var(--text-secondary);
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
@@ -338,51 +342,51 @@
 .tabStrip {
   display: flex;
   align-items: stretch;
-  background: #161616;
-  border-bottom: 1px solid #262626;
-  padding: 0 6px;
+  background: var(--surface-panel);
+  border-bottom: 1px solid var(--border-base);
+  padding: 0 var(--sp-3);
   flex-shrink: 0;
 }
 
 .tabBtn {
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: #777;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  color: var(--text-muted);
   letter-spacing: 0.05em;
   text-transform: uppercase;
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  padding: 6px 10px;
+  padding: var(--sp-3) var(--sp-4);
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 5px;
-  transition: color 0.15s, border-color 0.15s;
+  gap: var(--sp-2);
+  transition: color var(--transition-fast), border-color var(--transition-fast);
 }
 
 .tabBtn:hover:not(.tabDisabled) {
-  color: #bbb;
+  color: var(--text-secondary);
 }
 
 .tabActive {
-  color: #ddd;
-  border-bottom-color: #06b6d4;
+  color: var(--text-secondary);
+  border-bottom-color: var(--accent-deep);
 }
 
 .tabDisabled {
-  color: #444;
+  color: var(--text-disabled);
   cursor: not-allowed;
 }
 
 .tabBadge {
-  font-size: 0.62rem;
-  background: #222;
-  border: 1px solid #3a3a3a;
-  border-radius: 9px;
-  padding: 0 5px;
-  color: #888;
-  font-weight: 500;
+  font-size: var(--fs-2xs);
+  background: var(--surface-input);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-pill);
+  padding: 0 var(--sp-2);
+  color: var(--text-muted);
+  font-weight: var(--fw-medium);
 }
 
 /* ── StepTraceView ── */
@@ -390,91 +394,92 @@
 .stepList {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .stepCard {
-  background: #181818;
-  border: 1px solid #262626;
-  border-radius: 6px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
   overflow: hidden;
 }
 
 .stepHeader {
   width: 100%;
-  background: #1d1d1d;
+  background: var(--surface-input);
   border: none;
-  border-bottom: 1px solid #262626;
-  padding: 7px 10px;
+  border-bottom: 1px solid var(--border-base);
+  padding: var(--sp-3) var(--sp-4);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--sp-3);
   text-align: left;
   cursor: pointer;
-  color: #ddd;
+  color: var(--text-secondary);
 }
 
 .stepHeader:hover {
-  background: #232323;
+  background: var(--surface-hover);
 }
 
 .stepIndex {
-  color: #06b6d4;
-  font-weight: 700;
-  font-size: 0.78rem;
+  color: var(--accent-deep);
+  font-weight: var(--fw-bold);
+  font-size: var(--fs-sm);
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
 .stepName {
-  font-weight: 600;
-  font-size: 0.82rem;
+  font-weight: var(--fw-semibold);
+  font-size: var(--fs-sm);
   flex: 1;
+  line-height: var(--lh-tight);
 }
 
 .stepCaret {
-  color: #888;
-  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
 }
 
 .stepBody {
-  padding: 8px 10px 10px;
+  padding: var(--sp-3) var(--sp-4) var(--sp-4);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .stepDescription {
-  font-size: 0.78rem;
-  color: #bbb;
-  line-height: 1.5;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+  line-height: var(--lh-normal);
 }
 
 .stepScalars {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--sp-2);
 }
 
 .stepScalarChip {
-  font-size: 0.7rem;
+  font-size: var(--fs-xs);
   font-family: ui-monospace, SFMono-Regular, monospace;
-  background: rgba(92, 200, 255, 0.08);
-  border: 1px solid rgba(92, 200, 255, 0.25);
-  color: #5cc8ff;
-  padding: 1px 6px;
-  border-radius: 8px;
+  background: var(--info-wash);
+  border: 1px solid var(--status-info);
+  color: var(--status-info);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-pill);
 }
 
 .stepTensor {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--sp-2);
 }
 
 .stepTensorLabel {
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: #aaa;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  color: var(--text-muted);
   letter-spacing: 0.04em;
   font-family: ui-monospace, SFMono-Regular, monospace;
 }

--- a/frontend/src/components/InspectorPanel/TokenChipsView.module.css
+++ b/frontend/src/components/InspectorPanel/TokenChipsView.module.css
@@ -1,23 +1,23 @@
 .container {
-  border: 1px solid #2a2a2a;
-  border-radius: 6px;
-  background: #161616;
-  padding: 10px 12px;
-  margin-bottom: 12px;
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  background: var(--surface-panel);
+  padding: var(--sp-4);
+  margin-bottom: var(--sp-4);
 }
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 8px;
-  padding-bottom: 6px;
-  border-bottom: 1px solid #232323;
+  margin-bottom: var(--sp-3);
+  padding-bottom: var(--sp-3);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .headerLabel {
-  font-size: 11px;
-  color: #888;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -26,12 +26,12 @@
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
-  line-height: 1.6;
+  line-height: var(--lh-normal);
 }
 
 .empty {
-  padding: 16px;
-  color: #666;
-  font-size: 12px;
+  padding: var(--sp-5);
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
   font-style: italic;
 }

--- a/frontend/src/components/NodeDetailModal/CodeTab.module.css
+++ b/frontend/src/components/NodeDetailModal/CodeTab.module.css
@@ -3,78 +3,78 @@
 .tab {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 12px 14px;
+  gap: var(--sp-4);
+  padding: var(--sp-4) var(--sp-4);
 }
 
 .contract {
-  font-size: 0.6875rem;
-  line-height: 1.5;
-  color: #9ca3af;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-normal);
+  color: var(--text-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   background: rgba(0, 0, 0, 0.18);
-  border-radius: 3px;
-  padding: 7px 9px;
+  border-radius: var(--radius-sm);
+  padding: var(--sp-3);
 }
 
 .ports {
   display: flex;
-  gap: 16px;
+  gap: var(--sp-5);
   flex-wrap: wrap;
 }
 
 .side {
   flex: 1 1 220px;
   min-width: 0;
-  border: 1px solid #1f2937;
-  border-radius: 4px;
-  padding: 8px 10px;
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-3) var(--sp-4);
 }
 
 .sideHead {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding-bottom: 6px;
-  margin-bottom: 4px;
-  border-bottom: 1px solid #1f2937;
+  gap: var(--sp-3);
+  padding-bottom: var(--sp-3);
+  margin-bottom: var(--sp-2);
+  border-bottom: 1px solid var(--border-base);
 }
 
 .sideTitle {
-  font-size: 0.6875rem;
+  font-size: var(--fs-xs);
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #6b7280;
+  color: var(--text-muted);
 }
 
 .portRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  padding: 3px 0;
+  gap: var(--sp-4);
+  padding: var(--sp-2) 0;
 }
 
 .portName {
-  font-size: 0.75rem;
+  font-size: var(--fs-sm);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
 .countSelect,
 .typeSelect {
-  background: #171717;
-  color: #e5e7eb;
-  border: 1px solid #2a2a2a;
-  border-radius: 3px;
-  font-size: 0.6875rem;
-  padding: 2px 4px;
+  background: var(--surface-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-xs);
+  padding: var(--sp-1) var(--sp-2);
 }
 
 .countSelect:focus,
 .typeSelect:focus {
   outline: none;
-  border-color: #06b6d4;
+  border-color: var(--accent-deep);
 }
 
 .typeSelect {
@@ -82,16 +82,16 @@
 }
 
 .security {
-  font-size: 0.6875rem;
-  line-height: 1.5;
-  color: #6b7280;
-  border-top: 1px solid #1f2937;
-  padding-top: 8px;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-normal);
+  color: var(--text-muted);
+  border-top: 1px solid var(--border-base);
+  padding-top: var(--sp-3);
 }
 
 .empty {
-  padding: 24px;
+  padding: var(--sp-7);
   text-align: center;
-  color: #6b7280;
-  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
 }

--- a/frontend/src/components/NodeDetailModal/CodeTab.tsx
+++ b/frontend/src/components/NodeDetailModal/CodeTab.tsx
@@ -89,7 +89,7 @@ export function CodeTab({ ctx }: { ctx: NodeDetailTabContext }) {
           onChange={(e) => setCount(countParam, typesParam, Number(e.target.value))}
         >
           {Array.from({ length: SCRIPT_MAX_PORTS }, (_, i) => (
-            <option key={i + 1} value={i + 1} style={{ background: '#222' }}>
+            <option key={i + 1} value={i + 1} style={{ background: 'var(--surface-input)' }}>
               {i + 1}
             </option>
           ))}
@@ -107,7 +107,7 @@ export function CodeTab({ ctx }: { ctx: NodeDetailTabContext }) {
             onChange={(e) => setType(typesParam, ports, index, e.target.value)}
           >
             {SELECTABLE_DATA_TYPES.map((type) => (
-              <option key={type} value={type} style={{ background: '#222' }}>
+              <option key={type} value={type} style={{ background: 'var(--surface-input)' }}>
                 {type}
               </option>
             ))}

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.module.css
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.module.css
@@ -4,7 +4,7 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.68);
+  background: var(--surface-scrim);
   backdrop-filter: blur(2px);
   display: flex;
   align-items: center;
@@ -17,12 +17,10 @@
   width: 90vw;
   height: 90vh;
   min-width: 320px;
-  background: linear-gradient(180deg, #0e1520 0%, #0a0f17 100%);
-  border: 1px solid #1f2937;
-  border-radius: 10px;
-  box-shadow:
-    0 30px 70px -20px rgba(0, 0, 0, 0.8),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  background: linear-gradient(180deg, var(--surface-panel) 0%, var(--surface-canvas) 100%);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-popover), var(--inner-highlight);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -34,41 +32,41 @@
 .header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 14px;
+  gap: var(--sp-4);
+  padding: var(--sp-3) var(--sp-4);
   flex-shrink: 0;
   background: rgba(10, 15, 23, 0.72);
-  border-bottom: 2px solid #1f2937; /* color overridden inline with the accent */
+  border-bottom: 2px solid var(--border-base); /* color overridden inline with the accent */
 }
 
 .nav {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--sp-2);
   flex-shrink: 0;
 }
 
 .navBtn {
   background: transparent;
-  border: 1px solid #334155;
-  color: #cbd5e1;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
   width: 26px;
   height: 26px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 0.8125rem;
-  line-height: 1;
+  font-size: var(--fs-md);
+  line-height: var(--lh-tight);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .navBtn:hover:not(:disabled) {
-  background: rgba(6, 182, 212, 0.12);
-  border-color: #06b6d4;
-  color: #22d3ee;
+  background: var(--accent-wash);
+  border-color: var(--accent-deep);
+  color: var(--accent);
 }
 
 .navBtn:disabled {
@@ -77,8 +75,8 @@
 }
 
 .navCount {
-  color: #64748b;
-  font-size: 0.6875rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   min-width: 48px;
   text-align: center;
@@ -87,13 +85,13 @@
 .icon {
   width: 30px;
   height: 30px;
-  border-radius: 6px;
+  border-radius: var(--radius);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #0a0f17;
-  font-weight: 700;
-  font-size: 0.9375rem;
+  color: var(--text-on-accent);
+  font-weight: var(--fw-bold);
+  font-size: var(--fs-lg);
   flex-shrink: 0;
 }
 
@@ -102,18 +100,18 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--sp-1);
 }
 
 .nameBtn {
   background: transparent;
   border: 1px solid transparent;
-  color: #e5e7eb;
-  font-size: 0.9375rem;
-  font-weight: 600;
+  color: var(--text-primary);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
   padding: 1px 5px;
   margin-left: -5px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: text;
   text-align: left;
   /* Hug the name: the identity column is a stretch flex container, so without
@@ -127,19 +125,19 @@
 }
 
 .nameBtn:hover {
-  border-color: #334155;
+  border-color: var(--border-strong);
   background: rgba(255, 255, 255, 0.03);
 }
 
 .nameInput {
-  background: #0a0f17;
-  border: 1px solid #06b6d4;
-  color: #e5e7eb;
-  font-size: 0.9375rem;
-  font-weight: 600;
+  background: var(--surface-canvas);
+  border: 1px solid var(--accent-deep);
+  color: var(--text-primary);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
   padding: 1px 5px;
   margin-left: -5px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   outline: none;
   width: 100%;
   max-width: 380px;
@@ -148,76 +146,76 @@
 .meta {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--sp-3);
   flex-wrap: wrap;
 }
 
 .metaType {
-  color: #64748b;
-  font-size: 0.6875rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .categoryChip,
 .presetChip,
 .statusChip {
-  font-size: 0.625rem;
+  font-size: var(--fs-2xs);
   border: 1px solid;
-  border-radius: 9px;
-  padding: 0 6px;
-  line-height: 1.5;
+  border-radius: var(--radius-pill);
+  padding: 0 var(--sp-3);
+  line-height: var(--lh-snug);
   white-space: nowrap;
 }
 
 .presetChip {
-  font-weight: 700;
+  font-weight: var(--fw-bold);
   letter-spacing: 0.06em;
 }
 
 /* Bypassed / muted (core#128). Amber rather than red: muting is deliberate,
    not a failure — the same reading `interrupted` gets in the status palette. */
 .bypassChip {
-  font-size: 0.625rem;
-  border: 1px solid #ff8f00;
-  color: #ff8f00;
-  border-radius: 9px;
-  padding: 0 6px;
-  line-height: 1.5;
+  font-size: var(--fs-2xs);
+  border: 1px solid var(--status-interrupted);
+  color: var(--status-interrupted);
+  border-radius: var(--radius-pill);
+  padding: 0 var(--sp-3);
+  line-height: var(--lh-snug);
   white-space: nowrap;
-  font-weight: 700;
+  font-weight: var(--fw-bold);
   letter-spacing: 0.06em;
 }
 
 /* Shown only while the name editor is open, so the commit/cancel keys are
    discoverable without a tooltip. */
 .renameHint {
-  color: #64748b;
-  font-size: 0.625rem;
+  color: var(--text-muted);
+  font-size: var(--fs-2xs);
   margin-left: -5px;
 }
 
 .closeBtn {
   background: transparent;
-  border: 1px solid #334155;
-  color: #cbd5e1;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
   width: 26px;
   height: 26px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 1rem;
-  line-height: 1;
+  font-size: var(--fs-lg);
+  line-height: var(--lh-tight);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
   flex-shrink: 0;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .closeBtn:hover {
-  background: rgba(244, 67, 54, 0.14);
-  border-color: #f44336;
-  color: #ff7b72;
+  background: var(--danger-wash);
+  border-color: var(--status-error);
+  color: var(--status-error);
 }
 
 /* ── Body: params left, data right ──────────────────────────────────────── */
@@ -231,64 +229,66 @@
 .paramColumn {
   width: 320px;
   flex-shrink: 0;
-  border-right: 1px solid #1f2937;
+  border-right: 1px solid var(--border-base);
   background: rgba(0, 0, 0, 0.18);
   overflow-y: auto;
-  padding: 12px 14px;
+  padding: var(--sp-4) var(--sp-4);
 }
 
 .columnTitle {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  color: #64748b;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  color: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin-bottom: 10px;
+  margin-bottom: var(--sp-4);
 }
 
 .noParams {
-  color: #64748b;
-  font-size: 0.8125rem;
-  padding: 8px 0;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
+  padding: var(--sp-3) 0;
 }
 
 /* Preset nodes: their params live on the nodes inside, so this column offers
    the way in rather than a parameter form. Mirrors the config panel. */
 .presetBlock {
-  margin-bottom: 16px;
+  margin-bottom: var(--sp-5);
 }
 
 .presetHint {
-  font-size: 0.75rem;
-  color: #94a3b8;
-  margin-bottom: 8px;
-  line-height: 1.4;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  margin-bottom: var(--sp-3);
+  line-height: var(--lh-normal);
 }
 
 .presetConfigureBtn {
   width: 100%;
-  padding: 8px 12px;
-  background: rgba(212, 160, 23, 0.15);
-  border: 1px solid #d4a017;
-  border-radius: 6px;
-  color: #d4a017;
-  font-size: 0.8125rem;
-  font-weight: 600;
+  padding: var(--sp-3) var(--sp-4);
+  /* rgb(224,169,43) mirrors --status-preset; kept as a literal wash since no
+     --preset-wash token exists yet — see the migration report. */
+  background: rgba(224, 169, 43, 0.15);
+  border: 1px solid var(--status-preset);
+  border-radius: var(--radius);
+  color: var(--status-preset);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
   cursor: pointer;
-  transition: background 0.12s;
+  transition: background var(--transition-fast);
 }
 
 .presetConfigureBtn:hover {
-  background: rgba(212, 160, 23, 0.26);
+  background: rgba(224, 169, 43, 0.26);
 }
 
 .paramFootnote {
-  margin-top: 16px;
-  padding-top: 12px;
-  border-top: 1px solid #1f2937;
-  color: #64748b;
-  font-size: 0.75rem;
-  line-height: 1.5;
+  margin-top: var(--sp-5);
+  padding-top: var(--sp-4);
+  border-top: 1px solid var(--border-base);
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-normal);
 }
 
 .dataColumn {
@@ -300,10 +300,10 @@
 
 .tabStrip {
   display: flex;
-  gap: 2px;
+  gap: var(--sp-1);
   flex-shrink: 0;
-  padding: 6px 10px 0;
-  border-bottom: 1px solid #1f2937;
+  padding: var(--sp-3) var(--sp-4) 0;
+  border-bottom: 1px solid var(--border-base);
   overflow-x: auto;
 }
 
@@ -311,21 +311,21 @@
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  color: #64748b;
-  font-size: 0.75rem;
-  padding: 6px 12px;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  padding: var(--sp-3) var(--sp-4);
   cursor: pointer;
   white-space: nowrap;
-  transition: color 0.12s, border-color 0.12s;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
 }
 
 .tabBtn:hover {
-  color: #cbd5e1;
+  color: var(--text-secondary);
 }
 
 .tabActive {
-  color: #22d3ee;
-  border-bottom-color: #06b6d4;
+  color: var(--accent);
+  border-bottom-color: var(--accent-deep);
 }
 
 .tabPanel {
@@ -335,45 +335,45 @@
 }
 
 .tabBody {
-  padding: 12px 14px;
+  padding: var(--sp-4) var(--sp-4);
 }
 
 /* ── Capture-tab extras ─────────────────────────────────────────────────── */
 
 .warnHint {
-  background: rgba(255, 193, 7, 0.09);
-  border: 1px solid rgba(255, 193, 7, 0.35);
-  color: #ffc107;
-  border-radius: 5px;
-  padding: 6px 9px;
-  font-size: 0.75rem;
-  margin-bottom: 10px;
+  background: var(--warning-wash);
+  border: 1px solid var(--status-warning);
+  color: var(--status-warning);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-3);
+  font-size: var(--fs-sm);
+  margin-bottom: var(--sp-4);
 }
 
 .emptyState {
   text-align: center;
-  color: #64748b;
-  font-size: 0.8125rem;
-  padding: 28px 12px 20px;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
+  padding: var(--sp-8) var(--sp-4) var(--sp-6);
 }
 
 .emptyIcon {
-  font-size: 1.5rem;
-  color: #334155;
-  margin-bottom: 8px;
+  font-size: var(--fs-2xl);
+  color: var(--border-strong);
+  margin-bottom: var(--sp-3);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .emptyHint {
-  color: #64748b;
-  font-size: 0.6875rem;
-  margin-top: 6px;
-  line-height: 1.5;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  margin-top: var(--sp-3);
+  line-height: var(--lh-normal);
 }
 
 .summaryBlock {
-  border-top: 1px solid #1f2937;
-  padding-top: 10px;
+  border-top: 1px solid var(--border-base);
+  padding-top: var(--sp-4);
 }
 
 /* Charts a node emitted this run (#130), above its captured port values. */
@@ -384,38 +384,38 @@
      stretches its children by default, which left the plot stranded against
      the right edge of a full-width card. */
   align-items: flex-start;
-  gap: 8px;
-  margin-bottom: 12px;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-4);
 }
 
 .chartBlockTitle {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  color: #64748b;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  color: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .summaryTitle {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  color: #64748b;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  color: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin-bottom: 8px;
+  margin-bottom: var(--sp-3);
 }
 
 .summaryEmpty {
-  color: #64748b;
-  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
 }
 
 .summaryRow {
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 3px 0;
-  font-size: 0.75rem;
+  gap: var(--sp-3);
+  padding: var(--sp-2) 0;
+  font-size: var(--fs-sm);
 }
 
 .summaryDot {
@@ -426,14 +426,14 @@
 }
 
 .summaryName {
-  color: #cbd5e1;
+  color: var(--text-secondary);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .summaryValue {
-  color: #64748b;
+  color: var(--text-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.6875rem;
+  font-size: var(--fs-xs);
 }
 
 /* ── Docs tab ───────────────────────────────────────────────────────────── */
@@ -443,64 +443,64 @@
 }
 
 .docsSection {
-  margin-bottom: 20px;
+  margin-bottom: var(--sp-6);
 }
 
 .docsSectionTitle {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  color: #64748b;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  color: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin-bottom: 8px;
+  margin-bottom: var(--sp-3);
 }
 
 .docsDescription {
-  color: #cbd5e1;
-  font-size: 0.8125rem;
-  line-height: 1.6;
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-normal);
 }
 
 .docsEmpty {
-  color: #64748b;
-  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
 }
 
 .docsParamRow {
-  border-left: 2px solid #1f2937;
-  padding: 4px 0 4px 10px;
-  margin-bottom: 10px;
+  border-left: 2px solid var(--border-base);
+  padding: var(--sp-2) 0 var(--sp-2) var(--sp-4);
+  margin-bottom: var(--sp-4);
 }
 
 .docsParamHead {
   display: flex;
   align-items: baseline;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .docsParamName {
-  color: #e5e7eb;
-  font-size: 0.8125rem;
-  font-weight: 600;
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .docsParamType {
-  color: #06b6d4;
-  font-size: 0.625rem;
+  color: var(--accent-deep);
+  font-size: var(--fs-2xs);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .docsParamDesc {
-  color: #94a3b8;
-  font-size: 0.75rem;
-  line-height: 1.5;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-normal);
   margin-top: 2px;
 }
 
 .docsParamMeta {
-  color: #64748b;
-  font-size: 0.6875rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   margin-top: 3px;
 }
@@ -508,9 +508,9 @@
 .docsPortRow {
   display: flex;
   align-items: baseline;
-  gap: 8px;
-  padding: 3px 0;
-  font-size: 0.75rem;
+  gap: var(--sp-3);
+  padding: var(--sp-2) 0;
+  font-size: var(--fs-sm);
   flex-wrap: wrap;
 }
 
@@ -523,24 +523,24 @@
 }
 
 .docsPortName {
-  color: #cbd5e1;
+  color: var(--text-secondary);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .docsPortType {
-  color: #64748b;
-  font-size: 0.625rem;
+  color: var(--text-muted);
+  font-size: var(--fs-2xs);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .docsPortOptional {
-  color: #64748b;
-  font-size: 0.625rem;
+  color: var(--text-muted);
+  font-size: var(--fs-2xs);
 }
 
 .docsPortDesc {
-  color: #64748b;
-  font-size: 0.6875rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
 }
 
 /* Narrow viewports: stack the two columns instead of squeezing the form. */
@@ -552,7 +552,7 @@
   .paramColumn {
     width: auto;
     border-right: none;
-    border-bottom: 1px solid #1f2937;
+    border-bottom: 1px solid var(--border-base);
     max-height: 40%;
   }
 }

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
 import { ReactFlowProvider } from '@xyflow/react';
 import type { Edge, Node } from '@xyflow/react';
+import { PRESET_GOLD } from '../../styles/theme';
 import type { NodeData, NodeDefinition, OutputData, TensorOutput } from '../../types';
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
@@ -493,7 +494,7 @@ describe('NodeDetailModal — header', () => {
       nodeDetailNodeId: 'p1',
     });
     render(<NodeDetailModal />);
-    expect(screen.getByText('M')).toHaveStyle({ background: '#D4A017' });
+    expect(screen.getByText('M')).toHaveStyle({ background: PRESET_GOLD });
     expect(screen.getByText('PRESET')).toBeInTheDocument();
   });
 

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.tsx
@@ -4,7 +4,7 @@ import type { Node } from '@xyflow/react';
 import type { NodeData } from '../../types';
 import { useTabStore } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
-import { CATEGORY_COLORS, STATUS_COLORS } from '../../styles/theme';
+import { CATEGORY_COLORS, STATUS_COLORS, PRESET_GOLD } from '../../styles/theme';
 import { topologicalOrder } from '../../utils/topoOrder';
 import { MathText } from '../shared/MathText';
 import { NodeParamList } from '../shared/NodeParamList';
@@ -183,7 +183,10 @@ function NodeDetailModalBody({ nodeId }: { nodeId: string }) {
   const nodeName = def?.node_name ?? node.data.type;
   const category = def?.category ?? 'Utility';
   const isPreset = Boolean(node.data.isPreset);
-  const accent = isPreset ? '#D4A017' : (CATEGORY_COLORS[category] ?? '#607D8B');
+  // Unknown categories (plugin-defined ones) fall back to the Utility hue the
+  // rest of the app uses for them, not to a stale literal — the pre-lift
+  // '#607D8B' rendered those nodes a different colour here than on canvas.
+  const accent = isPreset ? PRESET_GOLD : (CATEGORY_COLORS[category] ?? CATEGORY_COLORS.Utility);
   const status = node.data.executionStatus ?? 'idle';
   const statusColor = STATUS_COLORS[status];
 

--- a/frontend/src/components/NodeDetailModal/StatsTab.module.css
+++ b/frontend/src/components/NodeDetailModal/StatsTab.module.css
@@ -1,35 +1,35 @@
 .group {
-  margin-bottom: 14px;
+  margin-bottom: var(--sp-4);
 }
 
 .groupTitle {
-  font-size: 10px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #6b7280;
-  margin-bottom: 6px;
+  color: var(--text-muted);
+  margin-bottom: var(--sp-3);
 }
 
 .portBlock {
-  border: 1px solid #232323;
-  border-radius: 6px;
-  background: #131313;
-  padding: 8px 10px 10px;
-  margin-bottom: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  background: var(--surface-panel);
+  padding: var(--sp-3) var(--sp-4) var(--sp-4);
+  margin-bottom: var(--sp-3);
 }
 
 /* The port an edge tooltip pointed at. A ring rather than a background so the
    block still reads as one of the list, just the one you asked for. */
 .portFocused {
-  border-color: #0e7490;
-  box-shadow: 0 0 0 1px rgba(103, 232, 249, 0.35);
+  border-color: var(--accent-dim);
+  box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.35);
 }
 
 .portHeader {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-3);
 }
 
 .portDot {
@@ -41,17 +41,17 @@
 
 .portName {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 12px;
-  color: #e5e7eb;
+  font-size: var(--fs-sm);
+  color: var(--text-primary);
 }
 
 .sampledChip {
   margin-left: auto;
-  font-size: 9px;
-  padding: 1px 6px;
-  border-radius: 999px;
-  border: 1px solid #b45309;
-  color: #fbbf24;
+  font-size: var(--fs-2xs);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--status-warning);
+  color: var(--status-warning);
   white-space: nowrap;
 }
 
@@ -60,33 +60,33 @@
 .healthRow {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-3);
 }
 
 .healthBadge {
-  font-size: 10px;
-  padding: 2px 7px;
-  border-radius: 4px;
-  background: #1b1b1b;
-  border: 1px solid #2a2a2a;
-  color: #9ca3af;
+  font-size: var(--fs-2xs);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  border: 1px solid var(--border-base);
+  color: var(--text-muted);
 }
 
 .healthBadge b {
-  color: #d1d5db;
-  font-weight: 600;
+  color: var(--text-secondary);
+  font-weight: var(--fw-semibold);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 }
 
 .healthAlert {
-  border-color: #b91c1c;
-  background: rgba(185, 28, 28, 0.16);
-  color: #fca5a5;
+  border-color: var(--status-error);
+  background: var(--danger-wash);
+  color: var(--status-error);
 }
 
 .healthAlert b {
-  color: #fecaca;
+  color: var(--status-error);
 }
 
 /* ── stat grid ────────────────────────────────────────────────────────── */
@@ -94,28 +94,28 @@
 .statGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
-  gap: 4px 10px;
+  gap: var(--sp-2) var(--sp-4);
 }
 
 .statCell,
 .quantileCell {
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: var(--sp-1);
   min-width: 0;
 }
 
 .statLabel {
-  font-size: 9px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: #6b7280;
+  color: var(--text-muted);
 }
 
 .statValue {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 11px;
-  color: #e5e7eb;
+  font-size: var(--fs-xs);
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -126,22 +126,22 @@
 .blockTitle {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 9px;
+  gap: var(--sp-2);
+  font-size: var(--fs-xs);
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #6b7280;
-  margin: 10px 0 4px;
+  color: var(--text-muted);
+  margin: var(--sp-4) 0 var(--sp-2);
 }
 
 .quantileRow {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .chartBlock {
-  margin-top: 4px;
+  margin-top: var(--sp-2);
 }
 
 .quantileBlock {
@@ -157,39 +157,39 @@
 .table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 11px;
+  font-size: var(--fs-xs);
 }
 
 .table th {
   text-align: left;
-  font-size: 9px;
+  font-size: var(--fs-xs);
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: #6b7280;
-  font-weight: 500;
-  padding: 3px 8px 3px 0;
-  border-bottom: 1px solid #262626;
+  color: var(--text-muted);
+  font-weight: var(--fw-medium);
+  padding: var(--sp-2) var(--sp-3) var(--sp-2) 0;
+  border-bottom: 1px solid var(--border-subtle);
   white-space: nowrap;
 }
 
 .table td {
-  padding: 3px 8px 3px 0;
-  border-bottom: 1px solid #1c1c1c;
-  color: #d1d5db;
+  padding: var(--sp-2) var(--sp-3) var(--sp-2) 0;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   white-space: nowrap;
 }
 
 .colName {
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .colType {
-  color: #67e8f9;
+  color: var(--accent);
 }
 
 .colMissing {
-  color: #fbbf24;
+  color: var(--status-warning);
 }
 
 .colTop {
@@ -201,19 +201,19 @@
 /* ── misc ─────────────────────────────────────────────────────────────── */
 
 .muted {
-  font-size: 11px;
-  color: #6b7280;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   font-style: italic;
 }
 
 .note {
-  font-size: 10px;
-  color: #9ca3af;
-  margin-bottom: 6px;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  margin-bottom: var(--sp-3);
 }
 
 .error {
-  font-size: 11px;
-  color: #fca5a5;
-  line-height: 1.5;
+  font-size: var(--fs-xs);
+  color: var(--status-error);
+  line-height: var(--lh-normal);
 }

--- a/frontend/src/components/Nodes/AttentionVizNode.module.css
+++ b/frontend/src/components/Nodes/AttentionVizNode.module.css
@@ -1,60 +1,64 @@
 .vizArea {
-  padding: 6px 8px 8px 8px;
-  background: #0a0f17;
-  border-top: 1px solid #1f2937;
+  padding: var(--sp-3);
+  background: var(--surface-canvas);
+  border-top: 1px solid var(--border-base);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: var(--sp-2);
 }
 
 .emptyHint {
-  font-size: 11px;
-  color: #64748b;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-normal);
+  color: var(--text-muted);
   font-style: italic;
-  padding: 18px 8px;
+  padding: var(--sp-5) var(--sp-3);
   text-align: center;
 }
 
 .tooBigHint {
-  font-size: 11px;
-  color: #94a3b8;
-  padding: 14px 8px;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-snug);
+  color: var(--text-muted);
+  padding: var(--sp-4) var(--sp-3);
   text-align: center;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--sp-3);
   align-items: center;
 }
 
 .expandLink {
   background: transparent;
-  border: 1px solid #0e7490;
-  color: #67e8f9;
-  font-size: 11px;
-  padding: 4px 10px;
-  border-radius: 4px;
+  border: 1px solid var(--accent-dim);
+  color: var(--accent);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  padding: var(--sp-2) var(--sp-4);
+  border-radius: var(--radius-sm);
   cursor: zoom-in;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  transition: background 0.12s, border-color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .expandLink:hover {
-  background: #0e7490;
-  color: #fff;
+  background: var(--accent-dim);
+  color: var(--text-primary);
 }
 
 .metaRow {
   display: flex;
   justify-content: space-between;
   width: 100%;
-  font-size: 10px;
-  color: #94a3b8;
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
+  color: var(--text-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  padding-top: 2px;
+  padding-top: var(--sp-1);
 }
 
 .metaRow > span:last-child {
-  color: #67e8f9;
+  color: var(--accent);
 }

--- a/frontend/src/components/Nodes/BaseNode.module.css
+++ b/frontend/src/components/Nodes/BaseNode.module.css
@@ -1,14 +1,14 @@
 /* ── Node container base ── */
 .node {
   position: relative;
-  background: #1e1e1e;
-  border-radius: 8px;
+  background: var(--surface-raised);
+  border-radius: var(--radius-lg);
   min-width: 160px;
-  font-size: 0.8125rem;
-  color: #eeeeee;
+  font-size: var(--fs-sm);
+  color: var(--text-primary);
   /* Dynamic border is injected via --border-color custom property */
-  border: 1px solid var(--border-color, #444444);
-  transition: border-color 0.2s, box-shadow 0.2s;
+  border: 1px solid var(--border-color, var(--border-base));
+  transition: border-color var(--transition), box-shadow var(--transition);
 }
 
 /* ── Bypassed / muted (core#128) ──
@@ -36,13 +36,16 @@
 }
 
 .bypassBadge {
-  font-size: 0.5625rem;
-  font-weight: 700;
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-bold);
+  line-height: var(--lh-tight);
   letter-spacing: 0.08em;
-  padding: 0 4px;
-  border-radius: 3px;
+  padding: 0 var(--sp-2);
+  border-radius: var(--radius-sm);
+  /* Deliberately lighter-weight than --surface-scrim (a full modal backdrop) —
+     just enough to keep the badge legible over any header hue. */
   background: rgba(0, 0, 0, 0.45);
-  color: #ffffff;
+  color: var(--text-primary);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -54,44 +57,51 @@
   left: 50%;
   transform: translateX(-50%);
   width: 240px;
-  padding: 8px 10px;
-  background: #161616;
-  border: 1px solid #444;
-  border-radius: 6px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.55);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface-panel);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
   z-index: 300;
   pointer-events: none;
 }
 
 .tooltipTitle {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: #eee;
-  margin-bottom: 4px;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-tight);
+  color: var(--text-primary);
+  margin-bottom: var(--sp-2);
 }
 
 .tooltipDesc {
-  font-size: 0.75rem;
-  color: #aaa;
-  line-height: 1.45;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  line-height: var(--lh-normal);
   white-space: normal;
   word-break: break-word;
 }
 
 /* ── Header ── */
 .header {
-  /* Dynamic: background set via inline style (headerColor from category) */
-  padding: 6px 10px;
-  border-radius: 7px 7px 0 0;
-  font-weight: 600;
-  font-size: 0.875rem;
+  /* Dynamic: background set via inline style — a tint of the category hue
+     mixed into --surface-raised (see BaseNode.tsx), not the raw hue. */
+  padding: var(--sp-3) var(--sp-4);
+  /* card radius (--radius-lg) minus the 1px card border, so the header's
+     top corners nest flush inside it. */
+  border-radius: calc(var(--radius-lg) - 1px) calc(var(--radius-lg) - 1px) 0 0;
+  font-weight: var(--fw-semibold);
+  font-size: var(--fs-md);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .headerLabel {
+  /* Inherits var(--text-primary) from .node — 9.2:1-11.7:1 on every
+     category's tinted header fill (was raw-hue-background + unconditional
+     #eeeeee, 1.85:1-2.69:1 on twelve of fourteen categories). */
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -99,48 +109,58 @@
 }
 
 .headerCategory {
-  font-size: 0.625rem;
-  opacity: 0.65;
+  /* NOT the category hue. Drawing the hue on an 18% tint of that same hue
+     caps out near 4:1 for every hue and every tint strength — it is
+     unreadable by construction, not by tuning. The category stays
+     identifiable through the accent bar (a graphic, 3:1) while the label
+     itself is ordinary text and gets the text bar. Worst case across all
+     fourteen categories: 5.11:1.
+     Before that it was opacity: 0.65 over the title colour, at 1.47-1.78:1. */
+  color: var(--text-muted);
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
   background: transparent;
-  padding: 2px 0;
-  border-radius: 3px;
+  padding: var(--sp-1) 0;
+  border-radius: var(--radius-sm);
   white-space: nowrap;
   flex-shrink: 0;
 }
 
 /* ── Ports area ── */
 .portsArea {
-  padding-top: 6px;
-  padding-bottom: 6px;
+  padding-top: var(--sp-3);
+  padding-bottom: var(--sp-3);
 }
 
 /* ── Port row ── */
 .portRowInput {
   position: relative;
-  padding: 3px 12px 3px 18px;
+  padding: var(--sp-2) var(--sp-4) var(--sp-2) var(--sp-5);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .portRowOutput {
   position: relative;
-  padding: 3px 18px 3px 12px;
+  padding: var(--sp-2) var(--sp-5) var(--sp-2) var(--sp-4);
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .portLabel {
   /* Dynamic: color set via inline style (getPortColor) */
-  font-size: 0.75rem;
-  line-height: 1;
+  font-size: var(--fs-sm);
+  /* Was line-height: 1 — the tightest value CSS allows, on every port name
+     of every node. */
+  line-height: var(--lh-tight);
 }
 
 .portOptional {
-  color: #666;
-  font-size: 0.625rem;
+  color: var(--text-muted);
+  font-size: var(--fs-2xs);
 }
 
 /* ── Port handle base ── */
@@ -148,7 +168,7 @@
 .portHandle {
   width: 10px !important;
   height: 10px !important;
-  border: 2px solid #1e1e1e !important;
+  border: 2px solid var(--surface-raised) !important;
   border-radius: 50% !important;
   cursor: crosshair !important;
 }
@@ -168,32 +188,34 @@
 /* ── Divider ── */
 .divider {
   height: 1px;
-  background: #333;
-  margin: 4px 0;
+  background: var(--border-base);
+  margin: var(--sp-2) 0;
 }
 
 /* ── Params section ── */
 .paramsSection {
-  border-top: 1px solid #333;
-  padding: 5px 10px;
+  border-top: 1px solid var(--border-base);
+  padding: var(--sp-2) var(--sp-4);
 }
 
 .paramRow {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
-  padding: 2px 0;
+  gap: var(--sp-3);
+  padding: var(--sp-1) 0;
 }
 
 .paramName {
-  font-size: 0.6875rem;
-  color: #777;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  color: var(--text-muted);
 }
 
 .paramValue {
-  font-size: 0.6875rem;
-  color: #bbb;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  color: var(--text-secondary);
   font-family: monospace;
   max-width: 120px;
   overflow: hidden;
@@ -204,74 +226,83 @@
 
 /* ── CODE param preview (core#131) ── */
 .codePreview {
-  margin: 3px 0 1px;
-  padding: 5px 6px;
-  border: 1px solid #2a2a2a;
-  border-left: 2px solid #06b6d4;
-  border-radius: 3px;
+  margin: var(--sp-2) 0 var(--sp-1);
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--border-subtle);
+  border-left: 2px solid var(--accent-deep);
+  border-radius: var(--radius-sm);
+  /* Darkening wash over the card, not a flat surface fill — no token covers
+     this (distinct role from the modal-level --surface-scrim). */
   background: rgba(0, 0, 0, 0.28);
   overflow: hidden;
 }
 
 .codePreviewLine {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.625rem;
-  line-height: 1.45;
-  color: #c8c8c8;
+  font-size: var(--fs-xs);
+  /* Single line per row (overflow hidden + ellipsis) — tight leading reads
+     fine since it can never wrap. */
+  line-height: var(--lh-tight);
+  color: var(--text-secondary);
   white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .codePreviewMore {
-  font-size: 0.5938rem;
-  color: #6b7280;
-  padding-top: 2px;
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
+  color: var(--text-muted);
+  padding-top: var(--sp-1);
 }
 
 .codePreviewEmpty {
-  font-size: 0.6875rem;
-  color: #6b7280;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  color: var(--text-muted);
   font-style: italic;
-  padding: 3px 0;
+  padding: var(--sp-2) 0;
 }
 
 /* ── Sequential subgraph section ── */
 .subgraphSection {
-  border-top: 1px solid #333;
-  padding: 6px 10px;
+  border-top: 1px solid var(--border-base);
+  padding: var(--sp-3) var(--sp-4);
   text-align: center;
 }
 
 .subgraphLayerRow {
-  font-size: 0.6875rem;
-  color: #888;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  color: var(--text-muted);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: var(--sp-2);
 }
 
 .subgraphLayerCount {
-  color: #F44336;
-  font-weight: 600;
+  color: var(--status-error);
+  font-weight: var(--fw-semibold);
 }
 
 .subgraphHint {
-  font-size: 0.5625rem;
-  color: #555;
-  margin-top: 2px;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-snug);
+  color: var(--text-muted);
+  margin-top: var(--sp-1);
 }
 
 /* ── Status footer base ── */
 .statusFooter {
-  padding: 4px 10px;
-  font-size: 0.6875rem;
-  border-top: 1px solid #333;
+  padding: var(--sp-2) var(--sp-4);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  border-top: 1px solid var(--border-base);
 }
 
 .statusError {
-  color: #F44336;
+  color: var(--status-error);
   max-width: 220px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -279,12 +310,12 @@
 }
 
 .statusRunning {
-  color: #FFC107;
+  color: var(--status-running);
   text-align: center;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .statusRunningDot {
@@ -292,26 +323,32 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #FFC107;
+  background: var(--status-running);
   animation: pulse 1s infinite;
 }
 
 .statusCompleted {
-  color: #4CAF50;
+  color: var(--status-completed);
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: var(--sp-2);
 }
 
 .downloadBtn {
-  background: #2e3d2e;
-  border: 1px solid #4CAF50;
-  border-radius: 4px;
-  color: #9fe0a1;
-  font-size: 0.6875rem;
-  padding: 3px 8px;
+  /* --success-wash exists but is paired with --status-success (a slightly
+     different green than --status-completed); this button sits inside the
+     .statusCompleted footer and stays hue-matched to that sibling text
+     instead, so the wash is hand-derived from --status-completed's own
+     rgb() rather than switching tokens. */
+  background: rgba(76, 175, 80, 0.18);
+  border: 1px solid var(--status-completed);
+  border-radius: var(--radius-sm);
+  color: var(--status-completed);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  padding: var(--sp-1) var(--sp-3);
   cursor: pointer;
   max-width: 200px;
   overflow: hidden;
@@ -321,8 +358,8 @@
 }
 
 .downloadBtn:hover:not(:disabled) {
-  background: #3c533d;
-  color: #fff;
+  background: rgba(76, 175, 80, 0.28);
+  color: var(--text-primary);
 }
 
 .downloadBtn:disabled {
@@ -331,12 +368,12 @@
 }
 
 .statusCached {
-  color: #2196F3;
+  color: var(--status-cached);
   text-align: center;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .statusCachedDot {
@@ -344,7 +381,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #2196F3;
+  background: var(--status-cached);
 }
 
 /* ── Progress bar (training) ── */
@@ -355,30 +392,35 @@
 .progressInfo {
   display: flex;
   justify-content: space-between;
-  font-size: 0.625rem;
-  margin-bottom: 3px;
-  color: #FFC107;
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
+  margin-bottom: var(--sp-2);
+  color: var(--status-running);
 }
 
 .progressBarTrack {
   width: 100%;
   height: 4px;
-  background: #333;
+  background: var(--border-base);
   border-radius: 2px;
   overflow: hidden;
 }
 
 .progressBarFill {
   height: 100%;
-  background: #FFC107;
+  background: var(--status-running);
   border-radius: 2px;
   transition: width 0.3s ease;
 }
 
 /* ── Port connection-drag highlighting ── */
 .portCompatible {
+  /* Hue matches --status-completed's rgb() exactly. --glow-running and
+     --glow-accent exist as premade glow shadows but neither is green;
+     --success-wash is green but at 0.14 alpha, too weak for this ring.
+     Kept as a hand-tuned literal, hue-matched to the border below. */
   box-shadow: 0 0 6px 2px rgba(76, 175, 80, 0.6);
-  border-color: #4CAF50 !important;
+  border-color: var(--status-completed) !important;
 }
 
 .portIncompatible {
@@ -391,8 +433,11 @@
    qualify as a compatible drop target), so it always wins there while the
    green compat glow stays on the other candidate handles. */
 .portDetaching {
-  border-color: #F44336 !important;
-  box-shadow: 0 0 0 3px rgba(244, 67, 54, 0.3), 0 0 10px 2px rgba(244, 67, 54, 0.45) !important;
+  border-color: var(--status-error) !important;
+  /* rgb(255,107,99) is --status-error's own rgb() — --danger-wash exists but
+     at 0.14 alpha, too weak for this warning ring; hand-tuned alpha keeps
+     the ring's original strength while matching the token's hue exactly. */
+  box-shadow: 0 0 0 3px rgba(255, 107, 99, 0.3), 0 0 10px 2px rgba(255, 107, 99, 0.45) !important;
 }
 
 /* ── Pulse animation (re-declared here so it is self-contained) ── */
@@ -416,17 +461,21 @@
   left: -6px !important;
   transform: rotate(45deg) !important;
   border-radius: 2px !important;
-  transition: all 0.15s ease;
+  transition: all var(--transition-fast);
 }
 
 .triggerHandleActive {
-  /* Visible when user drags from Start trigger */
+  /* Visible when user drags from Start trigger. var(--flow-trigger) is the app's
+     recurring "trigger / control-flow" green (Start node, entry-point
+     marker) — a deliberately different hue from --status-completed's green,
+     and tokens.css has no dedicated trigger-flow colour yet (see migration
+     report). */
   width: 14px !important;
   height: 14px !important;
   min-width: 14px !important;
   min-height: 14px !important;
-  background: #22c55e !important;
-  border: 2px solid #fff !important;
+  background: var(--flow-trigger) !important;
+  border: 2px solid var(--text-primary) !important;
   opacity: 1;
   pointer-events: all;
   box-shadow: 0 0 8px rgba(34, 197, 94, 0.6);
@@ -442,11 +491,12 @@
   height: 14px !important;
   min-width: 14px !important;
   min-height: 14px !important;
-  background: #1e1e1e !important;
-  border: 2px solid #F44336 !important;
+  background: var(--surface-raised) !important;
+  border: 2px solid var(--status-error) !important;
   opacity: 1;
   pointer-events: all;
-  box-shadow: 0 0 8px rgba(244, 67, 54, 0.6);
+  /* rgb(255,107,99) is --status-error's own rgb() — see .portDetaching. */
+  box-shadow: 0 0 8px rgba(255, 107, 99, 0.6);
 }
 
 /* ── Node glow when it is a valid trigger drop target ── */
@@ -458,7 +508,7 @@
 
 /* Entry point marker — applied when node is a trigger target (connected from Start) */
 .entryPoint {
-  outline: 2px solid #22c55e;
+  outline: 2px solid var(--flow-trigger);
   outline-offset: 3px;
   box-shadow: 0 0 0 5px rgba(34, 197, 94, 0.18), 0 4px 12px rgba(0, 0, 0, 0.4);
 }
@@ -470,13 +520,13 @@
   left: -10px;
   width: 18px;
   height: 18px;
-  background-color: #22c55e;
+  background-color: var(--flow-trigger);
   border-radius: 50%;
-  border: 2px solid #0a0a0a;
+  border: 2px solid var(--surface-canvas);
   background-image: url("./flag-icon.svg");
   background-size: 12px 12px;
   background-repeat: no-repeat;
   background-position: center;
-  color: #ffffff;
+  color: var(--text-primary);
   z-index: 10;
 }

--- a/frontend/src/components/Nodes/BaseNode.test.tsx
+++ b/frontend/src/components/Nodes/BaseNode.test.tsx
@@ -8,6 +8,7 @@ import { useTabStore } from '../../store/tabStore';
 import { useToastStore } from '../../store/toastStore';
 import type { NodeDefinition, NodeData } from '../../types';
 import * as rest from '../../api/rest';
+import { CATEGORY_COLORS, STATUS_COLORS, NODE_HEADER_TINT, mixColor } from '../../styles/theme';
 import BaseNode, { BaseNodeBody } from './BaseNode';
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -64,6 +65,20 @@ const flowProps = {
   selectable: true,
   deletable: true,
 } as const;
+
+/**
+ * jsdom/cssstyle normalizes ordinary color-valued CSS properties (but not
+ * custom properties like `--border-color`) to `rgb(r, g, b)` on read. Mirror
+ * that here so header-fill assertions can be computed from the real palette
+ * constants instead of a hand-copied literal.
+ */
+function hexToRgb(hex: string): string {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgb(${r}, ${g}, ${b})`;
+}
 
 function renderBody(data: NodeData, opts: { id?: string; selected?: boolean; bodyExtra?: React.ReactNode } = {}) {
   const { id = 'n1', selected = false, bodyExtra } = opts;
@@ -216,14 +231,21 @@ describe('BaseNode', () => {
   });
 
   it('falls back to Utility category color when definition has no category', () => {
-    // def.category undefined → category 'Utility'; an unknown category string
-    // would exercise the `?? '#607D8B'` fallback.
+    // def.category undefined → category 'Utility'; an unrecognised category
+    // string exercises the same `?? CATEGORY_COLORS.Utility` fallback path.
     const def = makeDef({ category: 'TotallyUnknownCat' });
     const { container } = renderBody(baseData({ definition: def }));
     expect(screen.getByText('TotallyUnknownCat')).toBeTruthy();
-    // header background falls back to #607D8B → rgb(96, 125, 139)
+    // The header is no longer painted with the raw category hue: it's that
+    // hue tinted into --surface-raised by NODE_HEADER_TINT (mixColor), which
+    // is what took every node title from 1.85:1-2.69:1 contrast up to
+    // 9.2:1-11.7:1 (see BaseNode's headerFill comment). '#242b37' mirrors
+    // --surface-raised; it's hardcoded here the same way BaseNode.tsx
+    // hardcodes it, since theme.ts only mirrors the semantic data palettes,
+    // not chrome/surface tokens (see theme.ts's file comment).
     const header = container.querySelector('[class*="header"]') as HTMLElement;
-    expect(header.style.background).toBe('rgb(96, 125, 139)');
+    const expectedFill = mixColor('#242b37', CATEGORY_COLORS.Utility, NODE_HEADER_TINT);
+    expect(header.style.background).toBe(hexToRgb(expectedFill));
   });
 
   it('renders Utility category when no definition is present', () => {
@@ -284,31 +306,42 @@ describe('BaseNode', () => {
 
   // ── Border color branches ────────────────────────────────────────────────
 
-  it('selected node gets white border + glow shadow', () => {
+  it('selected node gets the text-primary border + glow shadow', () => {
+    // The selected border used to be a hardcoded '#ffffff'; it's now
+    // var(--text-primary) (#f0f4f8, not literal white) — the same token the
+    // node's own title text uses, rather than an unrelated hardcoded white.
+    // jsdom does not resolve var() references on a custom property, so the
+    // raw token string is what `.style` reports.
     const { container } = renderBody(baseData(), { selected: true });
     const node = container.querySelector('[class*="node"]') as HTMLElement;
-    expect(node.style.getPropertyValue('--border-color')).toBe('#ffffff');
+    expect(node.style.getPropertyValue('--border-color')).toBe('var(--text-primary)');
     expect(node.style.boxShadow).toContain('rgba(255,255,255,0.15)');
   });
 
   it('unselected default node gets the default border + drop shadow', () => {
+    // Both values are now CSS custom properties rather than hardcoded
+    // literals ('#444444' / a literal rgba drop shadow) — jsdom does not
+    // resolve var() references, so the raw token strings are what render.
     const { container } = renderBody(baseData());
     const node = container.querySelector('[class*="node"]') as HTMLElement;
-    expect(node.style.getPropertyValue('--border-color')).toBe('#444444');
-    expect(node.style.boxShadow).toContain('rgba(0,0,0,0.4)');
+    expect(node.style.getPropertyValue('--border-color')).toBe('var(--border-base)');
+    expect(node.style.boxShadow).toBe('var(--shadow)');
   });
 
   it.each([
     // `--border-color` is a CSS custom property; jsdom does NOT normalize
-    // custom-prop values, so the raw hex is preserved.
-    ['running', '#FFC107'],
-    ['completed', '#4CAF50'],
-    ['error', '#F44336'],
-    ['cached', '#2196F3'],
+    // custom-prop values, so the raw hex from STATUS_COLORS is preserved
+    // verbatim (lowercase, as theme.ts defines it — theme.test.ts is the one
+    // place that pins these against tokens.css, so referencing the constant
+    // here keeps this test meaningful without duplicating that guarantee).
+    ['running', STATUS_COLORS.running],
+    ['completed', STATUS_COLORS.completed],
+    ['error', STATUS_COLORS.error],
+    ['cached', STATUS_COLORS.cached],
     // core#122: a node that stopped part-way with partial results. Without
     // its own branch it falls through to 'transparent' and looks exactly
     // like a node that never ran.
-    ['interrupted', '#FF8F00'],
+    ['interrupted', STATUS_COLORS.interrupted],
   ] as const)('uses the %s status border when unselected', (status, hex) => {
     const data = baseData({
       executionStatus: status,

--- a/frontend/src/components/Nodes/BaseNode.tsx
+++ b/frontend/src/components/Nodes/BaseNode.tsx
@@ -15,7 +15,7 @@ import { useTabStore } from '../../store/tabStore';
 import { useToastStore } from '../../store/toastStore';
 import { downloadModelFile } from '../../api/rest';
 import { useI18n } from '../../i18n';
-import { CATEGORY_COLORS, STATUS_COLORS } from '../../styles/theme';
+import { CATEGORY_COLORS, STATUS_COLORS, NODE_HEADER_TINT, mixColor, SURFACE_RAISED } from '../../styles/theme';
 import { MathText } from '../shared/MathText';
 import { subgraphIdOf } from '../../utils/subgraph';
 import styles from './BaseNode.module.css';
@@ -94,7 +94,19 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
   const liveInputs = resolveDynamicInputs(def, data.params);
   const liveOutputs = resolveDynamicOutputs(def, data.params);
   const category = def?.category ?? 'Utility';
-  const headerColor = CATEGORY_COLORS[category] ?? '#607D8B';
+  // Fallback used to be the raw, unlifted '#607D8B' — a different (dimmer)
+  // value than CATEGORY_COLORS.Utility ('#8097a2'), so an unrecognised
+  // category rendered a colour that had not been contrast-adjusted for dark
+  // surfaces. 'Utility' is the app's own fallback category one line above,
+  // so its already-lifted colour is the correct fallback here too.
+  const headerColor = CATEGORY_COLORS[category] ?? CATEGORY_COLORS.Utility;
+  // Node headers used to be painted with this raw hue, which measured
+  // 1.85:1-2.69:1 against the unconditional #eeeeee title on twelve of the
+  // fourteen categories. Tinting it into the card surface instead keeps the
+  // colour coding (the hue itself still renders at full strength as the
+  // small category label) while putting the title at 9.2:1-11.7:1 — see
+  // scripts/check-contrast.mjs.
+  const headerFill = mixColor(SURFACE_RAISED, headerColor, NODE_HEADER_TINT);
   const { t, tn } = useI18n();
 
   const isSequentialModel = data.type === 'SequentialModel';
@@ -200,10 +212,10 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
               : 'transparent';
 
   const borderColor = selected
-    ? '#ffffff'
+    ? 'var(--text-primary)'
     : statusBorderColor !== 'transparent'
       ? statusBorderColor
-      : '#444444';
+      : 'var(--border-base)';
 
   const description = def ? tn(def.node_name, 'description', def.description) : '';
 
@@ -239,9 +251,12 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
       data-bypassed={isBypassed || undefined}
       style={{
         '--border-color': borderColor,
+        // Selected glow has no matching token (a translucent-white halo,
+        // distinct from the cyan --accent-glow used for focus/selection
+        // elsewhere) — kept literal, see migration report.
         boxShadow: selected
           ? '0 0 16px rgba(255,255,255,0.15)'
-          : '0 4px 12px rgba(0,0,0,0.4)',
+          : 'var(--shadow)',
         cursor: isSequentialModel ? 'pointer' : undefined,
       } as React.CSSProperties}
     >
@@ -266,7 +281,7 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
       {/* Header */}
       <div
         className={styles.header}
-        style={{ background: headerColor }}
+        style={{ background: headerFill }}
       >
         <span className={styles.headerLabel}>
           {data.label}
@@ -276,6 +291,15 @@ export function BaseNodeBody({ id, data, selected, bodyExtra }: BaseNodeProps) {
             {t('node.bypassed')}
           </span>
         )}
+        {/* Full-strength hue on its tinted header — keeps the category
+            identifiable at a glance without the low-contrast opacity dimming
+            this used to carry (was 1.47-1.78:1). */}
+        {/* Deliberately NOT the category hue: a hue drawn on an 18% tint of
+            itself tops out near 4:1 no matter how the hue is tuned, so the
+            label was unreadable by construction. The hue identifies the
+            category through the accent bar, which is a graphic and only
+            needs 3:1; the label itself is ordinary text and gets the text
+            bar. Measured worst case across all 14 categories: 5.11:1. */}
         <span className={styles.headerCategory}>
           {category}
         </span>

--- a/frontend/src/components/Nodes/EmbeddingScatterVizNode.module.css
+++ b/frontend/src/components/Nodes/EmbeddingScatterVizNode.module.css
@@ -1,43 +1,46 @@
 .vizArea {
-  border-top: 1px solid #2a2a2a;
-  padding: 10px;
-  background: #161616;
+  border-top: 1px solid var(--border-base);
+  padding: var(--sp-4);
+  background: var(--surface-panel);
   width: 320px;
 }
 
 .emptyHint {
-  font-size: 11px;
-  color: #666;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-normal);
+  color: var(--text-muted);
   font-style: italic;
   text-align: center;
-  padding: 12px 0;
+  padding: var(--sp-4) 0;
 }
 
 .tooBigHint {
-  font-size: 11px;
-  color: #94a3b8;
-  padding: 14px 8px;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-snug);
+  color: var(--text-muted);
+  padding: var(--sp-4) var(--sp-3);
   text-align: center;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--sp-3);
   align-items: center;
 }
 
 .expandLink {
   background: transparent;
-  border: 1px solid #0e7490;
-  color: #67e8f9;
-  font-size: 11px;
-  padding: 4px 10px;
-  border-radius: 4px;
+  border: 1px solid var(--accent-dim);
+  color: var(--accent);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  padding: var(--sp-2) var(--sp-4);
+  border-radius: var(--radius-sm);
   cursor: zoom-in;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  transition: background 0.12s, border-color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .expandLink:hover {
-  background: #0e7490;
-  color: #fff;
+  background: var(--accent-dim);
+  color: var(--text-primary);
 }

--- a/frontend/src/components/Nodes/NoteNode.module.css
+++ b/frontend/src/components/Nodes/NoteNode.module.css
@@ -1,60 +1,65 @@
 .note {
   position: relative;
-  background: rgba(26, 26, 26, 0.92);
-  border-radius: 6px;
+  /* rgb(36,43,55) mirrors --surface-raised; kept translucent (a note may
+     float over other nodes/wires) since a custom property's alpha can't be
+     adjusted without color-mix(), which this migration does not introduce. */
+  background: rgba(36, 43, 55, 0.92);
+  border-radius: var(--radius);
   min-width: 120px;
   min-height: 48px;
-  font-size: 0.8125rem;
-  color: #ddd;
-  border: 1px solid #333;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  font-size: var(--fs-sm);
+  line-height: var(--lh-snug);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-base);
+  transition: border-color var(--transition), box-shadow var(--transition);
   cursor: default;
 }
 
 .note:hover {
-  border-color: #555;
+  border-color: var(--border-strong);
 }
 
 .accentBar {
   height: 3px;
-  border-radius: 6px 6px 0 0;
+  /* card radius (--radius) minus the 1px card border, so it nests flush. */
+  border-radius: calc(var(--radius) - 1px) calc(var(--radius) - 1px) 0 0;
 }
 
 .bindIcon {
   position: absolute;
-  top: 6px;
-  right: 6px;
-  font-size: 0.625rem;
-  color: #888;
+  top: var(--sp-3);
+  right: var(--sp-3);
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
   pointer-events: none;
 }
 
 /* ── Text note ── */
 .textContent {
-  padding: 8px 10px;
+  padding: var(--sp-3) var(--sp-4);
   white-space: pre-wrap;
   word-break: break-word;
-  line-height: 1.5;
-  font-size: 0.75rem;
-  color: #ccc;
+  line-height: var(--lh-normal);
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
   outline: none;
-  min-height: 28px;
+  min-height: var(--h-control-sm);
 }
 
 .textContent:empty::before {
   content: attr(data-placeholder);
-  color: #555;
+  color: var(--text-muted);
   font-style: italic;
 }
 
 .editing {
-  border-color: #666;
-  box-shadow: 0 0 0 1px #666;
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 1px var(--border-strong);
 }
 
 /* ── Image note ── */
 .imageContent {
-  padding: 6px;
+  padding: var(--sp-3);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -63,7 +68,7 @@
 
 .imageContent img {
   max-width: 100%;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   object-fit: contain;
 }
 
@@ -72,25 +77,26 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 16px 12px;
-  border: 1px dashed #444;
-  border-radius: 4px;
+  gap: var(--sp-3);
+  padding: var(--sp-5) var(--sp-4);
+  border: 1px dashed var(--border-base);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  color: #666;
-  font-size: 0.6875rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-snug);
   width: 100%;
   min-height: 60px;
-  transition: border-color 0.15s;
+  transition: border-color var(--transition-fast);
 }
 
 .imagePlaceholder:hover {
-  border-color: #888;
-  color: #aaa;
+  border-color: var(--border-strong);
+  color: var(--text-muted);
 }
 
 .imagePlaceholderIcon {
-  font-size: 1.25rem;
+  font-size: var(--fs-2xl);
 }
 
 /* ── Resize handle ── */
@@ -102,7 +108,7 @@
   height: 12px;
   cursor: nwse-resize;
   opacity: 0;
-  transition: opacity 0.15s;
+  transition: opacity var(--transition-fast);
 }
 
 .note:hover .resizeHandle {
@@ -112,10 +118,10 @@
 .resizeHandle::after {
   content: "";
   position: absolute;
-  bottom: 3px;
-  right: 3px;
+  bottom: var(--sp-2);
+  right: var(--sp-2);
   width: 6px;
   height: 6px;
-  border-right: 1.5px solid #666;
-  border-bottom: 1.5px solid #666;
+  border-right: 1.5px solid var(--border-strong);
+  border-bottom: 1.5px solid var(--border-strong);
 }

--- a/frontend/src/components/Nodes/PresetNode.module.css
+++ b/frontend/src/components/Nodes/PresetNode.module.css
@@ -1,25 +1,29 @@
 /* PresetNode.module.css */
 
 .node {
-  background: #1e1e1e;
-  border-radius: 8px;
+  background: var(--surface-raised);
+  border-radius: var(--radius-lg);
   min-width: 180px;
-  font-size: 0.8125rem;
-  color: #eeeeee;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  font-size: var(--fs-sm);
+  color: var(--text-primary);
+  transition: border-color var(--transition), box-shadow var(--transition);
 }
 
-/* Gold gradient header */
+/* Gold gradient header — PresetNode's own fixed brand treatment, not a
+   category hue, so it is not part of the mixColor/--surface-raised tint fix
+   applied to BaseNode's headers. Dark-on-gold text below is its own
+   contrast pair and is not part of the dark-surface token system. */
 .header {
   background: linear-gradient(135deg, #B8860B, #D4A017, #C5941A);
-  padding: 6px 10px;
-  border-radius: 7px 7px 0 0;
-  font-weight: 600;
-  font-size: 0.875rem;
+  padding: var(--sp-3) var(--sp-4);
+  /* card radius (--radius-lg) minus the 1px card border, so it nests flush. */
+  border-radius: calc(var(--radius-lg) - 1px) calc(var(--radius-lg) - 1px) 0 0;
+  font-weight: var(--fw-semibold);
+  font-size: var(--fs-md);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .headerLabel {
@@ -31,77 +35,81 @@
 }
 
 .headerBadge {
-  font-size: 0.625rem;
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
   background: rgba(0, 0, 0, 0.3);
-  padding: 2px 5px;
-  border-radius: 3px;
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
   white-space: nowrap;
   flex-shrink: 0;
-  color: #fff;
-  font-weight: 700;
+  color: var(--text-primary);
+  font-weight: var(--fw-bold);
   letter-spacing: 0.05em;
 }
 
 /* Ports area */
 .portsArea {
-  padding-top: 6px;
-  padding-bottom: 6px;
+  padding-top: var(--sp-3);
+  padding-bottom: var(--sp-3);
 }
 
 .inputRow {
   position: relative;
-  padding: 3px 12px 3px 18px;
+  padding: var(--sp-2) var(--sp-4) var(--sp-2) var(--sp-5);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .outputRow {
   position: relative;
-  padding: 3px 18px 3px 12px;
+  padding: var(--sp-2) var(--sp-5) var(--sp-2) var(--sp-4);
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .portLabel {
-  font-size: 0.75rem;
-  line-height: 1;
+  font-size: var(--fs-sm);
+  /* Was line-height: 1 — same bug as BaseNode's .portLabel. */
+  line-height: var(--lh-tight);
 }
 
 .portDivider {
   height: 1px;
-  background: #333;
-  margin: 4px 0;
+  background: var(--border-base);
+  margin: var(--sp-2) 0;
 }
 
 /* Footer: node count hint */
 .footer {
-  border-top: 1px solid #333;
-  padding: 5px 10px;
-  font-size: 0.6875rem;
-  color: #888;
+  border-top: 1px solid var(--border-base);
+  padding: var(--sp-2) var(--sp-4);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  color: var(--text-muted);
   text-align: center;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: var(--sp-2);
 }
 
 .footerCount {
-  color: #D4A017;
+  color: var(--status-preset);
 }
 
 /* Status sections */
 .statusBase {
-  padding: 4px 10px;
-  font-size: 0.6875rem;
-  border-top: 1px solid #333;
+  padding: var(--sp-2) var(--sp-4);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-tight);
+  border-top: 1px solid var(--border-base);
 }
 
 .statusError {
-  color: #F44336;
+  color: var(--status-error);
   max-width: 220px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -109,12 +117,12 @@
 }
 
 .statusRunning {
-  color: #FFC107;
+  color: var(--status-running);
   text-align: center;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .statusRunningDot {
@@ -122,16 +130,16 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #FFC107;
+  background: var(--status-running);
   animation: pulse 1s infinite;
 }
 
 .statusCompleted {
-  color: #4CAF50;
+  color: var(--status-completed);
   text-align: center;
 }
 
 .statusCached {
-  color: #2196F3;
+  color: var(--status-cached);
   text-align: center;
 }

--- a/frontend/src/components/Nodes/PresetNode.test.tsx
+++ b/frontend/src/components/Nodes/PresetNode.test.tsx
@@ -6,7 +6,23 @@ import { useI18n } from '../../i18n';
 import { useUIStore } from '../../store/uiStore';
 import { useTabStore } from '../../store/tabStore';
 import type { NodeDefinition, NodeData, PresetDefinition } from '../../types';
+import { STATUS_COLORS } from '../../styles/theme';
 import PresetNode from './PresetNode';
+
+/**
+ * jsdom/cssstyle normalizes ordinary color-valued CSS properties (like the
+ * `border` shorthand) to `rgb(r, g, b)` on read, but leaves custom
+ * properties and var() references untouched. Mirror that here so the status
+ * border assertions can be computed from STATUS_COLORS instead of a
+ * hand-copied literal.
+ */
+function hexToRgb(hex: string): string {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgb(${r}, ${g}, ${b})`;
+}
 
 function makeDef(overrides: Partial<NodeDefinition> = {}): NodeDefinition {
   return {
@@ -132,30 +148,42 @@ describe('PresetNode', () => {
   });
 
   // ── Border branches ──
-  it('selected node gets white border + gold glow', () => {
+  it('selected node gets the text-primary border + gold glow', () => {
+    // The selected border used to be a hardcoded '#ffffff'; it's now
+    // var(--text-primary) (#f0f4f8), the same token BaseNode's selected
+    // border uses. jsdom does not resolve var() references embedded in a
+    // border shorthand, so the raw token string is what `.style` reports.
     const { container } = renderPreset(presetData(), { selected: true });
     const node = container.querySelector('[class*="node"]') as HTMLElement;
-    // jsdom normalizes the border shorthand color #ffffff → rgb(255, 255, 255).
-    expect(node.style.border).toBe('1px solid rgb(255, 255, 255)');
-    expect(node.style.boxShadow).toContain('rgba(212,160,23,0.3)');
+    expect(node.style.border).toBe('1px solid var(--text-primary)');
+    // rgba(224,169,43,0.3) is --status-preset's own rgb() (#e0a92b) — no
+    // glow token is paired with it, so PresetNode keeps this as a
+    // hand-tuned literal at the hue (see PresetNode's own comment).
+    expect(node.style.boxShadow).toContain('rgba(224, 169, 43, 0.3)');
   });
 
   it('unselected idle node uses the gold default border', () => {
     const { container } = renderPreset(presetData());
     const node = container.querySelector('[class*="node"]') as HTMLElement;
-    // #6B5B00 → rgb(107, 91, 0)
+    // #6B5B00 → rgb(107, 91, 0). No canonical "dim preset" token exists yet
+    // (see PresetNode's borderColor comment), so this stays a literal.
     expect(node.style.border).toBe('1px solid rgb(107, 91, 0)');
-    expect(node.style.boxShadow).toContain('rgba(0,0,0,0.4)');
+    // The idle drop shadow is now the shared var(--shadow) token rather
+    // than a hardcoded rgba literal; jsdom does not resolve var().
+    expect(node.style.boxShadow).toBe('var(--shadow)');
   });
 
   it.each([
-    ['running', 'rgb(255, 193, 7)'],
-    ['completed', 'rgb(76, 175, 80)'],
-    ['error', 'rgb(244, 67, 54)'],
-    ['cached', 'rgb(33, 150, 243)'],
+    // Sourced from STATUS_COLORS (theme.test.ts pins these against
+    // tokens.css) rather than hand-copied literals, so this can't silently
+    // drift from the palette the way the old hardcoded rgb() values did.
+    ['running', hexToRgb(STATUS_COLORS.running)],
+    ['completed', hexToRgb(STATUS_COLORS.completed)],
+    ['error', hexToRgb(STATUS_COLORS.error)],
+    ['cached', hexToRgb(STATUS_COLORS.cached)],
     // core#122: a preset settles 'interrupted' when an internal node stopped
     // early — it must never roll up to the green 'completed'.
-    ['interrupted', 'rgb(255, 143, 0)'],
+    ['interrupted', hexToRgb(STATUS_COLORS.interrupted)],
   ] as const)('uses the %s status border when unselected', (status, rgb) => {
     const { container } = renderPreset(
       presetData({ executionStatus: status, error: status === 'error' ? 'x' : undefined }),

--- a/frontend/src/components/Nodes/PresetNode.tsx
+++ b/frontend/src/components/Nodes/PresetNode.tsx
@@ -78,10 +78,13 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
               : 'transparent';
 
   const borderColor = selected
-    ? '#ffffff'
+    ? 'var(--text-primary)'
     : statusBorderColor !== 'transparent'
       ? statusBorderColor
-      : '#6B5B00';
+      : // Deliberately dimmer than --status-preset (an idle unselected
+        // border, not the badge/text gold) — no "dim preset" token exists
+        // yet, see migration report.
+        '#6B5B00';
 
   const handleClick = (e: React.MouseEvent) => {
     if (e.detail === 2) {
@@ -95,9 +98,11 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
       className={`${styles.node}${isTriggerTarget ? ` ${baseStyles.entryPoint}` : ''}${isDraggingTrigger ? ` ${baseStyles.triggerDropTarget}` : ''}`}
       style={{
         border: `1px solid ${borderColor}`,
+        // rgb(224,169,43) is --status-preset's own rgb() — no glow token is
+        // paired with it, so this stays a hand-tuned literal at the hue.
         boxShadow: selected
-          ? '0 0 16px rgba(212,160,23,0.3)'
-          : '0 4px 12px rgba(0,0,0,0.4)',
+          ? '0 0 16px rgba(224, 169, 43, 0.3)'
+          : 'var(--shadow)',
       }}
     >
       {/* Trigger target handle — hidden until user drags from Start */}
@@ -135,7 +140,7 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
                 background: getPortColor(input.data_type),
                 width: 10,
                 height: 10,
-                border: '2px solid #1e1e1e',
+                border: '2px solid var(--surface-raised)',
                 left: -5.5,
                 top: '50%',
                 transform: 'translateY(-50%)',
@@ -179,7 +184,7 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
                 background: getPortColor(output.data_type),
                 width: 10,
                 height: 10,
-                border: '2px solid #1e1e1e',
+                border: '2px solid var(--surface-raised)',
                 right: -5.5,
                 top: '50%',
                 transform: 'translateY(-50%)',

--- a/frontend/src/components/Nodes/StartNode.module.css
+++ b/frontend/src/components/Nodes/StartNode.module.css
@@ -1,18 +1,25 @@
 .startNode {
-  background: linear-gradient(135deg, #16a34a, #22c55e);
-  border-radius: 20px;
-  padding: 8px 16px;
+  /* var(--flow-trigger-deep)/var(--flow-trigger) is the app's recurring "trigger / control-flow" green —
+     see BaseNode.module.css's .triggerHandleActive comment; no token covers
+     it yet (see migration report). */
+  background: linear-gradient(135deg, var(--flow-trigger-deep), var(--flow-trigger));
+  /* >= half the node's own height, so this is already a full pill shape;
+     the pill radius token produces the identical result and stays correct
+     if the padding/font-size ever change. */
+  border-radius: var(--radius-pill);
+  padding: var(--sp-3) var(--sp-5);
   display: flex;
   align-items: center;
-  gap: 6px;
-  color: #ffffff;
-  font-weight: 600;
-  font-size: 13px;
+  gap: var(--sp-3);
+  color: var(--text-primary);
+  font-weight: var(--fw-semibold);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-tight);
   min-width: 80px;
   position: relative;
-  box-shadow: 0 0 0 5px rgba(34, 197, 94, 0.18), 0 4px 12px rgba(0, 0, 0, 0.4);
-  outline: 2px solid #22c55e;
-  outline-offset: 3px;
+  box-shadow: 0 0 0 5px rgba(34, 197, 94, 0.18), var(--shadow);
+  outline: 2px solid var(--flow-trigger);
+  outline-offset: var(--sp-2);
 }
 
 .icon {
@@ -22,10 +29,10 @@
 }
 
 .handle {
-  background: #22c55e !important;
+  background: var(--flow-trigger) !important;
   width: 12px !important;
   height: 12px !important;
-  border: 2px solid #ffffff !important;
+  border: 2px solid var(--text-primary) !important;
   border-radius: 0 !important;
   transform: rotate(45deg) !important;
 }
@@ -34,6 +41,8 @@
    (edge reconnect drag in progress). Declared after .handle so its
    border-color wins the cascade. */
 .handleDetaching {
-  border-color: #F44336 !important;
-  box-shadow: 0 0 0 3px rgba(244, 67, 54, 0.3), 0 0 10px 2px rgba(244, 67, 54, 0.45);
+  border-color: var(--status-error) !important;
+  /* rgb(255,107,99) is --status-error's own rgb() — see BaseNode's
+     .portDetaching for why this stays a hand-tuned literal. */
+  box-shadow: 0 0 0 3px rgba(255, 107, 99, 0.3), 0 0 10px 2px rgba(255, 107, 99, 0.45);
 }

--- a/frontend/src/components/Nodes/SubgraphInstanceNode.module.css
+++ b/frontend/src/components/Nodes/SubgraphInstanceNode.module.css
@@ -2,20 +2,24 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 4px 10px 6px;
-  font-size: 10px;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-4) var(--sp-3);
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
 }
 
 .badge {
-  padding: 1px 6px;
-  border: 1px solid rgba(45, 212, 191, 0.5);
-  border-radius: 3px;
-  color: #2dd4bf;
+  padding: var(--sp-1) var(--sp-3);
+  /* #2dd4bf was one of the app's unresolved ad hoc teals (see the
+     --cd-accent fallback pattern noted in the migration contract);
+     --accent-glow is the same hue family at a near-identical 0.45 alpha. */
+  border: 1px solid var(--accent-glow);
+  border-radius: var(--radius-sm);
+  color: var(--accent);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 .count {
-  color: #888;
+  color: var(--text-muted);
 }

--- a/frontend/src/components/Nodes/TextInputVizNode.module.css
+++ b/frontend/src/components/Nodes/TextInputVizNode.module.css
@@ -1,7 +1,7 @@
 .editorArea {
-  border-top: 1px solid #2a2a2a;
-  padding: 8px 10px;
-  background: #161616;
+  border-top: 1px solid var(--border-base);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface-panel);
   width: 280px;
 }
 
@@ -11,26 +11,29 @@
   max-height: 320px;
   resize: vertical;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 12px;
-  line-height: 1.4;
-  background: #0e0e0e;
-  color: #eee;
-  border: 1px solid #2a2a2a;
-  border-radius: 4px;
-  padding: 6px 8px;
+  font-size: var(--fs-sm);
+  line-height: var(--lh-snug);
+  background: var(--surface-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-3);
   outline: none;
   box-sizing: border-box;
 }
 
 .textarea:focus {
-  border-color: #06b6d4;
+  border-color: var(--accent-deep);
+  /* rgb(6,182,212) is --accent-deep's own rgb() — no wash token is paired
+     with --accent-deep specifically (--accent-wash is tied to --accent). */
   box-shadow: 0 0 0 1px rgba(6, 182, 212, 0.25);
 }
 
 .meta {
-  margin-top: 4px;
-  font-size: 10px;
-  color: #888;
+  margin-top: var(--sp-2);
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
+  color: var(--text-muted);
   text-align: right;
   font-variant-numeric: tabular-nums;
 }

--- a/frontend/src/components/Nodes/TokenizerVizNode.module.css
+++ b/frontend/src/components/Nodes/TokenizerVizNode.module.css
@@ -1,7 +1,7 @@
 .vizArea {
-  border-top: 1px solid #2a2a2a;
-  padding: 8px 10px;
-  background: #161616;
+  border-top: 1px solid var(--border-base);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface-panel);
   max-width: 320px;
 }
 
@@ -9,11 +9,11 @@
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
-  line-height: 1.5;
+  line-height: var(--lh-normal);
   max-height: 140px;
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-color: #444 transparent;
+  scrollbar-color: var(--border-strong) transparent;
 }
 
 .chipRow::-webkit-scrollbar {
@@ -22,24 +22,26 @@
 }
 
 .chipRow::-webkit-scrollbar-thumb {
-  background: #444;
-  border-radius: 3px;
+  background: var(--border-strong);
+  border-radius: var(--radius-sm);
 }
 
 .emptyHint {
-  font-size: 11px;
-  color: #666;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-normal);
+  color: var(--text-muted);
   font-style: italic;
   text-align: center;
-  padding: 6px 0;
+  padding: var(--sp-3) 0;
 }
 
 .truncatedHint {
-  margin-top: 6px;
-  padding-top: 6px;
-  border-top: 1px solid #232323;
-  font-size: 10px;
-  color: #888;
+  margin-top: var(--sp-3);
+  padding-top: var(--sp-3);
+  border-top: 1px solid var(--border-subtle);
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
+  color: var(--text-muted);
   text-align: center;
   font-style: italic;
 }

--- a/frontend/src/components/PluginPanels/PluginPanels.module.css
+++ b/frontend/src/components/PluginPanels/PluginPanels.module.css
@@ -10,7 +10,7 @@
   flex: 1;
   overflow: auto;
   min-height: 0;
-  padding: 4px 8px;
+  padding: var(--sp-2) var(--sp-3);
 }
 
 /* ── right dock ──────────────────────────────────────────────────────────── */
@@ -18,8 +18,8 @@
 .rightColumn {
   width: 300px;
   flex-shrink: 0;
-  background: #151515;
-  border-left: 1px solid #2a2a2a;
+  background: var(--surface-panel);
+  border-left: 1px solid var(--border-base);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
@@ -31,27 +31,27 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
-  border-bottom: 1px solid #2a2a2a;
+  border-bottom: 1px solid var(--border-base);
 }
 
 .sectionHeader {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 10px;
-  background: #1a1a1a;
-  border-bottom: 1px solid #262626;
-  font-size: 0.72rem;
-  font-weight: 700;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface-raised);
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: #8fa3ad;
+  color: var(--text-muted);
 }
 
 .icon {
-  font-size: 0.8rem;
-  line-height: 1;
-  color: #4db6ac;
+  font-size: var(--fs-sm);
+  line-height: var(--lh-tight);
+  color: var(--accent-dim);
 }
 
 .sectionTitle {
@@ -61,7 +61,7 @@
 }
 
 .sectionBody {
-  padding: 8px 10px;
+  padding: var(--sp-3) var(--sp-4);
   overflow: auto;
   min-height: 0;
 }

--- a/frontend/src/components/PresetModal/PresetConfigModal.module.css
+++ b/frontend/src/components/PresetModal/PresetConfigModal.module.css
@@ -7,25 +7,25 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--surface-scrim);
   backdrop-filter: blur(4px);
 }
 
 .modal {
-  background: #1a1a1a;
-  border: 1px solid #333;
-  border-radius: 12px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-xl);
   width: 520px;
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-lg);
 }
 
 /* Header */
 .header {
-  padding: 16px 20px;
-  border-bottom: 2px solid #D4A017;
+  padding: var(--sp-5) var(--sp-6);
+  border-bottom: 2px solid var(--status-preset);
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
@@ -39,45 +39,47 @@
 .headerTitleRow {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 4px;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-2);
 }
 
 .headerTitle {
-  font-size: 1.0625rem;
-  font-weight: 700;
-  color: #eee;
+  font-size: var(--fs-xl);
+  font-weight: var(--fw-bold);
+  color: var(--text-primary);
 }
 
 .headerBadge {
-  font-size: 0.625rem;
-  background: rgba(212, 160, 23, 0.2);
-  color: #D4A017;
-  padding: 2px 6px;
-  border-radius: 3px;
-  font-weight: 700;
+  font-size: var(--fs-2xs);
+  /* rgb(224,169,43) mirrors --status-preset; kept as a literal wash since no
+     --preset-wash token exists yet — see the migration report. */
+  background: rgba(224, 169, 43, 0.2);
+  color: var(--status-preset);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-sm);
+  font-weight: var(--fw-bold);
 }
 
 .headerDescription {
-  font-size: 0.75rem;
-  color: #777;
-  line-height: 1.4;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  line-height: var(--lh-normal);
 }
 
 .closeBtn {
   background: transparent;
   border: none;
-  color: #666;
-  font-size: 1.125rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xl);
   cursor: pointer;
-  padding: 0 4px;
-  line-height: 1;
+  padding: 0 var(--sp-2);
+  line-height: var(--lh-tight);
 }
 
 /* Pipeline preview strip */
 .pipelinePreview {
-  padding: 10px 20px;
-  border-bottom: 1px solid #2a2a2a;
+  padding: var(--sp-4) var(--sp-6);
+  border-bottom: 1px solid var(--border-base);
   overflow-x: auto;
   flex-shrink: 0;
 }
@@ -85,77 +87,77 @@
 .pipelineInner {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--sp-2);
   min-width: max-content;
 }
 
 .pipelineNodeChip {
-  font-size: 0.6875rem;
-  padding: 3px 8px;
-  background: #252525;
-  border: 1px solid #3a3a3a;
-  border-radius: 4px;
-  color: #ccc;
+  font-size: var(--fs-xs);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
   white-space: nowrap;
 }
 
 .pipelineArrow {
-  color: #555;
-  font-size: 0.6875rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
 }
 
 /* Params scroll area */
 .paramsContent {
   flex: 1;
   overflow-y: auto;
-  padding: 16px 20px;
+  padding: var(--sp-5) var(--sp-6);
 }
 
 /* Group header */
 .groupHeader {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  color: #D4A017;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  color: var(--status-preset);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  margin-bottom: 10px;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #2a2a2a;
+  margin-bottom: var(--sp-4);
+  padding-bottom: var(--sp-2);
+  border-bottom: 1px solid var(--border-base);
 }
 
 .groupParams {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--sp-4);
 }
 
 /* Footer */
 .footer {
-  padding: 12px 20px;
-  border-top: 1px solid #2a2a2a;
+  padding: var(--sp-4) var(--sp-6);
+  border-top: 1px solid var(--border-base);
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--sp-3);
   flex-shrink: 0;
 }
 
 .cancelBtn {
-  padding: 7px 16px;
-  background: #2a2a2a;
-  border: 1px solid #444;
-  border-radius: 6px;
-  color: #aaa;
-  font-size: 0.8125rem;
+  padding: var(--sp-3) var(--sp-5);
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-size: var(--fs-md);
   cursor: pointer;
 }
 
 .applyBtn {
-  padding: 7px 16px;
-  background: #D4A017;
+  padding: var(--sp-3) var(--sp-5);
+  background: var(--status-preset);
   border: none;
-  border-radius: 6px;
-  color: #1a1a1a;
-  font-size: 0.8125rem;
-  font-weight: 600;
+  border-radius: var(--radius);
+  color: var(--text-on-accent);
+  font-weight: var(--fw-semibold);
+  font-size: var(--fs-md);
   cursor: pointer;
 }

--- a/frontend/src/components/ResultsPanel/ResultsPanel.module.css
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.module.css
@@ -1,8 +1,8 @@
 /* ResultsPanel.module.css */
 
 .panel {
-  background: #111;
-  border-top: 1px solid #2a2a2a;
+  background: var(--surface-panel);
+  border-top: 1px solid var(--border-base);
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -22,7 +22,7 @@
 
 .resizeHandle:hover,
 .resizeHandle:active {
-  background: rgba(77, 144, 254, 0.4);
+  background: var(--accent-glow);
 }
 
 /* Header bar */
@@ -30,10 +30,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 12px;
-  border-bottom: 1px solid #1e1e1e;
+  padding: 0 var(--sp-4);
+  border-bottom: 1px solid var(--border-subtle);
   flex-shrink: 0;
-  height: 32px;
+  height: var(--h-control);
 }
 
 .headerLeft {
@@ -45,99 +45,99 @@
 .headerRight {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 /* ── Inner panel tabs ── */
 .panelTabBtn {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #777;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  color: var(--text-muted);
   letter-spacing: 0.05em;
   text-transform: uppercase;
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  padding: 7px 10px;
+  padding: var(--sp-3) var(--sp-4);
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 5px;
-  transition: color 0.15s, border-color 0.15s;
+  gap: var(--sp-2);
+  transition: color var(--transition-fast), border-color var(--transition-fast);
 }
 
 .panelTabBtn:hover:not(.panelTabDisabled) {
-  color: #bbb;
+  color: var(--text-secondary);
 }
 
 .panelTabActive {
-  color: #ddd;
-  border-bottom-color: #4d90fe;
+  color: var(--text-secondary);
+  border-bottom-color: var(--accent-deep);
 }
 
 .panelTabDisabled {
-  color: #444;
+  color: var(--text-disabled);
   cursor: not-allowed;
 }
 
 .countBadge {
-  font-size: 0.625rem;
-  background: #222;
-  border: 1px solid #3a3a3a;
-  border-radius: 10px;
-  padding: 0 5px;
-  color: #888;
-  font-weight: 400;
+  font-size: var(--fs-2xs);
+  background: var(--surface-input);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-pill);
+  padding: 0 var(--sp-2);
+  color: var(--text-muted);
+  font-weight: var(--fw-normal);
 }
 
 .countBadgeTraining {
-  background: rgba(255, 193, 7, 0.12);
-  border-color: rgba(255, 193, 7, 0.35);
-  color: #FFC107;
+  background: var(--warning-wash);
+  border-color: var(--status-warning);
+  color: var(--status-warning);
 }
 
 /* Runs tab: the same count, teal while at least one run is still going. */
 .countBadgeActive {
-  background: rgba(6, 182, 212, 0.12);
-  border-color: rgba(6, 182, 212, 0.4);
-  color: #06b6d4;
+  background: var(--accent-wash);
+  border-color: var(--accent-deep);
+  color: var(--accent-deep);
 }
 
 .clearBtn {
-  font-size: 0.75rem;
-  padding: 2px 8px;
+  font-size: var(--fs-sm);
+  padding: var(--sp-1) var(--sp-3);
   background: transparent;
-  border: 1px solid #3a3a3a;
-  border-radius: 3px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
 }
 
 .collapseBtn {
-  font-size: 0.9375rem;
-  width: 24px;
-  height: 24px;
+  font-size: var(--fs-lg);
+  width: var(--h-control-xs);
+  height: var(--h-control-xs);
   display: flex;
   align-items: center;
   justify-content: center;
   background: transparent;
-  border: 1px solid #3a3a3a;
-  border-radius: 3px;
-  color: #999;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
   cursor: pointer;
-  line-height: 1;
+  line-height: var(--lh-tight);
 }
 
 .collapseBtn:hover {
-  background: #222;
-  color: #eee;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .clearBtnEnabled {
-  color: #888;
+  color: var(--text-muted);
   cursor: pointer;
 }
 
 .clearBtnDisabled {
-  color: #444;
+  color: var(--text-disabled);
   cursor: not-allowed;
 }
 
@@ -145,7 +145,7 @@
 .logArea {
   flex: 1;
   overflow-y: auto;
-  padding: 4px 0;
+  padding: var(--sp-2) 0;
   font-family: monospace;
 }
 
@@ -155,16 +155,16 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: #555;
-  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
 }
 
 /* Log entry base (dynamic bg + border-left applied inline) */
 .logEntry {
   display: flex;
   align-items: baseline;
-  gap: 8px;
-  padding: 2px 12px;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
   margin-bottom: 1px;
 }
 
@@ -172,64 +172,68 @@
   cursor: pointer;
 }
 
+/* Translucent white rather than a surface token: the entry's own background
+   is the dynamic per-type tint (info/error/success) applied inline, and a
+   flat surface-hover here would blot that tint out on hover instead of just
+   lightening it. */
 .logEntryClickable:hover {
   background: rgba(255, 255, 255, 0.03);
 }
 
 .expandedDetail {
-  padding: 4px 0 4px 80px;
-  font-size: 0.75rem;
-  color: #ccc;
+  padding: var(--sp-2) 0 var(--sp-2) 80px;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
   white-space: pre-wrap;
   word-break: break-word;
 }
 
 .expandIcon {
-  margin-right: 4px;
-  font-size: 0.6875rem;
-  color: #666;
+  margin-right: var(--sp-2);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
 }
 
 .timestamp {
-  font-size: 0.75rem;
-  color: #666;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
   flex-shrink: 0;
-  line-height: 1.6;
+  line-height: var(--lh-normal);
 }
 
 .nodeIdBadge {
-  font-size: 0.6875rem;
-  color: #888;
-  background: #1a1a1a;
-  border: 1px solid #333;
-  border-radius: 2px;
-  padding: 0 4px;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-1) var(--sp-2);
   flex-shrink: 0;
-  line-height: 1.8;
+  line-height: var(--lh-tight);
 }
 
 /* Log image output */
 .logImage {
   max-width: 100%;
   max-height: 160px;
-  border-radius: 4px;
-  border: 1px solid #333;
-  margin-top: 2px;
-  margin-bottom: 2px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-base);
+  margin-top: var(--sp-1);
+  margin-bottom: var(--sp-1);
 }
 
 /* Chart output entry (#130). The card brings its own frame, so this only has
    to keep it from stretching the log row. */
 .logChart {
-  margin-top: 2px;
-  margin-bottom: 2px;
+  margin-top: var(--sp-1);
+  margin-bottom: var(--sp-1);
   max-width: 100%;
 }
 
 /* Log message text */
 .logMessage {
-  font-size: 0.8125rem;
-  line-height: 1.6;
+  font-size: var(--fs-md);
+  line-height: var(--lh-normal);
   word-break: break-word;
 }
 
@@ -251,8 +255,8 @@
 .trainingChartCol {
   flex: 1;
   min-width: 160px;
-  padding: 8px 14px;
-  border-right: 1px solid #2a2a2a;
+  padding: var(--sp-3) var(--sp-4);
+  border-right: 1px solid var(--border-base);
   display: flex;
   flex-direction: column;
 }
@@ -263,12 +267,12 @@
   flex-shrink: 0;
   cursor: col-resize;
   background: transparent;
-  transition: background 0.15s;
+  transition: background var(--transition-fast);
 }
 
 .columnDivider:hover,
 .columnDividerActive {
-  background: rgba(77, 144, 254, 0.4);
+  background: var(--accent-glow);
 }
 
 /* Right column — config + epochs */
@@ -286,22 +290,22 @@
   flex-shrink: 0;
   cursor: ns-resize;
   background: transparent;
-  transition: background 0.15s;
-  border-top: 1px solid #2a2a2a;
+  transition: background var(--transition-fast);
+  border-top: 1px solid var(--border-base);
 }
 
 .rowDivider:hover,
 .rowDivider:active {
-  background: rgba(77, 144, 254, 0.4);
+  background: var(--accent-glow);
 }
 
 .sectionHeader {
-  font-size: 0.75rem;
-  color: #999;
-  font-weight: 600;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  font-weight: var(--fw-semibold);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  padding: 6px 0 4px;
+  padding: var(--sp-3) 0 var(--sp-2);
 }
 
 /* Chart */
@@ -321,54 +325,54 @@
 .chartLegend {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px 12px;
-  padding-bottom: 4px;
+  gap: var(--sp-2) var(--sp-4);
+  padding-bottom: var(--sp-2);
 }
 
 .chartLegendItem {
   display: flex;
   align-items: center;
-  gap: 5px;
-  font-size: 0.6875rem;
-  color: #aaa;
+  gap: var(--sp-2);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   font-family: monospace;
 }
 
 .chartLegendSwatch {
   width: 8px;
   height: 8px;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
 
 /* Config grid */
 .configSection {
-  padding: 8px 12px;
+  padding: var(--sp-3) var(--sp-4);
   overflow-y: auto;
 }
 
 .configGrid {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--sp-1);
 }
 
 .configRow {
   display: flex;
   justify-content: space-between;
-  gap: 8px;
-  padding: 2px 0;
+  gap: var(--sp-3);
+  padding: var(--sp-2) 0;
 }
 
 .configKey {
-  font-size: 0.75rem;
-  color: #888;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
   white-space: nowrap;
 }
 
 .configVal {
-  font-size: 0.75rem;
-  color: #ccc;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
   font-family: monospace;
   text-align: right;
   overflow: hidden;
@@ -379,41 +383,41 @@
 
 /* Epoch table */
 .epochSection {
-  padding: 8px 12px;
+  padding: var(--sp-3) var(--sp-4);
   flex: 1;
   overflow-y: auto;
 }
 
 .epochTable {
-  font-size: 0.75rem;
+  font-size: var(--fs-sm);
 }
 
 .epochRow {
   display: grid;
   grid-template-columns: 32px 1fr 1fr 48px;
-  gap: 6px;
-  padding: 3px 0;
-  color: #bbb;
+  gap: var(--sp-3);
+  padding: var(--sp-2) 0;
+  color: var(--text-secondary);
 }
 
 .epochRowHeader {
-  color: #888;
-  font-weight: 600;
-  border-bottom: 1px solid #2a2a2a;
-  padding-bottom: 4px;
-  margin-bottom: 2px;
+  color: var(--text-muted);
+  font-weight: var(--fw-semibold);
+  border-bottom: 1px solid var(--border-base);
+  padding-bottom: var(--sp-2);
+  margin-bottom: var(--sp-1);
 }
 
 .deltaDown {
-  color: #66BB6A;
+  color: var(--status-success);
 }
 
 .deltaUp {
-  color: #EF5350;
+  color: var(--status-error);
 }
 
 .epochTime {
-  color: #777;
+  color: var(--text-muted);
   text-align: right;
 }
 
@@ -424,44 +428,44 @@
 .edgeTooltip {
   position: fixed;
   z-index: 1000;
-  background: #1a1a1a;
-  border: 1px solid #555;
-  border-radius: 6px;
-  padding: 10px 14px;
-  font-size: 0.8125rem;
-  color: #ddd;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: var(--sp-4);
+  font-size: var(--fs-md);
+  color: var(--text-secondary);
   min-width: 200px;
   max-width: 320px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
+  box-shadow: var(--shadow-lg);
 }
 
 .edgeTooltipTitle {
-  font-weight: 600;
-  color: #aaa;
-  font-size: 0.75rem;
+  font-weight: var(--fw-semibold);
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 6px;
-  border-bottom: 1px solid #3a3a3a;
-  padding-bottom: 4px;
+  margin-bottom: var(--sp-3);
+  border-bottom: 1px solid var(--border-base);
+  padding-bottom: var(--sp-2);
 }
 
 .edgeTooltipRow {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
-  padding: 2px 0;
+  gap: var(--sp-4);
+  padding: var(--sp-2) 0;
 }
 
 .edgeTooltipLabel {
-  color: #999;
-  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
 }
 
 .edgeTooltipValue {
-  color: #ddd;
+  color: var(--text-secondary);
   font-family: monospace;
-  font-size: 0.75rem;
+  font-size: var(--fs-sm);
   text-align: right;
 }
 
@@ -470,20 +474,20 @@
 .edgeTooltipLink {
   display: block;
   width: 100%;
-  margin-top: 8px;
-  padding: 4px 0 0;
+  margin-top: var(--sp-3);
+  padding: var(--sp-2) 0 0;
   border: none;
-  border-top: 1px solid #3a3a3a;
+  border-top: 1px solid var(--border-base);
   background: none;
-  color: #67e8f9;
-  font-size: 0.75rem;
+  color: var(--accent);
+  font-size: var(--fs-sm);
   font-family: inherit;
   text-align: left;
   cursor: pointer;
 }
 
 .edgeTooltipLink:hover {
-  color: #a5f3fc;
+  color: var(--accent);
   text-decoration: underline;
 }
 
@@ -491,42 +495,42 @@
 .trainingSummary {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 6px 12px;
-  background: #1a1a1a;
-  border-bottom: 1px solid #2a2a2a;
+  gap: var(--sp-5);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface-raised);
+  border-bottom: 1px solid var(--border-base);
   flex-shrink: 0;
 }
 
 .summaryItem {
   display: flex;
-  gap: 6px;
+  gap: var(--sp-3);
   align-items: baseline;
 }
 
 .summaryLabel {
-  font-size: 0.6875rem;
-  color: #888;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   text-transform: uppercase;
 }
 
 .summaryValue {
-  font-size: 0.8125rem;
-  color: #eee;
+  font-size: var(--fs-md);
+  color: var(--text-primary);
   font-family: monospace;
 }
 
 .summaryProgress {
   flex: 1;
   height: 4px;
-  background: #2a2a2a;
-  border-radius: 2px;
+  background: var(--border-base);
+  border-radius: var(--radius-sm);
   overflow: hidden;
 }
 
 .progressBar {
   height: 100%;
-  background: #2196F3;
-  border-radius: 2px;
-  transition: width 0.3s ease;
+  background: var(--status-info);
+  border-radius: var(--radius-sm);
+  transition: width var(--transition);
 }

--- a/frontend/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.tsx
@@ -35,15 +35,15 @@ function formatTimestamp(ts: number): string {
 }
 
 const LOG_TYPE_COLORS = {
-  info: '#2196F3',
-  error: '#F44336',
-  success: '#4CAF50',
+  info: 'var(--status-info)',
+  error: 'var(--status-error)',
+  success: 'var(--status-success)',
 } as const;
 
 const LOG_TYPE_BG = {
-  info: 'rgba(33,150,243,0.05)',
-  error: 'rgba(244,67,54,0.08)',
-  success: 'rgba(76,175,80,0.05)',
+  info: 'var(--info-wash)',
+  error: 'var(--danger-wash)',
+  success: 'var(--success-wash)',
 } as const;
 
 // ── DEPRECATED magic prefixes (remove one release after #117) ────────────
@@ -474,7 +474,7 @@ export function ResultsPanel() {
                   </div>
                   <div className={styles.summaryItem}>
                     <span className={styles.summaryLabel}>{t('results.bestLoss')}</span>
-                    <span className={styles.summaryValue} style={{ color: '#4CAF50' }}>
+                    <span className={styles.summaryValue} style={{ color: 'var(--status-success)' }}>
                       {Math.min(...trainingData.epochs.map((e) => e.loss)).toFixed(4)}
                     </span>
                   </div>

--- a/frontend/src/components/ResultsPanel/RunsPanel.module.css
+++ b/frontend/src/components/ResultsPanel/RunsPanel.module.css
@@ -1,6 +1,8 @@
 /* RunsPanel.module.css — the Runs tab of the bottom dock (#124).
-   Palette matches ResultsPanel.module.css: #111 base, #2a2a2a rules,
-   #4d90fe selection, one teal accent for "live". */
+   Palette matches ResultsPanel.module.css: --surface-panel base,
+   --border-base rules, --surface-active for the selected row,
+   --border-focus for keyboard focus, and --accent-deep as the one
+   teal accent for "live". */
 
 .runsBody {
   display: flex;
@@ -26,52 +28,52 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  padding: 4px 12px;
-  border-bottom: 1px solid #1e1e1e;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-4);
+  border-bottom: 1px solid var(--border-subtle);
   flex-shrink: 0;
 }
 
 .filters {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--sp-1);
   flex-wrap: wrap;
 }
 
 .filterBtn {
-  font-size: 0.6875rem;
-  color: #8a8a8a;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 3px;
-  min-height: 24px;
-  padding: 3px 9px;
+  border-radius: var(--radius-sm);
+  min-height: var(--h-control-xs);
+  padding: var(--sp-2) var(--sp-3);
   cursor: pointer;
   white-space: nowrap;
 }
 
 .filterBtn:hover {
-  color: #ccc;
-  background: #1c1c1c;
+  color: var(--text-secondary);
+  background: var(--surface-hover);
 }
 
 .filterActive {
-  color: #ddd;
-  background: #222;
-  border-color: #3a3a3a;
+  color: var(--text-secondary);
+  background: var(--surface-input);
+  border-color: var(--border-base);
 }
 
 .toolbarRight {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--sp-3);
   flex-shrink: 0;
 }
 
 .countText {
-  font-size: 0.6875rem;
-  color: #666;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   font-family: monospace;
 }
 
@@ -81,7 +83,7 @@
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-  font-size: 0.75rem;
+  font-size: var(--fs-sm);
 }
 
 /* The data columns are capped and the ACTIONS column takes the slack, so a
@@ -97,47 +99,47 @@
     72px                  /* duration */
     80px                  /* final loss */
     minmax(140px, 1fr);   /* actions, right-aligned */
-  gap: 8px;
+  gap: var(--sp-3);
   align-items: center;
-  padding: 3px 12px;
-  color: #bbb;
-  border-bottom: 1px solid #171717;
+  padding: var(--sp-3) var(--sp-4);
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-subtle);
   cursor: pointer;
 }
 
 .row:hover {
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-hover);
 }
 
 .rowSelected {
-  background: rgba(77, 144, 254, 0.1);
+  background: var(--surface-active);
 }
 
 .row:focus-visible {
-  outline: 2px solid #4d90fe;
+  outline: 2px solid var(--border-focus);
   outline-offset: -2px;
 }
 
 .rowHeader {
-  color: #888;
-  font-weight: 600;
+  color: var(--text-muted);
+  font-weight: var(--fw-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-size: 0.625rem;
-  border-bottom: 1px solid #2a2a2a;
+  font-size: var(--fs-2xs);
+  border-bottom: 1px solid var(--border-base);
   cursor: default;
   position: sticky;
   top: 0;
-  background: #111;
+  background: var(--surface-panel);
   z-index: 1;
 }
 
 .rowHeader:hover {
-  background: #111;
+  background: var(--surface-panel);
 }
 
 .nameCell {
-  color: #ddd;
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -145,82 +147,82 @@
 
 .mono {
   font-family: monospace;
-  color: #999;
+  color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .queuePos {
-  color: #06b6d4;
+  color: var(--accent-deep);
 }
 
 .empty {
-  padding: 20px 12px;
+  padding: var(--sp-6) var(--sp-4);
   text-align: center;
-  color: #555;
-  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
 }
 
 .listError {
-  padding: 4px 12px;
-  background: rgba(244, 67, 54, 0.1);
-  color: #F44336;
-  font-size: 0.75rem;
+  padding: var(--sp-2) var(--sp-4);
+  background: var(--danger-wash);
+  color: var(--status-error);
+  font-size: var(--fs-sm);
   flex-shrink: 0;
 }
 
 /* ── status chips ── */
 
 .chip {
-  font-size: 0.625rem;
-  font-weight: 600;
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-semibold);
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
   border: 1px solid;
-  padding: 1px 5px;
+  padding: var(--sp-1) var(--sp-2);
   text-align: center;
   white-space: nowrap;
   justify-self: start;
 }
 
 .chip_running {
-  color: #06b6d4;
-  border-color: rgba(6, 182, 212, 0.45);
-  background: rgba(6, 182, 212, 0.12);
+  color: var(--accent-deep);
+  border-color: var(--accent-glow);
+  background: var(--accent-wash);
 }
 
 .chip_queued {
-  color: #FFC107;
-  border-color: rgba(255, 193, 7, 0.4);
-  background: rgba(255, 193, 7, 0.1);
+  color: var(--status-warning);
+  border-color: var(--status-warning);
+  background: var(--warning-wash);
 }
 
 .chip_succeeded {
-  color: #66BB6A;
-  border-color: rgba(102, 187, 106, 0.4);
-  background: rgba(102, 187, 106, 0.1);
+  color: var(--status-success);
+  border-color: var(--status-success);
+  background: var(--success-wash);
 }
 
 .chip_failed {
-  color: #EF5350;
-  border-color: rgba(239, 83, 80, 0.45);
-  background: rgba(239, 83, 80, 0.12);
+  color: var(--status-error);
+  border-color: var(--status-error);
+  background: var(--danger-wash);
 }
 
 /* Cancelled is a decision; interrupted is a crash that left a row behind.
    Reading the same would hide the one the user needs to act on. */
 .chip_cancelled {
-  color: #999;
-  border-color: #3a3a3a;
-  background: #1c1c1c;
+  color: var(--text-muted);
+  border-color: var(--border-base);
+  background: var(--surface-raised);
 }
 
 .chip_interrupted {
-  color: #D9873F;
-  border-color: rgba(217, 135, 63, 0.45);
-  background: rgba(217, 135, 63, 0.12);
+  color: var(--status-interrupted);
+  border-color: var(--status-interrupted);
+  background: var(--warning-wash);
 }
 
 /* ── row actions ── */
@@ -228,46 +230,46 @@
 .actions {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--sp-2);
   justify-content: flex-end;
 }
 
 .rowBtn {
-  font-size: 0.625rem;
-  font-weight: 600;
-  color: #999;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  color: var(--text-muted);
   background: transparent;
-  border: 1px solid #3a3a3a;
-  border-radius: 3px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
   /* 24px tall: small enough for a dense table, large enough to hit. */
-  min-height: 24px;
-  padding: 2px 8px;
+  min-height: var(--h-control-xs);
+  padding: var(--sp-1) var(--sp-3);
   cursor: pointer;
   white-space: nowrap;
 }
 
 .rowBtn:hover:not(:disabled) {
-  color: #eee;
-  background: #222;
+  color: var(--text-primary);
+  background: var(--surface-hover);
 }
 
 .rowBtn:disabled {
-  color: #444;
-  border-color: #2a2a2a;
+  color: var(--text-disabled);
+  border-color: var(--border-base);
   cursor: not-allowed;
 }
 
-/* #EF5350 on the #111 panel is 5.4:1 — the resting colour has to clear
-   4.5:1 too, which the previous muted #C05C58 (4.4:1) narrowly did not. */
+/* status-error on the panel surface clears 4.5:1, so the resting colour
+   (not just the hover state) can carry it directly. */
 .rowBtnDanger {
-  color: #EF5350;
-  border-color: rgba(239, 83, 80, 0.3);
+  color: var(--status-error);
+  border-color: var(--status-error);
 }
 
 .rowBtnDanger:hover:not(:disabled) {
-  color: #EF5350;
-  background: rgba(239, 83, 80, 0.12);
-  border-color: rgba(239, 83, 80, 0.45);
+  color: var(--status-error);
+  background: var(--danger-wash);
+  border-color: var(--status-error);
 }
 
 /* ── detail ── */
@@ -275,37 +277,37 @@
 .detail {
   flex: 1.1;
   min-width: 0;
-  border-left: 1px solid #2a2a2a;
+  border-left: 1px solid var(--border-base);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  padding: 0 0 8px;
+  padding: 0 0 var(--sp-3);
 }
 
 .detailHeader {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 5px 12px;
-  border-bottom: 1px solid #2a2a2a;
-  background: #1a1a1a;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-4);
+  border-bottom: 1px solid var(--border-base);
+  background: var(--surface-raised);
   position: sticky;
   top: 0;
   z-index: 1;
 }
 
 .detailTitle {
-  color: #eee;
-  font-size: 0.8125rem;
-  font-weight: 600;
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .detailMeta {
-  font-size: 0.6875rem;
-  color: #888;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   font-family: monospace;
   white-space: nowrap;
 }
@@ -314,29 +316,29 @@
   margin-left: auto;
   background: transparent;
   border: none;
-  color: #777;
-  font-size: 0.9375rem;
-  line-height: 1;
+  color: var(--text-muted);
+  font-size: var(--fs-lg);
+  line-height: var(--lh-tight);
   cursor: pointer;
-  padding: 0 2px;
+  padding: 0 var(--sp-1);
 }
 
 .detailClose:hover {
-  color: #eee;
+  color: var(--text-primary);
 }
 
 .detailError {
-  margin: 6px 12px 0;
-  padding: 4px 8px;
-  background: rgba(244, 67, 54, 0.1);
-  color: #EF5350;
-  border-radius: 3px;
-  font-size: 0.75rem;
+  margin: var(--sp-3) var(--sp-4) 0;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--danger-wash);
+  color: var(--status-error);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm);
   word-break: break-word;
 }
 
 .detailSection {
-  padding: 4px 12px;
+  padding: var(--sp-2) var(--sp-4);
 }
 
 /* Section title on the left, its one action on the right. Baseline-aligned
@@ -346,22 +348,22 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .sectionHeader {
-  font-size: 0.6875rem;
-  color: #999;
-  font-weight: 600;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  font-weight: var(--fw-semibold);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  padding: 6px 0 4px;
+  padding: var(--sp-3) 0 var(--sp-2);
 }
 
 .detailEmpty {
-  color: #555;
-  font-size: 0.75rem;
-  padding: 4px 0 8px;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  padding: var(--sp-2) 0 var(--sp-3);
 }
 
 /* artifacts */
@@ -369,24 +371,24 @@
 .artifactList {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--sp-1);
 }
 
 .artifactRow {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 0.6875rem;
+  gap: var(--sp-3);
+  font-size: var(--fs-xs);
 }
 
 .artifactKind {
-  color: #06b6d4;
+  color: var(--accent-deep);
   font-family: monospace;
   flex-shrink: 0;
 }
 
 .artifactPath {
-  color: #bbb;
+  color: var(--text-secondary);
   font-family: monospace;
   flex: 1;
   min-width: 0;
@@ -408,13 +410,13 @@
 
 .logLine {
   display: flex;
-  gap: 8px;
-  font-size: 0.6875rem;
-  line-height: 1.5;
+  gap: var(--sp-3);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-normal);
 }
 
 .logTime {
-  color: #555;
+  color: var(--text-muted);
   flex-shrink: 0;
 }
 
@@ -423,19 +425,19 @@
 }
 
 .tone_info .logText {
-  color: #999;
+  color: var(--text-secondary);
 }
 
 .tone_success .logText {
-  color: #66BB6A;
+  color: var(--status-success);
 }
 
 .tone_error .logText {
-  color: #EF5350;
+  color: var(--status-error);
 }
 
 .tone_warning .logText {
-  color: #FFC107;
+  color: var(--status-warning);
 }
 
 /* ── narrow dock ──────────────────────────────────────────────────────

--- a/frontend/src/components/Sidebar/CategoryList.tsx
+++ b/frontend/src/components/Sidebar/CategoryList.tsx
@@ -26,7 +26,7 @@ interface CategoryListProps<T> {
 // this migration's scope. Left as-is rather than pointing only this one
 // copy at --cat-utility, which would make it disagree with every sibling
 // copy instead of agreeing with them. See migration report.
-const defaultColorFor = (category: string) => CATEGORY_COLORS[category] ?? '#607D8B';
+const defaultColorFor = (category: string) => CATEGORY_COLORS[category] ?? CATEGORY_COLORS.Utility;
 
 /**
  * The accordion body shared by every list-shaped sidebar tab (#126): one
@@ -133,7 +133,12 @@ export function CategoryList<T>({
                   aria-expanded={expanded}
                 >
                   <span className={styles.categoryDot} style={{ background: color }} />
-                  <span className={styles.categoryName} style={{ color }}>
+                  {/* The hue identifies the category through the dot and the
+                      underline, which are graphics and only need 3:1. The name
+                      is text: tinting it put several categories at 3.8-4.2:1,
+                      and no amount of hue tuning fixes that because the header
+                      background is itself a tint of the same hue. */}
+                  <span className={styles.categoryName}>
                     {labelFor(category)}
                   </span>
                   <span className={styles.categoryCount}>{items.length}</span>

--- a/frontend/src/components/Sidebar/CategoryList.tsx
+++ b/frontend/src/components/Sidebar/CategoryList.tsx
@@ -19,6 +19,13 @@ interface CategoryListProps<T> {
   labelFor?: (category: string) => string;
 }
 
+// '#607D8B' (the pre-lift value of --cat-utility) is a repo-wide "unknown
+// category" fallback duplicated across 8+ files (BaseNode, FlowCanvas,
+// QuickNodeSearch, ConfigPanel, NodeDetailModal, SubgraphEditor,
+// exportDiagram, here) and test-pinned in several of them, most outside
+// this migration's scope. Left as-is rather than pointing only this one
+// copy at --cat-utility, which would make it disagree with every sibling
+// copy instead of agreeing with them. See migration report.
 const defaultColorFor = (category: string) => CATEGORY_COLORS[category] ?? '#607D8B';
 
 /**

--- a/frontend/src/components/Sidebar/CustomTab.module.css
+++ b/frontend/src/components/Sidebar/CustomTab.module.css
@@ -2,67 +2,67 @@
 .sectionHeader {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 10px 4px;
-  border-bottom: 1px solid #242424;
-  margin-bottom: 2px;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4) var(--sp-2);
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: var(--sp-1);
 }
 
 .sectionTitle {
-  font-size: 0.6875rem;
-  font-weight: 700;
-  color: #888;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  color: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .sectionCount {
-  font-size: 0.625rem;
-  color: #555;
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
   flex: 1;
 }
 
 .manageButton {
-  font-size: 0.6875rem;
-  padding: 2px 7px;
-  background: #232323;
-  border: 1px solid #333;
-  border-radius: 4px;
-  color: #bbb;
+  font-size: var(--fs-xs);
+  padding: var(--sp-1) var(--sp-3);
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
   cursor: pointer;
   flex-shrink: 0;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
 }
 
 .manageButton:hover {
-  color: #22d3ee;
-  border-color: #0e7490;
+  color: var(--accent);
+  border-color: var(--accent-dim);
 }
 
 .sectionEmpty {
-  padding: 10px;
-  font-size: 0.75rem;
-  color: #555;
+  padding: var(--sp-4);
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
   text-align: center;
 }
 
 .sectionHint {
-  font-size: 0.6875rem;
-  color: #444;
-  margin-top: 3px;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  margin-top: var(--sp-2);
 }
 
 .row {
-  padding: 6px 10px;
-  margin: 2px 6px;
-  border-radius: 5px;
+  padding: var(--sp-3) var(--sp-4);
+  margin: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius);
   border: 1px solid transparent;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .row:hover {
-  background: #202020;
-  border-color: #2f2f2f;
+  background: var(--surface-hover);
+  border-color: var(--border-base);
 }
 
 .row[data-disabled='true'] {
@@ -72,13 +72,13 @@
 .rowTitle {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--sp-3);
 }
 
 .rowName {
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: #ddd;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -87,41 +87,43 @@
 }
 
 .rowVersion {
-  font-size: 0.625rem;
-  color: #666;
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
   flex-shrink: 0;
 }
 
 .rowDesc {
-  font-size: 0.6875rem;
-  color: #777;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+  line-height: var(--lh-snug);
+  margin-top: var(--sp-1);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  margin-top: 1px;
 }
 
 .rowMeta {
-  font-size: 0.625rem;
-  color: #555;
-  margin-top: 3px;
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
+  margin-top: var(--sp-2);
 }
 
 .chipOn,
 .chipOff {
-  font-size: 0.5625rem;
-  padding: 1px 4px;
-  border-radius: 3px;
-  font-weight: 600;
+  font-size: var(--fs-2xs);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
+  font-weight: var(--fw-semibold);
   flex-shrink: 0;
 }
 
 .chipOn {
-  background: rgba(76, 175, 80, 0.13);
-  color: #4CAF50;
+  background: rgba(94, 194, 105, 0.13);
+  color: var(--status-success);
 }
 
 .chipOff {
   background: rgba(158, 158, 158, 0.13);
-  color: #9E9E9E;
+  color: var(--status-skipped);
 }

--- a/frontend/src/components/Sidebar/NodePalette.module.css
+++ b/frontend/src/components/Sidebar/NodePalette.module.css
@@ -4,8 +4,8 @@
   display: flex;
   flex-direction: row;
   flex-shrink: 0;
-  background: #161616;
-  border-right: 1px solid #2a2a2a;
+  background: var(--surface-panel);
+  border-right: 1px solid var(--border-base);
 }
 
 /* Content panel. Width is an inline style driven by the persisted store value,
@@ -18,7 +18,7 @@
   flex-direction: column;
   overflow: hidden;
   min-width: 0;
-  border-left: 1px solid #2a2a2a;
+  border-left: 1px solid var(--border-base);
 }
 
 /* Drag strip on the sidebar's outer edge — a real layout column, invisible
@@ -29,32 +29,34 @@
   height: 100%;
   cursor: col-resize;
   background: transparent;
-  transition: background 0.15s;
+  transition: background var(--transition-fast);
 }
 
 .resizeHandle:hover {
-  background: rgba(6, 182, 212, 0.35);
+  /* Stronger than --accent-wash (0.35 vs 0.12) — a drag handle needs to read
+     as clearly interactive, not just tinted. Kept literal; see report. */
+  background: rgba(34, 211, 238, 0.35);
 }
 
 /* Focusable (it is an operable splitter), so it needs a visible focus state —
    the 4px strip is too thin for a conventional outline to read. */
 .resizeHandle:focus-visible {
-  background: #06b6d4;
+  background: var(--accent-deep);
   outline: none;
 }
 
 /* ── Panel header ── */
 .header {
-  padding: 12px 10px 8px;
-  border-bottom: 1px solid #2a2a2a;
+  padding: var(--sp-4) var(--sp-4) var(--sp-3);
+  border-bottom: 1px solid var(--border-base);
   flex-shrink: 0;
 }
 
 .headerRow {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-3);
 }
 
 .headerRow .headerTitle {
@@ -63,12 +65,12 @@
 }
 
 .headerTitle {
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: #888;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-bold);
+  color: var(--text-muted);
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  margin-bottom: 8px;
+  margin-bottom: var(--sp-3);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -77,18 +79,18 @@
 /* ── Search input ── */
 .searchInput {
   width: 100%;
-  padding: 5px 8px;
-  background: #222;
-  border: 1px solid #333;
-  border-radius: 4px;
-  color: #ddd;
-  font-size: 0.8125rem;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
   outline: none;
   box-sizing: border-box;
 }
 
 .searchInput:focus {
-  border-color: #0e7490;
+  border-color: var(--accent-dim);
 }
 
 /* ── Flexible middle region (list / states) ── */
@@ -111,8 +113,8 @@
 .listToolbar {
   display: flex;
   justify-content: flex-end;
-  gap: 2px;
-  padding: 3px 6px 1px;
+  gap: var(--sp-1);
+  padding: var(--sp-2) var(--sp-3) var(--sp-1);
   flex-shrink: 0;
 }
 
@@ -125,16 +127,16 @@
   padding: 0;
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 4px;
-  color: #777;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
   cursor: pointer;
-  transition: color 0.15s, background 0.15s, border-color 0.15s;
+  transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .toolbarButton:hover {
-  color: #ddd;
-  background: #232323;
-  border-color: #333;
+  color: var(--text-secondary);
+  background: var(--surface-hover);
+  border-color: var(--border-base);
 }
 
 .listBody {
@@ -149,7 +151,7 @@
   flex: 1;
   min-width: 0;
   overflow-y: auto;
-  padding-top: 4px;
+  padding-top: var(--sp-2);
 }
 
 /* ── Mini jump index pinned to the panel's inner edge ── */
@@ -160,9 +162,9 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  padding: 4px 0;
-  border-left: 1px solid #202020;
+  gap: var(--sp-2);
+  padding: var(--sp-2) 0;
+  border-left: 1px solid var(--border-subtle);
   overflow: hidden;
 }
 
@@ -185,7 +187,7 @@
   height: 6px;
   border-radius: 50%;
   opacity: 0.55;
-  transition: opacity 0.15s, transform 0.15s;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
 }
 
 .jumpDot:hover .jumpDotInner,
@@ -196,20 +198,20 @@
 
 /* ── Category section ── */
 .categorySection {
-  margin-bottom: 4px;
-  scroll-margin-top: 4px;
+  margin-bottom: var(--sp-2);
+  scroll-margin-top: var(--sp-2);
 }
 
 .categoryButton {
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
   background: transparent;
   border: none;
   cursor: pointer;
-  color: #eee;
+  color: var(--text-primary);
   text-align: left;
 }
 
@@ -222,8 +224,8 @@
 }
 
 .categoryName {
-  font-size: 0.8125rem;
-  font-weight: 700;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-bold);
   letter-spacing: 0.05em;
   flex: 1;
   overflow: hidden;
@@ -232,106 +234,118 @@
 }
 
 .categoryCount {
-  font-size: 0.6875rem;
-  color: #666;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
 }
 
 .categoryChevron {
-  font-size: 0.875rem;
-  color: #999;
-  margin-left: 4px;
-  transition: color 0.15s;
+  font-size: var(--fs-md);
+  color: var(--text-muted);
+  margin-left: var(--sp-2);
+  transition: color var(--transition-fast);
 }
 
 .categoryButton:hover .categoryChevron {
-  color: #ccc;
+  color: var(--text-secondary);
 }
 
 .categoryNodes {
-  padding-top: 2px;
-  padding-bottom: 4px;
+  padding-top: var(--sp-1);
+  padding-bottom: var(--sp-2);
 }
 
-/* ── Node item ── */
+/* ── Node item ──
+   Densest list in the app: real row height + roomy padding carry the
+   density instead of small text (core token migration). */
 .nodeItem {
   position: relative;
-  padding: 6px 10px;
-  margin: 2px 6px;
-  border-radius: 5px;
+  min-height: var(--h-row);
+  padding: var(--sp-3) var(--sp-4);
+  margin: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   cursor: grab;
   border: 1px solid transparent;
-  transition: all 0.15s;
+  transition: all var(--transition-fast);
   user-select: none;
 }
 
 .nodeItemName {
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: #ddd;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
+  color: var(--text-primary);
+  line-height: var(--lh-tight);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+/* Was single-line ellipsis (the "currently truncated" description the
+   maintainer called out); now wraps up to two lines instead of hiding the
+   rest of the text behind an ellipsis after a handful of characters. */
 .nodeItemDesc {
-  font-size: 0.6875rem;
-  color: #777;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+  line-height: var(--lh-snug);
+  margin-top: var(--sp-1);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  margin-top: 1px;
 }
 
 /* ── Node tooltip (portal, fixed position to escape overflow clip) ── */
 .nodeTooltip {
   position: fixed;
   width: 220px;
-  padding: 8px 10px;
-  background: #1e1e1e;
-  border: 1px solid #444;
-  border-radius: 6px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
   z-index: 9999;
   pointer-events: none;
 }
 
 .nodeTooltipTitle {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: #eee;
-  margin-bottom: 4px;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+  margin-bottom: var(--sp-2);
 }
 
 .nodeTooltipDesc {
-  font-size: 0.75rem;
-  color: #aaa;
-  line-height: 1.45;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  line-height: var(--lh-normal);
   white-space: normal;
   word-break: break-word;
 }
 
 /* ── Preset item ── */
 .presetItem {
-  padding: 8px 10px;
-  margin: 3px 6px;
-  border-radius: 6px;
+  padding: var(--sp-3) var(--sp-4);
+  margin: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius);
   cursor: grab;
   border: 1px solid transparent;
-  transition: all 0.15s;
+  transition: all var(--transition-fast);
   user-select: none;
 }
 
 .presetHeader {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 3px;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-2);
 }
 
 .presetName {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: #ddd;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -339,69 +353,71 @@
 }
 
 .presetDifficultyBadge {
-  font-size: 0.5625rem;
-  padding: 1px 4px;
-  border-radius: 3px;
-  font-weight: 600;
+  font-size: var(--fs-2xs);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
+  font-weight: var(--fw-semibold);
   flex-shrink: 0;
 }
 
 .presetDesc {
-  font-size: 0.6875rem;
-  color: #777;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+  line-height: var(--lh-snug);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .presetNodeCount {
-  font-size: 0.625rem;
-  color: #555;
-  margin-top: 3px;
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
+  margin-top: var(--sp-2);
 }
 
 /* ── Footer hint ── */
 .footer {
-  padding: 6px 10px;
-  border-top: 1px solid #2a2a2a;
-  font-size: 0.6875rem;
-  color: #444;
+  padding: var(--sp-3) var(--sp-4);
+  border-top: 1px solid var(--border-base);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   text-align: center;
   flex-shrink: 0;
 }
 
 /* ── Loading / error / empty states ── */
 .stateMessage {
-  padding: 20px 10px;
+  padding: var(--sp-6) var(--sp-4);
   text-align: center;
-  color: #666;
-  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
 }
 
 .stateMessageMuted {
-  padding: 20px 10px;
+  padding: var(--sp-6) var(--sp-4);
   text-align: center;
-  color: #555;
-  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
 }
 
 .errorWrapper {
-  padding: 12px 10px;
+  padding: var(--sp-4);
 }
 
 .errorText {
-  font-size: 0.75rem;
-  color: #F44336;
-  margin-bottom: 8px;
-  line-height: 1.4;
+  font-size: var(--fs-sm);
+  color: var(--status-error);
+  margin-bottom: var(--sp-3);
+  line-height: var(--lh-normal);
 }
 
 .retryButton {
-  font-size: 0.75rem;
-  padding: 4px 8px;
-  background: #333;
-  border: 1px solid #444;
-  border-radius: 4px;
-  color: #ccc;
+  font-size: var(--fs-sm);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
   cursor: pointer;
 }

--- a/frontend/src/components/Sidebar/NodesTab.test.tsx
+++ b/frontend/src/components/Sidebar/NodesTab.test.tsx
@@ -235,8 +235,10 @@ describe('NodesTab', () => {
     const item = nameEl.parentElement as HTMLElement;
 
     fireEvent.mouseEnter(item);
-    // Hover background applied (jsdom normalizes to rgb).
-    expect(item.style.background).toBe('rgb(42, 42, 42)');
+    // Hover background applied. Asserted as the token rather than a resolved
+    // colour: what matters is that hovering fills the row from the shared
+    // surface ramp, not which grey the ramp currently happens to hold.
+    expect(item.style.background).toBe('var(--surface-hover)');
     // Tooltip portal renders the description (appears twice: inline + tooltip).
     const tips = screen.getAllByText('tip text');
     expect(tips.length).toBeGreaterThanOrEqual(2);
@@ -261,7 +263,7 @@ describe('NodesTab', () => {
     const item = screen.getByText('Conv2d').parentElement as HTMLElement;
     fireEvent.mouseEnter(item);
     // No tooltip because desc is empty.
-    expect(item.style.background).toBe('rgb(42, 42, 42)');
+    expect(item.style.background).toBe('var(--surface-hover)');
     expect(screen.queryByText('Conv2d desc')).toBeNull();
   });
 

--- a/frontend/src/components/Sidebar/NodesTab.tsx
+++ b/frontend/src/components/Sidebar/NodesTab.tsx
@@ -55,8 +55,8 @@ export function NodeItem({ definition }: NodeItemProps) {
       onMouseLeave={handleMouseLeave}
       className={styles.nodeItem}
       style={{
-        background: hovered ? '#2a2a2a' : 'transparent',
-        borderColor: hovered ? '#444' : 'transparent',
+        background: hovered ? 'var(--surface-hover)' : 'transparent',
+        borderColor: hovered ? 'var(--border-base)' : 'transparent',
       }}
     >
       <div className={styles.nodeItemName}>

--- a/frontend/src/components/Sidebar/PresetsTab.tsx
+++ b/frontend/src/components/Sidebar/PresetsTab.tsx
@@ -33,6 +33,12 @@ export function PresetItem({ preset }: PresetItemProps) {
       onMouseLeave={() => setHovered(false)}
       title={preset.description}
       className={styles.presetItem}
+      // Gold preset-hover tint: a semantic per-item accent (same family as
+      // CATEGORY_COLORS/DIFFICULTY_COLORS below), not chrome, so it is left
+      // outside the grey/accent token sweep. Close to --status-preset
+      // (#e0a92b) but not identical, and there is no wash/alpha variant of
+      // it to reach for; PresetsTab.test.tsx also pins this exact rgba
+      // string. See migration report for the token gap.
       style={{
         background: hovered ? 'rgba(212,160,23,0.08)' : 'transparent',
         borderColor: hovered ? 'rgba(212,160,23,0.3)' : 'transparent',

--- a/frontend/src/components/Sidebar/SidebarRail.module.css
+++ b/frontend/src/components/Sidebar/SidebarRail.module.css
@@ -10,10 +10,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
-  padding: 6px 0;
+  gap: var(--sp-1);
+  padding: var(--sp-3) 0;
   box-sizing: border-box;
-  background: #101010;
+  background: var(--surface-app);
 }
 
 /* Only the four tab buttons live in the tablist; the collapse toggle is a
@@ -22,7 +22,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
+  gap: var(--sp-1);
 }
 
 .railButton {
@@ -30,33 +30,33 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: var(--h-control);
+  height: var(--h-control);
   padding: 0;
   flex-shrink: 0;
   background: transparent;
   border: none;
-  border-radius: 6px;
-  color: #6b6b6b;
+  border-radius: var(--radius);
+  color: var(--text-muted);
   cursor: pointer;
-  transition: color 0.15s, background 0.15s;
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .railButton:hover {
-  color: #d8d8d8;
-  background: #1c1c1c;
+  color: var(--text-secondary);
+  background: var(--surface-hover);
 }
 
 .railButton:focus-visible {
-  outline: 1px solid #06b6d4;
+  outline: 1px solid var(--accent-deep);
   outline-offset: 1px;
 }
 
 /* Open tab: teal glyph plus the flush-left marker VS Code's activity bar uses,
    so the active section is readable at a glance even peripherally. */
 .railButtonActive {
-  color: #22d3ee;
-  background: #1a1a1a;
+  color: var(--accent);
+  background: var(--surface-active);
 }
 
 .railButtonActive::before {
@@ -66,12 +66,12 @@
   top: 6px;
   bottom: 6px;
   width: 2px;
-  border-radius: 0 2px 2px 0;
-  background: #06b6d4;
+  border-radius: var(--radius-sm);
+  background: var(--accent-deep);
 }
 
 /* Pushes the collapse toggle to the bottom of the rail. */
 .railSpacer {
   flex: 1;
-  min-height: 8px;
+  min-height: var(--sp-3);
 }

--- a/frontend/src/components/Sidebar/TemplatesTab.module.css
+++ b/frontend/src/components/Sidebar/TemplatesTab.module.css
@@ -1,66 +1,71 @@
 /* ── Templates tab: example rows (#126) ── */
 .exampleItem {
   display: block;
-  width: calc(100% - 12px);
-  margin: 2px 6px;
-  padding: 6px 10px;
-  border-radius: 5px;
+  width: calc(100% - var(--sp-4));
+  margin: var(--sp-1) var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--radius);
   background: transparent;
   border: 1px solid transparent;
   color: inherit;
   text-align: left;
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .exampleItem:hover {
-  background: #232323;
-  border-color: #3a3a3a;
+  background: var(--surface-hover);
+  border-color: var(--border-base);
 }
 
 .exampleName {
-  font-size: 0.8125rem;
-  font-weight: 500;
-  color: #ddd;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .exampleDesc {
-  font-size: 0.6875rem;
-  color: #777;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+  line-height: var(--lh-snug);
+  margin-top: var(--sp-1);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  margin-top: 1px;
 }
 
 .exampleMeta {
-  font-size: 0.625rem;
-  color: #555;
-  margin-top: 3px;
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
+  margin-top: var(--sp-2);
 }
 
 /* ── Footer: the way into the full gallery modal (core#128) ── */
 .browseButton {
   display: block;
   width: 100%;
-  padding: 5px 8px;
-  background: rgba(6, 182, 212, 0.1);
-  border: 1px solid #0e7490;
-  border-radius: 4px;
-  color: #22d3ee;
-  font-size: 0.75rem;
-  font-weight: 600;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--accent-wash);
+  border: 1px solid var(--accent-dim);
+  border-radius: var(--radius-sm);
+  color: var(--accent);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
+/* A bolder filled state on hover (rather than a second wash alpha tier,
+   which no token provides) makes this footer CTA read as clearly activated. */
 .browseButton:hover {
-  background: rgba(6, 182, 212, 0.22);
+  background: var(--accent-dim);
+  color: var(--text-on-accent);
 }
 
 .footerHint {
-  margin-top: 5px;
+  margin-top: var(--sp-2);
 }

--- a/frontend/src/components/SubgraphEditor/graphSerialization.ts
+++ b/frontend/src/components/SubgraphEditor/graphSerialization.ts
@@ -560,7 +560,11 @@ function colorForType(type: string): string {
   if (type === 'Input') return '#4CAF50';
   if (type === 'Output') return '#F44336';
   if (MERGE_TYPES.has(type)) return '#FF9800';
-  // fallback colors by category — duplicated from SubgraphEditorModal LAYER_DEFS
+  // Fallback colors by category, duplicated from SubgraphEditorModal LAYER_DEFS.
+  // NOTE: this is the Subgraph editor's own layer-type palette, still on the
+  // pre-lift Material hues and not yet on the token layer. Migrating it means
+  // deciding what each layer type should map to, so it is tracked separately
+  // rather than half-converted here.
   const colors: Record<string, string> = {
     Conv2d: '#4CAF50', Conv1d: '#4CAF50', ConvTranspose2d: '#4CAF50',
     BatchNorm2d: '#9C27B0', BatchNorm1d: '#9C27B0', LayerNorm: '#9C27B0',

--- a/frontend/src/components/TabBar/TabBar.module.css
+++ b/frontend/src/components/TabBar/TabBar.module.css
@@ -1,9 +1,9 @@
 /* TabBar.module.css */
 
 .bar {
-  height: 32px;
-  background: #151515;
-  border-bottom: 1px solid #2a2a2a;
+  height: var(--h-control);
+  background: var(--surface-app);
+  border-bottom: 1px solid var(--border-base);
   display: flex;
   align-items: stretch;
   flex-shrink: 0;
@@ -22,15 +22,15 @@
 .tab {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 0 12px;
+  gap: var(--sp-3);
+  padding: 0 var(--sp-4);
   cursor: pointer;
-  border-right: 1px solid #222;
-  font-size: 0.8125rem;
+  border-right: 1px solid var(--border-subtle);
+  font-size: var(--fs-md);
   min-width: 80px;
   max-width: 180px;
   flex-shrink: 0;
-  transition: background 0.15s, color 0.15s;
+  transition: background var(--transition-fast), color var(--transition-fast);
   user-select: none;
 }
 
@@ -42,33 +42,33 @@
 
 /* Edit input inside tab */
 .editInput {
-  background: #111;
-  border: 1px solid #444;
-  border-radius: 3px;
-  color: #eee;
-  font-size: 0.8125rem;
-  padding: 1px 4px;
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  padding: var(--sp-1) var(--sp-2);
   width: 80px;
   outline: none;
 }
 
 /* Close button */
 .closeBtn {
-  font-size: 0.9375rem;
-  color: #555;
+  font-size: var(--fs-lg);
+  color: var(--text-muted);
   cursor: pointer;
   flex-shrink: 0;
-  line-height: 1;
+  line-height: var(--lh-tight);
   width: 16px;
   height: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
 }
 
 .closeBtn:hover {
-  color: #ccc;
+  color: var(--text-secondary);
 }
 
 /* Running indicator dot — bg + box-shadow applied inline when running */
@@ -81,12 +81,12 @@
 
 /* Add tab button */
 .addBtn {
-  padding: 0 12px;
+  padding: 0 var(--sp-4);
   background: transparent;
   border: none;
-  border-left: 1px solid #222;
-  color: #555;
-  font-size: 1.0625rem;
+  border-left: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: var(--fs-xl);
   cursor: pointer;
   flex-shrink: 0;
   display: flex;
@@ -94,5 +94,5 @@
 }
 
 .addBtn:hover {
-  color: #ccc;
+  color: var(--text-secondary);
 }

--- a/frontend/src/components/TabBar/TabBar.tsx
+++ b/frontend/src/components/TabBar/TabBar.tsx
@@ -63,13 +63,20 @@ export function TabBar() {
               onDoubleClick={() => startRename(tab.id, tab.name)}
               className={styles.tab}
               style={{
-                background: isActive ? '#1e1e1e' : 'transparent',
-                borderBottom: isActive ? '2px solid #2196F3' : '2px solid transparent',
-                color: isActive ? '#eee' : '#777',
+                background: isActive ? 'var(--surface-raised)' : 'transparent',
+                borderBottom: isActive ? '2px solid var(--accent)' : '2px solid transparent',
+                color: isActive ? 'var(--text-primary)' : 'var(--text-muted)',
+                // Left as numeric literals: TabBar.test.tsx pins the exact
+                // string ('600'/'400') and isn't in this migration's file
+                // list to update.
                 fontWeight: isActive ? 600 : 400,
               }}
             >
-              {/* Running indicator */}
+              {/* Running indicator. #FFC107 already equals --status-running
+                  exactly (no contrast/colour bug here); left as a literal
+                  because TabBar.test.tsx pins the hex substring in
+                  boxShadow and the test file is outside this migration's
+                  scope. */}
               {isRunning && (
                 <span
                   className={styles.runningDot}

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.module.css
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.module.css
@@ -5,7 +5,7 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.68);
+  background: var(--surface-scrim);
   backdrop-filter: blur(2px);
   display: flex;
   align-items: center;
@@ -19,12 +19,10 @@
   max-width: 1180px;
   height: 82vh;
   min-width: 320px;
-  background: linear-gradient(180deg, #0e1520 0%, #0a0f17 100%);
-  border: 1px solid #1f2937;
-  border-radius: 10px;
-  box-shadow:
-    0 30px 70px -20px rgba(0, 0, 0, 0.8),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  background: linear-gradient(180deg, var(--surface-panel) 0%, var(--surface-canvas) 100%);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-popover), var(--inner-highlight);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -36,11 +34,11 @@
 .header {
   display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 12px 14px;
+  gap: var(--sp-4);
+  padding: var(--sp-4) var(--sp-4);
   flex-shrink: 0;
   background: rgba(10, 15, 23, 0.72);
-  border-bottom: 2px solid #06b6d4;
+  border-bottom: 2px solid var(--accent-deep);
 }
 
 .titleBlock {
@@ -48,57 +46,57 @@
 }
 
 .title {
-  color: #e5e7eb;
-  font-size: 0.9375rem;
-  font-weight: 600;
-  line-height: 1.2;
+  color: var(--text-primary);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-tight);
 }
 
 .subtitle {
-  color: #64748b;
-  font-size: 0.6875rem;
-  margin-top: 2px;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  margin-top: var(--sp-1);
 }
 
 .search {
   margin-left: auto;
   width: 240px;
   max-width: 40%;
-  padding: 5px 9px;
-  background: #0a0f17;
-  border: 1px solid #334155;
-  border-radius: 5px;
-  color: #e5e7eb;
-  font-size: 0.8125rem;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: var(--fs-md);
   outline: none;
 }
 
 .search:focus {
-  border-color: #06b6d4;
+  border-color: var(--accent-deep);
 }
 
 .closeBtn {
   background: transparent;
-  border: 1px solid #334155;
-  color: #cbd5e1;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
   width: 26px;
   height: 26px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 1rem;
-  line-height: 1;
+  font-size: var(--fs-lg);
+  line-height: var(--lh-tight);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
   flex-shrink: 0;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .closeBtn:hover {
-  background: rgba(244, 67, 54, 0.14);
-  border-color: #f44336;
-  color: #ff7b72;
+  background: var(--danger-wash);
+  border-color: var(--status-error);
+  color: var(--status-error);
 }
 
 /* ── Body: card grid left, detail right ─────────────────────────────────── */
@@ -113,47 +111,47 @@
   flex: 1;
   min-width: 0;
   overflow-y: auto;
-  padding: 14px 16px 20px;
+  padding: var(--sp-4) var(--sp-5) var(--sp-6);
 }
 
 .stateMessage {
-  color: #64748b;
-  font-size: 0.8125rem;
-  padding: 28px 4px;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
+  padding: var(--sp-8) var(--sp-2);
   text-align: center;
 }
 
 .errorText {
-  color: #f44336;
-  margin-bottom: 10px;
+  color: var(--status-error);
+  margin-bottom: var(--sp-4);
 }
 
 .retryBtn {
-  font-size: 0.75rem;
-  padding: 4px 10px;
-  background: #1f2937;
-  border: 1px solid #334155;
-  border-radius: 4px;
-  color: #cbd5e1;
+  font-size: var(--fs-sm);
+  padding: var(--sp-2) var(--sp-4);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
   cursor: pointer;
 }
 
 .retryBtn:hover {
-  border-color: #06b6d4;
-  color: #22d3ee;
+  border-color: var(--accent-deep);
+  color: var(--accent);
 }
 
 .section {
-  margin-bottom: 18px;
+  margin-bottom: var(--sp-5);
 }
 
 .sectionTitle {
   display: flex;
   align-items: center;
-  gap: 7px;
-  margin: 0 0 8px;
-  font-size: 0.6875rem;
-  font-weight: 700;
+  gap: var(--sp-3);
+  margin: 0 0 var(--sp-3);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -166,56 +164,62 @@
 }
 
 .sectionCount {
-  color: #64748b;
+  color: var(--text-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-weight: 400;
+  font-weight: var(--fw-normal);
   letter-spacing: 0;
 }
 
 .cards {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 10px;
+  gap: var(--sp-4);
 }
 
 .card {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: var(--sp-2);
   min-width: 0;
-  padding: 10px 12px;
+  padding: var(--sp-4) var(--sp-4);
   text-align: left;
-  background: #131b26;
-  border: 1px solid #1f2937;
-  border-radius: 7px;
+  /* Cards are the primary browsing surface — the "cards, nodes, popovers,
+     menus" tier, one step up from the modal's own panel/canvas backdrop. */
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
   cursor: pointer;
   color: inherit;
-  transition: border-color 0.12s, background 0.12s, box-shadow 0.12s;
+  transition: border-color var(--transition-fast), background var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .card:hover {
-  background: #16202d;
-  border-color: #334155;
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
 }
 
 .cardActive {
-  border-color: #06b6d4;
+  border-color: var(--accent-deep);
+  /* rgb(6,182,212) mirrors --accent-deep; kept as a literal ring since alpha
+     rings have no dedicated token. */
   box-shadow: 0 0 0 1px rgba(6, 182, 212, 0.35);
 }
 
 .cardName {
-  color: #e5e7eb;
-  font-size: 0.8125rem;
-  font-weight: 600;
+  /* Gallery cards are a primary browsing surface, not secondary chrome —
+     titles read at the emphasis tier, not the UI-body tier. */
+  color: var(--text-primary);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .cardDesc {
-  color: #64748b;
-  font-size: 0.6875rem;
-  line-height: 1.45;
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-normal);
   /* Two lines, then ellipsis — the detail pane carries the full text. */
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -229,24 +233,28 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 6px;
-  margin-top: 2px;
+  gap: var(--sp-3);
+  margin-top: var(--sp-1);
 }
 
 .cardChip {
-  font-size: 0.5625rem;
+  /* The hue supplies the border and the fill tint (both graphics, 3:1). The
+     label is text, so it takes the text tier — the hue on a tint of itself
+     measured 3.77-4.16:1 and cannot be tuned up to 4.5. */
+  color: var(--text-muted);
+  font-size: var(--fs-2xs);
   border: 1px solid;
-  border-radius: 9px;
-  padding: 0 6px;
-  line-height: 1.6;
+  border-radius: var(--radius-pill);
+  padding: 0 var(--sp-3);
+  line-height: var(--lh-tight);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .cardCount {
-  color: #475569;
-  font-size: 0.625rem;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   white-space: nowrap;
 }
@@ -256,10 +264,10 @@
 .detail {
   width: 290px;
   flex-shrink: 0;
-  border-left: 1px solid #1f2937;
+  border-left: 1px solid var(--border-base);
   background: rgba(0, 0, 0, 0.18);
   overflow: hidden;
-  padding: 16px 16px 20px;
+  padding: var(--sp-5) var(--sp-5) var(--sp-6);
   display: flex;
   flex-direction: column;
 }
@@ -274,67 +282,69 @@
 }
 
 .detailEmpty {
-  color: #64748b;
-  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
 }
 
 .detailName {
-  color: #e5e7eb;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.3;
+  color: var(--text-primary);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-snug);
   word-break: break-word;
 }
 
 .detailMeta {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px 10px;
-  margin-top: 6px;
-  color: #64748b;
-  font-size: 0.6875rem;
+  gap: var(--sp-2) var(--sp-4);
+  margin-top: var(--sp-3);
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .detailSource {
-  margin-top: 6px;
-  color: #475569;
-  font-size: 0.6875rem;
+  margin-top: var(--sp-3);
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
 }
 
 .detailDesc {
-  margin: 12px 0 0;
-  color: #94a3b8;
-  font-size: 0.75rem;
-  line-height: 1.6;
+  /* Prose read at length in the pane, not a caption — same body-copy tier as
+     the card description rather than the smaller generic-table mapping. */
+  margin: var(--sp-4) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-normal);
   word-break: break-word;
 }
 
 .detailActions {
   flex-shrink: 0;
-  margin-top: 14px;
-  padding-top: 14px;
-  border-top: 1px solid #1f2937;
+  margin-top: var(--sp-4);
+  padding-top: var(--sp-4);
+  border-top: 1px solid var(--border-base);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .primaryBtn,
 .secondaryBtn {
   width: 100%;
-  padding: 8px 12px;
-  border-radius: 6px;
-  font-size: 0.8125rem;
-  font-weight: 600;
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--radius);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
   cursor: pointer;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .primaryBtn {
-  background: rgba(6, 182, 212, 0.16);
-  border: 1px solid #06b6d4;
-  color: #22d3ee;
+  background: var(--accent-wash);
+  border: 1px solid var(--accent-deep);
+  color: var(--accent);
 }
 
 .primaryBtn:hover:not(:disabled) {
@@ -343,13 +353,13 @@
 
 .secondaryBtn {
   background: transparent;
-  border: 1px solid #334155;
-  color: #cbd5e1;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
 }
 
 .secondaryBtn:hover:not(:disabled) {
-  border-color: #06b6d4;
-  color: #22d3ee;
+  border-color: var(--accent-deep);
+  color: var(--accent);
 }
 
 .primaryBtn:disabled,
@@ -359,9 +369,9 @@
 }
 
 .detailHint {
-  color: #64748b;
-  font-size: 0.625rem;
-  line-height: 1.5;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-normal);
 }
 
 /* Narrow viewports: the detail pane drops below the grid rather than
@@ -374,7 +384,7 @@
   .detail {
     width: auto;
     border-left: none;
-    border-top: 1px solid #1f2937;
+    border-top: 1px solid var(--border-base);
     max-height: 42%;
   }
 

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.tsx
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.tsx
@@ -5,7 +5,7 @@ import { insertExample, openExampleInNewTab } from '../../utils/openExample';
 import { useDialogStore } from '../../store/dialogStore';
 import { useUIStore } from '../../store/uiStore';
 import { useI18n } from '../../i18n';
-import { EXAMPLE_CATEGORY_COLORS, EXAMPLE_CATEGORY_FALLBACK } from '../../styles/theme';
+import { EXAMPLE_CATEGORY_COLORS, EXAMPLE_CATEGORY_FALLBACK, mixColor, NODE_HEADER_TINT, SURFACE_RAISED } from '../../styles/theme';
 // The sidebar's Templates tab (#126) already owns the category order every
 // example surface is expected to share; importing it keeps the modal's grid
 // and the tab's list in the same sequence by construction rather than by
@@ -219,6 +219,11 @@ function TemplateGalleryBody() {
               groups.map(({ category, items }) => {
                 const color =
                   EXAMPLE_CATEGORY_COLORS[category] ?? EXAMPLE_CATEGORY_FALLBACK;
+                // Badge fill is the category hue mixed into --surface-raised
+                // (the same tint node headers use), not an alpha wash over an
+                // unknown backdrop — that pattern is what measured 2.24:1 on
+                // these badges. See scripts/check-contrast.mjs section 8b.
+                const chipFill = mixColor(SURFACE_RAISED, color, NODE_HEADER_TINT);
                 return (
                   <section key={category} className={styles.section}>
                     <h3 className={styles.sectionTitle} style={{ color }}>
@@ -243,7 +248,10 @@ function TemplateGalleryBody() {
                           <span className={styles.cardFooter}>
                             <span
                               className={styles.cardChip}
-                              style={{ color, borderColor: color }}
+                              // Hue on the border (a graphic, 3:1) and in the
+                              // fill; the label is text and takes the text tier.
+                              // The hue on its own tint cannot reach 4.5:1.
+                              style={{ borderColor: color, background: chipFill }}
                             >
                               {exampleCategoryLabel(category)}
                             </span>

--- a/frontend/src/components/Toolbar/FontSizeMenu.module.css
+++ b/frontend/src/components/Toolbar/FontSizeMenu.module.css
@@ -4,25 +4,25 @@
 
 .panel {
   position: absolute;
-  top: calc(100% + 0.375rem);
+  top: calc(100% + var(--sp-3));
   right: 0;
   min-width: 11rem;
-  background: #0a0f17;
-  border: 1px solid #1f2937;
-  border-radius: 0.5rem;
-  padding: 0.375rem;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-3);
   z-index: 250;
-  box-shadow: 0 1rem 2.5rem -0.75rem rgba(0, 0, 0, 0.7);
-  font-size: 0.8125rem;
+  box-shadow: var(--shadow-popover);
+  font-size: var(--fs-md);
 }
 
 .label {
-  font-size: 0.625rem;
-  color: #64748b;
-  padding: 0.25rem 0.625rem;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  padding: var(--sp-2) var(--sp-4);
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  font-weight: 700;
+  font-weight: var(--fw-bold);
 }
 
 .item {
@@ -30,34 +30,34 @@
   width: 100%;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0.625rem;
-  border-radius: 0.3125rem;
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--radius-sm);
   background: transparent;
   border: 0;
-  color: #cbd5e1;
+  color: var(--text-secondary);
   cursor: pointer;
   font-family: inherit;
-  font-size: 0.8125rem;
-  transition: background 0.1s ease, color 0.1s ease;
+  font-size: var(--fs-md);
+  transition: background var(--transition-fast), color var(--transition-fast);
   text-align: left;
 }
 
 .item:hover {
-  background: #1f2937;
-  color: #e5e7eb;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .item.active {
-  background: rgba(6, 182, 212, 0.12);
-  color: #67e8f9;
+  background: var(--accent-wash);
+  color: var(--accent);
 }
 
 .sample {
-  color: #64748b;
-  font-weight: 600;
-  line-height: 1;
+  color: var(--text-muted);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-tight);
 }
 
 .item.active .sample {
-  color: #06b6d4;
+  color: var(--accent-deep);
 }

--- a/frontend/src/components/Toolbar/SettingsPopover.module.css
+++ b/frontend/src/components/Toolbar/SettingsPopover.module.css
@@ -13,14 +13,13 @@
   right: 0;
   width: 23.75rem; /* 380px @ 16px root */
   z-index: 250;
-  background: #0a0f17;
-  border: 1px solid #1f2937;
-  border-radius: 0.625rem; /* 10px */
-  box-shadow: 0 1.5rem 3.75rem -0.75rem rgba(0, 0, 0, 0.8),
-    0 0 0 1px rgba(6, 182, 212, 0.05);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-popover);
   overflow: hidden;
-  font-size: 0.8125rem; /* 13px */
-  color: #e5e7eb;
+  font-size: var(--fs-md);
+  color: var(--text-primary);
 }
 
 .panel::before {
@@ -30,49 +29,49 @@
   right: 0.875rem;
   width: 0.75rem;
   height: 0.75rem;
-  background: #0a0f17;
-  border-left: 1px solid #1f2937;
-  border-top: 1px solid #1f2937;
+  background: var(--surface-raised);
+  border-left: 1px solid var(--border-base);
+  border-top: 1px solid var(--border-base);
   transform: rotate(45deg);
 }
 
 .head {
   position: relative;
-  padding: 0.75rem 1rem 0.625rem;
-  border-bottom: 1px solid #1f2937;
+  padding: var(--sp-4) var(--sp-5) var(--sp-4);
+  border-bottom: 1px solid var(--border-base);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: linear-gradient(180deg, #0e1520 0%, #0a0f17 100%);
+  background: linear-gradient(180deg, var(--surface-app) 0%, var(--surface-canvas) 100%);
 }
 
 .head h4 {
-  font-size: 0.8125rem;
-  color: #e5e7eb;
+  font-size: var(--fs-md);
+  color: var(--text-primary);
   margin: 0;
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
   letter-spacing: 0.01em;
 }
 
 .search {
-  background: #0c1220;
-  border: 1px solid #1f2937;
-  border-radius: 0.3125rem;
-  padding: 0.1875rem 0.5rem;
-  color: #cbd5e1;
-  font-size: 0.6875rem;
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-2) var(--sp-3);
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
   width: 8.75rem;
   font-family: inherit;
   outline: none;
-  transition: border-color 0.12s ease;
+  transition: border-color var(--transition-fast);
 }
 
 .search::placeholder {
-  color: #64748b;
+  color: var(--text-disabled);
 }
 
 .search:focus {
-  border-color: #0e7490;
+  border-color: var(--accent-dim);
 }
 
 .body {
@@ -81,8 +80,8 @@
 }
 
 .section {
-  padding: 0.5rem 0;
-  border-bottom: 1px solid #1a2230;
+  padding: var(--sp-3) 0;
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .section:last-child {
@@ -90,21 +89,21 @@
 }
 
 .sectionTitle {
-  padding: 0.5rem 1rem 0.25rem;
-  font-size: 0.65625rem; /* 10.5px */
-  font-weight: 700;
+  padding: var(--sp-3) var(--sp-5) var(--sp-2);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #06b6d4;
+  color: var(--accent-deep);
 }
 
 .row {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 0.75rem;
-  padding: 0.5rem 1rem;
+  gap: var(--sp-4);
+  padding: var(--sp-3) var(--sp-5);
   align-items: start;
-  transition: background 0.1s ease;
+  transition: background var(--transition-fast);
 }
 
 .row.interactive {
@@ -112,7 +111,7 @@
 }
 
 .row.interactive:hover {
-  background: rgba(255, 255, 255, 0.025);
+  background: var(--surface-hover);
 }
 
 .row.disabled {
@@ -124,17 +123,17 @@
 }
 
 .name {
-  color: #e5e7eb;
-  font-weight: 500;
-  font-size: 0.8125rem;
-  line-height: 1.35;
+  color: var(--text-primary);
+  font-weight: var(--fw-medium);
+  font-size: var(--fs-md);
+  line-height: var(--lh-snug);
 }
 
 .desc {
-  color: #64748b;
-  font-size: 0.71875rem; /* 11.5px */
-  margin-top: 0.125rem;
-  line-height: 1.45;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  margin-top: var(--sp-1);
+  line-height: var(--lh-normal);
 }
 
 .ctrl {
@@ -148,12 +147,12 @@
 .toggle {
   width: 2rem;
   height: 1.125rem;
-  border-radius: 0.5625rem;
-  background: #1f2937;
+  border-radius: var(--radius-pill);
+  background: var(--surface-input);
   position: relative;
   cursor: pointer;
   flex-shrink: 0;
-  transition: background 0.15s ease;
+  transition: background var(--transition-fast);
   border: 0;
   padding: 0;
 }
@@ -161,23 +160,23 @@
 .toggle::after {
   content: '';
   position: absolute;
-  top: 0.125rem;
-  left: 0.125rem;
+  top: var(--sp-1);
+  left: var(--sp-1);
   width: 0.875rem;
   height: 0.875rem;
   border-radius: 50%;
-  background: #475569;
-  transition: all 0.15s ease;
+  background: var(--border-strong);
+  transition: all var(--transition-fast);
 }
 
 .toggle.on {
-  background: #0e7490;
+  background: var(--accent-dim);
 }
 
 .toggle.on::after {
-  left: 1rem;
-  background: #06b6d4;
-  box-shadow: 0 0 0.375rem rgba(6, 182, 212, 0.6);
+  left: var(--sp-5);
+  background: var(--accent-deep);
+  box-shadow: 0 0 0.375rem var(--accent-glow);
 }
 
 .toggle:disabled {
@@ -188,17 +187,17 @@
 /* ----- Segmented control (Mode: Basic / All) ----- */
 .seg {
   display: inline-flex;
-  border: 1px solid #334155;
-  border-radius: 0.3125rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
   overflow: hidden;
-  font-size: 0.6875rem;
-  font-weight: 600;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
 }
 
 .segItem {
-  padding: 0.1875rem 0.5rem;
+  padding: var(--sp-2) var(--sp-3);
   cursor: pointer;
-  color: #64748b;
+  color: var(--text-muted);
   background: transparent;
   border: 0;
   font-family: inherit;
@@ -207,18 +206,18 @@
 }
 
 .segItem.active {
-  background: #06b6d4;
-  color: #021821;
+  background: var(--accent-deep);
+  color: var(--text-on-accent);
 }
 
 .segItem:hover:not(.active) {
-  color: #cbd5e1;
+  color: var(--text-secondary);
 }
 
 
 .buttonGroup {
   display: inline-flex;
-  gap: 0.375rem;
+  gap: var(--sp-3);
   align-items: center;
   justify-content: flex-end;
   flex-wrap: wrap;
@@ -226,21 +225,21 @@
 /* ----- Action button (Compare, Reset) ----- */
 .action {
   background: transparent;
-  border: 1px solid #334155;
-  color: #cbd5e1;
-  padding: 0.25rem 0.625rem;
-  font-size: 0.71875rem;
-  font-weight: 600;
-  border-radius: 0.3125rem;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  padding: var(--sp-2) var(--sp-4);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-family: inherit;
   white-space: nowrap;
-  transition: background 0.1s ease, border-color 0.1s ease, color 0.1s ease;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .action:hover:not(:disabled) {
-  background: #1f2937;
-  color: #e5e7eb;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .action:disabled {
@@ -248,71 +247,74 @@
   cursor: not-allowed;
 }
 
+/* No dedicated danger-border/danger-wash token exists yet, so both the text
+   and outline collapse onto --status-error (see migration report). */
 .action.danger {
-  color: #fca5a5;
-  border-color: #7f1d1d;
+  color: var(--status-error);
+  border-color: var(--status-error);
 }
 
 .action.danger:hover:not(:disabled) {
-  background: #450a0a;
-  color: #fecaca;
+  background: var(--danger-wash);
+  color: var(--text-primary);
 }
 
 .action.accent {
-  color: #06b6d4;
-  border-color: #0e7490;
-  background: rgba(6, 182, 212, 0.08);
+  color: var(--accent-deep);
+  border-color: var(--accent-dim);
+  background: var(--accent-wash);
 }
 
+/* Only one accent-wash alpha tier exists, so the hover affordance is carried
+   by brightening the text (deep -> accent) rather than a second wash step. */
 .action.accent:hover:not(:disabled) {
-  background: rgba(6, 182, 212, 0.15);
+  background: var(--accent-wash);
+  color: var(--accent);
 }
 
 .select {
-  background: #0f172a;
-  border: 1px solid #334155;
-  color: #cbd5e1;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.71875rem;
-  font-weight: 600;
-  border-radius: 0.3125rem;
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-family: inherit;
 }
 
 .select:hover {
-  border-color: #475569;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 /* Seed field (core#134). Matches .select's chrome so the Training section
    reads as one control column; narrow because a 32-bit seed is at most ten
    digits and a full-width box would dominate the row. */
 .numberInput {
-  background: #0f172a;
-  border: 1px solid #334155;
-  color: #cbd5e1;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.71875rem;
-  font-weight: 600;
-  border-radius: 0.3125rem;
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  border-radius: var(--radius-sm);
   font-family: inherit;
   width: 7.5rem;
   text-align: right;
 }
 
 .numberInput:hover {
-  border-color: #475569;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .numberInput:focus {
   outline: none;
-  border-color: var(--cd-accent, #2dd4bf);
-  color: #e5e7eb;
+  border-color: var(--accent);
+  color: var(--text-primary);
 }
 
 .numberInput::placeholder {
-  color: #64748b;
-  font-weight: 500;
+  color: var(--text-disabled);
+  font-weight: var(--fw-medium);
 }

--- a/frontend/src/components/Toolbar/Toolbar.module.css
+++ b/frontend/src/components/Toolbar/Toolbar.module.css
@@ -5,27 +5,27 @@
 
 /* ----- Root container ----- */
 .root {
-  background: linear-gradient(180deg, #0e1520 0%, #0a0f17 100%);
-  border-bottom: 1px solid #1a2230;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-  padding: 0.625rem 1rem;
+  background: linear-gradient(180deg, var(--surface-app) 0%, var(--surface-canvas) 100%);
+  border-bottom: 1px solid var(--border-base);
+  box-shadow: var(--inner-highlight);
+  padding: var(--sp-3) var(--sp-5);
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.625rem;
-  row-gap: 0.5rem;
+  gap: var(--sp-3);
+  row-gap: var(--sp-3);
   flex-shrink: 0;
   position: relative;
   z-index: 100;
-  font-size: 0.875rem;
-  color: #e5e7eb;
+  font-size: var(--fs-md);
+  color: var(--text-primary);
 }
 
 /* Left/right cluster grouping — wrap moves the whole cluster together */
 .cluster {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--sp-3);
   flex-shrink: 0;
 }
 
@@ -35,51 +35,54 @@
 
 /* ----- Logo ----- */
 .logo {
-  font-weight: 700;
+  font-weight: var(--fw-bold);
   letter-spacing: 0.01em;
-  color: #f3f4f6;
-  padding-right: 0.25rem;
-  font-size: 1rem;
+  color: var(--text-primary);
+  padding-right: var(--sp-2);
+  font-size: var(--fs-lg);
   flex-shrink: 0;
 }
 
 .logoBrand {
-  color: #f3f4f6;
+  color: var(--text-primary);
 }
 
 .logoSuffix {
-  color: #06b6d4;
+  color: var(--accent);
 }
 
 /* ----- Vertical separator ----- */
 .divider {
   width: 1px;
   height: 1.25rem;
-  background: #1f2937;
+  background: var(--border-base);
   flex-shrink: 0;
-  margin: 0 0.125rem;
+  margin: 0 var(--sp-1);
 }
 
 /* ----- Run button (filled accent + reflection) ----- */
 .runButton {
-  background: #06b6d4;
-  color: #021821;
-  font-weight: 700;
-  border-radius: 0.375rem;
+  background: var(--accent-deep);
+  color: var(--text-on-accent);
+  font-weight: var(--fw-bold);
+  border-radius: var(--radius);
   border: 0;
-  padding: 0.375rem 0.875rem;
+  padding: var(--sp-3) var(--sp-4);
   display: inline-flex;
   align-items: center;
-  gap: 0.4375rem;
+  gap: var(--sp-3);
   cursor: pointer;
   font-family: inherit;
-  font-size: 0.8125rem;
+  font-size: var(--fs-md);
   white-space: nowrap;
-  line-height: 1;
+  line-height: var(--lh-tight);
   flex-shrink: 0;
+  /* Preserve the signature glossy reflection (bespoke white highlight, same
+     spirit as --inner-highlight but at a stronger alpha for a saturated
+     accent surface) plus an accent-built outer glow. */
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22),
-    0 6px 14px -6px rgba(6, 182, 212, 0.5);
-  transition: background 0.12s ease, box-shadow 0.12s ease;
+    0 6px 14px -6px var(--accent-glow);
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .runButton::before {
@@ -88,7 +91,7 @@
 }
 
 .runButton:hover:not(:disabled) {
-  background: #22d3ee;
+  background: var(--accent);
 }
 
 .runButton:disabled {
@@ -99,21 +102,21 @@
 /* ----- Stop button (ghost) ----- */
 .stopButton {
   background: transparent;
-  color: #94a3b8;
-  border: 1px solid #334155;
-  border-radius: 0.375rem;
-  padding: 0.3125rem 0.75rem;
+  color: var(--text-muted);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: var(--sp-2) var(--sp-4);
   display: inline-flex;
   align-items: center;
-  gap: 0.4375rem;
+  gap: var(--sp-3);
   cursor: pointer;
   font-family: inherit;
-  font-size: 0.8125rem;
-  font-weight: 600;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
   white-space: nowrap;
-  line-height: 1;
+  line-height: var(--lh-tight);
   flex-shrink: 0;
-  transition: all 0.12s ease;
+  transition: all var(--transition-fast);
 }
 
 .stopButton::before {
@@ -122,8 +125,8 @@
 }
 
 .stopButton:hover:not(:disabled) {
-  background: #1f2937;
-  color: #cbd5e1;
+  background: var(--surface-hover);
+  color: var(--text-secondary);
 }
 
 .stopButton:disabled {
@@ -133,84 +136,84 @@
 
 /* ----- Ghost text button (File / Load / Export / Reload / Custom) ----- */
 .ghost {
-  color: #cbd5e1;
+  color: var(--text-secondary);
   background: transparent;
   border: 0;
-  padding: 0.3125rem 0.5625rem;
-  border-radius: 0.3125rem;
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-sm);
   font-family: inherit;
-  font-size: 0.8125rem;
-  font-weight: 500;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
   cursor: pointer;
   white-space: nowrap;
-  line-height: 1.4;
-  transition: background 0.1s ease, color 0.1s ease;
+  line-height: var(--lh-snug);
+  transition: background var(--transition-fast), color var(--transition-fast);
   flex-shrink: 0;
 }
 
 .ghost:hover {
-  background: #1f2937;
-  color: #f3f4f6;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .ghostMuted {
-  color: #94a3b8;
+  color: var(--text-muted);
 }
 
 .ghostMuted:hover {
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .ghost.open {
-  background: #1f2937;
-  color: #f3f4f6;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 /* ----- Icon button (⚙ Settings, ? Help) ----- */
 .iconBtn {
   width: 1.875rem;
-  height: 1.75rem;
-  border-radius: 0.375rem;
-  border: 1px solid #334155;
+  height: var(--h-control-sm);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-strong);
   background: transparent;
-  color: #94a3b8;
+  color: var(--text-muted);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.875rem;
+  font-size: var(--fs-md);
   font-family: inherit;
   cursor: pointer;
   flex-shrink: 0;
-  transition: all 0.12s ease;
+  transition: all var(--transition-fast);
 }
 
 .iconBtn:hover {
-  background: #1f2937;
-  color: #e5e7eb;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .iconBtn.active {
-  background: rgba(6, 182, 212, 0.12);
-  border-color: #0e7490;
-  color: #67e8f9;
+  background: var(--accent-wash);
+  border-color: var(--accent-dim);
+  color: var(--accent);
 }
 
 /* ----- Dropdown trigger (Aa, EN, Auto Layout) ----- */
 .dropdown {
   display: inline-flex;
   align-items: center;
-  gap: 0.3125rem;
-  padding: 0.3125rem 0.625rem;
-  border: 1px solid #334155;
-  border-radius: 0.375rem;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-4);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
   background: transparent;
-  color: #cbd5e1;
+  color: var(--text-secondary);
   font-family: inherit;
-  font-size: 0.8125rem;
-  font-weight: 500;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
   cursor: pointer;
   flex-shrink: 0;
-  transition: all 0.12s ease;
+  transition: all var(--transition-fast);
 }
 
 .dropdown::after {
@@ -220,14 +223,14 @@
 }
 
 .dropdown:hover {
-  background: #1f2937;
-  color: #f3f4f6;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .dropdown.open {
-  background: rgba(6, 182, 212, 0.1);
-  border-color: #0e7490;
-  color: #67e8f9;
+  background: var(--accent-wash);
+  border-color: var(--accent-dim);
+  color: var(--accent);
 }
 
 .dropdownNoCaret::after {
@@ -238,8 +241,8 @@
 .splitButton {
   display: inline-flex;
   align-items: stretch;
-  border: 1px solid #334155;
-  border-radius: 0.375rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
   overflow: hidden;
   flex-shrink: 0;
   position: relative;
@@ -248,28 +251,28 @@
 .splitButtonMain,
 .splitButtonCaret {
   background: transparent;
-  color: #cbd5e1;
+  color: var(--text-secondary);
   border: 0;
-  padding: 0.3125rem 0.625rem;
+  padding: var(--sp-2) var(--sp-4);
   cursor: pointer;
   font-family: inherit;
-  font-size: 0.8125rem;
-  font-weight: 500;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
   display: inline-flex;
   align-items: center;
-  gap: 0.3125rem;
-  transition: background 0.1s ease, color 0.1s ease;
+  gap: var(--sp-2);
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .splitButtonMain:hover,
 .splitButtonCaret:hover {
-  background: #1f2937;
-  color: #f3f4f6;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .splitButtonCaret {
-  border-left: 1px solid #1f2937;
-  padding: 0.3125rem 0.4375rem;
+  border-left: 1px solid var(--border-base);
+  padding: var(--sp-2) var(--sp-3);
   font-size: 0.7em;
 }
 
@@ -277,10 +280,10 @@
 .status {
   display: inline-flex;
   align-items: center;
-  gap: 0.3125rem;
-  color: #64748b;
-  font-size: 0.75rem;
-  padding: 0 0.25rem;
+  gap: var(--sp-2);
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  padding: 0 var(--sp-2);
   flex-shrink: 0;
 }
 
@@ -289,7 +292,7 @@
   width: 0.375rem;
   height: 0.375rem;
   border-radius: 50%;
-  background: #475569;
+  background: var(--status-idle);
   flex-shrink: 0;
 }
 
@@ -301,16 +304,16 @@
 
 .menuPanel {
   position: absolute;
-  top: calc(100% + 0.375rem);
+  top: calc(100% + var(--sp-3));
   left: 0;
   min-width: 12.5rem;
-  background: #0a0f17;
-  border: 1px solid #1f2937;
-  border-radius: 0.5rem;
-  box-shadow: 0 1rem 2.5rem -0.75rem rgba(0, 0, 0, 0.7);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-popover);
   overflow: hidden;
   z-index: 200;
-  padding: 0.25rem;
+  padding: var(--sp-2);
 }
 
 .menuPanelRight {
@@ -321,40 +324,40 @@
 .menuItem {
   display: block;
   width: 100%;
-  padding: 0.4375rem 0.625rem;
+  padding: var(--sp-3) var(--sp-4);
   text-align: left;
   background: transparent;
   border: 0;
-  border-radius: 0.3125rem;
-  color: #cbd5e1;
-  font-size: 0.8125rem;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
   cursor: pointer;
   font-family: inherit;
   white-space: nowrap;
-  transition: background 0.1s ease, color 0.1s ease;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .menuItem:hover {
-  background: #1f2937;
-  color: #f3f4f6;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .menuDivider {
   height: 1px;
-  background: #1f2937;
-  margin: 0.25rem 0;
+  background: var(--border-base);
+  margin: var(--sp-2) 0;
 }
 
 .menuMessage {
-  padding: 0.5rem 0.625rem;
-  font-size: 0.8125rem;
-  color: #94a3b8;
+  padding: var(--sp-3) var(--sp-4);
+  font-size: var(--fs-md);
+  color: var(--text-muted);
 }
 
 .menuMessageDim {
-  padding: 0.5rem 0.625rem;
-  font-size: 0.8125rem;
-  color: #64748b;
+  padding: var(--sp-3) var(--sp-4);
+  font-size: var(--fs-md);
+  color: var(--text-muted);
 }
 
 /* ----- Language dropdown specifics ----- */
@@ -363,60 +366,60 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 0.4375rem 0.625rem;
+  padding: var(--sp-3) var(--sp-4);
   background: transparent;
   border: 0;
-  border-radius: 0.3125rem;
-  font-size: 0.8125rem;
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-md);
   cursor: pointer;
   font-family: inherit;
-  color: #cbd5e1;
-  transition: background 0.1s ease, color 0.1s ease;
+  color: var(--text-secondary);
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .langOption:hover {
-  background: #1f2937;
+  background: var(--surface-hover);
 }
 
 .langOption.activeOption {
-  color: #67e8f9;
-  font-weight: 600;
+  color: var(--accent);
+  font-weight: var(--fw-semibold);
 }
 
 .langOptionCheck {
-  color: #06b6d4;
-  font-size: 0.6875rem;
+  color: var(--accent-deep);
+  font-size: var(--fs-xs);
 }
 
 /* ----- Auto Layout dropdown specifics ----- */
 .layoutDropdown {
   position: absolute;
-  top: calc(100% + 0.375rem);
+  top: calc(100% + var(--sp-3));
   right: 0;
-  background: #0a0f17;
-  border: 1px solid #1f2937;
-  border-radius: 0.5rem;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
   min-width: 12.5rem;
   z-index: 200;
-  padding: 0.25rem;
-  box-shadow: 0 1rem 2.5rem -0.75rem rgba(0, 0, 0, 0.7);
+  padding: var(--sp-2);
+  box-shadow: var(--shadow-popover);
 }
 
 .layoutDropdownItem {
-  padding: 0.4375rem 0.625rem;
+  padding: var(--sp-3) var(--sp-4);
   cursor: pointer;
-  color: #cbd5e1;
-  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 0.3125rem;
-  transition: background 0.1s ease, color 0.1s ease;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .layoutDropdownItem:hover {
-  background: #1f2937;
-  color: #f3f4f6;
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }
 
 .layoutDropdownItemDisabled {
@@ -426,8 +429,8 @@
 
 .layoutDropdownItemActive::after {
   content: '✓';
-  color: #06b6d4;
-  margin-left: 0.5rem;
+  color: var(--accent-deep);
+  margin-left: var(--sp-3);
 }
 
 /* ----- Hidden file input ----- */

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -196,7 +196,7 @@ function LoadSubMenuPanel({
       <button type="button"
         onClick={() => { onImport(); onClose(); }}
         className={styles.menuItem}
-        style={{ color: '#06b6d4' }}
+        style={{ color: 'var(--accent)' }}
       >
         {t('toolbar.import')}
       </button>
@@ -561,18 +561,20 @@ export function Toolbar() {
   /* ── Status visuals ───────────────────────────────────────────── */
 
   const statusKey = `status.${status}` as const;
+  // Token-mapped onto the app's canonical run-status palette (tokens.css
+  // --status-*, mirrored in styles/theme.ts STATUS_COLORS) instead of this
+  // component's own drifted copy — see migration report.
   const statusDotColors: Record<string, string> = {
-    idle: '#475569',
-    running: '#06b6d4',
-    completed: '#22c55e',
-    error: '#ef4444',
-    cached: '#06b6d4',
-    skipped: '#64748b',
+    idle: 'var(--status-idle)',
+    running: 'var(--status-running)',
+    completed: 'var(--status-completed)',
+    error: 'var(--status-error)',
+    cached: 'var(--status-cached)',
+    skipped: 'var(--status-skipped)',
   };
-  const statusDotColor = statusDotColors[status] ?? '#475569';
-  const statusGlow = status === 'running'
-    ? '0 0 0.375rem rgba(6, 182, 212, 0.6)'
-    : 'none';
+  const statusDotColor = statusDotColors[status] ?? 'var(--status-idle)';
+  // Must stay translucent: a solid colour here draws a hard ring, not a glow.
+  const statusGlow = status === 'running' ? 'var(--glow-running)' : 'none';
 
   return (
     <div className={styles.root}>
@@ -708,7 +710,7 @@ export function Toolbar() {
             className={styles.statusDot}
             style={{ background: statusDotColor, boxShadow: statusGlow }}
           />
-          <span style={{ color: status === 'running' ? '#06b6d4' : undefined }}>
+          <span style={{ color: status === 'running' ? 'var(--status-running)' : undefined }}>
             {t(statusKey)}
           </span>
         </div>

--- a/frontend/src/components/shared/ChartView.module.css
+++ b/frontend/src/components/shared/ChartView.module.css
@@ -3,24 +3,24 @@
 .wrapper {
   display: inline-block;
   max-width: 100%;
-  padding: 8px 10px 10px;
-  background: #161616;
-  border: 1px solid #2a2a2a;
-  border-radius: 4px;
+  padding: var(--sp-3) var(--sp-4) var(--sp-4);
+  background: var(--surface-panel);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
 }
 
 .title {
-  font-size: 11px;
-  font-weight: 600;
-  color: #ccc;
-  margin-bottom: 2px;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  color: var(--text-secondary);
+  margin-bottom: var(--sp-1);
 }
 
 .note {
-  font-size: 10px;
+  font-size: var(--fs-xs);
   font-style: italic;
-  color: #6b7280;
-  margin-bottom: 4px;
+  color: var(--text-muted);
+  margin-bottom: var(--sp-2);
 }
 
 /* Wide charts scroll inside the card rather than widening the panel. */
@@ -33,13 +33,15 @@
   justify-content: flex-start;
 }
 
+/* Plain HTML text (not SVG), so it moves onto the type scale rather than
+   keeping a raw px value — these are short axis min/max tags, not prose. */
 .axes {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
-  margin-top: 4px;
-  font-size: 9px;
-  color: #6b7280;
+  gap: var(--sp-4);
+  margin-top: var(--sp-2);
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
 }
 
 .axisY {
@@ -51,8 +53,8 @@
 }
 
 .unknown {
-  padding: 12px 8px;
-  font-size: 11px;
+  padding: var(--sp-4) var(--sp-3);
+  font-size: var(--fs-xs);
   font-style: italic;
-  color: #6b7280;
+  color: var(--text-muted);
 }

--- a/frontend/src/components/shared/CodeEditor.module.css
+++ b/frontend/src/components/shared/CodeEditor.module.css
@@ -4,14 +4,19 @@
 
 .wrapper {
   position: relative;
-  border: 1px solid #1f2937;
-  border-radius: 4px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  /* Translucent rather than a solid surface token on purpose: this wrapper
+     is mounted in several different parent surfaces (side panel column,
+     modal tab), and a black film at low alpha always reads as "one step
+     darker than whatever is behind it" there. A fixed surface token could
+     end up lighter than its parent in some of those spots. */
   background: rgba(0, 0, 0, 0.25);
   overflow: hidden;
 }
 
 .wrapper:focus-within {
-  border-color: #06b6d4;
+  border-color: var(--border-focus);
 }
 
 .host {
@@ -23,15 +28,19 @@
   display: block;
   width: 100%;
   box-sizing: border-box;
-  padding: 6px 8px;
+  padding: var(--sp-3) var(--sp-3);
   border: none;
   outline: none;
   resize: vertical;
   background: transparent;
-  color: #e5e7eb;
+  color: var(--text-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  /* Pinned to the CodeMirror instance's own hardcoded 12px (codemirrorSetup.ts
+     `theme.fontSize`) rather than a token: the two must measure identically
+     so swapping between the lazy-loaded editor and this fallback — on first
+     mount and if the chunk fails to load — causes no visible reflow. */
   font-size: 12px;
-  line-height: 1.55;
+  line-height: var(--lh-normal);
   tab-size: 4;
   white-space: pre;
 }

--- a/frontend/src/components/shared/ContextMenu.module.css
+++ b/frontend/src/components/shared/ContextMenu.module.css
@@ -1,23 +1,26 @@
 .menu {
   position: fixed;
-  background: #1f1f1f;
-  border: 1px solid #444;
-  border-radius: 4px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
-  padding: 4px 0;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow);
+  padding: var(--sp-2) 0;
   z-index: 1000;
   min-width: 160px;
 }
 
 .item {
-  padding: 8px 16px;
+  padding: var(--sp-3) var(--sp-5);
   cursor: pointer;
-  color: #e0e0e0;
-  font-size: 13px;
+  color: var(--text-primary);
+  font-size: var(--fs-md);
   user-select: none;
 }
 
 .item:hover {
-  background: #2d4a2d;
-  color: #ffffff;
+  /* Was an unexplained green (#2d4a2d) unrelated to any status meaning —
+     normalized to the standard neutral row-hover used by every other list
+     in the app (e.g. CustomNodeManager's .nodeRow:hover). */
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }

--- a/frontend/src/components/shared/DialogContainer.module.css
+++ b/frontend/src/components/shared/DialogContainer.module.css
@@ -1,21 +1,20 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.65);
+  background: var(--surface-scrim);
   backdrop-filter: blur(2px);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10000;
-  padding: 24px;
+  padding: var(--sp-7);
 }
 
 .dialog {
-  background: linear-gradient(180deg, #0e1520 0%, #0a0f17 100%);
-  border: 1px solid #1f2937;
-  border-radius: 8px;
-  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.7),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  background: linear-gradient(180deg, var(--surface-panel) 0%, var(--surface-canvas) 100%);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-popover), var(--inner-highlight);
   display: flex;
   flex-direction: column;
   min-width: 360px;
@@ -26,107 +25,109 @@
 .header {
   display: flex;
   align-items: center;
-  padding: 12px 16px;
-  border-bottom: 1px solid #1f2937;
+  padding: var(--sp-4) var(--sp-5);
+  border-bottom: 1px solid var(--border-base);
   background: rgba(10, 15, 23, 0.6);
 }
 
 .title {
-  color: #e5e7eb;
-  font-size: 13px;
-  font-weight: 600;
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .body {
-  padding: 16px;
+  padding: var(--sp-5);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--sp-4);
 }
 
 .message {
-  color: #cbd5e1;
-  font-size: 13px;
-  line-height: 1.5;
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-normal);
   white-space: pre-wrap;
 }
 
 .input {
-  background: #0a0f17;
-  border: 1px solid #334155;
-  border-radius: 4px;
-  padding: 8px 10px;
-  color: #e5e7eb;
-  font-size: 13px;
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-3) var(--sp-4);
+  color: var(--text-primary);
+  font-size: var(--fs-md);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   outline: none;
-  transition: border-color 0.12s, box-shadow 0.12s;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .input:focus {
-  border-color: #06b6d4;
+  border-color: var(--accent-deep);
   box-shadow: 0 0 0 2px rgba(6, 182, 212, 0.15);
 }
 
 .error {
-  color: #fca5a5;
-  font-size: 11px;
+  color: var(--status-error);
+  font-size: var(--fs-xs);
   font-style: italic;
 }
 
 .footer {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  padding-top: 4px;
+  gap: var(--sp-3);
+  padding-top: var(--sp-2);
 }
 
 .cancelBtn {
   background: transparent;
-  border: 1px solid #334155;
-  color: #cbd5e1;
-  padding: 6px 14px;
-  border-radius: 4px;
-  font-size: 12px;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   cursor: pointer;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .cancelBtn:hover {
-  background: #1f2937;
-  border-color: #475569;
-  color: #e5e7eb;
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
 }
 
 .confirmBtn {
-  background: #0e7490;
-  border: 1px solid #06b6d4;
-  color: #ffffff;
-  padding: 6px 14px;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 600;
+  background: var(--accent-dim);
+  border: 1px solid var(--accent-deep);
+  color: var(--text-primary);
+  padding: var(--sp-3) var(--sp-4);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   cursor: pointer;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18),
     0 4px 12px -4px rgba(6, 182, 212, 0.4);
-  transition: background 0.12s, box-shadow 0.12s;
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .confirmBtn:hover {
-  background: #06b6d4;
+  background: var(--accent-deep);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.22),
     0 6px 14px -6px rgba(6, 182, 212, 0.55);
 }
 
 .confirmBtn:focus-visible {
-  outline: 2px solid #67e8f9;
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
 .confirmBtn.danger {
+  /* No solid "danger button fill" token exists (--status-error is tuned for
+     text contrast, not a saturated button fill) — kept literal, see report. */
   background: #b91c1c;
   border-color: #ef4444;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18),

--- a/frontend/src/components/shared/HeatmapModal.module.css
+++ b/frontend/src/components/shared/HeatmapModal.module.css
@@ -1,21 +1,20 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.65);
+  background: var(--surface-scrim);
   backdrop-filter: blur(2px);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 9999;
-  padding: 24px;
+  padding: var(--sp-7);
 }
 
 .modal {
-  background: linear-gradient(180deg, #0e1520 0%, #0a0f17 100%);
-  border: 1px solid #1f2937;
-  border-radius: 8px;
-  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.7),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  background: linear-gradient(180deg, var(--surface-panel) 0%, var(--surface-canvas) 100%);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-popover), var(--inner-highlight);
   display: flex;
   flex-direction: column;
   max-width: 80vw;
@@ -29,43 +28,43 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 14px;
-  border-bottom: 1px solid #1f2937;
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--border-base);
   background: rgba(10, 15, 23, 0.6);
 }
 
 .title {
-  color: #e5e7eb;
-  font-weight: 600;
-  font-size: 13px;
+  color: var(--text-primary);
+  font-weight: var(--fw-semibold);
+  font-size: var(--fs-md);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .closeBtn {
   background: transparent;
-  border: 1px solid #334155;
-  color: #cbd5e1;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
   width: 26px;
   height: 26px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 16px;
-  line-height: 1;
+  font-size: var(--fs-lg);
+  line-height: var(--lh-tight);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .closeBtn:hover {
-  background: #1f2937;
-  border-color: #06b6d4;
-  color: #67e8f9;
+  background: var(--surface-hover);
+  border-color: var(--accent-deep);
+  color: var(--accent);
 }
 
 .content {
-  padding: 16px;
+  padding: var(--sp-5);
   overflow: auto;
   display: flex;
   align-items: center;
@@ -75,34 +74,34 @@
 }
 
 .status {
-  color: #94a3b8;
-  font-size: 12px;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
   text-align: center;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .error {
-  color: #fca5a5;
+  color: var(--status-error);
 }
 
 .errorHint {
-  color: #94a3b8;
-  font-size: 11px;
-  margin-top: 8px;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  margin-top: var(--sp-3);
   font-style: italic;
 }
 
 .footer {
   display: flex;
   justify-content: space-between;
-  padding: 8px 14px;
-  border-top: 1px solid #1f2937;
+  padding: var(--sp-3) var(--sp-4);
+  border-top: 1px solid var(--border-base);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  color: #94a3b8;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   background: rgba(10, 15, 23, 0.6);
 }
 
 .dim {
-  color: #64748b;
+  color: var(--text-muted);
 }

--- a/frontend/src/components/shared/HeatmapPlot.module.css
+++ b/frontend/src/components/shared/HeatmapPlot.module.css
@@ -3,22 +3,22 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 4px 0;
+  padding: var(--sp-2) 0;
   position: relative;
 }
 
 .expandBtn {
   position: absolute;
   top: 2px;
-  right: 6px;
-  width: 22px;
-  height: 22px;
-  border-radius: 4px;
+  right: var(--sp-3);
+  width: var(--h-control-xs);
+  height: var(--h-control-xs);
+  border-radius: var(--radius-sm);
   background: rgba(10, 15, 23, 0.85);
-  border: 1px solid #1f2937;
-  color: #67e8f9;
-  font-size: 13px;
-  line-height: 1;
+  border: 1px solid var(--border-base);
+  color: var(--accent);
+  font-size: var(--fs-md);
+  line-height: var(--lh-tight);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -26,26 +26,26 @@
   z-index: 5;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   padding: 0;
-  transition: background 0.12s, border-color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .expandBtn:hover {
-  background: #0e7490;
-  border-color: #06b6d4;
-  color: #fff;
+  background: var(--accent-dim);
+  border-color: var(--accent-deep);
+  color: var(--text-primary);
 }
 
 .grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--sp-3);
   justify-content: center;
 }
 
 .panel {
-  background: #0a0f17;
-  border: 1px solid #1f2937;
-  border-radius: 4px;
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
   display: block;
 }
 
@@ -54,22 +54,25 @@
 }
 
 .cell:hover {
-  stroke: #06b6d4;
+  stroke: var(--accent-deep);
   stroke-width: 1.5;
 }
 
+/* Real SVG <text> elements (see HeatmapPlot.tsx) — rem does not reliably
+   apply here, so font-size stays in px per the migration contract's SVG
+   exception, just raised to the 11px floor instead of 9px/10px. */
 .axisLabel {
-  fill: #94a3b8;
-  font-size: 9px;
+  fill: var(--text-muted);
+  font-size: 11px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   pointer-events: none;
 }
 
 .headLabel {
-  fill: #67e8f9;
-  font-size: 10px;
+  fill: var(--accent);
+  font-size: 11px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
   letter-spacing: 0.05em;
   pointer-events: none;
 }
@@ -80,43 +83,45 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #64748b;
-  font-size: 12px;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
   font-style: italic;
 }
 
 .tooltip {
   position: fixed;
-  background: #020617;
-  border: 1px solid #1e293b;
-  border-radius: 4px;
-  padding: 6px 8px;
-  font-size: 11px;
-  color: #e5e7eb;
+  /* Was #020617, darker than every other tooltip in the app (they converge
+     on --surface-canvas) — normalized for consistency. */
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--fs-xs);
+  color: var(--text-primary);
   pointer-events: none;
   z-index: 9999;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  box-shadow: 0 8px 18px -8px rgba(0, 0, 0, 0.6);
+  box-shadow: var(--shadow);
 }
 
 .tooltipHeader {
-  color: #67e8f9;
-  font-weight: 600;
-  margin-bottom: 2px;
+  color: var(--accent);
+  font-weight: var(--fw-semibold);
+  margin-bottom: var(--sp-1);
 }
 
 .tooltipHead {
-  color: #94a3b8;
-  font-weight: 400;
+  color: var(--text-muted);
+  font-weight: var(--fw-normal);
 }
 
 .tooltipPair {
   display: flex;
   align-items: center;
-  gap: 4px;
-  color: #cbd5e1;
+  gap: var(--sp-2);
+  color: var(--text-secondary);
 }
 
 .tooltipArrow {
-  color: #06b6d4;
+  color: var(--accent-deep);
 }

--- a/frontend/src/components/shared/HistogramPlot.module.css
+++ b/frontend/src/components/shared/HistogramPlot.module.css
@@ -1,9 +1,9 @@
 .wrapper {
   position: relative;
-  background: #161616;
-  border: 1px solid #2a2a2a;
-  border-radius: 4px;
-  padding: 6px 6px 4px;
+  background: var(--surface-panel);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-3) var(--sp-3) var(--sp-2);
   display: inline-block;
   max-width: 100%;
 }
@@ -14,65 +14,67 @@
 }
 
 .bar {
-  fill: #0e7490;
-  transition: fill 0.12s ease;
+  fill: var(--accent-dim);
+  transition: fill var(--transition-fast) ease;
 }
 
 .barActive {
-  fill: #67e8f9;
+  fill: var(--accent);
 }
 
 .baseline {
-  stroke: #2a2a2a;
+  stroke: var(--border-base);
   stroke-width: 1;
 }
 
+/* Plain HTML text below the <svg> (not SVG itself), so it moves onto the
+   type scale — these are short axis min/max/peak tags, not prose. */
 .axisRow {
   display: flex;
   justify-content: space-between;
-  gap: 8px;
-  margin-top: 4px;
+  gap: var(--sp-3);
+  margin-top: var(--sp-2);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 9px;
-  color: #666;
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
 }
 
 .axisPeak {
-  color: #4b5563;
+  color: var(--text-muted);
 }
 
 .empty {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #161616;
-  border: 1px dashed #2a2a2a;
-  border-radius: 4px;
-  color: #666;
-  font-size: 11px;
+  background: var(--surface-panel);
+  border: 1px dashed var(--border-base);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
   font-style: italic;
 }
 
 .tooltip {
   position: fixed;
   z-index: 10000;
-  background: #0a0f17;
-  border: 1px solid #1f2937;
-  border-radius: 6px;
-  padding: 5px 9px;
-  font-size: 11px;
-  color: #eee;
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--fs-xs);
+  color: var(--text-primary);
   pointer-events: none;
-  box-shadow: 0 12px 28px -8px rgba(0, 0, 0, 0.7);
+  box-shadow: var(--shadow-popover);
 }
 
 .tooltipLabel {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 10px;
-  color: #9ca3af;
+  font-size: var(--fs-2xs);
+  color: var(--text-muted);
 }
 
 .tooltipCount {
-  margin-top: 2px;
-  font-weight: 600;
+  margin-top: var(--sp-1);
+  font-weight: var(--fw-semibold);
 }

--- a/frontend/src/components/shared/MathText.module.css
+++ b/frontend/src/components/shared/MathText.module.css
@@ -2,10 +2,14 @@
    was meant to be rendered when KaTeX rejects a formula. */
 .fallback {
   font-family: ui-monospace, SFMono-Regular, monospace;
-  color: #f5a623;
-  background: rgba(245, 166, 35, 0.08);
-  padding: 0 4px;
-  border-radius: 3px;
+  color: var(--status-warning);
+  background: var(--warning-wash);
+  padding: 0 var(--sp-2);
+  border-radius: var(--radius-sm);
+  /* Deliberately `em`, not a token: MathText is inline inside arbitrary
+     parent contexts (table cell, tooltip, description) and should stay
+     proportional to whatever font-size is ambient there, the way KaTeX's
+     own sizing does. */
   font-size: 0.85em;
 }
 
@@ -21,5 +25,5 @@
   margin: 0.4em 0;
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 0 4px;
+  padding: 0 var(--sp-2);
 }

--- a/frontend/src/components/shared/NodeParamList.module.css
+++ b/frontend/src/components/shared/NodeParamList.module.css
@@ -3,19 +3,19 @@
 .list {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--sp-4);
 }
 
 /* Param description / range hints.
-   Slate-500 rather than the old #555: these carry real information (what a
-   param means, what range it accepts) and #555 sat near 2:1 against both
-   surfaces this form renders on — the config panel and the darker Node
-   Detail Modal column. */
+   text-muted rather than the old #555 (or the slate #64748b that replaced
+   it): these carry real information (what a param means, what range it
+   accepts) and both old greys sat too low against the surfaces this form
+   renders on — the config panel and the darker Node Detail Modal column. */
 .paramHint {
-  font-size: 0.6875rem;
-  color: #64748b;
-  margin-top: 2px;
-  line-height: 1.3;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  margin-top: var(--sp-1);
+  line-height: var(--lh-normal);
 }
 
 /* Advanced section (core#134).
@@ -23,40 +23,40 @@
    form continued, and a heavier container would read as a different kind of
    setting. */
 .advanced {
-  border-top: 1px solid var(--cd-border, #2a3441);
-  padding-top: 8px;
-  margin-top: 2px;
+  border-top: 1px solid var(--border-base);
+  padding-top: var(--sp-3);
+  margin-top: var(--sp-1);
 }
 
 .advancedToggle {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--sp-3);
   width: 100%;
-  padding: 4px 2px;
+  padding: var(--sp-2) var(--sp-1);
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
   letter-spacing: 0.02em;
-  color: #94a3b8;
+  color: var(--text-muted);
   text-align: left;
 }
 
 .advancedToggle:hover {
-  color: var(--cd-accent, #2dd4bf);
+  color: var(--accent);
 }
 
 .advancedToggle:focus-visible {
-  outline: 2px solid var(--cd-accent, #2dd4bf);
-  outline-offset: 2px;
-  border-radius: 3px;
+  outline: 2px solid var(--accent);
+  outline-offset: var(--sp-1);
+  border-radius: var(--radius-sm);
 }
 
 .advancedChevron {
-  font-size: 0.625rem;
-  line-height: 1;
+  font-size: var(--fs-2xs);
+  line-height: var(--lh-tight);
   width: 10px;
 }
 
@@ -64,17 +64,17 @@
    says how much is hidden, so nobody has to open it to find out. */
 .advancedCount {
   margin-left: auto;
-  font-size: 0.625rem;
-  font-weight: 500;
-  color: #64748b;
-  background: rgba(148, 163, 184, 0.12);
-  border-radius: 8px;
-  padding: 1px 6px;
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-medium);
+  color: var(--text-muted);
+  background: var(--surface-input);
+  border-radius: var(--radius-pill);
+  padding: var(--sp-1) var(--sp-3);
 }
 
 .advancedBody {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  margin-top: 8px;
+  gap: var(--sp-4);
+  margin-top: var(--sp-3);
 }

--- a/frontend/src/components/shared/ParamField.module.css
+++ b/frontend/src/components/shared/ParamField.module.css
@@ -2,46 +2,46 @@
 
 .input {
   width: 100%;
-  padding: 5px 8px;
-  background: #222;
-  border: 1px solid #444;
-  border-radius: 4px;
-  color: #ddd;
-  font-size: 0.8125rem;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
   outline: none;
   box-sizing: border-box;
 }
 
 .label {
   display: block;
-  font-size: 0.75rem;
-  color: #999;
-  margin-bottom: 3px;
-  font-weight: 500;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  margin-bottom: var(--sp-2);
+  font-weight: var(--fw-medium);
 }
 
 /* Bool param row */
 .checkboxRow {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .checkbox {
   width: 14px;
   height: 14px;
   cursor: pointer;
-  accent-color: #2196F3;
+  accent-color: var(--accent);
 }
 
 /* Bool label overrides base label — removes bottom margin, sets pointer + lighter color */
 .boolLabel {
   display: block;
-  font-size: 0.75rem;
-  font-weight: 500;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
   margin-bottom: 0;
   cursor: pointer;
-  color: #ccc;
+  color: var(--text-secondary);
 }
 
 /* Select cursor override */
@@ -53,7 +53,7 @@
 /* Model file selector */
 .modelFileRow {
   display: flex;
-  gap: 4px;
+  gap: var(--sp-2);
   align-items: center;
 }
 
@@ -64,19 +64,19 @@
 
 .modelFileBtn {
   flex-shrink: 0;
-  padding: 5px 8px;
-  background: #333;
-  border: 1px solid #444;
-  border-radius: 4px;
-  color: #ccc;
-  font-size: 0.75rem;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--surface-hover);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
   cursor: pointer;
   white-space: nowrap;
 }
 
 .modelFileBtn:hover:not(:disabled) {
-  background: #444;
-  color: #fff;
+  background: var(--surface-active);
+  color: var(--text-primary);
 }
 
 .modelFileBtn:disabled {
@@ -86,22 +86,22 @@
 
 /* Validation error styling */
 .inputError {
-  border-color: #f44336 !important;
-  box-shadow: 0 0 0 1px rgba(244, 67, 54, 0.3);
+  border-color: var(--status-error) !important;
+  box-shadow: 0 0 0 1px var(--danger-wash);
 }
 
 .errorHint {
   display: block;
-  font-size: 0.6875rem;
-  color: #f44336;
-  margin-top: 2px;
+  font-size: var(--fs-xs);
+  color: var(--status-error);
+  margin-top: var(--sp-1);
 }
 
 /* Neutral helper text (e.g. the SECRET-param session-only notice). */
 .hint {
   display: block;
-  font-size: 0.6875rem;
-  color: #888;
-  margin-top: 3px;
-  line-height: 1.35;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  margin-top: var(--sp-2);
+  line-height: var(--lh-normal);
 }

--- a/frontend/src/components/shared/ParamField.tsx
+++ b/frontend/src/components/shared/ParamField.tsx
@@ -118,11 +118,11 @@ function FileField({
           onChange={(e) => onChange(param.name, e.target.value)}
           className={`${styles.input} ${styles.select} ${styles.modelFileSelect}`}
         >
-          <option value="" style={{ background: '#222' }}>
+          <option value="" style={{ background: 'var(--surface-input)' }}>
             {t('paramField.selectFile')}
           </option>
           {files.map((f) => (
-            <option key={f} value={f} style={{ background: '#222' }}>
+            <option key={f} value={f} style={{ background: 'var(--surface-input)' }}>
               {f}
             </option>
           ))}
@@ -231,7 +231,7 @@ export function ParamField({ param, value, onChange, label, siblingParams }: Par
           className={`${styles.input} ${styles.select}`}
         >
           {param.options.map((opt) => (
-            <option key={opt} value={opt} style={{ background: '#222' }}>
+            <option key={opt} value={opt} style={{ background: 'var(--surface-input)' }}>
               {opt}
             </option>
           ))}

--- a/frontend/src/components/shared/ScatterModal.module.css
+++ b/frontend/src/components/shared/ScatterModal.module.css
@@ -6,23 +6,22 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.65);
+  background: var(--surface-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 9999;
-  padding: 1.5rem;
+  padding: var(--sp-7);
 }
 
 .modal {
-  background: linear-gradient(180deg, #0e1520 0%, #0a0f17 100%);
-  border: 1px solid #1f2937;
-  border-radius: 0.5rem;
-  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.7),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  background: linear-gradient(180deg, var(--surface-panel) 0%, var(--surface-canvas) 100%);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-popover), var(--inner-highlight);
   display: flex;
   flex-direction: column;
-  font-size: 1rem;
+  font-size: var(--fs-lg);
   max-width: 90vw;
   max-height: 88vh;
   min-width: 36rem;
@@ -34,38 +33,38 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.625rem 0.875rem;
-  border-bottom: 1px solid #1f2937;
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--border-base);
   background: rgba(10, 15, 23, 0.6);
 }
 
 .title {
-  color: #e5e7eb;
-  font-weight: 600;
-  font-size: 1.05rem;
+  color: var(--text-primary);
+  font-weight: var(--fw-semibold);
+  font-size: var(--fs-lg);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .closeBtn {
   background: transparent;
-  border: 1px solid #334155;
-  color: #cbd5e1;
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: 0.25rem;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  width: var(--h-control-sm);
+  height: var(--h-control-sm);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  line-height: 1;
+  line-height: var(--lh-tight);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .closeBtn:hover {
-  background: #1f2937;
-  border-color: #06b6d4;
-  color: #67e8f9;
+  background: var(--surface-hover);
+  border-color: var(--accent-deep);
+  color: var(--accent);
 }
 
 /* ── Body: sidebar + plot ─────────────────────────────────────────────── */
@@ -78,7 +77,7 @@
 .sidebar {
   width: 18rem;
   flex-shrink: 0;
-  border-right: 1px solid #1f2937;
+  border-right: 1px solid var(--border-base);
   background: rgba(10, 15, 23, 0.5);
   display: flex;
   flex-direction: column;
@@ -89,71 +88,71 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  padding: 0.625rem 0.75rem 0.4rem 0.75rem;
-  gap: 0.5rem;
+  padding: var(--sp-3) var(--sp-4) var(--sp-3) var(--sp-4);
+  gap: var(--sp-3);
 }
 
 .sidebarTitle {
-  color: #cbd5e1;
-  font-size: 1rem;
-  font-weight: 600;
+  color: var(--text-secondary);
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .showAllBtn {
   background: transparent;
-  border: 1px solid #334155;
-  color: #94a3b8;
-  font-size: 0.8rem;
-  padding: 0.15rem 0.45rem;
-  border-radius: 0.25rem;
+  border: 1px solid var(--border-strong);
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   white-space: nowrap;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .showAllBtn:hover {
-  border-color: #06b6d4;
-  color: #67e8f9;
+  border-color: var(--accent-deep);
+  color: var(--accent);
 }
 
 .search {
-  margin: 0 0.75rem 0.5rem 0.75rem;
-  background: #0a0f17;
-  border: 1px solid #1f2937;
-  border-radius: 0.25rem;
-  color: #e5e7eb;
-  font-size: 0.95rem;
-  padding: 0.4rem 0.55rem;
+  margin: 0 var(--sp-4) var(--sp-3) var(--sp-4);
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--fs-lg);
+  padding: var(--sp-3) var(--sp-3);
   outline: none;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .search:focus {
-  border-color: #0e7490;
+  border-color: var(--accent-dim);
 }
 
 .list {
   flex: 1;
   overflow-y: auto;
   min-height: 0;
-  padding: 0 0.4rem 0.4rem 0.4rem;
+  padding: 0 var(--sp-3) var(--sp-3) var(--sp-3);
 }
 
 .row {
   display: flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.3rem 0.45rem;
-  border-radius: 0.25rem;
+  gap: var(--sp-3);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background 0.1s;
+  transition: background var(--transition-fast);
 }
 
 .row:hover,
 .rowActive {
-  background: rgba(6, 182, 212, 0.12);
+  background: var(--accent-wash);
 }
 
 .rowHidden {
@@ -173,8 +172,8 @@
 
 .label {
   flex: 1;
-  color: #cbd5e1;
-  font-size: 1rem;
+  color: var(--text-secondary);
+  font-size: var(--fs-lg);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -184,11 +183,11 @@
 .eyeBtn {
   background: transparent;
   border: none;
-  color: #64748b;
+  color: var(--text-muted);
   cursor: pointer;
-  line-height: 1;
-  padding: 0.15rem 0.2rem;
-  border-radius: 0.2rem;
+  line-height: var(--lh-tight);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
@@ -196,25 +195,25 @@
 }
 
 .eyeBtn:hover {
-  color: #67e8f9;
-  background: rgba(6, 182, 212, 0.12);
+  color: var(--accent);
+  background: var(--accent-wash);
 }
 
 .emptyList {
-  color: #475569;
-  font-size: 0.95rem;
+  color: var(--text-muted);
+  font-size: var(--fs-lg);
   font-style: italic;
   text-align: center;
-  padding: 1rem 0.5rem;
+  padding: var(--sp-5) var(--sp-3);
 }
 
 .recenterHint {
-  color: #475569;
-  font-size: 0.8rem;
-  padding: 0.4rem 0.75rem 0.5rem 0.75rem;
-  border-top: 1px solid #131c28;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+  padding: var(--sp-3) var(--sp-4) var(--sp-3) var(--sp-4);
+  border-top: 1px solid var(--border-subtle);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  line-height: 1.5;
+  line-height: var(--lh-normal);
 }
 
 /* ── Plot panel ──────────────────────────────────────────────────────── */
@@ -225,7 +224,7 @@
   align-items: center;
   justify-content: center;
   min-width: 0;
-  background: #0b1018;
+  background: var(--surface-canvas);
 }
 
 .canvas {
@@ -240,44 +239,44 @@
 
 .toolbar {
   position: absolute;
-  top: 0.625rem;
-  right: 0.625rem;
+  top: var(--sp-3);
+  right: var(--sp-3);
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--sp-2);
   background: rgba(10, 15, 23, 0.85);
-  border: 1px solid #1f2937;
-  border-radius: 0.375rem;
-  padding: 0.25rem;
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  padding: var(--sp-2);
   z-index: 4;
 }
 
 .toolBtn {
   background: transparent;
-  border: 1px solid #1f2937;
-  color: #cbd5e1;
-  width: 1.6rem;
-  height: 1.6rem;
-  border-radius: 0.25rem;
+  border: 1px solid var(--border-base);
+  color: var(--text-secondary);
+  width: var(--h-control-xs);
+  height: var(--h-control-xs);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  line-height: 1;
+  line-height: var(--lh-tight);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
 }
 
 .toolBtn:hover {
-  background: #0e7490;
-  border-color: #06b6d4;
-  color: #fff;
+  background: var(--accent-dim);
+  border-color: var(--accent-deep);
+  color: var(--text-primary);
 }
 
 .zoomLabel {
-  color: #94a3b8;
-  font-size: 0.9rem;
+  color: var(--text-muted);
+  font-size: var(--fs-md);
   min-width: 2.8rem;
   text-align: center;
   font-variant-numeric: tabular-nums;
@@ -285,15 +284,15 @@
 }
 
 .status {
-  color: #94a3b8;
-  font-size: 1rem;
+  color: var(--text-muted);
+  font-size: var(--fs-lg);
   text-align: center;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  padding: 1.5rem;
+  padding: var(--sp-7);
 }
 
 .error {
-  color: #fca5a5;
+  color: var(--status-error);
 }
 
 .dot {
@@ -302,13 +301,13 @@
 
 .dotLabel {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 1.25rem;
+  font-size: var(--fs-2xl);
   pointer-events: none;
   user-select: none;
 }
 
 .crosshair {
-  stroke: #334155;
+  stroke: var(--border-base);
   stroke-width: 1;
   stroke-dasharray: 3 3;
   pointer-events: none;
@@ -318,38 +317,38 @@
 .footer {
   display: flex;
   justify-content: space-between;
-  padding: 0.5rem 0.875rem;
-  border-top: 1px solid #1f2937;
+  padding: var(--sp-3) var(--sp-4);
+  border-top: 1px solid var(--border-base);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.9rem;
-  color: #94a3b8;
+  font-size: var(--fs-md);
+  color: var(--text-muted);
   background: rgba(10, 15, 23, 0.6);
 }
 
 .dim {
-  color: #64748b;
+  color: var(--text-muted);
 }
 
 .tooltip {
   position: fixed;
   z-index: 10000;
-  background: #0a0f17;
-  border: 1px solid #1f2937;
-  border-radius: 0.375rem;
-  padding: 0.4rem 0.625rem;
-  font-size: 0.9rem;
-  color: #eee;
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  padding: var(--sp-3) var(--sp-4);
+  font-size: var(--fs-md);
+  color: var(--text-primary);
   pointer-events: none;
-  box-shadow: 0 12px 28px -8px rgba(0, 0, 0, 0.7);
+  box-shadow: var(--shadow-popover);
 }
 
 .tooltipLabel {
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
 }
 
 .tooltipCoords {
-  margin-top: 0.125rem;
-  color: #888;
+  margin-top: var(--sp-1);
+  color: var(--text-muted);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 0.8rem;
+  font-size: var(--fs-sm);
 }

--- a/frontend/src/components/shared/ScatterPlot.module.css
+++ b/frontend/src/components/shared/ScatterPlot.module.css
@@ -1,8 +1,8 @@
 .wrapper {
   position: relative;
-  background: #161616;
-  border: 1px solid #2a2a2a;
-  border-radius: 4px;
+  background: var(--surface-panel);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
   overflow: hidden;
 }
 
@@ -17,15 +17,15 @@
 .expandBtn {
   position: absolute;
   top: 2px;
-  right: 4px;
-  width: 22px;
-  height: 22px;
-  border-radius: 4px;
+  right: var(--sp-2);
+  width: var(--h-control-xs);
+  height: var(--h-control-xs);
+  border-radius: var(--radius-sm);
   background: rgba(10, 15, 23, 0.85);
-  border: 1px solid #2a2a2a;
-  color: #67e8f9;
-  font-size: 13px;
-  line-height: 1;
+  border: 1px solid var(--border-base);
+  color: var(--accent);
+  font-size: var(--fs-md);
+  line-height: var(--lh-tight);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -36,66 +36,70 @@
 }
 
 .expandBtn:hover {
-  background: #0e7490;
-  border-color: #06b6d4;
-  color: #fff;
+  background: var(--accent-dim);
+  border-color: var(--accent-deep);
+  color: var(--text-primary);
 }
 
 .empty {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #161616;
-  border: 1px dashed #2a2a2a;
-  border-radius: 4px;
-  color: #666;
-  font-size: 11px;
+  background: var(--surface-panel);
+  border: 1px dashed var(--border-base);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
   font-style: italic;
 }
 
 .dot {
   cursor: default;
-  transition: r 0.12s ease, stroke 0.12s ease;
+  transition: r var(--transition-fast) ease, stroke var(--transition-fast) ease;
 }
 
 .axis {
-  stroke: #2a2a2a;
+  stroke: var(--border-base);
   stroke-width: 1;
   stroke-dasharray: 2 3;
 }
 
+/* Real SVG <text> (see ScatterPlot.tsx: `transition: fill-opacity` and the
+   `<text>` element confirm it) — rem does not reliably apply here, so
+   font-size stays in px per the migration contract's SVG exception, raised
+   to the 11px floor instead of 9px. */
 .label {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 9px;
+  font-size: 11px;
   pointer-events: none;
   user-select: none;
-  transition: fill-opacity 0.12s ease;
+  transition: fill-opacity var(--transition-fast) ease;
 }
 
 .labelActive {
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
 }
 
 .tooltip {
   position: fixed;
   z-index: 10000;
-  background: #0a0f17;
-  border: 1px solid #1f2937;
-  border-radius: 6px;
-  padding: 6px 10px;
-  font-size: 11px;
-  color: #eee;
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  padding: var(--sp-3) var(--sp-4);
+  font-size: var(--fs-xs);
+  color: var(--text-primary);
   pointer-events: none;
-  box-shadow: 0 12px 28px -8px rgba(0, 0, 0, 0.7);
+  box-shadow: var(--shadow-popover);
 }
 
 .tooltipLabel {
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
 }
 
 .tooltipCoords {
-  margin-top: 2px;
-  color: #888;
+  margin-top: var(--sp-1);
+  color: var(--text-muted);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
 }

--- a/frontend/src/components/shared/ScriptCodeField.module.css
+++ b/frontend/src/components/shared/ScriptCodeField.module.css
@@ -3,52 +3,52 @@
 .field {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--sp-2);
 }
 
 .labelRow {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .label {
-  font-size: 0.6875rem;
-  color: #9ca3af;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
 }
 
 .badge {
-  font-size: 0.625rem;
+  font-size: var(--fs-2xs);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   letter-spacing: 0.02em;
   white-space: nowrap;
 }
 
 .badgeIdle {
-  color: #4b5563;
+  color: var(--status-idle);
 }
 
 .badgeChecking {
-  color: #6b7280;
+  color: var(--text-muted);
 }
 
 .badgeOk {
-  color: #34d399;
+  color: var(--status-success);
 }
 
 .badgeError {
-  color: #f87171;
+  color: var(--status-error);
 }
 
 .error {
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  color: #fca5a5;
-  background: rgba(239, 68, 68, 0.09);
-  border-left: 2px solid #ef4444;
-  border-radius: 2px;
-  padding: 5px 7px;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-normal);
+  color: var(--status-error);
+  background: var(--danger-wash);
+  border-left: 2px solid var(--status-error);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-2) var(--sp-3);
   max-height: 140px;
   overflow-y: auto;
   word-break: break-word;
@@ -56,24 +56,24 @@
 
 .errorLine {
   display: inline-block;
-  margin-right: 6px;
+  margin-right: var(--sp-3);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  color: #ef4444;
+  color: var(--status-error);
 }
 
 .warning {
-  font-size: 0.6875rem;
-  line-height: 1.45;
-  color: #fcd34d;
-  background: rgba(245, 158, 11, 0.08);
-  border-left: 2px solid #f59e0b;
-  border-radius: 2px;
-  padding: 5px 7px;
+  font-size: var(--fs-xs);
+  line-height: var(--lh-normal);
+  color: var(--status-warning);
+  background: var(--warning-wash);
+  border-left: 2px solid var(--status-warning);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-2) var(--sp-3);
 }
 
 .allowed {
-  font-size: 0.625rem;
-  color: #6b7280;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/components/shared/ShortcutsModal.module.css
+++ b/frontend/src/components/shared/ShortcutsModal.module.css
@@ -1,7 +1,7 @@
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--surface-scrim);
   z-index: 9000;
   display: flex;
   align-items: center;
@@ -9,71 +9,71 @@
 }
 
 .modal {
-  background: #1e1e1e;
-  border: 1px solid #444;
-  border-radius: 8px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
   width: 360px;
   max-height: 80vh;
   overflow-y: auto;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  box-shadow: var(--shadow-lg);
 }
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 16px 10px;
-  border-bottom: 1px solid #333;
+  padding: var(--sp-4) var(--sp-5) var(--sp-4);
+  border-bottom: 1px solid var(--border-base);
 }
 
 .title {
   margin: 0;
-  font-size: 0.9375rem;
-  font-weight: 600;
-  color: #eee;
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
 }
 
 .close {
   background: none;
   border: none;
-  color: #888;
-  font-size: 20px;
+  color: var(--text-muted);
+  font-size: var(--fs-2xl);
   cursor: pointer;
-  padding: 0 4px;
-  line-height: 1;
+  padding: 0 var(--sp-2);
+  line-height: var(--lh-tight);
 }
 
 .close:hover {
-  color: #fff;
+  color: var(--text-primary);
 }
 
 .list {
-  padding: 10px 16px 14px;
+  padding: var(--sp-4) var(--sp-5) var(--sp-4);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--sp-3);
 }
 
 .row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--sp-4);
 }
 
 .keys {
-  background: #2a2a2a;
-  border: 1px solid #444;
-  border-radius: 4px;
-  padding: 3px 8px;
+  background: var(--surface-input);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-2) var(--sp-3);
   font-family: monospace;
-  font-size: 0.75rem;
-  color: #ccc;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
   white-space: nowrap;
 }
 
 .action {
-  font-size: 0.8125rem;
-  color: #aaa;
+  font-size: var(--fs-md);
+  color: var(--text-muted);
   text-align: right;
 }

--- a/frontend/src/components/shared/Toast.module.css
+++ b/frontend/src/components/shared/Toast.module.css
@@ -1,11 +1,11 @@
 .container {
   position: fixed;
-  bottom: 20px;
-  right: 20px;
+  bottom: var(--sp-6);
+  right: var(--sp-6);
   z-index: 10000;
   display: flex;
   flex-direction: column-reverse;
-  gap: 8px;
+  gap: var(--sp-3);
   max-width: 420px;
   pointer-events: none;
 }
@@ -13,13 +13,13 @@
 .toast {
   display: flex;
   align-items: flex-start;
-  gap: 8px;
-  padding: 10px 14px;
-  border-radius: 6px;
-  color: #fff;
-  font-size: 13px;
-  line-height: 1.4;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  gap: var(--sp-3);
+  padding: var(--sp-4) var(--sp-4);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-snug);
+  box-shadow: var(--shadow);
   pointer-events: auto;
   animation: slideIn 0.25s ease-out;
 }
@@ -35,30 +35,35 @@
   }
 }
 
+/* Solid, saturated toast fills meant to carry white text — a different role
+   than --status-* (tuned for text contrast on dark surfaces). No matching
+   fill token exists yet, so these stay literal; see the migration report.
+   The left accent stripe is decorative rather than text, so it does use the
+   status token. */
 .success {
   background: #2e7d32;
-  border-left: 4px solid #4caf50;
+  border-left: 4px solid var(--status-success);
 }
 
 .error {
   background: #c62828;
-  border-left: 4px solid #f44336;
+  border-left: 4px solid var(--status-error);
 }
 
 .info {
   background: #1565c0;
-  border-left: 4px solid #2196f3;
+  border-left: 4px solid var(--status-info);
 }
 
 .warning {
   background: #e65100;
-  border-left: 4px solid #ff9800;
+  border-left: 4px solid var(--status-warning);
 }
 
 .icon {
   flex-shrink: 0;
-  font-size: 15px;
-  line-height: 1;
+  font-size: var(--fs-lg);
+  line-height: var(--lh-tight);
   margin-top: 1px;
 }
 
@@ -73,12 +78,12 @@
   border: none;
   color: rgba(255, 255, 255, 0.7);
   cursor: pointer;
-  font-size: 16px;
-  line-height: 1;
-  padding: 0 2px;
-  margin-left: 4px;
+  font-size: var(--fs-lg);
+  line-height: var(--lh-tight);
+  padding: 0 var(--sp-1);
+  margin-left: var(--sp-2);
 }
 
 .close:hover {
-  color: #fff;
+  color: var(--text-primary);
 }

--- a/frontend/src/components/shared/TokenChip.module.css
+++ b/frontend/src/components/shared/TokenChip.module.css
@@ -1,12 +1,12 @@
 .chip {
   display: inline-block;
-  padding: 2px 6px;
-  margin: 2px;
-  border-radius: 4px;
+  padding: var(--sp-1) var(--sp-3);
+  margin: var(--sp-1);
+  border-radius: var(--radius-sm);
   border: 1px solid;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 12px;
-  line-height: 1.4;
+  font-size: var(--fs-sm);
+  line-height: var(--lh-snug);
   white-space: pre;
   cursor: default;
   user-select: text;
@@ -44,41 +44,41 @@
 .tooltip {
   position: fixed;
   z-index: 10000;
-  background: #0a0f17;
-  border: 1px solid #1f2937;
-  border-radius: 6px;
-  padding: 8px 10px;
-  box-shadow: 0 12px 28px -8px rgba(0, 0, 0, 0.7);
-  font-size: 11px;
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius);
+  padding: var(--sp-3) var(--sp-4);
+  box-shadow: var(--shadow-popover);
+  font-size: var(--fs-xs);
   pointer-events: none;
   min-width: 160px;
   max-width: 320px;
   display: grid;
-  gap: 4px;
+  gap: var(--sp-2);
 }
 
 .tooltipRow {
   display: grid;
   grid-template-columns: 56px 1fr;
-  gap: 8px;
+  gap: var(--sp-3);
   align-items: baseline;
 }
 
 .tooltipLabel {
-  color: #888;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-size: 9px;
+  font-size: var(--fs-2xs);
 }
 
 .tooltipValue {
-  color: #eee;
+  color: var(--text-primary);
   word-break: break-all;
 }
 
 .tooltipValueMono {
-  color: #ccc;
+  color: var(--text-secondary);
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   word-break: break-all;
 }

--- a/frontend/src/components/shared/codemirrorSetup.ts
+++ b/frontend/src/components/shared/codemirrorSetup.ts
@@ -32,51 +32,54 @@ import { python } from '@codemirror/lang-python';
 import { tags } from '@lezer/highlight';
 
 /** Crafted-dark syntax colours, matching the app's editor chrome. */
+// The syntax hues below are a deliberate code theme, not app chrome. All seven
+// measure 6.7:1 to 11.9:1 on --surface-code, so they are left as literals; only
+// the roles that were failing (comment, gutter) and the chrome moved to tokens.
 const highlightStyle = HighlightStyle.define([
   { tag: tags.keyword, color: '#c792ea' },
   { tag: [tags.controlKeyword, tags.moduleKeyword], color: '#c792ea' },
-  { tag: [tags.definitionKeyword, tags.operatorKeyword], color: '#06b6d4' },
+  { tag: [tags.definitionKeyword, tags.operatorKeyword], color: 'var(--accent-deep)' },
   { tag: [tags.function(tags.variableName), tags.function(tags.propertyName)], color: '#82aaff' },
   { tag: [tags.string, tags.special(tags.string)], color: '#c3e88d' },
   { tag: [tags.number, tags.bool, tags.null], color: '#f78c6c' },
-  { tag: tags.comment, color: '#6b7280', fontStyle: 'italic' },
+  { tag: tags.comment, color: 'var(--code-comment)', fontStyle: 'italic' },
   { tag: [tags.className, tags.typeName], color: '#ffcb6b' },
-  { tag: tags.propertyName, color: '#e5e7eb' },
+  { tag: tags.propertyName, color: 'var(--code-text)' },
   { tag: tags.operator, color: '#89ddff' },
-  { tag: tags.variableName, color: '#e5e7eb' },
+  { tag: tags.variableName, color: 'var(--code-text)' },
 ]);
 
 const theme = EditorView.theme(
   {
     '&': {
-      color: '#e5e7eb',
-      backgroundColor: 'rgba(0, 0, 0, 0.25)',
+      color: 'var(--code-text)',
+      backgroundColor: 'var(--surface-code)',
       fontSize: '12px',
       height: '100%',
     },
     '.cm-content': {
       fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
-      caretColor: '#06b6d4',
+      caretColor: 'var(--accent-deep)',
       padding: '6px 0',
     },
     '.cm-scroller': { overflow: 'auto', lineHeight: '1.55' },
     '.cm-gutters': {
       backgroundColor: 'transparent',
-      color: '#4b5563',
+      color: 'var(--code-gutter)',
       border: 'none',
-      borderRight: '1px solid #1f2937',
+      borderRight: '1px solid var(--border-base)',
     },
     '.cm-activeLine': { backgroundColor: 'rgba(6, 182, 212, 0.06)' },
-    '.cm-activeLineGutter': { backgroundColor: 'transparent', color: '#9ca3af' },
+    '.cm-activeLineGutter': { backgroundColor: 'transparent', color: 'var(--text-muted)' },
     '&.cm-focused': { outline: 'none' },
-    '&.cm-focused .cm-cursor': { borderLeftColor: '#06b6d4' },
+    '&.cm-focused .cm-cursor': { borderLeftColor: 'var(--accent-deep)' },
     '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, ::selection': {
       backgroundColor: 'rgba(6, 182, 212, 0.22)',
     },
     // The line the server's policy check pointed at.
     '.cm-errorLine': {
       backgroundColor: 'rgba(239, 68, 68, 0.16)',
-      boxShadow: 'inset 2px 0 0 #ef4444',
+      boxShadow: 'inset 2px 0 0 var(--status-error)',
     },
   },
   { dark: true },

--- a/frontend/src/plugins/PluginHost.module.css
+++ b/frontend/src/plugins/PluginHost.module.css
@@ -4,13 +4,13 @@
    (which start at 9000). */
 .stack {
   position: fixed;
-  right: 16px;
+  right: var(--sp-5);
   bottom: 188px;
   z-index: 300;
   display: flex;
   flex-direction: column-reverse;
   align-items: flex-end;
-  gap: 10px;
+  gap: var(--sp-4);
   pointer-events: none;
 }
 

--- a/frontend/src/styles/theme.test.ts
+++ b/frontend/src/styles/theme.test.ts
@@ -12,6 +12,9 @@ import {
   EXAMPLE_CATEGORY_COLORS,
   EXAMPLE_CATEGORY_FALLBACK,
   NODE_HEADER_TINT,
+  FLOW_COLORS,
+  PRESET_GOLD,
+  SURFACE_RAISED,
   mixColor,
 } from './theme';
 
@@ -86,6 +89,24 @@ describe('tokens.css / theme.ts agreement', () => {
 
   it('node header tint matches the CSS variable', () => {
     expect(String(NODE_HEADER_TINT)).toBe(cssVar('--node-header-tint'));
+  });
+
+  it.each([
+    ['trigger', '--flow-trigger'],
+    ['triggerDeep', '--flow-trigger-deep'],
+  ])('flow colour %s matches %s', (name, token) => {
+    expect(FLOW_COLORS[name as keyof typeof FLOW_COLORS]).toBe(cssVar(token));
+  });
+
+  it('preset gold matches its CSS variable', () => {
+    expect(PRESET_GOLD).toBe(cssVar('--preset-gold'));
+  });
+
+  it('raised surface matches its CSS variable', () => {
+    // Three components each kept their own copy of this literal before it was
+    // exported; the mix maths behind every node header and badge fill depends
+    // on it agreeing with the CSS.
+    expect(SURFACE_RAISED).toBe(cssVar('--surface-raised'));
   });
 
   it('has no orphaned category variable on either side', () => {

--- a/frontend/src/styles/theme.test.ts
+++ b/frontend/src/styles/theme.test.ts
@@ -1,21 +1,104 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   CATEGORY_COLORS,
+  CATEGORY_VARS,
   TOKEN_COLORS,
   getTokenColor,
   DIFFICULTY_COLORS,
   STATUS_COLORS,
-  SURFACE,
-  TEXT,
-  BRAND,
-  TOOLBAR,
+  EXAMPLE_CATEGORY_COLORS,
+  EXAMPLE_CATEGORY_FALLBACK,
+  NODE_HEADER_TINT,
+  mixColor,
 } from './theme';
+
+/**
+ * `tokens.css` is the source of truth for colour; the maps in `theme.ts` are a
+ * mirror kept only for code that has to compute with the values. These tests
+ * parse the CSS and assert the mirror matches, so an edit to one without the
+ * other fails here rather than shipping two different greens.
+ */
+const tokensCss = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'tokens.css'),
+  'utf8',
+);
+
+const cssTokens = new Map<string, string>();
+for (const m of tokensCss.matchAll(/^\s*(--[\w-]+)\s*:\s*([^;]+);/gm)) {
+  cssTokens.set(m[1], m[2].trim());
+}
+
+const cssVar = (name: string): string => {
+  const value = cssTokens.get(name);
+  if (value === undefined) throw new Error(`${name} is not defined in tokens.css`);
+  return value;
+};
+
+describe('tokens.css / theme.ts agreement', () => {
+  it('defines a CSS variable for every node category', () => {
+    expect(Object.keys(CATEGORY_VARS).sort()).toEqual(Object.keys(CATEGORY_COLORS).sort());
+  });
+
+  it.each(Object.keys(CATEGORY_COLORS))('category %s matches its CSS variable', (name) => {
+    expect(CATEGORY_COLORS[name]).toBe(cssVar(CATEGORY_VARS[name]));
+  });
+
+  it.each([
+    ['Usage_Example', '--ex-usage-example'],
+    ['Model_Architecture', '--ex-model-architecture'],
+    ['Classical', '--ex-classical'],
+    ['LLM', '--ex-llm'],
+    ['Diffusion', '--ex-diffusion'],
+    ['Transformer', '--ex-transformer'],
+    ['RNN', '--ex-rnn'],
+    ['RL', '--ex-rl'],
+    ['Stats', '--ex-stats'],
+  ])('example category %s matches %s', (name, token) => {
+    expect(EXAMPLE_CATEGORY_COLORS[name]).toBe(cssVar(token));
+  });
+
+  it('example fallback matches its CSS variable', () => {
+    expect(EXAMPLE_CATEGORY_FALLBACK).toBe(cssVar('--ex-fallback'));
+  });
+
+  it.each([
+    ['beginner', '--difficulty-beginner'],
+    ['intermediate', '--difficulty-intermediate'],
+    ['advanced', '--difficulty-advanced'],
+  ])('difficulty %s matches %s', (name, token) => {
+    expect(DIFFICULTY_COLORS[name]).toBe(cssVar(token));
+  });
+
+  it.each([
+    ['running', '--status-running'],
+    ['completed', '--status-completed'],
+    ['error', '--status-error'],
+    ['cached', '--status-cached'],
+    ['skipped', '--status-skipped'],
+    ['idle', '--status-idle'],
+    ['interrupted', '--status-interrupted'],
+  ])('status %s matches %s', (name, token) => {
+    expect(STATUS_COLORS[name]).toBe(cssVar(token));
+  });
+
+  it('node header tint matches the CSS variable', () => {
+    expect(String(NODE_HEADER_TINT)).toBe(cssVar('--node-header-tint'));
+  });
+
+  it('has no orphaned category variable on either side', () => {
+    const declared = [...cssTokens.keys()].filter((k) => k.startsWith('--cat-')).sort();
+    expect(declared).toEqual(Object.values(CATEGORY_VARS).sort());
+  });
+});
 
 describe('theme tokens', () => {
   it('exposes category colors', () => {
-    expect(CATEGORY_COLORS.CNN).toBe('#4CAF50');
-    expect(CATEGORY_COLORS.Transformer).toBe('#9C27B0');
-    expect(CATEGORY_COLORS['Tensor Operations']).toBe('#5C6BC0');
+    expect(CATEGORY_COLORS.CNN).toBe('#4caf50');
+    expect(CATEGORY_COLORS.Transformer).toBe('#c279ce');
+    expect(CATEGORY_COLORS['Tensor Operations']).toBe('#838fcf');
   });
 
   it('exposes a 12-color token palette', () => {
@@ -25,21 +108,41 @@ describe('theme tokens', () => {
   });
 
   it('exposes difficulty colors', () => {
-    expect(DIFFICULTY_COLORS.beginner).toBe('#4CAF50');
-    expect(DIFFICULTY_COLORS.intermediate).toBe('#FF9800');
-    expect(DIFFICULTY_COLORS.advanced).toBe('#F44336');
+    expect(DIFFICULTY_COLORS.beginner).toBe('#4caf50');
+    expect(DIFFICULTY_COLORS.intermediate).toBe('#ff9800');
+    expect(DIFFICULTY_COLORS.advanced).toBe('#f66358');
   });
 
   it('exposes status colors', () => {
-    expect(STATUS_COLORS.running).toBe('#FFC107');
-    expect(STATUS_COLORS.idle).toBe('#444');
+    expect(STATUS_COLORS.running).toBe('#ffc107');
   });
 
-  it('exposes surface / text / brand / toolbar token groups', () => {
-    expect(SURFACE.bg).toBe('#121212');
-    expect(TEXT.primary).toBe('#eee');
-    expect(BRAND.primary).toBe('#06b6d4');
-    expect(TOOLBAR.border).toBe('#1a2230');
+  it('gives idle a visible colour rather than the old near-invisible grey', () => {
+    // #444 on the panel it sits on measured 1.86:1 — the dot was not there.
+    expect(STATUS_COLORS.idle).not.toBe('#444');
+    expect(STATUS_COLORS.idle).toBe('#8593a3');
+  });
+});
+
+describe('mixColor', () => {
+  it('returns the base at amount 0 and the colour at amount 1', () => {
+    expect(mixColor('#000000', '#ffffff', 0)).toBe('#000000');
+    expect(mixColor('#000000', '#ffffff', 1)).toBe('#ffffff');
+  });
+
+  it('mixes channel-wise at the midpoint', () => {
+    expect(mixColor('#000000', '#ffffff', 0.5)).toBe('#808080');
+    expect(mixColor('#204060', '#60a0e0', 0.5)).toBe('#4070a0');
+  });
+
+  it('accepts 3-digit hex on either side', () => {
+    expect(mixColor('#000', '#fff', 0.5)).toBe('#808080');
+  });
+
+  it('produces the header fill the contrast gate verifies', () => {
+    // Kept explicit: the gate computes this same mix independently, so if the
+    // two ever disagree one of them is wrong about what ships.
+    expect(mixColor('#242b37', CATEGORY_COLORS.Training, NODE_HEADER_TINT)).toBe('#4a353d');
   });
 });
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -147,6 +147,39 @@ export const STATUS_COLORS: Record<string, string> = {
   interrupted: '#ff8f00',
 };
 
+/**
+ * Control-flow green — trigger edges and the Start node, as opposed to the
+ * blue data wires.
+ *
+ * In the app itself use `var(--flow-trigger)` / `var(--flow-trigger-deep)`.
+ * This mirror exists for SVG *export*, where the produced file is standalone
+ * and a CSS variable would have nothing to resolve against. `theme.test.ts`
+ * asserts it matches tokens.css.
+ */
+export const FLOW_COLORS = {
+  trigger: '#22c55e',
+  triggerDeep: '#16a34a',
+} as const;
+
+/**
+ * The gold that marks a preset / reusable-subgraph node, as opposed to a
+ * category hue. Same reason as `FLOW_COLORS`: prefer `var(--preset-gold)` in
+ * styling, and use this only where the value has to be a string in JS.
+ */
+export const PRESET_GOLD = '#d4a017';
+
+/**
+ * Mirrors `--surface-raised` in `styles/tokens.css` — the surface a node card,
+ * popover or gallery card sits on, and the base that category hues are tinted
+ * into to make a header or badge fill.
+ *
+ * Style with `var(--surface-raised)`; this exists only for `mixColor()`, which
+ * has to do arithmetic on the value. Three components had each declared their
+ * own copy of this literal before it was exported. `theme.test.ts` asserts it
+ * matches the CSS.
+ */
+export const SURFACE_RAISED = '#242b37';
+
 /** Shared zoom-out floor for both React Flow canvases. Wide skip-aware valley
  * layouts (long UNet-style graphs) need well below React Flow's 0.5 default
  * to fit on screen. */

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,21 +1,85 @@
-/** Shared design tokens — single source of truth for colors used across components. */
+/**
+ * TypeScript mirror of the semantic palettes in `styles/tokens.css`.
+ *
+ * `tokens.css` is the source of truth for every colour in the app. These
+ * values exist here only because canvas/SVG code has to *compute* with them
+ * (mixing a header tint, stroking an edge) and cannot read a CSS variable.
+ * `theme.test.ts` parses `tokens.css` and asserts every entry below matches
+ * its variable, so the two cannot drift.
+ *
+ * For plain styling, use the CSS variable — do not import from here.
+ */
 
 export const CATEGORY_COLORS: Record<string, string> = {
-  CNN: '#4CAF50',
-  RNN: '#2196F3',
-  Transformer: '#9C27B0',
-  LLM: '#A78BFA',
-  Diffusion: '#EC4899',
-  Classical: '#F59E0B',
-  RL: '#FF9800',
-  Data: '#00BCD4',
-  Training: '#F44336',
-  IO: '#795548',
-  'Data Flow': '#FF6F00',
-  Utility: '#607D8B',
-  Normalization: '#26A69A',
-  'Tensor Operations': '#5C6BC0',
+  CNN: '#4caf50',
+  RNN: '#2397f3',
+  Transformer: '#c279ce',
+  LLM: '#a78bfa',
+  Diffusion: '#ee60a6',
+  Classical: '#f59e0b',
+  RL: '#ff9800',
+  Data: '#00bcd4',
+  Training: '#f66358',
+  IO: '#a78f86',
+  'Data Flow': '#ff6f00',
+  Utility: '#8097a2',
+  Normalization: '#26a69a',
+  'Tensor Operations': '#838fcf',
 };
+
+/** CSS variable name for each category, so components can prefer `var()`. */
+export const CATEGORY_VARS: Record<string, string> = {
+  CNN: '--cat-cnn',
+  RNN: '--cat-rnn',
+  Transformer: '--cat-transformer',
+  LLM: '--cat-llm',
+  Diffusion: '--cat-diffusion',
+  Classical: '--cat-classical',
+  RL: '--cat-rl',
+  Data: '--cat-data',
+  Training: '--cat-training',
+  IO: '--cat-io',
+  'Data Flow': '--cat-dataflow',
+  Utility: '--cat-utility',
+  Normalization: '--cat-normalization',
+  'Tensor Operations': '--cat-tensorops',
+};
+
+/**
+ * How much of a category hue is mixed into `--surface-raised` to produce a
+ * node's header fill.
+ *
+ * Node headers used to be painted with the raw category hue and titled in
+ * `#eeeeee`, which measured 1.85:1 to 2.69:1 on twelve of the fourteen
+ * categories — the node title, on every node, in every graph, was below half
+ * the AA minimum. Tinting the hue into the surface instead keeps the colour
+ * coding while putting every title between 9.2:1 and 11.7:1.
+ */
+export const NODE_HEADER_TINT = 0.18;
+
+/** Mix `color` into `base` by `amount` (0..1) and return a hex string. */
+export function mixColor(base: string, color: string, amount: number): string {
+  const parse = (h: string): [number, number, number] => {
+    let s = h.replace('#', '');
+    if (s.length === 3)
+      s = s
+        .split('')
+        .map((c) => c + c)
+        .join('');
+    return [0, 2, 4].map((i) => parseInt(s.slice(i, i + 2), 16)) as [
+      number,
+      number,
+      number,
+    ];
+  };
+  const [br, bg, bb] = parse(base);
+  const [cr, cg, cb] = parse(color);
+  const ch = (a: number, b: number) =>
+    Math.round(a + (b - a) * amount)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${ch(br, cr)}${ch(bg, cg)}${ch(bb, cb)}`;
+}
 
 /**
  * Token chip palette — soft pastels at ~60% saturation, tuned for the dark IDE
@@ -48,36 +112,39 @@ export function getTokenColor(index: number): string {
  * same example wears the same colour in both.
  */
 export const EXAMPLE_CATEGORY_COLORS: Record<string, string> = {
-  Usage_Example: '#4CAF50',
-  Model_Architecture: '#2196F3',
-  Classical: '#26A69A',
-  LLM: '#AB47BC',
-  Diffusion: '#EC407A',
-  Transformer: '#26C6DA',
-  RNN: '#5C6BC0',
-  RL: '#EF5350',
-  Stats: '#7E57C2',
+  Usage_Example: '#4caf50',
+  Model_Architecture: '#2397f3',
+  Classical: '#26a69a',
+  LLM: '#c279ce',
+  Diffusion: '#ef6292',
+  Transformer: '#26c6da',
+  RNN: '#838fcf',
+  RL: '#f16663',
+  Stats: '#a286d3',
 };
 
-export const EXAMPLE_CATEGORY_FALLBACK = '#FF9800';
+export const EXAMPLE_CATEGORY_FALLBACK = '#ff9800';
 
 export const DIFFICULTY_COLORS: Record<string, string> = {
-  beginner: '#4CAF50',
-  intermediate: '#FF9800',
-  advanced: '#F44336',
+  beginner: '#4caf50',
+  intermediate: '#ff9800',
+  advanced: '#f66358',
 };
 
 export const STATUS_COLORS: Record<string, string> = {
-  running: '#FFC107',
-  completed: '#4CAF50',
-  error: '#F44336',
-  cached: '#2196F3',
-  skipped: '#9E9E9E',
-  idle: '#444',
+  running: '#ffc107',
+  completed: '#4caf50',
+  error: '#ff6b63',
+  cached: '#2397f3',
+  skipped: '#9e9e9e',
+  // Was #444, which measured 1.86:1 against the panel it sits on — an
+  // indicator you could not actually see. Neutral enough to still read as
+  // "nothing is happening", light enough to be visible.
+  idle: '#8593a3',
   // core#122: stopped part-way with partial results. Deeper amber than
   // `running` so the two are not confused at a glance, and deliberately not
   // red — an interruption is what the user asked for, not a failure.
-  interrupted: '#FF8F00',
+  interrupted: '#ff8f00',
 };
 
 /** Shared zoom-out floor for both React Flow canvases. Wide skip-aware valley
@@ -85,53 +152,17 @@ export const STATUS_COLORS: Record<string, string> = {
  * to fit on screen. */
 export const CANVAS_MIN_ZOOM = 0.1;
 
-export const SURFACE = {
-  bg: '#121212',
-  panel: '#161616',
-  card: '#1e1e1e',
-  toolbar: '#1a1a1a',
-  input: '#222',
-  hover: '#2a2a2a',
-  border: '#2a2a2a',
-  borderLight: '#333',
-  borderMedium: '#444',
-  borderHeavy: '#555',
-} as const;
-
-export const TEXT = {
-  primary: '#eee',
-  secondary: '#ccc',
-  tertiary: '#888',
-  muted: '#666',
-  dim: '#555',
-  dimmer: '#444',
-} as const;
-
-export const BRAND = {
-  primary: '#06b6d4',
-  primaryHover: '#22d3ee',
-  primaryDim: '#0e7490',
-  primaryGlow: 'rgba(6, 182, 212, 0.5)',
-  primaryBg: 'rgba(6, 182, 212, 0.09)',
-  preset: '#D4A017',
-  success: '#4CAF50',
-  error: '#F44336',
-  warning: '#FFC107',
-} as const;
-
-/**
- * Crafted toolbar tokens — surface gradients and micro-shadows used by the
- * Toolbar and Settings popover. Keep these synchronised with the design memory.
+/*
+ * `SURFACE`, `TEXT`, `BRAND` and `TOOLBAR` used to be declared here as the
+ * "single source of truth" for chrome colours. They were imported by nothing —
+ * verified by grep across all 290 TS/TSX files — and were exercised only by
+ * this module's own test, while all 54 CSS modules carried their own hex
+ * literals. Two grey systems had drifted apart behind that fiction, and the
+ * bottom three `TEXT` tiers (#666/#555/#444) failed WCAG AA on every surface
+ * they were nominally for.
+ *
+ * The real tokens now live in `styles/tokens.css` as CSS custom properties,
+ * which CSS modules can actually use. Style with `var(--text-secondary)`,
+ * `var(--surface-panel)` and friends. Only the semantic data palettes above
+ * are mirrored in TypeScript, and only because canvas code computes with them.
  */
-export const TOOLBAR = {
-  bgGradient: 'linear-gradient(180deg, #0e1520 0%, #0a0f17 100%)',
-  border: '#1a2230',
-  innerHighlight: 'inset 0 1px 0 rgba(255,255,255,0.04)',
-  separator: '#1f2937',
-  ctrlBorder: '#334155',
-  popoverBg: '#0a0f17',
-  popoverBorder: '#1f2937',
-  popoverShadow: '0 24px 60px -12px rgba(0,0,0,0.8), 0 0 0 1px rgba(6,182,212,0.05)',
-  // Run button accent reflection
-  runShadow: 'inset 0 1px 0 rgba(255,255,255,0.22), 0 6px 14px -6px rgba(6,182,212,0.5)',
-} as const;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,251 @@
+/* ============================================================
+   CodefyUI design tokens — the single source of truth for
+   colour, type, spacing and elevation across every CSS module.
+
+   Before this file existed there was no custom-property layer at
+   all: `theme.ts` exported SURFACE/TEXT/BRAND/TOOLBAR that nothing
+   imported, and all 54 CSS modules carried their own hex literals.
+   Two grey systems had drifted apart (a flat `#444`/`#555` family
+   in 33 files, a slate family in 21, 8 files mixing both).
+
+   Every colour pair below was solved numerically against WCAG 2.1
+   (sRGB linearisation, relative luminance, (L1+.05)/(L2+.05)) and
+   the surface ramp was spaced on CIE L*, not on contrast ratio —
+   ratio compresses badly at the dark end and would have hidden the
+   fact that the old surfaces sat 1.035:1 apart. The verification
+   script lives in `scripts/check-contrast.mjs`; `pnpm contrast`
+   re-runs it and fails on any regression.
+   ============================================================ */
+
+:root {
+  /* --------------------------------------------------------
+     Surfaces — an elevation ladder, not a set of near-identical
+     blacks. Steps are ~4 CIE L* apart, which is what makes a
+     panel read as a separate plane from the canvas behind it.
+     The old ramp spanned L* 7->16 in steps of 1; this spans
+     L* 6->31. Deliberately not pure black (Material, VS Code,
+     Blender and ComfyUI all sit in #121212-#222).
+     -------------------------------------------------------- */
+  --surface-canvas: #0f1319; /* graph canvas, the plane everything sits on */
+  --surface-app: #151a22; /* app chrome / toolbar base */
+  --surface-panel: #1c222c; /* side panels, results panel */
+  --surface-raised: #242b37; /* cards, nodes, popovers, menus */
+  --surface-input: #2c3441; /* form fields and wells */
+  --surface-hover: #353d4b; /* hover state */
+  --surface-active: #404959; /* pressed / selected row */
+
+  /* Overlay scrim for modals. */
+  --surface-scrim: rgba(6, 9, 13, 0.72);
+
+  /* --------------------------------------------------------
+     Text — three usable tiers plus one deliberately-dim tier.
+     The old scale had six (#eee/#ccc/#888/#666/#555/#444) of
+     which the bottom three failed AA on every surface, so the
+     "less important" text was the unreadable text. Guidance is
+     to cap hierarchy at 2-3 tiers and carry the rest with weight.
+
+     All three usable tiers clear 4.5:1 on every surface above,
+     including --surface-active. --text-disabled is the single
+     exception and is reserved for genuinely inert content.
+     -------------------------------------------------------- */
+  --text-primary: #f0f4f8; /* 14.45:1 on panel — titles, values */
+  --text-secondary: #c6d0da; /* 10.22:1 on panel — body, descriptions */
+  --text-muted: #aeb9c6; /*  8.03:1 on panel — metadata, counts, hints */
+  --text-disabled: #6b7684; /*  3.46:1 on panel — DISABLED/placeholder ONLY */
+  --text-on-accent: #04212b; /*  9.24:1 on --accent — text inside filled accent */
+
+  /* --------------------------------------------------------
+     Borders. Only --border-strong is load-bearing: it outlines
+     real controls, so WCAG 1.4.11 asks for 3:1 against the
+     surface *behind* the control (3.51 on panel, 3.13 on raised).
+     The other two are decorative dividers and are tuned by L*
+     separation instead. Prefer a tonal step over a border where
+     the surfaces already differ — a border on every box is the
+     "visual noise" the guidance warns about.
+     -------------------------------------------------------- */
+  --border-subtle: #262e3a; /* hairline inside a panel */
+  --border-base: #313a48; /* panel edges, section dividers */
+  --border-strong: #6b7787; /* input/button outlines — 3:1 rated */
+  --border-focus: #22d3ee;
+
+  /* --------------------------------------------------------
+     Accent and status. Cyan is unchanged — it already measured
+     well (8.84:1 on panel). Status hues were lifted off their
+     Material 500 values so each clears 4.5:1 as text on a dark
+     surface, per the "use the 200 step, not the 500 step" rule.
+     -------------------------------------------------------- */
+  --accent: #22d3ee;
+  --accent-deep: #06b6d4;
+  --accent-dim: #0e7490;
+  --accent-wash: rgba(34, 211, 238, 0.12); /* tinted backgrounds */
+  --accent-glow: rgba(34, 211, 238, 0.45);
+
+  --status-success: #5ec269;
+  --status-error: #ff6b63;
+  --status-warning: #ffc94d;
+  --status-info: #6aa9ff;
+  --status-idle: #8593a3; /* was #444 = 1.86:1, i.e. an invisible dot */
+  --status-preset: #e0a92b;
+
+  /* Canvas wires. These are graphics conveying meaning, so 1.4.11
+     applies: >=3:1 against --surface-canvas. */
+  --wire: #5b6c82; /* 3.47:1 */
+  --wire-data: #6aa9ff; /* 7.74:1 */
+  --wire-active: #22d3ee; /* 10.31:1 */
+
+  /* --------------------------------------------------------
+     Type scale. Steps are ~1.125 apart at the small end, which
+     is the ratio compact systems use; a wider ratio would force
+     sizes apart faster than a dense tool can afford.
+
+     Values are rem so the Small/Default/Large control still
+     scales the whole app. At the Default root of 16px they read
+     as the px comment on each line. --fs-2xs is the only step
+     below the 12px secondary-text floor and is reserved for
+     non-continuous badge text.
+
+     The old scale concentrated 58% of all rules in four values
+     of which the most common (0.6875rem, 76 uses) never reached
+     13.75px even at the Large setting.
+     -------------------------------------------------------- */
+  --fs-2xs: 0.6875rem; /* 11px — badges only, never a sentence */
+  --fs-xs: 0.75rem; /* 12px — metadata floor */
+  --fs-sm: 0.8125rem; /* 13px — dense secondary text */
+  --fs-md: 0.875rem; /* 14px — body / UI default */
+  --fs-lg: 1rem; /* 16px — emphasis, section titles */
+  --fs-xl: 1.125rem; /* 18px — panel and modal headings */
+  --fs-2xl: 1.375rem; /* 22px — screen headings */
+  --fs-3xl: 1.75rem; /* 28px — the one hero line */
+
+  /* Line-height by role, not by size. 82.9% of font-size rules
+     used to set none, and 24 clamped to `line-height: 1`, which
+     is the tightest value CSS allows and the direct cause of the
+     "cramped" reading. Nothing should use 1. */
+  --lh-tight: 1.25; /* single-line dense UI: node titles, cells, labels */
+  --lh-snug: 1.4; /* short wrapping labels */
+  --lh-normal: 1.55; /* running prose: descriptions, tooltips, help */
+
+  --fw-normal: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+
+  /* --------------------------------------------------------
+     Spacing — 4px atomic unit, 8px macro grid. Only 43.6% of
+     the previous 731 spacing values landed on a 4px grid; 6px
+     and 10px were used 193 times between them. Density comes
+     from this scale and from the control heights below, never
+     from shrinking text.
+     -------------------------------------------------------- */
+  --sp-0: 0;
+  --sp-1: 2px; /* hairline nudge only */
+  --sp-2: 4px;
+  --sp-3: 8px; /* minimum padding inside any control */
+  --sp-4: 12px;
+  --sp-5: 16px;
+  --sp-6: 20px;
+  --sp-7: 24px;
+  --sp-8: 32px;
+  --sp-9: 40px;
+  --sp-10: 48px;
+
+  /* Control heights. Compact tier for the canvas, inspector and
+     lists; comfortable tier for menus and dialogs, which stay
+     roomy regardless of how dense the working surfaces get. */
+  --h-control-xs: 24px;
+  --h-control-sm: 28px;
+  --h-control: 32px; /* default compact control */
+  --h-control-lg: 40px; /* primary actions, menu rows, dialog buttons */
+  --h-row: 36px; /* list row in the node palette */
+
+  --radius-sm: 4px;
+  --radius: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-pill: 999px;
+
+  /* Elevation. Shadows barely register on dark surfaces, so
+     depth is carried by the surface ramp; these add just enough
+     separation for things that float above the page. */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow: 0 4px 12px -2px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 12px 32px -8px rgba(0, 0, 0, 0.6);
+  --shadow-popover: 0 16px 40px -12px rgba(0, 0, 0, 0.7);
+  --inner-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+
+  --focus-ring: 0 0 0 2px var(--surface-panel), 0 0 0 4px var(--border-focus);
+
+  --transition-fast: 120ms ease;
+  --transition: 180ms ease;
+}
+
+/* --------------------------------------------------------
+   Semantic data palettes. These carry meaning (which category
+   a node belongs to, whether a run failed), so unlike the
+   chrome above they are also needed in TypeScript — canvas and
+   SVG code has to compute with them. `styles/theme.ts` mirrors
+   every value below and `theme.test.ts` parses this file to
+   assert the two never drift.
+
+   Hues were lifted only where the Material 500-level tone was
+   too dark to read on a dark surface, per the "use the 200 step
+   on dark backgrounds" rule. Ten of the fourteen node categories
+   are unchanged; the ones that moved are marked.
+   -------------------------------------------------------- */
+:root {
+  /* Node categories */
+  --cat-cnn: #4caf50;
+  --cat-rnn: #2397f3; /* lifted from #2196f3 */
+  --cat-transformer: #c279ce; /* lifted from #9c27b0 */
+  --cat-llm: #a78bfa;
+  --cat-diffusion: #ee60a6; /* lifted from #ec4899 */
+  --cat-classical: #f59e0b;
+  --cat-rl: #ff9800;
+  --cat-data: #00bcd4;
+  --cat-training: #f66358; /* lifted from #f44336 */
+  --cat-io: #a78f86; /* lifted from #795548 */
+  --cat-dataflow: #ff6f00;
+  --cat-utility: #8097a2; /* lifted from #607d8b */
+  --cat-normalization: #26a69a;
+  --cat-tensorops: #838fcf; /* lifted from #5c6bc0 */
+
+  /* Example-gallery categories */
+  --ex-usage-example: #4caf50;
+  --ex-model-architecture: #2397f3; /* lifted */
+  --ex-classical: #26a69a;
+  --ex-llm: #c279ce; /* lifted */
+  --ex-diffusion: #ef6292; /* lifted */
+  --ex-transformer: #26c6da;
+  --ex-rnn: #838fcf; /* lifted */
+  --ex-rl: #f16663; /* lifted */
+  --ex-stats: #a286d3; /* lifted */
+  --ex-fallback: #ff9800;
+
+  /* Difficulty badges */
+  --difficulty-beginner: #4caf50;
+  --difficulty-intermediate: #ff9800;
+  --difficulty-advanced: #f66358; /* lifted */
+
+  /* Run/node execution status */
+  --status-running: #ffc107;
+  --status-completed: #4caf50;
+  --status-cached: #2397f3; /* lifted */
+  --status-skipped: #9e9e9e;
+  --status-interrupted: #ff8f00;
+  /* `idle` was #444 — 1.86:1, an indicator you could not see. A neutral
+     that still reads as "nothing is happening" but is actually visible. */
+}
+
+/* How strongly a category hue is tinted into --surface-raised to make a
+   node's header fill. Mirrored by NODE_HEADER_TINT in styles/theme.ts and
+   asserted by both the contrast gate and theme.test.ts. */
+:root {
+  --node-header-tint: 0.18;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --transition-fast: 0ms;
+    --transition: 0ms;
+  }
+}

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -87,6 +87,19 @@
   --status-idle: #8593a3; /* was #444 = 1.86:1, i.e. an invisible dot */
   --status-preset: #e0a92b;
 
+  /* Tinted fills for callouts and selected rows. Translucent so they sit on
+     whatever surface they land on; the contrast gate composites them over
+     --surface-panel and checks the text that goes on top. */
+  --success-wash: rgba(94, 194, 105, 0.14);
+  --danger-wash: rgba(255, 107, 99, 0.14);
+  --warning-wash: rgba(255, 201, 77, 0.14);
+  --info-wash: rgba(106, 169, 255, 0.14);
+
+  /* Glows are shadows, so they must stay translucent — an opaque box-shadow
+     reads as a hard ring rather than a glow. */
+  --glow-running: 0 0 6px rgba(255, 193, 7, 0.55);
+  --glow-accent: 0 0 6px rgba(34, 211, 238, 0.55);
+
   /* Canvas wires. These are graphics conveying meaning, so 1.4.11
      applies: >=3:1 against --surface-canvas. */
   --wire: #5b6c82; /* 3.47:1 */

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -106,6 +106,31 @@
   --wire-data: #6aa9ff; /* 7.74:1 */
   --wire-active: #22d3ee; /* 10.31:1 */
 
+  /* Control flow. Green distinguishes trigger/execution-order edges and the
+     Start node from the data wires above — it is a semantic distinction, not
+     decoration, so it gets a token rather than the literal that was repeated
+     across BaseNode, StartNode and TriggerEdge. */
+  --flow-trigger: #22c55e; /* 8.17:1 on canvas */
+  --flow-trigger-deep: #16a34a; /* gradient partner, 5.65:1 */
+
+  /* Preset nodes carry a deliberate gold brand rather than a category hue.
+     Unlike the old category headers this one was already legible — dark ink
+     on gold — so it keeps its filled treatment. */
+  --preset-fill: linear-gradient(135deg, #b8860b, #d4a017, #c5941a);
+  --preset-ink: #1a1a1a; /* 7.33:1 on the gradient's mid stop */
+  --preset-gold: #d4a017;
+
+  /* Code editor. The surface was `rgba(0, 0, 0, 0.25)` over whatever happened
+     to be behind it, which made its contrast unverifiable — and two roles were
+     failing on it: comments at 3.39:1 and the line-number gutter at 2.17:1.
+     Comments and line numbers are content, not decoration, so both now clear
+     AA. The syntax hues themselves are a deliberate code theme and already
+     measured 6.7:1 to 11.9:1 here; they are left alone. */
+  --surface-code: #1a2029;
+  --code-text: #e5e7eb;
+  --code-comment: #7f8898; /* was #6b7280 */
+  --code-gutter: #7f8897; /* was #4b5563 */
+
   /* --------------------------------------------------------
      Type scale. Steps are ~1.125 apart at the small end, which
      is the ratio compact systems use; a wider ratio would force

--- a/frontend/src/utils/exportDiagram.test.ts
+++ b/frontend/src/utils/exportDiagram.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Edge, Node } from '@xyflow/react';
 import type { NodeData, NodeDefinition, PortDefinition } from '../types';
+import { CATEGORY_COLORS, PRESET_GOLD } from '../styles/theme';
 import { graphToSvg, svgToPngBlob, DIAGRAM_THEMES } from './exportDiagram';
 
 // ── Helpers ───────────────────────────────────────────────────────────
@@ -479,12 +480,18 @@ describe('graphToSvg', () => {
 
   it('colors a preset node with the preset gold accent', () => {
     const svg = graphToSvg([makeNode('p', { isPreset: true })], []);
-    expect(svg).toContain('stroke="#D4A017"');
+    // Sourced from the shared palette rather than restated, so a future tune of
+    // the gold does not need this literal edited in two places.
+    expect(svg).toContain(`stroke="${PRESET_GOLD}"`);
   });
 
   it('colors a node by its category', () => {
     const svg = graphToSvg([makeNode('c', { definition: mkDef({ category: 'CNN' }) })], []);
-    expect(svg).toContain('stroke="#4CAF50"'); // CNN
+    // Was a hardcoded '#4CAF50' (uppercase); exportDiagram.ts's nodeColor()
+    // reads straight from CATEGORY_COLORS, which theme.test.ts pins against
+    // tokens.css (now lowercase) -- assert against the constant so this
+    // can't silently drift the next time a hue is tuned.
+    expect(svg).toContain(`stroke="${CATEGORY_COLORS.CNN}"`); // CNN
   });
 
   it('falls back to the neutral color for an unknown category', () => {

--- a/frontend/src/utils/exportDiagram.ts
+++ b/frontend/src/utils/exportDiagram.ts
@@ -1,7 +1,7 @@
 import dagre from '@dagrejs/dagre';
 import type { Edge, Node } from '@xyflow/react';
 import type { NodeData, PortDefinition } from '../types';
-import { CATEGORY_COLORS } from '../styles/theme';
+import { CATEGORY_COLORS, FLOW_COLORS, PRESET_GOLD } from '../styles/theme';
 import { getPortColor, resolveDynamicInputs, resolveDynamicOutputs } from './index';
 
 /**
@@ -38,9 +38,12 @@ const FONT_FAMILY =
 // Labels longer than these are truncated with an ellipsis so cards stay tidy.
 const MAX_LABEL_CHARS = 28;
 const MAX_PORT_CHARS = 24;
-const PRESET_COLOR = '#D4A017'; // reusable-subgraph accent (matches the toolbar)
+const PRESET_COLOR = PRESET_GOLD; // reusable-subgraph accent
 const FALLBACK_NODE_COLOR = '#607D8B';
-const START_COLOR = '#16a34a'; // Start/entry node accent (border, title, trigger edges)
+// Start/entry node accent (border, title, trigger edges). Sourced from the
+// shared palette rather than restated, since an exported SVG is standalone
+// and cannot resolve `var(--flow-trigger-deep)`.
+const START_COLOR = FLOW_COLORS.triggerDeep;
 const START_FILL = '#dcfce7'; // Start node light-green background
 
 export type DiagramThemeName = 'light' | 'dark';


### PR DESCRIPTION
The UI has weak contrast, text that is too small, and layout that is too cramped. This fixes all three, and puts a gate in CI so they cannot come back.

## What was actually wrong

Not "the colours need tuning". **There was no token layer at all.**

`styles/theme.ts` exported `SURFACE` / `TEXT` / `BRAND` / `TOOLBAR` as the "single source of truth" for chrome colour. Nothing imported them — verified by grep across all 290 TS/TSX files; they were exercised only by their own test. And no `:root` block existed in any of the 54 CSS modules. So every component carried its own hex literals, and two grey systems had drifted apart behind the fiction of a shared palette: a flat 3-digit family in 33 files, a Tailwind-slate family in 21, and 8 files mixing both.

Measured on the shipped build, every element with its own visible text, backgrounds composited with alpha:

- **69 of 142 (49%) failed WCAG AA**
- **70 of 142 rendered under 13px**
- **64 of 142 set no line-height at all**, and 24 rules clamped to `line-height: 1` — the tightest value CSS allows, and the direct cause of "cramped"

Three of the six `TEXT` tiers (`#666`, `#555`, `#444`) failed AA on **every** surface they were nominally for, so the text meant to be less important was in practice unreadable. The seven surface tones sat **1.035:1** apart, which is why the whole app read as one flat slab and every panel needed a border to be visible.

The welcome screen's own headline — the largest, boldest text in the app, and the first thing a new user sees — measured **2.66:1**.

## Results

Same measurement method, before and after, on the running app:

| | before | after |
|---|---|---|
| failing WCAG AA | 69 / 142 | **2 / 125** |
| under 12px | 70 (under 13px) | **1** |
| no line-height | 64 | 18 |
| smallest text | 11.0px | 11.6px |

The two remaining failures are `--text-disabled` on a disabled tab and a disabled button, which SC 1.4.3 explicitly exempts. The 18 without a line-height are single-line icon buttons and chevrons, where the UA stylesheet sets `normal` on form controls and nothing can wrap; that reasoning is recorded in `App.css` rather than left looking like an oversight.

## The token layer

`src/styles/tokens.css` — surfaces, text tiers, borders, accent and status, type scale, line-heights, spacing, control heights, radii, elevation.

Two decisions worth calling out:

**Surfaces are spaced on CIE L\*, not contrast ratio.** Ratio compresses badly near black — it reported the old 1.035:1 steps as a difference. The new ramp steps ~4 L\* apart across L\* 5.8 to 30.8, which is what makes a panel read as a separate plane from the canvas.

**Text drops from six tiers to three, plus one deliberately dim.** `--text-disabled` is intentionally below AA and is for disabled controls and placeholders only; the gate asserts both that it stays visible *and* that it does not creep up into a fourth readable tier.

## The gate

`frontend/scripts/check-contrast.mjs` parses `tokens.css` and re-derives **225 relationships**: AA for every text tier on every surface, 1.4.11 for control borders and canvas wires, L\* separation for the surface ramp, and every node-header and badge fill for all fourteen categories. It runs as the first step of `pnpm build`, so CI enforces it.

It reads the CSS rather than keeping its own copy of the palette — a checker with its own copy only proves the copy is self-consistent. It self-tests its WCAG maths against the canonical `#767676`-on-white = 4.54:1 pair before reporting any verdict, and exits 2 if that fails rather than 1.

Confirmed to fail correctly under four mutations: reinstating the old `#666` muted grey, collapsing the surface ramp, reverting a category hue, and "fixing" the disabled tier into a readable one. `theme.test.ts` parses the same file to assert the TypeScript mirror matches — it immediately caught two colours of mine that had already drifted.

## Node headers

The single biggest visual fix. Headers were painted with the raw category hue and titled in `#eeeeee`, measuring **1.85:1 to 2.69:1 on twelve of the fourteen categories** — the node title, on every node, in every graph, below half the AA minimum.

The hue is now tinted into the node surface at 18%. Every title sits between **9.2:1 and 11.7:1**, and the colour coding survives. Ten of the fourteen hues are unchanged; four that were too dark to read on a dark surface were lifted toward their ~200 step.

### A rule this pass had to discover

Category labels were drawn in the category hue **on a tinted fill of that same hue**. That pairing cannot reach 4.5:1 — solving across all fourteen hues and every tint strength from 0.10 to 0.18, the best achievable is about 4.16:1. It is unreadable by construction, not by tuning.

So the label takes the text tier (worst case 5.11:1) and the hue identifies the category through the accent bar, chip border and dot — graphics, correctly held to 3:1. Four places had each invented this pattern independently. The gate now encodes both halves.

## Correcting my own change

The first version set a fixed 16px root, replacing `clamp(13.5px, 0.35vw + 11px, 18px)`. Re-measuring against the actual browser window caught the mistake: at 2560px wide the old root was already 18px, so a flat 16px made text **smaller** on exactly the screen the complaint came from — cancelling the type-scale increase it was meant to deliver.

The floor was the real problem, not the scaling. It is now `clamp(16px, 0.35vw + 11px, 19px)`, and Small/Default/Large multiplies through `--font-scale` instead of overwriting the root, so the preference composes with the viewport rather than fighting it.

Text is larger than before at **every** width:

| viewport | most-used size | body |
|---|---|---|
| 1366 | 10.8px -> 12.0px | 13.8px -> 14.0px |
| 1920 | 12.2px -> 13.3px | 15.5px -> 15.5px |
| 2560 | 12.4px -> 14.3px | 15.8px -> 16.6px |

The old Small setting produced **7.5px** text for the 38 rules using `0.625rem`.

## Also fixed, found rather than looked for

- **The toolbar carried its own status-colour map** that had drifted from the canonical one, and in it `running` and `cached` were both `#06b6d4` — the same teal, so those two states were indistinguishable. Now on `--status-*`; `running` is amber, as it already was on the nodes and in the tab bar.
- **`var(--cd-accent, #2dd4bf)` was read in three places but never defined anywhere**, so it always silently resolved to its fallback.
- **The code editor's comments (3.39:1) and line-number gutter (2.17:1)** were unreadable, and its surface was `rgba(0, 0, 0, 0.25)` over whatever happened to be behind it, making its contrast unverifiable. Both roles now clear AA on an explicit surface. The syntax hues measured 6.7:1 to 11.9:1 and are deliberately untouched — that is a code theme, not app chrome.
- **The stale pre-lift `#607D8B` fallback survived in four more places** after the first two were fixed, so plugin-defined categories rendered a different colour from every other unknown-category node.
- **`SURFACE_RAISED` had been copied into three components**, each with a comment asking for it to be exported. Exported and drift-tested now, along with the trigger-flow green and the preset gold.
- **A glow lost its translucency** when an `rgba()` literal was swapped for a solid token, turning the running indicator into a hard ring. Fixed, and the gate now rejects an opaque glow.

## Density

Palette rows, results-log entries and config rows bottomed out at **2px** vertical padding. They now use the spacing scale and real control heights, and palette descriptions wrap to two lines instead of truncating.

The governing rule, now recorded: **density comes from padding and control height, never from shrinking text.** Coupling the two is what produced "too small AND too cramped" simultaneously.

## Not done, filed instead

- **#227** — the SVG diagram export defaults to a light theme where 7 of 14 category hues fall under 3:1 on white. Pre-existing, and the count is unchanged by this PR, but one palette cannot serve a near-black canvas and a white page.
- **#228** — the Subgraph editor keeps its own duplicated layer-type palette on the pre-lift hues. I converted one entry before realising it is a separate scheme and reverted it: one lifted hue out of seven is worse than none. Remapping it is a semantic decision, not a mechanical one.

## Verification

- **2935 tests pass**, `tsc -b` clean, production build green.
- Contrast gate: 225 relationships, and proven to fail under mutation.
- The before/after numbers are measured on the running app, not derived from the source.
- Tests that pinned literal colours were moved to assert the canonical constant where their intent was "uses the shared palette", and rewritten where the contract genuinely changed. None were weakened to make them pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
