### PR TITLE
fix(training): warn when an LR schedule's length disagrees with the run it feeds, and raise the torch floor to 2.5 (#244, #192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,39 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- **A learning-rate schedule whose length did not match the run said nothing**
+  ([#252]). `TrainingLoop` steps the scheduler once per epoch, so every
+  cycle-length parameter on `LRScheduler` counts epochs — while PyTorch counts
+  batches for several of the same parameters, and nothing reconciled the two.
+  A schedule could therefore be entirely wrong without one thing going red: no
+  exception, no warning, a loss curve that looks normal, and an accuracy a few
+  points short.
+
+  Worst was `OneCycleLR.total_steps`, whose default of 1000 is a plausible
+  batch count and an impossible epoch count: at 20 epochs the run traverses 2%
+  of the cycle, so the learning rate warms up and never anneals — for a user
+  who changed nothing. `CosineAnnealingLR.T_max` disagreeing with
+  `TrainingLoop.epochs` is the same trap one step less silent.
+
+  `TrainingLoop` now compares the two before the first epoch runs and says so
+  in the server log, in the run log the Runs panel reads back, and in the
+  canvas Log tab. Advisory only: it never changes the schedule and never fails
+  the run, because a truncated schedule is a legitimate choice. The default of
+  1000 is deliberately unchanged — a new default would rewrite what every
+  already-saved graph does, silently, on update. `CosineAnnealingWarmRestarts`
+  is inverted rather than exempt: it reuses the same value as `T_0`, where
+  equality would mean no restart ever happens.
+
+### Changed
+
+- **The declared torch floor is 2.5, up from 2.0.0** ([#252]). It is the
+  version the code already assumed: `torch.OutOfMemoryError` arrived there, and
+  the OOM classifier had been carrying a second lookup for the pre-2.5 spelling
+  that nothing exercised. That branch is gone; the message match stays, since
+  it is how MPS and out-of-tree backends report an OOM on any torch. Installs
+  on torch 2.0-2.4 are no longer supported.
 
 ## [2.1.1] — 2026-08-08
 
@@ -210,6 +242,7 @@ Release candidates before 1.0.0 are on the
 [#238]: https://github.com/CodefyUI/CodefyUI/pull/238
 [#239]: https://github.com/CodefyUI/CodefyUI/pull/239
 [#241]: https://github.com/CodefyUI/CodefyUI/pull/241
+[#252]: https://github.com/CodefyUI/CodefyUI/pull/252
 [@oyea0801]: https://github.com/oyea0801
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...main
 [2.1.1]: https://github.com/CodefyUI/CodefyUI/compare/2.1.0...2.1.1

--- a/backend/app/core/error_handling.py
+++ b/backend/app/core/error_handling.py
@@ -123,17 +123,22 @@ def is_out_of_memory(exc: BaseException) -> bool:
 
     Three shapes, because torch has three:
 
-    * the dedicated exception class, under BOTH of its spellings.
-      ``torch.cuda.OutOfMemoryError`` is the one that exists on 2.0-2.4 --
-      precisely the range this project's declared floor still admits --
-      and ``torch.OutOfMemoryError`` is the 2.5+ name it became an alias
-      of. Checking only the newer spelling would leave the older builds
-      relying on the message match below, which is the fallback rather
-      than the answer.
+    * ``torch.OutOfMemoryError``, the dedicated exception class. It arrived
+      in 2.5 and ``torch.cuda.OutOfMemoryError`` -- the only spelling on
+      2.0-2.4 -- is an alias of it from that release on, so with the 2.5
+      floor this project declares (core#192) the one name covers both. The
+      second ``getattr`` this used to do was a degradation path for
+      versions the floor no longer admits, and a second unexercised way to
+      detect the same condition is worse than none.
     * a plain ``RuntimeError`` whose message says so -- MPS reports
       ``"MPS backend out of memory"`` this way, and so do several
-      out-of-tree backends;
+      out-of-tree backends. NOT a version fallback: this is the only shape
+      those backends ever raise, on any torch.
     * a ``MemoryError``, which is what the CPU allocator raises.
+
+    The ``import torch`` still cannot be assumed to succeed -- ``app.core``
+    is imported by CLI paths that run without it -- so the lookup stays
+    defensive about the module, not about the attribute.
 
     The message match is deliberately narrow (``out of memory`` /
     ``CUDA out of memory``) so an unrelated RuntimeError is never dressed up
@@ -144,14 +149,7 @@ def is_out_of_memory(exc: BaseException) -> bool:
     try:
         import torch
 
-        oom_types = tuple({
-            candidate for candidate in (
-                getattr(torch, "OutOfMemoryError", None),
-                getattr(torch.cuda, "OutOfMemoryError", None),
-            )
-            if isinstance(candidate, type)
-        })
-        if oom_types and isinstance(exc, oom_types):
+        if isinstance(exc, torch.OutOfMemoryError):
             return True
     except Exception:  # noqa: BLE001 - classification must never raise
         pass

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -300,6 +300,227 @@ def _prepare_scheduler(
     return lr_scheduler
 
 
+#: Prefix every schedule-length note carries into the canvas log. The Log
+#: tab has no warning severity (``LogEntry.type`` is info/error/success), so
+#: the marker in the text is the only thing distinguishing an advisory from
+#: a ``Print`` node's output -- the same device ``PythonScript`` uses for its
+#: dropped-key notes.
+SCHEDULE_NOTE_PREFIX = "[TrainingLoop] "
+
+#: ``kind`` on the ``WarningSignal`` these notes are also sent as, which is
+#: what a client would branch on. Stable token; the sentence is the detail.
+SCHEDULE_WARNING_KIND = "lr_schedule_mismatch"
+
+#: The fact every one of the notes below is a consequence of.
+_PER_EPOCH = (
+    "TrainingLoop steps the scheduler once per EPOCH, so this parameter "
+    "counts epochs, not batches"
+)
+
+
+def _schedule_length_note(lr_scheduler: Any, epochs: int) -> str | None:
+    """One sentence about a schedule that does not fit this run, or ``None``.
+
+    Every scheduler ``LRScheduler`` builds is stepped once per EPOCH by the
+    loop below, while PyTorch's own documentation counts optimizer steps for
+    several of the same parameters. The two units are off by
+    ``len(dataloader)``, and nothing anywhere reconciles them -- so a
+    schedule can be entirely wrong for a run without a single thing going
+    red. That is the whole of #205 and #244:
+
+    * ``CosineAnnealingLR.T_max`` larger than ``epochs`` stops the run
+      partway down the cosine (the LR never reaches its minimum); smaller
+      than ``epochs`` is worse, because the cosine turns back UP past
+      ``T_max`` and the tail of the run trains at a rising LR. Either way
+      the loss curve looks plausible and the accuracy is simply a few
+      points short -- the size of gap people then go hunting for in their
+      augmentation.
+    * ``OneCycleLR.total_steps`` defaults to **1000** on the node, which is
+      a plausible batch count and an impossible epoch count. At 20 epochs
+      the run traverses 2% of the cycle: the LR warms up and never anneals,
+      which is the entire point of one-cycle. This one bites a user who
+      changed nothing. In the other direction it does not fail silently at
+      all -- ``OneCycleLR`` raises ``Tried to step N times`` and takes the
+      run with it, which is worth saying BEFORE the epochs that reach it.
+
+    Deliberately advisory, never fatal (#244 option 4, #205's "why not just
+    validate it"): a truncated schedule is a legitimate choice, and refusing
+    to run is too aggressive for a teaching tool.
+
+    ``CosineAnnealingWarmRestarts`` is the exception that stops this being a
+    universal "must equal epochs" rule, and it is inverted rather than
+    exempt: it reuses the node's ``T_max`` as ``T_0``, the length of the
+    FIRST cycle, so equality with ``epochs`` means no restart EVER happens.
+    It is warned about when ``T_0 >= epochs``, and silent below.
+
+    Read off the SCHEDULER OBJECT rather than the ``LRScheduler`` node's
+    params, so the check also covers a scheduler restored from a checkpoint,
+    built by a plugin node, or subclassed -- and so it describes what will
+    actually run rather than what was typed.
+    """
+    import torch.optim.lr_scheduler as sched_module
+
+    if lr_scheduler is None:
+        return None
+    try:
+        epochs = int(epochs)
+    except (TypeError, ValueError):
+        return None
+    if epochs < 1:
+        return None
+
+    def _count(attr: str) -> int | None:
+        """*attr* as a plain positive int, or None if it is anything else.
+
+        A plugin scheduler may carry a tensor, a float or nothing at all
+        under these names. An advisory has no business guessing.
+        """
+        value = getattr(lr_scheduler, attr, None)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            return None
+        return value
+
+    # Checked before CosineAnnealingLR only for the reader's sake: the two
+    # are siblings under LRScheduler, not parent and child, so the order
+    # cannot actually matter.
+    if isinstance(lr_scheduler, sched_module.CosineAnnealingWarmRestarts):
+        t_0 = _count("T_0")
+        if t_0 is not None and t_0 >= epochs:
+            return (
+                f"CosineAnnealingWarmRestarts restarts every T_0={t_0} epochs "
+                f"but TrainingLoop.epochs={epochs}, so no restart will ever "
+                f"happen and this run is a single cosine decay with extra "
+                f"steps. Warm restarts need T_0 SMALLER than epochs -- note "
+                f"this is the opposite of CosineAnnealingLR, where equality "
+                f"is the right setting. T_0 comes from LRScheduler.T_max."
+            )
+        return None
+
+    if isinstance(lr_scheduler, sched_module.CosineAnnealingLR):
+        t_max = _count("T_max")
+        if t_max is None or t_max == epochs:
+            return None
+        if t_max > epochs:
+            consequence = (
+                f"the run covers only {epochs} of the {t_max} epochs the "
+                f"cosine needs, so the learning rate never reaches its minimum"
+            )
+        else:
+            consequence = (
+                f"past T_max the cosine turns back UP, so the last "
+                f"{epochs - t_max} epoch(s) train at a RISING learning rate"
+            )
+        return (
+            f"CosineAnnealingLR anneals over T_max={t_max} epochs but "
+            f"TrainingLoop.epochs={epochs} ({_PER_EPOCH}) -- {consequence}. "
+            f"Set LRScheduler.T_max to {epochs} unless the mismatch is "
+            f"deliberate; nothing will fail either way, the accuracy is just "
+            f"quietly worse."
+        )
+
+    if isinstance(lr_scheduler, sched_module.OneCycleLR):
+        total = _count("total_steps")
+        if total is None or total == epochs:
+            return None
+        if total > epochs:
+            percent = 100.0 * epochs / total
+            return (
+                f"OneCycleLR spans total_steps={total} but "
+                f"TrainingLoop.epochs={epochs} ({_PER_EPOCH}) -- this run "
+                f"traverses only {percent:.1f}% of the one-cycle schedule, so "
+                f"the learning rate warms up and NEVER anneals, which is the "
+                f"whole point of one-cycle. Set LRScheduler.total_steps to "
+                f"{epochs}: it is an epoch count here, not the batch count "
+                f"OneCycleLR's own documentation means by a step."
+            )
+        return (
+            f"OneCycleLR spans total_steps={total} but "
+            f"TrainingLoop.epochs={epochs} ({_PER_EPOCH}) -- it will raise "
+            f"\"Tried to step {total + 1} times\" at the end of epoch "
+            f"{total + 1} and take the run down with it. Set "
+            f"LRScheduler.total_steps to {epochs}."
+        )
+
+    # The remaining two are not cycle lengths but periods, and only the
+    # degenerate case is reported: a scheduler wired into a run too short to
+    # ever reach its first drop does nothing at all, which is the same
+    # silent-accuracy-loss shape as the cosine cases above and the one
+    # reading of "the two disagree" that has no legitimate counter-example.
+    # A period merely LONGER than ideal is a tuning choice and stays silent.
+    if isinstance(lr_scheduler, sched_module.MultiStepLR):
+        milestones = getattr(lr_scheduler, "milestones", None)
+        try:
+            first = min(int(m) for m in milestones)
+        except (TypeError, ValueError):
+            return None
+        if first < epochs:
+            return None
+        return (
+            f"MultiStepLR's earliest milestone is epoch {first} but "
+            f"TrainingLoop.epochs={epochs} ({_PER_EPOCH}) -- no drop will "
+            f"ever happen and the run trains at a constant learning rate. "
+            f"Lower LRScheduler.step_size below {epochs}; the milestones are "
+            f"1x, 2x, 3x and 4x that value."
+        )
+
+    if isinstance(lr_scheduler, sched_module.StepLR):
+        step_size = _count("step_size")
+        if step_size is None or step_size < epochs:
+            return None
+        return (
+            f"StepLR drops the learning rate every {step_size} epochs but "
+            f"TrainingLoop.epochs={epochs} ({_PER_EPOCH}) -- the drop never "
+            f"happens and the run trains at a constant learning rate. Lower "
+            f"LRScheduler.step_size below {epochs}, or drop the scheduler."
+        )
+
+    # ExponentialLR decays every epoch (no length to disagree about) and
+    # ReduceLROnPlateau is metric-driven, so neither can be checked against
+    # an epoch count at all.
+    return None
+
+
+def _report_schedule_length(
+    lr_scheduler: Any, epochs: int, context: Any
+) -> str | None:
+    """Emit :func:`_schedule_length_note` everywhere it can be seen.
+
+    Three surfaces, because no single one reaches everybody:
+
+    * ``logger.warning`` -- the server console and the rotating log file.
+      The ONLY channel a ``run_graph.py`` invocation or an exported Python
+      script has at all.
+    * ``context.log_warning`` -- the run's durable event log, which the Runs
+      panel reads back as a ``warning``-toned line while the run is still
+      going. This is the one that arrives on TIME: it is queued the moment
+      the check runs, before the first epoch.
+    * the returned string, which the caller puts in the node's ``__log__``
+      so it also lands in the canvas Log tab. That one only appears when the
+      node finishes -- late, but the canvas has no earlier channel for it
+      (``useGraphExecution`` registers no ``run_warning`` handler and
+      ``LogEntry.type`` has no warning severity).
+
+    Never raises: an advisory must not be able to fail the run it is about.
+    """
+    try:
+        note = _schedule_length_note(lr_scheduler, epochs)
+    except Exception:  # noqa: BLE001 - a note is never worth an exception
+        logger.debug("could not check the LR schedule's length", exc_info=True)
+        return None
+    if note is None:
+        return None
+
+    logger.warning("%s", note)
+    log_warning = getattr(context, "log_warning", None)
+    if callable(log_warning):
+        try:
+            log_warning(SCHEDULE_WARNING_KIND, note)
+        except Exception:  # noqa: BLE001 - see above
+            logger.debug("could not record the LR schedule warning",
+                         exc_info=True)
+    return SCHEDULE_NOTE_PREFIX + note
+
+
 class TrainingLoopNode(BaseNode):
     """Train a model, optionally resuming a previous run.
 
@@ -412,6 +633,17 @@ class TrainingLoopNode(BaseNode):
     it instead; requesting ``val_accuracy`` without either gate above
     holding falls back to ``val_loss`` with a warning rather than
     comparing against a value that was never computed.
+
+    **The schedule's length (#205, #244).** The scheduler is stepped once
+    per EPOCH (the ``LR Scheduler step`` block below), which makes every
+    cycle-length parameter on ``LRScheduler`` an epoch count -- including
+    the two PyTorch itself counts batches for. Before the first epoch runs,
+    :func:`_schedule_length_note` compares the schedule the node was handed
+    against ``epochs`` and says so when they disagree, on the server log, on
+    the run's durable event log (the Runs panel) and in the node's
+    ``__log__`` (the canvas Log tab). Advisory only: it never changes the
+    schedule and never fails the run, because a truncated schedule is a
+    legitimate choice.
     """
 
     NODE_NAME = "TrainingLoop"
@@ -781,6 +1013,16 @@ class TrainingLoopNode(BaseNode):
         # it is usable for this model -- see _prepare_optimizer for the rule.
         optimizer, optimizer_mode = _prepare_optimizer(optimizer, model)
         lr_scheduler = _prepare_scheduler(lr_scheduler, optimizer, start_epoch, optimizer_mode)
+
+        # #205 / #244: does the schedule's length agree with this run's? The
+        # comparison is only possible HERE -- LRScheduler cannot see the
+        # TrainingLoop it feeds (nothing on ExecutionContext exposes the
+        # graph) and validate_graph has no non-fatal channel to say it in.
+        # Checked against the ABSOLUTE ``epochs``, not ``epochs -
+        # start_epoch``: a resumed scheduler is fast-forwarded to
+        # ``start_epoch`` by _prepare_scheduler, so the schedule still spans
+        # the whole run.
+        schedule_note = _report_schedule_length(lr_scheduler, epochs, context)
 
         if start_epoch >= epochs:
             logger.warning(
@@ -1429,6 +1671,13 @@ class TrainingLoopNode(BaseNode):
             # expects to see for "there is no loss scale to store".
             "grad_scaler_state": policy.state_dict(),
         }
+        if schedule_note is not None:
+            # The canvas half of #205/#244. ``__log__`` is the only result
+            # key the Log tab renders, and dunder-prefixed keys are filtered
+            # out of recorded outputs and port summaries, so this adds a log
+            # line and nothing else. Set unconditionally of how the run
+            # ended -- an interrupted run's schedule was just as wrong.
+            result["__log__"] = schedule_note
         if stopped_at is not None:
             result.update(interrupted_result(
                 epoch=completed_epochs, batch=stopped_at["batch"],

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,16 +31,19 @@ dependencies = [
     "numpy>=1.24.0",
     "matplotlib>=3.7.0",
     "Pillow>=10.0.0",
-    # NOTE (core#135): this floor is optimistic and has been for a while.
-    # `torch.OutOfMemoryError` (the class `error_handling.is_out_of_memory`
-    # prefers) arrived in 2.5, and `torch.amp.GradScaler(device=...)` -- the
-    # non-deprecated spelling the fp16 path uses -- in 2.4. Nothing BREAKS
-    # below those: the OOM classifier reaches the type through `getattr` and
-    # falls back to matching the message, and `AmpPolicy.for_device` catches
-    # a scaler it cannot build and degrades to fp32 with a warning. Raising
-    # the floor to 2.5 would be honest, and it needs a `uv.lock` regeneration
-    # that does not belong in this change.
-    "torch>=2.0.0",
+    # 2.5 is the floor the code actually assumes (core#192, split out of
+    # core#135). `torch.OutOfMemoryError` -- the public typed alias
+    # `error_handling.is_out_of_memory` matches on -- arrived in 2.5, and
+    # `torch.amp.GradScaler(device=...)`, the non-deprecated spelling the
+    # fp16 path uses, in 2.4. The declared floor said 2.0.0 while both of
+    # those carried a degradation path for versions nobody was testing;
+    # raising it is what let the OOM classifier's older-spelling branch go
+    # away instead of being a second, unexercised way to detect the same
+    # condition. NOTE: `backend/uv.lock` must be regenerated in the SAME
+    # commit as any change to this line -- `backend-test.yml` runs
+    # `uv lock --check` BEFORE it installs anything, so a pyproject-only
+    # bump fails all three matrices in about ten seconds.
+    "torch>=2.5",
     "torchvision>=0.15.0",
     "gymnasium>=0.29.0",
     "safetensors>=0.4.0",

--- a/backend/tests/test_checkpoint_node.py
+++ b/backend/tests/test_checkpoint_node.py
@@ -122,7 +122,7 @@ def test_scheduler_state_roundtrip(sched_type):
     take the **model weights** down with it. The saver therefore has to store
     something the loader can always read back, for every type the
     ``LRScheduler`` node is able to produce -- and torch has changed what those
-    state dicts contain between releases (this repo pins only ``torch>=2.0``,
+    state dicts contain between releases (this repo pins only ``torch>=2.5``,
     so CI resolves whatever is newest).
 
     The type to watch is ``MultiStepLR.milestones``, which is a

--- a/backend/tests/test_lr_schedule_length.py
+++ b/backend/tests/test_lr_schedule_length.py
@@ -1,0 +1,399 @@
+"""A learning-rate schedule that does not fit the run must SAY so (#205, #244).
+
+`TrainingLoop` steps the scheduler once per epoch, so every cycle-length
+parameter on `LRScheduler` is an epoch count -- including the two PyTorch
+itself counts optimizer steps for. Nothing reconciles the units, and nothing
+ever failed when they disagreed: the loss curve looks plausible and the
+accuracy is merely worse, which is the size of gap people then go hunting for
+in their augmentation or their architecture.
+
+Two shapes of that, and the second is the one that matters most:
+
+* `CosineAnnealingLR.T_max` different from `TrainingLoop.epochs` (#205) --
+  requires the user to have SET something wrong.
+* `OneCycleLR.total_steps` left at the node's default of 1000 (#244) --
+  requires the user to have changed NOTHING. Pick OneCycleLR from the
+  dropdown, press Run, and the schedule silently does not work.
+
+`test_the_default_one_cycle_schedule_really_does_never_anneal` and
+`test_a_short_cosine_really_does_raise_the_lr_back_up` are here so the rest
+of the file is testing a warning about something real, not a warning about a
+belief. Everything else asserts the advisory reaches a surface a user can
+actually read, and that it never fails a run to do it -- a truncated schedule
+is a legitimate choice (#244 option 4 was rejected on exactly that ground).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.optim.lr_scheduler as sched_module
+
+from app.core.execution_context import ExecutionContext, WarningSignal
+from app.nodes.training.training_loop_node import (
+    SCHEDULE_NOTE_PREFIX,
+    SCHEDULE_WARNING_KIND,
+    TrainingLoopNode,
+    _schedule_length_note,
+)
+
+
+def _loader(n=8, in_features=4, out_classes=2, batch_size=4):
+    X = torch.randn(n, in_features)
+    y = torch.randint(0, out_classes, (n,))
+    return torch.utils.data.DataLoader(
+        torch.utils.data.TensorDataset(X, y), batch_size=batch_size)
+
+
+def _train(scheduler_factory, epochs, *, context=None, lr=0.1):
+    """One tiny run with the scheduler *scheduler_factory* builds.
+
+    Returns the node's result. The scheduler is built over the same
+    optimizer the loop is handed, which is what `LRScheduler` does.
+    """
+    torch.manual_seed(0)
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=lr)
+    return TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": _loader(),
+            "optimizer": optimizer,
+            "loss_fn": nn.CrossEntropyLoss(),
+            "lr_scheduler": scheduler_factory(optimizer),
+        },
+        {"epochs": epochs, "device": "cpu"},
+        context=context,
+    )
+
+
+def _one_cycle(total_steps, max_lr=0.1):
+    return lambda opt: sched_module.OneCycleLR(
+        opt, max_lr=max_lr, total_steps=total_steps)
+
+
+def _cosine(t_max):
+    return lambda opt: sched_module.CosineAnnealingLR(opt, T_max=t_max)
+
+
+def _warnings_on(context: ExecutionContext) -> list[WarningSignal]:
+    signals, _dropped = context.outbox.drain()
+    return [s for s in signals if isinstance(s, WarningSignal)]
+
+
+# ── the traps are real ────────────────────────────────────────────────────
+
+
+def test_the_default_one_cycle_schedule_really_does_never_anneal():
+    """#244's claim, measured: at the node's default the LR only ever rises.
+
+    `total_steps=1000` over a realistic 5 epochs traverses 0.5% of the
+    cycle. One-cycle's entire benefit is the anneal -- the high-LR phase
+    explores, the low-LR phase converges -- and it never arrives.
+    """
+    res = _train(_one_cycle(1000), epochs=5)
+    history = res["metrics"]["lr_history"]
+
+    assert history == sorted(history), "the LR should still be climbing"
+    assert max(history) < 0.1 * 0.05, (
+        f"the LR barely left the floor: {history}")
+
+    # The same schedule told the truth about the run length does anneal, all
+    # the way to zero. This is the accuracy the default silently forfeits.
+    matched = _train(_one_cycle(5), epochs=5)["metrics"]["lr_history"]
+    assert max(matched) > 0.5 * 0.1, "the warm-up should reach near max_lr"
+    assert matched[-1] < matched[0], "the anneal should come back down"
+
+
+def test_a_short_cosine_really_does_raise_the_lr_back_up():
+    """#205's "worse in a different way": past T_max the cosine turns up."""
+    history = _train(_cosine(3), epochs=6)["metrics"]["lr_history"]
+    bottom = history.index(min(history))
+    assert bottom < len(history) - 1, "the minimum should not be the last epoch"
+    assert history[-1] > history[bottom], (
+        f"the tail should be climbing again: {history}")
+
+
+def test_one_cycle_shorter_than_the_run_takes_the_run_down():
+    """The other direction is not silent at all -- it raises mid-run.
+
+    Which is exactly why the advisory is worth emitting BEFORE the epochs
+    that reach it, rather than letting a user discover it forty minutes in.
+    """
+    with pytest.raises(ValueError, match="Tried to step"):
+        _train(_one_cycle(2), epochs=5)
+
+
+# ── what the note says ────────────────────────────────────────────────────
+
+
+def test_the_default_one_cycle_total_steps_is_reported():
+    """The #244 case: the user changed nothing and gets told anyway."""
+    note = _schedule_length_note(
+        _one_cycle(1000)(torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)),
+        epochs=20,
+    )
+    assert note is not None
+    assert "total_steps=1000" in note and "epochs=20" in note
+    # The consequence, in the words the failure does not give the user.
+    assert "never anneal" in note.lower()
+    # And the correction, spelled out as an epoch count -- the unit is the
+    # whole trap, so naming the number without the unit would not fix it.
+    assert "Set LRScheduler.total_steps to 20" in note
+    assert "not the batch count" in note
+
+
+def test_a_matching_one_cycle_says_nothing():
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    assert _schedule_length_note(_one_cycle(20)(opt), epochs=20) is None
+
+
+def test_a_one_cycle_shorter_than_the_run_names_the_crash_it_will_cause():
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    note = _schedule_length_note(_one_cycle(4)(opt), epochs=20)
+    assert note is not None
+    assert "Tried to step 5 times" in note
+
+
+@pytest.mark.parametrize(
+    "t_max, epochs, expected",
+    [
+        (200, 100, "never reaches its minimum"),
+        (50, 100, "RISING learning rate"),
+    ],
+)
+def test_a_cosine_that_disagrees_with_epochs_names_its_own_consequence(
+        t_max, epochs, expected):
+    """The two directions fail differently, so they read differently."""
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    note = _schedule_length_note(_cosine(t_max)(opt), epochs=epochs)
+    assert note is not None
+    assert expected in note
+    assert f"T_max={t_max}" in note and f"epochs={epochs}" in note
+
+
+def test_a_matching_cosine_says_nothing():
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    assert _schedule_length_note(_cosine(100)(opt), epochs=100) is None
+
+
+# ── warm restarts are the inverted case, not an exempt one ────────────────
+
+
+def test_warm_restarts_are_silent_when_the_cycle_is_shorter_than_the_run():
+    """T_0 < epochs is the CORRECT setting here, and must not be nagged at.
+
+    This is the subtlety that stops "T_max should equal epochs" being a
+    universal rule: `CosineAnnealingWarmRestarts` reuses the node's `T_max`
+    as `T_0`, the length of the first cycle.
+    """
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    sched = sched_module.CosineAnnealingWarmRestarts(opt, T_0=10)
+    assert _schedule_length_note(sched, epochs=100) is None
+
+
+@pytest.mark.parametrize("t_0", [50, 80])
+def test_warm_restarts_warn_the_other_way_round(t_0):
+    """T_0 >= epochs means no restart ever happens -- the opposite advice."""
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    sched = sched_module.CosineAnnealingWarmRestarts(opt, T_0=t_0)
+    note = _schedule_length_note(sched, epochs=50)
+    assert note is not None
+    assert "no restart" in note.lower()
+    # It must never repeat the CosineAnnealingLR advice, which would be
+    # actively wrong here: equality is the thing to avoid, not to aim for.
+    assert "SMALLER" in note
+    assert "Set LRScheduler.T_max to 50" not in note
+
+
+# ── schedulers that provably never fire ───────────────────────────────────
+
+
+def test_a_step_lr_whose_drop_never_arrives_is_reported():
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    note = _schedule_length_note(sched_module.StepLR(opt, step_size=50),
+                                 epochs=20)
+    assert note is not None
+    assert "constant learning rate" in note
+
+
+def test_a_step_lr_that_does_fire_says_nothing():
+    """A period merely longer than ideal is tuning, not a fault."""
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    assert _schedule_length_note(
+        sched_module.StepLR(opt, step_size=19), epochs=20) is None
+
+
+def test_a_multi_step_lr_whose_first_milestone_is_out_of_reach_is_reported():
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    note = _schedule_length_note(
+        sched_module.MultiStepLR(opt, milestones=[30, 60, 90, 120]), epochs=20)
+    assert note is not None
+    assert "30" in note and "constant learning rate" in note
+
+
+def test_a_multi_step_lr_that_reaches_its_first_milestone_says_nothing():
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    assert _schedule_length_note(
+        sched_module.MultiStepLR(opt, milestones=[10, 20, 30, 40]),
+        epochs=20) is None
+
+
+@pytest.mark.parametrize("factory", [
+    lambda opt: sched_module.ExponentialLR(opt, gamma=0.9),
+    lambda opt: sched_module.ReduceLROnPlateau(opt, factor=0.1),
+])
+def test_schedulers_with_no_length_are_never_reported(factory):
+    """Neither has an epoch-coupled length, so neither can disagree."""
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    assert _schedule_length_note(factory(opt), epochs=20) is None
+
+
+# ── the note must never break anything ────────────────────────────────────
+
+
+def test_no_scheduler_means_no_note():
+    assert _schedule_length_note(None, epochs=20) is None
+
+
+@pytest.mark.parametrize("epochs", [0, -1, None, "twenty"])
+def test_an_unusable_epoch_count_is_declined_rather_than_guessed_at(epochs):
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    assert _schedule_length_note(_one_cycle(1000)(opt), epochs=epochs) is None
+
+
+def test_a_scheduler_carrying_something_odd_is_declined_rather_than_guessed():
+    """A plugin scheduler may hold a tensor under these names. Say nothing."""
+    opt = torch.optim.SGD([nn.Parameter(torch.zeros(2))], lr=0.1)
+    sched = _cosine(50)(opt)
+    sched.T_max = torch.tensor(50)
+    assert _schedule_length_note(sched, epochs=20) is None
+
+
+def test_an_object_that_is_not_a_scheduler_at_all_is_declined():
+    assert _schedule_length_note(object(), epochs=20) is None
+
+
+# ── the surfaces a user can actually read ─────────────────────────────────
+
+
+def test_the_note_reaches_the_canvas_log_through_the_result():
+    """`__log__` is the only result key the canvas Log tab renders.
+
+    Marked with the node's own prefix, because `LogEntry.type` has no
+    warning severity -- an advisory and a `Print` node's output arrive in
+    the same colour.
+    """
+    res = _train(_one_cycle(1000), epochs=5)
+    assert "__log__" in res, "nothing would appear in the canvas log"
+    assert res["__log__"].startswith(SCHEDULE_NOTE_PREFIX)
+    assert "never anneal" in res["__log__"].lower()
+
+
+def test_a_schedule_that_fits_leaves_the_canvas_log_alone():
+    assert "__log__" not in _train(_one_cycle(5), epochs=5)
+
+
+def test_the_note_reaches_the_durable_run_log_as_a_warning():
+    """`log_warning` is what the Runs panel reads back, live, WHILE the run
+    is still going -- the only surface that gets this before the epochs it
+    is about have already been spent."""
+    context = ExecutionContext()
+    _train(_one_cycle(1000), epochs=5, context=context)
+
+    warnings = _warnings_on(context)
+    assert len(warnings) == 1, f"expected one warning, got {warnings}"
+    assert warnings[0].kind == SCHEDULE_WARNING_KIND
+    assert "never anneal" in warnings[0].detail.lower()
+
+
+def test_a_schedule_that_fits_produces_no_run_warning():
+    context = ExecutionContext()
+    _train(_one_cycle(5), epochs=5, context=context)
+    assert _warnings_on(context) == []
+
+
+def test_the_note_reaches_the_server_log_too(caplog):
+    """The only channel `run_graph.py` and an exported script have at all."""
+    with caplog.at_level(logging.WARNING,
+                         logger="app.nodes.training.training_loop_node"):
+        _train(_one_cycle(1000), epochs=5)
+    assert any("never anneal" in r.message.lower() for r in caplog.records)
+
+
+def test_the_warning_is_emitted_before_the_schedule_can_fail_the_run():
+    """Ordering is the point: the crash arrives at epoch 3, the note at 0."""
+    context = ExecutionContext()
+    with pytest.raises(ValueError, match="Tried to step"):
+        _train(_one_cycle(2), epochs=5, context=context)
+    warnings = _warnings_on(context)
+    assert len(warnings) == 1
+    assert "Tried to step 3 times" in warnings[0].detail
+
+
+# ── advisory, never fatal ─────────────────────────────────────────────────
+
+
+def test_a_mismatched_schedule_still_trains_the_full_run():
+    """#244 option 4 ("refuse to run") was rejected: a truncated schedule is
+    a legitimate choice, and refusing is too aggressive for a teaching tool.
+    """
+    res = _train(_cosine(200), epochs=4)
+    assert res["losses"].shape == (4,)
+    assert res["metrics"]["total_epochs_run"] == 4
+    # The schedule itself is untouched -- the advisory does not "fix" it
+    # behind the user's back, which would change what a saved graph does.
+    assert res["metrics"]["lr_history"] == sorted(
+        res["metrics"]["lr_history"], reverse=True)
+
+
+def test_a_run_with_no_context_still_gets_the_note():
+    """The REST contract runner and an exported script pass no context at
+    all, so the durable channel is simply absent there. The other two
+    surfaces must still work rather than the whole check being skipped."""
+    res = _train(_one_cycle(1000), epochs=2, context=None)
+    assert res["metrics"]["total_epochs_run"] == 2
+    assert "__log__" in res
+
+
+def test_a_durable_channel_that_fails_does_not_fail_the_run():
+    """An advisory must not be able to take down the run it is about."""
+    class _Hostile(ExecutionContext):
+        def log_warning(self, kind, detail, node_id=None):
+            raise RuntimeError("the outbox is on fire")
+
+    res = _train(_one_cycle(1000), epochs=2, context=_Hostile())
+    assert res["metrics"]["total_epochs_run"] == 2
+    # The surface that did work still carries it.
+    assert "never anneal" in res["__log__"].lower()
+
+
+# ── the length is the WHOLE run's, not this leg's ─────────────────────────
+
+
+def test_a_resumed_run_is_measured_against_the_absolute_epoch_count():
+    """`epochs` is the absolute target and the scheduler is fast-forwarded
+    to `start_epoch`, so the schedule still spans the whole run. Comparing
+    against the remaining epochs instead would warn about every resume."""
+    torch.manual_seed(0)
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    context = ExecutionContext()
+    res = TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": _loader(),
+            "optimizer": optimizer,
+            "loss_fn": nn.CrossEntropyLoss(),
+            "lr_scheduler": _cosine(6)(optimizer),
+            "start_epoch": 4,
+        },
+        {"epochs": 6, "device": "cpu"},
+        context=context,
+    )
+    assert res["metrics"]["total_epochs_run"] == 2
+    assert _warnings_on(context) == [], "T_max=6 matches epochs=6"
+    assert "__log__" not in res

--- a/backend/tests/test_node_oom.py
+++ b/backend/tests/test_node_oom.py
@@ -28,21 +28,17 @@ OOM_MESSAGE = (
     "CUDA out of memory. Tried to allocate 2.00 GiB. GPU 0 has a total "
     "capacity of 15.99 GiB of which 0 bytes is free.")
 
-#: `torch.OutOfMemoryError` arrived in torch 2.5 and the declared floor is
-#: lower, so the tests raise whichever shape the INSTALLED torch actually
-#: produces. That is not a workaround -- it is the same reason
-#: `is_out_of_memory` checks the type and the message: on an older build a
-#: CUDA allocation failure really is a bare `RuntimeError`, and the handler
-#: has to work there too.
-_TORCH_OOM = getattr(__import__("torch"), "OutOfMemoryError", None)
-has_oom_type = _TORCH_OOM is not None
-requires_oom_type = pytest.mark.skipif(
-    not has_oom_type, reason="torch < 2.5 has no OutOfMemoryError type")
+#: `torch.OutOfMemoryError` arrived in torch 2.5, which is the floor
+#: `backend/pyproject.toml` declares since core#192 -- so it is a plain
+#: attribute access here, not a `getattr` with a fallback. If this line ever
+#: raises `AttributeError`, the installed torch is below the declared floor
+#: and that is the bug.
+_TORCH_OOM = __import__("torch").OutOfMemoryError
 
 
 def _cuda_oom() -> BaseException:
     """The exception this torch raises when a CUDA allocation does not fit."""
-    return (_TORCH_OOM or RuntimeError)(OOM_MESSAGE)
+    return _TORCH_OOM(OOM_MESSAGE)
 
 
 class _HungryNode(BaseNode):
@@ -91,34 +87,47 @@ def _graph():
 # ── classification ────────────────────────────────────────────────────────
 
 
-@requires_oom_type
 def test_the_dedicated_torch_oom_type_is_recognised():
     """By TYPE, not by message -- the message match is the fallback."""
     assert is_out_of_memory(_TORCH_OOM("no message about memory here")) is True
 
 
 def test_both_spellings_of_the_oom_class_are_recognised():
-    """``torch.cuda.OutOfMemoryError`` is the one that exists on 2.0-2.4.
+    """``torch.cuda.OutOfMemoryError`` is an ALIAS from 2.5 on (core#192).
 
-    That range is exactly what this project's declared floor still admits,
-    so checking only the 2.5+ ``torch.OutOfMemoryError`` spelling would
-    leave those builds falling through to the MESSAGE match -- which is the
-    fallback, not the answer. On 2.5+ the two names are one object and this
-    asserts the same thing twice, which costs nothing and keeps the
-    guarantee pinned if they ever diverge again.
+    ``is_out_of_memory`` used to look both names up through ``getattr``
+    because 2.0-2.4 -- which the old ``torch>=2.0.0`` floor admitted -- only
+    had the ``torch.cuda`` one. With the floor at 2.5 the two names are one
+    object, so the single check covers both. This test is what would catch
+    a future release splitting them apart again, which is the only thing
+    that could make the removed branch matter.
     """
     import torch
 
-    for spelling in ("OutOfMemoryError",):
-        cls = getattr(torch, spelling, None)
-        if isinstance(cls, type):
-            assert is_out_of_memory(cls("silent")) is True
-        cuda_cls = getattr(torch.cuda, spelling, None)
-        if isinstance(cuda_cls, type):
-            assert is_out_of_memory(cuda_cls("silent")) is True
-    # At least one of the two must exist on any supported build.
-    assert (isinstance(getattr(torch, "OutOfMemoryError", None), type)
-            or isinstance(getattr(torch.cuda, "OutOfMemoryError", None), type))
+    assert torch.cuda.OutOfMemoryError is torch.OutOfMemoryError
+    assert is_out_of_memory(torch.OutOfMemoryError("silent")) is True
+    assert is_out_of_memory(torch.cuda.OutOfMemoryError("silent")) is True
+
+
+def test_the_declared_torch_floor_is_the_one_the_code_assumes():
+    """The floor and the code that leans on it must not drift apart.
+
+    ``is_out_of_memory`` reaches ``torch.OutOfMemoryError`` as a plain
+    attribute now. Lowering the floor back below 2.5 without restoring the
+    older spelling's branch would leave the classifier falling through to
+    the MESSAGE match on those builds -- silently, since a message match
+    still returns True for a real CUDA OOM and only fails for the ones
+    torch raises without one.
+    """
+    import re
+    from pathlib import Path
+
+    pyproject = (Path(__file__).resolve().parents[1] / "pyproject.toml")
+    spec = re.search(r'"torch>=([\d.]+)"', pyproject.read_text(encoding="utf-8"))
+    assert spec is not None, "no torch floor declared in backend/pyproject.toml"
+    major, minor = (int(part) for part in spec.group(1).split(".")[:2])
+    assert (major, minor) >= (2, 5), (
+        f"torch floor is {spec.group(1)}; torch.OutOfMemoryError needs >= 2.5")
 
 
 def test_a_torch_oom_is_recognised():

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -439,7 +439,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "tokenizers", specifier = ">=0.15.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
-    { name = "torch", specifier = ">=2.0.0" },
+    { name = "torch", specifier = ">=2.5" },
     { name = "torchvision", specifier = ">=0.15.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
     { name = "websockets", specifier = ">=12.0" },

--- a/docs/docs/usage/reproducing-baselines.md
+++ b/docs/docs/usage/reproducing-baselines.md
@@ -37,7 +37,7 @@ Use the layer editor's **Import** instead. It accepts this example's `graph.json
 |---|---|
 | Architecture | ResNet-18, CIFAR variant — 3x3 stride-1 stem, no maxpool, 4 stages of 2 BasicBlocks (64/128/256/512), 11,173,962 parameters |
 | Optimizer | SGD, lr 0.1, momentum 0.9, Nesterov, weight decay 5e-4 |
-| Schedule | `CosineAnnealingLR`, `T_max` equal to the epoch count (see the gotchas below — this pair is not validated) |
+| Schedule | `CosineAnnealingLR`, `T_max` equal to the epoch count (see the gotchas below — a mismatch is warned about, not enforced) |
 | Loss | Cross-entropy, no label smoothing |
 | Batch size | 128 train, 512 eval |
 | Epochs | 200 |
@@ -159,7 +159,7 @@ curl "http://127.0.0.1:8000/api/runs/<run_id>/metrics?format=csv" -o metrics.csv
 
   Miss a trigger and the run fails with a missing-input error naming a node much further downstream. Drop the one into `SequentialModel`, for instance, and `Optimizer` and `LRScheduler` are pruned with it; the run then dies complaining about `TrainingLoop`. Tracked as issue [#201](https://github.com/CodefyUI/CodefyUI/issues/201).
 
-- **Keep `LRScheduler.T_max` equal to `TrainingLoop.epochs`.** Cosine annealing is stepped once per epoch and reaches zero exactly at `T_max`. Set `T_max` too low and the learning rate sits at zero for the tail of the run; too high and it never anneals fully, which costs roughly a point of accuracy. Nothing validates the pair — the scheduler node cannot see the loop's epoch count. Tracked as issue [#205](https://github.com/CodefyUI/CodefyUI/issues/205).
+- **Keep `LRScheduler.T_max` equal to `TrainingLoop.epochs`.** Cosine annealing is stepped once per epoch and reaches zero exactly at `T_max`. Set `T_max` too high and the run stops partway down the curve, never annealing fully, which costs roughly a point of accuracy; too low and the cosine turns back **up** past `T_max`, so the tail of the run trains at a rising learning rate. `TrainingLoop` warns when the two disagree — in the server log, in the run log the Runs panel shows, and in the canvas Log tab — but it does not enforce the pair, because a truncated schedule is a legitimate choice and `CosineAnnealingWarmRestarts` reuses the same value as `T_0`, where equality would mean no restart ever happens. The same check covers `OneCycleLR.total_steps`, whose default of 1000 is a batch count no epoch budget reaches.
 - **`EvaluateModel` does not follow the run device.** Its `device` parameter defaults to `cpu` and offers no `auto`. Set it to `cuda` explicitly or evaluation will be slow. Tracked as issue [#204](https://github.com/CodefyUI/CodefyUI/issues/204).
 - **The first run downloads CIFAR-10** (about 170 MB). It lands in `backend/data/` by default, or in `<project>/assets/data` when a project directory is open. Later runs reuse it.
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/usage/reproducing-baselines.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/usage/reproducing-baselines.md
@@ -37,7 +37,7 @@ description: 研究等級的完整走訪 — 用純 GUI 節點、固定 seed、�
 |---|---|
 | 架構 | ResNet-18，CIFAR 版 — 3x3 stride-1 stem、沒有 maxpool、4 個 stage 各 2 個 BasicBlock（64/128/256/512），11,173,962 個參數 |
 | 優化器 | SGD，lr 0.1，動量 0.9，Nesterov，weight decay 5e-4 |
-| 學習率排程 | `CosineAnnealingLR`，`T_max` 等於總 epoch 數（見下方「值得先知道的坑」— 這一組沒有任何檢查會幫你驗） |
+| 學習率排程 | `CosineAnnealingLR`，`T_max` 等於總 epoch 數（見下方「值得先知道的坑」— 兩者不一致會出現提醒，但不會被擋下來） |
 | 損失函數 | 交叉熵，不做 label smoothing |
 | 批次大小 | 訓練 128，評估 512 |
 | Epoch 數 | 200 |
@@ -159,7 +159,7 @@ curl "http://127.0.0.1:8000/api/runs/<run_id>/metrics?format=csv" -o metrics.csv
 
   漏掉一條觸發線，執行就會失敗，而且錯誤訊息指的是下游很遠的另一個節點。舉例來說，漏掉指向 `SequentialModel` 的那一條，`Optimizer` 和 `LRScheduler` 會跟著一起被剪掉，然後執行會抱怨 `TrainingLoop`。記在 issue [#201](https://github.com/CodefyUI/CodefyUI/issues/201)。
 
-- **`LRScheduler.T_max` 要跟 `TrainingLoop.epochs` 保持一致。** cosine 退火是每個 epoch 走一步，而且剛好在 `T_max` 歸零。`T_max` 設太小，學習率在後段就一直是零；設太大則永遠退不完，大約會損失一個百分點的準確率。沒有任何檢查會幫你驗這一組 — 排程器節點看不到訓練迴圈的 epoch 數。記在 issue [#205](https://github.com/CodefyUI/CodefyUI/issues/205)。
+- **`LRScheduler.T_max` 要跟 `TrainingLoop.epochs` 保持一致。** cosine 退火是每個 epoch 走一步，而且剛好在 `T_max` 歸零。`T_max` 設太大，訓練會停在曲線中段、退火退不完，大約會損失一個百分點的準確率；設太小則更麻煩 — 過了 `T_max` 之後 cosine 會**再往上爬**，最後幾個 epoch 反而是在學習率上升的情況下訓練。兩者不一致時 `TrainingLoop` 會提醒你（伺服器記錄檔、執行紀錄面板的執行記錄，以及畫布下方的記錄分頁各一份），但不會強制擋下來：截斷的排程本身是合理的選擇，而且 `CosineAnnealingWarmRestarts` 是拿同一個值當 `T_0`，在那裡「相等」反而代表永遠不會重啟。同一組檢查也涵蓋 `OneCycleLR.total_steps`，它的預設值 1000 是以批次為單位的數字，任何 epoch 設定都到不了。
 - **`EvaluateModel` 不會跟著執行時的裝置走。** 它的 `device` 參數預設是 `cpu`，而且沒有 `auto` 可選。要自己設成 `cuda`，不然評估會很慢。記在 issue [#204](https://github.com/CodefyUI/CodefyUI/issues/204)。
 - **第一次執行會下載 CIFAR-10**（大約 170 MB）。預設會放到 `backend/data/`；如果有開專案目錄，則會放到 `<專案>/assets/data`。之後就會重複使用。
 

--- a/examples/Usage_Example/ResNet18-CIFAR10-Baseline/README.md
+++ b/examples/Usage_Example/ResNet18-CIFAR10-Baseline/README.md
@@ -166,7 +166,9 @@ back, and the Runs panel re-attaches and replays what it missed.
   the wall clock.
 - The `TrainingLoop.epochs` value and `LRScheduler.T_max` must stay equal —
   cosine annealing is stepped once per epoch and reaches zero exactly at
-  `T_max`. Nothing validates the pair (issue #205); the CI test below does.
+  `T_max`. `TrainingLoop` warns when they disagree but still runs, because a
+  truncated schedule is a legitimate choice; the CI test below is what holds
+  this graph to the pair.
 - **The `layers` string is in its lean form.** The layer editor's serializer
   writes a `position` on every node, a `params: {}` on every param-less node and
   explicit null handles on every edge; none of those are in the committed text.


### PR DESCRIPTION
> 中文摘要：`TrainingLoop` 是在 epoch 迴圈裡呼叫 `lr_scheduler.step()`，所以 `LRScheduler` 上每一個「週期長度」參數都是以 epoch 計算；但 PyTorch 官方對其中好幾個參數是以 batch 計算的，兩邊的單位從來沒有人對過。結果是排程完全不對也不會有任何徵兆：不會出錯、不會警告、loss 曲線看起來完全正常，只是準確率少了幾個百分點 —— 而那個幅度剛好就是大家會跑去懷疑資料增強或模型架構的幅度。最嚴重的是 `OneCycleLR.total_steps` 預設值 1000：那是一個合理的 batch 數、但不可能的 epoch 數，20 個 epoch 只會走完週期的 2%，學習率升上去之後從來不會退火下來 —— 而使用者什麼都沒改。這個 PR 在第一個 epoch 開始前就比對排程長度和 `epochs`，並在三個地方講出來（伺服器記錄檔、執行紀錄面板的執行記錄、畫布下方的記錄分頁）。**只是提醒，不會擋下執行**，也**沒有改動預設值**（改預設值會悄悄改變每一張已存檔的圖）。`CosineAnnealingWarmRestarts` 是反過來的例外：它把同一個 `T_max` 當成 `T_0`，相等反而代表永遠不會重啟，所以它是「小於 epochs 時安靜、大於等於時才提醒」。順帶把 torch 下限從 2.0.0 提到 2.5（#192），並在同一個 commit 重新產生 `uv.lock`。

## What was broken

`TrainingLoopNode` calls `lr_scheduler.step()` inside the **epoch** loop
(`training_loop_node.py`, the `LR Scheduler step` block). So every scheduler the
`LRScheduler` node builds counts epochs. PyTorch counts optimizer steps for
several of the same parameters, and nothing anywhere reconciled the two units.

Two shapes of that, and the second is the one that matters most:

* **`CosineAnnealingLR.T_max` different from `TrainingLoop.epochs`** (#205).
  Too high and the run stops partway down the cosine, so the learning rate
  never reaches its minimum. Too low is worse in a different way: past `T_max`
  the cosine turns back **up**, so the tail of the run trains at a rising
  learning rate. Measured in `test_a_short_cosine_really_does_raise_the_lr_back_up`.
* **`OneCycleLR.total_steps` left at the node's default of 1000** (#244). That
  is a plausible batch count and an impossible epoch count. At 5 epochs the
  learning rate goes `0.004 -> 0.004042` and is still climbing when the run
  ends; the same schedule told the truth about the run length goes
  `0.004 -> 0.095 -> 0.0`. One-cycle's entire benefit is the anneal, and it
  never arrives. Measured in
  `test_the_default_one_cycle_schedule_really_does_never_anneal`.

The second one bites a user who **changed nothing** — pick `OneCycleLR` from the
dropdown, press Run.

## Why it survived

Both halves of the failure are invisible. Nothing raises, the loss curve looks
plausible, and the accuracy is simply a few points short — the size of gap a
person then goes hunting for in their augmentation or their architecture.

#238 fixed the *information* half by writing the units into the parameter
descriptions. That is necessary and not sufficient: a description is read only
by someone who opens the tooltip, and the failure gives nobody a reason to go
looking.

## What this does

`_schedule_length_note` (`backend/app/nodes/training/training_loop_node.py`)
compares the scheduler `TrainingLoop` was handed against its own `epochs`,
before the first epoch runs. `_report_schedule_length` emits the sentence on
three surfaces, because no single one reaches everybody:

| surface | who sees it | when |
|---|---|---|
| `logger.warning` | server console, rotating log file — the only channel `run_graph.py` and an exported Python script have at all | before epoch 0 |
| `context.log_warning("lr_schedule_mismatch", ...)` | the run's durable event log, which the Runs panel reads back as a `warning`-toned line | before epoch 0, live |
| `result["__log__"]` | the canvas Log tab | when the node finishes |

Values are read off the **scheduler object** (`T_max`, `total_steps`, `T_0`,
`step_size`, `milestones`), not off the `LRScheduler` node's params — so the
check also covers a scheduler restored from a checkpoint or built by a plugin
node, and it describes what will actually run rather than what was typed.

The messages name the numbers, the consequence, and the correction. For
example, the #244 default at 20 epochs:

> `OneCycleLR spans total_steps=1000 but TrainingLoop.epochs=20 (TrainingLoop steps the scheduler once per EPOCH, so this parameter counts epochs, not batches) -- this run traverses only 2.0% of the one-cycle schedule, so the learning rate warms up and NEVER anneals, which is the whole point of one-cycle. Set LRScheduler.total_steps to 20: it is an epoch count here, not the batch count OneCycleLR's own documentation means by a step.`

One case is not silent at all and is warned about anyway:
`OneCycleLR` with `total_steps` **below** `epochs` raises
`ValueError: Tried to step N times` partway through the run and takes it down.
Saying so before the epochs that reach it is worth more than letting a user
discover it forty minutes in.

## What was chosen, and what was rejected

**Where the check lives: `TrainingLoop`.** The other two candidates do not work:

* `LRSchedulerNode.execute` cannot see the loop it feeds. `ExecutionContext`
  carries no graph reference (checked: `execution_context.py`), so the node has
  no route to `TrainingLoop.epochs` at all.
* Graph validation has no non-fatal channel. `validate_graph` returns a flat
  `list[str]`, every entry is an error, and `GraphValidationResponse` is
  `{valid, errors}` with no `warnings` field. Adding one means new plumbing
  through the schema, the REST route and the frontend — and #205 and #244 both
  say explicitly this must not be fatal.

`TrainingLoop` has the scheduler object and the epoch count in the same scope.
The comparison is local and needs no new plumbing.

**The default of 1000 is deliberately unchanged.** #244 weighed and rejected
changing it: a new default rewrites what every already-saved graph does,
silently, on update. A sentinel meaning "follow `TrainingLoop.epochs`" has the
same cost.

**Not fatal** (#244 option 4, #205's "why not just validate it"). A truncated
schedule is a legitimate choice and refusing to run is too aggressive for a
teaching tool. `test_a_mismatched_schedule_still_trains_the_full_run` pins that,
and also pins that the advisory does not "fix" the schedule behind the user's
back — which would be the same silent-behaviour-change the default is being
protected from.

**`CosineAnnealingWarmRestarts` is inverted, not exempt.** It reuses the node's
`T_max` as `T_0`, the length of the first cycle, so equality with `epochs` means
no restart ever happens. It is silent when `T_0 < epochs` (the correct setting)
and warns when `T_0 >= epochs`, with text that never repeats the
`CosineAnnealingLR` advice — that advice would be actively wrong here.

**Scope note for the reviewer.** `StepLR` and `MultiStepLR` are also covered,
but only in the degenerate case: a period or first milestone at or beyond
`epochs` means the drop provably never happens and the run trains at a constant
learning rate. That is the same silent-accuracy-loss shape, and the one reading
of "the two disagree" with no legitimate counter-example. A period merely longer
than ideal stays silent. This is one step past what #205 and #244 literally ask
for; say the word and it comes out.

## torch floor (#192)

`backend/pyproject.toml`: `torch>=2.0.0` becomes `torch>=2.5`, with
`backend/uv.lock` regenerated in the same commit (a one-line diff — the locked
2.11.0 already satisfied the new floor). That ordering is the whole reason the
bump failed in PR #191: `backend-test.yml` runs `uv lock --check` **before** it
installs anything.

Step 3 of #192 — the point of doing it at all — is done: `is_out_of_memory` no
longer looks the OOM class up under two spellings.
`torch.cuda.OutOfMemoryError is torch.OutOfMemoryError` from 2.5 on (asserted),
so the `getattr` pair was a degradation path for versions the floor no longer
admits, and a second unexercised way to detect the same condition is worse than
none. The message match **stays**: that is how MPS and out-of-tree backends
report an OOM on any torch, not a version fallback.

`test_the_declared_torch_floor_is_the_one_the_code_assumes` is what keeps the
floor and the code that leans on it from drifting apart again.

The `GradScaler` try/except in `core/amp.py` is untouched — it catches "this
device cannot build a scaler", not "this torch is too old", so the 2.5 floor
does not make it dead.

## What a reviewer should check

1. **The unit claim.** `lr_scheduler.step()` really is inside `for epoch in
   range(start_epoch, epochs)`. Everything here follows from that.
2. **The absolute-vs-relative epoch count.** The check compares against
   `epochs`, not `epochs - start_epoch`, because `_prepare_scheduler`
   fast-forwards a resumed scheduler to `start_epoch` — so the schedule still
   spans the whole run. Comparing against the remaining epochs would warn on
   every resume. Pinned by
   `test_a_resumed_run_is_measured_against_the_absolute_epoch_count`.
3. **`__log__` on `TrainingLoop`'s result.** It is set only when a note fired,
   so a healthy run's outputs are byte-for-byte what they were. Dunder-prefixed
   keys are already filtered out of recorded outputs and port summaries
   (`output_entries.py`, `graph_engine.py`), so this adds a log line and
   nothing else.
4. **The warm-restart inversion**, which is the one rule here that is not "make
   them equal".
5. **The `StepLR` / `MultiStepLR` scope call** flagged above.

## What is NOT delivered

#205's option 2 asks for "a non-blocking canvas hint ... dismissible". This
delivers the advisory and the run-log line; it does **not** draw anything on the
canvas node, and there is no dismiss affordance. That is not an oversight —
there is no canvas warning channel to use: `useGraphExecution` registers no
`run_warning` handler, and `LogEntry.type` is `info | error | success` with no
warning severity, which is why the canvas line carries a `[TrainingLoop]` text
prefix instead of a colour. Building that channel is a frontend change of its
own and is already noted as filed-not-done in `WarningSignal`'s docstring.

So #205 is left open on purpose rather than auto-closed. If the run-log advisory
is enough, close it by hand; if the canvas badge is still wanted, it now has one
producer waiting for a renderer.

## Testing

`backend/tests/test_lr_schedule_length.py`, 35 tests. Three of them
(`test_the_default_one_cycle_schedule_really_does_never_anneal`,
`test_a_short_cosine_really_does_raise_the_lr_back_up`,
`test_one_cycle_shorter_than_the_run_takes_the_run_down`) measure the traps
themselves, so the rest is testing a warning about something real rather than a
warning about a belief.

Verified failing without the change: neutering `_report_schedule_length` fails
the 6 surface tests; reverting `pyproject.toml` fails
`test_the_declared_torch_floor_is_the_one_the_code_assumes`.

Full backend suite: 3925 passed, 22 skipped. Three failures in
`test_python_script_node.py` / `test_tiered_policy.py` are pre-existing on this
machine (confirmed on a clean tree) and are an artefact of the local Python 3.14
interpreter; CI runs 3.10-3.12.

No frontend code is touched.

Closes #244. Closes #192. Addresses #205 (see "What is NOT delivered").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
