### PR TITLE
fix(security): gate the private C modules behind the blocklist, and scan every file the loader imports

### DIFF
--- a/backend/app/core/plugin_validator.py
+++ b/backend/app/core/plugin_validator.py
@@ -142,6 +142,209 @@ _DANGEROUS_MODULES = frozenset({
     # permission bits. No existing capability fits "read the shadow
     # database"; Tier 2 only, the same bucket as ``pickle`` / ``ctypes``.
     "readline", "spwd",
+
+    # ── core#215: the raw C modules the blocked ones are BUILT ON ────────
+    #
+    # core#183 closed ``nt`` / ``posix`` (see above) and stopped there. The
+    # siblings were never enumerated, and there are a lot of them: CPython
+    # writes most of the stdlib as a thin Python wrapper over a private C
+    # module, and the private module is the whole surface under a name this
+    # blocklist had never heard of. ``script_proxy._BLOCKED_IMPLEMENTATION_
+    # ROOTS`` -- the RUNTIME boundary for in-canvas scripts -- had recognised
+    # twelve of them as dangerous since long before this; that recognition
+    # was simply never ported here, to the INSTALL-time gate, which is the
+    # one a plugin or custom node passes through.
+    #
+    # The class was enumerated mechanically rather than by memory: import
+    # every name on this blocklist in a FRESH interpreter and diff
+    # ``sys.modules``, which is what turned up ``_overlapped`` and
+    # ``_interpreters`` sitting behind ``asyncio`` with nobody having listed
+    # either. Each was then VERIFIED individually -- the point of the
+    # exercise is what a module reaches, not what it is called.
+    #
+    # Tier 2 (no capability ever unlocks these), because each one's purpose
+    # is executing code or reaching the interpreter:
+    #
+    # ``_thread`` -- ``start_new_thread(fn, ())`` spawned a real OS thread
+    # (verified: got back a live native thread id and the worker ran).
+    # Matches ``threading``.
+    #
+    # ``_ctypes`` -- ``LoadLibrary("kernel32.dll")`` returned a live module
+    # handle (verified), and the surface holds ``CFuncPtr``,
+    # ``call_function``, ``_memmove_addr`` and ``_string_at_addr``:
+    # arbitrary foreign calls and arbitrary memory. Matches ``ctypes``.
+    #
+    # ``_pickle`` -- ``_pickle.loads(payload)`` executed a ``__reduce__``
+    # target and handed back its result (verified with a marked payload).
+    # Matches ``pickle``; deserialisation IS execution here.
+    #
+    # ``_signal`` -- ``raise_signal`` ("Send a signal to the executing
+    # process", its own docstring), ``signal`` (handler registration) and
+    # ``set_wakeup_fd``. One call kills or hijacks the server's own signal
+    # handling. Matches ``signal``.
+    #
+    # ``_asyncio`` -- the interesting one, because its surface looks inert
+    # (``Future``, ``Task``, loop bookkeeping) and is not.
+    # ``_asyncio._set_running_loop(obj)`` was verified to make the HOST's
+    # own ``asyncio.get_running_loop()`` return the attacker's object: this
+    # backend runs on asyncio, so that is process-global state poisoning of
+    # the loop the server itself resolves through -- the same category as
+    # ``torch.zeros = mine``, which this walker already refuses by name.
+    # Matches ``asyncio``.
+    #
+    # ``_imp`` -- ``create_dynamic`` is documented, in the module itself, as
+    # "Create an extension module": it loads an arbitrary native extension
+    # into this process. With ``create_builtin``, ``exec_dynamic`` and
+    # ``init_frozen`` beside it this is strictly lower-level than
+    # ``importlib``, which is already Tier 2.
+    #
+    # ``_frozen_importlib`` -- verified to BE ``importlib._bootstrap`` (an
+    # identity check, not a resemblance), and
+    # ``_frozen_importlib.__import__("subprocess")`` handed back the real
+    # ``subprocess`` module with a working ``.run``. That is a complete
+    # bypass of every import rule in this file: the walker sees one import
+    # of a module nobody has heard of, and the module hands over any other
+    # module by name at runtime.
+    #
+    # ``_frozen_importlib_external`` -- the same object for
+    # ``importlib._bootstrap_external``: ``SourceFileLoader``,
+    # ``SourcelessFileLoader``, ``ExtensionFileLoader``, ``FileFinder``,
+    # ``PathFinder``, and ``marshal`` (itself on this blocklist) bound as a
+    # plain attribute.
+    #
+    # ``_multiprocessing`` -- ``SemLock`` (named, cross-process
+    # semaphores), plus ``recv`` / ``send`` / ``closesocket`` operating
+    # directly on socket handles. Matches ``multiprocessing``.
+    #
+    # ``_posixsubprocess`` -- POSIX. Its entire surface is ``fork_exec``,
+    # whose own docstring reads "Spawn a fresh new child process. Fork a
+    # child process ... before calling exec() in the child process."
+    # Verified by reading that surface on a live Linux interpreter. Process
+    # execution with no ``subprocess`` anywhere.
+    #
+    # ``_posixshmem`` -- POSIX. Verified directly, not carried over from the
+    # issue: ``shm_open("/name", O_CREAT|O_RDWR)`` plus ``os.write``
+    # produced a real 64-byte object under ``/dev/shm`` holding a marked
+    # payload, visible outside the process, and ``shm_unlink`` removed it
+    # again -- all with no ``multiprocessing`` import at all.
+    #
+    # ``_winapi`` -- Windows. Verified: ``CreateProcess`` spawned a real
+    # process which ran ``cmd.exe`` and wrote a marked file. ``CreateFile``,
+    # ``CopyFile2``, ``CreateNamedPipe`` and ``CreateJunction`` are on the
+    # same module. This is ``subprocess`` and half of ``shutil``, raw.
+    #
+    # ``_overlapped`` -- Windows, and NOT on anybody's list before this: it
+    # only surfaced from the fresh-interpreter sweep, where ``import
+    # asyncio`` dragged it in. It is the raw async-I/O engine behind
+    # asyncio's ProactorEventLoop, and unlike ``select`` / ``fcntl`` (both
+    # deliberately accepted as "waits on handles somebody else already
+    # made") its surface contains connection-ESTABLISHING verbs:
+    # ``WSAConnect``, ``ConnectPipe``, and ``Overlapped.ConnectEx``. Stated
+    # honestly: it still needs a handle it cannot create itself, and every
+    # handle source is now gated, so this entry is completeness rather than
+    # a demonstrated standalone escape.
+    #
+    # ``msvcrt`` -- Windows. ``getch`` / ``getwch`` read a console keypress
+    # WITHOUT echoing it, with ``kbhit`` and ``ungetch`` alongside: a
+    # keystroke-capture primitive aimed at whatever console ``cdui start``
+    # was launched in. Also ``get_osfhandle`` / ``open_osfhandle`` (raw
+    # Win32 HANDLE <-> C file descriptor, in both directions), ``locking``,
+    # and ``SetErrorMode`` / ``heapmin`` (process-wide C-runtime state).
+    # Stated honestly: this one is gated on the module's own documented
+    # surface, read from a real Windows interpreter -- no live keystroke was
+    # captured, because the check ran without an interactive console.
+    "_thread", "_ctypes", "_pickle", "_signal", "_asyncio", "_imp",
+    "_frozen_importlib", "_frozen_importlib_external", "_multiprocessing",
+    "_posixsubprocess", "_posixshmem", "_winapi", "_overlapped", "msvcrt",
+    # ``_socket`` / ``_ssl`` / ``ssl`` and ``_sqlite3`` are the members of
+    # this class that a CAPABILITY covers rather than ``--trust-author``;
+    # they live in ``CAPABILITY_MODULES`` and the verification for each is
+    # recorded there, next to the group it joins.
+    "_socket", "_ssl", "ssl", "_sqlite3",
+
+    # ── core#216: surfaces nobody had considered at all ──────────────────
+    #
+    # Not "the raw thing behind something already blocked" -- these are
+    # whole capabilities that were simply never enumerated in either
+    # direction, the same way ``nt`` / ``posix`` never were. Tier 2 for all
+    # of them: no existing capability's consent line describes any of these,
+    # and inventing a fourth capability name is a vocabulary change that
+    # wants its own issue rather than a line in a tuple.
+    #
+    # ``winreg`` -- Windows registry, and the verification was end to end:
+    # created ``HKCU\\Software\\<probe>``, wrote a value, read it back,
+    # enumerated the REAL ``HKCU\\...\\CurrentVersion\\Run`` key (ten live
+    # entries -- OneDrive, Steam, Discord, Docker Desktop, ...), and deleted
+    # the probe key again. Create, write, read and delete all worked with
+    # zero declared capability. That Run key is the canonical
+    # survives-a-reboot persistence location on Windows and it is writable
+    # through the exact same API that just read it.
+    #
+    # ``_interpreters`` / ``_xxsubinterpreters`` -- an ``exec()`` this gate
+    # cannot see. Verified end to end: ``create()`` then ``exec(id, src)``
+    # ran attacker source in a sub-interpreter, and that source called
+    # ``os.system`` and wrote a marked file. ``run_string``, ``run_func``
+    # and ``call`` are the same door. The reason nothing caught it is
+    # precise: ``exec`` IS in ``_DANGEROUS_NAMES``, but ``_calls_the_builtin``
+    # only fires when the receiver resolves to ``builtins``, and this
+    # receiver is a module. BOTH names are listed because CPython RENAMED
+    # the module in 3.13 -- core#216 names only ``_xxsubinterpreters``,
+    # which does not exist on 3.13+, where the live primitive is called
+    # ``_interpreters``. Gating only the name in the issue would have been a
+    # no-op on every interpreter this project's own developers run.
+    #
+    # ``_interpchannels`` / ``_xxinterpchannels`` / ``_interpqueues`` -- the
+    # rest of the PEP 554 / PEP 734 family: channel and queue plumbing
+    # between interpreters. Verified they carry no execution primitive of
+    # their own, and listed anyway so the family is closed as a unit rather
+    # than by its most obvious member -- which is the failure mode
+    # ``nt``/``posix`` and this whole issue are about.
+    #
+    # ``pwd`` / ``grp`` -- POSIX account databases. Verified: ``getpwall()``
+    # enumerated 27 accounts with names, UIDs, home directories and login
+    # shells, ``getgrall()`` 58 groups with membership. Verified in the
+    # OTHER direction too, because it changes the verdict's honesty:
+    # ``/etc/passwd`` was world-readable to that account, so a plain
+    # ``open()`` -- deliberately ungated here -- already reaches the same
+    # content on a local-files host. What these add is a complete structured
+    # enumeration in one call, and the NSS-mediated case where the backing
+    # store is a directory service (LDAP/AD/SSSD) rather than a file. That
+    # second half was NOT verified; it is the same mechanism that made
+    # ``spwd`` blockable, and ``spwd`` is already on this list, so leaving
+    # its two siblings open was the odd position.
+    #
+    # ``syslog`` -- verified that ``openlog(ident="sshd",
+    # facility=LOG_AUTH)`` followed by ``syslog(...)`` is accepted with no
+    # error: the program name an entry is attributed to is caller-chosen, so
+    # this is log forgery into the auth facility, not just a log write. NOT
+    # verified that the entry landed in ``/var/log`` -- the test host had no
+    # listener on ``/dev/log`` -- so what is proven is that the API accepts
+    # an arbitrary identity and message.
+    #
+    # ``termios`` -- verified the part that matters: with ``sys.stdin`` NOT
+    # a tty, ``os.open("/dev/tty")`` plus ``tcgetattr`` still succeeded on
+    # the REAL controlling terminal, and ``tcsetattr`` and the ``ECHO`` flag
+    # are right there. So a plugin can turn echo off and read the terminal
+    # the server was launched from regardless of what its own stdio is
+    # attached to -- the common case for a self-hosted ``cdui start``.
+    #
+    # ``_curses`` / ``_curses_panel`` -- verified surface (301 names)
+    # including ``initscr``, ``noecho``, ``cbreak`` and ``endwin``: display
+    # and input takeover of that same terminal. ``_curses_panel`` is the
+    # window-stacking extension and adds nothing beyond ``_curses``; listed
+    # with it so the pair cannot drift.
+    #
+    # ``ossaudiodev`` -- opens OSS audio device files (``/dev/dsp``) for
+    # reading, which is microphone capture. This is the ONE entry in this
+    # commit gated WITHOUT a live reproduction: CPython removed the module
+    # in 3.13 and both interpreters available here are 3.14, so the gate
+    # rests on CPython's own documented surface. Said plainly rather than
+    # dressed up, because a reviewer should know which entries were proven
+    # and which were read.
+    "winreg", "_interpreters", "_xxsubinterpreters",
+    "_interpchannels", "_xxinterpchannels", "_interpqueues",
+    "pwd", "grp", "syslog", "termios", "_curses", "_curses_panel",
+    "ossaudiodev",
 })
 
 # Attribute-access patterns that are RCE in disguise whatever the receiver

--- a/backend/app/core/script_proxy.py
+++ b/backend/app/core/script_proxy.py
@@ -136,6 +136,19 @@ _CAPABILITY_TYPES: tuple[type, ...] = (
 #: ``numpy.random.bit_generator.RLock`` resolving to ``_thread`` on one numpy
 #: version and ``threading`` on another. Blocking only the wrapper would make
 #: the rule depend on which of the two a library happened to import from.
+#:
+#: core#215 -- this set used to be the ONLY place in the codebase that knew
+#: these names were dangerous. It is the RUNTIME boundary, for in-canvas
+#: scripts; the INSTALL-time gate a plugin or custom node passes through
+#: (:data:`app.core.plugin_validator._DANGEROUS_MODULES`) had never heard of
+#: any of them, so ``import _ctypes`` in a plugin was accepted with zero
+#: declaration while ``collections._ctypes`` was refused in a script. That
+#: recognition has now been ported: every name below is on the install-time
+#: blocklist too, except ``_io``, which is a documented accept in
+#: :data:`app.core.security_tiers.ACCEPTED_UNGATED_MODULES` because
+#: ``open()`` is deliberately ungated. A standing test in
+#: ``test_tiered_policy.py`` asserts that property, so the two boundaries
+#: cannot drift apart again in the direction that caused core#215.
 _BLOCKED_IMPLEMENTATION_ROOTS: frozenset[str] = frozenset({
     "nt", "posix", "_io", "_thread", "_socket", "_ssl", "_ctypes",
     "_pickle", "_winapi", "msvcrt", "_posixsubprocess", "_multiprocessing",

--- a/backend/app/core/security_tiers.py
+++ b/backend/app/core/security_tiers.py
@@ -148,7 +148,18 @@ CAPABILITIES: tuple[str, ...] = ("network", "filesystem", "process-env")
 #: that no capability hands over a module built for executing code; the one
 #: that hands over a general-purpose module says so in its summary.
 CAPABILITY_MODULES: dict[str, tuple[str, ...]] = {
-    "network": ("http", "requests", "socket", "urllib"),
+    # core#215/#216 -- `_socket` is the C module `socket` is built on, and
+    # reaching it by its own name is reaching `socket`: verified a real
+    # outbound TCP connection (1.1.1.1:80, HTTP request sent, "HTTP/1.1 301"
+    # read back) using nothing but `import _socket`, on Windows and Linux
+    # alike. `ssl` was never on the blocklist at all, and it is not merely a
+    # cipher library: `ssl.get_server_certificate((host, port))` opens a real
+    # connection itself (its source calls `create_connection`), verified by
+    # fetching 1411 bytes of live certificate from example.com:443 with
+    # `import ssl` and nothing declared. `_ssl` is the raw engine under it.
+    # All three are the same surface this capability's summary already
+    # describes -- "send and receive data from any host".
+    "network": ("_socket", "_ssl", "http", "requests", "socket", "ssl", "urllib"),
     "filesystem": (
         "bz2",
         "codecs",
@@ -164,6 +175,14 @@ CAPABILITY_MODULES: dict[str, tuple[str, ...]] = {
         "readline",
         "shutil",
         "sqlite3",
+        # core#215 -- the raw C module `sqlite3` is built on. Verified that
+        # `_sqlite3.connect(path)` creates a real database file at an
+        # arbitrary path (8192 bytes appeared where none existed) with no
+        # `sqlite3` import anywhere. Tagged to match its wrapper rather than
+        # re-tiered: see the note in `plugin_validator._DANGEROUS_MODULES`
+        # about extension loading, which is a question about the PAIR and is
+        # flagged rather than decided here.
+        "_sqlite3",
         "tarfile",
         "tempfile",
         "zipfile",
@@ -201,7 +220,7 @@ CAPABILITY_MODULES: dict[str, tuple[str, ...]] = {
 CAPABILITY_SUMMARY: dict[str, str] = {
     "network": (
         "reach the network -- send and receive data from any host, and write "
-        "what it downloads to disk (requests, urllib, http, socket)"
+        "what it downloads to disk (requests, urllib, http, socket, ssl)"
     ),
     "filesystem": (
         "use the file libraries -- pathlib, tempfile, shutil, zip/tar/gzip, "
@@ -341,11 +360,11 @@ TIER0_PATH_HELPERS: tuple[str, ...] = (
 #: verified directly, not merely reasoned about, by re-reading the
 #: assertion's comprehension before extending this dict for CI round 2.
 #:
-#: Four shapes below, not three:
+#: Two shapes below, not four (core#215 / core#216 closed the other two):
 #:
 #: 1. **Closed: the wrapper is already unrestricted, so the accelerator
-#:    grants nothing new.** ``_io`` (behind plain ``open()``, which
-#:    ``filesystem``'s own docstring explains was deliberately left
+#:    grants nothing new.** ``_io`` and ``_pyio`` (behind plain ``open()``,
+#:    which ``filesystem``'s own docstring explains was deliberately left
 #:    ungated) and ``_sre`` (behind ``re``, already in
 #:    :data:`TIER0_PURE_COMPUTE_MODULES` with zero declaration).
 #: 2. **Closed: pure computation, verified by import and inspection, not
@@ -356,39 +375,50 @@ TIER0_PATH_HELPERS: tuple[str, ...] = (
 #:    see core#177's own review for the specific check that caught
 #:    ``__pycache__`` being asserted safe on the strength of an argument
 #:    that was never actually tried.
-#: 3. **Deferred: raw C-implementation module sitting directly behind an
-#:    already-blocklisted or capability-gated wrapper.**
-#:    :data:`app.core.script_proxy._BLOCKED_IMPLEMENTATION_ROOTS` (the
-#:    runtime boundary for in-canvas scripts) already recognises every one
-#:    of them as dangerous; that recognition was simply never ported to the
-#:    install-time blocklist (core#215). Not resolved here even where the
-#:    wrapper's own capability is a one-line mechanical match (``_bz2``
-#:    behind ``bz2``, already ``filesystem``): CI round 2 kept the
-#:    you-decide-the-check / maintainer-decides-the-blocklist split rather
-#:    than treating "structurally the same shape as something already
-#:    deferred" as licence to resolve five more of them unilaterally.
-#: 4. **Deferred: a whole surface nobody had considered, not a hidden
-#:    implementation behind something already blocked.** ``winreg`` (full
-#:    Windows registry read/write/delete), ``_xxsubinterpreters``
-#:    (``run_string(id, script, shared)`` executes an arbitrary string in a
-#:    sub-interpreter -- an ``exec()``-equivalent primitive under a name
-#:    ``_DANGEROUS_NAMES`` never looks for), ``pwd`` / ``grp`` (POSIX user /
-#:    group database reads) and more added over two CI rounds -- tracked
-#:    separately (core#216).
 #:
-#: Two names broke shape 3/4's "defer, don't decide" pattern in CI round 2,
-#: each independently verified rather than assumed dangerous or assumed
-#: safe: ``readline`` (an attacker-directed file WRITE, proven) and ``spwd``
-#: (a shadow-password-database READ that bypasses its own file's permission
-#: bits via NSS, proven) are both on the blocklist outright -- see
-#: :data:`app.core.plugin_validator._DANGEROUS_MODULES` for the writeup on
-#: each.
+#: The two DEFERRED shapes this dict used to carry are gone, because
+#: core#215 and core#216 answered them:
+#:
+#: * shape 3 was "raw C-implementation module sitting behind an already
+#:   blocklisted or capability-gated wrapper", parked here because
+#:   :data:`app.core.script_proxy._BLOCKED_IMPLEMENTATION_ROOTS` (the
+#:   RUNTIME boundary for in-canvas scripts) already called them dangerous
+#:   while the INSTALL-time blocklist had never heard of them;
+#: * shape 4 was "a whole surface nobody had considered" -- ``winreg``,
+#:   the sub-interpreter family, the POSIX account databases, the tty
+#:   modules.
+#:
+#: Every one of those was verified individually and then either put on
+#: :data:`app.core.plugin_validator._DANGEROUS_MODULES` (with the writeup
+#: recorded there, next to the entry) or kept here with a reason that now
+#: states a VERDICT rather than a deferral. Three that had been assumed to
+#: be mechanical matches for their wrapper's capability turned out not to
+#: be, which is why the rule is still "verify, then decide" and not "the
+#: wrapper's tier, applied downward": ``_bz2`` and ``_lzma`` expose
+#: compressor objects over in-memory bytes and nothing else (their
+#: wrappers' ``filesystem`` tag comes from ``BZ2File`` / ``LZMAFile``,
+#: which are ordinary Python calling the already-unrestricted ``open()``),
+#: and ``resource`` cannot raise a limit past the ceiling it starts with.
+#:
+#: So an entry here is now always a decision that the module is ACCEPTED,
+#: not a placeholder. Landing on the blocklist instead is the other
+#: decision; nothing is untriaged. A future CPython that compiles in a new
+#: extension module still fails the enumeration test by name until someone
+#: makes one of those two decisions about it, which is the whole point of
+#: the pair.
 ACCEPTED_UNGATED_MODULES: dict[str, str] = {
     # ── shape 1: the wrapper is already unrestricted or already Tier 0 ──
     "_io": (
         "io / open() are unrestricted for installed files by design; "
         "gating the C accelerator under it grants nothing io doesn't "
         "already"
+    ),
+    "_pyio": (
+        "the PURE-PYTHON io implementation (_pyio.open is a full open()); "
+        "same verdict as _io for the same reason -- open() is deliberately "
+        "ungated, so neither implementation of it grants anything new. "
+        "Surfaced by walking sys.modules after importing each blocklisted "
+        "module in a fresh interpreter, not from a hand-written list"
     ),
     "_sre": (
         "the regex engine behind re, already in TIER0_PURE_COMPUTE_MODULES "
@@ -431,6 +461,26 @@ ACCEPTED_UNGATED_MODULES: dict[str, str] = {
     "time": "clock reads and sleep; not a secret, same category as datetime.now()",
     "xxsubtype": "CPython's own C-extension example/test module; no I/O",
     "zlib": "compress/decompress over in-memory bytes; no I/O",
+    # core#215 -- the compression accelerators, verified rather than assumed
+    # to match their wrappers' "filesystem" tag. Each exposes a compressor
+    # and a decompressor over in-memory bytes and NOTHING else (checked the
+    # full dir(): _bz2 is exactly {BZ2Compressor, BZ2Decompressor}; _lzma
+    # adds only filter/check constants; _zstd the same shape). The file
+    # access their wrappers are gated for lives in BZ2File / LZMAFile /
+    # ZstdFile, which are ordinary Python calling the already-unrestricted
+    # open(). Same category as zlib directly above, which was already
+    # accepted on exactly this reasoning.
+    "_bz2": "BZ2Compressor/BZ2Decompressor over in-memory bytes; no path "
+            "ever reaches it (bz2's file access is BZ2File, pure Python "
+            "over open()) -- same category as zlib above",
+    "_lzma": "LZMACompressor/LZMADecompressor plus filter constants, over "
+             "in-memory bytes; lzma's file access is LZMAFile, pure Python "
+             "over open() -- same category as zlib above",
+    "_zstd": "3.14+: the zstd compressor/decompressor over in-memory bytes; "
+             "same category as zlib / _bz2 / _lzma above",
+    "_hmac": "3.14+: HMAC over in-memory bytes (compute_sha256 and friends); "
+             "a keyed hash is a pure transform, same category as _hashlib "
+             "and the individual digest accelerators below",
     # hashing: pure, deterministic transforms of in-memory bytes
     "_blake2": "BLAKE2 hash; pure transform of in-memory bytes",
     "_md5": "MD5 hash; pure transform of in-memory bytes",
@@ -499,8 +549,8 @@ ACCEPTED_UNGATED_MODULES: dict[str, str] = {
                 "transform of in-memory bytes, same category as the "
                 "individual _md5/_sha1/etc. accelerators above",
     "_queue": "thread-safe FIFO held entirely in memory; no I/O of its own, "
-              "and needs _thread (already tracked, core#215) to do anything "
-              "concurrent -- inert on its own",
+              "and needs _thread (which is on the blocklist) to do "
+              "anything concurrent -- inert on its own",
     "_uuid": "UUID generation; uuid1() reads the network interface's MAC "
              "address for uniqueness, a minor hardware-identifier read, not "
              "a file/network/process/environment capability",
@@ -512,102 +562,25 @@ ACCEPTED_UNGATED_MODULES: dict[str, str] = {
                          "test scaffolding, not shipped functionality",
     "_xxtestfuzz": "CPython's own fuzz-testing scaffold module; test "
                    "infrastructure, not shipped functionality",
-    # ── shape 3: real capability, verified, deferred to the maintainer ──
-    "pwd": "POSIX: reads the password database (usernames, UIDs, home "
-           "directories, login shells) for every account on the machine "
-           "-- core#216",
-    "grp": "POSIX: reads the group database (group names, GIDs, membership) "
-           "-- core#216",
-    "syslog": "POSIX: writes to the system log, outside normal file I/O and "
-              "not covered by any existing capability -- core#216",
-    "_signal": "raw process-control primitives (raise_signal, set_wakeup_fd, "
-               "signal handler registration) behind signal, itself already "
-               "Tier-2-only -- core#215",
-    "_thread": "raw os-thread spawn behind threading (Tier-2-only today) -- core#215",
-    "_socket": 'raw socket behind socket (gated by "network" today) -- core#215',
-    "_ssl": "raw TLS behind ssl (not on the blocklist at all today) -- core#215",
-    "_ctypes": "raw native-call bridge behind ctypes (Tier-2-only today) -- core#215",
-    "_pickle": "raw deserialize-executes-code behind pickle (Tier-2-only today) -- core#215",
-    "_winapi": (
-        "Windows: raw CreateProcess and friends, ungated by name today -- core#215"
-    ),
-    "msvcrt": "Windows C runtime bindings, console/file-locking primitives -- core#215",
-    "_posixsubprocess": (
-        "the fork_exec primitive behind subprocess (Tier-2-only today) -- core#215"
-    ),
-    "_multiprocessing": (
-        "raw multiprocessing C helpers behind multiprocessing "
-        "(Tier-2-only today) -- core#215"
-    ),
-    "_imp": "raw import machinery, lower-level than importlib (Tier-2-only today) -- core#215",
-    "_frozen_importlib": "CPython's own bootstrap import machinery -- core#215",
-    "_frozen_importlib_external": "same as _frozen_importlib -- core#215",
-    # core#177 CI round 2 -- five more of shape 3, each a mechanical match to
-    # an already-blocked wrapper's own capability, deliberately NOT resolved
-    # here (see the header: "structurally the same shape" was not treated as
-    # licence to decide five more of these unilaterally).
-    "_asyncio": "raw C accelerator behind asyncio, itself already "
-                "Tier-2-only (no capability) -- core#215",
-    "_bz2": 'raw C accelerator behind bz2, itself already capability-gated '
-            '("filesystem") -- core#215',
-    "_lzma": 'raw C accelerator behind lzma, itself already capability-gated '
-             '("filesystem") -- core#215',
-    "_posixshmem": (
-        "raw POSIX shared-memory primitive (shm_open/shm_unlink) behind "
-        "multiprocessing.shared_memory; multiprocessing is already "
-        "Tier-2-only. Verified directly reachable WITHOUT ever importing "
-        "multiprocessing at all -- created a real /dev/shm object through "
-        "_posixshmem alone -- core#215"
-    ),
-    "_sqlite3": (
-        'raw C accelerator behind sqlite3, itself already capability-gated '
-        '("filesystem", and that module\'s own blocklist comment already '
-        "names extension-loading as part of the reason). Worth the "
-        "maintainer's attention regardless: verified directly that "
-        "Connection.enable_load_extension(True) + .load_extension(path) "
-        "loads an arbitrary shared library into the process -- a "
-        "ctypes-equivalent native-code primitive, which may mean "
-        "\"filesystem\" already under-describes what sqlite3/_sqlite3 grant, "
-        "not only that _sqlite3 needs the same tag its wrapper has -- "
-        "core#215"
-    ),
-    "winreg": "Windows: full registry read/write/delete -- persistence and "
-              "data-exfiltration primitive, no existing capability covers "
-              "it -- core#216",
-    "_xxsubinterpreters": (
-        "run_string(id, script, shared) executes an arbitrary string in a "
-        "sub-interpreter -- an exec()-equivalent primitive under a name "
-        "_DANGEROUS_NAMES never looks for -- core#216"
-    ),
-    # core#177 CI round 2 -- six more of shape 4 (standalone surfaces, no
-    # already-blocked wrapper to match):
-    "_curses": "terminal UI manipulation (raw mode, screen control) on a "
-               "REAL controlling tty if one is attached (e.g. `cdui start` "
-               "run in a terminal); not a file/network/process/environment "
-               "capability -- a display/input-takeover primitive scoped to "
-               "whatever tty the process happens to have -- core#216",
-    "_curses_panel": "curses' window-stacking extension; adds no capability "
-                     "beyond _curses itself -- core#216",
-    "ossaudiodev": "opens OSS audio device files (e.g. /dev/dsp) if present; "
-                   "a real, if obsolete and typically absent on a modern "
-                   "Linux/CI host, audio-capture primitive -- core#216",
-    "resource": "reads/sets the CURRENT process's own resource limits "
-                "(open files, CPU time, memory, ...); verified an "
-                "unprivileged process cannot raise a hard limit past its "
-                "existing ceiling (ValueError: not allowed to raise maximum "
-                "limit), so this is self-DoS-shaped, not privilege "
-                "escalation -- and CPU/memory DoS against the host process "
-                "is already explicitly out of this gate's stated scope (see "
-                "script_policy's own \"nothing here contains CPU or memory "
-                "either\") -- core#216",
-    "termios": "terminal I/O mode control (raw/cooked, echo) on a REAL "
-               "controlling tty if one is attached; same scope and severity "
-               "class as _curses above, tracked together -- core#216",
-    "_xxinterpchannels": "3.12+ only: channel-based communication between "
-                         "sub-interpreters, the companion module to "
-                         "_xxsubinterpreters above; does not itself execute "
-                         "code but is part of the same PEP 554 family -- "
-                         "core#216",
+    # ---- resolved by core#215 / core#216: the ACCEPT half --------------
+    #
+    # Everything the old "shape 3" / "shape 4" blocks parked here is gone:
+    # each name was verified individually and then either moved to
+    # plugin_validator._DANGEROUS_MODULES (the writeup lives beside the
+    # entry there) or kept as an accept with the reason restated as a
+    # verdict. `_bz2`, `_lzma` and `resource` are the three that stayed,
+    # and they are recorded above and below rather than here so they sit
+    # next to the entries they are the same category as.
+    "resource": "POSIX: reads/sets the CURRENT process's own resource limits "
+                "(open files, CPU time, memory, ...). Re-verified on a live "
+                "Linux interpreter rather than carried forward: setrlimit "
+                "raising RLIMIT_NOFILE past its existing hard limit was "
+                "refused outright (ValueError: not allowed to raise maximum "
+                "limit), and getrusage is introspection -- so this is "
+                "self-DoS-shaped, not privilege escalation, and CPU/memory "
+                "DoS against the host process is already explicitly out of "
+                "this gate's stated scope (see script_policy's own \"nothing "
+                "here contains CPU or memory either\")",
 }
 
 

--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -341,6 +341,258 @@ def test_validate_plugin_dir_still_skips_the_one_genuinely_unreachable_dir(tmp_p
     plugin_cli.validate_plugin_dir(root, [])  # does not raise
 
 
+# ── core#220: the scan globbed *.py, the loader imports more ──────────────
+#
+# core#182 established the property "what the scan considers in-tree matches
+# what the loader can import" and enforced it by DIRECTORY. The same property
+# was broken by file EXTENSION one layer down, and this is the worse half:
+# core#182's gap meant unscanned code in a directory the walk skipped, while
+# this one meant the walk never produced a single file to scan. The gate did
+# not fail open on a rule -- it never ran.
+
+
+def _plugin_with(tmp_path, filename: str, payload: bytes) -> Path:
+    """A minimal plugin tree whose ``nodes/`` holds one extra file."""
+    root = tmp_path / "pack"
+    (root / "nodes").mkdir(parents=True)
+    (root / "nodes" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "nodes" / filename).write_bytes(payload)
+    return root
+
+
+@pytest.mark.parametrize(
+    ("filename", "suffix"),
+    [
+        ("helper.pyc", ".pyc"),
+        ("helper.pyo", ".pyo"),
+        ("native.pyd", ".pyd"),
+        ("native.so", ".so"),
+        ("native.dylib", ".dylib"),
+    ],
+)
+def test_validate_plugin_dir_refuses_compiled_modules_it_cannot_scan(
+    tmp_path, filename, suffix
+):
+    """A plugin shipping a compiled module is refused BY NAME, loudly.
+
+    Before this, ``validate_plugin_dir`` globbed ``*.py`` while
+    ``plugin_loader.install_plugin_finder`` handed the whole plugin
+    directory to the stock ``FileFinder`` loaders, which accept every suffix
+    in ``importlib.machinery.all_suffixes()``. A pack whose ``nodes/`` held
+    ``helper.pyc`` and no ``helper.py`` was imported by
+    ``NodeRegistry.discover`` at server boot -- at full trust, with no
+    capability declared and without ``--trust-author`` -- having never been
+    opened by the gate.
+
+    Refusal rather than scanning is the honest answer for both kinds:
+    ``.pyc`` would need decompiling, and a ``.pyd`` / ``.so`` cannot be
+    AST-scanned even in principle. The alternative is importing code nobody
+    looked at, which is the thing this whole module exists to prevent.
+
+    The binary suffixes of OTHER platforms are refused too. A tarball is not
+    installed on the machine that built it, so a verdict that depended on
+    which OS ran the installer would be a verdict an attacker picks.
+    """
+    root = _plugin_with(tmp_path, filename, b"\x00\x01\x02 not source")
+    with pytest.raises(PluginValidationError) as excinfo:
+        plugin_cli.validate_plugin_dir(root, [])
+    message = str(excinfo.value)
+    assert filename in message, "the refusal must name the file"
+    assert suffix in message, "the refusal must name why it could not be scanned"
+
+
+def test_the_refused_bytecode_really_is_importable(tmp_path):
+    """Non-vacuity for the test above: prove the file it refuses is a file
+    the import system would genuinely have loaded, rather than a shape that
+    only looks dangerous.
+
+    Compiles a real payload to bytecode, deletes the source, and checks that
+    ``pkgutil`` -- the same enumeration ``NodeRegistry.discover`` walks with
+    -- reports it as an importable module while a ``*.py`` glob sees
+    nothing. Without this, the refusal could be guarding a phantom.
+    """
+    import pkgutil
+    import py_compile
+
+    root = tmp_path / "pack"
+    nodes = root / "nodes"
+    nodes.mkdir(parents=True)
+    (nodes / "__init__.py").write_text("", encoding="utf-8")
+    src = nodes / "payload_src.py"
+    src.write_text("import os\nos.system('whoami')\n", encoding="utf-8")
+    py_compile.compile(str(src), cfile=str(nodes / "helper.pyc"), doraise=True)
+    src.unlink()
+
+    scanned_by_the_old_glob = sorted(p.name for p in root.rglob("*.py"))
+    importable = sorted(m.name for m in pkgutil.iter_modules([str(nodes)]))
+    assert "helper" in importable, (
+        "the premise of core#220: pkgutil (what NodeRegistry.discover walks) "
+        "reports the bytecode-only module as importable"
+    )
+    assert scanned_by_the_old_glob == ["__init__.py"], (
+        "the other half of the premise: a *.py glob never sees it"
+    )
+    with pytest.raises(PluginValidationError):
+        plugin_cli.validate_plugin_dir(root, [])
+
+
+def test_validate_plugin_dir_scans_pyw_as_the_source_it_is(tmp_path):
+    """``.pyw`` is a loader suffix and is ordinary Python text, so it is
+    SCANNED rather than refused -- refusing it would be a false positive,
+    and skipping it was the bug.
+
+    Scanned on every platform, not only where ``SOURCE_SUFFIXES`` lists it.
+    ``.pyw`` is Windows-only as a loader suffix, so a scan running on Linux
+    would otherwise wave through a file that a Windows install of the same
+    tarball imports.
+    """
+    root = _plugin_with(tmp_path, "w.pyw", b"import os\nos.system('whoami')\n")
+    with pytest.raises(PluginValidationError) as excinfo:
+        plugin_cli.validate_plugin_dir(root, [])
+    assert "Importing 'os' is not allowed" in str(excinfo.value), (
+        "a .pyw should reach the ordinary AST rules, not the refuse-by-suffix "
+        "path -- it is source"
+    )
+
+    clean = _plugin_with(tmp_path / "ok", "w.pyw", b"VALUE = 1\n")
+    plugin_cli.validate_plugin_dir(clean, [])   # does not raise
+
+
+def test_the_scan_covers_every_suffix_the_import_system_accepts(tmp_path):
+    """The standing check core#220 asks for: a future CPython that adds a
+    loader suffix fails here instead of silently widening the hole.
+
+    Asked of the interpreter (``importlib.machinery.all_suffixes()``) rather
+    than compared against a copy of today's answer, and asserted on
+    BEHAVIOUR rather than on set membership -- every suffix gets a real file
+    written under a real plugin root, and the walk has to do one of exactly
+    two things with it: scan it as source, or refuse it by name. A third
+    outcome, "walked straight past it", is the state this closed, and a
+    membership check would not have distinguished the third from the second.
+    """
+    import importlib.machinery
+
+    accepts = set(importlib.machinery.all_suffixes())
+    assert accepts <= plugin_cli.LOADER_SUFFIXES, (
+        "this interpreter's import system accepts suffixes the plugin scan "
+        f"does not consider: {sorted(accepts - plugin_cli.LOADER_SUFFIXES)}"
+    )
+    assert set(importlib.machinery.SOURCE_SUFFIXES) <= plugin_cli.SCANNABLE_SUFFIXES
+
+    for index, suffix in enumerate(sorted(accepts | plugin_cli.LOADER_SUFFIXES)):
+        root = _plugin_with(
+            tmp_path / f"probe{index}",
+            "probe" + suffix,
+            b"import os\nos.system('whoami')\n",
+        )
+        with pytest.raises(PluginValidationError) as excinfo:
+            plugin_cli.validate_plugin_dir(root, [])
+        message = str(excinfo.value)
+        if suffix in plugin_cli.SCANNABLE_SUFFIXES:
+            assert "Importing 'os' is not allowed" in message, (
+                f"{suffix!r} is source, so it must reach the AST rules"
+            )
+        else:
+            assert suffix in message and "probe" in message, (
+                f"{suffix!r} cannot be scanned, so the refusal must name the "
+                f"file and say why -- silence is the core#220 bug"
+            )
+
+
+def test_longest_suffix_wins_so_a_versioned_extension_is_still_refused(tmp_path):
+    """``native.cp314-win_amd64.pyd`` ends with two loader suffixes, and
+    picking the short one would defeat the refusal.
+
+    Strip only ``.pyd`` and the stem is ``native.cp314-win_amd64``, which is
+    not an identifier -- so the "can an import statement name this?" screen
+    would skip it, and a real compiled extension (the exact filename
+    ``setuptools`` produces) would sail through unexamined. Strip the full
+    ``.cp314-win_amd64.pyd`` and the stem is ``native``, which it can.
+    """
+    import importlib.machinery
+
+    versioned = importlib.machinery.EXTENSION_SUFFIXES[0]
+    root = _plugin_with(tmp_path, "native" + versioned, b"\x00binary")
+    assert plugin_cli.loader_suffix(
+        root / "nodes" / ("native" + versioned)
+    ) == versioned, "longest match must win"
+    with pytest.raises(PluginValidationError):
+        plugin_cli.validate_plugin_dir(root, [])
+
+
+def test_a_cpython_written_bytecode_cache_is_not_mistaken_for_a_payload(tmp_path):
+    """The false positive the refusal must NOT produce.
+
+    Any plugin directory an interpreter has ever imported from carries a
+    ``__pycache__`` full of ``<name>.cpython-NNN.pyc`` -- this repo's own
+    built-in packs included, which is how this surfaced. Those are not
+    reachable by any import statement: strip ``.pyc`` and the stem is
+    ``real.cpython-314``, which is not a valid identifier, so no import can
+    name it. An attacker-placed ``payload.pyc`` in the SAME directory has
+    the stem ``payload``, which is.
+
+    Verified rather than argued, because the distinction carries the whole
+    rule: with a plugin exposed through the real loader,
+    ``import <pkg>.nodes.__pycache__.payload`` ran the planted bytecode
+    while ``import <pkg>.nodes.__pycache__.real`` raised
+    ``ModuleNotFoundError``, and ``pkgutil.iter_modules`` listed only the
+    first. So the refusal fires on the one that is reachable and stays quiet
+    on the one that is not -- the same structural test ``.git`` gets, applied
+    to a filename instead of a directory name.
+    """
+    import py_compile
+
+    root = tmp_path / "pack"
+    nodes = root / "nodes"
+    cache = nodes / "__pycache__"
+    cache.mkdir(parents=True)
+    (nodes / "__init__.py").write_text("", encoding="utf-8")
+    (nodes / "real.py").write_text("VALUE = 1\n", encoding="utf-8")
+    py_compile.compile(str(nodes / "real.py"), doraise=True)
+
+    artifacts = sorted(p.name for p in cache.iterdir())
+    assert artifacts, "py_compile should have written a cache file"
+    for name in artifacts:
+        assert not name[: -len(".pyc")].isidentifier(), (
+            f"{name} is CPython's own cache artifact; the premise of this "
+            "test is that its stem is unspellable as a module name"
+        )
+    plugin_cli.validate_plugin_dir(root, [])   # does not raise
+
+    # ...and the same directory with an attacker-named file in it does raise.
+    py_compile.compile(
+        str(nodes / "real.py"), cfile=str(cache / "payload.pyc"), doraise=True
+    )
+    with pytest.raises(PluginValidationError) as excinfo:
+        plugin_cli.validate_plugin_dir(root, [])
+    assert "payload.pyc" in str(excinfo.value)
+
+
+def test_validate_nodes_dir_refuses_the_same_compiled_module(tmp_path):
+    """The other entry point. ``validate_nodes_dir`` is a separate call into
+    the walker and used to carry its own ``*.py`` glob, so a fix applied to
+    one of the two would have left the narrower one open."""
+    nodes = tmp_path / "nodes"
+    nodes.mkdir()
+    (nodes / "helper.pyc").write_bytes(b"\x00\x01 not source")
+    with pytest.raises(PluginValidationError):
+        plugin_cli.validate_nodes_dir(nodes, [])
+
+
+def test_the_git_directory_exemption_survives_the_suffix_rule(tmp_path):
+    """``.git`` holds loose objects and packfiles with arbitrary names, and
+    it is skipped for a structural reason that the suffix rule must not
+    quietly undo: ``.git`` is not a valid identifier, so no import can name
+    a component spelled that way (core#182). A ``.pyc`` planted in there is
+    still unreachable."""
+    root = tmp_path / "pack"
+    (root / "nodes").mkdir(parents=True)
+    (root / "nodes" / "__init__.py").write_text("", encoding="utf-8")
+    (root / ".git").mkdir(parents=True)
+    (root / ".git" / "payload.pyc").write_bytes(b"\x00\x01 not source")
+    plugin_cli.validate_plugin_dir(root, [])   # does not raise
+
+
 # ── load_catalog ────────────────────────────────────────────────────────────
 
 def test_load_catalog_returns_three_direction_packs():

--- a/backend/tests/test_tiered_policy.py
+++ b/backend/tests/test_tiered_policy.py
@@ -243,6 +243,66 @@ _MATRIX: list[tuple[str, str | None]] = [
     ("threading", None),
 ]
 
+# core#215 / core#216 -- the same matrix, for the names core#183 stopped
+# short of. Two shapes, and they are kept in one list because the tier
+# question is identical for both:
+#
+#   * the raw C module a blocklisted one is BUILT ON. `os` had `nt`/`posix`;
+#     `socket` has `_socket`, `pickle` has `_pickle`, and so on down the
+#     stdlib. Reaching the private module by name is reaching the public one,
+#     so it takes the public one's tier -- which is what makes `_socket`
+#     "network" and `_thread` trusted-only, rather than one blanket answer.
+#   * a whole surface nobody had enumerated in either direction (`winreg`,
+#     the sub-interpreter family, the POSIX account databases, the tty
+#     modules). Tier 2 for all of them: no existing capability's consent
+#     sentence describes any of these, and `spwd` above is the precedent --
+#     "no capability fits" means trusted-only, not a new capability invented
+#     in passing.
+#
+# Every entry's verification is recorded in `plugin_validator`'s own comment
+# next to the name, or in `CAPABILITY_MODULES` for the ones a capability
+# covers. Platform is irrelevant here: the gate is a static AST walk, so
+# `import msvcrt` is refused on Linux and `import pwd` on Windows, which is
+# the correct answer for a tarball that can be installed anywhere.
+_MATRIX += [
+    # -- raw C implementations, capability-covered ----------------------
+    ("_socket", "network"),
+    ("_ssl", "network"),
+    # `ssl` itself was never on the blocklist at all, and it is not merely a
+    # cipher library: see the dedicated test below.
+    ("ssl", "network"),
+    ("_sqlite3", "filesystem"),
+    # -- raw C implementations, trusted-only ----------------------------
+    ("_thread", None),
+    ("_ctypes", None),
+    ("_pickle", None),
+    ("_signal", None),
+    ("_asyncio", None),
+    ("_imp", None),
+    ("_frozen_importlib", None),
+    ("_frozen_importlib_external", None),
+    ("_multiprocessing", None),
+    ("_posixsubprocess", None),
+    ("_posixshmem", None),
+    ("_winapi", None),
+    ("_overlapped", None),
+    ("msvcrt", None),
+    # -- surfaces nobody had considered, trusted-only -------------------
+    ("winreg", None),
+    ("_interpreters", None),
+    ("_xxsubinterpreters", None),
+    ("_interpchannels", None),
+    ("_xxinterpchannels", None),
+    ("_interpqueues", None),
+    ("pwd", None),
+    ("grp", None),
+    ("syslog", None),
+    ("termios", None),
+    ("_curses", None),
+    ("_curses_panel", None),
+    ("ossaudiodev", None),
+]
+
 
 @pytest.mark.parametrize(("module", "capability"), _MATRIX)
 def test_tier0_refuses_every_blocked_module(module, capability):
@@ -359,6 +419,284 @@ def test_the_platform_native_os_backing_module_is_always_on_the_blocklist():
         f"os.environ from (Lib/os.py: `from {native} import *`); it must stay "
         f"on the blocklist or importing it directly reaches everything "
         f"'process-env' gates with zero capability declared (core#183)"
+    )
+
+
+# ── core#215: the siblings core#183 stopped short of ───────────────────────
+
+def test_the_runtime_implementation_blocklist_is_ported_to_the_install_time_gate():
+    """core#215's literal complaint, as a standing check.
+
+    ``script_proxy._BLOCKED_IMPLEMENTATION_ROOTS`` is the RUNTIME boundary
+    for in-canvas scripts, and it has known since long before core#215 that
+    ``_thread``, ``_socket``, ``_ctypes``, ``_pickle``, ``_winapi``,
+    ``msvcrt``, ``_posixsubprocess``, ``_multiprocessing``, ``_imp`` and the
+    two ``_frozen_importlib`` modules are dangerous -- it refuses any value
+    whose defining module is one of them. That recognition was never carried
+    across to the INSTALL-time gate, so the same codebase held both of these
+    at once::
+
+        collections._ctypes    # refused: a script may not hold that
+        import _ctypes         # accepted: a plugin may, zero declaration
+
+    The two boundaries protect the same process from the same code, so a
+    name one of them calls dangerous cannot be a name the other has never
+    heard of. ``_io`` is the single exception and it is not a gap: it is a
+    documented ACCEPT in ``ACCEPTED_UNGATED_MODULES``, because ``open()`` is
+    deliberately ungated for installed files, so the assertion asks for
+    "classified", not "blocked".
+    """
+    from app.core import script_proxy
+
+    blocked = dangerous_modules()
+    accepted = set(tiers.ACCEPTED_UNGATED_MODULES)
+    unclassified = sorted(
+        name for name in script_proxy._BLOCKED_IMPLEMENTATION_ROOTS
+        if name not in blocked and name not in accepted
+    )
+    assert unclassified == [], (
+        "the in-canvas RUNTIME boundary refuses values defined by these "
+        f"modules, but the install-time gate has never heard of them: "
+        f"{unclassified}. A plugin can therefore `import` what a script "
+        "cannot even be handed. Put each on _DANGEROUS_MODULES, or record "
+        "an explicit accept in ACCEPTED_UNGATED_MODULES the way _io is"
+    )
+
+
+def test_the_underscore_implementation_of_a_blocked_module_is_classified_too():
+    """The SHAPE of core#215, not its list of names -- so the next one is
+    caught mechanically instead of by somebody auditing by hand again.
+
+    CPython's own convention is that a stdlib module ``x`` is a thin Python
+    wrapper over a private C module ``_x``: ``socket``/``_socket``,
+    ``pickle``/``_pickle``, ``signal``/``_signal``, ``ssl``/``_ssl``,
+    ``sqlite3``/``_sqlite3``, ``bz2``/``_bz2``, ``asyncio``/``_asyncio``.
+    Every one of those pairs was a hole. So: for each name on the blocklist,
+    if this interpreter actually HAS a module called ``_<name>``, that module
+    must be classified too -- blocked, or accepted with a reason.
+
+    Deliberately keyed on the interpreter (``importlib.util.find_spec``)
+    rather than a hardcoded list, the same "ask, don't assume" move
+    ``_compute_os_path_module_leaves`` makes: a future CPython that grows a
+    ``_webbrowser`` accelerator fails this test the day it ships.
+
+    What this canNOT see, said plainly so nobody mistakes it for total
+    coverage: the pairs whose names do not rhyme. ``_thread`` is behind
+    ``threading``, ``_posixsubprocess`` behind ``subprocess``,
+    ``_overlapped`` behind ``asyncio``. Those were found by importing every
+    blocklisted module in a fresh interpreter and diffing ``sys.modules``,
+    which is a sweep to re-run when auditing, not an assertion cheap enough
+    to run per-test. This covers the mechanical majority; the sweep covers
+    the rest.
+    """
+    import importlib.util
+
+    blocked = dangerous_modules()
+    accepted = set(tiers.ACCEPTED_UNGATED_MODULES)
+    unclassified = []
+    for name in sorted(blocked):
+        private = "_" + name
+        if private in blocked or private in accepted:
+            continue
+        try:
+            exists = importlib.util.find_spec(private) is not None
+        except (ImportError, ValueError):
+            exists = False
+        if exists:
+            unclassified.append((private, name))
+    assert unclassified == [], (
+        "these private C modules sit directly behind a module this gate "
+        f"already blocks, and are themselves unclassified: {unclassified}. "
+        "Reaching the private one by name reaches the public one's surface "
+        "(core#183 for nt/posix, core#215 for the rest) -- decide about each: "
+        "blocklist it (plus a CAPABILITY_MODULES group if its wrapper has "
+        "one), or record why it grants nothing in ACCEPTED_UNGATED_MODULES"
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "reaches"),
+    [
+        # Each line is a primitive VERIFIED to work through the raw module
+        # alone, with no import of its public wrapper anywhere. The verdicts
+        # are recorded next to the names in `plugin_validator`; these pin
+        # that the gate refuses the shape an attacker would actually write.
+        ("_thread", "_thread.start_new_thread(payload, ())"),
+        ("_socket", "_socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)"),
+        ("_ctypes", "_ctypes.LoadLibrary('kernel32.dll', 0)"),
+        ("_pickle", "_pickle.loads(blob)"),
+        ("_signal", "_signal.raise_signal(15)"),
+        ("_imp", "_imp.create_dynamic(spec)"),
+        ("_frozen_importlib", "_frozen_importlib.__import__('subprocess')"),
+        ("_winapi", "_winapi.CreateProcess(None, cmd, None, None, 0, 0, None, None, None)"),
+        ("_posixsubprocess", "_posixsubprocess.fork_exec(argv, argv, 1, (), None, None)"),
+        ("_posixshmem", "_posixshmem.shm_open('/x', 66, 384)"),
+        ("winreg", "winreg.SetValueEx(key, 'Run', 0, 1, payload)"),
+        ("_interpreters", "_interpreters.exec(iid, src)"),
+        ("_xxsubinterpreters", "_xxsubinterpreters.run_string(iid, src)"),
+        ("pwd", "pwd.getpwall()"),
+        ("grp", "grp.getgrall()"),
+        ("syslog", "syslog.openlog(ident='sshd')"),
+        ("termios", "termios.tcsetattr(fd, 0, attrs)"),
+        ("_curses", "_curses.initscr()"),
+    ],
+)
+def test_the_verified_escape_is_refused_at_tier0(module, reaches):
+    """One row per primitive that was actually made to run during the
+    core#215 / core#216 triage, refused at Tier 0 in the spelling an
+    attacker would use rather than only as a bare import.
+
+    The import is what the gate sees, so the import is what has to be
+    refused -- but writing the CALL out here is the point: it records what
+    the module was verified to REACH, in code, next to the assertion that it
+    is closed. ``_interpreters.exec(...)`` is the one worth reading twice:
+    ``exec`` is in ``_DANGEROUS_NAMES``, and the call rule still does not
+    fire on it, because ``_calls_the_builtin`` asks whether the receiver
+    resolves to ``builtins`` and this receiver is a module. Only the import
+    rule closes that door.
+    """
+    message = _refusal(f"import {module}\n\ndef go():\n    {reaches}\n")
+    assert f"Importing '{module}' is not allowed" in message
+
+
+def test_the_subinterpreter_exec_primitive_is_blocked_under_both_of_its_names():
+    """The rename is the trap, and gating only the name in the issue would
+    have shipped a no-op.
+
+    core#216 reports ``_xxsubinterpreters``. CPython RENAMED that module to
+    ``_interpreters`` in 3.13, so on 3.13+ -- which includes the interpreter
+    this repo's own developers run -- ``_xxsubinterpreters`` does not exist
+    and gating it protects nothing, while the live primitive sits under a
+    name still absent from every list. The reverse holds on 3.10-3.12, which
+    is what CI runs. Both names, or the gate is version-dependent.
+
+    Whichever name this interpreter actually has must also be REAL: the
+    assertion below refuses to pass vacuously on a Python that has neither.
+    """
+    import importlib.util
+
+    for name in ("_xxsubinterpreters", "_interpreters"):
+        assert name in dangerous_modules(), (
+            f"{name!r} executes arbitrary source in a sub-interpreter "
+            f"(create() + exec(id, src), verified to spawn a process from "
+            f"inside one); it must be blocked under BOTH spellings because "
+            f"CPython renamed it in 3.13"
+        )
+        message = _refusal(f"import {name}\n")
+        assert "--trust-author" in message, (
+            "no capability may ever unlock an exec() primitive"
+        )
+
+    present = [
+        name for name in ("_xxsubinterpreters", "_interpreters")
+        if importlib.util.find_spec(name) is not None
+    ]
+    assert present, (
+        "this interpreter has neither name, so the test above proved nothing "
+        "about a reachable module -- if CPython renamed it again, add the new "
+        "spelling to the blocklist and to this test"
+    )
+
+
+def test_ssl_alone_reaches_the_network_and_now_says_so():
+    """``ssl`` was never on the blocklist in either direction, and it is not
+    just a cipher library.
+
+    ``ssl.get_server_certificate((host, port))`` opens the connection
+    ITSELF -- its own source calls ``create_connection`` -- so ``import
+    ssl`` was outbound network egress at Tier 0 with nothing declared,
+    verified by fetching 1411 bytes of live certificate from a real host.
+    That makes an attacker-chosen host:port reachable, which is a beacon
+    whatever comes back.
+
+    core#215 flagged ``_ssl`` and noted in passing that its wrapper "is not
+    on the blocklist at all today". Gating the raw engine while leaving the
+    wrapper open would have been a gate protecting nothing, so both are on
+    ``network`` -- the capability whose consent line already promises
+    exactly this ("send and receive data from any host").
+    """
+    assert "ssl" in dangerous_modules()
+    assert tiers.capability_for_module("ssl") == "network"
+    assert tiers.capability_for_module("_ssl") == "network"
+    _tier1("import ssl\n\ndef go(h):\n    return ssl.get_server_certificate((h, 443))\n",
+           "network")
+    message = _refusal("import ssl\n", capabilities=["filesystem", "process-env"])
+    assert "requires capability 'network'" in message
+
+
+def test_the_capability_summaries_still_cover_what_was_added_to_their_groups():
+    """A group grew; the sentence a user answers y/N to has to still be true
+    of everything in it.
+
+    ``network`` gained ``_socket`` / ``_ssl`` / ``ssl`` and ``filesystem``
+    gained ``_sqlite3``. Both are covered by the existing wording -- the raw
+    modules are the same surface as the wrappers already named -- and this
+    pins that the wording was checked rather than assumed, the same way
+    ``test_the_process_env_summary_admits_what_the_os_module_is`` pins the
+    ``os`` framing.
+    """
+    network = tiers.CAPABILITY_SUMMARY["network"]
+    assert "any host" in network
+    assert "ssl" in network, "ssl joined the group; the consent line should say so"
+    filesystem = tiers.CAPABILITY_SUMMARY["filesystem"]
+    assert "sqlite3" in filesystem
+
+
+def test_the_compression_accelerators_were_verified_rather_than_matched():
+    """The one place this wave deliberately did NOT follow the wrapper's tier.
+
+    ``bz2`` and ``lzma`` are gated by ``filesystem``, and core#215 recorded
+    ``_bz2`` / ``_lzma`` as "a mechanical match to an already-blocked
+    wrapper's own capability". Checking rather than matching says otherwise:
+    ``dir(_bz2)`` is exactly ``{BZ2Compressor, BZ2Decompressor}`` and
+    ``_lzma`` adds only filter constants -- neither takes a path, and the
+    file access the wrappers are gated for lives in ``BZ2File`` /
+    ``LZMAFile``, ordinary Python calling the already-unrestricted
+    ``open()``. So they are accepted, in the same category as ``zlib``,
+    which was already accepted on exactly this reasoning.
+
+    This test exists because "same shape as something already blocked" is
+    the reasoning that would have blocked them, and it would have been
+    wrong. If a future CPython gives ``_bz2`` a path-taking entry point,
+    this fails and the decision gets re-made.
+    """
+    import importlib.util
+
+    for name in ("_bz2", "_lzma"):
+        assert name in tiers.ACCEPTED_UNGATED_MODULES
+        assert name not in dangerous_modules()
+        if importlib.util.find_spec(name) is None:  # pragma: no cover
+            continue
+        module = importlib.import_module(name)
+        public = {n for n in dir(module) if not n.startswith("_")}
+        takers = {n for n in public if "file" in n.lower() or "open" in n.lower()}
+        assert takers == set(), (
+            f"{name} grew a file-facing entry point ({sorted(takers)}); the "
+            f"accept in ACCEPTED_UNGATED_MODULES rests on it having none, so "
+            f"re-decide rather than editing this assertion"
+        )
+    _tier0("import _bz2\nimport _lzma\n")
+
+
+def test_nothing_is_left_deferred_in_the_accepted_set():
+    """``ACCEPTED_UNGATED_MODULES`` used to hold two kinds of entry: real
+    accepts, and known-dangerous names parked there with an issue number
+    while somebody decided. The parked ones were indistinguishable from the
+    accepts except by reading the reason string, which is how twenty-nine
+    live gaps sat in a green suite.
+
+    core#215 and core#216 emptied that second kind. This pins it: an entry
+    here is a VERDICT, so no reason string may still be pointing at an issue
+    as the place where the decision will be made.
+    """
+    parked = sorted(
+        name for name, reason in tiers.ACCEPTED_UNGATED_MODULES.items()
+        if "core#215" in reason or "core#216" in reason
+    )
+    assert parked == [], (
+        f"{parked} are recorded as accepted but their reason still defers to "
+        "an issue. Either the module is accepted -- say why, without the "
+        "issue number doing the work -- or it belongs on the blocklist"
     )
 
 

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -52,8 +52,8 @@ A plugin pack is Python that runs in the CodefyUI process. Before a third-party 
 
 | Capability | Unlocks | What you are agreeing to |
 |------------|---------|--------------------------|
-| `network` | `requests`, `urllib`, `http`, `socket` | The plugin can send and receive data from any host — **and write what it downloads to disk**, because `urllib.request.urlretrieve(url, dest)` is one call. |
-| `filesystem` | `pathlib`, `tempfile`, `shutil`, `zipfile`, `tarfile`, `gzip`, `bz2`, `lzma`, `codecs`, `sqlite3`, `glob`, `fileinput` | The plugin can use the file **libraries**. This is not a write boundary: plain `open(p, "w")` is a builtin and needs no declaration at all (see [What this is not](#what-this-is-not)). |
+| `network` | `requests`, `urllib`, `http`, `socket`, `ssl`, and the raw C modules behind them (`_socket`, `_ssl`) | The plugin can send and receive data from any host — **and write what it downloads to disk**, because `urllib.request.urlretrieve(url, dest)` is one call. |
+| `filesystem` | `pathlib`, `tempfile`, `shutil`, `zipfile`, `tarfile`, `gzip`, `bz2`, `lzma`, `codecs`, `sqlite3` (and `_sqlite3`), `glob`, `fileinput`, `readline` | The plugin can use the file **libraries**. This is not a write boundary: plain `open(p, "w")` is a builtin and needs no declaration at all (see [What this is not](#what-this-is-not)). |
 | `process-env` | `os`, `ntpath`, `posixpath`, `genericpath`, `nt`, `posix` | The plugin gets **the whole `os` module**: read *and change* this process's environment (**including any API keys in it**), start other programs (`os.execv`, `os.spawnve`, `os.startfile`), and delete or rename files. The name is what people ask for it for; the grant is bigger than the name. |
 
 Nothing else is a capability. `subprocess`, `sys`, `importlib`, `ctypes`, `pickle`, `marshal`, `dill`, `shelve`, `runpy`, `code`, `signal`, `atexit`, `webbrowser`, `threading`, `asyncio` and `multiprocessing` are Tier 2 only: **no capability hands over a module whose purpose is running code or reaching the interpreter.** Note the precise claim — `process-env` grants `os`, and `os` starts processes. What you do not get from any capability is a module built for executing code.
@@ -97,7 +97,7 @@ $ cdui plugin install alice/metric-logger
   Ref: default branch (a1b2c3d)
 
 > This plugin requests the following capabilities
-    network -> reach the network -- send and receive data from any host, and write what it downloads to disk (requests, urllib, http, socket)
+    network -> reach the network -- send and receive data from any host, and write what it downloads to disk (requests, urllib, http, socket, ssl)
   A capability is a declaration, not a sandbox: once granted, the plugin may
   use that group of modules and CodefyUI stops asking.
   Grant these? [y/N]:
@@ -122,6 +122,28 @@ Separately from every rule above — which holds whatever was declared, with no 
 The rule is receiver-independent, which cuts both ways: it also refuses the plugin's *own* method if it happens to share one of these names — `self.save(...)` on your own class is blocked exactly like `numpy.array(...).save(...)`, the same cost the script policy already imposes on a script's own `obj.save()`. At Tier 0 or Tier 1 alone, that means a class cannot define a method called `save`, `dump`, `hub`, or any of the others on the list, full stop.
 
 **`--trust-author` lifts this list entirely.** Once a plugin is installed with `--trust-author` and `[security] allowed_modules`, `.dump` / `.hub` / `.save` and the rest of it are ordinary attribute names again — a plugin trusted with `subprocess` and `ctypes` gains nothing from also being refused `arr.dump()`, and the refusal would otherwise have made it impossible to write a plugin with a method named `save` at all. This is unlike every rule in [What holds in every tier](#what-holds-in-every-tier), which stays refused without exception: those refuse *reflection*, which no capability or trust level ever buys; `.dump` and `.hub` are file writes and remote code fetches, and `--trust-author` already grants an equivalent or greater version of both by a shorter route.
+
+### Ship source, not bytecode
+
+Every file in a plugin tarball that Python's import system could load has to
+be readable as **source**. The installer scans the whole directory, not just
+`nodes/`, and it enumerates by what the loader accepts (`importlib.machinery.all_suffixes()`)
+rather than by `*.py`: `.py` and `.pyw` are scanned, and `.pyc` / `.pyo` /
+`.pyd` / `.so` / `.dylib` are **refused by name** at install time, on every
+platform regardless of which one you install from.
+
+The refusal is the honest answer rather than a policy preference. A `.pyc`
+would have to be decompiled to be scanned and a compiled extension cannot be
+scanned even in principle, so the alternative is importing code the gate
+never opened — which is exactly what used to happen: a pack whose `nodes/`
+held `helper.pyc` and no `helper.py` was imported at server boot, at full
+trust, with no capability declared and without `--trust-author`, having never
+been looked at.
+
+Compilation artifacts are not affected. CPython writes its cache as
+`__pycache__/<name>.cpython-311.pyc`, whose stem is not a valid identifier,
+so no `import` statement can name it — those are skipped. An
+attacker-supplied `__pycache__/payload.pyc` **can** be named, and is refused.
 
 ### What this is not
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -52,8 +52,8 @@ cdui plugin uninstall deep
 
 | 能力 | 解鎖 | 你正在同意的事 |
 |------------|---------|--------------------------|
-| `network` | `requests`、`urllib`、`http`、`socket` | 這個外掛可以與任何主機收發資料——**並把下載到的內容寫入磁碟**，因為 `urllib.request.urlretrieve(url, dest)` 只要一行。 |
-| `filesystem` | `pathlib`、`tempfile`、`shutil`、`zipfile`、`tarfile`、`gzip`、`bz2`、`lzma`、`codecs`、`sqlite3`、`glob`、`fileinput` | 這個外掛可以使用檔案**函式庫**。這不是寫入的邊界：單純的 `open(p, "w")` 是內建函式，完全不需要任何宣告（見[這不是什麼](#這不是什麼)）。 |
+| `network` | `requests`、`urllib`、`http`、`socket`、`ssl`，以及它們背後的原始 C 模組（`_socket`、`_ssl`） | 這個外掛可以與任何主機收發資料——**並把下載到的內容寫入磁碟**，因為 `urllib.request.urlretrieve(url, dest)` 只要一行。 |
+| `filesystem` | `pathlib`、`tempfile`、`shutil`、`zipfile`、`tarfile`、`gzip`、`bz2`、`lzma`、`codecs`、`sqlite3`（含 `_sqlite3`）、`glob`、`fileinput`、`readline` | 這個外掛可以使用檔案**函式庫**。這不是寫入的邊界：單純的 `open(p, "w")` 是內建函式，完全不需要任何宣告（見[這不是什麼](#這不是什麼)）。 |
 | `process-env` | `os`、`ntpath`、`posixpath`、`genericpath`、`nt`、`posix` | 這個外掛拿到**整個 `os` 模組**：讀取*並修改*此行程的環境變數（**包含其中的 API 金鑰**）、啟動其他程式（`os.execv`、`os.spawnve`、`os.startfile`），以及刪除或重新命名檔案。這個名字是大家索取它的理由，但授予的範圍比名字大。 |
 
 除此之外都不是能力。`subprocess`、`sys`、`importlib`、`ctypes`、`pickle`、`marshal`、`dill`、`shelve`、`runpy`、`code`、`signal`、`atexit`、`webbrowser`、`threading`、`asyncio`、`multiprocessing` 一律只能走第 2 級：**沒有任何能力會交出一個「本身就是用來執行程式碼、或伸手進入直譯器」的模組。** 請注意這句話的精確之處——`process-env` 授予 `os`，而 `os` 會啟動行程。任何能力都不會給你的，是一個為執行程式碼而生的模組。
@@ -121,6 +121,22 @@ $ cdui plugin install alice/metric-logger
 這條規則不看接收者是誰，所以是雙向的：外掛**自己的**方法只要剛好同名，一樣會被擋下——你自己類別上的 `self.save(...)`，會被擋得跟 `numpy.array(...).save(...)`一模一樣，這正是腳本政策早就加諸在腳本自己的 `obj.save()` 上的同一種代價。單獨在第 0 級或第 1 級底下，這代表一個類別完全不能定義名叫 `save`、`dump`、`hub`，或清單上其他任何一個名字的方法。
 
 **`--trust-author` 會把整份清單解除。** 一旦外掛以 `--trust-author` 加上 `[security] allowed_modules` 安裝，`.dump` / `.hub` / `.save` 以及清單上其他項目，就又變回普通的屬性名稱——一個已經被信任可以用 `subprocess`、`ctypes` 的外掛，再多攔一個 `arr.dump()` 什麼也保護不到，而且不解除的話，根本不可能寫出一個帶有 `save` 方法的外掛。這跟[每一級都成立的規則](#每一級都成立的規則)裡的每一條都不同——那些不論在哪一級都毫無例外地拒絕：它們攔的是**反射能力**，沒有任何能力或信任層級買得到；而 `.dump` 與 `.hub` 是檔案寫入與遠端程式碼抓取，`--trust-author` 早就用更短的路徑，給了等同或更大的授權。
+
+### 請附原始碼，不要附位元組碼
+
+外掛壓縮檔裡只要是 Python 匯入系統載入得了的檔案，都必須是可讀的**原始碼**。
+安裝時掃描的是整個目錄（不只 `nodes/`），且枚舉依據是載入器接受的副檔名
+（`importlib.machinery.all_suffixes()`）而不是 `*.py`：`.py` 與 `.pyw` 會被掃描，
+`.pyc`、`.pyo`、`.pyd`、`.so`、`.dylib` 則在安裝時**點名拒絕**，而且不論你從哪個平台安裝都一樣。
+
+拒絕是誠實的答案，不是偏好：`.pyc` 要反組譯才能掃，編譯好的擴充模組則原則上就不可能做 AST 掃描。
+否則就是匯入一份閘門從未打開過的程式碼——而這正是以前發生的事：`nodes/` 裡只有 `helper.pyc`
+而沒有 `helper.py` 的套件，會在伺服器啟動時被匯入，以完全信任執行，沒有宣告任何能力，
+也不需要 `--trust-author`，而且從頭到尾沒被看過一眼。
+
+編譯快取不受影響。CPython 寫的快取是 `__pycache__/<name>.cpython-311.pyc`，
+它的主檔名不是合法識別字，任何 `import` 語句都叫不出它，所以會被跳過；
+攻擊者放的 `__pycache__/payload.pyc` **叫得出來**，因此會被拒絕。
 
 ### 這不是什麼
 

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -20,6 +20,7 @@ which ``security.allowed_modules`` the user accepted.
 from __future__ import annotations
 
 import argparse
+import importlib.machinery
 import json
 import os
 import re
@@ -407,24 +408,171 @@ def _denied_attributes_for(allowed_modules: list[str]) -> frozenset[str]:
     return frozenset() if allowed_modules else TIER0_DENIED_ATTRS
 
 
+# ── core#220: the walk covers what the LOADER covers, by extension ─────────
+#
+# ``validate_plugin_dir`` used to enumerate ``*.py``. The loader imports more
+# than that: ``plugin_loader.install_plugin_finder`` sets the synthetic
+# package's ``__path__`` to the plugin directory, which puts the stock
+# ``FileFinder`` loaders in charge, and those accept every suffix in
+# ``importlib.machinery.all_suffixes()``. Verified on a real interpreter, not
+# reasoned about -- a plugin whose ``nodes/`` held only ``helper.pyc``,
+# ``w.pyw`` and ``native.cp314-win_amd64.pyd``::
+#
+#     loader suffixes:        ['.py', '.pyw', '.pyc', '.cp314-win_amd64.pyd', '.pyd']
+#     files a *.py glob sees: ['__init__.py']            (i.e. none of them)
+#     pkgutil reports:        ['helper', 'native', 'w']  (i.e. all of them)
+#     validate_plugin_dir():  ACCEPTED, no exception
+#
+# ...and the ``.pyc`` then imported and ran its ``os.system`` payload. That is
+# not the gate failing open on a rule; it is the gate never running, which is
+# strictly worse and is why this is keyed on the interpreter's own answer
+# rather than on a hardcoded list -- the same "ask, don't assume" move
+# ``_compute_os_path_module_leaves`` makes for ``os.path``.
+#
+# ``.pyw`` and the extension suffixes are unioned in explicitly ON TOP of
+# ``all_suffixes()`` because that function answers for the CURRENT
+# interpreter, and a tarball is not installed on the machine that built it:
+# ``.pyw`` is a source suffix only on Windows, and ``.so`` / ``.pyd`` /
+# ``.dylib`` each exist on exactly one platform. Scanning the union means the
+# verdict on a given tarball does not depend on which OS ran the installer.
+_EXTRA_SOURCE_SUFFIXES = frozenset({".pyw"})
+_CROSS_PLATFORM_BINARY_SUFFIXES = frozenset({
+    ".pyc", ".pyo", ".pyd", ".so", ".dylib",
+})
+
+#: Suffixes that are Python SOURCE and can therefore be handed to the AST
+#: gate. ``.pyw`` is ordinary Python text -- only the launcher treats it
+#: differently -- so it is scanned, not refused.
+SCANNABLE_SUFFIXES: frozenset[str] = (
+    frozenset(importlib.machinery.SOURCE_SUFFIXES) | _EXTRA_SOURCE_SUFFIXES
+)
+
+#: Every suffix an ``import`` statement can resolve to a file, anywhere this
+#: tarball might be installed. Asserted against ``all_suffixes()`` by a
+#: standing test, so a future CPython that grows a loader suffix fails loudly
+#: instead of silently widening the hole this closed.
+LOADER_SUFFIXES: frozenset[str] = (
+    frozenset(importlib.machinery.all_suffixes())
+    | SCANNABLE_SUFFIXES
+    | _CROSS_PLATFORM_BINARY_SUFFIXES
+)
+
+
+def loader_suffix(path: Path) -> str | None:
+    """The loader suffix *path* would be imported under, or ``None``.
+
+    Longest match wins, because the extension suffixes nest:
+    ``native.cp314-win_amd64.pyd`` ends with both ``.cp314-win_amd64.pyd``
+    and ``.pyd``, and the longer one is the right answer twice over -- it is
+    what the refusal message should name, and stripping only ``.pyd`` would
+    leave a stem of ``native.cp314-win_amd64``, which the identifier test in
+    :func:`_names_an_importable_module` would then wave through.
+
+    A name that is ONLY a suffix (a file literally called ``.py``) answers
+    ``None``: the stem would be empty, so there is no module name for an
+    ``import`` statement to spell.
+    """
+    name = path.name
+    best: str | None = None
+    for suffix in LOADER_SUFFIXES:
+        if len(name) > len(suffix) and name.endswith(suffix):
+            if best is None or len(suffix) > len(best):
+                best = suffix
+    return best
+
+
+def _names_an_importable_module(path: Path, suffix: str) -> bool:
+    """Whether an ``import`` statement could name the module *path* holds.
+
+    The same structural question ``_VALIDATION_SKIP_DIRS`` asks about
+    ``.git``, applied to a FILE: strip the loader suffix and ask whether what
+    is left is a valid Python identifier. If it is not, no import statement
+    -- absolute or relative -- can name it, so nothing can reach it.
+
+    This exists for exactly one shape, and getting it wrong in either
+    direction is a real failure, so it was verified rather than reasoned
+    about. CPython writes its own bytecode cache as
+    ``__pycache__/real.cpython-314.pyc``; an attacker writes
+    ``__pycache__/payload.pyc``. Both are ``.pyc`` files in the same
+    directory, and they are not the same thing::
+
+        __pycache__/payload.pyc            stem 'payload'          identifier
+        __pycache__/real.cpython-314.pyc   stem 'real.cpython-314' NOT
+
+        pkgutil.iter_modules(__pycache__)          -> ['payload']
+        import <pkg>.nodes.__pycache__.payload     -> OK, ran the bytecode
+        import <pkg>.nodes.__pycache__.real        -> ModuleNotFoundError
+
+    So the refusal has to fire on the first and must NOT fire on the second:
+    a plugin directory that any interpreter has ever imported from has a
+    ``__pycache__`` full of the second kind, including this repo's own
+    built-in packs, and refusing to install over an ordinary compilation
+    artifact would be a false positive with no matching security value.
+
+    Applied only to the suffixes that get REFUSED. Source files are scanned
+    whatever they are called: scanning is never wrong, and the previous
+    ``*.py`` glob scanned an unimportably-named ``my-node.py`` too.
+    """
+    return path.name[: -len(suffix)].isidentifier()
+
+
+def _validate_importable_tree(
+    root: Path,
+    allowed_modules: list[str],
+    capabilities: Iterable[str],
+    *,
+    skip_dirs: frozenset[str] = frozenset(),
+) -> None:
+    """AST-scan every importable source file under *root*; refuse the rest.
+
+    "The rest" is the whole point. A ``.pyc`` cannot be AST-scanned without
+    decompiling it and a ``.pyd`` / ``.so`` cannot be scanned even in
+    principle, so the only two honest answers are "refuse" and "import
+    unexamined code at full trust". This picks the first, by name, with a
+    message that says which file and why -- never a silent skip, which is
+    exactly what the ``*.py`` glob was doing.
+    """
+    if not root.exists():
+        return
+    root_resolved = root.resolve()
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel_parts = path.resolve().relative_to(root_resolved).parts
+        if skip_dirs and any(part in skip_dirs for part in rel_parts):
+            continue
+        suffix = loader_suffix(path)
+        if suffix is None:
+            continue
+        rel = "/".join(rel_parts)
+        if suffix not in SCANNABLE_SUFFIXES:
+            if not _names_an_importable_module(path, suffix):
+                continue
+            raise PluginValidationError(
+                f"'{rel}' cannot be installed: Python's import system loads "
+                f"'{suffix}' files, but they are compiled rather than source, "
+                f"so the security scan cannot look inside one. Every file a "
+                f"plugin can have imported has to be readable as source -- "
+                f"ship the '.py' this was built from instead"
+            )
+        content = path.read_bytes()
+        if not content.strip():
+            continue
+        validate_python_source(
+            content,
+            path.name,
+            allowed_modules=allowed_modules,
+            capabilities=list(capabilities),
+            denied_attributes=_denied_attributes_for(allowed_modules),
+        )
+
+
 def validate_nodes_dir(
     nodes_dir: Path,
     allowed_modules: list[str],
     capabilities: Iterable[str] = (),
 ) -> None:
-    if not nodes_dir.exists():
-        return
-    for py in sorted(nodes_dir.rglob("*.py")):
-        content = py.read_bytes()
-        if not content.strip():
-            continue
-        validate_python_source(
-            content,
-            py.name,
-            allowed_modules=allowed_modules,
-            capabilities=list(capabilities),
-            denied_attributes=_denied_attributes_for(allowed_modules),
-        )
+    _validate_importable_tree(nodes_dir, allowed_modules, capabilities)
 
 
 # Directories within an extracted plugin tarball that are *not* reachable
@@ -475,19 +623,29 @@ def validate_plugin_dir(
     allowed_modules: list[str],
     capabilities: Iterable[str] = (),
 ) -> None:
-    """Walk the entire plugin directory and validate every Python source file.
+    """Walk the entire plugin directory and validate every importable file.
 
     The original ``validate_nodes_dir`` only checked ``nodes/`` which left a
-    bypass via top-level helpers. This visits every ``.py`` file in the tree
-    except the ones under :data:`_VALIDATION_SKIP_DIRS` -- ``.git`` alone,
-    the one name provably unreachable through Python's import system (not a
-    valid identifier, so no ``import`` can ever name it). Nothing else is
-    skipped: ``examples/``, ``tests/``, ``docs/``, ``assets/`` and
-    ``__pycache__`` all get scanned too (core#182), because the plugin
-    loader registers the WHOLE directory as a namespace package's
-    ``__path__``, so a scanned ``nodes/foo.py`` can ``from ..tests import
-    payload`` -- or ``from ..__pycache__ import payload`` -- into any of
-    them.
+    bypass via top-level helpers. This visits every file in the tree that
+    Python's import system could load, except the ones under
+    :data:`_VALIDATION_SKIP_DIRS` -- ``.git`` alone, the one name provably
+    unreachable through Python's import system (not a valid identifier, so
+    no ``import`` can ever name it). Nothing else is skipped: ``examples/``,
+    ``tests/``, ``docs/``, ``assets/`` and ``__pycache__`` all get scanned
+    too (core#182), because the plugin loader registers the WHOLE directory
+    as a namespace package's ``__path__``, so a scanned ``nodes/foo.py`` can
+    ``from ..tests import payload`` -- or ``from ..__pycache__ import
+    payload`` -- into any of them.
+
+    "Every file the import system could load" is by EXTENSION as well as by
+    directory since core#220: this used to glob ``*.py`` while the loader
+    also accepts ``.pyw``, ``.pyc`` and ``.pyd`` / ``.so``, so a plugin
+    shipping ``nodes/helper.pyc`` and no ``helper.py`` was never scanned at
+    all -- the gate did not fail open, it never ran. Source suffixes are
+    scanned; compiled ones are refused by name (see
+    :func:`_validate_importable_tree`), because a plugin has no legitimate
+    reason to ship a bytecode-only or binary module through this path and
+    neither can be AST-scanned.
 
     *capabilities* are the ones the user confirmed at install time. They are
     passed to every file rather than per-file, because a capability is a
@@ -500,23 +658,12 @@ def validate_plugin_dir(
     accepted, and refusing ``arr.dump()`` to a plugin trusted with
     ``subprocess`` protects nothing.
     """
-    if not plugin_root.exists():
-        return
-    root_resolved = plugin_root.resolve()
-    for py in sorted(plugin_root.rglob("*.py")):
-        rel_parts = py.resolve().relative_to(root_resolved).parts
-        if any(part in _VALIDATION_SKIP_DIRS for part in rel_parts):
-            continue
-        content = py.read_bytes()
-        if not content.strip():
-            continue
-        validate_python_source(
-            content,
-            py.name,
-            allowed_modules=allowed_modules,
-            capabilities=list(capabilities),
-            denied_attributes=_denied_attributes_for(allowed_modules),
-        )
+    _validate_importable_tree(
+        plugin_root,
+        allowed_modules,
+        capabilities,
+        skip_dirs=_VALIDATION_SKIP_DIRS,
+    )
 
 
 # ── runtime helpers ────────────────────────────────────────────────────────


### PR DESCRIPTION
> 中文摘要：補上外掛安全閘門的三個缺口。第一，#183 只擋了 `nt`/`posix`，但 CPython 大部分標準函式庫都是薄薄的 Python 外殼包住一個私有 C 模組，這些兄弟模組全都沒被列管——`_socket` 實測連上 1.1.1.1:80 並讀回回應、`_ctypes` 載入 kernel32、`_winapi.CreateProcess` 真的生出一個行程、`_pickle.loads` 執行了 `__reduce__`、`_frozen_importlib.__import__("subprocess")` 直接交出真正的 subprocess、`_asyncio._set_running_loop` 讓主程式自己的 `asyncio.get_running_loop()` 回傳攻擊者的物件。第二，`winreg`（實測完整建立／寫入／讀回／列舉真實 Run 機碼／刪除）與子直譯器的 `exec` 原語（實測在子直譯器裡跑 `os.system` 生出行程）也沒被列管；後者必須擋兩個名字，因為 CPython 在 3.13 把 `_xxsubinterpreters` 改名成 `_interpreters`，只擋 issue 上的舊名字在 3.13+ 完全無效。順帶查出 `ssl` 本身從來就不在黑名單上，而 `ssl.get_server_certificate()` 自己會開連線——實測在零宣告的情況下抓回一張真實憑證。第三，掃描只走 `*.py`，但載入器接受 `.pyc`／`.pyw`／`.pyd`，所以只放 `helper.pyc` 的外掛從頭到尾沒被掃過一次——不是閘門判錯，是閘門根本沒跑。現在掃描改問直譯器本身（`importlib.machinery.all_suffixes()`），原始碼照掃，編譯過的檔案點名拒絕。三個 issue 全數關閉；每一項的驗證證據、以及三個「查完之後決定不擋」的例外，都寫在下面。

Closes #215
Closes #216
Closes #220

---

## The shape all three share

Nothing here is a rule that judged wrong. In all three cases a name, or a whole file, was never enumerated in either direction — not blocked, not accepted, never asked about. That is the same failure #183 was, and it is the failure mode a blocklist has: the default is grant, so an unclassified name is reachable until somebody notices by hand.

## Gap 1 (#215) — the private C modules the blocklist is built on

`script_proxy._BLOCKED_IMPLEMENTATION_ROOTS` — the **runtime** boundary, for in-canvas scripts — had listed twelve of these as dangerous for a long time. The **install-time** gate, the one a plugin or custom node actually passes through, had never heard of any of them. The same codebase held both of these at once:

```python
collections._ctypes    # refused: a script may not hold that
import _ctypes         # accepted: a plugin may, zero declaration
```

I did not work from the issue's list. I enumerated the class mechanically — import every module on the blocklist in a **fresh** interpreter and diff `sys.modules` — which surfaced `_overlapped` and `_interpreters` sitting behind `asyncio` with nobody having listed either. Then each name was verified individually.

### What was verified, per module

**Tier 2 (blocklist, no capability ever):**

| module | what I actually made it do |
|---|---|
| `_thread` | `start_new_thread` returned a live native thread id and the worker ran |
| `_ctypes` | `LoadLibrary("kernel32.dll")` returned a live handle `0x7ffbcae50000`; surface holds `CFuncPtr`, `call_function`, `_memmove_addr`, `_string_at_addr` |
| `_pickle` | `loads()` executed a `__reduce__` target and returned its result |
| `_signal` | surface: `raise_signal` ("Send a signal to the executing process" — its own docstring), `signal`, `set_wakeup_fd` |
| `_asyncio` | **`_set_running_loop(obj)` made the HOST's `asyncio.get_running_loop()` return the attacker's object.** This backend runs on asyncio; that is process-global poisoning of the loop the server resolves through |
| `_imp` | `create_dynamic` is documented in the module as "Create an extension module" — loads an arbitrary native extension into the process |
| `_frozen_importlib` | **is** `importlib._bootstrap` (identity check), and `__import__("subprocess")` handed back the real module with a working `.run` — a complete bypass of every import rule in the file |
| `_frozen_importlib_external` | `SourceFileLoader`, `SourcelessFileLoader`, `ExtensionFileLoader`, `FileFinder`, `PathFinder`, and `marshal` (itself blocked) bound as a plain attribute |
| `_multiprocessing` | `SemLock` (named cross-process semaphores) plus `recv`/`send`/`closesocket` on socket handles |
| `_posixsubprocess` | entire surface is `fork_exec`, docstring: "Spawn a fresh new child process. Fork a child process … before calling exec() in the child process" |
| `_posixshmem` | `shm_open("/name", O_CREAT\|O_RDWR)` + `os.write` produced a real 64-byte object under `/dev/shm` holding my marker, visible outside the process; `shm_unlink` removed it. No `multiprocessing` import anywhere |
| `_winapi` | **`CreateProcess` spawned a real process (pid 26912) which ran `cmd.exe` and wrote my marker file.** Also `CreateFile`, `CopyFile2`, `CreateNamedPipe`, `CreateJunction` |
| `_overlapped` | *(new — not in the issue)* raw async I/O behind asyncio's ProactorEventLoop. Unlike `select`/`fcntl` (accepted as readiness-only) its surface has connection-**establishing** verbs: `WSAConnect`, `ConnectPipe`, `Overlapped.ConnectEx` |
| `msvcrt` | `getch`/`getwch` read a console keypress **without echo**, with `kbhit`/`ungetch`; plus `get_osfhandle`/`open_osfhandle` (raw HANDLE ↔ fd, both directions), `locking`, `SetErrorMode` |

**Capability-covered, because their wrapper is:**

- `_socket` → `network`. **Verified real egress**: connected to `1.1.1.1:80`, sent an HTTP request, read back `HTTP/1.1 301 Moved Permanently`, using only `import _socket`. Reproduced on Windows and Linux.
- `_ssl`, `ssl` → `network`. See "the `ssl` finding" below.
- `_sqlite3` → `filesystem`. **Verified** `connect(path)` created a real 8192-byte database file where none existed, with no `sqlite3` import. `enable_load_extension(True)` was *accepted* on this build (extension loading compiled in — the subsequent `load_extension` failed only because the probe library does not exist, i.e. the loader tried).

### The `ssl` finding (not in either issue)

#215's table notes in passing that `_ssl`'s wrapper is "not on the blocklist at all today". Gating the raw engine while leaving the wrapper open would be a gate protecting nothing, so I checked what `ssl` alone reaches:

```
ssl ALONE reached the network: got 1411 bytes of PEM, starts '-----BEGIN CERTIFICATE-----\nMIID5jCCA42g'
```

`ssl.get_server_certificate((host, port))` opens the connection **itself** — its source calls `create_connection`. So `import ssl` was outbound network egress at Tier 0, with nothing declared, to an attacker-chosen host:port. Both `ssl` and `_ssl` now sit under `network`, whose consent line already promises exactly this.

### Three names I deliberately did **not** gate

This is the part worth a reviewer's attention, because "structurally the same shape as something already blocked" is the reasoning that would have gated them, and it would have been wrong:

- **`_bz2`** — `dir(_bz2)` is exactly `{BZ2Compressor, BZ2Decompressor}`. No path ever reaches it. The `filesystem` tag on `bz2` comes from `BZ2File`, which is ordinary Python calling the already-unrestricted `open()`. Same category as `zlib`, already accepted on exactly this reasoning.
- **`_lzma`** — same, plus filter constants.
- **`resource`** — re-verified rather than carried forward: `setrlimit` raising `RLIMIT_NOFILE` past its hard limit was refused (`ValueError: not allowed to raise maximum limit`). Self-DoS shaped, and CPU/memory DoS is already explicitly out of this gate's stated scope.

A test pins the `_bz2`/`_lzma` decision to the property it rests on, so if a future CPython gives either a path-taking entry point it fails rather than being silently wrong.

## Gap 2 (#216) — surfaces nobody had considered

Tier 2 for all of these: no existing capability's consent sentence describes any of them, and inventing a fourth capability name is a vocabulary change that wants its own issue. `spwd` is the precedent — "no capability fits" means trusted-only.

**`winreg`** — verified end to end on a real Windows box:

```
WROTE and READ BACK HKCU\Software\CodefyUIVerifyProbe\payload = 'CODEFYUI-VERIFY-PAYLOAD'
HKCU Run key is READABLE and the same handle type is writable; entries:
  ['OneDrive', 'org.openvpn.client', 'Steam', 'LGHUB', 'electron.app.CurseForge',
   'Discord', 'Duet Display', 'GoogleChromeAutoLaunch_…', 'Docker Desktop', 'MicrosoftEdgeAutoLaunch_…']
DeleteKey removed the probe key again (create/write/read/delete all worked)
```

Create, write, read, delete, all with zero declared capability. That Run key is the canonical survives-a-reboot persistence location and it is writable through the same API that just read it. I read the real one rather than writing to it.

**`_interpreters` / `_xxsubinterpreters`** — verified end to end:

```
EXECUTED ARBITRARY SOURCE in a sub-interpreter via _interpreters
  ... and it ran os.system in there; file says 'CODEFYUI-VERIFY-PAYLOAD'
```

`create()` then `exec(id, src)` ran attacker source in a sub-interpreter, and that source called `os.system` and spawned a process. `run_string`, `run_func` and `call` are the same door.

Why nothing caught it, precisely: `exec` **is** in `_DANGEROUS_NAMES`, but `_calls_the_builtin` only fires when the receiver resolves to `builtins`, and this receiver is a module. Only the import rule can close it.

**Both names are gated, and that matters.** CPython renamed the module to `_interpreters` in 3.13. #216 names only `_xxsubinterpreters`, which does not exist on 3.13+ — gating only the issue's name would have shipped a no-op on every interpreter this project's own developers run. Confirmed across the range:

| interpreter | present as |
|---|---|
| 3.10.20 | `_xxsubinterpreters` |
| 3.12.13 | `_xxsubinterpreters` |
| 3.14 (Win + Linux) | `_interpreters` |

`_interpchannels` / `_xxinterpchannels` / `_interpqueues` carry no execution primitive of their own (verified) and are gated anyway, so the PEP 554 / 734 family is closed as a unit rather than by its most obvious member — which is the exact failure this whole wave is about.

**POSIX, verified in WSL Ubuntu:**

- `pwd` / `grp` — `getpwall()` enumerated 27 accounts with names, UIDs, home directories and login shells; `getgrall()` 58 groups. **Verified in the other direction too, because it changes the honesty of the verdict:** `/etc/passwd` was world-readable to that account, so plain `open()` — deliberately ungated here — already reaches the local-files content. What these add is a complete structured enumeration in one call, and the NSS-mediated case where the backing store is a directory service (LDAP/AD/SSSD) rather than a file. **That second half I did not verify.** It is the same mechanism that made `spwd` blockable, and `spwd` is already on the list, so leaving its two siblings open was the odd position.
- `syslog` — verified `openlog(ident="sshd", facility=LOG_AUTH)` + `syslog(...)` is accepted with no error: the program name an entry is attributed to is caller-chosen, so this is log **forgery** into the auth facility. **Not verified that the entry landed in `/var/log`** — the test host had no listener on `/dev/log` (grep found 0 matches). What is proven is that the API accepts an arbitrary identity and message.
- `termios` — verified the part that matters: with `sys.stdin` **not** a tty, `os.open("/dev/tty")` + `tcgetattr` still succeeded on the real controlling terminal, and `tcsetattr` and `ECHO` are right there. A plugin can turn echo off and read the terminal the server was launched from regardless of its own stdio — the common case for a self-hosted `cdui start`.
- `_curses` / `_curses_panel` — verified surface (301 names) including `initscr`, `noecho`, `cbreak`, `endwin`: display and input takeover of that same terminal.

**One entry gated without a live reproduction, stated plainly:**

- **`ossaudiodev`** — opens OSS audio device files (`/dev/dsp`) for reading, which is microphone capture. CPython **removed** the module in 3.13 and both interpreters available to me are 3.14, so this rests on CPython's own documented surface, not on something I made run. It is the only entry in this PR in that position, and a reviewer should treat it as such.

## Gap 3 (#220) — the scan globbed `*.py`, the loader imports more

The most serious of the three, because it bypassed the mechanism rather than one entry on a list. Reproduced before the fix:

```
loader suffixes the import system accepts:
    ['.py', '.pyw', '.pyc', '.cp314-win_amd64.pyd', '.pyd']
directory contains:                     ['__init__.py', 'helper.pyc', 'native.cp314-win_amd64.pyd', 'w.pyw']
files a *.py glob would scan:           ['__init__.py']
modules pkgutil reports as importable:  ['helper', 'native', 'w']

validate_plugin_dir(root, []) -> ACCEPTED (no exception raised)
can the .pyc actually be imported and run?
   YES -- executed, module.MARK = 'pwned'
```

(The `whoami` in the payload really ran — its output is the first line of that transcript.) The gate did not fail open on a rule; **it never ran**.

### How the scan and the loader now agree

The walk asks the interpreter rather than carrying a list — the same "ask, don't assume" move `_compute_os_path_module_leaves` already makes for `os.path`:

- `SCANNABLE_SUFFIXES` = `importlib.machinery.SOURCE_SUFFIXES` ∪ `{.pyw}` → **scanned as source**.
- `LOADER_SUFFIXES` = `all_suffixes()` ∪ scannable ∪ `{.pyc, .pyo, .pyd, .so, .dylib}` → everything else here is **refused by name**, with a message saying which file and why.

`.pyw` and the foreign-platform binary suffixes are unioned in **on top of** `all_suffixes()` deliberately: that function answers for the *current* interpreter, and a tarball is not installed on the machine that built it. `.pyw` is a source suffix only on Windows; `.so`/`.pyd`/`.dylib` each exist on one platform. Scanning the union means the verdict on a given tarball does not depend on which OS ran the installer — otherwise that is a choice the attacker makes.

Refusal rather than scanning is the honest answer for both kinds: a `.pyc` would need decompiling and a `.pyd`/`.so` cannot be AST-scanned even in principle. The alternative is importing code nobody looked at.

### The false positive this must not produce

Any plugin directory an interpreter has ever imported from carries a `__pycache__` full of `<name>.cpython-NNN.pyc` — including this repo's own built-in packs, which is how it surfaced (the first cut of this fix broke `test_stats_pack.py`). The distinction is not the directory, it is whether an `import` statement can name the file, verified against the real loader rather than argued:

```
__pycache__ contains: ['payload.pyc', 'real.cpython-314.pyc']
pkgutil.iter_modules(__pycache__): ['payload']

payload.pyc            stem='payload'           isidentifier=True
real.cpython-314.pyc   stem='real.cpython-314'  isidentifier=False

import <pkg>.nodes.__pycache__.payload -> OK, VALUE='ATTACKER BYTECODE'
import <pkg>.nodes.__pycache__.real    -> ModuleNotFoundError
```

So the refusal fires on the reachable one and stays quiet on the artifact — the same structural test `.git` already gets (`".git".isidentifier()` is `False`), applied to a filename instead of a directory name. Longest-suffix matching is load-bearing here: strip only `.pyd` from `native.cp314-win_amd64.pyd` and the stem stops being an identifier, so the real compiled extension setuptools produces would slip through the very screen that protects the cache artifacts. There is a test for exactly that.

## The enumeration test, before and after

`test_every_builtin_module_is_classified_as_blocked_or_accepted` (core#177) walks the running interpreter's `sys.builtin_module_names` and requires every name to be blocked or explicitly accepted.

| interpreter | unclassified before | after |
|---|---|---|
| 3.14 Windows | 4 (`_hmac`, `_interpchannels`, `_interpqueues`, `_interpreters`) | 0 |
| 3.14 Linux (WSL) | 0 | 0 |
| 3.12 / 3.10 | 0 | 0 |

**That test was failing on `main` on 3.14** — one of three pre-existing failures in the baseline — and this PR fixes it. `_interpreters` was sitting in that list: the live `exec()` primitive, unclassified, on the interpreter I am typing this on.

The count alone understates it, because the names #215/#216 tracked were *already* classified — parked in `ACCEPTED_UNGATED_MODULES` with an issue number as their reason, indistinguishable from a real accept except by reading the string. That is how 29 live gaps sat in a green suite. `ACCEPTED_UNGATED_MODULES` went 76 → 77 entries while **29 deferred entries became 0**, and a new test (`test_nothing_is_left_deferred_in_the_accepted_set`) makes an entry there mean a verdict rather than a placeholder.

## Tests

**`backend/tests/test_tiered_policy.py`** — the tier matrix grew 29 rows, each exercised at Tier 0 / 1 / 2 (four parametrized tests), plus:

- `test_the_runtime_implementation_blocklist_is_ported_to_the_install_time_gate` — #215's literal complaint as a standing check: a name the runtime boundary calls dangerous cannot be one the install-time gate has never heard of. `_io` is the one exception and it is a documented accept, so the assertion asks for "classified", not "blocked".
- `test_the_underscore_implementation_of_a_blocked_module_is_classified_too` — the **shape**, not the list: for every blocklisted name, if this interpreter has `_<name>`, it must be classified. Keyed on `importlib.util.find_spec`, so a future CPython growing a `_webbrowser` accelerator fails the day it ships. Its docstring says plainly what it cannot see (`_thread` behind `threading`, `_posixsubprocess` behind `subprocess`, `_overlapped` behind `asyncio` — the pairs whose names do not rhyme, which is what the fresh-interpreter sweep is for).
- `test_the_verified_escape_is_refused_at_tier0` — 18 rows, one per primitive I actually made run, written as the call an attacker would use so the evidence sits next to the assertion.
- `test_the_subinterpreter_exec_primitive_is_blocked_under_both_of_its_names` — including a non-vacuity guard that fails if the interpreter has neither name.
- `test_ssl_alone_reaches_the_network_and_now_says_so`
- `test_the_compression_accelerators_were_verified_rather_than_matched` — pins the `_bz2`/`_lzma` accept to the property it rests on.
- `test_nothing_is_left_deferred_in_the_accepted_set`

**`backend/tests/test_plugin_cli.py`** — for #220:

- `test_validate_plugin_dir_refuses_compiled_modules_it_cannot_scan` — parametrized over `.pyc` / `.pyo` / `.pyd` / `.so` / `.dylib`; asserts the refusal names the file *and* the suffix.
- `test_the_refused_bytecode_really_is_importable` — non-vacuity: compiles a payload, deletes the source, and checks `pkgutil` (what `NodeRegistry.discover` walks) reports it while a `*.py` glob sees nothing. Without this the refusal could be guarding a phantom.
- `test_validate_plugin_dir_scans_pyw_as_the_source_it_is` — `.pyw` reaches the AST rules rather than the refuse-by-suffix path, and a clean `.pyw` still installs.
- `test_the_scan_covers_every_suffix_the_import_system_accepts` — the standing check #220 asks for, asserted on **behaviour**: every suffix gets a real file under a real plugin root and the walk must scan it or refuse it. A membership check would not have told "refused" apart from "walked past".
- `test_longest_suffix_wins_so_a_versioned_extension_is_still_refused`
- `test_a_cpython_written_bytecode_cache_is_not_mistaken_for_a_payload`
- `test_validate_nodes_dir_refuses_the_same_compiled_module` — the other entry point, which carried its own glob.
- `test_the_git_directory_exemption_survives_the_suffix_rule`

**Every new test was confirmed to fail without the source change** (source stashed, tests kept): 124 failures on the un-fixed tree, 0 with the fix.

## What a reviewer should check

1. **The three non-gates.** `_bz2`, `_lzma`, `resource` stay accepted. If you disagree with any of those, that is the argument to have — they are the only places I decided *against* the shape.
2. **`ossaudiodev`** is the one module gated on documentation rather than a reproduction. Said in the code comment too.
3. **`pwd`/`grp`'s honest half** — the local-files content is already reachable via the deliberately-ungated `open()`; the incremental grant is the NSS/directory-service case, which I could not verify.
4. **`_sqlite3` is tagged `filesystem` to match `sqlite3`, not re-tiered.** But the pair loads arbitrary shared libraries (`enable_load_extension` was accepted on this build), which is a `ctypes`-equivalent native-code primitive. That may mean `filesystem` under-describes what **both** grant — a question about the existing `sqlite3` mapping, not about the new entry, so I flagged it in the code rather than changing someone else's decision in a security PR. Worth its own issue.
5. **The blocklist feeds two other things.** `script_policy.TIER0_GATEWAY_MODULE_ATTRS` and `script_proxy._BLOCKED_DEFINING_ROOTS` both derive from `dangerous_modules()`, so the in-canvas script tier now also refuses these as attribute names and defining roots. Full suite is green, but that widening is worth a look — the non-underscore additions are `ssl`, `winreg`, `msvcrt`, `pwd`, `grp`, `syslog`, `termios`, `ossaudiodev`, none of which are plausible attribute names on numpy/torch/pandas.
6. **`cdui plugin link` still does not validate at all.** Pre-existing and deliberate (dev loop, the author's own checkout, loaded in place) — but it means #220's fix covers the `install` path, not the `link` path. Not changed here; noting it so it is a decision rather than a gap.
7. **The loader itself is unchanged.** #220's own suggested direction; narrowing PEP-420 `__path__` needs a custom finder/loader, which the same reasoning already rejected for directories in #182.

## Test status

Full suite, Windows / CPython 3.14: **4051 passed, 22 skipped, 2 failed.**

Both failures are pre-existing on this interpreter and unrelated — verified by running the suite on the clean tree first, which gives **3** failures:

- `test_python_script_node.py::test_no_reachable_callable_takes_a_file_path` (pre-existing)
- `test_tiered_policy.py::test_the_purity_guard_can_see_impurity_in_both_path_implementations` (pre-existing; 3.14's `ntpath.exists`/`isfile`/`isdir`/`islink`/`lexists` are C fast paths in `nt`, so the probe's `os.stat` interception no longer sees them — a 3.14 incompatibility in that test, not a blunted screen. CI runs 3.10–3.12.)
- `test_tiered_policy.py::test_every_builtin_module_is_classified_as_blocked_or_accepted` — **fixed by this PR.**

Classification invariants were additionally re-run standalone on 3.10, 3.12 and 3.14 (Windows) and 3.14 (Linux/WSL): zero unclassified builtins, zero blocked-and-accepted overlap, zero unclassified underscore siblings, zero Tier-0 overlap, capability containment intact, on every one.

Docs updated in both locales (`docs/docs/advanced/plugins.md` and the zh-TW mirror): the `network` and `filesystem` capability tables, and a new "Ship source, not bytecode" section explaining what a plugin may ship and why the refusal exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
