### PR TITLE
feat(vla): PushWorldEnv + PushWorldDemos - language-conditioned push env and DART demonstrations (#311)

### DIFF
--- a/backend/app/nodes/vla/pushworld_demos_node.py
+++ b/backend/app/nodes/vla/pushworld_demos_node.py
@@ -1,0 +1,360 @@
+"""PushWorldDemos node (#311) -- scripted-expert demonstrations for BC.
+
+Rolls PushWorld episodes with the scripted expert and packages every step
+as a behavior-cloning sample. Two design choices carry the closed-loop
+result and are worth knowing before turning knobs:
+
+**demo_noise is DART, not decoration.** With ``demo_noise > 0`` the action
+EXECUTED in the environment is perturbed while the RECORDED label stays the
+expert's. Pure on-trajectory demonstrations contain no recovery states, so
+a cloned policy that drifts a pixel off the expert manifold has never seen
+its situation and compounds the error -- measured here: 4% closed-loop
+success trained clean vs 24% with noise 0.5 on an otherwise identical
+prototype, before any architecture change. Perturbed states with corrective
+labels are what closed-loop control learns from.
+
+**Actions appear in the sample's data AND target.** A sample is
+``((image, instruction_tokens, action_chunk), action_chunk)`` -- the chunk
+rides along inside ``data`` so a flow-matching model can noise it INSIDE
+``forward`` while the TrainingLoop contract (``outputs = model(data);
+loss = loss_fn(outputs, targets)``) stays untouched. A regression model
+simply ignores ``data[2]``.
+
+Instructions are UTF-8 BYTES zero-padded to ``TEXT_LEN`` -- at this scale a
+byte embedding (256 rows) is the whole language stack, and BPE would buy
+nothing but a 50k-row table. Images are stored uint8 and converted per
+``__getitem__``, which is 4x less resident memory than float storage
+(~28 KB/sample at 96px; the default 600 episodes come to ~15k samples,
+~0.4 GB).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+from torch.utils.data import Dataset
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+from .pushworld_env_node import PushWorldFactory, scripted_expert_action
+
+logger = logging.getLogger(__name__)
+
+#: Instruction encoding length, bytes. The template maxes out at 40
+#: characters of ASCII; 48 leaves room without wasting attention tokens.
+TEXT_LEN = 48
+
+#: Seed offset separating the holdout episode stream from training's, so
+#: the two sets can never share an episode at any `episodes` value.
+_HOLDOUT_SEED_OFFSET = 1_000_000
+
+
+def encode_instruction(text: str, length: int = TEXT_LEN) -> torch.Tensor:
+    """UTF-8 bytes, zero-padded/truncated to *length*, as int64 (length,)."""
+    raw = text.encode("utf-8")[:length]
+    out = torch.zeros(length, dtype=torch.long)
+    out[: len(raw)] = torch.tensor(list(raw), dtype=torch.long)
+    return out
+
+
+class PushWorldDemoDataset(Dataset):
+    """BC samples over uint8 frames; float conversion happens per item."""
+
+    def __init__(self, images_u8: torch.Tensor, tokens: torch.Tensor,
+                 chunks: torch.Tensor):
+        self.images_u8 = images_u8
+        self.tokens = tokens
+        self.chunks = chunks
+
+    def __len__(self) -> int:
+        return self.images_u8.shape[0]
+
+    def __getitem__(self, index: int):
+        image = self.images_u8[index].float() / 255.0
+        chunk = self.chunks[index]
+        return (image, self.tokens[index], chunk), chunk
+
+
+def _collect(
+    factory: PushWorldFactory,
+    episodes: int,
+    chunk: int,
+    demo_noise: float,
+    seed0: int,
+    noise_gen: torch.Generator,
+    video_episodes: int = 0,
+    should_stop=None,
+    on_episode=None,
+) -> tuple[list, list, list, list, int | None]:
+    """Roll episodes; returns (images_u8, tokens, chunks, video, stopped_at)."""
+    images: list[torch.Tensor] = []
+    tokens: list[torch.Tensor] = []
+    chunks: list[torch.Tensor] = []
+    video: list[torch.Tensor] = []
+    stopped_at: int | None = None
+    for index in range(episodes):
+        if should_stop is not None and should_stop():
+            stopped_at = index
+            break
+        episode = factory.episode(seed=seed0 + index)
+        frames: list[torch.Tensor] = []
+        actions: list[torch.Tensor] = []
+        done = False
+        while not done:
+            frames.append(episode.render())
+            action = scripted_expert_action(episode)
+            actions.append(action)
+            executed = action
+            if demo_noise > 0 and torch.rand(1, generator=noise_gen).item() < 0.5:
+                executed = torch.clamp(
+                    action + torch.randn(2, generator=noise_gen) * demo_noise,
+                    -1.0, 1.0)
+            done = episode.step(executed)
+        instruction = encode_instruction(episode.instruction)
+        total = len(actions)
+        for t in range(total):
+            step_chunk = [actions[min(t + k, total - 1)] for k in range(chunk)]
+            images.append((frames[t].clamp(0, 1) * 255).round().to(torch.uint8))
+            tokens.append(instruction)
+            chunks.append(torch.stack(step_chunk))
+        if index < video_episodes:
+            video.extend(
+                (f.clamp(0, 1) * 255).round().to(torch.uint8) for f in frames)
+        if on_episode is not None:
+            on_episode(index + 1)
+    return images, tokens, chunks, video, stopped_at
+
+
+class PushWorldDemosNode(BaseNode):
+    NODE_NAME = "PushWorldDemos"
+    CATEGORY = "VLA"
+    DESCRIPTION = (
+        "Roll the scripted expert through PushWorld episodes and emit "
+        "behavior-cloning samples ((image, instruction bytes, action "
+        "chunk), action chunk) plus a held-out split and a demo video "
+        "tensor for VideoWrite. demo_noise executes DART-style perturbed "
+        "actions while recording the expert's - the recovery data "
+        "closed-loop control needs."
+    )
+
+    # Consumes the live env handle and owns a multi-second collection pass
+    # whose products (three stacked tensors per split) no fingerprint
+    # describes -- the DataMixDataset shape of the rule.
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="env",
+                data_type=DataType.ANY,
+                description="PushWorldEnv handle",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="dataset",
+                data_type=DataType.DATASET,
+                description=(
+                    "Training samples ((image f32 (3,S,S), instruction "
+                    "int64 (48,), chunk f32 (H,2)), chunk) - feed DataLoader"
+                ),
+            ),
+            PortDefinition(
+                name="holdout",
+                data_type=DataType.DATASET,
+                description=(
+                    "Held-out episodes from a disjoint seed stream, for "
+                    "VLAActionEval / a val DataLoader"
+                ),
+            ),
+            PortDefinition(
+                name="num_samples",
+                data_type=DataType.SCALAR,
+                description="Training samples emitted",
+            ),
+            PortDefinition(
+                name="demo_video",
+                data_type=DataType.TENSOR,
+                description=(
+                    "First episodes' frames, uint8 (T,3,S,S) - wire into "
+                    "VideoWrite to watch the (noise-perturbed) expert"
+                ),
+            ),
+            PortDefinition(
+                name="instruction_example",
+                data_type=DataType.STRING,
+                description="First episode's instruction, for a quick sanity read",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="episodes",
+                param_type=ParamType.INT,
+                default=600,
+                min_value=1,
+                max_value=20000,
+                description=(
+                    "Training episodes to roll (~25 samples each; 600 is "
+                    "~15k samples / ~0.4 GB resident at 96px)"
+                ),
+            ),
+            ParamDefinition(
+                name="chunk",
+                param_type=ParamType.INT,
+                default=8,
+                min_value=1,
+                max_value=64,
+                description=(
+                    "Actions per sample (the action-chunk horizon H; SmolVLA "
+                    "uses 50 at robot scale). Must match VLAModel's chunk. "
+                    "Past the episode end the last action repeats."
+                ),
+            ),
+            ParamDefinition(
+                name="demo_noise",
+                param_type=ParamType.FLOAT,
+                default=0.5,
+                min_value=0.0,
+                max_value=2.0,
+                description=(
+                    "DART perturbation scale: with probability 1/2 per step, "
+                    "N(0, noise) is added to the EXECUTED action while the "
+                    "expert's stays the label. 0 disables - measured to "
+                    "collapse closed-loop success (4% vs 24% at 0.5 in the "
+                    "prototype); keep it on unless studying exactly that."
+                ),
+            ),
+            ParamDefinition(
+                name="holdout_episodes",
+                param_type=ParamType.INT,
+                default=60,
+                min_value=0,
+                max_value=2000,
+                description="Held-out episodes (disjoint seeds), 0 = empty holdout",
+            ),
+            ParamDefinition(
+                name="video_episodes",
+                param_type=ParamType.INT,
+                default=4,
+                min_value=0,
+                max_value=16,
+                description="Episodes recorded into demo_video (0 = none)",
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description="Base seed - same seed and params reproduce the datasets exactly",
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        from ...core.loop_control import ProgressThrottle, interrupted_result, stop_checker
+
+        factory = inputs["env"]
+        if not isinstance(factory, PushWorldFactory):
+            raise TypeError(
+                "PushWorldDemos: the env input must come from PushWorldEnv "
+                f"(got {type(factory).__name__}).")
+
+        episodes = max(1, int(params.get("episodes", 600) or 600))
+        chunk = max(1, min(64, int(params.get("chunk", 8) or 8)))
+        demo_noise = max(0.0, float(params.get("demo_noise", 0.5) or 0.0))
+        holdout_episodes = max(0, int(params.get("holdout_episodes", 60) or 0))
+        video_episodes = max(0, min(16, int(params.get("video_episodes", 4) or 0)))
+        seed = max(0, int(params.get("seed", 0) or 0))
+
+        should_stop = stop_checker(context)
+        throttle = ProgressThrottle(progress_callback)
+        noise_gen = torch.Generator().manual_seed(seed + 991)
+
+        def report(done_episodes: int) -> None:
+            throttle.emit({
+                "event": "progress",
+                "phase": "collect",
+                "episode": done_episodes,
+                "total_episodes": episodes + holdout_episodes,
+            })
+
+        images, tokens, chunks, video, stopped_at = _collect(
+            factory, episodes, chunk, demo_noise, seed, noise_gen,
+            video_episodes=video_episodes, should_stop=should_stop,
+            on_episode=report)
+
+        holdout_images: list = []
+        holdout_tokens: list = []
+        holdout_chunks: list = []
+        if stopped_at is None and holdout_episodes:
+            holdout_images, holdout_tokens, holdout_chunks, _, hold_stop = _collect(
+                factory, holdout_episodes, chunk, demo_noise,
+                seed + _HOLDOUT_SEED_OFFSET, noise_gen,
+                should_stop=should_stop,
+                on_episode=lambda n: report(episodes + n))
+            if hold_stop is not None:
+                stopped_at = episodes + hold_stop
+
+        def build(imgs: list, toks: list, chks: list) -> PushWorldDemoDataset:
+            if not imgs:
+                size = factory.image_size
+                return PushWorldDemoDataset(
+                    torch.zeros(0, 3, size, size, dtype=torch.uint8),
+                    torch.zeros(0, TEXT_LEN, dtype=torch.long),
+                    torch.zeros(0, chunk, 2))
+            return PushWorldDemoDataset(
+                torch.stack(imgs), torch.stack(toks), torch.stack(chks))
+
+        dataset = build(images, tokens, chunks)
+        holdout = build(holdout_images, holdout_tokens, holdout_chunks)
+        if len(dataset) == 0:
+            raise RuntimeError(
+                "PushWorldDemos: stopped before any episode finished - "
+                "no dataset to hand downstream.")
+
+        instruction_example = ""
+        if tokens:
+            raw = bytes(b for b in tokens[0].tolist() if b)
+            instruction_example = raw.decode("utf-8", "replace")
+
+        demo_video = (
+            torch.stack(video) if video
+            else torch.zeros(0, 3, factory.image_size, factory.image_size,
+                             dtype=torch.uint8))
+
+        note = (
+            f"{len(dataset):,} samples from "
+            f"{stopped_at if stopped_at is not None else episodes} episodes "
+            f"(chunk {chunk}, demo_noise {demo_noise:g}), "
+            f"{len(holdout):,} holdout samples, "
+            f"{demo_video.shape[0]} video frames."
+        )
+        logger.info("PushWorldDemos: %s", note)
+        result: dict[str, Any] = {
+            "dataset": dataset,
+            "holdout": holdout,
+            "num_samples": len(dataset),
+            "demo_video": demo_video,
+            "instruction_example": instruction_example,
+            "__log__": note,
+        }
+        if stopped_at is not None:
+            # Partial data is still usable data, but the run must say so
+            # rather than pass it off as the requested collection.
+            result.update(interrupted_result(episode=stopped_at))
+        return result

--- a/backend/app/nodes/vla/pushworld_env_node.py
+++ b/backend/app/nodes/vla/pushworld_env_node.py
@@ -1,0 +1,348 @@
+"""PushWorldEnv node (#311) -- a language-conditioned 2D push benchmark.
+
+The environment side of the VLA epic (#309): an agent disc, colored pucks,
+colored ring targets, and an instruction of the form "push the {color} puck
+to the {color} target". With distractors present, neither the puck nor the
+target is inferable from pixels alone -- the policy must READ the text, and
+the swapped-instruction ablation in VLARollout can measure that it does.
+
+This is PushT's spirit (the Diffusion Policy / LeRobot benchmark) at
+zero-dependency scale: pure torch, no pygame/pymunk/gymnasium, seeded and
+deterministic, ~4 ms per episode including rendering, so demonstration
+collection and closed-loop evaluation both run inside a node without any
+simulator install. Contact dynamics are deliberately simple (circle-overlap
+resolution rather than rigid-body physics): the research questions this
+canvas targets -- language grounding, head paradigms, chunking, data
+mixtures -- live above the contact model.
+
+Everything is drawn as anti-aliased distance-field masks on a cached
+meshgrid, layered painting, ``(3, S, S)`` float [0,1] -- no renderer
+dependency either.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+logger = logging.getLogger(__name__)
+
+#: Named colors an episode samples from. Six entries: up to four pucks and
+#: two targets can be on screen with every color distinct.
+PALETTE: dict[str, tuple[float, float, float]] = {
+    "red": (0.86, 0.20, 0.18),
+    "green": (0.00, 0.71, 0.31),
+    "blue": (0.15, 0.43, 1.00),
+    "yellow": (0.94, 0.78, 0.00),
+    "magenta": (0.83, 0.21, 0.51),
+    "cyan": (0.16, 0.63, 0.60),
+}
+_COLOR_NAMES = list(PALETTE)
+
+#: Entity radii in arena units ([0,1]^2 arena). Chosen so a 96px render
+#: keeps every entity several pixels wide and the agent can slip between
+#: two pucks: agent < puck < target ring.
+R_AGENT = 0.055
+R_PUCK = 0.070
+R_TARGET = 0.095
+#: Largest per-step displacement, arena units -- actions are [-1,1]^2 times
+#: this many arena units per step.
+MAX_SPEED = 0.05
+#: The goal puck's center must come this close to the target's center.
+SUCCESS_DIST = 0.05
+#: Keep-out from the walls at placement time.
+_MARGIN = 0.13
+
+
+class PushWorldEpisode:
+    """One live episode: reset state, step dynamics, render frames.
+
+    Positions live in [0,1]^2. All randomness comes from the constructor
+    seed, so (seed, config) -> identical episode, which is what makes
+    demonstrations and evaluations reproducible per seed.
+    """
+
+    def __init__(self, image_size: int, n_distractors: int, max_steps: int,
+                 seed: int):
+        self.image_size = image_size
+        self.n_distractors = n_distractors
+        self.max_steps = max_steps
+        self.gen = torch.Generator().manual_seed(seed)
+        axis = torch.linspace(0.0, 1.0, image_size)
+        self._grid_y, self._grid_x = torch.meshgrid(axis, axis, indexing="ij")
+        self._reset()
+
+    # -- setup ----------------------------------------------------------
+
+    def _rand(self, n: int) -> torch.Tensor:
+        return torch.rand(n, generator=self.gen)
+
+    def _place(self, existing: list[torch.Tensor], min_sep: float) -> torch.Tensor:
+        for _ in range(200):
+            p = _MARGIN + self._rand(2) * (1 - 2 * _MARGIN)
+            if all(torch.linalg.vector_norm(p - q) >= min_sep for q in existing):
+                return p
+        return p  # crowded fallback; the radii keep it playable
+
+    def _reset(self) -> None:
+        n_pucks = 1 + self.n_distractors
+        n_targets = 2 if self.n_distractors > 0 else 1
+        order = torch.randperm(len(_COLOR_NAMES), generator=self.gen).tolist()
+        self.puck_colors = [_COLOR_NAMES[i] for i in order[:n_pucks]]
+        order2 = torch.randperm(len(_COLOR_NAMES), generator=self.gen).tolist()
+        self.target_colors = [_COLOR_NAMES[i] for i in order2[:n_targets]]
+        placed: list[torch.Tensor] = []
+        self.targets: list[torch.Tensor] = []
+        for _ in range(n_targets):
+            p = self._place(placed, 2.6 * R_TARGET)
+            self.targets.append(p)
+            placed.append(p)
+        self.pucks: list[torch.Tensor] = []
+        for _ in range(n_pucks):
+            p = self._place(placed, 2.4 * R_TARGET)
+            self.pucks.append(p)
+            placed.append(p)
+        self.agent = self._place(placed, R_AGENT + R_PUCK + 0.02)
+        # The goal is always puck 0 -- colors are freshly shuffled per
+        # episode, so "which color is the goal" still varies uniformly.
+        self.goal_puck = 0
+        self.goal_target = int(self._rand(1).item() * n_targets) % n_targets
+        self.instruction = (
+            f"push the {self.puck_colors[0]} puck to the "
+            f"{self.target_colors[self.goal_target]} target")
+        self.steps = 0
+        self.success = False
+
+    # -- dynamics -------------------------------------------------------
+
+    def step(self, action: torch.Tensor) -> bool:
+        """Advance one step; returns True when the episode is over."""
+        move = torch.clamp(action.detach().float().view(2), -1.0, 1.0) * MAX_SPEED
+        self.agent = torch.clamp(self.agent + move, R_AGENT, 1 - R_AGENT)
+        for i, puck in enumerate(self.pucks):
+            offset = puck - self.agent
+            dist = torch.linalg.vector_norm(offset)
+            min_dist = R_AGENT + R_PUCK
+            if dist < min_dist:
+                normal = offset / (dist + 1e-8)
+                self.pucks[i] = torch.clamp(
+                    self.agent + normal * min_dist, R_PUCK, 1 - R_PUCK)
+        # Puck-puck separation, single pass -- enough at these densities.
+        for i in range(len(self.pucks)):
+            for j in range(i + 1, len(self.pucks)):
+                offset = self.pucks[j] - self.pucks[i]
+                dist = torch.linalg.vector_norm(offset)
+                if dist < 2 * R_PUCK:
+                    normal = offset / (dist + 1e-8)
+                    shift = (2 * R_PUCK - dist) / 2
+                    self.pucks[i] = torch.clamp(
+                        self.pucks[i] - normal * shift, R_PUCK, 1 - R_PUCK)
+                    self.pucks[j] = torch.clamp(
+                        self.pucks[j] + normal * shift, R_PUCK, 1 - R_PUCK)
+        self.steps += 1
+        goal_dist = torch.linalg.vector_norm(
+            self.pucks[self.goal_puck] - self.targets[self.goal_target])
+        if goal_dist < SUCCESS_DIST:
+            self.success = True
+        return self.success or self.steps >= self.max_steps
+
+    # -- rendering ------------------------------------------------------
+
+    def _circle(self, center: torch.Tensor, radius: float) -> torch.Tensor:
+        aa = 1.5 / self.image_size
+        d = torch.sqrt((self._grid_x - center[0]) ** 2
+                       + (self._grid_y - center[1]) ** 2)
+        return torch.clamp((radius - d) / aa, 0.0, 1.0)
+
+    def _ring(self, center: torch.Tensor, radius: float, width: float) -> torch.Tensor:
+        aa = 1.5 / self.image_size
+        d = torch.sqrt((self._grid_x - center[0]) ** 2
+                       + (self._grid_y - center[1]) ** 2)
+        return torch.clamp((width - torch.abs(d - radius)) / aa, 0.0, 1.0)
+
+    def render(self) -> torch.Tensor:
+        """Current frame as ``(3, S, S)`` float [0,1]."""
+        canvas = torch.full((3, self.image_size, self.image_size), 0.09)
+
+        def paint(base: torch.Tensor, mask: torch.Tensor,
+                  rgb: tuple[float, float, float]) -> torch.Tensor:
+            color = torch.tensor(rgb).view(3, 1, 1)
+            m = mask.unsqueeze(0)
+            return base * (1 - m) + color * m
+
+        for target, name in zip(self.targets, self.target_colors):
+            canvas = paint(canvas, self._ring(target, R_TARGET, 0.016), PALETTE[name])
+        for puck, name in zip(self.pucks, self.puck_colors):
+            canvas = paint(canvas, self._circle(puck, R_PUCK), PALETTE[name])
+        canvas = paint(canvas, self._circle(self.agent, R_AGENT), (0.92, 0.92, 0.92))
+        return canvas
+
+
+def _rotate_toward(u: torch.Tensor, v: torch.Tensor, max_angle: float) -> torch.Tensor:
+    """Rotate unit vector *u* toward unit vector *v* by at most *max_angle*."""
+    cross = u[0] * v[1] - u[1] * v[0]
+    dot = torch.clamp(u[0] * v[0] + u[1] * v[1], -1.0, 1.0)
+    angle = torch.atan2(cross, dot)
+    step = torch.clamp(angle, -max_angle, max_angle)
+    c, s = torch.cos(step), torch.sin(step)
+    return torch.stack([c * u[0] - s * u[1], s * u[0] + c * u[1]])
+
+
+def scripted_expert_action(episode: PushWorldEpisode) -> torch.Tensor:
+    """The demonstration policy: get behind the goal puck, push through it.
+
+    Three regimes, recomputed every step so the expert self-corrects:
+    aligned behind the puck -> push toward the target through the puck's
+    center; near the puck on the wrong side -> orbit around it (never plow
+    through); far away -> walk to the point behind it. Validated at 100/100
+    episodes, mean 23 steps, on the default configuration.
+    """
+    puck = episode.pucks[episode.goal_puck]
+    target = episode.targets[episode.goal_target]
+    to_target = target - puck
+    dist_target = torch.linalg.vector_norm(to_target)
+    push_dir = to_target / (dist_target + 1e-8)
+    rel = episode.agent - puck
+    dist_agent = torch.linalg.vector_norm(rel)
+    behind = -push_dir
+    gap = R_AGENT + R_PUCK + 0.012
+    aligned = (rel / (dist_agent + 1e-8) * behind).sum() > 0.85
+    if aligned and dist_agent < gap + 0.05:
+        goal = puck + push_dir * 0.03
+    elif dist_agent < gap + 0.06:
+        u = rel / (dist_agent + 1e-8)
+        goal = puck + _rotate_toward(u, behind, 0.5) * gap
+    else:
+        goal = puck + behind * gap
+    delta = goal - episode.agent
+    if torch.linalg.vector_norm(delta) < 1e-6:
+        return torch.zeros(2)
+    return torch.clamp(delta / MAX_SPEED, -1.0, 1.0)
+
+
+class PushWorldFactory:
+    """The env handle on the wire: immutable config, fresh episode per seed.
+
+    Consumers (PushWorldDemos, VLARollout) call :meth:`episode` with their
+    own seed streams, so the factory itself carries no mutable state.
+    """
+
+    def __init__(self, image_size: int, n_distractors: int, max_steps: int):
+        self.image_size = image_size
+        self.n_distractors = n_distractors
+        self.max_steps = max_steps
+        self.action_dim = 2
+
+    def episode(self, seed: int, max_steps: int | None = None) -> PushWorldEpisode:
+        return PushWorldEpisode(
+            image_size=self.image_size,
+            n_distractors=self.n_distractors,
+            max_steps=self.max_steps if max_steps is None else max_steps,
+            seed=seed,
+        )
+
+
+class PushWorldEnvNode(BaseNode):
+    NODE_NAME = "PushWorldEnv"
+    CATEGORY = "VLA"
+    DESCRIPTION = (
+        "A language-conditioned 2D push environment (PushT's spirit, pure "
+        "torch): an agent disc, colored pucks, colored ring targets, and an "
+        "instruction naming which puck goes to which target. With "
+        "distractors, pixels alone cannot identify the goal - the policy "
+        "must read the instruction. Feed the env handle to PushWorldDemos "
+        "for demonstrations and VLARollout for closed-loop evaluation."
+    )
+
+    # The output is a live handle consumers construct episodes from. It is
+    # immutable config and rebuilding costs microseconds, so there is
+    # nothing for a cache to buy -- and an object identity crossing runs
+    # out of ExecutionCache is exactly the #253/#254 shape of surprise.
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="env",
+                data_type=DataType.ANY,
+                description=(
+                    "Environment handle (episode factory) for "
+                    "PushWorldDemos and VLARollout"
+                ),
+            ),
+            PortDefinition(
+                name="image_size",
+                data_type=DataType.SCALAR,
+                description="Render size in pixels - match VLAModel's image_size",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="image_size",
+                param_type=ParamType.INT,
+                default=96,
+                min_value=32,
+                max_value=256,
+                description=(
+                    "Rendered frame size in pixels (square). 96 matches the "
+                    "PushT convention and keeps a 4080-class GPU fed."
+                ),
+            ),
+            ParamDefinition(
+                name="n_distractors",
+                param_type=ParamType.INT,
+                default=1,
+                min_value=0,
+                max_value=3,
+                description=(
+                    "Extra pucks beside the goal puck. At 0 there is one "
+                    "puck and one target and language is decoration; from 1 "
+                    "up there are two targets and 2+ pucks, so the "
+                    "instruction is the ONLY way to know the goal."
+                ),
+            ),
+            ParamDefinition(
+                name="max_steps",
+                param_type=ParamType.INT,
+                default=60,
+                min_value=10,
+                max_value=1000,
+                description=(
+                    "Steps before an episode times out. The scripted expert "
+                    "needs ~23 on average; policies are slower - VLARollout "
+                    "can raise its own budget per evaluation."
+                ),
+            ),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any]) -> dict[str, Any]:
+        image_size = int(params.get("image_size", 96) or 96)
+        n_distractors = max(0, min(3, int(params.get("n_distractors", 1) or 0)))
+        max_steps = max(10, int(params.get("max_steps", 60) or 60))
+        factory = PushWorldFactory(image_size, n_distractors, max_steps)
+        sample = factory.episode(seed=0)
+        logger.info(
+            "PushWorldEnv: %dpx, %d distractor(s), %d max steps",
+            image_size, n_distractors, max_steps)
+        return {
+            "env": factory,
+            "image_size": image_size,
+            "__log__": (
+                f"PushWorld {image_size}px, {n_distractors} distractor(s), "
+                f"{1 + n_distractors} puck(s) / "
+                f"{2 if n_distractors else 1} target(s), max {max_steps} "
+                f"steps. Example instruction: \"{sample.instruction}\"."
+            ),
+        }

--- a/backend/tests/test_pushworld_nodes.py
+++ b/backend/tests/test_pushworld_nodes.py
@@ -1,0 +1,208 @@
+"""PushWorldEnv + PushWorldDemos (#311): determinism, expert quality, and
+the BC sample contract the VLA training stack builds on."""
+
+import re
+
+import pytest
+import torch
+
+from app.nodes.vla.pushworld_demos_node import (
+    TEXT_LEN,
+    PushWorldDemosNode,
+    encode_instruction,
+)
+from app.nodes.vla.pushworld_env_node import (
+    PushWorldEnvNode,
+    PushWorldFactory,
+    scripted_expert_action,
+)
+
+_SIZE = 48  # small render keeps the suite fast; dynamics are size-free
+
+
+def _factory(**overrides) -> PushWorldFactory:
+    config = {"image_size": _SIZE, "n_distractors": 1, "max_steps": 60}
+    config.update(overrides)
+    return PushWorldFactory(**config)
+
+
+# ── environment ─────────────────────────────────────────────────────────
+
+
+def test_same_seed_reproduces_the_episode_exactly():
+    a = _factory().episode(seed=7)
+    b = _factory().episode(seed=7)
+    assert a.instruction == b.instruction
+    assert torch.equal(a.render(), b.render())
+    done_a = a.step(torch.tensor([1.0, 0.5]))
+    done_b = b.step(torch.tensor([1.0, 0.5]))
+    assert done_a == done_b
+    assert torch.equal(a.render(), b.render())
+
+
+def test_different_seeds_differ():
+    a = _factory().episode(seed=1)
+    b = _factory().episode(seed=2)
+    assert not torch.equal(a.render(), b.render())
+
+
+def test_instruction_matches_the_template():
+    episode = _factory().episode(seed=3)
+    assert re.fullmatch(
+        r"push the \w+ puck to the \w+ target", episode.instruction)
+
+
+def test_distractors_control_entity_counts():
+    lone = _factory(n_distractors=0).episode(seed=0)
+    assert len(lone.pucks) == 1 and len(lone.targets) == 1
+    crowded = _factory(n_distractors=3).episode(seed=0)
+    assert len(crowded.pucks) == 4 and len(crowded.targets) == 2
+    # colors distinct within each entity class
+    assert len(set(crowded.puck_colors)) == 4
+    assert len(set(crowded.target_colors)) == 2
+
+
+def test_render_shape_and_range():
+    frame = _factory().episode(seed=0).render()
+    assert frame.shape == (3, _SIZE, _SIZE)
+    assert 0.0 <= frame.min() and frame.max() <= 1.0
+
+
+def test_episode_times_out_at_max_steps():
+    episode = _factory(max_steps=10).episode(seed=5)
+    done = False
+    for _ in range(10):
+        assert not done
+        done = episode.step(torch.zeros(2))  # standing still cannot succeed
+    assert done and not episode.success
+
+
+def test_scripted_expert_succeeds_on_effectively_every_episode():
+    successes = 0
+    steps = []
+    for seed in range(100):
+        episode = _factory().episode(seed=1000 + seed)
+        done = False
+        while not done:
+            done = episode.step(scripted_expert_action(episode))
+        if episode.success:
+            successes += 1
+            steps.append(episode.steps)
+    assert successes >= 99
+    assert sum(steps) / len(steps) < 40
+
+
+# ── demos node ──────────────────────────────────────────────────────────
+
+
+def _demos(**param_overrides):
+    params = {
+        "episodes": 6, "chunk": 4, "demo_noise": 0.5,
+        "holdout_episodes": 3, "video_episodes": 2, "seed": 0,
+    }
+    params.update(param_overrides)
+    factory = _factory()
+    return PushWorldDemosNode().execute({"env": factory}, params)
+
+
+def test_sample_contract_shapes_dtypes_and_target_identity():
+    result = _demos()
+    dataset = result["dataset"]
+    (image, tokens, chunk), target = dataset[0]
+    assert image.shape == (3, _SIZE, _SIZE) and image.dtype == torch.float32
+    assert 0.0 <= image.min() and image.max() <= 1.0
+    assert tokens.shape == (TEXT_LEN,) and tokens.dtype == torch.int64
+    assert chunk.shape == (4, 2) and chunk.dtype == torch.float32
+    # the chunk rides in data AND target, and they are the same actions
+    assert torch.equal(chunk, target)
+    assert result["num_samples"] == len(dataset) > 0
+
+
+def test_chunk_pads_by_repeating_the_last_action():
+    result = _demos(demo_noise=0.0)
+    dataset = result["dataset"]
+    (_, _, chunk), _ = dataset[len(dataset) - 1]  # last step of last episode
+    assert torch.equal(chunk[0], chunk[1])
+    assert torch.equal(chunk[0], chunk[3])
+
+
+def test_datasets_are_deterministic_per_seed():
+    a = _demos()["dataset"]
+    b = _demos()["dataset"]
+    assert torch.equal(a.images_u8, b.images_u8)
+    assert torch.equal(a.tokens, b.tokens)
+    assert torch.equal(a.chunks, b.chunks)
+    c = _demos(seed=1)["dataset"]
+    assert not torch.equal(a.images_u8[:16], c.images_u8[:16])
+
+
+def test_holdout_is_disjoint_from_training():
+    result = _demos()
+    train, holdout = result["dataset"], result["holdout"]
+    assert len(holdout) > 0
+    # disjoint seed streams -> the first frames cannot coincide
+    assert not torch.equal(train.images_u8[0], holdout.images_u8[0])
+
+
+def test_demo_video_and_instruction_example():
+    result = _demos()
+    video = result["demo_video"]
+    assert video.dtype == torch.uint8
+    assert video.dim() == 4 and video.shape[1:] == (3, _SIZE, _SIZE)
+    assert video.shape[0] > 0
+    assert re.fullmatch(
+        r"push the \w+ puck to the \w+ target", result["instruction_example"])
+
+
+def test_default_collate_batches_the_nested_samples():
+    dataset = _demos()["dataset"]
+    loader = torch.utils.data.DataLoader(dataset, batch_size=5, shuffle=False)
+    (images, tokens, chunks), targets = next(iter(loader))
+    assert images.shape == (5, 3, _SIZE, _SIZE)
+    assert tokens.shape == (5, TEXT_LEN)
+    assert chunks.shape == (5, 4, 2)
+    assert targets.shape == (5, 4, 2)
+
+
+def test_stop_mid_collection_returns_partial_and_says_so():
+    class _StopAfterFirstCheck:
+        def __init__(self):
+            self.calls = 0
+
+        def should_stop(self):
+            self.calls += 1
+            return self.calls > 2
+
+    result = PushWorldDemosNode().execute(
+        {"env": _factory()},
+        {"episodes": 50, "chunk": 4, "demo_noise": 0.0,
+         "holdout_episodes": 0, "video_episodes": 0, "seed": 0},
+        context=_StopAfterFirstCheck(),
+    )
+    assert "__interrupted__" in result
+    assert 0 < len(result["dataset"]) < 50 * 60
+
+
+def test_wrong_env_input_is_a_clear_error():
+    with pytest.raises(TypeError, match="PushWorldEnv"):
+        PushWorldDemosNode().execute({"env": object()}, {"episodes": 1})
+
+
+def test_encode_instruction_pads_and_truncates():
+    short = encode_instruction("abc")
+    assert short.shape == (TEXT_LEN,)
+    assert short[:3].tolist() == [97, 98, 99]
+    assert short[3:].sum() == 0
+    long = encode_instruction("x" * 100)
+    assert long.shape == (TEXT_LEN,) and (long != 0).all()
+
+
+# ── env node ────────────────────────────────────────────────────────────
+
+
+def test_env_node_outputs_factory_and_size():
+    result = PushWorldEnvNode().execute(
+        {}, {"image_size": _SIZE, "n_distractors": 1, "max_steps": 60})
+    assert isinstance(result["env"], PushWorldFactory)
+    assert result["image_size"] == _SIZE
+    assert "push the" in result["__log__"]

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -974,6 +974,36 @@ const zhTW: NodeTranslations = {
     },
   },
 
+  // ── VLA ──
+  PushWorldEnv: {
+    description:
+      '語言條件式 2D 推物環境（PushT 精神、純 torch）：一個白色 agent、' +
+      '彩色圓盤 puck 與彩色圓環目標，指令指定哪個 puck 要推到哪個目標。' +
+      '有干擾物時單靠畫面無法判斷目標，策略必須讀懂指令。' +
+      '把 env 接給 PushWorldDemos 與 VLARollout',
+    params: {
+      image_size: '渲染畫面邊長（像素，正方形）；96 對齊 PushT 慣例',
+      n_distractors: '目標 puck 之外的干擾 puck 數；0 時語言只是裝飾，≥1 時指令是唯一的目標線索',
+      max_steps: '單回合步數上限；腳本專家平均約 23 步，VLARollout 評估時可另設預算',
+    },
+  },
+  PushWorldDemos: {
+    description:
+      '用腳本專家滾 PushWorld 回合，產出行為複製樣本' +
+      '（(影像, 指令位元組, 動作區塊), 動作區塊）、' +
+      '一份獨立種子的驗證切分，與可接 VideoWrite 的示範影片張量。' +
+      'demo_noise 是 DART 式擾動：執行帶噪動作、標註保留專家動作，' +
+      '這正是閉環控制需要的回復資料',
+    params: {
+      episodes: '訓練回合數（每回合約 25 個樣本；600 回合約 1.5 萬樣本、約 0.4 GB）',
+      chunk: '每個樣本的動作數（動作區塊長度 H，須與 VLAModel 的 chunk 一致）；超過回合結尾時重複最後一個動作',
+      demo_noise: 'DART 擾動強度：每步以 1/2 機率對執行動作加 N(0, noise)，標註仍為專家動作；實測關掉會讓閉環成功率崩潰（4% vs 24%）',
+      holdout_episodes: '驗證回合數（獨立種子流，與訓練集永不重疊；0 = 空）',
+      video_episodes: '錄進 demo_video 的回合數（0 = 不錄）',
+      seed: '基礎種子；同種子同參數可完全重現資料集',
+    },
+  },
+
   // ── Custom ──
   AddScalar: {
     description: '將純量值加到張量上（自訂節點範例）',


### PR DESCRIPTION
> 中文摘要：#311 的環境端。PushWorldEnv 是純 torch 的語言條件式 2D 推物環境（PushT 精神、零相依）：白色 agent、彩色 puck、彩色圓環目標，指令模板「push the {color} puck to the {color} target」；有干擾物時畫面本身無法判斷目標，策略必須讀指令——這讓 VLARollout 的指令對調消融有意義。線路上的 env 是不可變的 episode 工廠（per-seed 決定性）。PushWorldDemos 用腳本專家（驗證 100/100、平均 23 步）收集行為複製樣本 ((影像, 指令位元組, 動作區塊), 動作區塊)，demo_noise 是 DART 式擾動：執行帶噪動作、標註保留專家——原型實測沒有它閉環成功率 4%、有它 24%。獨立種子流的 holdout、可直接接 VideoWrite 的示範影片張量、uint8 儲存（600 回合約 0.4 GB）、loop_control Stop 支援與誠實的 interrupted 標記。

Part of epic #309; implements the env half of #311 (model/rollout follow in
the next PR).

## Design points

- **Language has a causal role.** With `n_distractors >= 1` there are two
  targets and 2+ pucks, colors freshly shuffled per episode — the
  instruction is the only way to know the goal. This is what makes the
  swapped-instruction ablation (coming with VLARollout) a real measurement.
- **The wire handle is a factory, not an episode.** `PushWorldFactory` is
  immutable config; consumers construct seeded episodes. Determinism per
  (seed, config) is tested tensor-exact.
- **demo_noise is DART, not decoration.** Executed action perturbed,
  expert label recorded. Prototype measurement on otherwise identical
  training: 4% closed-loop success without vs 24% with noise 0.5 — pure
  on-trajectory demos contain no recovery states. Default 0.5, and the
  param text says why turning it off collapses closed-loop success.
- **Sample contract.** `((image f32 (3,S,S), instruction int64 (48,),
  chunk f32 (H,2)), chunk)` — actions ride in data AND target so a
  flow-matching model can noise them inside `forward` while the
  TrainingLoop contract stays untouched (torch default_collate recurses
  into nested tuples; `to_device` already moves them).
- Instructions are UTF-8 bytes padded to 48 — at this scale a 256-row byte
  embedding is the whole language stack; BPE would buy a 50k-row table.
- uint8 frame storage, float per `__getitem__`: 4x less resident memory.
- Stop-aware collection (loop_control), partial dataset + honest
  `__interrupted__` marker.

## Verification

```
cd backend
.venv/Scripts/python.exe -m pytest tests/test_pushworld_nodes.py -q   # 17 passed
.venv/Scripts/python.exe -m pytest tests/test_api_nodes.py -q         # zh-TW ratchet
uvx ruff@0.14.4 check .
```

Expert quality is pinned in-suite: >= 99/100 episodes succeed, mean < 40
steps. Determinism is pinned tensor-exact for env and datasets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7hg6NttgDyNBcf49Na9kj
