### PR TITLE
fix(llm,canvas): make Stop interrupt an LLM generation, and give the reconnect press a view

### DIFF
--- a/backend/app/nodes/llm/llm_chat_node.py
+++ b/backend/app/nodes/llm/llm_chat_node.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import io
 import json
+import logging
 import os
 from collections.abc import AsyncIterator, Callable
 from typing import Any
@@ -21,6 +22,8 @@ from ...core.node_base import (
     ParamType,
     PortDefinition,
 )
+
+logger = logging.getLogger(__name__)
 
 ProviderAdapter = Callable[[ChatRequest, httpx.AsyncClient], AsyncIterator[dict[str, Any]]]
 
@@ -178,12 +181,27 @@ class LLMChatNode(BaseNode):
         *,
         context: Any = None,
     ) -> dict[str, Any]:
+        from ...core.loop_control import interrupted_result
+
         provider = _normalize_provider(params.get("provider", "ChatGPT API"))
         req = _build_request(provider, inputs, params)
-        text, usage = asyncio.run(_collect_chat(req, _ADAPTERS[provider], progress_callback))
+        text, usage, stopped_after = asyncio.run(
+            _collect_chat(req, _ADAPTERS[provider], progress_callback,
+                          context=context)
+        )
         result: dict[str, Any] = {"text": text}
         if usage:
             result["__usage__"] = usage
+        if stopped_after is not None:
+            # #155: whatever the model had already streamed stays on the
+            # `text` port -- a student who stops a long generation should
+            # see the half-written answer, not an empty string -- but the
+            # run is not allowed to call a truncated completion a success.
+            # ``batch`` is the shared "how far the loop got" field the other
+            # interruptible nodes use (DDPMSampler counts denoising steps in
+            # it, Map counts items); here it counts streamed chunks.
+            result.update(interrupted_result(batch=stopped_after,
+                                             chars=len(text)))
         return result
 
 
@@ -391,30 +409,112 @@ def _coerce_pil_image(value: Any) -> Any:
     raise TypeError(f"Unsupported image input type for LLMChat: {type(value).__name__}")
 
 
+async def _close_stream(stream: Any) -> None:
+    """Tear down a provider stream now rather than eventually. Never raises.
+
+    Every adapter in ``_ADAPTERS`` is an async GENERATOR that holds an open
+    ``async with client.stream(...)`` across its yields. Merely breaking out
+    of the ``async for`` therefore leaves the HTTP response -- and the socket
+    under it -- alive until the garbage collector or ``asyncio.run``'s
+    closing ``shutdown_asyncgens`` gets to it, which is AFTER the
+    ``AsyncClient`` that owns the connection has already been closed.
+    ``aclose()`` throws ``GeneratorExit`` in at the suspended yield, which
+    runs the adapter's ``async with`` exit and releases the connection while
+    its client is still alive. One mechanism covers all four provider options
+    precisely because all three adapter modules are written this way; none of
+    them needs a provider-specific cancel call.
+
+    ``aclose`` is looked up rather than assumed: ``ProviderAdapter`` promises
+    only an ``AsyncIterator``, which a hand-rolled iterator class or a test
+    double can satisfy without one.
+
+    Swallowing is deliberate. This runs on the way out of a generation that
+    has already produced its result -- or that the user has just stopped --
+    and a transport hiccup while hanging up is worth a log line, not a failed
+    node or an exception that masks the real one on the way out.
+    """
+    aclose = getattr(stream, "aclose", None)
+    if not callable(aclose):
+        return
+    try:
+        await aclose()
+    except Exception:  # noqa: BLE001 - see the docstring
+        logger.warning(
+            "could not close the LLM provider stream cleanly; the connection "
+            "will be reclaimed when the client is torn down",
+            exc_info=True,
+        )
+
+
 async def _collect_chat(
     req: ChatRequest,
     adapter: ProviderAdapter,
     progress_callback: Any | None = None,
-) -> tuple[str, dict[str, int]]:
+    *,
+    context: Any = None,
+) -> tuple[str, dict[str, int], int | None]:
+    """Drain *adapter*'s event stream, or stop early when the run is stopping.
+
+    Returns ``(text, usage, stopped_after)``, where ``stopped_after`` is None
+    for a generation that finished on its own and otherwise the number of
+    chunks that had arrived when ``context.should_stop()`` flipped.
+
+    #155: before this, ``context`` was a dead parameter all the way down and
+    Stop simply did not apply to an LLM call -- the click was acknowledged
+    and the node kept streaming until the provider decided to finish, which
+    with ``max_tokens`` up to 200_000 is minutes of a class waiting. The
+    check is one ``threading.Event.is_set()`` per streamed chunk (see
+    ``loop_control.stop_checker``), which is nothing next to the network
+    round trip that delivered the chunk.
+
+    It is checked AFTER the chunk is appended and reported, so the partial
+    text always includes everything that actually arrived, and once BEFORE
+    the request goes out, so a stop that landed while this node sat in the
+    queue does not still pay for a whole generation.
+
+    Known limit, deliberate: the stop lands on the next chunk boundary, so a
+    provider that has gone quiet -- still thinking, or stalled -- is not
+    interrupted until it says something or ``_common.TIMEOUT`` expires. The
+    await that would have to be cancelled lives inside the adapter, and
+    racing every ``__anext__`` against a timer would cost a task per token.
+    Same shape as the other interruptible nodes, which cannot preempt a
+    single long batch either.
+    """
+    from ...core.loop_control import stop_checker
+
+    should_stop = stop_checker(context)
     chunks: list[str] = []
+    stopped_after: int | None = None
+
     async with httpx.AsyncClient() as client:
-        async for event in adapter(req, client):
-            etype = event.get("type")
-            if etype == "text_delta":
-                delta = str(event.get("text", ""))
-                chunks.append(delta)
-                if progress_callback is not None:
-                    progress_callback({"text": "".join(chunks)})
-            elif etype == "error":
-                raise RuntimeError(str(event.get("message", "LLM provider error")))
-            elif etype == "done":
-                message = event.get("message") or {}
-                content = str(message.get("content") or "".join(chunks))
-                raw_usage = event.get("usage")
-                usage = raw_usage if isinstance(raw_usage, dict) else {}
-                return content, {
-                    str(k): int(v)
-                    for k, v in usage.items()
-                    if isinstance(v, (int, float))
-                }
-    return "".join(chunks), {}
+        # Bound to a name so it can be closed on every exit path, not only
+        # the one that runs the generator to exhaustion.
+        stream = adapter(req, client)
+        try:
+            if should_stop():
+                return "", {}, 0
+            async for event in stream:
+                etype = event.get("type")
+                if etype == "text_delta":
+                    delta = str(event.get("text", ""))
+                    chunks.append(delta)
+                    if progress_callback is not None:
+                        progress_callback({"text": "".join(chunks)})
+                elif etype == "error":
+                    raise RuntimeError(str(event.get("message", "LLM provider error")))
+                elif etype == "done":
+                    message = event.get("message") or {}
+                    content = str(message.get("content") or "".join(chunks))
+                    raw_usage = event.get("usage")
+                    usage = raw_usage if isinstance(raw_usage, dict) else {}
+                    return content, {
+                        str(k): int(v)
+                        for k, v in usage.items()
+                        if isinstance(v, (int, float))
+                    }, None
+                if should_stop():
+                    stopped_after = len(chunks)
+                    break
+        finally:
+            await _close_stream(stream)
+    return "".join(chunks), {}, stopped_after

--- a/backend/tests/test_llm_chat_node.py
+++ b/backend/tests/test_llm_chat_node.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import json
+
+import httpx
 import pytest
 import torch
 
+from app.core.execution_context import INTERRUPTED_KEY, ExecutionContext
+from app.core.llm_proxy import codex_auth
 from app.core.node_base import DataType, ParamType
 from app.nodes.llm import llm_chat_node
 from app.nodes.llm.llm_chat_node import LLMChatNode, _build_request, _normalize_provider
@@ -66,9 +71,9 @@ def test_provider_aliases():
 def test_execute_builds_openai_request(monkeypatch):
     seen = {}
 
-    async def fake_collect(req, adapter, progress_callback=None):
+    async def fake_collect(req, adapter, progress_callback=None, *, context=None):
         seen["req"] = req
-        return "assistant text", {"input_tokens": 3, "output_tokens": 4}
+        return "assistant text", {"input_tokens": 3, "output_tokens": 4}, None
 
     monkeypatch.setattr(llm_chat_node, "_collect_chat", fake_collect)
     res = LLMChatNode().execute(
@@ -97,9 +102,9 @@ def test_execute_builds_openai_request(monkeypatch):
 def test_ollama_maps_to_custom_provider(monkeypatch):
     seen = {}
 
-    async def fake_collect(req, adapter, progress_callback=None):
+    async def fake_collect(req, adapter, progress_callback=None, *, context=None):
         seen["req"] = req
-        return "local", {}
+        return "local", {}, None
 
     monkeypatch.setattr(llm_chat_node, "_collect_chat", fake_collect)
     res = LLMChatNode().execute(
@@ -153,3 +158,223 @@ def test_missing_api_key_raises(monkeypatch):
 
     with pytest.raises(ValueError, match="requires openai_api_key"):
         _build_request("openai", {}, params(openai_api_key="", prompt="hi"))
+
+
+# ── #155: Stop lands mid-generation ───────────────────────────────────────
+#
+# Before this, ``context`` was a dead parameter on the streaming path: the
+# five long-loop nodes treated in #122 (PR #154) grew ``should_stop()``
+# checks and LLMChat was missed, so Stop was acknowledged and the node kept
+# streaming until the provider decided to finish -- minutes, with
+# ``max_tokens`` up to 200_000.
+
+
+class _EndlessSSE(httpx.AsyncByteStream):
+    """A response body that keeps emitting *frame*, and records its teardown.
+
+    ``closed`` alone proves nothing: an abandoned adapter generator IS
+    eventually finalized -- by refcounting, or by ``asyncio.run``'s closing
+    ``shutdown_asyncgens`` -- so the body ends up closed either way. What
+    separates a released connection from a leaked one is WHEN, so
+    ``client_was_open_at_close`` records whether the ``AsyncClient`` that
+    owns the connection was still alive at teardown. True means the
+    adapter's ``async with client.stream(...)`` exit ran on the way out of
+    the loop, as it should; False means it ran during or after the client's
+    own teardown, i.e. the response outlived the client it belonged to.
+
+    ``limit`` keeps a regression to a failed assertion instead of a hang.
+    """
+
+    def __init__(self, frame: bytes, limit: int = 500) -> None:
+        self._frame = frame
+        self._limit = limit
+        self.sent = 0
+        self.closed = False
+        #: Set by the client factory before the request goes out.
+        self.client: httpx.AsyncClient | None = None
+        self.client_was_open_at_close: bool | None = None
+
+    def _record_close(self) -> None:
+        self.closed = True
+        if self.client_was_open_at_close is None:
+            self.client_was_open_at_close = (
+                self.client is not None and not self.client.is_closed)
+
+    async def __aiter__(self):
+        try:
+            while self.sent < self._limit:
+                self.sent += 1
+                yield self._frame
+        except GeneratorExit:
+            self._record_close()
+            raise
+
+    async def aclose(self) -> None:
+        self._record_close()
+
+
+def _openai_frame(text: str) -> bytes:
+    return f"data: {json.dumps({'choices': [{'delta': {'content': text}}]})}\n\n".encode()
+
+
+def _anthropic_frame(text: str) -> bytes:
+    payload = {"type": "content_block_delta",
+               "delta": {"type": "text_delta", "text": text}}
+    return f"data: {json.dumps(payload)}\n\n".encode()
+
+
+def _codex_frame(text: str) -> bytes:
+    payload = {"type": "response.output_text.delta", "delta": text}
+    return f"data: {json.dumps(payload)}\n\n".encode()
+
+
+# Every provider the node offers, each with the SSE dialect its adapter
+# parses. All four go through the same two-line stop, because all three
+# adapter modules are async generators over ``client.stream`` -- there is no
+# provider-specific cancel call to get wrong.
+STREAMING_PROVIDERS = [
+    pytest.param("ChatGPT API", _openai_frame, id="openai"),
+    pytest.param("Claude API", _anthropic_frame, id="anthropic"),
+    pytest.param("Ollama", _openai_frame, id="ollama"),
+    pytest.param("Codex", _codex_frame, id="codex"),
+]
+
+
+def _install_mock_transport(monkeypatch, body: _EndlessSSE) -> None:
+    """Point every ``AsyncClient`` this node builds at *body*."""
+    real_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, headers={"content-type": "text/event-stream"}, stream=body)
+
+    def fake_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        client = real_client(*args, **kwargs)
+        body.client = client
+        return client
+
+    monkeypatch.setattr(llm_chat_node.httpx, "AsyncClient", fake_client)
+
+    async def fake_access(client, force_refresh=False):
+        return "access-token", "account-id"
+
+    monkeypatch.setattr(codex_auth, "get_valid_access", fake_access)
+
+
+@pytest.mark.parametrize("provider,frame", STREAMING_PROVIDERS)
+def test_stop_mid_stream_keeps_the_partial_text_and_closes_the_stream(
+    monkeypatch, provider, frame
+):
+    """Stop lands on the next chunk; partial text survives; socket released."""
+    body = _EndlessSSE(frame("tok "))
+    _install_mock_transport(monkeypatch, body)
+
+    ctx = ExecutionContext()
+    seen: list[str] = []
+
+    def on_progress(payload):
+        # Drive the stop off the node's own stream, the way a user's click
+        # lands: partway through, with plenty of generation left to do.
+        seen.append(payload["text"])
+        if len(seen) == 2:
+            ctx.cancel()
+
+    result = LLMChatNode().execute(
+        {}, params(provider=provider, prompt="write an essay"),
+        on_progress, context=ctx,
+    )
+
+    assert result["text"] == "tok tok ", "the partial completion must survive"
+    assert seen[-1] == "tok tok "
+
+    marker = result[INTERRUPTED_KEY]
+    assert marker["batch"] == 2, "stopped after the chunk the click landed on"
+    assert marker["chars"] == len(result["text"])
+    assert "__usage__" not in result, "an interrupted generation reports no usage"
+
+    assert body.closed
+    assert body.client_was_open_at_close, (
+        "the provider response outlived its client -- breaking out of the "
+        "`async for` does not run the adapter's `async with client.stream()` "
+        "exit, so the connection is only reclaimed when the abandoned "
+        "generator is finalized, after the client it belonged to is gone"
+    )
+    assert body.sent < 10, (
+        f"kept reading after the stop ({body.sent} frames pulled)"
+    )
+
+
+@pytest.mark.parametrize("provider,frame", STREAMING_PROVIDERS)
+def test_an_uninterrupted_generation_is_unchanged(monkeypatch, provider, frame):
+    """The stop plumbing must not alter a run nobody stopped."""
+    body = _EndlessSSE(frame("hi"), limit=1)
+    _install_mock_transport(monkeypatch, body)
+
+    result = LLMChatNode().execute({}, params(provider=provider, prompt="hi"))
+
+    assert result["text"] == "hi"
+    assert INTERRUPTED_KEY not in result
+    assert body.closed, "the normal path should hang up promptly too"
+
+
+def test_a_stop_that_landed_before_the_call_skips_the_provider_entirely(
+    monkeypatch,
+):
+    """A node dequeued after Stop must not pay for a whole generation."""
+    requests: list[httpx.Request] = []
+    body = _EndlessSSE(_openai_frame("tok "))
+    real_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, stream=body)
+
+    monkeypatch.setattr(
+        llm_chat_node.httpx, "AsyncClient",
+        lambda *a, **kw: real_client(*a, transport=httpx.MockTransport(handler), **kw),
+    )
+
+    ctx = ExecutionContext()
+    ctx.cancel()
+    result = LLMChatNode().execute({}, params(prompt="write an essay"), context=ctx)
+
+    assert result["text"] == ""
+    assert result[INTERRUPTED_KEY]["batch"] == 0
+    assert requests == [], "the request went out after the run was stopped"
+
+
+async def test_a_context_free_call_still_streams():
+    """``context=None`` -- the export runner, most unit tests -- never stops."""
+    async def adapter(req, client):
+        yield {"type": "text_delta", "text": "a"}
+        yield {"type": "done", "message": {"content": "ab"},
+               "usage": {"input_tokens": 1, "output_tokens": 2}}
+
+    text, usage, stopped = await llm_chat_node._collect_chat(
+        _build_request("openai", {}, params(prompt="hi")), adapter)
+
+    assert (text, usage, stopped) == (
+        "ab", {"input_tokens": 1, "output_tokens": 2}, None)
+
+
+async def test_close_stream_tolerates_an_iterator_without_aclose():
+    """``ProviderAdapter`` promises an AsyncIterator, which need not close."""
+    class _Plain:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    await llm_chat_node._close_stream(_Plain())  # must not raise
+
+
+async def test_close_stream_swallows_a_failing_teardown(caplog):
+    """A hiccup while hanging up must not fail a node that has its result."""
+    class _Boom:
+        async def aclose(self):
+            raise RuntimeError("connection reset")
+
+    await llm_chat_node._close_stream(_Boom())
+    assert "could not close the LLM provider stream" in caplog.text

--- a/frontend/src/utils/reconnect.test.ts
+++ b/frontend/src/utils/reconnect.test.ts
@@ -155,6 +155,41 @@ describe('redirectMouseDownToReconnectAnchor', () => {
     expect(event.stopPropagation).toHaveBeenCalledTimes(1);
   });
 
+  it('carries a `view`, so the d3 handlers on the canvas can read `event.view.document` (#219)', () => {
+    // The dispatched press bubbles into React Flow's canvas, where BOTH d3
+    // gesture recognizers dereference `event.view` on every mousedown:
+    // d3-drag's `mousedowned` calls `nodrag(event.view)` and d3-zoom's calls
+    // `dragDisable(event.view)` — the same function, whose first statement
+    // is `view.document.documentElement`, unguarded, in a dependency we do
+    // not own. A `MouseEvent` built without `view` has `view === null`, and
+    // that read is exactly the "Cannot read properties of null (reading
+    // 'document')" #219 recorded. The listener below is that read, verbatim.
+    const canvas = mountCanvas();
+    const { received } = mountAnchorFixture('e1', 'target', canvas);
+    const handle = document.createElement('div');
+    canvas.appendChild(handle);
+
+    let thrown: unknown = null;
+    canvas.addEventListener('mousedown', (e) => {
+      try {
+        void (e as MouseEvent).view!.document.documentElement;
+      } catch (err) {
+        // jsdom reports a listener throw to window.onerror rather than
+        // propagating it out of dispatchEvent, so it has to be captured
+        // here or the test would pass while the canvas was breaking.
+        thrown = err;
+      }
+    });
+
+    const event = stubEvent({ currentTarget: handle });
+    expect(redirectMouseDownToReconnectAnchor(event, 'e1')).toBe(true);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].view).not.toBeNull();
+    expect(received[0].view).toBe(canvas.ownerDocument.defaultView);
+    expect(thrown).toBeNull();
+  });
+
   it('returns false and leaves the event untouched when no anchor exists', () => {
     const event = stubEvent();
     expect(redirectMouseDownToReconnectAnchor(event, 'e1')).toBe(false);

--- a/frontend/src/utils/reconnect.ts
+++ b/frontend/src/utils/reconnect.ts
@@ -119,6 +119,63 @@ const escapeCssString = (value: string): string =>
   value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
 /**
+ * Build the synthetic left-button `mousedown` that starts a reconnect.
+ *
+ * `view` is load-bearing (#219), and the comment that used to sit at the
+ * dispatch site — "nothing downstream reads `event.view`" — was wrong. The
+ * press BUBBLES into React Flow's canvas, and both d3 gesture recognizers
+ * mounted there dereference `view` on every mousedown they see: d3-drag's
+ * `mousedowned` calls `nodrag(event.view)` and d3-zoom's calls
+ * `dragDisable(event.view)` — the same function, whose first statement is
+ * `view.document.documentElement`, with no null check, in a dependency we do
+ * not own (d3-drag/src/nodrag.js). A `MouseEvent` constructed without `view`
+ * has `view === null`, so omitting it throws exactly the "Cannot read
+ * properties of null (reading 'document')" #219 recorded — from inside React
+ * Flow, on a press we synthesized ourselves.
+ *
+ * The window is taken from the anchor's OWN document rather than the ambient
+ * global, because that is the realm the element actually lives in.
+ *
+ * The fallback is what the original omission was really working around.
+ * jsdom validates `view` by identity against its own global proxy, and under
+ * vitest the copied globals mean NO window object passes — not `window`, not
+ * `globalThis`, not `document.defaultView`, which are all the same rejected
+ * object there. So the standard init is tried first (that is what a real
+ * browser gets, byte for byte what a user's press looks like) and only when
+ * the constructor refuses is `view` installed as an own property, which
+ * shadows the prototype getter and reads back identically to every consumer.
+ * Without that second path the guard would be untestable, which is how it
+ * went missing in the first place.
+ */
+function createReconnectPress(
+  doc: Document,
+  clientX: number,
+  clientY: number,
+): MouseEvent {
+  const init: MouseEventInit = {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    buttons: 1,
+    clientX,
+    clientY,
+  };
+  // Null for a detached document: no window to name, and `view: null` is the
+  // constructor's own default, so that degrades to the old behavior rather
+  // than throwing.
+  const view = doc.defaultView;
+  if (!view) return new MouseEvent('mousedown', init);
+
+  try {
+    return new MouseEvent('mousedown', { ...init, view });
+  } catch {
+    const press = new MouseEvent('mousedown', init);
+    Object.defineProperty(press, 'view', { value: view, configurable: true });
+    return press;
+  }
+}
+
+/**
  * Redirect a connection-starting mousedown from a connected input Handle to
  * the given edge's target reconnect anchor.
  *
@@ -169,20 +226,9 @@ export function redirectMouseDownToReconnectAnchor(
   if (!anchor) return false;
 
   // The anchor's own handler requires button === 0 and reads the pointer
-  // position from the event, so mirror the original press exactly. `view` is
-  // intentionally omitted: nothing downstream reads `event.view`
-  // (@xyflow/system resolves the document from `event.target`), and jsdom's
-  // UIEvent init rejects window objects passed through vitest's copied
-  // globals (same reason @testing-library/dom omits it).
+  // position from the event, so mirror the original press exactly.
   anchor.dispatchEvent(
-    new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-      button: 0,
-      buttons: 1,
-      clientX: event.clientX,
-      clientY: event.clientY,
-    }),
+    createReconnectPress(doc, event.clientX, event.clientY),
   );
   event.preventDefault();
   event.stopPropagation();


### PR DESCRIPTION
> 中文摘要:兩件互不相關的小修補,合成一個 PR 只因為兩件都太小、各自送審不划算。第一件 (#155):按下停止對進行中的 LLM 生成完全無效 —— #122 那一波把五個長迴圈節點都補上停止檢查,唯獨漏掉 LLMChat,它的 context 參數形同虛設,所以一次長生成會一路跑到供應商自己結束,以 max_tokens 上限二十萬來算就是好幾分鐘。現在每收到一段文字就檢查一次停止旗標,停下來時把已經產生的半篇回答照樣送出並標記為「被中斷」,同時確實把 HTTP 串流關掉、不留連線。第二件 (#219):我們自己合成的滑鼠按下事件少了 view 欄位,而 React Flow 底層的 d3 會直接讀 event.view.document,沒有做空值檢查,這正是回報中那個 TypeError 的來源;現在把該事件所屬視窗補上。

Two unrelated leftovers. Neither is big enough to justify its own review, so
they share one. There is no connection between them beyond that.

---

## Item A --- #155: Stop did nothing to an LLM generation

### What was broken

`LLMChatNode.execute` accepted a `context` and never used it. The token loop
in `_collect_chat` iterated the provider stream to completion no matter what
the run was doing. So Stop was acknowledged by the UI, the engine noted the
cancellation, and the node kept streaming until the provider decided to
finish on its own. With `max_tokens` allowed up to 200,000 that is minutes of
a class watching a button that did nothing.

### Why it survived

It was found and deliberately deferred. The #122 long-loop audit (PR #154)
swept every `execute()` in the tree and gave `TrainingLoop`,
`DiffusionTrainingLoop`, `EvaluateModel`, `DDPMSampler` and `Map` a
`should_stop()` check; its "audited, deliberately not in this PR" table lists
`LLMChat` first, noting it is "stoppable in two lines but the
partial-response semantics (and `max_tokens` up to 200k) deserve their own
change". This is that change.

### What it does now

`_collect_chat` takes the `context` and resolves it through the existing
`loop_control.stop_checker`, so `context` is a live parameter end to end.
The flag is read once **before** the request goes out --- a node dequeued
after the user already stopped should not pay for a whole generation --- and
once **after** each streamed chunk is appended and reported, so the partial
text always contains everything that actually arrived. The check is a single
`threading.Event.is_set()`, which is nothing next to the network round trip
that delivered the chunk.

On a stop the node returns its partial text on the `text` port and merges the
existing `interrupted_result(...)` marker, exactly as the other five do. No
new convention: `graph_engine` already turns `__interrupted__` into an
`interrupted` node status instead of `completed`, and the marker's `batch`
field is the same "how far the loop got" number `DDPMSampler` uses for
denoising steps and `Map` uses for items --- here it counts streamed chunks,
alongside a `chars` extra. Nothing raises; `CancellationError` still comes
from the engine at the node boundary, which is where the run's outcome is
decided.

`__usage__` is omitted on an interrupted call. Token accounting only arrives
in the provider's terminal event, which by definition never came.

### Closing the stream, per provider

This is the half that is easy to get wrong, so it is worth a reviewer's
attention.

All four provider options go through three adapter modules --- `openai_like`
(serving both **ChatGPT API** and **Ollama**), `anthropic`, and `codex` ---
and every one of them is an **async generator** that holds an
`async with client.stream(...)` open across its yields. That means breaking
out of the `async for` does **not** close anything. The response, and the
socket under it, stay alive until the abandoned generator is finalized by
refcounting or by `asyncio.run`'s closing `shutdown_asyncgens` --- which
happens *after* the `AsyncClient` that owns the connection has already been
torn down.

So the loop now closes the generator explicitly, in a `finally`, on every
exit path. `aclose()` throws `GeneratorExit` in at the suspended yield, which
runs the adapter's own `async with` exit and releases the connection while
its client is still alive. **One mechanism covers all four providers**
precisely because all three modules are written the same way --- there is no
provider-specific cancel call to get wrong, and none of them needs one.

Two details behind that:

- `aclose` is looked up with `getattr`, not assumed. `ProviderAdapter`'s type
  is `AsyncIterator`, which a hand-rolled iterator class or a test double can
  satisfy without an `aclose`.
- It swallows and logs. This runs on the way out of a generation that already
  produced its result, or that the user just stopped; a transport hiccup
  while hanging up is worth a log line, not a failed node, and must not mask
  the exception already on its way out.

The same `finally` also tightens the **normal** path, which previously left
the generator suspended at its final `done` yield until something collected
it.

### Known limit, stated deliberately

The stop lands on the next chunk boundary. A provider that has gone quiet ---
still thinking, or stalled --- is not interrupted until it emits something or
`_common.TIMEOUT` (120s read) expires. The `await` that would have to be
cancelled lives inside the adapter, and racing every `__anext__` against a
timer would cost an asyncio task per token, which is not "cheap enough to run
per chunk". Same shape as the other five nodes, none of which can preempt a
single long batch either.

### Tests

In `backend/tests/test_llm_chat_node.py`, driven through
`LLMChatNode().execute` over `httpx.MockTransport`, **parametrized across all
four provider options** with each adapter's real SSE dialect (Codex's auth
handshake is stubbed):

| Test | What it catches |
| --- | --- |
| `test_stop_mid_stream_keeps_the_partial_text_and_closes_the_stream` | a stop that never lands; partial text discarded; the marker missing or misreporting where it stopped; the connection left open; the loop reading on after the stop |
| `test_an_uninterrupted_generation_is_unchanged` | the stop plumbing changing a run nobody stopped |
| `test_a_stop_that_landed_before_the_call_skips_the_provider_entirely` | a node dequeued after Stop still issuing the request (asserts zero requests reached the transport) |
| `test_a_context_free_call_still_streams` | `context=None` --- the export runner, `invoke_node`, most unit tests --- breaking |
| `test_close_stream_tolerates_an_iterator_without_aclose` | assuming `AsyncIterator` implies `aclose` |
| `test_close_stream_swallows_a_failing_teardown` | a failed hang-up turning a finished node into a failed one |

The stop is driven off the node's own `progress_callback` after two chunks,
the way a click lands mid-generation, rather than by pre-cancelling.

**The connection-cleanup assertion is about timing, not just closure**, and
that is the one worth reading. An abandoned generator *is* eventually
finalized, so a naive `body.closed` check passes with or without the fix ---
it did, when I first wrote it, and the mutation run caught that. The fixture
therefore records whether the owning `AsyncClient` was **still open** at
teardown. True means the adapter's `async with client.stream(...)` exit ran
on the way out of the loop, as it should; false means the response outlived
the client it belonged to.

All three behaviours were mutation-checked: removing the per-chunk check,
removing the stream close, and removing the pre-flight check each break at
least one test (the first two break all four provider cases).

### What I could not test

**No provider was contacted for real.** There is no API key in this
environment for OpenAI or Anthropic, no Codex session, and no local Ollama
instance. Everything above is exercised against `httpx.MockTransport` with
each provider's SSE dialect replayed through its real adapter, which is how
the existing adapter tests in this repo work. That covers the parsing, the
stop and the teardown; it does not prove a live socket is released against a
real endpoint. Worth a manual check by whoever has a key.

---

## Item B --- #219: the reconnect press was missing its `view`

### The premise had to be corrected first

#219 reads as if a CodefyUI drag handler dereferences `event.view`. It does
not: **no file under `frontend/src` reads `.view` off an event at all.** The
unguarded read is in a dependency, and here it is exactly:

- `d3-drag/src/nodrag.js` --- `function(view) { var root = view.document.documentElement, ... }`
- reached from `d3-drag/src/drag.js`'s `mousedowned` as `nodrag(event.view)`
- and from `d3-zoom/src/zoom.js`'s `mousedowned` as `dragDisable(event.view)`,
  which is the *same function* --- `d3-drag/src/index.js` re-exports `nodrag`
  as `dragDisable`

Both are installed by `@xyflow` on the canvas: d3-drag on nodes, d3-zoom on
the pane, which is why `FlowCanvas` leaving `panOnDrag`/`zoomOnScroll` at
their defaults is enough to arm it. Every `mousedown` reaching them is
dereferenced with no null check.

### The defect in code we own

`frontend/src/utils/reconnect.ts`'s `redirectMouseDownToReconnectAnchor` ---
the #115 "drag a connected input handle to detach its edge" path, called from
`BaseNode` and `PresetNode` --- dispatched a **bubbling** synthetic
`mousedown` with `view` omitted, under this comment:

```
// `view` is intentionally omitted: nothing downstream reads `event.view`
// (@xyflow/system resolves the document from `event.target`), and jsdom's
// UIEvent init rejects window objects passed through vitest's copied
// globals (same reason @testing-library/dom omits it).
```

The first clause is wrong, as above. The second clause is right, and is the
real reason the field went missing. A `MouseEvent` constructed without `view`
has `view === null`, the press bubbles into the canvas, and d3 reads
`.document` off it --- producing precisely the `TypeError: Cannot read
properties of null (reading 'document')` that #219 recorded, from inside
React Flow, on an event we manufactured ourselves.

Note what that means: this is reachable **on a real mouse press**, not only
from an automation harness. No browser run was done for this PR, so that is a
code-inspection claim plus a unit test reproducing the exact deref --- not a
reproduction in Chrome.

### The fix, and the awkward part

The press is now built by a small `createReconnectPress` helper that takes the
window from the **anchor's own document** (`doc.defaultView`) rather than the
ambient global, because that is the realm the element lives in. If the
document is detached and has no `defaultView`, `view` stays null, which is the
constructor's own default and degrades to today's behaviour rather than
throwing.

The awkward part, and the thing to push back on if you disagree: **jsdom
rejects every window object under vitest.** It validates `view` by identity
against its own global proxy, and vitest's copied globals mean `window`,
`globalThis` and `document.defaultView` are all the same object and none of
them passes --- I probed all three and each throws
`Failed to construct 'MouseEvent': member view is not of type Window`. So the
helper tries the standard init first (what a real browser gets, byte for byte
what a user's press looks like) and only if the constructor refuses installs
`view` as an own property, which shadows the prototype getter and reads back
identically to every consumer. Without that second path the guard would be
untestable, which is how it went missing in the first place.

### Test

`frontend/src/utils/reconnect.test.ts` gains one case that mounts the real
React Flow edge DOM inside a `.react-flow` canvas, attaches a listener
performing **d3's read verbatim** (`event.view.document.documentElement`), and
asserts the dispatched press carries the canvas document's window and that
the read did not throw. The thrown error is captured inside the listener
because jsdom reports a listener throw to `window.onerror` rather than
propagating it out of `dispatchEvent` --- without that, the test would pass
while the canvas was breaking.

Reverting the fix fails it with `expected null not to be null`.

### What this does not fix

- **The symptom in #219's own report.** Those errors correlated with node-add
  in a synthetic-`DragEvent` e2e. Nothing in the drop path (`useDragAndDrop`
  -> `screenToFlowPosition` -> `addNode`) touches `.view`; the likeliest
  source is the harness's own view-less `mousedown` reaching d3-zoom on the
  pane. That is an event we do not construct, so this PR cannot change it.
  What it fixes is the same defect in code we do own. #219's "one real mouse
  drag with the console open" is still the thing that would settle the
  original sighting.
- **A plugin dispatching a view-less event.** The issue cites the plugin API
  as a reason to care, and the hazard is real --- but the unguarded read is
  inside d3, and the only host-side options are patching a dependency or
  intercepting foreign events at the canvas boundary and rewriting them.
  Rewriting events we did not create, from third parties, is a surprising
  side effect that can mask genuine plugin bugs, so I did not do it. Say the
  word if you want the boundary normalizer; it is about ten lines.

---

## Verification

- CI green on all five checks: pytest 3.10 / 3.11 / 3.12, the frontend
  build+tsc+test job, and the control-byte scan.
- `backend` locally: full `pytest tests/` --- 3901 passed, 22 skipped. Three
  failures in `test_python_script_node.py` and `test_tiered_policy.py` are
  **not from this diff**: I re-ran them against a stashed (unmodified) tree
  and got the same three. They are a local-interpreter artifact --- `uv`
  resolved this worktree's venv to CPython **3.14**, which is outside the
  matrix, and both tests reason about stdlib module classification. All three
  pass in CI on every supported version.
- `frontend`: `pnpm test` --- 138 files, 2960 tests, all green.
- `pnpm exec tsc -b` clean; `pnpm build` (including the contrast gate) clean.
- `scripts/check_control_bytes.py` clean over 1095 tracked files.
- `git status --porcelain` shows exactly the four intended files, no
  line-ending churn.

Closes #155
Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)
