### PR TITLE
chore: bump versions to 2.2.0 and promote the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,27 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [2.2.0] — 2026-08-10
+
+The release that makes a re-run mean something.
+
+The headline is a correctness bug nobody had noticed: **a second Run of a
+shipped training example did no training at all, and reported success.**
+Measured on `plugins/foundations/examples/C2-5/MLP-MNIST-Training`, counting
+real `TrainingLoop.execute()` calls across three runs against one cache: `1`,
+`0`, `0`. Four of the six shipped graphs that train were affected, two of them
+teaching-plugin examples students open in class. It stayed invisible because a
+preset reported `completed` whether its contents ran or came from cache — both
+halves of that are fixed here.
+
+The rest divides into three: the same cache-correctness family (a hit must not
+skip a side effect, a mutation, or a file write), a security pass driven by
+CodefyUI now being evaluated for shared company servers rather than one
+student's laptop, and the quality gates that stop the next round of this being
+found by hand.
+
 ### Fixed
 
 - **Every request-body size cap could be walked past by chunking, and four
@@ -444,6 +465,7 @@ Release candidates before 1.0.0 are on the
 [#242]: https://github.com/CodefyUI/CodefyUI/issues/242
 [#265]: https://github.com/CodefyUI/CodefyUI/issues/265
 [@oyea0801]: https://github.com/oyea0801
-[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...main
+[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.2.0...main
+[2.2.0]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...2.2.0
 [2.1.1]: https://github.com/CodefyUI/CodefyUI/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/CodefyUI/CodefyUI/compare/2.0.0...2.1.0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefyui-backend"
-version = "2.1.1"
+version = "2.2.0"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
 # Names the copyright holder in distribution metadata. Until this landed, no
 # file in the repository said who owns CodefyUI, which left the commercial

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "codefyui-backend"
-version = "2.1.1"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codefyui-frontend",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "AGPL-3.0-only",
   "author": "CodefyUI (https://github.com/CodefyUI)",
   "packageManager": "pnpm@9.15.0",


### PR DESCRIPTION
> 中文摘要：2.1.1 之後累積了 14 個 commit，一個使用者都拿不到——包含這次發版最主要的理由：內建教學範例按第二次 Run 完全不訓練，而且回報成功。三個版本欄位加變更記錄提升，就是 RELEASING.md 第一步的清單，沒有別的。

Fourteen commits have landed above the `2.1.1` tag and none is reachable by anyone running a released build.

## Why this one matters more than the usual housekeeping

The headline is #253: **a second Run of a shipped training example did no training at all, and reported success.** Measured on `plugins/foundations/examples/C2-5/MLP-MNIST-Training`, counting real `TrainingLoop.execute()` calls across three runs against one shared cache:

```
before: 1, 0, 0
after:  1, 1, 1
```

Four of the six shipped graphs that train were affected, two of them teaching-plugin examples students open in class. A student changes a hyperparameter, presses Run, sees `completed` and a loss curve — from the previous run — and concludes the parameter did nothing.

It stayed invisible because a preset reported `completed` whether its contents executed or came from cache (#260). Both halves are fixed.

## What is in it

- **Cache correctness** — #253, #223, #254, #259. A hit must not skip training, a side effect, a mutation, or a file write.
- **Security** — #251 (SECRET params were written verbatim into the run database), #215/#216/#220 (the plugin gate missed `_ctypes`, `_socket`, `winreg`, and never scanned `.pyc`/`.pyd` at all — plus `_frozen_importlib`, a complete import-gate bypass neither issue named), #265/#242 (every body-size cap could be walked past by chunking).
- **Correctness in training** — #244 (`OneCycleLR.total_steps` defaults to 1000 while the scheduler steps per epoch, so the LR warms up and never anneals), #205, #149, #155.
- **Quality gates** — #245: a Windows CI job, `ruff` landing green, `cdui test` running both halves.
- **Deployment and legal** — #249 (it can now go behind a reverse proxy, with tested nginx and systemd configs), #248 (a named copyright holder, a DCO, and the docs no longer overstate what AGPL requires).

## What is in this PR specifically

The three hand-edited version fields and the changelog promotion — the RELEASING.md step-1 checklist, nothing else. `test_all_version_fields_agree` passes (14 tests in `test_version_surfacing.py`).

## After merge

Tag with `--cleanup=verbatim`, per the warning #241 added, then verify the headings survived before publishing.