### PR TITLE
fix(cache): a second Run of a training graph must actually train (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,39 @@ received — each links to the release it was published as.
 
 ### Fixed
 
+- **The second Run of a training graph did no training, and reported success**
+  ([#253]). `TrainingLoop` inherited the default `cacheable = True`, and a
+  cache hit replays a node's recorded outputs without calling it — so no
+  weights were updated, no metrics were written, and the canvas said
+  `completed` anyway. On four of the six shipped examples that train, run 2
+  and run 3 executed the training loop zero times. Two of those are teaching
+  plugin examples students open in class (`C2-5 MLP-MNIST-Training`,
+  `C3-1 LeNet-MNIST-Training`). Change a hyperparameter, press Run, and the
+  loss curve you get back is the previous run's, with nothing to tell you.
+
+  The other two shipped training graphs were protected only by accident, and
+  the accident is scheduled for removal: their `ModelSaver` may only write
+  under `./data`, `Dataset`'s cache fingerprint walks all of `./data`, so the
+  write happened to invalidate the dataset. Scoping that walk ([#259]) would
+  have broken those graphs too. This fix does not depend on it.
+
+  `SequentialModel` was the other half. It owns the weights `TrainingLoop`
+  mutates, declared no inputs, and was cacheable — a root nothing could ever
+  invalidate, so run 2 was handed run 1's *already trained* module. Making
+  only `TrainingLoop` re-run would therefore have traded "no training at all"
+  for "every run silently continues from the last run's weights", which is
+  arguably worse because the numbers still look plausible. It now carries
+  `StatefulModuleMixin` like every other weight-owning node, so **Settings →
+  Training Behavior → Persist weights between runs** and **Reset all weights
+  now** decide which of the two happens, and the node writes which one it did
+  to its Log tab on every run.
+
+  Also fixes a latent engine race this exposed: nodes at one topological
+  level run concurrently on an unseeded run and shared one mutable
+  `current_node_id`, so a node's persisted weights could be filed under a
+  concurrent sibling's node id — out of reach of "Reset all weights now".
+  Each node now gets its own view of that field.
+
 - **A learning-rate schedule whose length did not match the run said nothing**
   ([#252]). `TrainingLoop` steps the scheduler once per epoch, so every
   cycle-length parameter on `LRScheduler` counts epochs — while PyTorch counts
@@ -243,6 +276,8 @@ Release candidates before 1.0.0 are on the
 [#239]: https://github.com/CodefyUI/CodefyUI/pull/239
 [#241]: https://github.com/CodefyUI/CodefyUI/pull/241
 [#252]: https://github.com/CodefyUI/CodefyUI/pull/252
+[#253]: https://github.com/CodefyUI/CodefyUI/issues/253
+[#259]: https://github.com/CodefyUI/CodefyUI/issues/259
 [@oyea0801]: https://github.com/oyea0801
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...main
 [2.1.1]: https://github.com/CodefyUI/CodefyUI/compare/2.1.0...2.1.1

--- a/backend/app/core/execution_context.py
+++ b/backend/app/core/execution_context.py
@@ -338,8 +338,17 @@ class ExecutionContext:
     backward_mode: bool = False
     auto_backward: bool = False
 
-    # Mutated per-node by graph_engine before each execute() call so that
+    # Set per-node by graph_engine before each execute() call so that
     # StatefulModuleMixin.get_or_build_module knows which node it is in.
+    #
+    # The node sees it on a SHALLOW COPY of this context, made per node --
+    # never on the shared instance (#253). Nodes at one topological level run
+    # concurrently on an unseeded run, so a single shared field is read by
+    # one node's worker thread after the next node has already overwritten
+    # it, and the weights get persisted under the wrong node's id. Everything
+    # else on the copy is the same object, so this field is the only one that
+    # is per-node; do not add another that needs to be written by a node and
+    # read by the engine.
     current_node_id: str = ""
 
     # Populated during a run when backward_mode is True. Maps

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -2103,8 +2103,29 @@ async def execute_graph(
                                                       payload=data))
 
                     # Tell stateful nodes which node-id they belong to.
+                    #
+                    # On a PER-NODE VIEW of the context, not the shared one
+                    # (#253). ``current_node_id`` used to be assigned here
+                    # and read much later, inside the worker thread, with an
+                    # ``await`` in between -- so on an unseeded run, where
+                    # ``max_workers`` is 4, the sibling that acquired the
+                    # semaphore next overwrote the field before this node's
+                    # thread ever read it, and `StatefulModuleMixin` filed
+                    # the node's weights under a DIFFERENT node's id. It
+                    # never showed up because a seeded run is a serial run
+                    # (see ``max_workers`` above) and the stateful nodes that
+                    # existed were all mid-chain, one per level.
+                    #
+                    # ``copy.copy`` and not ``replace``/``deepcopy``: every
+                    # collaborator on the context -- the stop event, the
+                    # outbox, ``node_state_store``, ``grad_targets`` -- must
+                    # stay the SAME object, so cancellation, logging and
+                    # gradient capture are unaffected. Only the scalar field
+                    # differs per node.
+                    node_context = context
                     if context is not None:
-                        context.current_node_id = node_id
+                        node_context = copy.copy(context)
+                        node_context.current_node_id = node_id
 
                     # Per-node seeding (#134). Every node starts from a seed
                     # derived from (run seed, node id), so its weight init,
@@ -2122,7 +2143,7 @@ async def execute_graph(
                         inputs,
                         params,
                         progress_callback=_progress_bridge,
-                        context=context,
+                        context=node_context,
                     )
                     result = await loop.run_in_executor(None, fn)
                     # Everything this node queued goes out BEFORE its

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -653,6 +653,22 @@ class TrainingLoopNode(BaseNode):
         "learning rate scheduling, and gradient clipping."
     )
 
+    #: #253. Training IS a side effect: it mutates the incoming model's
+    #: weights and the optimizer's buffers in place, and writes a metric
+    #: series per epoch. A cache hit replays the recorded outputs without
+    #: calling ``execute``, so none of that happens -- the second Run of a
+    #: graph did no training at all and still reported success. The returned
+    #: ``model`` handle looks like the whole story and is not, which is the
+    #: same shape as the writer nodes in #143 and ``PythonScript`` in #256.
+    #:
+    #: Deliberately independent of what feeds this node. Making the weight
+    #: source non-cacheable propagates down here for SequentialModel-shaped
+    #: graphs, but ``ModelLoader``/``CheckpointLoader`` stay cacheable by
+    #: #144, so a resume-from-disk graph would still cache the training away.
+    #: ``DiffusionTrainingLoop`` already declared this; the generic loop did
+    #: not, and inherited ``True`` from ``BaseNode``.
+    cacheable = False
+
     @classmethod
     def define_inputs(cls) -> list[PortDefinition]:
         return [

--- a/backend/app/nodes/utility/sequential_node.py
+++ b/backend/app/nodes/utility/sequential_node.py
@@ -5,12 +5,25 @@ training nodes (MODEL world).
 It reads a JSON layer specification and builds a real nn.Sequential that
 can be passed to Optimizer and TrainingLoop.  Users describe the architecture
 with familiar parameters; no Python coding required.
+
+**Why this node is stateful (#253).** It OWNS trainable parameters, and
+``TrainingLoop`` mutates them in place. That breaks the cache's
+``f(params, upstream) -> output`` assumption exactly the way it breaks for
+every layer node, so it carries :class:`StatefulModuleMixin` like they do --
+which is also what makes ``Persist weights between runs`` and ``Reset all
+weights now`` (Settings > Training Behavior) mean anything here. Before
+#253 this node was a cacheable ROOT with no inputs, so nothing could ever
+invalidate it: run 2 was handed run 1's already-trained module straight out
+of ``ExecutionCache``, and with ``TrainingLoop`` cacheable too, no training
+happened at all. ``DiffusionUNet`` is the same shape done right and was the
+model for this.
 """
 
 import logging
 from typing import Any
 
 from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+from ...core.stateful_module import StatefulModuleMixin
 
 logger = logging.getLogger(__name__)
 
@@ -224,7 +237,7 @@ def _build_layer(cfg: dict) -> "torch.nn.Module":
     return cls(**p)
 
 
-class SequentialModelNode(BaseNode):
+class SequentialModelNode(StatefulModuleMixin, BaseNode):
     NODE_NAME = "SequentialModel"
     CATEGORY = "Training"
     DESCRIPTION = (
@@ -232,6 +245,14 @@ class SequentialModelNode(BaseNode):
         "Double-click to open the architecture editor and drag-and-drop layers. "
         "Outputs a MODEL that can be connected to Optimizer and TrainingLoop."
     )
+
+    #: The whole architecture lives in one param, so the layer spec IS the
+    #: structure. Edit the architecture and the hash changes, which drops the
+    #: persisted weights -- correct, since they no longer fit the new shapes.
+    #: Changing anything else about the run (learning rate, epochs, batch
+    #: size) leaves the hash alone and therefore keeps the weights, which is
+    #: the point of the setting.
+    structural_params = ("layers",)
 
     @classmethod
     def define_inputs(cls) -> list[PortDefinition]:
@@ -283,16 +304,79 @@ class SequentialModelNode(BaseNode):
             ),
         ]
 
-    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+    def build_module(self, params: dict[str, Any]) -> "torch.nn.Module":
         import json
+
         from .graph_model import build_graph_model
 
-        layers_str = params.get("layers", "{}")
-        spec = json.loads(layers_str)
-        model = build_graph_model(spec)
+        return build_graph_model(json.loads(params.get("layers", "{}")))
+
+    def _weights_are_persisted(
+        self, context: Any, params: dict[str, Any],
+    ) -> bool:
+        """True when THIS call will be handed weights an earlier run trained.
+
+        Asked before :meth:`get_or_build_module`, because that call is what
+        makes the answer stop being true. A miss inside the store drops the
+        node's other structure hashes, so "my hash is already there" is
+        exactly "the module I am about to get was built by an earlier run".
+
+        Never raises -- an advisory log line must not be able to fail the
+        node that produces it.
+        """
+        store = getattr(context, "node_state_store", None)
+        if (
+            context is None
+            or not getattr(context, "weights_persistent", False)
+            or store is None
+            or not getattr(context, "current_node_id", "")
+        ):
+            return False
+        try:
+            wanted = self._structure_hash(params)
+            return any(
+                key[2] == wanted
+                for key in store.keys_for_node(
+                    context.graph_id, context.current_node_id)
+            )
+        except Exception:  # noqa: BLE001 - advisory only
+            logger.debug("could not inspect persisted node state", exc_info=True)
+            return False
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        resumed = self._weights_are_persisted(context, params)
+        model = self.get_or_build_module(context, params)
 
         total = sum(p.numel() for p in model.parameters())
         layer_count = len(model.layers)
         logger.info("Built graph model with %d layers, %s parameters", layer_count, f"{total:,}")
 
-        return {"model": model}
+        # #253: say which of the two happened. Whether a rerun continues
+        # training or restarts it is a real choice with no obviously right
+        # default, so the node does not make it silently -- the setting
+        # decides and this line reports the decision. ``__log__`` is the one
+        # result key the canvas Log tab renders, and dunder keys are filtered
+        # out of recorded outputs and port summaries, so this adds a log line
+        # and nothing else (same mechanism as TrainingLoop's schedule note).
+        if resumed:
+            note = (
+                f"Continuing from weights an earlier run left behind "
+                f"({total:,} parameters). Training resumes from those weights "
+                f"rather than starting over. To start from a fresh "
+                f"initialisation, use Settings > Training Behavior > "
+                f"'Reset all weights now', or turn off 'Persist weights "
+                f"between runs'."
+            )
+        else:
+            note = (
+                f"Fresh initialisation ({total:,} parameters across "
+                f"{layer_count} layers)."
+            )
+
+        return {"model": model, "__log__": note}

--- a/backend/tests/test_cache_training_nodes.py
+++ b/backend/tests/test_cache_training_nodes.py
@@ -1,0 +1,511 @@
+"""Regression tests for #253 - the second Run of a training graph must train.
+
+A cache hit returns the RECORDED outputs dict without calling ``execute``
+again. For ``TrainingLoop`` that means the weights are never updated and the
+per-epoch metrics are never written, while the node still reports success:
+the second Run of a shipped teaching example did no training at all and the
+canvas said ``completed``.
+
+Two things were wrong and either one alone keeps the bug alive.
+
+* ``TrainingLoop`` inherited ``cacheable = True`` from ``BaseNode``. Training
+  is a side effect on objects the node was handed, so the recorded outputs
+  do not describe it -- the same shape as the writer nodes in #143.
+  ``DiffusionTrainingLoop`` had already declared ``cacheable = False``; the
+  generic loop had not.
+* ``SequentialModel`` owns the weights, declared no inputs, and was
+  cacheable. A cacheable node with no inputs is a ROOT that nothing can ever
+  invalidate, so run 2 was handed run 1's *already trained* module straight
+  out of the cache. Making only ``TrainingLoop`` non-cacheable therefore
+  trades "no training at all" for "every run silently continues from the
+  last run's weights", which is not obviously better. It now carries
+  ``StatefulModuleMixin`` like every other weight-owning node, so the
+  existing ``Persist weights between runs`` setting decides which of the two
+  happens and the node says in its log which one it did.
+
+Why these tests count real ``execute()`` calls instead of reading statuses:
+the shipped examples wrap the training path in a preset, and a preset whose
+internals were ALL cache hits still reports ``completed`` (#260). Status is
+precisely the thing that lied here, so it is never the assertion.
+
+Why the substituted dataset does not weaken the end-to-end test: on the
+shipped graph the only thing standing between ``TrainingLoop`` and a cache
+hit today is an accident -- ``ModelSaver`` may only write under ``./data``,
+and ``DatasetNode.cache_fingerprint`` walks all of ``./data``, so the write
+dirties the dataset's key. #259 is filed to scope that walk, which would
+remove the accident. The fixture dataset below has no external state at all,
+so it is *more* cacheable than the shipped ``Dataset``, never less: this
+graph is fully cacheable end to end and the fix has to hold on its own.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.core.cache import ExecutionCache
+from app.core.execution_context import ExecutionContext
+from app.core.graph_engine import execute_graph, expand_presets
+from app.core.node_base import BaseNode, DataType, PortDefinition
+from app.core.node_registry import registry
+from app.core.node_state_store import NodeStateStore
+from app.nodes.training.diffusion_training_loop_node import DiffusionTrainingLoopNode
+from app.nodes.training.training_loop_node import TrainingLoopNode
+from app.nodes.utility.sequential_node import SequentialModelNode
+
+#: The example #253 was finally measured on: a plain "train an MLP and plot
+#: the loss curve" graph from the teaching pack, with no writer node anywhere
+#: and the training path inside a preset. Four of the six shipped graphs that
+#: train have that shape.
+_SHIPPED_EXAMPLE = (
+    Path(__file__).resolve().parents[2]
+    / "plugins" / "foundations" / "examples"
+    / "C2-5" / "MLP-MNIST-Training" / "graph.json"
+)
+
+FIXTURE_NODE = "_MnistShapedFixtureDataset253"
+
+#: MNIST's shape and label range exactly, so the shipped 784 -> 128 -> 64 ->
+#: 10 layer spec runs verbatim. Tiny enough that one epoch is milliseconds.
+_SAMPLES = 32
+_CLASSES = 10
+
+
+class _MnistShapedFixtureDatasetNode(BaseNode):
+    """A deterministic stand-in for the MNIST download.
+
+    Emits ``[N, 1, 28, 28]`` float images and integer labels -- the shapes
+    the shipped graph's ``Flatten`` -> ``Linear(784, 128)`` and
+    ``CrossEntropyLoss`` already expect, so nothing downstream is adjusted
+    for it. No file access and no ``cache_fingerprint``, which is the point:
+    it cannot accidentally invalidate anything, so the graph it feeds is
+    cacheable from end to end.
+    """
+
+    NODE_NAME = FIXTURE_NODE
+    CATEGORY = "Data"
+    DESCRIPTION = "Fixed MNIST-shaped tensor dataset for cache tests."
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="dataset", data_type=DataType.DATASET)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        import torch
+
+        images = (
+            torch.arange(_SAMPLES * 28 * 28, dtype=torch.float32)
+            .reshape(_SAMPLES, 1, 28, 28)
+            / (_SAMPLES * 28 * 28)
+        )
+        targets = torch.arange(_SAMPLES) % _CLASSES
+        return {"dataset": torch.utils.data.TensorDataset(images, targets)}
+
+
+MODEL_SOURCE_NODE = "_CacheableModelSource253"
+
+
+class _CacheableModelSourceNode(BaseNode):
+    """A legitimately cacheable node that hands out a model.
+
+    Stands in for ``ModelLoader`` / ``CheckpointLoader``, which #144
+    deliberately keeps ``cacheable = True`` (with a content fingerprint over
+    the file they read) so that resuming from a checkpoint does not re-read
+    it every run. A test node rather than the real ones because those need a
+    weights file on disk, and the file is not what is being tested -- only
+    that ``TrainingLoop`` still runs when its model arrives from a node that
+    is a cache hit.
+    """
+
+    NODE_NAME = MODEL_SOURCE_NODE
+    CATEGORY = "Test"
+    DESCRIPTION = "Cacheable source of a small model."
+    cacheable = True
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="model", data_type=DataType.MODEL)]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        import torch.nn as nn
+
+        return {"model": nn.Sequential(nn.Flatten(), nn.Linear(784, _CLASSES))}
+
+
+@pytest.fixture(autouse=True)
+def _register_fixture_dataset():
+    registry._nodes[FIXTURE_NODE] = _MnistShapedFixtureDatasetNode
+    registry._nodes[MODEL_SOURCE_NODE] = _CacheableModelSourceNode
+    yield
+    registry._nodes.pop(FIXTURE_NODE, None)
+    registry._nodes.pop(MODEL_SOURCE_NODE, None)
+
+
+def _node_name(node_cls: type[BaseNode]) -> str:
+    return node_cls.NODE_NAME
+
+
+def _shipped_graph_without_the_download() -> tuple[list[dict], list[dict]]:
+    """The shipped example, preset expanded, MNIST swapped for tensors.
+
+    Everything that #253 is about executes exactly as shipped: the real
+    ``SequentialModel`` with the file's own 784 -> 128 -> 64 -> 10 layer
+    JSON, the real ``DataLoader``, ``Optimizer``, ``Loss``, ``TrainingLoop``,
+    ``Visualize`` and ``Print``, wired by the file's own edges and the
+    preset's own edges.
+
+    Two rewrites, both on the data side:
+
+    * the preset is expanded through the production :func:`expand_presets`,
+      because the ``Dataset`` node to swap lives inside it. #253's own
+      measurements confirmed the wrapped and expanded forms behave
+      identically -- the wrapper hides the cache decision (#260), it does not
+      change it.
+    * ``Dataset`` becomes the fixture node above, and one epoch is enough.
+    """
+    payload = json.loads(_SHIPPED_EXAMPLE.read_text(encoding="utf-8"))
+    nodes, edges, _ = expand_presets(payload["nodes"], payload["edges"])
+
+    swapped = False
+    shrunk = False
+    for node in nodes:
+        if node["type"] == "Dataset":
+            node["type"] = FIXTURE_NODE
+            node["data"]["params"] = {}
+            swapped = True
+        elif node["type"] == "TrainingLoop":
+            node["data"]["params"].update(epochs=1, device="cpu")
+            shrunk = True
+        elif node["type"] == "DataLoader":
+            node["data"]["params"].update(batch_size=8, num_workers=0)
+
+    # The shipped file is the fixture. If it stops containing the nodes this
+    # test rewrites, the rewrite silently became a no-op and everything below
+    # would still pass while testing a different graph.
+    assert swapped, f"{_SHIPPED_EXAMPLE} no longer contains a Dataset node"
+    assert shrunk, f"{_SHIPPED_EXAMPLE} no longer contains a TrainingLoop node"
+    assert any(n["type"] == "SequentialModel" for n in nodes), (
+        f"{_SHIPPED_EXAMPLE} no longer contains a SequentialModel node")
+    return nodes, edges
+
+
+def _only(nodes: list[dict], node_type: str) -> str:
+    ids = [n["id"] for n in nodes if n["type"] == node_type]
+    assert len(ids) == 1, f"expected exactly one {node_type}, found {ids}"
+    return ids[0]
+
+
+@pytest.mark.parametrize(
+    "node_cls",
+    [TrainingLoopNode, DiffusionTrainingLoopNode, SequentialModelNode],
+    ids=_node_name,
+)
+def test_training_and_weight_owning_nodes_are_not_cacheable(
+    node_cls: type[BaseNode],
+) -> None:
+    """Necessary but nowhere near sufficient -- see the end-to-end test.
+
+    ``TrainingLoop`` mutates the model and optimizer it is handed and writes
+    a metric series; ``SequentialModel`` owns the weights that get mutated.
+    Neither is described by its recorded outputs, so neither may be replayed
+    from the cache.
+    """
+    assert node_cls.cacheable is False, (
+        f"{node_cls.NODE_NAME} owns or mutates trainable parameters, so a "
+        "cache hit that skips execute() skips the part that mattered. It "
+        "must opt out with `cacheable = False`."
+    )
+
+
+@pytest.mark.asyncio
+async def test_shipped_example_trains_on_every_run() -> None:
+    """The #253 repro: run the shipped graph twice against one cache.
+
+    Counts real ``TrainingLoopNode.execute`` calls. Before the fix this was
+    ``1`` then ``0`` -- run 2 did no training and reported success.
+    """
+    nodes, edges = _shipped_graph_without_the_download()
+
+    train_calls: list[int] = []
+    model_calls: list[int] = []
+    counted = {"train": 0, "model": 0}
+
+    real_train = TrainingLoopNode.execute
+    real_model = SequentialModelNode.execute
+
+    def counting_train(self, *args, **kwargs):
+        counted["train"] += 1
+        return real_train(self, *args, **kwargs)
+
+    def counting_model(self, *args, **kwargs):
+        counted["model"] += 1
+        return real_model(self, *args, **kwargs)
+
+    cache = ExecutionCache()
+    statuses: dict[str, str] = {}
+
+    async def track(node_id, status, data):
+        if status in ("completed", "cached", "skipped", "error"):
+            statuses[node_id] = status
+
+    TrainingLoopNode.execute = counting_train
+    SequentialModelNode.execute = counting_model
+    try:
+        for _ in range(2):
+            before = counted["train"], counted["model"]
+            await execute_graph(nodes, edges, on_progress=track, cache=cache)
+            train_calls.append(counted["train"] - before[0])
+            model_calls.append(counted["model"] - before[1])
+    finally:
+        TrainingLoopNode.execute = real_train
+        SequentialModelNode.execute = real_model
+
+    assert train_calls == [1, 1], (
+        "every Run of a training graph must actually train. TrainingLoop "
+        f"executed {train_calls} time(s) per run; a 0 means that run was "
+        "served from the cache and silently skipped training."
+    )
+    assert model_calls == [1, 1], (
+        "SequentialModel owns the weights TrainingLoop mutates, so it may "
+        f"not be replayed from the cache either (executed {model_calls} "
+        "time(s) per run). A cached hand-back is run 1's trained module."
+    )
+
+    # Without this the test would pass just as well in a world where caching
+    # had stopped working entirely and every node always re-executed. The
+    # Loss node is pure, cacheable and unchanged between the two runs, so it
+    # MUST be a cache hit on run 2 if the cache is really discriminating --
+    # which is the property #253 depends on. It also pins that the fixture
+    # dataset really did leave this graph cacheable end to end, i.e. that
+    # the assertions above are not riding on an invalidation somewhere
+    # upstream (the accident #259 is filed to remove).
+    loss_id = _only(nodes, "Loss")
+    dataset_id = _only(nodes, FIXTURE_NODE)
+    assert statuses[loss_id] == "cached", (
+        "the pure Loss node must still hit the cache on the second run -- "
+        "otherwise this test cannot tell '#253 fixed' apart from 'caching "
+        f"stopped working entirely' (status was {statuses[loss_id]!r})"
+    )
+    assert statuses[dataset_id] == "cached", (
+        "the fixture dataset must hit the cache on the second run, proving "
+        "TrainingLoop re-ran on its own merits rather than because an "
+        f"upstream node invalidated it (status was {statuses[dataset_id]!r})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_training_still_runs_when_the_model_source_is_cacheable() -> None:
+    """``TrainingLoop`` must not rely on its upstream being non-cacheable.
+
+    ``SequentialModel`` going non-cacheable propagates down to the loop for
+    the graphs in the shipped examples, which is enough to hide whether the
+    loop's OWN ``cacheable`` flag matters. It does: ``ModelLoader`` and
+    ``CheckpointLoader`` are deliberately cacheable (#144, so that resuming
+    from a checkpoint does not re-read the file every run), and a graph that
+    trains a model loaded from disk is a fully cacheable chain from end to
+    end. ``_CacheableModelSource`` below stands in for those two -- what
+    matters is only that the model arrives from a cacheable node.
+    """
+    nodes = [
+        {"id": "start", "type": "Start", "data": {"params": {}}},
+        {"id": "src", "type": MODEL_SOURCE_NODE, "data": {"params": {}}},
+        {"id": "data", "type": FIXTURE_NODE, "data": {"params": {}}},
+        {"id": "loader", "type": "DataLoader",
+         "data": {"params": {"batch_size": 8, "shuffle": False,
+                             "num_workers": 0}}},
+        {"id": "opt", "type": "Optimizer",
+         "data": {"params": {"type": "SGD", "lr": 0.05}}},
+        {"id": "loss", "type": "Loss",
+         "data": {"params": {"type": "CrossEntropyLoss"}}},
+        {"id": "train", "type": "TrainingLoop",
+         "data": {"params": {"epochs": 1, "device": "cpu"}}},
+    ]
+    edges = [
+        {"id": "t1", "source": "start", "target": "src",
+         "sourceHandle": "trigger", "type": "trigger"},
+        {"id": "t2", "source": "start", "target": "data",
+         "sourceHandle": "trigger", "type": "trigger"},
+        {"id": "t3", "source": "start", "target": "loss",
+         "sourceHandle": "trigger", "type": "trigger"},
+        {"id": "e1", "source": "data", "target": "loader",
+         "sourceHandle": "dataset", "targetHandle": "dataset"},
+        {"id": "e2", "source": "loader", "target": "train",
+         "sourceHandle": "dataloader", "targetHandle": "dataloader"},
+        {"id": "e3", "source": "src", "target": "opt",
+         "sourceHandle": "model", "targetHandle": "model"},
+        {"id": "e4", "source": "src", "target": "train",
+         "sourceHandle": "model", "targetHandle": "model"},
+        {"id": "e5", "source": "opt", "target": "train",
+         "sourceHandle": "optimizer", "targetHandle": "optimizer"},
+        {"id": "e6", "source": "loss", "target": "train",
+         "sourceHandle": "loss_fn", "targetHandle": "loss_fn"},
+    ]
+
+    counted = {"train": 0}
+    per_run: list[int] = []
+    real_train = TrainingLoopNode.execute
+
+    def counting_train(self, *args, **kwargs):
+        counted["train"] += 1
+        return real_train(self, *args, **kwargs)
+
+    cache = ExecutionCache()
+    statuses: dict[str, str] = {}
+
+    async def track(node_id, status, data):
+        if status in ("completed", "cached", "skipped", "error"):
+            statuses[node_id] = status
+
+    TrainingLoopNode.execute = counting_train
+    try:
+        for _ in range(2):
+            before = counted["train"]
+            await execute_graph(nodes, edges, on_progress=track, cache=cache)
+            per_run.append(counted["train"] - before)
+    finally:
+        TrainingLoopNode.execute = real_train
+
+    assert per_run == [1, 1], (
+        "TrainingLoop must execute on every run even when every node feeding "
+        f"it is cacheable; it ran {per_run} time(s) per run."
+    )
+    assert statuses["src"] == "cached", (
+        "the cacheable model source must still be a cache hit on run 2, or "
+        "this test is not exercising the case it exists for "
+        f"(status was {statuses['src']!r})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_roots_persist_under_their_own_node_ids() -> None:
+    """Weights must be filed under the node that owns them.
+
+    A prerequisite for the fix above rather than a separate feature. Nodes
+    at one topological level run concurrently on an UNSEEDED run (a seeded
+    run is serial, #134), and the engine used to hand every one of them the
+    same ``ExecutionContext`` after setting ``current_node_id`` on it. With
+    an ``await`` between that assignment and the worker thread's read, the
+    node that acquired the semaphore next won, and ``StatefulModuleMixin``
+    persisted one node's weights under another node's id -- so 'Reset all
+    weights now' could not reach them and two nodes could collide.
+
+    Latent until now because the stateful nodes that existed were mid-chain,
+    one per level. ``SequentialModel`` is a root, and several models on one
+    canvas all start at level 0.
+    """
+    spec = json.loads(
+        json.loads(_SHIPPED_EXAMPLE.read_text(encoding="utf-8"))
+        ["nodes"][1]["data"]["params"]["layers"]
+    )
+    model_ids = [f"model-{i}" for i in range(4)]
+    nodes = [{"id": "start", "type": "Start", "data": {"params": {}}}] + [
+        {"id": mid, "type": "SequentialModel",
+         # A different width per node, so a swap cannot be masked by the
+         # two modules happening to hash the same.
+         "data": {"params": {"layers": json.dumps(_widen(spec, 16 + i))}}}
+        for i, mid in enumerate(model_ids)
+    ]
+    edges = [
+        {"id": f"t{i}", "source": "start", "target": mid,
+         "sourceHandle": "trigger", "type": "trigger"}
+        for i, mid in enumerate(model_ids)
+    ]
+
+    store = NodeStateStore()
+    context = ExecutionContext(
+        graph_id="test-253-race",
+        device="cpu",
+        weights_persistent=True,
+        node_state_store=store,
+        # No seed on purpose: that is what lets the engine run these four
+        # roots concurrently, which is the whole point of the test.
+        seed=None,
+    )
+    await execute_graph(nodes, edges, context=context)
+
+    stored_ids = sorted(key[1] for key in store._store)
+    assert stored_ids == sorted(model_ids), (
+        "each model's weights must be persisted under its own node id; got "
+        f"{stored_ids}. A missing or duplicated id means one node's context "
+        "was overwritten by a concurrent sibling."
+    )
+
+
+def _widen(spec: dict, hidden: int) -> dict:
+    """The shipped layer spec with a different hidden width."""
+    out = json.loads(json.dumps(spec))
+    for node in out["nodes"]:
+        params = node.get("params") or {}
+        if "out_features" in params and params["out_features"] != 10:
+            params["out_features"] = hidden
+        if "in_features" in params and params["in_features"] != 784:
+            params["in_features"] = hidden
+    return out
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("persistent", [True, False], ids=["persist", "fresh"])
+async def test_rerun_says_whether_it_continued_or_started_over(
+    persistent: bool,
+) -> None:
+    """Whichever a rerun does, the user has to be able to tell.
+
+    "Run again" continuing from the last run's weights is not wrong, but it
+    is wrong to do it silently -- the losses look plausible either way, which
+    is what made #253 hard to see. ``SequentialModel`` now routes the choice
+    through the existing ``Persist weights between runs`` setting and reports
+    in its ``__log__`` which of the two happened.
+    """
+    nodes, edges = _shipped_graph_without_the_download()
+    model_id = _only(nodes, "SequentialModel")
+
+    store = NodeStateStore()
+    cache = ExecutionCache()
+    notes: list[str] = []
+
+    for _ in range(2):
+        logs: dict[str, str] = {}
+
+        async def track(node_id, status, data, _logs=logs):
+            if isinstance(data, dict) and "__log__" in data:
+                _logs[node_id] = str(data["__log__"])
+
+        context = ExecutionContext(
+            graph_id="test-253",
+            device="cpu",
+            weights_persistent=persistent,
+            node_state_store=store,
+        )
+        await execute_graph(
+            nodes, edges, on_progress=track, context=context, cache=cache)
+        assert model_id in logs, (
+            "SequentialModel must report which weights it used; nothing "
+            "reached the node's log")
+        notes.append(logs[model_id])
+
+    assert notes[0].startswith("Fresh initialisation"), notes[0]
+    if persistent:
+        assert notes[1].startswith("Continuing from weights"), (
+            "with weight persistence on, the second Run continues training "
+            "from the first Run's weights and has to say so, or the loss "
+            f"curve is unexplainable (log line was {notes[1]!r})")
+        assert len(store) == 1, (
+            "the persisted module should be in the node state store, where "
+            "'Reset all weights now' can reach it")
+    else:
+        assert notes[1].startswith("Fresh initialisation"), (
+            "with weight persistence off, every Run must re-initialise, and "
+            f"say so (log line was {notes[1]!r})")
+        assert len(store) == 0, (
+            "nothing may be persisted when the setting is off")

--- a/backend/tests/test_cache_training_nodes.py
+++ b/backend/tests/test_cache_training_nodes.py
@@ -404,10 +404,11 @@ async def test_concurrent_roots_persist_under_their_own_node_ids() -> None:
     one per level. ``SequentialModel`` is a root, and several models on one
     canvas all start at level 0.
     """
-    spec = json.loads(
-        json.loads(_SHIPPED_EXAMPLE.read_text(encoding="utf-8"))
-        ["nodes"][1]["data"]["params"]["layers"]
-    )
+    payload = json.loads(_SHIPPED_EXAMPLE.read_text(encoding="utf-8"))
+    spec = json.loads(next(
+        n["data"]["params"]["layers"] for n in payload["nodes"]
+        if n["type"] == "SequentialModel"
+    ))
     model_ids = [f"model-{i}" for i in range(4)]
     nodes = [{"id": "start", "type": "Start", "data": {"params": {}}}] + [
         {"id": mid, "type": "SequentialModel",

--- a/docs/docs/usage/running-graphs.md
+++ b/docs/docs/usage/running-graphs.md
@@ -46,9 +46,13 @@ Some nodes still opt out of caching entirely with `cacheable = False`, for two d
 
 **The node's purpose is a side effect.** `ImageWriter`, `ModelSaver`, and `CheckpointSaver` exist to write a file; a cache hit would return the recorded `{"path": ...}` without touching disk, which is wrong when the node's whole point is the write (deleting the output and re-running must recreate it). These re-execute every run regardless of what feeds them.
 
+`TrainingLoop` is in this group too, for the same reason in a different medium: what it produces is not the `model` handle it returns but the *change* to the weights that handle points at, plus a metric series per epoch. Neither survives a cache hit — so it re-executes every run, regardless of whether everything feeding it was unchanged.
+
 **The node might have a side effect and only its author knows.** `PythonScript` runs code you type on the canvas. `code` is a cache-keyed parameter, so an *edited* script re-runs — but an unedited script over unchanged inputs is exactly where a hit happens, and a script can mutate an input tensor or model in place, change process-global `torch`/`numpy` state, or use whatever an `ANY`-typed input port handed it. None of that is visible to the node's type or to any check on its source, so it opts out unconditionally. See [the PythonScript node](../advanced/python-script-node.md#caching).
 
-The same opt-out covers nodes whose output escapes the cache key for other reasons — `GaussianNoise`, `DDPMSampler`, `BackwardOnce`, `DiffusionTrainingLoop`, and every layer that owns weights (`Linear`, `Conv2d`, `LSTM` and the rest), whose parameters drift as training proceeds.
+The same opt-out covers nodes whose output escapes the cache key for other reasons — `GaussianNoise`, `DDPMSampler`, `BackwardOnce`, `DiffusionTrainingLoop`, and every node that owns weights (`SequentialModel`, `DiffusionUNet`, and every layer node: `Linear`, `Conv2d`, `LSTM` and the rest), whose parameters drift as training proceeds.
+
+For those weight-owning nodes, what a second **Run** does with the weights is your choice rather than the cache's: **Settings → Training Behavior → Persist weights between runs** (on by default) continues from where the last run finished, and **Reset all weights now** throws them away so the next run starts from a fresh initialisation. `SequentialModel` states which of the two it did in its **Log** tab every run, so a loss curve that starts unexpectedly low always has a written explanation.
 
 Opting out **propagates downstream**: every node fed by one of these re-executes too, because a cache key records only the *keys* of upstream nodes, not their actual outputs. A cached downstream node would otherwise hand back a stale result computed from data that has since changed.
 


### PR DESCRIPTION
> 中文摘要：`TrainingLoop` 沒有宣告 `cacheable`，所以繼承了預設的 `True`。快取命中會直接把上次記錄的輸出丟回來、根本不呼叫 `execute()`，於是權重沒更新、每個 epoch 的指標沒寫入，畫面卻回報成功。六個內建有訓練的圖裡有四個會踩到，其中兩個是學生上課直接打開的教學插件範例。實測未經修改的 `C2-5/MLP-MNIST-Training`：修正前三次執行只訓練了一次，修正後三次都有訓練。
>
> 但只改 `TrainingLoop` 一行是不夠的，而且會製造新的 bug：`SequentialModel` 擁有權重、沒有任何輸入、而且可快取，是一個「沒有東西能讓它失效」的根節點，所以第二次執行拿到的是第一次已經訓練過的同一個模型物件。只讓 `TrainingLoop` 重跑，等於把「完全沒訓練」換成「每次都默默從上次的權重繼續」——後者其實更糟，因為數字看起來很合理。
>
> 這裡採用的規則就是這個 codebase 自己已經寫在 `stateful_module.py` 和快取文件裡的那條：**擁有可訓練參數的節點不可快取**。`SequentialModel` 現在和其他每一個擁有權重的節點一樣掛上 `StatefulModuleMixin`（`DiffusionUNet` 是同樣形狀而且早就做對了）。這同時把「再按一次 Run 是繼續訓練還是重來」交回給既有的「在多次執行間保留權重」設定和「立即重置所有權重」按鈕決定，而不是由我硬編一個答案；節點每次執行都會在 Log 分頁寫出這次到底是哪一種，所以 loss 曲線起點偏低永遠有白紙黑字的解釋。
>
> 另外順手修掉一個被這次改動暴露出來的既有 race：同一層的節點在未設 seed 時是並行跑的，卻共用同一個 `ExecutionContext` 的 `current_node_id`，導致某個節點的權重會被存到另一個節點的 id 底下。

## What was wrong

`TrainingLoopNode` declared no `cacheable`, so it inherited `True` from `BaseNode`. A cache hit returns a node's recorded outputs without calling `execute` at all — correct for a pure node, wrong for one whose product is a side effect. What `TrainingLoop` produces is not the `model` handle it returns but the *change* to the weights that handle points at, plus a metric series per epoch. Neither survives a hit. Same shape as the writer nodes in #143 and `PythonScript` in #256.

Measured on the **unmodified** shipped `plugins/foundations/examples/C2-5/MLP-MNIST-Training/graph.json`, counting real `TrainingLoopNode.execute()` calls rather than trusting status:

```
before          after
  run 1: 1        run 1: 1
  run 2: 0        run 2: 1
  run 3: 0        run 3: 1
```

`plugins/deep/examples/C3-1/LeNet-MNIST-Training/graph.json` measured identically, `1/0/0` before and `1/1/1` after. Both are teaching-pack examples students open in class.

## Why it survived this long

Two reasons, and both are worth recording because they will hide the next one too.

**The status lies.** All four affected graphs wrap the training path in a preset, and a preset whose internals were *all* cache hits still reports `completed` (#260, filed separately, deliberately not fixed here). There was no observable signal at any level: no error, no warning, a loss curve that renders normally — it is just the previous run's.

**Two of the six shipped training graphs were protected by accident.** `ModelSaver` may only write under `./data`, and `DatasetNode.cache_fingerprint` walks all of `./data`, so the saver's write happened to dirty the dataset's key and propagate a miss down to the loop. That is the coupling #259 records, and #259 exists to scope that walk — which would remove the protection. **This fix does not rely on it**, and neither does its test: the end-to-end test's dataset has no external state at all, so the graph is cacheable from end to end and the fix has to hold on its own merits.

## The rule I settled on, and what I rejected

**A node that owns trainable parameters is not cacheable**, because downstream training mutates its output in place and the recorded outputs stop describing it.

That is not a new rule — it is the one already written down in `backend/app/core/stateful_module.py` ("the cache assumes `f(params, upstream) -> output` is deterministic, which breaks once the module's internal weights drift") and in `docs/docs/usage/running-graphs.md` ("every layer that owns weights … whose parameters drift as training proceeds"). Every layer node already follows it via `StatefulModuleMixin`. `SequentialModel` was the single node in the whole registry that owned weights, was cacheable, **and** declared no inputs — a root nothing could ever invalidate. `DiffusionUNet` is the same shape (weight-owning, `define_inputs() == []`) already done correctly with the mixin, and was the model for this change.

So `SequentialModel` now carries `StatefulModuleMixin` too. Consequences:

- It is `cacheable = False`, so run 2 can never be handed run 1's trained module out of `ExecutionCache`.
- Whether a rerun *continues* from the previous run's weights or starts fresh is decided by the existing **Settings → Training Behavior → Persist weights between runs** toggle (on by default on the canvas) and the existing **Reset all weights now** button, both of which previously did nothing for this node in either direction.
- `structural_params = ("layers",)`: edit the architecture and the persisted weights are dropped (they no longer fit); change the learning rate or the epoch count and they are kept, which is the point of the setting.

**Rejected — `cacheable = False` on `TrainingLoop` alone.** It fixes the reported symptom and creates a quieter one. `SequentialModel` stays cached, hands back the same mutated object every run, and every Run silently continues training. Measured on a monkeypatched build: `0.4089 → 0.4042 → 0.3995`. Numbers that look plausible are worse than numbers that are obviously stale.

**Rejected — keep `SequentialModel` cacheable but rebuild inside `execute`.** A node that is declared cacheable and then ignores its own cache is a worse lie than the bug, and the engine's downstream non-cacheability propagation would not fire for it.

**Rejected — always rebuild with fresh weights, no mixin.** Simpler and it does fix #253, but it hard-codes "Run again means retrain from scratch" and leaves the shipped **Persist weights between runs** toggle false for the product's most important weight-owning node. A user who turns that on, trains, and presses Run would get a fresh model with no indication — a new silent-wrong-answer of exactly the family this wave is hunting.

## Can the user tell which happened?

Yes, and this is the part I would most like a second opinion on. `SequentialModel` writes one line to its **Log** tab on every run, via the same `__log__` mechanism `TrainingLoop`'s schedule note uses (#252):

```
Fresh initialisation (109,386 parameters across 6 layers).

Continuing from weights an earlier run left behind (109,386 parameters).
Training resumes from those weights rather than starting over. To start
from a fresh initialisation, use Settings > Training Behavior > 'Reset all
weights now', or turn off 'Persist weights between runs'.
```

Verified end to end on the shipped C2-5 graph with a real `NodeStateStore`:

```
weights_persistent = True              weights_persistent = False
  run 1  loss 1.0346  "Fresh"            run 1  loss 1.0346  "Fresh"
  run 2  loss 0.3928  "Continuing"       run 2  loss 1.0294  "Fresh"
  run 3  loss 0.3300  "Continuing"       run 3  loss 1.0467  "Fresh"
```

Training happens on every run in both columns, which is #253 fixed; the difference between the columns is the user's setting, and the log line says which column you are in.

**The open judgement call:** the canvas default for `weights_persistent` is **on**, so out of the box a second Run of a shipped example now *continues* training rather than restarting it. I believe that is right — it is what the setting already promises, it is what every layer node already does, and it is now stated in the log rather than inferred — but "what should Run again mean for a teaching example" is a product decision, not an engineering one. If you would rather shipped examples restart by default, the change is small and localised, and I would rather ask than assume.

## The engine race this exposed

Found while testing, fixed here because the fix above is wrong without it, **not** as scope creep. It closes nothing.

Nodes at one topological level run concurrently on an unseeded run (`max_workers = 4`; a seeded run is serial, #134). The engine assigned `context.current_node_id = node_id` on the one shared `ExecutionContext` and then `await`ed `run_in_executor` — so the sibling that acquired the semaphore next overwrote the field before the first node's worker thread ever read it. `StatefulModuleMixin` then persisted that node's weights under a **different node's id**, where "Reset all weights now" cannot reach them and two nodes can collide. Observed directly: the model built by node `mlp` was stored under key `('test-253', 'pipeline__dataset', ...)`.

Latent until now because a seeded run is serial and every stateful node that existed was mid-chain, one per level. `SequentialModel` is a root, and roots are exactly what run concurrently at level 0.

The fix is a per-node `copy.copy` of the context. Shallow on purpose: the stop event, the outbox, `node_state_store` and `grad_targets` all stay the same object, so cancellation, logging and gradient capture are untouched; only that one scalar differs per node.

## Tests

New file `backend/tests/test_cache_training_nodes.py`, 8 tests. None of them reads a preset's status, because status is the thing that lied.

1. `test_training_and_weight_owning_nodes_are_not_cacheable` — the cheap class contract over `TrainingLoop`, `DiffusionTrainingLoop`, `SequentialModel`. Necessary, nowhere near sufficient; its docstring says so.
2. `test_shipped_example_trains_on_every_run` — **the main one.** Reads the shipped C2-5 `graph.json` off disk, expands its preset through the production `expand_presets`, and runs it **twice against one `ExecutionCache`**, counting real `TrainingLoopNode.execute` and `SequentialModelNode.execute` calls. The only substitution is the MNIST download, replaced by a fixture emitting `[N, 1, 28, 28]` tensors and integer labels — MNIST's exact shape, so the file's own 784-128-64-10 layer JSON, `DataLoader`, `Optimizer`, `Loss`, `TrainingLoop`, `Visualize` and `Print` all execute as shipped. The substitution makes the graph *more* cacheable, never less, which is the opposite direction from the one that invalidated #253's first measurement. Two control assertions pin that: the `Loss` node and the dataset must both be `cached` on run 2, so the test cannot pass in a world where caching had simply stopped working, and cannot be riding on an upstream invalidation.
3. `test_training_still_runs_when_the_model_source_is_cacheable` — `TrainingLoop`'s own flag, isolated. `SequentialModel` going non-cacheable propagates downstream and masks whether the loop's flag matters; `ModelLoader`/`CheckpointLoader` stay cacheable by #144, so a train-from-a-checkpoint graph is cacheable end to end and needs it. A stand-in cacheable model source proves the loop runs anyway.
4. `test_concurrent_roots_persist_under_their_own_node_ids` — four `SequentialModel` roots, unseeded, assert each one's weights land under its own id.
5. `test_rerun_says_whether_it_continued_or_started_over[persist|fresh]` — the visibility contract, both settings.

**Mutation-checked.** Each source change reverted in turn, confirmed red, restored:

| reverted | tests that go red |
|---|---|
| `TrainingLoop.cacheable = False` | the class contract **and** `test_training_still_runs_when_the_model_source_is_cacheable` |
| `SequentialModel` back to plain `BaseNode` | the class contract, `test_shipped_example_trains_on_every_run`, `test_rerun_says_...[persist]` |
| the per-node context copy | `test_concurrent_roots_...`, `test_rerun_says_...[persist]` — 3/3 runs, not flaky |

The first mutation initially failed *only* the class-contract test, which is what prompted test 3 — the end-to-end test alone could not see `TrainingLoop`'s own flag.

CI is green on Python 3.10, 3.11 and 3.12, plus the byte scan.

Locally (Windows, CPython 3.12) the full suite is **4112 passed, 22 skipped, 1 failed in 3m35s**. The one failure is `test_tiered_policy.py::test_the_purity_guard_can_see_impurity_in_both_path_implementations`, which **reproduces on a clean tree** (verified by stashing this branch and re-running) and passes on CI. It is #258, and measuring it turned up something that issue should have: it is not 3.14-only. On **CPython 3.12.13 on Windows**, `ntpath.exists`, `isfile`, `isdir` and `islink` already resolve to `nt` rather than `genericpath` — #258 measured 3.11.15 as `genericpath`, so the move landed by 3.12, not in 3.14. CI cannot see it because CI is `ubuntu-latest`, where `os.path` is `posixpath` and those four still resolve to `genericpath`. Left in #258 as a comment; nothing here depends on it.

## What a reviewer should check

- **The product call**, first: canvas default is persist-on, so a second Run of a shipped example now continues training. Is that what you want for a teaching example, given it is now stated in the Log tab? Everything else here is uncontroversial; this is the one judgement I made on your behalf.
- The wording of the two log lines — they are the whole visibility story, and they render in the node's Log tab through `output_entries.py`'s node-agnostic `__log__` path (proven by `TrainingLoop`'s schedule note in #252, no frontend change needed).
- That the per-node `copy.copy` of `ExecutionContext` is safe for every field. I checked that all mutable collaborators are shared by reference and that nothing else writes a scalar on the context during node execution, and added a note on the field forbidding a second per-node scalar — but it is the change with the widest blast radius here.
- That the fixture-dataset substitution in the end-to-end test is honest. It replaces the download and nothing else; the argument that it cannot manufacture the bug is that it has no external state, so it only ever makes the graph *more* cacheable.
- `structural_params = ("layers",)` — editing the architecture drops the persisted weights, editing hyperparameters keeps them. That is the intended split.

## Not touched

- **#260** (preset reports `completed` when every internal node was a cache hit) — different layer, filed separately. It is why this was invisible; no test here depends on preset status.
- **#254** (cacheable nodes that mutate a passed-in model/optimizer in place). `ModelLoader` and `CheckpointLoader` stay `cacheable = True` per #144, exactly as #254 describes; nothing here contradicts it. Test 3 above actually depends on that staying true.
- **#259** (scope `Dataset`'s fingerprint). Unblocked by this: #253 no longer depends on the over-invalidation, which was that issue's stated prerequisite.

## Not verified in a browser

Backend-only change plus docs; no frontend file is touched. The `__log__` render path is the existing node-agnostic one already used by `Print` and by `TrainingLoop`'s shipped schedule note, so I checked it by reading `output_entries.py` rather than by driving Chrome through two full MNIST runs. Flagging it rather than leaving it unsaid.

Closes #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
