### PR TITLE
fix(security): the write rule and the delete rule are not the same rule, and neither may name the database (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,42 @@ received — each links to the release it was published as.
 
 ### Fixed
 
+- **A path typed into a node parameter could overwrite the run database, and
+  an unattended prune could delete a file it never wrote** ([#224]). One
+  write-scoped rule — "stay inside the project data directory" — guarded both
+  directions, and on a default install the database is inside that directory.
+
+  *Write.* With the default `cdui start` and no `--project`, `PROJECT_DIR` is
+  `None`, the project-mode derivation never runs, and `MODELS_DIR` stays
+  `backend/data/models` — one level below `codefyui.db`. So `../codefyui.db`
+  as a `CheckpointSaver`, `ModelSaver` or `ImageWriter` path resolved to the
+  live database and passed the guard, and a training run wrote a `.pt` payload
+  over it. No plugin and no mislabelled row required. Project mode was never
+  affected: there `MODELS_DIR` is `<project>/assets/models` and the database,
+  which stays install-global, is outside the data root entirely.
+
+  *Delete.* `RunStore.prune` unlinks the file of every pruned artifact row
+  whose `kind` is `checkpoint`. `kind` is a free-text column and the plugin
+  API can log artifacts, so a row claiming `kind="checkpoint"` with a path
+  pointing at anything else under the data root had that file removed by a
+  background sweep, with no user action and no confirmation.
+
+  Both now have their own rule, because they ask different questions. Writes
+  stay permissive — the data directory is a node's to write into — minus
+  CodefyUI's own storage: the database and its SQLite `-wal` / `-shm` /
+  `-journal` sidecars, derived from `DB_PATH` at call time and compared with
+  case folding so a differently-cased spelling cannot slip past on Windows.
+  Deletes no longer trust the row at all: retention removes a file only where
+  it can prove it wrote it — a generated checkpoint filename under
+  `MODELS_DIR/interrupted/` or `MODELS_DIR/periodic/`, the only two places
+  the interrupt and periodic writers put anything. Everything else is skipped
+  and logged, and the row still goes either way.
+
+  Nothing about ordinary use changes: checkpoints, saved models and written
+  images work exactly as before in both modes, including to arbitrary
+  sub-directories under the data root. A `CheckpointSaver` file the user named
+  themselves was never touched by retention before and still is not.
+
 - **Every request-body size cap could be walked past by chunking, and four
   routes had no cap at all** ([#265], [#242]). Three routes capped their body
   by comparing `Content-Length` to `MAX_RUN_BODY_BYTES`. A chunked request —
@@ -443,6 +479,7 @@ Release candidates before 1.0.0 are on the
 [#259]: https://github.com/CodefyUI/CodefyUI/issues/259
 [#242]: https://github.com/CodefyUI/CodefyUI/issues/242
 [#265]: https://github.com/CodefyUI/CodefyUI/issues/265
+[#224]: https://github.com/CodefyUI/CodefyUI/issues/224
 [@oyea0801]: https://github.com/oyea0801
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...main
 [2.1.1]: https://github.com/CodefyUI/CodefyUI/compare/2.1.0...2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,15 @@ received — each links to the release it was published as.
   *Write.* With the default `cdui start` and no `--project`, `PROJECT_DIR` is
   `None`, the project-mode derivation never runs, and `MODELS_DIR` stays
   `backend/data/models` — one level below `codefyui.db`. So `../codefyui.db`
-  as a `CheckpointSaver`, `ModelSaver` or `ImageWriter` path resolved to the
-  live database and passed the guard, and a training run wrote a `.pt` payload
-  over it. No plugin and no mislabelled row required. Project mode was never
-  affected: there `MODELS_DIR` is `<project>/assets/models` and the database,
-  which stays install-global, is outside the data root entirely.
+  as a `CheckpointSaver` or `ModelSaver` path resolved to the live database
+  and passed the guard, and a training run wrote a `.pt` payload over it. No
+  plugin and no mislabelled row required. Project mode was never affected:
+  there `MODELS_DIR` is `<project>/assets/models` and the database, which
+  stays install-global, is outside the data root entirely. `ImageWriter`
+  shares the same rule but was not reachable this way — it forces the file
+  extension to match its `format`, so `../codefyui.db` was rewritten to
+  `codefyui.png` and landed beside the database; what it could overwrite was
+  any file under the data root ending in an image extension.
 
   *Delete.* `RunStore.prune` unlinks the file of every pruned artifact row
   whose `kind` is `checkpoint`. `kind` is a free-text column and the plugin

--- a/backend/app/core/checkpoints.py
+++ b/backend/app/core/checkpoints.py
@@ -136,6 +136,15 @@ aged out of the keep-last-N window, so it does not, and structurally cannot,
 bound how many periodic checkpoints a single STILL-RUNNING job accumulates
 -- see ``TrainingLoopNode``'s ``checkpoint_every`` docs for that trade-off.
 
+The sweep deletes only what it can prove it wrote (#224). The delete guard
+is :func:`owned_checkpoint_path`, NOT the write guard: "may a node write
+here" is a permissive question and "did we write this" is not, and letting
+one answer both made an unattended, irreversible sweep as broad as an
+ordinary write. Which is what makes the paragraph above true in the first
+place -- ``interrupted/`` and ``periodic/`` are not merely where these files
+happen to go, they are the definition of what retention is allowed to
+remove.
+
 Durability
 ----------
 ``write_checkpoint`` stages to a temporary file in the destination
@@ -159,11 +168,13 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 from ..config import settings
+from .data_paths import resolve_data_path
 
 logger = logging.getLogger(__name__)
 
@@ -179,27 +190,87 @@ INTERRUPT_DIRNAME = "interrupted"
 #: path-safety rules.
 PERIODIC_DIRNAME = "periodic"
 
+#: The sub-directories of ``MODELS_DIR`` this module writes into on its own
+#: initiative, and therefore owns the lifecycle of. Retention will unlink a
+#: file under one of these and nowhere else -- see
+#: :func:`owned_checkpoint_path`.
+OWNED_DIRNAMES = (INTERRUPT_DIRNAME, PERIODIC_DIRNAME)
+
 #: Cap on each path component built from a run/node id. Long enough to stay
 #: recognisable, short enough that a deep MODELS_DIR plus two components
 #: cannot push the whole path past Windows' 260-character default limit.
 MAX_NAME_PART = 48
+
+#: The filename shape :func:`interrupt_checkpoint_path` and
+#: :func:`periodic_checkpoint_path` produce: two id components, then the
+#: position (``-e<epoch>`` with an optional ``b<batch>``), then ``.pt``.
+#: The numbers accept a leading ``-`` because both builders pass their
+#: arguments through ``int()`` rather than rejecting a negative epoch.
+#: ``test_generated_checkpoint_names_are_recognised_as_owned`` asserts the
+#: builders and this pattern agree, so the two cannot drift apart silently.
+_OWNED_NAME = re.compile(r"^.+-e-?\d+(?:b-?\d+)?\.pt$")
 
 
 def resolve_checkpoint_path(path: str | Path) -> Path:
     """Absolute, validated destination for *path*.
 
     A relative path is taken as relative to ``MODELS_DIR``. The result must
-    stay inside the project data directory -- this is the only thing
-    standing between a graph parameter and an arbitrary file write.
+    stay inside the project data directory and must not name CodefyUI's own
+    storage -- this is the only thing standing between a graph parameter and
+    an arbitrary file write. The rule itself lives in
+    :func:`core.data_paths.resolve_data_path`, shared with ``ModelSaver``
+    and ``ImageWriter``; see that module for what "own storage" covers and
+    why the data root alone was not enough (#224).
+
+    WRITE scope only. Retention's delete uses :func:`owned_checkpoint_path`,
+    which is deliberately much narrower -- see that function.
+    """
+    return resolve_data_path(path, base=settings.MODELS_DIR)
+
+
+def owned_checkpoint_path(path: str | Path) -> Path | None:
+    """Resolve *path* iff this module wrote it; ``None`` otherwise (#224).
+
+    The DELETE rule, and it is not the write rule. ``resolve_checkpoint_path``
+    answers "may a node write here", which is a permissive question by
+    design: the whole data directory is a node's to write into. Retention
+    asks a different one -- "did WE write this, so that removing the row
+    obliges us to remove the file" -- and answering it with the write rule
+    made an unattended, irreversible sweep as broad as an ordinary write.
+
+    Only two call sites ever produce a ``checkpoint``-kind artifact row:
+    ``loop_control.save_interrupt_checkpoint`` and
+    ``save_periodic_checkpoint``, which write to
+    :func:`interrupt_checkpoint_path` and :func:`periodic_checkpoint_path`
+    respectively -- both under a sub-directory of ``MODELS_DIR`` named in
+    :data:`OWNED_DIRNAMES`, both with a generated filename. ``kind`` is an
+    open vocabulary (see ``run_store``'s ``ARTIFACT_KIND_*`` comment) and the
+    plugin API can log artifacts, so anything else claiming to be a
+    ``checkpoint`` is by definition not one of ours and is left alone.
+
+    Note what this does NOT cover, on purpose: a ``CheckpointSaver`` the
+    user wired into the graph. That node writes where the user told it to
+    and records no artifact row at all, so retention never saw it before
+    this change either -- and if something starts logging one, the file
+    still belongs to the user, exactly as ``RunStore.delete_run`` already
+    reasons about explicitly-named artifact files.
+
+    ``Path.resolve()`` runs first, so a symlink planted inside ``periodic/``
+    that points at the database resolves to the database, lands outside the
+    owned directories and is refused. Returns the resolved path when it is
+    ours, ``None`` when it is not -- callers log the rejection rather than
+    raising, because one odd row must not fail a whole prune.
     """
     resolved = Path(path)
     if not resolved.is_absolute():
         resolved = settings.MODELS_DIR / resolved
     resolved = resolved.resolve()
 
-    data_root = settings.MODELS_DIR.parent.resolve()
-    if not resolved.is_relative_to(data_root):
-        raise ValueError("Output path must be within the project data directory")
+    if not _OWNED_NAME.match(resolved.name):
+        return None
+    models_dir = settings.MODELS_DIR.resolve()
+    if not any(resolved.is_relative_to(models_dir / d) for d in OWNED_DIRNAMES):
+        return None
     return resolved
 
 
@@ -388,21 +459,25 @@ def unlink_checkpoint(path: str | Path) -> bool:
     hand-deleted file is just as possible) or a permissions error are all
     logged and swallowed. Never raises.
 
-    Only removes a path that resolves inside the project data directory --
-    the same rule :func:`resolve_checkpoint_path` enforces on write. An
-    artifact's ``kind`` is an open vocabulary (see ``run_store``'s
-    ``ARTIFACT_KIND_*`` comment), so a row mislabelled ``checkpoint`` by
-    something outside this module's own writers must not turn an automatic
-    sweep into a delete of an arbitrary file.
+    Only removes a path :func:`owned_checkpoint_path` recognises as one this
+    module itself wrote -- a generated filename under ``MODELS_DIR/interrupted/``
+    or ``MODELS_DIR/periodic/``. Until #224 the guard here was
+    :func:`resolve_checkpoint_path`, the WRITE rule, which permits anything
+    under the data root: an artifact's ``kind`` is an open vocabulary (see
+    ``run_store``'s ``ARTIFACT_KIND_*`` comment) and the plugin API can log
+    artifacts, so a row mislabelled ``checkpoint`` turned this automatic
+    sweep into a delete of an arbitrary file -- on a default install, up to
+    and including ``codefyui.db`` itself. Prove-we-wrote-it replaces
+    trust-the-row.
 
     Returns True when a file was actually removed.
     """
-    try:
-        resolved = resolve_checkpoint_path(path)
-    except ValueError:
+    resolved = owned_checkpoint_path(path)
+    if resolved is None:
         logger.warning(
-            "retention: not deleting artifact path %r -- it resolves "
-            "outside the project data directory", str(path),
+            "retention: not deleting artifact path %r -- it is not a file "
+            "this server wrote (expected a generated checkpoint name under "
+            "MODELS_DIR/%s)", str(path), " or MODELS_DIR/".join(OWNED_DIRNAMES),
         )
         return False
     try:

--- a/backend/app/core/data_paths.py
+++ b/backend/app/core/data_paths.py
@@ -1,0 +1,135 @@
+"""Which files under the data root a node may write to (#224).
+
+Every node that turns a graph parameter into a filesystem write shares one
+rule, and it lives here so there is exactly one copy of it. Before #224
+there were three: ``core.checkpoints.resolve_checkpoint_path``,
+``nodes/io/model_saver_node.py`` and ``nodes/io/image_writer_node.py`` each
+open-coded "resolve, then require ``MODELS_DIR.parent``", which meant three
+places to fix and three places to forget.
+
+The rule
+--------
+1. A relative path is taken as relative to the caller's *base* directory
+   (``MODELS_DIR`` for checkpoints and saved models, ``<data>/output`` for
+   written images) -- the caller passes it, because the defaults differ.
+2. The resolved result must stay under the **data root**,
+   ``MODELS_DIR.parent``. Unchanged: this is what has always kept a graph
+   parameter from writing to an arbitrary place on the machine.
+3. The resolved result must not be one of :func:`protected_paths` --
+   CodefyUI's own storage, which is under the data root but is engine state
+   rather than anything a node produces.
+
+Rule 3 is what #224 adds. Rules 1-2 alone let a graph parameter name the
+run database: with the default ``cdui start`` and no ``--project``,
+``PROJECT_DIR`` is ``None``, the project-mode derivation in ``config.py``
+never runs, and ``MODELS_DIR`` falls back to ``backend/data/models`` --
+whose parent is the directory holding ``codefyui.db``. So
+``path="../codefyui.db"`` on a ``CheckpointSaver`` (or ``ImageWriter``,
+which resolves relative paths one level deeper under ``<data>/output``)
+resolved to the live database and a training run would have written a
+``.pt`` payload straight over it. No mislabelled artifact row and no
+plugin required -- just a path typed into a node parameter.
+
+The issue this comes from argued the installed layout was narrower than
+dev because ``MODELS_DIR`` is ``<project>/assets/models``. That is true in
+project mode and only in project mode, which is not the default.
+
+What is protected, and what deliberately is not
+-----------------------------------------------
+:func:`protected_paths` names the SQLite database and its three possible
+sidecars (``-wal``, ``-shm``, ``-journal`` -- ``core.db`` runs in WAL mode,
+where truncating the ``-wal`` corrupts the database just as effectively as
+truncating the main file). All four are derived from ``settings.DB_PATH``
+at call time rather than hardcoded, so an installation that moves the
+database keeps the protection.
+
+``GRAPHS_DIR`` was considered and rejected. In project mode it already sits
+outside the data root, so protecting it would change nothing there; in
+default mode it is ``<data>/graphs``, which a node writing an image into it
+would indeed clobber. But it is a DIRECTORY whose position relative to the
+data root is configuration-dependent -- several tests already point
+``GRAPHS_DIR`` at the same directory they use as the data root, and a
+protected entry that can be configured to equal the root would deny every
+legitimate write. ``DB_PATH`` is a file and can never degenerate that way.
+Widening to directories wants an explicit containment invariant first.
+
+Case folding, and why there is none here
+----------------------------------------
+``../CODEFYUI.DB-WAL`` names the same file as ``../codefyui.db-wal`` on
+Windows and a different one on POSIX, and this module does nothing about
+that -- because ``pathlib`` already does. Comparison and ``is_relative_to``
+run on the platform flavour, and ``PureWindowsPath`` compares
+case-insensitively. ``Path.resolve()`` is NOT enough on its own: it
+canonicalises the case of components that exist on disk but falls back to
+lexical normalisation for ones that do not, and the ``-wal`` sidecar is
+absent whenever the database is closed. An earlier revision of this module
+folded case explicitly through ``os.path.normcase``; mutation-testing the
+guard showed removing that layer changed no outcome, because the comparison
+underneath was already doing it. ``test_a_case_differing_spelling_of_the_
+database_is_refused`` pins the behaviour rather than the mechanism, so this
+stays correct if the mechanism ever needs to come back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..config import settings
+
+#: Suffixes SQLite appends to the database filename for its journals. WAL
+#: mode (``core.db`` sets ``PRAGMA journal_mode=WAL``) uses the first two;
+#: ``-journal`` is the rollback-journal name any non-WAL fallback would use.
+_DB_SIDECAR_SUFFIXES = ("-wal", "-shm", "-journal")
+
+
+def data_root() -> Path:
+    """The directory a node's writes must stay inside.
+
+    Read from ``settings`` on every call, never cached: tests monkeypatch
+    ``MODELS_DIR``, and project mode repoints it during settings validation.
+    """
+    return settings.MODELS_DIR.parent.resolve()
+
+
+def protected_paths() -> tuple[Path, ...]:
+    """Files under the data root that no node may write to or delete.
+
+    CodefyUI's own storage. See the module docstring for why this is the
+    database and its sidecars specifically, and why it holds in both
+    directions rather than only on the delete side.
+    """
+    db = settings.DB_PATH.resolve()
+    return (db, *(db.with_name(db.name + s) for s in _DB_SIDECAR_SUFFIXES))
+
+
+def is_protected(path: Path) -> bool:
+    """True when *path* is part of CodefyUI's own storage.
+
+    *path* must already be absolute and resolved. ``is_relative_to`` rather
+    than ``==`` so the check keeps working if anything directory-shaped is
+    ever added to :func:`protected_paths`; for a plain file the two agree.
+    """
+    return any(path.is_relative_to(reserved) for reserved in protected_paths())
+
+
+def resolve_data_path(path: str | Path, *, base: Path) -> Path:
+    """Absolute, validated destination for a node's file write.
+
+    *base* is what a relative *path* is taken as relative to. Raises
+    ``ValueError`` with a message meant for the user's node error panel:
+    one for leaving the data root, a different one for naming CodefyUI's
+    own storage, because those are different mistakes with different fixes.
+    """
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = base / resolved
+    resolved = resolved.resolve()
+
+    if not resolved.is_relative_to(data_root()):
+        raise ValueError("Output path must be within the project data directory")
+    if is_protected(resolved):
+        raise ValueError(
+            "Output path is part of CodefyUI's own storage (the run "
+            f"database) and cannot be written by a node: {resolved}"
+        )
+    return resolved

--- a/backend/app/core/data_paths.py
+++ b/backend/app/core/data_paths.py
@@ -24,15 +24,25 @@ run database: with the default ``cdui start`` and no ``--project``,
 ``PROJECT_DIR`` is ``None``, the project-mode derivation in ``config.py``
 never runs, and ``MODELS_DIR`` falls back to ``backend/data/models`` --
 whose parent is the directory holding ``codefyui.db``. So
-``path="../codefyui.db"`` on a ``CheckpointSaver`` (or ``ImageWriter``,
-which resolves relative paths one level deeper under ``<data>/output``)
-resolved to the live database and a training run would have written a
-``.pt`` payload straight over it. No mislabelled artifact row and no
-plugin required -- just a path typed into a node parameter.
+``path="../codefyui.db"`` on a ``CheckpointSaver`` or a ``ModelSaver``
+resolved to the live database and a training run wrote a ``.pt`` payload
+straight over it. No mislabelled artifact row and no plugin required --
+just a path typed into a node parameter.
 
 The issue this comes from argued the installed layout was narrower than
 dev because ``MODELS_DIR`` is ``<project>/assets/models``. That is true in
 project mode and only in project mode, which is not the default.
+
+``ImageWriter`` is here for consistency, not because it was reachable the
+same way: it forces the file extension to match its ``format`` parameter,
+so ``../codefyui.db`` was rewritten to ``codefyui.png`` and written BESIDE
+the database rather than over it. What it could do was overwrite any file
+under the data root ending in an image extension, which is the same
+over-broad containment rule and reason enough to share one definition of
+it. Both writers that rewrite an extension re-validate afterwards, so the
+path written is the path checked -- ``DB_PATH`` is env-overridable, and a
+database named ``store.safetensors`` would otherwise be reachable through
+exactly that rewrite.
 
 What is protected, and what deliberately is not
 -----------------------------------------------

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -1121,6 +1121,18 @@ class RunStore:
         store does not otherwise own the lifecycle of, and at least one
         (``tensorboard``) is a DIRECTORY, not a file -- widening this beyond
         checkpoints is a deliberately separate decision.
+
+        **And ``kind == "checkpoint"`` is not on its own enough to delete
+        anything (#224).** ``kind`` is a free-text column, and
+        ``ExecutionContext.log_artifact`` -- which the plugin API reaches --
+        writes both the kind and the path. A row is therefore a CLAIM, not
+        evidence. ``unlink_checkpoint`` re-derives the answer from the path
+        instead: it removes a file only where
+        ``checkpoints.owned_checkpoint_path`` recognises it as one this
+        server wrote, i.e. a generated filename under
+        ``MODELS_DIR/interrupted/`` or ``MODELS_DIR/periodic/``. Anything
+        else is skipped and logged. The row still goes either way; retention
+        over the table does not depend on the file being removable.
         """
         if keep_last < 0:
             raise ValueError(f"keep_last must be >= 0, got {keep_last}")

--- a/backend/app/nodes/io/checkpoint_node.py
+++ b/backend/app/nodes/io/checkpoint_node.py
@@ -197,10 +197,12 @@ class CheckpointLoaderNode(BaseNode):
         # project data directory.
         try:
             p = resolve_checkpoint_path(path)
-        except ValueError:
-            raise ValueError(
-                "Checkpoint file path must be within the project data directory"
-            ) from None
+        except ValueError as exc:
+            # The reason is carried through rather than flattened to the
+            # containment message: since #224 there are two ways to fail
+            # this rule (outside the data directory, or naming CodefyUI's
+            # own storage) and they need different fixes from the user.
+            raise ValueError(f"Checkpoint file path rejected: {exc}") from None
 
         if not p.exists():
             raise FileNotFoundError(f"Checkpoint file not found: {p}")

--- a/backend/app/nodes/io/image_writer_node.py
+++ b/backend/app/nodes/io/image_writer_node.py
@@ -63,14 +63,16 @@ class ImageWriterNode(BaseNode):
         # with ModelSaver and the checkpoint writers (#224). A relative path
         # lands under <data>/output rather than MODELS_DIR, which is why the
         # base is passed rather than assumed.
+        #
+        # This node was never able to reach the database (the forced
+        # extension below rewrote the name first); what it could overwrite
+        # was any file under the data root ending in an image extension.
         p = resolve_data_path(path, base=settings.MODELS_DIR.parent / "output")
 
-        # Ensure correct extension. Done BEFORE the directory is created and
-        # re-validated afterwards: the path that gets written must be the
-        # path that was checked, not one derived from it. ``with_suffix``
-        # cannot currently escape the data root (it only rewrites the final
-        # suffix), but "cannot currently" is not a property worth relying on
-        # in the one place that turns a parameter into a file write.
+        # Ensure correct extension, then re-validate: the path written must
+        # be the path checked. Not theoretical -- DB_PATH is env-overridable,
+        # so a database named `store.png` is reachable by asking for
+        # `store.jpg` with format=PNG and letting the rewrite do the rest.
         ext_map = {"PNG": ".png", "JPEG": ".jpg", "BMP": ".bmp", "TIFF": ".tiff"}
         expected_ext = ext_map.get(fmt, ".png")
         if p.suffix.lower() != expected_ext:

--- a/backend/app/nodes/io/image_writer_node.py
+++ b/backend/app/nodes/io/image_writer_node.py
@@ -49,33 +49,35 @@ class ImageWriterNode(BaseNode):
         ]
 
     def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
-        from pathlib import Path
-
         from torchvision.utils import save_image
 
         from ...config import settings
+        from ...core.data_paths import resolve_data_path
 
         image = inputs["image"]
         path = params.get("path", "output.png")
         fmt = params.get("format", "PNG")
 
-        p = Path(path)
-        if not p.is_absolute():
-            p = settings.MODELS_DIR.parent / "output" / p
-        p = p.resolve()
+        # Inside the data directory, and not over CodefyUI's own storage --
+        # ``core.data_paths`` owns both halves of that rule and is shared
+        # with ModelSaver and the checkpoint writers (#224). A relative path
+        # lands under <data>/output rather than MODELS_DIR, which is why the
+        # base is passed rather than assumed.
+        p = resolve_data_path(path, base=settings.MODELS_DIR.parent / "output")
 
-        # Restrict writes to project data directory
-        data_root = settings.MODELS_DIR.parent.resolve()
-        if not p.is_relative_to(data_root):
-            raise ValueError("Output path must be within the project data directory")
-
-        p.parent.mkdir(parents=True, exist_ok=True)
-
-        # Ensure correct extension
+        # Ensure correct extension. Done BEFORE the directory is created and
+        # re-validated afterwards: the path that gets written must be the
+        # path that was checked, not one derived from it. ``with_suffix``
+        # cannot currently escape the data root (it only rewrites the final
+        # suffix), but "cannot currently" is not a property worth relying on
+        # in the one place that turns a parameter into a file write.
         ext_map = {"PNG": ".png", "JPEG": ".jpg", "BMP": ".bmp", "TIFF": ".tiff"}
         expected_ext = ext_map.get(fmt, ".png")
         if p.suffix.lower() != expected_ext:
-            p = p.with_suffix(expected_ext)
+            p = resolve_data_path(p.with_suffix(expected_ext),
+                                  base=settings.MODELS_DIR.parent / "output")
+
+        p.parent.mkdir(parents=True, exist_ok=True)
 
         # Handle batched tensors: save first image
         if image.dim() == 4:

--- a/backend/app/nodes/io/model_saver_node.py
+++ b/backend/app/nodes/io/model_saver_node.py
@@ -77,6 +77,9 @@ class ModelSaverNode(BaseNode):
                 raise ValueError("safetensors format only supports state_dict mode, not full_model")
             if p.suffix not in (".safetensors",):
                 # Re-validated: the path written must be the path checked.
+                # DB_PATH is env-overridable, so a database named
+                # `store.safetensors` is reachable by asking for `store.pt`
+                # and letting this rewrite land on it (#224).
                 p = resolve_data_path(p.with_suffix(".safetensors"),
                                       base=settings.MODELS_DIR)
 

--- a/backend/app/nodes/io/model_saver_node.py
+++ b/backend/app/nodes/io/model_saver_node.py
@@ -58,30 +58,27 @@ class ModelSaverNode(BaseNode):
 
     def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
         import torch
-        from pathlib import Path
 
         from ...config import settings
+        from ...core.data_paths import resolve_data_path
 
         model = inputs["model"]
         path = params.get("path", "model_weights.pt")
         save_mode = params.get("save_mode", "state_dict")
         fmt = params.get("format", "pytorch")
 
-        p = Path(path)
-        if not p.is_absolute():
-            p = settings.MODELS_DIR / p
-        p = p.resolve()
-
-        # Restrict writes to project data directory
-        data_root = settings.MODELS_DIR.parent.resolve()
-        if not p.is_relative_to(data_root):
-            raise ValueError("Output path must be within the project data directory")
+        # Inside the data directory, and not over CodefyUI's own storage --
+        # ``core.data_paths`` owns both halves of that rule and is shared
+        # with ImageWriter and the checkpoint writers (#224).
+        p = resolve_data_path(path, base=settings.MODELS_DIR)
 
         if fmt == "safetensors":
             if save_mode == "full_model":
                 raise ValueError("safetensors format only supports state_dict mode, not full_model")
             if p.suffix not in (".safetensors",):
-                p = p.with_suffix(".safetensors")
+                # Re-validated: the path written must be the path checked.
+                p = resolve_data_path(p.with_suffix(".safetensors"),
+                                      base=settings.MODELS_DIR)
 
         p.parent.mkdir(parents=True, exist_ok=True)
 

--- a/backend/tests/test_data_path_safety.py
+++ b/backend/tests/test_data_path_safety.py
@@ -363,6 +363,33 @@ async def test_prune_does_not_delete_a_foreign_name_inside_an_owned_directory(
     assert intruder.exists()
 
 
+@pytest.mark.parametrize("where", ["", "checkpoints", "../scratch"])
+async def test_prune_does_not_delete_a_generated_looking_name_elsewhere(
+    store, default_layout, where,
+):
+    """The directory half of the rule, on its own.
+
+    ``run3-loop1-e12.pt`` is exactly the shape the generators produce, and
+    a user who has seen one of those files is quite likely to name their own
+    the same way -- or to copy one somewhere they can find it again. The
+    filename alone therefore proves nothing; retention has to see it in a
+    directory it owns. Added because reverting only the containment check
+    left every other test in this file green."""
+    target = (default_layout.models / where / "run3-loop1-e12.pt").resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"named like ours, not ours")
+
+    run = await _make_run(store)
+    await store.add_artifact(run.id, "checkpoint", str(target))
+    await store.mark_finished(run.id, "succeeded")
+
+    assert await store.prune(keep_last=0) == 1
+    assert target.exists(), (
+        "retention deleted a file it never wrote, on the strength of its "
+        "filename alone"
+    )
+
+
 async def test_prune_does_not_follow_a_symlink_out_of_an_owned_directory(
     store, default_layout,
 ):

--- a/backend/tests/test_data_path_safety.py
+++ b/backend/tests/test_data_path_safety.py
@@ -11,10 +11,12 @@ Both were reachable, and neither needed a hostile plugin:
   ``PROJECT_DIR`` is ``None``, so ``config.py``'s project derivation never
   runs and ``MODELS_DIR`` stays ``backend/data/models`` -- one level below
   ``codefyui.db``. ``path="../codefyui.db"`` typed into a ``CheckpointSaver``
-  (or ``ModelSaver``, or ``ImageWriter``) resolved to the live database and
-  passed the guard, because the database is inside the data directory. The
-  issue's own mitigation ("the installed layout is narrower, ``MODELS_DIR``
-  is ``assets/models``") describes project mode only.
+  or a ``ModelSaver`` resolved to the live database and passed the guard,
+  because the database is inside the data directory. The issue's own
+  mitigation ("the installed layout is narrower, ``MODELS_DIR`` is
+  ``assets/models``") describes project mode only. ``ImageWriter``, which
+  the issue also named, turns out NOT to have been reachable -- see
+  ``test_the_image_writer_node_refuses_to_name_the_database``.
 * **Delete.** ``kind`` is a free-text column and
   ``ExecutionContext.log_artifact`` -- reachable from the plugin API --
   writes both the kind and the path, so a row claiming ``kind="checkpoint"``
@@ -181,15 +183,61 @@ def test_the_model_saver_node_cannot_overwrite_the_database(default_layout):
     assert default_layout.db.read_bytes() == DB_BYTES
 
 
-def test_the_image_writer_node_cannot_overwrite_the_database(default_layout):
-    """ImageWriter resolves a relative path one level deeper than the
-    others (``<data>/output``), so the traversal that reaches the database
-    is shorter -- the guard has to be about the RESOLVED path, not the
-    number of ``..`` segments."""
+def test_the_image_writer_node_refuses_to_name_the_database(default_layout):
+    """ImageWriter never actually reached the database, and this test does
+    not claim it did.
+
+    It forces the extension to match the format parameter, so
+    ``path="../codefyui.db"`` was silently rewritten to ``codefyui.png``
+    and written beside the database rather than over it -- verified against
+    the pre-fix logic, and it holds for every value of ``format``,
+    including one no dropdown offers. The issue this closes asserted the
+    database was reachable "as a checkpoint or image target"; the image
+    half of that is wrong.
+
+    What was real for this node is the same over-broad containment rule:
+    any file under the data root that happens to end in an image extension
+    (a user's own dataset images, say) was a valid target. It goes through
+    the shared rule for that reason, and refusing the database outright is
+    then a free consequence -- worth having, because "silently wrote
+    codefyui.png" only stops being a database write for as long as nobody
+    edits the extension-forcing logic."""
     with pytest.raises(ValueError, match="CodefyUI's own storage"):
         ImageWriterNode().execute({"image": torch.zeros(3, 4, 4)},
                                   {"path": "../codefyui.db"})
     assert default_layout.db.read_bytes() == DB_BYTES
+    assert not (default_layout.data / "codefyui.png").exists()
+
+
+def test_forcing_an_extension_cannot_land_on_the_database(tmp_path, monkeypatch):
+    """The two writers that rewrite the file extension AFTER validating
+    re-validate the rewritten path, because otherwise the path checked is
+    not the path written.
+
+    Reachable rather than theoretical: ``DB_PATH`` is env-overridable
+    (``CODEFYUI_DB_PATH``), so a deployment can name the database anything
+    -- including something whose extension is the one a writer forces. Here
+    the parameter names an innocuous file, and it is the rewrite that turns
+    it into the database."""
+    data = tmp_path / "data"
+    (data / "models").mkdir(parents=True)
+    monkeypatch.setattr(settings, "MODELS_DIR", data / "models")
+
+    monkeypatch.setattr(settings, "DB_PATH", data / "models" / "store.safetensors")
+    (data / "models" / "store.safetensors").write_bytes(DB_BYTES)
+    model, _ = _model_and_opt()
+    with pytest.raises(ValueError, match="CodefyUI's own storage"):
+        ModelSaverNode().execute({"model": model},
+                                 {"path": "store.pt", "format": "safetensors"})
+    assert (data / "models" / "store.safetensors").read_bytes() == DB_BYTES
+
+    monkeypatch.setattr(settings, "DB_PATH", data / "output" / "store.png")
+    (data / "output").mkdir()
+    (data / "output" / "store.png").write_bytes(DB_BYTES)
+    with pytest.raises(ValueError, match="CodefyUI's own storage"):
+        ImageWriterNode().execute({"image": torch.zeros(3, 4, 4)},
+                                  {"path": "store.jpg", "format": "PNG"})
+    assert (data / "output" / "store.png").read_bytes() == DB_BYTES
 
 
 def test_an_absolute_path_to_the_database_is_refused_too(default_layout):

--- a/backend/tests/test_data_path_safety.py
+++ b/backend/tests/test_data_path_safety.py
@@ -1,0 +1,459 @@
+"""What a node may write, and what retention may delete (#224).
+
+Two directions, one root cause. ``resolve_checkpoint_path`` was a WRITE
+rule -- "do not let a node write outside the project data directory" -- and
+it ended up doing DELETE duty as well, guarding ``RunStore.prune``'s
+unattended unlink of every pruned ``checkpoint``-kind artifact.
+
+Both were reachable, and neither needed a hostile plugin:
+
+* **Write.** With the default ``cdui start`` and no ``--project``,
+  ``PROJECT_DIR`` is ``None``, so ``config.py``'s project derivation never
+  runs and ``MODELS_DIR`` stays ``backend/data/models`` -- one level below
+  ``codefyui.db``. ``path="../codefyui.db"`` typed into a ``CheckpointSaver``
+  (or ``ModelSaver``, or ``ImageWriter``) resolved to the live database and
+  passed the guard, because the database is inside the data directory. The
+  issue's own mitigation ("the installed layout is narrower, ``MODELS_DIR``
+  is ``assets/models``") describes project mode only.
+* **Delete.** ``kind`` is a free-text column and
+  ``ExecutionContext.log_artifact`` -- reachable from the plugin API --
+  writes both the kind and the path, so a row claiming ``kind="checkpoint"``
+  with a path pointing at anything else under the data root had that file
+  unlinked by a background sweep, with no user action and no confirmation.
+
+The fix is two rules, not one widened rule, because the questions differ.
+The write rule stays permissive (the data directory is a node's to write
+into) minus CodefyUI's own storage. The delete rule is
+prove-we-wrote-it: a generated filename under a directory this server owns.
+Tests below are grouped by direction, then by "the ordinary thing still
+works", which is the constraint that rules out simply tightening both.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from app.config import Settings, settings
+from app.core import data_paths
+from app.core.checkpoints import (
+    INTERRUPT_DIRNAME,
+    PERIODIC_DIRNAME,
+    interrupt_checkpoint_path,
+    owned_checkpoint_path,
+    periodic_checkpoint_path,
+    resolve_checkpoint_path,
+    write_checkpoint,
+)
+from app.core.db import Database
+from app.core.run_store import RunProvenance, RunStore
+from app.nodes.io.checkpoint_node import CheckpointLoaderNode, CheckpointSaverNode
+from app.nodes.io.image_writer_node import ImageWriterNode
+from app.nodes.io.model_saver_node import ModelSaverNode
+
+#: Contents given to the stand-in database file. Any assertion that the
+#: database survived compares against these bytes rather than merely
+#: checking ``exists()`` -- a write that truncated it to zero bytes would
+#: still leave the path there.
+DB_BYTES = b"SQLite format 3\x00-- the real database, not a checkpoint"
+
+GRAPH = {
+    "name": "demo",
+    "nodes": [{"id": "a", "type": "Start", "position": {"x": 0, "y": 0},
+               "data": {"params": {}}}],
+    "edges": [],
+}
+OPTIONS = {"device": "cpu", "seed": 7, "record_outputs": True,
+           "lane": "queued"}
+
+
+def _model_and_opt():
+    model = nn.Linear(4, 2)
+    return model, torch.optim.SGD(model.parameters(), lr=0.01)
+
+
+# ── layout fixtures ───────────────────────────────────────────────────────
+#
+# Both mirror a real install rather than inventing a shape. conftest.py
+# already redirects settings.DB_PATH to a temp directory OUTSIDE the data
+# root for isolation, which would make every test here vacuously pass, so
+# each fixture places the database where that mode actually puts it.
+
+
+@pytest.fixture
+def default_layout(tmp_path, monkeypatch):
+    """The default (no ``--project``) layout: the database is one level
+    above MODELS_DIR, inside the data root."""
+    data = tmp_path / "data"
+    (data / "models").mkdir(parents=True)
+    db = data / "codefyui.db"
+    db.write_bytes(DB_BYTES)
+    monkeypatch.setattr(settings, "MODELS_DIR", data / "models")
+    monkeypatch.setattr(settings, "IMAGES_DIR", data / "images")
+    monkeypatch.setattr(settings, "DB_PATH", db)
+    return SimpleNamespace(data=data, models=data / "models", db=db)
+
+
+@pytest.fixture
+def project_layout(tmp_path, monkeypatch):
+    """Project mode, with the roots taken from the REAL ``Settings``
+    derivation rather than hand-built, so this keeps testing the shipped
+    layout if that derivation changes. DB_PATH is install-global (never
+    derived from PROJECT_DIR -- see ``_derive_project_roots``) and so sits
+    outside the data root entirely."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    derived = Settings(PROJECT_DIR=proj)
+    assert derived.MODELS_DIR == proj / "assets" / "models"
+
+    install = tmp_path / "install"
+    install.mkdir()
+    db = install / "codefyui.db"
+    db.write_bytes(DB_BYTES)
+
+    derived.MODELS_DIR.mkdir(parents=True)
+    monkeypatch.setattr(settings, "MODELS_DIR", derived.MODELS_DIR)
+    monkeypatch.setattr(settings, "IMAGES_DIR", derived.IMAGES_DIR)
+    monkeypatch.setattr(settings, "GRAPHS_DIR", derived.GRAPHS_DIR)
+    monkeypatch.setattr(settings, "DB_PATH", db)
+    return SimpleNamespace(proj=proj, models=derived.MODELS_DIR, db=db)
+
+
+@pytest.fixture
+def store(tmp_path):
+    database = Database(tmp_path / "runstore.db")
+    database.connect()
+    try:
+        yield RunStore(database)
+    finally:
+        database.close()
+
+
+async def _make_run(store: RunStore):
+    return await store.create_run(graph_snapshot=GRAPH, options=OPTIONS,
+                                  provenance=RunProvenance())
+
+
+# ── 1. the write direction ────────────────────────────────────────────────
+
+
+def test_the_database_is_inside_the_data_root_on_a_default_install(
+    default_layout,
+):
+    """The premise, pinned. Everything below is only interesting because
+    the containment rule -- the whole of the old guard -- says yes here."""
+    resolved = (settings.MODELS_DIR / "../codefyui.db").resolve()
+    assert resolved == default_layout.db.resolve()
+    assert resolved.is_relative_to(data_paths.data_root()), (
+        "if the database ever stops being inside the data root on a default "
+        "install, this whole file is testing a shape that no longer exists"
+    )
+
+
+def test_a_checkpoint_path_cannot_name_the_run_database(default_layout):
+    with pytest.raises(ValueError, match="CodefyUI's own storage"):
+        resolve_checkpoint_path("../codefyui.db")
+
+
+def test_the_checkpoint_saver_node_cannot_overwrite_the_database(
+    default_layout,
+):
+    """End to end through the node, which is how a user reaches this: a
+    path typed into a graph parameter, no plugin and no mislabelled row."""
+    model, opt = _model_and_opt()
+    with pytest.raises(ValueError, match="CodefyUI's own storage"):
+        CheckpointSaverNode().execute(
+            {"model": model, "optimizer": opt},
+            {"path": "../codefyui.db", "epoch": 1},
+        )
+    assert default_layout.db.read_bytes() == DB_BYTES
+
+
+def test_the_model_saver_node_cannot_overwrite_the_database(default_layout):
+    model, _ = _model_and_opt()
+    with pytest.raises(ValueError, match="CodefyUI's own storage"):
+        ModelSaverNode().execute({"model": model},
+                                 {"path": "../codefyui.db"})
+    assert default_layout.db.read_bytes() == DB_BYTES
+
+
+def test_the_image_writer_node_cannot_overwrite_the_database(default_layout):
+    """ImageWriter resolves a relative path one level deeper than the
+    others (``<data>/output``), so the traversal that reaches the database
+    is shorter -- the guard has to be about the RESOLVED path, not the
+    number of ``..`` segments."""
+    with pytest.raises(ValueError, match="CodefyUI's own storage"):
+        ImageWriterNode().execute({"image": torch.zeros(3, 4, 4)},
+                                  {"path": "../codefyui.db"})
+    assert default_layout.db.read_bytes() == DB_BYTES
+
+
+def test_an_absolute_path_to_the_database_is_refused_too(default_layout):
+    """The traversal is incidental; naming the file outright is the same
+    mistake and gets the same answer."""
+    model, opt = _model_and_opt()
+    with pytest.raises(ValueError, match="CodefyUI's own storage"):
+        CheckpointSaverNode().execute(
+            {"model": model, "optimizer": opt},
+            {"path": str(default_layout.db)},
+        )
+    assert default_layout.db.read_bytes() == DB_BYTES
+
+
+@pytest.mark.parametrize("sidecar", ["-wal", "-shm", "-journal"])
+def test_the_databases_sqlite_sidecars_are_refused(default_layout, sidecar):
+    """``core.db`` runs in WAL mode. Truncating ``codefyui.db-wal`` loses
+    every committed transaction still sitting in it, so protecting only the
+    main file would leave the corruption reachable by a one-character
+    change to the path."""
+    with pytest.raises(ValueError, match="CodefyUI's own storage"):
+        resolve_checkpoint_path(f"../codefyui.db{sidecar}")
+
+
+@pytest.mark.skipif(os.name != "nt",
+                    reason="only Windows treats these as the same file")
+@pytest.mark.parametrize("spelling", ["../CODEFYUI.DB", "../CODEFYUI.DB-WAL"])
+def test_a_case_differing_spelling_of_the_database_is_refused(
+    default_layout, spelling,
+):
+    """``Path.resolve()`` canonicalises the case of components that EXIST on
+    disk but falls back to lexical normalisation for ones that do not, so an
+    exact string comparison is not sound on a case-insensitive filesystem.
+
+    Both spellings are here because only the second one actually needs the
+    case folding: ``codefyui.db`` exists in the fixture, so ``resolve()``
+    hands back the on-disk casing by itself. The ``-wal`` sidecar does not
+    exist -- it is created when the database is opened and removed on a
+    clean close -- so nothing canonicalises it, and a case-sensitive
+    comparison lets it straight through to a write that corrupts the
+    database the moment SQLite reopens it.
+
+    On POSIX these ARE different files and refusing them would be wrong,
+    hence the skip rather than a platform branch inside the rule."""
+    with pytest.raises(ValueError, match="CodefyUI's own storage"):
+        resolve_checkpoint_path(spelling)
+
+
+def test_a_path_outside_the_data_root_still_reports_the_old_reason(
+    default_layout, tmp_path,
+):
+    """Two ways to fail, two messages: leaving the data directory is a
+    different mistake from naming CodefyUI's own storage, and the user
+    fixes them differently."""
+    with pytest.raises(ValueError, match="within the project data directory"):
+        resolve_checkpoint_path(tmp_path / "elsewhere" / "x.pt")
+
+
+def test_the_checkpoint_loader_surfaces_which_rule_it_failed(default_layout):
+    """The node used to flatten every ValueError to the containment
+    message, which would now be a lie for the protected case."""
+    model, opt = _model_and_opt()
+    with pytest.raises(ValueError, match="CodefyUI's own storage"):
+        CheckpointLoaderNode().execute(
+            {"model": model, "optimizer": opt},
+            {"path": "../codefyui.db", "device": "cpu"},
+        )
+
+
+# ── 2. the delete direction ───────────────────────────────────────────────
+
+
+async def test_prune_does_not_delete_a_mislabelled_row_pointing_at_the_database(
+    store, default_layout,
+):
+    """The issue's own scenario, with the worst available target. The row
+    is inside the data root, so the write-scoped guard said yes; the
+    ownership guard says no."""
+    run = await _make_run(store)
+    await store.add_artifact(run.id, "checkpoint", str(default_layout.db))
+    await store.mark_finished(run.id, "succeeded")
+
+    assert await store.prune(keep_last=0) == 1
+    assert default_layout.db.read_bytes() == DB_BYTES, (
+        "an unattended prune deleted the run database because a row "
+        "claimed the file was a checkpoint"
+    )
+
+
+async def test_prune_does_not_delete_a_checkpoint_named_file_it_did_not_write(
+    store, default_layout,
+):
+    """Not every ``.pt`` under MODELS_DIR is ours -- a user's own saved
+    model sits right there, and a ``CheckpointSaver`` they wired up writes
+    exactly here by default."""
+    users_own = default_layout.models / "my_best_model.pt"
+    users_own.write_bytes(b"hours of training")
+
+    run = await _make_run(store)
+    await store.add_artifact(run.id, "checkpoint", str(users_own))
+    await store.mark_finished(run.id, "succeeded")
+
+    assert await store.prune(keep_last=0) == 1
+    assert users_own.exists(), "retention deleted a file it never wrote"
+
+
+async def test_prune_does_not_delete_a_foreign_name_inside_an_owned_directory(
+    store, default_layout,
+):
+    """Owning the directory is not enough on its own: the filename has to
+    be one the generators produce. Something else dropping a file into
+    ``periodic/`` does not make that file ours."""
+    owned_dir = default_layout.models / PERIODIC_DIRNAME
+    owned_dir.mkdir(parents=True)
+    intruder = owned_dir / "notes.pt"
+    intruder.write_bytes(b"not a generated name")
+
+    run = await _make_run(store)
+    await store.add_artifact(run.id, "checkpoint", str(intruder))
+    await store.mark_finished(run.id, "succeeded")
+
+    assert await store.prune(keep_last=0) == 1
+    assert intruder.exists()
+
+
+async def test_prune_does_not_follow_a_symlink_out_of_an_owned_directory(
+    store, default_layout,
+):
+    """A correctly-named file in the right directory that is really a link
+    to the database. ``resolve()`` runs before the containment check, so
+    the link resolves to the database, lands outside the owned directory
+    and is refused -- and the unlink would have removed the TARGET, not the
+    link, had it gone ahead."""
+    owned_dir = default_layout.models / PERIODIC_DIRNAME
+    owned_dir.mkdir(parents=True)
+    link = owned_dir / "r1-n1-e1.pt"
+    try:
+        link.symlink_to(default_layout.db)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable (Windows needs the privilege)")
+
+    run = await _make_run(store)
+    await store.add_artifact(run.id, "checkpoint", str(link))
+    await store.mark_finished(run.id, "succeeded")
+
+    assert await store.prune(keep_last=0) == 1
+    assert default_layout.db.read_bytes() == DB_BYTES
+
+
+async def test_prune_still_deletes_a_periodic_checkpoint_this_server_wrote(
+    store, default_layout,
+):
+    """The whole point of the sweep, exercised through the real generator
+    rather than a hand-written path: retention that stopped removing its
+    own files would leak a model-sized orphan per checkpoint event."""
+    target = periodic_checkpoint_path("run-abc", "loop1", epoch=4)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"a periodic checkpoint")
+
+    run = await _make_run(store)
+    await store.add_artifact(run.id, "checkpoint", str(target))
+    await store.mark_finished(run.id, "succeeded")
+
+    assert await store.prune(keep_last=0) == 1
+    assert not target.exists(), "retention leaked its own checkpoint file"
+
+
+def test_generated_checkpoint_names_are_recognised_as_owned(default_layout):
+    """The anti-drift assertion. ``owned_checkpoint_path`` matches a
+    filename pattern that the two generators have to keep producing; if
+    either one's naming changes without the pattern following, retention
+    silently stops cleaning up and nothing else notices."""
+    generated = [
+        interrupt_checkpoint_path("run-abc", "loop1", epoch=0, batch=0),
+        interrupt_checkpoint_path("a" * 80, "b" * 80, epoch=12, batch=340),
+        interrupt_checkpoint_path("!!!", "@@@", epoch=-1, batch=-1),
+        periodic_checkpoint_path("run-abc", "loop1", epoch=4),
+        periodic_checkpoint_path("preset1__inner", "n/o:d*e", epoch=999),
+        periodic_checkpoint_path("!!!", "@@@", epoch=-1),
+    ]
+    for path in generated:
+        assert owned_checkpoint_path(path) == path.resolve(), (
+            f"{path.name!r} is written by this module but retention would "
+            "refuse to clean it up"
+        )
+    assert {p.parent.name for p in generated} == {INTERRUPT_DIRNAME,
+                                                 PERIODIC_DIRNAME}
+
+
+# ── 3. the ordinary paths, which must not have moved ──────────────────────
+
+
+def test_an_ordinary_checkpoint_write_still_works(default_layout):
+    model, opt = _model_and_opt()
+    res = CheckpointSaverNode().execute(
+        {"model": model, "optimizer": opt},
+        {"path": "training.pt", "epoch": 3},
+    )
+    assert (default_layout.models / "training.pt").exists()
+    assert res["model"] is model
+
+    loaded = CheckpointLoaderNode().execute(
+        {"model": nn.Linear(4, 2), "optimizer": torch.optim.SGD(
+            nn.Linear(4, 2).parameters(), lr=0.01)},
+        {"path": "training.pt", "device": "cpu"},
+    )
+    assert loaded["epoch"] == 3
+
+
+def test_an_ordinary_model_save_still_works(default_layout):
+    model, _ = _model_and_opt()
+    res = ModelSaverNode().execute({"model": model},
+                                   {"path": "weights.pt"})
+    assert (default_layout.models / "weights.pt").exists()
+    assert res["path"].endswith("weights.pt")
+
+
+def test_an_ordinary_image_write_still_works(default_layout):
+    res = ImageWriterNode().execute({"image": torch.zeros(3, 8, 8)},
+                                    {"path": "picture.png", "format": "PNG"})
+    written = default_layout.data / "output" / "picture.png"
+    assert written.exists()
+    assert res["path"] == str(written)
+
+
+def test_a_write_elsewhere_under_the_data_root_still_works(default_layout):
+    """The write rule is still permissive by design -- a sibling directory
+    of MODELS_DIR that nothing in particular owns is an ordinary place for
+    a graph to put a file, and narrowing to an allow-list of known
+    sub-directories would have broken that."""
+    model, _ = _model_and_opt()
+    ModelSaverNode().execute({"model": model},
+                             {"path": "../scratch/run7/weights.pt"})
+    assert (default_layout.data / "scratch" / "run7" / "weights.pt").exists()
+
+
+def test_ordinary_writes_still_work_in_project_mode(project_layout):
+    """The layout the issue's mitigation argument described. The database
+    is install-global here, so it is outside the data root and the
+    protected set never fires -- what this pins is that adding it changed
+    nothing for the mode that was already safe."""
+    model, opt = _model_and_opt()
+    CheckpointSaverNode().execute(
+        {"model": model, "optimizer": opt},
+        {"path": "training.pt", "epoch": 1},
+    )
+    ModelSaverNode().execute({"model": model}, {"path": "weights.pt"})
+    ImageWriterNode().execute({"image": torch.zeros(3, 4, 4)},
+                              {"path": "shot.png"})
+
+    assert (project_layout.models / "training.pt").exists()
+    assert (project_layout.models / "weights.pt").exists()
+    assert (project_layout.proj / "assets" / "output" / "shot.png").exists()
+    assert project_layout.db.read_bytes() == DB_BYTES
+
+
+def test_the_engines_own_checkpoint_writers_still_work(default_layout):
+    """``write_checkpoint(resolve=False)`` is how the interrupt and
+    periodic paths write, and their targets have to survive both rules:
+    accepted on the way in, recognised as ours on the way out."""
+    model, opt = _model_and_opt()
+    for target in (interrupt_checkpoint_path("r", "n", epoch=1, batch=2),
+                   periodic_checkpoint_path("r", "n", epoch=1)):
+        written = write_checkpoint(target, model, opt, epoch=1, resolve=False)
+        assert written.exists()
+        assert resolve_checkpoint_path(written) == written.resolve()
+        assert owned_checkpoint_path(written) == written.resolve()

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -1101,11 +1101,14 @@ async def test_prune_keeps_the_checkpoint_file_of_an_interrupted_run(
     keep_last=0 (config.py's "inverted zero" -- a real, documented
     configuration, not a hypothetical one)."""
     models = tmp_path / "models"
-    models.mkdir()
+    (models / "interrupted").mkdir(parents=True)
     monkeypatch.setattr(settings, "MODELS_DIR", models)
 
     run = await _make_run(store)
-    checkpoint_file = models / "crash_recovery.pt"
+    # Under interrupted/ with a generated name, i.e. a file retention DOES
+    # own and WOULD delete (#224) -- otherwise the ownership guard, not the
+    # interrupted-status exemption this test is about, is what saves it.
+    checkpoint_file = models / "interrupted" / "run1-node1-e3b12.pt"
     checkpoint_file.write_bytes(b"the run's only path back")
     await store.add_artifact(run.id, "checkpoint", str(checkpoint_file))
     await store.mark_finished(run.id, "interrupted")
@@ -1122,17 +1125,17 @@ async def test_prune_deletes_the_checkpoint_files_of_pruned_runs(
     store, db, tmp_path, monkeypatch,
 ):
     models = tmp_path / "models"
-    models.mkdir()
+    (models / "periodic").mkdir(parents=True)
     monkeypatch.setattr(settings, "MODELS_DIR", models)
 
     old_run = await _make_run(store)
-    old_file = models / "old.pt"
+    old_file = models / "periodic" / "old-node1-e1.pt"
     old_file.write_bytes(b"old checkpoint")
     await store.add_artifact(old_run.id, "checkpoint", str(old_file))
     await store.mark_finished(old_run.id, "succeeded")
 
     kept_run = await _make_run(store)
-    kept_file = models / "kept.pt"
+    kept_file = models / "periodic" / "kept-node1-e1.pt"
     kept_file.write_bytes(b"kept checkpoint")
     await store.add_artifact(kept_run.id, "checkpoint", str(kept_file))
     await store.mark_finished(kept_run.id, "succeeded")
@@ -1146,13 +1149,16 @@ async def test_prune_tolerates_a_checkpoint_file_already_gone(
     store, db, tmp_path, monkeypatch,
 ):
     """A file removed by hand (or an earlier, interrupted prune) must not
-    turn a successful prune into a failed one."""
+    turn a successful prune into a failed one.
+
+    Under periodic/ with a generated name so the ownership guard (#224)
+    passes and the FileNotFoundError branch is the one being exercised."""
     models = tmp_path / "models"
-    models.mkdir()
+    (models / "periodic").mkdir(parents=True)
     monkeypatch.setattr(settings, "MODELS_DIR", models)
 
     run = await _make_run(store)
-    missing = models / "already_gone.pt"
+    missing = models / "periodic" / "gone-node1-e7.pt"
     await store.add_artifact(run.id, "checkpoint", str(missing))
     await store.mark_finished(run.id, "succeeded")
     assert not missing.exists()
@@ -1183,10 +1189,11 @@ async def test_prune_does_not_touch_a_non_checkpoint_artifact_file(
 async def test_prune_refuses_to_delete_a_checkpoint_path_outside_the_data_dir(
     store, db, tmp_path, monkeypatch,
 ):
-    """Defense in depth: the SAME path-safety rule ``write_checkpoint``
-    enforces on write also guards the delete, so a row whose path was not
-    produced by this module's own writers cannot become an arbitrary file
-    deletion."""
+    """A row whose path was not produced by this module's own writers
+    cannot become an arbitrary file deletion. Outside the data directory is
+    the easy half; ``test_prune_does_not_delete_a_checkpoint_row_pointing_
+    inside_the_data_dir`` in test_data_path_safety.py covers the half that
+    the write-scoped guard used to wave through (#224)."""
     models = tmp_path / "data" / "models"
     models.mkdir(parents=True)
     monkeypatch.setattr(settings, "MODELS_DIR", models)


### PR DESCRIPTION
> 中文摘要：一條「不要寫到專案資料夾外面」的規則，同時被用來管「節點可以寫哪裡」和「保留機制可以刪哪個檔案」。預設安裝（沒有 `--project`）底下，資料庫 `codefyui.db` 就在那個資料夾裡面，所以在節點參數打 `../codefyui.db` 就能讓訓練把權重檔蓋在資料庫上；而保留機制只憑一列 `kind="checkpoint"` 的紀錄就刪檔，那個 `kind` 是自由文字、外掛也寫得進去。現在拆成兩條規則：寫入維持寬鬆（資料夾本來就是給節點寫的），但把資料庫和它的 SQLite 附屬檔（`-wal`／`-shm`／`-journal`）無條件排除；刪除改成「只刪我自己寫的」——`MODELS_DIR/interrupted/` 或 `MODELS_DIR/periodic/` 底下、而且檔名符合產生規則的檔案，其他一律略過並記錄。一般用法完全沒變，存檢查點、存模型、寫圖片在預設模式和專案模式都照舊。順帶更正 issue 留言裡的一點：`ImageWriter` 其實碰不到資料庫。

`Closes #224`

## What was actually reachable

Both directions verified against the real settings object in this worktree before designing anything, because the issue's own mitigation argument turns on which one you are in.

### Delete — as filed

`RunStore.prune` unlinks the file behind every pruned artifact row whose `kind` is `checkpoint`. `kind` is a free-text column and `ExecutionContext.log_artifact` — which the plugin API reaches — writes both the kind and the path. A row is therefore a *claim*, not evidence. The guard was `resolve_checkpoint_path`, which permits anything under `MODELS_DIR.parent`, so a row claiming `kind="checkpoint"` with a path pointing at anything else under the data root had that file removed by a background sweep, with no user action and no confirmation.

### Write — the correction in the issue comment, confirmed

The issue argued the blast radius was bounded because "the installed layout is narrower than dev: `MODELS_DIR` is `assets/models`". That holds **only in project mode**. With the default `cdui start` and no `--project`, `PROJECT_DIR` is `None`, the derivation in `config.py` never runs, and `MODELS_DIR` stays `backend/data/models` — one level below the database:

```
PROJECT_DIR: None
MODELS_DIR : <worktree>\backend\data\models
DB_PATH    : <worktree>\backend\data\codefyui.db
resolve_checkpoint_path('../codefyui.db') -> <worktree>\backend\data\codefyui.db
IS THE DB  : True
```

So `../codefyui.db` typed into a `CheckpointSaver` or `ModelSaver` parameter resolved to the live database and a training run wrote a `.pt` payload over it. No mislabelled row, no plugin — a lower bar than the scenario the issue was filed for. Reproduced in a test that fails on the pre-fix code by asserting the database's bytes are unchanged, not merely that it still exists.

### One claim in the issue comment that does not hold: `ImageWriter`

The comment says an ordinary parameter could name `codefyui.db` "as a checkpoint **or image** target". The checkpoint half is right. The image half is not, and I checked rather than repeating it.

`ImageWriter` forces the file extension to match its `format` parameter *after* validating, so `../codefyui.db` was rewritten to `codefyui.png` and written **beside** the database rather than over it. Replayed against the pre-fix logic verbatim to confirm — it holds for every value of `format`, including one no dropdown offers, because the lookup falls back to `.png`:

```
path='../codefyui.db'      fmt=PNG    allowed=True  writes -> codefyui.png    IS_DB=False
path='../codefyui.db'      fmt=TIFF   allowed=True  writes -> codefyui.tiff   IS_DB=False
path='../codefyui.db-wal'  fmt=PNG    allowed=True  writes -> codefyui.png    IS_DB=False
path='../codefyui.db'      fmt=bogus  allowed=True  writes -> codefyui.png    IS_DB=False
```

What *was* real for that node is the same over-broad containment rule: any file under the data root ending in an image extension — a user's own dataset images, say — was a valid target. It still goes through the shared rule for that reason, and refusing the database outright is then free. `test_the_image_writer_node_refuses_to_name_the_database` says all of this in its docstring rather than implying a reachability that was never there.

## What was built

**Two rules, not one widened rule**, because the questions genuinely differ. "May a node write here" is a permissive question — the data directory is a node's to write into, including sub-directories nothing in particular owns. "Did *we* write this, so that removing the row obliges us to remove the file" is not. Letting one answer serve both is what made an unattended, irreversible sweep as broad as an ordinary write. One rule with a strictness flag would have kept them coupled at exactly the point where they need to diverge, and the two rules do not even take the same inputs: the write rule needs a *base* for relative resolution, the delete rule needs the set of directories the engine owns.

### The write rule — `core/data_paths.resolve_data_path`

New module, one definition, three callers. Before this there were three open-coded copies of "resolve, then require `MODELS_DIR.parent`" (`checkpoints.resolve_checkpoint_path`, `model_saver_node.py`, `image_writer_node.py`) — three places to fix and three places to forget.

Containment under the data root is unchanged. What is added is `protected_paths()`: the database **and its three SQLite sidecars** (`-wal`, `-shm`, `-journal`), derived from `settings.DB_PATH` at call time rather than hardcoded, so an installation that moves the database keeps the protection. The sidecars are not padding — `core.db` sets `PRAGMA journal_mode=WAL`, and a write over `codefyui.db-wal` loses every committed transaction still sitting in it. Protecting only the main file would leave the corruption reachable by a four-character change to the path.

The two writers that rewrite a file extension after validating now re-validate the rewritten path, so the path written is the path checked. Reachable rather than theoretical: `DB_PATH` is env-overridable (`CODEFYUI_DB_PATH`), so a database named `store.safetensors` is hit by asking `ModelSaver` for `store.pt` with `format=safetensors` and letting the rewrite land on it.

`CheckpointLoader` no longer flattens every `ValueError` to the containment message. There are two ways to fail this rule now and they need different fixes from the user.

### The delete rule — `checkpoints.owned_checkpoint_path`

Prove-we-wrote-it replaces trust-the-row. Only two call sites ever produce a `checkpoint`-kind artifact row — `loop_control.save_interrupt_checkpoint` and `save_periodic_checkpoint` — and both write a *generated* filename under `MODELS_DIR/interrupted/` or `MODELS_DIR/periodic/`. Retention removes a file only where the path has that shape: the right directory **and** the right filename. Anything else is skipped and logged; the row still goes either way, so retention over the table never depends on the file being removable.

Both halves are load-bearing and are tested separately (the second one only after mutation-checking showed it was not — see below). `resolve()` runs before the containment check, which is what makes a symlink planted inside `periodic/` resolve to its target, land outside, and be refused.

This answers the issue's closing question — whether `kind` should stay open-vocabulary for the delete path — by making the answer not matter. `kind` stays as it is; the sweep simply stops treating it as evidence.

A `CheckpointSaver` the user wired into the graph is deliberately **not** covered: it writes where the user told it to and records no artifact row at all, so retention never reached it before this change either. If something starts logging one, the file still belongs to the user — the same reasoning `RunStore.delete_run` already applies to explicitly-named artifact files.

## What was rejected

- **Protecting `GRAPHS_DIR` as well.** Tempting: in default mode it is `<data>/graphs`, so a node could overwrite a saved graph, and in project mode it already sits outside the data root so protecting it would cost nothing there. Rejected because it is a *directory* whose position relative to the data root is configuration-dependent — several existing tests already point `GRAPHS_DIR` at the same directory they use as the data root, and a protected entry that can be configured to *equal* the root would deny every legitimate write. `DB_PATH` is a file and cannot degenerate that way. Widening the protected set to directories wants an explicit containment invariant first.
- **An allow-list of write roots** (`MODELS_DIR`, `IMAGES_DIR`, `<data>/output`, …) instead of "data root minus protected". Narrower, and it breaks working graphs: writing to a sibling directory under the data root is ordinary today. `test_a_write_elsewhere_under_the_data_root_still_works` pins that it still is.
- **Explicit case folding via `os.path.normcase`.** The first draft did this, reasoning that `Path.resolve()` only canonicalises the case of components that *exist* on disk — true, and the `-wal` sidecar is absent whenever the database is closed. Mutation-checking the guard showed removing the layer changed no outcome: `PureWindowsPath` already compares case-insensitively, so it was defending something already defended. Removed. The test pins the *behaviour* (`../CODEFYUI.DB-WAL` is refused on Windows, and only on Windows, where it really is the same file) rather than the mechanism, so it stays correct if the mechanism ever needs to come back.
- **Widening to the read paths** (`model_loader_node.py`, `image_batch_reader_node.py`, `image_folder_dataset_node.py` each still hold their own copy of the containment rule). Out of scope here: reads are a different risk with a different answer, and `CheckpointLoader` — which goes through the shared function — already picks up the protection for free. Worth its own issue.

## Proof the normal paths still work

`test_data_path_safety.py` closes with a regression section, and the wider suite is unchanged:

- `CheckpointSaver` → `CheckpointLoader` round-trip, default mode.
- `ModelSaver` and `ImageWriter`, default mode, landing where they always did (`MODELS_DIR/…` and `<data>/output/…`).
- A write to `../scratch/run7/weights.pt` — an arbitrary sibling directory under the data root — still allowed.
- All three in **project mode**, with the roots taken from the real `Settings(PROJECT_DIR=…)` derivation rather than hand-built, so this keeps testing the shipped layout if that derivation ever changes. The database is install-global there and outside the data root, so what this pins is that the protected set changed nothing for the mode that was already safe.
- `write_checkpoint(resolve=False)` for both engine-side writers: accepted by the write rule on the way in, recognised by the delete rule on the way out.
- `test_generated_checkpoint_names_are_recognised_as_owned` is the anti-drift device — every path the two generators produce (long ids, punctuation-heavy node ids, negative epochs) must be recognised as ours, so a change to either generator that outran the pattern fails loudly instead of silently switching retention off.

## Tests and mutation-checks

29 new tests in `backend/tests/test_data_path_safety.py`. Four existing retention tests in `test_run_store.py` moved their fixture files under `periodic/` or `interrupted/` with generated names — two of them would otherwise have passed for the *new* reason rather than the one they were written to assert, which is worse than failing.

Full suite: **4349 passed, 22 skipped**. `ruff check .` clean at the repo root.

Every source change reverted in turn, against `tests/test_data_path_safety.py tests/test_run_store.py` (baseline 117 passed):

| # | Reverted | Result |
|---|---|---|
| M1 | write rule: the protected-path check | **12 red** |
| M2 | protected set: the SQLite sidecars | **4 red** |
| M3 | delete rule: guard with the old write rule again | **5 red** |
| M4 | delete rule: the generated-filename check | **1 red** |
| M5 | delete rule: the owned-directory check | **3 red** |
| M6 | `CheckpointLoader`: flatten the rejection reason again | **1 red** |
| M7 | `ImageWriter`: restore the inline containment-only rule | **2 red** |
| M8 | `ModelSaver`: restore the inline containment-only rule | **2 red** |
| M9 | `ImageWriter`: only the post-rewrite re-validation | **1 red** |
| M10 | `ModelSaver`: only the post-rewrite re-validation | **1 red** |
| M11 | the whole #224 guard, both directions (true pre-fix state) | **19 red** |
| M12 | the moved retention fixtures in `test_run_store.py` | **1 red** |

Two findings from the matrix rather than from review, both fixed in this branch:

- **M5 came back green on the first pass.** Nothing covered the owned-*directory* check on its own — the two halves of the delete rule were only ever exercised together, so a revert that kept the filename check left every test passing. `test_prune_does_not_delete_a_generated_looking_name_elsewhere` closes it, parametrised over three places a plausibly-named user file sits.
- **The `normcase` layer survived its mutation**, which is how it was found to be redundant (above).

M11 is the honest one: reverting the entire change turns 19 tests red, including the issue's exact filed scenario (`test_prune_does_not_delete_a_mislabelled_row_pointing_at_the_database`) and the write direction the comment added.

M12 makes 1 test red rather than 4, which is the expected shape — the other three moved fixtures assert survival or absence-of-raise and would pass in either location. They moved so they keep testing what they were written to test.

## Left open

- The **read** guards still hold their own copies of the containment rule (`model_loader_node.py`, `image_batch_reader_node.py`, `image_folder_dataset_node.py`). Not touched here; worth a follow-up so the "one definition" claim covers all six call sites rather than the three that write.
- `GRAPHS_DIR` remains writable by a node in default mode, for the degeneracy reason above. If the protected set ever grows a directory, it needs an invariant that a protected entry may not contain the data root.
- `RunStore.prune` still logs at INFO for what it removed and WARNING for what it refused. On a shared server that skipped-and-logged line is the only signal that a plugin is logging artifact rows it does not own; nothing surfaces it in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
