### PR TITLE
feat(llm): LM evaluation and generation - PerplexityEvaluate, TextGenerate

### DIFF
--- a/backend/app/nodes/llm/perplexity_evaluate_node.py
+++ b/backend/app/nodes/llm/perplexity_evaluate_node.py
@@ -1,0 +1,190 @@
+"""PerplexityEvaluateNode — 語言模型的驗證損失與困惑度。
+
+`EvaluateModel` 是 argmax 準確率（分類專用），對語言模型沒有意義。這顆吃
+訓練好的 causal LM 和打包好的 `(input_ids, labels)` 驗證資料，跑一遍計算
+token 加權的平均 cross-entropy 與 perplexity（``exp(val_loss)``）— LM 訓練
+的標準評估數字。標籤為 -100 的位置不計入。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.amp import PRECISIONS
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class PerplexityEvaluateNode(BaseNode):
+    NODE_NAME = "PerplexityEvaluate"
+    CATEGORY = "LLM"
+    DESCRIPTION = (
+        "Evaluate a causal language model on packed (input_ids, labels) "
+        "blocks: token-weighted mean cross-entropy (val_loss) and perplexity "
+        "= exp(val_loss). Positions labeled -100 are ignored. Wire "
+        "TrainingLoop.model and a validation LMTokenizedDataset in; "
+        "perplexity is per-token and only comparable on the same dataset "
+        "and tokenizer."
+    )
+
+    # Same reasoning as EvaluateModel (#254): the measurement depends on the
+    # model's live WEIGHTS (which the cache key cannot see), and the node
+    # logs val_loss/perplexity metric points — a side effect a cache replay
+    # would silently drop.
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="model", data_type=DataType.MODEL,
+                           description="Trained causal LM (input_ids (B,T) -> logits (B,T,V))"),
+            PortDefinition(name="dataset", data_type=DataType.DATASET,
+                           description="Packed (input_ids, labels) blocks (LMTokenizedDataset output)"),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="val_loss", data_type=DataType.SCALAR,
+                           description="Token-weighted mean cross-entropy"),
+            PortDefinition(name="perplexity", data_type=DataType.SCALAR,
+                           description="exp(val_loss)"),
+            PortDefinition(name="tokens", data_type=DataType.SCALAR,
+                           description="Number of tokens scored (ignore_index positions excluded)"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="batch_size", param_type=ParamType.INT, default=8,
+                min_value=1, max_value=256,
+                description="Evaluation batch size (speed/memory only; the result is identical)",
+            ),
+            ParamDefinition(
+                name="max_batches", param_type=ParamType.INT, default=0,
+                min_value=0,
+                description="Evaluate at most N batches (0 = the whole dataset)",
+            ),
+            ParamDefinition(
+                name="device", param_type=ParamType.SELECT, default="auto",
+                options=["auto", "cpu", "cuda", "mps"],
+                description="Device to evaluate on ('auto' follows the global device)",
+            ),
+            ParamDefinition(
+                name="precision", param_type=ParamType.SELECT, default="bf16",
+                options=list(PRECISIONS), advanced=True,
+                description=(
+                    "Autocast precision for the forward pass. bf16 halves "
+                    "activation memory on Ampere+ and is the LM-eval "
+                    "default; a device that cannot honour it falls back to "
+                    "fp32 and says so. fp32 is the number to publish."
+                ),
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import math
+
+        import torch
+        import torch.nn.functional as F
+        from torch.utils.data import DataLoader
+
+        from ...core.amp import AmpPolicy
+        from ...core.device_utils import resolve_node_device
+        from ...core.loop_control import (
+            EVENT_BATCH,
+            ProgressThrottle,
+            interrupted_result,
+            loader_length,
+            stop_checker,
+        )
+
+        model = inputs.get("model")
+        dataset = inputs.get("dataset")
+        if model is None:
+            raise ValueError("PerplexityEvaluate requires a `model` input.")
+        if dataset is None:
+            raise ValueError("PerplexityEvaluate requires a `dataset` input.")
+
+        batch_size = max(1, int(params.get("batch_size", 8)))
+        max_batches = max(0, int(params.get("max_batches", 0) or 0))
+        device = resolve_node_device(params.get("device"), context)
+        policy = AmpPolicy.for_device(params.get("precision", "bf16"), device)
+
+        loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
+        model = model.to(device)
+        model.eval()
+
+        should_stop = stop_checker(context)
+        throttle = ProgressThrottle(progress_callback)
+        total_batches = loader_length(loader)
+        if max_batches and total_batches is not None:
+            total_batches = min(total_batches, max_batches)
+        stopped_at_batch: int | None = None
+
+        loss_sum = 0.0
+        token_count = 0
+        with torch.no_grad():
+            for batch_index, batch in enumerate(loader):
+                if max_batches and batch_index >= max_batches:
+                    break
+                if should_stop():
+                    stopped_at_batch = batch_index
+                    break
+                input_ids = batch[0].to(device)
+                targets = batch[1].to(device)
+                with policy.autocast():
+                    logits = model(input_ids)
+                # Sum-reduced CE in fp32 so the running total is exact;
+                # ignore_index positions contribute neither loss nor count.
+                flat_logits = logits.reshape(-1, logits.shape[-1]).float()
+                flat_targets = targets.reshape(-1)
+                loss_sum += float(F.cross_entropy(
+                    flat_logits, flat_targets,
+                    ignore_index=-100, reduction="sum",
+                ).item())
+                token_count += int((flat_targets != -100).sum().item())
+                running = loss_sum / token_count if token_count else 0.0
+                throttle.emit({
+                    "event": EVENT_BATCH,
+                    "batch": batch_index + 1,
+                    "total_batches": total_batches,
+                    "val_loss": round(running, 6),
+                })
+
+        if token_count == 0:
+            raise RuntimeError(
+                "PerplexityEvaluate scored zero tokens — the dataset is "
+                "empty or every label is ignore_index (-100)."
+            )
+        val_loss = loss_sum / token_count
+        # exp() overflows float64 beyond ~709; an untrained model's CE can
+        # legitimately sit near ln(vocab) ~ 11, but a broken run can hand us
+        # anything. Cap the exponent and say nothing — the val_loss output
+        # carries the exact number either way.
+        perplexity = math.exp(min(val_loss, 700.0))
+
+        result: dict[str, Any] = {
+            "val_loss": float(val_loss),
+            "perplexity": float(perplexity),
+            "tokens": int(token_count),
+        }
+        if stopped_at_batch is not None:
+            result.update(interrupted_result(batch=stopped_at_batch))
+        elif context is not None:
+            context.log_metric("val_loss", float(val_loss), 1)
+            context.log_metric("perplexity", float(perplexity), 1)
+        return result

--- a/backend/app/nodes/llm/text_generate_node.py
+++ b/backend/app/nodes/llm/text_generate_node.py
@@ -1,0 +1,204 @@
+"""TextGenerateNode — 用訓練好的 causal LM 逐 token 取樣生成文字。
+
+`LLMChat` 呼叫外部 API；沒有節點能從「畫布上剛訓練出來的權重」生成文字。
+這顆吃 MODEL + tokenizer，從 prompt 開始自迴歸取樣（temperature / top-k /
+top-p，種子化可重現），是訓練成果最直觀的質性驗證：TinyStories 練完，
+"Once upon a time" 應該接得出通順的小故事。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+
+class TextGenerateNode(BaseNode):
+    NODE_NAME = "TextGenerate"
+    CATEGORY = "LLM"
+    DESCRIPTION = (
+        "Autoregressively sample text from a trained causal LM: encode the "
+        "prompt with the LMTokenizer handle, feed the model token by token "
+        "with temperature / top-k / top-p sampling (seeded, reproducible), "
+        "stop at EOS or max_new_tokens, and decode the result. The most "
+        "direct qualitative check of a canvas-trained language model."
+    )
+
+    # The output depends on the model's live WEIGHTS (rule 2 of the
+    # cacheable contract): a cache hit would replay text from a model the
+    # training loop has since updated.
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="model", data_type=DataType.MODEL,
+                           description="Trained causal LM (input_ids (B,T) -> logits (B,T,V))"),
+            PortDefinition(name="tokenizer", data_type=DataType.ANY,
+                           description="Tokenizer handle from LMTokenizer (encode/decode/eos_id)"),
+            PortDefinition(name="prompt", data_type=DataType.STRING,
+                           description="Prompt text. Optional — falls back to the `prompt` param.",
+                           optional=True),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(name="text", data_type=DataType.STRING,
+                           description="Prompt plus the generated completion"),
+            PortDefinition(name="token_count", data_type=DataType.SCALAR,
+                           description="Number of new tokens generated"),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="prompt", param_type=ParamType.STRING,
+                default="Once upon a time",
+                description="Prompt used when no `prompt` input is connected",
+            ),
+            ParamDefinition(
+                name="max_new_tokens", param_type=ParamType.INT, default=200,
+                min_value=1, max_value=4096,
+                description="Maximum tokens to generate",
+            ),
+            ParamDefinition(
+                name="temperature", param_type=ParamType.FLOAT, default=0.8,
+                min_value=0.0, max_value=2.0,
+                description="Sampling temperature (0 = greedy argmax)",
+            ),
+            ParamDefinition(
+                name="top_k", param_type=ParamType.INT, default=50,
+                min_value=0, max_value=1000, advanced=True,
+                description="Keep only the k most likely tokens before sampling (0 = disabled)",
+            ),
+            ParamDefinition(
+                name="top_p", param_type=ParamType.FLOAT, default=0.95,
+                min_value=0.0, max_value=1.0, advanced=True,
+                description="Nucleus sampling: keep the smallest set of tokens whose probability sums to p (1 = disabled)",
+            ),
+            ParamDefinition(
+                name="seed", param_type=ParamType.INT, default=0,
+                min_value=0, advanced=True,
+                description="Sampling seed — the same seed and weights reproduce the same text",
+            ),
+            ParamDefinition(
+                name="device", param_type=ParamType.SELECT, default="auto",
+                options=["auto", "cpu", "cuda", "mps"],
+                description="Device to run the forward passes on",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import torch
+
+        from ...core.device_utils import resolve_node_device
+        from ...core.loop_control import (
+            ProgressThrottle,
+            interrupted_result,
+            stop_checker,
+        )
+
+        model = inputs.get("model")
+        tokenizer = inputs.get("tokenizer")
+        if model is None:
+            raise ValueError("TextGenerate requires a `model` input.")
+        if (
+            tokenizer is None
+            or not hasattr(tokenizer, "encode")
+            or not hasattr(tokenizer, "decode")
+            or not hasattr(tokenizer, "eos_id")
+        ):
+            raise ValueError(
+                "TextGenerate requires a `tokenizer` input from the "
+                "LMTokenizer node (an object with encode/decode/eos_id)."
+            )
+
+        prompt_input = inputs.get("prompt")
+        prompt = str(prompt_input) if prompt_input is not None else str(params.get("prompt", ""))
+        max_new_tokens = max(1, min(4096, int(params.get("max_new_tokens", 200))))
+        temperature = max(0.0, float(params.get("temperature", 0.8)))
+        top_k = max(0, int(params.get("top_k", 50)))
+        top_p = float(params.get("top_p", 0.95))
+        seed = int(params.get("seed", 0))
+        device = resolve_node_device(params.get("device"), context)
+
+        eos_id = int(tokenizer.eos_id)
+        ids: list[int] = [int(t) for t in tokenizer.encode(prompt)]
+        if not ids:
+            ids = [eos_id]
+
+        # The context window: the model says so if it can (CausalLMModel
+        # exposes max_seq_len); otherwise fall back to a safe 1024.
+        window = int(getattr(model, "max_seq_len", 1024) or 1024)
+
+        model = model.to(device)
+        model.eval()
+        # Sampling happens on CPU in fp32 regardless of the model device, so
+        # a fixed seed reproduces the same text on cpu and cuda alike.
+        generator = torch.Generator(device="cpu").manual_seed(seed)
+        should_stop = stop_checker(context)
+        throttle = ProgressThrottle(progress_callback)
+
+        generated = 0
+        stopped_early: int | None = None
+        with torch.no_grad():
+            for step in range(max_new_tokens):
+                if should_stop():
+                    stopped_early = step
+                    break
+                window_ids = ids[-window:]
+                input_ids = torch.tensor([window_ids], dtype=torch.int64, device=device)
+                logits = model(input_ids)
+                last = logits[0, -1].detach().float().cpu()
+
+                if temperature == 0.0:
+                    next_id = int(torch.argmax(last).item())
+                else:
+                    last = last / temperature
+                    if top_k and top_k < last.shape[0]:
+                        kth = torch.topk(last, top_k).values[-1]
+                        last[last < kth] = float("-inf")
+                    if 0.0 < top_p < 1.0:
+                        sorted_logits, sorted_indices = torch.sort(last, descending=True)
+                        probs = torch.softmax(sorted_logits, dim=-1)
+                        cumulative = torch.cumsum(probs, dim=-1)
+                        # Keep the first token whose cumulative crosses p.
+                        cutoff = cumulative > top_p
+                        cutoff[1:] = cutoff[:-1].clone()
+                        cutoff[0] = False
+                        sorted_logits[cutoff] = float("-inf")
+                        last = torch.full_like(last, float("-inf"))
+                        last[sorted_indices] = sorted_logits
+                    probs = torch.softmax(last, dim=-1)
+                    next_id = int(torch.multinomial(probs, 1, generator=generator).item())
+
+                ids.append(next_id)
+                generated += 1
+                throttle.emit({
+                    "event": "generate",
+                    "tokens": generated,
+                    "max_new_tokens": max_new_tokens,
+                })
+                if next_id == eos_id:
+                    break
+
+        text = tokenizer.decode(ids)
+        result: dict[str, Any] = {"text": text, "token_count": int(generated)}
+        if stopped_early is not None:
+            result.update(interrupted_result(token=stopped_early))
+        return result

--- a/backend/tests/test_perplexity_evaluate_node.py
+++ b/backend/tests/test_perplexity_evaluate_node.py
@@ -1,0 +1,113 @@
+"""Tests for PerplexityEvaluateNode."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader, TensorDataset
+
+from app.nodes.llm.causal_lm_model_node import CausalLMModelNode
+from app.nodes.llm.perplexity_evaluate_node import PerplexityEvaluateNode
+
+TINY = {
+    "vocab_size": 256, "d_model": 32, "n_layers": 2, "n_heads": 2,
+    "d_ff": 64, "max_seq_len": 32, "seed": 3,
+}
+
+
+def tiny_model():
+    return CausalLMModelNode().execute({}, TINY)["model"]
+
+
+def packed_dataset(num_samples=6, seq_len=8, with_ignore=False):
+    generator = torch.Generator().manual_seed(0)
+    inputs = torch.randint(0, TINY["vocab_size"], (num_samples, seq_len),
+                           dtype=torch.int64, generator=generator)
+    labels = torch.roll(inputs, shifts=-1, dims=1)
+    if with_ignore:
+        labels[:, -2:] = -100
+    return TensorDataset(inputs, labels)
+
+
+def manual_reference(model, dataset, batch_size, max_batches=0):
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
+    model = model.eval()
+    loss_sum = 0.0
+    count = 0
+    with torch.no_grad():
+        for index, (x, y) in enumerate(loader):
+            if max_batches and index >= max_batches:
+                break
+            logits = model(x)
+            loss_sum += float(F.cross_entropy(
+                logits.reshape(-1, logits.shape[-1]).float(),
+                y.reshape(-1), ignore_index=-100, reduction="sum",
+            ).item())
+            count += int((y.reshape(-1) != -100).sum().item())
+    return loss_sum / count, count
+
+
+def test_node_metadata():
+    assert PerplexityEvaluateNode.NODE_NAME == "PerplexityEvaluate"
+    assert PerplexityEvaluateNode.CATEGORY == "LLM"
+    assert PerplexityEvaluateNode.cacheable is False
+
+
+def test_matches_manual_token_weighted_cross_entropy():
+    model = tiny_model()
+    dataset = packed_dataset(num_samples=6, seq_len=8)
+    result = PerplexityEvaluateNode().execute(
+        {"model": model, "dataset": dataset},
+        {"batch_size": 4, "device": "cpu", "precision": "fp32"},
+    )
+    expected_loss, expected_tokens = manual_reference(model, dataset, batch_size=4)
+    assert result["tokens"] == expected_tokens == 6 * 8
+    assert result["val_loss"] == pytest.approx(expected_loss, rel=1e-6)
+    assert result["perplexity"] == pytest.approx(math.exp(expected_loss), rel=1e-6)
+
+
+def test_ignore_index_positions_are_excluded():
+    model = tiny_model()
+    dataset = packed_dataset(num_samples=4, seq_len=8, with_ignore=True)
+    result = PerplexityEvaluateNode().execute(
+        {"model": model, "dataset": dataset},
+        {"batch_size": 4, "device": "cpu", "precision": "fp32"},
+    )
+    expected_loss, expected_tokens = manual_reference(model, dataset, batch_size=4)
+    assert result["tokens"] == expected_tokens == 4 * 6  # two ignored per row
+    assert result["val_loss"] == pytest.approx(expected_loss, rel=1e-6)
+
+
+def test_max_batches_caps_the_evaluation():
+    model = tiny_model()
+    dataset = packed_dataset(num_samples=6, seq_len=8)
+    result = PerplexityEvaluateNode().execute(
+        {"model": model, "dataset": dataset},
+        {"batch_size": 4, "max_batches": 1, "device": "cpu", "precision": "fp32"},
+    )
+    expected_loss, expected_tokens = manual_reference(
+        model, dataset, batch_size=4, max_batches=1,
+    )
+    assert result["tokens"] == expected_tokens == 4 * 8
+    assert result["val_loss"] == pytest.approx(expected_loss, rel=1e-6)
+
+
+def test_all_ignored_labels_raise_an_actionable_error():
+    model = tiny_model()
+    inputs = torch.zeros((2, 8), dtype=torch.int64)
+    labels = torch.full((2, 8), -100, dtype=torch.int64)
+    with pytest.raises(RuntimeError, match="zero tokens"):
+        PerplexityEvaluateNode().execute(
+            {"model": model, "dataset": TensorDataset(inputs, labels)},
+            {"device": "cpu", "precision": "fp32"},
+        )
+
+
+def test_missing_inputs_are_refused():
+    with pytest.raises(ValueError, match="model"):
+        PerplexityEvaluateNode().execute({"dataset": packed_dataset()}, {})
+    with pytest.raises(ValueError, match="dataset"):
+        PerplexityEvaluateNode().execute({"model": tiny_model()}, {})

--- a/backend/tests/test_text_generate_node.py
+++ b/backend/tests/test_text_generate_node.py
@@ -1,0 +1,184 @@
+"""Tests for TextGenerateNode."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from app.nodes.llm.text_generate_node import TextGenerateNode
+
+VOCAB = 64
+
+
+class AlphaTokenizer:
+    """A..Z <-> 0..25; eos configurable. Honors the LMTokenizer contract."""
+
+    encoding_name = "alpha-test"
+
+    def __init__(self, eos_id: int = 63):
+        self.eos_id = eos_id
+
+    def encode(self, text: str) -> list[int]:
+        return [ord(ch) - 65 for ch in text if 65 <= ord(ch) <= 90]
+
+    def decode(self, ids: list[int]) -> str:
+        return "".join(chr(65 + i) if 0 <= i < 26 else "#" for i in ids)
+
+
+class NextTokenModel(nn.Module):
+    """Deterministic toy LM: always predicts (last_token + 1) % VOCAB."""
+
+    max_seq_len = 16
+
+    def __init__(self):
+        super().__init__()
+        # An unused parameter so .to(device) has something to move.
+        self.bias = nn.Parameter(torch.zeros(1))
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        batch, seq_len = input_ids.shape
+        logits = torch.zeros(batch, seq_len, VOCAB)
+        for b in range(batch):
+            for t in range(seq_len):
+                logits[b, t, (int(input_ids[b, t]) + 1) % VOCAB] = 10.0
+        return logits + self.bias
+
+
+class UniformModel(nn.Module):
+    """All-zero logits -> uniform sampling distribution."""
+
+    max_seq_len = 16
+
+    def __init__(self):
+        super().__init__()
+        self.bias = nn.Parameter(torch.zeros(1))
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        batch, seq_len = input_ids.shape
+        return torch.zeros(batch, seq_len, VOCAB) + self.bias
+
+
+def generate(model, tokenizer, params):
+    return TextGenerateNode().execute(
+        {"model": model, "tokenizer": tokenizer},
+        {"device": "cpu", **params},
+    )
+
+
+def test_node_metadata():
+    assert TextGenerateNode.NODE_NAME == "TextGenerate"
+    assert TextGenerateNode.CATEGORY == "LLM"
+    assert TextGenerateNode.cacheable is False
+
+
+def test_greedy_continuation_is_exact():
+    result = generate(NextTokenModel(), AlphaTokenizer(), {
+        "prompt": "AB", "max_new_tokens": 3, "temperature": 0.0,
+    })
+    assert result["text"] == "ABCDE"
+    assert result["token_count"] == 3
+
+
+def test_generation_stops_at_eos():
+    result = generate(NextTokenModel(), AlphaTokenizer(eos_id=5), {
+        "prompt": "AB", "max_new_tokens": 20, "temperature": 0.0,
+    })
+    # 1 -> generates 2,3,4,5(eos) and stops.
+    assert result["token_count"] == 4
+    assert result["text"].startswith("ABCDE")
+
+
+def test_prompt_longer_than_window_slides():
+    tokenizer = AlphaTokenizer()
+    model = NextTokenModel()
+    prompt = "".join(chr(65 + i) for i in range(20))  # 20 ids > window 16
+    result = generate(model, tokenizer, {
+        "prompt": prompt, "max_new_tokens": 2, "temperature": 0.0,
+    })
+    assert result["text"] == prompt + "UV"
+
+
+def test_prompt_input_port_overrides_param():
+    result = TextGenerateNode().execute(
+        {"model": NextTokenModel(), "tokenizer": AlphaTokenizer(), "prompt": "XY"},
+        {"prompt": "AB", "max_new_tokens": 1, "temperature": 0.0, "device": "cpu"},
+    )
+    assert result["text"] == "XYZ"
+
+
+def test_seeded_sampling_is_reproducible():
+    first = generate(UniformModel(), AlphaTokenizer(), {
+        "prompt": "A", "max_new_tokens": 12, "temperature": 1.0,
+        "top_k": 0, "top_p": 1.0, "seed": 7,
+    })
+    second = generate(UniformModel(), AlphaTokenizer(), {
+        "prompt": "A", "max_new_tokens": 12, "temperature": 1.0,
+        "top_k": 0, "top_p": 1.0, "seed": 7,
+    })
+    third = generate(UniformModel(), AlphaTokenizer(), {
+        "prompt": "A", "max_new_tokens": 12, "temperature": 1.0,
+        "top_k": 0, "top_p": 1.0, "seed": 8,
+    })
+    assert first["text"] == second["text"]
+    assert first["text"] != third["text"]
+
+
+def test_top_k_one_is_greedy_even_at_high_temperature():
+    result = generate(NextTokenModel(), AlphaTokenizer(), {
+        "prompt": "AB", "max_new_tokens": 3, "temperature": 1.5, "top_k": 1,
+    })
+    assert result["text"] == "ABCDE"
+
+
+def test_tokenizer_contract_is_refused():
+    class NoDecode:
+        eos_id = 0
+
+        def encode(self, text):
+            return [1]
+
+    with pytest.raises(ValueError, match="LMTokenizer"):
+        TextGenerateNode().execute(
+            {"model": NextTokenModel(), "tokenizer": NoDecode()}, {},
+        )
+
+
+def test_trained_causal_lm_reproduces_a_memorized_cycle():
+    from app.nodes.llm.causal_lm_model_node import CausalLMModelNode
+    from app.nodes.llm.lm_cross_entropy_loss_node import LMCrossEntropyLossNode
+
+    model = CausalLMModelNode().execute({}, {
+        "vocab_size": 256, "d_model": 32, "n_layers": 2, "n_heads": 2,
+        "d_ff": 64, "max_seq_len": 32, "seed": 5,
+    })["model"]
+    loss_fn = LMCrossEntropyLossNode().execute({}, {})["loss_fn"]
+
+    cycle = torch.arange(16, dtype=torch.int64)
+    sequence = cycle.repeat(2)  # 0..15 0..15
+    inputs = sequence[:-1].unsqueeze(0)
+    targets = sequence[1:].unsqueeze(0)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=5e-3)
+    for _ in range(150):
+        optimizer.zero_grad()
+        loss = loss_fn(model(inputs), targets)
+        loss.backward()
+        optimizer.step()
+    assert float(loss.detach()) < 0.2  # memorized
+
+    class IdTokenizer:
+        encoding_name = "id-test"
+        eos_id = 255
+
+        def encode(self, text):
+            return [int(piece) for piece in text.split() if piece.strip()]
+
+        def decode(self, ids):
+            return " ".join(str(i) for i in ids)
+
+    result = TextGenerateNode().execute(
+        {"model": model, "tokenizer": IdTokenizer()},
+        {"prompt": "0 1 2 3 4 5", "max_new_tokens": 6,
+         "temperature": 0.0, "device": "cpu"},
+    )
+    assert result["text"] == " ".join(str(i) for i in range(12))

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -829,6 +829,29 @@ const zhTW: NodeTranslations = {
       cache_dir: '覆寫快取目錄（相對路徑解析在資料目錄內）。',
     },
   },
+  PerplexityEvaluate: {
+    description:
+      '在打包好的 (input_ids, labels) 驗證資料上評估 causal LM：輸出 token 加權的平均 cross-entropy（val_loss）與 perplexity = exp(val_loss)。標籤為 -100 的位置不計入。接 TrainingLoop.model 與驗證用的 LMTokenizedDataset；perplexity 是逐 token 指標，只在相同資料集與 tokenizer 下可比較。',
+    params: {
+      batch_size: '評估批次大小（只影響速度／記憶體，結果相同）。',
+      max_batches: '最多評估 N 個批次（0 = 整個資料集）。',
+      device: '評估用的裝置（auto 跟隨全域裝置）。',
+      precision: '前向的 autocast 精度。bf16 在 Ampere+ 省一半激活記憶體，是 LM 評估預設；裝置不支援會退回 fp32 並註明。要發表的數字請用 fp32。',
+    },
+  },
+  TextGenerate: {
+    description:
+      '用訓練好的 causal LM 自迴歸生成文字：以 LMTokenizer 編碼 prompt、逐 token 取樣（temperature / top-k / top-p，種子化可重現）、遇 EOS 或 max_new_tokens 停止並解碼。畫布上訓練成果最直觀的質性驗證。',
+    params: {
+      prompt: '沒有接 prompt 輸入時使用的提示文字。',
+      max_new_tokens: '最多生成的 token 數。',
+      temperature: '取樣溫度（0 = greedy argmax）。',
+      top_k: '取樣前只保留機率最高的 k 個 token（0 = 關閉）。',
+      top_p: 'Nucleus 取樣：保留累積機率達 p 的最小 token 集合（1 = 關閉）。',
+      seed: '取樣種子 — 相同種子與權重會重現相同文字。',
+      device: '前向運算的裝置。',
+    },
+  },
   EmbeddingScatter: {
     description:
       '把高維嵌入投影到 2D 來「看見」嵌入空間的幾何結構。語意相近的字會聚成一群。PCA 是線性、決定性、快；t-SNE 是非線性、會更好保留局部鄰域結構，但每次跑出來的版面都略有不同。',


### PR DESCRIPTION
> 中文摘要：補上 LM 節點組的最後一塊 — PerplexityEvaluate（token 加權平均 cross-entropy 與 perplexity，-100 不計入，fp32 sum 累計保證精確）與 TextGenerate（temperature / top-k / top-p 種子化取樣、CPU 端取樣保證跨裝置可重現、依模型 max_seq_len 滑動視窗、EOS 停止）。附 15 個測試（含與手算參照完全一致、訓練後的 CausalLMModel 以 greedy 重現記憶序列）與七節點全鏈 CPU 煙霧驗證（訓練 loss 7.99→2.65、ppl 4.26、生成接近語料的文字）。

Closes #291. Completes the node set for epic #292 (with #293 + #294).

## What

- **PerplexityEvaluate** [LLM]: token-weighted mean CE (sum-reduced fp32 running total) + `perplexity = exp(val_loss)` over packed `(input_ids, labels)` blocks; `-100` excluded from loss and count; `batch_size` / `max_batches` / `device` / `precision` (amp fallback contract); Stop + throttled progress; logs `val_loss`/`perplexity` metrics. `cacheable=False`.
- **TextGenerate** [LLM]: autoregressive sampling — temperature (0 = greedy), top-k, nucleus top-p; CPU-side seeded sampling so cpu/cuda reproduce identical text; sliding window from the model's `max_seq_len`; EOS stop; optional `prompt` input port overriding the param. `cacheable=False`.
- zh-TW catalog entries.

## Verified with

```
backend/.venv/Scripts/python.exe -m pytest tests/test_perplexity_evaluate_node.py tests/test_text_generate_node.py tests/test_api_nodes.py tests/test_cache_live_handle_nodes.py -q   # 67 passed
# full seven-node chain smoke (CPU): corpus -> tokenize -> pack -> train -> eval -> generate
#   train loss 7.986 -> 2.650; val_loss 1.449, ppl 4.26 over 2048 tokens; near-coherent memorized sample
uvx ruff@0.14.4 check ...   # clean
backend/.venv/Scripts/python.exe scripts/check_control_bytes.py   # OK
cd frontend && pnpm exec tsc -b   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7hg6NttgDyNBcf49Na9kj