### PR TITLE
fix(errors): the beginner-friendly error mapping was unreachable in production

### DIFF
--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -2207,7 +2207,15 @@ async def execute_graph(
 
         # All attempts failed
         assert last_error is not None
-        error_detail: dict[str, str] = {"error": str(last_error)}
+        # `str(exc)` never contains the exception's class name -- str(KeyError('tensor'))
+        # is "'tensor'". The UI's beginner-friendly error mapping used to scan for a
+        # "KeyError:" prefix that this payload could not produce, so every rule in it
+        # was unreachable. Send the type as its own field instead of asking the client
+        # to recover it from the message shape.
+        error_detail: dict[str, str] = {
+            "error": str(last_error),
+            "error_type": type(last_error).__name__,
+        }
         if settings.DEBUG and last_traceback:
             error_detail["traceback"] = last_traceback
         if error_mode == "fail_fast":

--- a/backend/tests/test_error_type_payload.py
+++ b/backend/tests/test_error_type_payload.py
@@ -1,0 +1,109 @@
+"""The error payload must carry the exception's class, not just its message.
+
+`str(exc)` drops the class name -- `str(KeyError('tensor'))` is `"'tensor'"`.
+The UI's beginner-friendly error mapping keyed off a `KeyError:` prefix that
+this payload could never contain, so every rule in it was unreachable while
+its own tests passed against strings the backend does not emit.
+
+Sending `error_type` alongside `error` makes the mapping structural rather
+than a guess at the message's shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.graph_engine import execute_graph
+from app.core.node_base import BaseNode, DataType, PortDefinition
+from app.core.node_registry import registry
+
+
+def _start_node(nid="start"):
+    return {"id": nid, "type": "Start", "data": {"params": {}}}
+
+
+def _trigger(eid, src, tgt):
+    return {"id": eid, "source": src, "target": tgt, "sourceHandle": "trigger", "type": "trigger"}
+
+
+def _raising_node(name: str, exc: BaseException):
+    class _Raiser(BaseNode):
+        NODE_NAME = name
+        CATEGORY = "Test"
+        DESCRIPTION = "Raises a specific exception type"
+
+        @classmethod
+        def define_inputs(cls):
+            return []
+
+        @classmethod
+        def define_outputs(cls):
+            return [PortDefinition(name="out", data_type=DataType.ANY)]
+
+        def execute(self, inputs, params):
+            raise exc
+
+    return _Raiser
+
+
+async def _run_and_capture(name: str, exc: BaseException) -> dict:
+    """Run a one-node graph that raises, return the emitted error detail."""
+    captured: dict = {}
+
+    async def on_progress(node_id, status, data):
+        if status == "error":
+            captured.update(data or {})
+
+    registry._nodes[name] = _raising_node(name, exc)
+    try:
+        await execute_graph(
+            [_start_node(), {"id": "1", "type": name, "data": {"params": {}}}],
+            [_trigger("et", "start", "1")],
+            on_progress=on_progress,
+            error_mode="continue",
+        )
+    finally:
+        registry._nodes.pop(name, None)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_error_payload_names_the_exception_class():
+    detail = await _run_and_capture("_TestKeyError", KeyError("tensor"))
+    assert detail["error_type"] == "KeyError"
+
+
+@pytest.mark.asyncio
+async def test_message_stays_the_bare_str_of_the_exception():
+    """The class name belongs in its own field, not glued onto the message."""
+    detail = await _run_and_capture("_TestKeyError2", KeyError("tensor"))
+    # This is exactly why the prefix scan could never work.
+    assert detail["error"] == "'tensor'"
+    assert "KeyError" not in detail["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        (RuntimeError("mat1 and mat2 shapes cannot be multiplied (64x784 and 512x10)"), "RuntimeError"),
+        (ValueError("epochs must be positive"), "ValueError"),
+        (TypeError("unsupported operand"), "TypeError"),
+        (ZeroDivisionError("division by zero"), "ZeroDivisionError"),
+    ],
+)
+async def test_error_type_is_reported_for_every_exception_class(exc, expected):
+    detail = await _run_and_capture(f"_TestRaise{expected}", exc)
+    assert detail["error_type"] == expected
+    assert detail["error"] == str(exc)
+
+
+@pytest.mark.asyncio
+async def test_a_custom_exception_class_reports_its_own_name():
+    class GraphMisconfigured(RuntimeError):
+        pass
+
+    detail = await _run_and_capture(
+        "_TestCustomExc", GraphMisconfigured("the optimizer has no parameters")
+    )
+    assert detail["error_type"] == "GraphMisconfigured"

--- a/frontend/src/hooks/useGraphExecution.ts
+++ b/frontend/src/hooks/useGraphExecution.ts
@@ -10,6 +10,7 @@ import { useToastStore } from '../store/toastStore';
 import { useUIStore } from '../store/uiStore';
 import { getRun, validateGraph } from '../api/rest';
 import { findEntryPoints } from '../utils/findEntryPoints';
+import { friendlyError } from '../utils/errorMessages';
 import { useI18n } from '../i18n';
 import { RECONNECTED_EVENT, type ExecutionWebSocket } from '../api/ws';
 
@@ -144,9 +145,14 @@ export function useGraphExecution() {
             eventTab?.nodes.find((n) => n.id === data.node_id)?.data?.label ??
             String(data.node_id).slice(0, 8);
 
+          // Map the exception here, where `error_type` is still available --
+          // the panels only ever see the composed line, and the type cannot be
+          // recovered from `str(exc)` afterwards.
+          const detail = data.error ? friendlyError(data.error, data.error_type) : '';
+
           store.addTabLog(tabId, {
             nodeId: data.node_id,
-            message: `Node ${nodeLabel} ${data.status}${data.error ? ': ' + data.error : ''}`,
+            message: `Node ${nodeLabel} ${data.status}${detail ? ': ' + detail : ''}`,
             type:
               data.status === 'error'
                 ? 'error'

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -336,6 +336,14 @@ const en = {
   // Execution errors
   'execution.error.noEntryPoints': 'No entry points defined. Drag a Start node from the palette and connect it to the node you want to start execution from.',
 
+  // Beginner-facing rewrites of raw Python/PyTorch exceptions (see
+  // utils/errorMessages.ts). Each one names what to change, not just what broke.
+  'error.missingTensorInput': "This node expected a 'tensor' input but did not receive one. Check that every required input is connected.",
+  'error.missingInput': "Missing required input '{key}'. Check that it is connected.",
+  'error.linearShapeMismatch': 'Size mismatch: this layer received {got} features but is configured for {expected}. Set the layer\'s in_features to {got}, or change the previous layer so it outputs {expected}.',
+  'error.invalidReshape': 'Cannot reshape to {shape}: the tensor has {size} elements, which does not divide evenly into that shape. Check the batch size and the dimensions of the previous layer.',
+  'error.channelMismatch': 'Channel mismatch: this layer is configured for {expected} input channels but received {got}. Set its in_channels to {got}, or change what feeds it.',
+
   // Re-attach (#121): the run kept going while the tab was closed.
   'execution.reattached': 'Reconnected to a run that is still in progress',
 

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -322,6 +322,14 @@ const zhTW: Record<TranslationKey, string> = {
   // Execution errors
   'execution.error.noEntryPoints': '尚未定義起始節點。請從節點面板拖曳一個 Start 節點，並連接到要開始執行的節點。',
 
+  // Beginner-facing rewrites of raw Python/PyTorch exceptions (see
+  // utils/errorMessages.ts). Each one names what to change, not just what broke.
+  'error.missingTensorInput': '這個節點需要一個 tensor 輸入，但沒有收到。請檢查所有必要的輸入是否都已接線。',
+  'error.missingInput': '缺少必要的輸入「{key}」。請檢查這個輸入是否已接線。',
+  'error.linearShapeMismatch': '尺寸不符：這一層收到 {got} 個特徵，但它設定的是 {expected} 個。請把這一層的 in_features 改成 {got}，或調整前一層讓它輸出 {expected} 個。',
+  'error.invalidReshape': '無法變形成 {shape}：這個 tensor 有 {size} 個元素，無法整除成該形狀。請檢查批次大小與前一層的維度。',
+  'error.channelMismatch': '通道數不符：這一層設定的輸入通道是 {expected}，但收到 {got}。請把它的 in_channels 改成 {got}，或調整接到它的來源。',
+
   // Re-attach (#121): the run kept going while the tab was closed.
   'execution.reattached': '已重新連上仍在執行中的工作',
 

--- a/frontend/src/utils/errorMessages.test.ts
+++ b/frontend/src/utils/errorMessages.test.ts
@@ -1,54 +1,120 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach } from 'vitest';
 import { friendlyError } from './errorMessages';
+import { useI18n } from '../i18n';
 
-describe('friendlyError', () => {
-  it('maps KeyError for "tensor" to a tensor-specific hint', () => {
-    const out = friendlyError("KeyError: 'tensor'");
-    expect(out).toBe(
-      "This node expected a 'tensor' input but did not receive one. Check that all required inputs are connected.",
+/**
+ * These previously fed `friendlyError` strings like "KeyError: 'tensor'".
+ * The backend cannot produce that: it sends `str(exc)`, and
+ * `str(KeyError('tensor'))` is `"'tensor'"`. So every rule passed its test
+ * and never fired in production. The payloads below are what the backend
+ * actually emits, now that the type travels as its own field.
+ */
+
+beforeEach(() => {
+  useI18n.setState({ locale: 'en' });
+});
+
+describe('friendlyError — payloads the backend actually sends', () => {
+  it('names the missing tensor input from a bare KeyError message', () => {
+    // str(KeyError('tensor')) === "'tensor'"
+    const out = friendlyError("'tensor'", 'KeyError');
+    expect(out).toContain('tensor');
+    expect(out).toContain('connected');
+  });
+
+  it('names any other missing input', () => {
+    expect(friendlyError("'weights'", 'KeyError')).toContain("'weights'");
+  });
+
+  it('does not treat a quoted word as a KeyError without the type', () => {
+    // No error_type and no traceback -> nothing to key off. It must pass
+    // through rather than guess that any quoted token is a missing port.
+    expect(friendlyError("'tensor'")).toBe("'tensor'");
+  });
+
+  it('turns a Linear size mismatch into the two numbers to change', () => {
+    const raw = 'mat1 and mat2 shapes cannot be multiplied (64x784 and 512x10)';
+    const out = friendlyError(raw, 'RuntimeError');
+    expect(out).toContain('784');
+    expect(out).toContain('512');
+    expect(out).toContain('in_features');
+    expect(out).not.toBe(raw);
+  });
+
+  it('explains an invalid reshape with the element count', () => {
+    const raw = "shape '[2, 3]' is invalid for input of size 5";
+    const out = friendlyError(raw, 'RuntimeError');
+    expect(out).toContain('[2, 3]');
+    expect(out).toContain('5');
+  });
+
+  it('explains a conv channel mismatch', () => {
+    const raw =
+      'Given groups=1, weight of size [16, 3, 3, 3], expected input[1, 1, 28, 28] to have 3 channels, but got 1 channels instead';
+    const out = friendlyError(raw, 'RuntimeError');
+    expect(out).toContain('in_channels');
+    expect(out).toContain('3');
+    expect(out).toContain('1');
+  });
+
+  it('surfaces a ValueError message without the class name', () => {
+    expect(friendlyError('epochs must be positive', 'ValueError')).toBe(
+      'epochs must be positive',
     );
   });
 
-  it('maps KeyError for any other key to a generic missing-data message', () => {
-    expect(friendlyError("KeyError: 'weights'")).toBe(
-      "Missing required data: 'weights'. Ensure all inputs are connected.",
+  it('passes an unrecognised message through unchanged', () => {
+    expect(friendlyError('something went sideways', 'RuntimeError')).toBe(
+      'something went sideways',
     );
   });
 
-  it('detects KeyError embedded in a longer traceback', () => {
-    const raw = 'Traceback (most recent call last):\n  ...\nKeyError: \'labels\'';
-    expect(friendlyError(raw)).toBe(
-      "Missing required data: 'labels'. Ensure all inputs are connected.",
-    );
+  it('returns an empty message unchanged', () => {
+    expect(friendlyError('')).toBe('');
+  });
+});
+
+describe('friendlyError — untyped sources (run records, DEBUG tracebacks)', () => {
+  it('recovers the class from a traceback when no type field is given', () => {
+    const raw = "Traceback (most recent call last):\n  ...\nKeyError: 'labels'";
+    expect(friendlyError(raw)).toContain("'labels'");
   });
 
-  it('maps RuntimeError shape-invalid to a shape-mismatch message', () => {
-    const raw = "RuntimeError: shape '[2, 3]' is invalid for input of size 5";
-    expect(friendlyError(raw)).toBe(
-      'Tensor shape mismatch. Check the dimensions of connected nodes.',
-    );
+  it('still matches shape errors with no type at all', () => {
+    const raw = 'mat1 and mat2 shapes cannot be multiplied (8x128 and 64x10)';
+    expect(friendlyError(raw)).toContain('in_features');
   });
 
-  it('extracts and trims the message after ValueError:', () => {
+  it('trims a ValueError prefix when it arrives inside a traceback', () => {
     expect(friendlyError('ValueError:   too many values to unpack  ')).toBe(
       'too many values to unpack',
     );
   });
+});
 
-  it('returns the raw message unchanged when nothing matches', () => {
-    const raw = 'TypeError: unsupported operand type(s)';
-    expect(friendlyError(raw)).toBe(raw);
-  });
-
-  it('returns an empty string unchanged', () => {
-    expect(friendlyError('')).toBe('');
-  });
-
-  it('prefers the KeyError branch over a co-occurring ValueError', () => {
-    // KeyError is checked first; a ValueError later in the string is ignored.
-    const raw = "KeyError: 'tensor'\nValueError: ignored";
-    expect(friendlyError(raw)).toBe(
-      "This node expected a 'tensor' input but did not receive one. Check that all required inputs are connected.",
+describe('friendlyError — idempotence', () => {
+  it('a second pass over already-friendly text is a no-op', () => {
+    // ResultsPanel and RunsPanel both call this on lines that were already
+    // mapped once at ingestion.
+    const once = friendlyError(
+      'mat1 and mat2 shapes cannot be multiplied (64x784 and 512x10)',
     );
+    expect(friendlyError(once)).toBe(once);
+  });
+});
+
+describe('friendlyError — localization', () => {
+  it('returns Traditional Chinese under the zh-TW locale', () => {
+    useI18n.setState({ locale: 'zh-TW' });
+    const out = friendlyError(
+      'mat1 and mat2 shapes cannot be multiplied (64x784 and 512x10)',
+    );
+    expect(out).toContain('784');
+    expect(out).toMatch(/[一-鿿]/); // actually Chinese, not English
+  });
+
+  it('a raw message with no rule stays raw in either locale', () => {
+    useI18n.setState({ locale: 'zh-TW' });
+    expect(friendlyError('unmapped failure')).toBe('unmapped failure');
   });
 });

--- a/frontend/src/utils/errorMessages.ts
+++ b/frontend/src/utils/errorMessages.ts
@@ -1,28 +1,74 @@
 /**
- * Maps raw Python exception strings to beginner-friendly error messages.
+ * Maps a raw Python exception into a message a beginner can act on.
+ *
+ * The exception type arrives as its own field (`error_type` on the backend's
+ * error payload). It used to be recovered by scanning the message for a
+ * `KeyError:` prefix — which `str(exc)` never produces, since
+ * `str(KeyError('tensor'))` is just `"'tensor'"`. Every rule here was
+ * therefore unreachable in production while its tests passed, because the
+ * tests fed it strings carrying a prefix the backend could not emit.
+ *
+ * `errorType` is optional: run records and server-level errors have no typed
+ * field, and in DEBUG the payload carries a traceback whose last line *does*
+ * name the class. So a prefix scan stays as a fallback for those sources.
+ *
+ * Anything unrecognised is returned unchanged, which also makes a second pass
+ * over already-friendly text a no-op — several panels call this on messages
+ * that were mapped once already at ingestion.
  */
-export function friendlyError(raw: string): string {
-  // KeyError with specific key name
-  const keyErrorMatch = raw.match(/KeyError:\s*'([^']+)'/);
-  if (keyErrorMatch) {
-    const key = keyErrorMatch[1];
-    if (key === 'tensor') {
-      return "This node expected a 'tensor' input but did not receive one. Check that all required inputs are connected.";
+import { useI18n } from '../i18n';
+
+/** Recover the class name from a traceback's last line, for untyped sources. */
+function typeFromTraceback(raw: string): string | undefined {
+  return raw.match(/\b([A-Z]\w*(?:Error|Exception))\s*:/)?.[1];
+}
+
+export function friendlyError(raw: string, errorType?: string): string {
+  if (!raw) return raw;
+  const t = useI18n.getState().t;
+  const kind = errorType || typeFromTraceback(raw);
+
+  // A missing input. The key names the port the node wanted.
+  if (kind === 'KeyError') {
+    // Typed payloads give a bare "'tensor'"; tracebacks give "KeyError: 'tensor'".
+    const key = raw.match(/'([^']+)'/)?.[1];
+    if (key) {
+      return key === 'tensor'
+        ? t('error.missingTensorInput')
+        : t('error.missingInput', { key });
     }
-    return `Missing required data: '${key}'. Ensure all inputs are connected.`;
   }
 
-  // RuntimeError: shape mismatch
-  if (/RuntimeError:.*shape\s+'[^']*'\s+is invalid/.test(raw)) {
-    return 'Tensor shape mismatch. Check the dimensions of connected nodes.';
+  // The most common mistake in a first CNN or MLP: a Linear layer's
+  // in_features does not match what the previous layer produced. PyTorch's own
+  // wording names two matrices the student never typed, so it reads as an
+  // internal fault rather than a wiring mistake.
+  const matmul = raw.match(
+    /mat1 and mat2 shapes cannot be multiplied \(\d+x(\d+) and (\d+)x\d+\)/,
+  );
+  if (matmul) {
+    return t('error.linearShapeMismatch', { got: matmul[1], expected: matmul[2] });
   }
 
-  // ValueError: extract the message after "ValueError:"
-  const valueErrorMatch = raw.match(/ValueError:\s*(.*)/);
-  if (valueErrorMatch) {
-    return valueErrorMatch[1].trim();
+  // A reshape/view whose target shape does not divide the tensor's size.
+  const invalidShape = raw.match(/shape\s+'(\[[^\]]*\])'\s+is invalid for input of size (\d+)/);
+  if (invalidShape) {
+    return t('error.invalidReshape', { shape: invalidShape[1], size: invalidShape[2] });
   }
 
-  // Default: return raw message unchanged
+  // Channel mismatch between a conv layer and its input.
+  const channels = raw.match(
+    /expected input\[[^\]]*\] to have (\d+) channels, but got (\d+) channels/,
+  );
+  if (channels) {
+    return t('error.channelMismatch', { expected: channels[1], got: channels[2] });
+  }
+
+  // ValueError already carries a message written for a human — surface it
+  // without the class name, which adds nothing for a beginner.
+  if (kind === 'ValueError') {
+    return raw.replace(/^ValueError:\s*/, '').trim() || raw;
+  }
+
   return raw;
 }


### PR DESCRIPTION
> 中文摘要：`friendlyError` 那三條「把 Python 例外翻成初學者看得懂的話」的規則，**在正式環境裡從來沒有生效過**。它們比對的是 `KeyError:` 這種前綴，但後端送出的是 `str(例外)`，而 `str(KeyError('tensor'))` 就只是 `"'tensor'"`，永遠不含類別名。它的測試之所以會過，是因為測試餵的是後端根本產不出來的字串。學生忘了接線時，看到的就是一個孤零零的 `'tensor'`。這個 PR 讓例外類別以獨立欄位傳過來（結構化，而不是猜字串長相），並補上初學者最常撞到的 Linear 尺寸不符錯誤，全部走 i18n。

## The bug

```
frontend/src/utils/errorMessages.ts   matched  /KeyError:\s*'([^']+)'/
backend/app/core/graph_engine.py:2210 sent     {"error": str(last_error)}

>>> str(KeyError('tensor'))
"'tensor'"
```

`str()` never includes the class name, so **all three rules were unreachable**. Verified against the running Python, not inferred.

The tests passed because they fed it strings the backend cannot emit:

```js
friendlyError("KeyError: 'tensor'")   // the test
"'tensor'"                            // what actually arrives
```

So a student who forgot to connect an input saw the literal text `'tensor'`. The prepared sentence explaining that a required input is missing had been sitting there unreachable the whole time.

## The fix is structural, not a better guess

The exception class now travels as its own `error_type` field, and the mapping runs at ingestion in `useGraphExecution`, where that field is still in scope — the panels only ever see the composed log line, and the type cannot be recovered from `str(exc)` afterwards.

A prefix scan stays as a **fallback** for sources that genuinely have no typed field: run records, server-level errors, and DEBUG payloads, whose traceback's last line does name the class.

## The error a first CNN actually hits

`mat1 and mat2 shapes cannot be multiplied (64x784 and 512x10)` appeared **nowhere** in the codebase, despite being the single most common mistake in a first MLP or CNN — a `Linear` layer's `in_features` not matching what came before. PyTorch names two matrices the student never typed, so it reads as an internal fault rather than a wiring mistake.

It now reads:

> Size mismatch: this layer received **784** features but is configured for **512**. Set the layer's `in_features` to 784, or change the previous layer so it outputs 512.

Conv channel mismatches and invalid reshapes get the same treatment — each names the parameter to change and the number to change it to.

## Localized

All of these go through i18n, so a zh-TW class stops hitting English at the exact moment something breaks:

> 尺寸不符：這一層收到 784 個特徵，但它設定的是 512 個。請把這一層的 in_features 改成 784，或調整前一層讓它輸出 512 個。

## One message deliberately removed

`'Tensor shape mismatch. Check the dimensions of connected nodes.'` said strictly **less** than the PyTorch message it replaced — it discarded the shape and the size. Replaced with a rule that keeps both.

## Verification

- **15 frontend cases**, rewritten against real payloads: the bare-`'tensor'` KeyError, each shape rule, the untyped-traceback fallback, the locale switch (asserting the output is actually Chinese, not just different), and the idempotence property that `ResultsPanel`/`RunsPanel`'s second pass relies on.
- **8 backend cases** pinning `error_type` across five exception classes including a custom subclass, and asserting the message stays the bare `str(exc)` — the property that made the old scan impossible.
- One negative test worth calling out: a quoted word with **no** type must pass through unchanged, so the mapping never guesses that any `'foo'` is a missing port.
- `tsc -b` clean; frontend 137 files / 2897 tests green.
