### PR TITLE
docs: add CHANGELOG.md, and make promoting it step 1 of a release

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -6,10 +6,30 @@ maintainer's job is to push the tag and check the result before publishing.
 ## TL;DR — happy path
 
 ```bash
-# from main, after the version-bump commit is in
+# 1. Promote CHANGELOG.md's [Unreleased] section to the new version, and
+#    bump the three version fields (see "Before you tag" below).
+# 2. From main, once that commit is in:
 git tag 1.0.0rcN
 git push origin 1.0.0rcN
 ```
+
+## Before you tag
+
+Two things are done by hand, and nothing else in the pipeline checks them for
+you:
+
+1. **Promote `CHANGELOG.md`.** Rename `## [Unreleased]` to
+   `## [X.Y.Z] — YYYY-MM-DD`, open a fresh empty `## [Unreleased]` above it, and
+   update the `[Unreleased]` compare link at the bottom to point at the new tag.
+   The tag annotation — which becomes the GitHub release body — should say the
+   same thing; the changelog is what answers "what is on main that nobody has
+   yet" *between* releases, which the tag cannot.
+
+2. **Bump the version in all three files**, which are edited by hand and which
+   nothing reconciles: `backend/pyproject.toml`, `backend/uv.lock` (regenerate
+   with `uv lock`), and `frontend/package.json`. A mismatch between them ships
+   silently — the frontend claiming one version while the backend claims
+   another — so check all three before tagging.
 
 Then on GitHub:
 1. Wait for **Release Build** to finish (≈2 min) — produces a draft release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+All notable changes to CodefyUI are recorded here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+**Why this file exists.** Release notes previously lived only in the annotated
+git tag, which `release-build.yml` copies into the GitHub release body. That is
+fine for reading a published release and useless for the question that actually
+matters between releases: *what has landed on `main` that nobody has yet?* Eight
+commits — including three plugin-sandbox security fixes — sat unreleased before
+this file was added, with nothing in the repository saying so.
+
+The `Unreleased` section is the answer to that question. `.github/RELEASING.md`
+step 1 is to promote it.
+
+**Versions before this file.** Their notes were written as tag annotations and
+were never in the repository. Rather than reconstruct them here from commit
+history — which would produce a different document than the one users actually
+received — each links to the release it was published as.
+
+## [Unreleased]
+
+### Security
+
+- Closed three bypasses in the plugin and custom-node AST gate: `import nt` /
+  `import posix` (the C-level modules `os` itself imports from and re-exports —
+  neither had ever been enumerated), a skip-directory scan gap, and an
+  allowlisted-library attribute escape. ([#221])
+
+### Added
+
+- Periodic checkpointing on `TrainingLoop` (`checkpoint_every`), so a run killed
+  by SIGKILL, an OOM kill or a restart keeps its completed epochs instead of
+  losing all of them. Checkpoints were previously written only after the loop
+  returned, or on a cooperative stop that needs the process alive. ([#226])
+- Per-epoch `val_accuracy` and a `monitor` option for early stopping.
+  `TrainingLoop` recorded six metric series and not one of them was accuracy, so
+  the curve people actually read for a classifier did not exist. ([#218])
+
+### Fixed
+
+- `GET /api/execution/outputs/...` returned 500 for any tensor containing NaN or
+  Inf, taking the inspector's I/O tab down with it — Starlette renders with
+  `allow_nan=False`. Also: writers that always write, content-aware cache keys,
+  and a validate/execute agreement. ([#225])
+- A graph submitted with `{"device": "cuda"}` trained on the GPU and then
+  silently evaluated on the CPU: `EvaluateModel.device` was the one selector in
+  the training path that could not follow the run device. ([#212])
+- Delete removed the last-*clicked* node rather than the one on screen, because
+  the store's `selectedNodeId` and React Flow's per-node `selected` flag were two
+  competing sources of truth. Also: log attribution to the event's own tab, an
+  untranslated `Cancel` in every dialog, and a silent IndexedDB→localStorage
+  fallback that brought back the 5 MB ceiling unannounced. ([#213])
+- Layer-editor auto-layout was all-or-nothing: one node with a position turned
+  the gate off and the other sixty-nine stacked at the origin, which reads as
+  data loss rather than a layout bug. ([#214])
+
+### Internal
+
+- Test and CI hygiene: fixture paths (eight tests errored when pytest ran from
+  the repo root, which is how the contribution docs invoke it), test isolation, a
+  byte-scan guard, and two deflaked timing tests. ([#217])
+
+## Released
+
+Notes for these live in their GitHub release, written as the tag annotation:
+
+| Version | Date | Notes |
+|---|---|---|
+| 2.0.0 | 2026-08-05 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/2.0.0) |
+| 1.4.2 | 2026-07-20 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.4.2) |
+| 1.4.1 | 2026-07-20 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.4.1) |
+| 1.4.0 | 2026-07-18 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.4.0) |
+| 1.3.0 | 2026-06-13 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.3.0) |
+| 1.2.1 | 2026-06-04 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.2.1) |
+| 1.2.0 | 2026-06-02 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.2.0) |
+| 1.1.2 | 2026-06-02 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.1.2) |
+| 1.1.1 | 2026-06-02 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.1.1) |
+| 1.1.0 | 2026-06-01 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.1.0) |
+| 1.0.3 | 2026-05-05 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.0.3) |
+| 1.0.2 | 2026-05-05 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.0.2) |
+| 1.0.1 | 2026-05-05 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.0.1) |
+| 1.0.0 | 2026-05-05 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.0.0) |
+
+Release candidates before 1.0.0 are on the
+[releases page](https://github.com/CodefyUI/CodefyUI/releases).
+
+[#212]: https://github.com/CodefyUI/CodefyUI/pull/212
+[#213]: https://github.com/CodefyUI/CodefyUI/pull/213
+[#214]: https://github.com/CodefyUI/CodefyUI/pull/214
+[#217]: https://github.com/CodefyUI/CodefyUI/pull/217
+[#218]: https://github.com/CodefyUI/CodefyUI/pull/218
+[#221]: https://github.com/CodefyUI/CodefyUI/pull/221
+[#225]: https://github.com/CodefyUI/CodefyUI/pull/225
+[#226]: https://github.com/CodefyUI/CodefyUI/pull/226
+[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.0.0...main


### PR DESCRIPTION
> 中文摘要：這個 repo 完全沒有 changelog（查過 git 歷史，是從來沒建過，不是建了又刪）。發布說明只存在於 git tag 的註解裡，`release-build.yml` 會把它複製成 GitHub release 的內容。這對「看已發布的版本」夠用，但完全回答不了兩次發布之間真正要緊的問題：**main 上已經有什麼、但還沒送到任何人手上？** 寫這份檔案時，累積了八個 commit 沒發布，其中包含三個外掛沙箱的安全修補，而 repo 裡沒有任何地方講這件事。

## What this adds

`CHANGELOG.md` with an `Unreleased` section that answers exactly that question. Right now it lists what is sitting on `main` unreleased:

- **Security** — three AST-gate bypasses (`import nt` / `import posix`, a skip-directory scan gap, an allowlisted-library attribute escape) ([#221])
- **Added** — periodic checkpointing so a killed server does not lose the run ([#226]); per-epoch `val_accuracy` + early-stopping monitor ([#218])
- **Fixed** — a 500 on any tensor containing NaN, which took the inspector down ([#225]); GPU-train-then-silently-CPU-evaluate ([#212]); Delete removing the wrong node ([#213]); all-or-nothing layer auto-layout ([#214])

## Prior versions are linked, not reconstructed

Their notes were written as tag annotations and were **never in the repository**. Rebuilding them here from commit history would produce a different document than the one users actually received — an honest pointer to each release beats a plausible fabrication.

## RELEASING.md gains a "Before you tag" section

Its TL;DR opened with `# from main, after the version-bump commit is in` and **never said how to produce that commit**. The three hand-edited version fields (`backend/pyproject.toml`, `backend/uv.lock`, `frontend/package.json`) were undocumented, and nothing reconciles them — a mismatch ships silently, with the frontend claiming one version and the backend another.

Both manual steps are now written down: promote the changelog, then bump all three.

## Note on ordering

This deliberately does **not** reference `cdui --version` or the version-agreement test, both of which arrive in #236. Nothing here forward-references work that has not landed, so it is correct on `main` whether it merges before or after that PR.

Byte scan clean over 1082 tracked files.

[#212]: https://github.com/CodefyUI/CodefyUI/pull/212
[#213]: https://github.com/CodefyUI/CodefyUI/pull/213
[#214]: https://github.com/CodefyUI/CodefyUI/pull/214
[#218]: https://github.com/CodefyUI/CodefyUI/pull/218
[#221]: https://github.com/CodefyUI/CodefyUI/pull/221
[#225]: https://github.com/CodefyUI/CodefyUI/pull/225
[#226]: https://github.com/CodefyUI/CodefyUI/pull/226