### PR TITLE
feat(llm): CausalLMModel + LMCrossEntropyLoss, a trainable decoder-only LM as MODEL

### DIFF
--- a/backend/app/nodes/llm/_lm_modules.py
+++ b/backend/app/nodes/llm/_lm_modules.py
@@ -1,0 +1,237 @@
+"""Torch modules behind CausalLMModel / LMCrossEntropyLoss.
+
+Module-scope classes on purpose (#283): ``ModelSaver(save_mode="full_model")``
+pickles the whole ``nn.Module``, and pickle stores a class by module plus
+qualified name — a class created inside a function has no name anyone can
+import it back by. ``torch`` is imported at the top HERE, and the node modules
+import this module inside ``execute``, so the node registry's metadata scan
+never pays the torch import (the same split ``sequential_modules.py`` uses).
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+import torch.utils.checkpoint
+from torch import nn
+
+
+class RotaryEmbedding(nn.Module):
+    """Rotary position embedding (RoPE) applied to q/k head dims.
+
+    The rotation method is named ``rotate`` — NOT ``apply`` — because
+    ``nn.Module.apply(fn)`` is the recursive initializer walk, and the
+    model's weight-init pass visits this module through it.
+    """
+
+    def __init__(self, head_dim: int, max_seq_len: int, base: float = 10000.0):
+        super().__init__()
+        if head_dim % 2 != 0:
+            raise ValueError(
+                "positional='rope' needs an even head dimension "
+                f"(d_model / n_heads), got {head_dim}"
+            )
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)
+        )
+        t = torch.arange(max_seq_len, dtype=torch.float32)
+        freqs = torch.outer(t, inv_freq)
+        # (max_seq_len, head_dim/2) each; kept fp32 and cast at rotate time.
+        self.register_buffer("cos", freqs.cos(), persistent=False)
+        self.register_buffer("sin", freqs.sin(), persistent=False)
+
+    def rotate(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, H, T, D). Rotate pairs (even, odd) by position angle.
+        seq_len = x.shape[-2]
+        cos = self.cos[:seq_len].to(dtype=x.dtype, device=x.device)
+        sin = self.sin[:seq_len].to(dtype=x.dtype, device=x.device)
+        x1 = x[..., 0::2]
+        x2 = x[..., 1::2]
+        rotated = torch.empty_like(x)
+        rotated[..., 0::2] = x1 * cos - x2 * sin
+        rotated[..., 1::2] = x1 * sin + x2 * cos
+        return rotated
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, d_model: int, n_heads: int, dropout: float,
+                 rope: RotaryEmbedding | None):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=True)
+        self.proj = nn.Linear(d_model, d_model, bias=True)
+        self.dropout = dropout
+        self.rope = rope
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch, seq_len, d_model = x.shape
+        qkv = self.qkv(x)
+        q, k, v = qkv.split(d_model, dim=2)
+
+        def heads(t: torch.Tensor) -> torch.Tensor:
+            return t.view(batch, seq_len, self.n_heads, self.head_dim).transpose(1, 2)
+
+        q, k, v = heads(q), heads(k), heads(v)
+        if self.rope is not None:
+            q = self.rope.rotate(q)
+            k = self.rope.rotate(k)
+        out = F.scaled_dot_product_attention(
+            q, k, v,
+            is_causal=True,
+            dropout_p=self.dropout if self.training else 0.0,
+        )
+        out = out.transpose(1, 2).contiguous().view(batch, seq_len, d_model)
+        return self.proj(out)
+
+
+class MLP(nn.Module):
+    def __init__(self, d_model: int, d_ff: int, activation: str, dropout: float):
+        super().__init__()
+        self.fc_in = nn.Linear(d_model, d_ff, bias=True)
+        self.fc_out = nn.Linear(d_ff, d_model, bias=True)
+        self.act = {"gelu": nn.GELU(), "relu": nn.ReLU(), "silu": nn.SiLU()}[activation]
+        self.drop = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.drop(self.fc_out(self.act(self.fc_in(x))))
+
+
+def make_norm(kind: str, d_model: int) -> nn.Module:
+    return nn.RMSNorm(d_model) if kind == "rmsnorm" else nn.LayerNorm(d_model)
+
+
+class Block(nn.Module):
+    """Pre-norm transformer block: x + attn(norm(x)); x + mlp(norm(x))."""
+
+    def __init__(self, d_model: int, n_heads: int, d_ff: int, dropout: float,
+                 norm: str, activation: str, rope: RotaryEmbedding | None):
+        super().__init__()
+        self.norm_attn = make_norm(norm, d_model)
+        self.attn = CausalSelfAttention(d_model, n_heads, dropout, rope)
+        self.norm_mlp = make_norm(norm, d_model)
+        self.mlp = MLP(d_model, d_ff, activation, dropout)
+        self.drop = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.drop(self.attn(self.norm_attn(x)))
+        x = x + self.mlp(self.norm_mlp(x))
+        return x
+
+
+class CausalLMModule(nn.Module):
+    """GPT-style decoder-only LM: token ids in, next-token logits out."""
+
+    def __init__(self, *, vocab_size: int, d_model: int, n_layers: int,
+                 n_heads: int, d_ff: int, max_seq_len: int, dropout: float,
+                 positional: str, norm: str, activation: str,
+                 tie_embeddings: bool, gradient_checkpointing: bool,
+                 init_std: float):
+        super().__init__()
+        self.max_seq_len = max_seq_len
+        self.positional = positional
+        self.gradient_checkpointing = gradient_checkpointing
+
+        self.tok_emb = nn.Embedding(vocab_size, d_model)
+        rope: RotaryEmbedding | None = None
+        if positional == "learned":
+            self.pos_emb: nn.Module | None = nn.Embedding(max_seq_len, d_model)
+        elif positional == "sinusoidal":
+            self.pos_emb = None
+            position = torch.arange(max_seq_len, dtype=torch.float32).unsqueeze(1)
+            div = torch.exp(
+                torch.arange(0, d_model, 2, dtype=torch.float32)
+                * (-math.log(10000.0) / d_model)
+            )
+            pe = torch.zeros(max_seq_len, d_model)
+            pe[:, 0::2] = torch.sin(position * div)
+            pe[:, 1::2] = torch.cos(position * div)
+            self.register_buffer("sin_pos", pe, persistent=False)
+        else:  # rope
+            self.pos_emb = None
+            rope = RotaryEmbedding(d_model // n_heads, max_seq_len)
+            self.rope = rope
+
+        self.drop = nn.Dropout(dropout)
+        self.blocks = nn.ModuleList([
+            Block(d_model, n_heads, d_ff, dropout, norm, activation, rope)
+            for _ in range(n_layers)
+        ])
+        self.norm_final = make_norm(norm, d_model)
+        self.lm_head = nn.Linear(d_model, vocab_size, bias=False)
+        if tie_embeddings:
+            self.lm_head.weight = self.tok_emb.weight
+
+        # GPT-2-style init: normal(0, init_std) everywhere, residual output
+        # projections scaled down by sqrt(2 * n_layers) so the residual
+        # stream's variance stays stable at depth.
+        self.apply(lambda m: _init_module(m, init_std))
+        scaled = init_std / math.sqrt(2 * n_layers)
+        for block in self.blocks:
+            nn.init.normal_(block.attn.proj.weight, mean=0.0, std=scaled)
+            nn.init.normal_(block.mlp.fc_out.weight, mean=0.0, std=scaled)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        if input_ids.dim() != 2:
+            raise ValueError(
+                "CausalLM expects input_ids of shape (batch, seq_len), "
+                f"got {tuple(input_ids.shape)}"
+            )
+        seq_len = input_ids.shape[1]
+        if seq_len > self.max_seq_len:
+            raise ValueError(
+                f"Sequence length {seq_len} exceeds max_seq_len "
+                f"{self.max_seq_len}"
+            )
+        x = self.tok_emb(input_ids)
+        if self.positional == "learned":
+            positions = torch.arange(seq_len, device=input_ids.device)
+            x = x + self.pos_emb(positions)  # type: ignore[misc]
+        elif self.positional == "sinusoidal":
+            x = x + self.sin_pos[:seq_len].to(dtype=x.dtype)
+        x = self.drop(x)
+        for block in self.blocks:
+            if self.gradient_checkpointing and self.training:
+                x = torch.utils.checkpoint.checkpoint(
+                    block, x, use_reentrant=False,
+                )
+            else:
+                x = block(x)
+        x = self.norm_final(x)
+        return self.lm_head(x)
+
+
+def _init_module(module: nn.Module, init_std: float) -> None:
+    if isinstance(module, nn.Linear):
+        nn.init.normal_(module.weight, mean=0.0, std=init_std)
+        if module.bias is not None:
+            nn.init.zeros_(module.bias)
+    elif isinstance(module, nn.Embedding):
+        nn.init.normal_(module.weight, mean=0.0, std=init_std)
+
+
+class LMCrossEntropy(nn.Module):
+    """Token-level cross-entropy that flattens (B, T, V) internally.
+
+    Deliberately NOT a subclass of ``nn.CrossEntropyLoss``: TrainingLoop
+    opens its val-accuracy argmax path for that isinstance, and an argmax
+    over dim=1 of (B, T, V) logits is the time axis, not the vocabulary.
+    """
+
+    def __init__(self, ignore_index: int = -100, label_smoothing: float = 0.0):
+        super().__init__()
+        self.ignore_index = ignore_index
+        self.label_smoothing = label_smoothing
+
+    def forward(self, logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        if logits.dim() == 3:
+            logits = logits.reshape(-1, logits.shape[-1])
+            targets = targets.reshape(-1)
+        return F.cross_entropy(
+            logits,
+            targets,
+            ignore_index=self.ignore_index,
+            label_smoothing=self.label_smoothing,
+        )

--- a/backend/app/nodes/llm/causal_lm_model_node.py
+++ b/backend/app/nodes/llm/causal_lm_model_node.py
@@ -1,0 +1,212 @@
+"""CausalLMModelNode — 建一個可訓練的 GPT-style decoder-only transformer。
+
+LLM 分類原本只有前向示範節點（TransformerEncoder/Decoder 吃 TENSOR 吐 TENSOR，
+不是可訓練的 MODEL），SequentialModel 的層編輯器也排不出帶殘差的注意力區塊。
+這顆補上「語言模型本體」：輸出一個真正的 `MODEL`，可以直接接 Optimizer、
+TrainingLoop、CheckpointSaver 與 LM 評估／生成節點，在畫布上訓練出一個真的
+小語言模型（預設參數約 2.02 億，對應 epic #292 的 200M 驗收）。
+
+Forward contract: ``input_ids`` int64 ``(B, T)`` → logits float ``(B, T, vocab)``.
+Causal masking 在模型內部（SDPA ``is_causal=True``），不需要外接 AttentionMask。
+純 torch 實作，不依賴 ``transformers``。Torch modules live in
+``_lm_modules.py`` (module-scope for full_model pickling, #283); this module
+imports it lazily so the registry's metadata scan stays torch-free.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+POSITIONAL_MODES = ["learned", "sinusoidal", "rope"]
+NORM_KINDS = ["layernorm", "rmsnorm"]
+ACTIVATIONS = ["gelu", "relu", "silu"]
+
+
+class CausalLMModelNode(BaseNode):
+    NODE_NAME = "CausalLMModel"
+    CATEGORY = "LLM"
+    DESCRIPTION = (
+        "Build a trainable GPT-style decoder-only transformer language model. "
+        "Outputs a real MODEL (input_ids (B,T) int64 -> logits (B,T,vocab)) for "
+        "Optimizer / TrainingLoop / CheckpointSaver, plus its exact trainable "
+        "parameter count. Causal masking is internal; pair with "
+        "LMCrossEntropyLoss and packed LM data. Defaults are a ~202M-parameter "
+        "shape (d_model 1024, 12 layers, gpt2 vocab, tied embeddings)."
+    )
+
+    # Owns trainable parameters and hands out a live MODEL handle (rules 1
+    # and 2 of the cacheable contract): a cache hit would replay a handle
+    # whose weights a later TrainingLoop already moved.
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="model",
+                data_type=DataType.MODEL,
+                description="Freshly initialized causal LM (torch nn.Module)",
+            ),
+            PortDefinition(
+                name="param_count",
+                data_type=DataType.SCALAR,
+                description="Exact trainable-parameter count, so a graph can prove its model size",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="vocab_size", param_type=ParamType.INT, default=50257,
+                min_value=256, max_value=300000,
+                description="Vocabulary size (50257 = tiktoken gpt2; keep it matched to the LMTokenizer encoding)",
+            ),
+            ParamDefinition(
+                name="d_model", param_type=ParamType.INT, default=1024,
+                min_value=64, max_value=8192,
+                description="Embedding / residual-stream width",
+            ),
+            ParamDefinition(
+                name="n_layers", param_type=ParamType.INT, default=12,
+                min_value=1, max_value=64,
+                description="Number of transformer blocks",
+            ),
+            ParamDefinition(
+                name="n_heads", param_type=ParamType.INT, default=16,
+                min_value=1, max_value=64,
+                description="Attention heads (d_model must divide evenly by n_heads)",
+            ),
+            ParamDefinition(
+                name="d_ff", param_type=ParamType.INT, default=4096,
+                min_value=64, max_value=32768,
+                description="Feed-forward hidden width (typically 4x d_model)",
+            ),
+            ParamDefinition(
+                name="max_seq_len", param_type=ParamType.INT, default=1024,
+                min_value=16, max_value=8192,
+                description="Maximum sequence length the model accepts",
+            ),
+            ParamDefinition(
+                name="dropout", param_type=ParamType.FLOAT, default=0.0,
+                min_value=0.0, max_value=0.9, advanced=True,
+                description="Dropout on attention/MLP/embeddings (0 is standard for single-epoch LM pretraining)",
+            ),
+            ParamDefinition(
+                name="positional", param_type=ParamType.SELECT, default="learned",
+                options=POSITIONAL_MODES, advanced=True,
+                description="Position encoding: learned embedding, fixed sinusoidal, or rotary (RoPE)",
+            ),
+            ParamDefinition(
+                name="norm", param_type=ParamType.SELECT, default="layernorm",
+                options=NORM_KINDS, advanced=True,
+                description="Normalization layer (pre-norm blocks either way)",
+            ),
+            ParamDefinition(
+                name="activation", param_type=ParamType.SELECT, default="gelu",
+                options=ACTIVATIONS, advanced=True,
+                description="Feed-forward activation",
+            ),
+            ParamDefinition(
+                name="tie_embeddings", param_type=ParamType.BOOL, default=True,
+                advanced=True,
+                description="Share the token-embedding matrix with the output head (saves vocab*d_model params)",
+            ),
+            ParamDefinition(
+                name="gradient_checkpointing", param_type=ParamType.BOOL,
+                default=False, advanced=True,
+                description="Recompute activations in backward to trade compute for memory",
+            ),
+            ParamDefinition(
+                name="init_std", param_type=ParamType.FLOAT, default=0.02,
+                min_value=0.001, max_value=0.2, advanced=True,
+                description="Weight init standard deviation (residual projections are scaled down by sqrt(2*n_layers))",
+            ),
+            ParamDefinition(
+                name="seed", param_type=ParamType.INT, default=0,
+                min_value=0, advanced=True,
+                description="Initialization seed — the same seed builds identical weights",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import torch
+
+        from ._lm_modules import CausalLMModule
+
+        vocab_size = int(params.get("vocab_size", 50257))
+        d_model = int(params.get("d_model", 1024))
+        n_layers = int(params.get("n_layers", 12))
+        n_heads = int(params.get("n_heads", 16))
+        d_ff = int(params.get("d_ff", 4096))
+        max_seq_len = int(params.get("max_seq_len", 1024))
+        dropout = float(params.get("dropout", 0.0))
+        positional = str(params.get("positional", "learned"))
+        norm = str(params.get("norm", "layernorm"))
+        activation = str(params.get("activation", "gelu"))
+        tie_embeddings = bool(params.get("tie_embeddings", True))
+        gradient_checkpointing = bool(params.get("gradient_checkpointing", False))
+        init_std = float(params.get("init_std", 0.02))
+        seed = int(params.get("seed", 0))
+
+        if d_model % n_heads != 0:
+            raise ValueError(
+                f"d_model ({d_model}) must divide evenly by n_heads ({n_heads})"
+            )
+        if positional not in POSITIONAL_MODES:
+            raise ValueError(f"Unknown positional mode: {positional!r}")
+        if norm not in NORM_KINDS:
+            raise ValueError(f"Unknown norm kind: {norm!r}")
+        if activation not in ACTIVATIONS:
+            raise ValueError(f"Unknown activation: {activation!r}")
+
+        # fork_rng so a fixed init seed never disturbs the run-level RNG
+        # stream other nodes derive from (deterministic mode, DataLoader
+        # shuffles). CPU-only: the model is built on CPU and moved to its
+        # device later by Optimizer/TrainingLoop.
+        with torch.random.fork_rng(devices=[]):
+            torch.manual_seed(seed)
+            model = CausalLMModule(
+                vocab_size=vocab_size,
+                d_model=d_model,
+                n_layers=n_layers,
+                n_heads=n_heads,
+                d_ff=d_ff,
+                max_seq_len=max_seq_len,
+                dropout=dropout,
+                positional=positional,
+                norm=norm,
+                activation=activation,
+                tie_embeddings=tie_embeddings,
+                gradient_checkpointing=gradient_checkpointing,
+                init_std=init_std,
+            )
+
+        param_count = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        if progress_callback:
+            progress_callback({
+                "event": "built",
+                "param_count": param_count,
+                "layers": n_layers,
+                "d_model": d_model,
+            })
+        return {"model": model, "param_count": int(param_count)}

--- a/backend/app/nodes/llm/lm_cross_entropy_loss_node.py
+++ b/backend/app/nodes/llm/lm_cross_entropy_loss_node.py
@@ -1,0 +1,87 @@
+"""LMCrossEntropyLossNode — 語言模型用的 next-token cross-entropy。
+
+`Loss` 節點給的 ``nn.CrossEntropyLoss`` 期望 logits ``(N, C)`` 或
+``(N, C, d1, ...)``，但 causal LM 的 forward 吐 ``(B, T, vocab)``、標籤是
+``(B, T)`` — 形狀直接餵會炸。這顆輸出一個會自己攤平的 LOSS_FN：
+``loss(logits (B,T,V), targets (B,T)) = mean CE over B*T``，含 ``ignore_index``
+與 label smoothing，接上既有 TrainingLoop（含它的 val-loss 路徑與 bf16
+autocast）就能訓練語言模型。
+
+損失類別本身住在 ``_lm_modules.py``（module-scope、可被 full_model pickle，
+#283），這裡只在 ``execute`` 內延遲 import，讓 registry 掃描不用付 torch 的
+啟動成本。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class LMCrossEntropyLossNode(BaseNode):
+    NODE_NAME = "LMCrossEntropyLoss"
+    CATEGORY = "LLM"
+    DESCRIPTION = (
+        "Next-token cross-entropy loss for language models: accepts logits "
+        "(B,T,vocab) against targets (B,T) by flattening internally — the "
+        "shapes CausalLMModel and LMTokenizedDataset produce. Supports "
+        "ignore_index and label smoothing. Use this instead of the generic "
+        "Loss node's CrossEntropyLoss for LM training."
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="loss_fn",
+                data_type=DataType.LOSS_FN,
+                description="Callable loss(logits (B,T,V) or (N,V), targets) -> scalar mean CE",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="ignore_index",
+                param_type=ParamType.INT,
+                default=-100,
+                description="Target positions with this value contribute no loss (padding convention)",
+            ),
+            ParamDefinition(
+                name="label_smoothing",
+                param_type=ParamType.FLOAT,
+                default=0.0,
+                min_value=0.0,
+                max_value=0.3,
+                advanced=True,
+                description="Label smoothing factor (0 = off)",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        from ._lm_modules import LMCrossEntropy
+
+        loss_fn = LMCrossEntropy(
+            ignore_index=int(params.get("ignore_index", -100)),
+            label_smoothing=float(params.get("label_smoothing", 0.0)),
+        )
+        return {"loss_fn": loss_fn}

--- a/backend/tests/test_causal_lm_model_node.py
+++ b/backend/tests/test_causal_lm_model_node.py
@@ -1,0 +1,184 @@
+"""Tests for CausalLMModelNode."""
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+import torch
+
+from app.nodes.llm.causal_lm_model_node import CausalLMModelNode
+
+TINY = {
+    "vocab_size": 256,
+    "d_model": 64,
+    "n_layers": 2,
+    "n_heads": 4,
+    "d_ff": 128,
+    "max_seq_len": 32,
+    "seed": 7,
+}
+
+
+def build(**overrides):
+    params = {**TINY, **overrides}
+    return CausalLMModelNode().execute({}, params), params
+
+
+def test_node_metadata():
+    assert CausalLMModelNode.NODE_NAME == "CausalLMModel"
+    assert CausalLMModelNode.CATEGORY == "LLM"
+    assert CausalLMModelNode.define_inputs() == []
+    assert CausalLMModelNode.cacheable is False
+
+
+def test_param_count_matches_analytic_formula_tied():
+    res, p = build()
+    d, layers, ff, vocab, seq = (
+        p["d_model"], p["n_layers"], p["d_ff"], p["vocab_size"], p["max_seq_len"],
+    )
+    per_block = (
+        (3 * d * d + 3 * d)      # qkv
+        + (d * d + d)            # attn out proj
+        + (d * ff + ff)          # mlp in
+        + (ff * d + d)           # mlp out
+        + 4 * d                  # two LayerNorms (weight + bias each)
+    )
+    expected = (
+        vocab * d                # token embedding (tied with lm_head)
+        + seq * d                # learned positions
+        + layers * per_block
+        + 2 * d                  # final LayerNorm
+    )
+    assert res["param_count"] == expected
+    assert res["param_count"] == sum(
+        t.numel() for t in res["model"].parameters() if t.requires_grad
+    )
+
+
+def test_untied_head_adds_vocab_by_d_model():
+    tied, p = build()
+    untied, _ = build(tie_embeddings=False)
+    assert untied["param_count"] - tied["param_count"] == p["vocab_size"] * p["d_model"]
+    assert untied["model"].lm_head.weight is not untied["model"].tok_emb.weight
+    assert tied["model"].lm_head.weight is tied["model"].tok_emb.weight
+
+
+def test_forward_shape_contract():
+    res, p = build()
+    ids = torch.randint(0, p["vocab_size"], (3, 20), dtype=torch.int64)
+    logits = res["model"](ids)
+    assert logits.shape == (3, 20, p["vocab_size"])
+    assert logits.dtype == torch.float32
+
+
+def test_forward_is_causal():
+    # Changing tokens after position t must not change logits at <= t.
+    res, p = build()
+    model = res["model"].eval()
+    base = torch.randint(0, p["vocab_size"], (1, 16), dtype=torch.int64)
+    changed = base.clone()
+    changed[0, 10:] = (changed[0, 10:] + 1) % p["vocab_size"]
+    with torch.no_grad():
+        out_base = model(base)
+        out_changed = model(changed)
+    assert torch.allclose(out_base[0, :10], out_changed[0, :10], atol=1e-5)
+    assert not torch.allclose(out_base[0, 10:], out_changed[0, 10:], atol=1e-3)
+
+
+def test_same_seed_same_weights_different_seed_differs():
+    a, _ = build()
+    b, _ = build()
+    c, _ = build(seed=8)
+    for pa, pb in zip(a["model"].parameters(), b["model"].parameters()):
+        assert torch.equal(pa, pb)
+    assert any(
+        not torch.equal(pa, pc)
+        for pa, pc in zip(a["model"].parameters(), c["model"].parameters())
+    )
+
+
+def test_build_does_not_disturb_global_rng():
+    torch.manual_seed(1234)
+    before = torch.rand(3)
+    torch.manual_seed(1234)
+    build()
+    after = torch.rand(3)
+    assert torch.equal(before, after)
+
+
+def test_invalid_head_split_names_the_params():
+    with pytest.raises(ValueError, match="d_model.*n_heads"):
+        build(n_heads=5)
+
+
+def test_sequence_longer_than_max_seq_len_is_refused():
+    res, p = build()
+    ids = torch.zeros((1, p["max_seq_len"] + 1), dtype=torch.int64)
+    with pytest.raises(ValueError, match="max_seq_len"):
+        res["model"](ids)
+
+
+@pytest.mark.parametrize("positional", ["learned", "sinusoidal", "rope"])
+@pytest.mark.parametrize("norm", ["layernorm", "rmsnorm"])
+def test_variants_forward_and_backward(positional, norm):
+    res, p = build(positional=positional, norm=norm, activation="silu")
+    ids = torch.randint(0, p["vocab_size"], (2, 12), dtype=torch.int64)
+    logits = res["model"](ids)
+    logits.sum().backward()
+    grads = [t.grad for t in res["model"].parameters() if t.requires_grad]
+    assert any(g is not None and g.abs().sum() > 0 for g in grads)
+
+
+def test_gradient_checkpointing_trains():
+    res, p = build(gradient_checkpointing=True)
+    model = res["model"].train()
+    ids = torch.randint(0, p["vocab_size"], (2, 12), dtype=torch.int64)
+    model(ids).sum().backward()
+    assert model.tok_emb.weight.grad is not None
+
+
+def test_full_model_pickle_roundtrip():
+    # ModelSaver's full_model mode pickles the module; function-local
+    # classes would fail here (#283).
+    res, p = build()
+    clone = pickle.loads(pickle.dumps(res["model"]))
+    ids = torch.randint(0, p["vocab_size"], (1, 8), dtype=torch.int64)
+    with torch.no_grad():
+        assert torch.allclose(res["model"].eval()(ids), clone.eval()(ids), atol=1e-6)
+
+
+def test_tiny_model_overfits_through_real_training_loop():
+    from torch.utils.data import DataLoader, TensorDataset
+
+    from app.nodes.llm.lm_cross_entropy_loss_node import LMCrossEntropyLossNode
+    from app.nodes.training.training_loop_node import TrainingLoopNode
+
+    res, p = build(d_model=32, d_ff=64, n_heads=2)
+    model = res["model"]
+    generator = torch.Generator().manual_seed(0)
+    inputs = torch.randint(
+        0, p["vocab_size"], (8, 16), dtype=torch.int64, generator=generator,
+    )
+    labels = torch.roll(inputs, shifts=-1, dims=1)
+    dataset = TensorDataset(inputs, labels)
+    loader = DataLoader(dataset, batch_size=8, shuffle=False)
+    loss_fn = LMCrossEntropyLossNode().execute({}, {})["loss_fn"]
+    optimizer = torch.optim.AdamW(model.parameters(), lr=3e-3)
+
+    out = TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": loader,
+            "optimizer": optimizer,
+            "loss_fn": loss_fn,
+        },
+        {"epochs": 60, "device": "cpu"},
+    )
+    losses = out["losses"]
+    first = float(losses[0])
+    last = float(losses[-1])
+    # ln(256) ~ 5.55 at init; memorizing 8 repeated sequences must cut the
+    # loss to a small fraction of that.
+    assert first > 3.0
+    assert last < first * 0.35

--- a/backend/tests/test_lm_cross_entropy_loss_node.py
+++ b/backend/tests/test_lm_cross_entropy_loss_node.py
@@ -1,0 +1,82 @@
+"""Tests for LMCrossEntropyLossNode."""
+
+from __future__ import annotations
+
+import pickle
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from app.nodes.llm.lm_cross_entropy_loss_node import LMCrossEntropyLossNode
+
+
+def make(params=None):
+    return LMCrossEntropyLossNode().execute({}, params or {})["loss_fn"]
+
+
+def test_node_metadata():
+    assert LMCrossEntropyLossNode.NODE_NAME == "LMCrossEntropyLoss"
+    assert LMCrossEntropyLossNode.CATEGORY == "LLM"
+    assert LMCrossEntropyLossNode.define_inputs() == []
+
+
+def test_matches_manually_reshaped_cross_entropy():
+    torch.manual_seed(0)
+    logits = torch.randn(2, 5, 11)
+    targets = torch.randint(0, 11, (2, 5))
+    loss = make()(logits, targets)
+    reference = F.cross_entropy(logits.reshape(-1, 11), targets.reshape(-1))
+    assert torch.isclose(loss, reference)
+
+
+def test_accepts_already_flat_shapes():
+    torch.manual_seed(0)
+    logits = torch.randn(10, 7)
+    targets = torch.randint(0, 7, (10,))
+    assert torch.isclose(make()(logits, targets), F.cross_entropy(logits, targets))
+
+
+def test_ignore_index_masks_positions():
+    torch.manual_seed(0)
+    logits = torch.randn(1, 4, 5)
+    targets = torch.tensor([[1, 2, -100, -100]])
+    loss = make()(logits, targets)
+    reference = F.cross_entropy(logits[0, :2], targets[0, :2])
+    assert torch.isclose(loss, reference)
+
+
+def test_label_smoothing_changes_the_loss():
+    torch.manual_seed(0)
+    logits = torch.randn(2, 3, 9)
+    targets = torch.randint(0, 9, (2, 3))
+    plain = make()(logits, targets)
+    smoothed = make({"label_smoothing": 0.1})(logits, targets)
+    assert not torch.isclose(plain, smoothed)
+
+
+def test_not_an_nn_cross_entropy_instance():
+    # TrainingLoop opens its val-accuracy argmax path for
+    # isinstance(nn.CrossEntropyLoss); (B,T,V) logits would argmax the
+    # time axis there, so this loss must NOT be a subclass.
+    fn = make()
+    assert not isinstance(fn, nn.CrossEntropyLoss)
+    assert isinstance(fn, nn.Module)
+
+
+def test_gradient_flows():
+    logits = torch.randn(2, 4, 6, requires_grad=True)
+    targets = torch.randint(0, 6, (2, 4))
+    make()(logits, targets).backward()
+    assert logits.grad is not None
+    assert float(logits.grad.abs().sum()) > 0
+
+
+def test_full_model_pickle_roundtrip():
+    fn = pickle.loads(pickle.dumps(make({"ignore_index": -1})))
+    logits = torch.randn(1, 3, 4)
+    targets = torch.tensor([[0, 3, -1]])
+    reference = F.cross_entropy(
+        logits.reshape(-1, 4), targets.reshape(-1), ignore_index=-1,
+    )
+    assert torch.isclose(fn(logits, targets), reference)

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -758,6 +758,34 @@ const zhTW: NodeTranslations = {
       show_special_tokens: '是否輸出 tokenizer 的特殊 token（BOS/EOS/CLS/SEP/...）。',
     },
   },
+  CausalLMModel: {
+    description:
+      '建立一個可訓練的 GPT-style decoder-only transformer 語言模型。輸出真正的 MODEL（input_ids (B,T) int64 → logits (B,T,vocab)），可直接接 Optimizer / TrainingLoop / CheckpointSaver，另輸出精確的可訓練參數量讓圖能證明模型大小。因果遮罩在模型內部；搭配 LMCrossEntropyLoss 與打包好的 LM 資料使用。預設形狀約 2.02 億參數（d_model 1024、12 層、gpt2 詞彙表、共享嵌入）。',
+    params: {
+      vocab_size: '詞彙表大小（50257 = tiktoken gpt2；請與 LM tokenizer 的 encoding 保持一致）。',
+      d_model: '嵌入／殘差流寬度。',
+      n_layers: 'Transformer 區塊層數。',
+      n_heads: '注意力頭數（d_model 必須能被 n_heads 整除）。',
+      d_ff: '前饋隱藏層寬度（通常是 d_model 的 4 倍）。',
+      max_seq_len: '模型接受的最大序列長度。',
+      dropout: '注意力／MLP／嵌入的 dropout（單一 epoch 的 LM 預訓練通常設 0）。',
+      positional: '位置編碼：learned 可學習嵌入、sinusoidal 固定正弦、rope 旋轉位置編碼（RoPE）。',
+      norm: '正規化層（兩種都用 pre-norm 區塊）。',
+      activation: '前饋層的激活函數。',
+      tie_embeddings: '讓輸出層與 token 嵌入矩陣共享權重（省下 vocab×d_model 個參數）。',
+      gradient_checkpointing: '反向傳播時重算激活值，用計算換記憶體。',
+      init_std: '權重初始化的標準差（殘差投影會再除以 sqrt(2×n_layers)）。',
+      seed: '初始化種子 — 相同種子建出完全相同的權重。',
+    },
+  },
+  LMCrossEntropyLoss: {
+    description:
+      '語言模型用的 next-token cross-entropy：內部自動攤平，接受 logits (B,T,vocab) 對 targets (B,T) — 正是 CausalLMModel 與打包 LM 資料產出的形狀。支援 ignore_index 與 label smoothing。LM 訓練請用這顆，而不是通用 Loss 節點的 CrossEntropyLoss。',
+    params: {
+      ignore_index: '目標值等於此數的位置不計損失（padding 慣例）。',
+      label_smoothing: '標籤平滑係數（0 = 關閉）。',
+    },
+  },
   WordVector: {
     description:
       '為每個輸入單字查找預訓練向量。預訓練嵌入會把語意相近的字放在一起，所以 $king - man + woman \\approx queen$。預設 `demo-16d` 後端隨安裝附帶；`glove-*` 後端會在第一次使用時下載真實 GloVe 向量。',


### PR DESCRIPTION
> 中文摘要：新增可訓練的 GPT-style decoder-only 語言模型節點 CausalLMModel（純 torch、SDPA 因果遮罩、learned/sinusoidal/RoPE 位置編碼、LayerNorm/RMSNorm、權重共享、gradient checkpointing、種子化初始化，輸出 MODEL 與精確參數量；預設約 2.02 億參數），以及 LM 專用損失 LMCrossEntropyLoss（內部攤平 (B,T,V)/(B,T)，支援 ignore_index 與 label smoothing）。torch 模組放在 module-scope 的 _lm_modules.py 以支援 full_model pickle（#283 的教訓），節點內延遲 import。附 26 個單元/整合測試（含解析參數量驗證、因果性檢查、經真實 TrainingLoop 的 CPU 過擬合測試）與 zh-TW 目錄條目。

Closes #289. Part of epic #292 (train a real ~200M causal LM end-to-end on the canvas).

## What

- **CausalLMModel** [LLM]: trainable GPT-style pre-norm decoder-only transformer, plain torch (no `transformers`). `input_ids (B,T) int64 -> logits (B,T,vocab)`, SDPA `is_causal` masking, learned/sinusoidal/RoPE positions, LayerNorm/RMSNorm, gelu/relu/silu, tied embeddings, gradient checkpointing, GPT-2-style scaled residual init, seeded + `fork_rng`-isolated initialization. Outputs `model:MODEL` + `param_count:SCALAR` (defaults = ~202M shape). `cacheable=False` (owns weights, hands out a live MODEL handle).
- **LMCrossEntropyLoss** [LLM]: `LOSS_FN` flattening `(B,T,V)`/`(B,T)` internally, `ignore_index` + label smoothing. Deliberately not an `nn.CrossEntropyLoss` subclass so TrainingLoop's val-accuracy isinstance gate stays closed for LM logits.
- `_lm_modules.py`: module-scope torch classes so `ModelSaver(full_model)` pickling works (#283); nodes import it lazily inside `execute` (same split as `sequential_modules.py`).
- zh-TW catalog entries for both nodes.

## Verified with

```
backend/.venv/Scripts/python.exe -m pytest tests/test_causal_lm_model_node.py tests/test_lm_cross_entropy_loss_node.py -q   # 26 passed
backend/.venv/Scripts/python.exe -m pytest tests/test_cache_live_handle_nodes.py tests/test_cache_training_nodes.py tests/test_api_nodes.py -q   # 60 passed
uvx ruff@0.14.4 check backend/app/nodes/llm/ backend/tests/test_causal_lm_model_node.py backend/tests/test_lm_cross_entropy_loss_node.py   # clean
backend/.venv/Scripts/python.exe scripts/check_control_bytes.py   # OK
cd frontend && pnpm exec tsc -b   # clean
```

Tests that fail without the change: all of `test_causal_lm_model_node.py` / `test_lm_cross_entropy_loss_node.py` (new nodes), and `test_api_nodes.py::test_no_new_node_ships_without_a_zh_tw_entry` guards the catalog entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7hg6NttgDyNBcf49Na9kj