### PR TITLE
docs(training): state the epoch units on LRScheduler, where the mistake is made

### DIFF
--- a/backend/app/nodes/training/lr_scheduler_node.py
+++ b/backend/app/nodes/training/lr_scheduler_node.py
@@ -30,11 +30,57 @@ class LRSchedulerNode(BaseNode):
                 description="Scheduler type",
                 options=["StepLR", "CosineAnnealingLR", "ExponentialLR", "ReduceLROnPlateau", "CosineAnnealingWarmRestarts", "MultiStepLR", "OneCycleLR"],
             ),
-            ParamDefinition(name="step_size", param_type=ParamType.INT, default=10, description="Step size for StepLR"),
-            ParamDefinition(name="gamma", param_type=ParamType.FLOAT, default=0.1, description="Decay factor (for StepLR/ExponentialLR)"),
-            ParamDefinition(name="T_max", param_type=ParamType.INT, default=50, description="Max iterations for CosineAnnealingLR"),
+            ParamDefinition(
+                name="step_size",
+                param_type=ParamType.INT,
+                default=10,
+                description=(
+                    "StepLR: epochs between each LR drop. MultiStepLR: drops at "
+                    "1x, 2x, 3x and 4x this value. TrainingLoop steps the "
+                    "scheduler once per EPOCH, so this counts epochs, not batches."
+                ),
+            ),
+            ParamDefinition(
+                name="gamma",
+                param_type=ParamType.FLOAT,
+                default=0.1,
+                description=(
+                    "Decay factor for StepLR, MultiStepLR and ExponentialLR. "
+                    "ReduceLROnPlateau reuses it as its `factor`."
+                ),
+            ),
+            ParamDefinition(
+                name="T_max",
+                param_type=ParamType.INT,
+                default=50,
+                description=(
+                    "CosineAnnealingLR: length of one cosine cycle, in epochs. "
+                    "Normally set this EQUAL to TrainingLoop.epochs — the "
+                    "scheduler steps once per epoch, so a smaller value ends the "
+                    "run mid-cycle at a high LR and a larger one stops partway "
+                    "down the curve, typically costing a few points of accuracy "
+                    "with nothing to show that the schedule was the cause. "
+                    "Deliberately NOT enforced: a truncated schedule is a valid "
+                    "choice. CosineAnnealingWarmRestarts reuses this value as "
+                    "`T_0`, the length of the FIRST restart cycle, where equality "
+                    "with epochs would mean no restart ever happens."
+                ),
+            ),
             ParamDefinition(name="max_lr", param_type=ParamType.FLOAT, default=0.01, description="Max learning rate for OneCycleLR"),
-            ParamDefinition(name="total_steps", param_type=ParamType.INT, default=1000, description="Total training steps for OneCycleLR"),
+            ParamDefinition(
+                name="total_steps",
+                param_type=ParamType.INT,
+                default=1000,
+                description=(
+                    "OneCycleLR: length of the one-cycle schedule. TrainingLoop "
+                    "steps the scheduler once per EPOCH, so set this to "
+                    "TrainingLoop.epochs — NOT to the number of batches, which is "
+                    "what OneCycleLR's own documentation means by a step. The "
+                    "default of 1000 is far larger than any usual epoch count, so "
+                    "leaving it alone traverses only the beginning of the cycle: "
+                    "the LR warms up slightly and never anneals."
+                ),
+            ),
         ]
 
     def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/test_lr_scheduler_units.py
+++ b/backend/tests/test_lr_scheduler_units.py
@@ -1,0 +1,83 @@
+"""LRScheduler's epoch-vs-batch units must be stated where the user is standing.
+
+`TrainingLoop` steps the scheduler once per EPOCH
+(training_loop_node.py, inside the epoch loop, after validation). Three of
+this node's parameters are therefore in epochs, and two of them are named
+after PyTorch concepts that mean something else:
+
+- `T_max` is a cosine cycle length that should normally equal
+  `TrainingLoop.epochs`. Getting it wrong costs a few points of accuracy and
+  looks like an architecture problem (#205).
+- `total_steps` is OneCycleLR's cycle length. Upstream, a "step" is an
+  optimizer step (a batch); here it is an epoch. The default of 1000 is far
+  larger than any usual epoch count, so leaving it alone traverses only the
+  start of the cycle.
+
+These are documentation guards, not behaviour tests -- the wording IS the
+fix, so it is what regresses. Each asserts the load-bearing fact rather than
+an exact sentence, so the prose can still be edited.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.nodes.training.lr_scheduler_node import LRSchedulerNode
+
+
+def _param(name: str):
+    for p in LRSchedulerNode.define_params():
+        if p.name == name:
+            return p
+    raise AssertionError(f"LRScheduler has no param {name!r}")
+
+
+def _desc(name: str) -> str:
+    return _param(name).description.lower()
+
+
+@pytest.mark.parametrize("name", ["step_size", "T_max", "total_steps"])
+def test_epoch_unit_parameters_say_epoch(name):
+    """The unit is the trap, so the unit has to be in the description."""
+    assert "epoch" in _desc(name), f"{name} does not state its unit"
+
+
+def test_t_max_names_the_coupling_to_the_training_loop():
+    desc = _desc("T_max")
+    assert "trainingloop.epochs" in desc.replace(" ", "").replace("`", "")
+
+
+def test_t_max_does_not_present_the_coupling_as_a_rule():
+    """A truncated schedule is legitimate; warm restarts require inequality."""
+    desc = _desc("T_max")
+    assert "not enforced" in desc or "deliberately not" in desc
+
+
+def test_t_max_documents_its_second_meaning():
+    """The same value is passed as CosineAnnealingWarmRestarts' T_0."""
+    assert "warmrestarts" in _desc("T_max").replace(" ", "")
+    assert "t_0" in _desc("T_max")
+
+
+def test_total_steps_warns_that_it_is_not_batches():
+    desc = _desc("total_steps")
+    assert "batch" in desc, "does not warn against the upstream meaning"
+
+
+def test_gamma_lists_every_scheduler_that_reads_it():
+    """It is also ReduceLROnPlateau's `factor`, which the old text omitted."""
+    desc = _desc("gamma")
+    for sched in ("steplr", "multisteplr", "exponentiallr", "reducelronplateau"):
+        assert sched in desc.replace(" ", ""), f"gamma omits {sched}"
+
+
+def test_step_size_documents_the_multistep_reuse():
+    assert "multisteplr" in _desc("step_size").replace(" ", "")
+
+
+def test_every_documented_scheduler_type_is_actually_supported():
+    """Guards the descriptions against naming a type the node cannot build."""
+    options = {o.lower() for o in _param("type").options}
+    named = {"steplr", "multisteplr", "exponentiallr", "reducelronplateau",
+             "cosineannealinglr", "cosineannealingwarmrestarts", "onecyclelr"}
+    assert named <= options

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -502,11 +502,15 @@ const zhTW: NodeTranslations = {
     description: '建立學習率排程器',
     params: {
       type: '排程器類型',
-      step_size: 'StepLR 的步長',
-      gamma: '衰減因子',
-      T_max: 'CosineAnnealingLR 的最大迭代數',
+      step_size:
+        'StepLR：每隔幾個 epoch 降一次學習率。MultiStepLR：在此值的 1、2、3、4 倍處各降一次。TrainingLoop 是每個 epoch 走一步排程器，所以這裡算的是 epoch，不是 batch。',
+      gamma:
+        'StepLR、MultiStepLR、ExponentialLR 的衰減因子；ReduceLROnPlateau 也拿它當 factor。',
+      T_max:
+        'CosineAnnealingLR：一個 cosine 週期的長度，單位是 epoch。通常應該設成和 TrainingLoop.epochs 一樣——排程器每個 epoch 走一步，設小了會在學習率還很高的時候就結束，設大了則是只走到曲線中途，兩者通常會少掉幾個百分點的準確率，而且畫面上完全看不出來是排程造成的。這裡刻意不強制：截斷的排程本來就是合理選擇。CosineAnnealingWarmRestarts 會把這個值當成 T_0（第一次重啟前的週期長度），那種情況下設成和 epochs 一樣反而永遠不會重啟。',
       max_lr: 'OneCycleLR 的最大學習率',
-      total_steps: 'OneCycleLR 的總訓練步數',
+      total_steps:
+        'OneCycleLR：整個 one-cycle 排程的長度。TrainingLoop 是每個 epoch 走一步，所以這裡要填 TrainingLoop.epochs，不是 batch 數（OneCycleLR 官方文件講的 step 是 batch）。預設值 1000 遠大於一般的 epoch 數，照著不改就只會走到週期的開頭：學習率稍微升上去，然後從來不會退火下來。',
     },
   },
 


### PR DESCRIPTION
**Addresses #205 — its first bullet (say it in the parameter description) only.** The issue also asks for a dismissible canvas hint when a CosineAnnealingLR and the TrainingLoop it feeds disagree; that is UI work and is not in here, so the issue stays open.

> 中文摘要：`TrainingLoop` 是**每個 epoch** 走一步排程器，所以這個節點有三個參數的單位是 epoch，而其中兩個的名字來自 PyTorch、在上游是別的意思——描述裡完全沒講。`T_max` 應該等於 `TrainingLoop.epochs`，設錯會安靜掉幾個百分點的準確率，看起來像架構問題。另外在寫這份修正時發現一個比 #205 更嚴重的：`OneCycleLR.total_steps` 預設 1000，但排程器是按 epoch 走的，所以一個 50 epoch 的訓練只走完週期的 5%，學習率升上去之後**從來不會退火下來**。

## The stepping cadence is the root of all of it

Verified at `training_loop_node.py` — `lr_scheduler.step()` sits inside the epoch loop, after validation. So `step_size`, `T_max` and `total_steps` all count **epochs**. None of them said so.

## `T_max` — the issue's subject

A cosine cycle length that should normally equal `TrainingLoop.epochs`. The two live on different nodes with nothing between them but memory. Set too low and the run ends at a high LR; set too high and it stops partway down the curve. Either way it costs a few points of accuracy and looks like an architecture problem.

**Documented, not enforced** — exactly as the issue asks. A truncated schedule is a legitimate choice, and `CosineAnnealingWarmRestarts` reuses this same value as `T_0`, where equality with `epochs` would mean **no restart ever happens**. That second meaning was undocumented too: one parameter, two schedulers, two different jobs.

## Found while writing this, and worse

```python
ParamDefinition(name="total_steps", ..., default=1000, ...)   # OneCycleLR
```

Upstream, a OneCycleLR "step" is an **optimizer step — a batch**. Here the scheduler is stepped per epoch, so the default is not merely mis-scaled, it is in the wrong unit. A 50-epoch run traverses 5% of the cycle: the LR warms up slightly and never anneals, with nothing on screen indicating it.

The default is **left alone** — changing it would alter what every saved graph does, which is not a docs PR's call. The description now states what it has to be. Worth deciding separately whether the default should change.

## Two smaller corrections

- `gamma` named StepLR and ExponentialLR, but MultiStepLR reads it too, and ReduceLROnPlateau reuses it as its `factor`.
- `step_size` did not mention that MultiStepLR derives its milestones from it (1x, 2x, 3x, 4x).

zh-TW mirror updated to match.

## On testing prose

10 guards. The wording **is** the fix here, so the wording is what regresses — but each test asserts the load-bearing fact (does it say "epoch"? does it name the coupling? does it warn against the batch meaning?) rather than an exact sentence, so the prose stays editable.

`tsc -b` clean; 72 scheduler/node/API tests pass; byte scan clean.
