### PR TITLE
feat(plugins): name built-in packs that shipped but were never installed

### DIFF
--- a/backend/tests/test_builtin_pack_discovery.py
+++ b/backend/tests/test_builtin_pack_discovery.py
@@ -1,0 +1,145 @@
+"""A built-in pack that shipped but was never installed must be visible.
+
+The failure this covers (#175): a release adds a pack, `cdui update` puts its
+files on disk, but the server loads only what the lockfile records and nothing
+re-syncs it. The pack is fully installable and completely invisible — the
+class updates as instructed, the new chapter's nodes are not in the palette,
+and nothing anywhere says why. `stats` shipped exactly this way.
+
+Discoverability only: nothing here installs or enables a pack. Running code a
+user did not ask for because a release shipped it is a consent decision, and
+it stays theirs.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+import dev  # scripts/dev.py -- conftest puts scripts/ on sys.path
+import plugins as plugin_cli  # scripts/plugins.py
+
+
+@pytest.fixture
+def catalog_of(monkeypatch):
+    """Install a fake catalog + lockfile pair."""
+
+    def _apply(catalog: dict, installed: dict):
+        monkeypatch.setattr(plugin_cli, "load_catalog", lambda: {"plugins": catalog})
+        monkeypatch.setattr(
+            plugin_cli, "load_lockfile", lambda: {"plugins": installed}
+        )
+
+    return _apply
+
+
+BUILTIN_A = {"kind": "builtin", "name": "Pack A", "path": "plugins/a"}
+BUILTIN_B = {"kind": "builtin", "name": "Pack B", "path": "plugins/b"}
+FROM_GITHUB = {"kind": "github", "name": "Third Party", "path": "plugins/x"}
+
+
+def test_lists_a_builtin_pack_that_was_never_installed(catalog_of):
+    catalog_of({"a": BUILTIN_A}, {})
+    assert plugin_cli.available_builtin_packs() == [("a", "Pack A")]
+
+
+def test_omits_packs_that_are_already_installed(catalog_of):
+    catalog_of({"a": BUILTIN_A, "b": BUILTIN_B}, {"a": {"enabled": True}})
+    assert plugin_cli.available_builtin_packs() == [("b", "Pack B")]
+
+
+def test_a_disabled_pack_still_counts_as_installed(catalog_of):
+    """Disabling is a decision the user already made -- do not nag."""
+    catalog_of({"a": BUILTIN_A}, {"a": {"enabled": False}})
+    assert plugin_cli.available_builtin_packs() == []
+
+
+def test_ignores_non_builtin_catalog_entries(catalog_of):
+    catalog_of({"x": FROM_GITHUB}, {})
+    assert plugin_cli.available_builtin_packs() == []
+
+
+def test_falls_back_to_the_id_when_an_entry_has_no_name(catalog_of):
+    catalog_of({"a": {"kind": "builtin", "path": "plugins/a"}}, {})
+    assert plugin_cli.available_builtin_packs() == [("a", "a")]
+
+
+def test_result_is_sorted(catalog_of):
+    catalog_of({"z": BUILTIN_B, "a": BUILTIN_A}, {})
+    assert [pid for pid, _ in plugin_cli.available_builtin_packs()] == ["a", "z"]
+
+
+def test_a_broken_lockfile_yields_no_notice_rather_than_raising(monkeypatch):
+    def boom():
+        raise OSError("lockfile is a directory")
+
+    monkeypatch.setattr(plugin_cli, "load_lockfile", boom)
+    assert plugin_cli.available_builtin_packs() == []
+
+
+# ── `cdui plugin list` ───────────────────────────────────────────────────────
+
+def test_plugin_list_names_available_packs_when_none_are_installed(
+    catalog_of, capsys
+):
+    catalog_of({"stats": {"kind": "builtin", "name": "Stats", "path": "p"}}, {})
+    assert plugin_cli.cmd_list(argparse.Namespace()) == 0
+    out = capsys.readouterr().out
+    assert "stats" in out
+    assert "cdui plugin install stats" in out
+
+
+def test_plugin_list_names_available_packs_alongside_installed_ones(
+    catalog_of, capsys
+):
+    catalog_of(
+        {"a": BUILTIN_A, "b": BUILTIN_B},
+        {"a": {"enabled": True, "source_kind": "builtin", "source": "a",
+               "manifest": {"name": "Pack A", "version": "0.1.0"}}},
+    )
+    assert plugin_cli.cmd_list(argparse.Namespace()) == 0
+    out = capsys.readouterr().out
+    assert "Pack A" in out           # the installed one
+    assert "cdui plugin install b" in out  # and the one that is not
+
+
+def test_plugin_list_says_nothing_extra_when_everything_is_installed(
+    catalog_of, capsys
+):
+    catalog_of(
+        {"a": BUILTIN_A},
+        {"a": {"enabled": True, "source_kind": "builtin", "source": "a",
+               "manifest": {"name": "Pack A"}}},
+    )
+    plugin_cli.cmd_list(argparse.Namespace())
+    assert "cdui plugin install" not in capsys.readouterr().out
+
+
+# ── the `cdui start` banner ──────────────────────────────────────────────────
+
+def test_start_banner_names_available_packs(monkeypatch, capsys):
+    monkeypatch.setattr(
+        plugin_cli, "available_builtin_packs", lambda: [("stats", "Stats")]
+    )
+    dev._print_uninstalled_builtin_packs()
+    out = capsys.readouterr().out
+    assert "stats (Stats)" in out
+    assert "cdui plugin install stats" in out
+
+
+def test_start_banner_is_silent_when_nothing_is_pending(monkeypatch, capsys):
+    monkeypatch.setattr(plugin_cli, "available_builtin_packs", lambda: [])
+    dev._print_uninstalled_builtin_packs()
+    assert capsys.readouterr().out == ""
+
+
+def test_start_banner_never_breaks_startup(monkeypatch, capsys):
+    """A notice must not be the reason a server fails to start."""
+
+    def boom():
+        raise RuntimeError("plugin subsystem exploded")
+
+    monkeypatch.setattr(plugin_cli, "available_builtin_packs", boom)
+    dev._print_uninstalled_builtin_packs()  # must not raise
+    assert capsys.readouterr().out == ""

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1268,6 +1268,46 @@ def _probe_host(host: str) -> str:
     return "127.0.0.1" if host in ("0.0.0.0", "::") else host
 
 
+def _print_uninstalled_builtin_packs() -> None:
+    """Name any built-in pack that shipped on disk but was never installed.
+
+    A release can add a pack — `stats` did — and `cdui update` puts its files
+    in place, but the server loads only what the lockfile records and nothing
+    re-syncs it. The pack is then fully installable and completely invisible:
+    a class follows the update instructions, the new chapter's nodes are not
+    in the palette, and no message anywhere explains why.
+
+    This is discoverability only. Nothing is enabled on the user's behalf —
+    running code someone did not ask for because a release shipped it is a
+    consent decision, not a startup detail, so the pack still installs by hand.
+
+    `cdui start` has already hopped into the venv (`_SKIP_VENV_EXEC` excludes
+    it), so scripts/plugins.py's `app.core.*` imports resolve here. Guarded
+    anyway: a notice must never be the reason a server fails to start.
+    """
+    try:
+        scripts_dir = str(Path(__file__).resolve().parent)
+        if scripts_dir not in sys.path:
+            sys.path.insert(0, scripts_dir)
+        import plugins as plugin_cli  # noqa: PLC0415 — late import: needs venv
+
+        available = plugin_cli.available_builtin_packs()
+    except Exception:
+        return
+    if not available:
+        return
+    ids = " ".join(pack_id for pack_id, _ in available)
+    names = ", ".join(f"{pack_id} ({name})" for pack_id, name in available)
+    print(t(
+        f"    有尚未安裝的內建外掛：{names}",
+        f"    Built-in packs available but not installed: {names}",
+    ))
+    print(t(
+        f"    安裝：cdui plugin install {ids}",
+        f"    Install with: cdui plugin install {ids}",
+    ))
+
+
 def _display_url(host: str, port: int) -> str:
     """Clickable URL for a bind host: wildcard/loopback render as
     localhost; a concrete LAN IP renders as itself."""
@@ -1429,6 +1469,7 @@ def start() -> None:
                 "    NOTE: anyone who can reach this port controls the "
                 "instance; use only on trusted networks.",
             ))
+        _print_uninstalled_builtin_packs()
 
     if foreground:
         print("=== CodefyUI 啟動（前景；Ctrl+C 停止）===")

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -200,6 +200,29 @@ def load_catalog() -> dict[str, Any]:
         return {"schema": 1, "plugins": {}}
 
 
+def available_builtin_packs() -> list[tuple[str, str]]:
+    """Built-in packs shipped on disk that this install has never installed.
+
+    A release can add a pack (``stats`` did), and its files land on disk with
+    the update — but the server only loads what the lockfile records, and
+    nothing re-syncs it. So the pack is fully installable and completely
+    invisible: the nodes never appear, and no message anywhere says why.
+
+    Returns ``(id, display name)`` pairs, sorted, so callers can name them.
+    """
+    try:
+        catalog = load_catalog().get("plugins", {})
+        installed = load_lockfile().get("plugins", {})
+    except Exception:  # never let discoverability break a caller
+        return []
+    out: list[tuple[str, str]] = []
+    for pack_id, entry in catalog.items():
+        if entry.get("kind") != "builtin" or pack_id in installed:
+            continue
+        out.append((pack_id, str(entry.get("name") or pack_id)))
+    return sorted(out)
+
+
 # ── source parsing ─────────────────────────────────────────────────────────
 
 # Accepts owner/repo or owner/repo@ref; owner/repo names are GitHub-permissible.
@@ -1060,11 +1083,31 @@ def _install_github(owner: str, repo: str, ref: str, args, lockfile) -> int:
     return 0
 
 
+def _print_available_builtins() -> None:
+    """Name the built-in packs sitting on disk uninstalled.
+
+    `cdui plugin list` is where the docs send a student whose node is missing
+    (I0-0 says so in as many words), so a pack the update dropped on disk but
+    never registered has to be visible from here — otherwise "it is not
+    installed" and "it does not exist" look identical.
+    """
+    available = available_builtin_packs()
+    if not available:
+        return
+    section("可安裝的內建外掛（尚未安裝）", "Built-in packs available (not installed)")
+    width = max(len(pid) for pid, _ in available) + 2
+    for pack_id, name in available:
+        print(f"  {BOLD}{pack_id.ljust(width)}{RESET}{name}")
+    ids = " ".join(pid for pid, _ in available)
+    info(f"安裝：cdui plugin install {ids}", f"Install with: cdui plugin install {ids}")
+
+
 def cmd_list(args: argparse.Namespace) -> int:
     lockfile = load_lockfile()
     plugins = lockfile.get("plugins", {})
     if not plugins:
         info("尚未安裝任何外掛", "No plugins installed yet")
+        _print_available_builtins()
         return 0
 
     section("已安裝外掛", "Installed plugins")
@@ -1098,6 +1141,7 @@ def cmd_list(args: argparse.Namespace) -> int:
             print(
                 f"  {DIM}{plugin_id.ljust(width)}{name}  [disabled]  {'  '.join(bits)}{RESET}"
             )
+    _print_available_builtins()
     return 0
 
 


### PR DESCRIPTION
**Addresses #175 — the discoverability half only.** Deliberately NOT closing it: whether a shipped pack should auto-enable is a consent decision and stays the maintainer's call.

> 中文摘要：新的內建外掛包會隨著版本更新落到磁碟上，但伺服器只載入 lockfile 裡記錄的東西，而沒有任何機制去同步。結果是包裝好好的、可以安裝、卻完全看不見——全班照著更新指示做，新章節的節點就是不會出現，而且沒有任何訊息說明原因。這個 PR 讓 `cdui plugin list` 和 `cdui start` 主動把「已經在磁碟上但還沒安裝」的內建包列出來。**不會自動安裝或啟用**——那是同意權的問題，留給你決定。

## The gap is wider than the issue says

The issue describes `stats`. Measured on this machine, `cdui plugin list` reports `c1`–`c6` installed — the *old* chapter packs — and **all five current packs uninstalled**:

```
▶ Installed plugins
  c1                 Chapter 1 — 基本資訊  v0.1.0  builtin:c1
  ...
  c6                 Chapter 6 — 前沿技術  v0.1.0  builtin:c6

▶ Built-in packs available (not installed)
  deep         Deep Models — 視覺與序列
  edu          EDU — 動手做教學節點
  foundations  Foundations — 資料表示與經典 ML
  rl           Reinforcement Learning — 強化學習
  stats        Stats — 描述統計與圖表
  Install with: cdui plugin install deep edu foundations rl stats
```

That second section is what this PR adds. An install that has faithfully run `cdui update` has **none** of the current teaching content loaded, and no way to find that out — "not installed" and "does not exist" are indistinguishable from the node palette.

## Where it now says so

- **`cdui plugin list`** — where the textbook sends a student whose node is missing (`I0-0.mdx`: 「用 `cdui plugin list` 確認裝好」). It previously dead-ended on *"No plugins installed yet"*, which is exactly the case where naming the available packs matters most.
- **the `cdui start` banner** — so the teacher sees it before the class does.

## Deliberately not included

**No auto-install, no auto-enable.** Running code the user did not ask for because a release shipped it is a consent decision, and it stays theirs. That is the half of #175 held for the maintainer, and it is why this closes only the discoverability part — a `cdui plugin sync` verb remains the open question.

Other judgement calls:

- A pack the user **disabled counts as installed**, so a deliberate choice is not re-nagged.
- `available_builtin_packs()` swallows a broken catalog or lockfile, and the start banner swallows everything. A notice must never be the reason a server fails to start.
- The banner sits after the LAN lines and its security warning, so it never pushes that warning off a short terminal.

## Verification

- 13 new cases in `backend/tests/test_builtin_pack_discovery.py` covering the helper, both call sites, the disabled-pack rule, the sort order, and both failure-swallowing paths.
- `test_plugin_cli.py`, `test_dev_cli.py`, `test_plugin_dev_env.py` — 77 passed.
- Run for real against this checkout; the output above is the actual command, not a mock.

