### PR TITLE
feat(llm): DataMixDataset - weighted, seeded mixture of text corpora

### DIFF
--- a/backend/app/nodes/data/_hf_adapter.py
+++ b/backend/app/nodes/data/_hf_adapter.py
@@ -75,3 +75,24 @@ class HFTorchTextDataset(Dataset):
         # row is data the user pointed at, and failing the whole load over one
         # odd cell is worse than tokenizing its text form.
         return "" if value is None else str(value)
+
+
+class MixedTextDataset(Dataset):
+    """Rows drawn from several text datasets by a precomputed index.
+
+    The mixing NODE decides the order once (seeded, so it is reproducible)
+    and stores only ``(source, row)`` index pairs; rows are read lazily from
+    the underlying datasets, so mixing two HF-backed corpora never
+    materialises their text.
+    """
+
+    def __init__(self, sources: list[Any], index: list[tuple[int, int]]) -> None:
+        self._sources = sources
+        self._index = index
+
+    def __len__(self) -> int:
+        return len(self._index)
+
+    def __getitem__(self, idx: int) -> str:
+        source, row = self._index[idx]
+        return str(self._sources[source][row])

--- a/backend/app/nodes/llm/data_mix_dataset_node.py
+++ b/backend/app/nodes/llm/data_mix_dataset_node.py
@@ -1,0 +1,249 @@
+"""DataMixDatasetNode — 依權重、可重現地混合多個文字語料（#300）。
+
+資料混合與課程研究的入口：TinyStories 配多少比例的 wikitext？先簡單後困難
+的排序有沒有差？這顆吃 2–6 個 TextCorpusDataset 的輸出，依權重以種子化的
+順序交錯（interleave）或依序串接（concat）成一個新的文字資料集，接
+LMTokenizedDataset 之後就是可研究的混合預訓練資料。
+
+決定的是「列的順序」而不是列的內容：混合結果只存 (來源, 列號) 索引、
+逐列惰性讀取，混兩個 HF 語料不會把文字實體化進記憶體。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+    resolve_count_param,
+)
+
+_MIN_SOURCES = 2
+_MAX_SOURCES = 6
+#: Draw source picks in batches: one multinomial per row would put a python
+#: loop around a kernel launch for every row of a million-row corpus.
+_DRAW_CHUNK = 8192
+
+
+class DataMixDatasetNode(BaseNode):
+    NODE_NAME = "DataMixDataset"
+    CATEGORY = "LLM"
+    DESCRIPTION = (
+        "Mix 2-6 text corpora into one dataset of raw text rows — by "
+        "weighted, seeded interleaving (rows drawn proportionally, without "
+        "replacement, deterministic per seed) or ordered concatenation "
+        "(corpus_1 fully, then corpus_2, ... — a curriculum). Feed "
+        "TextCorpusDataset outputs in and the result into "
+        "LMTokenizedDataset to study data mixtures."
+    )
+
+    # Consumes live DATASET handles a fingerprint cannot describe (the
+    # cacheable contract's rule 2, from the consumer side).
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return cls.define_inputs_dynamic(None)
+
+    @classmethod
+    def define_inputs_dynamic(
+        cls, params: dict[str, Any] | None = None,
+    ) -> list[PortDefinition]:
+        count = resolve_count_param(
+            params, "sources",
+            default=_MIN_SOURCES, minimum=_MIN_SOURCES, maximum=_MAX_SOURCES)
+        return [
+            PortDefinition(
+                name=f"corpus_{index + 1}",
+                data_type=DataType.DATASET,
+                description=f"Text corpus {index + 1} (rows of raw text)",
+            )
+            for index in range(count)
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="dataset",
+                data_type=DataType.DATASET,
+                description="Mixed rows of raw text (lazy; order fixed by the seed)",
+            ),
+            PortDefinition(
+                name="num_rows",
+                data_type=DataType.SCALAR,
+                description="Total rows in the mixture",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="sources",
+                param_type=ParamType.INT,
+                default=_MIN_SOURCES,
+                min_value=_MIN_SOURCES,
+                max_value=_MAX_SOURCES,
+                description="How many corpus input ports this node has",
+            ),
+            ParamDefinition(
+                name="weights",
+                param_type=ParamType.STRING,
+                default="0.5, 0.5",
+                description=(
+                    "Comma-separated draw weights, one per source "
+                    "(normalized; interleave mode only). A source that "
+                    "empties stops being drawn and the rest renormalize — "
+                    "the tail of the mixture is whatever corpora remain."
+                ),
+            ),
+            ParamDefinition(
+                name="mode",
+                param_type=ParamType.SELECT,
+                default="interleave",
+                options=["interleave", "concat"],
+                description=(
+                    "interleave: seeded proportional draws without "
+                    "replacement. concat: corpus_1 fully, then corpus_2, "
+                    "... — an ordered curriculum."
+                ),
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description="Interleave order seed — the same seed and inputs reproduce the same mixture",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        import torch
+
+        from ..data._hf_adapter import MixedTextDataset
+
+        count = resolve_count_param(
+            params, "sources",
+            default=_MIN_SOURCES, minimum=_MIN_SOURCES, maximum=_MAX_SOURCES)
+        sources: list[Any] = []
+        for index in range(count):
+            corpus = inputs.get(f"corpus_{index + 1}")
+            if corpus is None:
+                raise ValueError(
+                    f"DataMixDataset: corpus_{index + 1} is not connected "
+                    f"(sources={count}).")
+            sources.append(corpus)
+        lengths = [len(source) for source in sources]
+        if any(length == 0 for length in lengths):
+            empty = [i + 1 for i, length in enumerate(lengths) if length == 0]
+            raise RuntimeError(
+                f"DataMixDataset: corpus_{empty[0]} has no rows.")
+
+        mode = str(params.get("mode", "interleave") or "interleave")
+        seed = max(0, int(params.get("seed", 0) or 0))
+
+        if mode == "concat":
+            index_pairs = [
+                (source_index, row)
+                for source_index in range(count)
+                for row in range(lengths[source_index])
+            ]
+        else:
+            weights = self._parse_weights(
+                str(params.get("weights", "") or ""), count)
+            index_pairs = self._interleave(lengths, weights, seed, torch)
+
+        dataset = MixedTextDataset(sources, index_pairs)
+        breakdown = ", ".join(
+            f"corpus_{i + 1}: {lengths[i]:,}" for i in range(count))
+        return {
+            "dataset": dataset,
+            "num_rows": len(dataset),
+            "__log__": (
+                f"Mixed {len(dataset):,} rows ({mode}, seed {seed}) from "
+                f"{breakdown}."
+            ),
+        }
+
+    @staticmethod
+    def _parse_weights(raw: str, count: int) -> list[float]:
+        pieces = [piece.strip() for piece in raw.split(",") if piece.strip()]
+        if not pieces:
+            # Absent/blank (a hand-built graph without the param): equal
+            # weights, the only default that works for every source count.
+            return [1.0 / count] * count
+        if len(pieces) != count:
+            raise ValueError(
+                f"DataMixDataset: weights has {len(pieces)} values but "
+                f"sources={count}; give one weight per corpus, e.g. "
+                f"\"{', '.join(['1'] * count)}\".")
+        try:
+            values = [float(piece) for piece in pieces]
+        except ValueError as exc:
+            raise ValueError(
+                f"DataMixDataset: weights must be numbers, got {raw!r}."
+            ) from exc
+        if any(value <= 0 for value in values):
+            raise ValueError(
+                "DataMixDataset: every weight must be positive — a source "
+                "with weight 0 should simply not be wired.")
+        total = sum(values)
+        return [value / total for value in values]
+
+    @staticmethod
+    def _interleave(
+        lengths: list[int], weights: list[float], seed: int, torch: Any,
+    ) -> list[tuple[int, int]]:
+        """Proportional draws without replacement, deterministic per seed.
+
+        Draws come in chunks (one multinomial call for thousands of picks);
+        when a source empties mid-chunk its remaining picks are discarded
+        and the probabilities renormalize over what is left — so the tail
+        of the mixture is drawn from the corpora that still have rows,
+        exactly as the weights param documents.
+        """
+        generator = torch.Generator().manual_seed(seed)
+        remaining = list(lengths)
+        next_row = [0] * len(lengths)
+        pairs: list[tuple[int, int]] = []
+        total = sum(lengths)
+        while len(pairs) < total:
+            active = [i for i in range(len(lengths)) if remaining[i] > 0]
+            if len(active) == 1:
+                source = active[0]
+                pairs.extend(
+                    (source, row)
+                    for row in range(next_row[source], lengths[source]))
+                break
+            probabilities = torch.tensor(
+                [weights[i] if remaining[i] > 0 else 0.0
+                 for i in range(len(lengths))],
+                dtype=torch.float64)
+            probabilities = probabilities / probabilities.sum()
+            draws = torch.multinomial(
+                probabilities,
+                min(_DRAW_CHUNK, total - len(pairs)),
+                replacement=True,
+                generator=generator,
+            )
+            for source in draws.tolist():
+                if remaining[source] == 0:
+                    # This source emptied earlier in the chunk; the rest of
+                    # the chunk is stale against the new probabilities.
+                    break
+                pairs.append((source, next_row[source]))
+                next_row[source] += 1
+                remaining[source] -= 1
+        return pairs

--- a/backend/tests/test_data_mix_dataset_node.py
+++ b/backend/tests/test_data_mix_dataset_node.py
@@ -1,0 +1,100 @@
+"""Tests for DataMixDatasetNode (#300)."""
+
+from __future__ import annotations
+
+import pytest
+
+from torch.utils.data import Dataset
+
+from app.nodes.llm.data_mix_dataset_node import DataMixDatasetNode
+
+
+class LocalTextListDataset(Dataset):
+    """Minimal rows-of-strings corpus for the tests."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __len__(self):
+        return len(self._rows)
+
+    def __getitem__(self, idx):
+        return self._rows[idx]
+
+
+def _corpora(*sizes, prefix=("a", "b", "c", "d")):
+    return [
+        LocalTextListDataset([f"{prefix[i]}{row}" for row in range(size)])
+        for i, size in enumerate(sizes)
+    ]
+
+
+def _mix(corpora, params=None):
+    inputs = {f"corpus_{i + 1}": corpus for i, corpus in enumerate(corpora)}
+    return DataMixDatasetNode().execute(
+        inputs, {"sources": len(corpora), **(params or {})})
+
+
+def test_node_metadata_and_dynamic_ports():
+    assert DataMixDatasetNode.NODE_NAME == "DataMixDataset"
+    assert DataMixDatasetNode.CATEGORY == "LLM"
+    assert DataMixDatasetNode.cacheable is False
+    assert [p.name for p in DataMixDatasetNode.define_inputs_dynamic({"sources": 4})] == [
+        "corpus_1", "corpus_2", "corpus_3", "corpus_4"]
+    assert len(DataMixDatasetNode.define_inputs_dynamic({"sources": 99})) == 6
+
+
+def test_concat_is_an_ordered_curriculum():
+    result = _mix(_corpora(3, 2), {"mode": "concat"})
+    assert result["num_rows"] == 5
+    assert [result["dataset"][i] for i in range(5)] == ["a0", "a1", "a2", "b0", "b1"]
+
+
+def test_interleave_is_deterministic_per_seed_and_exhaustive():
+    first = _mix(_corpora(20, 10), {"seed": 7, "weights": "0.5, 0.5"})
+    second = _mix(_corpora(20, 10), {"seed": 7, "weights": "0.5, 0.5"})
+    third = _mix(_corpora(20, 10), {"seed": 8, "weights": "0.5, 0.5"})
+    rows = [first["dataset"][i] for i in range(first["num_rows"])]
+    assert rows == [second["dataset"][i] for i in range(second["num_rows"])]
+    assert rows != [third["dataset"][i] for i in range(third["num_rows"])]
+    # Without replacement: every row appears exactly once.
+    assert sorted(rows) == sorted(f"a{i}" for i in range(20)) + sorted(
+        f"b{i}" for i in range(10)) or len(set(rows)) == 30
+    assert first["num_rows"] == 30
+
+
+def test_interleave_respects_the_weights_roughly():
+    result = _mix(_corpora(8000, 8000), {"weights": "0.8, 0.2", "seed": 3})
+    head = [result["dataset"][i] for i in range(2000)]
+    share_a = sum(1 for row in head if row.startswith("a")) / len(head)
+    assert 0.74 <= share_a <= 0.86
+
+
+def test_rows_within_a_source_keep_their_order():
+    result = _mix(_corpora(50, 50), {"seed": 5})
+    seen_a = [row for row in (result["dataset"][i] for i in range(100))
+              if row.startswith("a")]
+    assert seen_a == [f"a{i}" for i in range(50)]
+
+
+def test_exhausted_source_hands_the_tail_to_the_rest():
+    result = _mix(_corpora(3, 300), {"weights": "0.5, 0.5", "seed": 1})
+    tail = [result["dataset"][i] for i in range(result["num_rows"])][-200:]
+    assert all(row.startswith("b") for row in tail)
+
+
+def test_weight_count_mismatch_and_bad_values_are_refused():
+    with pytest.raises(ValueError, match="one weight per corpus"):
+        _mix(_corpora(2, 2), {"weights": "1"})
+    with pytest.raises(ValueError, match="numbers"):
+        _mix(_corpora(2, 2), {"weights": "a, b"})
+    with pytest.raises(ValueError, match="positive"):
+        _mix(_corpora(2, 2), {"weights": "1, 0"})
+
+
+def test_missing_corpus_and_empty_corpus_are_refused():
+    with pytest.raises(ValueError, match="corpus_2 is not connected"):
+        DataMixDatasetNode().execute(
+            {"corpus_1": LocalTextListDataset(["x"])}, {"sources": 2})
+    with pytest.raises(RuntimeError, match="corpus_2 has no rows"):
+        _mix([LocalTextListDataset(["x"]), LocalTextListDataset([])])

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -880,6 +880,16 @@ const zhTW: NodeTranslations = {
       cache_dir: '存放 token 快取檔的子目錄（留空 = 資料目錄下的共用快取）。',
     },
   },
+  DataMixDataset: {
+    description:
+      '把 2–6 個文字語料混成一個原始文字列的資料集 — 依權重、種子化的交錯（比例抽取、不重複、同種子可重現），或依序串接（corpus_1 全部、再 corpus_2… 的課程式排序）。接 TextCorpusDataset 的輸出進來，結果餵給 LMTokenizedDataset，就能研究資料混合比例與課程順序的影響。混合只記錄（來源, 列號）索引、逐列惰性讀取，不會把語料文字實體化。',
+    params: {
+      sources: '這顆節點有幾個語料輸入埠。',
+      weights: '逗號分隔的抽取權重，每個來源一個（會正規化；只在 interleave 模式使用）。抽完的來源不再被抽，其餘來源重新正規化 — 混合的尾段就是還有剩的語料。',
+      mode: 'interleave：種子化的比例抽取、不重複。concat：corpus_1 全部、再 corpus_2… — 有順序的課程。',
+      seed: '交錯順序的種子 — 相同種子與輸入會重現同一個混合順序。',
+    },
+  },
   PerplexityEvaluate: {
     description:
       '在沒看過的文字上為訓練好的語言模型打分。它會跑完整個資料集，把每一個計分位置的 cross-entropy 平均起來，再回報 $\\mathrm{perplexity} = \\exp(\\text{val\\_loss})$ — 大致可以讀成「模型在每一步大約是在幾個機率相當的 token 之間猶豫」，所以在 50257 個 token 的詞彙表上亂猜就是 50257。這個平均值是「每個 token」的，而且綁定這份資料集與這套 tokenizer，因此只有用同樣方式量出來的數字才能互相比較。',


### PR DESCRIPTION
> 中文摘要：#292 wave 2 的資料混合節點 — 2–6 個動態語料輸入，依權重種子化交錯（不重複、來源耗盡後其餘重新正規化、來源內保序）或 concat 課程式串接；只存（來源, 列號）索引、逐列惰性讀取（新的 MixedTextDataset adapter），混 HF 語料不實體化文字；weights 留空即等權。附 8 個測試（動態埠、決定性、比例、課程序、尾段行為、錯誤訊息）與 zh-TW 條目。

Closes #300. Completes wave 2 of epic #292 (with #302 and #303).

Verification: `pytest tests/test_data_mix_dataset_node.py` + api/cache invariants + corpus/packing suites — 114 passed; ruff / control-bytes / frontend `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7hg6NttgDyNBcf49Na9kj