### PR TITLE
fix(cli+api): scope `cdui stop` to this install, refuse `cdui update` under a live server, cap POST /api/runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Open [http://localhost:8000](http://localhost:8000). The single uvicorn process 
 | Command | Description |
 |---------|-------------|
 | `cdui install` | Install backend deps; download prebuilt frontend (or local build if `pnpm` available) |
-| `cdui update` | Update to the latest release (prebuilt path) or pull `main` (when building from source) and re-sync the frontend. Never prompts — reuses the PyTorch variant and dev tooling already in the venv unless `--gpu` / `--dev` override |
+| `cdui update` | Update to the latest release (prebuilt path) or pull `main` (when building from source) and re-sync the frontend. Never prompts — reuses the PyTorch variant and dev tooling already in the venv unless `--gpu` / `--dev` override. Refuses while a server is running — `cdui stop` first |
 | `cdui start` | Production mode — single uvicorn on `:8000`, in the background (no Node needed). `--foreground`/`-f` runs it attached |
 | `cdui status` | btop / k9s-style dashboard: CPU, memory, disk, GPU, top processes, plus the server's PID and health. Refreshes live by default (every 2s, `Ctrl+C` to quit); pass a number to set the interval (`cdui status 1`), or `--once` for a single frame. Piped/non-interactive output is single-frame automatically |
 | `cdui dev` | Developer mode — backend `:8000` + Vite HMR `:5173` (requires Node + pnpm) |
 | `cdui build` | Build the frontend bundle locally (requires Node + pnpm) |
-| `cdui stop` | Stop all services (including the background server) |
+| `cdui stop` | Stop **this install's** services: the background server, plus leftovers started from this directory (foreground `cdui start`, `cdui dev`'s Vite). `--all` stops every CodefyUI and Vite process on the machine instead — including other people's, so avoid it on a shared host |
 | `cdui test` | Run backend tests |
 | `cdui clean` | Remove virtualenv, `node_modules`, and `frontend/dist` |
 | `cdui uninstall` | Clean + remove the PATH launcher |

--- a/backend/app/api/routes_runs.py
+++ b/backend/app/api/routes_runs.py
@@ -25,21 +25,25 @@ is what ``test_auth_drift.py`` guards for those two, and what
 guards here).
 
 Errors: 400 for a malformed submit or an unknown status filter, 404 for an
-unknown run, 503 when the service is not on ``app.state`` (the
-``routes_execution_outputs._get_store`` precedent — the lifespan does not
-run under httpx's ASGITransport).
+unknown run, 413 for a submit over ``MAX_RUN_BODY_BYTES``, 503 when the
+service is not on ``app.state`` (the ``routes_execution_outputs._get_store``
+precedent — the lifespan does not run under httpx's ASGITransport). All of
+them answer ``{"detail": ...}``; the 9-key run envelope belongs to
+``routes_graph_run`` / ``routes_apps``, not here.
 """
 
 from __future__ import annotations
 
 import csv
 import io
+import json
 from dataclasses import asdict
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import Response
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from ..config import settings
 from ..core.run_service import (
@@ -85,6 +89,80 @@ class SubmitRunRequest(BaseModel):
     graph: dict[str, Any]
     options: Any = None
     name: str | None = None
+
+
+def _reject_oversized_body(request: Request) -> None:
+    """413 when ``Content-Length`` declares more than ``MAX_RUN_BODY_BYTES``.
+
+    Same setting, same comparison and same message text as the two sibling
+    submit routes (``routes_graph_run`` step 2, ``routes_apps`` step 3), so a
+    client that talks to more than one of them sees one behaviour. Only the
+    envelope differs, and only because these routes have different envelopes:
+    the sibling routes answer with the 9-key run envelope on every path, this
+    router answers with ``{"detail": ...}`` on every path (see the module
+    docstring). Borrowing their envelope for this one status would make
+    ``POST /api/runs`` the only route in the file a client had to special-case.
+
+    Checked against the header BEFORE anything reads the body, which is why
+    ``submit_run`` parses its own body instead of declaring a pydantic
+    parameter: FastAPI reads and JSON-parses a declared body before the
+    endpoint (and before its dependencies) runs, so a cap placed after that
+    point has already paid for the bytes it is refusing.
+
+    Advisory, exactly like the siblings: a chunked request declares no length
+    and is not caught here. The cap that matters for this route is the one on
+    what gets *persisted* — every submit writes an immutable ``graph_snapshot``
+    row, a queued run never reaches a terminal state, and the keep-last-N
+    retention only prunes finished runs (``RUN_RETENTION_KEEP_LAST``), so
+    without this nothing at all reclaims an oversized submit.
+    """
+    content_length = request.headers.get("content-length")
+    if content_length is None:
+        return
+    try:
+        declared_bytes = int(content_length)
+    except ValueError:
+        declared_bytes = 0
+    if declared_bytes > settings.MAX_RUN_BODY_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"request body is {declared_bytes} bytes "
+                f"(max {settings.MAX_RUN_BODY_BYTES})"
+            ),
+        )
+
+
+async def _read_submit_body(request: Request) -> SubmitRunRequest:
+    """Read and validate the submit body by hand, keeping FastAPI's 422.
+
+    Hand-parsing is the price of capping before the read; it must not also
+    cost callers the error shape they already handle. Both failure modes are
+    re-raised as ``RequestValidationError`` with the same ``loc`` prefix
+    FastAPI applies (``("body", ...)``) and ``include_url=False``, so a bad
+    submit answers byte-for-byte what a declared pydantic body answered.
+    """
+    raw = await request.body()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RequestValidationError([{
+            "type": "json_invalid",
+            "loc": ("body", exc.pos),
+            "msg": "JSON decode error",
+            "input": {},
+            "ctx": {"error": exc.msg},
+        }], body=raw)
+    try:
+        return SubmitRunRequest.model_validate(payload)
+    except ValidationError as exc:
+        raise RequestValidationError(
+            [
+                {**err, "loc": ("body", *err.get("loc", ()))}
+                for err in exc.errors(include_url=False)
+            ],
+            body=payload,
+        )
 
 
 async def _queue_positions(service: RunService,
@@ -179,8 +257,21 @@ async def _require_run(service: RunService, run_id: str) -> RunRecord:
     return record
 
 
-@router.post("")
-async def submit_run(body: SubmitRunRequest, request: Request):
+@router.post("", openapi_extra={
+    # Hand-parsing the body takes it out of the generated schema, and an
+    # endpoint whose /docs page shows no request body is worse documentation
+    # than the cap is worth. Re-declare the same model, inlined because
+    # nothing references the component any more.
+    "requestBody": {
+        "required": True,
+        "content": {
+            "application/json": {
+                "schema": SubmitRunRequest.model_json_schema(),
+            },
+        },
+    },
+})
+async def submit_run(request: Request):
     """Persist and schedule a run. Returns as soon as it is scheduled.
 
     Deliberately does NOT wait for the run: that is the entire point of the
@@ -192,7 +283,12 @@ async def submit_run(body: SubmitRunRequest, request: Request):
     device's FIFO (#123). Poll the row, or long-poll ``/events``, either
     way; a queued run parks the long poll properly instead of returning
     empty pages.
+
+    The body is capped and parsed here rather than declared as a pydantic
+    parameter — see ``_reject_oversized_body`` for why the order matters.
     """
+    _reject_oversized_body(request)
+    body = await _read_submit_body(request)
     service = _get_service(request)
     try:
         result = await service.submit(body.graph, options=body.options,

--- a/backend/tests/test_api_runs.py
+++ b/backend/tests/test_api_runs.py
@@ -330,6 +330,104 @@ async def test_submit_rejects_bad_input(client, payload, expected):
     assert response.status_code == expected, response.text
 
 
+# ── body cap (#250 item 3) ────────────────────────────────────────────────
+# The two sibling submit routes have capped their request bodies against
+# Content-Length since they were written (test_api_graph_run's
+# test_run_413_payload_too_large, test_api_apps_invoke's
+# test_invoke_413_body_cap_writes_no_row). This route was simply missed, and
+# it is the one where the omission persists: every submit writes a
+# graph_snapshot row, and retention only prunes finished runs.
+
+
+async def test_submit_413_over_the_body_cap(client, monkeypatch):
+    """Same status, same setting and same message as the sibling routes."""
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 16)
+    response = await client.post("/api/runs", json={"graph": _graph()})
+    assert response.status_code == 413, response.text
+    detail = response.json()["detail"]
+    assert "max 16" in detail, detail
+    assert "bytes" in detail
+
+
+async def test_submit_413_writes_no_run_row(client, monkeypatch):
+    """The point of the cap: an over-cap submit leaves nothing behind.
+
+    A rejected submit that still recorded its graph would be the worst of
+    both worlds — the row and its graph_snapshot are what accumulate, and a
+    queued or running row is never eligible for retention at all.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 16)
+    assert (await client.post(
+        "/api/runs", json={"graph": _graph()})).status_code == 413
+    listing = (await client.get("/api/runs")).json()
+    assert listing["total"] == 0
+    assert listing["runs"] == []
+
+
+async def test_submit_cap_is_checked_before_the_body_is_read(client, monkeypatch):
+    """Ordering, proved by behaviour rather than by reading the source.
+
+    The payload is over the cap AND is not valid JSON. Refusing on the
+    header first answers 413; reading the body first answers 422 on the
+    decode error. So this fails the moment the guard moves after the read —
+    which is exactly what declaring a pydantic body parameter would do,
+    since FastAPI reads and parses a declared body before the endpoint (and
+    before its dependencies) runs.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 16)
+    response = await client.post(
+        "/api/runs",
+        content=b"{ this is not json, and it is well over sixteen bytes",
+        headers={"content-type": "application/json"},
+    )
+    assert response.status_code == 413, response.text
+
+
+async def test_submit_under_the_cap_is_unaffected(client, monkeypatch):
+    """A body inside the cap still submits — the guard is a ceiling, not a
+    gate. Pinned because the cheapest way to pass the tests above is to
+    reject everything."""
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 1024 * 1024)
+    response = await client.post("/api/runs", json={"graph": _graph()})
+    assert response.status_code == 200, response.text
+    await _poll_until_terminal(client, response.json()["run_id"])
+
+
+async def test_submit_keeps_fastapis_422_for_a_bad_body(client):
+    """Hand-parsing the body must not change the error callers already
+    handle: same 422, same ``("body", ...)`` loc prefix, same detail list."""
+    response = await client.post("/api/runs", json={"options": {}})
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert isinstance(detail, list) and detail
+    assert detail[0]["loc"][:2] == ["body", "graph"]
+    assert detail[0]["type"] == "missing"
+    # pydantic's docs URL is stripped, exactly as FastAPI strips it.
+    assert "url" not in detail[0]
+
+
+async def test_submit_keeps_fastapis_422_for_malformed_json(client):
+    response = await client.post(
+        "/api/runs",
+        content=b"{not json",
+        headers={"content-type": "application/json"},
+    )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail[0]["type"] == "json_invalid"
+    assert detail[0]["loc"][0] == "body"
+
+
+def test_submit_still_documents_its_request_body():
+    """Hand-parsing takes the body out of the generated schema unless it is
+    put back — an endpoint with no documented body on /docs is a regression
+    a passing test suite would otherwise never notice."""
+    post = app.openapi()["paths"]["/api/runs"]["post"]
+    schema = post["requestBody"]["content"]["application/json"]["schema"]
+    assert set(schema["properties"]) == {"graph", "options", "name"}
+    assert schema["required"] == ["graph"]
+
+
 async def test_submit_requires_the_session_token(run_app):
     async with AsyncClient(transport=ASGITransport(app=app),
                            base_url=BASE_URL) as anonymous:

--- a/backend/tests/test_dev_shared_host.py
+++ b/backend/tests/test_dev_shared_host.py
@@ -98,12 +98,17 @@ def test_rejects_an_unrelated_process_inside_our_checkout(rooted):
 
 
 def test_vite_is_matched_as_a_path_component_not_a_substring(rooted):
-    """A bare substring test would claim `invite.py` is a dev server. It
-    lives in ROOT, so the ownership half would not save it."""
-    assert not dev._is_this_install_process(
-        ["python", str(rooted / "scripts" / "invite.py")], str(rooted))
+    """A bare substring test would claim `invite.py` is a dev server, and a
+    stem-only test would claim a graph named `vite.json` is. Both live in
+    ROOT, so the ownership half of the rule cannot save them."""
+    for benign in (str(rooted / "scripts" / "invite.py"),
+                   str(rooted / "graphs" / "vite.json"),
+                   str(rooted / "backend" / "vitest.config.ts")):
+        assert not dev._is_this_install_process(["python", benign],
+                                                str(rooted)), benign
     # The spellings that must still match.
     for part in ("vite",
+                 str(rooted / "frontend" / "node_modules" / ".bin" / "vite.cmd"),
                  str(rooted / "frontend" / "node_modules" / "vite" / "bin"
                      / "vite.js")):
         assert dev._is_this_install_process(["node", part], str(rooted)), part

--- a/backend/tests/test_dev_shared_host.py
+++ b/backend/tests/test_dev_shared_host.py
@@ -1,0 +1,376 @@
+"""`cdui stop` and `cdui update` on a machine with more than one user (#250).
+
+Both commands were written for the deployment CodefyUI actually had — one
+student, one laptop, one checkout — and both are wrong in the same way once a
+second person shares the box:
+
+* ``stop`` swept the whole machine (``pkill -f "uvicorn app.main:app"`` and,
+  worse, ``pkill -f vite``), so one person stopping their server stopped
+  everyone's training and every unrelated Vite dev server on the host.
+* ``update`` never asked whether a server was running before it realigned the
+  checkout, deleted ``frontend/dist`` and rewrote the venv underneath it.
+
+ISOLATION, and it matters here more than usual: ``update()`` calls
+``shutil.rmtree(DIST_DIR)`` inline in this process. Stubbing ``run`` only
+redirects the *subprocesses* — the deletion still happens, against the
+developer's real ``frontend/dist``. Every test below therefore redirects
+``ROOT``, ``VENV``, ``DIST_DIR`` and both server state files at ``tmp_path``
+before calling anything.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import dev  # scripts/dev.py — conftest puts scripts/ on sys.path
+
+
+# ── ownership matching: is that process ours, and is it THIS install's? ──
+
+
+@pytest.fixture
+def rooted(tmp_path, monkeypatch):
+    """ROOT redirected at a scratch checkout directory."""
+    root = tmp_path / "codefyui"
+    root.mkdir()
+    monkeypatch.setattr(dev, "ROOT", root)
+    return root
+
+
+def test_under_root_accepts_the_root_and_its_children(rooted):
+    assert dev._under_root(str(rooted))
+    assert dev._under_root(str(rooted / "backend"))
+    assert dev._under_root(str(rooted / "frontend" / "node_modules"))
+
+
+def test_under_root_rejects_a_sibling_sharing_the_prefix(rooted, tmp_path):
+    """``codefyui-old`` is not inside ``codefyui``. A bare ``startswith``
+    would say it is, and would then stop that other install's server."""
+    assert not dev._under_root(str(tmp_path / "codefyui-old" / "backend"))
+    assert not dev._under_root(str(tmp_path / "somewhere-else"))
+    assert not dev._under_root(None)
+    assert not dev._under_root("")
+
+
+def test_matches_our_background_server_by_launch_path(rooted):
+    """`cdui start` runs the venv's own uvicorn, so the absolute path in
+    argv[0] already identifies the install."""
+    cmdline = [str(rooted / "backend" / ".venv" / "bin" / "uvicorn"),
+               "app.main:app", "--host", "127.0.0.1", "--port", "8000"]
+    assert dev._is_this_install_process(cmdline, None)
+
+
+def test_matches_dev_mode_vite_by_working_directory(rooted):
+    """`cdui dev` starts the frontend in ``<root>/frontend``. A globally
+    installed vite has no ROOT path in its argv, so cwd is what settles it."""
+    assert dev._is_this_install_process(
+        ["node", "/usr/lib/node_modules/vite/bin/vite.js"],
+        str(rooted / "frontend"),
+    )
+
+
+def test_rejects_another_installs_server(rooted, tmp_path):
+    """The whole point: a colleague's CodefyUI is a CodefyUI, and is not ours."""
+    theirs = tmp_path / "home-someone-else" / "CodefyUI"
+    cmdline = [str(theirs / "backend" / ".venv" / "bin" / "uvicorn"),
+               "app.main:app"]
+    assert not dev._is_this_install_process(cmdline, str(theirs / "backend"))
+
+
+def test_rejects_an_unrelated_vite_dev_server(rooted):
+    """`pkill -f vite` was never scoped to CodefyUI at all — it ended any
+    Vite any developer on the machine happened to be running."""
+    assert not dev._is_this_install_process(
+        ["node", "/srv/marketing-site/node_modules/vite/bin/vite.js"],
+        "/srv/marketing-site",
+    )
+
+
+def test_rejects_an_unrelated_process_inside_our_checkout(rooted):
+    """Living in ROOT is not enough — an editor, a shell or a test runner
+    opened here must survive `cdui stop`."""
+    assert not dev._is_this_install_process(
+        ["python", "-m", "pytest", "tests/"], str(rooted / "backend"))
+    assert not dev._is_this_install_process([], str(rooted))
+
+
+def test_vite_is_matched_as_a_path_component_not_a_substring(rooted):
+    """A bare substring test would claim `invite.py` is a dev server. It
+    lives in ROOT, so the ownership half would not save it."""
+    assert not dev._is_this_install_process(
+        ["python", str(rooted / "scripts" / "invite.py")], str(rooted))
+    # The spellings that must still match.
+    for part in ("vite",
+                 str(rooted / "frontend" / "node_modules" / "vite" / "bin"
+                     / "vite.js")):
+        assert dev._is_this_install_process(["node", part], str(rooted)), part
+
+
+# ── the psutil scan ──────────────────────────────────────────────────────
+
+
+class _FakeProc:
+    def __init__(self, pid, cmdline, cwd=None, cwd_denied=False):
+        self.info = {"pid": pid, "cmdline": cmdline}
+        self._cwd = cwd
+        self._denied = cwd_denied
+
+    def cwd(self):
+        if self._denied:
+            raise PermissionError("access denied")
+        return self._cwd
+
+
+class _FakePsutil:
+    """Just enough psutil for ``_this_install_pids``."""
+
+    def __init__(self, procs, self_pid, parent_pids=()):
+        self._procs = procs
+        self._self_pid = self_pid
+        self._parents = [SimpleNamespace(pid=p) for p in parent_pids]
+
+    def process_iter(self, attrs=None):
+        return list(self._procs)
+
+    def Process(self):  # noqa: N802 — mirrors psutil's own capitalisation
+        return SimpleNamespace(pid=self._self_pid, parents=lambda: self._parents)
+
+
+def _install_fake_psutil(monkeypatch, procs, parent_pids=()):
+    fake = _FakePsutil(procs, self_pid=dev.os.getpid(), parent_pids=parent_pids)
+    monkeypatch.setitem(sys.modules, "psutil", fake)
+    return fake
+
+
+def test_scan_finds_ours_and_leaves_everything_else(rooted, monkeypatch):
+    ours_backend = _FakeProc(
+        101, [str(rooted / "backend" / ".venv" / "bin" / "uvicorn"),
+              "app.main:app"])
+    ours_vite = _FakeProc(
+        102, ["node", "vite"], cwd=str(rooted / "frontend"))
+    theirs = _FakeProc(
+        201, ["/home/bob/CodefyUI/backend/.venv/bin/uvicorn", "app.main:app"],
+        cwd="/home/bob/CodefyUI/backend")
+    other_vite = _FakeProc(
+        202, ["node", "/srv/site/node_modules/vite/bin/vite.js"],
+        cwd="/srv/site")
+    unrelated = _FakeProc(203, ["sshd", "-D"], cwd="/")
+    _install_fake_psutil(
+        monkeypatch, [ours_backend, ours_vite, theirs, other_vite, unrelated])
+
+    assert dev._this_install_pids() == [101, 102]
+
+
+def test_scan_never_returns_our_own_process_or_an_ancestor(rooted, monkeypatch):
+    """`cdui stop` runs from inside ROOT. Killing ourselves, or the shell
+    that launched us, would be a spectacular way to succeed."""
+    me = dev.os.getpid()
+    procs = [
+        _FakeProc(me, [str(rooted / "x" / "vite")]),
+        _FakeProc(7, [str(rooted / "y" / "vite")]),
+        _FakeProc(9, [str(rooted / "backend" / "uvicorn"), "app.main:app"]),
+    ]
+    _install_fake_psutil(monkeypatch, procs, parent_pids=(7,))
+    assert dev._this_install_pids() == [9]
+
+
+def test_scan_skips_a_process_whose_cwd_is_denied(rooted, monkeypatch):
+    """Another user's process denies ``cwd()``. Unreadable means not ours."""
+    denied = _FakeProc(301, ["node", "vite"], cwd_denied=True)
+    _install_fake_psutil(monkeypatch, [denied])
+    assert dev._this_install_pids() == []
+
+
+def test_scan_is_empty_without_psutil(rooted, monkeypatch):
+    """No psutil, no identification — and then only the pidfile server is
+    stopped. Failing to stop a stray is recoverable; stopping someone
+    else's server is not."""
+    monkeypatch.setitem(sys.modules, "psutil", None)
+    assert dev._this_install_pids() == []
+
+
+# ── stop(): scoped by default, machine-wide only on --all ────────────────
+
+
+@pytest.fixture
+def stopped(rooted, tmp_path, monkeypatch):
+    """`stop()` with every process-ending call captured instead of made."""
+    monkeypatch.setattr(dev, "SERVER_PIDFILE", tmp_path / "server.pid")
+    monkeypatch.setattr(dev, "SERVER_ADDRFILE", tmp_path / "server.addr")
+    shell: list[list[str]] = []
+    targeted: list[int] = []
+    groups: list[int] = []
+    monkeypatch.setattr(dev.subprocess, "run",
+                        lambda cmd, **kw: shell.append([str(c) for c in cmd]))
+    monkeypatch.setattr(dev, "_terminate_pid", targeted.append)
+    monkeypatch.setattr(dev, "_terminate_posix", groups.append)
+    monkeypatch.setattr(dev, "_this_install_pids", list)
+    monkeypatch.setattr(dev, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(dev, "_has_psutil", lambda: True)
+    monkeypatch.setattr(sys, "argv", ["cdui", "stop"])
+    return SimpleNamespace(shell=shell, targeted=targeted, groups=groups)
+
+
+def _machine_wide(shell):
+    """Commands that end processes this install does not own."""
+    joined = [" ".join(cmd) for cmd in shell]
+    return [c for c in joined
+            if "pkill" in c or "/IM" in c or "WINDOWTITLE" in c]
+
+
+def test_stop_does_not_sweep_the_whole_machine(stopped):
+    """The regression this whole file exists for."""
+    dev.stop()
+    assert _machine_wide(stopped.shell) == []
+
+
+def test_stop_all_still_sweeps_the_whole_machine(stopped, monkeypatch):
+    """The old behaviour is preserved, just no longer the default: it is
+    still the only thing that catches a server whose checkout is gone."""
+    monkeypatch.setattr(sys, "argv", ["cdui", "stop", "--all"])
+    dev.stop()
+    assert _machine_wide(stopped.shell), stopped.shell
+
+
+def test_stop_all_says_out_loud_what_it_is_about_to_do(stopped, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["cdui", "stop", "--all"])
+    dev.stop()
+    assert "--all" in capsys.readouterr().out
+
+
+def test_stop_still_ends_leftovers_from_this_install(stopped, monkeypatch):
+    """A foreground `cdui start` leaves no pidfile, so the scoped sweep is
+    what stops it — deleting the sweep outright would have broken that."""
+    monkeypatch.setattr(dev, "_this_install_pids", lambda: [111, 222])
+    dev.stop()
+    assert stopped.targeted == [111, 222]
+
+
+def test_stop_still_ends_the_pidfile_server(stopped):
+    dev.SERVER_PIDFILE.write_text("4242")
+    dev.SERVER_ADDRFILE.write_text("127.0.0.1:8000")
+    dev.stop()
+    hit = (4242 in stopped.groups
+           or any("4242" in " ".join(cmd) for cmd in stopped.shell))
+    assert hit, stopped.shell
+    assert not dev.SERVER_PIDFILE.exists()
+
+
+def test_stop_does_not_end_the_pidfile_server_twice(stopped, monkeypatch):
+    """The scan sees the background server too; it has already been stopped
+    through its process group, and signalling it again is noise at best."""
+    dev.SERVER_PIDFILE.write_text("4242")
+    dev.SERVER_ADDRFILE.write_text("127.0.0.1:8000")
+    monkeypatch.setattr(dev, "_this_install_pids", lambda: [4242, 999])
+    dev.stop()
+    assert stopped.targeted == [999]
+
+
+def test_stop_admits_when_it_cannot_identify_strays(stopped, monkeypatch, capsys):
+    monkeypatch.setattr(dev, "_has_psutil", lambda: False)
+    dev.stop()
+    assert "psutil" in capsys.readouterr().out
+
+
+# ── update(): refuse while a server is running ───────────────────────────
+
+
+@pytest.fixture
+def updatable(rooted, tmp_path, monkeypatch):
+    """`update()` with every destructive edge redirected at tmp_path.
+
+    ``run`` and ``install`` are captured, and DIST_DIR points at a throwaway
+    directory because ``shutil.rmtree`` runs inline in this process.
+    ``CODEFYUI_FORCE_BUILD`` keeps update on the build-from-source branch so
+    ``_resolve_release_tag()`` never reaches for the network.
+    """
+    (rooted / ".git").mkdir()
+    dist = rooted / "frontend" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    monkeypatch.setattr(dev, "VENV", rooted / "backend" / ".venv")
+    monkeypatch.setattr(dev, "DIST_DIR", dist)
+    monkeypatch.setattr(dev, "SERVER_PIDFILE", tmp_path / "server.pid")
+    monkeypatch.setattr(dev, "SERVER_ADDRFILE", tmp_path / "server.addr")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(dev, "run", lambda cmd, **kw: calls.append(list(cmd)))
+    monkeypatch.setattr(dev, "install", lambda **kw: calls.append(["install"]))
+    monkeypatch.setattr(dev, "_resolve_update_options", lambda argv: ("skip", False))
+    monkeypatch.setenv("CODEFYUI_FORCE_BUILD", "1")
+    monkeypatch.setattr(sys, "argv", ["cdui", "update"])
+    return SimpleNamespace(calls=calls, dist=dist)
+
+
+def test_update_refuses_while_a_server_is_running(updatable, monkeypatch, capsys):
+    """No git checkout, no rmtree, no reinstall — and a message that names
+    the command to run first."""
+    dev.SERVER_PIDFILE.write_text("4242")
+    dev.SERVER_ADDRFILE.write_text("127.0.0.1:8000")
+    monkeypatch.setattr(dev, "_pid_alive", lambda pid: True)
+
+    with pytest.raises(SystemExit) as exc:
+        dev.update()
+
+    assert exc.value.code == 1
+    assert updatable.calls == [], updatable.calls
+    assert (updatable.dist / "index.html").exists(), \
+        "update deleted the dist of a server that is still serving it"
+    message = capsys.readouterr().err
+    assert "cdui stop" in message
+    assert "4242" in message
+
+
+def test_update_proceeds_when_no_server_is_running(updatable, monkeypatch):
+    monkeypatch.setattr(dev, "_pid_alive", lambda pid: False)
+    dev.update()
+    assert ["install"] in updatable.calls
+    assert any(cmd[:2] == ["git", "checkout"] for cmd in updatable.calls)
+    assert not updatable.dist.exists()
+
+
+def test_update_is_not_blocked_by_a_stale_pidfile(updatable, monkeypatch):
+    """A crashed server leaves its pidfile behind. Reusing the liveness check
+    `cdui status` already runs means the stale file is cleared, not obeyed —
+    otherwise a crash would make the install permanently un-updatable."""
+    dev.SERVER_PIDFILE.write_text("4242")
+    dev.SERVER_ADDRFILE.write_text("127.0.0.1:8000")
+    monkeypatch.setattr(dev, "_pid_alive", lambda pid: False)
+
+    dev.update()
+
+    assert ["install"] in updatable.calls
+    assert not dev.SERVER_PIDFILE.exists()
+
+
+def test_update_help_still_answers_while_a_server_is_running(
+        rooted, tmp_path, monkeypatch, capsys):
+    """`--help` must not become collateral damage of the refusal: option
+    resolution (which exits on --help) runs before the liveness check.
+
+    Built by hand rather than on the `updatable` fixture because the real
+    ``_resolve_update_options`` is the thing under test here.
+    """
+    (rooted / ".git").mkdir()
+    dist = rooted / "frontend" / "dist"
+    dist.mkdir(parents=True)
+    monkeypatch.setattr(dev, "VENV", rooted / "backend" / ".venv")
+    monkeypatch.setattr(dev, "DIST_DIR", dist)
+    pidfile = tmp_path / "server.pid"
+    pidfile.write_text("4242")
+    monkeypatch.setattr(dev, "SERVER_PIDFILE", pidfile)
+    monkeypatch.setattr(dev, "SERVER_ADDRFILE", tmp_path / "server.addr")
+    monkeypatch.setattr(dev, "_pid_alive", lambda pid: True)
+    calls: list[list[str]] = []
+    monkeypatch.setattr(dev, "run", lambda cmd, **kw: calls.append(list(cmd)))
+    monkeypatch.setattr(dev, "install", lambda **kw: calls.append(["install"]))
+    monkeypatch.setattr(sys, "argv", ["cdui", "update", "--help"])
+
+    with pytest.raises(SystemExit):
+        dev.update()
+
+    assert calls == []
+    assert dist.exists()
+    assert "cdui update" in capsys.readouterr().out

--- a/docs/docs/getting-started/cli-commands.md
+++ b/docs/docs/getting-started/cli-commands.md
@@ -13,12 +13,12 @@ description: The cdui launcher commands — install, start, status, dev, build, 
 | Command | Description |
 |---------|-------------|
 | `cdui install` | Install backend deps; download the prebuilt frontend (or build locally if `pnpm` is available). |
-| `cdui update` | Update to the latest release (prebuilt path) or pull `main` (source build) and re-sync the frontend. Never prompts — reuses the PyTorch variant and dev tooling already in the venv unless `--gpu` / `--dev` override. |
+| `cdui update` | Update to the latest release (prebuilt path) or pull `main` (source build) and re-sync the frontend. Never prompts — reuses the PyTorch variant and dev tooling already in the venv unless `--gpu` / `--dev` override. Refuses while a server is running (it would delete the `frontend/dist` that server is serving) — `cdui stop` first. |
 | `cdui start` | Production mode — single uvicorn on `:8000`, in the background (no Node needed). `--foreground` / `-f` runs it attached. |
 | `cdui status` | btop / k9s-style dashboard: CPU, memory, disk, GPU, top processes, plus the server's PID and health. Refreshes live (every 2s; `Ctrl+C` to quit). Pass a number to set the interval (`cdui status 1`), or `--once` for a single frame. |
 | `cdui dev` | Developer mode — backend `:8000` + Vite HMR `:5173` (requires Node + pnpm). |
 | `cdui build` | Build the frontend bundle locally (requires Node + pnpm). |
-| `cdui stop` | Stop all services (including the background server). |
+| `cdui stop` | Stop **this install's** services: the background server from the pidfile, plus leftovers started from this directory (a foreground `cdui start`, `cdui dev`'s Vite, stray workers). Add `--all` to stop every CodefyUI and Vite process on the machine instead — that reaches other people's servers and unrelated Vite dev servers, so avoid it on a shared host. |
 | `cdui test` | Run backend tests. |
 | `cdui clean` | Remove the virtualenv, `node_modules`, and `frontend/dist`. |
 | `cdui uninstall` | Clean + remove the PATH launcher. |

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/cli-commands.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/cli-commands.md
@@ -13,12 +13,12 @@ description: cdui 啟動器指令 —— install、start、status、dev、build�
 | 指令 | 說明 |
 |------|------|
 | `cdui install` | 安裝後端依賴；下載預編好的前端（若有 `pnpm` 則改在本地 build）。 |
-| `cdui update` | 更新到最新 release（prebuilt 路徑），或拉取 `main`（原始碼建置）並重新同步前端。不會詢問任何問題 —— 除非用 `--gpu` / `--dev` 覆蓋，否則沿用 venv 中既有的 PyTorch 變體與 dev 工具。 |
+| `cdui update` | 更新到最新 release（prebuilt 路徑），或拉取 `main`（原始碼建置）並重新同步前端。不會詢問任何問題 —— 除非用 `--gpu` / `--dev` 覆蓋，否則沿用 venv 中既有的 PyTorch 變體與 dev 工具。伺服器還在執行時會拒絕（它會刪掉那台伺服器正在服務的 `frontend/dist`）—— 請先 `cdui stop`。 |
 | `cdui start` | 正式模式 —— 單一 uvicorn 跑 `:8000`，在背景執行（不需要 Node）。`--foreground`／`-f` 改為前景執行。 |
 | `cdui status` | btop／k9s 風格的儀表板：CPU、記憶體、磁碟、GPU、前幾名程序，外加伺服器的 PID 與健康狀態。即時刷新（每 2 秒；`Ctrl+C` 離開）。傳入一個數字可設定間隔（`cdui status 1`），或用 `--once` 只顯示單一畫面。 |
 | `cdui dev` | 開發者模式 —— 後端 `:8000` + Vite HMR `:5173`（需要 Node + pnpm）。 |
 | `cdui build` | 在本地建置前端 bundle（需要 Node + pnpm）。 |
-| `cdui stop` | 停止所有服務（包含背景伺服器）。 |
+| `cdui stop` | 停止**這個安裝**的服務：pidfile 記錄的背景伺服器，加上從這個目錄啟動的殘留行程（前景 `cdui start`、`cdui dev` 的 Vite、遺留 worker）。加上 `--all` 則改為停止整台機器上所有 CodefyUI 與 Vite 行程 —— 那會波及其他使用者的伺服器與無關的 Vite dev server，共用主機請勿使用。 |
 | `cdui test` | 執行後端測試。 |
 | `cdui clean` | 移除虛擬環境、`node_modules` 與 `frontend/dist`。 |
 | `cdui uninstall` | clean + 移除 PATH 上的啟動器。 |

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -2144,10 +2144,14 @@ def _under_root(path: "str | None") -> bool:
     return candidate == root or candidate.startswith(root + os.sep)
 
 
-#: `vite` as a whole path component or file stem — ``node_modules/vite/…``,
-#: ``…/vite.js``, or the bare word — never as a substring, so a script named
-#: `invite.py` is not mistaken for a dev server.
-_VITE_RE = re.compile(r"(^|[\\/])vite([\\/.]|$)")
+#: `vite` as a whole path component (``node_modules/vite/…``) or as the
+#: executable itself (``…/vite``, ``…/vite.js``, ``…\vite.cmd``). Never a
+#: bare substring: `invite.py` is not a dev server, and neither is a graph
+#: file someone happened to name `vite.json`.
+_VITE_RE = re.compile(
+    r"(^|[\\/])vite[\\/]"
+    r"|(^|[\\/])vite(\.(js|cjs|mjs|cmd|exe|bat|ps1))?$"
+)
 
 
 def _looks_like_a_codefyui_service(cmdline: "list[str]") -> bool:

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -13,6 +13,8 @@
                       --yes / -y         略過互動，自動偵測 + 非 dev
                 從 TTY 不帶旗標執行會跳出互動選單；從非 TTY（curl|bash、CI）走 --yes。
     update      拉取最新版本並重新安裝依賴（接受同 install 的旗標）
+                伺服器還在執行時會拒絕（會刪掉它正在服務的 dist），
+                請先 cdui stop。
     build       建置 frontend dist（需 Node + pnpm，給開發者）
     dev         啟動開發伺服器（HMR；需 Node + pnpm）
     start       啟動 production（單一 uvicorn，用 frontend/dist；不需 Node）
@@ -44,7 +46,11 @@
                 離開碼：0 成功、1 失敗/取消/無法送出、2 參數錯誤、130 Ctrl+C
                 （Ctrl+C 只是停止跟隨，run 仍在伺服器上繼續執行）。
                 離線、不需要伺服器的單次執行請用 backend/run_graph.py。
-    stop        停止所有服務（含背景伺服器）
+    stop        停止「這個安裝」的服務：pidfile 記錄的背景伺服器，加上從這個
+                目錄啟動的殘留行程（前景 start、dev 模式的 vite、遺留 worker）。
+                旗標：--all   改為停止整台機器上所有 CodefyUI 與 Vite 行程。
+                              會波及其他使用者、以及與 CodefyUI 無關的 Vite
+                              dev server；共用主機請勿使用。
     test        執行 backend 測試
     clean       移除虛擬環境、node_modules 與 frontend/dist
     uninstall   解除安裝：clean + 移除全域 cdui launcher
@@ -1201,6 +1207,28 @@ def update() -> None:
     # this process already imported the old dev.py either way.
     gpu, dev = _resolve_update_options(sys.argv[2:])
 
+    # Nothing below this line is survivable by a running server: the checkout
+    # is hard-realigned under it, the frontend/dist it is serving is deleted,
+    # and its dependencies are rewritten in the venv it imported from. The
+    # result is not a crash — it is a server that stays up, keeps answering,
+    # and returns 404 for its own JavaScript, which is far harder to
+    # recognise than a clean refusal. On one laptop that was survivable
+    # because you knew you had started it; on a shared box the server you
+    # break is usually not yours.
+    #
+    # `_running_server_pid()` is the same liveness check `cdui status` runs,
+    # deliberately: two answers to "is it running" would eventually disagree.
+    # It also clears a stale pidfile as a side effect, so a crashed server
+    # cannot block an update forever.
+    running = _running_server_pid()
+    if running is not None:
+        err(f"伺服器正在執行中（PID {running}，{_display_url(*_server_addr())}），"
+            f"不能在此時 update。請先執行 cdui stop。",
+            f"A CodefyUI server is running (PID {running}, "
+            f"{_display_url(*_server_addr())}) — refusing to update underneath "
+            f"it. Stop it first: cdui stop")
+        sys.exit(1)
+
     # Decide whether this install will use a prebuilt release dist (no Node) or
     # build the frontend from source (pnpm available / forced). On the prebuilt
     # path we MUST pin the backend to the same release tag as the dist — pulling
@@ -2031,7 +2059,9 @@ def dev() -> None:
 
 
 def stop() -> None:
-    print("=== 停止所有服務 ===")
+    """停止此安裝的服務。加 --all 才會掃掉整台機器上的 CodefyUI / Vite。"""
+    sweep_everything = "--all" in sys.argv[2:]
+    print("=== 停止服務 ===")
     # First, stop the tracked background server gracefully via its PID. On
     # POSIX it was started with start_new_session, so its PID is also its
     # process-group leader — kill the whole group to catch any children.
@@ -2048,14 +2078,182 @@ def stop() -> None:
     SERVER_PIDFILE.unlink(missing_ok=True)
     SERVER_ADDRFILE.unlink(missing_ok=True)
 
-    # Sweep up anything else (foreground starts, dev-mode vite, stray workers).
+    # Then sweep up anything the pidfile does not know about — a foreground
+    # `cdui start`, a `cdui dev` vite, a worker that outlived its parent.
+    if sweep_everything:
+        _sweep_every_install()
+    else:
+        _sweep_this_install(already_stopped=pid)
+    print("=== 完成 ===")
+
+
+def _sweep_this_install(already_stopped: "int | None" = None) -> None:
+    """Stop leftover processes started FROM THIS CHECKOUT, and only those.
+
+    The sweep exists for a real reason: a foreground start writes no pidfile,
+    so without it `cdui stop` cannot stop what `cdui start -f` began. What it
+    must not do is reach outside this install. On one laptop those are the
+    same set; on a shared server they are not, and the untargeted version of
+    this sweep ends everyone else's training — plus every unrelated Vite dev
+    server on the box, which was never CodefyUI's to kill.
+
+    Scoped by ownership rather than by name: a process counts only when it
+    both looks like ours AND runs out of ``ROOT``.
+    """
+    strays = [p for p in _this_install_pids() if p != already_stopped]
+    for stray in strays:
+        print(t(f"  停止此安裝的殘留行程（PID {stray}）...",
+                f"  Stopping leftover process from this install (PID {stray})..."))
+        _terminate_pid(stray)
+    if not _has_psutil():
+        print(t("  （未安裝 psutil，無法辨識殘留行程；只停止了 pidfile 記錄的伺服器）",
+                "  (psutil unavailable — leftover processes cannot be "
+                "identified; only the pidfile server was stopped)"))
+
+
+def _sweep_every_install() -> None:
+    """`--all`: the pre-#250 machine-wide sweep, kept but no longer default.
+
+    Still the right thing on a single-user machine whose pidfile has been
+    lost, and the only thing that catches a server started from a checkout
+    that no longer exists. It is opt-in because it cannot tell whose server
+    it is stopping, and `pkill -f vite` is not even scoped to CodefyUI.
+    """
+    print(t("  --all：停止這台機器上所有 CodefyUI 與 Vite 行程（含其他使用者的）...",
+            "  --all: stopping EVERY CodefyUI and Vite process on this "
+            "machine (other people's included)..."))
     if sys.platform == "win32":
         subprocess.run(["taskkill", "/F", "/IM", "uvicorn.exe"], capture_output=True)
         subprocess.run(["taskkill", "/F", "/FI", "WINDOWTITLE eq vite*"], capture_output=True)
     else:
         subprocess.run(["pkill", "-f", "uvicorn app.main:app"], capture_output=True)
         subprocess.run(["pkill", "-f", "vite"], capture_output=True)
-    print("=== 完成 ===")
+
+
+def _under_root(path: "str | None") -> bool:
+    """True when *path* is ROOT itself or lives inside it.
+
+    ``normcase`` so Windows' case and separator variants compare equal, and
+    the explicit ``+ os.sep`` so a sibling checkout called ``codefyui-old``
+    is not mistaken for a child of ``codefyui``.
+    """
+    if not path:
+        return False
+    root = os.path.normcase(str(ROOT))
+    candidate = os.path.normcase(str(path))
+    return candidate == root or candidate.startswith(root + os.sep)
+
+
+#: `vite` as a whole path component or file stem — ``node_modules/vite/…``,
+#: ``…/vite.js``, or the bare word — never as a substring, so a script named
+#: `invite.py` is not mistaken for a dev server.
+_VITE_RE = re.compile(r"(^|[\\/])vite([\\/.]|$)")
+
+
+def _looks_like_a_codefyui_service(cmdline: "list[str]") -> bool:
+    """Name-only test: is this the shape of a CodefyUI backend or a Vite?
+
+    ``app.main:app`` is the uvicorn target every start path uses; ``vite``
+    covers the dev-mode frontend. Says nothing about WHOSE it is — that is
+    ``_is_this_install_process``'s job, and answering this one first keeps
+    the ownership check (which costs a ``cwd()`` syscall) off every process
+    on the machine.
+    """
+    parts = [os.path.normcase(part) for part in cmdline]
+    return any("app.main:app" in part or _VITE_RE.search(part)
+               for part in parts)
+
+
+def _is_this_install_process(cmdline: "list[str]", cwd: "str | None") -> bool:
+    """True for a CodefyUI backend / Vite dev server owned by THIS checkout.
+
+    Two independent questions, both of which must answer yes: does it look
+    like one of ours, and is it *this* install's? The second is satisfied
+    either by a launch path inside ROOT (the venv's ``uvicorn`` and
+    ``node_modules/vite`` both are) or by a working directory inside ROOT
+    (``cdui dev`` starts the backend in ``backend/`` and the frontend in
+    ``frontend/``).
+
+    A pure function of what a process reports, so the matching rule can be
+    tested without spawning anything.
+    """
+    if not _looks_like_a_codefyui_service(cmdline):
+        return False
+    return any(_under_root(part) for part in cmdline) or _under_root(cwd)
+
+
+def _this_install_pids() -> "list[int]":
+    """PIDs matching ``_is_this_install_process``, minus us and our parents.
+
+    Needs psutil — a declared backend dependency, and ``stop`` runs inside
+    the venv, so it is there in every supported install. When it is not, the
+    list is empty and only the pidfile server is stopped: failing to stop a
+    stray is recoverable, stopping the wrong process is not.
+    """
+    try:
+        import psutil  # noqa: PLC0415 — optional, ships with the backend
+    except ImportError:
+        return []
+
+    ours = {os.getpid()}
+    try:
+        ours.update(parent.pid for parent in psutil.Process().parents())
+    except Exception:  # noqa: BLE001 — a missing ancestor must not stop the sweep
+        pass
+
+    found: list[int] = []
+    for proc in psutil.process_iter(["pid", "cmdline"]):
+        try:
+            pid = proc.info["pid"]
+            if pid in ours:
+                continue
+            cmdline = proc.info.get("cmdline") or []
+            if not _looks_like_a_codefyui_service(cmdline):
+                continue
+            if _is_this_install_process(cmdline, None):
+                found.append(pid)
+                continue
+            # The launch path did not settle ownership, so fall back to the
+            # working directory — a second syscall, and one that is denied
+            # for other users' processes, which is why it is asked last and
+            # only of the handful that got this far.
+            try:
+                cwd = proc.cwd()
+            except Exception:  # noqa: BLE001 — psutil raises several types
+                continue
+            if _is_this_install_process(cmdline, cwd):
+                found.append(pid)
+        except Exception:  # noqa: BLE001 — a process that vanished mid-scan
+            continue
+    return found
+
+
+def _terminate_pid(pid: int) -> None:
+    """Stop ONE process (plus its children on Windows).
+
+    Deliberately not ``_terminate_posix``: that signals the whole process
+    GROUP, which is correct for the background server (started with
+    ``start_new_session``, so its group is exactly itself and its children)
+    and wrong for a swept stray, whose group is whatever shell job launched
+    it — potentially the caller's own script.
+    """
+    if sys.platform == "win32":
+        subprocess.run(["taskkill", "/F", "/T", "/PID", str(pid)],
+                       capture_output=True)
+        return
+    import signal  # noqa: PLC0415 — only needed here, POSIX only
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        return
+    for _ in range(20):  # up to ~2s for a graceful shutdown
+        if not _pid_alive(pid):
+            return
+        time.sleep(0.1)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
 
 
 def _terminate_posix(pid: int) -> None:


### PR DESCRIPTION
> 中文摘要：三個「一個人一台筆電」時代留下來的假設，在共用主機上會咬人。`cdui stop` 原本會 `pkill` 掉整台機器上所有 uvicorn 和 vite（包含別人的訓練，以及跟 CodefyUI 完全無關的 Vite dev server），現在只停掉「這個安裝」的行程 —— 判斷方式是同時符合「長得像我們的」和「從這個目錄啟動的」；舊的全機掃描保留成 `cdui stop --all`，而且會先講清楚它要做什麼。`cdui update` 原本完全不檢查伺服器是否在跑，就直接把 checkout 硬對齊、刪掉那台伺服器正在服務的 `frontend/dist`、再把它腳下的 venv 重裝一遍，結果不是崩潰，而是一台「還活著、還會回應、但自己的 JavaScript 全部 404」的伺服器；現在只要 pidfile 裡的 PID 還活著就拒絕，並叫你先 `cdui stop`。`POST /api/runs` 原本沒有請求大小上限，但它的兩個兄弟端點都有 —— 而且只有它的後果會留下來（每次 submit 都寫一筆 graph_snapshot，排隊中的 run 永遠不會進入終態，而回收機制只清理已完成的 run）。三項都補了測試，也都做過「把修正拿掉、確認測試會紅」的驗證。

Closes #250.

Three findings from the shared-server audit, grouped because each is small,
contained, and independent. All three were right for the deployment CodefyUI
was actually written for — one student, one laptop, one checkout — and all
three are wrong the moment a second person shares the machine.

## 1. `cdui stop` stopped every CodefyUI on the machine, and every Vite

After gracefully stopping its own pidfile PID, `stop()` ran a machine-wide
sweep: `pkill -f "uvicorn app.main:app"` and `pkill -f vite` on POSIX,
`taskkill /F /IM uvicorn.exe` plus a `WINDOWTITLE eq vite*` filter on Windows.

The comment stated the intent honestly — "sweep up anything else (foreground
starts, dev-mode vite, stray workers)" — and on one laptop that intent and
that implementation are the same thing. On a shared box they are not: one
person's `cdui stop` ends everyone's training mid-run. And `pkill -f vite`
was never scoped to CodefyUI at all; it ended any Vite dev server any
developer on that host happened to have running.

**What I chose:** scope the sweep to this install, and keep the machine-wide
version as an explicit opt-in.

A process is stopped only when *both* halves answer yes:

* **Is it ours?** `app.main:app` (the uvicorn target every start path uses),
  or `vite` as a whole path component (`node_modules/vite/…`) or the
  executable itself (`…/vite`, `vite.js`, `vite.cmd`). Matched that way
  rather than as a substring, so a script named `invite.py`, a graph named
  `vite.json` and `vitest.config.ts` are all left alone — each of which lives
  inside `ROOT`, where the ownership half of the rule cannot rule it out.
* **Is it *this* install's?** Either it was launched from a path inside `ROOT`
  (the venv's own `uvicorn`, `node_modules/vite`) or it is running with a
  working directory inside `ROOT` (`cdui dev` starts the backend in
  `backend/` and the frontend in `frontend/`). `_under_root` compares on
  `normcase` + an explicit separator, so a sibling checkout named
  `codefyui-old` is not treated as a child of `codefyui`.

The identification uses psutil, which is already a declared backend
dependency and `stop` already runs inside the venv. When it is somehow
missing, the scan returns nothing and says so out loud: failing to stop a
stray is recoverable, stopping someone else's server is not.

A plain `cdui stop` still does the obvious thing for the single-user case —
a foreground `cdui start` writes no pidfile, and the scoped sweep is what
catches it. `cdui stop --all` restores the old behaviour verbatim for the
cases that genuinely need it (a lost pidfile, or a server started from a
checkout that no longer exists), and prints what it is about to do first.

Swept strays are ended per-PID rather than per-process-group. That is
deliberate and is not what the pidfile path does: the background server is
started with `start_new_session`, so its group is exactly itself and its
children, while a stray's group is whatever shell job launched it —
potentially the caller's own script.

**Rejected:** deleting the sweep (it exists for a real reason — a foreground
start leaves no pidfile, and `cdui stop` would silently stop working for it).
**Rejected:** making the scoped behaviour opt-in behind a flag and leaving
the machine-wide sweep as the default — the damaging behaviour should not be
what you get by typing the obvious command.
**Rejected:** scoping via a path-embedded `pkill -f "<ROOT>"` pattern — it
puts an arbitrary filesystem path into a regex, and gives no answer at all
on Windows.

## 2. `cdui update` deleted `frontend/dist` out from under a running server

There was no liveness check anywhere on the update path. Against a live
instance, `cdui update` hard-realigned the git checkout underneath the
running process, deleted the static assets that process was serving, and
reinstalled into the shared venv beneath it. The failure mode is not a
crash — it is a server that stays up, keeps answering, and returns 404 for
its own JavaScript, which is considerably harder to recognise than a clean
refusal.

**How it detects a live server:** `_running_server_pid()` — the same check
`cdui status` already runs. Reusing it was the point: two independent answers
to "is it running" would eventually disagree. It also clears a stale pidfile
as a side effect, so a crashed server cannot make an install permanently
un-updatable.

Placement matters and is pinned by tests: the check sits *after*
`_resolve_update_options()` (so `--help` and bad flags still exit cleanly,
which an existing test already required) and *before* the first git command,
the `rmtree`, and `install()`.

The re-exec behaviour is untouched — `update` stays in `_SKIP_VENV_EXEC` and
this path calls no `os.execv`.

## 3. `POST /api/runs` had no body cap

Both sibling submit routes have capped against `Content-Length` since they
were written (`routes_graph_run.py:609`, `routes_apps.py:587`), against the
same `settings.MAX_RUN_BODY_BYTES`. This route was simply missed — and it is
the one where the omission persists rather than passes: every submit writes
an immutable `graph_snapshot` row, a queued run never reaches a terminal
state, and keep-last-N retention only prunes finished ones. Nothing reclaims
an oversized submit.

The guard is the siblings' guard, against the same setting, with the same
message text. **The envelope differs, and only the envelope:** the sibling
routes answer with the 9-key run envelope on every path, this router answers
`{"detail": ...}` on every path. Borrowing their envelope for one status
would make `POST /api/runs` the only route in the file a client has to
special-case — and `cdui run` already reads `detail` off a non-200 to report
the server's own message, so `{"detail": ...}` *is* the shape a client of
this route sees today.

Getting the ordering right cost a little more than a copy-paste. FastAPI
reads and JSON-parses a declared pydantic body *before* the endpoint runs,
and before its dependencies are solved (verified against the installed
FastAPI 0.139.2, not assumed) — so a cap placed after that point has already
paid for the bytes it is refusing, which is the exact anti-pattern #242 is
filed for. `submit_run` therefore takes a raw `Request` and parses its own
body. Two consequences, both handled:

* **422 parity.** Malformed JSON and schema violations are re-raised as
  `RequestValidationError` with the same `("body", ...)` loc prefix FastAPI
  applies and `include_url=False`, so a bad submit answers exactly what a
  declared pydantic body answered. Pinned by tests.
* **/docs.** Hand-parsing removes the body from the generated schema, so the
  same model is re-declared through `openapi_extra`. Also pinned by a test —
  it is the kind of regression a green suite otherwise never notices.

### Checked for a fourth uncapped graph route — there are four more

Reported rather than fixed here, deliberately (see below):

| Route | Body | Cap |
|---|---|---|
| `POST /api/graph/save` (`routes_graph.py:98`) | full `GraphData`, written to disk | none |
| `POST /api/graph/validate` (`routes_graph.py:86`) | full `GraphData` | none |
| `POST /api/graph/export` (`routes_graph.py:204`) | full `GraphExportRequest`, feeds codegen | none |
| `POST /api/presets/create` (`routes_presets.py:29`) | graph fragment, written to disk | none |

There is also `WS /ws/execution` (`ws_execution.py:527`), which accepts a
whole graph over the socket with no frame-size limit — no `Content-Length`
exists there, so it needs a different mechanism entirely.

I did not fix these in this PR, and that is a scope call rather than an
oversight. All four take pydantic bodies, so capping them *before the read*
means converting four more handlers to raw-`Request` parsing — including
`/api/graph/save` and `/api/graph/validate`, which the editor calls on
effectively every canvas interaction. Capping them *after* the read instead
would be four fresh instances of the buffer-then-check mechanism #242 exists
to remove. Either way it is a different change from "copy the guard", with
different risk, and it deserves its own issue and its own review rather than
riding along here. Worth noting the asymmetry it leaves: the two routes that
*are* capped carry only `inputs`, while these four accept an entire unbounded
graph document.

Also confirmed: there is no global body-size middleware. `main.py` registers
CORS, `auth_guard` and `host_guard`, none of which inspect size.

## Tests

New file `backend/tests/test_dev_shared_host.py` (23 tests) and 7 new tests in
`backend/tests/test_api_runs.py`.

The `dev.py` tests follow the isolation rule this repo learned the hard way:
`ROOT`, `VENV`, `DIST_DIR` and both server state files are redirected at
`tmp_path` before anything is called, because `shutil.rmtree(DIST_DIR)` runs
inline in the test process — stubbing `run` alone would delete the
developer's real `frontend/dist`. Two tests assert the sandbox dist survives.

The scoped sweep is covered both with an injected fake psutil (self/ancestor
exclusion, the `cwd()`-denied path, the no-psutil path) and, during
development, against real spawned processes: a live `app.main:app` process
run from a different interpreter with a working directory outside `ROOT` is
correctly left alone, as is a live vite-shaped process outside `ROOT`, while
the in-`ROOT` server and its interpreter child are both found.

**Mutation-checked** — each source change reverted in turn, matching tests
confirmed red:

| Mutation | Red |
|---|---|
| revert `routes_runs.py` entirely | 4 failed (413 status, no-row, before-the-read ordering, openapi body) |
| remove the `update()` liveness guard | 2 failed (refusal, stale-pidfile clearing) |
| `stop()` always calls `_sweep_every_install()` | 4 failed |
| `_under_root` → bare `startswith` | 1 failed (sibling-prefix checkout) |
| `_is_this_install_process` → ignore ownership | 4 failed |
| loosen the `vite` matcher back to a stem match | 1 failed (`vite.json` / `vitest.config.ts`) |

Full backend suite green (4142 passed, 22 skipped) on CPython 3.11, which is
inside the CI matrix and avoids the pre-existing Windows 3.12+ failures
tracked in #258. `scripts/check_control_bytes.py` clean.

## Docs

`cdui stop` and `cdui update` descriptions updated in `README.md`, the CLI
command reference and its zh-TW translation, plus the `dev.py` usage banner —
`--all` is a new flag and a refusal is new behaviour, so neither should be
discovered by surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
