### PR TITLE
docs(legal): name a copyright holder, add a DCO CONTRIBUTING.md, and correct the AGPL claim on the docs site

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -141,9 +141,12 @@ jobs:
         run: |
           # The tarball redistributes compiled third-party code (React, KaTeX
           # and its fonts, ...), so the AGPL license text and the third-party
-          # attribution notices must travel with it. Copy them into dist so
+          # attribution notices must travel with it. NOTICE rides along for
+          # the same reason: it is where the copyright holder is named, and a
+          # redistributed binary that carries no attribution is exactly the
+          # gap the file exists to close (core#248). Copy them into dist so
           # they land at the top level of the archive.
-          cp LICENSE THIRD_PARTY_NOTICES.md frontend/dist/
+          cp LICENSE NOTICE THIRD_PARTY_NOTICES.md frontend/dist/
           # Pack from inside the dist dir so extraction lands cleanly with
           # `tar -xzf frontend-dist.tar.gz -C frontend/dist` (no strip needed).
           tar -czf frontend-dist.tar.gz -C frontend/dist .

--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -2,11 +2,28 @@
 
 CodefyUI is available under a dual path licensing model.
 
+## Licensor
+
+Copyright (C) 2026 CodefyUI (https://github.com/CodefyUI) and the CodefyUI
+contributors. See [NOTICE](NOTICE).
+
+Commercial licenses are granted by the copyright holder named above. Inbound
+contributions are accepted under the Developer Certificate of Origin 1.1 plus
+the dual-licensing term stated in [CONTRIBUTING.md](CONTRIBUTING.md), so that
+contributed code can be offered on either path.
+
 ## Open Source Path
 
 The default public license is AGPL-3.0-only. This path is intended for
 individual developers, small teams, education, research, community use, and
 any other use case that can comply with AGPL-3.0.
+
+**Running the unmodified program does not require a commercial license.**
+AGPL-3.0 explicitly affirms unlimited permission to run the unmodified
+program, and the §13 network clause applies only if you *modify* it. A
+company that deploys CodefyUI as published, on an internal server, is on the
+open source path and owes nothing. See the
+[Licensing FAQ](https://docs.codefyui.com/licensing).
 
 ## Commercial Path
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,305 @@
+# Contributing to CodefyUI
+
+Thanks for wanting to help. This document covers the three things you need before your first pull request: how to sign your commits, how to get a working development environment, and what the review conventions in this repository actually are.
+
+> 中文摘要：送 PR 前請先讀「Signing your work」一節——每個 commit 都要用 `git commit -s` 加上 DCO 簽署，否則因為本專案採雙軌授權，你的程式碼無法被納入商業授權路徑。開發環境設定與各項檢查指令列在下面，指令都是從 `scripts/dev.py` 與 CI workflow 直接核對過的，不是憑印象寫的。
+
+**Table of contents**
+
+- [Signing your work (DCO)](#signing-your-work-dco)
+- [Development environment](#development-environment)
+- [Running the checks](#running-the-checks)
+- [Branches and pull requests](#branches-and-pull-requests)
+- [House style](#house-style)
+
+---
+
+## Signing your work (DCO)
+
+**Every commit must carry a `Signed-off-by` trailer.** Add it automatically:
+
+```bash
+git commit -s -m "fix(engine): ..."
+```
+
+That appends one line to the commit message, using your configured `user.name` and `user.email`:
+
+```
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
+Use your real name and a real, reachable email address. Anonymous and pseudonymous sign-offs cannot serve the purpose the sign-off exists for.
+
+Forgot it? Fix the last commit with `git commit --amend -s --no-edit`, or a whole branch with:
+
+```bash
+git rebase --signoff main
+```
+
+Then force-push your branch. This rewrites commit hashes, which is fine on your own PR branch.
+
+### Why a dual-licensed project needs this
+
+CodefyUI is published under **AGPL-3.0-only**, and the maintainers also offer a **separate commercial license** to organizations that cannot work under copyleft terms (see [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md)). That second path only functions if the project can account for where every line of code came from and under what terms it arrived.
+
+Put concretely: if someone pastes code they do not own into a pull request and it lands in `main`, the project has distributed code it had no right to distribute — and every downstream user inherits the problem. The sign-off is how you state, on the record and per commit, that this is not what happened.
+
+The [Developer Certificate of Origin](https://developercertificate.org/) is the lightweight instrument for this. It is not a copyright assignment and it is not a CLA. **You keep the copyright in your contribution.** You are certifying provenance, not handing over ownership, and the certification lives in the git history rather than in a signed document somebody has to file and track.
+
+### Inbound licensing
+
+Two things are true when you sign off on a commit here.
+
+1. **You certify the DCO 1.1 terms below.** That is the standard, unmodified text used across the Linux kernel and hundreds of other projects.
+2. **You agree your contribution may be distributed by the project on either licensing path** — under AGPL-3.0-only, and under the commercial license offered by the copyright holder named in [NOTICE](NOTICE).
+
+Point 2 is stated here as an inbound term of contributing, not as a separate agreement you sign. It is spelled out explicitly because the DCO on its own certifies *provenance* and submission under the project's open source license; it does not by itself say anything about a second, proprietary license. Rather than leave that gap implicit, the project states its position where you can read it before you contribute.
+
+If you are contributing on behalf of an employer, make sure you actually have the authority to agree to both points. If you are not comfortable with point 2, say so in the pull request before doing the work and the maintainers will discuss it with you rather than merge something on an unclear basis.
+
+### Developer Certificate of Origin 1.1
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+---
+
+## Development environment
+
+### Prerequisites
+
+| Tool | Needed for | Notes |
+|---|---|---|
+| `git` | everything | |
+| [`uv`](https://github.com/astral-sh/uv) | the Python backend | Replaces `pip` and `venv`. Every backend command below goes through it. |
+| `pnpm` + Node.js 24+ | frontend work | **Optional.** Only needed if you touch `frontend/`, run `cdui dev`, or build the bundle yourself. |
+
+### The short path
+
+```bash
+git clone https://github.com/CodefyUI/CodefyUI.git
+cd CodefyUI
+./cdui install --dev          # Windows: .\cdui.cmd install --dev
+```
+
+`--dev` is not optional for contributors. Without it the backend is installed as `.` rather than `.[dev]`, `pytest` never lands in the virtualenv, and `cdui test` exits with "not found". If you already installed without it, re-run with `--dev`.
+
+`cdui install` creates `backend/.venv`, installs the backend editable, and then either builds `frontend/dist` (if pnpm is present) or downloads the prebuilt bundle from the latest release. Useful flags:
+
+| Flag | Effect |
+|---|---|
+| `--dev` / `--no-dev` | install the `[dev]` extra (pytest, httpx, httpx-ws, tensorboard) |
+| `--gpu auto` | detect your driver and pick the matching PyTorch wheel |
+| `--gpu cpu` \| `cu118` \| `cu121` \| `cu124` \| `cu126` \| `cu128` \| `rocm6.1` \| `rocm6.2` \| `mps` \| `skip` | pick the wheel yourself; `skip` leaves an existing torch alone |
+| `--yes` / `-y` | non-interactive; same as `--gpu auto --no-dev` |
+
+With no flags on a TTY you get an interactive menu. See [GPU and Device Setup](https://docs.codefyui.com/getting-started/gpu-device) for how to choose.
+
+> `make install`, `make dev`, `make test`, `make clean` and `make stop` are thin wrappers around `./cdui` and add nothing. They hardcode the POSIX launcher, so on Windows use `.\cdui.cmd <command>` directly.
+
+### Doing it by hand
+
+If you would rather not use the task runner:
+
+```bash
+cd backend
+uv venv --python 3.11
+source .venv/bin/activate     # Windows: .venv\Scripts\activate
+uv pip install -e ".[dev]"
+```
+
+### Watch out: uv will pick a Python newer than CI uses
+
+`uv venv --python 3.11` pins the version. **Bare `uv` commands in a fresh clone or worktree do not** — they resolve to whatever the newest CPython on your machine is, which today can be 3.14. CI never tests that:
+
+- `backend/pyproject.toml` declares `requires-python = ">=3.10"`.
+- `.github/workflows/backend-test.yml` runs a matrix of **3.10, 3.11, 3.12** only.
+- `cdui install` and both launchers (`cdui`, `cdui.cmd`) hardcode **3.11**.
+
+So a test that passes locally on 3.14 tells you nothing about 3.10, and a syntax feature you reach for might be above the declared floor. Always create the venv with an explicit `--python 3.11` (or `3.10` if you want to develop against the floor), and let CI cover the rest.
+
+### Running the app
+
+```bash
+./cdui dev      # backend :8000 with --reload + Vite :5173 with HMR. Needs pnpm.
+./cdui start    # one uvicorn on :8000 serving the prebuilt frontend/dist. No Node needed.
+```
+
+`cdui dev` streams both processes in the foreground with `[backend]` / `[frontend]` prefixes; Ctrl+C stops both. `cdui start` daemonizes by default — use `cdui status` and `cdui stop` to manage it, or `--foreground` to attach.
+
+Use `cdui dev` when you are changing frontend code. Use `cdui start` when you are only touching the backend, or when you want to see what an end user sees. If you changed frontend source and want `cdui start` to reflect it, rebuild first with `./cdui build`.
+
+More detail: [Dev Install](https://docs.codefyui.com/getting-started/dev-install) and [CLI Commands](https://docs.codefyui.com/getting-started/cli-commands).
+
+---
+
+## Running the checks
+
+There is no lint step and no formatter in this repository — do not go looking for one. There is also no pre-commit hook, so **nothing runs automatically**. These are the real gates, and you run them yourself.
+
+### `cdui test` only runs the backend
+
+This surprises people, so it is worth stating flatly. From `scripts/dev.py:2471`, the whole function is:
+
+```python
+def test() -> None:
+    pytest = _require_venv_tool("pytest")
+    run([pytest], cwd=BACKEND_DIR)
+```
+
+That is `pytest` with no arguments, in `backend/`, discovering `backend/tests/` via `testpaths` in `pyproject.toml`. It never touches the frontend. **If you changed anything under `frontend/`, `cdui test` passing means nothing about your change.**
+
+### The full local set
+
+Run every line that applies to what you touched:
+
+```bash
+# Repository root -- always. Guards against stray C0 control bytes,
+# which no test, type check or grep catches (ripgrep silently skips them).
+python scripts/check_control_bytes.py
+
+# Backend -- if you touched backend/, examples/, plugins/ or scripts/
+./cdui test
+
+# Backend -- if you edited backend/pyproject.toml. CI runs this BEFORE
+# installing anything, so a drifted lock fails all three matrices in
+# about ten seconds. Regenerate the lock in the SAME commit as the
+# dependency change.
+cd backend && uv lock --check
+
+# Frontend -- if you touched frontend/
+cd frontend && pnpm install
+cd frontend && pnpm exec tsc -b
+cd frontend && pnpm test
+cd frontend && pnpm build
+```
+
+Two notes on the frontend commands:
+
+- **`tsc -b`, not `tsc --noEmit`.** `frontend/tsconfig.json` is a solution-style config with `"files": []` and project references, so `tsc --noEmit` against it checks **zero files** and passes no matter what is broken. Build mode follows the references and actually type-checks `src/`.
+- **`pnpm build` includes the contrast gate.** The build script is `node scripts/check-contrast.mjs && tsc -b && vite build` — the first step re-derives every WCAG contrast relationship claimed by `frontend/src/styles/tokens.css` and fails the build if a token pair drops below threshold. Run it alone with `pnpm contrast` when you are editing colours.
+
+### What CI runs that you cannot easily run locally
+
+- **`backend-test.yml`** runs the whole suite on Python 3.10, 3.11 and 3.12, plus `uv lock --check` and a smoke import (`from app.main import app`) that catches import-time syntax errors.
+- **`byte-scan.yml`** runs `scripts/check_control_bytes.py` over every tracked file on every PR, with no path filter.
+- **`frontend-build.yml`** runs install, `tsc -b`, `pnpm build`, a `dist/` sanity check, then `pnpm test` — on `frontend/**` changes only.
+
+### Tests are required
+
+A pull request that changes behaviour needs a test that fails without the change. This is not negotiable for bug fixes: the test is the evidence that the bug was real and that it is now gone. For UI changes, unit tests are necessary but not sufficient — maintainers additionally verify UI-touching changes in a real browser before merging.
+
+If a change genuinely cannot be tested, say so in the PR body and explain why, rather than leaving reviewers to notice.
+
+---
+
+## Branches and pull requests
+
+**Never push to `main`.** Every change lands through a pull request, including one-line documentation fixes and CI repairs. There are no exceptions to this and no size below which it stops applying.
+
+```bash
+git switch -c fix/short-description main
+# ... work, with `git commit -s` ...
+git push -u origin fix/short-description
+gh pr create
+```
+
+### Commit subjects
+
+Conventional-commit format: `type(scope): imperative summary`.
+
+```
+fix(engine): NaN-safe outputs when a loss diverges mid-epoch
+feat(training): periodic checkpointing so a killed server does not lose the run
+docs(licensing): state what AGPL section 13 actually requires
+ci: pin pyarrow below 25 until the segfault is fixed upstream
+```
+
+Types actually in use here, by frequency: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `ci`, `perf`. Common scopes follow the area touched — `frontend`, `backend`, `ui`, `plugins`, `training`, `cli`, `nodes`, `security`, `examples`. The scope is optional; the type is not.
+
+Keep the subject under about 72 characters, write it in the imperative, and make it say what the change *does* rather than what area it touches. `fix(cache): a second Run of a training graph must actually train` is a real subject from this repo and a good model: a reader who never opens the diff still knows what was broken.
+
+### PR bodies
+
+Bodies here are **prose, not a checklist**. Look at any recently merged PR for the shape. What reviewers expect:
+
+- **A `> 中文摘要：` blockquote at the top.** One paragraph of Traditional Chinese summarising what changed and why. It goes first, before the English prose, because it is what the maintainer reads to decide whether the framing is right.
+- **`Closes #NNN`** for every issue the PR actually resolves. Do not use a closing keyword on an issue the PR only partly addresses — describe what you delivered and what remains, and leave it open.
+- **Why the change matters**, with the concrete failure it fixes. "From the issue: a server process died 13 minutes in and all 101 completed epochs were unrecoverable" is worth more than "improves reliability".
+- **What changed**, as prose or a short list, including the decisions you made and rejected alternatives. If you did something non-obvious, explain why the obvious thing was wrong.
+- **What you verified**, with the commands you actually ran and their outcome. Claims of "tests pass" without the command are not evidence.
+- **What you deliberately did not do**, if a reviewer might expect it.
+
+Detail is welcome. Under-explaining costs a review round trip; over-explaining costs nobody anything.
+
+---
+
+## House style
+
+### No pictographic emoji
+
+Do not put emoji in code, in log output, in the UI, in commit messages, or in PR bodies. The reason is concrete, not aesthetic: CodefyUI runs on Windows consoles where the active code page is often cp950 or cp1252, and a single emoji in a print statement crashes the process with a `UnicodeEncodeError`. It has happened repeatedly.
+
+Use ASCII markers (`[OK]`, `[WARN]`, `->`) instead. A small set of functional glyphs is fine and already used throughout: check and cross marks, gear and bullet, arrows, and box-drawing or bar characters for terminal tables and charts.
+
+This is a convention, not a CI gate — `byte-scan.yml` checks for raw C0 control bytes, not for emoji. Nobody will catch it for you.
+
+### Documentation and translations
+
+`docs/` is a Docusaurus site with a full Traditional Chinese translation under `docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/`. **If you change an English page, change its zh-TW counterpart in the same PR.** A missing translation silently falls back to English, so drift is invisible until a reader hits a half-translated section.
+
+Build the site before pushing docs changes — `onBrokenLinks` is set to `throw`, so a bad relative link fails the build rather than shipping:
+
+```bash
+cd docs && pnpm install && pnpm build
+```
+
+### User-facing strings are bilingual
+
+The app ships English and Traditional Chinese. New user-facing text — node descriptions, parameter labels, error messages, CLI output — needs both.
+
+### Where to start
+
+Read the [Architecture](https://docs.codefyui.com/advanced/architecture) page first. The single most important thing to know is that CodefyUI is **backend-authoritative**: `GET /api/nodes` returns every node definition and one React component renders all of them, so adding a node is a backend-only change.
+
+Browse the [issue tracker](https://github.com/CodefyUI/CodefyUI/issues) for something to pick up. If an issue is not clear, ask in a comment before writing code — a question costs a day, a wrong implementation costs a week.
+
+---
+
+## License
+
+By contributing you agree that your contributions are licensed as described in [Signing your work](#signing-your-work-dco) above: AGPL-3.0-only, and available to the copyright holder for the commercial path. See [LICENSE](LICENSE), [NOTICE](NOTICE), and [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md).

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,45 @@
+CodefyUI
+Copyright (C) 2026 CodefyUI (https://github.com/CodefyUI)
+and the CodefyUI contributors.
+
+CodefyUI is a visual, node-based deep learning pipeline builder.
+Project home: https://github.com/CodefyUI/CodefyUI
+
+
+LICENSING
+---------
+
+CodefyUI is offered under a dual-path licensing model.
+
+  Open source path
+      GNU Affero General Public License, version 3.0 only
+      (SPDX: AGPL-3.0-only). The complete license text is in the file
+      LICENSE distributed with this software. This path covers individual
+      developers, small teams, education, research, community use, and any
+      other use case that can comply with AGPL-3.0 -- including running the
+      unmodified program inside a company.
+
+  Commercial path
+      A separate proprietary license, granted by the copyright holder named
+      above, for proprietary, closed-source, SaaS, OEM, enterprise, or other
+      use that needs terms outside AGPL-3.0. See COMMERCIAL-LICENSE.md.
+
+This NOTICE file is informational. It does not modify the terms of LICENSE.
+Where this file and LICENSE disagree, LICENSE governs.
+
+
+THIRD-PARTY COMPONENTS
+----------------------
+
+CodefyUI redistributes third-party software, both as Python dependencies and
+as compiled assets inside the prebuilt frontend bundle. Their copyright
+notices and license terms are collected in THIRD_PARTY_NOTICES.md, which is
+distributed alongside this file.
+
+
+CONTRIBUTIONS
+-------------
+
+Contributions are accepted under the Developer Certificate of Origin 1.1 and
+the inbound licensing terms stated in CONTRIBUTING.md. Contributors retain
+copyright in their own contributions.

--- a/README.md
+++ b/README.md
@@ -314,11 +314,21 @@ source .venv/bin/activate
 pytest tests/ -v
 ```
 
+## Contributing
+
+Pull requests are welcome. Contributions are accepted under the [Developer Certificate of Origin 1.1](https://developercertificate.org/) — commit with `git commit -s`.
+
+Read **[CONTRIBUTING.md](CONTRIBUTING.md)** first: it covers the sign-off, how to get a dev environment running, and the PR conventions this repo actually follows.
+
 ## License
+
+Copyright (C) 2026 CodefyUI (https://github.com/CodefyUI) and the CodefyUI contributors. See [NOTICE](NOTICE).
 
 CodefyUI uses a dual path licensing model:
 
 - **Open source path**: AGPL-3.0-only for individual developers, small teams, education, research, community use, and any other use case that can comply with AGPL-3.0.
 - **Commercial path**: proprietary, closed-source, SaaS, OEM, enterprise, or other use cases that need terms outside AGPL-3.0 should contact the maintainers for a commercial license.
+
+Running the unmodified program — including on an internal company server — is permitted under AGPL-3.0 and needs no purchase. AGPL-3.0 §13's source-offer requirement is conditioned on *modifying* the program. See the [Licensing FAQ](https://docs.codefyui.com/licensing) for the details, including what counts as a modification when you write a custom node or a plugin.
 
 Commercial licensing contact: https://github.com/CodefyUI/CodefyUI/issues

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,6 +2,16 @@
 name = "codefyui-backend"
 version = "2.1.1"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
+# Names the copyright holder in distribution metadata. Until this landed, no
+# file in the repository said who owns CodefyUI, which left the commercial
+# path in COMMERCIAL-LICENSE.md with no identifiable licensor (core#248).
+# The string here matches NOTICE, the README license section and the docs
+# footer -- change all four together if the holder is ever restated as a
+# person or a registered entity. `email` is deliberately omitted rather than
+# guessed: PEP 621 allows a name-only entry, and the project's published
+# contact is the issue tracker, not a mailbox.
+authors = [{ name = "CodefyUI" }]
+maintainers = [{ name = "CodefyUI" }]
 requires-python = ">=3.10"
 # PEP 639 SPDX license expression (bare string). The previous PEP 621
 # table form `{ text = "..." }` is rejected by setuptools >= 77 with

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -68,5 +68,9 @@ CodefyUI is **backend-authoritative**: `GET /api/nodes` returns every node defin
 
 CodefyUI uses a dual-path licensing model:
 
-- **Open source** — [AGPL-3.0-only](https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE) for individuals, small teams, education, research, and community use.
+- **Open source** — [AGPL-3.0-only](https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE) for individual developers, small teams, education, research, community use, **and any other use case that can comply with AGPL-3.0**.
 - **Commercial** — for proprietary, closed-source, SaaS, OEM, or enterprise use that needs terms outside AGPL-3.0, [contact the maintainers](https://github.com/CodefyUI/CodefyUI/issues).
+
+**Running CodefyUI unmodified — including on an internal company server — is permitted under AGPL-3.0 and needs no purchase.** Section 13's source-offer requirement is conditioned on *modifying* the program. The [Licensing FAQ](/licensing) works through what that means in practice, including how custom nodes and plugins are treated and what the commercial license actually covers.
+
+Copyright (C) 2026 CodefyUI and the CodefyUI contributors. Contributions are accepted under the Developer Certificate of Origin 1.1 — see [CONTRIBUTING.md](https://github.com/CodefyUI/CodefyUI/blob/main/CONTRIBUTING.md).

--- a/docs/docs/licensing.md
+++ b/docs/docs/licensing.md
@@ -1,0 +1,88 @@
+---
+sidebar_position: 5
+title: Licensing FAQ
+description: What AGPL-3.0 actually requires of CodefyUI users, whether running it internally triggers section 13, how custom nodes and plugins are treated, and what the commercial license covers.
+---
+
+# Licensing FAQ
+
+CodefyUI uses a **dual-path licensing model**.
+
+- **Open source path** — [AGPL-3.0-only](https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE) for individual developers, small teams, education, research, community use, **and any other use case that can comply with AGPL-3.0**.
+- **Commercial path** — for proprietary, closed-source, SaaS, OEM, enterprise, or other use that needs terms outside AGPL-3.0. [Contact the maintainers](https://github.com/CodefyUI/CodefyUI/issues).
+
+The copyright holder is **CodefyUI** (https://github.com/CodefyUI) and the CodefyUI contributors — see [NOTICE](https://github.com/CodefyUI/CodefyUI/blob/main/NOTICE).
+
+:::note This page is not legal advice
+Everything below is the CodefyUI project's own reading of the license it publishes under. It is written so you can see what the project intends and check it against the license text yourself. It is not legal advice, and it does not create or modify any license. Where this page and [LICENSE](https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE) disagree, LICENSE governs. If your situation needs certainty rather than an interpretation, the commercial license exists for exactly that.
+:::
+
+## Does running CodefyUI internally, unmodified, trigger AGPL section 13?
+
+**No.**
+
+AGPL-3.0 section 2 (*Basic Permissions*) says:
+
+> This License explicitly affirms your unlimited permission to run the unmodified Program.
+
+And the network clause in section 13 is conditioned on modification:
+
+> Notwithstanding any other provision of this License, **if you modify the Program**, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version [...]
+
+So a company that installs CodefyUI as published and runs it on an internal server — for any number of employees, for commercial purposes, behind the firewall or not — has **no obligation under section 13 and needs no commercial license**. That is the ordinary open source path working as intended, not a loophole.
+
+Two things follow, and both are worth stating plainly because evaluators often assume the opposite:
+
+- **"Commercial use" is not what triggers the commercial license.** AGPL-3.0 places no restriction on using the software for profit. What triggers the commercial path is needing terms the AGPL does not give you — chiefly the ability to keep modifications closed.
+- **Distributing an unmodified copy is also fine**, provided you pass along the license and the source (section 4/6). You do not need permission from the project to hand a colleague the installer.
+
+## Does writing a custom node or a plugin count as modifying the Program?
+
+**This is the question that actually matters, and the honest answer is: probably yes, and the project treats it as yes.**
+
+The mechanics are not in dispute. A [custom node](/advanced/custom-nodes) is a Python file that subclasses `BaseNode` from `app.core.node_base` and is imported into the running backend. A [plugin pack](/advanced/plugins) is, in the plugin documentation's own words, "Python that runs in the CodefyUI process." Both import CodefyUI's own API, run inside CodefyUI's process, and are meaningless without it. CodefyUI publishes **no linking exception** — nothing in LICENSE carves out separately-authored modules the way the LGPL or a Classpath exception would.
+
+**The project's interpretation:** a custom node or plugin pack that imports CodefyUI's Python API and executes in the CodefyUI process is part of a *modified version* of the Program for AGPL purposes. If you then let users interact with that deployment remotely over a network, section 13's source-offer requirement is engaged, and it reaches your node or plugin code too.
+
+What that does and does not mean in practice:
+
+| Situation | The project's reading |
+|---|---|
+| You write a custom node and use it yourself on your own machine. | Nothing is triggered. Section 13 is about users interacting **remotely over a network**; private use is not conveying. |
+| You write a custom node, deploy CodefyUI on an internal server, and colleagues use it through the browser. | Section 13 is engaged. Offer the Corresponding Source — including your node — to those users. Inside one organization that is usually a link to an internal repository, not a public release. |
+| You publish a plugin pack. | Publish it under AGPL-3.0-compatible terms. This is the normal case and the one the [plugin template](https://github.com/CodefyUI/CodefyUI-Plugin-Official) is set up for. |
+| You want to ship a proprietary node or plugin, or run a modified CodefyUI as a service without releasing your changes. | This is what the commercial license is for. |
+
+:::caution Where the uncertainty actually sits
+Whether a plugin is a derivative work of its host is a genuinely contested question in copyright law, it varies by jurisdiction, and no court has settled it for the AGPL. The project states the reading above so you know what it intends and will not surprise you with a different one. It is not a legal opinion and it is not binding on anyone else's counsel. If you need an answer you can rely on, take the commercial license — it removes the question rather than answering it.
+:::
+
+## Do my graphs and my trained models fall under the AGPL?
+
+**No, in the project's reading.** A `graph.json` you build on the canvas, the weights a training run produces, and any charts or exports are output from running the Program. AGPL-3.0 section 2 addresses this directly:
+
+> The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work.
+
+A graph description and a tensor of learned weights are your data, not CodefyUI's code. Nothing in the AGPL asks you to publish them.
+
+The one thing to keep separate is the training *data* you feed in and any pretrained weights you download — those carry their own licenses from wherever you obtained them, entirely independent of CodefyUI's.
+
+## What does the commercial license cover, and who grants it?
+
+**Who grants it:** CodefyUI (https://github.com/CodefyUI), the copyright holder named in [NOTICE](https://github.com/CodefyUI/CodefyUI/blob/main/NOTICE). Inbound contributions are accepted under the Developer Certificate of Origin 1.1 plus an explicit dual-licensing term — see [CONTRIBUTING.md](https://github.com/CodefyUI/CodefyUI/blob/main/CONTRIBUTING.md) — so that contributed code can be offered on either path.
+
+**What it covers:** terms outside AGPL-3.0, for the cases the open source path cannot serve.
+
+- Proprietary or closed-source modifications you do not want to publish.
+- Offering a modified CodefyUI as a hosted or SaaS product.
+- OEM redistribution, or embedding CodefyUI in a product shipped under your own license.
+- Shipping proprietary custom nodes or plugin packs (see the question above).
+- Enterprise deployments whose internal policy forbids copyleft obligations regardless of whether they are actually triggered.
+
+**What it does not do:** it does not take anything away from the open source path, and it is not a support contract. Terms and pricing are negotiated per case.
+
+Start the conversation on the [issue tracker](https://github.com/CodefyUI/CodefyUI/issues). See also [COMMERCIAL-LICENSE.md](https://github.com/CodefyUI/CodefyUI/blob/main/COMMERCIAL-LICENSE.md).
+
+## Third-party components
+
+CodefyUI redistributes third-party software, both as Python dependencies and as compiled assets inside the prebuilt frontend bundle (React, KaTeX and its fonts, and others). Their copyright notices and license terms are collected in [THIRD_PARTY_NOTICES.md](https://github.com/CodefyUI/CodefyUI/blob/main/THIRD_PARTY_NOTICES.md), which ships inside the release tarball alongside `LICENSE` and `NOTICE`. All of them are permissive; none imposes copyleft obligations of its own.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -128,6 +128,7 @@ const config: Config = {
         {
           title: 'License',
           items: [
+            {label: 'Licensing FAQ', to: '/licensing'},
             {
               label: 'AGPL-3.0',
               href: 'https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE',
@@ -139,7 +140,9 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} CodefyUI. Built with Docusaurus.`,
+      // Holder string is mirrored in NOTICE, the README license section and
+      // backend/pyproject.toml's `authors` -- change all four together.
+      copyright: `Copyright © ${new Date().getFullYear()} CodefyUI and the CodefyUI contributors. Built with Docusaurus.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/intro.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/intro.md
@@ -68,5 +68,9 @@ CodefyUI 採 **後端權威** 設計：`GET /api/nodes` 回傳所有節點定義
 
 CodefyUI 採用雙軌授權模式：
 
-- **開源路徑** — [AGPL-3.0-only](https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE)，適用於個人開發者、小型團隊、教育、研究與社群使用。
+- **開源路徑** — [AGPL-3.0-only](https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE)，適用於個人開發者、小型團隊、教育、研究、社群使用，**以及任何能遵守 AGPL-3.0 的其他使用情境**。
 - **商業路徑** — 若需要閉源、SaaS、OEM 或企業部署等不適合 AGPL-3.0 的條款，請[聯絡維護者](https://github.com/CodefyUI/CodefyUI/issues)。
+
+**未經修改直接執行 CodefyUI——包含架在公司內部伺服器上——是 AGPL-3.0 明文允許的，不需要購買授權。** 第 13 條的「提供原始碼」義務，前提是你*修改了*本程式。[授權常見問題](/licensing)會逐項說明這在實務上代表什麼，包含自訂節點與外掛怎麼算、以及商業授權實際涵蓋哪些情況。
+
+Copyright (C) 2026 CodefyUI 及 CodefyUI 貢獻者。貢獻以 Developer Certificate of Origin 1.1 為準——請見 [CONTRIBUTING.md](https://github.com/CodefyUI/CodefyUI/blob/main/CONTRIBUTING.md)。

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/licensing.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/licensing.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 5
+title: 授權常見問題
+description: AGPL-3.0 對 CodefyUI 使用者實際的要求是什麼、內部執行會不會觸發第 13 條、自訂節點與外掛怎麼算，以及商業授權涵蓋哪些範圍。
+---
+
+# 授權常見問題
+
+CodefyUI 採用**雙軌授權模式**。
+
+- **開源路徑** — [AGPL-3.0-only](https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE)，適用於個人開發者、小型團隊、教育、研究、社群使用，**以及任何能遵守 AGPL-3.0 的其他使用情境**。
+- **商業路徑** — 若需要閉源、SaaS、OEM、企業部署，或其他不適合 AGPL-3.0 的條款，請[聯絡維護者](https://github.com/CodefyUI/CodefyUI/issues)。
+
+著作權人為 **CodefyUI**（https://github.com/CodefyUI）及 CodefyUI 貢獻者——見 [NOTICE](https://github.com/CodefyUI/CodefyUI/blob/main/NOTICE)。
+
+:::note 本頁不是法律意見
+以下全部是 CodefyUI 專案自己對所採用授權條款的解讀。這樣寫是為了讓你看得到專案的意圖，並能自己拿授權原文對照。它不是法律意見，也不會建立或修改任何授權。若本頁與 [LICENSE](https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE) 有出入，以 LICENSE 為準。如果你的情況需要的是確定性而不是解讀，商業授權存在的目的正是如此。
+:::
+
+## 未經修改在內部執行，會觸發 AGPL 第 13 條嗎？
+
+**不會。**
+
+AGPL-3.0 第 2 條（*Basic Permissions*）寫著：
+
+> This License explicitly affirms your unlimited permission to run the unmodified Program.
+>
+> （本授權明確確認你擁有執行未修改程式的無限制權利。）
+
+而第 13 條的網路條款，前提是「你修改了程式」：
+
+> Notwithstanding any other provision of this License, **if you modify the Program**, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version [...]
+>
+> （儘管本授權另有規定，**若你修改了本程式**，你的修改版本必須向所有透過電腦網路遠端與之互動的使用者，明顯地提供取得該版本 Corresponding Source 的機會 [...]）
+
+所以，一家公司照發行版本安裝 CodefyUI 並跑在內部伺服器上——不論多少員工使用、是否為營利目的、在不在防火牆後面——**對第 13 條沒有任何義務，也不需要商業授權**。這是開源路徑本來就該有的樣子，不是鑽漏洞。
+
+有兩件事因此成立，而且值得明講，因為評估者常常反過來假設：
+
+- **「商業使用」本身不是觸發商業授權的原因。** AGPL-3.0 完全不限制以營利為目的使用軟體。真正觸發商業路徑的，是你需要 AGPL 給不了你的條款——主要是「把修改保持閉源」的能力。
+- **散布未經修改的副本同樣沒問題**，只要一併附上授權與原始碼（第 4 / 6 條）。把安裝程式給同事，不需要向專案取得許可。
+
+## 寫自訂節點或外掛，算不算修改本程式？
+
+**這才是真正重要的問題，而誠實的答案是：很可能算，而且專案就是這樣認定的。**
+
+事實面沒有爭議。[自訂節點](/advanced/custom-nodes)是一個 Python 檔案，繼承 `app.core.node_base` 的 `BaseNode`，並被 import 進執行中的後端。[外掛包](/advanced/plugins)用外掛文件自己的話說，就是「在 CodefyUI 行程內執行的 Python」。兩者都 import CodefyUI 自己的 API、都在 CodefyUI 的行程裡執行，離開 CodefyUI 就沒有意義。而 CodefyUI **沒有提供 linking exception**——LICENSE 裡沒有任何條文像 LGPL 或 Classpath exception 那樣，把獨立撰寫的模組切出去。
+
+**專案的解讀：** 一個 import CodefyUI Python API、並在 CodefyUI 行程內執行的自訂節點或外掛包，就 AGPL 而言屬於本程式*修改版本*的一部分。如果你接著讓使用者透過網路遠端使用這個部署，第 13 條的原始碼提供義務就被觸發，而且範圍涵蓋你的節點或外掛程式碼。
+
+實務上這代表什麼、不代表什麼：
+
+| 情境 | 專案的解讀 |
+|---|---|
+| 你寫了一個自訂節點，只在自己電腦上用。 | 什麼都不會觸發。第 13 條談的是**透過網路遠端互動**的使用者；私人使用不構成 conveying。 |
+| 你寫了自訂節點，把 CodefyUI 架在內部伺服器上，同事透過瀏覽器使用。 | 第 13 條被觸發。請向這些使用者提供 Corresponding Source——包含你的節點。在同一個組織內，這通常是一個內部 repository 的連結，而不是公開釋出。 |
+| 你公開發布一個外掛包。 | 請用與 AGPL-3.0 相容的條款發布。這是最常見的情況，也是[外掛範本](https://github.com/CodefyUI/CodefyUI-Plugin-Official)預設的做法。 |
+| 你想出貨閉源的節點或外掛，或想把修改過的 CodefyUI 當服務跑而不釋出修改。 | 這就是商業授權存在的原因。 |
+
+:::caution 不確定性到底在哪裡
+「外掛算不算其宿主的衍生著作」在著作權法上是真的有爭議的問題，各法域見解不同，也還沒有法院針對 AGPL 給出定論。專案把上面的解讀寫出來，是為了讓你知道專案的意圖，不會事後拿另一套說法來找你。它不是法律意見，也不拘束任何其他人的法務。如果你需要的是一個可以依賴的答案，請取得商業授權——它不是回答這個問題，而是讓這個問題消失。
+:::
+
+## 我建的圖和訓練出來的模型會受 AGPL 約束嗎？
+
+**依專案的解讀，不會。** 你在畫布上建出來的 `graph.json`、訓練產生的權重，以及任何圖表或匯出檔，都是執行本程式的**輸出**。AGPL-3.0 第 2 條直接處理了這件事：
+
+> The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work.
+>
+> （執行受本授權涵蓋之著作所產生的輸出，只有在其內容本身構成受涵蓋著作時，才受本授權涵蓋。）
+
+一份圖的描述、一組學到的權重張量，是你的資料，不是 CodefyUI 的程式碼。AGPL 沒有要求你公開它們。
+
+唯一要分開看的是你餵進去的訓練**資料**以及你下載的預訓練權重——那些帶著它們各自來源的授權，與 CodefyUI 完全無關。
+
+## 商業授權涵蓋什麼？由誰授予？
+
+**由誰授予：** CodefyUI（https://github.com/CodefyUI），也就是 [NOTICE](https://github.com/CodefyUI/CodefyUI/blob/main/NOTICE) 中列名的著作權人。外部貢獻以 Developer Certificate of Origin 1.1 加上一條明示的雙軌授權條款收受——見 [CONTRIBUTING.md](https://github.com/CodefyUI/CodefyUI/blob/main/CONTRIBUTING.md)——以確保貢獻的程式碼可以走任一條路徑。
+
+**涵蓋什麼：** AGPL-3.0 以外的條款，用於開源路徑服務不了的情況。
+
+- 你不想公開的閉源或專有修改。
+- 把修改過的 CodefyUI 當成託管服務或 SaaS 產品提供。
+- OEM 轉散布，或把 CodefyUI 內嵌到以你自己授權出貨的產品中。
+- 出貨閉源的自訂節點或外掛包（見上一題）。
+- 內部政策禁止 copyleft 義務的企業部署——不論該義務實際上有沒有被觸發。
+
+**它不做什麼：** 它不會從開源路徑拿走任何東西，也不是技術支援合約。條款與價格逐案商議。
+
+請從[問題追蹤器](https://github.com/CodefyUI/CodefyUI/issues)開始接洽。另見 [COMMERCIAL-LICENSE.md](https://github.com/CodefyUI/CodefyUI/blob/main/COMMERCIAL-LICENSE.md)。
+
+## 第三方元件
+
+CodefyUI 會轉散布第三方軟體，包含 Python 相依套件，以及預先建置的前端 bundle 內的編譯資產（React、KaTeX 及其字型等）。它們的著作權聲明與授權條款收錄在 [THIRD_PARTY_NOTICES.md](https://github.com/CodefyUI/CodefyUI/blob/main/THIRD_PARTY_NOTICES.md)，該檔會與 `LICENSE`、`NOTICE` 一起放進 release tarball。這些元件全部是寬鬆授權，沒有任何一個帶有自己的 copyleft 義務。

--- a/docs/i18n/zh-TW/docusaurus-theme-classic/footer.json
+++ b/docs/i18n/zh-TW/docusaurus-theme-classic/footer.json
@@ -39,6 +39,10 @@
     "message": "外掛範本",
     "description": "The label of footer link with label=Plugin Template linking to https://github.com/CodefyUI/CodefyUI-Plugin-Official"
   },
+  "link.item.label.Licensing FAQ": {
+    "message": "授權常見問題",
+    "description": "The label of footer link with label=Licensing FAQ linking to /licensing"
+  },
   "link.item.label.AGPL-3.0": {
     "message": "AGPL-3.0",
     "description": "The label of footer link with label=AGPL-3.0 linking to https://github.com/CodefyUI/CodefyUI/blob/main/LICENSE"
@@ -48,7 +52,7 @@
     "description": "The label of footer link with label=Commercial linking to https://github.com/CodefyUI/CodefyUI/blob/main/COMMERCIAL-LICENSE.md"
   },
   "copyright": {
-    "message": "Copyright © 2026 CodefyUI. 以 Docusaurus 建置。",
+    "message": "Copyright © 2026 CodefyUI 及 CodefyUI 貢獻者。以 Docusaurus 建置。",
     "description": "The footer copyright"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "2.1.1",
   "license": "AGPL-3.0-only",
+  "author": "CodefyUI (https://github.com/CodefyUI)",
   "packageManager": "pnpm@9.15.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
> 中文摘要：這個 PR 處理三件在公司法務審查會卡住、但都不是程式問題的事。第一，整個 repo 找不到著作權人是誰，所以 COMMERCIAL-LICENSE.md 提供的商業條款沒有可以授權的主體——現在補上 `NOTICE`、README 著作權行、`backend/pyproject.toml` 的 `authors`、`frontend/package.json` 的 `author`，並在 COMMERCIAL-LICENSE.md 加上「授權人」一節；`NOTICE` 也一併放進 release tarball。第二，git 歷史裡零筆 `Signed-off-by`，而外部貢獻者的程式碼（#239）已經進了核心，那段程式碼在沒有授權讓與的情況下不能走商業路徑——新增 `CONTRIBUTING.md`，採 DCO 1.1 簽署再加上一條明示的雙軌授權條款，開發環境與檢查指令全部是從 `scripts/dev.py` 與 CI workflow 逐條核對出來的。第三，文件網站把 AGPL 說成只給個人與教育用，漏掉 README 寫的「以及任何能遵守 AGPL-3.0 的情況」，等於自己把企業使用者推走——`intro.md` 已改成與 README 一致，並新增 `/licensing` 授權常見問題頁，中英雙語都有。

Closes #248.

---

## MAINTAINER ACTION REQUIRED before merging

**You must confirm or replace the copyright holder string.** I do not know your legal name or which entity you intend to hold the copyright, and inventing one would be worse than leaving the gap. I used the identity the repository already asserts — `docs/docusaurus.config.ts:142` has been rendering `Copyright © <year> CodefyUI` on every docs page since the site went up — so the string is:

```
Copyright (C) 2026 CodefyUI (https://github.com/CodefyUI)
and the CodefyUI contributors.
```

`2026` is the year of the first commit (`2026-03-21`), verified from git history.

It now appears in six places, and they are meant to stay identical:

| File | Form |
|---|---|
| `NOTICE` | full statement |
| `README.md` (License section) | one line + link to `NOTICE` |
| `COMMERCIAL-LICENSE.md` (new Licensor section) | one line + link to `NOTICE` |
| `backend/pyproject.toml` | `authors = [{ name = "CodefyUI" }]`, same for `maintainers` |
| `frontend/package.json` | `"author": "CodefyUI (https://github.com/CodefyUI)"` |
| `docs/docusaurus.config.ts` + `docs/i18n/zh-TW/.../footer.json` | footer copyright, extended to include contributors |

**"CodefyUI" is a project name, not a legal person.** For the open source path that is completely fine — plenty of projects attribute to the project. For the commercial path it is the weakest link: counsel on the buying side will ask who the contracting party is, and "CodefyUI" alone does not answer it. If you intend to sell commercial licences, replace it with your legal name or a registered entity. The `authors` field in `backend/pyproject.toml` deliberately carries no `email` for the same reason — I was not going to lift your personal address out of git history and present it as the project's contact.

`backend/pyproject.toml` has a comment at the change site listing all the other places to update together, so this does not drift later.

---

## What was wrong, and what changed

### 1. Nobody owned the software

`grep -rn "Copyright" README.md COMMERCIAL-LICENSE.md THIRD_PARTY_NOTICES.md backend/pyproject.toml frontend/package.json` returned exactly one hit, and it belonged to KaTeX. `COMMERCIAL-LICENSE.md` offered proprietary terms and routed buyers to the public issue tracker without naming anyone who could grant those terms.

Added:

- **`NOTICE`** at the repository root — holder, both licensing paths, a pointer to `THIRD_PARTY_NOTICES.md`, and a statement that contributions come in under the DCO. It explicitly says it is informational and that `LICENSE` governs on conflict, so it cannot be read as amending the licence.
- **Copyright line in `README.md`**, plus a short **Contributing** section above it pointing at `CONTRIBUTING.md`.
- **`authors` and `maintainers` in `backend/pyproject.toml`** so the holder appears in distribution metadata, and **`author` in `frontend/package.json`** which had `license` but no owner.
- **A `## Licensor` section in `COMMERCIAL-LICENSE.md`**, which is where the question is actually asked.

`NOTICE` also ships in the release tarball. `.github/workflows/release-build.yml:146` was `cp LICENSE THIRD_PARTY_NOTICES.md frontend/dist/` — that list is the single place this is decided (nothing in `scripts/dev.py` copies legal files, so a local `cdui build` never had them either). It is now `cp LICENSE NOTICE THIRD_PARTY_NOTICES.md frontend/dist/`, matching the pattern established for `THIRD_PARTY_NOTICES.md` in #98. A redistributed bundle of compiled third-party code that carries no attribution for the thing wrapping it is exactly the gap `NOTICE` exists to close.

**Not touched:** the `Copyright (C) <year> <name of author>` placeholder at `LICENSE:632`. That is standard FSF appendix boilerplate present in every copy of the AGPL and is supposed to be there.

### 2. Contributed code had no inbound grant

Zero `Signed-off-by` trailers in all of git history, while `oyea0801`'s PR #239 had already added `backend/app/api/routes_data_files.py` and modified `backend/app/core/node_base.py` and `main.py`. That is core code, and without a grant it cannot be offered on the commercial path.

**New `CONTRIBUTING.md`.** It is DCO, not a CLA, per the issue. Structure:

- **`git commit -s`**, the recovery paths (`--amend -s --no-edit`, `git rebase --signoff main`), and the verbatim DCO 1.1 text.
- **Why a dual-licensed project needs it**, in plain terms: if unowned code lands in `main`, the project distributed something it had no right to distribute and every downstream user inherits the problem.
- **An explicit inbound dual-licensing term**, and this is the one place I did not simply follow the issue. The DCO certifies *provenance* and submission "under the open source license indicated in the file". It does **not**, on its own, grant the right to relicense a contribution commercially — that is precisely the gap the issue identifies, and a DCO-only `CONTRIBUTING.md` claiming to close it would have been false comfort. So the document states two things a contributor agrees to: the standard unmodified DCO 1.1, **and** that their contribution may be distributed by the project on either path. It is stated as an inbound term of contributing rather than a separate signed document, which keeps it DCO-weight. **If commercial licensing becomes a real revenue line, a proper CLA is the stronger instrument** and this should be revisited then.
- **Development environment**, verified line by line against `scripts/dev.py` and the workflows rather than guessed:
  - `cdui install --dev` is not optional — without it the backend installs as `.` rather than `.[dev]`, pytest never lands in `backend/.venv`, and `cdui test` exits "not found".
  - **`cdui test` runs the backend only** (`scripts/dev.py:2471`, quoted in full — three lines, bare `pytest` in `backend/`). Stated flatly, because a frontend contributor watching it go green learns nothing about their change.
  - **uv will pick a Python newer than CI uses.** Confirmed live: `uv lock --check` in a fresh worktree here reported `Using CPython 3.14.3`, while `backend-test.yml` tests 3.10/3.11/3.12 and `cdui install` hardcodes 3.11. Documented with the explicit `--python 3.11` fix.
  - The full local check set, and which CI job runs what: `python scripts/check_control_bytes.py`, `cdui test`, `uv lock --check` when `pyproject.toml` changes, and for the frontend `pnpm exec tsc -b` / `pnpm test` / `pnpm build`.
  - **`tsc -b`, not `tsc --noEmit`** — `frontend/tsconfig.json` is solution-style with `"files": []`, so `--noEmit` checks zero files and passes regardless.
  - **`pnpm build` contains the contrast gate** (`node scripts/check-contrast.mjs && tsc -b && vite build`); `pnpm contrast` runs it alone.
  - There is **no linter, no formatter and no pre-commit hook** in this repo. The document says so, so nobody wastes an afternoon looking.
- **PR conventions as actually practised**: conventional-commit subjects (types listed by real frequency from 400 commits: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `ci`, `perf`), the `> 中文摘要：` blockquote first, `Closes #NNN` only for issues genuinely resolved, prose bodies covering why / what / what you verified / what you deliberately did not do, and tests required with browser verification for UI changes.
- **Branch and PR only**, no exceptions, no size below which it stops applying.
- **No pictographic emoji**, with the actual reason (cp950/cp1252 consoles raise `UnicodeEncodeError`), and the honest note that `byte-scan.yml` checks for raw C0 control bytes and will **not** catch emoji for you.
- **Translations move with the English page**, since a missing zh-TW file silently falls back to English and the drift is invisible.

**This does not fix the existing history.** #239's commits still carry no sign-off. Asking `oyea0801` for a retroactive grant — a comment on the PR agreeing the contribution may be distributed under both paths is enough — is still a maintainer action, and the issue is right that it gets harder with every month.

### 3. The docs site was talking companies out of using it

`docs/docs/intro.md:71` described the open source path as "for individuals, small teams, education, research, and community use" and stopped, dropping the README's closing "**and any other use case that can comply with AGPL-3.0**". A company read the docs site, concluded enterprise use needed a purchase, and landed on a commercial path with nobody to sell it.

The licence says the opposite. `LICENSE:146-147`: *"This License explicitly affirms your unlimited permission to run the unmodified Program."* And §13 opens *"if you modify the Program"* (`LICENSE:542-548`). Running it unmodified on an internal server triggers nothing.

- **`intro.md` now matches the README**, with a paragraph stating plainly that unmodified internal use needs no purchase, plus the copyright line.
- **New `/licensing` page** — a Licensing FAQ, linked from `intro.md`, the README, `COMMERCIAL-LICENSE.md`, and the docs footer.

## How the custom-node question is hedged

This is the question that actually decides an evaluation, and it is the part of this PR worth reviewing most carefully.

The mechanics are not disputable and the page states them: `custom-nodes.md:10` tells users to subclass `BaseNode` from `app.core.node_base` in-process, `plugins.md:43` says "A plugin pack is Python that runs in the CodefyUI process", and CodefyUI publishes no linking exception.

The page then gives **the project's interpretation, labelled as such**: a custom node or plugin that imports CodefyUI's API and runs in its process is part of a modified version for AGPL purposes, so serving it to remote users engages §13 and reaches that code. A four-row table works through the cases — private local use (nothing triggered, §13 is about remote interaction), internal server with colleagues (engaged; inside one org that is a link to an internal repo, not a public release), publishing a pack (use AGPL-compatible terms), and shipping something proprietary (that is what the commercial licence is for).

Three separate hedges surround it:

1. A **note admonition at the top of the page**: everything on it is the project's own reading, it is not legal advice, it creates and modifies nothing, `LICENSE` governs on conflict.
2. A **caution admonition directly under the custom-node answer**: whether a plugin is a derivative work of its host is genuinely contested, varies by jurisdiction, and no court has settled it for the AGPL. The project states its reading so you know what it intends and will not be surprised later — it is not a legal opinion and binds nobody else's counsel.
3. **The commercial licence is offered as the resolution**, framed as removing the question rather than answering it.

I also added a fourth question the issue did not list — **do graphs and trained models fall under the AGPL?** — because it is the first thing an evaluator worries about and `LICENSE` answers it cleanly: output is covered only if, given its content, it constitutes a covered work. A `graph.json` and a weight tensor are your data. Training data and downloaded pretrained weights carry their own separate licences.

The "who grants it" answer points at `NOTICE` and at `CONTRIBUTING.md`'s inbound term, closing the loop back to items 1 and 2.

## Translations

Both changed pages are mirrored into `docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/` — the intro edit and a full translation of the licensing FAQ, with the AGPL quotations kept in English and glossed in Chinese so the licence text is never paraphrased away. The new footer link is translated in `docs/i18n/zh-TW/docusaurus-theme-classic/footer.json`, and the zh-TW footer copyright is updated to match.

## Verification

| Check | Result |
|---|---|
| `cd docs && pnpm install --frozen-lockfile && pnpm build` | exit 0; both locales built; `build/licensing.html` and `build/zh-TW/licensing.html` present; zh-TW page confirmed rendering the translation, not the English fallback; footer link renders as "Licensing FAQ" / "授權常見問題" |
| `python scripts/check_control_bytes.py` | `OK: no raw C0 control bytes in 1102 tracked files` (run after staging, so the new files were in scope) |
| `cd backend && uv lock --check` | exit 0 — adding `authors`/`maintainers` does not drift the lock, so `backend-test.yml`'s pre-install gate stays green |
| Pictographic emoji scan over all 13 touched files | clean; only U+2192 on pre-existing lines, which is one of the permitted functional glyphs |
| `git status --porcelain` | empty after commit |

`docs pnpm build` also emitted two **pre-existing** broken-anchor warnings, both in zh-TW pages this PR does not touch: `/zh-TW/advanced/python-script-node` links to `/zh-TW/usage/running-graphs#what-is-never-cached`, and `/zh-TW/usage/graph-as-a-function` links to `#reproducible-runs-seed`. They are warnings, not errors, and the build exits 0. Left alone deliberately — unrelated to this change and worth their own fix.

No application code was touched, so there is nothing to browser-test.

## On #141

This delivers the DCO and dev-environment halves of **#141** (contributor onboarding). **Deliberately not closed** — the rest of that issue is still open:

- **An architecture tour for newcomers.** `CONTRIBUTING.md` points at the existing Architecture page and states the one load-bearing fact (backend-authoritative: `GET /api/nodes` drives the UI, so adding a node is a backend-only change), but a real "here is how a request becomes a tensor" walkthrough is not written.
- **Good-first-issue curation.** No issues are labelled, so "browse the tracker" is the best the document can currently say.
- **A code of conduct**, if you want one — there is none, and `.github/` still holds only `RELEASING.md` and the workflows.

## Found but not fixed

- **A third contributor identity the issue did not mention.** `git shortlog -sne` shows `latteine` / `李駿毅 Junyi Li <felix.tc.tw@gmail.com>` with 4 commits, including the original `scripts/dev.py` task runner (`fb94443`), moving it to the root (`713cb9b`), `install.sh` (`149d345`), and a UI effects-cleanup fix (#19, `3ff0f41`). That is not peripheral — it is the tooling every contributor and every installer runs. **If that identity is not you under a second email, it is a second retroactive grant to collect**, and it predates #239 by months.
- **`cdui build` produces a `frontend/dist` with no `LICENSE`, `NOTICE` or `THIRD_PARTY_NOTICES.md`.** Only the release tarball gets them, because the copy lives solely in `release-build.yml`. Harmless today (nobody redistributes a local build), but it is an asymmetry between the two writers of the same artifact, in the same spirit as the build-stamp schema comment already in `scripts/dev.py`.
- **`scripts/dev.py:2476-2478`** has an indented comment block orphaned at module level just after `test()`. Cosmetic, valid Python, untouched.
- **This commit deliberately carries no `Signed-off-by`.** A DCO sign-off is a personal attestation and it is yours to make, not mine to generate in your name. If you want the PR that introduces the rule to also be the first to follow it, amend before merging: `git commit --amend -s --no-edit && git push --force-with-lease`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
