### PR TITLE
fix(plugins): the catalog advertised 14 nodes that no pack installs

### DIFF
--- a/backend/tests/test_plugin_catalog_honesty.py
+++ b/backend/tests/test_plugin_catalog_honesty.py
@@ -1,0 +1,109 @@
+"""The plugin catalog may only advertise nodes that actually install.
+
+`cdui plugin search` and `cdui plugin info` print `plugins/registry.json`'s
+and each manifest's prose verbatim (`scripts/plugins.py:1509,1657,1911`), and
+that prose is where a student learns what to type into the node palette. A
+name in there that no `.py` file registers is not a documentation nit: the
+student types it, the palette returns nothing, and the lab stops.
+
+Fourteen such names shipped before this file existed -- `Edu-Conv2d`,
+`Edu-MaxPool2d`, `Edu-RNNCell`, `Edu-LSTMCell`, `Edu-LayerNorm`,
+`Edu-Resample`, `Edu-DenoiseStep`, `Edu-SVM`, `Edu-DecisionTree`,
+`Edu-SlidingWindow`, `Edu-VectorSimilarity`, `Edu-PPOClip`, `Edu-GRPO`,
+`Edu-PreferenceLoss`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+import dev  # scripts/dev.py -- conftest puts scripts/ on sys.path
+
+PLUGINS_DIR = dev.ROOT / "plugins"
+REGISTRY = PLUGINS_DIR / "registry.json"
+
+# Names shaped like a pack node. Bare CamelCase is deliberately excluded --
+# the prose legitimately says things like "policy gradient" and "max-pool" as
+# English, and only the hyphenated form is what a student types.
+NODE_NAME_RE = re.compile(r"\b((?:Edu|Stats)-[A-Za-z0-9]+)\b")
+
+
+def _registered_node_names() -> set[str]:
+    """Every NODE_NAME a pack actually registers, read off disk."""
+    names: set[str] = set()
+    for path in PLUGINS_DIR.rglob("*_node.py"):
+        text = path.read_text(encoding="utf-8")
+        names.update(re.findall(r"""NODE_NAME\s*=\s*["']([^"']+)["']""", text))
+    return names
+
+
+def _pack_manifests() -> list[Path]:
+    return sorted(PLUGINS_DIR.glob("*/cdui.plugin.toml"))
+
+
+@pytest.fixture(scope="module")
+def registered() -> set[str]:
+    names = _registered_node_names()
+    assert names, "found no NODE_NAME anywhere under plugins/ -- scan is broken"
+    return names
+
+
+def test_registry_advertises_only_nodes_that_exist(registered: set[str]):
+    text = REGISTRY.read_text(encoding="utf-8")
+    phantom = sorted({n for n in NODE_NAME_RE.findall(text) if n not in registered})
+    assert not phantom, (
+        f"plugins/registry.json names nodes that no pack registers: {phantom}. "
+        f"`cdui plugin search` prints these, and the palette has no such node."
+    )
+
+
+@pytest.mark.parametrize("manifest", _pack_manifests(), ids=lambda p: p.parent.name)
+def test_manifest_advertises_only_nodes_that_exist(manifest: Path, registered: set[str]):
+    text = manifest.read_text(encoding="utf-8")
+    phantom = sorted({n for n in NODE_NAME_RE.findall(text) if n not in registered})
+    assert not phantom, (
+        f"{manifest.parent.name}/cdui.plugin.toml names nodes that do not exist: "
+        f"{phantom}"
+    )
+
+
+def test_every_pack_in_the_registry_has_a_manifest():
+    entries = json.loads(REGISTRY.read_text(encoding="utf-8"))["plugins"]
+    for pack_id, entry in entries.items():
+        path = dev.ROOT / entry["path"]
+        assert path.is_dir(), f"{pack_id}: registry path {entry['path']} does not exist"
+        assert (path / "cdui.plugin.toml").is_file(), f"{pack_id}: no cdui.plugin.toml"
+
+
+def _preset_names() -> set[str]:
+    names: set[str] = set()
+    for path in (dev.ROOT / "backend" / "app" / "presets").glob("*.json"):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        name = data.get("preset_name") or data.get("name")
+        if name:
+            names.add(str(name))
+    return names
+
+
+def test_example_graphs_only_reference_nodes_that_exist(registered: set[str]):
+    """A shipped example that names a missing node fails on Run, not on load."""
+    presets = _preset_names()
+    broken: list[str] = []
+    for graph_path in PLUGINS_DIR.rglob("examples/**/graph.json"):
+        graph = json.loads(graph_path.read_text(encoding="utf-8"))
+        for node in graph.get("nodes", []):
+            node_type = str(node.get("type", ""))
+            # Core nodes are bare and covered by test_builtin_examples.py.
+            if ":" not in node_type:
+                continue
+            namespace, _, name = node_type.partition(":")
+            # `preset:` is the built-in preset namespace, not a pack.
+            known = presets if namespace == "preset" else registered
+            if name not in known:
+                rel = graph_path.relative_to(dev.ROOT).as_posix()
+                broken.append(f"{rel} -> {node_type}")
+    assert not broken, f"example graphs reference nodes that do not exist: {broken}"

--- a/plugins/deep/cdui.plugin.toml
+++ b/plugins/deep/cdui.plugin.toml
@@ -2,7 +2,7 @@
 id              = "deep"
 name            = "Deep Models — 視覺與序列"
 version         = "0.1.0"
-description     = "Educational nodes for the I3–I4 hands-on track: vision (conv with sliding window, max-pool, residual block, resample, diffusion denoise step, cross-attention, patchify) and sequence (RNN / LSTM cell, self-attention, multi-head attention, layer norm). Stepped out so learners watch each tensor transform."
+description     = "Educational nodes for the I3–I4 hands-on track: vision (residual block, patchify) and attention (self-, cross- and multi-head), plus 17 worked example graphs for lessons C3-1 through C6-2. Stepped out so learners watch each tensor transform."
 schema_version  = 1
 requires_codefyui = ">=0.2.0"
 

--- a/plugins/foundations/cdui.plugin.toml
+++ b/plugins/foundations/cdui.plugin.toml
@@ -2,7 +2,7 @@
 id              = "foundations"
 name            = "Foundations — 資料表示與經典 ML"
 version         = "0.1.0"
-description     = "Educational nodes for the I1–I2 hands-on track: data representation (column stats, image sliding window, token embedding, vector similarity) and classical ML (KNN, linear / logistic regression, SVM, decision tree, feed-forward network). Every node exposes its intermediate steps in verbose mode."
+description     = "Educational nodes for the I1–I2 hands-on track: data representation (column stats, token embedding) and classical ML (KNN, linear / logistic regression, feed-forward network), plus 11 worked example graphs for lessons C1-2 through C2-4. Every node exposes its intermediate steps in verbose mode."
 schema_version  = 1
 requires_codefyui = ">=0.2.0"
 

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -10,14 +10,14 @@
     },
     "foundations": {
       "name": "Foundations — 資料表示與經典 ML",
-      "description": "Data-representation and classical-ML teaching nodes for hands-on modules I1–I2: Edu-ColumnStats, Edu-SlidingWindow, Edu-TokenEmbedding, Edu-VectorSimilarity, Edu-KNN, Edu-LinearRegression, Edu-LogisticRegression, Edu-SVM, Edu-DecisionTree, Edu-FFN. Each step is recorded in verbose mode.",
+      "description": "Data-representation and classical-ML teaching nodes for hands-on modules I1–I2: Edu-ColumnStats, Edu-TokenEmbedding, Edu-KNN, Edu-LinearRegression, Edu-LogisticRegression, Edu-FFN. Each step is recorded in verbose mode.",
       "kind": "builtin",
       "path": "plugins/foundations",
       "chapters": ["C1", "C2"]
     },
     "deep": {
       "name": "Deep Models — 視覺與序列",
-      "description": "Vision and sequence teaching nodes for hands-on modules I3–I4: Edu-Conv2d, Edu-MaxPool2d, Edu-ResBlock, Edu-Resample, Edu-DenoiseStep, Edu-CrossAttention, Edu-Patchify, Edu-RNNCell, Edu-LSTMCell, Edu-SelfAttention, Edu-MultiHeadAttention, Edu-LayerNorm. Stepped out so each tensor transform is visible.",
+      "description": "Vision and sequence teaching nodes for hands-on modules I3–I4: Edu-ResBlock, Edu-Patchify, Edu-CrossAttention, Edu-SelfAttention, Edu-MultiHeadAttention. Stepped out so each tensor transform is visible.",
       "kind": "builtin",
       "path": "plugins/deep",
       "chapters": ["C3", "C4", "C6"]
@@ -31,7 +31,7 @@
     },
     "rl": {
       "name": "Reinforcement Learning — 強化學習",
-      "description": "Reinforcement-learning teaching nodes for hands-on module I5: Edu-PolicyGradient, Edu-PPOClip, Edu-GRPO, Edu-PreferenceLoss. Each RL update is exposed as softmax → gather → baseline → ratio → clip → loss.",
+      "description": "Reinforcement-learning teaching nodes for hands-on module I5: Edu-PolicyGradient. The RL update is exposed as softmax → gather → baseline → loss.",
       "kind": "builtin",
       "path": "plugins/rl",
       "chapters": ["C5"]

--- a/plugins/rl/cdui.plugin.toml
+++ b/plugins/rl/cdui.plugin.toml
@@ -2,7 +2,7 @@
 id              = "rl"
 name            = "Reinforcement Learning — 強化學習"
 version         = "0.1.0"
-description     = "Educational nodes for the I5 hands-on track: policy gradient (REINFORCE), PPO clip, GRPO group-normalized advantage, and RLHF preference loss. Each RL update is exposed step by step — softmax, gather, baseline, ratio, clip, loss — so the learner sees how rewards become a gradient."
+description     = "Educational content for the I5 hands-on track. One stepped-out node, Edu-PolicyGradient (REINFORCE), which exposes softmax → gather → log → baseline → loss so the learner sees how rewards become a gradient; plus four worked example graphs built from core nodes: the RL framework (C5-1), REINFORCE itself (C5-2), an RLHF reward model scoring two candidates (C5-3), and GRPO's group-relative advantage (C5-4)."
 schema_version  = 1
 requires_codefyui = ">=0.2.0"
 
@@ -12,4 +12,4 @@ examples_dir = "examples"
 
 [lessons]
 chapters = ["C5"]
-lessons  = ["C5-1", "C5-2", "C5-4"]
+lessons  = ["C5-1", "C5-2", "C5-3", "C5-4"]


### PR DESCRIPTION
> 中文摘要：`plugins/registry.json` 和三個外掛的 manifest 宣傳了 14 個根本不存在的節點。`cdui plugin search` / `cdui plugin info` 就是照著這段文字印給學生看的，所以學生照著裝好外掛、照著打節點名字，面板卻搜不到，而且分不出是「節點不存在」還是「安裝壞了」。這個 PR 把描述改成只列真的裝得起來的節點，並加上測試，讓文字再也不能和程式碼脫節。

## The defect

`plugins/registry.json` and three pack manifests named nodes that exist in **no `.py` file anywhere**:

`Edu-Conv2d`, `Edu-MaxPool2d`, `Edu-Resample`, `Edu-DenoiseStep`, `Edu-RNNCell`, `Edu-LSTMCell`, `Edu-LayerNorm`, `Edu-SlidingWindow`, `Edu-VectorSimilarity`, `Edu-SVM`, `Edu-DecisionTree`, `Edu-PPOClip`, `Edu-GRPO`, `Edu-PreferenceLoss`.

This is not a documentation nit. `cdui plugin search` and `cdui plugin info` print that prose verbatim (`scripts/plugins.py:1509`, `:1657`, `:1911`), so it is where a student learns what to type into the node palette. They install the pack the book told them to, type the name the catalog gave them, and the palette returns nothing — with no way to tell a missing node from a broken install.

The gap was wide:

| pack | advertised | actually ships |
|---|---|---|
| `deep` | 12 | **5** |
| `foundations` | 10 | **6** |
| `rl` | 4 | **1** |
| `stats` | 8 | 8 |
| `edu` | 8 | 8 |

## What changed

Descriptions now say what installs. The packs are not diminished by this — `rl` ships one stepped-out node **plus four worked example graphs** that teach the RL framework (C5-1), REINFORCE (C5-2), an RLHF reward model (C5-3) and GRPO's group-relative advantage (C5-4) out of core nodes. Saying that is more useful than naming four nodes that were never written.

`rl`'s lesson list also gains `C5-3`, which has had an example directory all along.

The `Edu-PolicyGradient` summary is now taken from the node's own docstring (`softmax → gather → log → baseline → loss`) rather than describing a ratio/clip step it does not have.

## The guard

Prose drifts from code silently, so this is enforced rather than corrected:

- `test_registry_advertises_only_nodes_that_exist` and its per-manifest parametrized sibling scan every `Edu-*` / `Stats-*` name against the `NODE_NAME`s actually on disk. **Verified to fail on the pre-fix catalog**, naming all 14.
- `test_example_graphs_only_reference_nodes_that_exist` covers the other direction. A shipped example naming a node that does not exist fails on **Run**, not on load, so it would otherwise reach a student mid-lesson. Writing it immediately surfaced that `preset:` is a separate namespace from pack nodes, and it now resolves those against `backend/app/presets/`.
- `test_every_pack_in_the_registry_has_a_manifest` pins the registry `path` fields.

The regex deliberately matches only the hyphenated form. Prose legitimately says "max-pool" and "policy gradient" as English; only `Edu-Foo` is what a student types.

## Scope

The 14 missing nodes are a **real content gap and stay one**. This change makes the catalog honest about it rather than papering over it. Building them out belongs with the wider teaching-content work, not here.
