### PR TITLE
feat(version): make the running version discoverable, and pin the three copies

### DIFF
--- a/backend/app/core/version.py
+++ b/backend/app/core/version.py
@@ -1,0 +1,51 @@
+"""The running CodefyUI version, resolved once.
+
+There was no way for a user or a bug reporter to say which version they were
+on: the FastAPI app declared none, ``/api/health`` returned none, and there
+was no ``cdui --version``. The only runtime signal was
+``frontend/dist/build-info.json``, which describes the frontend bundle rather
+than the backend. For a tool handed to a class, that makes triage guesswork.
+
+``importlib.metadata`` is the source of truth because it reads what is
+actually installed, not what the checkout happens to say -- those differ
+exactly when it matters, e.g. a `cdui update` that fetched a newer dist but
+left the backend on an older commit.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version as _package_version
+from pathlib import Path
+
+PACKAGE_NAME = "codefyui-backend"
+
+#: Reported when neither installed metadata nor pyproject.toml can be read.
+#: Deliberately not a plausible-looking version -- a wrong number in a bug
+#: report is worse than an obvious "unknown".
+UNKNOWN_VERSION = "0.0.0+unknown"
+
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+_VERSION_RE = re.compile(r'^version\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
+
+
+def _version_from_pyproject() -> str | None:
+    """Fallback for a source checkout that was never installed (`cdui dev`)."""
+    try:
+        text = _PYPROJECT.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    # Only the [project] table's own version -- a `[tool.*]` section further
+    # down could carry an unrelated one.
+    head = text.split("\n[", 1)[0] if text.startswith("[project]") else text
+    match = _VERSION_RE.search(head)
+    return match.group(1) if match else None
+
+
+@lru_cache(maxsize=1)
+def get_version() -> str:
+    try:
+        return _package_version(PACKAGE_NAME)
+    except PackageNotFoundError:
+        return _version_from_pyproject() or UNKNOWN_VERSION

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -70,6 +70,7 @@ from .core.logging_config import setup_logging
 from .core.node_registry import registry
 from .core.node_state_store import NodeStateStore
 from .core.port_stats import PortStatsCache
+from .core.version import get_version
 from .core import plugin_loader
 from .core.plugin_loader import (
     MANIFEST_FILENAME,
@@ -356,7 +357,7 @@ async def lifespan(app: FastAPI):
     app.state.db = None
 
 
-app = FastAPI(title=settings.APP_NAME, lifespan=lifespan)
+app = FastAPI(title=settings.APP_NAME, version=get_version(), lifespan=lifespan)
 
 
 # ── Security middleware ───────────────────────────────────────────────
@@ -481,6 +482,11 @@ async def _cache_usage() -> dict[str, dict[str, int]]:
 async def health():
     body = {
         "status": "ok",
+        # Unconditional, unlike `project` below: this is a new capability
+        # rather than a refactor, and the whole point is that a bug reporter
+        # on any install can state their version. It is also the first thing
+        # `cdui status` and the install check can assert against.
+        "version": get_version(),
         "nodes_loaded": len(registry.nodes),
         "presets_loaded": len(preset_registry.presets),
         "caches": await _cache_usage(),

--- a/backend/tests/test_version_surfacing.py
+++ b/backend/tests/test_version_surfacing.py
@@ -1,0 +1,152 @@
+"""The running version must be discoverable, and the three copies must agree.
+
+Before this, nothing reported a version: the FastAPI app declared none,
+`/api/health` returned none, there was no `cdui --version`, and no
+`__version__` existed anywhere. A bug report from a classroom could not state
+which version it came from.
+
+The version also lives in three files that are bumped by hand -- there is no
+bump command -- so `test_all_version_fields_agree` is the only thing standing
+between a release and a frontend that claims one version while the backend
+claims another.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+import dev  # scripts/dev.py -- conftest puts scripts/ on sys.path
+from app.core.version import UNKNOWN_VERSION, get_version
+from app.main import app
+
+ROOT = dev.ROOT
+SEMVER = re.compile(r"^\d+\.\d+\.\d+")
+
+
+def _pyproject_version() -> str:
+    text = (ROOT / "backend" / "pyproject.toml").read_text(encoding="utf-8")
+    return re.search(r'^version\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE).group(1)
+
+
+def _package_json_version() -> str:
+    data = json.loads((ROOT / "frontend" / "package.json").read_text(encoding="utf-8"))
+    return data["version"]
+
+
+def _uv_lock_version() -> str | None:
+    """The codefyui-backend entry in backend/uv.lock, if present."""
+    text = (ROOT / "backend" / "uv.lock").read_text(encoding="utf-8")
+    m = re.search(
+        r'\[\[package\]\]\s*\nname\s*=\s*"codefyui-backend"\s*\nversion\s*=\s*"([^"]+)"',
+        text,
+    )
+    return m.group(1) if m else None
+
+
+# ── The three copies must agree ──────────────────────────────────────────────
+
+def test_all_version_fields_agree():
+    """Nothing else asserts this, and every bump edits all three by hand."""
+    fields = {
+        "backend/pyproject.toml": _pyproject_version(),
+        "frontend/package.json": _package_json_version(),
+    }
+    lock = _uv_lock_version()
+    if lock is not None:
+        fields["backend/uv.lock"] = lock
+    assert len(set(fields.values())) == 1, f"version fields disagree: {fields}"
+
+
+def test_the_version_looks_like_a_version():
+    assert SEMVER.match(_pyproject_version())
+
+
+# ── The library helper ───────────────────────────────────────────────────────
+
+def test_get_version_matches_pyproject():
+    assert get_version() == _pyproject_version()
+
+
+def test_get_version_falls_back_to_pyproject_without_installed_metadata(monkeypatch):
+    """A source checkout that was never pip-installed still reports a number."""
+    from importlib.metadata import PackageNotFoundError
+
+    import app.core.version as version_mod
+
+    def boom(_name):
+        raise PackageNotFoundError(_name)
+
+    monkeypatch.setattr(version_mod, "_package_version", boom)
+    version_mod.get_version.cache_clear()
+    try:
+        assert version_mod.get_version() == _pyproject_version()
+    finally:
+        version_mod.get_version.cache_clear()
+
+
+def test_unreadable_everything_reports_an_obviously_wrong_version(monkeypatch):
+    """A plausible-looking wrong number in a bug report is worse than 'unknown'."""
+    from importlib.metadata import PackageNotFoundError
+
+    import app.core.version as version_mod
+
+    def boom(_name):
+        raise PackageNotFoundError(_name)
+
+    monkeypatch.setattr(version_mod, "_package_version", boom)
+    monkeypatch.setattr(version_mod, "_version_from_pyproject", lambda: None)
+    version_mod.get_version.cache_clear()
+    try:
+        assert version_mod.get_version() == UNKNOWN_VERSION
+    finally:
+        version_mod.get_version.cache_clear()
+
+
+# ── The three surfaces ───────────────────────────────────────────────────────
+
+async def test_health_reports_the_version(test_client):
+    body = (await test_client.get("/api/health")).json()
+    assert body["version"] == _pyproject_version()
+
+
+async def test_health_reports_the_version_outside_project_mode(test_client, monkeypatch):
+    """Unlike `project`, this key is unconditional -- see main.py's comment."""
+    from app.api import routes_graph
+
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", None)
+    body = (await test_client.get("/api/health")).json()
+    assert "version" in body
+
+
+def test_the_fastapi_app_declares_it():
+    assert app.version == _pyproject_version()
+
+
+def test_openapi_carries_it():
+    """This is what an external caller of a published graph reads."""
+    assert app.openapi()["info"]["version"] == _pyproject_version()
+
+
+# ── `cdui --version` ─────────────────────────────────────────────────────────
+
+def test_cdui_version_helper_agrees():
+    assert dev._codefyui_version() == _pyproject_version()
+
+
+def test_cdui_version_does_not_need_the_venv(monkeypatch):
+    """It must answer on a half-finished install; that is when it is asked."""
+    called = []
+    monkeypatch.setattr(dev, "_ensure_uv", lambda: called.append("uv"))
+    dev._codefyui_version()
+    assert called == []
+
+
+@pytest.mark.parametrize("flag", ["--version", "-V", "version"])
+def test_all_three_spellings_are_accepted(flag):
+    """Pinned against the dispatch block in dev.py's __main__."""
+    source = (ROOT / "scripts" / "dev.py").read_text(encoding="utf-8")
+    assert f'"{flag}"' in source

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -76,6 +76,7 @@ import argparse
 import json
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -2502,6 +2503,28 @@ def uninstall() -> None:
     print(f"=== 解除安裝完成。若要完全移除，請手動刪除：{ROOT} ===")
 
 
+def _codefyui_version() -> str:
+    """Version string for `cdui --version`.
+
+    Reads `backend/pyproject.toml` directly rather than importing
+    `app.core.version`, because this must answer without the venv -- a
+    half-finished install is one of the cases where someone needs the number.
+    Falls back to the dist build stamp, which a no-Node install always has
+    even when the checkout is missing.
+    """
+    try:
+        text = (BACKEND_DIR / "pyproject.toml").read_text(encoding="utf-8")
+        m = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
+        if m:
+            return m.group(1)
+    except OSError:
+        pass
+    stamp = _read_build_stamp()
+    if isinstance(stamp, dict) and stamp.get("tag"):
+        return f"{stamp['tag']} (from dist build stamp)"
+    return "unknown"
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 COMMANDS = {
@@ -2566,6 +2589,13 @@ def _dispatch_project_subcommand() -> int:
 
 
 if __name__ == "__main__":
+    # Before anything else, including the uv bootstrap: `--version` has to
+    # answer on a broken or half-installed machine, because that is exactly
+    # when someone is being asked which version they are on.
+    if len(sys.argv) >= 2 and sys.argv[1] in ("--version", "-V", "version"):
+        print(f"CodefyUI {_codefyui_version()}")
+        sys.exit(0)
+
     # Long-form sub-grouped commands come first.
     if len(sys.argv) >= 2 and sys.argv[1] == "plugin":
         sys.exit(_dispatch_plugin_subcommand())


### PR DESCRIPTION
> 中文摘要：目前**沒有任何地方查得到執行中的版本號**——FastAPI 沒宣告、`/api/health` 沒有、沒有 `cdui --version`、整棵樹裡也沒有 `__version__`。學生回報問題時第一句「你是哪個版本」就答不出來。這個 PR 讓三個地方都回答得出來，另外補上一個測試：版本號散在三個手改的檔案裡、沒有任何指令會一起改，所以現在至少有東西擋住「前端說一個版本、後端說另一個版本」的發布。

## What was missing

- `backend/app/main.py:359` — `FastAPI(title=settings.APP_NAME, lifespan=lifespan)`, no `version=`
- `/api/health` — returned `status`, `nodes_loaded`, `presets_loaded`, `caches`, and nothing else
- no `cdui --version` — the `COMMANDS` dict had no version handler
- no `__version__` constant for CodefyUI anywhere in the tree

The only runtime version signal was `frontend/dist/build-info.json`, which describes the **frontend bundle**, not the backend. For a tool handed to a class, every bug report starts with guesswork.

## Three surfaces now answer

```
$ cdui --version
CodefyUI 2.0.0

$ curl -s localhost:8000/api/health | jq '{status, version}'
{ "status": "ok", "version": "2.0.0" }

$ curl -s localhost:8000/openapi.json | jq .info.version
"2.0.0"
```

## Two deliberate design points

**`get_version()` reads `importlib.metadata` first**, not the checkout. That reports what is actually *installed* — and the two differ exactly when it matters, e.g. a `cdui update` that fetched a newer dist but left the backend on an older commit. It falls back to `pyproject.toml` for a source checkout that was never installed, and then to `0.0.0+unknown`. That last value is deliberately implausible: a wrong-but-believable number in a bug report is worse than an admission of ignorance.

**`cdui --version` deliberately does not use that helper.** It parses pyproject directly and is dispatched **before `_ensure_uv()`**, because it has to answer on a broken or half-installed machine — which is precisely when someone is being asked what version they have. If even the checkout is unreadable it falls back to the dist build stamp, which a no-Node install always has.

## One thing to note about `/api/health`

The `version` key is **unconditional**, unlike the neighbouring `project` key. `project` is omitted (not null) outside project mode to preserve a byte-for-byte refactor guard. This one is a new capability, and its entire purpose is that *any* install can state its version — so hiding it in some modes would defeat it. Reasoning recorded in the code next to the existing comment.

## The gap this exposed

The version lives in **three hand-edited files** — `backend/pyproject.toml`, `backend/uv.lock`, `frontend/package.json` — with no bump command and nothing asserting they match. Every past bump was a hand-made commit touching all three.

`test_all_version_fields_agree` is now the only thing standing between a release and a frontend claiming one version while the backend claims another. It is written against *whatever* the version is, so it needs no maintenance at bump time.

## Verification

16 cases: field agreement across all three files, both fallback paths (missing metadata, and everything unreadable), all three surfaces including `openapi.json`, and a test that `--version` never reaches the venv bootstrap.
