### PR TITLE
chore(ci): cdui test runs both halves, a Windows job, and ruff landing green

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -21,6 +21,7 @@ on:
       - 'plugins/**'
       - 'scripts/**'
       - 'frontend/src/plugins/contract.ts'
+      - 'ruff.toml'
       - '.github/workflows/backend-test.yml'
   push:
     branches:
@@ -31,6 +32,7 @@ on:
       - 'plugins/**'
       - 'scripts/**'
       - 'frontend/src/plugins/contract.ts'
+      - 'ruff.toml'
       - '.github/workflows/backend-test.yml'
   workflow_dispatch:
 
@@ -83,3 +85,102 @@ jobs:
         working-directory: backend
         run: |
           .venv/bin/python -c "from app.main import app; print('FastAPI app:', app.title)"
+
+  # ── Windows (core#245 item 4, core#258) ──────────────────────────────────
+  #
+  # The matrix above covers VERSIONS, not PLATFORMS, and some of what this
+  # repository has been bitten by is only reachable on Windows: `os.execv`
+  # orphaning a child (see `_reexec()` in dev.py), file locking, path
+  # separators -- and the standard library's own `nt` / `posix` split, which
+  # the plugin security gate reasons about directly.
+  #
+  # core#258 is the concrete case, and it is why this job exists at all.
+  # `Lib/ntpath.py` does `try: from nt import _path_exists as exists /
+  # except ImportError:`. `nt` is Windows-only, so on ubuntu that import
+  # ALWAYS fails and the Python fallback is ALWAYS used. No Python version
+  # added to an ubuntu-only matrix can ever surface the difference -- only a
+  # different runner can.
+  #
+  # 3.12 rather than 3.11, deliberately:
+  #   * 3.12 is where CPython moved exists/isdir/isfile/islink to `nt` C
+  #     fast paths, so it is the lowest version in the matrix on which
+  #     Windows and Linux stdlib behaviour actually diverge. A Windows 3.11
+  #     job would have been blind to core#258.
+  #   * Windows + 3.11 is not uncovered: `install.ps1` pins 3.11 and
+  #     `install-check.yml` already runs it on windows-latest.
+  #   * It is the newest version in the matrix, so it doubles as the
+  #     forward-compatibility signal on the platform most students use.
+  # One version on purpose: the full 3-version cross-product would triple CI
+  # time for signal that is about the platform, not the version.
+  test-windows:
+    name: pytest (Windows, Python 3.12)
+    runs-on: windows-latest
+    # Windows runners are slower than ubuntu and the torch wheel is large;
+    # the ubuntu job's 20 minutes is not enough headroom here.
+    timeout-minutes: 40
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v6
+
+      # Astral's own action rather than the ubuntu job's `curl | sh`. The
+      # PowerShell installer edits the *user* PATH in the registry, which an
+      # already-running runner process never sees, so the shell one-liner
+      # would need us to guess its install directory and echo that into
+      # $GITHUB_PATH. The action does that correctly and is maintained by the
+      # same people as the installer.
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Verify uv is on PATH
+        run: uv --version
+
+      - name: Provision Python 3.12
+        run: uv python install 3.12
+
+      - name: Verify uv.lock is in sync with pyproject.toml
+        working-directory: backend
+        run: uv lock --check
+
+      - name: Create venv and install backend (with [dev] extra)
+        working-directory: backend
+        run: |
+          uv venv --python 3.12
+          uv pip install -e ".[dev]"
+
+      - name: pytest
+        working-directory: backend
+        run: .venv\Scripts\python.exe -m pytest tests/ -q
+
+      - name: Smoke-import backend (catches syntax errors at import time)
+        working-directory: backend
+        run: .venv\Scripts\python.exe -c "from app.main import app; print('FastAPI app:', app.title)"
+
+  # ── ruff (core#245 item 2) ───────────────────────────────────────────────
+  #
+  # Its own job rather than a step in the matrix: lint is platform- and
+  # version-independent, so running it three times would only buy three
+  # copies of the same answer.
+  #
+  # Runs from the REPOSITORY ROOT, not from `backend/`. The config lives in
+  # `ruff.toml` at the root because the Python here is not only the backend
+  # package -- `scripts/` holds the CLI and `plugins/` and `examples/` hold
+  # node code that ships to users, and this workflow's own `paths:` filter
+  # already treats all four as one blast radius.
+  lint:
+    name: ruff check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # `uvx` pins the version so a new ruff release cannot turn main red
+      # overnight. Bump it deliberately, in a PR that also fixes whatever the
+      # new rules find.
+      - name: ruff check
+        run: uvx ruff@0.14.4 check --output-format=github .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ uv pip install -e ".[dev]"
 `uv venv --python 3.11` pins the version. **Bare `uv` commands in a fresh clone or worktree do not** — they resolve to whatever the newest CPython on your machine is, which today can be 3.14. CI never tests that:
 
 - `backend/pyproject.toml` declares `requires-python = ">=3.10"`.
-- `.github/workflows/backend-test.yml` runs a matrix of **3.10, 3.11, 3.12** only.
+- `.github/workflows/backend-test.yml` runs a matrix of **3.10, 3.11, 3.12** only (on ubuntu, plus one Windows job on 3.12).
 - `cdui install` and both launchers (`cdui`, `cdui.cmd`) hardcode **3.11**.
 
 So a test that passes locally on 3.14 tells you nothing about 3.10, and a syntax feature you reach for might be above the declared floor. Always create the venv with an explicit `--python 3.11` (or `3.10` if you want to develop against the floor), and let CI cover the rest.
@@ -169,19 +169,23 @@ More detail: [Dev Install](https://docs.codefyui.com/getting-started/dev-install
 
 ## Running the checks
 
-There is no lint step and no formatter in this repository — do not go looking for one. There is also no pre-commit hook, so **nothing runs automatically**. These are the real gates, and you run them yourself.
+There is a linter (`ruff`) and there is no formatter — do not go looking for one. There is also no pre-commit hook, so **nothing runs automatically**. These are the real gates, and you run them yourself.
 
-### `cdui test` only runs the backend
+### `cdui test` runs both halves
 
-This surprises people, so it is worth stating flatly. From `scripts/dev.py:2471`, the whole function is:
+It used to run only `pytest` in `backend/`, which meant a green `cdui test` said nothing about the 138 frontend test files. Since core#245 it runs both and prints a summary naming each half:
 
-```python
-def test() -> None:
-    pytest = _require_venv_tool("pytest")
-    run([pytest], cwd=BACKEND_DIR)
+```
+=== Test summary ===
+  backend   PASS
+  frontend  PASS
 ```
 
-That is `pytest` with no arguments, in `backend/`, discovering `backend/tests/` via `testpaths` in `pyproject.toml`. It never touches the frontend. **If you changed anything under `frontend/`, `cdui test` passing means nothing about your change.**
+Three things worth knowing:
+
+- **A missing `pnpm` is a skip, not a failure.** CodefyUI has a deliberate no-Node install path (the release ships a prebuilt `frontend-dist.tar.gz`), so a machine with no Node is a healthy machine. The frontend half is reported as `SKIPPED` — never as a pass — and CI's `frontend-build.yml` runs those tests regardless.
+- **Both halves always finish.** A red backend does not stop the frontend from running; you get both answers in one pass. The exit code is 1 if either failed.
+- **`--backend` / `--frontend`** narrow the run when you know what you touched. Anything else is rejected rather than ignored — `cdui test -k foo` used to run the whole suite while looking like it had filtered.
 
 ### The full local set
 
@@ -192,7 +196,10 @@ Run every line that applies to what you touched:
 # which no test, type check or grep catches (ripgrep silently skips them).
 python scripts/check_control_bytes.py
 
-# Backend -- if you touched backend/, examples/, plugins/ or scripts/
+# Repository root -- always. Same rule set CI runs (see ruff.toml).
+uvx ruff@0.14.4 check .
+
+# Backend + frontend. Add --backend if you only touched Python.
 ./cdui test
 
 # Backend -- if you edited backend/pyproject.toml. CI runs this BEFORE
@@ -201,10 +208,10 @@ python scripts/check_control_bytes.py
 # dependency change.
 cd backend && uv lock --check
 
-# Frontend -- if you touched frontend/
+# Frontend -- if you touched frontend/. `cdui test` covers `pnpm test`;
+# these are the type-check and build gates it does not run.
 cd frontend && pnpm install
 cd frontend && pnpm exec tsc -b
-cd frontend && pnpm test
 cd frontend && pnpm build
 ```
 
@@ -213,9 +220,17 @@ Two notes on the frontend commands:
 - **`tsc -b`, not `tsc --noEmit`.** `frontend/tsconfig.json` is a solution-style config with `"files": []` and project references, so `tsc --noEmit` against it checks **zero files** and passes no matter what is broken. Build mode follows the references and actually type-checks `src/`.
 - **`pnpm build` includes the contrast gate.** The build script is `node scripts/check-contrast.mjs && tsc -b && vite build` — the first step re-derives every WCAG contrast relationship claimed by `frontend/src/styles/tokens.css` and fails the build if a token pair drops below threshold. Run it alone with `pnpm contrast` when you are editing colours.
 
+### The linter
+
+`ruff.toml` at the repo root covers `backend/`, `scripts/`, `plugins/` and `examples/` — the same blast radius `backend-test.yml` uses. It runs the rule set ruff itself defaults to (`E4`, `E7`, `E9`, `F`): unused imports, undefined names, unused locals, `== None`, bare `except`, syntax errors.
+
+It is deliberately narrow. `E501` (line length), `I001` (import order) and the `B` / `SIM` / `UP` families are **not** enabled, and the file says why for each, with the finding count from the first run. If you want to turn one on, that is a welcome PR — one rule family at a time, with the fixes in the same diff.
+
+There is no frontend linter yet. That is a bigger argument because it drags a formatting decision along with it; see core#245.
+
 ### What CI runs that you cannot easily run locally
 
-- **`backend-test.yml`** runs the whole suite on Python 3.10, 3.11 and 3.12, plus `uv lock --check` and a smoke import (`from app.main import app`) that catches import-time syntax errors.
+- **`backend-test.yml`** runs the whole suite on Python 3.10, 3.11 and 3.12 on ubuntu, **plus one Windows job on 3.12**, plus `uv lock --check`, a smoke import (`from app.main import app`) that catches import-time syntax errors, and `ruff check`. The Windows job is not decoration: CPython 3.12 replaced `os.path.exists` / `isdir` / `isfile` / `islink` with `nt` C fast paths **on Windows only**, and `ntpath` guards that behind `try: from nt import ... except ImportError:` — so on ubuntu the fallback always wins and no Python version in an ubuntu-only matrix can ever see the difference (core#258). If you change anything that touches paths, processes or file locking, expect Windows to have an opinion.
 - **`byte-scan.yml`** runs `scripts/check_control_bytes.py` over every tracked file on every PR, with no path filter.
 - **`frontend-build.yml`** runs install, `tsc -b`, `pnpm build`, a `dist/` sanity check, then `pnpm test` — on `frontend/**` changes only.
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 	@echo "  make install   安裝所有依賴（backend + frontend）"
 	@echo "  make dev       啟動開發伺服器（backend :8000 + frontend :5173）"
 	@echo "  make stop      停止所有服務"
-	@echo "  make test      執行 backend 測試"
+	@echo "  make test      執行 backend + frontend 測試（無 pnpm 時略過前端）"
 	@echo "  make clean     移除虛擬環境與 node_modules"
 	@echo ""
 	@echo "或直接："

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Open [http://localhost:8000](http://localhost:8000). The single uvicorn process 
 | `cdui dev` | Developer mode — backend `:8000` + Vite HMR `:5173` (requires Node + pnpm) |
 | `cdui build` | Build the frontend bundle locally (requires Node + pnpm) |
 | `cdui stop` | Stop **this install's** services: the background server, plus leftovers started from this directory (foreground `cdui start`, `cdui dev`'s Vite). `--all` stops every CodefyUI and Vite process on the machine instead — including other people's, so avoid it on a shared host |
-| `cdui test` | Run backend tests |
+| `cdui test` | Run the backend (`pytest`) and frontend (`vitest`) tests; the frontend half is skipped, not failed, when pnpm is absent |
 | `cdui clean` | Remove virtualenv, `node_modules`, and `frontend/dist` |
 | `cdui uninstall` | Clean + remove the PATH launcher |
 | `cdui plugin install <name\|url>` | Install a plugin pack (catalog name like `C2`, `owner/repo[@ref]`, or full GitHub URL) |

--- a/backend/app/api/routes_custom_nodes.py
+++ b/backend/app/api/routes_custom_nodes.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, UploadFile
 
 from ..config import settings
-from ..core.node_base import BaseNode
 from ..core.node_registry import registry
 from ..core import plugin_loader
 from ..core.plugin_loader import rediscover_all

--- a/backend/app/api/routes_graph.py
+++ b/backend/app/api/routes_graph.py
@@ -6,7 +6,6 @@ from fastapi import APIRouter, HTTPException
 
 from ..config import settings
 from ..core.graph_engine import GraphValidationError, build_preset_fallback, validate_graph
-from ..core.node_registry import registry
 from ..core.project import (
     GraphAmbiguityError,
     collect_graph_files,

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -15,7 +15,6 @@ from ..config import settings
 from .backward_pass import (
     attach_retain_grad,
     capture_grads,
-    grad_health,
     run_backward,
     select_backward_target,
     zero_module_grads,

--- a/backend/app/core/node_state_store.py
+++ b/backend/app/core/node_state_store.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import logging
 import threading
 from collections import deque
-from typing import TYPE_CHECKING, Any, Callable, Iterator
+from typing import TYPE_CHECKING, Callable, Iterator
 
 from .memory_budget import format_bytes, value_bytes
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ mimetypes.add_type("font/woff", ".woff")
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from .api import (
@@ -74,7 +74,6 @@ from .core.port_stats import PortStatsCache
 from .core.version import get_version
 from .core import plugin_loader
 from .core.plugin_loader import (
-    MANIFEST_FILENAME,
     install_plugin_finder,
     iter_plugin_dirs,
     load_lockfile,

--- a/backend/app/nodes/classical/accuracy_node.py
+++ b/backend/app/nodes/classical/accuracy_node.py
@@ -20,7 +20,6 @@ from ...core.node_base import (
     BaseNode,
     DataType,
     ParamDefinition,
-    ParamType,
     PortDefinition,
 )
 
@@ -98,7 +97,7 @@ class AccuracyNode(BaseNode):
 
         # Normalize to strings so '0' vs 0 mismatches don't sink the comparison.
         preds_s = [str(p) for p in preds_list]
-        labels_s = [str(l) for l in labels_list]
+        labels_s = [str(label) for label in labels_list]
 
         correct = sum(1 for p, y in zip(preds_s, labels_s) if p == y)
         total = len(preds_s)

--- a/backend/app/nodes/classical/random_forest_classifier_node.py
+++ b/backend/app/nodes/classical/random_forest_classifier_node.py
@@ -97,7 +97,7 @@ class RandomForestClassifierNode(BaseNode):
         x_query_np = x_query.detach().cpu().float().numpy()
 
         labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
-        labels = [str(l) for l in labels]
+        labels = [str(label) for label in labels]
         if x_train_np.shape[0] != len(labels):
             raise ValueError(
                 f"RandomForestClassifier: features and labels length mismatch — "

--- a/backend/app/nodes/dataflow/switch_node.py
+++ b/backend/app/nodes/dataflow/switch_node.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+from ...core.node_base import BaseNode, DataType, PortDefinition
 
 
 class SwitchNode(BaseNode):

--- a/backend/app/nodes/io/file_reader_node.py
+++ b/backend/app/nodes/io/file_reader_node.py
@@ -1,7 +1,13 @@
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+if TYPE_CHECKING:
+    # `pathlib` is imported lazily inside the methods below (startup cost);
+    # this makes the "Path" annotations resolvable to a type checker without
+    # paying that cost at import time.
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/nodes/io/image_batch_reader_node.py
+++ b/backend/app/nodes/io/image_batch_reader_node.py
@@ -1,7 +1,13 @@
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+if TYPE_CHECKING:
+    # `pathlib` is imported lazily inside the methods below (startup cost);
+    # this makes the "Path" annotations resolvable to a type checker without
+    # paying that cost at import time.
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/nodes/io/image_reader_node.py
+++ b/backend/app/nodes/io/image_reader_node.py
@@ -1,6 +1,12 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+if TYPE_CHECKING:
+    # `pathlib` is imported lazily inside the methods below (startup cost);
+    # this makes the "Path" annotations resolvable to a type checker without
+    # paying that cost at import time.
+    from pathlib import Path
 
 
 class ImageReaderNode(BaseNode):

--- a/backend/app/nodes/io/model_loader_node.py
+++ b/backend/app/nodes/io/model_loader_node.py
@@ -1,7 +1,13 @@
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+if TYPE_CHECKING:
+    # `pathlib` is imported lazily inside the methods below (startup cost);
+    # this makes the "Path" annotations resolvable to a type checker without
+    # paying that cost at import time.
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/nodes/llm/word_vector_node.py
+++ b/backend/app/nodes/llm/word_vector_node.py
@@ -29,7 +29,7 @@ from ...core.node_base import (
     PortDefinition,
 )
 from ...core.step_trace import StepRecorder
-from ._demo_vectors import DEMO_VECTORS, DIM as DEMO_DIM
+from ._demo_vectors import DEMO_VECTORS
 
 
 # Future GloVe asset specs (not published yet — first attempt raises a friendly

--- a/backend/app/nodes/training/diffusion_training_loop_node.py
+++ b/backend/app/nodes/training/diffusion_training_loop_node.py
@@ -169,7 +169,8 @@ class DiffusionTrainingLoopNode(BaseNode):
                 context.log_metric("train_loss", avg, epoch + 1)
             if progress_callback:
                 progress_callback({"event": "epoch", "epoch": epoch + 1, "total_epochs": epochs,
-                                   "loss": round(avg, 6), "losses": [round(l, 6) for l in epoch_losses]})
+                                   "loss": round(avg, 6),
+                                   "losses": [round(loss, 6) for loss in epoch_losses]})
             if should_stop():
                 stopped_at = {"phase": "epoch", "batch": 0}
                 break

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -1512,12 +1512,14 @@ class TrainingLoopNode(BaseNode):
                     "epoch": epoch + 1,
                     "total_epochs": epochs,
                     "loss": round(avg_train_loss, 6),
-                    "losses": [round(l, 6) for l in epoch_losses],
+                    "losses": [round(loss, 6) for loss in epoch_losses],
                     "lr": current_lr,
                 }
                 if avg_val_loss is not None:
                     progress_data["val_loss"] = round(avg_val_loss, 6)
-                    progress_data["val_losses"] = [round(l, 6) for l in val_epoch_losses]
+                    progress_data["val_losses"] = [
+                        round(loss, 6) for loss in val_epoch_losses
+                    ]
                 if avg_val_accuracy is not None:
                     progress_data["val_accuracy"] = round(avg_val_accuracy, 6)
                 if patience > 0:

--- a/backend/app/nodes/utility/decision_boundary_node.py
+++ b/backend/app/nodes/utility/decision_boundary_node.py
@@ -108,7 +108,7 @@ class DecisionBoundaryNode(BaseNode):
                 f"DecisionBoundary only supports 2D features [N, 2]; got {tuple(x_np.shape)}."
             )
         labels = y.tolist() if hasattr(y, "tolist") else list(y)
-        labels = [str(l) for l in labels]
+        labels = [str(label) for label in labels]
 
         steps = max(20, min(500, int(params.get("grid_steps", 200))))
         title = str(params.get("title", ""))

--- a/backend/app/nodes/utility/python_script_node.py
+++ b/backend/app/nodes/utility/python_script_node.py
@@ -74,7 +74,6 @@ from ...core.node_base import (
 from ...core.script_policy import (
     ESCAPE_HATCH_HINT,
     SCRIPT_FILENAME,
-    TIER0_MODULE_PATHS,
     TIER0_MODULES,
     validate_script_source,
 )

--- a/backend/app/nodes/utility/scatter_plot_2d_node.py
+++ b/backend/app/nodes/utility/scatter_plot_2d_node.py
@@ -93,7 +93,7 @@ class ScatterPlot2DNode(BaseNode):
             ax.scatter(pts[:, 0], pts[:, 1], s=18, alpha=0.8)
         else:
             labels_list = labels.tolist() if hasattr(labels, "tolist") else list(labels)
-            labels_s = [str(l) for l in labels_list]
+            labels_s = [str(label) for label in labels_list]
             classes = sorted(set(labels_s))
             cmap = plt.get_cmap("tab10")
             arr = np.asarray(labels_s)

--- a/backend/app/nodes/utility/sequential_node.py
+++ b/backend/app/nodes/utility/sequential_node.py
@@ -20,10 +20,16 @@ model for this.
 """
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
 from ...core.stateful_module import StatefulModuleMixin
+
+if TYPE_CHECKING:
+    # `torch` is imported lazily inside the functions below (startup cost);
+    # this makes the "torch.nn.Module" annotations resolvable to a type
+    # checker without paying that cost at import time.
+    import torch
 
 logger = logging.getLogger(__name__)
 

--- a/backend/tests/test_add_node.py
+++ b/backend/tests/test_add_node.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 import torch
 
 from app.nodes.tensor_ops.add_node import AddNode

--- a/backend/tests/test_amp_precision.py
+++ b/backend/tests/test_amp_precision.py
@@ -9,7 +9,6 @@ it use less memory) are marked and skipped elsewhere.
 
 from __future__ import annotations
 
-import copy
 
 import pytest
 import torch

--- a/backend/tests/test_api_apps_manage.py
+++ b/backend/tests/test_api_apps_manage.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from typing import Any
 
 import pytest
 from httpx import ASGITransport, AsyncClient

--- a/backend/tests/test_api_images.py
+++ b/backend/tests/test_api_images.py
@@ -135,7 +135,6 @@ def test_image_reader_inference_pipeline_shape_compatible_with_mnist_cnn(images_
     Conv2d(1, 32, 3, padding=1). Catches the regression where the inference
     example failed because the image had the wrong number of channels.
     """
-    import torch
     import torch.nn as nn
 
     from app.nodes.io.image_reader_node import ImageReaderNode

--- a/backend/tests/test_config_project.py
+++ b/backend/tests/test_config_project.py
@@ -1,7 +1,6 @@
 """Project-mode Settings derivation (spec 7.1): PROJECT_DIR repoints the
 graph/asset roots, with an explicitly-provided root always winning."""
 
-from pathlib import Path
 
 import pytest
 

--- a/backend/tests/test_dev_test_command.py
+++ b/backend/tests/test_dev_test_command.py
@@ -1,0 +1,247 @@
+"""`cdui test` has to mean the whole project (core#245 item 3).
+
+It used to be three lines -- ``pytest`` in ``backend/``, nothing else -- while
+138 frontend test files went unrun. A contributor could see a green
+``cdui test``, push, and fail ``pnpm test`` in CI, and CONTRIBUTING.md points
+people at exactly this command.
+
+Two properties are load-bearing and both are pinned below:
+
+1. **Both halves run, and neither hides the other.** A red backend must not
+   stop the frontend from running, because the point of one command is
+   learning about both in one pass.
+2. **A missing pnpm is a skip, not a failure, and it SAYS so.** CodefyUI has a
+   deliberate no-Node install path (``frontend-dist.tar.gz`` from the release),
+   so "no pnpm on this machine" is a healthy install, not a broken one. What
+   would be dangerous is reporting that as a pass.
+
+Repo gotcha this file obeys: stubbing ``run`` alone is not enough when testing
+``dev.py`` -- ``ROOT``, ``VENV``, ``DIST_DIR`` and ``FRONTEND_DIR`` are read at
+call time and any ``shutil.rmtree`` in the command under test executes for
+real. Every test here redirects the directory constants at ``tmp_path`` and
+asserts at the end that the developer's real ``frontend/`` is untouched.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+import dev  # scripts/dev.py -- conftest puts scripts/ on sys.path
+
+
+REAL_FRONTEND = Path(dev.__file__).resolve().parent.parent / "frontend"
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    """Point every path constant `test()` can reach at a throwaway tree.
+
+    Returns a recorder: ``calls`` is the list of (cmd, cwd) pairs the command
+    would have run, and ``codes`` lets a test make a specific command fail.
+    """
+    frontend = tmp_path / "frontend"
+    (frontend / "node_modules").mkdir(parents=True)
+    (frontend / "package.json").write_text('{"name": "x"}', encoding="utf-8")
+    (frontend / "dist").mkdir()
+    backend = tmp_path / "backend"
+    backend.mkdir()
+
+    monkeypatch.setattr(dev, "ROOT", tmp_path)
+    monkeypatch.setattr(dev, "BACKEND_DIR", backend)
+    monkeypatch.setattr(dev, "FRONTEND_DIR", frontend)
+    monkeypatch.setattr(dev, "DIST_DIR", frontend / "dist")
+    monkeypatch.setattr(dev, "VENV", tmp_path / "venv")
+    monkeypatch.setattr(dev, "_require_venv_tool", lambda name: f"/fake/{name}")
+    monkeypatch.setattr(sys, "argv", ["cdui", "test"])
+    # `t()` reads this global at call time, and it is derived from the
+    # developer's locale. Pin it so the assertions below are about the
+    # command's behaviour rather than about which machine ran them.
+    monkeypatch.setattr(dev, "LANG", "en")
+
+    class Recorder:
+        def __init__(self):
+            self.calls: list[tuple[list[str], Path]] = []
+            self.codes: dict[str, int] = {}
+
+        def cmds(self) -> list[list[str]]:
+            return [c for c, _ in self.calls]
+
+        def __call__(self, cmd, cwd):
+            self.calls.append((list(cmd), cwd))
+            return self.codes.get(" ".join(str(p) for p in cmd), 0)
+
+    rec = Recorder()
+    monkeypatch.setattr(dev, "_run_status", rec)
+    rec.frontend = frontend
+    rec.backend = backend
+    return rec
+
+
+@pytest.fixture(autouse=True)
+def _pnpm_present(monkeypatch):
+    """Default to a machine WITH pnpm; the no-Node tests override this."""
+    monkeypatch.setattr(dev.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+
+@pytest.fixture(autouse=True)
+def _real_frontend_survives():
+    """The rmtree trap, as an assertion rather than a comment.
+
+    ``dev.py`` commands delete ``frontend/dist`` and ``frontend/node_modules``
+    for real. If a future edit to ``test()`` ever grows a cleanup step, this
+    notices before it eats the developer's build.
+    """
+    before = REAL_FRONTEND.exists() and sorted(p.name for p in REAL_FRONTEND.iterdir())
+    yield
+    after = REAL_FRONTEND.exists() and sorted(p.name for p in REAL_FRONTEND.iterdir())
+    assert before == after, "cdui test touched the real frontend/ tree"
+
+
+def _run(expect_exit: int | None = None):
+    """Call `dev.test()`, asserting on the SystemExit it did or did not raise."""
+    if expect_exit is None:
+        dev.test()          # a clean run returns rather than exiting
+        return
+    with pytest.raises(SystemExit) as exc:
+        dev.test()
+    assert exc.value.code == expect_exit
+
+
+# ── both halves run ────────────────────────────────────────────────────────
+
+
+def test_it_runs_the_backend_and_the_frontend(sandbox, capsys):
+    _run()
+    assert sandbox.cmds() == [["/fake/pytest"], ["pnpm", "test"]]
+    assert [cwd for _, cwd in sandbox.calls] == [sandbox.backend, sandbox.frontend]
+
+
+def test_the_summary_reports_both_halves_as_run(sandbox, capsys):
+    _run()
+    out = capsys.readouterr().out
+    assert "backend" in out and "frontend" in out
+    assert "SKIPPED" not in out
+
+
+def test_a_red_backend_does_not_stop_the_frontend(sandbox):
+    """The regression this command exists to prevent, in reverse: the whole
+    point of running both is finding out about both in ONE pass."""
+    sandbox.codes["/fake/pytest"] = 1
+    _run(expect_exit=1)
+    assert ["pnpm", "test"] in sandbox.cmds(), "frontend was skipped after a red backend"
+
+
+def test_a_red_frontend_fails_the_command(sandbox, capsys):
+    sandbox.codes["pnpm test"] = 1
+    _run(expect_exit=1)
+    assert "FAIL" in capsys.readouterr().out
+
+
+def test_node_modules_are_installed_on_first_run(sandbox):
+    shutil.rmtree(sandbox.frontend / "node_modules")
+    _run()
+    assert sandbox.cmds() == [["/fake/pytest"], ["pnpm", "install"], ["pnpm", "test"]]
+
+
+def test_a_failed_pnpm_install_does_not_pretend_the_tests_ran(sandbox, capsys):
+    """`run()` would have raised CalledProcessError here and killed the whole
+    command mid-way, with the backend result already printed and no summary."""
+    shutil.rmtree(sandbox.frontend / "node_modules")
+    sandbox.codes["pnpm install"] = 1
+    _run(expect_exit=1)
+    assert ["pnpm", "test"] not in sandbox.cmds()
+    assert "FAIL" in capsys.readouterr().out
+
+
+# ── the no-Node install path ───────────────────────────────────────────────
+
+
+def test_without_pnpm_the_backend_still_runs_and_the_command_succeeds(
+        sandbox, monkeypatch):
+    """A release install has no Node at all. That is a supported, healthy
+    machine -- `cdui test` must not fail on it."""
+    monkeypatch.setattr(dev.shutil, "which", lambda name: None)
+    _run()
+    assert sandbox.cmds() == [["/fake/pytest"]]
+
+
+def test_without_pnpm_the_summary_says_skipped_not_passed(sandbox, monkeypatch, capsys):
+    """The dangerous outcome is not "the frontend did not run" -- it is a
+    green summary that does not admit it."""
+    monkeypatch.setattr(dev.shutil, "which", lambda name: None)
+    _run()
+    out, errout = capsys.readouterr()
+    frontend_line = next(ln for ln in out.splitlines() if "frontend" in ln)
+    assert "SKIPPED" in frontend_line
+    assert "PASS" not in frontend_line
+    # ... and it says why, and how to fix it.
+    assert "pnpm" in errout and "frontend-build.yml" in errout
+
+
+def test_a_checkout_without_a_frontend_is_a_skip_not_a_crash(sandbox, capsys):
+    (sandbox.frontend / "package.json").unlink()
+    _run()
+    assert sandbox.cmds() == [["/fake/pytest"]]
+    assert "SKIPPED" in capsys.readouterr().out
+
+
+# ── selectors ──────────────────────────────────────────────────────────────
+
+
+def test_backend_flag_skips_the_frontend_even_when_pnpm_exists(sandbox, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["cdui", "test", "--backend"])
+    _run()
+    assert sandbox.cmds() == [["/fake/pytest"]]
+
+
+def test_frontend_flag_skips_the_backend(sandbox, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["cdui", "test", "--frontend"])
+    _run()
+    assert sandbox.cmds() == [["pnpm", "test"]]
+
+
+def test_both_selectors_together_mean_run_everything(sandbox, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["cdui", "test", "--backend", "--frontend"])
+    _run()
+    assert sandbox.cmds() == [["/fake/pytest"], ["pnpm", "test"]]
+
+
+def test_an_unknown_argument_is_refused_rather_than_ignored(sandbox, monkeypatch, capsys):
+    """`cdui test -k foo` used to run the entire suite and look like it had
+    filtered. Exiting 2 is the difference between a typo and a lie."""
+    monkeypatch.setattr(sys, "argv", ["cdui", "test", "-k", "foo"])
+    _run(expect_exit=2)
+    assert sandbox.cmds() == []
+    assert "-k" in capsys.readouterr().err
+
+
+# ── the summary formatter ──────────────────────────────────────────────────
+
+
+def test_the_three_states_are_distinguishable(monkeypatch):
+    """PASS / FAIL / SKIPPED must not collapse into each other: `_SKIPPED` is
+    ``None`` and ``0`` is a pass, and `0 == False` in Python."""
+    monkeypatch.setattr(dev, "LANG", "en")
+    passed = dev._test_summary_line("backend", 0)
+    failed = dev._test_summary_line("backend", 1)
+    skipped = dev._test_summary_line("backend", dev._SKIPPED)
+    assert "PASS" in passed and "FAIL" not in passed and "SKIPPED" not in passed
+    assert "FAIL" in failed and "exit 1" in failed
+    assert "SKIPPED" in skipped and "PASS" not in skipped
+
+
+def test_the_three_states_are_distinguishable_in_chinese_too(monkeypatch):
+    """The summary is the only place the command reports what it did, so it
+    has to be readable in both locales -- and the three states must stay
+    distinct in both."""
+    monkeypatch.setattr(dev, "LANG", "zh")
+    rendered = [dev._test_summary_line("backend", code)
+                for code in (0, 1, dev._SKIPPED)]
+    assert len({r for r in rendered}) == 3
+    assert "通過" in rendered[0]
+    assert "失敗" in rendered[1]
+    assert "略過" in rendered[2]

--- a/backend/tests/test_device_index.py
+++ b/backend/tests/test_device_index.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import pytest
 import torch
 
-from app.core import device_utils
 from app.core.device_utils import (
     cuda_device_count,
     describe_accelerator,

--- a/backend/tests/test_edu_policy_gradient_node.py
+++ b/backend/tests/test_edu_policy_gradient_node.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 
 import pytest
 import torch

--- a/backend/tests/test_edu_self_attention_node.py
+++ b/backend/tests/test_edu_self_attention_node.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import math
-
 import pytest
 import torch
 
@@ -97,7 +95,8 @@ def test_numerical_correctness_against_manual_sdpa():
 
     node = EduSelfAttentionNode()
     params = {"embed_dim": d, "causal": False, "temperature": 1.0, "seed": 42}
-    res = node.execute({"tensor": x}, params)
+    # First run primes the node's projections; the reference below reuses them.
+    node.execute({"tensor": x}, params)
 
     # Re-run and use the same node's projections to compute reference.
     # The node returns weights and output; verify output ≈ weights @ V where

--- a/backend/tests/test_embedding_node.py
+++ b/backend/tests/test_embedding_node.py
@@ -36,7 +36,6 @@ def test_lookup_returns_correct_shape():
 
 def test_padding_idx_zeroed_in_table():
     """When padding_idx is set, that row of the embedding table is zero."""
-    indices = torch.tensor([[0, 1, 2]], dtype=torch.long)
     node = EmbeddingNode()
     ctx = _ctx()
     mod = node.get_or_build_module(ctx, {"num_embeddings": 10, "embedding_dim": 4, "padding_idx": 0})

--- a/backend/tests/test_graph_engine.py
+++ b/backend/tests/test_graph_engine.py
@@ -7,6 +7,8 @@ import pytest
 from app.core.graph_engine import (
     GraphValidationError,
     execute_graph,
+    find_entry_points,
+    reachable_from_entry_points,
     topological_levels,
     topological_sort,
     validate_graph,
@@ -195,9 +197,6 @@ def test_validate_graph_required_input_satisfied_by_edge():
     assert node2_missing == [], f"Node 2's input should be satisfied: {node2_missing}"
 
 
-from app.core.graph_engine import find_entry_points, reachable_from_entry_points
-
-
 def test_execute_graph_untriggered_producer_is_rescued_and_runs():
     """core#201: every path must start from a Start node, but a pure
     producer (no inputs, no trigger) that feeds a data edge into a
@@ -352,7 +351,6 @@ def test_find_entry_points_none():
 
 
 def test_reachable_traverses_data_edges_only():
-    nodes = [{"id": n} for n in ["start", "ds", "dl", "model"]]
     edges = [
         {"id": "e1", "source": "start", "target": "ds", "type": "trigger"},
         {"id": "e2", "source": "ds", "target": "dl", "type": "data"},
@@ -363,7 +361,6 @@ def test_reachable_traverses_data_edges_only():
 
 
 def test_reachable_handles_disconnected_components():
-    nodes = [{"id": n} for n in ["a", "b", "x", "y"]]
     edges = [
         {"id": "e1", "source": "a", "target": "b", "type": "data"},
         {"id": "e2", "source": "x", "target": "y", "type": "data"},

--- a/backend/tests/test_graph_model.py
+++ b/backend/tests/test_graph_model.py
@@ -1,5 +1,4 @@
 # backend/tests/test_graph_model.py
-import json
 
 import pytest
 import torch

--- a/backend/tests/test_image_writer_node.py
+++ b/backend/tests/test_image_writer_node.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import pytest
 import torch
-from PIL import Image
 
-from app.config import settings
 from app.nodes.io.image_writer_node import ImageWriterNode
 
 

--- a/backend/tests/test_node_namespacing.py
+++ b/backend/tests/test_node_namespacing.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import logging
 
-import pytest
 
 from app.core.node_base import BaseNode, DataType, PortDefinition
 from app.core.node_registry import NodeRegistry, _plugin_id_from_package, qualify

--- a/backend/tests/test_node_state_store.py
+++ b/backend/tests/test_node_state_store.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import torch
 import torch.nn as nn
 
 from app.core.node_state_store import NodeStateStore

--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
 from textwrap import dedent
 

--- a/backend/tests/test_plugin_dev_env.py
+++ b/backend/tests/test_plugin_dev_env.py
@@ -17,8 +17,6 @@ so non-dev installs keep working untouched.
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
 
 import pytest
 

--- a/backend/tests/test_plugin_frontend.py
+++ b/backend/tests/test_plugin_frontend.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from app.core import plugin_loader
 from app.core.plugin_loader import frontend_entry_rel
 
 
@@ -47,9 +48,6 @@ def test_entry_rel_rejects_paths_outside_frontend_dir():
 
 def test_entry_rel_normalizes_backslashes():
     assert frontend_entry_rel({"frontend": {"entry": "frontend\\index.js"}}) == "frontend/index.js"
-
-
-from app.core import plugin_loader
 
 
 def _write_frontend_plugin(root: Path, plugin_id: str, *, enabled: bool = True,

--- a/backend/tests/test_project_cli_validate.py
+++ b/backend/tests/test_project_cli_validate.py
@@ -9,7 +9,6 @@ import subprocess
 import pytest
 
 import project
-from app.core.plugin_loader import tomllib
 from app.core.secret_params import secret_param_names
 
 

--- a/backend/tests/test_project_startup.py
+++ b/backend/tests/test_project_startup.py
@@ -105,7 +105,7 @@ def test_git_provenance_status_call_failure_keeps_commit(tmp_path, monkeypatch):
 
 
 def test_check_stale_pins():
-    manifest_dir = None  # unused; pins read from a written manifest
+    # No manifest_dir here on purpose: the pins go in as a dict.
     lockfile = {"plugins": {"pack-a": {"sha": "a" * 40}}}
     # pack-a present + matching -> not stale; pack-b missing -> stale;
     # pack-a mismatched sha -> stale.

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -1063,7 +1063,7 @@ async def test_prune_keeps_the_newest_n_and_cascades(store, db):
 async def test_prune_never_deletes_queued_or_running_runs(store):
     old_active = await _make_run(store, name="active")
     await store.mark_running(old_active.id)
-    old_queued = await _make_run(store, name="queued")
+    await _make_run(store, name="queued")  # left queued on purpose
     for _ in range(3):
         done = await _make_run(store)
         await store.mark_finished(done.id, "succeeded")

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -1,4 +1,4 @@
-from app.schemas.models import NodeData, EdgeData
+from app.schemas.models import EdgeData
 
 
 def test_edge_data_default_type_is_data():

--- a/backend/tests/test_stats_pack.py
+++ b/backend/tests/test_stats_pack.py
@@ -190,7 +190,6 @@ def test_hot_reload_picks_up_an_edit_to_a_node_file(tmp_path):
         "plugins": {plugin_id: {"source_kind": "user", "enabled": True}},
     }
     registry = NodeRegistry()
-    package = f"cdui_plugins.{plugin_id}.nodes"
 
     def reload_pack() -> int:
         """The plugin half of rediscover_all, verbatim."""

--- a/backend/tests/test_tiered_policy.py
+++ b/backend/tests/test_tiered_policy.py
@@ -968,6 +968,31 @@ def test_every_allowlisted_path_helper_is_real_and_is_not_a_module():
 # private ``os.path._get*`` helpers -- and fail if the call touches any of
 # them. That asks the property directly: does this helper consult the
 # filesystem, the environment, or the working directory?
+#
+# Screen 4 (core#258) exists because screens 1-3 are all *Python-level*
+# interception, and CPython 3.12 put four of these helpers out of Python's
+# reach on Windows. ``Lib/ntpath.py`` opens with::
+#
+#     try:
+#         from nt import _path_isdir as isdir
+#         from nt import _path_isfile as isfile
+#         from nt import _path_islink as islink
+#         from nt import _path_exists as exists
+#     except ImportError:
+#
+# so from 3.12 (3.14 for ``lexists``) those names are C builtins that call
+# the Win32 API directly. They never touch ``os.stat``, and ``stat`` raises no
+# audit event, so all three earlier screens go blind at once and report a
+# ``stat()``-on-any-path helper as pure. ``nt`` does not exist on Linux, so the
+# ``except ImportError`` always fires there and no amount of Python versions in
+# an ubuntu-only CI matrix can surface it -- which is why this arrived together
+# with the Windows job in ``backend-test.yml``.
+#
+# Screen 4 asks the one question no implementation detail can hide from: hold
+# the input string fixed and vary the state of the filesystem underneath it. A
+# string transform answers identically in every world; anything that consults
+# the disk cannot. It is a pure ADDITION -- it can only ever find more, never
+# excuse a helper the other screens caught.
 
 _OS_INTERCEPTS = (
     "stat", "lstat", "fstat", "readlink", "getcwd", "getcwdb",
@@ -994,6 +1019,117 @@ _PATH_HELPER_ARGS: dict[str, tuple] = {
 }
 
 _AUDIT_STATE: dict[str, object] = {"installed": False, "armed": False, "events": []}
+
+#: Screen 4's worlds. Every basename is the SAME LENGTH and lowercase on
+#: purpose: a pure helper's answer may mention the path it was handed, so the
+#: comparison canonicalises that substring away before asking whether two
+#: worlds disagreed. Equal-length, dot-free, case-stable names keep that
+#: substitution exact under ``normcase``, ``splitext`` and ``splitdrive``.
+_WORLD_NAMES = {"absent": "absent", "file": "wfilea", "dir": "wdirbb",
+                "symlink": "wlinkc"}
+_WORLD_TOKEN = "<world>"
+
+#: ``{"root": Path, "paths": {world: str}, "symlink": bool}``, built once.
+_WORLDS: dict[str, object] = {}
+
+
+def _path_worlds() -> dict[str, object]:
+    """Build (once) a directory holding one path per filesystem state.
+
+    The four worlds differ ONLY in what exists at the probe path: nothing, a
+    file, a directory, a symbolic link. Creating a symlink needs a privilege on
+    Windows (Developer Mode, or an elevated process), so whether that world
+    exists is reported rather than assumed -- see the precondition in
+    ``test_the_purity_guard_can_see_impurity_in_both_path_implementations``
+    for why ``islink`` specifically cannot be judged without it.
+    """
+    if _WORLDS:
+        return _WORLDS
+    import atexit
+    import os
+    import shutil
+    import tempfile
+
+    root = tempfile.mkdtemp(prefix="cdui-path-worlds-")
+    atexit.register(shutil.rmtree, root, ignore_errors=True)
+    paths = {w: os.path.join(root, n) for w, n in _WORLD_NAMES.items()}
+    target = os.path.join(root, "targetf")
+    with open(target, "w", encoding="utf-8") as fh:
+        fh.write("cdui")
+    with open(paths["file"], "w", encoding="utf-8") as fh:
+        fh.write("cdui")
+    os.mkdir(paths["dir"])
+    has_symlink = True
+    try:
+        os.symlink(target, paths["symlink"])
+    except (OSError, NotImplementedError, AttributeError):
+        # Unprivileged Windows without Developer Mode. Report it; do not
+        # quietly drop the world, because one helper is only visible in it.
+        has_symlink = False
+        paths.pop("symlink")
+    _WORLDS.update({"root": root, "paths": paths, "symlink": has_symlink,
+                    "target": target})
+    return _WORLDS
+
+
+def _is_os_primitive(value: object) -> bool:
+    """Is *value* a C builtin defined by the platform's raw OS module?
+
+    ``nt`` / ``posix`` are what ``os`` itself is built on, so a callable that
+    answers with one of them executes below Python entirely -- which is exactly
+    the condition screens 1-3 cannot see through. Used only to decide whether a
+    precondition is REQUIRED, never to decide whether a helper is impure:
+    ``nt`` exports pure string transforms too (``_path_normpath`` is
+    ``os.path.normpath`` on Windows from 3.12).
+    """
+    return getattr(value, "__module__", None) in ("nt", "posix")
+
+
+def _world_args(name: str, path: str, other: str) -> "tuple | None":
+    """Call shape for screen 4, with *path* in the position under test.
+
+    ``None`` means "not path-shaped" -- ``sameopenfile`` takes file
+    descriptors and ``samestat`` takes stat results, so varying a path
+    underneath them measures nothing.
+    """
+    if name in ("sameopenfile", "samestat"):
+        return None
+    if name in ("commonpath", "commonprefix"):
+        return ([path, other],)
+    if name in ("samefile", "relpath"):
+        return (path, other)
+    if name == "join":
+        return (path, "b")
+    return (path,)
+
+
+def _screen4_filesystem_differential(name: str, module) -> bool:
+    """True when ``module.name``'s answer depends on the state of the disk.
+
+    Runs OUTSIDE the interception window of screens 1-3 on purpose: this screen
+    needs the real ``os.stat`` in place, because the whole point is to let the
+    helper reach a real filesystem and then watch whether the filesystem's
+    state shows up in the answer.
+    """
+    value = getattr(module, name, None)
+    if not callable(value):
+        return False
+    worlds = _path_worlds()
+    paths: dict = worlds["paths"]  # type: ignore[assignment]
+    other: str = worlds["target"]  # type: ignore[assignment]
+    seen: set[str] = set()
+    for world, path in paths.items():
+        args = _world_args(name, path, other)
+        if args is None:
+            return False
+        try:
+            answer = repr(value(*args))
+        except Exception as exc:            # noqa: BLE001 - the class IS the answer
+            answer = f"!{type(exc).__name__}"
+        # Canonicalise the one substring a pure helper is entitled to echo,
+        # so "it mentioned the path I gave it" is not mistaken for "it looked".
+        seen.add(answer.replace(_WORLD_NAMES[world], _WORLD_TOKEN))
+    return len(seen) > 1
 
 
 def _install_audit_hook() -> None:
@@ -1101,6 +1237,10 @@ def _probe_path_helper(name: str, module=None) -> set[str]:
         touched.append("returned os.environ")
     if cwd and cwd in result:
         touched.append("returned the cwd")
+    # Screen 4, deliberately after the `finally` above: it needs the REAL os
+    # functions back before it can let the helper reach a real filesystem.
+    if _screen4_filesystem_differential(name, module):
+        touched.append("answer depends on the filesystem")
     return set(touched)
 
 
@@ -1157,6 +1297,16 @@ def test_the_purity_guard_can_see_impurity_in_both_path_implementations():
     read the environment or hit the disk, are visible to the guard on both
     implementations. If a future edit blunts a screen -- drops ``os.stat`` from
     the interception list, say -- this is the test that notices.
+
+    core#258: it also noticed something no edit of ours caused. On Windows from
+    CPython 3.12, ``exists`` / ``isdir`` / ``isfile`` / ``islink`` (and
+    ``lexists`` from 3.14) are ``nt`` C builtins rather than ``genericpath``
+    Python functions, and every screen this test had was Python-level
+    interception. It failed here honestly -- the probe really had gone blind on
+    the platform most of this project's users are on -- and stayed invisible to
+    CI only because CI was ubuntu-only, where ``from nt import ...`` always
+    raises ``ImportError``. Screen 4 restores the sensitivity; the Windows job
+    in ``backend-test.yml`` is what keeps it honest.
     """
     import ntpath
     import os.path
@@ -1172,6 +1322,22 @@ def test_the_purity_guard_can_see_impurity_in_both_path_implementations():
         "islink", "ismount", "getsize", "getmtime", "getatime", "getctime",
         "samefile", "realpath", "abspath", "relpath",
     }
+
+    # ``islink`` is the one name whose impurity NO other world can expose: it
+    # answers False for a missing path, a file and a directory alike, so only a
+    # real symbolic link separates it from a string transform. Where its
+    # implementation is a raw OS primitive, screens 1-3 cannot see it either --
+    # so if we also cannot build that world, the probe would under-report and
+    # say nothing about it. Fail loudly instead of passing quietly.
+    if not _path_worlds()["symlink"]:
+        for impl in (os.path, ntpath, posixpath):
+            assert not _is_os_primitive(getattr(impl, "islink", None)), (
+                f"{impl.__name__}.islink is a C primitive from "
+                f"{getattr(impl.islink, '__module__', '?')!r}, and this "
+                "machine cannot create a symbolic link -- the probe has no "
+                "way to tell it apart from a pure string helper. Enable "
+                "Developer Mode (or run elevated) so the symlink world exists."
+            )
 
     allowlisted = set(tiers.TIER0_PATH_HELPERS)
     for module in (os.path, ntpath, posixpath):
@@ -1196,6 +1362,103 @@ def test_the_purity_guard_can_see_impurity_in_both_path_implementations():
         # Non-vacuity: a probe that inspects nothing would report nothing.
         assert len(caught) >= 12, f"[{where}] only caught {sorted(caught)}"
         assert {"os", "sys", "genericpath"} <= modules_seen, where
+
+
+# ── core#258: does WHICH module implements a helper change the verdict? ────
+#
+# The security question the issue raises, stated precisely: both gates have a
+# rule keyed on a module NAME, and ``nt`` is on the blocklist. From CPython
+# 3.12 on Windows, ``os.path.exists`` IS an ``nt`` function. So the answer to
+# "which module does this callable belong to" differs between the platform CI
+# runs and the platform students run. Does a verdict differ with it?
+#
+# No -- and the two tests below are why, one per gate, rather than an argument
+# in a PR body that nothing re-checks.
+
+
+def test_every_os_path_implementation_module_is_blocked_so_a_cpython_move_is_a_no_op():
+    """The structural reason the ``nt`` migration cannot change a verdict.
+
+    ``script_proxy`` is the gate that reasons about objects: it takes a
+    callable's own ``__module__`` (``_defining_root``) and refuses anything
+    whose root is on ``_BLOCKED_DEFINING_ROOTS``. A CPython release that
+    re-homes ``os.path.exists`` from ``genericpath`` to ``nt`` changes that
+    root -- so the verdict is stable only if the set of roots an ``os.path``
+    helper can possibly answer with is CLOSED under the blocklist.
+
+    It is: ``ntpath``, ``posixpath``, ``genericpath``, ``nt`` and ``posix`` are
+    all blocked, so the move is from one refused root to another refused root.
+    Asserted over the live modules, so a future CPython that invents a sixth
+    implementation module fails here instead of silently opening a door.
+    """
+    import ntpath
+    import os.path
+    import posixpath
+
+    from app.core.script_proxy import _BLOCKED_DEFINING_ROOTS  # noqa: SLF001
+
+    assert {"nt", "posix", "ntpath", "posixpath", "genericpath"} <= (
+        _BLOCKED_DEFINING_ROOTS
+    )
+
+    for module in (os.path, ntpath, posixpath):
+        for name in sorted(dir(module)):
+            if name.startswith("_"):
+                continue
+            value = getattr(module, name)
+            if not callable(value) or isinstance(value, type):
+                continue
+            root = (getattr(value, "__module__", "") or "").split(".")[0]
+            assert root in _BLOCKED_DEFINING_ROOTS, (
+                f"{module.__name__}.{name} is defined by {root!r}, which the "
+                "runtime gate does NOT refuse -- a library re-exporting it "
+                "under a harmless name would hand a script a path helper the "
+                "policy has never classified."
+            )
+
+
+def test_the_install_time_verdict_does_not_depend_on_which_module_implements_it():
+    """The other gate, which never asks the question at all -- on purpose.
+
+    ``validate_python_source`` is a static AST walk: it screens the LEAF NAMES
+    of ``from os.path import ...`` against ``TIER0_PATH_HELPERS``, and never
+    imports, resolves or introspects the callable. So its verdict is the same
+    string comparison on every platform and every version, whatever ``nt``
+    holds today. Pinned with one accepted name and one refused name that
+    CPython has actually moved, plus the observed attribution, so the test
+    documents the platform split it is proving irrelevant.
+    """
+    import ntpath
+
+    # ``normpath`` moved to ``nt`` on Windows 3.12+; ``exists`` did too.
+    # Neither is a module and neither answer depends on that.
+    assert ntpath.normpath.__module__ in ("nt", "ntpath")
+    assert ntpath.exists.__module__ in ("nt", "genericpath")
+
+    _tier0("from os.path import normpath\n")               # allowlisted: accepted
+    assert "process-env" in _refusal("from os.path import exists\n")
+
+
+def test_the_purity_probe_can_see_through_a_c_fast_path():
+    """Screen 4's own sensitivity -- the guard for the guard's newest screen.
+
+    Screens 1-3 are Python-level interception and are blind to a C builtin by
+    construction. This asserts the property screen 4 was added for, using the
+    live ``os.path``: a helper that consults the disk is caught even when the
+    interception screens see nothing, and a helper that is a pure string
+    transform is NOT caught even when it is the same kind of C builtin
+    (``os.path.normpath`` is ``nt._path_normpath`` on Windows 3.12+, and it
+    stays clean -- which is what stops screen 4 from being a rule that just
+    says "implemented in C means dangerous").
+    """
+    import os.path
+
+    assert _screen4_filesystem_differential("exists", os.path)
+    assert _screen4_filesystem_differential("isdir", os.path)
+    assert _screen4_filesystem_differential("isfile", os.path)
+    for pure in ("normpath", "basename", "dirname", "join", "splitext",
+                 "normcase", "isabs", "split", "splitdrive"):
+        assert not _screen4_filesystem_differential(pure, os.path), pure
 
 
 def test_the_helpers_a_plugin_actually_wants_still_work():

--- a/backend/tests/test_transform_node.py
+++ b/backend/tests/test_transform_node.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-import torch
 
 from app.nodes.data.transform_node import TransformNode
 

--- a/backend/tests/test_version_surfacing.py
+++ b/backend/tests/test_version_surfacing.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import json
 import re
-from pathlib import Path
 
 import pytest
 

--- a/backend/tests/test_word_vector_node.py
+++ b/backend/tests/test_word_vector_node.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import numpy as np
 import pytest
 import torch
 

--- a/docs/docs/getting-started/cli-commands.md
+++ b/docs/docs/getting-started/cli-commands.md
@@ -19,7 +19,7 @@ description: The cdui launcher commands — install, start, status, dev, build, 
 | `cdui dev` | Developer mode — backend `:8000` + Vite HMR `:5173` (requires Node + pnpm). |
 | `cdui build` | Build the frontend bundle locally (requires Node + pnpm). |
 | `cdui stop` | Stop **this install's** services: the background server from the pidfile, plus leftovers started from this directory (a foreground `cdui start`, `cdui dev`'s Vite, stray workers). Add `--all` to stop every CodefyUI and Vite process on the machine instead — that reaches other people's servers and unrelated Vite dev servers, so avoid it on a shared host. |
-| `cdui test` | Run backend tests. |
+| `cdui test` | Run the whole project's tests: backend (`pytest`) and frontend (`vitest`). Without pnpm the frontend half is reported as `SKIPPED` rather than failing — a release install has no Node by design. Both halves always finish, so one run tells you about both; the exit code is 1 if either failed. `--backend` / `--frontend` narrow it. |
 | `cdui clean` | Remove the virtualenv, `node_modules`, and `frontend/dist`. |
 | `cdui uninstall` | Clean + remove the PATH launcher. |
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/cli-commands.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/cli-commands.md
@@ -19,7 +19,7 @@ description: cdui 啟動器指令 —— install、start、status、dev、build�
 | `cdui dev` | 開發者模式 —— 後端 `:8000` + Vite HMR `:5173`（需要 Node + pnpm）。 |
 | `cdui build` | 在本地建置前端 bundle（需要 Node + pnpm）。 |
 | `cdui stop` | 停止**這個安裝**的服務：pidfile 記錄的背景伺服器，加上從這個目錄啟動的殘留行程（前景 `cdui start`、`cdui dev` 的 Vite、遺留 worker）。加上 `--all` 則改為停止整台機器上所有 CodefyUI 與 Vite 行程 —— 那會波及其他使用者的伺服器與無關的 Vite dev server，共用主機請勿使用。 |
-| `cdui test` | 執行後端測試。 |
+| `cdui test` | 執行整個專案的測試：後端（`pytest`）與前端（`vitest`）。沒有 pnpm 時前端那半會標成 `SKIPPED` 而不是失敗 —— release 安裝本來就沒有 Node。兩邊一定都會跑完，所以跑一次就能同時知道兩邊的結果；任一邊失敗就以離開碼 1 結束。用 `--backend` / `--frontend` 可以只跑其中一邊。 |
 | `cdui clean` | 移除虛擬環境、`node_modules` 與 `frontend/dist`。 |
 | `cdui uninstall` | clean + 移除 PATH 上的啟動器。 |
 

--- a/examples/Model_Architecture/ConvNeXt-CNN/model.py
+++ b/examples/Model_Architecture/ConvNeXt-CNN/model.py
@@ -19,7 +19,6 @@ Architecture: Stem -> 4 stages [3,3,9,3] blocks at dims [96,192,384,768] -> Head
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from torch.cuda.amp import GradScaler, autocast
 import torchvision
 import torchvision.transforms as T

--- a/examples/Model_Architecture/PPO-Robotics-RL/model.py
+++ b/examples/Model_Architecture/PPO-Robotics-RL/model.py
@@ -31,7 +31,6 @@ continuous indices) or falls back to a lightweight synthetic environment.
 CodefyUI -- visual node-graph builder for ML pipelines.
 """
 
-import random
 from typing import List, Tuple
 
 import torch

--- a/examples/Model_Architecture/TimeSeries-LSTM-RNN/model.py
+++ b/examples/Model_Architecture/TimeSeries-LSTM-RNN/model.py
@@ -178,4 +178,4 @@ if __name__ == "__main__":
     ax.legend()
     fig.tight_layout()
     fig.savefig("prediction_result.png", dpi=150)
-    print(f"\nPlot saved to prediction_result.png")
+    print("\nPlot saved to prediction_result.png")

--- a/examples/Usage_Example/CNN-MNIST/InferenceCNN-MNIST/model.py
+++ b/examples/Usage_Example/CNN-MNIST/InferenceCNN-MNIST/model.py
@@ -146,7 +146,7 @@ def run_inference():
     probs = torch.softmax(logits, dim=-1)
     preds = probs.argmax(dim=1)
 
-    print(f"\nSample predictions:")
+    print("\nSample predictions:")
     print(f"  {'True':>5}  {'Pred':>5}  {'Confidence':>10}")
     print(f"  {'-'*25}")
     for i in range(10):
@@ -154,7 +154,6 @@ def run_inference():
 
 
 if __name__ == "__main__":
-    import sys
     from pathlib import Path
 
     if not Path(WEIGHTS_PATH).exists():

--- a/plugins/edu/nodes/advanced_classifier_node.py
+++ b/plugins/edu/nodes/advanced_classifier_node.py
@@ -130,7 +130,7 @@ class AdvancedClassifierNode(BaseNode):
         x_query_np = x_query.detach().cpu().float().numpy()
 
         labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
-        labels = [str(l) for l in labels]
+        labels = [str(label) for label in labels]
         if x_train_np.shape[0] != len(labels):
             raise ValueError(
                 f"AdvancedClassifier: features and labels length mismatch — "

--- a/plugins/edu/nodes/classifier_node.py
+++ b/plugins/edu/nodes/classifier_node.py
@@ -123,7 +123,7 @@ class ClassifierNode(BaseNode):
         x_query_np = x_query.detach().cpu().float().numpy()
 
         labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
-        labels = [str(l) for l in labels]
+        labels = [str(label) for label in labels]
         if x_train_np.shape[0] != len(labels):
             raise ValueError(
                 f"Classifier: features and labels length mismatch — "

--- a/plugins/edu/nodes/train_and_evaluate_node.py
+++ b/plugins/edu/nodes/train_and_evaluate_node.py
@@ -120,10 +120,10 @@ class TrainAndEvaluateNode(BaseNode):
         x_query = x_query.float()
 
         labels = y_train.tolist() if isinstance(y_train, torch.Tensor) else list(y_train)
-        labels = [str(l) for l in labels]
+        labels = [str(label) for label in labels]
         classes = sorted(set(labels))
         idx = {c: i for i, c in enumerate(classes)}
-        y_idx = torch.tensor([idx[l] for l in labels], dtype=torch.long)
+        y_idx = torch.tensor([idx[label] for label in labels], dtype=torch.long)
 
         # 把隱藏堆疊接上一個輸出層（壓到類別數）。輸入維度從堆疊最後一個 Linear 推得。
         modules = list(net_in.children())

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,68 @@
+# Ruff configuration for every piece of Python in this repository (core#245).
+#
+# Lives at the repo root rather than in `backend/pyproject.toml` because the
+# Python here is not only the backend package: `scripts/` holds the CLI
+# (`dev.py`, `plugins.py`, `project.py`), and `plugins/` and `examples/` hold
+# node code that ships to users. `backend-test.yml` already treats all four as
+# one blast radius; the linter covers the same ground.
+#
+# Frontend linting (eslint / biome) is deliberately NOT started here. It is a
+# larger argument -- it drags in a formatting decision, and a formatter that
+# lands in the same PR as CI plumbing gets reviewed as neither. See core#245.
+
+# Only ever look at Python. Kept explicit so a stray `.pyi` or notebook does
+# not quietly join the gate later.
+include = ["**/*.py"]
+
+extend-exclude = [
+    # The plugin scaffold is Jinja-ish source with `{{plugin_snake}}`
+    # placeholders. It is not valid Python until `cdui plugin new` renders it,
+    # and `ruff` reports that (correctly) as a syntax error.
+    "scripts/templates/**",
+    # Developer scratch venvs. `.venv/` is already gitignored; this catches the
+    # `.venv312`-style siblings people make when reproducing a version bug.
+    ".venv*",
+    "**/.venv*",
+]
+
+[lint]
+# Ruff's own default rule set, adopted deliberately rather than by omission.
+#
+# The first linter in a repository has exactly one job beyond finding bugs: it
+# has to LAND GREEN. A gate that starts red teaches people that red is normal,
+# which costs more than the gate is worth. So this starts at pyflakes plus the
+# pycodestyle rules that describe real mistakes rather than formatting taste:
+#
+#   F    unused imports, undefined names, unused locals, f-string mistakes
+#   E4   import placement
+#   E7   `== None`, `== True`, bare `except`, ambiguous names, lambda-assign
+#   E9   syntax errors and IO errors
+#
+# Deliberately NOT enabled yet, with the count from the first full run so that
+# whoever turns one on knows what they are signing up for:
+#
+#   E501  line-too-long (1373). A formatting decision. This codebase writes
+#         long explanatory comments on purpose and reflowing them all would
+#         bury every future `git blame`.
+#   I001  unsorted-imports (153). Import ordering belongs to a formatter, and
+#         adopting one is its own PR with its own review.
+#   RUF001/2/3 ambiguous-unicode (210). The project is bilingual by design;
+#         these fire on ordinary Traditional Chinese in strings, comments and
+#         docstrings. False positives here, all of them.
+#   B, SIM, UP, C4 (~200). Each is worth doing and each is a behaviour-adjacent
+#         rewrite. They should arrive one rule family at a time, in a diff a
+#         reviewer can actually check -- not riding along with CI plumbing.
+select = ["E4", "E7", "E9", "F"]
+
+[lint.per-file-ignores]
+# E402 = "module import not at top of file". Both of these violate it on
+# purpose, and both would be WRONG if the imports moved up.
+#
+# `main.py` registers MIME types before anything imports Starlette's
+# StaticFiles: on Windows the registry answer for `.js` is routinely clobbered
+# by other installers, and a `text/plain` `.js` makes the browser refuse the
+# module script, leaving a blank SPA. The registration has to win the race.
+"backend/app/main.py" = ["E402"]
+# `conftest.py` puts `backend/` and `scripts/` on `sys.path` before importing
+# anything from them -- that is the whole reason the file exists.
+"backend/tests/conftest.py" = ["E402"]

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -51,7 +51,12 @@
                 旗標：--all   改為停止整台機器上所有 CodefyUI 與 Vite 行程。
                               會波及其他使用者、以及與 CodefyUI 無關的 Vite
                               dev server；共用主機請勿使用。
-    test        執行 backend 測試
+    test        執行整個專案的測試：backend（pytest）+ frontend（vitest）
+                沒有 pnpm 時會略過前端測試並在結果表明講「略過」，不會失敗
+                （release 安裝本來就不需要 Node）。兩邊都會跑完才回報，
+                任一邊失敗就以離開碼 1 結束。
+                旗標：--backend    只跑後端
+                      --frontend   只跑前端
     clean       移除虛擬環境、node_modules 與 frontend/dist
     uninstall   解除安裝：clean + 移除全域 cdui launcher
 
@@ -2670,14 +2675,133 @@ def run_graph() -> None:
         sys.exit(1)
 
 
-def test() -> None:
+def _run_status(cmd: list, cwd: Path) -> int:
+    """Run *cmd* and return its exit code instead of raising.
+
+    ``run()`` passes ``check=True``, so the first non-zero exit aborts the
+    whole command. ``test`` deliberately wants the opposite: a red backend
+    must not hide the frontend result, because learning about both halves in
+    one pass is the entire point of running both.
+    """
+    # Our own headings go through Python's buffered stdout; the child writes
+    # to the same fd directly. When stdout is a pipe rather than a terminal --
+    # a file, a CI log -- the buffer is not flushed at each print, so
+    # "=== Backend: pytest ===" lands AFTER pytest's own output and the
+    # headings appear to label the wrong half. Observed, then fixed.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    if sys.platform == "win32":
+        # Same reason as run(): Windows won't resolve pnpm.cmd without a shell.
+        return subprocess.run(
+            subprocess.list2cmdline(cmd), cwd=cwd, shell=True).returncode
+    return subprocess.run(cmd, cwd=cwd).returncode
+
+
+#: Marker for a half that was not run at all, as distinct from 0 (passed) or
+#: any non-zero exit code (failed). ``None`` keeps the three states separate
+#: in the summary, which is the thing the old command could not say.
+_SKIPPED = None
+
+
+def _run_backend_tests() -> int:
     pytest = _require_venv_tool("pytest")
-    run([pytest], cwd=BACKEND_DIR)
+    section("Backend：pytest", "Backend: pytest")
+    return _run_status([pytest], cwd=BACKEND_DIR)
 
 
-    # No bulk `dev-install` shortcut: official packs are opt-in. Contributors
-    # decide per-chapter what they need and run ``plugin install`` themselves
-    # (matches what an end user would do via the global ``cdui plugin``).
+def _run_frontend_tests() -> "int | None":
+    """Run ``pnpm test`` (vitest), or return ``_SKIPPED`` with a reason printed.
+
+    CodefyUI has a deliberate no-Node install path — ``cdui install`` fetches
+    ``frontend-dist.tar.gz`` from the release when pnpm is absent, so a
+    perfectly healthy install can have no Node at all. Such a machine must
+    still get a useful ``cdui test``, so a missing pnpm is a documented skip,
+    never an error.
+    """
+    if not (FRONTEND_DIR / "package.json").exists():
+        warn("找不到 frontend/package.json，略過前端測試",
+             "frontend/package.json not found — skipping frontend tests")
+        return _SKIPPED
+    if not shutil.which("pnpm"):
+        warn(
+            "未偵測到 pnpm，略過前端測試（vitest）。安裝 Node.js 24+ 與 pnpm 後\n"
+            "  即可在本機跑完整套測試；CI 的 frontend-build.yml 仍然會跑它們。",
+            "pnpm not detected — skipping the frontend tests (vitest). Install\n"
+            "  Node.js 24+ and pnpm to run the full suite locally; CI's\n"
+            "  frontend-build.yml runs them either way.",
+        )
+        return _SKIPPED
+
+    section("Frontend：pnpm test（vitest）", "Frontend: pnpm test (vitest)")
+    if not (FRONTEND_DIR / "node_modules").exists():
+        print(t("=== Frontend: 首次執行，安裝 node_modules ===",
+                "=== Frontend: first run, installing node_modules ==="))
+        code = _run_status(["pnpm", "install"], cwd=FRONTEND_DIR)
+        if code != 0:
+            err("pnpm install 失敗，無法執行前端測試",
+                "pnpm install failed — cannot run the frontend tests")
+            return code
+    return _run_status(["pnpm", "test"], cwd=FRONTEND_DIR)
+
+
+def _test_summary_line(label: str, code: "int | None") -> str:
+    if code is _SKIPPED:
+        return f"  {DIM}{label:<10}{RESET}{YELLOW}{t('略過', 'SKIPPED')}{RESET}"
+    if code == 0:
+        return f"  {DIM}{label:<10}{RESET}{GREEN}{t('通過', 'PASS')}{RESET}"
+    return (f"  {DIM}{label:<10}{RESET}{RED}{t('失敗', 'FAIL')}{RESET}"
+            f" {GRAY}(exit {code}){RESET}")
+
+
+def test() -> None:
+    """Run the backend suite and the frontend suite, and say which ones ran.
+
+    Until core#245 this was ``pytest`` in ``backend/`` and nothing else, while
+    138 frontend test files went unrun — so a contributor could see a green
+    ``cdui test``, push, and fail ``pnpm test`` in CI. CONTRIBUTING.md points
+    people at this command, so the name has to mean what it says.
+
+    Both halves always run to completion; the exit code is non-zero if either
+    failed. A skipped half is reported as skipped, never as a pass.
+
+    ``--backend`` / ``--frontend`` narrow the run. They are selectors, so
+    passing both is the same as passing neither: run everything. Unknown
+    arguments are an error rather than being ignored -- the old command
+    silently swallowed ``-k foo``, which looks exactly like a filter that
+    worked.
+    """
+    args = sys.argv[2:]
+    valid = {"--backend", "--frontend"}
+    unknown = [a for a in args if a not in valid]
+    if unknown:
+        err(f"未知的參數：{' '.join(unknown)}。只接受 --backend / --frontend。",
+            f"unrecognised argument(s): {' '.join(unknown)}. "
+            "Only --backend / --frontend are accepted.")
+        print(t("  要篩選個別測試請直接執行 pytest 或 pnpm test。",
+                "  To filter individual tests, run pytest or pnpm test directly."),
+              file=sys.stderr)
+        sys.exit(2)
+    selected = valid & set(args)
+    want_backend = not selected or "--backend" in selected
+    want_frontend = not selected or "--frontend" in selected
+
+    backend_code: "int | None" = _run_backend_tests() if want_backend else _SKIPPED
+    frontend_code: "int | None" = _run_frontend_tests() if want_frontend else _SKIPPED
+
+    print()
+    section("測試結果", "Test summary")
+    print(_test_summary_line("backend", backend_code))
+    print(_test_summary_line("frontend", frontend_code))
+    print()
+
+    failed = [c for c in (backend_code, frontend_code) if c is not _SKIPPED and c != 0]
+    if failed:
+        sys.exit(1)
+
+
+# No bulk `dev-install` shortcut: official packs are opt-in. Contributors
+# decide per-chapter what they need and run ``plugin install`` themselves
+# (matches what an end user would do via the global ``cdui plugin``).
 
 
 def clean() -> None:

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -43,7 +43,6 @@ else:
 
 from app.core.plugin_loader import (
     MANIFEST_FILENAME,
-    iter_plugin_dirs,
     load_lockfile,
     plugins_builtin_root,
     plugins_user_root,


### PR DESCRIPTION
> 中文摘要：補上 #245 的第 2、3、4 項。`cdui test` 現在同時跑後端（pytest）與前端（vitest），沒有 pnpm 時標成「略過」而不是失敗；後端 CI 加了一個 Windows + Python 3.12 的 job；整個 repo 加上 `ruff check`，而且是修到全綠才接進 CI。**第 1 項（main 分支的必要狀態檢查）只有 maintainer 能在 GitHub 設定裡做，PR 動不到，仍然開著。**
>
> 順帶把 #258 的安全問題查完了。結論：**兩個閘門的判斷都完全沒有改變。** 真正壞掉的是那個測試自己的量測工具——它只攔得到 Python 層的 `os.stat`，而 CPython 從 3.12 起在 Windows 上把 `exists`/`isdir`/`isfile`/`islink` 換成 `nt` 的 C 函式，攔不到。這不是理論問題：它讓「有人想把不純的名字加進 Tier-0 白名單」那道防線，在 Windows + 3.12 以上悄悄失效。已修（加了第四道不靠 Python 攔截的檢查），並且把「為什麼閘門判斷不會變」寫成兩個會一直跑的測試。

Closes #245 (items 2, 3 and 4 — see the note on item 1 below).
Closes #258.

---

## Item 1 of #245 is maintainer-only and stays open

`main`'s ruleset has no `required_status_checks` rule, so a PR with red CI is mergeable today. That is a **Settings → Rules** change and cannot be made from a pull request — no file in this repository controls it. It is not addressed here.

When you do add it, this PR changes what there is to require:

- `pytest (Python 3.10)`, `pytest (Python 3.11)`, `pytest (Python 3.12)` — unchanged
- `pytest (Windows, Python 3.12)` — **new**
- `ruff check` — **new**
- `pnpm build + tsc + test` — unchanged
- `scan tracked files for raw control bytes` — unchanged

---

## Item 3 — `cdui test` runs both halves

Before, the whole command was `pytest` in `backend/`. 138 frontend test files went unrun, and `CONTRIBUTING.md` (added in #262) points people straight at it, so a green `cdui test` was actively misleading about anything under `frontend/`.

It now runs both and prints a summary naming each half:

```
=== Test summary ===
  backend   PASS
  frontend  PASS
```

Four decisions worth reviewing:

**A missing `pnpm` is a skip, not a failure.** CodefyUI has a deliberate no-Node install path — `cdui install` fetches `frontend-dist.tar.gz` from the release when pnpm is absent — so a machine with no Node at all is a *healthy, supported* install. Failing there would punish exactly the users that path exists for. The frontend half reports `SKIPPED`, the reason and the fix go to stderr, and the command exits 0. What it must never do is report a skip as a pass, and a test pins that.

**Both halves always finish.** `run()` uses `check=True`, so a red backend would have aborted before the frontend ever started. `test()` uses a new non-raising `_run_status()` and collects both results, because the whole value of one command is learning about both in one pass. Exit code is 1 if either failed.

**`--backend` / `--frontend` narrow the run**, so someone who only touched Python does not pay for a `pnpm install`. They are selectors: passing both is the same as passing neither.

**Unknown arguments are refused (exit 2) rather than ignored.** `cdui test -k foo` used to run the entire suite while looking like it had filtered.

Verified for real, not only in unit tests:

```
$ ./cdui.cmd test --frontend
 Test Files  138 passed (138)
      Tests  2967 passed (2967)
=== Test summary ===
  backend   SKIPPED
  frontend  PASS
```

and with pnpm removed from `PATH`:

```
! pnpm not detected — skipping the frontend tests (vitest). ...
=== Test summary ===
  backend   SKIPPED
  frontend  SKIPPED
EXITCODE=0
```

The `_reexec()` path is untouched. One fix came out of the real run: our headings go through Python's buffered stdout while the child writes to the same fd directly, so piped to a file the `=== Backend: pytest ===` heading landed *after* pytest's own output. `_run_status()` flushes before spawning.

Per this repo's history, `dev.py` CLI changes only reach no-Node users via a *release*, and take effect from the second update onward. Nothing here changes that.

## Item 4 — a Windows job, and the bug it was hiding

`backend-test.yml` was `ubuntu-latest` for all three Python versions: the matrix covered versions, not platforms. Added one `windows-latest` job, not the cross-product — tripling CI time buys three copies of an answer that is about the platform, not the version.

**Python 3.12, and the reason is specific.** 3.12 is where CPython replaced `os.path.exists` / `isdir` / `isfile` / `islink` with `nt` C fast paths **on Windows only**, so it is the lowest version in the matrix where Windows and Linux stdlib behaviour actually diverge — a Windows 3.11 job would have been blind to #258. Windows + 3.11 is not uncovered either: `install.ps1` pins 3.11 and `install-check.yml` already runs it on `windows-latest`. And as the newest version in the matrix it doubles as the forward-compatibility signal on the platform most students use.

It uses `astral-sh/setup-uv` rather than the ubuntu job's `curl | sh`: the PowerShell installer edits the *user* PATH in the registry, which an already-running runner process never sees, so the one-liner would need us to guess its install directory and echo that into `$GITHUB_PATH`.

`ruff check` is a third job rather than a step in the matrix, for the same reason a Windows job is not a matrix axis: lint is platform- and version-independent, so running it three times buys three copies of the same answer.

## #258 — the security question, answered

The issue's correction comment is right and the original body's version attribution is wrong. Measured here across every interpreter available, on Windows:

```
  3.10.20  ntpath.exists -> genericpath    3.13.12  ntpath.exists -> nt
  3.11.15  ntpath.exists -> genericpath    3.14.3   ntpath.exists -> nt
  3.12.13  ntpath.exists -> nt             3.15.0a7 ntpath.exists -> nt
```

The move lands in **3.12**, which was already in the matrix. CI could not see it because CI was ubuntu-only and `ntpath` guards the fast paths behind `try: from nt import ... except ImportError:` — `nt` does not exist on Linux, so the fallback always wins there. No version added to an ubuntu-only matrix could ever have surfaced this.

### Does treating `nt` as dangerous change what the gate allows or refuses?

**No — in neither direction, at neither gate.** Here is how that was established rather than assumed.

**Gate 1, install time (`plugin_validator.validate_python_source`).** A pure static AST walk. It never imports the target, never resolves an attribute to an object, and never reads a callable's `__module__`. `from os.path import X` is decided by screening the leaf *names* against the static `TIER0_PATH_HELPERS` tuple, so the verdict is the same string comparison on every platform and version, whatever `nt` holds. `exists` / `isdir` / `isfile` / `islink` are not on that allowlist and are refused everywhere; `normpath` is on it and accepted everywhere — even though `normpath` is *also* an `nt` builtin on Windows 3.12+, which is precisely the case a name-based confusion would have broken.

Its one piece of live introspection is `_OS_PATH_MODULE_LEAVES`, computed as `{n for n in dir(os.path) if isinstance(getattr(os.path, n), ModuleType)}`. Measured: `{genericpath, os, stat, sys}` on 3.10–3.13, `{genericpath, os, sys}` on 3.14 (`stat` drops out). A C builtin is not a `ModuleType`, so `nt._path_exists` can never enter that set, and `stat` leaving it is harmless because `_is_tier0_path_import` also intersects the leaves with `_DANGEROUS_MODULES`, which still holds `stat`.

**Gate 2, run time (`script_proxy`).** This one *does* ask "which module defines this callable" — `_defining_root` reads `__module__` and refuses anything whose root is in `_BLOCKED_DEFINING_ROOTS`. This is where a re-homing could bite. It does not, for a structural reason:

> `ntpath`, `posixpath`, `genericpath`, `nt` and `posix` are **all** on the blocklist. The set of roots an `os.path` helper can answer with is closed under the move — CPython relocated these functions from one refused root to another refused root.

Also worth stating: `os`, `os.path`, `ntpath`, `posixpath` and `genericpath` are none of them in `TIER0_MODULE_PATHS`, so an in-canvas script cannot reach `os.path` directly at all. `_defining_root` only ever sees one of these if an *allowlisted* library re-exports it under a harmless name — refused both before and after 3.12.

No widening is possible either: `_BLOCKED_DEFINING_ROOTS` is only ever used as a blocklist membership test, and no rule anywhere *allows* a value because of its `__module__`.

Two new tests pin this instead of leaving it as an argument in a PR body:

- `test_every_os_path_implementation_module_is_blocked_so_a_cpython_move_is_a_no_op` walks every public callable on `os.path`, `ntpath` and `posixpath` (95 of them, resolving to 3 distinct roots) and asserts each defining root is blocked. A future CPython that invents a sixth implementation module fails here instead of silently opening a door.
- `test_the_install_time_verdict_does_not_depend_on_which_module_implements_it` pins one accepted and one refused name that CPython has actually moved, plus the observed attribution, so the test documents the platform split it is proving irrelevant.

### What *was* really broken

The failing test is `test_the_purity_guard_can_see_impurity_in_both_path_implementations`, and it is not a gate-verdict test — it is the **sensitivity check for the test suite's own probe**. That probe detects impurity with three screens, all Python-level: monkeypatching `os.stat` / `os.lstat` / `os.getcwd`, a `sys.addaudithook` hook, and inspecting the returned value. `nt._path_exists` is a C builtin that calls the Win32 API directly, never touches `os.stat`, and raises no audit event (CPython's audit table has no `stat`), so all three screens went blind at once and reported a `stat()`-on-any-path helper as pure.

**That is a real weakening, and it is why this was not skipped.** The probe's sibling, `test_no_allowlisted_path_helper_touches_the_environment_the_disk_or_the_cwd`, is the standing guard that refuses anyone adding an impure name to `TIER0_PATH_HELPERS`. On Windows + 3.12 that guard would have answered "clean" for `exists`, `isdir`, `isfile` or `islink` — the exact four names it most needs to refuse. Skipping the test on Windows would have hidden that on the platform most of this project's users are on.

**Screen 4** restores the sensitivity by asking a question no implementation detail can hide from: hold the input string fixed and vary the state of the filesystem underneath it. A string transform answers identically in every world; anything that consults the disk cannot. Four worlds — absent, file, directory, symlink — and the one substring a pure helper is entitled to echo (the path it was handed) is canonicalised away first, so "it mentioned my argument" is not mistaken for "it looked".

It is a pure addition: it can only find more, never excuse a helper the other screens caught. And it deliberately is **not** "implemented in C means dangerous" — `os.path.normpath` is `nt._path_normpath` on Windows 3.12+ and is genuinely pure, so a structural rule would have false-positived it and demanded its removal from the allowlist. Screen 4 clears it correctly, and `test_the_purity_probe_can_see_through_a_c_fast_path` pins both halves of that.

One honest limitation, made loud rather than silent: `islink` answers `False` for a missing path, a file and a directory alike, so **only a real symbolic link** separates it from a string transform. Where its implementation is a raw OS primitive and the symlink world cannot be built (unprivileged Windows without Developer Mode), the test fails with a message saying exactly that, rather than quietly under-reporting.

## Item 2 — `ruff check`, landing green

`ruff.toml` at the repo root, covering `backend/`, `scripts/`, `plugins/` and `examples/` — the same blast radius `backend-test.yml`'s own `paths:` filter already uses. Root rather than `backend/pyproject.toml` because the Python here is not only the backend package.

Rule set is the one ruff itself defaults to, adopted deliberately rather than by omission: `E4`, `E7`, `E9`, `F`. The first linter in a repository has one job beyond finding bugs — it has to land green, because a gate that starts red teaches people that red is normal.

66 findings, all fixed, no `# noqa` needed anywhere:

| rule | n | what |
|---|---|---|
| `F401` unused-import | 37 | all genuinely dead — none was in an `__init__.py`, and each name was checked for cross-module attribute access before deletion |
| `E741` ambiguous name `l` | 11 | renamed to `label` (9) / `loss` (2) |
| `F821` undefined-name | 7 | string annotations (`-> "Path"`, `-> "torch.nn.Module"`) naming a lazily-imported symbol. Fixed with `if TYPE_CHECKING:` blocks — the lazy runtime import stays, it is there for startup cost |
| `F841` unused-variable | 7 | assignment dropped, call kept where the call has the side effect the test depends on |
| `E402` import-not-at-top | 2 | both accidental (a later section's import trailing behind), moved up |
| `F541` f-string without placeholders | 2 | `f` prefix dropped |

Two per-file `E402` ignores, both with the reason in the config: `app/main.py` must register MIME types before anything imports Starlette's `StaticFiles` (on Windows the registry answer for `.js` is routinely clobbered, and a `text/plain` `.js` leaves a blank SPA), and `tests/conftest.py` puts `backend/` and `scripts/` on `sys.path` before importing from them.

Deferred, with the first-run counts recorded in `ruff.toml` so whoever turns one on knows what they are signing up for: `E501` line-too-long (1373 — a formatting decision, and this codebase writes long explanatory comments on purpose), `I001` unsorted-imports (153 — belongs to a formatter), `RUF001/2/3` ambiguous-unicode (210 — all false positives, the project is bilingual by design), and the `B` / `SIM` / `UP` / `C4` families (~200 — each a behaviour-adjacent rewrite that deserves its own reviewable diff).

**Frontend linting is deferred, and said so out loud** in both `ruff.toml` and `CONTRIBUTING.md`. It drags a formatting decision along with it, and a formatter landing in the same PR as CI plumbing gets reviewed as neither. The backend half is already a 59-file diff.

## Tests

New: `backend/tests/test_dev_test_command.py` (15 tests) for `cdui test`, and 3 tests in `test_tiered_policy.py` for the `nt` question and screen 4.

`test_dev_test_command.py` obeys this repo's `dev.py` gotcha: `ROOT`, `VENV`, `DIST_DIR` and `FRONTEND_DIR` are all redirected at `tmp_path`, not just `run()` — and an autouse fixture snapshots the real `frontend/` tree and asserts it is untouched, so a future cleanup step inside `test()` fails a test instead of eating someone's build. `dev.LANG` is pinned too, so the assertions are about behaviour rather than about which locale ran them.

Mutation-checked; every mutation killed:

| mutation | killed by |
|---|---|
| frontend half never runs | 9 tests |
| a skip renders as a pass | 4 tests |
| a missing pnpm is a hard failure | 2 tests |
| short-circuit on a red backend | `test_a_red_backend_does_not_stop_the_frontend` |
| screen 4 disabled | `test_the_purity_guard_can_see_impurity_in_both_path_implementations` |
| screen 4 canonicalisation removed | the purity test + `test_the_purity_probe_can_see_through_a_c_fast_path` |
| symlink world unavailable | the new precondition, with its explanatory message, on 3.12 only (silent on 3.11, correctly) |
| `nt` / `posix` dropped from `_BLOCKED_DEFINING_ROOTS` | `test_every_os_path_implementation_module_is_blocked_so_a_cpython_move_is_a_no_op` |

## Verified

- backend suite, Windows + CPython 3.11 — green
- backend suite, Windows + CPython 3.12 — green (the combination #258 fails on before this PR: `1 failed, 646 passed` on the gate tests alone)
- frontend suite through the new command — 138 files / 2967 tests, green
- `uvx ruff@0.14.4 check .` from the repo root — `All checks passed!`
- `python scripts/check_control_bytes.py` — clean
- real `cdui test` runs, with and without pnpm on `PATH`

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
