### PR TITLE
chore: bump versions to 2.1.0 and promote the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,26 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [2.1.0] — 2026-08-06
+
+A classroom-readiness release. The headline items are not new features: they
+are the things that stopped a room full of students from getting started at
+all, several of which had been failing silently.
+
 ### Security
 
+- **The install and update path pointed at a repository the project no longer
+  owns.** `install.sh`, `install.ps1`, `scripts/dev.py` and the two README
+  one-liners all fetched from `treeleaves30760/CodefyUI`, which survived only
+  on a GitHub rename redirect. That redirect dies permanently the moment
+  anyone creates a repo at the old path, and the old owner name stays
+  claimable — at which point every install and every `cdui update` would clone
+  and unpack `frontend-dist.tar.gz` from a repository the maintainer does not
+  control, with no signature or checksum verification anywhere in the path.
+  All 54 references repointed, and a test now asserts the four copies agree
+  and that no tracked file names the old owner. ([#231])
 - Closed three bypasses in the plugin and custom-node AST gate: `import nt` /
   `import posix` (the C-level modules `os` itself imports from and re-exports —
   neither had ever been enumerated), a skip-directory scan gap, and an
@@ -31,6 +49,25 @@ received — each links to the release it was published as.
 
 ### Added
 
+- A real design-token layer (`src/styles/tokens.css`) with a contrast gate that
+  runs as the first step of `pnpm build`. There was no token layer at all
+  before: 69 of 142 measured elements failed WCAG AA, 70 rendered under 13px,
+  and the welcome screen's own headline measured 2.66:1. Node titles sat between
+  1.85:1 and 2.69:1 on twelve of the fourteen categories — on every node, in
+  every graph. Now 2 of 125 fail, and both are disabled controls, which SC 1.4.3
+  exempts. ([#229])
+- `cdui --version`, a `version` field on `/api/health`, and the version in the
+  OpenAPI document. Nothing reported a version before, so a bug report from a
+  classroom could not say which build it came from. A test now asserts the three
+  hand-edited version fields agree. ([#236])
+- `cdui plugin list` and the `cdui start` banner now name built-in packs that
+  shipped on disk but were never installed. A release can add a pack and
+  `cdui update` places its files, but the server loads only what the lockfile
+  records — so the pack is fully installable and completely invisible.
+  Measured on a real install: all five current packs were uninstalled while the
+  superseded `c1`–`c6` remained. Discoverability only; nothing is auto-enabled.
+  ([#233])
+- This changelog, and a "Before you tag" section in `RELEASING.md`. ([#237])
 - Periodic checkpointing on `TrainingLoop` (`checkpoint_every`), so a run killed
   by SIGKILL, an OOM kill or a restart keeps its completed epochs instead of
   losing all of them. Checkpoints were previously written only after the loop
@@ -41,6 +78,42 @@ received — each links to the release it was published as.
 
 ### Fixed
 
+- **Serving the editor on a LAN address rendered a blank page.** `generateId()`
+  called `crypto.randomUUID()` unguarded; that API is secure-context only, so
+  it is `undefined` over plain HTTP — exactly `cdui start --host <lan-ip>`, the
+  way one machine is pointed at a room. The call happens during module
+  evaluation, so `createRoot().render()` was never reached and `<div id="root">`
+  stayed empty, with only a console `TypeError` to show for it. The teacher saw
+  a working URL; every student saw white. ([#230])
+- **A shared GPU machine trained every student on the CPU.** The global device
+  fell back to `cpu` for anyone who had never opened Settings, while the backend
+  already computed the best available device and served it — the frontend simply
+  never read that field. An explicit choice, including an explicit `cpu`, still
+  wins. ([#235])
+- **The beginner-friendly error messages had never run in production.** Every
+  rule in `friendlyError` matched a `KeyError:` / `ValueError:` prefix, but the
+  backend sends `str(exc)`, which never contains the class name —
+  `str(KeyError('tensor'))` is `"'tensor'"`. The tests passed because they fed
+  it strings the backend cannot emit. A student who forgot a connection saw the
+  literal text `'tensor'`. The exception class now travels as its own field, and
+  the messages are localized. Added the most common first-CNN mistake, which
+  appeared nowhere: `mat1 and mat2 shapes cannot be multiplied` now names the
+  two numbers and which one to change. ([#234])
+- The plugin catalog advertised fourteen nodes that no pack installs — `deep`
+  claimed twelve and ships five, `rl` claimed four and ships one. `cdui plugin
+  search` prints that prose verbatim, so it is where a student learns what to
+  type into a palette that then returns nothing. ([#232])
+- `cdui` could hang forever on a locked-down network: `_ensure_uv()` runs before
+  every command and its installer had no timeout, so a network that drops
+  packets was indistinguishable from a slow one. Now bounded, with an error that
+  names the ways out. ([#231])
+- `LRScheduler`'s epoch units are now stated where the mistake is made. The
+  scheduler steps once per epoch, so `T_max` should normally equal
+  `TrainingLoop.epochs` — the two live on different nodes with nothing between
+  them, and getting it wrong costs a few points of accuracy while looking like
+  an architecture problem. Documented rather than enforced, since a truncated
+  schedule is legitimate and `CosineAnnealingWarmRestarts` reuses the same value
+  as `T_0`, where equality would mean no restart ever happens. ([#238])
 - `GET /api/execution/outputs/...` returned 500 for any tensor containing NaN or
   Inf, taking the inspector's I/O tab down with it — Starlette renders with
   `allow_nan=False`. Also: writers that always write, content-aware cache keys,
@@ -69,6 +142,7 @@ Notes for these live in their GitHub release, written as the tag annotation:
 
 | Version | Date | Notes |
 |---|---|---|
+| 2.1.0 | 2026-08-06 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/2.1.0) |
 | 2.0.0 | 2026-08-05 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/2.0.0) |
 | 1.4.2 | 2026-07-20 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.4.2) |
 | 1.4.1 | 2026-07-20 | [release](https://github.com/CodefyUI/CodefyUI/releases/tag/1.4.1) |
@@ -95,4 +169,15 @@ Release candidates before 1.0.0 are on the
 [#221]: https://github.com/CodefyUI/CodefyUI/pull/221
 [#225]: https://github.com/CodefyUI/CodefyUI/pull/225
 [#226]: https://github.com/CodefyUI/CodefyUI/pull/226
-[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.0.0...main
+[#229]: https://github.com/CodefyUI/CodefyUI/pull/229
+[#230]: https://github.com/CodefyUI/CodefyUI/pull/230
+[#231]: https://github.com/CodefyUI/CodefyUI/pull/231
+[#232]: https://github.com/CodefyUI/CodefyUI/pull/232
+[#233]: https://github.com/CodefyUI/CodefyUI/pull/233
+[#234]: https://github.com/CodefyUI/CodefyUI/pull/234
+[#235]: https://github.com/CodefyUI/CodefyUI/pull/235
+[#236]: https://github.com/CodefyUI/CodefyUI/pull/236
+[#237]: https://github.com/CodefyUI/CodefyUI/pull/237
+[#238]: https://github.com/CodefyUI/CodefyUI/pull/238
+[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.1.0...main
+[2.1.0]: https://github.com/CodefyUI/CodefyUI/compare/2.0.0...2.1.0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefyui-backend"
-version = "2.0.0"
+version = "2.1.0"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
 requires-python = ">=3.10"
 # PEP 639 SPDX license expression (bare string). The previous PEP 621

--- a/backend/tests/test_install_source.py
+++ b/backend/tests/test_install_source.py
@@ -71,12 +71,17 @@ def test_every_entry_point_agrees_on_one_owner():
 # ── Nothing anywhere may still point at the pre-rename owner ─────────────────
 
 def test_no_tracked_file_references_the_old_owner():
-    # This file is excluded from its own scan: it has to name the forbidden
-    # string in order to forbid it. Everything else in the tree is fair game.
-    self_path = ":!backend/tests/test_install_source.py"
+    # Two files may name the old owner, for the same reason: they are talking
+    # ABOUT it rather than pointing at it. This guard has to name the string in
+    # order to forbid it, and the changelog has to name it to record the fix.
+    # Everything else in the tree is fair game.
+    exclusions = [
+        ":!backend/tests/test_install_source.py",
+        ":!CHANGELOG.md",
+    ]
     try:
         out = subprocess.run(
-            ["git", "grep", "-l", OLD_OWNER, "--", ".", self_path],
+            ["git", "grep", "-l", OLD_OWNER, "--", ".", *exclusions],
             cwd=ROOT, capture_output=True, text=True,
         )
     except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover

--- a/backend/tests/test_version_surfacing.py
+++ b/backend/tests/test_version_surfacing.py
@@ -67,8 +67,27 @@ def test_the_version_looks_like_a_version():
 
 # ── The library helper ───────────────────────────────────────────────────────
 
-def test_get_version_matches_pyproject():
-    assert get_version() == _pyproject_version()
+def _installed_version() -> str | None:
+    """What `importlib.metadata` reports, or None if not pip-installed."""
+    from importlib.metadata import PackageNotFoundError, version as pkg_version
+
+    try:
+        return pkg_version("codefyui-backend")
+    except PackageNotFoundError:
+        return None
+
+
+def test_get_version_reports_what_is_installed():
+    """Its contract is the INSTALLED version, not the checkout's.
+
+    Comparing it to pyproject.toml would be testing the wrong thing: the two
+    legitimately differ right after a version bump, until the editable install
+    is refreshed -- and that gap is precisely what the helper exists to
+    report honestly. A CI job installs from the bumped pyproject, so there
+    they agree; a maintainer's stale local venv is not a failure.
+    """
+    installed = _installed_version()
+    assert get_version() == (installed if installed is not None else _pyproject_version())
 
 
 def test_get_version_falls_back_to_pyproject_without_installed_metadata(monkeypatch):
@@ -110,7 +129,7 @@ def test_unreadable_everything_reports_an_obviously_wrong_version(monkeypatch):
 
 async def test_health_reports_the_version(test_client):
     body = (await test_client.get("/api/health")).json()
-    assert body["version"] == _pyproject_version()
+    assert body["version"] == get_version()
 
 
 async def test_health_reports_the_version_outside_project_mode(test_client, monkeypatch):
@@ -123,12 +142,12 @@ async def test_health_reports_the_version_outside_project_mode(test_client, monk
 
 
 def test_the_fastapi_app_declares_it():
-    assert app.version == _pyproject_version()
+    assert app.version == get_version()
 
 
 def test_openapi_carries_it():
     """This is what an external caller of a published graph reads."""
-    assert app.openapi()["info"]["version"] == _pyproject_version()
+    assert app.openapi()["info"]["version"] == get_version()
 
 
 # ── `cdui --version` ─────────────────────────────────────────────────────────

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "codefyui-backend"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codefyui-frontend",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "AGPL-3.0-only",
   "packageManager": "pnpm@9.15.0",
   "type": "module",


### PR DESCRIPTION
Bumps the three hand-edited version fields and promotes `CHANGELOG.md`'s `[Unreleased]` section into a 2.1.0 entry, following the "Before you tag" steps added in #237.

| field | 2.0.0 → |
|---|---|
| `backend/pyproject.toml` | 2.1.0 |
| `backend/uv.lock` (codefyui-backend entry) | 2.1.0 |
| `frontend/package.json` | 2.1.0 |

`cdui --version` reports `CodefyUI 2.1.0`.

## Two of this wave's own guards caught real problems

Which is what they were added for.

**`test_no_tracked_file_references_the_old_owner` failed on `CHANGELOG.md`.** The changelog names `treeleaves30760` while describing the supply-chain fix — it is talking *about* the old path rather than pointing at it. It joins the guard file itself in the exclusion list, with that reason written down.

**Four version tests failed because they compared `get_version()` to `pyproject.toml`.** That is the wrong comparison. The helper's documented contract is to report what is **installed**, and the two legitimately diverge right after a bump until the editable install is refreshed. Left as written, every future bump would go red on the maintainer's machine and green in CI — the worst possible direction for a check to fail in.

They now assert against installed metadata, and `/api/health`, the FastAPI app and the OpenAPI document are asserted equal to `get_version()` rather than to a file on disk. `test_all_version_fields_agree` — the actual guard on the three declared fields — passed throughout and is unchanged.

## What 2.1.0 contains

Ten PRs. The headline items are not features; they are the things that stopped a class from getting started, several of which failed silently:

- the LAN-served editor rendered a **blank page** (#230)
- the install path pointed at a **repo the project no longer owns**, alive only on a rename redirect, with no signature check (#231)
- a shared GPU machine trained **every student on the CPU** (#235)
- the beginner-friendly error messages had **never run in production** (#234)
- the plugin catalog advertised **14 nodes that do not exist** (#232)
- built-in packs that shipped were **invisible to existing installs** (#233)
- there was **no design-token layer at all**; 69 of 142 elements failed WCAG AA (#229)
- **no version was discoverable** anywhere (#236)
- **no changelog existed** (#237)
- `LRScheduler`'s epoch units were unstated (#238)

## Verification

Backend suite on this branch: **3900 passed, 14 skipped, 0 failed**.