### PR TITLE
fix(device): a shared GPU box silently trained every student on the CPU

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,8 @@ import 'katex/dist/katex.min.css';
 import './App.css';
 import App from './App';
 import { getSessionToken } from './api/_auth';
+import { fetchDevices } from './api/rest';
+import { useUIStore } from './store/uiStore';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) throw new Error('Root element not found');
@@ -18,6 +20,21 @@ if (!rootElement) throw new Error('Root element not found');
 getSessionToken().catch((err) => {
   console.error('[CodefyUI] Auth bootstrap failed:', err);
 });
+
+// The global device defaulted to 'cpu' for anyone who had never opened
+// Settings, and the backend's own answer — `describe_accelerator().default`,
+// the best device present — was fetched but never read. On a shared lab box
+// that meant every student trained on the CPU while the GPU sat idle, with
+// nothing on screen suggesting otherwise.
+//
+// Done here rather than in SettingsPopover because that component only mounts
+// when the popover is opened, which is exactly the thing the student does not
+// know to do. An explicit choice still wins; see `adoptDefaultDevice`.
+fetchDevices()
+  .then((r) => useUIStore.getState().adoptDefaultDevice(r.default))
+  .catch(() => {
+    /* No device list — keep the CPU default, which always works. */
+  });
 
 createRoot(rootElement).render(
   <StrictMode>

--- a/frontend/src/store/uiStore.test.ts
+++ b/frontend/src/store/uiStore.test.ts
@@ -182,6 +182,48 @@ describe('useUIStore', () => {
     });
   });
 
+  describe('adoptDefaultDevice', () => {
+    it('adopts the backend default when the user has never chosen', () => {
+      // The shared-lab case: nothing persisted, so the CPU placeholder is not
+      // a preference and the GPU should be picked up.
+      useUIStore.getState().adoptDefaultDevice('cuda');
+      expect(useUIStore.getState().globalDevice).toBe('cuda');
+    });
+
+    it('does not persist what it adopts', () => {
+      // Re-derived every start, so the profile follows the hardware and a
+      // shared machine does not hand a stale device to the next student.
+      useUIStore.getState().adoptDefaultDevice('cuda');
+      expect(localStorage.getItem(KEYS.GLOBAL_DEVICE)).toBeNull();
+    });
+
+    it('leaves an explicit choice alone', () => {
+      useUIStore.getState().setGlobalDevice('cpu');
+      useUIStore.getState().adoptDefaultDevice('cuda');
+      expect(useUIStore.getState().globalDevice).toBe('cpu');
+    });
+
+    it('treats an explicit cpu as a real choice, not the placeholder', () => {
+      // The value cannot distinguish them -- only the key's presence can.
+      // A student may pick CPU deliberately to leave the GPU to someone else.
+      localStorage.setItem(KEYS.GLOBAL_DEVICE, 'cpu');
+      useUIStore.getState().adoptDefaultDevice('cuda');
+      expect(useUIStore.getState().globalDevice).toBe('cpu');
+    });
+
+    it('ignores an empty or missing default', () => {
+      useUIStore.getState().adoptDefaultDevice('');
+      expect(useUIStore.getState().globalDevice).toBe('cpu');
+      expect(localStorage.getItem(KEYS.GLOBAL_DEVICE)).toBeNull();
+    });
+
+    it('is a no-op when the default already matches', () => {
+      useUIStore.getState().adoptDefaultDevice('cpu');
+      expect(useUIStore.getState().globalDevice).toBe('cpu');
+      expect(localStorage.getItem(KEYS.GLOBAL_DEVICE)).toBeNull();
+    });
+  });
+
   describe('setEdgeStyle', () => {
     it('updates the style and persists each valid value', () => {
       useUIStore.getState().setEdgeStyle('curve');

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -60,6 +60,9 @@ interface UIState {
    * Nodes whose own device param is 'auto' follow this. */
   globalDevice: string;
   setGlobalDevice: (device: string) => void;
+  /** Adopt the backend's best-available device, unless the user has picked one.
+   * Called once at startup — see `main.tsx`. */
+  adoptDefaultDevice: (device: string) => void;
   /** How value edges are drawn on the canvas: orthogonal circuit-board
    * traces ('circuit') or the classic curved beziers ('curve'). */
   edgeStyle: EdgeStyle;
@@ -126,7 +129,7 @@ const loadFontSize = (): FontSize => {
   return 'default';
 };
 
-export const useUIStore = create<UIState>((set) => ({
+export const useUIStore = create<UIState>((set, get) => ({
   tooltipsEnabled: localStorage.getItem(TOOLTIPS_KEY) !== 'false',
   toggleTooltips: () =>
     set((state) => {
@@ -175,6 +178,18 @@ export const useUIStore = create<UIState>((set) => ({
   globalDevice: loadGlobalDevice(),
   setGlobalDevice: (device) => {
     localStorage.setItem(GLOBAL_DEVICE_KEY, device);
+    set({ globalDevice: device });
+  },
+  adoptDefaultDevice: (device) => {
+    // An explicit choice always wins — including an explicit 'cpu', which a
+    // student may have picked deliberately to leave the GPU to someone else.
+    // Presence of the key is what marks a choice; its value cannot, because
+    // the pre-fetch placeholder is also 'cpu'.
+    if (localStorage.getItem(GLOBAL_DEVICE_KEY) !== null) return;
+    if (!device || device === get().globalDevice) return;
+    // Deliberately NOT persisted. Re-derived every start, so the same profile
+    // follows the hardware — a laptop docked to a GPU box picks it up, and a
+    // shared machine does not hand out a stale device to the next student.
     set({ globalDevice: device });
   },
   edgeStyle: loadEdgeStyle(),


### PR DESCRIPTION
> 中文摘要：只要沒有手動開過設定，全域運算裝置就是 `cpu`。後端其實早就算好「這台機器最好的裝置是哪一個」並從 `/api/system/devices` 送出來，但前端只拿了 `devices` 清單、**從來沒讀過 `default`**。所以一整班共用一台有 GPU 的機器時，GPU 閒著，每個學生都在 CPU 上跑訓練，畫面上也沒有任何提示。改成啟動時採用後端算出的預設；學生自己選過的一律不覆蓋。

## The defect

```ts
// uiStore.ts:90
const loadGlobalDevice = (): string => localStorage.getItem(GLOBAL_DEVICE_KEY) || 'cpu';
```

Anyone who had never opened Settings ran on the CPU.

The backend already computes the right answer — `describe_accelerator()` returns `default`, the best device present, served from `/api/system/devices`. `SettingsPopover` fetched that response and used only `r.devices` to populate the dropdown. **`r.default` was never read by anything in the frontend.**

On a lab machine shared by a class, the GPU sits idle while everyone waits on CPU training, and nothing on screen suggests otherwise. The only fix available today is for the teacher to walk each student through opening Settings and picking `cuda`.

## Why startup, not the popover

`SettingsPopover` only mounts when the popover is opened — which is exactly the thing the student does not know to do. Adopting there would apply the default only *after* the student had already found the setting.

So it runs once in `main.tsx`, alongside the existing session-token bootstrap.

## Two properties, both pinned by tests

**An explicit choice always wins, including an explicit `cpu`.** A student may pick CPU deliberately to leave the GPU to a classmate. The stored *value* cannot distinguish that from the placeholder — the placeholder is also `cpu`. Only the presence of the key can, so that is what `adoptDefaultDevice` checks:

```ts
if (localStorage.getItem(GLOBAL_DEVICE_KEY) !== null) return;
```

**The adopted value is not persisted.** It is re-derived every start, so the same profile follows the hardware: a laptop docked to a GPU box picks it up, and a shared machine does not hand a stale device to the next student who sits down at it.

## Verification

6 new cases in `uiStore.test.ts` — adoption on a fresh profile, non-persistence, explicit-choice precedence, the explicit-`cpu`-vs-placeholder distinction, an empty default, and the already-matching no-op.

Frontend: 137 files / 2896 tests green. `tsc -b` clean.

## Not included

`device_utils.py` resolves a literal `"auto"` global to CPU rather than best-available. That value is not reachable from the device dropdown (the backend's `devices` list contains only concrete devices), so it is a separate, lower-priority question about graphs that carry it in saved state.
