### PR TITLE
feat(data): give CSVReader a file picker like ImageReader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,11 @@ backend/data/images/*
 # Bundled MNIST digit used by the InferenceCNN-MNIST quick-start example
 !backend/data/images/test_digit.png
 # Per-run TensorBoard event files (core#136, TrainingLoop's `tensorboard` param).
+# Uploads for DATA_FILE params (CSVReader's file picker). User data — the
+# directory ships empty, exactly like backend/data/images/.
+backend/data/files/*
+!backend/data/files/.gitkeep
+
 backend/data/runs/
 backend/data/cifar-10-batches-py/
 backend/data/cifar-10-python.tar.gz

--- a/backend/app/api/routes_data_files.py
+++ b/backend/app/api/routes_data_files.py
@@ -1,0 +1,112 @@
+"""API routes for managing tabular / plain-data files (list, upload, download, delete).
+
+Mirrors ``routes_images.py`` — kept as a separate module so each file kind
+can evolve its own extension whitelist without branching inside one handler.
+Backs the ``DATA_FILE`` param type used by CSVReader, so a learner picks a
+file from a dropdown instead of typing a filesystem path.
+"""
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+
+from ..config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/files", tags=["files"])
+
+ALLOWED_EXTENSIONS = {".csv", ".tsv", ".txt", ".json"}
+
+
+def _safe_path(base_dir: Path, filename: str) -> Path:
+    """Resolve *filename* under *base_dir* and ensure it stays within it."""
+    resolved = (base_dir / filename).resolve()
+    if not resolved.is_relative_to(base_dir.resolve()):
+        raise HTTPException(status_code=400, detail="Invalid filename")
+    return resolved
+
+
+@router.get("")
+async def list_data_files():
+    """List all data files in the data-files directory."""
+    files_dir = settings.DATA_FILES_DIR
+    files_dir.mkdir(parents=True, exist_ok=True)
+
+    files = []
+    for f in sorted(files_dir.iterdir()):
+        if f.is_file() and f.suffix.lower() in ALLOWED_EXTENSIONS:
+            files.append({
+                "filename": f.name,
+                "size": f.stat().st_size,
+            })
+    return files
+
+
+@router.post("/upload")
+async def upload_data_file(file: UploadFile):
+    """Upload a data file."""
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="No filename provided")
+
+    safe_name = Path(file.filename).name
+    ext = Path(safe_name).suffix.lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type: {ext}. Allowed: {', '.join(sorted(ALLOWED_EXTENSIONS))}",
+        )
+
+    files_dir = settings.DATA_FILES_DIR
+    files_dir.mkdir(parents=True, exist_ok=True)
+    dest = _safe_path(files_dir, safe_name)
+
+    content = await file.read()
+    if len(content) > settings.MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="File too large")
+
+    dest.write_bytes(content)
+
+    logger.info("Uploaded data file: %s (%d bytes)", safe_name, len(content))
+    return {"filename": safe_name, "size": len(content)}
+
+
+@router.get("/download/{filename:path}")
+async def download_data_file(filename: str):
+    """Download a data file as an attachment."""
+    files_dir = settings.DATA_FILES_DIR
+    filepath = _safe_path(files_dir, filename)
+
+    if not filepath.exists():
+        raise HTTPException(status_code=404, detail=f"File not found: {filename}")
+    if not filepath.is_file():
+        raise HTTPException(status_code=400, detail="Not a file")
+    if filepath.suffix.lower() not in ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Not a data file")
+
+    logger.info("Downloading data file: %s (%d bytes)", filename, filepath.stat().st_size)
+    return FileResponse(
+        path=filepath,
+        filename=filepath.name,
+        media_type="application/octet-stream",
+    )
+
+
+@router.delete("/{filename}")
+async def delete_data_file(filename: str):
+    """Delete a data file."""
+    files_dir = settings.DATA_FILES_DIR
+    filepath = _safe_path(files_dir, filename)
+
+    if not filepath.exists():
+        raise HTTPException(status_code=404, detail=f"File not found: {filename}")
+    if not filepath.is_file():
+        raise HTTPException(status_code=400, detail="Not a file")
+    if filepath.suffix.lower() not in ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Not a data file")
+
+    filepath.unlink()
+    logger.info("Deleted data file: %s", filename)
+    return {"message": f"Deleted {filename}"}

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -186,6 +186,9 @@ class Settings(BaseSettings):
     PRESETS_DIR: Path = Path(__file__).parent / "presets"
     MODELS_DIR: Path = Path(__file__).parent.parent / "data" / "models"
     IMAGES_DIR: Path = Path(__file__).parent.parent / "data" / "images"
+    # Uploads for DATA_FILE params (CSVReader et al). Separate from IMAGES_DIR
+    # so each kind keeps its own extension whitelist and its own dropdown.
+    DATA_FILES_DIR: Path = Path(__file__).parent.parent / "data" / "files"
     EXAMPLES_DIR: Path = Path(__file__).parent.parent.parent / "examples"
 
     # ── Project directory (spec 7.1) ───────────────────────────────────

--- a/backend/app/core/node_base.py
+++ b/backend/app/core/node_base.py
@@ -38,6 +38,11 @@ class ParamType(str, Enum):
     SELECT = "select"
     MODEL_FILE = "model_file"
     IMAGE_FILE = "image_file"
+    # Tabular / plain-data upload (CSV, TSV, TXT, JSON). Same editor widget as
+    # IMAGE_FILE — a dropdown of files already uploaded to DATA_FILES_DIR plus
+    # an upload button — so a reader node never requires the learner to type a
+    # filesystem path.
+    DATA_FILE = "data_file"
     TENSOR_GRID = "tensor_grid"
     # Session-only secret (e.g. an API key). The editor masks the input and
     # never persists the value; the save endpoint and the publish pre-flight

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,7 @@ from .api import (
     routes_apps,
     routes_custom_nodes,
     routes_examples,
+    routes_data_files,
     routes_execution_outputs,
     routes_execution_state,
     routes_graph,
@@ -441,6 +442,7 @@ app.include_router(routes_plugins.router)
 app.include_router(routes_plugin_frontend.router)
 app.include_router(routes_models.router)
 app.include_router(routes_images.router)
+app.include_router(routes_data_files.router)
 app.include_router(routes_execution_outputs.router)
 app.include_router(routes_execution_state.router)
 app.include_router(routes_runs.router)

--- a/backend/app/nodes/data/csv_reader_node.py
+++ b/backend/app/nodes/data/csv_reader_node.py
@@ -61,6 +61,18 @@ class CSVReaderNode(BaseNode):
         from ...config import settings
 
         path = Path(path_str)
+        # A bare filename is what the DATA_FILE upload dropdown produces —
+        # resolve it against DATA_FILES_DIR so picking a file never depends on
+        # the working directory. Checked before the project-mode branch, and
+        # only when the value has no directory component, so existing values
+        # like "data/samples/iris.csv" keep their old resolution untouched.
+        # Living here rather than in execute() matters: cache_fingerprint()
+        # calls this too, so an uploaded file gets fingerprinted by its real
+        # contents instead of silently falling back to None.
+        if not path.is_absolute() and path.parent == Path("."):
+            candidate = settings.DATA_FILES_DIR / path.name
+            if candidate.is_file():
+                return candidate
         if settings.PROJECT_DIR is not None and not path.is_absolute():
             # The bundled sample is special-cased to the install (cwd stays
             # backend/ even in project mode) so demos keep working (spec 7.2).
@@ -117,10 +129,11 @@ class CSVReaderNode(BaseNode):
         return [
             ParamDefinition(
                 name="path",
-                param_type=ParamType.STRING,
-                default="data/samples/iris.csv",
+                param_type=ParamType.DATA_FILE,
+                default="",
                 description=(
-                    "Path to the CSV file (absolute or relative to the backend "
+                    "CSV file to read. Pick one you uploaded from the dropdown, "
+                    "or type a path (absolute, or relative to the backend "
                     "working dir; in project mode, relative paths resolve "
                     "inside the project directory)."
                 ),
@@ -160,7 +173,10 @@ class CSVReaderNode(BaseNode):
 
         path_str = str(params.get("path", "")).strip()
         if not path_str:
-            raise ValueError("CSVReader requires a non-empty `path` param.")
+            raise ValueError(
+                "CSVReader has no file selected. Pick one from the `path` "
+                "dropdown, or use the upload button next to it to add a CSV."
+            )
         path = self._resolve_path(path_str)
         if not path.exists():
             raise FileNotFoundError(f"CSVReader: file not found at {path}")

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -727,6 +727,56 @@ export interface ImageFileInfo {
   size: number;
 }
 
+// ── Data files (CSV / TSV / TXT / JSON) — backs the `data_file` param type ──
+export interface DataFileInfo {
+  filename: string;
+  size: number;
+}
+
+export async function listDataFiles(): Promise<DataFileInfo[]> {
+  const res = await fetch(`${BASE_URL}/files`);
+  if (!res.ok) throw new Error(`Failed to list data files: ${res.statusText}`);
+  return res.json();
+}
+
+export async function uploadDataFile(file: File): Promise<DataFileInfo> {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await apiFetch(`${BASE_URL}/files/upload`, {
+    method: 'POST',
+    body: form,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail ?? `Upload failed: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+export async function deleteDataFile(filename: string) {
+  const res = await apiFetch(`${BASE_URL}/files/${encodeURIComponent(filename)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error(`Delete failed: ${res.statusText}`);
+  return res.json();
+}
+
+export async function downloadDataFile(filename: string) {
+  const urlPath = filename.split('/').map(encodeURIComponent).join('/');
+  const res = await fetch(`${BASE_URL}/files/download/${urlPath}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail ?? `Download failed: ${res.statusText}`);
+  }
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename.split('/').pop() as string;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export async function listImageFiles(): Promise<ImageFileInfo[]> {
   const res = await fetch(`${BASE_URL}/images`);
   if (!res.ok) throw new Error(`Failed to list image files: ${res.statusText}`);

--- a/frontend/src/components/shared/ParamField.test.tsx
+++ b/frontend/src/components/shared/ParamField.test.tsx
@@ -4,8 +4,9 @@ import type { ParamDefinition } from '../../types';
 import { useToastStore } from '../../store/toastStore';
 import { useI18n } from '../../i18n';
 
-// Mock the REST file backends used by the model_file / image_file variants so
-// we can drive list/upload/download success + failure paths deterministically.
+// Mock the REST file backends used by the model_file / image_file / data_file
+// variants so we can drive list/upload/download success + failure paths
+// deterministically.
 vi.mock('../../api/rest', () => ({
   validateScript: vi.fn(),
   listModelFiles: vi.fn(),
@@ -14,6 +15,9 @@ vi.mock('../../api/rest', () => ({
   listImageFiles: vi.fn(),
   uploadImageFile: vi.fn(),
   downloadImageFile: vi.fn(),
+  listDataFiles: vi.fn(),
+  uploadDataFile: vi.fn(),
+  downloadDataFile: vi.fn(),
 }));
 
 import {
@@ -23,6 +27,9 @@ import {
   listImageFiles,
   uploadImageFile,
   downloadImageFile,
+  listDataFiles,
+  uploadDataFile,
+  downloadDataFile,
 } from '../../api/rest';
 vi.mock('./ScriptCodeField', () => ({
   ScriptCodeField: ({ param, displayLabel }: any) => (
@@ -57,13 +64,19 @@ beforeEach(() => {
     listImageFiles,
     uploadImageFile,
     downloadImageFile,
+    listDataFiles,
+    uploadDataFile,
+    downloadDataFile,
   ].forEach((fn) => vi.mocked(fn).mockReset());
   vi.mocked(listModelFiles).mockResolvedValue([{ filename: 'm1.pt' } as any]);
   vi.mocked(listImageFiles).mockResolvedValue([{ filename: 'a.png' } as any]);
+  vi.mocked(listDataFiles).mockResolvedValue([{ filename: 'grades.csv' } as any]);
   vi.mocked(uploadModelFile).mockResolvedValue({ filename: 'up.pt' } as any);
   vi.mocked(uploadImageFile).mockResolvedValue({ filename: 'up.png' } as any);
+  vi.mocked(uploadDataFile).mockResolvedValue({ filename: 'up.csv' } as any);
   vi.mocked(downloadModelFile).mockResolvedValue(undefined as any);
   vi.mocked(downloadImageFile).mockResolvedValue(undefined as any);
+  vi.mocked(downloadDataFile).mockResolvedValue(undefined as any);
 });
 
 afterEach(() => {
@@ -487,6 +500,33 @@ describe('ParamField — image_file FileField backend', () => {
     fireEvent.change(fileInput, { target: { files: [new File(['x'], 'n.png')] } });
     await waitFor(() => expect(uploadImageFile).toHaveBeenCalled());
     await waitFor(() => expect(onChange).toHaveBeenCalledWith('img', 'up.png'));
+  });
+});
+
+describe('ParamField — data_file FileField backend', () => {
+  it('uses the data backend list/upload', async () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ParamField param={mkParam({ name: 'path', param_type: 'data_file' })} value="" onChange={onChange} />,
+    );
+    await waitFor(() => expect(listDataFiles).toHaveBeenCalled());
+    await screen.findByRole('option', { name: 'grades.csv' });
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput.accept).toContain('.csv');
+    fireEvent.change(fileInput, { target: { files: [new File(['a,b\n1,2\n'], 'n.csv')] } });
+    await waitFor(() => expect(uploadDataFile).toHaveBeenCalled());
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('path', 'up.csv'));
+  });
+
+  it('starts empty on a fresh node rather than inheriting a previous pick', async () => {
+    // Regression guard: the dropdown lists every uploaded file, but a newly
+    // dragged node's value must stay '' until the learner picks one.
+    render(
+      <ParamField param={mkParam({ name: 'path', param_type: 'data_file' })} value="" onChange={() => {}} />,
+    );
+    await waitFor(() => expect(listDataFiles).toHaveBeenCalled());
+    await screen.findByRole('option', { name: 'grades.csv' });
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('');
   });
 });
 

--- a/frontend/src/components/shared/ParamField.tsx
+++ b/frontend/src/components/shared/ParamField.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ParamDefinition } from '../../types';
 import {
+  downloadDataFile,
   downloadImageFile,
   downloadModelFile,
+  listDataFiles,
   listImageFiles,
   listModelFiles,
+  uploadDataFile,
   uploadImageFile,
   uploadModelFile,
 } from '../../api/rest';
@@ -48,6 +51,14 @@ const IMAGE_FILE_BACKEND: FileFieldBackend = {
   download: downloadImageFile,
   accept: '.png,.jpg,.jpeg,.bmp,.webp,.gif,.tiff',
   uploadTitleKey: 'paramField.upload.image',
+};
+
+const DATA_FILE_BACKEND: FileFieldBackend = {
+  list: listDataFiles,
+  upload: uploadDataFile,
+  download: downloadDataFile,
+  accept: '.csv,.tsv,.txt,.json',
+  uploadTitleKey: 'paramField.upload.data',
 };
 
 function FileField({
@@ -200,6 +211,18 @@ export function ParamField({ param, value, onChange, label, siblingParams }: Par
         onChange={onChange}
         displayLabel={displayLabel}
         backend={IMAGE_FILE_BACKEND}
+      />
+    );
+  }
+
+  if (param.param_type === 'data_file') {
+    return (
+      <FileField
+        param={param}
+        value={value}
+        onChange={onChange}
+        displayLabel={displayLabel}
+        backend={DATA_FILE_BACKEND}
       />
     );
   }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -306,6 +306,7 @@ const en = {
   // ParamField (file picker for model / image params)
   'paramField.upload.model': 'Upload model file',
   'paramField.upload.image': 'Upload image file',
+  'paramField.upload.data': 'Upload data file (CSV)',
   'paramField.download': 'Download selected file',
   'paramField.refresh': 'Refresh file list',
   'paramField.selectFile': '-- select file --',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -292,6 +292,7 @@ const zhTW: Record<TranslationKey, string> = {
   // ParamField（模型 / 影像檔案選擇器）
   'paramField.upload.model': '上傳模型檔案',
   'paramField.upload.image': '上傳影像檔案',
+  'paramField.upload.data': '上傳資料檔案（CSV）',
   'paramField.download': '下載選取的檔案',
   'paramField.refresh': '重新整理檔案列表',
   'paramField.selectFile': '-- 選擇檔案 --',

--- a/frontend/src/plugins/contract.ts
+++ b/frontend/src/plugins/contract.ts
@@ -31,7 +31,7 @@ export interface ParamDefinition {
   name: string;
   param_type:
     | 'int' | 'float' | 'string' | 'bool'
-    | 'select' | 'model_file' | 'image_file' | 'tensor_grid' | 'secret'
+    | 'select' | 'model_file' | 'image_file' | 'data_file' | 'tensor_grid' | 'secret'
     | 'code';
   default: unknown;
   description: string;

--- a/frontend/src/plugins/contract.v2.assert.ts
+++ b/frontend/src/plugins/contract.v2.assert.ts
@@ -40,7 +40,7 @@ interface ParamDefinition {
   name: string;
   param_type:
     | 'int' | 'float' | 'string' | 'bool'
-    | 'select' | 'model_file' | 'image_file' | 'tensor_grid' | 'secret'
+    | 'select' | 'model_file' | 'image_file' | 'data_file' | 'tensor_grid' | 'secret'
     | 'code';
   default: unknown;
   description: string;

--- a/frontend/src/plugins/ops.ts
+++ b/frontend/src/plugins/ops.ts
@@ -64,8 +64,8 @@ function validateParamValue(p: ParamDefinition, value: unknown): string | null {
       if (typeof value !== 'string') return `param '${p.name}' expects a string`;
       break;
     default:
-      // model_file / image_file / tensor_grid carry editor-managed payloads;
-      // accept whatever the caller sends.
+      // model_file / image_file / data_file / tensor_grid carry
+      // editor-managed payloads; accept whatever the caller sends.
       return null;
   }
   if (typeof value === 'number') {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,6 +12,8 @@ export interface ParamDefinition {
   param_type:
     | 'int' | 'float' | 'string' | 'bool' | 'select'
     | 'model_file' | 'image_file' | 'tensor_grid' | 'secret'
+    /** Tabular / plain-data upload (CSV, TSV, TXT, JSON); same widget as image_file. */
+    | 'data_file'
     /** Multi-line Python source; rendered with a code editor (core#131). */
     | 'code';
   default: any;

--- a/scripts/templates/plugin/ui/src/sdk/types.ts
+++ b/scripts/templates/plugin/ui/src/sdk/types.ts
@@ -15,7 +15,7 @@ export interface ParamDefinition {
   name: string;
   param_type:
     | 'int' | 'float' | 'string' | 'bool'
-    | 'select' | 'model_file' | 'image_file' | 'tensor_grid' | 'secret'
+    | 'select' | 'model_file' | 'image_file' | 'data_file' | 'tensor_grid' | 'secret'
     | 'code';
   default: unknown;
   description: string;


### PR DESCRIPTION
CSVReader's `path` was a plain STRING, so the only way to point it at a file was to type a filesystem path — which a learner cannot be expected to do, and which breaks the moment a graph is shared (the path names a directory that only exists on the author's machine).

Add a `DATA_FILE` param type that reuses the ImageReader upload widget: a dropdown of files already uploaded plus an upload button. Backed by a new `/api/files` router mirroring `routes_images.py`, storing under `DATA_FILES_DIR` with its own extension whitelist (.csv/.tsv/.txt/.json) so the two dropdowns never mix.

Path resolution is additive. A bare filename — what the dropdown produces — resolves against DATA_FILES_DIR; anything with a directory component keeps the old project-dir/cwd behaviour untouched, so existing graphs (including the bundled `data/samples/iris.csv`) still load.

The default is now "" rather than a baked sample path: a graph should describe the flow, not assume a file the recipient does not have.