### PR TITLE
chore(install): point every install and update path at CodefyUI/CodefyUI

### DIFF
--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -14,4 +14,4 @@ If you need proprietary, closed-source, SaaS, OEM, enterprise, or other terms
 that are not compatible with AGPL-3.0, contact the maintainers for a separate
 commercial license.
 
-Commercial licensing contact: https://github.com/treeleaves30760/CodefyUI/issues
+Commercial licensing contact: https://github.com/CodefyUI/CodefyUI/issues

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ A visual, node-based deep learning pipeline builder. Design CNN, RNN, Transforme
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.sh | bash
 ```
 
 ```powershell
 # Windows (PowerShell)
-powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.ps1 | iex"
 ```
 
 Installs only what's needed to run the app: `git`, `uv`, and Python (via uv). The frontend bundle is downloaded prebuilt from the latest GitHub release, and the backend is **checked out at that same release tag** so the two stay in sync — **no Node.js or pnpm required for end users**. After install, **open a new terminal** and run from anywhere:
@@ -206,11 +206,11 @@ loss`; `Edu-Patchify` makes `unfold → permute → flatten` visible. Switch
 
 ### Writing your own plugin
 
-Fork the [**Official Plugin Template**](https://github.com/treeleaves30760/CodefyUI-Plugin-Official) — a working, MIT-licensed plugin with two example nodes, a sample example graph, a test suite, and a fully-commented manifest. The README there walks you through every field and the AST security gate.
+Fork the [**Official Plugin Template**](https://github.com/CodefyUI/CodefyUI-Plugin-Official) — a working, MIT-licensed plugin with two example nodes, a sample example graph, a test suite, and a fully-commented manifest. The README there walks you through every field and the AST security gate.
 
 ```bash
 # Install the template itself to see the pattern live
-cdui plugin install treeleaves30760/CodefyUI-Plugin-Official
+cdui plugin install CodefyUI/CodefyUI-Plugin-Official
 
 # After forking
 cdui plugin install your-username/your-fork
@@ -321,4 +321,4 @@ CodefyUI uses a dual path licensing model:
 - **Open source path**: AGPL-3.0-only for individual developers, small teams, education, research, community use, and any other use case that can comply with AGPL-3.0.
 - **Commercial path**: proprietary, closed-source, SaaS, OEM, enterprise, or other use cases that need terms outside AGPL-3.0 should contact the maintainers for a commercial license.
 
-Commercial licensing contact: https://github.com/treeleaves30760/CodefyUI/issues
+Commercial licensing contact: https://github.com/CodefyUI/CodefyUI/issues

--- a/backend/app/nodes/llm/word_vector_node.py
+++ b/backend/app/nodes/llm/word_vector_node.py
@@ -34,7 +34,7 @@ from ._demo_vectors import DEMO_VECTORS, DIM as DEMO_DIM
 
 # Future GloVe asset specs (not published yet — first attempt raises a friendly
 # error pointing users at the offline ``demo-16d`` backend).
-_GLOVE_PLACEHOLDER_URL = "https://github.com/treeleaves30760/CodefyUI/releases/download/llm-assets-v0/{name}"
+_GLOVE_PLACEHOLDER_URL = "https://github.com/CodefyUI/CodefyUI/releases/download/llm-assets-v0/{name}"
 
 
 @lru_cache(maxsize=8)

--- a/backend/tests/test_install_source.py
+++ b/backend/tests/test_install_source.py
@@ -1,0 +1,153 @@
+"""Guards on where an install and an update fetch code from.
+
+Four independent copies of the repo path exist -- ``install.sh``,
+``install.ps1``, ``scripts/dev.py`` and the README one-liners -- in three
+languages that cannot share a constant, because the shell installers run
+before Python exists. So the single source of truth has to be a test.
+
+The failure this prevents is not untidiness. A GitHub rename redirect keeps
+an old ``owner/repo`` path working only until somebody creates a new repo at
+that path, and the old owner name stays claimable forever. Since
+``dev.fetch_release_dist`` verifies no signature or checksum, a stale path
+that gets claimed turns every install and every ``cdui update`` into code
+execution from a repo the maintainer does not control.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+import pytest
+
+import dev  # scripts/dev.py -- conftest puts scripts/ on sys.path
+
+ROOT = dev.ROOT
+EXPECTED_REPO = "CodefyUI/CodefyUI"
+OLD_OWNER = "treeleaves30760"
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+# ── The four copies must agree ───────────────────────────────────────────────
+
+def test_dev_py_release_repo():
+    assert dev.RELEASE_REPO == EXPECTED_REPO
+
+
+def test_install_sh_names_the_same_repo():
+    text = _read("install.sh")
+    assert f'RELEASE_REPO="{EXPECTED_REPO}"' in text
+    assert f'REPO="https://github.com/{EXPECTED_REPO}.git"' in text
+
+
+def test_install_ps1_names_the_same_repo():
+    text = _read("install.ps1")
+    assert f"$ReleaseRepo = '{EXPECTED_REPO}'" in text
+    assert f"$Repo = 'https://github.com/{EXPECTED_REPO}.git'" in text
+
+
+def test_readme_one_liners_fetch_from_the_same_repo():
+    text = _read("README.md")
+    for script in ("install.sh", "install.ps1"):
+        url = f"https://raw.githubusercontent.com/{EXPECTED_REPO}/main/{script}"
+        assert url in text, f"README does not point {script} at {EXPECTED_REPO}"
+
+
+def test_every_entry_point_agrees_on_one_owner():
+    """Whatever the repo is called, all four must say the same thing."""
+    pattern = re.compile(r"github(?:usercontent)?\.com/([\w.-]+)/CodefyUI\b")
+    owners = set()
+    for rel in ("install.sh", "install.ps1", "scripts/dev.py", "README.md"):
+        owners.update(pattern.findall(_read(rel)))
+    owners.add(dev.RELEASE_REPO.split("/")[0])
+    assert owners == {EXPECTED_REPO.split("/")[0]}, (
+        f"install entry points disagree on the owner: {sorted(owners)}"
+    )
+
+
+# ── Nothing anywhere may still point at the pre-rename owner ─────────────────
+
+def test_no_tracked_file_references_the_old_owner():
+    try:
+        out = subprocess.run(
+            ["git", "grep", "-l", OLD_OWNER, "--", "."],
+            cwd=ROOT, capture_output=True, text=True,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover
+        pytest.skip(f"git unavailable: {exc}")
+    if out.returncode not in (0, 1):  # pragma: no cover
+        pytest.skip(f"git grep unavailable here: {out.stderr.strip()}")
+    stale = [line for line in out.stdout.splitlines() if line.strip()]
+    assert not stale, (
+        f"these files still reference the pre-rename owner {OLD_OWNER!r}, "
+        f"which survives only on a GitHub redirect: {stale}"
+    )
+
+
+# ── The uv bootstrap must not be able to hang forever ────────────────────────
+
+def test_uv_install_timeout_default(monkeypatch):
+    monkeypatch.delenv("CODEFYUI_UV_INSTALL_TIMEOUT", raising=False)
+    assert dev._uv_install_timeout() == 180
+
+
+def test_uv_install_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("CODEFYUI_UV_INSTALL_TIMEOUT", "600")
+    assert dev._uv_install_timeout() == 600
+
+
+def test_uv_install_timeout_zero_disables_the_limit(monkeypatch):
+    monkeypatch.setenv("CODEFYUI_UV_INSTALL_TIMEOUT", "0")
+    assert dev._uv_install_timeout() == 0
+
+
+def test_uv_install_timeout_rejects_nonsense(monkeypatch):
+    monkeypatch.setenv("CODEFYUI_UV_INSTALL_TIMEOUT", "soon")
+    assert dev._uv_install_timeout() == 180
+    monkeypatch.setenv("CODEFYUI_UV_INSTALL_TIMEOUT", "-5")
+    assert dev._uv_install_timeout() == 0
+
+
+def test_ensure_uv_passes_a_timeout_to_the_installer(monkeypatch):
+    monkeypatch.setattr(dev.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(dev, "_reexec", lambda *_a, **_k: None)
+    monkeypatch.setenv("CODEFYUI_UV_INSTALL_TIMEOUT", "45")
+    seen = {}
+
+    def fake_run(*args, **kwargs):
+        seen.update(kwargs)
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(dev.subprocess, "run", fake_run)
+    dev._ensure_uv()
+    assert seen.get("timeout") == 45
+
+
+def test_ensure_uv_exits_with_advice_when_the_download_hangs(monkeypatch, capsys):
+    monkeypatch.setattr(dev.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(dev, "_reexec", lambda *_a, **_k: None)
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="uv-install", timeout=180)
+
+    monkeypatch.setattr(dev.subprocess, "run", fake_run)
+    with pytest.raises(SystemExit) as exc:
+        dev._ensure_uv()
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    # Must name the escape hatch, not just report failure.
+    assert "CODEFYUI_UV_INSTALL_TIMEOUT" in err
+    assert "docs.astral.sh" in err
+
+
+def test_ensure_uv_is_a_noop_when_uv_is_already_installed(monkeypatch):
+    monkeypatch.setattr(dev.shutil, "which", lambda _name: "/usr/bin/uv")
+
+    def explode(*_a, **_k):  # pragma: no cover - must never run
+        raise AssertionError("_ensure_uv shelled out despite uv being present")
+
+    monkeypatch.setattr(dev.subprocess, "run", explode)
+    dev._ensure_uv()

--- a/backend/tests/test_install_source.py
+++ b/backend/tests/test_install_source.py
@@ -71,9 +71,12 @@ def test_every_entry_point_agrees_on_one_owner():
 # ── Nothing anywhere may still point at the pre-rename owner ─────────────────
 
 def test_no_tracked_file_references_the_old_owner():
+    # This file is excluded from its own scan: it has to name the forbidden
+    # string in order to forbid it. Everything else in the tree is fair game.
+    self_path = ":!backend/tests/test_install_source.py"
     try:
         out = subprocess.run(
-            ["git", "grep", "-l", OLD_OWNER, "--", "."],
+            ["git", "grep", "-l", OLD_OWNER, "--", ".", self_path],
             cwd=ROOT, capture_output=True, text=True,
         )
     except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,4 +32,4 @@ touches `docs/`. Set the Pages source to **GitHub Actions** in repo Settings →
 
 The site is served at **https://docs.codefyui.com/** — `url: 'https://docs.codefyui.com'`, `baseUrl: '/'`, with a one-line `static/CNAME`. The subdomain's DNS (a `CNAME` record) points at GitHub Pages.
 
-To revert to the GitHub Pages project URL, set `url` to `https://treeleaves30760.github.io` and `baseUrl` to `'/CodefyUI/'`, and remove `static/CNAME`.
+To revert to the GitHub Pages project URL, set `url` to `https://codefyui.github.io` and `baseUrl` to `'/CodefyUI/'`, and remove `static/CNAME`.

--- a/docs/docs/advanced/graph-copilot.md
+++ b/docs/docs/advanced/graph-copilot.md
@@ -15,12 +15,12 @@ Graph Copilot is built on two CodefyUI features: the [plugin frontend extension 
 ## Installation
 
 ```bash
-cdui plugin install treeleaves30760/CodefyUI-Plugin-Graph-Copilot
+cdui plugin install CodefyUI/CodefyUI-Plugin-Graph-Copilot
 ```
 
 Then reload the editor (press F5 or close and reopen the tab). The Graph Copilot panel appears as a floating widget in the editor.
 
-Plugin source and issues: [github.com/treeleaves30760/CodefyUI-Plugin-Graph-Copilot](https://github.com/treeleaves30760/CodefyUI-Plugin-Graph-Copilot)
+Plugin source and issues: [github.com/CodefyUI/CodefyUI-Plugin-Graph-Copilot](https://github.com/CodefyUI/CodefyUI-Plugin-Graph-Copilot)
 
 ## Quick start
 

--- a/docs/docs/advanced/plugin-frontend-extensions.md
+++ b/docs/docs/advanced/plugin-frontend-extensions.md
@@ -247,7 +247,7 @@ api.nodes.registerRenderer('my_plugin:MyNode', {
 });
 ```
 
-The [plugin template](https://github.com/treeleaves30760/CodefyUI-Plugin-Official)'s SDK wraps this with `createRoot`, so you can write the body as a React component.
+The [plugin template](https://github.com/CodefyUI/CodefyUI-Plugin-Official)'s SDK wraps this with `createRoot`, so you can write the body as a React component.
 
 ### `api.events` — live run events
 

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -152,11 +152,11 @@ cdui plugin new my-plugin --ui     # also a React frontend wired to the SDK
 
 It generates a manifest, an example node, a test (with the `cdui_plugins.<id>` namespace shim so `pytest` works locally), and — with `--ui` — a Vite + React `ui/` whose `src/sdk/` is the typed plugin SDK. The plugin lands in `./my-plugin/`; link it with `cdui plugin dev` (below) and start editing.
 
-For a richer reference, fork the **[Official Plugin Template](https://github.com/treeleaves30760/CodefyUI-Plugin-Official)** — a working, MIT-licensed plugin with two example nodes, a sample example graph, a test suite, and a fully-commented manifest. Its README walks through every field and the AST security gate.
+For a richer reference, fork the **[Official Plugin Template](https://github.com/CodefyUI/CodefyUI-Plugin-Official)** — a working, MIT-licensed plugin with two example nodes, a sample example graph, a test suite, and a fully-commented manifest. Its README walks through every field and the AST security gate.
 
 ```bash
 # Install the template itself to see the pattern live
-cdui plugin install treeleaves30760/CodefyUI-Plugin-Official
+cdui plugin install CodefyUI/CodefyUI-Plugin-Official
 
 # After forking
 cdui plugin install your-username/your-fork

--- a/docs/docs/getting-started/dev-install.md
+++ b/docs/docs/getting-started/dev-install.md
@@ -15,7 +15,7 @@ If you only want to *run* CodefyUI, use the [one-line installer](./installation)
 ## 1. Clone the repository
 
 ```bash
-git clone https://github.com/treeleaves30760/CodefyUI.git
+git clone https://github.com/CodefyUI/CodefyUI.git
 cd CodefyUI
 ```
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -17,12 +17,12 @@ The quick installer automatically sets up `git`, `uv`, and Python (via uv). The 
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.sh | bash
 ```
 
 ```powershell
 # Windows (PowerShell)
-powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.ps1 | iex"
 ```
 
 By default this installs to `~/CodefyUI` (macOS/Linux) or `%USERPROFILE%\CodefyUI` (Windows). Override with the `CODEFYUI_DIR` environment variable.

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -25,12 +25,12 @@ Install only what's needed to run the app (`git`, `uv`, and Python) — **no Nod
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.sh | bash
 ```
 
 ```powershell
 # Windows (PowerShell)
-powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.ps1 | iex"
 ```
 
 Then open a new terminal and run:
@@ -68,5 +68,5 @@ CodefyUI is **backend-authoritative**: `GET /api/nodes` returns every node defin
 
 CodefyUI uses a dual-path licensing model:
 
-- **Open source** — [AGPL-3.0-only](https://github.com/treeleaves30760/CodefyUI/blob/main/LICENSE) for individuals, small teams, education, research, and community use.
-- **Commercial** — for proprietary, closed-source, SaaS, OEM, or enterprise use that needs terms outside AGPL-3.0, [contact the maintainers](https://github.com/treeleaves30760/CodefyUI/issues).
+- **Open source** — [AGPL-3.0-only](https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE) for individuals, small teams, education, research, and community use.
+- **Commercial** — for proprietary, closed-source, SaaS, OEM, or enterprise use that needs terms outside AGPL-3.0, [contact the maintainers](https://github.com/CodefyUI/CodefyUI/issues).

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -15,12 +15,12 @@ const config: Config = {
 
   // Production URL: served at the root of the custom subdomain (see static/CNAME).
   // (To revert to the GitHub Pages project URL, set url to
-  //  'https://treeleaves30760.github.io' + baseUrl '/CodefyUI/' and drop static/CNAME.)
+  //  'https://codefyui.github.io' + baseUrl '/CodefyUI/' and drop static/CNAME.)
   url: 'https://docs.codefyui.com',
   baseUrl: '/',
 
   // GitHub Pages deployment config.
-  organizationName: 'treeleaves30760',
+  organizationName: 'CodefyUI',
   projectName: 'CodefyUI',
   trailingSlash: false,
 
@@ -48,7 +48,7 @@ const config: Config = {
         docs: {
           routeBasePath: '/', // docs served at the site root
           sidebarPath: './sidebars.ts',
-          editUrl: 'https://github.com/treeleaves30760/CodefyUI/tree/main/docs/',
+          editUrl: 'https://github.com/CodefyUI/CodefyUI/tree/main/docs/',
           editLocalizedFiles: true,
         },
         blog: false,
@@ -96,7 +96,7 @@ const config: Config = {
           position: 'right',
         },
         {
-          href: 'https://github.com/treeleaves30760/CodefyUI',
+          href: 'https://github.com/CodefyUI/CodefyUI',
           label: 'GitHub',
           position: 'right',
         },
@@ -117,11 +117,11 @@ const config: Config = {
         {
           title: 'Project',
           items: [
-            {label: 'GitHub', href: 'https://github.com/treeleaves30760/CodefyUI'},
-            {label: 'Issues', href: 'https://github.com/treeleaves30760/CodefyUI/issues'},
+            {label: 'GitHub', href: 'https://github.com/CodefyUI/CodefyUI'},
+            {label: 'Issues', href: 'https://github.com/CodefyUI/CodefyUI/issues'},
             {
               label: 'Plugin Template',
-              href: 'https://github.com/treeleaves30760/CodefyUI-Plugin-Official',
+              href: 'https://github.com/CodefyUI/CodefyUI-Plugin-Official',
             },
           ],
         },
@@ -130,11 +130,11 @@ const config: Config = {
           items: [
             {
               label: 'AGPL-3.0',
-              href: 'https://github.com/treeleaves30760/CodefyUI/blob/main/LICENSE',
+              href: 'https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE',
             },
             {
               label: 'Commercial',
-              href: 'https://github.com/treeleaves30760/CodefyUI/blob/main/COMMERCIAL-LICENSE.md',
+              href: 'https://github.com/CodefyUI/CodefyUI/blob/main/COMMERCIAL-LICENSE.md',
             },
           ],
         },

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/graph-copilot.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/graph-copilot.md
@@ -15,12 +15,12 @@ Graph Copilot 建構於兩項 CodefyUI 功能之上：[外掛前端擴充 API](/
 ## 安裝
 
 ```bash
-cdui plugin install treeleaves30760/CodefyUI-Plugin-Graph-Copilot
+cdui plugin install CodefyUI/CodefyUI-Plugin-Graph-Copilot
 ```
 
 接著重新載入編輯器（按 F5 或關閉後重新開啟分頁）。Graph Copilot 面板將以浮動小工具的形式出現在編輯器中。
 
-外掛原始碼與問題回報：[github.com/treeleaves30760/CodefyUI-Plugin-Graph-Copilot](https://github.com/treeleaves30760/CodefyUI-Plugin-Graph-Copilot)
+外掛原始碼與問題回報：[github.com/CodefyUI/CodefyUI-Plugin-Graph-Copilot](https://github.com/CodefyUI/CodefyUI-Plugin-Graph-Copilot)
 
 ## 快速上手
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
@@ -247,7 +247,7 @@ api.nodes.registerRenderer('my_plugin:MyNode', {
 });
 ```
 
-[外掛模板](https://github.com/treeleaves30760/CodefyUI-Plugin-Official)的 SDK 會用 `createRoot` 包裝它，讓你能以 React 元件撰寫內容區。
+[外掛模板](https://github.com/CodefyUI/CodefyUI-Plugin-Official)的 SDK 會用 `createRoot` 包裝它，讓你能以 React 元件撰寫內容區。
 
 ### `api.events` — 即時執行事件
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -151,11 +151,11 @@ cdui plugin new my-plugin --ui     # 另含一個接好 SDK 的 React 前端
 
 它會產生 manifest、一個範例節點、一個測試（內含 `cdui_plugins.<id>` 命名空間 shim，讓本地 `pytest` 可直接執行），並在加上 `--ui` 時產生一個 Vite + React 的 `ui/`，其 `src/sdk/` 即為型別化的外掛 SDK。外掛會建立在 `./my-plugin/`；用下方的 `cdui plugin dev` 連結後即可開始編輯。
 
-若需更完整的參考，可 Fork **[官方外掛模板](https://github.com/treeleaves30760/CodefyUI-Plugin-Official)**——一個可運作、採 MIT 授權的外掛，包含兩個範例節點、一張範例圖、一套測試，以及一份完整註解的資訊清單 (manifest)。它的 README 逐欄解說每個欄位與 AST 安全閘門。
+若需更完整的參考，可 Fork **[官方外掛模板](https://github.com/CodefyUI/CodefyUI-Plugin-Official)**——一個可運作、採 MIT 授權的外掛，包含兩個範例節點、一張範例圖、一套測試，以及一份完整註解的資訊清單 (manifest)。它的 README 逐欄解說每個欄位與 AST 安全閘門。
 
 ```bash
 # Install the template itself to see the pattern live
-cdui plugin install treeleaves30760/CodefyUI-Plugin-Official
+cdui plugin install CodefyUI/CodefyUI-Plugin-Official
 
 # After forking
 cdui plugin install your-username/your-fork

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/dev-install.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/dev-install.md
@@ -15,7 +15,7 @@ description: 用於開發或貢獻 CodefyUI 的手動 uv + pnpm 設定，支援�
 ## 1. Clone 專案
 
 ```bash
-git clone https://github.com/treeleaves30760/CodefyUI.git
+git clone https://github.com/CodefyUI/CodefyUI.git
 cd CodefyUI
 ```
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -17,12 +17,12 @@ description: 透過一行指令安裝 CodefyUI —— 一般使用者只需要 g
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.sh | bash
 ```
 
 ```powershell
 # Windows (PowerShell)
-powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.ps1 | iex"
 ```
 
 預設安裝到 `~/CodefyUI`（macOS/Linux）或 `%USERPROFILE%\CodefyUI`（Windows）。可用環境變數 `CODEFYUI_DIR` 覆寫。

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/intro.md
@@ -25,12 +25,12 @@ description: 視覺化、節點式的深度學習管線建構工具。在瀏覽�
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.sh | bash
 ```
 
 ```powershell
 # Windows (PowerShell)
-powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.ps1 | iex"
 ```
 
 接著重新開啟一個 terminal 並執行：
@@ -68,5 +68,5 @@ CodefyUI 採 **後端權威** 設計：`GET /api/nodes` 回傳所有節點定義
 
 CodefyUI 採用雙軌授權模式：
 
-- **開源路徑** — [AGPL-3.0-only](https://github.com/treeleaves30760/CodefyUI/blob/main/LICENSE)，適用於個人開發者、小型團隊、教育、研究與社群使用。
-- **商業路徑** — 若需要閉源、SaaS、OEM 或企業部署等不適合 AGPL-3.0 的條款，請[聯絡維護者](https://github.com/treeleaves30760/CodefyUI/issues)。
+- **開源路徑** — [AGPL-3.0-only](https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE)，適用於個人開發者、小型團隊、教育、研究與社群使用。
+- **商業路徑** — 若需要閉源、SaaS、OEM 或企業部署等不適合 AGPL-3.0 的條款，請[聯絡維護者](https://github.com/CodefyUI/CodefyUI/issues)。

--- a/docs/i18n/zh-TW/docusaurus-theme-classic/footer.json
+++ b/docs/i18n/zh-TW/docusaurus-theme-classic/footer.json
@@ -29,23 +29,23 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/treeleaves30760/CodefyUI"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/CodefyUI/CodefyUI"
   },
   "link.item.label.Issues": {
     "message": "問題回報",
-    "description": "The label of footer link with label=Issues linking to https://github.com/treeleaves30760/CodefyUI/issues"
+    "description": "The label of footer link with label=Issues linking to https://github.com/CodefyUI/CodefyUI/issues"
   },
   "link.item.label.Plugin Template": {
     "message": "外掛範本",
-    "description": "The label of footer link with label=Plugin Template linking to https://github.com/treeleaves30760/CodefyUI-Plugin-Official"
+    "description": "The label of footer link with label=Plugin Template linking to https://github.com/CodefyUI/CodefyUI-Plugin-Official"
   },
   "link.item.label.AGPL-3.0": {
     "message": "AGPL-3.0",
-    "description": "The label of footer link with label=AGPL-3.0 linking to https://github.com/treeleaves30760/CodefyUI/blob/main/LICENSE"
+    "description": "The label of footer link with label=AGPL-3.0 linking to https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE"
   },
   "link.item.label.Commercial": {
     "message": "商業授權",
-    "description": "The label of footer link with label=Commercial linking to https://github.com/treeleaves30760/CodefyUI/blob/main/COMMERCIAL-LICENSE.md"
+    "description": "The label of footer link with label=Commercial linking to https://github.com/CodefyUI/CodefyUI/blob/main/COMMERCIAL-LICENSE.md"
   },
   "copyright": {
     "message": "Copyright © 2026 CodefyUI. 以 Docusaurus 建置。",

--- a/frontend/src/components/shared/HeatmapPlot.tsx
+++ b/frontend/src/components/shared/HeatmapPlot.tsx
@@ -151,7 +151,7 @@ function SinglePanel({
   // 9px monospace ≈ 6.5px. Column labels rotate -45°, so their vertical
   // projection is ``charW × len × sin(45°)`` plus padding for the font
   // ascender (otherwise the leading characters get clipped against the
-  // SVG top edge — see https://github.com/treeleaves30760/CodefyUI/...).
+  // SVG top edge — see https://github.com/CodefyUI/CodefyUI/...).
   const charW = 6.5;
   const showLabels = n <= 16;
   const maxColLen = showLabels && colLabels

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 # CodefyUI 一鍵安裝腳本 (Windows / PowerShell)
 # 用法：
-#   powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.ps1 | iex"
+#   powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.ps1 | iex"
 #
 # 環境變數：
 #   $env:CODEFYUI_DIR           自訂安裝路徑（預設 $HOME\CodefyUI）
@@ -9,8 +9,8 @@
 
 $ErrorActionPreference = 'Stop'
 
-$Repo = 'https://github.com/treeleaves30760/CodefyUI.git'
-$ReleaseRepo = 'treeleaves30760/CodefyUI'
+$Repo = 'https://github.com/CodefyUI/CodefyUI.git'
+$ReleaseRepo = 'CodefyUI/CodefyUI'
 $ReleaseAsset = 'frontend-dist.tar.gz'
 $InstallDir = if ($env:CODEFYUI_DIR) { $env:CODEFYUI_DIR } else { Join-Path $HOME 'CodefyUI' }
 $ReleaseTag = if ($env:CODEFYUI_RELEASE_TAG) { $env:CODEFYUI_RELEASE_TAG } else { 'latest' }

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # CodefyUI 一鍵安裝腳本
-# 用法：curl -fsSL https://raw.githubusercontent.com/treeleaves30760/CodefyUI/main/install.sh | bash
+# 用法：curl -fsSL https://raw.githubusercontent.com/CodefyUI/CodefyUI/main/install.sh | bash
 #
 # 環境變數：
 #   CODEFYUI_DIR          自訂安裝路徑（預設 $HOME/CodefyUI）
@@ -12,8 +12,8 @@ set -euo pipefail
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
 BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
 
-REPO="https://github.com/treeleaves30760/CodefyUI.git"
-RELEASE_REPO="treeleaves30760/CodefyUI"
+REPO="https://github.com/CodefyUI/CodefyUI.git"
+RELEASE_REPO="CodefyUI/CodefyUI"
 RELEASE_ASSET="frontend-dist.tar.gz"
 INSTALL_DIR="${CODEFYUI_DIR:-$HOME/CodefyUI}"
 RELEASE_TAG="${CODEFYUI_RELEASE_TAG:-latest}"

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -245,7 +245,7 @@ def _apply_dev_env() -> None:
     DEV_USER_DATA_DIR.mkdir(parents=True, exist_ok=True)
     (DEV_USER_DATA_DIR / "plugins").mkdir(parents=True, exist_ok=True)
 
-RELEASE_REPO = "treeleaves30760/CodefyUI"
+RELEASE_REPO = "CodefyUI/CodefyUI"
 RELEASE_ASSET = "frontend-dist.tar.gz"
 
 
@@ -326,21 +326,72 @@ def _require_venv_tool(tool_name: str) -> str:
     sys.exit(1)
 
 
+def _uv_install_timeout() -> int:
+    """Seconds to allow for the uv bootstrap download. 0 disables the limit."""
+    raw = os.environ.get("CODEFYUI_UV_INSTALL_TIMEOUT", "").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 180
+
+
 def _ensure_uv() -> None:
     if shutil.which("uv"):
         return
-    print("=== uv 未安裝，正在自動安裝 ===")
-    if sys.platform == "win32":
-        subprocess.run(
-            ["powershell", "-c", "irm https://astral.sh/uv/install.ps1 | iex"],
-            check=True,
+    # This runs before EVERY command, so an unbounded download here wedges
+    # `cdui status`, `cdui stop`, everything. School and lab networks commonly
+    # drop packets rather than refusing them, which is indistinguishable from
+    # a slow link until something imposes a deadline.
+    timeout = _uv_install_timeout()
+    limit = t(f"（最多等待 {timeout} 秒）", f" (waiting up to {timeout}s)") if timeout else ""
+    print(t(
+        f"=== uv 未安裝，正在從 https://astral.sh 自動安裝{limit} ===",
+        f"=== uv is not installed; downloading it from https://astral.sh{limit} ===",
+    ))
+    try:
+        if sys.platform == "win32":
+            subprocess.run(
+                ["powershell", "-c", "irm https://astral.sh/uv/install.ps1 | iex"],
+                check=True,
+                timeout=timeout or None,
+            )
+        else:
+            # curl's own deadlines matter as well as the outer one: without
+            # them a black-holed connection sits in connect() and the process
+            # is only ever torn down from outside.
+            connect = min(30, timeout) if timeout else 30
+            max_time = f" --max-time {timeout}" if timeout else ""
+            subprocess.run(
+                f"curl -LsSf --connect-timeout {connect}{max_time}"
+                " https://astral.sh/uv/install.sh | sh",
+                shell=True,
+                check=True,
+                timeout=timeout or None,
+            )
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError, OSError) as exc:
+        timed_out = isinstance(exc, subprocess.TimeoutExpired)
+        why = t(
+            f"逾時（超過 {timeout} 秒）" if timed_out else "失敗",
+            f"timed out after {timeout}s" if timed_out else "failed",
         )
-    else:
-        subprocess.run(
-            "curl -LsSf https://astral.sh/uv/install.sh | sh",
-            shell=True,
-            check=True,
-        )
+        print(t(
+            f"\n錯誤：自動安裝 uv {why}。\n"
+            f"  CodefyUI 需要 uv 才能執行任何指令。若這台機器連不到網際網路\n"
+            f"  （教室或實驗室網路常見），請改用下列任一方式：\n"
+            f"    1. 自行安裝 uv 後重試：https://docs.astral.sh/uv/getting-started/installation/\n"
+            f"    2. 從別處下載 uv，放進 PATH 之後再執行同一個指令\n"
+            f"    3. 網路很慢但可用時，加大逾時：CODEFYUI_UV_INSTALL_TIMEOUT=600\n",
+            f"\nError: installing uv {why}.\n"
+            f"  CodefyUI needs uv before it can run any command. If this machine\n"
+            f"  cannot reach the internet (common on school and lab networks),\n"
+            f"  use one of these instead:\n"
+            f"    1. Install uv yourself, then retry:\n"
+            f"       https://docs.astral.sh/uv/getting-started/installation/\n"
+            f"    2. Copy a uv binary onto this machine, put it on PATH, rerun the command\n"
+            f"    3. On a slow but working link, raise the limit:\n"
+            f"       CODEFYUI_UV_INSTALL_TIMEOUT=600\n",
+        ), file=sys.stderr)
+        sys.exit(1)
     # 安裝後重新啟動自身，讓新 PATH 生效
     _reexec(sys.executable, sys.argv)
 

--- a/scripts/templates/plugin/README.md
+++ b/scripts/templates/plugin/README.md
@@ -1,6 +1,6 @@
 # {{plugin_name}}
 
-A [CodefyUI](https://github.com/treeleaves30760/CodefyUI) plugin, scaffolded with `cdui plugin new`.
+A [CodefyUI](https://github.com/CodefyUI/CodefyUI) plugin, scaffolded with `cdui plugin new`.
 
 ## Develop
 


### PR DESCRIPTION
> 中文摘要：所有安裝與 `cdui update` 都還在向舊帳號 `treeleaves30760/CodefyUI` 抓檔案，目前只是靠 GitHub 的改名轉址活著。只要有人在舊路徑開一個新 repo，轉址就永久失效，而下載流程沒有任何簽章或雜湊檢查，等於全班的安裝會從別人的 repo 抓程式來執行。這個 PR 把 23 個檔案共 54 處全部改成 `CodefyUI/CodefyUI`，並加上測試防止再走回頭路。順帶修掉 `_ensure_uv()` 沒有逾時、在封鎖網路的教室裡會無限卡住的問題。

## The exposure

Every end-user install and every `cdui update` fetched from `treeleaves30760/CodefyUI` — a path this repo has not used since it moved to the CodefyUI org. It kept working only because GitHub serves a rename redirect:

```
$ git remote -v
  git@github.com:CodefyUI/CodefyUI.git

$ curl -o /dev/null -w '%{http_code} -> %{redirect_url}' \
    https://api.github.com/repos/treeleaves30760/CodefyUI/releases/latest
  301 -> https://api.github.com/repositories/1187503592/releases/latest
```

**That redirect stops permanently the moment anyone creates a repo at the old path**, and the old owner name stays claimable indefinitely. `fetch_release_dist()` (`scripts/dev.py:402-450`) verifies no signature and no checksum, so if that happened, `install.sh`, `install.ps1` and `cdui update` would `git clone` and unpack `frontend-dist.tar.gz` from a repo the maintainer does not control — on every student machine that runs the documented one-liner.

54 references across 23 files: the two README one-liners users are told to pipe into a shell, `RELEASE_REPO` in `dev.py`, both installers, both docs locales, the two sibling plugin repos (both also moved to the org — verified against the API), and the docs site's own `organizationName`.

Rewritten at byte level, so no line endings moved — a text-mode rewrite would have flipped CRLF across whole files and buried the real diff.

## Why a test is the single source of truth

The four copies of the repo path live in three languages and **cannot** share a constant: the shell installers run before Python exists. So the guard has to be a test.

- `test_every_entry_point_agrees_on_one_owner` extracts the owner out of `install.sh`, `install.ps1`, `scripts/dev.py` and `README.md` and asserts they are all the same. It is written against *whatever* the owner is, so a future rename fails loudly in one place instead of drifting three ways.
- `test_no_tracked_file_references_the_old_owner` git-greps the whole tree, so a stale path cannot creep back in through a docs page.

## Also here: `_ensure_uv` could hang forever

`_ensure_uv()` runs before **every** command (`dev.py:2489`) and shelled out to `irm https://astral.sh/... | iex` / `curl -LsSf ... | sh` with `check=True` and **no timeout on either call**.

Networks that drop packets rather than refusing them — the norm on school and lab networks — are indistinguishable from a slow link. So `cdui start`, `cdui status`, even `cdui stop` printed one line (in Chinese only) and then blocked indefinitely, with no output and no way to tell working from wedged.

Now:

- bounded by `CODEFYUI_UV_INSTALL_TIMEOUT`, default **180s**; `0` restores the old unbounded behaviour
- curl gets its own `--connect-timeout` and `--max-time`, so it fails at the socket rather than waiting to be killed from outside
- on timeout or failure the message names the three ways out — install uv yourself, copy a binary onto the machine, or raise the limit — instead of a bare traceback
- the progress line now goes through `t()` like the other 104 CLI strings

## Verification

- 13 new cases in `backend/tests/test_install_source.py`
- `test_dev_cli.py`, `test_dev_dist_stamp.py`, `test_dev_run_command.py`, `test_dev_update_options.py`, `test_check_control_bytes.py` — 107 passed
- `scripts/check_control_bytes.py` — clean over 1082 tracked files

Not changed: `word_vector_node.py`'s GloVe asset URL points at the new org now, but that release asset still does not exist — it was a placeholder before this PR and remains one.
