### PR TITLE
feat(training): per-step scheduling with warmup families, and research telemetry

### DIFF
--- a/backend/app/nodes/training/lr_scheduler_node.py
+++ b/backend/app/nodes/training/lr_scheduler_node.py
@@ -47,7 +47,23 @@ class LRSchedulerNode(BaseNode):
                 param_type=ParamType.SELECT,
                 default="StepLR",
                 description="Scheduler type",
-                options=["StepLR", "CosineAnnealingLR", "ExponentialLR", "ReduceLROnPlateau", "CosineAnnealingWarmRestarts", "MultiStepLR", "OneCycleLR"],
+                options=["StepLR", "CosineAnnealingLR", "ExponentialLR", "ReduceLROnPlateau", "CosineAnnealingWarmRestarts", "MultiStepLR", "OneCycleLR", "warmup_cosine", "warmup_linear", "constant_with_warmup"],
+            ),
+            ParamDefinition(
+                name="warmup_steps",
+                param_type=ParamType.INT,
+                default=100,
+                min_value=1,
+                description=(
+                    "warmup_cosine / warmup_linear / constant_with_warmup: "
+                    "steps of linear LR ramp from ~0 to the optimizer's LR "
+                    "before the decay phase. Denominated in SCHEDULER steps "
+                    "— pair with TrainingLoop's scheduler_step="
+                    "optimizer_step and set total_steps to the run's "
+                    "max_steps so 'warm up for 100 steps then anneal over "
+                    "1500' means exactly that (#297)."
+                ),
+                visible_when={"type": ["warmup_cosine", "warmup_linear", "constant_with_warmup"]},
             ),
             ParamDefinition(
                 name="step_size",
@@ -127,6 +143,33 @@ class LRSchedulerNode(BaseNode):
                 max_lr=params.get("max_lr", 0.01),
                 total_steps=params.get("total_steps", 1000),
             )
+        elif sched_type in ("warmup_cosine", "warmup_linear", "constant_with_warmup"):
+            # The standard LM pretraining shapes (#297): a linear ramp from
+            # ~0 to the optimizer's LR over warmup_steps, then cosine decay,
+            # linear decay to ~0, or a constant hold — all denominated in
+            # scheduler STEPS over total_steps. Meant for TrainingLoop's
+            # scheduler_step=optimizer_step; at the default per-epoch
+            # stepping these traverse one point per epoch like everything
+            # else here.
+            warmup = max(1, int(params.get("warmup_steps", 100) or 100))
+            total = max(warmup + 1, int(params.get("total_steps", 1000) or 1000))
+            remainder = total - warmup
+            # start_factor cannot be exactly 0 (torch rejects it); 1e-8 of
+            # the base LR is indistinguishable from cold.
+            ramp = lr_scheduler.LinearLR(
+                optimizer, start_factor=1e-8, end_factor=1.0,
+                total_iters=warmup)
+            if sched_type == "warmup_cosine":
+                decay = lr_scheduler.CosineAnnealingLR(optimizer, T_max=remainder)
+            elif sched_type == "warmup_linear":
+                decay = lr_scheduler.LinearLR(
+                    optimizer, start_factor=1.0, end_factor=1e-8,
+                    total_iters=remainder)
+            else:  # constant_with_warmup
+                decay = lr_scheduler.ConstantLR(
+                    optimizer, factor=1.0, total_iters=0)
+            sched = lr_scheduler.SequentialLR(
+                optimizer, schedulers=[ramp, decay], milestones=[warmup])
         else:
             raise ValueError(f"Unsupported scheduler type: {sched_type}")
 

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -876,6 +876,76 @@ class TrainingLoopNode(BaseNode):
                 advanced=True,
             ),
             ParamDefinition(
+                name="scheduler_step",
+                param_type=ParamType.SELECT,
+                default="epoch",
+                options=["epoch", "optimizer_step"],
+                description=(
+                    "When the LR scheduler advances (#297). `epoch` is the "
+                    "historical behavior; `optimizer_step` steps it after "
+                    "every optimizer update, which is what step-denominated "
+                    "schedules (warmup_cosine, OneCycleLR with total_steps = "
+                    "max_steps) need in a step-budgeted run. "
+                    "ReduceLROnPlateau is metric-driven and stays per-epoch "
+                    "in either mode."
+                ),
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="log_grad_norm",
+                param_type=ParamType.BOOL,
+                default=False,
+                description=(
+                    "Record the pre-clip global gradient norm each "
+                    "log_interval-th optimizer step as a grad_norm series "
+                    "(plus grad_norm_clipped when grad_clip_norm is set) — "
+                    "the raw material of loss-spike and stability forensics "
+                    "(#298)."
+                ),
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="log_update_ratio",
+                param_type=ParamType.BOOL,
+                default=False,
+                description=(
+                    "Record ||lr x grad|| / ||weights|| (global "
+                    "approximation) each log_interval-th optimizer step as "
+                    "an update_ratio series — the classic signal for "
+                    "learning-rate health: ~1e-3 is a common healthy scale "
+                    "(#298)."
+                ),
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="val_every_steps",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description=(
+                    "Evaluate the wired val_dataloader every N optimizer "
+                    "steps mid-epoch and record a val_loss_step series "
+                    "(0 = off). For epochs=1 + max_steps runs this is the "
+                    "only way to get a validation CURVE instead of one "
+                    "terminal point (#298)."
+                ),
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="checkpoint_every_steps",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description=(
+                    "Save a periodic checkpoint every N optimizer steps "
+                    "(0 = off). Step-milestone snapshots are the raw "
+                    "material for studying capability emergence; per-epoch "
+                    "checkpointing never fires inside a single-epoch run "
+                    "(#298). Same size warning as checkpoint_every."
+                ),
+                advanced=True,
+            ),
+            ParamDefinition(
                 name="deterministic",
                 param_type=ParamType.BOOL,
                 default=False,
@@ -1016,6 +1086,14 @@ class TrainingLoopNode(BaseNode):
         batch_metrics = bool(params.get("batch_metrics", False))
         max_steps = int(params.get("max_steps", 0) or 0)
         log_interval = max(1, int(params.get("log_interval", 1) or 1))
+        # #297/#298 research controls, all default-off / historical-default.
+        scheduler_per_step = str(
+            params.get("scheduler_step", "epoch") or "epoch") == "optimizer_step"
+        log_grad_norm = bool(params.get("log_grad_norm", False))
+        log_update_ratio = bool(params.get("log_update_ratio", False))
+        val_every_steps = max(0, int(params.get("val_every_steps", 0) or 0))
+        checkpoint_every_steps = max(
+            0, int(params.get("checkpoint_every_steps", 0) or 0))
         accumulate_steps = max(1, int(params.get("accumulate_steps", 1) or 1))
 
         # Built once for the whole call, so the fallback warning is logged
@@ -1209,7 +1287,7 @@ class TrainingLoopNode(BaseNode):
         # this means "the configured budget was spent and the run is done".
         step_budget_reached = False
 
-        def apply_gradients() -> bool:
+        def apply_gradients() -> tuple[bool, float | None]:
             """Clip, step, and clear -- one accumulation window's update.
 
             Clipping happens HERE rather than after each micro-batch's
@@ -1223,12 +1301,127 @@ class TrainingLoopNode(BaseNode):
             this point, so a clip measured on them would compare a number
             around 65536x too large against the threshold.
             """
+            grad_norm_value: float | None = None
             if grad_clip > 0:
                 policy.unscale_(optimizer)
-                torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+                # clip_grad_norm_ returns the PRE-clip total norm — the
+                # measurement #298's telemetry wants, for free.
+                total_norm = torch.nn.utils.clip_grad_norm_(
+                    model.parameters(), grad_clip)
+                grad_norm_value = float(total_norm)
+            elif log_grad_norm or log_update_ratio:
+                # Norm-only measurement: an infinite threshold clips
+                # nothing, and the unscale keeps the number meaningful
+                # under fp16 exactly as in the clipping branch.
+                policy.unscale_(optimizer)
+                total_norm = torch.nn.utils.clip_grad_norm_(
+                    model.parameters(), float("inf"))
+                grad_norm_value = float(total_norm)
             applied = policy.step(optimizer)
             optimizer.zero_grad()
-            return applied
+            return applied, grad_norm_value
+
+        import torch.optim.lr_scheduler as _sched_module
+        scheduler_is_plateau = isinstance(
+            lr_scheduler, _sched_module.ReduceLROnPlateau)
+
+        def after_optimizer_step(grad_norm_value: float | None) -> None:
+            """#297/#298 per-optimizer-step work.
+
+            Called only after a step actually applied, with the pre-clip
+            gradient norm when one was measured. Scheduler stepping comes
+            first so a schedule denominated in optimizer steps advances
+            exactly once per step; the telemetry series are thinned by
+            ``log_interval`` like the batch-loss series.
+            """
+            nonlocal periodic_checkpoint_bytes
+            if (scheduler_per_step and lr_scheduler is not None
+                    and not scheduler_is_plateau):
+                lr_scheduler.step()
+            thinned = optimizer_steps % log_interval == 0
+            if grad_norm_value is not None and log_grad_norm and thinned:
+                record_metric("grad_norm", grad_norm_value, optimizer_steps)
+                if grad_clip > 0:
+                    record_metric(
+                        "grad_norm_clipped",
+                        min(grad_norm_value, float(grad_clip)),
+                        optimizer_steps)
+            if grad_norm_value is not None and log_update_ratio and thinned:
+                with torch.no_grad():
+                    weight_sq = 0.0
+                    for parameter in model.parameters():
+                        if parameter.requires_grad:
+                            weight_sq += float(
+                                parameter.detach().float().norm() ** 2)
+                weight_norm = weight_sq ** 0.5
+                lr_now = float(optimizer.param_groups[0].get("lr", 0.0))
+                record_metric(
+                    "update_ratio",
+                    lr_now * grad_norm_value / max(weight_norm, 1e-12),
+                    optimizer_steps)
+            if (val_every_steps and val_dataloader is not None
+                    and optimizer_steps % val_every_steps == 0):
+                # A mid-epoch validation pass: eval mode + no_grad consume
+                # no RNG, so the training stream is undisturbed. The result
+                # is its OWN series (val_loss_step, x = optimizer steps)
+                # rather than more points on the per-epoch val_loss curve,
+                # which has a different x-axis.
+                was_training = model.training
+                model.eval()
+                step_val_sum = 0.0
+                step_val_batches = 0
+                with torch.no_grad():
+                    for step_batch in val_dataloader:
+                        if should_stop():
+                            break
+                        if (isinstance(step_batch, (list, tuple))
+                                and len(step_batch) == 2):
+                            step_data = to_device(step_batch[0], device)
+                            step_targets = to_device(step_batch[1], device)
+                        else:
+                            step_data = (
+                                to_device(step_batch, device)
+                                if hasattr(step_batch, "to") else step_batch)
+                            step_targets = None
+                        with policy.autocast():
+                            step_out = model(step_data)
+                            step_loss = (
+                                loss_fn(step_out, step_targets)
+                                if step_targets is not None
+                                else loss_fn(step_out))
+                        step_val_sum += float(step_loss.item())
+                        step_val_batches += 1
+                if step_val_batches:
+                    record_metric(
+                        "val_loss_step",
+                        step_val_sum / step_val_batches,
+                        optimizer_steps)
+                if was_training:
+                    model.train()
+            if (checkpoint_every_steps
+                    and optimizer_steps % checkpoint_every_steps == 0):
+                # ``epoch=optimizer_steps`` on purpose: the periodic
+                # filename is stamped ``-e{epoch}``, and step milestones
+                # need DISTINCT files (they are emergence snapshots, not a
+                # rolling latest). The trade is that the checkpoint's
+                # stored epoch field carries the step count — resuming
+                # start_epoch from one of these is not meaningful, and the
+                # param description says so.
+                milestone_path = save_periodic_checkpoint(
+                    context, model, optimizer,
+                    epoch=optimizer_steps,
+                    losses=torch.tensor(
+                        epoch_losses, dtype=torch.float32)
+                    if epoch_losses else None,
+                    lr_scheduler=lr_scheduler,
+                    scaler_state=policy.state_dict(),
+                )
+                if milestone_path is not None:
+                    try:
+                        periodic_checkpoint_bytes += Path(
+                            milestone_path).stat().st_size
+                    except OSError:
+                        pass
 
         # ``epoch`` is the ABSOLUTE epoch index for the whole training run, not
         # an offset into this call: a resume at start_epoch=2 with epochs=4 runs
@@ -1298,8 +1491,10 @@ class TrainingLoopNode(BaseNode):
                 global_batch += 1
 
                 if pending >= accumulate_steps:
-                    if apply_gradients():
+                    applied_step, step_grad_norm = apply_gradients()
+                    if applied_step:
                         optimizer_steps += 1
+                        after_optimizer_step(step_grad_norm)
                     pending = 0
 
                 if batch_metrics and global_batch % log_interval == 0:
@@ -1358,8 +1553,10 @@ class TrainingLoopNode(BaseNode):
             # resident until some later run's first epoch zeroed it.
             if pending:
                 if stopped_at is None and not step_budget_reached:
-                    if apply_gradients():
+                    applied_step, step_grad_norm = apply_gradients()
+                    if applied_step:
                         optimizer_steps += 1
+                        after_optimizer_step(step_grad_norm)
                     # Re-checked here and not only inside the batch loop:
                     # a budget reached BY the tail step must end the run now,
                     # rather than after the next epoch has read one more
@@ -1469,11 +1666,13 @@ class TrainingLoopNode(BaseNode):
             if lr_scheduler is not None:
                 # ReduceLROnPlateau needs a metric
                 if hasattr(lr_scheduler, "step"):
-                    import torch.optim.lr_scheduler as sched_module
-                    if isinstance(lr_scheduler, sched_module.ReduceLROnPlateau):
+                    if scheduler_is_plateau:
+                        # Metric-driven: stays per-epoch in BOTH
+                        # scheduler_step modes — there is no per-step metric
+                        # for it to react to (#297).
                         metric = avg_val_loss if avg_val_loss is not None else avg_train_loss
                         lr_scheduler.step(metric)
-                    else:
+                    elif not scheduler_per_step:
                         lr_scheduler.step()
 
             # ── Early stopping check ──

--- a/backend/tests/test_training_research_controls.py
+++ b/backend/tests/test_training_research_controls.py
@@ -1,0 +1,197 @@
+"""Tests for the #297/#298 research controls on TrainingLoop + LRScheduler."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from app.nodes.training.lr_scheduler_node import LRSchedulerNode
+from app.nodes.training.training_loop_node import TrainingLoopNode
+
+
+class _RecordingContext:
+    """Collects ``log_metric`` calls; everything else is a no-op."""
+
+    def __init__(self):
+        self.deterministic = False
+        self.current_node_id = "train"
+        self.metrics = []
+        self.seed = None
+
+    def should_stop(self):
+        return False
+
+    def log_metric(self, name, value, step, node_id=None):
+        self.metrics.append((name, value, step))
+
+    def can_record_artifacts(self):
+        return False
+
+
+def _dataset(n=8):
+    torch.manual_seed(0)
+    return TensorDataset(
+        torch.randn(n, 4), torch.randint(0, 2, (n,), dtype=torch.int64))
+
+
+def _train(params, *, context=None, scheduler=None, val=False, n=8, batch_size=2):
+    torch.manual_seed(0)
+    model = nn.Linear(4, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    inputs = {
+        "model": model,
+        "dataloader": DataLoader(_dataset(n), batch_size=batch_size),
+        "optimizer": optimizer,
+        "loss_fn": nn.CrossEntropyLoss(),
+    }
+    if scheduler is not None:
+        inputs["lr_scheduler"] = scheduler(optimizer)
+    if val:
+        inputs["val_dataloader"] = DataLoader(_dataset(4), batch_size=2)
+    result = TrainingLoopNode().execute(
+        inputs, {"device": "cpu", **params}, context=context)
+    return result, inputs
+
+
+def _series(ctx, name):
+    return [(value, step) for metric, value, step in ctx.metrics if metric == name]
+
+
+# ── #297: warmup schedule families ─────────────────────────────────────────
+
+
+def _make_sched(kind, warmup, total):
+    def factory(optimizer):
+        return LRSchedulerNode().execute(
+            {"optimizer": optimizer},
+            {"type": kind, "warmup_steps": warmup, "total_steps": total},
+        )["scheduler"]
+    return factory
+
+
+@pytest.mark.parametrize("kind", ["warmup_cosine", "warmup_linear", "constant_with_warmup"])
+def test_warmup_families_ramp_from_cold_to_base(kind):
+    optimizer = torch.optim.SGD([nn.Parameter(torch.zeros(1))], lr=0.1)
+    sched = _make_sched(kind, warmup=10, total=100)(optimizer)
+    assert optimizer.param_groups[0]["lr"] < 1e-6  # cold start
+    for _ in range(10):
+        optimizer.step()
+        sched.step()
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(0.1, rel=1e-3)
+
+
+def test_warmup_cosine_and_linear_anneal_while_constant_holds():
+    ends = {}
+    for kind in ("warmup_cosine", "warmup_linear", "constant_with_warmup"):
+        optimizer = torch.optim.SGD([nn.Parameter(torch.zeros(1))], lr=0.1)
+        sched = _make_sched(kind, warmup=5, total=50)(optimizer)
+        for _ in range(50):
+            optimizer.step()
+            sched.step()
+        ends[kind] = optimizer.param_groups[0]["lr"]
+    assert ends["warmup_cosine"] < 0.005
+    assert ends["warmup_linear"] < 0.005
+    assert ends["constant_with_warmup"] == pytest.approx(0.1, rel=1e-3)
+
+
+# ── #297: scheduler_step=optimizer_step ────────────────────────────────────
+
+
+def test_per_step_scheduler_advances_once_per_optimizer_step():
+    result, inputs = _train(
+        {"epochs": 1, "max_steps": 3, "scheduler_step": "optimizer_step"},
+        scheduler=_make_sched("warmup_cosine", warmup=2, total=10),
+    )
+    # 3 optimizer steps -> the scheduler took exactly 3 steps (last_epoch
+    # counts them), not the 1 the per-epoch mode would have taken.
+    assert inputs["lr_scheduler"].last_epoch == 3
+
+
+def test_default_epoch_stepping_is_unchanged():
+    result, inputs = _train(
+        {"epochs": 2},
+        scheduler=_make_sched("warmup_cosine", warmup=2, total=10),
+    )
+    assert inputs["lr_scheduler"].last_epoch == 2
+
+
+# ── #298: gradient-norm and update-ratio telemetry ─────────────────────────
+
+
+def test_log_grad_norm_records_per_optimizer_step():
+    ctx = _RecordingContext()
+    _train({"epochs": 1, "log_grad_norm": True}, context=ctx)
+    series = _series(ctx, "grad_norm")
+    assert [step for _, step in series] == [1, 2, 3, 4]
+    assert all(value > 0 for value, _ in series)
+    assert not _series(ctx, "grad_norm_clipped")  # no clipping configured
+
+
+def test_grad_norm_clipped_is_bounded_by_the_threshold():
+    ctx = _RecordingContext()
+    _train({"epochs": 1, "log_grad_norm": True, "grad_clip_norm": 0.001},
+           context=ctx)
+    clipped = _series(ctx, "grad_norm_clipped")
+    assert clipped
+    assert all(value <= 0.001 + 1e-9 for value, _ in clipped)
+
+
+def test_log_update_ratio_records_positive_values():
+    ctx = _RecordingContext()
+    _train({"epochs": 1, "log_update_ratio": True}, context=ctx)
+    series = _series(ctx, "update_ratio")
+    assert len(series) == 4
+    assert all(value > 0 for value, _ in series)
+
+
+def test_telemetry_off_by_default():
+    ctx = _RecordingContext()
+    _train({"epochs": 1}, context=ctx)
+    assert not _series(ctx, "grad_norm")
+    assert not _series(ctx, "update_ratio")
+    assert not _series(ctx, "val_loss_step")
+
+
+# ── #298: mid-epoch validation curve ───────────────────────────────────────
+
+
+def test_val_every_steps_records_a_curve_and_restores_training_mode():
+    ctx = _RecordingContext()
+    result, inputs = _train(
+        {"epochs": 1, "val_every_steps": 2}, context=ctx, val=True)
+    series = _series(ctx, "val_loss_step")
+    assert [step for _, step in series] == [2, 4]
+    assert all(value > 0 for value, _ in series)
+    # The per-epoch val series still exists independently.
+    assert result["val_losses"].shape == (1,)
+
+
+def test_val_every_steps_without_val_loader_is_silent():
+    ctx = _RecordingContext()
+    _train({"epochs": 1, "val_every_steps": 2}, context=ctx)
+    assert not _series(ctx, "val_loss_step")
+
+
+# ── #298: step-milestone checkpoints ───────────────────────────────────────
+
+
+def test_checkpoint_every_steps_fires_on_distinct_milestones(monkeypatch):
+    calls = []
+
+    def fake_periodic(context, model, optimizer, *, epoch, losses=None,
+                      lr_scheduler=None, scaler_state=None, node_id=None):
+        calls.append(epoch)
+        return None
+
+    import app.nodes.training.training_loop_node as tl
+    monkeypatch.setattr(tl, "save_periodic_checkpoint", fake_periodic, raising=False)
+    # save_periodic_checkpoint is imported inside execute; patch the source.
+    import app.core.loop_control as lc
+    monkeypatch.setattr(lc, "save_periodic_checkpoint", fake_periodic)
+
+    _train({"epochs": 1, "checkpoint_every_steps": 2},
+           context=_RecordingContext())
+    # 4 optimizer steps -> milestones at steps 2 and 4, stamped DISTINCTLY.
+    assert calls == [2, 4]

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -481,6 +481,11 @@ const zhTW: NodeTranslations = {
       accumulate_steps: '累積這麼多批之後才做一次優化器更新，同時把每一批的損失除以同一個數字。batch_size 8 搭配 4，梯度會等同於 batch_size 32，但記憶體裡同時只放 8 筆（1 = 關閉）。',
       max_steps: '總共跑滿這麼多次優化器更新後就停止，不論 epochs 設定為何。算的是優化器更新次數而不是批次數，所以不管 accumulate_steps 設多少意思都一樣（0 = 不限制）',
       log_interval: '開啟批次指標時，每 N 批記錄一次。長時間執行時調高可以讓圖表稀疏一點。',
+      scheduler_step: '學習率排程器何時前進（#297）。epoch 是歷史行為；optimizer_step 會在每次優化器更新後走一步 — 以步數計價的排程（warmup_cosine、total_steps = max_steps 的 OneCycleLR）在步數預算的執行裡需要這個模式。ReduceLROnPlateau 由指標驅動，兩種模式下都維持每 epoch 一步。',
+      log_grad_norm: '每 log_interval 個優化器步記錄一次裁剪前的全域梯度範數（grad_norm 序列；設定 grad_clip_norm 時另記 grad_norm_clipped）— loss 突波與穩定性鑑識的原料（#298）。',
+      log_update_ratio: '每 log_interval 個優化器步記錄 ||lr×grad|| / ||weights||（全域近似）為 update_ratio 序列 — 學習率健康度的經典訊號，約 1e-3 是常見的健康量級（#298）。',
+      val_every_steps: '每 N 個優化器步在接入的 val_dataloader 上做一次訓練中途驗證，記錄 val_loss_step 序列（0 = 關閉）。epochs=1 + max_steps 的跑法裡，這是取得驗證「曲線」而非單一終點的唯一方式（#298）。',
+      checkpoint_every_steps: '每 N 個優化器步存一個週期檢查點（0 = 關閉）。步數里程碑快照是研究能力湧現的原料；單 epoch 的跑法裡每 epoch 檢查點永遠不會觸發（#298）。檔案大小警告同 checkpoint_every；快照的 epoch 欄位承載的是步數，不適合拿來續訓。',
       deterministic: '要求 PyTorch 使用決定性的運算核心。沒有決定性實作的運算會發出警告，而不會讓執行失敗。',
       tensorboard: '同時把指標寫成 TensorBoard 事件檔，放在這次執行專屬的資料夾裡。用 `tensorboard --logdir <路徑>` 開啟；該路徑會列在這次執行的產出檔案中。',
     },
@@ -510,7 +515,9 @@ const zhTW: NodeTranslations = {
         'CosineAnnealingLR：一個 cosine 週期的長度，單位是 epoch。通常應該設成和 TrainingLoop.epochs 一樣——排程器每個 epoch 走一步，設小了會在學習率還很高的時候就結束，設大了則是只走到曲線中途，兩者通常會少掉幾個百分點的準確率，而且畫面上完全看不出來是排程造成的。這裡刻意不強制：截斷的排程本來就是合理選擇。CosineAnnealingWarmRestarts 會把這個值當成 T_0（第一次重啟前的週期長度），那種情況下設成和 epochs 一樣反而永遠不會重啟。',
       max_lr: 'OneCycleLR 的最大學習率',
       total_steps:
-        'OneCycleLR：整個 one-cycle 排程的長度。TrainingLoop 是每個 epoch 走一步，所以這裡要填 TrainingLoop.epochs，不是 batch 數（OneCycleLR 官方文件講的 step 是 batch）。預設值 1000 遠大於一般的 epoch 數，照著不改就只會走到週期的開頭：學習率稍微升上去，然後從來不會退火下來。',
+        'OneCycleLR：整個 one-cycle 排程的長度。TrainingLoop 是每個 epoch 走一步，所以這裡要填 TrainingLoop.epochs，不是 batch 數（OneCycleLR 官方文件講的 step 是 batch）。預設值 1000 遠大於一般的 epoch 數，照著不改就只會走到週期的開頭：學習率稍微升上去，然後從來不會退火下來。warmup 家族也用這個值當總長。',
+      warmup_steps:
+        'warmup_cosine / warmup_linear / constant_with_warmup：先以線性斜坡從 ~0 升到優化器學習率的步數，之後才進入衰減段。以「排程器步」計價 — 搭配 TrainingLoop 的 scheduler_step=optimizer_step 並把 total_steps 設成該跑的 max_steps，「暖身 100 步再在 1500 步內退火」才是字面意思（#297）。',
     },
   },
 


### PR DESCRIPTION
> 中文摘要：#292 wave 2 — 訓練迴圈成為研究儀器。#297：LRScheduler 新增 warmup_cosine / warmup_linear / constant_with_warmup（SequentialLR 斜坡+衰減，warmup_steps/total_steps 以排程步計價）；TrainingLoop 新增 scheduler_step=epoch|optimizer_step（每次優化器步進走一步；ReduceLROnPlateau 維持每 epoch）。#298：log_grad_norm（裁剪前全域梯度範數，裁剪呼叫免費回傳）、log_update_ratio（||lr×grad||/||w||）、val_every_steps（訓練中途驗證曲線，獨立 val_loss_step 序列、不擾動 RNG）、checkpoint_every_steps（步數里程碑快照、逐里程碑獨立檔名）。全部預設關閉／維持歷史行為；13 個新測試 + 既有套件 146 全綠。

Closes #297. Closes #298. Part of epic #292 wave 2 (follows #302).

Verification: `pytest tests/test_training_research_controls.py` (13 new) plus TrainingLoop / LRScheduler / schedule-length / api / cache suites — 146 passed; `uvx ruff@0.14.4 check` clean; control-bytes clean; frontend `tsc -b` clean; zh-TW entries for all six new params (ratchet green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7hg6NttgDyNBcf49Na9kj