### PR TITLE
fix(security): one request-body cap, counted as the bytes arrive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,32 @@ received — each links to the release it was published as.
 
 ### Fixed
 
+- **Every request-body size cap could be walked past by chunking, and four
+  routes had no cap at all** ([#265], [#242]). Three routes capped their body
+  by comparing `Content-Length` to `MAX_RUN_BODY_BYTES`. A chunked request —
+  `Transfer-Encoding: chunked` — declares no `Content-Length`, so all three
+  checks were skipped in full by any client that chose to chunk. They were
+  advisory, not enforcing, on every route that had one.
+
+  Four more routes took a body with no cap at all (`POST /api/graph/save`,
+  `/validate`, `/export`, `/api/presets/create`), and the four upload routes
+  read the whole file into memory *before* comparing it to `MAX_UPLOAD_SIZE`,
+  so a request far larger than the limit was buffered in full and only then
+  refused.
+
+  All of it is replaced by one mechanism that counts bytes as they arrive on
+  the ASGI receive channel, so it holds whether or not a length was declared
+  and covers every route rather than the three that remembered to ask. Two
+  ceilings still apply and are resolved per path: `MAX_RUN_BODY_BYTES`
+  (64 MB) everywhere, `MAX_UPLOAD_SIZE` (500 MB) on the upload routes.
+
+  User-visible where it was not before: `POST /api/graph/save` with a 70 MB
+  graph is now a 413. The 413 on `/api/graph/run/{name}` and
+  `/api/apps/{slug}/invoke` keeps the 9-key envelope those routes promise, so
+  clients generated from the per-app OpenAPI document are unaffected.
+  WebSocket messages are unchanged — they are bounded by uvicorn's
+  `ws_max_size` (16 MB) at the transport.
+
 - **The second Run of a training graph did no training, and reported success**
   ([#253]). `TrainingLoop` inherited the default `cacheable = True`, and a
   cache hit replays a node's recorded outputs without calling it — so no
@@ -328,6 +354,8 @@ Release candidates before 1.0.0 are on the
 [#251]: https://github.com/CodefyUI/CodefyUI/issues/251
 [#253]: https://github.com/CodefyUI/CodefyUI/issues/253
 [#259]: https://github.com/CodefyUI/CodefyUI/issues/259
+[#242]: https://github.com/CodefyUI/CodefyUI/issues/242
+[#265]: https://github.com/CodefyUI/CodefyUI/issues/265
 [@oyea0801]: https://github.com/oyea0801
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...main
 [2.1.1]: https://github.com/CodefyUI/CodefyUI/compare/2.1.0...2.1.1

--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -584,23 +584,13 @@ async def invoke_app(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # 3. Body cap against Content-Length, before reading the body
-    #    (routes_graph_run step-2 pattern).
-    content_length = request.headers.get("content-length")
-    if content_length is not None:
-        try:
-            declared_bytes = int(content_length)
-        except ValueError:
-            declared_bytes = 0
-        if declared_bytes > settings.MAX_RUN_BODY_BYTES:
-            return error_response(
-                413, run_id=run_id, graph=slug, app=slug,
-                code="payload_too_large",
-                message=(
-                    f"request body is {declared_bytes} bytes "
-                    f"(max {settings.MAX_RUN_BODY_BYTES})"
-                ),
-            )
+    # 3. The body cap used to live here, comparing Content-Length against
+    #    MAX_RUN_BODY_BYTES. core.body_limit now counts the bytes as they
+    #    arrive, for every route, so a chunked body cannot walk past it
+    #    (core#265). It fires when step 5 reads the body — deliberately AFTER
+    #    the key check above, so a bad key still answers 401 rather than
+    #    having a size failure mask an auth failure. main.py's
+    #    RequestBodyTooLarge handler renders the 413 with this envelope.
 
     # 4. Resolve slug -> (app, active version, record_io) in ONE SELECT
     #    join — atomic against concurrent publish (the row shows either

--- a/backend/app/api/routes_custom_nodes.py
+++ b/backend/app/api/routes_custom_nodes.py
@@ -106,6 +106,10 @@ async def upload_custom_node(file: UploadFile):
     custom_dir.mkdir(parents=True, exist_ok=True)
     dest = _safe_path(custom_dir, Path(file.filename).name)
 
+    # Bounded before it is read: core.body_limit caps the multipart BODY as it
+    # arrives, so this can no longer buffer an unbounded upload and then refuse
+    # it (core#242). The check below measures the FILE rather than the body and
+    # enforces the documented number exactly.
     content = await file.read()
     if len(content) > settings.MAX_UPLOAD_SIZE:
         raise HTTPException(status_code=413, detail="File too large")

--- a/backend/app/api/routes_data_files.py
+++ b/backend/app/api/routes_data_files.py
@@ -63,6 +63,14 @@ async def upload_data_file(file: UploadFile):
     files_dir.mkdir(parents=True, exist_ok=True)
     dest = _safe_path(files_dir, safe_name)
 
+    # This read used to be unbounded: an oversized upload was buffered in full
+    # and only then compared to the limit, and a request far larger still was
+    # read in full before being refused (core#242). core.body_limit now bounds
+    # the multipart BODY as it arrives, so the most this can buffer is
+    # MAX_UPLOAD_SIZE plus the envelope allowance.
+    #
+    # The check below stays: it measures the FILE, not the body, and it is the
+    # one that enforces the documented number exactly.
     content = await file.read()
     if len(content) > settings.MAX_UPLOAD_SIZE:
         raise HTTPException(status_code=413, detail="File too large")

--- a/backend/app/api/routes_graph_run.py
+++ b/backend/app/api/routes_graph_run.py
@@ -24,7 +24,6 @@ from uuid import uuid4
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from ..config import settings
 from ..core import api_contract
 from ..core.api_contract import InputCoercionError, OutputSerializationError
 from ..core.device_utils import resolve_device
@@ -606,21 +605,12 @@ async def run_graph_as_function(name: str, request: Request):
     #    pre-flight rejections.
     run_id = uuid4().hex
 
-    # 2. Body size cap, checked against Content-Length BEFORE reading the body.
-    content_length = request.headers.get("content-length")
-    if content_length is not None:
-        try:
-            declared_bytes = int(content_length)
-        except ValueError:
-            declared_bytes = 0
-        if declared_bytes > settings.MAX_RUN_BODY_BYTES:
-            return error_response(
-                413, run_id=run_id, graph=name, code="payload_too_large",
-                message=(
-                    f"request body is {declared_bytes} bytes "
-                    f"(max {settings.MAX_RUN_BODY_BYTES})"
-                ),
-            )
+    # 2. The body cap used to live here, comparing Content-Length against
+    #    MAX_RUN_BODY_BYTES. It was advisory — a chunked request declares no
+    #    length and walked straight past it — and it is now enforced for every
+    #    route by core.body_limit, which counts the bytes as they arrive. The
+    #    413 still answers with this module's envelope; main.py's
+    #    RequestBodyTooLarge handler renders it (core#265).
 
     # 3. Strict name matching: execute exactly what was named, or nothing.
     if _sanitize_name(name) != name:

--- a/backend/app/api/routes_images.py
+++ b/backend/app/api/routes_images.py
@@ -61,6 +61,10 @@ async def upload_image_file(file: UploadFile):
     images_dir.mkdir(parents=True, exist_ok=True)
     dest = _safe_path(images_dir, safe_name)
 
+    # Bounded before it is read: core.body_limit caps the multipart BODY as it
+    # arrives, so this can no longer buffer an unbounded upload and then refuse
+    # it (core#242). The check below measures the FILE rather than the body and
+    # enforces the documented number exactly.
     content = await file.read()
     if len(content) > settings.MAX_UPLOAD_SIZE:
         raise HTTPException(status_code=413, detail="File too large")

--- a/backend/app/api/routes_models.py
+++ b/backend/app/api/routes_models.py
@@ -58,6 +58,10 @@ async def upload_model_file(file: UploadFile):
     models_dir.mkdir(parents=True, exist_ok=True)
     dest = _safe_path(models_dir, safe_name)
 
+    # Bounded before it is read: core.body_limit caps the multipart BODY as it
+    # arrives, so this can no longer buffer an unbounded upload and then refuse
+    # it (core#242). The check below measures the FILE rather than the body and
+    # enforces the documented number exactly.
     content = await file.read()
     if len(content) > settings.MAX_UPLOAD_SIZE:
         raise HTTPException(status_code=413, detail="File too large")

--- a/backend/app/api/routes_runs.py
+++ b/backend/app/api/routes_runs.py
@@ -91,56 +91,24 @@ class SubmitRunRequest(BaseModel):
     name: str | None = None
 
 
-def _reject_oversized_body(request: Request) -> None:
-    """413 when ``Content-Length`` declares more than ``MAX_RUN_BODY_BYTES``.
-
-    Same setting, same comparison and same message text as the two sibling
-    submit routes (``routes_graph_run`` step 2, ``routes_apps`` step 3), so a
-    client that talks to more than one of them sees one behaviour. Only the
-    envelope differs, and only because these routes have different envelopes:
-    the sibling routes answer with the 9-key run envelope on every path, this
-    router answers with ``{"detail": ...}`` on every path (see the module
-    docstring). Borrowing their envelope for this one status would make
-    ``POST /api/runs`` the only route in the file a client had to special-case.
-
-    Checked against the header BEFORE anything reads the body, which is why
-    ``submit_run`` parses its own body instead of declaring a pydantic
-    parameter: FastAPI reads and JSON-parses a declared body before the
-    endpoint (and before its dependencies) runs, so a cap placed after that
-    point has already paid for the bytes it is refusing.
-
-    Advisory, exactly like the siblings: a chunked request declares no length
-    and is not caught here. The cap that matters for this route is the one on
-    what gets *persisted* — every submit writes an immutable ``graph_snapshot``
-    row, a queued run never reaches a terminal state, and the keep-last-N
-    retention only prunes finished runs (``RUN_RETENTION_KEEP_LAST``), so
-    without this nothing at all reclaims an oversized submit.
-    """
-    content_length = request.headers.get("content-length")
-    if content_length is None:
-        return
-    try:
-        declared_bytes = int(content_length)
-    except ValueError:
-        declared_bytes = 0
-    if declared_bytes > settings.MAX_RUN_BODY_BYTES:
-        raise HTTPException(
-            status_code=413,
-            detail=(
-                f"request body is {declared_bytes} bytes "
-                f"(max {settings.MAX_RUN_BODY_BYTES})"
-            ),
-        )
-
-
 async def _read_submit_body(request: Request) -> SubmitRunRequest:
     """Read and validate the submit body by hand, keeping FastAPI's 422.
 
-    Hand-parsing is the price of capping before the read; it must not also
-    cost callers the error shape they already handle. Both failure modes are
-    re-raised as ``RequestValidationError`` with the same ``loc`` prefix
-    FastAPI applies (``("body", ...)``) and ``include_url=False``, so a bad
-    submit answers byte-for-byte what a declared pydantic body answered.
+    The body cap that used to sit in front of this read is gone. It compared
+    ``Content-Length`` to ``MAX_RUN_BODY_BYTES`` and was advisory — a chunked
+    request declares no length and was never measured at all — so it is
+    replaced by ``core.body_limit``, which counts the bytes as they arrive and
+    covers every route rather than the three that remembered to ask (core#265).
+    The cap still matters most here: every submit writes an immutable
+    ``graph_snapshot`` row, a queued run never reaches a terminal state, and
+    keep-last-N retention only prunes finished runs
+    (``RUN_RETENTION_KEEP_LAST``), so nothing else reclaims an oversized submit.
+
+    The hand-parse stays. It no longer buys the cap anything — the middleware
+    refuses inside ``request.body()`` whoever calls it — but it is what keeps
+    this route's 422 identical to a declared pydantic body's: both failure
+    modes are re-raised as ``RequestValidationError`` with the same ``loc``
+    prefix FastAPI applies (``("body", ...)``) and ``include_url=False``.
     """
     raw = await request.body()
     try:
@@ -284,10 +252,10 @@ async def submit_run(request: Request):
     way; a queued run parks the long poll properly instead of returning
     empty pages.
 
-    The body is capped and parsed here rather than declared as a pydantic
-    parameter — see ``_reject_oversized_body`` for why the order matters.
+    The body is parsed here rather than declared as a pydantic parameter —
+    see ``_read_submit_body``. Its size ceiling is enforced by
+    ``core.body_limit`` for every route, not by this one.
     """
-    _reject_oversized_body(request)
     body = await _read_submit_body(request)
     service = _get_service(request)
     try:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -36,9 +36,17 @@ class Settings(BaseSettings):
     HOST: str = "127.0.0.1"
     PORT: int = 8000
     CORS_ORIGINS: list[str] = ["http://localhost:5173", "http://localhost:5174", "http://localhost:3000"]
+    # Largest FILE accepted by the four upload routes. The multipart body
+    # carrying it is bounded a shade higher (this plus an envelope allowance)
+    # by core.body_limit; the routes themselves enforce this exact number
+    # against the decoded file. See body_limit's module docstring.
     MAX_UPLOAD_SIZE: int = 500 * 1024 * 1024  # 500 MB
-    # Cap for POST /api/graph/run/{name} request bodies, checked against
-    # Content-Length before the body is read (-> 413 payload_too_large).
+    # Default request-body ceiling for EVERY route that is not an upload
+    # (-> 413). Enforced by core.body_limit, which counts bytes as they arrive
+    # on the ASGI receive channel, so it holds for chunked requests that
+    # declare no Content-Length as well. Until core#265 this was three
+    # hand-rolled Content-Length comparisons on three routes, each of which a
+    # chunked client walked straight past.
     # 64 MB comfortably covers a handful of base64 image inputs.
     # Env-overridable as CODEFYUI_MAX_RUN_BODY_BYTES.
     MAX_RUN_BODY_BYTES: int = 64 * 1024 * 1024  # 64 MB

--- a/backend/app/core/body_limit.py
+++ b/backend/app/core/body_limit.py
@@ -1,0 +1,205 @@
+"""One request-body ceiling for the whole HTTP surface, counted as bytes arrive.
+
+Why this exists (core#265, core#242)
+------------------------------------
+Three routes used to cap their own bodies by reading ``Content-Length`` and
+comparing it to ``MAX_RUN_BODY_BYTES`` before touching the body. Four more
+routes (``/api/graph/save``, ``/api/graph/validate``, ``/api/graph/export``,
+``/api/presets/create``) had no cap at all, and the four upload routes read the
+entire file into memory and *then* compared it to ``MAX_UPLOAD_SIZE``.
+
+The deeper problem was not the coverage gap, it was that a ``Content-Length``
+comparison answers nothing about a **chunked** request: ``Transfer-Encoding:
+chunked`` declares no length, so every one of those guards was skipped in full
+by any client that chose to chunk. They were advisory, not enforcing.
+
+Counting bytes as they arrive fixes both at once. There is exactly one place a
+body can enter the application — the ASGI ``receive`` callable — so wrapping it
+bounds every route, present and future, chunked or not.
+
+Prior art, and why it is not used verbatim
+------------------------------------------
+Starlette 1.6 ships ``starlette.middleware.body_limit.RequestBodyLimitMiddleware``
+and it is the right *design*: wrap ``receive``, keep a running total, short-
+circuit on ``Content-Length`` when it is offered. Its design is adopted here.
+Its implementation is not, for two measured reasons (both reproduced against
+this app's middleware stack before deciding):
+
+1. It also wraps ``send`` and, when ``Content-Length`` exceeds the limit, it
+   **replaces whatever response the application produced** with a plain-text
+   413 — including a 401. ``POST /api/apps/{slug}/invoke`` checks its API key
+   before it reads the body precisely so a bad key answers 401; under that
+   middleware an oversized request with a bad key answers 413 instead. Silently
+   converting an auth failure into a size failure is not a trade this repo can
+   make (see ``core/auth.py``'s threat model).
+2. Its 413 body changes shape depending on the transport: ``text/plain`` when
+   ``Content-Length`` was present (the ``send`` path above), JSON when the
+   request was chunked (the ``receive`` path). Two shapes for one condition,
+   and neither is the 9-key run envelope that ``/api/graph/run/{name}`` and
+   ``/api/apps/{slug}/invoke`` promise on every response — a promise their
+   per-app OpenAPI document hands to third-party client generators.
+
+So the rule here is narrower and stated positively: **the limit bounds what the
+application reads.** A body nobody reads is never buffered and is never
+refused, which is what keeps every route's own auth and routing decisions
+ahead of this one.
+
+The two limits
+--------------
+``MAX_RUN_BODY_BYTES`` (64 MB) is a *graph* ceiling and applies to everything by
+default. ``MAX_UPLOAD_SIZE`` (500 MB) is a *file* ceiling and applies to the
+four upload routes. A single global number could only be one of those: 64 MB
+everywhere breaks model uploads, 500 MB everywhere makes the graph limit
+decorative. Both are read at request time, never captured at construction, so
+an env override or a test's monkeypatch takes effect.
+
+Note the upload ceiling is deliberately the file limit *plus* a small envelope
+allowance. ``MAX_UPLOAD_SIZE`` is documented as the largest **file** you may
+upload, but what crosses the wire is a multipart body: boundaries, a
+``Content-Disposition`` header and the filename ride along with it. Capping the
+body at exactly the file limit would make a file of exactly the documented size
+un-uploadable. The routes keep their own ``len(content) > MAX_UPLOAD_SIZE``
+check because it measures a different quantity — the file, not the body — and
+it is the one that enforces the documented number exactly. This middleware is
+what stops that check from having to buffer an unbounded request first.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from ..config import settings
+
+# Routes whose body is a file upload rather than a graph, and which therefore
+# answer to MAX_UPLOAD_SIZE. Exact paths, not prefixes: a frozenset lookup is
+# the cheapest possible test on a hot path, and an exact match cannot be
+# widened by accident the way a prefix can (a future `/api/files/uploads-list`
+# would silently inherit the 500 MB ceiling under `startswith`).
+UPLOAD_PATHS = frozenset({
+    "/api/files/upload",
+    "/api/images/upload",
+    "/api/models/upload",
+    "/api/custom-nodes/upload",
+})
+
+# Headroom over MAX_UPLOAD_SIZE for the multipart envelope around the file:
+# boundary lines, the Content-Disposition header and the filename. Measured at
+# a few hundred bytes for a single-file POST; 64 KB is generous enough that a
+# pathological filename cannot eat it and small enough (0.013% of the 500 MB
+# default) that it is not a limit of its own.
+MULTIPART_ENVELOPE_ALLOWANCE = 64 * 1024
+
+
+class RequestBodyTooLarge(HTTPException):
+    """413, raised from the wrapped ``receive`` the instant a body outgrows
+    its ceiling.
+
+    An ``HTTPException`` subclass on purpose, and this is load-bearing rather
+    than stylistic. FastAPI wraps body parsing in ``except Exception`` and
+    converts anything it catches into ``400 There was an error parsing the
+    body`` — except ``HTTPException``, which it re-raises untouched with the
+    comment "If a middleware raises an HTTPException, it should be raised
+    again" (``fastapi/routing.py``). Any other base class would have this cap
+    silently answering 400 on every route that declares a pydantic body.
+
+    Being an ``HTTPException`` is also what routes the error to Starlette's
+    ``ExceptionMiddleware``, which sits *inside* CORS — so the 413 comes back
+    with the CORS headers a browser needs in order to read it.
+    """
+
+    def __init__(self, *, limit: int, declared: int | None) -> None:
+        self.limit = limit
+        self.declared = declared
+        if declared is None:
+            # Streaming refusal: the total is unknown and unknowable — that is
+            # the entire point of the chunked case. Report the ceiling only,
+            # and never a running total, which would just be "the limit plus
+            # one chunk" dressed up as a measurement.
+            detail = f"request body exceeds max {limit} bytes"
+        else:
+            detail = f"request body is {declared} bytes (max {limit})"
+        super().__init__(status_code=413, detail=detail)
+
+
+def limit_for_path(path: str) -> int:
+    """Body ceiling in bytes for *path*. Read at request time, deliberately."""
+    if path in UPLOAD_PATHS:
+        return settings.MAX_UPLOAD_SIZE + MULTIPART_ENVELOPE_ALLOWANCE
+    return settings.MAX_RUN_BODY_BYTES
+
+
+class BodySizeLimitMiddleware:
+    """Pure-ASGI middleware bounding every HTTP request body.
+
+    Pure ASGI rather than ``BaseHTTPMiddleware``: the job is to substitute one
+    callable (``receive``) before the application reads it, which is precisely
+    what the raw interface is for. ``BaseHTTPMiddleware`` would run the whole
+    downstream app in a task group to achieve the same substitution, which is
+    both more machinery and more failure modes than a wrapped coroutine.
+
+    Non-HTTP scopes are passed straight through. WebSocket frames are a
+    different transport and are bounded by uvicorn's ``ws_max_size`` (16 MB by
+    default), enforced by the ``websockets`` library while it assembles
+    fragments — the same "count as it arrives" property this class gives HTTP.
+
+    Where it is registered matters and is documented at the call site in
+    ``main.py``: it must sit INSIDE the ``BaseHTTPMiddleware`` guards, because
+    an exception raised from an upstream ``receive`` does not survive that
+    class's task-group plumbing and ends up rewritten as a 400.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        limit = limit_for_path(scope["path"])
+        declared = _declared_length(scope)
+        seen = 0
+
+        async def receive_capped() -> Message:
+            nonlocal seen
+            # Cheap path first: when the client offered a length and it is
+            # already over, refuse without reading a byte. Raised HERE and not
+            # in __call__ because this middleware sits OUTSIDE
+            # ExceptionMiddleware — an exception raised before the app is
+            # entered escapes upward to ServerErrorMiddleware and becomes a
+            # 500. Raised from inside receive it surfaces within the request,
+            # where ExceptionMiddleware -- and so main.py's
+            # RequestBodyTooLarge handler -- can render it.
+            if declared is not None and declared > limit:
+                raise RequestBodyTooLarge(limit=limit, declared=declared)
+            message = await receive()
+            # The enforcing path: a chunked request declares no length, so the
+            # running total is the only thing that can refuse it.
+            if message["type"] == "http.request":
+                seen += len(message.get("body", b""))
+                if seen > limit:
+                    raise RequestBodyTooLarge(limit=limit, declared=None)
+            return message
+
+        await self.app(scope, receive_capped, send)
+
+
+def _declared_length(scope: Scope) -> int | None:
+    """``Content-Length`` as an int, or None when absent or unparseable.
+
+    A malformed header reads as "no declared length" rather than as zero:
+    treating garbage as a measurement is how a cap gets talked past.
+
+    The invariant that makes this header safe to consult at all: it can only
+    ever cause an EARLIER refusal, never a later one. The running total is
+    unconditional, so every way of lying here — a negative value, a zero, a
+    duplicated header, an unparseable one — costs the sender the short-circuit
+    and nothing else. Nothing read from this header can widen the limit.
+    """
+    for key, value in scope.get("headers", ()):
+        if key == b"content-length":
+            try:
+                return int(value)
+            except ValueError:
+                return None
+    return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 from urllib.parse import urlparse
+from uuid import uuid4
 
 # Windows reads MIME types from the registry, which other installers (VS, IIS,
 # antivirus, etc.) routinely clobber — `.js` often ends up as `text/plain`,
@@ -65,6 +66,7 @@ from .core.auth import (
     session_token,
     write_token_file,
 )
+from .core.body_limit import BodySizeLimitMiddleware, RequestBodyTooLarge
 from .core.cache import execution_cache_stats
 from .core.db import Database
 from .core.logging_config import setup_logging
@@ -370,10 +372,10 @@ app = FastAPI(title=settings.APP_NAME, version=get_version(), lifespan=lifespan)
 # Order matters: Starlette applies the *last-added* middleware *first*. We
 # want the request to flow as:
 #
-#   incoming → host_guard → auth_guard → CORS → route handler
+#   incoming → host_guard → auth_guard → body_limit → CORS → route handler
 #
 # Because middleware adds in reverse order, we add CORS first (innermost),
-# auth second, host third (outermost).
+# the body cap second, auth third, host fourth (outermost).
 
 # Innermost: CORS preflight + response headers.
 app.add_middleware(
@@ -384,6 +386,34 @@ app.add_middleware(
     allow_headers=["Content-Type", TOKEN_HEADER, "Authorization"],
     expose_headers=[],
 )
+
+# Request-body ceiling, counted as the bytes arrive (core#265, core#242).
+#
+# DO NOT MOVE THIS OUTSIDE THE TWO GUARDS BELOW. The position is not a matter
+# of taste and not merely about precedence — the cap stops working. Measured,
+# by relocating it and running the suite: 17 tests fail and an over-limit
+# request answers 400 "There was an error parsing the body" instead of 413.
+#
+# The reason is that auth_guard and host_guard are BaseHTTPMiddleware, which
+# runs the downstream app in a task group and pumps `receive` through its own
+# wrapper. An exception raised from an UPSTREAM `receive` does not survive that
+# plumbing as itself; it surfaces to FastAPI's body parser as a generic
+# failure, and FastAPI's `except Exception` rewrites it to a 400. Registered
+# here, the cap's `receive` is the one the route reads from directly, so
+# RequestBodyTooLarge reaches ExceptionMiddleware intact.
+#
+# Being inside the guards is also the behaviour we want on its own terms. An
+# oversized request with a bad Host still answers 421 and one with no session
+# token still answers 403, because both refuse without ever reading the body —
+# and a body nobody reads is never counted. A size failure never masks an auth
+# failure, and an unauthenticated caller is never handed a 413 that tells it
+# the route exists.
+#
+# INSIDE CORS, finally: the 413 is rendered by ExceptionMiddleware (innermost
+# of all), so it travels back out through CORSMiddleware and picks up the
+# Access-Control-Allow-Origin header a cross-origin caller needs in order to
+# read the status at all.
+app.add_middleware(BodySizeLimitMiddleware)
 
 
 @app.middleware("http")
@@ -434,6 +464,48 @@ async def host_guard(request: Request, call_next):
             content={"detail": "Misdirected Request (Host not allowed)"},
         )
     return await call_next(request)
+
+
+@app.exception_handler(RequestBodyTooLarge)
+async def body_too_large(request: Request, exc: RequestBodyTooLarge):
+    """Render the body cap's 413 in the shape the calling route promises.
+
+    One mechanism counts the bytes; this is the one place that decides how the
+    refusal *reads*. Two routes answer with the 9-key run envelope on every
+    single response, and that is not a local style choice — the per-app
+    OpenAPI document served at ``GET /api/apps/{slug}/openapi.json`` types its
+    ``default`` response as ``RunEnvelope``, so third-party clients generated
+    from it decode a 413 as an envelope. Everything else in the API answers
+    ``{"detail": ...}``, which is what the previous ``POST /api/runs`` cap
+    returned and what FastAPI returns for every other HTTPException.
+
+    Reached via Starlette's ``ExceptionMiddleware``: ``RequestBodyTooLarge``
+    is an ``HTTPException`` subclass, and handler lookup walks the MRO, so
+    this wins over the default HTTPException handler without displacing it
+    for any other status.
+    """
+    params = request.path_params
+    path = request.url.path
+    if path.startswith("/api/graph/run/"):
+        return routes_graph_run.error_response(
+            413,
+            run_id=uuid4().hex,
+            graph=params.get("name", ""),
+            code="payload_too_large",
+            message=exc.detail,
+        )
+    if path.startswith("/api/apps/") and path.endswith("/invoke"):
+        # version stays None: the cap fires before any version is resolved.
+        slug = params.get("slug", "")
+        return routes_graph_run.error_response(
+            413,
+            run_id=uuid4().hex,
+            graph=slug,
+            app=slug,
+            code="payload_too_large",
+            message=exc.detail,
+        )
+    return JSONResponse(status_code=413, content={"detail": exc.detail})
 
 
 # ── Routers ────────────────────────────────────────────────────────────

--- a/backend/tests/test_api_apps_invoke.py
+++ b/backend/tests/test_api_apps_invoke.py
@@ -615,12 +615,20 @@ async def test_queue_timeout_expires_while_queued(
 async def test_invoke_413_body_cap_writes_no_row(
     test_client, app_db, api_key, monkeypatch,
 ):
-    """POST with Content-Length > MAX_RUN_BODY_BYTES returns 413 with no
-    runs row. The cap is checked against the header before the body is
-    read; the envelope has all 9 keys, error.code == "payload_too_large",
-    and version is None (pre-resolution failure)."""
-    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 10)
+    """POST over MAX_RUN_BODY_BYTES returns 413 with no runs row.
+
+    The envelope has all 9 keys, error.code == "payload_too_large", and
+    version is None (the cap fires before any version is resolved). Since
+    core#265 the cap is enforced by ``core.body_limit`` for every route rather
+    than by this one, but the envelope is unchanged — the per-app OpenAPI
+    document types the 413 as a RunEnvelope for generated clients.
+
+    Note the publish happens BEFORE the monkeypatch, which it did not have to
+    before: the setup calls ``/api/graph/save``, and a 10-byte ceiling now
+    applies to that route too. That is the coverage gap core#265 was about.
+    """
     await _publish(test_client, SLUG, _echo_graph())
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 10)
     key_headers = _bearer(api_key["token"])
 
     # Send a body larger than the tiny cap (10 bytes). The actual body
@@ -642,6 +650,36 @@ async def test_invoke_413_body_cap_writes_no_row(
     # No rows written for pre-resolution failures.
     rows = await _run_rows(app_db)
     assert len(rows) == 0
+
+
+@pytest.mark.asyncio
+async def test_invoke_401_beats_the_body_cap(
+    test_client, app_db, api_key, monkeypatch,
+):
+    """A bad key on an oversized body answers 401, not 413.
+
+    This route checks its key BEFORE it reads the body, on purpose, and the
+    body cap must not disturb that. The ordering is not hypothetical: the
+    obvious way to build a global cap — Starlette's own
+    RequestBodyLimitMiddleware — also wraps ``send`` and replaces whatever
+    response the app produced with a plain-text 413 whenever Content-Length
+    is over the limit, turning exactly this 401 into a 413. core.body_limit
+    refuses only what the application actually READS, which is what keeps
+    every route's own auth answer in front of it.
+    """
+    await _publish(test_client, SLUG, _echo_graph())
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 10)
+
+    resp = await test_client.post(
+        f"/api/apps/{SLUG}/invoke",
+        json={"inputs": {"x": "far larger than ten bytes"}},
+        headers={"Authorization": "Bearer cdui_not_a_real_key"},
+    )
+    assert resp.status_code == 401, resp.text
+    body = resp.json()
+    assert set(body.keys()) == ENVELOPE_KEYS
+    assert body["error"]["code"] == "invalid_key"
+    assert resp.headers.get("WWW-Authenticate") == "Bearer"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_api_data_files.py
+++ b/backend/tests/test_api_data_files.py
@@ -1,0 +1,490 @@
+"""Security properties of the data-files API (core#242 item 1).
+
+``routes_data_files.py`` takes a filename straight from the user on three of
+its four routes, and those routes were verified BY HAND at review time — which
+is exactly the state that lets a guard regress silently. This file pins the
+behaviour that review observed, so a change to ``_safe_path``, to the
+extension whitelist or to a route's path converter has to break a test rather
+than a deployment.
+
+Reading the traversal tests: the exact string the ROUTE sees
+------------------------------------------------------------
+httpx removes ``..`` segments from a URL before it sends it, the same way a
+browser does — ``/api/files/download/../../etc/passwd`` leaves this process as
+``/api/etc/passwd`` and answers 404 from the router without ever reaching the
+handler. A test written that way passes whether or not the guard exists.
+
+So the tests below percent-encode the dots (``%2e%2e/``). httpx forwards that
+untouched, and the ASGI layer decodes it back into ``scope["path"]`` — leaving
+the handler with the literal ``../../etc/passwd``, which is precisely what an
+attacker using ``curl --path-as-is``, a raw socket or a proxy that does not
+normalise produces against a real uvicorn. The encoding is a transport
+detail; the server-side input is the real one.
+
+Where an outcome differs between Windows and POSIX it is branched explicitly
+rather than smoothed over — backslash is a path separator on one and an
+ordinary filename character on the other, and CI runs both.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.api.routes_data_files import ALLOWED_EXTENSIONS
+
+# No module-level asyncio mark: pyproject sets asyncio_mode = "auto", and a
+# blanket mark would also land on the synchronous unit test below.
+
+# Traversal payloads from the core#242 table that mean the same thing on both
+# platforms. The backslash entry is handled separately, below, because it does
+# not.
+TRAVERSAL_INPUTS = [
+    "../../etc/passwd",
+    "subdir/../../../secret.csv",
+    "/etc/passwd",
+    "a/../../../../../../tmp/x.csv",
+]
+
+BACKSLASH_INPUT = "..\\..\\windows\\system32\\config\\sam"
+
+
+def _verbatim(filename: str) -> str:
+    """Encode *filename* so the route receives it character for character.
+
+    Only the dots need encoding: ``.`` is what triggers a client's dot-segment
+    removal, and ``%2e`` is decoded back to ``.`` before the handler sees it.
+    Slashes are left alone so the URL keeps the same shape an attacker's would.
+    """
+    return filename.replace(".", "%2e")
+
+
+@pytest.fixture
+def data_files_dir(tmp_path, monkeypatch):
+    """Redirect settings.DATA_FILES_DIR at a temp dir for each test.
+
+    Read at request time by every route, so patching the attribute is enough —
+    and it means no test can touch the real ``backend/data/data_files``.
+    """
+    d = tmp_path / "data_files"
+    d.mkdir()
+    monkeypatch.setattr("app.config.settings.DATA_FILES_DIR", d)
+    return d
+
+
+# ── path traversal: download ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("filename", TRAVERSAL_INPUTS)
+async def test_download_traversal_is_refused(test_client, data_files_dir, filename):
+    """Every traversal payload core#242 recorded as refused, still refused.
+
+    400 rather than 404 is the assertion that matters: it proves the request
+    reached the handler and ``_safe_path`` turned it away, instead of being
+    lost to URL normalisation on the way in (which would make this test pass
+    with the guard deleted).
+    """
+    resp = await test_client.get(f"/api/files/download/{_verbatim(filename)}")
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == "Invalid filename"
+
+
+async def test_download_backslash_traversal_never_escapes(test_client, data_files_dir):
+    """``..\\..\\windows\\...`` — one payload, two correct answers.
+
+    On Windows a backslash separates path components, so this escapes the data
+    dir and ``_safe_path`` refuses it (400). On POSIX the same bytes are a
+    single, legal — if bizarre — filename that resolves INSIDE the data dir,
+    so the honest answer is "no such file" (404). Both platforms run this
+    suite in CI; neither serves anything from outside, which is the property
+    being pinned.
+    """
+    resp = await test_client.get(f"/api/files/download/{_verbatim(BACKSLASH_INPUT)}")
+    if os.name == "nt":
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"] == "Invalid filename"
+    else:
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["detail"].startswith("File not found:")
+
+
+async def test_download_never_serves_a_real_file_above_the_data_dir(
+    test_client, data_files_dir, tmp_path,
+):
+    """The guard against a file that actually exists, one level up.
+
+    The parametrised cases above point at paths that are absent on the test
+    machine, so a broken guard could still answer 404 there and look fine.
+    Here the target is real, readable and has an allowed extension — the only
+    thing standing between it and the response body is ``_safe_path``.
+    """
+    secret = tmp_path / "secret.csv"
+    secret.write_bytes(b"api_key,value\nprod,hunter2\n")
+
+    resp = await test_client.get("/api/files/download/%2e%2e/secret%2ecsv")
+    assert resp.status_code == 400, resp.text
+    assert b"hunter2" not in resp.content
+    assert secret.exists()
+
+
+async def test_download_of_dot_quad_resolves_inside_the_data_dir(
+    test_client, data_files_dir,
+):
+    """``....//....//x.csv`` is NOT a traversal, and core#242 says so.
+
+    ``....`` is an ordinary directory name — only ``.`` and ``..`` are dot
+    segments — so this resolves to ``<data dir>/..../x.csv``, stays inside the
+    sandbox, and is simply not there. Pinned because the distinction is easy
+    to lose: the answer is 404 from the HANDLER (note the echoed filename in
+    the detail, which a router-level 404 does not carry), never 400, and a
+    future "fix" that starts refusing it would be refusing a legal name.
+    """
+    resp = await test_client.get(f"/api/files/download/{_verbatim('....//....//x.csv')}")
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["detail"] == "File not found: ....//....//x.csv"
+
+
+async def test_download_of_percent_encoded_traversal_is_refused(
+    test_client, data_files_dir, tmp_path,
+):
+    """``%2e%2e%2fsecret.csv``, sent with its encoding intact, is refused.
+
+    core#242 filed this one alongside ``....//....//x.csv`` as "resolved
+    inside the base dir", which is what a BROWSER produces: it decodes the
+    escapes itself and collapses the result before the request leaves, so the
+    server is handed ``/api/files/secret.csv`` and the traversal is gone. A
+    client that forwards the escapes — this one, curl --path-as-is — gets them
+    decoded by the ASGI layer instead, the handler sees ``../secret.csv``, and
+    the guard answers 400. Both paths are safe; only the second one exercises
+    the guard, so that is the one worth a test.
+    """
+    (tmp_path / "secret.csv").write_bytes(b"leak")
+
+    resp = await test_client.get("/api/files/download/%2e%2e%2fsecret.csv")
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == "Invalid filename"
+    assert b"leak" not in resp.content
+
+
+# ── path traversal: delete ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("filename", TRAVERSAL_INPUTS)
+async def test_delete_traversal_never_reaches_the_handler(
+    test_client, data_files_dir, tmp_path, filename,
+):
+    """Delete refuses these one layer earlier than download does.
+
+    ``@router.delete("/{filename}")`` has no ``:path`` converter, so a name
+    containing a separator matches no route at all and the router answers 404
+    before any handler runs — which is why these are 404 here and 400 on the
+    download route. The distinction is worth pinning: widening that converter
+    to ``{filename:path}`` would silently move the entire burden onto
+    ``_safe_path``, and this test is what would notice.
+    """
+    decoy = tmp_path / "secret.csv"
+    decoy.write_bytes(b"still here")
+
+    resp = await test_client.delete(f"/api/files/{_verbatim(filename)}")
+    assert resp.status_code == 404, resp.text
+    assert decoy.exists()
+
+
+async def test_delete_backslash_traversal_never_escapes(
+    test_client, data_files_dir, tmp_path,
+):
+    """The backslash payload is the one that DOES reach delete's handler.
+
+    It has no forward slash, so it matches ``{filename}`` on both platforms.
+    From there Windows resolves it out of the data dir and ``_safe_path``
+    refuses it (400), while on POSIX it is one odd-looking filename that is
+    simply absent (404). Nothing outside the data dir is unlinked either way.
+    """
+    decoy = tmp_path / "secret.csv"
+    decoy.write_bytes(b"still here")
+
+    resp = await test_client.delete(f"/api/files/{_verbatim(BACKSLASH_INPUT)}")
+    if os.name == "nt":
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["detail"] == "Invalid filename"
+    else:
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["detail"].startswith("File not found:")
+    assert decoy.exists()
+
+
+# ── the extension whitelist ──────────────────────────────────────────────
+
+
+def test_allowed_extensions_are_exactly_the_documented_four():
+    """A whitelist is only a whitelist while it is short.
+
+    Pinned as a set so that adding an entry is a deliberate act with a test
+    change attached — the failure mode this guards against is someone
+    accepting ``.py`` or ``.zip`` for one node's convenience and handing the
+    upload route an arbitrary-file-write surface.
+    """
+    assert ALLOWED_EXTENSIONS == {".csv", ".tsv", ".txt", ".json"}
+
+
+@pytest.mark.parametrize("filename", ["evil.exe", "keys.pem", "bundle.zip", "noext"])
+async def test_upload_rejects_a_disallowed_extension(
+    test_client, data_files_dir, filename,
+):
+    """Upload is where a bad extension costs the most — it is the only route
+    that writes. ``noext`` is in the list because a suffix-less name yields
+    ``""``, and an empty string must fail the membership test like any other
+    value rather than slipping through some falsy shortcut.
+    """
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": (filename, b"payload", "application/octet-stream")},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "Unsupported file type" in resp.json()["detail"]
+    assert list(data_files_dir.iterdir()) == []
+
+
+async def test_upload_extension_check_is_case_insensitive(test_client, data_files_dir):
+    """``.CSV`` is a CSV. The check lowercases before comparing, and it has to
+    stay that way — a case-sensitive whitelist would reject a file a student
+    exported from Excel on Windows.
+    """
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": ("REPORT.CSV", b"a,b\n1,2\n", "text/csv")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert (data_files_dir / "REPORT.CSV").exists()
+
+
+async def test_download_refuses_a_file_with_a_disallowed_extension(
+    test_client, data_files_dir,
+):
+    """A file inside the data dir is still not downloadable unless its
+    extension is on the list.
+
+    This is the second half of the whitelist and the half that is easy to
+    forget: something else may have written into that directory (a node's
+    output, a stray key file a user dropped in), and the upload guard says
+    nothing about those.
+    """
+    (data_files_dir / "id_rsa.pem").write_bytes(b"-----BEGIN PRIVATE KEY-----")
+
+    resp = await test_client.get("/api/files/download/id_rsa.pem")
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == "Not a data file"
+    assert b"PRIVATE KEY" not in resp.content
+
+
+async def test_delete_refuses_a_file_with_a_disallowed_extension(
+    test_client, data_files_dir,
+):
+    """The same whitelist on delete, and here it is a write guard: without it
+    this route deletes any file in the directory, not just data files.
+    """
+    victim = data_files_dir / "id_rsa.pem"
+    victim.write_bytes(b"-----BEGIN PRIVATE KEY-----")
+
+    resp = await test_client.delete("/api/files/id_rsa.pem")
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == "Not a data file"
+    assert victim.exists()
+
+
+async def test_download_and_delete_refuse_a_directory(test_client, data_files_dir):
+    """A directory name passes ``_safe_path`` — it is inside the sandbox — so
+    the ``is_file`` check is what stops FileResponse being handed a directory
+    and ``unlink`` being called on one.
+    """
+    (data_files_dir / "nested").mkdir()
+
+    resp = await test_client.get("/api/files/download/nested")
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == "Not a file"
+
+    resp = await test_client.delete("/api/files/nested")
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == "Not a file"
+    assert (data_files_dir / "nested").is_dir()
+
+
+# ── upload filename reduction ────────────────────────────────────────────
+
+
+async def test_upload_strips_directory_components_from_the_filename(
+    test_client, data_files_dir, tmp_path,
+):
+    """``Path(filename).name`` is upload's guard, and it runs BEFORE
+    ``_safe_path``.
+
+    A multipart filename never passes through URL routing, so nothing
+    normalises it on the way in: the handler gets whatever the client typed.
+    The reduction is what turns ``../../evil.csv`` into ``evil.csv``, and the
+    assertion that matters is not just where the file landed but that the two
+    levels it aimed at are untouched.
+    """
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": ("../../evil.csv", b"x,y\n1,2\n", "text/csv")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["filename"] == "evil.csv"
+    assert (data_files_dir / "evil.csv").read_bytes() == b"x,y\n1,2\n"
+    # Nothing appeared beside or above the data dir.
+    assert [p.name for p in tmp_path.iterdir()] == ["data_files"]
+    assert not (tmp_path.parent / "evil.csv").exists()
+
+
+async def test_upload_flattens_a_nested_filename(test_client, data_files_dir):
+    """The same reduction with no traversal in it: ``subdir/nested.csv`` lands
+    flat. Pinned so the guard cannot be "fixed" into creating subdirectories,
+    which ``list`` does not show and ``delete``'s route cannot address.
+    """
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": ("subdir/nested.csv", b"a\n", "text/csv")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["filename"] == "nested.csv"
+    assert (data_files_dir / "nested.csv").exists()
+    assert not (data_files_dir / "subdir").exists()
+
+
+# ── the size ceiling ─────────────────────────────────────────────────────
+
+
+async def test_upload_over_the_size_limit_is_refused_with_413(
+    test_client, data_files_dir, monkeypatch,
+):
+    """The route's own ceiling, in the route's own words.
+
+    Deliberately only 1 KB over: ``core.body_limit`` caps the multipart BODY
+    at MAX_UPLOAD_SIZE plus an envelope allowance, so a payload this size
+    sails past the middleware and is refused by the handler's own
+    ``len(content)`` check — which is the one that enforces the documented
+    number exactly. Nothing is written.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_UPLOAD_SIZE", 1024)
+
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": ("big.csv", b"c" * 2048, "text/csv")},
+    )
+    assert resp.status_code == 413, resp.text
+    assert resp.json()["detail"] == "File too large"
+    assert not (data_files_dir / "big.csv").exists()
+
+
+async def test_upload_at_the_size_limit_still_succeeds(
+    test_client, data_files_dir, monkeypatch,
+):
+    """The counterweight to the test above: a file of exactly the limit is
+    accepted. Without this, refusing every upload would pass the 413 test.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_UPLOAD_SIZE", 1024)
+
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": ("exact.csv", b"c" * 1024, "text/csv")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["size"] == 1024
+    assert (data_files_dir / "exact.csv").stat().st_size == 1024
+
+
+# ── listing ──────────────────────────────────────────────────────────────
+
+
+async def test_list_skips_subdirectories_and_other_extensions(
+    test_client, data_files_dir,
+):
+    """``list`` feeds the DATA_FILE dropdown, so anything it returns is
+    something a learner can pick and a node will try to open.
+
+    A subdirectory would be un-openable, and a file outside the whitelist
+    would be un-downloadable — both are entries that can only produce a
+    confusing error later. ``is_file()`` and the suffix test keep them out.
+    """
+    (data_files_dir / "train.csv").write_bytes(b"a,b\n1,2\n")
+    (data_files_dir / "notes.txt").write_bytes(b"hello")
+    (data_files_dir / "id_rsa.pem").write_bytes(b"secret")
+    nested = data_files_dir / "nested"
+    nested.mkdir()
+    (nested / "inner.csv").write_bytes(b"a\n")
+
+    resp = await test_client.get("/api/files")
+    assert resp.status_code == 200, resp.text
+    listed = {item["filename"]: item["size"] for item in resp.json()}
+    assert set(listed) == {"train.csv", "notes.txt"}
+    assert listed["train.csv"] == 8
+
+
+async def test_list_creates_the_data_dir_when_it_is_missing(
+    test_client, tmp_path, monkeypatch,
+):
+    """First run on a fresh install: the directory does not exist yet, and
+    listing must answer an empty list rather than raising.
+    """
+    missing = tmp_path / "not-created-yet"
+    monkeypatch.setattr("app.config.settings.DATA_FILES_DIR", missing)
+
+    resp = await test_client.get("/api/files")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+    assert missing.is_dir()
+
+
+# ── the ordinary path ────────────────────────────────────────────────────
+
+
+async def test_upload_list_download_delete_roundtrip(test_client, data_files_dir):
+    """The whole lifecycle a learner actually walks, in one test.
+
+    Its job is to keep the guards above honest: every other test in this file
+    asserts that something is refused, and all of them would still pass if the
+    router refused everything.
+    """
+    payload = b"feature,label\n1.0,0\n2.0,1\n"
+
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": ("train.csv", payload, "text/csv")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"filename": "train.csv", "size": len(payload)}
+
+    resp = await test_client.get("/api/files")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == [{"filename": "train.csv", "size": len(payload)}]
+
+    resp = await test_client.get("/api/files/download/train.csv")
+    assert resp.status_code == 200, resp.text
+    assert resp.content == payload
+    assert "train.csv" in resp.headers.get("content-disposition", "")
+
+    resp = await test_client.delete("/api/files/train.csv")
+    assert resp.status_code == 200, resp.text
+    assert not (data_files_dir / "train.csv").exists()
+
+    resp = await test_client.get("/api/files/download/train.csv")
+    assert resp.status_code == 404, resp.text
+    resp = await test_client.get("/api/files")
+    assert resp.json() == []
+
+
+async def test_download_and_delete_of_a_missing_file_report_404(
+    test_client, data_files_dir,
+):
+    """A name that is perfectly legal but absent is "not found", not
+    "invalid" — the two answers must stay distinguishable, because a 400 here
+    would send a learner hunting for a bad filename instead of a missing file.
+    """
+    resp = await test_client.get("/api/files/download/absent.csv")
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["detail"] == "File not found: absent.csv"
+
+    resp = await test_client.delete("/api/files/absent.csv")
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["detail"] == "File not found: absent.csv"

--- a/backend/tests/test_body_limit.py
+++ b/backend/tests/test_body_limit.py
@@ -1,0 +1,612 @@
+"""The one request-body ceiling: core.body_limit (core#265, core#242).
+
+The headline test in this file is ``test_chunked_body_over_the_limit_is_refused``
+and everything else supports it. Every guard this replaces compared
+``Content-Length`` to a limit, and a chunked request declares no
+``Content-Length`` — so the old guards were not merely missing from four
+routes, they were skipped in full on all three routes that had them. A suite
+that does not send a chunked body has not tested the bug.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import AsyncIterator
+
+import pytest
+
+from app.core.body_limit import (
+    MULTIPART_ENVELOPE_ALLOWANCE,
+    UPLOAD_PATHS,
+    limit_for_path,
+)
+
+# No module-level asyncio mark: pyproject sets asyncio_mode = "auto", and a
+# blanket mark would also land on the two synchronous unit tests below.
+
+
+async def _chunks(total: int, chunk: int = 32) -> AsyncIterator[bytes]:
+    """Yield *total* bytes in *chunk*-sized pieces.
+
+    Handing httpx an async iterator (rather than a bytes object) is what makes
+    it send ``Transfer-Encoding: chunked`` with no ``Content-Length`` at all.
+    ``chunk`` stays deliberately small in the tests below so that no single
+    piece is over the limit — only the RUNNING TOTAL is, which is the property
+    a Content-Length comparison cannot have.
+    """
+    sent = 0
+    while sent < total:
+        n = min(chunk, total - sent)
+        yield b"a" * n
+        sent += n
+
+
+def _graph() -> dict:
+    return {
+        "name": "cap-probe",
+        "nodes": [
+            {"id": "start", "type": "Start",
+             "position": {"x": 0, "y": 0}, "data": {"params": {}}},
+        ],
+        "edges": [],
+    }
+
+
+# ── the hole every previous guard had ────────────────────────────────────
+
+
+async def test_chunked_body_over_the_limit_is_refused(test_client, monkeypatch):
+    """A chunked request with NO Content-Length that exceeds the limit is
+    refused. This is the case every guard this replaces missed.
+
+    Note the shape of the send: 320 bytes in 32-byte pieces against a 100-byte
+    ceiling. No individual piece is over the limit, so nothing but a running
+    total can refuse this — and there is no Content-Length to consult even if
+    something wanted to.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+    resp = await test_client.post(
+        "/api/graph/save",
+        content=_chunks(320, chunk=32),
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 413, resp.text
+
+    # Prove the request really did exercise the hole rather than quietly
+    # arriving with a length header that an old-style guard could have read.
+    sent = resp.request.headers
+    assert "content-length" not in {k.lower() for k in sent}
+    assert sent.get("transfer-encoding") == "chunked"
+
+
+async def test_chunked_body_under_the_limit_still_succeeds(test_client):
+    """The cap is a ceiling, not a gate: chunked transfer is not itself
+    suspicious. Pinned because the cheapest way to pass the test above is to
+    refuse every request that has no Content-Length."""
+    resp = await test_client.post("/api/graph/save", json=_graph())
+    assert resp.status_code == 200, resp.text
+
+    body = json.dumps(_graph()).encode()
+
+    async def _stream() -> AsyncIterator[bytes]:
+        for i in range(0, len(body), 16):
+            yield body[i:i + 16]
+
+    resp = await test_client.post(
+        "/api/graph/save",
+        content=_stream(),
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def test_chunked_body_is_refused_on_the_run_route_with_its_envelope(
+    test_client, monkeypatch, tmp_path,
+):
+    """The chunked hole is closed on /api/graph/run too, and the 413 still
+    arrives as the 9-key envelope that route promises on every response."""
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    assert (await test_client.post(
+        "/api/graph/save", json=_graph())).status_code == 200
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+
+    resp = await test_client.post(
+        "/api/graph/run/cap-probe",
+        content=_chunks(320, chunk=32),
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 413, resp.text
+    body = resp.json()
+    assert set(body.keys()) == {
+        "status", "run_id", "graph", "app", "version",
+        "device", "outputs", "error", "timing",
+    }
+    assert body["error"]["code"] == "payload_too_large"
+    assert body["graph"] == "cap-probe"
+    assert body["run_id"]
+
+
+async def test_chunked_body_is_refused_on_submit(test_client, monkeypatch):
+    """POST /api/runs keeps its {"detail": ...} shape, chunked or not."""
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+    resp = await test_client.post(
+        "/api/runs",
+        content=_chunks(320, chunk=32),
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 413, resp.text
+    assert "max 100" in resp.json()["detail"]
+
+
+# ── the four routes that had no cap at all (core#265) ────────────────────
+
+
+@pytest.mark.parametrize("path", [
+    "/api/graph/save",
+    "/api/graph/validate",
+    "/api/graph/export",
+    "/api/presets/create",
+])
+async def test_previously_uncapped_route_refuses_an_oversized_body(
+    test_client, monkeypatch, path,
+):
+    """Each route that took a pydantic body with no size check of its own.
+
+    The payload is deliberately not valid JSON for any of these schemas: a
+    413 proves the refusal happens while the body is being READ, before
+    FastAPI parses or validates it. A 422 here would mean the bytes were paid
+    for first.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+    resp = await test_client.post(
+        path,
+        content=b"{" + b"x" * 400,
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 413, f"{path}: {resp.text}"
+    assert "max 100" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize("path", [
+    "/api/graph/save",
+    "/api/graph/validate",
+    "/api/graph/export",
+    "/api/presets/create",
+])
+async def test_previously_uncapped_route_refuses_a_chunked_oversized_body(
+    test_client, monkeypatch, path,
+):
+    """The same four routes, with no Content-Length to lean on."""
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+    resp = await test_client.post(
+        path,
+        content=_chunks(400, chunk=32),
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 413, f"{path}: {resp.text}"
+
+
+# ── the hot path (the editor calls these on ordinary interaction) ────────
+
+
+async def test_hot_path_requests_are_unaffected(test_client, tmp_path, monkeypatch):
+    """/api/graph/save and /api/graph/validate at the PRODUCTION default.
+
+    No monkeypatched ceiling anywhere in this test: an ordinary graph must
+    still round-trip under the real 64 MB limit, because these two routes fire
+    on ordinary canvas interaction and a cap that costs them anything is a cap
+    that will be removed.
+    """
+    monkeypatch.setattr("app.config.settings.GRAPHS_DIR", tmp_path)
+    save = await test_client.post("/api/graph/save", json=_graph())
+    assert save.status_code == 200, save.text
+    check = await test_client.post("/api/graph/validate", json=_graph())
+    assert check.status_code == 200, check.text
+
+
+# ── two limits, resolved per path ────────────────────────────────────────
+
+
+async def test_a_declared_oversize_body_is_refused_without_reading_a_byte(
+    monkeypatch,
+):
+    """The Content-Length short-circuit, pinned by the property that makes it
+    worth having.
+
+    The running total alone would already refuse this request — but only after
+    reading up to the limit, which at the 64 MB default means buffering 64 MB
+    to reject a body that announced itself as larger. When a client declares a
+    length that is already over, the right number of bytes to read is zero.
+
+    Asserted against the ASGI callable directly because that is where "was
+    receive ever awaited" is observable at all; through an HTTP client both
+    paths look identical.
+    """
+    from app.core.body_limit import BodySizeLimitMiddleware, RequestBodyTooLarge
+
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+    reads = 0
+
+    async def receive():
+        nonlocal reads
+        reads += 1
+        return {"type": "http.request", "body": b"a" * 400, "more_body": False}
+
+    async def app(scope, recv, send):
+        await recv()
+
+    async def send(message):  # pragma: no cover - never reached
+        raise AssertionError("no response should be sent")
+
+    scope = {
+        "type": "http",
+        "path": "/api/graph/save",
+        "method": "POST",
+        "headers": [(b"content-length", b"400")],
+    }
+    with pytest.raises(RequestBodyTooLarge) as excinfo:
+        await BodySizeLimitMiddleware(app)(scope, receive, send)
+
+    assert reads == 0, "the body was read despite an over-limit Content-Length"
+    assert excinfo.value.status_code == 413
+    assert excinfo.value.declared == 400
+
+
+@pytest.mark.parametrize("header", [
+    b"not-a-number",   # unparseable
+    b"-1",             # negative
+    b"0",              # understated to nothing
+    b"1 2",            # two values smuggled into one header
+])
+async def test_a_lying_content_length_cannot_widen_the_cap(monkeypatch, header):
+    """The invariant that makes the header safe to consult at all.
+
+    ``Content-Length`` is attacker-controlled, so the only sound way to read it
+    is one that can cause an EARLIER refusal and never a later one. Every way
+    of lying here costs the sender the short-circuit and nothing else, because
+    the running total is unconditional. A guard that trusted the header — or
+    that treated garbage as zero — would be walked past by sending one.
+    """
+    from app.core.body_limit import BodySizeLimitMiddleware, RequestBodyTooLarge
+
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+
+    async def receive():
+        return {"type": "http.request", "body": b"a" * 400, "more_body": False}
+
+    async def app(scope, recv, send):
+        await recv()
+
+    async def send(message):  # pragma: no cover - never reached
+        raise AssertionError("no response should be sent")
+
+    scope = {
+        "type": "http",
+        "path": "/api/graph/save",
+        "method": "POST",
+        "headers": [(b"content-length", header)],
+    }
+    with pytest.raises(RequestBodyTooLarge) as excinfo:
+        await BodySizeLimitMiddleware(app)(scope, receive, send)
+    # declared is None -> it was the running total that refused this, which is
+    # the whole point: the header bought the sender nothing.
+    assert excinfo.value.declared is None
+
+
+def test_limit_for_path_distinguishes_uploads_from_graphs(monkeypatch):
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 111)
+    monkeypatch.setattr("app.config.settings.MAX_UPLOAD_SIZE", 999)
+    assert limit_for_path("/api/graph/save") == 111
+    assert limit_for_path("/api/runs") == 111
+    for upload in UPLOAD_PATHS:
+        assert limit_for_path(upload) == 999 + MULTIPART_ENVELOPE_ALLOWANCE
+    # Exact match only: a sibling path must not inherit the upload ceiling.
+    assert limit_for_path("/api/files/upload-batch") == 111
+
+
+def test_limits_are_read_per_request_not_captured_at_import(monkeypatch):
+    """The middleware must not snapshot settings at construction, or an env
+    override (and every test's monkeypatch) would be ignored."""
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 7)
+    assert limit_for_path("/api/graph/save") == 7
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 8)
+    assert limit_for_path("/api/graph/save") == 8
+
+
+@pytest.fixture
+def data_files_dir(tmp_path, monkeypatch):
+    d = tmp_path / "files"
+    d.mkdir()
+    monkeypatch.setattr("app.config.settings.DATA_FILES_DIR", d)
+    return d
+
+
+async def test_upload_uses_the_upload_ceiling_not_the_graph_ceiling(
+    test_client, data_files_dir, monkeypatch,
+):
+    """The point of having two limits.
+
+    MAX_RUN_BODY_BYTES is pinned to 100 bytes here — a single global number
+    would refuse this upload outright. It succeeds because the upload routes
+    resolve to MAX_UPLOAD_SIZE instead.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+    monkeypatch.setattr("app.config.settings.MAX_UPLOAD_SIZE", 50_000)
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": ("probe.csv", b"c" * 20_000, "text/csv")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["size"] == 20_000
+
+
+async def test_upload_at_exactly_the_documented_file_limit_succeeds(
+    test_client, data_files_dir, monkeypatch,
+):
+    """The boundary case the envelope allowance exists for.
+
+    MAX_UPLOAD_SIZE is documented as the largest FILE you may upload. What
+    crosses the wire is a multipart body — boundary lines, a
+    Content-Disposition header, the filename — so a body ceiling set to
+    exactly the file limit would make a file of exactly the documented size
+    un-uploadable. It must not.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_UPLOAD_SIZE", 4096)
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": ("exact.csv", b"c" * 4096, "text/csv")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["size"] == 4096
+    assert (data_files_dir / "exact.csv").stat().st_size == 4096
+
+
+async def test_upload_one_byte_over_the_file_limit_is_refused(
+    test_client, data_files_dir, monkeypatch,
+):
+    """Just past the documented file limit and still well inside the body
+    ceiling: the ROUTE refuses it, and says so in its own words."""
+    monkeypatch.setattr("app.config.settings.MAX_UPLOAD_SIZE", 4096)
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": ("over.csv", b"c" * 4097, "text/csv")},
+    )
+    assert resp.status_code == 413, resp.text
+    assert resp.json()["detail"] == "File too large"
+    assert not (data_files_dir / "over.csv").exists()
+
+
+async def test_upload_past_the_body_ceiling_is_refused_before_it_is_read(
+    test_client, data_files_dir, monkeypatch,
+):
+    """Far past the limit: the MIDDLEWARE refuses it, so the route never
+    buffers it. This is core#242 — the old code read the whole thing first
+    and nothing bounded a request larger still."""
+    monkeypatch.setattr("app.config.settings.MAX_UPLOAD_SIZE", 4096)
+    over = 4096 + MULTIPART_ENVELOPE_ALLOWANCE + 1024
+    resp = await test_client.post(
+        "/api/files/upload",
+        files={"file": ("huge.csv", b"c" * over, "text/csv")},
+    )
+    assert resp.status_code == 413, resp.text
+    # The middleware's wording, not the route's — proof of which layer refused.
+    assert resp.json()["detail"] != "File too large"
+    assert "max" in resp.json()["detail"]
+    assert not (data_files_dir / "huge.csv").exists()
+
+
+_BOUNDARY = "cdui-test-boundary"
+
+
+async def _multipart_stream(payload_bytes: int,
+                            chunk: int = 8192) -> AsyncIterator[bytes]:
+    """A REAL multipart body for one .csv field, yielded in pieces.
+
+    Genuine multipart rather than filler: python-multipart parses
+    incrementally and rejects garbage long before enough of it arrives, so a
+    stream of nonsense would answer 400 and prove nothing about the ceiling.
+    """
+    head = (
+        f"--{_BOUNDARY}\r\n"
+        'Content-Disposition: form-data; name="file"; filename="huge.csv"\r\n'
+        "Content-Type: text/csv\r\n\r\n"
+    ).encode()
+    tail = f"\r\n--{_BOUNDARY}--\r\n".encode()
+    yield head
+    sent = 0
+    while sent < payload_bytes:
+        n = min(chunk, payload_bytes - sent)
+        yield b"c" * n
+        sent += n
+    yield tail
+
+
+async def test_chunked_upload_past_the_body_ceiling_is_refused(
+    test_client, data_files_dir, monkeypatch,
+):
+    """The upload routes get the streaming refusal too, not just the
+    Content-Length one — a valid multipart body with no declared length is
+    still cut off the moment the running total passes the ceiling."""
+    monkeypatch.setattr("app.config.settings.MAX_UPLOAD_SIZE", 1024)
+    over = 1024 + MULTIPART_ENVELOPE_ALLOWANCE + 4096
+    resp = await test_client.post(
+        "/api/files/upload",
+        content=_multipart_stream(over),
+        headers={"content-type":
+                 f"multipart/form-data; boundary={_BOUNDARY}"},
+    )
+    assert resp.status_code == 413, resp.text
+    assert "content-length" not in {k.lower() for k in resp.request.headers}
+    assert not (data_files_dir / "huge.csv").exists()
+
+
+async def test_a_chunked_upload_inside_the_ceiling_still_lands(
+    test_client, data_files_dir, monkeypatch,
+):
+    """The same streaming path, under the ceiling: the file must arrive
+    intact. Pinned so the test above cannot be satisfied by refusing every
+    streamed upload."""
+    monkeypatch.setattr("app.config.settings.MAX_UPLOAD_SIZE", 50_000)
+    resp = await test_client.post(
+        "/api/files/upload",
+        content=_multipart_stream(20_000),
+        headers={"content-type":
+                 f"multipart/form-data; boundary={_BOUNDARY}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["size"] == 20_000
+    assert (data_files_dir / "huge.csv").stat().st_size == 20_000
+
+
+async def test_the_cap_is_not_swallowed_by_fastapis_body_parser(
+    test_client, monkeypatch, data_files_dir,
+):
+    """A regression guard on why RequestBodyTooLarge subclasses HTTPException.
+
+    FastAPI wraps body parsing in ``except Exception`` and rewrites whatever
+    it catches into ``400 There was an error parsing the body`` — every
+    exception except HTTPException, which it re-raises. Any other base class
+    would turn this cap into a silent 400 on every route with a declared body,
+    which is exactly what a multipart route reports for a malformed body. So
+    the two outcomes must stay distinguishable: too-big is 413, malformed is
+    400.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_UPLOAD_SIZE", 1024)
+    over = 1024 + MULTIPART_ENVELOPE_ALLOWANCE + 4096
+    too_big = await test_client.post(
+        "/api/files/upload",
+        content=_multipart_stream(over),
+        headers={"content-type":
+                 f"multipart/form-data; boundary={_BOUNDARY}"},
+    )
+    assert too_big.status_code == 413, too_big.text
+    assert "parsing the body" not in too_big.text
+
+
+# ── composition with the auth stack (must not reorder anything) ──────────
+
+
+def test_the_cap_sits_inside_both_guards_and_outside_cors():
+    """Pin the middleware ORDER structurally, not just in a comment.
+
+    Outermost first. The cap must stay inside both BaseHTTPMiddleware guards:
+    an exception raised from an upstream ``receive`` does not survive that
+    class's task-group plumbing, and an over-limit request ends up answering
+    400 "There was an error parsing the body" instead of 413. Moving it out
+    reddens 17 tests, but every one of those failures reads as a puzzle; this
+    one names the rule.
+    """
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.middleware.cors import CORSMiddleware
+
+    from app.core.body_limit import BodySizeLimitMiddleware
+    from app.main import app
+
+    layers = [
+        (m.cls, getattr(m.kwargs.get("dispatch"), "__name__", None))
+        for m in app.user_middleware
+    ]
+    assert layers == [
+        (BaseHTTPMiddleware, "host_guard"),
+        (BaseHTTPMiddleware, "auth_guard"),
+        (BodySizeLimitMiddleware, None),
+        (CORSMiddleware, None),
+    ], layers
+
+
+async def test_a_disallowed_host_still_wins_over_an_oversized_body(
+    test_client, monkeypatch,
+):
+    """host_guard is OUTSIDE the cap and must stay there.
+
+    An oversized body with a forged Host answers 421, not 413. Beyond
+    ordering, this is the cheaper refusal: host_guard never reads the body, so
+    nothing is counted and nothing is buffered.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+    resp = await test_client.post(
+        "/api/graph/save",
+        content=b"x" * 400,
+        headers={"content-type": "application/json", "host": "evil.example"},
+    )
+    assert resp.status_code == 421, resp.text
+
+
+async def test_a_missing_session_token_still_wins_over_an_oversized_body(
+    test_client, monkeypatch,
+):
+    """auth_guard is OUTSIDE the cap and must stay there: an unauthenticated
+    oversized request answers 403, and is not told that it was also too big."""
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+    resp = await test_client.post(
+        "/api/graph/save",
+        content=b"x" * 400,
+        headers={"content-type": "application/json",
+                 "x-codefyui-token": "wrong"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+async def test_the_413_carries_cors_headers(test_client, monkeypatch):
+    """The cap sits INSIDE CORSMiddleware so a cross-origin caller can
+    actually read the status. Without the header the browser reports an
+    opaque network error and the 413 is invisible."""
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 100)
+    resp = await test_client.post(
+        "/api/graph/save",
+        content=b"x" * 400,
+        headers={"content-type": "application/json",
+                 "origin": "http://localhost:5173"},
+    )
+    assert resp.status_code == 413
+    assert resp.headers.get("access-control-allow-origin") == \
+        "http://localhost:5173"
+
+
+async def test_a_body_nobody_reads_is_not_refused(test_client, monkeypatch):
+    """The stated rule: the cap bounds what the application READS.
+
+    POST /api/nodes/reload declares no body. An oversized one is never read,
+    never buffered and therefore never refused. This is not an oversight — it
+    is what keeps every route's own auth check ahead of the cap, including
+    /api/apps/{slug}/invoke's 401, which fires before that route reads its
+    body.
+    """
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 10)
+    resp = await test_client.post("/api/nodes/reload", content=b"x" * 400)
+    assert resp.status_code == 200, resp.text
+
+
+async def test_the_websocket_is_not_touched_by_the_http_cap(monkeypatch):
+    """Non-HTTP scopes pass straight through, and this is deliberate.
+
+    The cap is an HTTP body limit; a WebSocket has no request body to count.
+    A message far over MAX_RUN_BODY_BYTES therefore still reaches the socket's
+    own handler and gets that handler's answer — here, the malformed-JSON
+    error — rather than an HTTP 413 the client could not receive anyway.
+
+    What bounds a WS message is the transport: uvicorn's ``ws_max_size``
+    (16 MB by default) is enforced by the ``websockets`` library while it
+    assembles fragments, which is the same "count as it arrives" property
+    this module gives HTTP. Making that ceiling an explicit CodefyUI setting
+    rather than an inherited uvicorn default is filed as follow-up work.
+    """
+    from httpx import AsyncClient
+    from httpx_ws import aconnect_ws
+    from httpx_ws.transport import ASGIWebSocketTransport
+
+    from app.config import settings
+    from app.core.auth import TOKEN_QUERY_PARAM, session_token
+    from app.main import app
+
+    monkeypatch.setattr("app.config.settings.MAX_RUN_BODY_BYTES", 10)
+    async with AsyncClient(
+        transport=ASGIWebSocketTransport(app=app),
+        base_url=f"http://127.0.0.1:{settings.PORT}",
+    ) as client:
+        path = f"/ws/execution?{TOKEN_QUERY_PARAM}={session_token()}"
+        async with aconnect_ws(path, client) as ws:
+            await ws.send_text("z" * 4000)
+            reply = json.loads(await ws.receive_text())
+            assert reply["type"] == "error"
+            assert "malformed" in reply["error"]

--- a/docs/docs/usage/graph-as-a-function.md
+++ b/docs/docs/usage/graph-as-a-function.md
@@ -196,7 +196,8 @@ A ready-made graph for these exact calls ships in `examples/Usage_Example/Api-Fu
 
 ## 8. Limits and gotchas
 
-- 403 (missing/invalid token) and 421 (Host guard) arrive WITHOUT the envelope — they fire before the route.
+- 403 (missing/invalid token) and 421 (Host guard) arrive WITHOUT the envelope — they fire before the route. 413 keeps the envelope on this route and on `/invoke`.
+- The `MAX_RUN_BODY_BYTES` ceiling is not specific to `/run`: it applies to **every** endpoint except the four upload routes, which answer to `MAX_UPLOAD_SIZE` (default 500 MB) instead. So `POST /api/graph/save` with a 70 MB graph is a 413 too. It is counted as the bytes arrive rather than read off `Content-Length`, which means a chunked request — one that declares no length at all — is measured like any other.
 - This server never emits 504; a 504 always came from an intermediary.
 - `record_outputs=true` makes inputs and results readable by anyone on the LAN who learns the `run_id` (the GET outputs endpoint is auth-exempt; transport is plain HTTP). Published apps: run records are key-protected in SQLite; the inspector store is editor-only — invokes never write to it. To make a graph stable and key-protected: [publish it](./publish).
 - Do not put secrets in `default` values — `GET /contract` and `/load` are unauthenticated.


### PR DESCRIPTION
> 中文摘要：原本三條路線用 `Content-Length` 擋請求大小，但 chunked 請求根本不送這個標頭，所以三條全部形同虛設；另外四條路線加上四個上傳路線完全沒擋，上傳更是「先把整個檔案讀進記憶體、再來比大小」。這個 PR 用單一機制取代全部：在 ASGI `receive` 上邊收邊算位元組，不管有沒有 `Content-Length` 都成立，也自動涵蓋未來新增的路線。兩個上限依路徑決定：一般路線 64 MB、上傳路線 500 MB。位置放在 `host_guard`／`auth_guard` **裡面**、CORS 裡面——這不是風格問題，放到外面整個機制會壞掉（實測 17 個測試紅，且回 400 而非 413）。三個舊的 per-route 檢查已刪除。WebSocket 不在此機制內，因為它本來就被 uvicorn 的 `ws_max_size`（預設 16 MB）擋住，另開議題追蹤。

Closes #265. Closes #242.

## What was broken

Three routes capped their own request body by reading `Content-Length` and comparing it to `settings.MAX_RUN_BODY_BYTES` — `routes_graph_run`, `routes_apps`, and `routes_runs` (the last added only recently, in #264).

**A `Content-Length` comparison answers nothing about a chunked request.** `Transfer-Encoding: chunked` declares no length at all, so all three checks were skipped in full by any client that chose to chunk. This is the part that matters: it is not "four routes were missed", it is that the mechanism did not do what its name implied *on any route that had it*.

On top of that:

- `POST /api/graph/save`, `/api/graph/validate`, `/api/graph/export` and `POST /api/presets/create` took a pydantic body with no cap whatsoever.
- The four upload routes (`/api/files/upload`, `/api/images/upload`, `/api/models/upload`, `/api/custom-nodes/upload`) read the entire file into memory and *then* compared it to `MAX_UPLOAD_SIZE`. A request far larger than the limit was buffered in full before being refused — #242. Note this PR found two more instances than that issue lists: `routes_models.py` and `routes_custom_nodes.py` have the identical shape.

## What was built

`backend/app/core/body_limit.py`. It wraps the ASGI `receive` callable and keeps a running total, so it works whether or not a length was declared. There is exactly one place a body can enter the application, which is why this covers every route — present and future — instead of the three that remembered to ask.

### Starlette already offers one, and it is not used verbatim

Starlette 1.6 ships `starlette.middleware.body_limit.RequestBodyLimitMiddleware` (and per-`Route` `max_body_size`, which FastAPI does not expose). Its *design* is adopted here. Its implementation is not, for two reasons that were **reproduced against this app's actual middleware stack before deciding**, not assumed:

1. **It converts a 401 into a 413.** It also wraps `send`, and when `Content-Length` is over the limit it replaces whatever response the application produced with a plain-text 413. `POST /api/apps/{slug}/invoke` checks its API key *before* it reads the body precisely so a bad key answers 401; under that middleware an oversized request with a bad key answers 413 instead. Verified directly.
2. **Its 413 changes shape with the transport.** `text/plain` when a length was declared (the `send` path above), JSON when the request was chunked (the `receive` path). Two shapes for one condition, and neither is the 9-key run envelope.

So the rule here is narrower and stated positively: **the limit bounds what the application reads.** A body nobody reads is never buffered and never refused, which is what keeps every route's own auth and routing decisions in front of it.

### How it knows which of the two limits applies

Per path, resolved at request time (never captured at construction, so an env override and a test's monkeypatch both take effect):

- `MAX_RUN_BODY_BYTES` (64 MB) — everything.
- `MAX_UPLOAD_SIZE` (500 MB) — the four upload paths, matched as an exact frozenset rather than a prefix so a future `/api/files/upload-batch` cannot silently inherit the 500 MB ceiling.

A single global number could only ever be one of those: 64 MB everywhere breaks model uploads, 500 MB everywhere makes the graph limit decorative.

The upload ceiling is the file limit **plus a 64 KB multipart envelope allowance**. `MAX_UPLOAD_SIZE` documents the largest *file*; what crosses the wire is a multipart *body* carrying boundaries, a `Content-Disposition` header and the filename. Capping the body at exactly the file limit would make a file of exactly the documented size un-uploadable. The routes therefore keep their own `len(content) > MAX_UPLOAD_SIZE` check — it measures a different quantity and is the one that enforces the documented number exactly. What changed is that it can no longer be handed an unbounded request first.

### Why `RequestBodyTooLarge` subclasses `HTTPException`

Load-bearing, not stylistic. FastAPI wraps body parsing in `except Exception` and rewrites whatever it catches into `400 There was an error parsing the body` — everything except `HTTPException`, which it re-raises untouched with the comment *"If a middleware raises an HTTPException, it should be raised again"*. Any other base class would have this cap silently answering 400 on every route with a declared body. There is a regression test for exactly this.

## Where it sits in the middleware stack, and why

```
incoming -> host_guard -> auth_guard -> body_limit -> CORS -> route handler
```

**Auth ordering and behaviour are unchanged.** Nothing was reordered; the cap was inserted after both guards.

The position is not a matter of taste — **outside the guards the mechanism stops working.** Measured by relocating it and running the suite: 17 tests fail and an over-limit request answers `400 There was an error parsing the body` instead of 413. The reason is that `auth_guard` and `host_guard` are `BaseHTTPMiddleware`, which runs the downstream app in a task group and pumps `receive` through its own wrapper; an exception raised from an *upstream* `receive` does not survive that plumbing as itself, and FastAPI's `except Exception` then rewrites it. Registered inside them, the cap's `receive` is the one the route reads from directly, so the exception reaches `ExceptionMiddleware` intact.

Being inside the guards is also right on its own terms: an oversized request with a forged Host still answers 421 and one with no session token still answers 403, because both refuse *without reading the body* — and a body nobody reads is never counted. A size failure never masks an auth failure, and an unauthenticated caller is never handed a 413 that tells it the route exists.

Inside CORS, finally, so the 413 (rendered by `ExceptionMiddleware`, innermost of all) travels back out through `CORSMiddleware` and picks up the `Access-Control-Allow-Origin` header a cross-origin caller needs in order to read the status at all.

Because a comment is not a guard, the order is pinned structurally by `test_the_cap_sits_inside_both_guards_and_outside_cors`.

## The 413 response shape is preserved

`/api/graph/run/{name}` and `/api/apps/{slug}/invoke` answer with the 9-key envelope on **every** response, and that is not a local style choice: the per-app OpenAPI document served at `GET /api/apps/{slug}/openapi.json` types its `default` response as `RunEnvelope`, and `docs/usage/publish.md` advertises it as importable into openapi-generator as-is. Third-party clients generated from it decode a 413 as an envelope. A uniform `{"detail": ...}` would have broken that silently — no test would have caught the OpenAPI drift.

So one mechanism counts the bytes and one exception handler in `main.py` decides how the refusal *reads*: the envelope for those two routes, `{"detail": ...}` (unchanged) everywhere else, including `POST /api/runs`.

## What was deleted

- `routes_graph_run.py` — the step-2 `Content-Length` cap.
- `routes_apps.py` — the step-3 `Content-Length` cap.
- `routes_runs.py` — `_reject_oversized_body` and its call site.

The upload routes' file-size checks are **kept**, deliberately: body bytes and file bytes are two different quantities, and with the envelope allowance the file check is still reachable and still the thing that enforces the documented 500 MB exactly. Docstrings whose stated rationale no longer held (`_read_submit_body`, `submit_run`, and the `MAX_RUN_BODY_BYTES` comment in `config.py`) were corrected rather than left to go stale.

## Hot path

`/api/graph/save` and `/api/graph/validate` run on ordinary canvas interaction, so the cost was measured, not asserted:

| | |
|---|---|
| Middleware overhead, isolated (200k iterations, best of 3) | **0.70 us/request** |
| `/api/graph/validate` end-to-end, median of 300 | **1278 us/request** |
| Share of one round trip | **0.055%** |

Reproduced twice (0.704 us / 0.697 us). The work per request is one frozenset lookup, one closure, and — per body chunk — one `len()` and one integer compare.

## Tests

`backend/tests/test_body_limit.py` (33) and `backend/tests/test_api_data_files.py` (30 — #242 item 1; that router handled user-supplied filenames and had no tests at all, its traversal behaviour having been verified only by hand at review time), plus one added to `test_api_apps_invoke.py`. Full backend suite: **4219 passed, 22 skipped** (baseline before this branch: 4188).

The central one is `test_chunked_body_over_the_limit_is_refused`: 320 bytes sent in 32-byte pieces against a 100-byte ceiling, so **no individual chunk is over the limit** and there is no `Content-Length` to consult — only a running total can refuse it. It also asserts the request really was chunked, so the test cannot pass for the wrong reason. Every previously-uncapped route is covered both ways (declared length and chunked), with a deliberately malformed payload so a 413 proves the refusal precedes parsing.

Also covered: the hot path at the production default; upload boundary behaviour at exactly `MAX_UPLOAD_SIZE`, one byte over, and past the body ceiling; that 403/421/401 still win over an oversized body; CORS headers on the 413; and that a body nobody reads is not refused.

`Content-Length` is attacker-controlled, so the invariant that makes it safe to consult is pinned too: it can only ever cause an *earlier* refusal, never a later one. Unparseable, negative, zero and smuggled-duplicate values are all parametrised, and each one buys the sender the loss of the short-circuit and nothing else — the running total is unconditional.

**Mutation-checked, nine mutations, all red:**

| # | Mutation | Result |
|---|---|---|
| M1 | streaming counter removed (the chunked hole reopens) | red |
| M2 | `Content-Length` short-circuit removed | red |
| M3 | upload paths lose their raised ceiling (one global number) | red |
| M4 | multipart envelope allowance set to 0 | red |
| M5 | `RequestBodyTooLarge` no longer an `HTTPException` | red |
| M6 | middleware not registered at all | red |
| M7 | run-route envelope rendering dropped | red |
| M8 | invoke envelope rendering dropped | red |
| M9 | middleware moved outside the guards | red (17 tests) |

M2 was **green on the first pass** — the running total also catches a declared-oversize body, so the short-circuit was unpinned. It is worth keeping because it refuses *without reading a byte* rather than after buffering up to the limit, so a test was added that asserts `receive` is never awaited. That is the only reason the count is nine and not eight.

## What a reviewer should check

1. **The middleware position.** It is the one thing in here that is easy to "tidy" and silently break; the failure mode is a 400 rather than an exception, so it looks like a body-parsing bug. The structural test and the comment at the call site both say so.
2. **That the envelope really is preserved** on the two routes that promise it — and that you agree the OpenAPI `default` -> `RunEnvelope` contract was the right thing to protect.
3. **The multipart envelope allowance.** 64 KB of headroom over `MAX_UPLOAD_SIZE` is a judgement call. The alternative is that a file of exactly the documented size cannot be uploaded.
4. **Keeping the upload routes' file-size checks.** I argue they answer a different question (file vs. body) rather than duplicating one; disagree if you read it otherwise.
5. **The new 413s.** `POST /api/graph/save` with a >64 MB graph now fails where it previously succeeded. Documented in `graph-as-a-function.md` §8 and in the changelog.

## Not covered: the WebSocket

`WS /ws/execution` is not capped by this mechanism, and the reasoning is on the record rather than left silent. A WebSocket has no request body to count, and its messages are **already bounded** — contrary to the premise in #265 that there is "no frame limit at all". uvicorn's `ws_max_size` defaults to 16 MB and is enforced by the `websockets` library *while it assembles fragments*, which is the same count-as-it-arrives property this PR gives HTTP. `cdui start` passes no override, so the default is what runs.

An app-level check on `receive_text()` would not improve on that: by then the message is already assembled, and `len()` on the returned `str` counts characters, not bytes, so it would be a weaker bound than the transport's. What is genuinely missing is that 16 MB is an inherited uvicorn default rather than an explicit CodefyUI setting — filed as a follow-up rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
