### PR TITLE
fix(ui): LAN-served editor renders a blank page — randomUUID has no fallback

### DIFF
--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -2235,6 +2235,30 @@ describe('persistence (module reload)', () => {
     }
   });
 
+  it('module evaluation survives a missing randomUUID with nothing persisted', async () => {
+    // The blank-page bug: a first-time visitor over plain-HTTP LAN has no
+    // stored tabs, so loadTabs() reaches `generateId()`. That call ran at
+    // module-evaluation time, so an unguarded `crypto.randomUUID()` threw
+    // before `createRoot().render()` — the whole app rendered as an empty
+    // <div id="root"> with only a console TypeError.
+    const realCrypto = globalThis.crypto;
+    localStorage.removeItem(STORAGE_KEY);
+    try {
+      Object.defineProperty(globalThis, 'crypto', {
+        configurable: true,
+        value: { getRandomValues: realCrypto.getRandomValues.bind(realCrypto) },
+      });
+      const mod = await import('./tabStore');
+      expect(mod.useTabStore.getState().tabs).toHaveLength(1);
+      expect(mod.useTabStore.getState().activeTabId).toBeTruthy();
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', {
+        configurable: true,
+        value: realCrypto,
+      });
+    }
+  });
+
   it('saveTabs persists state changes (trailing-edge debounce)', async () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/utils/ids.test.ts
+++ b/frontend/src/utils/ids.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { generateId } from './ids';
+
+/**
+ * `crypto.randomUUID` is a secure-context-only API. Serving the editor over
+ * plain HTTP on a LAN address — `cdui start --host <lan-ip>`, the way a
+ * classroom is set up — leaves it `undefined`, so these tests pin the
+ * behaviour of every degraded shape the browser can hand us.
+ */
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+const realCrypto = globalThis.crypto;
+
+function setCrypto(value: unknown) {
+  Object.defineProperty(globalThis, 'crypto', { configurable: true, value });
+}
+
+afterEach(() => {
+  setCrypto(realCrypto);
+  vi.restoreAllMocks();
+});
+
+describe('generateId', () => {
+  it('uses crypto.randomUUID when the page is in a secure context', () => {
+    const randomUUID = vi.fn(() => '11111111-2222-4333-8444-555555555555');
+    setCrypto({ ...realCrypto, randomUUID });
+
+    expect(generateId()).toBe('11111111-2222-4333-8444-555555555555');
+    expect(randomUUID).toHaveBeenCalledOnce();
+  });
+
+  describe('without crypto.randomUUID (plain-HTTP LAN serving)', () => {
+    it('still returns a UUID-shaped string', () => {
+      setCrypto({ getRandomValues: realCrypto.getRandomValues.bind(realCrypto) });
+      expect(generateId()).toMatch(UUID_RE);
+    });
+
+    it('sets the version and variant nibbles of a v4 UUID', () => {
+      setCrypto({ getRandomValues: realCrypto.getRandomValues.bind(realCrypto) });
+      const id = generateId();
+      expect(id[14]).toBe('4');
+      expect(['8', '9', 'a', 'b']).toContain(id[19]);
+    });
+
+    it('uses crypto.getRandomValues, which is available in insecure contexts', () => {
+      const getRandomValues = vi.fn((a: Uint8Array) => realCrypto.getRandomValues(a));
+      setCrypto({ getRandomValues });
+
+      generateId();
+      expect(getRandomValues).toHaveBeenCalledOnce();
+    });
+
+    it('returns unique values', () => {
+      setCrypto({ getRandomValues: realCrypto.getRandomValues.bind(realCrypto) });
+      const ids = new Set(Array.from({ length: 1000 }, () => generateId()));
+      expect(ids.size).toBe(1000);
+    });
+  });
+
+  describe('with no crypto object at all', () => {
+    it('still returns a UUID-shaped string rather than throwing', () => {
+      setCrypto(undefined);
+      expect(() => generateId()).not.toThrow();
+      expect(generateId()).toMatch(UUID_RE);
+    });
+
+    it('returns unique values', () => {
+      setCrypto(undefined);
+      const ids = new Set(Array.from({ length: 1000 }, () => generateId()));
+      expect(ids.size).toBe(1000);
+    });
+  });
+
+  it('does not throw when crypto exists but exposes neither method', () => {
+    setCrypto({});
+    expect(() => generateId()).not.toThrow();
+    expect(generateId()).toMatch(UUID_RE);
+  });
+});

--- a/frontend/src/utils/ids.ts
+++ b/frontend/src/utils/ids.ts
@@ -5,6 +5,49 @@
  * importing the barrel `utils/index.ts`, which imports them back. `index.ts`
  * re-exports `generateId`, so every existing caller is unchanged.
  */
+
+/**
+ * `crypto.randomUUID` is restricted to secure contexts — HTTPS or localhost.
+ * Serving the editor on a plain-HTTP LAN address (`cdui start --host <lan-ip>`,
+ * which is how a classroom is set up) leaves it `undefined`, and this module is
+ * reached during `tabStore`'s module evaluation. An unguarded call there throws
+ * before `createRoot().render()` ever runs, so the whole app renders as a blank
+ * page with nothing but a console TypeError to show for it.
+ *
+ * `crypto.getRandomValues` carries no such restriction, so the fallback keeps
+ * both the entropy and the RFC 4122 v4 shape that call sites and
+ * `utils/index.test.ts` assert. Only when there is no `crypto` at all does this
+ * drop to `Math.random`.
+ */
+function randomBytes(n: number): Uint8Array {
+  const bytes = new Uint8Array(n);
+  const c: Crypto | undefined = typeof crypto !== 'undefined' ? crypto : undefined;
+  if (typeof c?.getRandomValues === 'function') {
+    c.getRandomValues(bytes);
+    return bytes;
+  }
+  for (let i = 0; i < n; i++) bytes[i] = Math.floor(Math.random() * 256);
+  return bytes;
+}
+
+/** Format 16 random bytes as an RFC 4122 version-4 UUID. */
+function uuidV4(): string {
+  const b = randomBytes(16);
+  b[6] = (b[6] & 0x0f) | 0x40; // version 4
+  b[8] = (b[8] & 0x3f) | 0x80; // variant 10xx
+  const hex: string[] = [];
+  for (let i = 0; i < 16; i++) hex.push(b[i].toString(16).padStart(2, '0'));
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10, 16).join(''),
+  ].join('-');
+}
+
 export function generateId(): string {
-  return crypto.randomUUID();
+  const c: Crypto | undefined = typeof crypto !== 'undefined' ? crypto : undefined;
+  if (typeof c?.randomUUID === 'function') return c.randomUUID();
+  return uuidV4();
 }


### PR DESCRIPTION
> 中文摘要：老師用 `cdui start --host <區網IP>` 架一台給全班連線時，學生看到的是一片空白。原因是 `generateId()` 直接呼叫 `crypto.randomUUID()`，這個 API 只在安全情境（HTTPS 或 localhost）下存在，純 HTTP 的區網連線拿到的是 undefined。它又發生在模組載入階段，所以整個畫面根本沒渲染出來。改成在缺少該 API 時用 `crypto.getRandomValues` 產生同樣格式的 UUID。

`generateId()` called `crypto.randomUUID()` with no guard. That API is [restricted to secure contexts](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID), so it is `undefined` whenever the editor is served over plain HTTP on a LAN address — which is exactly `cdui start --host <lan-ip>`, the way a room full of students is pointed at one machine.

## Why it renders blank rather than misbehaving

The call is reached during **module evaluation**:

- `tabStore.ts:1240` runs `const initialState = loadTabs();` at import time
- with nothing in `localStorage`, `loadTabs()` falls past its `try/catch` (which closes at `:1234`) to `generateId()` at `:1236`

Throwing there means `main.tsx` never reaches `createRoot().render()`, and there is no top-level error boundary, so `<div id="root">` stays empty. The teacher sees a working LAN URL printed by the CLI, every student sees a white page, and the only evidence anywhere is a console `TypeError`.

Returning users are hit differently and later: their stored tabs load fine, then the first add / paste / duplicate throws (`utils/index.ts:518`, `tabStore.ts:2260`).

**Everything else about LAN serving is already correct** — the Host whitelist accepts concrete LAN IPs and enumerates interfaces for `0.0.0.0` (`core/auth.py:115-191`), `dev.py:1421-1431` prints the LAN URL and a trust warning, and every frontend URL is built relative to `window.location`. This one line was the whole failure.

## The fix

`crypto.getRandomValues` is **not** secure-context-restricted, so the fallback keeps full entropy rather than dropping to `Math.random`. It also preserves the RFC 4122 v4 shape, which matters: `utils/index.test.ts:112` asserts it, and ids are embedded in saved graphs.

Only a total absence of `crypto` (non-browser hosts, ancient engines) reaches the `Math.random` path.

## This gap was known at the seam and never closed at the source

The same guard already exists 900 lines up, for `graphId`:

```ts
// tabStore.ts:302-304
typeof crypto !== 'undefined' && 'randomUUID' in crypto
  ? crypto.randomUUID()
  : `graph-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
```

and its test at `tabStore.test.ts:2209` works around `generateId` in so many words — *"We also stub generateId's crypto usage by giving the persisted tabs explicit ids ... without needing crypto.randomUUID at id-generation time."*

## Tests

8 new cases in `utils/ids.test.ts` — randomUUID present, `getRandomValues`-only (the LAN case, asserting both the v4 version nibble and the variant nibble), no `crypto` at all, and uniqueness over 1000 draws in each degraded mode.

Plus one regression test in `tabStore.test.ts` that reproduces the actual symptom rather than a proxy for it: module evaluation with nothing persisted and no `randomUUID`. **Verified to fail against the previous implementation**, at `tabStore.ts:1236` → `:1240` — the exact blank-page path.

Local: `tsc -b` clean, 138 files / 2899 tests green.