### PR TITLE
chore: bump versions to 2.1.1 and promote the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,35 @@ received — each links to the release it was published as.
 
 Nothing yet.
 
+## [2.1.1] — 2026-08-08
+
+A small release cut for one reason: the CSVReader file picker landed on `main`
+two commits after the 2.1.0 tag, so nobody running a released version had it.
+The textbook's I1-1 lab instructs students to upload `grades.csv` through that
+picker, which made the instructions false for every installed copy. Shipping it
+is the fix.
+
+### Added
+
+- **`CSVReader` gets a file picker, like `ImageReader` already had** ([#239],
+  contributed by [@oyea0801]). `path` was a free-text field defaulting to
+  `data/samples/iris.csv`, so using your own CSV meant knowing where CodefyUI
+  keeps its data directory and typing a path relative to it. It is now a
+  dropdown plus an upload button: pick the file off your machine and it stays
+  in the dropdown for every later graph. The default is now empty — a starter
+  graph should not name a file that only exists on the author's computer.
+  Adds `/api/files` for listing and uploading data files.
+
+  The eight shipped example graphs that read a CSV all set `path` explicitly
+  with a directory component, so the changed default does not affect them.
+
+### Fixed
+
+- **The release guide gave advice that was wrong in one detail** ([#241]).
+  It said `git tag -m "..."` was unaffected by the comment-stripping that eats
+  markdown headings from tag annotations. It is not — `-m` loses them exactly
+  as `-F` does, verified both ways. Only `--cleanup=verbatim` preserves them.
+
 ## [2.1.0] — 2026-08-06
 
 A classroom-readiness release. The headline items are not new features: they
@@ -179,5 +208,9 @@ Release candidates before 1.0.0 are on the
 [#236]: https://github.com/CodefyUI/CodefyUI/pull/236
 [#237]: https://github.com/CodefyUI/CodefyUI/pull/237
 [#238]: https://github.com/CodefyUI/CodefyUI/pull/238
-[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.1.0...main
+[#239]: https://github.com/CodefyUI/CodefyUI/pull/239
+[#241]: https://github.com/CodefyUI/CodefyUI/pull/241
+[@oyea0801]: https://github.com/oyea0801
+[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...main
+[2.1.1]: https://github.com/CodefyUI/CodefyUI/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/CodefyUI/CodefyUI/compare/2.0.0...2.1.0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefyui-backend"
-version = "2.1.0"
+version = "2.1.1"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
 requires-python = ">=3.10"
 # PEP 639 SPDX license expression (bare string). The previous PEP 621

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "codefyui-backend"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codefyui-frontend",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "AGPL-3.0-only",
   "packageManager": "pnpm@9.15.0",
   "type": "module",


### PR DESCRIPTION
Cuts 2.1.1 so the two commits that landed after the 2.1.0 tag actually reach users.

## Why now, rather than waiting

`git rev-list -n1 2.1.0` is `a6175d9`. Two commits sit above it on `main`:

- `23514ca` — #239, CSVReader file picker
- `b3496b9` — #241, release-doc correction

The first one is the reason this is not just housekeeping. The textbook PR that realigns the I-series labs (AI-Algo-Textbook#78) rewrote I1-1 to say:

> 點一下 `CSVReader` 節點，右側參數面板的 `path` 是一個下拉選單加一個上傳按鈕

On 2.1.0 that is false. `git show 2.1.0:backend/app/nodes/data/csv_reader_node.py` still has `path` as `ParamType.STRING` defaulting to `data/samples/iris.csv`. A student installs 2.1.0, follows the lab, and looks for an upload button that is not there.

Note the asymmetry: I1-2 says the same thing about `ImageReader`, and that one **is** true on 2.1.0 — `ImageReader.path` has been `ParamType.IMAGE_FILE` all along. #239 was written to bring CSVReader up to it. So exactly one lab section is ahead of the release, and shipping closes the gap rather than requiring the textbook to be walked back.

## What is in it

Three hand-edited version fields plus the changelog promotion — the RELEASING.md step-1 checklist, nothing else. `test_all_version_fields_agree` passes (14 tests in `test_version_surfacing.py`).

## After merge

Tag with `--cleanup=verbatim`, per the warning #241 just added.