### PR TITLE
feat(media): video on the canvas - MEDIA_VIDEO kind, /api/media inline route, VideoWrite + VideoLoad (#310)

### DIFF
--- a/backend/app/api/routes_media.py
+++ b/backend/app/api/routes_media.py
@@ -1,0 +1,79 @@
+"""Serve run-produced media inline (#310).
+
+The download routes (``routes_images``, ``routes_models``) force
+``application/octet-stream`` because their job is handing the user a file.
+This route exists for the opposite job: letting the editor PLAY what a run
+produced — a ``<video>`` or ``<img>`` element pointed at ``/api/media/...``
+needs a real ``Content-Type``, and (for mp4 seeking) the Range support
+``FileResponse`` provides.
+
+Read-only by design: files appear here exclusively through nodes writing
+under ``settings.MEDIA_DIR`` (VideoWrite), so there is no upload and no
+delete — the auth model stays "GETs are unauthenticated reads", same as
+every other download route.
+"""
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+
+from ..config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/media", tags=["media"])
+
+#: Extension -> Content-Type. An allowlist rather than ``mimetypes.guess``:
+#: only kinds a browser can render inline belong here, and a file written
+#: with any other suffix stays unreachable through this route.
+_MEDIA_TYPES = {
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".gif": "image/gif",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+}
+
+
+def _safe_path(base_dir: Path, filename: str) -> Path:
+    """Resolve *filename* under *base_dir* and ensure it stays within it."""
+    resolved = (base_dir / filename).resolve()
+    if not resolved.is_relative_to(base_dir.resolve()):
+        raise HTTPException(status_code=400, detail="Invalid filename")
+    return resolved
+
+
+@router.get("")
+async def list_media_files():
+    """List playable files under the media directory (recursive)."""
+    media_dir = settings.MEDIA_DIR
+    media_dir.mkdir(parents=True, exist_ok=True)
+
+    files = []
+    for f in sorted(media_dir.rglob("*")):
+        if f.is_file() and f.suffix.lower() in _MEDIA_TYPES:
+            files.append({
+                "filename": f.relative_to(media_dir).as_posix(),
+                "size": f.stat().st_size,
+            })
+    return files
+
+
+@router.get("/{filename:path}")
+async def serve_media_file(filename: str):
+    """Serve one media file inline, with its real Content-Type."""
+    media_dir = settings.MEDIA_DIR
+    filepath = _safe_path(media_dir, filename)
+
+    if not filepath.exists():
+        raise HTTPException(status_code=404, detail=f"File not found: {filename}")
+    if not filepath.is_file():
+        raise HTTPException(status_code=400, detail="Not a file")
+    media_type = _MEDIA_TYPES.get(filepath.suffix.lower())
+    if media_type is None:
+        raise HTTPException(status_code=400, detail="Not a playable media file")
+
+    return FileResponse(path=filepath, media_type=media_type)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -224,6 +224,11 @@ class Settings(BaseSettings):
     # Uploads for DATA_FILE params (CSVReader et al). Separate from IMAGES_DIR
     # so each kind keeps its own extension whitelist and its own dropdown.
     DATA_FILES_DIR: Path = Path(__file__).parent.parent / "data" / "files"
+    # Run-produced playable media (VideoWrite et al, #310). Separate from
+    # IMAGES_DIR because that directory is an UPLOAD store with a delete
+    # endpoint, while this one is node OUTPUT served inline by /api/media;
+    # keeping them apart means neither route can touch the other's files.
+    MEDIA_DIR: Path = Path(__file__).parent.parent / "data" / "media"
     EXAMPLES_DIR: Path = Path(__file__).parent.parent.parent / "examples"
 
     # ── Project directory (spec 7.1) ───────────────────────────────────
@@ -295,6 +300,10 @@ class Settings(BaseSettings):
             self.IMAGES_DIR = assets / "images"
         if "MODELS_DIR" not in explicit:
             self.MODELS_DIR = assets / "models"
+        if "MEDIA_DIR" not in explicit:
+            # Under assets/ like images/models, so it stays inside
+            # data_paths.data_root() (MODELS_DIR.parent) in project mode too.
+            self.MEDIA_DIR = assets / "media"
         return self
 
     @property

--- a/backend/app/core/node_base.py
+++ b/backend/app/core/node_base.py
@@ -82,6 +82,21 @@ MEDIA_IMAGE = "image"
 # payload keys.
 MEDIA_CHART = "chart"
 
+# ``MEDIA_VIDEO`` contract (#310): the port's value is a small REFERENCE dict,
+# never the bytes. Video cannot ride the event stream the way MEDIA_IMAGE
+# does -- one ``node_status`` event is capped at
+# ``RUN_EVENT_PAYLOAD_CAP_BYTES`` (128 KB), two orders of magnitude under a
+# clip -- so the file lives under ``settings.MEDIA_DIR`` and the event carries
+# where to find it:
+#
+#   {"path": str,     # required: POSIX-style path RELATIVE to MEDIA_DIR
+#    "url": str,      # required: "/api/media/<path>", served with a real
+#                     #   Content-Type so <video>/<img> can play it inline
+#    "format": "mp4" | "gif" | "webm",                # required
+#    "fps": float, "frames": int,                     # optional metadata the
+#    "width": int, "height": int, "bytes": int}       #   client shows as-is
+MEDIA_VIDEO = "video"
+
 
 @dataclass
 class PortDefinition:

--- a/backend/app/core/output_entries.py
+++ b/backend/app/core/output_entries.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Callable
 
 from ..config import settings
@@ -232,11 +232,14 @@ def _video_payload(value: Any) -> dict[str, Any] | None:
     fmt = value.get("format")
     if not isinstance(path, str) or not path or not isinstance(fmt, str):
         return None
-    # Path.is_absolute() alone is platform-shaped: on Windows "/leak/a.mp4"
-    # has no drive and counts as relative. Anything rooted or escaping is
-    # refused on every platform.
-    if (Path(path).is_absolute() or path.startswith(("/", "\\"))
-            or path.startswith("..")):
+    # Judged under BOTH path flavours, because the native Path is
+    # platform-shaped in both directions: on Windows "/leak/a.mp4" has no
+    # drive and counts as relative; on POSIX "C:/leak/a.mp4" is one odd
+    # filename that is_absolute() waves through. A reference must be
+    # relative and descend-only on every platform.
+    posix, windows = PurePosixPath(path), PureWindowsPath(path)
+    if (posix.is_absolute() or windows.is_absolute() or windows.drive
+            or ".." in posix.parts or ".." in windows.parts):
         return None
     return {key: value[key] for key in _VIDEO_REFERENCE_KEYS if key in value}
 

--- a/backend/app/core/output_entries.py
+++ b/backend/app/core/output_entries.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from ..config import settings
-from .node_base import MEDIA_CHART, MEDIA_IMAGE
+from .node_base import MEDIA_CHART, MEDIA_IMAGE, MEDIA_VIDEO
 from .node_registry import registry
 
 logger = logging.getLogger(__name__)
@@ -210,12 +210,44 @@ def _object_payload(value: Any) -> dict[str, Any] | None:
     return value
 
 
+#: Keys of a MEDIA_VIDEO reference the wire forwards. A closed list rather
+#: than passthrough so a node cannot smuggle an oversized payload (or the
+#: bytes themselves) through a port declared as a reference.
+_VIDEO_REFERENCE_KEYS = ("path", "url", "format", "fps", "frames", "width",
+                         "height", "bytes")
+
+
+def _video_payload(value: Any) -> dict[str, Any] | None:
+    """Validate a MEDIA_VIDEO reference dict, or skip it.
+
+    The contract (see node_base) is a pointer to a file under MEDIA_DIR, so
+    the two things worth refusing here are a non-reference value and a path
+    that is not relative — an absolute path in the event stream would leak
+    the server's filesystem layout to every attached client and could never
+    be fetched through ``/api/media`` anyway.
+    """
+    if not isinstance(value, dict):
+        return None
+    path = value.get("path")
+    fmt = value.get("format")
+    if not isinstance(path, str) or not path or not isinstance(fmt, str):
+        return None
+    # Path.is_absolute() alone is platform-shaped: on Windows "/leak/a.mp4"
+    # has no drive and counts as relative. Anything rooted or escaping is
+    # refused on every platform.
+    if (Path(path).is_absolute() or path.startswith(("/", "\\"))
+            or path.startswith("..")):
+        return None
+    return {key: value[key] for key in _VIDEO_REFERENCE_KEYS if key in value}
+
+
 #: Per-kind envelope builders. A kind absent from this map falls back to
 #: :func:`_object_payload`, which is why adding a kind needs no entry here
 #: unless its payload needs a container the node's raw value does not have.
 _MEDIA_PAYLOADS: dict[str, Callable[[Any], dict[str, Any] | None]] = {
     MEDIA_IMAGE: _image_payload,
     MEDIA_CHART: _object_payload,
+    MEDIA_VIDEO: _video_payload,
 }
 
 #: Keys an entry dict already uses for its own bookkeeping. Since an entry

--- a/backend/app/core/video_io.py
+++ b/backend/app/core/video_io.py
@@ -1,0 +1,219 @@
+"""Video encode/decode helpers shared by VideoWrite / VideoLoad (#310).
+
+There is deliberately no Python video library behind this module. torchvision
+removed its video API in 0.26 (pointing at torchcodec), and pulling in PyAV or
+imageio-ffmpeg for one feature is against the house rule that turning a
+feature on should cost an install nothing (the tensorboard precedent). So:
+
+- GIF is the ZERO-DEPENDENCY path, both directions, via Pillow — always
+  available, plays in every ``<img>`` tag.
+- MP4 uses the ``ffmpeg`` BINARY over a rawvideo pipe when one is on PATH —
+  no Python dependency, and the error when it is missing names the gif
+  fallback. ffmpeg is the one binary every machine doing video work already
+  has; we shell out to it rather than vendor a decoder.
+
+Frames move through this module in one canonical shape: ``(T, H, W, 3)``
+uint8, produced by :func:`frames_to_uint8_thwc` from whatever a graph hands
+us — ``(T, C, H, W)`` or ``(T, H, W, C)``, float [0,1] or uint8, gray or RGB.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+#: Read/write timeout for one ffmpeg invocation. Encoding a research-scale
+#: clip (a few hundred small frames) is sub-second; this is a hang guard,
+#: not a budget.
+_FFMPEG_TIMEOUT_S = 120
+
+
+def ffmpeg_path() -> str | None:
+    """Absolute path of the ffmpeg binary, or None when not installed."""
+    return shutil.which("ffmpeg")
+
+
+def ffprobe_path() -> str | None:
+    return shutil.which("ffprobe")
+
+
+def frames_to_uint8_thwc(frames: Any) -> Any:
+    """Normalize a frames tensor to ``(T, H, W, 3)`` uint8.
+
+    Accepts ``(T, C, H, W)`` or ``(T, H, W, C)`` with C in {1, 3}, float
+    (clamped to [0,1]) or uint8. Layout is decided by which axis holds a
+    channel count; when BOTH axis 1 and axis 3 could be channels (e.g.
+    ``(T, 3, H, 3)``) the torch-conventional ``(T, C, H, W)`` wins.
+    """
+    import torch
+
+    if not isinstance(frames, torch.Tensor):
+        raise TypeError(f"frames must be a tensor, got {type(frames).__name__}")
+    if frames.dim() != 4:
+        raise ValueError(
+            f"frames must be 4D (T, C, H, W) or (T, H, W, C), got shape "
+            f"{tuple(frames.shape)}")
+    t = frames.detach().cpu()
+    if t.shape[1] in (1, 3):
+        t = t.permute(0, 2, 3, 1)  # (T, C, H, W) -> (T, H, W, C)
+    elif t.shape[3] not in (1, 3):
+        raise ValueError(
+            f"neither axis 1 nor axis 3 is a channel count in shape "
+            f"{tuple(frames.shape)}")
+    if t.shape[3] == 1:
+        t = t.expand(-1, -1, -1, 3)
+    if t.dtype != torch.uint8:
+        t = (t.float().clamp(0.0, 1.0) * 255.0).round().to(torch.uint8)
+    return t.contiguous()
+
+
+def write_gif(frames_thwc: Any, path: Path, fps: float) -> None:
+    from PIL import Image
+
+    duration_ms = max(20, round(1000.0 / max(0.1, fps)))
+    images = [Image.fromarray(frame.numpy()) for frame in frames_thwc]
+    images[0].save(
+        path, save_all=True, append_images=images[1:],
+        duration=duration_ms, loop=0)
+
+
+def write_mp4(frames_thwc: Any, path: Path, fps: float) -> None:
+    """Encode via ffmpeg's rawvideo stdin pipe (h264, yuv420p, faststart)."""
+    ffmpeg = ffmpeg_path()
+    if ffmpeg is None:
+        raise RuntimeError(
+            "MP4 output needs the ffmpeg binary on PATH and none was found. "
+            "Install ffmpeg, or set format=gif — the gif path has no "
+            "external dependency.")
+    # yuv420p subsamples chroma 2x2, so h264 refuses odd dimensions; a 1px
+    # crop is invisible at these sizes and keeps the caller's frames intact.
+    height = frames_thwc.shape[1] - (frames_thwc.shape[1] % 2)
+    width = frames_thwc.shape[2] - (frames_thwc.shape[2] % 2)
+    frames = frames_thwc[:, :height, :width, :]
+    cmd = [
+        ffmpeg, "-y", "-loglevel", "error",
+        "-f", "rawvideo", "-pix_fmt", "rgb24",
+        "-s", f"{width}x{height}", "-r", f"{fps}",
+        "-i", "-",
+        "-c:v", "libx264", "-pix_fmt", "yuv420p",
+        "-movflags", "+faststart",
+        str(path),
+    ]
+    proc = subprocess.run(
+        cmd, input=frames.numpy().tobytes(),
+        capture_output=True, timeout=_FFMPEG_TIMEOUT_S)
+    if proc.returncode != 0:
+        tail = proc.stderr.decode("utf-8", "replace").strip()[-500:]
+        raise RuntimeError(f"ffmpeg failed (exit {proc.returncode}): {tail}")
+
+
+def read_gif(path: Path, max_frames: int = 0, stride: int = 1) -> tuple[Any, float]:
+    """Decode a GIF -> ``((T, 3, H, W) float [0,1], fps)`` via Pillow."""
+    import numpy as np
+    import torch
+    from PIL import Image, ImageSequence
+
+    stride = max(1, stride)
+    frames: list[Any] = []
+    durations: list[int] = []
+    with Image.open(path) as image:
+        for index, frame in enumerate(ImageSequence.Iterator(image)):
+            durations.append(int(frame.info.get("duration", 0)) or 100)
+            if index % stride != 0:
+                continue
+            frames.append(np.asarray(frame.convert("RGB")))
+            if max_frames and len(frames) >= max_frames:
+                break
+    if not frames:
+        raise ValueError(f"no frames decoded from {path.name}")
+    stacked = torch.from_numpy(np.stack(frames))  # (T, H, W, 3) uint8
+    fps = 1000.0 / (sum(durations) / len(durations))
+    # Same convention as read_video_ffmpeg: fps describes the RETURNED
+    # sequence, so striding scales it down and playback duration holds.
+    return stacked.permute(0, 3, 1, 2).float() / 255.0, fps / stride
+
+
+def _probe(path: Path) -> tuple[int, int, float]:
+    """(width, height, fps) of the first video stream, via ffprobe."""
+    import json
+
+    ffprobe = ffprobe_path()
+    if ffprobe is None:
+        raise RuntimeError(
+            "Reading this container needs the ffprobe binary on PATH "
+            "(ships with ffmpeg) and none was found. Install ffmpeg, or "
+            "use gif files — the gif path has no external dependency.")
+    cmd = [
+        ffprobe, "-v", "error", "-select_streams", "v:0",
+        "-show_entries", "stream=width,height,r_frame_rate",
+        "-of", "json", str(path),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, timeout=_FFMPEG_TIMEOUT_S)
+    if proc.returncode != 0:
+        tail = proc.stderr.decode("utf-8", "replace").strip()[-300:]
+        raise RuntimeError(f"ffprobe failed on {path.name}: {tail}")
+    streams = json.loads(proc.stdout.decode("utf-8", "replace")).get("streams") or []
+    if not streams:
+        raise ValueError(f"{path.name} has no video stream")
+    stream = streams[0]
+    width, height = int(stream["width"]), int(stream["height"])
+    try:
+        fps = float(Fraction(stream.get("r_frame_rate", "10/1")))
+    except (ValueError, ZeroDivisionError):
+        fps = 10.0
+    return width, height, fps
+
+
+def read_video_ffmpeg(
+    path: Path, max_frames: int = 0, stride: int = 1,
+) -> tuple[Any, float]:
+    """Decode mp4/webm -> ``((T, 3, H, W) float [0,1], fps)`` via ffmpeg.
+
+    Streams rawvideo from ffmpeg's stdout frame by frame and stops as soon
+    as ``max_frames`` are kept, so a long video with a cap never buffers
+    whole; without a cap the full clip is materialized in memory — that is
+    the caller's stated intent.
+    """
+    import numpy as np
+    import torch
+
+    width, height, fps = _probe(path)
+    ffmpeg = ffmpeg_path()
+    if ffmpeg is None:  # ffprobe found but ffmpeg missing: broken install
+        raise RuntimeError("ffprobe is on PATH but ffmpeg is not")
+    stride = max(1, stride)
+    cmd = [
+        ffmpeg, "-loglevel", "error", "-i", str(path),
+        "-f", "rawvideo", "-pix_fmt", "rgb24", "-",
+    ]
+    frame_bytes = width * height * 3
+    kept: list[Any] = []
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        index = 0
+        while True:
+            chunk = proc.stdout.read(frame_bytes)
+            if len(chunk) < frame_bytes:
+                break
+            if index % stride == 0:
+                kept.append(np.frombuffer(chunk, dtype=np.uint8).reshape(
+                    height, width, 3).copy())
+                if max_frames and len(kept) >= max_frames:
+                    proc.terminate()
+                    break
+            index += 1
+    finally:
+        proc.stdout.close()
+        stderr = proc.stderr.read()
+        proc.stderr.close()
+        returncode = proc.wait(timeout=_FFMPEG_TIMEOUT_S)
+    if not kept:
+        tail = stderr.decode("utf-8", "replace").strip()[-300:]
+        raise ValueError(
+            f"no frames decoded from {path.name}"
+            + (f" (ffmpeg exit {returncode}: {tail})" if returncode else ""))
+    stacked = torch.from_numpy(np.stack(kept))
+    return stacked.permute(0, 3, 1, 2).float() / 255.0, fps / stride

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,7 @@ from .api import (
     routes_images,
     routes_keys,
     routes_llm,
+    routes_media,
     routes_models,
     routes_nodes,
     routes_plugin_frontend,
@@ -521,6 +522,7 @@ app.include_router(routes_plugins.router)
 app.include_router(routes_plugin_frontend.router)
 app.include_router(routes_models.router)
 app.include_router(routes_images.router)
+app.include_router(routes_media.router)
 app.include_router(routes_data_files.router)
 app.include_router(routes_execution_outputs.router)
 app.include_router(routes_execution_state.router)

--- a/backend/app/nodes/io/video_load_node.py
+++ b/backend/app/nodes/io/video_load_node.py
@@ -1,0 +1,128 @@
+"""VideoLoadNode — decode a video file into a frames tensor (#310).
+
+The ingestion half of video support: rollout clips written by VideoWrite,
+demonstration recordings, any mp4/webm/gif on disk become ``(T, 3, H, W)``
+float [0,1] for whatever the graph does next (dataset building, frame
+analysis, re-encoding a subsample). GIF decodes through Pillow with no
+dependency; mp4/webm shell out to the ffmpeg binary (see core.video_io for
+why there is no Python video library here).
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+logger = logging.getLogger(__name__)
+
+
+class VideoLoadNode(BaseNode):
+    NODE_NAME = "VideoLoad"
+    CATEGORY = "IO"
+    DESCRIPTION = (
+        "Decode a video file (mp4/webm via the ffmpeg binary, gif via "
+        "Pillow) into a frames tensor (T,3,H,W) float [0,1], with fps and "
+        "frame count. Relative paths resolve under the media directory, "
+        "where VideoWrite puts its clips."
+    )
+
+    # The output mirrors a file that can change or vanish between runs, and
+    # nothing fingerprints its content -- a cache hit could describe a video
+    # that is no longer on disk (the ImageWriter/#143 shape of the rule,
+    # from the reading side).
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="path",
+                data_type=DataType.STRING,
+                description="Video file path (overrides the path param when wired)",
+                optional=True,
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="frames",
+                data_type=DataType.TENSOR,
+                description="Decoded frames (T, 3, H, W), float [0,1]",
+            ),
+            PortDefinition(
+                name="fps",
+                data_type=DataType.SCALAR,
+                description="Frames per second after stride",
+            ),
+            PortDefinition(
+                name="num_frames",
+                data_type=DataType.SCALAR,
+                description="Number of decoded frames",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="path",
+                param_type=ParamType.STRING,
+                default="clip.mp4",
+                description=(
+                    "Video file: absolute, or relative to the media "
+                    "directory (VideoWrite's output lands there)"
+                ),
+            ),
+            ParamDefinition(
+                name="max_frames",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description=(
+                    "Stop after this many decoded frames (0 = all). An "
+                    "uncapped long video is materialized whole in memory."
+                ),
+            ),
+            ParamDefinition(
+                name="stride",
+                param_type=ParamType.INT,
+                default=1,
+                min_value=1,
+                description="Keep every Nth frame (fps output scales down to match)",
+            ),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        from ...config import settings
+        from ...core.video_io import read_gif, read_video_ffmpeg
+
+        raw = inputs.get("path") or params.get("path", "")
+        if not raw or not str(raw).strip():
+            raise ValueError("VideoLoad: no path given")
+        path = Path(str(raw))
+        if not path.is_absolute():
+            path = settings.MEDIA_DIR / path
+        if not path.exists():
+            raise FileNotFoundError(f"VideoLoad: file not found: {path}")
+
+        max_frames = max(0, int(params.get("max_frames", 0) or 0))
+        stride = max(1, int(params.get("stride", 1) or 1))
+
+        if path.suffix.lower() == ".gif":
+            frames, fps = read_gif(path, max_frames=max_frames, stride=stride)
+        else:
+            frames, fps = read_video_ffmpeg(path, max_frames=max_frames, stride=stride)
+
+        logger.info("Decoded %s: %d frames at %.2f fps", path, frames.shape[0], fps)
+        return {
+            "frames": frames,
+            "fps": float(fps),
+            "num_frames": int(frames.shape[0]),
+            "__log__": (
+                f"Decoded {path.name}: {frames.shape[0]} frames "
+                f"({frames.shape[3]}x{frames.shape[2]}) at {fps:.2f} fps."
+            ),
+        }

--- a/backend/app/nodes/io/video_write_node.py
+++ b/backend/app/nodes/io/video_write_node.py
@@ -1,0 +1,213 @@
+"""VideoWriteNode — turn a frames tensor into a playable clip (#310).
+
+The canvas's first video producer: rollout recordings, diffusion sampling
+chains, augmentation previews — anything shaped ``(T, C, H, W)`` or
+``(T, H, W, C)`` becomes an mp4 (ffmpeg binary on PATH) or a gif (Pillow,
+zero dependencies), written under ``settings.MEDIA_DIR`` and served inline
+by ``/api/media``. The ``video`` output is a small REFERENCE dict — the
+event stream's 128 KB cap is two orders of magnitude under a clip, so the
+bytes never ride the wire (see MEDIA_VIDEO in node_base).
+"""
+
+import logging
+from typing import Any
+
+from ...core.node_base import (
+    BaseNode,
+    DataType,
+    MEDIA_IMAGE,
+    MEDIA_VIDEO,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Longest side of the base64 PNG preview frame. The preview rides the
+#: event stream, so it must stay far under the 128 KB payload cap even
+#: when sharing the budget with the video entry and a tensor summary.
+_PREVIEW_MAX_SIDE = 256
+
+
+class VideoWriteNode(BaseNode):
+    NODE_NAME = "VideoWrite"
+    CATEGORY = "IO"
+    DESCRIPTION = (
+        "Encode a frames tensor (T,C,H,W) or (T,H,W,C) into a playable "
+        "video under the media directory - mp4 via the ffmpeg binary when "
+        "one is on PATH, gif via Pillow with no dependency at all - and "
+        "emit a reference the editor plays inline."
+    )
+
+    # The write to disk IS this node's output (the ImageWriter rule, #143):
+    # a cache hit would hand back a reference whose file may no longer
+    # exist, so the file must be (re)written every run.
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="frames",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Video frames: (T,C,H,W) or (T,H,W,C), float [0,1] or "
+                    "uint8, gray or RGB"
+                ),
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="video",
+                data_type=DataType.ANY,
+                description="Playable-clip reference (path, url, format, fps, frames)",
+                media=MEDIA_VIDEO,
+            ),
+            PortDefinition(
+                name="path",
+                data_type=DataType.STRING,
+                description="Absolute path of the written file",
+            ),
+            PortDefinition(
+                name="preview",
+                data_type=DataType.STRING,
+                description="Middle frame as a PNG, so the clip has a face "
+                            "even where video is not rendered yet",
+                media=MEDIA_IMAGE,
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="filename",
+                param_type=ParamType.STRING,
+                default="clip",
+                description=(
+                    "Name under the media directory (subfolders allowed); "
+                    "the extension follows the chosen format. Same name "
+                    "overwrites - vary it per run to keep several clips."
+                ),
+            ),
+            ParamDefinition(
+                name="format",
+                param_type=ParamType.SELECT,
+                default="auto",
+                options=["auto", "mp4", "gif"],
+                description=(
+                    "auto: mp4 when an ffmpeg binary is on PATH, else gif. "
+                    "gif always works (Pillow); mp4 needs ffmpeg installed."
+                ),
+            ),
+            ParamDefinition(
+                name="fps",
+                param_type=ParamType.FLOAT,
+                default=10.0,
+                min_value=0.5,
+                max_value=60.0,
+                description="Playback frames per second",
+            ),
+            ParamDefinition(
+                name="resize",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description=(
+                    "Output height in pixels, aspect kept, nearest-neighbor "
+                    "(0 = native). Small research renders (96px) are easier "
+                    "to watch at 2-3x."
+                ),
+            ),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        import base64
+        import io
+
+        import torch
+        from PIL import Image
+
+        from ...config import settings
+        from ...core.data_paths import resolve_data_path
+        from ...core.video_io import ffmpeg_path, frames_to_uint8_thwc, write_gif, write_mp4
+
+        frames = frames_to_uint8_thwc(inputs["frames"])
+        if frames.shape[0] == 0:
+            raise ValueError("VideoWrite: frames tensor has zero frames")
+
+        fps = float(params.get("fps", 10.0) or 10.0)
+        resize = max(0, int(params.get("resize", 0) or 0))
+        if resize and resize != frames.shape[1]:
+            scale = resize / frames.shape[1]
+            width = max(2, round(frames.shape[2] * scale))
+            resized = torch.nn.functional.interpolate(
+                frames.permute(0, 3, 1, 2).float(),
+                size=(resize, width), mode="nearest")
+            frames = resized.round().to(torch.uint8).permute(0, 2, 3, 1).contiguous()
+
+        fmt = str(params.get("format", "auto") or "auto")
+        if fmt == "auto":
+            fmt = "mp4" if ffmpeg_path() else "gif"
+        if fmt == "mp4":
+            # write_mp4 crops odd dimensions for yuv420p; do it HERE so the
+            # reference dict below describes the file actually written.
+            height = frames.shape[1] - (frames.shape[1] % 2)
+            width = frames.shape[2] - (frames.shape[2] % 2)
+            frames = frames[:, :height, :width, :]
+
+        media_dir = settings.MEDIA_DIR.resolve()
+        media_dir.mkdir(parents=True, exist_ok=True)
+        filename = str(params.get("filename", "clip") or "clip")
+        p = resolve_data_path(filename, base=media_dir)
+        expected_ext = "." + fmt
+        if p.suffix.lower() != expected_ext:
+            # The path written must be the path checked (the ImageWriter
+            # extension-rewrite rule): re-validate after forcing the suffix.
+            p = resolve_data_path(p.with_suffix(expected_ext), base=media_dir)
+        # resolve_data_path guarantees the data ROOT; the /api/media URL
+        # contract additionally needs the file under MEDIA_DIR itself.
+        if not p.is_relative_to(media_dir):
+            raise ValueError(
+                "VideoWrite: filename must stay under the media directory "
+                f"({media_dir}), got {p}")
+        p.parent.mkdir(parents=True, exist_ok=True)
+
+        if fmt == "gif":
+            write_gif(frames, p, fps)
+        else:
+            write_mp4(frames, p, fps)
+
+        preview = frames[frames.shape[0] // 2]
+        image = Image.fromarray(preview.numpy())
+        if max(image.size) > _PREVIEW_MAX_SIDE:
+            image.thumbnail((_PREVIEW_MAX_SIDE, _PREVIEW_MAX_SIDE))
+        buf = io.BytesIO()
+        image.save(buf, format="PNG")
+
+        relative = p.relative_to(media_dir).as_posix()
+        size = p.stat().st_size
+        reference = {
+            "path": relative,
+            "url": f"/api/media/{relative}",
+            "format": fmt,
+            "fps": fps,
+            "frames": int(frames.shape[0]),
+            "width": int(frames.shape[2]),
+            "height": int(frames.shape[1]),
+            "bytes": size,
+        }
+        logger.info("Wrote %s (%d frames, %d bytes)", p, frames.shape[0], size)
+        return {
+            "video": reference,
+            "path": str(p),
+            "preview": base64.b64encode(buf.getvalue()).decode("ascii"),
+            "__log__": (
+                f"Wrote {relative} ({fmt}, {frames.shape[0]} frames at "
+                f"{fps:g} fps, {size:,} bytes)."
+            ),
+        }

--- a/backend/tests/test_api_media.py
+++ b/backend/tests/test_api_media.py
@@ -1,0 +1,74 @@
+"""The /api/media route: inline playback semantics (#310).
+
+What distinguishes this route from the download routes is the Content-Type —
+a browser will only PLAY a clip served with its real mime, so that header is
+the contract under test, alongside the same traversal guard every file route
+carries.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def media_dir(tmp_path, monkeypatch):
+    d = tmp_path / "media"
+    d.mkdir()
+    monkeypatch.setattr("app.config.settings.MEDIA_DIR", d)
+    return d
+
+
+@pytest.mark.asyncio
+async def test_serves_gif_inline_with_real_mime(test_client, media_dir):
+    payload = b"GIF89a-not-really-but-served-verbatim"
+    (media_dir / "clip.gif").write_bytes(payload)
+
+    resp = await test_client.get("/api/media/clip.gif")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/gif"
+    assert resp.content == payload
+    # inline playback, not a download
+    assert "attachment" not in resp.headers.get("content-disposition", "")
+
+
+@pytest.mark.asyncio
+async def test_serves_mp4_from_a_subfolder(test_client, media_dir):
+    sub = media_dir / "rollouts"
+    sub.mkdir()
+    (sub / "run1.mp4").write_bytes(b"\x00\x00\x00 ftypisom")
+
+    resp = await test_client.get("/api/media/rollouts/run1.mp4")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "video/mp4"
+
+
+@pytest.mark.asyncio
+async def test_missing_file_is_404(test_client, media_dir):
+    resp = await test_client.get("/api/media/absent.mp4")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_is_refused(test_client, media_dir):
+    resp = await test_client.get("/api/media/..%2Fsecret.mp4")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_unplayable_extension_is_refused(test_client, media_dir):
+    (media_dir / "notes.txt").write_bytes(b"text")
+    resp = await test_client.get("/api/media/notes.txt")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_list_walks_subfolders_with_posix_names(test_client, media_dir):
+    (media_dir / "a.gif").write_bytes(b"x")
+    sub = media_dir / "deep"
+    sub.mkdir()
+    (sub / "b.mp4").write_bytes(b"y")
+    (media_dir / "ignored.txt").write_bytes(b"z")
+
+    resp = await test_client.get("/api/media")
+    assert resp.status_code == 200
+    names = {item["filename"] for item in resp.json()}
+    assert names == {"a.gif", "deep/b.mp4"}

--- a/backend/tests/test_video_nodes.py
+++ b/backend/tests/test_video_nodes.py
@@ -1,0 +1,235 @@
+"""VideoWrite / VideoLoad and the MEDIA_VIDEO wire contract (#310).
+
+The gif tests are the zero-dependency path and always run; mp4 tests skip
+cleanly on machines without an ffmpeg binary — CI must stay green either way.
+"""
+
+import base64
+import io
+
+import pytest
+import torch
+from PIL import Image
+
+from app.core.output_entries import build_node_output_entries
+from app.core.video_io import ffmpeg_path, frames_to_uint8_thwc
+from app.nodes.io.video_load_node import VideoLoadNode
+from app.nodes.io.video_write_node import VideoWriteNode
+
+needs_ffmpeg = pytest.mark.skipif(
+    ffmpeg_path() is None, reason="no ffmpeg binary on PATH")
+
+
+@pytest.fixture
+def media_dirs(tmp_path, monkeypatch):
+    """Point MEDIA_DIR (and the data root around it) at a temp tree."""
+    data = tmp_path / "data"
+    models = data / "models"
+    media = data / "media"
+    models.mkdir(parents=True)
+    media.mkdir(parents=True)
+    monkeypatch.setattr("app.config.settings.MODELS_DIR", models)
+    monkeypatch.setattr("app.config.settings.MEDIA_DIR", media)
+    monkeypatch.setattr("app.config.settings.DB_PATH", data / "codefyui.db")
+    return media
+
+
+def _frames(t=6, h=32, w=48) -> torch.Tensor:
+    """(T, 3, H, W) float ramp — distinct per frame so striding is testable."""
+    base = torch.linspace(0.0, 1.0, t).view(t, 1, 1, 1)
+    return base.expand(t, 3, h, w).clone()
+
+
+# ── frames_to_uint8_thwc ────────────────────────────────────────────────
+
+
+def test_layout_tchw_becomes_thwc_uint8():
+    out = frames_to_uint8_thwc(_frames())
+    assert out.shape == (6, 32, 48, 3)
+    assert out.dtype == torch.uint8
+    assert out[0].float().mean() == 0.0
+    assert out[-1].float().mean() == 255.0
+
+
+def test_layout_thwc_uint8_passes_through():
+    raw = torch.randint(0, 256, (4, 20, 30, 3), dtype=torch.uint8)
+    out = frames_to_uint8_thwc(raw)
+    assert out.shape == (4, 20, 30, 3)
+    assert torch.equal(out, raw)
+
+
+def test_grayscale_channel_expands_to_rgb():
+    out = frames_to_uint8_thwc(torch.rand(3, 1, 16, 16))
+    assert out.shape == (3, 16, 16, 3)
+    assert torch.equal(out[..., 0], out[..., 1])
+
+
+def test_non_4d_frames_are_refused():
+    with pytest.raises(ValueError, match="4D"):
+        frames_to_uint8_thwc(torch.rand(3, 16, 16))
+
+
+# ── VideoWrite (gif path — no dependency) ───────────────────────────────
+
+
+def test_video_write_gif_writes_file_and_reference(media_dirs):
+    node = VideoWriteNode()
+    result = node.execute(
+        {"frames": _frames()},
+        {"filename": "clips/test", "format": "gif", "fps": 5.0, "resize": 0},
+    )
+    ref = result["video"]
+    assert ref["format"] == "gif"
+    assert ref["path"] == "clips/test.gif"
+    assert ref["url"] == "/api/media/clips/test.gif"
+    assert ref["frames"] == 6
+    assert ref["width"] == 48 and ref["height"] == 32
+    assert (media_dirs / "clips" / "test.gif").exists()
+    assert ref["bytes"] == (media_dirs / "clips" / "test.gif").stat().st_size
+    # the preview is a decodable PNG of the middle frame
+    png = base64.b64decode(result["preview"])
+    assert Image.open(io.BytesIO(png)).size == (48, 32)
+
+
+def test_video_write_resize_scales_height_keeping_aspect(media_dirs):
+    node = VideoWriteNode()
+    result = node.execute(
+        {"frames": _frames(h=32, w=48)},
+        {"filename": "small", "format": "gif", "fps": 5.0, "resize": 64},
+    )
+    assert result["video"]["height"] == 64
+    assert result["video"]["width"] == 96
+
+
+def test_video_write_refuses_escaping_media_dir(media_dirs):
+    node = VideoWriteNode()
+    with pytest.raises(ValueError, match="media directory"):
+        node.execute(
+            {"frames": _frames()},
+            {"filename": "../escape", "format": "gif", "fps": 5.0},
+        )
+
+
+def test_video_write_refuses_empty_frames(media_dirs):
+    with pytest.raises(ValueError, match="zero frames"):
+        VideoWriteNode().execute(
+            {"frames": torch.zeros(0, 3, 8, 8)},
+            {"filename": "empty", "format": "gif", "fps": 5.0},
+        )
+
+
+# ── VideoLoad (gif path) ────────────────────────────────────────────────
+
+
+def test_gif_roundtrip_preserves_count_shape_and_fps(media_dirs):
+    VideoWriteNode().execute(
+        {"frames": _frames()},
+        {"filename": "loop", "format": "gif", "fps": 10.0},
+    )
+    result = VideoLoadNode().execute({}, {"path": "loop.gif", "max_frames": 0, "stride": 1})
+    frames = result["frames"]
+    assert frames.shape == (6, 3, 32, 48)
+    assert frames.dtype == torch.float32
+    assert 0.0 <= frames.min() and frames.max() <= 1.0
+    assert result["num_frames"] == 6
+    assert result["fps"] == pytest.approx(10.0, rel=0.05)
+
+
+def test_video_load_stride_and_max_frames(media_dirs):
+    VideoWriteNode().execute(
+        {"frames": _frames(t=8)},
+        {"filename": "strided", "format": "gif", "fps": 10.0},
+    )
+    result = VideoLoadNode().execute(
+        {}, {"path": "strided.gif", "max_frames": 3, "stride": 2})
+    assert result["num_frames"] == 3
+    assert result["fps"] == pytest.approx(5.0, rel=0.05)
+
+
+def test_video_load_input_port_overrides_param(media_dirs):
+    write = VideoWriteNode().execute(
+        {"frames": _frames()},
+        {"filename": "wired", "format": "gif", "fps": 5.0},
+    )
+    result = VideoLoadNode().execute(
+        {"path": write["path"]}, {"path": "does-not-exist.gif"})
+    assert result["num_frames"] == 6
+
+
+def test_video_load_missing_file_is_a_clear_error(media_dirs):
+    with pytest.raises(FileNotFoundError, match="not found"):
+        VideoLoadNode().execute({}, {"path": "nope.gif"})
+
+
+# ── mp4 path (needs the ffmpeg binary) ──────────────────────────────────
+
+
+@needs_ffmpeg
+def test_mp4_roundtrip(media_dirs):
+    write = VideoWriteNode().execute(
+        {"frames": _frames(t=10, h=32, w=48)},
+        {"filename": "clip", "format": "mp4", "fps": 10.0},
+    )
+    assert write["video"]["format"] == "mp4"
+    assert (media_dirs / "clip.mp4").exists()
+    result = VideoLoadNode().execute({}, {"path": "clip.mp4"})
+    assert result["num_frames"] == 10
+    assert result["frames"].shape == (10, 3, 32, 48)
+    assert result["fps"] == pytest.approx(10.0, rel=0.05)
+
+
+@needs_ffmpeg
+def test_mp4_odd_dimensions_are_cropped_even(media_dirs):
+    write = VideoWriteNode().execute(
+        {"frames": _frames(t=4, h=33, w=49)},
+        {"filename": "odd", "format": "mp4", "fps": 5.0},
+    )
+    assert write["video"]["height"] == 32
+    assert write["video"]["width"] == 48
+
+
+def test_format_auto_picks_a_working_encoder(media_dirs):
+    result = VideoWriteNode().execute(
+        {"frames": _frames()},
+        {"filename": "auto", "format": "auto", "fps": 5.0},
+    )
+    expected = "mp4" if ffmpeg_path() else "gif"
+    assert result["video"]["format"] == expected
+
+
+# ── MEDIA_VIDEO wire contract ───────────────────────────────────────────
+
+
+def _entries_for(result):
+    return build_node_output_entries(
+        "completed", result, {"video": ["video"], "image": ["preview"]})
+
+
+def test_video_entry_reaches_the_wire(media_dirs):
+    result = VideoWriteNode().execute(
+        {"frames": _frames()},
+        {"filename": "wire", "format": "gif", "fps": 5.0},
+    )
+    entries = _entries_for(result)
+    video = [e for e in entries if e["output_kind"] == "video"]
+    assert len(video) == 1
+    assert video[0]["port"] == "video"
+    assert video[0]["video"]["url"] == "/api/media/wire.gif"
+    image = [e for e in entries if e["output_kind"] == "image"]
+    assert len(image) == 1 and image[0]["port"] == "preview"
+
+
+def test_video_payload_refuses_absolute_paths_and_junk():
+    from app.core.output_entries import _video_payload
+
+    assert _video_payload("not a dict") is None
+    assert _video_payload({"format": "mp4"}) is None  # no path
+    assert _video_payload({"path": "a.mp4"}) is None  # no format
+    assert _video_payload({"path": "C:/leak/a.mp4", "format": "mp4"}) is None
+    assert _video_payload({"path": "/leak/a.mp4", "format": "mp4"}) is None
+    assert _video_payload({"path": "../up.mp4", "format": "mp4"}) is None
+    kept = _video_payload(
+        {"path": "ok.mp4", "format": "mp4", "url": "/api/media/ok.mp4",
+         "junk": "dropped", "fps": 10.0})
+    assert kept == {"path": "ok.mp4", "format": "mp4",
+                    "url": "/api/media/ok.mp4", "fps": 10.0}

--- a/backend/tests/test_video_nodes.py
+++ b/backend/tests/test_video_nodes.py
@@ -225,9 +225,13 @@ def test_video_payload_refuses_absolute_paths_and_junk():
     assert _video_payload("not a dict") is None
     assert _video_payload({"format": "mp4"}) is None  # no path
     assert _video_payload({"path": "a.mp4"}) is None  # no format
+    # rooted/escaping paths refused on EVERY platform, both path flavours
     assert _video_payload({"path": "C:/leak/a.mp4", "format": "mp4"}) is None
+    assert _video_payload({"path": "C:leak.mp4", "format": "mp4"}) is None
     assert _video_payload({"path": "/leak/a.mp4", "format": "mp4"}) is None
+    assert _video_payload({"path": "\\\\srv\\share\\a.mp4", "format": "mp4"}) is None
     assert _video_payload({"path": "../up.mp4", "format": "mp4"}) is None
+    assert _video_payload({"path": "a/../../up.mp4", "format": "mp4"}) is None
     kept = _video_payload(
         {"path": "ok.mp4", "format": "mp4", "url": "/api/media/ok.mp4",
          "junk": "dropped", "fps": 10.0})

--- a/docs/docs/advanced/custom-nodes.md
+++ b/docs/docs/advanced/custom-nodes.md
@@ -102,9 +102,22 @@ def execute(self, inputs, params, progress_callback=None, *, context=None):
 
 Every number in a spec must be a finite, plain Python `float` or `int`: run events are serialised with `allow_nan=False`, and a `numpy.float32` is not JSON-serialisable at all. Keep specs small — a `node_status` payload over 128 KB is replaced by an elision marker. The full per-kind payload reference lives in the [stats pack's README](https://github.com/CodefyUI/CodefyUI/blob/main/plugins/stats/README.md), which is the reference implementation.
 
+## Emitting a playable video
+
+`media=MEDIA_VIDEO` is the third built-in kind, and it works by **reference**: a clip cannot ride the event stream (one `node_status` event is capped at 128 KB), so the file lives under `settings.MEDIA_DIR` and the port's value is a small dict pointing at it. `/api/media/<path>` serves the file inline with a real `Content-Type`, so the editor's `<video>`/`<img>` elements play it directly:
+
+```python
+{"path": "rollouts/run1.mp4",          # POSIX-style, RELATIVE to MEDIA_DIR
+ "url": "/api/media/rollouts/run1.mp4",
+ "format": "mp4",                       # mp4 | gif | webm
+ "fps": 10.0, "frames": 240, "width": 96, "height": 96, "bytes": 81234}
+```
+
+Don't hand-build these — write frames through the `VideoWrite` node (or call `core.video_io` from your node), which owns the encoding (mp4 via an `ffmpeg` binary on PATH, gif via Pillow with no dependency at all), the path containment, and the reference shape. An absolute `path` is refused at the wire.
+
 ### Your own media kind
 
-Neither kind is special-cased. The resolver keys on whatever string a port declares, and any port value that is a non-empty dict is shipped through untouched, so a pack declaring `media="waveform"` already arrives in the browser as `{"output_kind": "waveform", ...}`. Only *rendering* it needs a frontend change; an editor that does not know a kind ignores it rather than breaking.
+No kind is special-cased. The resolver keys on whatever string a port declares, and any port value that is a non-empty dict is shipped through untouched, so a pack declaring `media="waveform"` already arrives in the browser as `{"output_kind": "waveform", ...}`. Only *rendering* it needs a frontend change; an editor that does not know a kind ignores it rather than breaking.
 
 :::tip
 Need to package existing nodes rather than write new behavior? Use a **[preset](./presets)**. Want to share nodes with others as an installable bundle? Build a **[plugin pack](./plugins)**.

--- a/frontend/src/components/ResultsPanel/ResultsPanel.module.css
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.module.css
@@ -222,6 +222,17 @@
   margin-bottom: var(--sp-1);
 }
 
+/* Log video output (#310) — taller than .logImage because a clip carries
+   playback controls, and 160px leaves them unusable. */
+.logVideo {
+  max-width: 100%;
+  max-height: 240px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-base);
+  margin-top: var(--sp-1);
+  margin-bottom: var(--sp-1);
+}
+
 /* Chart output entry (#130). The card brings its own frame, so this only has
    to keep it from stretching the log row. */
 .logChart {

--- a/frontend/src/components/ResultsPanel/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel/ResultsPanel.tsx
@@ -402,6 +402,25 @@ export function ResultsPanel() {
                     )}
                     {entry.kind === 'chart' && entry.chart?.kind ? (
                       <ChartView chart={entry.chart} className={styles.logChart} />
+                    ) : entry.kind === 'video' && entry.video?.url ? (
+                      // #310: same-origin reference served by /api/media with
+                      // a real Content-Type. A gif is an animated image, not
+                      // a <video> source — browsers refuse it there.
+                      entry.video.format === 'gif' ? (
+                        <img
+                          src={entry.video.url}
+                          alt="output clip"
+                          className={styles.logVideo}
+                        />
+                      ) : (
+                        <video
+                          src={entry.video.url}
+                          controls
+                          loop
+                          preload="metadata"
+                          className={styles.logVideo}
+                        />
+                      )
                     ) : entry.kind === 'image' && entry.image?.data ? (
                       <img
                         src={`data:image/${entry.image.format};base64,${entry.image.data}`}

--- a/frontend/src/hooks/useGraphExecution.ts
+++ b/frontend/src/hooks/useGraphExecution.ts
@@ -199,6 +199,21 @@ export function useGraphExecution() {
           });
         }
 
+        // #310: a video entry is a REFERENCE (path/url/format) to a file the
+        // backend wrote under its media dir — never bytes. No legacy
+        // fallback — the kind postdates the flat-field era entirely.
+        for (const entry of ofKind('video')) {
+          const payload = entry.video;
+          if (!payload?.url || !payload?.format) continue;
+          store.addTabLog(tabId, {
+            nodeId: data.node_id,
+            message: '',
+            kind: 'video',
+            video: { ...payload, ...(entry.port ? { port: entry.port } : {}) },
+            type: 'info',
+          });
+        }
+
         // #130: a chart entry carries a spec the client draws itself. No
         // legacy fallback — the kind postdates the flat-field era entirely.
         for (const entry of ofKind('chart')) {

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -537,6 +537,28 @@ const zhTW: NodeTranslations = {
       format: '影像格式',
     },
   },
+  VideoWrite: {
+    description:
+      '將幀張量 (T,C,H,W) 或 (T,H,W,C) 編碼為可播放影片並寫入媒體目錄——' +
+      'PATH 上有 ffmpeg 時輸出 mp4，否則以 Pillow 輸出 gif（零相依），' +
+      '並發出可在編輯器內嵌播放的參照',
+    params: {
+      filename: '媒體目錄下的檔名（可含子資料夾）；副檔名依格式決定，同名會覆寫',
+      format: 'auto：PATH 上有 ffmpeg 則 mp4，否則 gif。gif 永遠可用；mp4 需要安裝 ffmpeg',
+      fps: '播放幀率（每秒幀數）',
+      resize: '輸出高度（像素），等比縮放、最近鄰（0 = 原始大小）；96px 的研究畫面放大 2-3 倍較易觀看',
+    },
+  },
+  VideoLoad: {
+    description:
+      '解碼影片檔（mp4/webm 走 ffmpeg，gif 走 Pillow）為幀張量 (T,3,H,W)、' +
+      '值域 [0,1]，並輸出 fps 與幀數；相對路徑以媒體目錄為基準（VideoWrite 的輸出位置）',
+    params: {
+      path: '影片檔案：絕對路徑，或相對於媒體目錄',
+      max_frames: '最多解碼幀數（0 = 全部）；未設上限的長片會整段載入記憶體',
+      stride: '每 N 幀取 1 幀（fps 輸出會等比例下降）',
+    },
+  },
   ImageBatchReader: {
     description: '從目錄讀取所有影像，堆疊為批次張量 (N, C, H, W)',
     params: {

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -43,7 +43,7 @@ import { useProjectStore } from './projectStore';
  * render, so a later node pack can add its own kind; unknown kinds are
  * ignored by the panel rather than rendered wrong.
  */
-export type LogKind = 'text' | 'image' | 'progress' | 'chart';
+export type LogKind = 'text' | 'image' | 'progress' | 'chart' | 'video';
 
 /** Base64 media payload of a `kind: 'image'` entry. */
 export interface LogImagePayload {
@@ -52,6 +52,27 @@ export interface LogImagePayload {
   encoding: string;
   data: string;
   /** Output port the image came from, when the backend named one. */
+  port?: string;
+}
+
+/**
+ * Reference payload of a `kind: 'video'` entry (#310). Never the bytes —
+ * one node_status event is capped at 128 KB, so the backend writes the
+ * file under its media dir and ships where to find it; `url` is served by
+ * `/api/media` with a real Content-Type (GETs are unauthenticated reads).
+ */
+export interface LogVideoPayload {
+  /** POSIX-style path relative to the backend's media directory. */
+  path: string;
+  /** Same-origin URL a <video>/<img> element can point at directly. */
+  url: string;
+  format: string;
+  fps?: number;
+  frames?: number;
+  width?: number;
+  height?: number;
+  bytes?: number;
+  /** Output port the clip came from, when the backend named one. */
   port?: string;
 }
 
@@ -111,6 +132,8 @@ export interface LogEntry {
   progress?: Record<string, any>;
   /** Set when `kind === 'chart'` (#130) — the spec to draw. */
   chart?: LogChartPayload;
+  /** Set when `kind === 'video'` (#310) — the clip reference to play. */
+  video?: LogVideoPayload;
 }
 
 interface UndoSnapshot {


### PR DESCRIPTION
> 中文摘要：實作 #310 的畫布影片輸出/輸入。事件流有 128KB 上限，影片改走「參照」：節點把檔案寫進新的 `settings.MEDIA_DIR`，新路由 `/api/media` 以真實 Content-Type 內嵌播放（FileResponse 支援 Range，`<video>` 可拖動進度），`MEDIA_VIDEO` port 種類只在線路上傳一個經驗證的小 dict。零新增 Python 相依：gif 走 Pillow（永遠可用），mp4 在 PATH 上有 ffmpeg 執行檔時以 subprocess 管道編碼，缺 ffmpeg 時錯誤訊息會指向 gif 後備。VideoWrite 另輸出一張 MEDIA_IMAGE 預覽幀；VideoLoad 反向解碼（gif 走 Pillow、mp4/webm 走 ffmpeg）。前端 LogKind 增加 'video'，結果面板 mp4 用 `<video>`、gif 用 `<img>` 播放，並補上兩個節點的 zh-TW 條目。

Closes #310. First slice of the VLA epic #309.

## What

- `MEDIA_VIDEO = "video"` port kind (node_base) — the port's value is a small
  reference dict, never bytes; `_video_payload` (output_entries) validates it
  at the wire and refuses absolute/escaping paths on every platform.
- `settings.MEDIA_DIR` (`<data>/media`, project mode `assets/media`) +
  `GET /api/media/{path}` serving mp4/webm/gif/png/jpg inline with real mime
  — the existing download routes force `application/octet-stream`, which a
  `<video>` element cannot play. GET stays an unauthenticated read like every
  other download route.
- `core/video_io.py` — one canonical frames shape `(T,H,W,3) uint8` plus
  gif (Pillow) and mp4 (ffmpeg binary, rawvideo pipe) codecs both ways. No
  Python video library: torchvision 0.26 removed its video API, and the house
  rule (the tensorboard precedent) is that turning a feature on costs an
  install nothing.
- `VideoWrite` [IO]: `(T,C,H,W)`/`(T,H,W,C)`, float or uint8, gray or RGB;
  `format` auto|mp4|gif (auto = mp4 iff ffmpeg on PATH), `fps`, `resize`
  (output height, aspect kept); outputs the reference, the absolute path, and
  a middle-frame PNG preview (MEDIA_IMAGE). `cacheable = False` (the
  ImageWriter #143 rule). Odd dimensions are cropped even for yuv420p and the
  reference describes the file actually written.
- `VideoLoad` [IO]: gif via Pillow, mp4/webm via ffmpeg/ffprobe; `max_frames`
  cap stops the decode early; `stride` scales the reported fps down so
  playback duration holds; wired `path` input overrides the param
  (VideoWrite -> VideoLoad chains).
- Frontend: `LogKind` + `LogVideoPayload`, `useGraphExecution` branch,
  results-panel player (`<video controls loop>` for mp4, `<img>` for gif —
  a gif is not a valid `<video>` source), `.logVideo` styles, zh-TW entries.
- Docs: MEDIA_VIDEO contract section in `custom-nodes.md`.

## Verification

```
cd backend
.venv/Scripts/python.exe -m pytest tests/test_video_nodes.py tests/test_api_media.py -q   # 23 passed
.venv/Scripts/python.exe -m pytest tests/test_api_nodes.py tests/test_auth_drift.py tests/test_cache_writer_nodes.py tests/test_cache_live_handle_nodes.py tests/test_cache_file_nodes.py -q
uvx ruff@0.14.4 check .
cd ../frontend && pnpm exec tsc -b
```

mp4 tests skip cleanly when no ffmpeg binary is on PATH (CI stays green
either way); on this machine (ffmpeg present) the roundtrip runs: write 10
frames -> mp4 -> decode -> same count/shape/fps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7hg6NttgDyNBcf49Na9kj
