### PR TITLE
chore(training,run): work through the deferred review follow-ups, and skip the stale ones (#189, #190, #193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,15 +46,21 @@ received — each links to the release it was published as.
   follow the same rule, and a non-boolean is refused with a message saying
   so.
 
-- **Determinism could be welded on for the life of the server process**
+- **Determinism could stay applied after the run that asked for it had gone**
   ([#190]). `execute_graph` enters the refcounted determinism scope by hand
   and pairs it in a `finally`, and two statements sat outside that pairing:
   creating the outbox pump task, and awaiting it during teardown. Either one
-  raising left the scope's depth above zero permanently, which stops
-  `torch.use_deterministic_algorithms` from ever being restored again — and
-  suppresses every later run's baseline capture as well. Both are now inside
-  the guard. Narrow paths, but the consequence had quietly grown from "one
-  run loses its restore" to "this process never restores again".
+  raising left the scope open, holding `torch.use_deterministic_algorithms`
+  at the failed run's setting and suppressing every later run's baseline
+  capture. Both are now inside the guard.
+
+  Scope, measured rather than assumed: on CPython the depth does come back
+  once the traceback is released, because finalising the suspended generator
+  runs the `finally` that was skipped. So this is bounded by whatever holds
+  the traceback — a stored exception, an unretrieved task — rather than
+  permanent, which is less severe than [#190] states. It is still a
+  correctness property resting on an interpreter detail nothing in the code
+  states, on a setting that is process-global.
 
 - **A failing wake-up on the run gate replaced the exception the run
   actually failed with** ([#190]). `_RunExclusion._wake` guarded the one line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,74 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- **A graph with a non-numeric value on a bounded parameter crashed the
+  validator instead of being refused** ([#193]). `validate_graph` compared
+  every value straight against its declared `min_value`/`max_value`, so
+  `"abc" < 0.0` — or `null < 0.0` — raised a `TypeError` that escaped the
+  function entirely. `POST /api/graph/run` turns that function's *return
+  value* into its 409 `invalid_graph` response, so the client got a 500
+  naming nothing at all. Every parameter with a declared bound was reachable
+  this way, on every node, not just the training ones.
+
+  `null` is the case the canvas can produce by itself: clearing a numeric
+  input yields `NaN`, which `JSON.stringify` writes as `null` into the saved
+  graph. A non-comparable value is now reported as an ordinary validation
+  error naming the parameter.
+
+- **The execution WebSocket read `"deterministic": "false"` as a request for
+  deterministic kernels** ([#189]). The socket coerced the flag with
+  `bool()` while passing its sibling `seed` through untouched, so a client
+  bug became a silently different run rather than the error the canvas
+  already knows how to display. Both halves of the reproducibility pair now
+  follow the same rule, and a non-boolean is refused with a message saying
+  so.
+
+- **Determinism could be welded on for the life of the server process**
+  ([#190]). `execute_graph` enters the refcounted determinism scope by hand
+  and pairs it in a `finally`, and two statements sat outside that pairing:
+  creating the outbox pump task, and awaiting it during teardown. Either one
+  raising left the scope's depth above zero permanently, which stops
+  `torch.use_deterministic_algorithms` from ever being restored again — and
+  suppresses every later run's baseline capture as well. Both are now inside
+  the guard. Narrow paths, but the consequence had quietly grown from "one
+  run loses its restore" to "this process never restores again".
+
+- **A failing wake-up on the run gate replaced the exception the run
+  actually failed with** ([#190]). `_RunExclusion._wake` guarded the one line
+  that cannot realistically fail and left the following `await` bare, and
+  both callers release inside an `@asynccontextmanager`'s `finally` — where a
+  raise substitutes itself for the body's exception. The hold was always
+  given back correctly; only the reported error was lost.
+
+### Changed
+
+- **`value_bytes` now says when it stops measuring** ([#193]). The
+  `MAX_WALK_ITEMS` cap already logged that its total was a lower bound;
+  `MAX_WALK_DEPTH` returned a smaller number in silence, which makes an
+  under-count indistinguishable from a genuinely small value. The module
+  docstring also claimed over-counting as *the* safe direction — true of
+  cross-measurement sharing, and not true of the three things that make the
+  walk under-count, which is the direction that costs memory.
+
+### Added
+
+- **The optimizer and loss applicability tables are now checked against the
+  installed torch** ([#189]). `#134` declares which algorithm accepts which
+  hyperparameter rather than inferring it from `inspect.signature`, because
+  inferring it would forward `eps` to Adagrad — whose torch default is 1e-10
+  against the Adam family's 1e-8 — and silently retune every existing Adagrad
+  graph. The cost of declaring is that the table can stop describing torch
+  without anything saying so. Two tests per node close that: one asserts each
+  declared set still equals "accepts it *and* agrees with our default", the
+  other fails when any new keyword appears in a torch signature. Neither
+  forwards anything automatically.
+
+- **OOM crossed with determinism** ([#193]). Both paths reach for
+  process-global state and their interaction had no test. Two now pin it: OOM
+  recovery runs *inside* the determinism scope, and an OOM unwinds that scope
+  rather than stranding it.
 
 ## [2.2.0] — 2026-08-10
 
@@ -464,6 +531,9 @@ Release candidates before 1.0.0 are on the
 [#259]: https://github.com/CodefyUI/CodefyUI/issues/259
 [#242]: https://github.com/CodefyUI/CodefyUI/issues/242
 [#265]: https://github.com/CodefyUI/CodefyUI/issues/265
+[#189]: https://github.com/CodefyUI/CodefyUI/issues/189
+[#190]: https://github.com/CodefyUI/CodefyUI/issues/190
+[#193]: https://github.com/CodefyUI/CodefyUI/issues/193
 [@oyea0801]: https://github.com/oyea0801
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.2.0...main
 [2.2.0]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...2.2.0

--- a/backend/app/api/ws_execution.py
+++ b/backend/app/api/ws_execution.py
@@ -346,13 +346,21 @@ class _ExecutionSocket:
             "record_outputs": bool(data.get("record_outputs", False)),
             "error_mode": data.get("error_mode", "fail_fast"),
             "max_retries": data.get("max_retries", 0),
-            # Reproducibility (#134). Passed through UNVALIDATED on purpose:
-            # ``normalize_options`` owns the seed's type and range, and
-            # coercing here would turn a client bug ("seed": "42") into a
-            # silently different run instead of the RunSubmitError the
-            # canvas already knows how to show.
+            # Reproducibility (#134). BOTH passed through UNVALIDATED, and
+            # that pairing is the point (#189): ``normalize_options`` owns
+            # the type of each, and coercing here would turn a client bug
+            # ("seed": "42", "deterministic": "no") into a silently
+            # different run instead of the RunSubmitError the canvas
+            # already knows how to show. ``deterministic`` used to be
+            # ``bool(...)``-ed, which made every truthy string a request
+            # for deterministic kernels — including the string "false".
+            #
+            # The educational flags below stay coerced, deliberately: they
+            # are pre-v2 fields whose lenient handling (and whose
+            # non-service defaults) is the compatibility contract with the
+            # canvas, not a reproducibility guarantee.
             "seed": data.get("seed"),
-            "deterministic": bool(data.get("deterministic", False)),
+            "deterministic": data.get("deterministic", False),
             # Educational feature flags. The defaults below are the pre-v2
             # ones verbatim, including weights_persistent defaulting to
             # TRUE here (the canvas keeps its weights) where the service's

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -2342,12 +2342,21 @@ async def execute_graph(
     # Hand-entering means the pairing is not the language's job any more,
     # so every statement between the two has to be looked at (#190). The
     # cost of getting it wrong went UP when the scope became refcounted:
-    # under save-and-restore a skipped exit cost one run its restore, while
-    # under refcounting the depth never returns to 0, so determinism is
-    # never restored again for the LIFE OF THE PROCESS and every later
-    # scope's baseline capture is suppressed too (see
-    # ``seeding.deterministic_scope``). One unlucky teardown poisons the
-    # server until someone restarts it.
+    # a skipped exit used to cost one run its restore, whereas now the
+    # depth does not return to 0, so ``use_deterministic_algorithms`` stays
+    # at the failed run's setting and every LATER scope's baseline capture
+    # is suppressed as well (see ``seeding.deterministic_scope``).
+    #
+    # How far that actually reaches, measured rather than assumed, because
+    # #190 overstates it: ``deterministic_scope`` is a generator-based
+    # context manager, so once the traceback holding this frame is released
+    # CPython finalises the suspended generator and runs the very
+    # ``finally`` that was skipped. The window is therefore however long
+    # something holds the traceback -- a stored exception, an unretrieved
+    # task -- not the life of the process. Still worth closing: it is a
+    # process-global setting whose correctness would otherwise rest on an
+    # interpreter detail nothing here states, and which no implementation
+    # without prompt refcounting provides.
     determinism = deterministic_scope(wants_determinism)
     determinism.__enter__()
 

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -1189,12 +1189,46 @@ def validate_graph(
             if param_def.name not in param_values:
                 continue
             value = param_values[param_def.name]
-            if param_def.min_value is not None and value < param_def.min_value:
+            # Both comparisons under one guard, because a bound is only
+            # meaningful against a value that can be ORDERED against it and
+            # the check used to assume that silently (#193). ``"abc" < 1``
+            # and ``None < 1`` both raise TypeError, and the raise escaped
+            # ``validate_graph`` entirely: the run route is written to turn
+            # this function's return value into a 409 ``invalid_graph``
+            # envelope, so a value it could not compare arrived at the
+            # client as a 500 with no idea which parameter caused it.
+            #
+            # Not hypothetical in either direction. A hand-authored
+            # graph.json or a direct API POST can put a string on an INT
+            # param; and the canvas's own numeric field yields NaN for a
+            # CLEARED input, which ``JSON.stringify`` writes as ``null`` --
+            # so a saved graph with an emptied box was a 500 waiting to be
+            # re-run. A non-comparable value is a validation error, and is
+            # now reported as one, naming the parameter like its
+            # neighbours.
+            #
+            # ``except TypeError`` rather than an isinstance check on
+            # (int, float): the predicate that matters is "does it order
+            # against the bound", which numpy scalars and a plugin's own
+            # numeric type satisfy without being either.
+            try:
+                below = (param_def.min_value is not None
+                         and value < param_def.min_value)
+                above = (param_def.max_value is not None
+                         and value > param_def.max_value)
+            except TypeError:
+                errors.append(
+                    f"Parameter '{param_def.name}' on node {node['id']} ({node['type']}): "
+                    f"value {value!r} is not a number, so it cannot be "
+                    f"checked against its allowed range"
+                )
+                continue
+            if below:
                 errors.append(
                     f"Parameter '{param_def.name}' on node {node['id']} ({node['type']}): "
                     f"value {value} is below minimum {param_def.min_value}"
                 )
-            if param_def.max_value is not None and value > param_def.max_value:
+            if above:
                 errors.append(
                     f"Parameter '{param_def.name}' on node {node['id']} ({node['type']}): "
                     f"value {value} is above maximum {param_def.max_value}"
@@ -2304,10 +2338,29 @@ async def execute_graph(
     # Entered by hand rather than with a ``with`` block so the whole body
     # below keeps its indentation; the paired exit lives in the ``finally``
     # that already owns this function's teardown.
+    #
+    # Hand-entering means the pairing is not the language's job any more,
+    # so every statement between the two has to be looked at (#190). The
+    # cost of getting it wrong went UP when the scope became refcounted:
+    # under save-and-restore a skipped exit cost one run its restore, while
+    # under refcounting the depth never returns to 0, so determinism is
+    # never restored again for the LIFE OF THE PROCESS and every later
+    # scope's baseline capture is suppressed too (see
+    # ``seeding.deterministic_scope``). One unlucky teardown poisons the
+    # server until someone restarts it.
     determinism = deterministic_scope(wants_determinism)
     determinism.__enter__()
 
-    pump_task = asyncio.create_task(_pump(), name=f"outbox-pump:{run_id or '-'}")
+    # Gap 1: outside the try below, and ``create_task`` raises RuntimeError
+    # on a loop that is closing. ``BaseException`` because a leaked depth
+    # outlives whatever is being torn down.
+    try:
+        pump_task = asyncio.create_task(_pump(),
+                                        name=f"outbox-pump:{run_id or '-'}")
+    except BaseException:
+        determinism.__exit__(None, None, None)
+        raise
+
     try:
         # Before the forward pass: zero any accumulated gradients on persisted
         # modules so backward_mode doesn't keep summing across runs.
@@ -2390,12 +2443,22 @@ async def execute_graph(
         except Exception:  # noqa: BLE001 - a lost event must not mask the outcome
             logger.warning("final signal flush failed", exc_info=True)
         finally:
-            pump_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await pump_task
-            # Hand determinism back to whatever the process had before this
-            # run. Last, so nothing above can skip it.
-            determinism.__exit__(None, None, None)
+            # Gap 2: ``await pump_task`` re-raises anything ``_pump`` died
+            # of that is not CancelledError, and the exit used to be its
+            # PEER rather than its finally — so the comment below ("nothing
+            # above can skip it") was true of the outer chain and false of
+            # the three lines it sat under. ``_pump`` catches Exception
+            # around ``_deliver`` but not around its own ``outbox.wait()``,
+            # and never catches BaseException at all, so the path is narrow
+            # rather than closed.
+            try:
+                pump_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await pump_task
+            finally:
+                # Hand determinism back to whatever the process had before
+                # this run. Last, and now genuinely unskippable.
+                determinism.__exit__(None, None, None)
 
 
 async def _maybe_await(val: Any) -> Any:

--- a/backend/app/core/memory_budget.py
+++ b/backend/app/core/memory_budget.py
@@ -48,6 +48,23 @@ earlier than strictly necessary -- and the alternative (a process-wide
 refcounted ledger of every storage every store has ever seen) buys accuracy
 nobody can observe at a cost everybody pays on every put.
 
+Which way it errs, stated once and honestly
+-------------------------------------------
+"Over-counting is the safe direction" is true of sharing and is NOT the
+direction of everything here, so it must not be read as a property of the
+measurement as a whole (#193). Three things make it UNDER-count, and
+under-counting is the direction that costs memory -- a value stays resident
+that the budget would otherwise have evicted:
+
+* :data:`MAX_WALK_DEPTH` stops the descent; payload below the cap measures 0.
+* :data:`MAX_WALK_ITEMS` stops the walk outright, mid-structure.
+* a measurement that raises returns 0 rather than a partial total.
+
+All three are deliberate -- a budget must not fail a run or become the slow
+part of one -- and all three are logged at debug level when they fire, so
+"why does the reported total look low" has an answer in the log rather than
+only in this docstring.
+
 Caveats, stated rather than hidden
 ----------------------------------
 * Sizes are measured ONCE, when a value is stored. A module that later grows
@@ -119,11 +136,15 @@ def value_bytes(value: Any) -> int:
     wrapper whose ``nbytes`` is a property that raises), so "no object in
     this repo triggers it" is not a guarantee about anything.
 
-    A measurement that gives up returns 0, not the partial total: the walk
-    is recursive, so the count lives in the frames the exception unwound.
-    Under-counting keeps a value that should have been evicted, which costs
-    memory; an exception loses a run. That is the trade being made, and it
-    is worth knowing which way it errs before trusting a budget.
+    A measurement that gives up returns 0, not the partial total: the
+    running count is :func:`_walk`'s local, and an exception leaves by the
+    one path that does not return it. (The walk is ITERATIVE -- an earlier
+    version of this paragraph blamed the recursion, which had already been
+    replaced by the stack above.) Under-counting keeps a value that should
+    have been evicted, which costs memory; an exception loses a run. That is
+    the trade being made, and it is worth knowing which way it errs before
+    trusting a budget -- see the module docstring for the other two ways it
+    errs the same way.
     """
     try:
         return _walk(value)
@@ -145,6 +166,12 @@ def _walk(value: Any) -> int:
     seen_storage: set[tuple] = set()
     stack: list[tuple[Any, int]] = [(value, 0)]
     items = 0
+    #: Containers the depth cap refused to descend into. Counted rather
+    #: than dropped in silence (#193): the items cap already says when it
+    #: truncates, and the depth cap under-counts by exactly the same
+    #: mechanism -- everything below it measures 0 -- so a total that looks
+    #: implausibly low should be answerable from the log either way.
+    undescended = 0
 
     while stack:
         obj, depth = stack.pop()
@@ -198,6 +225,10 @@ def _walk(value: Any) -> int:
             continue
 
         if depth >= MAX_WALK_DEPTH:
+            # Only a container loses anything by not being descended into;
+            # everything else down here measures 0 whether we look or not.
+            if isinstance(obj, (dict, list, tuple, set, frozenset)):
+                undescended += 1
             continue
         if isinstance(obj, dict):
             if id(obj) in visited:
@@ -215,6 +246,11 @@ def _walk(value: Any) -> int:
                 stack.append((item, depth + 1))
             continue
 
+    if undescended:
+        logger.debug(
+            "byte measurement did not descend past depth %d into %d "
+            "container(s); the total is a lower bound",
+            MAX_WALK_DEPTH, undescended)
     return total
 
 

--- a/backend/app/core/run_service.py
+++ b/backend/app/core/run_service.py
@@ -1009,18 +1009,38 @@ class _RunExclusion:
         ``shield`` is what fixes it: the notification is its own task, so
         the cancel takes this await and leaves the task running. The
         CancelledError still propagates, as it must.
+
+        "Never let a failure here replace the exception on its way out" is
+        the rule, and it used to be enforced over the ``ensure_future`` line
+        alone (#190) — while the await nine lines below it, which is where
+        a failing notification actually SURFACES, was unguarded. Both call
+        sites are ``finally`` blocks of an ``@asynccontextmanager``, so a
+        raise out of here does not merely add noise: it substitutes itself
+        for whatever the run was already failing with, and the original is
+        gone.
+
+        Swallowing costs nothing that was not already lost. ``_notify_all``
+        failing means the waiters were not woken either way; the difference
+        is only whether the caller's own exception survives to be reported.
+        Logged at warning, because the one thing that can raise here is a
+        condition bound to another loop, which is a bug worth seeing.
         """
         try:
             notify = asyncio.ensure_future(self._notify_all())
         except RuntimeError:  # pragma: no cover - loop already gone
             # Nothing can be waiting without a loop to wait on, and the
-            # counters are already back. Never let a teardown-time failure
-            # here replace the exception on its way out.
+            # counters are already back.
             return
         self._wakes.add(notify)
         notify.add_done_callback(self._wakes.discard)
         notify.add_done_callback(_swallow_task_result)
-        await asyncio.shield(notify)
+        try:
+            await asyncio.shield(notify)
+        except Exception:  # noqa: BLE001 - see above; CancelledError is a
+            # BaseException and so still propagates, which is required:
+            # ``shield`` re-raises the cancel that landed on this await.
+            logger.warning("run gate: waking the waiters failed",
+                           exc_info=True)
 
     async def _notify_all(self) -> None:
         async with self._condition:

--- a/backend/tests/test_dataloader_node.py
+++ b/backend/tests/test_dataloader_node.py
@@ -290,18 +290,29 @@ def test_predicted_draws_leaves_no_global_rng_pinned():
     Asserted by DRAWING either side rather than by comparing saved state
     blobs: a pinned RNG is only a problem because of what the next caller
     gets out of it, and two consecutive calls to a pinned generator return
-    the same number — which is exactly the assertion below.
-    """
-    _predicted_draws(21, "loader-1", 0, 4)
-    first = (random.random(), float(np.random.random()),
-             float(torch.rand(1)))
-    _predicted_draws(21, "loader-1", 0, 4)
-    second = (random.random(), float(np.random.random()),
-              float(torch.rand(1)))
+    the same number.
 
-    assert first != second, (
-        "a global RNG is still pinned to the derived worker seed: "
-        f"{first} came back again as {second}")
+    Compared PER RNG, and that is not cosmetic. A single tuple comparison
+    passes as soon as any ONE component moves — and ``random`` always moves,
+    because it is the one the old code did restore, so its stream advances
+    across the two calls. The tuple version of this test was green against
+    a helper that pinned both numpy and torch; only the per-generator
+    version fails, and it names which one.
+    """
+    def _after_a_call() -> dict[str, float]:
+        _predicted_draws(21, "loader-1", 0, 4)
+        return {
+            "random": random.random(),
+            "numpy": float(np.random.random()),
+            "torch": float(torch.rand(1)),
+        }
+
+    first, second = _after_a_call(), _after_a_call()
+    pinned = sorted(name for name in first if first[name] == second[name])
+
+    assert not pinned, (
+        f"still pinned to the derived worker seed: {pinned} — the same "
+        f"number came back from a fresh draw ({first} then {second})")
 
 
 def test_a_seeded_multi_worker_loader_iterates_and_seeds_its_workers():

--- a/backend/tests/test_dataloader_node.py
+++ b/backend/tests/test_dataloader_node.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import pickle
 import random
 
+import numpy as np
 import pytest
 import torch
 from torch.utils.data import DataLoader, TensorDataset
@@ -241,6 +243,27 @@ def _tagged_draws(seed, dataset, node_id="loader-1"):
     return by_worker
 
 
+@contextlib.contextmanager
+def _global_rngs_restored():
+    """Put ``random``, numpy and torch back exactly as they were.
+
+    ``seed_rngs`` seeds all THREE process-global RNGs, so a helper that
+    saves only ``random``'s state hands every test that runs afterwards a
+    numpy and a torch stream pinned to a derived constant (#190). Nothing
+    in the suite depends on that today — the point is that nothing should
+    be able to start, because the symptom would surface as an unrelated
+    test going flaky depending on collection order, which is close to the
+    most expensive class of bug to chase.
+    """
+    states = (random.getstate(), np.random.get_state(), torch.get_rng_state())
+    try:
+        yield
+    finally:
+        random.setstate(states[0])
+        np.random.set_state(states[1])
+        torch.set_rng_state(states[2])
+
+
 def _predicted_draws(seed, node_id, worker_id, count):
     """What ``worker_init_fn`` promises worker *worker_id* will draw.
 
@@ -248,17 +271,37 @@ def _predicted_draws(seed, node_id, worker_id, count):
     this worker) — which is the property the function exists for. torch's
     own per-worker seeding would produce a different stream, so this is
     what tells "our seeding took effect" apart from "torch seeded it".
+
+    Seeds the globals to get there, and hands them back; see
+    :func:`_global_rngs_restored`.
     """
     from app.core.execution_context import ExecutionContext
     from app.core.seeding import derive_seed, seed_rngs
 
     base = ExecutionContext(seed=seed).derive_seed(f"dataloader:{node_id}")
-    state = random.getstate()
-    try:
+    with _global_rngs_restored():
         seed_rngs(derive_seed(base, f"worker:{worker_id}"))
         return [random.random() for _ in range(count)]
-    finally:
-        random.setstate(state)
+
+
+def test_predicted_draws_leaves_no_global_rng_pinned():
+    """The measuring stick must not move what it measures (#190).
+
+    Asserted by DRAWING either side rather than by comparing saved state
+    blobs: a pinned RNG is only a problem because of what the next caller
+    gets out of it, and two consecutive calls to a pinned generator return
+    the same number — which is exactly the assertion below.
+    """
+    _predicted_draws(21, "loader-1", 0, 4)
+    first = (random.random(), float(np.random.random()),
+             float(torch.rand(1)))
+    _predicted_draws(21, "loader-1", 0, 4)
+    second = (random.random(), float(np.random.random()),
+              float(torch.rand(1)))
+
+    assert first != second, (
+        "a global RNG is still pinned to the derived worker seed: "
+        f"{first} came back again as {second}")
 
 
 def test_a_seeded_multi_worker_loader_iterates_and_seeds_its_workers():

--- a/backend/tests/test_graph_engine.py
+++ b/backend/tests/test_graph_engine.py
@@ -158,6 +158,41 @@ def test_validate_graph_param_above_max():
     assert any("above maximum" in e and "'p'" in e for e in errors)
 
 
+@pytest.mark.parametrize("value", ["abc", None, [1], {"a": 1}])
+def test_validate_graph_reports_an_uncomparable_param_instead_of_raising(value):
+    """A bounded param holding a non-number is an ERROR, not a crash (#193).
+
+    The range check compared straight against ``min_value``/``max_value``,
+    so ``"abc" < 0.0`` raised a TypeError that escaped ``validate_graph``
+    altogether — and the run route turns this function's RETURN VALUE into
+    its 409 ``invalid_graph`` envelope, so the client got a 500 naming
+    nothing. Every param with a declared bound was reachable this way, not
+    just the training ones.
+
+    ``None`` is in the list because it is the one the canvas can produce on
+    its own: clearing a numeric input yields NaN, which ``JSON.stringify``
+    writes as ``null`` into the saved graph.
+    """
+    nodes = [
+        {"id": "1", "type": "Dropout", "data": {"params": {"p": value}}},
+    ]
+    errors = validate_graph(nodes, [])
+    assert any("is not a number" in e and "'p'" in e for e in errors), errors
+
+
+def test_validate_graph_still_accepts_a_bool_on_a_bounded_param():
+    """bool is an int subclass and orders fine; it was never the problem.
+
+    Pinned so the fix above is not "reject anything that is not int|float",
+    which would newly reject graphs that validate today.
+    """
+    nodes = [
+        {"id": "1", "type": "Dropout", "data": {"params": {"p": True}}},
+    ]
+    errors = validate_graph(nodes, [])
+    assert not any("'p'" in e for e in errors), errors
+
+
 def test_validate_graph_param_within_range_no_error():
     """Dropout 'p' within [0.0, 1.0] should not produce a range error."""
     nodes = [

--- a/backend/tests/test_health_project.py
+++ b/backend/tests/test_health_project.py
@@ -1,12 +1,30 @@
-"""/api/health gains an additive `project` field (spec ID4).
+"""/api/health's additive `project` field (spec ID4), and the shape it sits in.
 
-Additive is scoped to PROJECT MODE ONLY: the byte-for-byte non-project
-refactor guard (spec header Global Constraints) means the key must be
-ABSENT -- not merely null -- when settings.PROJECT_DIR is None, so a
-non-project response body stays identical to pre-Task-10 main.py.
+The original version of this file claimed a non-project response body "stays
+identical to pre-Task-10 main.py". That has not been true for some time and
+was never going to stay true: `version` was added unconditionally and openly
+("this is a new capability rather than a refactor" -- see `health()` in
+`app/main.py`), and `caches` followed for #135. Repeating a dead byte-for-byte
+guarantee in a docstring is worse than not having one, because it reads as an
+invariant somebody is enforcing (#193).
+
+What IS still load-bearing, and what the tests below actually check:
+
+* `project` must be ABSENT, not null, outside project mode. The frontend
+  normalises with `data.project ?? null` and `isProjectMode` keys off a
+  strict `!== null`, so a literal `null` would work but `undefined` from a
+  MISSING key is what the normalisation exists to convert -- and the
+  distinction is only testable from this side.
+* The top-level key set is fixed. Additive is a decision, not a drift: a new
+  key arriving here should break this test once, on purpose, and be added to
+  the list by the person who added it.
 """
 
 from app.api import routes_graph  # for the shared settings object
+
+#: Every top-level key `/api/health` returns outside project mode. `project`
+#: is the one conditional key and is asserted separately below.
+_BASE_KEYS = {"status", "version", "nodes_loaded", "presets_loaded", "caches"}
 
 
 async def test_health_project_key_absent_when_unset(test_client, monkeypatch):
@@ -21,3 +39,21 @@ async def test_health_project_dir_in_project_mode(test_client, monkeypatch, tmp_
     monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", tmp_path)
     r = await test_client.get("/api/health")
     assert r.json()["project"] == str(tmp_path)
+
+
+async def test_health_body_carries_exactly_the_documented_keys(
+    test_client, monkeypatch, tmp_path,
+):
+    """The replacement for the dead "identical to pre-Task-10" claim (#193).
+
+    Both modes, because the whole point of `project` being conditional is
+    that it is the ONLY difference between them.
+    """
+    settings = routes_graph.settings
+
+    monkeypatch.setattr(settings, "PROJECT_DIR", None)
+    assert set((await test_client.get("/api/health")).json()) == _BASE_KEYS
+
+    monkeypatch.setattr(settings, "PROJECT_DIR", tmp_path)
+    assert set((await test_client.get("/api/health")).json()) == (
+        _BASE_KEYS | {"project"})

--- a/backend/tests/test_loss_node.py
+++ b/backend/tests/test_loss_node.py
@@ -251,3 +251,95 @@ def test_every_conditional_param_hides_exactly_where_it_does_not_apply():
     assert always_visible == {"type", "reduction"}, (
         "a new always-visible param needs an explicit decision: every loss "
         "must accept it, or execute() must reject it where it does not")
+
+
+# ── the tables against the torch that is actually installed (#189) ────────
+
+
+def _accepting(param, node_default):
+    """Losses whose signature takes *param* AND defaults it to ours."""
+    import inspect
+
+    import torch.nn as nn
+
+    found = set()
+    for name in loss_node.LOSS_TYPES:
+        signature = inspect.signature(getattr(nn, name).__init__).parameters
+        if param in signature and signature[param].default == node_default:
+            found.add(name)
+    return found
+
+
+def test_the_applicability_tables_match_the_installed_torch_signatures():
+    """Same guard as ``Optimizer``'s, for the loss side of #134.
+
+    A declared table describes torch at the moment it was written and has
+    no way of noticing when that stops being true. This is the noticing.
+    """
+    for param, node_default, declared in (
+        ("weight", None, loss_node._WEIGHT_TYPES),
+        ("ignore_index", loss_node.DEFAULT_IGNORE_INDEX,
+         loss_node._IGNORE_INDEX_TYPES),
+        ("label_smoothing", 0.0, loss_node._LABEL_SMOOTHING_TYPES),
+        ("pos_weight", None, loss_node._POS_WEIGHT_TYPES),
+    ):
+        found = _accepting(param, node_default)
+        assert found == set(declared), (
+            f"the {param} table no longer matches this torch: it accepts-"
+            f"and-agrees for {sorted(found)}, the node declares "
+            f"{sorted(declared)}")
+
+
+def test_reduction_really_is_the_argument_all_of_them_share():
+    """``LOSS_TYPES``' header comment, asserted rather than asserted-in-prose.
+
+    ``execute`` puts ``reduction`` in ``kwargs`` unconditionally, so a loss
+    that stopped taking it would fail at construction for every user of that
+    type — with a TypeError from inside torch rather than anything naming
+    this node.
+    """
+    assert _accepting("reduction", "mean") == set(loss_node.LOSS_TYPES)
+
+
+#: Every keyword each loss took when this was written (torch 2.13), minus
+#: ``self``. ``size_average``/``reduce`` are torch's own deprecated pair and
+#: are recorded, not exposed. A snapshot; see the test below.
+_TORCH_LOSS_KWARGS = {
+    "CrossEntropyLoss": {"ignore_index", "label_smoothing", "reduce",
+                         "reduction", "size_average", "weight"},
+    "MSELoss": {"reduce", "reduction", "size_average"},
+    "BCEWithLogitsLoss": {"pos_weight", "reduce", "reduction", "size_average",
+                          "weight"},
+    "L1Loss": {"reduce", "reduction", "size_average"},
+    "SmoothL1Loss": {"beta", "reduce", "reduction", "size_average"},
+    "NLLLoss": {"ignore_index", "reduce", "reduction", "size_average",
+                "weight"},
+    "KLDivLoss": {"log_target", "reduce", "reduction", "size_average"},
+    "HuberLoss": {"delta", "reduction"},
+    "BCELoss": {"reduce", "reduction", "size_average", "weight"},
+    "MarginRankingLoss": {"margin", "reduce", "reduction", "size_average"},
+    "CosineEmbeddingLoss": {"margin", "reduce", "reduction", "size_average"},
+}
+
+
+def test_no_new_torch_loss_knob_arrives_unnoticed():
+    """The loss half of #189's ask. See the Optimizer twin for the rationale.
+
+    Note what this already reveals: ``SmoothL1Loss.beta``, ``HuberLoss.delta``
+    and ``KLDivLoss.log_target`` are real hyperparameters torch offers and
+    the node does not expose. That is a standing decision, not an oversight
+    — recorded here so it stays a decision.
+    """
+    import inspect
+
+    import torch.nn as nn
+
+    current = {}
+    for name in loss_node.LOSS_TYPES:
+        signature = inspect.signature(getattr(nn, name).__init__).parameters
+        current[name] = {k for k in signature if k != "self"}
+
+    assert current == _TORCH_LOSS_KWARGS, (
+        "this torch's loss signatures differ from the recorded ones. For "
+        "each added keyword: expose it (a ParamDefinition plus an "
+        "applicability set) or record it above as reviewed-and-declined.")

--- a/backend/tests/test_memory_budget.py
+++ b/backend/tests/test_memory_budget.py
@@ -8,6 +8,8 @@ shares its parent's storage, and a payload that is not tensors at all.
 
 from __future__ import annotations
 
+import logging
+
 import torch
 import torch.nn as nn
 
@@ -138,6 +140,39 @@ def test_nesting_past_the_depth_cap_stops_rather_than_recursing():
     # No RecursionError, and the answer is a lower bound rather than a lie
     # about the shape of the data.
     assert value_bytes(payload) == 0
+
+
+def test_the_depth_cap_says_so_instead_of_truncating_in_silence(caplog):
+    """#193: the two caps must be equally audible.
+
+    The items cap already logged "the total is a lower bound" when it fired.
+    The depth cap returned a smaller number and said nothing, which makes an
+    under-count -- the direction that costs memory, since a value the budget
+    should have evicted stays resident -- indistinguishable from a genuinely
+    small value. This is the log that tells the two apart.
+    """
+    payload: object = torch.zeros(1000)
+    for _ in range(MAX_WALK_DEPTH + 10):
+        payload = [payload]
+
+    with caplog.at_level(logging.DEBUG, logger="app.core.memory_budget"):
+        assert value_bytes(payload) == 0
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("lower bound" in m for m in messages), (
+        f"the depth cap truncated in silence: {messages}")
+
+
+def test_a_measurement_that_fits_says_nothing(caplog):
+    """The counterpart: no cap fired, so there is no log line to chase.
+
+    Without this, the assertion above passes just as well against a
+    ``logger.debug`` fired unconditionally on every cache write.
+    """
+    payload = [[torch.zeros(1000)], (torch.zeros(1000),)]
+    with caplog.at_level(logging.DEBUG, logger="app.core.memory_budget"):
+        assert value_bytes(payload) == 8000
+    messages = [r.getMessage() for r in caplog.records]
+    assert not [m for m in messages if "lower bound" in m], messages
 
 
 def test_a_tensor_on_the_meta_device_falls_back_to_the_element_formula():

--- a/backend/tests/test_node_oom.py
+++ b/backend/tests/test_node_oom.py
@@ -10,6 +10,7 @@ state the next test inherits.
 from __future__ import annotations
 
 import pytest
+import torch
 
 from app.core.cache import ExecutionCache
 from app.core.error_handling import (
@@ -19,6 +20,7 @@ from app.core.error_handling import (
     memory_digest,
     release_cached_memory,
 )
+from app.core.execution_context import ExecutionContext
 from app.core.graph_engine import execute_graph
 from app.core.node_base import BaseNode, DataType, PortDefinition
 from app.core.node_registry import registry
@@ -302,3 +304,98 @@ async def test_continue_mode_records_the_oom_and_carries_on():
     await execute_graph(nodes, edges, on_progress=observe,
                         error_mode="continue")
     assert ("n1", "error") in statuses
+
+
+# ── crossed with determinism (#193) ──────────────────────────────────────
+#
+# Both paths reach for PROCESS-GLOBAL state: OOM recovery calls
+# ``torch.cuda.empty_cache()``, and a deterministic run holds a refcounted
+# scope over ``torch.use_deterministic_algorithms``. Neither had a test
+# saying what happens when one unwinds through the other.
+
+
+@pytest.fixture
+def _determinism_restored():
+    """Give torch its flags back whatever the test does to them."""
+    previously = torch.are_deterministic_algorithms_enabled()
+    warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+    torch.use_deterministic_algorithms(False)
+    try:
+        yield
+    finally:
+        torch.use_deterministic_algorithms(previously, warn_only=warn_only)
+
+
+@pytest.mark.asyncio
+async def test_oom_recovery_runs_INSIDE_the_deterministic_scope(
+    _determinism_restored, monkeypatch,
+):
+    """Ordering, asserted from inside the recovery rather than after it.
+
+    The question a crossover test has to answer is not "did both happen"
+    but "which one was still in force while the other ran". Recovery that
+    fired AFTER the scope unwound would be touching the allocator with the
+    process's determinism setting already handed back — a different, and
+    much harder to reason about, ordering than the one the code intends.
+
+    ``release_cached_memory`` is the probe point because it is the last
+    thing the recovery does and the one that touches the allocator. It is
+    stubbed rather than allowed to run: on a CPU-only box it returns before
+    reaching ``empty_cache()`` at all (see its ``kind != "cuda"`` guard), so
+    letting it run would assert nothing while LOOKING like it asserted the
+    interaction. This test pins the ordering; it does not pretend to
+    exercise a real CUDA free.
+    """
+    from app.core import graph_engine as engine
+    from app.core.seeding import determinism_depth
+
+    seen: list[tuple[bool, int]] = []
+
+    def _probe(device: str = "") -> None:
+        seen.append((torch.are_deterministic_algorithms_enabled(),
+                     determinism_depth()))
+
+    monkeypatch.setattr(engine, "release_cached_memory", _probe)
+
+    _HungryNode.boom = _cuda_oom()
+    nodes, edges = _graph()
+    with pytest.raises(NodeOOMError):
+        await execute_graph(
+            nodes, edges,
+            context=ExecutionContext(device="cpu", deterministic=True))
+
+    assert seen, "OOM recovery never ran"
+    enabled, depth = seen[0]
+    assert enabled, "recovery ran after determinism was handed back"
+    assert depth == 1, f"expected to be inside exactly one scope, saw {depth}"
+
+
+@pytest.mark.asyncio
+async def test_an_oom_in_a_deterministic_run_still_unwinds_the_scope(
+    _determinism_restored,
+):
+    """And the NEXT run is unaffected — which is the whole point of #134.
+
+    An OOM leaves ``execute_graph`` by the same ``finally`` that owns the
+    scope's exit, so this is the ordinary path rather than a corner. It is
+    pinned because the two mechanisms are independent and nothing else says
+    they compose: a future recovery step that returned early, or unwound by
+    some other route, would strand the depth and weld determinism on for
+    the life of the process.
+    """
+    from app.core.seeding import determinism_depth
+
+    _HungryNode.boom = _cuda_oom()
+    nodes, edges = _graph()
+    with pytest.raises(NodeOOMError):
+        await execute_graph(
+            nodes, edges,
+            context=ExecutionContext(device="cpu", deterministic=True))
+
+    assert determinism_depth() == 0, "the OOM stranded the scope's depth"
+    assert not torch.are_deterministic_algorithms_enabled()
+
+    # The next run asked for nothing and must get nothing.
+    _HungryNode.boom = None
+    await execute_graph(nodes, edges, context=ExecutionContext(device="cpu"))
+    assert not torch.are_deterministic_algorithms_enabled()

--- a/backend/tests/test_optimizer_node.py
+++ b/backend/tests/test_optimizer_node.py
@@ -314,3 +314,138 @@ def test_every_conditional_param_hides_exactly_where_it_does_not_apply():
         "a new always-visible param needs an explicit decision: every "
         "algorithm must accept it, or execute() must reject it where it "
         "does not (see weight_decay)")
+
+
+# ── the tables against the torch that is actually installed (#189) ────────
+
+
+def _accepting(param, node_default):
+    """Algorithms whose signature takes *param* AND defaults it to ours."""
+    import inspect
+
+    import torch.optim as optim
+
+    found = set()
+    for name in optimizer_node.OPTIMIZER_TYPES:
+        signature = inspect.signature(getattr(optim, name).__init__).parameters
+        if param in signature and signature[param].default == node_default:
+            found.add(name)
+    return found
+
+
+def test_the_applicability_tables_match_the_installed_torch_signatures():
+    """The declared sets ARE "accepts it, and agrees with our default".
+
+    #134 declares applicability instead of inferring it, and that stays the
+    right call: inferring it would forward ``eps`` to Adagrad, whose torch
+    default is 1e-10 against this node's 1e-8, silently retuning every
+    existing Adagrad graph on upgrade. What declaring costs is that the
+    table can quietly stop describing torch — a release that adds
+    ``momentum`` to another algorithm, or that changes a default, leaves the
+    set behind with nothing to say so.
+
+    This closes the "with nothing to say so" part, and only that: it asserts
+    the declaration, it does not derive it. A failure here is a decision to
+    make by hand, not a line to delete.
+    """
+    from app.core.param_values import parse_float_sequence
+
+    betas_default = parse_float_sequence(
+        optimizer_node.DEFAULT_BETAS, name="betas", length=2)
+
+    for param, node_default, declared in (
+        ("momentum", 0.0, optimizer_node._MOMENTUM_TYPES),
+        ("betas", betas_default, optimizer_node._BETAS_TYPES),
+        ("eps", optimizer_node.DEFAULT_EPS, optimizer_node._EPS_TYPES),
+        ("amsgrad", False, optimizer_node._AMSGRAD_TYPES),
+        ("nesterov", False, optimizer_node._SGD_ONLY),
+        ("dampening", 0.0, optimizer_node._SGD_ONLY),
+    ):
+        found = _accepting(param, node_default)
+        assert found == set(declared), (
+            f"the {param} table no longer matches this torch: it accepts-"
+            f"and-agrees for {sorted(found)}, the node declares "
+            f"{sorted(declared)}. Decide per algorithm — forwarding is only "
+            f"a no-op where torch's default equals ours (see eps/Adagrad "
+            f"for why that matters)")
+
+
+def test_adagrad_is_excluded_from_eps_because_its_default_differs():
+    """The one exclusion that is a JUDGEMENT rather than an absence.
+
+    Every other algorithm missing from a table is missing because torch has
+    no such knob. Adagrad has ``eps`` and is left out anyway, so a reader
+    checking the table against the signature would find a discrepancy and
+    "fix" it. Pinned here so the reason is executable rather than a comment.
+    """
+    import inspect
+
+    import torch.optim as optim
+
+    signature = inspect.signature(optim.Adagrad.__init__).parameters
+    assert "eps" in signature, "Adagrad stopped taking eps; revisit the table"
+    assert signature["eps"].default != optimizer_node.DEFAULT_EPS, (
+        "Adagrad's eps default now matches ours, so the reason it is "
+        "excluded from _EPS_TYPES has gone away — including it would now be "
+        "the no-op it was not before")
+    assert "Adagrad" not in optimizer_node._EPS_TYPES
+
+
+#: Every keyword each optimizer took when this was written (torch 2.13),
+#: minus ``self``/``params``. A snapshot, and deliberately a whole one --
+#: see the test below for why it is not narrowed to the knobs we expose.
+_TORCH_OPTIMIZER_KWARGS = {
+    "Adam": {"amsgrad", "betas", "capturable", "decoupled_weight_decay",
+             "differentiable", "eps", "foreach", "fused", "lr", "maximize",
+             "weight_decay"},
+    "SGD": {"dampening", "differentiable", "foreach", "fused", "lr",
+            "maximize", "momentum", "nesterov", "weight_decay"},
+    "AdamW": {"amsgrad", "betas", "capturable", "differentiable", "eps",
+              "foreach", "fused", "lr", "maximize", "weight_decay"},
+    "RMSprop": {"alpha", "capturable", "centered", "differentiable", "eps",
+                "foreach", "lr", "maximize", "momentum", "weight_decay"},
+    "Adagrad": {"differentiable", "eps", "foreach", "fused",
+                "initial_accumulator_value", "lr", "lr_decay", "maximize",
+                "weight_decay"},
+    "RAdam": {"betas", "capturable", "decoupled_weight_decay",
+              "differentiable", "eps", "foreach", "lr", "maximize",
+              "weight_decay"},
+    "NAdam": {"betas", "capturable", "decoupled_weight_decay",
+              "differentiable", "eps", "foreach", "lr", "maximize",
+              "momentum_decay", "weight_decay"},
+    "Rprop": {"capturable", "differentiable", "etas", "foreach", "lr",
+              "maximize", "step_sizes"},
+    "ASGD": {"alpha", "capturable", "differentiable", "foreach", "lambd",
+             "lr", "maximize", "t0", "weight_decay"},
+}
+
+
+def test_no_new_torch_optimizer_knob_arrives_unnoticed():
+    """A new hyperparameter must break something. This is the something.
+
+    Deliberately a snapshot of the WHOLE signature rather than of the knobs
+    the node exposes: the gap #189 names is a torch release ADDING one, and
+    a test that only looks at the params already declared cannot see a param
+    that is not declared yet.
+
+    It will therefore also fire for plumbing nobody wants on a node
+    (``fused``, ``capturable``). That is the intended cost — the fix is one
+    line in the dict above, written by someone who looked at what changed,
+    which is the entire point. A table that drifts for years in silence is
+    the alternative being rejected here.
+    """
+    import inspect
+
+    import torch.optim as optim
+
+    current = {}
+    for name in optimizer_node.OPTIMIZER_TYPES:
+        signature = inspect.signature(getattr(optim, name).__init__).parameters
+        current[name] = {k for k in signature if k not in ("self", "params")}
+
+    assert current == _TORCH_OPTIMIZER_KWARGS, (
+        "this torch's optimizer signatures differ from the recorded ones. "
+        "For each added keyword: expose it (a ParamDefinition plus an "
+        "applicability set) or record it above as reviewed-and-declined. Do "
+        "NOT start forwarding automatically — see the eps/Adagrad note at "
+        "the top of optimizer_node.py.")

--- a/backend/tests/test_run_service.py
+++ b/backend/tests/test_run_service.py
@@ -1752,6 +1752,54 @@ async def test_two_cancels_do_not_wedge_the_gate_shut(hold):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("hold", ["exclusive", "shared"])
+async def test_a_failing_wake_does_not_replace_the_runs_own_exception(hold):
+    """#190: the release path must not overwrite what the run failed with.
+
+    Both holds release inside the ``finally`` of an
+    ``@asynccontextmanager``, so an exception raised there SUBSTITUTES
+    itself for the body's — the user gets a message about the notifier and
+    the actual failure is gone. The guard on ``_wake`` covered the
+    ``ensure_future`` line only, which is the half that cannot fail in
+    practice; the await below it, where a failing notification actually
+    surfaces, was bare.
+
+    Asserted on the exception IDENTITY, not just its type: a replacement
+    would most plausibly be a RuntimeError, and so is what we inject.
+    """
+    class _FlakyGate(_RunExclusion):
+        """Subclassed rather than patched: ``_RunExclusion`` has __slots__."""
+
+        explode = True
+
+        async def _notify_all(self) -> None:
+            if self.explode:
+                raise RuntimeError("condition is bound to another loop")
+            await _RunExclusion._notify_all(self)
+
+    gate = _FlakyGate()
+    original = RuntimeError("what the run actually failed with")
+
+    with pytest.raises(RuntimeError) as caught:
+        async with getattr(gate, hold)():
+            raise original
+
+    assert caught.value is original, (
+        f"the run's exception was replaced by {caught.value!r}")
+    assert not gate.busy, "the gate stayed held"
+
+    # And it is genuinely reusable: the hold is given back before the
+    # notification is even attempted, so a failed wake cannot wedge it.
+    gate.explode = False
+
+    async def _take() -> str:
+        async with gate.exclusive():
+            return "in"
+
+    assert await asyncio.wait_for(_take(), timeout=2.0) == "in"
+
+
+@pytest.mark.asyncio
 async def test_a_cancelled_waiter_does_not_block_the_next_run():
     """The queue behind a cancelled waiter must still drain.
 

--- a/backend/tests/test_seeding.py
+++ b/backend/tests/test_seeding.py
@@ -611,6 +611,99 @@ async def test_two_overlapping_runs_do_not_latch_determinism(
     assert determinism_depth() == 0
 
 
+# ── the engine's hand-entered scope must be unskippable (#190) ──────────
+#
+# ``execute_graph`` enters the scope with a bare ``__enter__`` and pairs it
+# in a ``finally``, which means the pairing is not the language's job and
+# every statement in between is a place it can be lost. Under refcounting a
+# lost exit does not cost one run its restore -- it strands the depth above
+# zero for the life of the PROCESS, which suppresses every later scope's
+# baseline capture as well.
+
+
+@pytest.fixture
+def _determinism_depth_isolated():
+    """Contain a leak so a FAILING test here does not poison the session.
+
+    The failure under test is exactly "the depth never comes back", and a
+    stranded depth would turn a dozen unrelated tests red for a reason none
+    of them names. The assertion still has to run first -- this only cleans
+    up after it.
+    """
+    import app.core.seeding as seeding
+
+    try:
+        yield
+    finally:
+        seeding._DETERMINISM_DEPTH = 0
+        seeding._DETERMINISM_BASELINE = None
+
+
+@pytest.mark.asyncio
+async def test_a_pump_that_cannot_be_started_still_gives_the_depth_back(
+    _determinism_probe, _determinism_depth_isolated, monkeypatch,
+):
+    """The pump task is created BETWEEN ``__enter__`` and the guarded body.
+
+    ``asyncio.create_task`` raises ``RuntimeError`` on a loop that is
+    closing, which is precisely when a server is being torn down and least
+    able to notice that determinism has been welded on.
+
+    Only the pump's own creation is failed -- matched on the task name --
+    so nothing else in the run is disturbed by the patch.
+    """
+    from app.core import graph_engine as engine
+
+    real_create_task = asyncio.create_task
+
+    def _fail_the_pump(coro, *args, name=None, **kwargs):
+        if name and name.startswith("outbox-pump"):
+            coro.close()  # or Python warns it was never awaited
+            raise RuntimeError("event loop is closed")
+        return real_create_task(coro, *args, name=name, **kwargs)
+
+    monkeypatch.setattr(engine.asyncio, "create_task", _fail_the_pump)
+
+    nodes, edges = _probe_graph()
+    with pytest.raises(RuntimeError, match="event loop is closed"):
+        await execute_graph(
+            nodes, edges,
+            context=ExecutionContext(device="cpu", deterministic=True))
+
+    assert determinism_depth() == 0, "the scope leaked its depth"
+    assert not torch.are_deterministic_algorithms_enabled()
+
+
+@pytest.mark.asyncio
+async def test_a_pump_that_dies_mid_run_still_gives_the_depth_back(
+    _determinism_probe, _determinism_depth_isolated,
+):
+    """``await pump_task`` re-raises whatever killed the pump.
+
+    ``_pump`` catches ``Exception`` around ``_deliver`` but NOT around its
+    own ``outbox.wait()``, and catches nothing at all above ``Exception``,
+    so this is narrow rather than closed. The exit used to be that await's
+    PEER statement, so anything coming back out of it went straight past.
+
+    Raising from ``wait`` is the honest injection point: it is the one line
+    of the pump with no handler over it.
+    """
+    from app.core.execution_context import EventOutbox
+
+    class _ExplodingOutbox(EventOutbox):
+        async def wait(self) -> None:
+            raise RuntimeError("pump died")
+
+    nodes, edges = _probe_graph()
+    context = ExecutionContext(device="cpu", deterministic=True,
+                               outbox=_ExplodingOutbox())
+    with pytest.raises(RuntimeError, match="pump died"):
+        await execute_graph(nodes, edges, context=context)
+
+    assert determinism_depth() == 0, "the scope leaked its depth"
+    assert not torch.are_deterministic_algorithms_enabled()
+
+
 def test_deterministic_scope_restores_the_cublas_env_var():
     """The env var leaks into every subprocess spawned afterwards.
 

--- a/backend/tests/test_seeding.py
+++ b/backend/tests/test_seeding.py
@@ -627,8 +627,8 @@ def _determinism_depth_isolated():
 
     The failure under test is exactly "the depth never comes back", and a
     stranded depth would turn a dozen unrelated tests red for a reason none
-    of them names. The assertion still has to run first -- this only cleans
-    up after it.
+    of them names. The assertions still run first -- this only cleans up
+    after them.
     """
     import app.core.seeding as seeding
 
@@ -637,6 +637,37 @@ def _determinism_depth_isolated():
     finally:
         seeding._DETERMINISM_DEPTH = 0
         seeding._DETERMINISM_BASELINE = None
+
+
+def _assert_scope_closed_before_the_exception_left(depth_at_raise: int) -> None:
+    """Both tests below assert INSIDE their ``except``, and here is why.
+
+    Measured while writing them: with the guard removed the depth really is
+    1 at the moment the exception is caught -- and 0 again as soon as the
+    ``except`` block ends. ``deterministic_scope`` is a generator-based
+    context manager, so once the traceback (which holds ``execute_graph``'s
+    frame, which holds the generator) is released, CPython's refcounting
+    finalises the suspended generator, which throws GeneratorExit at the
+    ``yield`` and runs the very ``finally`` that was skipped.
+
+    That is worth writing down, because it makes #190's severity claim --
+    "determinism is never restored again in that process" -- too strong for
+    CPython as it stands. What is true is narrower and still worth fixing:
+    the scope stays open for as long as anything holds the traceback (a
+    stored exception on a run row, a task that nobody retrieved, a
+    ``sys.last_value``), it depends on an interpreter detail no code here
+    states, and it evaporates on any implementation without prompt
+    refcounting.
+
+    So the property to pin is the one that does not depend on the garbage
+    collector: the scope was closed BEFORE the exception left the engine.
+    Asserting after ``pytest.raises`` would pass either way and prove
+    nothing -- it did, until this was measured.
+    """
+    assert depth_at_raise == 0, (
+        "the scope was still open when the exception left execute_graph; "
+        "it was closed later only because the traceback was released and "
+        "the generator got finalised")
 
 
 @pytest.mark.asyncio
@@ -665,12 +696,16 @@ async def test_a_pump_that_cannot_be_started_still_gives_the_depth_back(
     monkeypatch.setattr(engine.asyncio, "create_task", _fail_the_pump)
 
     nodes, edges = _probe_graph()
-    with pytest.raises(RuntimeError, match="event loop is closed"):
+    try:
         await execute_graph(
             nodes, edges,
             context=ExecutionContext(device="cpu", deterministic=True))
+    except RuntimeError as exc:
+        assert "event loop is closed" in str(exc)
+        _assert_scope_closed_before_the_exception_left(determinism_depth())
+    else:
+        pytest.fail("the pump was supposed to fail to start")
 
-    assert determinism_depth() == 0, "the scope leaked its depth"
     assert not torch.are_deterministic_algorithms_enabled()
 
 
@@ -697,10 +732,14 @@ async def test_a_pump_that_dies_mid_run_still_gives_the_depth_back(
     nodes, edges = _probe_graph()
     context = ExecutionContext(device="cpu", deterministic=True,
                                outbox=_ExplodingOutbox())
-    with pytest.raises(RuntimeError, match="pump died"):
+    try:
         await execute_graph(nodes, edges, context=context)
+    except RuntimeError as exc:
+        assert "pump died" in str(exc)
+        _assert_scope_closed_before_the_exception_left(determinism_depth())
+    else:
+        pytest.fail("the pump was supposed to die")
 
-    assert determinism_depth() == 0, "the scope leaked its depth"
     assert not torch.are_deterministic_algorithms_enabled()
 
 

--- a/backend/tests/test_ws_execution.py
+++ b/backend/tests/test_ws_execution.py
@@ -185,6 +185,36 @@ async def test_ws_execute_rejects_a_non_integer_seed():
 
 
 @pytest.mark.asyncio
+async def test_ws_execute_rejects_a_non_boolean_deterministic():
+    """#189: the reproducibility pair follows ONE rule, not two.
+
+    ``deterministic`` used to be coerced with ``bool()`` while its sibling
+    ``seed`` was passed through, so ``"deterministic": "false"`` — a
+    perfectly ordinary client bug — asked for deterministic kernels and
+    said nothing about it. A run's reproducibility settings are exactly the
+    ones where a silent reinterpretation is worst: the user gets a number
+    they cannot reproduce and no reason why.
+
+    The string below is chosen to be TRUTHY under ``bool()`` and to mean
+    the opposite of what it would have been read as.
+    """
+    async with AsyncClient(
+        transport=ASGIWebSocketTransport(app=app),
+        base_url=_BASE_URL,
+    ) as client:
+        async with aconnect_ws(_WS_PATH_WITH_TOKEN, client) as ws:
+            await ws.send_text(json.dumps({
+                "action": "execute",
+                "deterministic": "false",
+                "nodes": [{"id": "start", "type": "Start", "data": {"params": {}}}],
+                "edges": [],
+            }))
+            msg = json.loads(await ws.receive_text())
+            assert msg["type"] == "execution_error"
+            assert "deterministic" in msg["error"]
+
+
+@pytest.mark.asyncio
 async def test_ws_unknown_action():
     """Unknown actions should return an error message."""
     async with AsyncClient(


### PR DESCRIPTION
> 中文摘要：處理 #189、#190、#193 這三個放很久的「程式碼審查待辦」，總共 12 個項目。每一項都先拿現在的程式碼查證過才決定要不要動手，結果有 4 項不用做：1 項早就修好了（#193 第 1 項，`EvaluateModel` 的 `precision` 其實已經有了，英文說明、繁中翻譯、測試都齊全），1 項的前提根本不成立（#193 第 6 項），另外 2 項是前端的設計判斷，不適合塞進這個以後端為主的 PR。實際動手的有 8 項，新增 15 個測試，每個會改變行為的地方都做過「把修改還原、確認對應測試會變紅」的檢查，14/14 全部如預期變紅。查證時另外挖出一個沒人列過、但比原本那項嚴重的真正缺陷：圖裡任何一個有上下限的參數只要放了非數字的值，`validate_graph` 會直接拋 `TypeError` 崩掉，讓本來該回 409「圖不合法」的請求變成 500，而且完全不說是哪個參數；畫布把清空的數字欄位存成 `null`，光靠正常操作就能踩到。這個一併修好。三個 issue 裡只有 #190 全部做完，所以只有它用關閉關鍵字，另外兩個會留言說明還剩什麼。

Closes #190.

Twelve deferred review items across three issues, all in the training /
run-service area. Every one was checked against the current code before
anything was written -- this area has moved a long way since they were filed
(#252, #261, #268, #271) -- and four of the twelve did not survive that check.

## Per-item verdicts

### #189 -- three follow-ups from the #134 review

| # | Item | Verdict | Evidence |
|---|---|---|---|
| 1 | The WS path coerces `deterministic` but leaves `seed` uncoerced | **Implemented** | `ws_execution.py` read the flag as `bool(data.get("deterministic", False))`, so `"deterministic": "false"` -- truthy under `bool()`, and the opposite of what it says -- asked for deterministic kernels and reported nothing. `normalize_options` already rejects a non-boolean; the coercion was the only thing standing between the client bug and that error. Both halves of the reproducibility pair now pass through untouched. The pre-v2 educational flags stay coerced, deliberately: their lenient handling is the compatibility contract with the canvas, and `weights_persistent` even defaults differently here than in the service. |
| 2 | Three params promoted to basic grew the node cards | **Deliberately skipped (frontend)** | Premise re-verified and it holds. `BaseNode.tsx:408-423` gives every non-`advanced` param a permanent row on the card, while an `advanced` one earns a row only once its value differs from its default -- so `label_smoothing`, `pin_memory` and `momentum` do each cost a row on every card using them. But the ask ("should basic imply on-the-card, or only not-behind-the-fold") is a UI density decision, in `BaseNode.tsx`, needing browser e2e per repo convention. It does not belong in a backend-shaped diff. Left open with the mechanism recorded so nobody has to re-derive it. |
| 3 | A signature-consistency assertion for the applicability tables | **Implemented (tests only)** | No production change -- #134's declared tables are untouched and nothing was switched to signature-driven forwarding. Four tests, two per node: one asserts each declared set still equals "torch accepts it **and** defaults it to ours", the other snapshots the whole accepted-keyword surface so a new torch knob fails loudly instead of leaving the table quietly behind. Adagrad's exclusion from `_EPS_TYPES` gets its own test, being the one exclusion that is a judgement (it *has* `eps`, at 1e-10) rather than an absence -- and therefore the one a reader would "fix". |

### #190 -- three robustness gaps from the #134 round-2 re-review

| # | Item | Verdict | Evidence |
|---|---|---|---|
| 1 | A skipped `deterministic_scope.__exit__` costs more than it used to | **Implemented -- two gaps, and the severity claim corrected** | The issue names `await pump_task`. Reading the region turned up a second, more plausible gap: `asyncio.create_task(_pump(), ...)` sits *between* `__enter__` and the `try:` whose `finally` owns the exit, and `create_task` raises `RuntimeError` on a closing loop. The named path is real too -- the exit was that await's **peer statement**, not its `finally`, so the comment "Last, so nothing above can skip it" was true of the outer chain and false of the three lines it sat under. Both guarded. See the correction below on how far the leak actually reaches. |
| 2 | `_wake` guards the wrong half | **Implemented** | Confirmed exactly as filed: the `try` spanned one statement, and the `await asyncio.shield(notify)` nine lines below -- where a failing notification actually surfaces -- was bare. Both callers release inside an `@asynccontextmanager`'s `finally`, where a raise substitutes itself for the body's exception. The hold was always given back correctly, so only the reported error was ever at risk; still worth closing, because the comment already claimed it was. `CancelledError` is a `BaseException` and so still propagates, which `shield` requires. |
| 3 | `_predicted_draws` leaves numpy and torch pinned | **Implemented** | Measured before touching it: two consecutive calls left numpy and torch returning identical downstream draws, because the helper restored `random`'s state while `seed_rngs` seeds all three. Now restores all three. Test hygiene, as the issue says. |

### #193 -- six follow-ups from the #135 review

| # | Item | Verdict | Evidence |
|---|---|---|---|
| 1 | `precision` on the standalone `EvaluateModel` node | **Already fixed** | Landed in the same commit that created `amp.py` (`7839033`, "feat(training): AMP (bf16-first), gradient accumulation..."). `evaluate_model_node.py:87-104` declares it with an English `description=`; the zh-TW catalog entry is at `frontend/src/i18n/nodeLocales/zh-TW.ts:493`; `test_evaluate_model_node.py:182` pins its vocabulary and default against `TrainingLoop`'s. The issue's worry that the both-locales rule could not be met is moot -- `test_api_nodes.py:417` now *enforces* a zh-TW entry for every param of every translated node, and `EvaluateModel` is on that list. |
| 2 | Surface cache usage in the frontend | **Deliberately skipped (frontend)** | Live, and larger than it reads. `HealthInfo` has no `caches` and `fetchHealth` drops it -- but so are `nodes_loaded` and `presets_loaded` dropped, and `fetchHealth` is called exactly once, at bootstrap, for the `project` field. There is no health surface in the UI to add a line to, so this is "build one": a poll, a placement decision, byte formatting, strings in both locales, and browser e2e. A feature, not a review follow-up. |
| 3 | `MAX_WALK_DEPTH` under-counts silently, and the comment's direction claim is wrong | **Implemented** | Both halves of "either count the truncation or state the real direction". The depth cap now counts the containers it refused to descend into and logs a lower-bound line, matching what the items cap already did. The module docstring's "over-counting is the safe direction" is true of cross-measurement sharing and is now scoped to it, with the three things that make the walk *under*-count named -- that being the direction which costs memory. Found in passing: the same docstring blamed the recursion for why a failed measurement returns 0, in a walk whose own docstring three paragraphs earlier says it is iterative. Corrected. |
| 4 | `test_health_project.py` states an invariant that is no longer true | **Implemented** | "a non-project response body stays identical to pre-Task-10 main.py" -- false since `version` was added ("a new capability rather than a refactor", says `health()` itself) and again since `caches` arrived for #135. Rather than only delete the claim, the file now asserts the invariant that *is* still load-bearing: the top-level key set is fixed, and `project` is the one conditional key. A new key breaks it once, on purpose. |
| 5 | No test covers OOM crossed with determinism | **Implemented** | Two tests: recovery runs *inside* the scope (asserted from within the recovery, not after it), and an OOM unwinds the scope rather than stranding it. Stated plainly in the docstring that on a CPU-only box `release_cached_memory` returns before reaching `empty_cache()`, so it is stubbed and this pins the ordering rather than pretending to exercise a real CUDA free. |
| 6 | `accumulate_steps="abc"` raises a bare `ValueError` | **Stale premise -- the real defect on that path fixed instead** | Two things are wrong with it. There is no "typed validation error the other parameters produce": `checkpoint_every`, `max_steps` and `log_interval` use the identical bare-`int()` idiom, and `epochs`, `early_stopping_patience` and `grad_clip_norm` are not coerced at all (`epochs="abc"` reaches `range()` and fails deeper, with less information). And `execute()` is **unreachable** with that value -- `accumulate_steps` declares `min_value=1`, so `validate_graph` evaluates `"abc" < 1` first and dies. See below. |

## Correcting #190 item 1's severity claim

The issue says a skipped exit means "determinism is never restored again in
that process". Measured while writing the test, that is too strong for
CPython. `deterministic_scope` is a generator-based context manager, so once
the traceback -- which holds `execute_graph`'s frame, which holds the
generator -- is released, refcounting finalises the suspended generator, which
throws `GeneratorExit` at the `yield` and runs the very `finally` that was
skipped. Depth is 1 inside the `except` block and 0 immediately after it.

What is true is narrower and still worth fixing: the scope stays open for as
long as anything holds the traceback (a stored exception on a run row, a task
nobody retrieved, `sys.last_value`), it depends on an interpreter detail no
code here states, and it evaporates on any implementation without prompt
refcounting.

This found a test bug rather than only a documentation one. Both tests
originally asserted after `pytest.raises` and passed against the unfixed code
-- the garbage collector was doing the cleanup. They now assert inside the
`except`, which pins the property that does not depend on the collector: the
scope was closed before the exception left the engine. The reasoning is in the
helper's docstring, not left as folklore.

## Found along the way, on no list

`validate_graph`'s range check compared every value straight against its bound:

```python
if param_def.min_value is not None and value < param_def.min_value:
```

A non-numeric value raises `TypeError` there and nothing catches it, so it
escaped `validate_graph` entirely. `POST /api/graph/run` turns that function's
**return value** into its 409 `invalid_graph` envelope, so what should have
been a named validation error arrived as a 500 identifying nothing.

Registry-wide, not a training bug: every param with a declared bound is
reachable -- `Dropout.p`, `Conv2d.kernel_size`, `EvaluateModel.batch_size`. And
`null` is reachable from the canvas alone, without hand-editing anything:
clearing a numeric input yields `NaN` (`ParamField.tsx:285`), which
`JSON.stringify` writes as `null` into the saved graph.

Guarded on `except TypeError` rather than an isinstance check, because the
predicate that matters is "does it order against the bound" -- which numpy
scalars and a plugin's own numeric type satisfy without being `int` or `float`.
A test pins that `bool` still passes, so the fix cannot quietly narrow to
"reject anything that is not int|float" and start refusing graphs that
validate today.

## Verification

- Full backend suite green (4342 passed, 22 skipped).
- `ruff@0.14.4 check .` clean, at the version CI pins.
- 15 new tests. Every behavioural change mutation-checked: source change
  reverted, matching test confirmed red, change restored. **14/14 went red.**
  Two of them only after the tests were fixed -- see the correction above.

## Not closed

Only **#190** is fully resolved. #189 and #193 each keep one open frontend item
(#189 item 2, #193 item 2) and are left open with a comment stating exactly what
remains -- half-addressed issues being auto-closed is a known problem here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
