### PR TITLE
fix(export): give the SVG diagram's light theme its own palette, and gate it

### DIFF
--- a/frontend/scripts/check-contrast.mjs
+++ b/frontend/scripts/check-contrast.mjs
@@ -62,6 +62,92 @@ const lstar = (colour) => {
   return y <= 216 / 24389 ? (y * 24389) / 27 : Math.cbrt(y) * 116 - 16;
 };
 
+/** CIE Lab (D65). Needed for CIEDE2000 below; L* alone cannot tell two hues
+ *  of equal lightness apart, which is exactly the failure mode a categorical
+ *  palette has — fourteen colours that all clear 3:1 on white but look alike
+ *  is a different bug, not a fix. */
+const lab = (colour) => {
+  const [r, g, b] = toRgb(colour).map((v) => {
+    const c = v / 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  const xyz = [
+    0.4124564 * r + 0.3575761 * g + 0.1804375 * b,
+    0.2126729 * r + 0.7151522 * g + 0.072175 * b,
+    0.0193339 * r + 0.119192 * g + 0.9503041 * b,
+  ];
+  const wp = [0.95047, 1.0, 1.08883];
+  const f = (t) => (t > 216 / 24389 ? Math.cbrt(t) : ((t * 24389) / 27 + 16) / 116);
+  const [fx, fy, fz] = xyz.map((v, i) => f(v / wp[i]));
+  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)];
+};
+
+/** CIEDE2000 perceptual colour difference. ~1.0 is the just-noticeable
+ *  difference; a categorical palette wants its closest pair well above that.
+ *  Sanity-checked below against two pairs from the Sharma et al. reference
+ *  data set. */
+const deltaE2000Lab = ([L1, a1, b1], [L2, a2, b2]) => {
+  const deg = (x) => (x * 180) / Math.PI;
+  const rad = (x) => (x * Math.PI) / 180;
+  const C1 = Math.hypot(a1, b1);
+  const C2 = Math.hypot(a2, b2);
+  const Cb = (C1 + C2) / 2;
+  const G = 0.5 * (1 - Math.sqrt(Cb ** 7 / (Cb ** 7 + 25 ** 7)));
+  const a1p = (1 + G) * a1;
+  const a2p = (1 + G) * a2;
+  const C1p = Math.hypot(a1p, b1);
+  const C2p = Math.hypot(a2p, b2);
+  const h1p = (deg(Math.atan2(b1, a1p)) + 360) % 360;
+  const h2p = (deg(Math.atan2(b2, a2p)) + 360) % 360;
+  const dLp = L2 - L1;
+  const dCp = C2p - C1p;
+  let dhp = 0;
+  if (C1p * C2p !== 0) {
+    dhp = h2p - h1p;
+    if (dhp > 180) dhp -= 360;
+    else if (dhp < -180) dhp += 360;
+  }
+  const dHp = 2 * Math.sqrt(C1p * C2p) * Math.sin(rad(dhp) / 2);
+  const Lbp = (L1 + L2) / 2;
+  const Cbp = (C1p + C2p) / 2;
+  let hbp;
+  if (C1p * C2p === 0) hbp = h1p + h2p;
+  else if (Math.abs(h1p - h2p) <= 180) hbp = (h1p + h2p) / 2;
+  else hbp = h1p + h2p < 360 ? (h1p + h2p + 360) / 2 : (h1p + h2p - 360) / 2;
+  const T =
+    1 -
+    0.17 * Math.cos(rad(hbp - 30)) +
+    0.24 * Math.cos(rad(2 * hbp)) +
+    0.32 * Math.cos(rad(3 * hbp + 6)) -
+    0.2 * Math.cos(rad(4 * hbp - 63));
+  const Rc = 2 * Math.sqrt(Cbp ** 7 / (Cbp ** 7 + 25 ** 7));
+  const Sl = 1 + (0.015 * (Lbp - 50) ** 2) / Math.sqrt(20 + (Lbp - 50) ** 2);
+  const Sc = 1 + 0.045 * Cbp;
+  const Sh = 1 + 0.015 * Cbp * T;
+  const Rt = -Math.sin(rad(60 * Math.exp(-(((hbp - 275) / 25) ** 2)))) * Rc;
+  return Math.sqrt(
+    (dLp / Sl) ** 2 + (dCp / Sc) ** 2 + (dHp / Sh) ** 2 + Rt * (dCp / Sc) * (dHp / Sh)
+  );
+};
+const deltaE2000 = (a, b) => deltaE2000Lab(lab(a), lab(b));
+
+/** Smallest CIEDE2000 distance between any two members of a palette, with the
+ *  pair that produced it — that pair is the one a reader has to tell apart. */
+const closestPair = (entries) => {
+  let min = Infinity;
+  let pair = ['', ''];
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      const d = deltaE2000(entries[i][1], entries[j][1]);
+      if (d < min) {
+        min = d;
+        pair = [entries[i][0], entries[j][0]];
+      }
+    }
+  }
+  return { min, pair };
+};
+
 /** Alpha-composite `fg` over `bg`, both as rgb triples. */
 const overlay = (fg, alpha, bg) =>
   fg.map((v, i) => v * alpha + bg[i] * (1 - alpha));
@@ -78,10 +164,36 @@ const selfTests = [
   ['#767676 on #ffffff', contrast('#767676', '#ffffff'), 4.54, 0.01],
   ['#000000 on #ffffff', contrast('#000000', '#ffffff'), 21.0, 0.001],
   ['#ffffff on #ffffff', contrast('#ffffff', '#ffffff'), 1.0, 0.001],
+  // CIEDE2000 against the Sharma/Wu/Dalal reference pairs. Pair 1 is the one
+  // that exercises the hue-rotation term, which is the part of the formula
+  // everyone gets wrong; pair 4 is a constructed unit distance.
+  [
+    'dE00 Sharma pair 1',
+    deltaE2000Lab([50, 2.6772, -79.7751], [50, 0, -82.7485]),
+    2.0425,
+    0.0001,
+  ],
+  [
+    'dE00 Sharma pair 2',
+    deltaE2000Lab([50, 3.1571, -77.2803], [50, 0, -82.7485]),
+    2.8615,
+    0.0001,
+  ],
+  [
+    'dE00 Sharma pair 4',
+    deltaE2000Lab([50, -1.3802, -84.2814], [50, 0, -82.7485]),
+    1.0,
+    0.0001,
+  ],
+  ['dE00 of a colour with itself', deltaE2000('#4caf50', '#4caf50'), 0, 1e-9],
+  // Lab of pure white is (100, 0, 0) — proves the sRGB -> Lab leg, which the
+  // reference pairs above skip because they start in Lab.
+  ['L* of #ffffff via lab()', lab('#ffffff')[0], 100, 0.001],
+  ['L* of #000000 via lab()', lab('#000000')[0], 0, 0.001],
 ];
 for (const [name, got, want, tol] of selfTests) {
   if (Math.abs(got - want) > tol) {
-    console.error(`contrast maths is wrong: ${name} = ${got.toFixed(3)}, expected ${want}`);
+    console.error(`colour maths is wrong: ${name} = ${got.toFixed(4)}, expected ${want}`);
     process.exit(2);
   }
 }
@@ -265,6 +377,148 @@ for (const role of ['--code-text', '--code-comment', '--code-gutter']) {
 for (const glow of ['--glow-running', '--glow-accent']) {
   if (!/rgba\([^)]*,\s*0?\.\d+\s*\)/.test(t(glow))) {
     failures.push(`${glow} must use a translucent rgba() colour, got: ${t(glow)}`);
+  }
+}
+
+/* ---------- 11. The SVG diagram export ----------
+
+   Everything above gates the app. `utils/exportDiagram.ts` renders the same
+   graph as a standalone SVG in a second theme, and the default is the *light*
+   one — the version that ends up in a student's report or a slide deck. That
+   path had no gate at all, which is how seven of the fourteen category hues
+   came to be drawn as a card border on white at 2.15:1 to 3.00:1, and all
+   fourteen as the card's title text below 4.5:1 (core#227).
+
+   Adding a second palette without extending this script would just move the
+   unchecked colour decision one layer down, so the export's palettes are
+   declared in tokens.css and re-derived here like everything else. The theme
+   names and roles below must stay in step with DIAGRAM_THEMES; theme.test.ts
+   is what holds the TypeScript mirror to these same tokens. */
+
+const DIAGRAM_CATEGORIES = [
+  'cnn', 'rnn', 'transformer', 'llm', 'diffusion', 'classical', 'rl',
+  'data', 'training', 'io', 'dataflow', 'utility', 'normalization', 'tensorops',
+];
+const DIAGRAM_TYPES = [
+  'tensor', 'model', 'dataset', 'dataloader', 'optimizer', 'loss-fn',
+  'scalar', 'string', 'image', 'list', 'transform', 'any',
+];
+
+/* Each theme names where its palettes come from. The dark export reuses the
+   app's hues (already tuned for a dark surface); the light export has its own,
+   because a hue legible on a near-black canvas is not legible on paper. */
+const DIAGRAM_THEMES = [
+  {
+    name: 'light',
+    page: '--diagram-light-page',
+    card: '--diagram-light-card',
+    ink: '--diagram-light-ink',
+    wire: '--diagram-light-wire',
+    preset: '--diagram-light-preset',
+    start: '--diagram-light-start',
+    startFill: '--diagram-light-start-fill',
+    category: (slug) => `--diagram-light-${slug}`,
+    type: (slug) => `--diagram-light-type-${slug}`,
+    // The light palette is a fresh design, so it is held to a real floor.
+    minSeparation: 8,
+  },
+  {
+    name: 'dark',
+    page: '--diagram-dark-page',
+    card: '--diagram-dark-card',
+    ink: '--diagram-dark-ink',
+    wire: '--diagram-dark-wire',
+    preset: '--diagram-dark-preset',
+    start: '--diagram-dark-start',
+    startFill: '--diagram-dark-start-fill',
+    category: (slug) => `--cat-${slug}`,
+    type: (slug) => `--type-${slug}`,
+    // The canvas palette's closest pair is --cat-classical / --cat-rl at 3.71
+    // dE00 — two ambers that were already hard to tell apart before any of
+    // this, and repainting the whole app to part them is a separate change.
+    // The floor records that state so it cannot get worse; it is NOT a licence
+    // to relax the light one.
+    minSeparation: 3.5,
+  },
+];
+
+for (const theme of DIAGRAM_THEMES) {
+  const page = t(theme.page);
+  const card = t(theme.card);
+  const label = `diagram/${theme.name}`;
+
+  // Port labels are ordinary text on the card.
+  check(`${label}: ink on the card`, contrast(t(theme.ink), card), 4.5);
+
+  const accents = [
+    ...DIAGRAM_CATEGORIES.map((slug) => [slug, theme.category(slug), card]),
+    ['preset', theme.preset, card],
+    // The Start card has its own fill, so its accent is measured against that
+    // rather than the ordinary card.
+    ['start', theme.start, t(theme.startFill)],
+  ];
+  for (const [role, token, behind] of accents) {
+    // Two roles, two bars: the hue outlines the card (1.4.11, a graphic that
+    // identifies an object) *and* is painted as the card's title (1.4.3, text).
+    check(`${label}: ${role} as a card border`, contrast(t(token), behind), 3);
+    check(`${label}: ${role} as the card title`, contrast(t(token), behind), 4.5);
+  }
+  // A Start card is a filled box, so its fill has to hold the border's other
+  // side and be told apart from an ordinary card.
+  check(`${label}: start accent against the page`, contrast(t(theme.start), page), 3);
+  if (deltaE2000(t(theme.startFill), card) < 5) {
+    failures.push(
+      `${label}: the Start card fill is only ${deltaE2000(t(theme.startFill), card).toFixed(1)} ` +
+        `dE00 from an ordinary card (needs 5) — the entry point stops standing out`
+    );
+  }
+
+  // Wires are drawn on the page, under the cards. An edge is a graphic that
+  // says two nodes are connected, so it needs 3:1 whatever hue it wears.
+  check(`${label}: neutral wire on the page`, contrast(t(theme.wire), page), 3);
+  for (const slug of DIAGRAM_TYPES) {
+    check(`${label}: ${slug} wire on the page`, contrast(t(theme.type(slug)), page), 3);
+  }
+
+  // Fourteen hues that all clear 3:1 on white but look alike is a different
+  // failure, so measure them against each other too.
+  const cats = closestPair(
+    DIAGRAM_CATEGORIES.map((slug) => [slug, t(theme.category(slug))])
+  );
+  if (cats.min < theme.minSeparation) {
+    failures.push(
+      `${label}: categories ${cats.pair.join(' and ')} are only ${cats.min.toFixed(2)} dE00 ` +
+        `apart (needs ${theme.minSeparation}) — they are the pair a reader has to tell apart`
+    );
+  }
+  checked += 1;
+  const types = closestPair(DIAGRAM_TYPES.map((slug) => [slug, t(theme.type(slug))]));
+  if (types.min < 5) {
+    failures.push(
+      `${label}: wire types ${types.pair.join(' and ')} are only ${types.min.toFixed(2)} dE00 apart (needs 5)`
+    );
+  }
+  checked += 1;
+}
+
+/* 11b. A light category hue is a restatement of its dark counterpart for a
+        white page, not a new colour: same hue, lower lightness. If someone
+        "fixes" a contrast failure by rotating a hue instead of darkening it,
+        the export stops agreeing with the app a reader is looking at, and the
+        colour coding silently means two different things in two places. */
+for (const slug of DIAGRAM_CATEGORIES) {
+  const [, da, db] = lab(t(`--cat-${slug}`));
+  const [, la, lb] = lab(t(`--diagram-light-${slug}`));
+  const drift = Math.abs(
+    ((Math.atan2(lb, la) - Math.atan2(db, da)) * 180) / Math.PI
+  );
+  const wrapped = drift > 180 ? 360 - drift : drift;
+  checked += 1;
+  if (wrapped > 12) {
+    failures.push(
+      `--diagram-light-${slug} sits ${wrapped.toFixed(1)} degrees of hue from --cat-${slug} ` +
+        `(needs <= 12) — the light export must be the same colour, darkened, not a different one`
+    );
   }
 }
 

--- a/frontend/src/styles/theme.test.ts
+++ b/frontend/src/styles/theme.test.ts
@@ -5,6 +5,13 @@ import { describe, expect, it } from 'vitest';
 import {
   CATEGORY_COLORS,
   CATEGORY_VARS,
+  CATEGORY_COLORS_ON_LIGHT,
+  CATEGORY_LIGHT_VARS,
+  DATA_TYPE_COLORS_ON_LIGHT,
+  DATA_TYPE_LIGHT_VARS,
+  DATA_TYPE_VARS,
+  DIAGRAM_CHROME,
+  DIAGRAM_CHROME_VARS,
   TOKEN_COLORS,
   getTokenColor,
   DIFFICULTY_COLORS,
@@ -17,6 +24,7 @@ import {
   SURFACE_RAISED,
   mixColor,
 } from './theme';
+import { DATA_TYPE_COLORS } from '../utils';
 
 /**
  * `tokens.css` is the source of truth for colour; the maps in `theme.ts` are a
@@ -112,6 +120,84 @@ describe('tokens.css / theme.ts agreement', () => {
   it('has no orphaned category variable on either side', () => {
     const declared = [...cssTokens.keys()].filter((k) => k.startsWith('--cat-')).sort();
     expect(declared).toEqual(Object.values(CATEGORY_VARS).sort());
+  });
+
+  // Hex case differs by history: tokens.css is lowercase throughout, while
+  // DATA_TYPE_COLORS predates it and is uppercase. Same colour either way.
+  const sameColour = (a: string, b: string) => expect(a.toLowerCase()).toBe(b.toLowerCase());
+
+  it.each(Object.keys(DATA_TYPE_COLORS))('data type %s matches its CSS variable', (name) => {
+    sameColour(DATA_TYPE_COLORS[name], cssVar(DATA_TYPE_VARS[name]));
+  });
+
+  it('has no orphaned data-type variable on either side', () => {
+    const declared = [...cssTokens.keys()].filter((k) => k.startsWith('--type-')).sort();
+    expect(declared).toEqual(Object.values(DATA_TYPE_VARS).sort());
+    expect(Object.keys(DATA_TYPE_VARS).sort()).toEqual(Object.keys(DATA_TYPE_COLORS).sort());
+  });
+});
+
+/**
+ * The SVG export's light theme (core#227). It is a second palette, so it is
+ * exactly the kind of thing that drifts from the token layer — these hold it
+ * in place, and `scripts/check-contrast.mjs` proves the tokens themselves are
+ * legible. Between the two, neither a bad value nor a stale copy can ship.
+ */
+describe('tokens.css / diagram export palette agreement', () => {
+  it('covers every node category', () => {
+    expect(Object.keys(CATEGORY_COLORS_ON_LIGHT).sort()).toEqual(
+      Object.keys(CATEGORY_COLORS).sort(),
+    );
+    expect(Object.keys(CATEGORY_LIGHT_VARS).sort()).toEqual(
+      Object.keys(CATEGORY_COLORS).sort(),
+    );
+  });
+
+  it.each(Object.keys(CATEGORY_COLORS_ON_LIGHT))(
+    'light category %s matches its CSS variable',
+    (name) => {
+      expect(CATEGORY_COLORS_ON_LIGHT[name]).toBe(cssVar(CATEGORY_LIGHT_VARS[name]));
+    },
+  );
+
+  it('covers every data type', () => {
+    expect(Object.keys(DATA_TYPE_COLORS_ON_LIGHT).sort()).toEqual(
+      Object.keys(DATA_TYPE_COLORS).sort(),
+    );
+    expect(Object.keys(DATA_TYPE_LIGHT_VARS).sort()).toEqual(
+      Object.keys(DATA_TYPE_COLORS).sort(),
+    );
+  });
+
+  it.each(Object.keys(DATA_TYPE_COLORS_ON_LIGHT))(
+    'light data type %s matches its CSS variable',
+    (name) => {
+      expect(DATA_TYPE_COLORS_ON_LIGHT[name]).toBe(cssVar(DATA_TYPE_LIGHT_VARS[name]));
+    },
+  );
+
+  it.each(
+    (['light', 'dark'] as const).flatMap((theme) =>
+      (Object.keys(DIAGRAM_CHROME_VARS) as (keyof typeof DIAGRAM_CHROME.light)[]).map(
+        (role) => [theme, role] as const,
+      ),
+    ),
+  )('%s diagram chrome %s matches its CSS variable', (theme, role) => {
+    expect(DIAGRAM_CHROME[theme][role]).toBe(
+      cssVar(`--diagram-${theme}-${DIAGRAM_CHROME_VARS[role]}`),
+    );
+  });
+
+  it('has no orphaned diagram variable on either side', () => {
+    const declared = [...cssTokens.keys()].filter((k) => k.startsWith('--diagram-')).sort();
+    const mirrored = [
+      ...Object.values(CATEGORY_LIGHT_VARS),
+      ...Object.values(DATA_TYPE_LIGHT_VARS),
+      ...(['light', 'dark'] as const).flatMap((theme) =>
+        Object.values(DIAGRAM_CHROME_VARS).map((role) => `--diagram-${theme}-${role}`),
+      ),
+    ].sort();
+    expect(declared).toEqual(mirrored);
   });
 });
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -46,6 +46,154 @@ export const CATEGORY_VARS: Record<string, string> = {
 };
 
 /**
+ * The same fourteen categories, darkened for a white page.
+ *
+ * `CATEGORY_COLORS` is tuned for the app's near-black canvas; on the white
+ * card the SVG exporter draws by default, those hues measured 2.15:1 to
+ * 3.09:1 as a border and every one of them failed the 4.5:1 the exporter also
+ * needs from them as the card's title text (core#227). Each value below is its
+ * counterpart above converted to OKLCH, hue held, chroma pushed to the gamut
+ * edge and lightness lowered until it clears the bar — so the hue a reader
+ * knows from the app survives (at most 1.3 degrees of drift) while the
+ * measurement changes.
+ *
+ * Mirrors the `--diagram-light-*` tokens; `theme.test.ts` asserts the match,
+ * and `scripts/check-contrast.mjs` re-derives every measurement above.
+ */
+export const CATEGORY_COLORS_ON_LIGHT: Record<string, string> = {
+  CNN: '#1a8626',
+  RNN: '#0077c8',
+  Transformer: '#9f58ab',
+  LLM: '#7f61cc',
+  Diffusion: '#c93d86',
+  Classical: '#7e4e00',
+  RL: '#a96300',
+  Data: '#018091',
+  Training: '#d14039',
+  IO: '#866f66',
+  'Data Flow': '#ad4900',
+  Utility: '#617782',
+  Normalization: '#008278',
+  'Tensor Operations': '#6570ad',
+};
+
+/** `--diagram-light-*` variable name for each category. */
+export const CATEGORY_LIGHT_VARS: Record<string, string> = {
+  CNN: '--diagram-light-cnn',
+  RNN: '--diagram-light-rnn',
+  Transformer: '--diagram-light-transformer',
+  LLM: '--diagram-light-llm',
+  Diffusion: '--diagram-light-diffusion',
+  Classical: '--diagram-light-classical',
+  RL: '--diagram-light-rl',
+  Data: '--diagram-light-data',
+  Training: '--diagram-light-training',
+  IO: '--diagram-light-io',
+  'Data Flow': '--diagram-light-dataflow',
+  Utility: '--diagram-light-utility',
+  Normalization: '--diagram-light-normalization',
+  'Tensor Operations': '--diagram-light-tensorops',
+};
+
+/**
+ * Port/wire hues darkened for a white page, same derivation as
+ * `CATEGORY_COLORS_ON_LIGHT`. A wire has to be visible as a line before its
+ * colour can mean anything, and LIST measured 1.51:1 on white. Held to the
+ * 3:1 graphic bar rather than 4.5:1 — the hue is never drawn as text, and the
+ * type it stands for is spelled out in bold beside both of its ports. Five of
+ * the twelve already cleared 3:1 and keep their canvas value.
+ *
+ * Keyed by the same uppercase data-type names as `DATA_TYPE_COLORS`.
+ */
+export const DATA_TYPE_COLORS_ON_LIGHT: Record<string, string> = {
+  TENSOR: '#40a445',
+  MODEL: '#2095f2',
+  DATASET: '#d27c00',
+  DATALOADER: '#9c27b0',
+  OPTIMIZER: '#f44336',
+  LOSS_FN: '#e91e63',
+  SCALAR: '#029fb3',
+  STRING: '#6aa01f',
+  IMAGE: '#ff5722',
+  LIST: '#8d9800',
+  TRANSFORM: '#b78901',
+  ANY: '#919191',
+};
+
+/** `--diagram-light-type-*` variable name for each data type. */
+export const DATA_TYPE_LIGHT_VARS: Record<string, string> = {
+  TENSOR: '--diagram-light-type-tensor',
+  MODEL: '--diagram-light-type-model',
+  DATASET: '--diagram-light-type-dataset',
+  DATALOADER: '--diagram-light-type-dataloader',
+  OPTIMIZER: '--diagram-light-type-optimizer',
+  LOSS_FN: '--diagram-light-type-loss-fn',
+  SCALAR: '--diagram-light-type-scalar',
+  STRING: '--diagram-light-type-string',
+  IMAGE: '--diagram-light-type-image',
+  LIST: '--diagram-light-type-list',
+  TRANSFORM: '--diagram-light-type-transform',
+  ANY: '--diagram-light-type-any',
+};
+
+/** `--type-*` variable name for each data type (the canvas / dark values). */
+export const DATA_TYPE_VARS: Record<string, string> = {
+  TENSOR: '--type-tensor',
+  MODEL: '--type-model',
+  DATASET: '--type-dataset',
+  DATALOADER: '--type-dataloader',
+  OPTIMIZER: '--type-optimizer',
+  LOSS_FN: '--type-loss-fn',
+  SCALAR: '--type-scalar',
+  STRING: '--type-string',
+  IMAGE: '--type-image',
+  LIST: '--type-list',
+  TRANSFORM: '--type-transform',
+  ANY: '--type-any',
+};
+
+/**
+ * Non-category chrome for each SVG export theme — the page, the card it draws
+ * nodes on, the ink for port labels, the default wire, and the two nodes that
+ * carry a brand rather than a category (preset gold, Start green).
+ *
+ * Mirrors the `--diagram-light-*` / `--diagram-dark-*` tokens. `exportDiagram`
+ * assembles these into `DIAGRAM_THEMES`; they live here so `theme.test.ts` can
+ * hold every one of them against `tokens.css`.
+ */
+export const DIAGRAM_CHROME = {
+  light: {
+    page: '#ffffff',
+    card: '#ffffff',
+    ink: '#0f172a',
+    wire: '#64748b',
+    preset: '#956e00',
+    start: '#00712f',
+    startFill: '#dcfce7',
+  },
+  dark: {
+    page: '#0a0a0a',
+    card: '#1e1e1e',
+    ink: '#e5e7eb',
+    wire: '#888888',
+    preset: '#d4a017',
+    start: '#22c55e',
+    startFill: '#1f3c2a',
+  },
+} as const;
+
+/** `--diagram-<theme>-<role>` variable name for each entry of {@link DIAGRAM_CHROME}. */
+export const DIAGRAM_CHROME_VARS: Record<keyof typeof DIAGRAM_CHROME.light, string> = {
+  page: 'page',
+  card: 'card',
+  ink: 'ink',
+  wire: 'wire',
+  preset: 'preset',
+  start: 'start',
+  startFill: 'start-fill',
+};
+
+/**
  * How much of a category hue is mixed into `--surface-raised` to produce a
  * node's header fill.
  *

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -54,8 +54,8 @@ export const CATEGORY_VARS: Record<string, string> = {
  * needs from them as the card's title text (core#227). Each value below is its
  * counterpart above converted to OKLCH, hue held, chroma pushed to the gamut
  * edge and lightness lowered until it clears the bar — so the hue a reader
- * knows from the app survives (at most 1.3 degrees of drift) while the
- * measurement changes.
+ * knows from the app survives while the measurement changes. Drift is at most
+ * 1.8 degrees of CIE Lab hue angle, which is what the contrast gate measures.
  *
  * Mirrors the `--diagram-light-*` tokens; `theme.test.ts` asserts the match,
  * and `scripts/check-contrast.mjs` re-derives every measurement above.

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -309,8 +309,8 @@
    The light hues are not hand-picked. Each is its dark counterpart converted
    to OKLCH, hue held fixed, chroma pushed to the sRGB gamut edge, and
    lightness lowered until it clears the bar on a white card. Hue drift is at
-   most 1.8 degrees, so a green category stays the same green a reader knows
-   from the app. The two exceptions are marked: Classical and RL are 3.71
+   most 1.8 degrees of CIE Lab hue angle, so a green category stays the same
+   green a reader knows from the app. Two are marked: Classical and RL are 3.71
    CIEDE2000 apart in the dark palette — its closest pair by a wide margin —
    and splitting them on lightness costs nothing on paper.
 

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -272,6 +272,114 @@
   --status-interrupted: #ff8f00;
   /* `idle` was #444 — 1.86:1, an indicator you could not see. A neutral
      that still reads as "nothing is happening" but is actually visible. */
+
+  /* Port / wire data types. What a port dot and the wire leaving it are
+     painted with, so the colour says what flows along the connection. These
+     were the last semantic palette still living only as hex literals in
+     TypeScript (`utils/index.ts` DATA_TYPE_COLORS); the values are unchanged,
+     they simply have a home in the token layer now so the contrast gate can
+     see them. `theme.test.ts` asserts the TS mirror still matches. */
+  --type-tensor: #4caf50;
+  --type-model: #2196f3;
+  --type-dataset: #ff9800;
+  --type-dataloader: #9c27b0;
+  --type-optimizer: #f44336;
+  --type-loss-fn: #e91e63;
+  --type-scalar: #00bcd4;
+  --type-string: #8bc34a;
+  --type-image: #ff5722;
+  --type-list: #cddc39;
+  --type-transform: #ffc107;
+  --type-any: #9e9e9e;
+}
+
+/* --------------------------------------------------------
+   Diagram export — the second theme.
+
+   `utils/exportDiagram.ts` renders a graph as a standalone SVG in one of two
+   themes, and **light is the default**: it is the version that goes into a
+   report or a slide deck. Everything above this block is tuned for the app's
+   near-black canvas, and a hue that reads on #0f1319 does not read on white —
+   the fourteen category hues measured 2.15:1 to 3.09:1 as a card border on a
+   white card, seven of them under the 3:1 that WCAG 1.4.11 asks of a border
+   that identifies an object, and *all* fourteen under the 4.5:1 the same hue
+   needs as the card's title text. So the light theme gets its own palette
+   rather than borrowing the dark one (core#227).
+
+   The light hues are not hand-picked. Each is its dark counterpart converted
+   to OKLCH, hue held fixed, chroma pushed to the sRGB gamut edge, and
+   lightness lowered until it clears the bar on a white card. Hue drift is at
+   most 1.8 degrees, so a green category stays the same green a reader knows
+   from the app. The two exceptions are marked: Classical and RL are 3.71
+   CIEDE2000 apart in the dark palette — its closest pair by a wide margin —
+   and splitting them on lightness costs nothing on paper.
+
+   Nothing in CSS references these; they are consumed by the SVG exporter
+   through the `styles/theme.ts` mirror, because an exported file is
+   standalone and has no `var()` to resolve. They live here so there is still
+   one place colour is decided, and so `scripts/check-contrast.mjs` gates the
+   export the same way it gates the app.
+   -------------------------------------------------------- */
+:root {
+  /* Dark theme chrome. The category and data-type hues above are already
+     tuned for a dark surface, so the dark export reuses them as-is. */
+  --diagram-dark-page: #0a0a0a;
+  --diagram-dark-card: #1e1e1e;
+  --diagram-dark-ink: #e5e7eb; /* 13.47:1 on the card */
+  --diagram-dark-wire: #888888; /*  5.58:1 on the page */
+  --diagram-dark-preset: #d4a017; /*  7.02:1 on the card */
+  --diagram-dark-start: #22c55e; /*  7.32:1 on the card */
+  /* The Start card used to be filled #dcfce7 in *both* themes — a pale green
+     box in a near-black diagram, with its title at 3.00:1 on it. This is the
+     same construction as a node header: the trigger green tinted into the
+     card at --node-header-tint. */
+  --diagram-dark-start-fill: #1f3c2a; /* --diagram-dark-start on it: 5.30:1 */
+
+  /* Light theme chrome. */
+  --diagram-light-page: #ffffff;
+  --diagram-light-card: #ffffff;
+  --diagram-light-ink: #0f172a; /* 17.85:1 on the card */
+  --diagram-light-wire: #64748b; /*  4.76:1 on the page — was #94a3b8, 2.56:1 */
+  --diagram-light-preset: #956e00; /*  4.66:1 on the card — was #d4a017, 2.38:1 */
+  --diagram-light-start: #00712f; /*  6.17:1 on the card — was #16a34a, 3.30:1 */
+  --diagram-light-start-fill: #dcfce7; /* --diagram-light-start on it: 5.62:1 */
+
+  /* Light category hues. Each clears 4.5:1 on the white card, which covers
+     both roles the hue plays there: the card border (1.4.11, 3:1) and the
+     card title, which is drawn in the same colour (1.4.3, 4.5:1). */
+  --diagram-light-cnn: #1a8626; /* 4.69 */
+  --diagram-light-rnn: #0077c8; /* 4.70 */
+  --diagram-light-transformer: #9f58ab; /* 4.71 */
+  --diagram-light-llm: #7f61cc; /* 4.68 */
+  --diagram-light-diffusion: #c93d86; /* 4.67 */
+  --diagram-light-classical: #7e4e00; /* 7.05 — darkened past the bar to part it from RL */
+  --diagram-light-rl: #a96300; /* 4.70 */
+  --diagram-light-data: #018091; /* 4.67 */
+  --diagram-light-training: #d14039; /* 4.66 */
+  --diagram-light-io: #866f66; /* 4.69 */
+  --diagram-light-dataflow: #ad4900; /* 5.63 — likewise parted from RL */
+  --diagram-light-utility: #617782; /* 4.70 */
+  --diagram-light-normalization: #008278; /* 4.70 */
+  --diagram-light-tensorops: #6570ad; /* 4.69 */
+
+  /* Light data-type hues. These paint the wires, and a wire has to be visible
+     as a line before its colour can mean anything — LIST measured 1.51:1 and
+     TRANSFORM 1.63:1 on white, i.e. an edge you could not see. Held to 3:1
+     (1.4.11) rather than 4.5:1: the hue is never text, and the type it stands
+     for is already spelled out in bold next to both of its ports. Five of the
+     twelve already cleared the bar and keep their canvas value. */
+  --diagram-light-type-tensor: #40a445; /* 3.18 */
+  --diagram-light-type-model: #2095f2; /* 3.16 */
+  --diagram-light-type-dataset: #d27c00; /* 3.17 */
+  --diagram-light-type-dataloader: #9c27b0; /* 6.30 — unchanged */
+  --diagram-light-type-optimizer: #f44336; /* 3.68 — unchanged */
+  --diagram-light-type-loss-fn: #e91e63; /* 4.35 — unchanged */
+  --diagram-light-type-scalar: #029fb3; /* 3.18 */
+  --diagram-light-type-string: #6aa01f; /* 3.15 */
+  --diagram-light-type-image: #ff5722; /* 3.16 — unchanged */
+  --diagram-light-type-list: #8d9800; /* 3.17 */
+  --diagram-light-type-transform: #b78901; /* 3.19 */
+  --diagram-light-type-any: #919191; /* 3.15 — unchanged */
 }
 
 /* How strongly a category hue is tinted into --surface-raised to make a

--- a/frontend/src/utils/exportDiagram.test.ts
+++ b/frontend/src/utils/exportDiagram.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Edge, Node } from '@xyflow/react';
 import type { NodeData, NodeDefinition, PortDefinition } from '../types';
-import { CATEGORY_COLORS, PRESET_GOLD } from '../styles/theme';
-import { graphToSvg, svgToPngBlob, DIAGRAM_THEMES } from './exportDiagram';
+import {
+  CATEGORY_COLORS,
+  CATEGORY_COLORS_ON_LIGHT,
+  DATA_TYPE_COLORS_ON_LIGHT,
+} from '../styles/theme';
+import {
+  graphToSvg,
+  svgToPngBlob,
+  DIAGRAM_THEMES,
+  type DiagramThemeName,
+} from './exportDiagram';
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
@@ -173,8 +182,10 @@ describe('graphToSvg', () => {
     // One colored dot per port (2 inputs + 1 output).
     expect(count(svg, '<circle')).toBe(3);
     expect(svg).toContain('<circle cx="12"'); // input dot at left padding
-    expect(svg).toContain('fill="#4CAF50"'); // TENSOR
-    expect(svg).toContain('fill="#2196F3"'); // MODEL
+    // Port dots wear the exported theme's data-type hues, not the canvas ones
+    // (the canvas TENSOR green measured 2.78:1 on the white card).
+    expect(svg).toContain(`fill="${DATA_TYPE_COLORS_ON_LIGHT.TENSOR}"`);
+    expect(svg).toContain(`fill="${DATA_TYPE_COLORS_ON_LIGHT.MODEL}"`);
     // Inputs anchor start (left), outputs anchor end (right).
     expect(svg).toContain('text-anchor="start"');
     expect(svg).toContain('text-anchor="end"');
@@ -280,15 +291,27 @@ describe('graphToSvg', () => {
 
   // ── Start node ───────────────────────────────────────────────────────
 
-  it('renders a Start node (type "start") with a light-green fill and green accent', () => {
+  it('renders a Start node (type "start") with a green fill and green accent', () => {
     const svg = graphToSvg([makeNode('s', { definition: mkDef({ category: 'Control' }) }, { type: 'start' })], []);
-    expect(svg).toContain('fill="#dcfce7"'); // light-green background
-    expect(svg).toContain('stroke="#16a34a"'); // green accent border
+    expect(svg).toContain(`fill="${DIAGRAM_THEMES.light.startFill}"`);
+    expect(svg).toContain(`stroke="${DIAGRAM_THEMES.light.startColor}"`);
+  });
+
+  it('gives the dark theme a dark Start fill rather than the light-green one', () => {
+    // The pale #dcfce7 used to be painted in both themes, so a dark diagram
+    // got one glaring white-green box with its title at 3.00:1 on it.
+    const svg = graphToSvg(
+      [makeNode('s', { definition: mkDef({ category: 'Control' }) }, { type: 'start' })],
+      [],
+      { theme: 'dark' },
+    );
+    expect(svg).toContain(`fill="${DIAGRAM_THEMES.dark.startFill}"`);
+    expect(svg).not.toContain('#dcfce7');
   });
 
   it('treats a node whose data.type is "Start" as a Start node', () => {
     const svg = graphToSvg([makeNode('s', { type: 'Start', definition: mkDef() })], []);
-    expect(svg).toContain('fill="#dcfce7"');
+    expect(svg).toContain(`fill="${DIAGRAM_THEMES.light.startFill}"`);
   });
 
   it('does not render the Start trigger port — just the green box and title', () => {
@@ -297,7 +320,7 @@ describe('graphToSvg', () => {
     expect(svg).toContain('>Start<');
     expect(count(svg, '<circle')).toBe(0); // no port dots
     expect(svg).not.toContain('trigger'); // trigger port not shown
-    expect(svg).toContain('fill="#dcfce7"'); // still a green box
+    expect(svg).toContain(`fill="${DIAGRAM_THEMES.light.startFill}"`); // still a green box
   });
 
   it('vertically centers the title of a port-less node (Start)', () => {
@@ -332,7 +355,7 @@ describe('graphToSvg', () => {
     const [d] = edgePaths(svg);
     // Ends at the target's top-left corner (x, y) — not at the input port row.
     expect(d.endsWith(`${t.x},${t.y}`)).toBe(true);
-    expect(svg).toContain('stroke="#16a34a"'); // trigger edges are green
+    expect(svg).toContain(`stroke="${DIAGRAM_THEMES.light.startColor}"`); // trigger edges are green
   });
 
   it('treats an edge with sourceHandle "trigger" as a trigger even without __trigger', () => {
@@ -425,12 +448,46 @@ describe('graphToSvg', () => {
     expect(count(svg, 'marker-end=')).toBe(0);
   });
 
-  it('colors edges by their data-type stroke by default', () => {
+  it('recolors a data-type edge into the exported theme', () => {
+    // The stroke arrives as the canvas painted it (TENSOR green). The exporter
+    // recovers what that colour *meant* and re-says it in the theme's palette,
+    // because the canvas value measures 2.78:1 on a white page.
     const nodes = [makeNode('a'), makeNode('b', {}, { position: { x: 300, y: 0 } })];
     const svg = graphToSvg(nodes, [makeEdge('e1', 'a', 'b', { stroke: '#4CAF50' })]);
-    expect(svg).toContain('stroke="#4CAF50"');
-    expect(svg).toContain('id="arrow-4CAF50"');
-    expect(svg).toContain('marker-end="url(#arrow-4CAF50)"');
+    const tensor = DATA_TYPE_COLORS_ON_LIGHT.TENSOR;
+    expect(svg).toContain(`stroke="${tensor}"`);
+    expect(svg).not.toContain('stroke="#4CAF50"');
+    expect(svg).toContain(`id="arrow-${tensor.replace('#', '')}"`);
+    expect(svg).toContain(`marker-end="url(#arrow-${tensor.replace('#', '')})"`);
+  });
+
+  it('keeps the canvas hue when the exported theme is the dark one', () => {
+    const nodes = [makeNode('a'), makeNode('b', {}, { position: { x: 300, y: 0 } })];
+    const svg = graphToSvg(nodes, [makeEdge('e1', 'a', 'b', { stroke: '#4CAF50' })], {
+      theme: 'dark',
+    });
+    expect(svg).toContain('stroke="#4CAF50"'); // already tuned for a dark page
+  });
+
+  it('reads the data type from the source port rather than the stroke', () => {
+    // A serialized graph whose edges lost their inline style still exports in
+    // colour: the source port names the type outright.
+    const srcDef = mkDef({ outputs: [port('m', 'MODEL')] });
+    const nodes = [
+      makeNode('a', { definition: srcDef }),
+      makeNode('b', {}, { position: { x: 300, y: 0 } }),
+    ];
+    const svg = graphToSvg(nodes, [makeEdge('e1', 'a', 'b', { sourceHandle: 'm' })]);
+    expect(svg).toContain(`stroke="${DATA_TYPE_COLORS_ON_LIGHT.MODEL}"`);
+  });
+
+  it('falls back to the neutral wire for a stroke of no known data type', () => {
+    // An unrecognised colour is one whose contrast on this page nothing has
+    // verified, and an invisible edge conveys nothing at all.
+    const nodes = [makeNode('a'), makeNode('b', {}, { position: { x: 300, y: 0 } })];
+    const svg = graphToSvg(nodes, [makeEdge('e1', 'a', 'b', { stroke: '#f0f0f0' })]);
+    expect(svg).not.toContain('stroke="#f0f0f0"');
+    expect(svg).toContain(`stroke="${DIAGRAM_THEMES.light.edgeStroke}"`);
   });
 
   it('uses the theme edge color when preserveEdgeColors is false', () => {
@@ -479,29 +536,49 @@ describe('graphToSvg', () => {
   // ── Node accent color ────────────────────────────────────────────────
 
   it('colors a preset node with the preset gold accent', () => {
-    const svg = graphToSvg([makeNode('p', { isPreset: true })], []);
     // Sourced from the shared palette rather than restated, so a future tune of
     // the gold does not need this literal edited in two places.
-    expect(svg).toContain(`stroke="${PRESET_GOLD}"`);
+    expect(graphToSvg([makeNode('p', { isPreset: true })], [])).toContain(
+      `stroke="${DIAGRAM_THEMES.light.presetColor}"`,
+    );
+    expect(graphToSvg([makeNode('p', { isPreset: true })], [], { theme: 'dark' })).toContain(
+      `stroke="${DIAGRAM_THEMES.dark.presetColor}"`,
+    );
   });
 
-  it('colors a node by its category', () => {
-    const svg = graphToSvg([makeNode('c', { definition: mkDef({ category: 'CNN' }) })], []);
-    // Was a hardcoded '#4CAF50' (uppercase); exportDiagram.ts's nodeColor()
-    // reads straight from CATEGORY_COLORS, which theme.test.ts pins against
-    // tokens.css (now lowercase) -- assert against the constant so this
-    // can't silently drift the next time a hue is tuned.
-    expect(svg).toContain(`stroke="${CATEGORY_COLORS.CNN}"`); // CNN
+  it('colors a node by its category, in the exported theme', () => {
+    // exportDiagram.ts's nodeColor() reads straight from the theme's palette,
+    // which theme.test.ts pins against tokens.css -- assert against the
+    // constants so this can't silently drift the next time a hue is tuned.
+    const light = graphToSvg([makeNode('c', { definition: mkDef({ category: 'CNN' }) })], []);
+    expect(light).toContain(`stroke="${CATEGORY_COLORS_ON_LIGHT.CNN}"`);
+    const dark = graphToSvg([makeNode('c', { definition: mkDef({ category: 'CNN' }) })], [], {
+      theme: 'dark',
+    });
+    expect(dark).toContain(`stroke="${CATEGORY_COLORS.CNN}"`);
+    // The two themes must not be the same palette wearing two names — that is
+    // the bug this replaced (core#227).
+    expect(CATEGORY_COLORS_ON_LIGHT.CNN).not.toBe(CATEGORY_COLORS.CNN);
   });
 
-  it('falls back to the neutral color for an unknown category', () => {
+  it('falls back to the theme Utility hue for an unknown category', () => {
+    // Was a bare '#607D8B' literal in both themes at once -- the pre-token
+    // Utility value, left behind when the in-app fallbacks moved to the
+    // palette.
     const svg = graphToSvg([makeNode('u', { definition: mkDef({ category: 'Nonexistent' }) })], []);
-    expect(svg).toContain('stroke="#607D8B"');
+    expect(svg).toContain(`stroke="${CATEGORY_COLORS_ON_LIGHT.Utility}"`);
+    expect(svg).not.toContain('#607D8B');
+    const dark = graphToSvg(
+      [makeNode('u', { definition: mkDef({ category: 'Nonexistent' }) })],
+      [],
+      { theme: 'dark' },
+    );
+    expect(dark).toContain(`stroke="${CATEGORY_COLORS.Utility}"`);
   });
 
-  it('falls back to the neutral color when a node has no definition', () => {
+  it('falls back to the theme Utility hue when a node has no definition', () => {
     const svg = graphToSvg([makeNode('n', { definition: undefined })], []);
-    expect(svg).toContain('stroke="#607D8B"');
+    expect(svg).toContain(`stroke="${CATEGORY_COLORS_ON_LIGHT.Utility}"`);
   });
 
   // ── Labels ───────────────────────────────────────────────────────────
@@ -538,6 +615,150 @@ describe('graphToSvg', () => {
 
   it('exposes both light and dark theme presets', () => {
     expect(Object.keys(DIAGRAM_THEMES).sort()).toEqual(['dark', 'light']);
+  });
+});
+
+// ── Contrast of the exported diagram (core#227) ───────────────────────
+//
+// The exporter's light theme is the default, so it is the version that ends
+// up in a report or a slide deck, and it used to draw node cards with the
+// app's category hues on white: seven of the fourteen were under 3:1 as a
+// border and all fourteen under 4.5:1 as the card's title, which is painted
+// in the same colour.
+//
+// These measure what the renderer actually emits, not what a constant claims,
+// so a palette that is correct but wired up wrong still fails. The other two
+// halves of the guarantee live elsewhere: `styles/theme.test.ts` holds the
+// palettes to `tokens.css`, and `scripts/check-contrast.mjs` (which `pnpm
+// build` runs first) re-derives every measurement from the CSS, including the
+// CIEDE2000 separation that keeps the fourteen telling apart from each other.
+
+/** WCAG 2.1 relative luminance, straight from the definition. */
+function luminance(hex: string): number {
+  const h = hex.replace('#', '');
+  const [r, g, b] = [0, 2, 4]
+    .map((i) => parseInt(h.slice(i, i + 2), 16) / 255)
+    .map((c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG 2.1 contrast ratio between two opaque colours. */
+function contrastRatio(a: string, b: string): number {
+  const [la, lb] = [luminance(a), luminance(b)];
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/** The border colour the exporter actually paints on a node card. */
+function renderedCardStroke(svg: string): string {
+  const m = svg.match(/<rect [^>]*\brx="8"[^>]*\bstroke="(#[0-9a-fA-F]{3,6})"/);
+  if (!m) throw new Error('no node card found in the exported SVG');
+  return m[1];
+}
+
+/** The colour of an edge line the exporter actually paints. */
+function renderedEdgeStroke(svg: string): string {
+  const m = svg.match(/<path d="M[^"]*" fill="none" stroke="(#[0-9a-fA-F]{3,6})"/);
+  if (!m) throw new Error('no edge found in the exported SVG');
+  return m[1];
+}
+
+const THEMES: DiagramThemeName[] = ['light', 'dark'];
+const CATEGORIES = Object.keys(CATEGORY_COLORS);
+const everyCategoryInEveryTheme = THEMES.flatMap((theme) =>
+  CATEGORIES.map((category) => [theme, category] as const),
+);
+
+describe('exported diagram contrast', () => {
+  it('checks all fourteen categories, so a new one cannot slip in unmeasured', () => {
+    expect(CATEGORIES).toHaveLength(14);
+    expect(everyCategoryInEveryTheme).toHaveLength(28);
+  });
+
+  it.each(everyCategoryInEveryTheme)(
+    '%s theme: the %s card border clears 3:1 on the card it outlines',
+    (theme, category) => {
+      const svg = graphToSvg([makeNode('n', { definition: mkDef({ category }) })], [], { theme });
+      const stroke = renderedCardStroke(svg);
+      // WCAG 1.4.11: a border is what identifies the card as an object.
+      expect(contrastRatio(stroke, DIAGRAM_THEMES[theme].nodeFill)).toBeGreaterThanOrEqual(3);
+    },
+  );
+
+  it.each(everyCategoryInEveryTheme)(
+    '%s theme: the %s card title clears 4.5:1 on the card it sits on',
+    (theme, category) => {
+      const svg = graphToSvg([makeNode('n', { definition: mkDef({ category }) })], [], { theme });
+      // The title is painted in the same hue as the border, so the hue is also
+      // text and WCAG 1.4.3 applies. This is the stricter of the two bars and
+      // the one every category failed in the light theme before core#227.
+      const title = svg.match(/font-weight="700" fill="(#[0-9a-fA-F]{3,6})"/);
+      expect(title).not.toBeNull();
+      expect(title![1]).toBe(renderedCardStroke(svg));
+      expect(contrastRatio(title![1], DIAGRAM_THEMES[theme].nodeFill)).toBeGreaterThanOrEqual(4.5);
+    },
+  );
+
+  it.each(THEMES)('%s theme: the brand and fallback accents clear 4.5:1 too', (theme) => {
+    const fill = DIAGRAM_THEMES[theme].nodeFill;
+    const preset = graphToSvg([makeNode('p', { isPreset: true })], [], { theme });
+    expect(contrastRatio(renderedCardStroke(preset), fill)).toBeGreaterThanOrEqual(4.5);
+
+    const unknown = graphToSvg(
+      [makeNode('u', { definition: mkDef({ category: 'Nonexistent' }) })],
+      [],
+      { theme },
+    );
+    expect(contrastRatio(renderedCardStroke(unknown), fill)).toBeGreaterThanOrEqual(4.5);
+
+    // A Start card carries its own fill, so it is measured against that.
+    const start = graphToSvg([makeNode('s', {}, { type: 'start' })], [], { theme });
+    expect(contrastRatio(renderedCardStroke(start), DIAGRAM_THEMES[theme].startFill))
+      .toBeGreaterThanOrEqual(4.5);
+  });
+
+  it.each(THEMES)('%s theme: port label ink clears 4.5:1 on the card', (theme) => {
+    const svg = graphToSvg([makeNode('n', { definition: mkDef({ inputs: [port('x')] }) })], [], {
+      theme,
+    });
+    const ink = svg.match(/font-size="11.5" fill="(#[0-9a-fA-F]{3,6})"/);
+    expect(ink).not.toBeNull();
+    expect(contrastRatio(ink![1], DIAGRAM_THEMES[theme].nodeFill)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  const DATA_TYPES = Object.keys(DATA_TYPE_COLORS_ON_LIGHT);
+  const everyTypeInEveryTheme = THEMES.flatMap((theme) =>
+    DATA_TYPES.map((dataType) => [theme, dataType] as const),
+  );
+
+  it.each(everyTypeInEveryTheme)(
+    '%s theme: a %s edge clears 3:1 against the page it is drawn on',
+    (theme, dataType) => {
+      const srcDef = mkDef({ outputs: [port('o', dataType)] });
+      const nodes = [
+        makeNode('a', { definition: srcDef }),
+        makeNode('b', {}, { position: { x: 300, y: 0 } }),
+      ];
+      const svg = graphToSvg(nodes, [makeEdge('e', 'a', 'b', { sourceHandle: 'o' })], { theme });
+      // An edge says two nodes are connected. Before it can mean anything by
+      // its hue it has to be visible as a line: LIST measured 1.51:1 on white.
+      expect(contrastRatio(renderedEdgeStroke(svg), DIAGRAM_THEMES[theme].background))
+        .toBeGreaterThanOrEqual(3);
+    },
+  );
+
+  it.each(THEMES)('%s theme: the neutral wire and trigger edge clear 3:1', (theme) => {
+    const page = DIAGRAM_THEMES[theme].background;
+    const nodes = [makeNode('a'), makeNode('b', {}, { position: { x: 300, y: 0 } })];
+    const plain = graphToSvg(nodes, [makeEdge('e', 'a', 'b')], { theme });
+    expect(contrastRatio(renderedEdgeStroke(plain), page)).toBeGreaterThanOrEqual(3);
+
+    const startDef = mkDef({ category: 'Control', outputs: [port('trigger', 'TRIGGER')] });
+    const trigger = graphToSvg(
+      [makeNode('s', { definition: startDef }, { type: 'start' }), makeNode('t')],
+      [makeEdge('e', 's', 't', { sourceHandle: 'trigger', targetHandle: '__trigger' })],
+      { theme },
+    );
+    expect(contrastRatio(renderedEdgeStroke(trigger), page)).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/frontend/src/utils/exportDiagram.ts
+++ b/frontend/src/utils/exportDiagram.ts
@@ -1,8 +1,13 @@
 import dagre from '@dagrejs/dagre';
 import type { Edge, Node } from '@xyflow/react';
 import type { NodeData, PortDefinition } from '../types';
-import { CATEGORY_COLORS, FLOW_COLORS, PRESET_GOLD } from '../styles/theme';
-import { getPortColor, resolveDynamicInputs, resolveDynamicOutputs } from './index';
+import {
+  CATEGORY_COLORS,
+  CATEGORY_COLORS_ON_LIGHT,
+  DATA_TYPE_COLORS_ON_LIGHT,
+  DIAGRAM_CHROME,
+} from '../styles/theme';
+import { DATA_TYPE_COLORS, resolveDynamicInputs, resolveDynamicOutputs } from './index';
 
 /**
  * Render the active tab's graph as a standalone, self-contained SVG showing
@@ -38,27 +43,83 @@ const FONT_FAMILY =
 // Labels longer than these are truncated with an ellipsis so cards stay tidy.
 const MAX_LABEL_CHARS = 28;
 const MAX_PORT_CHARS = 24;
-const PRESET_COLOR = PRESET_GOLD; // reusable-subgraph accent
-const FALLBACK_NODE_COLOR = '#607D8B';
-// Start/entry node accent (border, title, trigger edges). Sourced from the
-// shared palette rather than restated, since an exported SVG is standalone
-// and cannot resolve `var(--flow-trigger-deep)`.
-const START_COLOR = FLOW_COLORS.triggerDeep;
-const START_FILL = '#dcfce7'; // Start node light-green background
 
 export type DiagramThemeName = 'light' | 'dark';
 
+/**
+ * Everything the renderer needs to paint one theme. A theme owns its own
+ * category and data-type palettes rather than sharing the app's, because the
+ * app's are tuned for a near-black canvas: on the white card the light theme
+ * draws by default, the fourteen category hues measured 2.15:1 to 3.09:1 as a
+ * border and all fourteen were under the 4.5:1 they need as the card's title
+ * text, which is painted in the same colour (core#227).
+ *
+ * Every value comes from `styles/theme.ts`, which mirrors `styles/tokens.css`.
+ * Nothing here is a literal: an exported SVG is standalone and cannot resolve
+ * `var()`, but that is a reason to mirror the token layer, not to fork it.
+ */
 interface DiagramTheme {
+  /** Page behind the whole diagram. */
   background: string;
+  /** Fill of an ordinary node card. */
   nodeFill: string;
+  /** Port-label ink on the card. */
   nodeText: string;
+  /** Neutral wire, used when an edge's data type is unknown. */
   edgeStroke: string;
+  /** Card border and title, by node category. */
+  categoryColors: Record<string, string>;
+  /** Port dots and data-carrying wires, by data type (uppercase keys). */
+  typeColors: Record<string, string>;
+  /** A node whose category is unknown, or which has no definition at all. */
+  fallbackColor: string;
+  /** Reusable-subgraph (preset) accent. */
+  presetColor: string;
+  /** Start/entry node accent: border, title and trigger edges. */
+  startColor: string;
+  /** Start/entry node card fill. */
+  startFill: string;
 }
 
 export const DIAGRAM_THEMES: Record<DiagramThemeName, DiagramTheme> = {
-  light: { background: '#ffffff', nodeFill: '#ffffff', nodeText: '#0f172a', edgeStroke: '#94a3b8' },
-  dark: { background: '#0a0a0a', nodeFill: '#1e1e1e', nodeText: '#e5e7eb', edgeStroke: '#888888' },
+  light: {
+    background: DIAGRAM_CHROME.light.page,
+    nodeFill: DIAGRAM_CHROME.light.card,
+    nodeText: DIAGRAM_CHROME.light.ink,
+    edgeStroke: DIAGRAM_CHROME.light.wire,
+    categoryColors: CATEGORY_COLORS_ON_LIGHT,
+    typeColors: DATA_TYPE_COLORS_ON_LIGHT,
+    // An uncategorised node reads as plumbing, so it wears the Utility hue —
+    // the same substitution the in-app fallbacks make. This used to be a bare
+    // '#607D8B' literal, the pre-token Utility value, in both themes at once.
+    fallbackColor: CATEGORY_COLORS_ON_LIGHT.Utility,
+    presetColor: DIAGRAM_CHROME.light.preset,
+    startColor: DIAGRAM_CHROME.light.start,
+    startFill: DIAGRAM_CHROME.light.startFill,
+  },
+  dark: {
+    background: DIAGRAM_CHROME.dark.page,
+    nodeFill: DIAGRAM_CHROME.dark.card,
+    nodeText: DIAGRAM_CHROME.dark.ink,
+    edgeStroke: DIAGRAM_CHROME.dark.wire,
+    categoryColors: CATEGORY_COLORS,
+    typeColors: DATA_TYPE_COLORS,
+    fallbackColor: CATEGORY_COLORS.Utility,
+    presetColor: DIAGRAM_CHROME.dark.preset,
+    startColor: DIAGRAM_CHROME.dark.start,
+    startFill: DIAGRAM_CHROME.dark.startFill,
+  },
 };
+
+/**
+ * Canvas stroke hex -> the data type it stands for. Edges arrive carrying the
+ * colour the *canvas* painted them, which is a dark-theme value; the exporter
+ * has to recover what the colour meant before it can re-say it in the theme
+ * being exported. Built once, theme-independent.
+ */
+const TYPE_BY_CANVAS_STROKE = new Map<string, string>(
+  Object.entries(DATA_TYPE_COLORS).map(([type, hex]) => [hex.toLowerCase(), type]),
+);
 
 export interface GraphToSvgOptions {
   /** Visual theme of the exported diagram. Defaults to `light` (document-friendly). */
@@ -113,11 +174,16 @@ function isStartNode(node: Node<NodeData>): boolean {
 }
 
 /** Border/title color: Start green, else preset gold, else category color, else neutral. */
-function nodeColor(node: Node<NodeData>): string {
-  if (isStartNode(node)) return START_COLOR;
-  if (node.data.isPreset) return PRESET_COLOR;
+function nodeColor(node: Node<NodeData>, theme: DiagramTheme): string {
+  if (isStartNode(node)) return theme.startColor;
+  if (node.data.isPreset) return theme.presetColor;
   const category = node.data.definition?.category;
-  return (category && CATEGORY_COLORS[category]) || FALLBACK_NODE_COLOR;
+  return (category && theme.categoryColors[category]) || theme.fallbackColor;
+}
+
+/** Port-dot / wire color for a data type, in this theme's palette. */
+function portColor(dataType: string, theme: DiagramTheme): string {
+  return theme.typeColors[dataType.toUpperCase()] ?? theme.typeColors.ANY;
 }
 
 /** Display title for a node, truncated with an ellipsis when overly long. */
@@ -149,9 +215,30 @@ function portTspans(p: PortDefinition): string {
   return `<tspan>${esc(name)} : </tspan><tspan font-weight="700">${esc(type)}</tspan>`;
 }
 
-function edgeColor(edge: Edge, theme: DiagramTheme, preserve: boolean): string {
+/**
+ * Stroke for one edge, in the theme being exported.
+ *
+ * When colours are preserved the edge is painted in the theme's hue for the
+ * data type it carries — read from the source port when the handle resolves,
+ * otherwise recovered from the canvas stroke the edge arrived with. A stroke
+ * that maps to no known type falls back to the theme's neutral wire rather
+ * than being copied through: an unrecognised colour is by definition one whose
+ * contrast against this theme's page has not been verified, and an edge that
+ * cannot be seen conveys nothing at all (LIST measured 1.51:1 on white).
+ */
+function edgeColor(
+  edge: Edge,
+  theme: DiagramTheme,
+  preserve: boolean,
+  dataType?: string,
+): string {
+  if (!preserve) return theme.edgeStroke;
+  if (dataType) return portColor(dataType, theme);
   const stroke = edge.style?.stroke;
-  if (preserve && typeof stroke === 'string') return stroke;
+  if (typeof stroke === 'string') {
+    const recovered = TYPE_BY_CANVAS_STROKE.get(stroke.toLowerCase());
+    if (recovered) return portColor(recovered, theme);
+  }
   return theme.edgeStroke;
 }
 
@@ -161,7 +248,7 @@ function colorId(color: string): string {
 }
 
 /** Build a sized card descriptor for a node from its content. */
-function buildEntry(node: Node<NodeData>): Entry {
+function buildEntry(node: Node<NodeData>, theme: DiagramTheme): Entry {
   const def = node.data.definition;
   const isStart = isStartNode(node);
   // A Start node is a pure entry marker: just a green box with an outgoing
@@ -186,7 +273,7 @@ function buildEntry(node: Node<NodeData>): Entry {
     y: node.position.y,
     w,
     h,
-    color: nodeColor(node),
+    color: nodeColor(node, theme),
     label,
     isStart,
     inputs,
@@ -240,7 +327,7 @@ export function graphToSvg(
   const entries = new Map<string, Entry>();
   for (const n of nodes) {
     if (n.type === 'noteNode') continue;
-    entries.set(n.id, buildEntry(n));
+    entries.set(n.id, buildEntry(n, theme));
   }
 
   // Spread the cards out cleanly unless the caller wants the canvas positions.
@@ -281,11 +368,15 @@ export function graphToSvg(
     // at the target's top-left corner rather than an input port, and are drawn
     // in the Start green.
     const isTrigger = e.targetHandle === '__trigger' || e.sourceHandle === 'trigger';
-    const color = isTrigger ? START_COLOR : edgeColor(e, theme, preserveEdgeColors);
-    markerColors.set(colorId(color), color);
 
     // Outputs sit below the inputs, so an output's row is offset by the input count.
     const outIdx = e.sourceHandle ? s.outputs.findIndex((p) => p.name === e.sourceHandle) : -1;
+    const sourcePort = outIdx >= 0 ? s.outputs[outIdx] : undefined;
+    const color = isTrigger
+      ? theme.startColor
+      : edgeColor(e, theme, preserveEdgeColors, sourcePort?.data_type);
+    markerColors.set(colorId(color), color);
+
     const sx = s.x + s.w;
     const sy = outIdx >= 0 ? portRowY(s, s.inputs.length + outIdx) : s.y + s.h / 2;
 
@@ -356,7 +447,7 @@ function renderCard(e: Entry, theme: DiagramTheme): string {
   // Card surface (light green for Start) + accent-colored border.
   parts.push(
     `<rect x="${r2(e.x)}" y="${r2(e.y)}" width="${r2(e.w)}" height="${r2(e.h)}" ` +
-      `rx="8" ry="8" fill="${e.isStart ? START_FILL : theme.nodeFill}" ` +
+      `rx="8" ry="8" fill="${e.isStart ? theme.startFill : theme.nodeFill}" ` +
       `stroke="${esc(e.color)}" stroke-width="1.5" />`,
   );
 
@@ -378,7 +469,7 @@ function renderCard(e: Entry, theme: DiagramTheme): string {
     e.inputs.forEach((p, i) => {
       const cy = portRowY(e, i);
       parts.push(
-        `<circle cx="${r2(e.x + PAD_H)}" cy="${r2(cy)}" r="${DOT_R}" fill="${esc(getPortColor(p.data_type))}" />` +
+        `<circle cx="${r2(e.x + PAD_H)}" cy="${r2(cy)}" r="${DOT_R}" fill="${esc(portColor(p.data_type, theme))}" />` +
           `<text x="${r2(e.x + PAD_H + DOT_SPACE - 4)}" y="${r2(cy)}" text-anchor="start" ` +
           `dominant-baseline="central" font-family="${FONT_FAMILY}" font-size="${PORT_FS}" ` +
           `fill="${theme.nodeText}">${portTspans(p)}</text>`,
@@ -394,7 +485,7 @@ function renderCard(e: Entry, theme: DiagramTheme): string {
     e.outputs.forEach((p, j) => {
       const cy = portRowY(e, e.inputs.length + j);
       parts.push(
-        `<circle cx="${r2(e.x + e.w - PAD_H)}" cy="${r2(cy)}" r="${DOT_R}" fill="${esc(getPortColor(p.data_type))}" />` +
+        `<circle cx="${r2(e.x + e.w - PAD_H)}" cy="${r2(cy)}" r="${DOT_R}" fill="${esc(portColor(p.data_type, theme))}" />` +
           `<text x="${r2(e.x + e.w - PAD_H - DOT_SPACE + 4)}" y="${r2(cy)}" text-anchor="end" ` +
           `dominant-baseline="central" font-family="${FONT_FAMILY}" font-size="${PORT_FS}" ` +
           `fill="${theme.nodeText}">${portTspans(p)}</text>`,


### PR DESCRIPTION
> 中文摘要：匯出圖表的 SVG 預設用「淺色」主題，也就是學生報告和公司簡報裡真正會出現的那一版。它把節點卡片畫在白底上，卻沿用了為深色畫布調過的分類色：十四個分類裡有七個當邊框時低於 WCAG 要求的 3:1，而卡片標題本來就用同一個顏色畫，所以以文字 4.5:1 的標準來看，十四個全部不及格。重新量測還找出議題沒提到的四處：預設子圖的金色邊框 2.38:1、預設連線 2.56:1、十二種資料型別連線色有七種低於 3:1（LIST 只有 1.51:1，等於看不見的線），還有淺綠色的 Start 底色兩個主題共用，害深色圖裡出現一塊刺眼的白綠色方塊。現在淺色主題有自己的一套色盤，而且不是手挑的：每個顏色都是把深色版轉成 OKLCH、鎖住色相、彩度推到 sRGB 邊界，再降亮度直到通過標準，色相偏移最多 1.8 度，所以綠色的分類還是讀者在畫面上熟悉的那個綠。所有數值都放進 tokens.css，而 `pnpm build` 第一步跑的對比度檢查腳本現在也涵蓋匯出這條路徑：每個分類的兩道標準、品牌色與備援色、墨水色、每種連線色對背景，以及色盤內部的 CIEDE2000 感知差距——因為十四個都通過 3:1 但彼此看起來一樣，是另一種失敗。淺色色盤最接近的一對從深色色盤的 3.71 提升到 9.85。

`Closes #227`

## What was wrong

`utils/exportDiagram.ts` renders a graph as a standalone SVG in a `light` or `dark` theme. Light is the default — the document-friendly one, so it is the version that ends up in a student's report or a company slide deck. It drew node cards on a white card in the app's `CATEGORY_COLORS`, which are tuned for the near-black canvas.

I re-measured everything before touching anything. **The issue's numbers were accurate and are still current** — the combined mutation check below reproduces them digit for digit. But the issue undercounted the problem in two ways.

**First, the border bar is not the only bar.** The card title is painted in the same hue as the border (`exportDiagram.ts` `renderCard`), so the hue is also text. WCAG 1.4.11 asks 3:1 of the border; WCAG 1.4.3 asks 4.5:1 of the title. Seven of fourteen failed the border bar. **All fourteen failed the title bar**, best of them 3.09:1.

**Second, four more failures sit on the same path**, none of them in the issue:

| what | measured | needs |
|---|---|---|
| preset gold as a card border on white | 2.38:1 | 4.5 (it is also the title) |
| default wire `#94a3b8` on the white page | 2.56:1 | 3 |
| 7 of 12 data-type wire hues on the white page | 1.51:1 – 2.78:1 | 3 |
| Start green on the Start fill (**both** themes) | 3.00:1 | 4.5 |

`LIST` at 1.51:1 and `TRANSFORM` at 1.63:1 are edges you cannot see at all. And `#dcfce7` was hardcoded as the Start fill regardless of theme, so a dark diagram got one glaring pale-green box with its title at 3.00:1 on it.

## Before

Category hue as the node card's border and title. `#ffffff` is the light card, `#1e1e1e` the dark one.

| category | dark hex | on the dark card | on the white card | border 3:1 | title 4.5:1 |
|---|---|---|---|---|---|
| Classical | `#f59e0b` | 7.76 | **2.15** | FAIL | FAIL |
| RL | `#ff9800` | 7.73 | **2.16** | FAIL | FAIL |
| Data | `#00bcd4` | 7.26 | **2.30** | FAIL | FAIL |
| LLM | `#a78bfa` | 6.13 | **2.72** | FAIL | FAIL |
| CNN | `#4caf50` | 6.00 | **2.78** | FAIL | FAIL |
| Data Flow | `#ff6f00` | 5.97 | **2.79** | FAIL | FAIL |
| Normalization | `#26a69a` | 5.56 | **3.00** | FAIL | FAIL |
| IO | `#a78f86` | 5.49 | 3.04 | pass | FAIL |
| Transformer | `#c279ce` | 5.49 | 3.03 | pass | FAIL |
| Diffusion | `#ee60a6` | 5.45 | 3.06 | pass | FAIL |
| Utility | `#8097a2` | 5.45 | 3.06 | pass | FAIL |
| Training | `#f66358` | 5.43 | 3.07 | pass | FAIL |
| RNN | `#2397f3` | 5.39 | 3.09 | pass | FAIL |
| Tensor Operations | `#838fcf` | 5.39 | 3.09 | pass | FAIL |

Plus: preset gold `#d4a017` at **2.38** on white, Start green `#16a34a` at **3.00** on `#dcfce7`, wire `#94a3b8` at **2.56** on white, and the fallback `#607D8B` — a stale pre-token literal, shared by both themes — at 4.37 / 3.81.

Data-type wire hues on the page they are drawn on:

| data type | canvas hex | on `#0a0a0a` (dark page) | on `#ffffff` (light page) |
|---|---|---|---|
| LIST | `#cddc39` | 13.10 | **1.51** |
| TRANSFORM | `#ffc107` | 12.15 | **1.63** |
| STRING | `#8bc34a` | 9.43 | **2.10** |
| DATASET | `#ff9800` | 9.19 | **2.16** |
| SCALAR | `#00bcd4` | 8.62 | **2.30** |
| ANY | `#9e9e9e` | 7.39 | **2.68** |
| TENSOR | `#4caf50` | 7.12 | **2.78** |
| MODEL | `#2196f3` | 6.34 | 3.12 |
| IMAGE | `#ff5722` | 6.26 | 3.16 |
| OPTIMIZER | `#f44336` | 5.38 | 3.68 |
| LOSS_FN | `#e91e63` | 4.55 | 4.35 |
| DATALOADER | `#9c27b0` | 3.14 | 6.30 |

The dark theme was otherwise sound — every category clears 4.5:1 on the dark card, every wire clears 3:1 on the dark page.

## After

The light theme gets its own palette instead of borrowing the dark one. **None of it is hand-picked.** Each value is its dark counterpart converted to OKLCH, hue held fixed, chroma pushed to the sRGB gamut edge, and lightness lowered until it clears the bar on a white card. Hue drift is at most 1.8 degrees of CIE Lab hue angle, so a green category is still the same green a reader knows from the app.

| category | dark hex | on the dark card | light hex | on the white card | Lab hue drift |
|---|---|---|---|---|---|
| CNN | `#4caf50` | 6.00 | `#1a8626` | 4.69 | 1.09 deg |
| RNN | `#2397f3` | 5.39 | `#0077c8` | 4.70 | 1.61 deg |
| Transformer | `#c279ce` | 5.49 | `#9f58ab` | 4.71 | 0.15 deg |
| LLM | `#a78bfa` | 6.13 | `#7f61cc` | 4.68 | 1.58 deg |
| Diffusion | `#ee60a6` | 5.45 | `#c93d86` | 4.67 | 0.05 deg |
| Classical | `#f59e0b` | 7.76 | `#7e4e00` | 7.05 | 0.36 deg |
| RL | `#ff9800` | 7.73 | `#a96300` | 4.70 | 0.04 deg |
| Data | `#00bcd4` | 7.26 | `#018091` | 4.67 | 0.20 deg |
| Training | `#f66358` | 5.43 | `#d14039` | 4.66 | 0.81 deg |
| IO | `#a78f86` | 5.49 | `#866f66` | 4.69 | 0.81 deg |
| Data Flow | `#ff6f00` | 5.97 | `#ad4900` | 5.63 | 0.04 deg |
| Utility | `#8097a2` | 5.45 | `#617782` | 4.70 | 1.81 deg |
| Normalization | `#26a69a` | 5.56 | `#008278` | 4.70 | 0.09 deg |
| Tensor Operations | `#838fcf` | 5.39 | `#6570ad` | 4.69 | 1.12 deg |

Every one clears **both** bars in **both** themes. Chrome and brand:

| role | light | on its background | dark | on its background |
|---|---|---|---|---|
| preset gold | `#956e00` | 4.66 | `#d4a017` | 7.02 |
| Start accent | `#00712f` | 5.62 (on the Start fill) | `#22c55e` | 5.30 (on the Start fill) |
| Start fill | `#dcfce7` | 14.97 dE00 from a plain card | `#1f3c2a` | 17.64 dE00 from a plain card |
| default wire | `#64748b` | 4.76 | `#888888` | 5.58 |
| port-label ink | `#0f172a` | 17.85 | `#e5e7eb` | 13.47 |
| unknown category | theme Utility hue | 4.70 | theme Utility hue | 5.45 |

Data-type wire hues, held to 3:1 (they are never text, and the type is spelled out in bold beside both ports). Five of twelve already cleared it and keep their canvas value:

| data type | light hex | on the white page | dark hex | on the dark page |
|---|---|---|---|---|
| TENSOR | `#40a445` | 3.18 | `#4caf50` | 7.12 |
| MODEL | `#2095f2` | 3.16 | `#2196f3` | 6.34 |
| DATASET | `#d27c00` | 3.17 | `#ff9800` | 9.19 |
| DATALOADER | `#9c27b0` | 6.30 | `#9c27b0` | 3.14 |
| OPTIMIZER | `#f44336` | 3.68 | `#f44336` | 5.38 |
| LOSS_FN | `#e91e63` | 4.35 | `#e91e63` | 4.55 |
| SCALAR | `#029fb3` | 3.18 | `#00bcd4` | 8.62 |
| STRING | `#6aa01f` | 3.15 | `#8bc34a` | 9.43 |
| IMAGE | `#ff5722` | 3.16 | `#ff5722` | 6.26 |
| LIST | `#8d9800` | 3.17 | `#cddc39` | 13.10 |
| TRANSFORM | `#b78901` | 3.19 | `#ffc107` | 12.15 |
| ANY | `#919191` | 3.15 | `#9e9e9e` | 7.39 |

## Are the categories still distinguishable from each other?

Fourteen colours that all pass 3:1 on white but look alike is a different failure, so this is measured rather than eyeballed — with **CIEDE2000**, over all 91 pairs, and it is now part of the gate.

| palette | closest pair | dE00 |
|---|---|---|
| dark (ships today) | Classical / RL | 3.71 |
| light, derived naively at the bar | Classical / RL | 2.67 |
| **light, as shipped here** | **LLM / Tensor Operations** | **9.85** |

Classical and RL are two ambers 3.71 dE00 apart in the palette that ships today — its closest pair by a factor of 2.6, and a pre-existing weakness. Repainting the whole app to part them is a separate change, but a fresh light palette has no reason to inherit it, so Classical is darkened past its bar (to 7.05:1) and Data Flow likewise. That moves both out of the closest-five entirely. The light palette's floor is **2.6x better separated than the dark one's**.

Two more checks guard the shape of the answer, not just the numbers:

- **Hue fidelity.** A light hue must sit within 12 degrees of Lab hue angle from its dark counterpart. Without this, a future "fix" could clear a contrast failure by rotating a hue instead of darkening it, and the colour coding would quietly mean two different things in two places. Actual worst case is 1.81 degrees.
- **Start-card distinctness.** The Start fill must be at least 5 dE00 from a plain card, so the entry point keeps standing out.

I also rendered both themes as real SVGs — one card per category plus Start, a preset and an uncategorised plugin node — and looked at them. Attached as evidence to the extent a PR body can be; the numbers above are the reproducible part.

## Did you extend the existing gate, or add a new one?

**Extended the existing one.** `frontend/scripts/check-contrast.mjs` — the first step of `pnpm build` — grew a section 11 covering the export path, and the values it reads live in `tokens.css` like every other colour in the repo. A separate palette that the gate could not see would have been the same mistake one layer down, which is the whole point of the token layer.

The gate gained CIEDE2000 and CIE Lab. Both are **self-tested before any verdict is trusted**, in the style the script already used for the WCAG maths: three pairs from the Sharma/Wu/Dalal reference data set (including pair 1, which exercises the hue-rotation term everyone gets wrong), an identity case, and the two endpoints of the sRGB-to-Lab leg. A wrong implementation exits 2 rather than passing a palette.

Coverage is now 337 relationships across 175 tokens, up from 236 across 122.

## Single source of truth

`DATA_TYPE_COLORS` was the last semantic palette still living only as hex literals in TypeScript. It gets `--type-*` tokens (**values unchanged**, so the canvas is untouched and there is no visual change to the app) and `theme.test.ts` holds the mirror. Everything the exporter draws now traces back to `tokens.css`.

## Behaviour changes worth reviewing

- **Edges are recoloured into the theme being exported.** An edge arrives carrying the colour the *canvas* painted it, which is a dark-theme value; the exporter recovers what that colour meant (from the source port's data type where the handle resolves, else from the stroke) and re-says it in the theme's palette. A stroke matching no known data type falls back to the theme's neutral wire rather than being copied through — an unrecognised colour is by definition one whose contrast against this page nothing has verified. In practice the only producers are `DATA_TYPE_COLORS` and the `#555` canvas fallback, and `#555` measures 2.76:1 on the dark export page, so this fixes that too.
- **The dark theme's Start card changed.** It was `#dcfce7`, the light-green fill, in both themes. It is now the trigger green tinted into the dark card at `--node-header-tint` — the same construction as a node header.
- **The uncategorised-node fallback is per-theme.** It was the bare `#607D8B` literal (the pre-token Utility value) in both themes at once; it is now each theme's Utility hue, matching what the in-app fallbacks do. This is the open question the issue left.

## Tests

`frontend/src/utils/exportDiagram.test.ts` gained an `exported diagram contrast` block that **measures what the renderer actually emits**, not what a constant claims, so a correct palette wired up wrong still fails. It parses the border, title, ink and edge strokes back out of the generated SVG and applies the WCAG formula to them:

- every category x every theme, border >= 3:1 on the card it outlines (28 cases)
- every category x every theme, title >= 4.5:1 on the card it sits on, and the title must be the same colour as the border (28 cases)
- every data type x every theme, the edge >= 3:1 against the page (24 cases)
- brand, fallback and Start accents; port-label ink; the neutral wire and the trigger edge
- a guard asserting there are exactly 14 categories, so a fifteenth cannot slip in unmeasured

`frontend/src/styles/theme.test.ts` gained agreement tests for every new palette and a no-orphans check in both directions, so a token without a mirror (or a mirror without a token) fails.

The three layers do different jobs, deliberately: the gate proves the token *values* are legible, `theme.test.ts` proves the TypeScript copy has not drifted, and `exportDiagram.test.ts` proves the renderer actually uses them.

### Mutation check

Reverting the palette turns everything red, and reproduces the issue's table exactly.

**Mirror only** (`CATEGORY_COLORS_ON_LIGHT` reverted to the dark values, tokens left correct) — 37 failures: 14 drift assertions in `theme.test.ts`, 7 border and 14 title failures in `exportDiagram.test.ts`. The gate still passed, correctly: it reads `tokens.css`, which was untouched. That is the layer `theme.test.ts` exists to cover.

**Tokens and mirror together** — the gate reported 22 problems and named exactly the issue's seven borders at exactly the issue's ratios:

```
- diagram/light: classical as a card border: 2.15 (needs 3)
- diagram/light: rl as a card border: 2.16 (needs 3)
- diagram/light: data as a card border: 2.30 (needs 3)
- diagram/light: llm as a card border: 2.72 (needs 3)
- diagram/light: cnn as a card border: 2.78 (needs 3)
- diagram/light: dataflow as a card border: 2.79 (needs 3)
- diagram/light: normalization as a card border: 3.00 (needs 3)
```

plus all fourteen title failures and `categories classical and rl are only 3.71 dE00 apart (needs 8)`. 23 vitest tests failed alongside.

Four further mutations, each restored afterwards:

| mutation | caught by |
|---|---|
| `--diagram-light-cnn` set to the dark green | `cnn as a card border: 2.78` + `as the card title: 2.78` |
| `--diagram-light-cnn` rotated to a blue of the right contrast | `sits 140.1 degrees of hue from --cat-cnn (needs <= 12)` |
| `--diagram-light-normalization` set equal to `--diagram-light-data` | `categories data and normalization are only 0.00 dE00 apart` |
| `--diagram-light-type-list` reverted; dark Start fill flattened to the card | `list wire on the page: 1.51 (needs 3)` + `the Start card fill is only 0.0 dE00 from an ordinary card` |

## Verification

```
node scripts/check-contrast.mjs   Contrast gate passed - 337 colour relationships across 175 tokens
npx tsc -b --force                clean
npx vitest run                    138 files, 3114 tests, all passing
npx vite build                    built in 4.79s
```

`git status --porcelain` is empty.

## Left open (not in this PR)

- **`--cat-classical` / `--cat-rl` are 3.71 dE00 apart in the app itself.** Parting them means repainting node headers, palette rows and badges across the canvas, and wants its own before/after. The gate records the current state as a floor of 3.5 for the dark palette so it cannot get worse, with a comment saying plainly that it is a known-weak pre-existing pair and not a licence to relax the light floor of 8.
- **`--type-dataloader` measures 3.14:1 on the dark export page and would be tighter still on `--surface-canvas`.** The `--type-*` tokens are gated here only in their diagram roles; extending the gate to their canvas roles is a canvas change with a real blast radius, so it is a follow-up rather than something smuggled in behind a contrast fix.
- **The exporter never offers the dark theme.** `Toolbar.tsx` calls `graphToSvg` with no options, so `DIAGRAM_THEMES.dark` is reachable only through the API. Exposing it is a UI change, out of scope here — but it is now correct for when someone does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
