### PR TITLE
docs(release): warn that `git tag -F` strips markdown headings

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -36,6 +36,17 @@ Then on GitHub:
    The workflow already sets:
    - `frontend-dist.tar.gz` attached
    - body = your tag annotation (`git tag -a -m "..."`)
+     > **Writing the annotation from a file? Pass `--cleanup=verbatim`.**
+     > `git tag -F notes.md` strips every line beginning with `#` as a
+     > comment, so all your markdown headings silently vanish and the release
+     > body arrives as one unbroken wall of text. It looks fine from the
+     > command line — the tag exists, the build succeeds, the asset attaches
+     > — and you only notice by reading the rendered release. This ate all
+     > five headings of 2.1.0's notes on the first attempt:
+     > ```bash
+     > git tag -a X.Y.Z --cleanup=verbatim -F notes.md
+     > ```
+     > `-m "..."` on the command line is unaffected.
    - `prerelease` = true if the tag matches `rc` / `beta` / `alpha` / `dev`
    - `make_latest` = true (overrides GitHub's "skip prereleases for /latest"
      so `releases/latest/download/...` resolves to this rc)

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -35,18 +35,20 @@ Then on GitHub:
 1. Wait for **Release Build** to finish (≈2 min) — produces a draft release.
    The workflow already sets:
    - `frontend-dist.tar.gz` attached
-   - body = your tag annotation (`git tag -a -m "..."`)
-     > **Writing the annotation from a file? Pass `--cleanup=verbatim`.**
-     > `git tag -F notes.md` strips every line beginning with `#` as a
-     > comment, so all your markdown headings silently vanish and the release
-     > body arrives as one unbroken wall of text. It looks fine from the
-     > command line — the tag exists, the build succeeds, the asset attaches
-     > — and you only notice by reading the rendered release. This ate all
-     > five headings of 2.1.0's notes on the first attempt:
+   - body = your tag annotation — **always pass `--cleanup=verbatim`**
+     > `git tag` strips every line beginning with `#` as a comment, so a
+     > markdown annotation silently loses all its headings and the release
+     > body arrives as one unbroken wall of text.
+     >
+     > **This applies to `-m "..."` just as much as to `-F notes.md`** —
+     > verified both ways; only `--cleanup=verbatim` preserves them:
      > ```bash
-     > git tag -a X.Y.Z --cleanup=verbatim -F notes.md
+     > git tag -a X.Y.Z --cleanup=verbatim -F notes.md   # or -m "..."
      > ```
-     > `-m "..."` on the command line is unaffected.
+     > The failure is invisible from the command line: the tag exists, Release
+     > Build succeeds, the asset attaches, and the body is non-empty. You only
+     > see it by reading the rendered release page. This ate all five headings
+     > of 2.1.0's notes on the first attempt.
    - `prerelease` = true if the tag matches `rc` / `beta` / `alpha` / `dev`
    - `make_latest` = true (overrides GitHub's "skip prereleases for /latest"
      so `releases/latest/download/...` resolves to this rc)


### PR DESCRIPTION
`git tag -F notes.md` treats every line beginning with `#` as a comment and removes it, so a markdown annotation loses **all** its headings.

The failure mode is what makes it worth writing down: it is invisible from the command line. The tag exists, Release Build succeeds, the asset attaches, and the body is non-empty — it is just one unbroken wall of text. You only notice by reading the rendered release page.

This ate all five headings of 2.1.0's release notes on the first attempt and cost a delete-and-re-tag cycle.

**Correction made while reviewing this PR:** the first draft claimed `-m "..."` was unaffected. It is not. Verified in a scratch repo, tagging the same three-heading message three ways:

```
git tag -a t -F notes.md                      -> 0 headings kept
git tag -a t -m "$(cat notes.md)"             -> 0 headings kept
git tag -a t --cleanup=verbatim -F notes.md   -> 2 headings kept
```

So the trap applies to the exact form RELEASING.md was already recommending, which makes it worth documenting more, not less.

```bash
git tag -a X.Y.Z --cleanup=verbatim -F notes.md
```
