### PR TITLE
feat(vla): VLAModel (flow-matching | regression action expert) + VLARollout + VLAActionEval (#312)

### DIFF
--- a/backend/app/nodes/vla/vla_action_eval_node.py
+++ b/backend/app/nodes/vla/vla_action_eval_node.py
@@ -1,0 +1,197 @@
+"""VLAActionEval node (#312) -- open-loop action error on held-out demos.
+
+The fast, low-variance half of VLA evaluation: how close are the policy's
+predicted chunks to the expert's on states it never trained on? One number
+(mean squared error over action chunks), deterministic per seed, seconds
+to compute -- the complement to VLARollout's closed-loop success rate,
+which is the real thing but noisy and minutes-scale.
+
+The gap between the two is itself informative: low action MSE with low
+closed-loop success is the signature of compounding error (the policy is
+fine on-distribution and lost off it), which is exactly the effect
+demo_noise and execute_k exist to manage.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+
+logger = logging.getLogger(__name__)
+
+
+class VLAActionEvalNode(BaseNode):
+    NODE_NAME = "VLAActionEval"
+    CATEGORY = "VLA"
+    DESCRIPTION = (
+        "Open-loop evaluation: mean squared error between the policy's "
+        "predicted action chunks and the expert's, over a held-out demos "
+        "dataset (PushWorldDemos' holdout output). Fast and deterministic "
+        "per seed - the complement to VLARollout's closed-loop success "
+        "rate. A low MSE beside a low success rate is the compounding-"
+        "error signature."
+    )
+
+    # Consumes live handles (model, dataset); the number describes THIS
+    # run's weights.
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="model",
+                data_type=DataType.MODEL,
+                description="Trained VLAModel (needs predict_action)",
+            ),
+            PortDefinition(
+                name="dataset",
+                data_type=DataType.DATASET,
+                description=(
+                    "Held-out BC samples ((image, tokens, chunk), chunk) - "
+                    "PushWorldDemos' holdout output"
+                ),
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="action_mse",
+                data_type=DataType.SCALAR,
+                description="Mean squared error over evaluated action chunks",
+            ),
+            PortDefinition(
+                name="evaluated",
+                data_type=DataType.SCALAR,
+                description="Samples actually evaluated",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="max_samples",
+                param_type=ParamType.INT,
+                default=2048,
+                min_value=1,
+                max_value=100000,
+                description="Evaluate at most this many samples (0 caps nothing)",
+            ),
+            ParamDefinition(
+                name="batch_size",
+                param_type=ParamType.INT,
+                default=256,
+                min_value=1,
+                max_value=4096,
+                description="Inference batch size",
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description=(
+                    "Seeds the flow head's sampling noise so the number is "
+                    "reproducible (regression ignores it)"
+                ),
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="device",
+                param_type=ParamType.SELECT,
+                default="auto",
+                options=["auto", "cpu", "cuda", "mps"],
+                description="auto follows the run's device",
+                advanced=True,
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        from ...core.device_utils import resolve_node_device
+        from ...core.loop_control import ProgressThrottle, interrupted_result, stop_checker
+
+        model = inputs["model"]
+        dataset = inputs["dataset"]
+        if not hasattr(model, "predict_action"):
+            raise TypeError(
+                "VLAActionEval: the model input must be a VLAModel (it has "
+                "no predict_action).")
+        if len(dataset) == 0:
+            raise ValueError(
+                "VLAActionEval: the dataset is empty - wire PushWorldDemos' "
+                "holdout output (and set holdout_episodes > 0).")
+
+        max_samples = max(0, int(params.get("max_samples", 2048) or 0))
+        batch_size = max(1, int(params.get("batch_size", 256) or 256))
+        seed = max(0, int(params.get("seed", 0) or 0))
+        device = resolve_node_device(params.get("device"), context)
+        model_device = next(model.parameters()).device
+        model.to(device)
+
+        should_stop = stop_checker(context)
+        throttle = ProgressThrottle(progress_callback)
+        loader = torch.utils.data.DataLoader(
+            dataset, batch_size=batch_size, shuffle=False)
+        target_count = (
+            min(len(dataset), max_samples) if max_samples else len(dataset))
+
+        torch.manual_seed(seed)
+        error_sum = 0.0
+        evaluated = 0
+        stopped = False
+        try:
+            for batch, targets in loader:
+                if should_stop():
+                    stopped = True
+                    break
+                if evaluated >= target_count:
+                    break
+                images, tokens = batch[0], batch[1]
+                take = min(images.shape[0], target_count - evaluated)
+                images = images[:take].to(device)
+                tokens = tokens[:take].to(device)
+                expert = targets[:take].to(device)
+                predicted = model.predict_action(images, tokens)
+                error_sum += float(
+                    (predicted.float() - expert.float()).pow(2).sum())
+                evaluated += take
+                throttle.emit({
+                    "event": "progress",
+                    "evaluated": evaluated,
+                    "total_samples": target_count,
+                })
+        finally:
+            model.to(model_device)
+
+        if evaluated == 0:
+            raise RuntimeError("VLAActionEval: stopped before any sample ran.")
+
+        chunk_numel = dataset[0][1].numel()
+        action_mse = error_sum / (evaluated * chunk_numel)
+        if context is not None:
+            context.log_metric("action_mse", action_mse, 0)
+        note = f"action MSE {action_mse:.4f} over {evaluated:,} held-out samples."
+        logger.info("VLAActionEval: %s", note)
+        result: dict[str, Any] = {
+            "action_mse": action_mse,
+            "evaluated": evaluated,
+            "__log__": note,
+        }
+        if stopped:
+            result.update(interrupted_result(sample=evaluated))
+        return result

--- a/backend/app/nodes/vla/vla_model_node.py
+++ b/backend/app/nodes/vla/vla_model_node.py
@@ -1,0 +1,603 @@
+"""VLAModel node (#312) -- a mini vision-language-action policy.
+
+The policy side of the VLA epic (#309), shaped like the current literature
+at canvas scale: a vision+language encoder trunk feeding a chunked action
+expert, with the HEAD PARADIGM as a first-class research knob --
+
+- ``head_type="flow_matching"``: the pi0 / SmolVLA family. Training noises
+  the action chunk, the expert predicts the velocity field, inference
+  integrates Euler steps from pure noise.
+- ``head_type="regression"``: plain behavior cloning. The expert reads
+  learned queries and predicts the chunk directly; the loss is MSE.
+
+Both heads share the trunk, the data, and every other knob, so the two
+dominant continuous-action approaches can be compared with everything else
+held fixed. (Discretized action tokens, the OpenVLA family, would be a
+third head -- an issue away, not a rewrite.)
+
+**The loss comes out of a port.** A flow head trains on the residual
+``v_pred - v_target`` against zero; a regression head trains on MSE against
+the chunk. Wiring a generic loss to the wrong head would train the wrong
+objective SILENTLY -- so this node emits the mode-matched ``loss_fn``
+itself and there is no separate VLA loss node to mismatch.
+
+**forward(data) carries the actions.** A training sample is
+``((image, tokens, actions), actions)`` (see PushWorldDemos): flow matching
+needs the target actions INSIDE forward to noise them, and TrainingLoop's
+contract (``outputs = model(data); loss = loss_fn(outputs, targets)``)
+stays untouched. The regression head ignores ``data[2]``.
+
+**The vision stem defaults to a small conv pyramid.** A naive
+``patch_size x patch_size`` patchify is the ViT lineage but localizes
+poorly at 96px from scratch -- the "early convolutions help transformers
+see" result reproduces at this scale (see the numbers in the node
+description). ``vision_stem="patchify"`` keeps the classic stem available
+for exactly that study.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+from ...core.stateful_module import StatefulModuleMixin
+
+logger = logging.getLogger(__name__)
+
+HEAD_TYPES = ["flow_matching", "regression"]
+VISION_STEMS = ["conv", "patchify"]
+FLOW_TIME_DISTS = ["uniform", "beta"]
+
+#: The conv stem's fixed downsampling (three stride-2 convs).
+_CONV_STEM_FACTOR = 8
+
+
+class _EncoderBlock(nn.Module):
+    """Pre-LN self-attention + MLP, bidirectional -- the trunk unit."""
+
+    def __init__(self, d_model: int, n_heads: int, dropout: float):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d_model)
+        self.attn = nn.MultiheadAttention(
+            d_model, n_heads, dropout=dropout, batch_first=True)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.mlp = nn.Sequential(
+            nn.Linear(d_model, 4 * d_model), nn.GELU(),
+            nn.Dropout(dropout), nn.Linear(4 * d_model, d_model))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.norm1(x)
+        x = x + self.attn(h, h, h, need_weights=False)[0]
+        return x + self.mlp(self.norm2(x))
+
+
+class _ExpertBlock(nn.Module):
+    """Action-expert unit: self-attention over the chunk queries, then
+    cross-attention into the trunk's vision+language features."""
+
+    def __init__(self, d_model: int, n_heads: int, dropout: float):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d_model)
+        self.self_attn = nn.MultiheadAttention(
+            d_model, n_heads, dropout=dropout, batch_first=True)
+        self.norm2 = nn.LayerNorm(d_model)
+        self.cross_attn = nn.MultiheadAttention(
+            d_model, n_heads, dropout=dropout, batch_first=True)
+        self.norm3 = nn.LayerNorm(d_model)
+        self.mlp = nn.Sequential(
+            nn.Linear(d_model, 4 * d_model), nn.GELU(),
+            nn.Dropout(dropout), nn.Linear(4 * d_model, d_model))
+
+    def forward(self, x: torch.Tensor, context: torch.Tensor) -> torch.Tensor:
+        h = self.norm1(x)
+        x = x + self.self_attn(h, h, h, need_weights=False)[0]
+        x = x + self.cross_attn(self.norm2(x), context, context,
+                                need_weights=False)[0]
+        return x + self.mlp(self.norm3(x))
+
+
+class VLAModule(nn.Module):
+    """The policy: (image, instruction bytes[, actions]) -> head output.
+
+    ``forward`` is the TRAINING face (returns the residual for flow, the
+    predicted chunk for regression); :meth:`predict_action` is the
+    INFERENCE face both evaluation nodes call.
+    """
+
+    def __init__(
+        self,
+        *,
+        image_size: int,
+        patch_size: int,
+        d_model: int,
+        n_layers: int,
+        n_heads: int,
+        expert_layers: int,
+        chunk: int,
+        action_dim: int,
+        max_text_len: int,
+        head_type: str,
+        vision_stem: str,
+        dropout: float,
+    ):
+        super().__init__()
+        if head_type not in HEAD_TYPES:
+            raise ValueError(f"head_type must be one of {HEAD_TYPES}")
+        if vision_stem not in VISION_STEMS:
+            raise ValueError(f"vision_stem must be one of {VISION_STEMS}")
+        if vision_stem == "conv":
+            if image_size % _CONV_STEM_FACTOR:
+                raise ValueError(
+                    f"image_size must be divisible by {_CONV_STEM_FACTOR} "
+                    f"for the conv stem, got {image_size}")
+            n_vision_tokens = (image_size // _CONV_STEM_FACTOR) ** 2
+            self.stem = nn.Sequential(
+                nn.Conv2d(3, d_model // 4, 3, stride=2, padding=1), nn.GELU(),
+                nn.Conv2d(d_model // 4, d_model // 2, 3, stride=2, padding=1),
+                nn.GELU(),
+                nn.Conv2d(d_model // 2, d_model, 3, stride=2, padding=1),
+            )
+        else:
+            if image_size % patch_size:
+                raise ValueError(
+                    f"image_size must be divisible by patch_size, got "
+                    f"{image_size} / {patch_size}")
+            n_vision_tokens = (image_size // patch_size) ** 2
+            self.stem = nn.Conv2d(
+                3, d_model, kernel_size=patch_size, stride=patch_size)
+
+        self.image_size = image_size
+        self.chunk = chunk
+        self.action_dim = action_dim
+        self.max_text_len = max_text_len
+        self.head_type = head_type
+        self.d_model = d_model
+        # Runtime knobs predict_action reads; the node refreshes them every
+        # run so editing them never has to discard persisted weights.
+        self.flow_steps = 10
+        self.flow_time_dist = "uniform"
+
+        self.vision_pos = nn.Parameter(
+            torch.randn(1, n_vision_tokens, d_model) * 0.02)
+        self.text_embedding = nn.Embedding(256, d_model)
+        self.text_pos = nn.Parameter(
+            torch.randn(1, max_text_len, d_model) * 0.02)
+        self.dropout = nn.Dropout(dropout)
+        self.trunk = nn.ModuleList(
+            _EncoderBlock(d_model, n_heads, dropout) for _ in range(n_layers))
+        self.trunk_norm = nn.LayerNorm(d_model)
+
+        self.action_in = nn.Linear(action_dim, d_model)
+        self.queries = nn.Parameter(torch.randn(1, chunk, d_model) * 0.02)
+        self.query_pos = nn.Parameter(torch.randn(1, chunk, d_model) * 0.02)
+        self.time_mlp = nn.Sequential(
+            nn.Linear(d_model, d_model), nn.SiLU(),
+            nn.Linear(d_model, d_model))
+        self.expert = nn.ModuleList(
+            _ExpertBlock(d_model, n_heads, dropout)
+            for _ in range(expert_layers))
+        self.head = nn.Linear(d_model, action_dim)
+
+    # -- shared pieces --------------------------------------------------
+
+    def encode(self, image: torch.Tensor, tokens: torch.Tensor) -> torch.Tensor:
+        if image.dim() != 4 or image.shape[1] != 3:
+            raise ValueError(
+                f"image must be (B, 3, {self.image_size}, {self.image_size}), "
+                f"got {tuple(image.shape)}")
+        # Zero-centered input: measured to matter for the from-scratch small
+        # ViT (the slow-start plateau shortens visibly).
+        vision = self.stem(image * 2.0 - 1.0)
+        vision = vision.flatten(2).transpose(1, 2) + self.vision_pos
+        text = self.text_embedding(tokens) + self.text_pos
+        x = self.dropout(torch.cat([vision, text], dim=1))
+        for block in self.trunk:
+            x = block(x)
+        return self.trunk_norm(x)
+
+    def _time_embedding(self, t: torch.Tensor) -> torch.Tensor:
+        half = self.d_model // 2
+        freqs = torch.exp(
+            torch.arange(half, device=t.device, dtype=torch.float32)
+            * (-math.log(10000.0) / half))
+        angles = t[:, None].float() * freqs[None, :] * 1000.0
+        embedding = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
+        return self.time_mlp(embedding.to(self.queries.dtype))
+
+    def _expert_pass(self, queries: torch.Tensor,
+                     context: torch.Tensor) -> torch.Tensor:
+        x = queries
+        for block in self.expert:
+            x = block(x, context)
+        return self.head(x)
+
+    def _sample_time(self, batch: int, device: torch.device) -> torch.Tensor:
+        if self.flow_time_dist == "beta":
+            # More mass near t=0 (nearly pure noise) -- the pi0-style
+            # emphasis on the noisier end of the path.
+            dist = torch.distributions.Beta(
+                torch.tensor(1.0, device=device),
+                torch.tensor(1.5, device=device))
+            return dist.sample((batch,))
+        return torch.rand(batch, device=device)
+
+    # -- training face ---------------------------------------------------
+
+    def forward(self, data: Any) -> torch.Tensor:
+        if not isinstance(data, (tuple, list)) or len(data) < 2:
+            raise TypeError(
+                "VLAModel.forward expects (image, tokens, actions) as one "
+                "tuple -- the PushWorldDemos sample shape. Got "
+                f"{type(data).__name__}.")
+        image, tokens = data[0], data[1]
+        context = self.encode(image, tokens)
+        batch = image.shape[0]
+
+        if self.head_type == "regression":
+            queries = self.queries.expand(batch, -1, -1) + self.query_pos
+            return self._expert_pass(queries, context)
+
+        if len(data) < 3 or data[2] is None:
+            raise ValueError(
+                "flow_matching training needs the action chunk inside data "
+                "((image, tokens, actions)) so forward can noise it; wire "
+                "PushWorldDemos' dataset, not a bare (image, tokens) pair.")
+        actions = data[2]
+        t = self._sample_time(batch, image.device)
+        noise = torch.randn_like(actions)
+        t_wide = t[:, None, None].to(actions.dtype)
+        noised = (1 - t_wide) * noise + t_wide * actions
+        velocity_target = actions - noise
+        queries = (self.action_in(noised) + self.query_pos
+                   + self._time_embedding(t)[:, None, :])
+        velocity_pred = self._expert_pass(queries, context)
+        # The residual, so the loss is mean(residual^2) with no second
+        # forward output to thread through TrainingLoop.
+        return velocity_pred - velocity_target
+
+    # -- inference face --------------------------------------------------
+
+    @torch.no_grad()
+    def predict_action(self, image: torch.Tensor,
+                       tokens: torch.Tensor) -> torch.Tensor:
+        """(B, 3, S, S) + (B, L) -> (B, chunk, action_dim)."""
+        was_training = self.training
+        self.eval()
+        try:
+            context = self.encode(image, tokens)
+            batch = image.shape[0]
+            if self.head_type == "regression":
+                queries = self.queries.expand(batch, -1, -1) + self.query_pos
+                return self._expert_pass(queries, context)
+            steps = max(1, int(self.flow_steps))
+            x = torch.randn(
+                batch, self.chunk, self.action_dim, device=image.device,
+                dtype=self.queries.dtype)
+            dt = 1.0 / steps
+            for index in range(steps):
+                t = torch.full((batch,), index * dt, device=image.device)
+                queries = (self.action_in(x) + self.query_pos
+                           + self._time_embedding(t)[:, None, :])
+                x = x + self._expert_pass(queries, context) * dt
+            return x
+        finally:
+            self.train(was_training)
+
+
+class VLABehaviorLoss(nn.Module):
+    """The mode-matched loss VLAModel emits on its ``loss_fn`` port.
+
+    flow_matching: ``outputs`` IS the residual, so the loss is its squared
+    mean and ``targets`` is deliberately unused. regression: plain MSE.
+    Reductions in float32 so bf16 autocast cannot degrade them. Must never
+    subclass CrossEntropyLoss/NLLLoss -- TrainingLoop's accuracy gate keys
+    on that isinstance.
+    """
+
+    def __init__(self, head_type: str):
+        super().__init__()
+        self.head_type = head_type
+
+    def forward(self, outputs: torch.Tensor,
+                targets: torch.Tensor | None = None) -> torch.Tensor:
+        if self.head_type == "flow_matching":
+            return outputs.float().pow(2).mean()
+        if targets is None:
+            raise ValueError("regression loss needs targets")
+        return F.mse_loss(outputs.float(), targets.float())
+
+
+def _resolve_config(params: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "image_size": int(params.get("image_size", 96) or 96),
+        "patch_size": int(params.get("patch_size", 8) or 8),
+        "d_model": int(params.get("d_model", 192) or 192),
+        "n_layers": int(params.get("n_layers", 4) or 4),
+        "n_heads": int(params.get("n_heads", 6) or 6),
+        "expert_layers": int(params.get("expert_layers", 2) or 2),
+        "chunk": int(params.get("chunk", 8) or 8),
+        "action_dim": int(params.get("action_dim", 2) or 2),
+        "max_text_len": int(params.get("max_text_len", 48) or 48),
+        "head_type": str(params.get("head_type", "flow_matching")
+                         or "flow_matching"),
+        "vision_stem": str(params.get("vision_stem", "conv") or "conv"),
+        "dropout": float(params.get("dropout", 0.0) or 0.0),
+    }
+
+
+class VLAModelNode(StatefulModuleMixin, BaseNode):
+    NODE_NAME = "VLAModel"
+    CATEGORY = "VLA"
+    DESCRIPTION = (
+        "A mini vision-language-action policy: vision stem + byte-level "
+        "instruction embedding -> transformer trunk -> chunked action "
+        "expert. head_type picks the paradigm - flow_matching (pi0/SmolVLA "
+        "family: noise the chunk, learn the velocity field, Euler-integrate "
+        "at inference) or regression (direct MSE behavior cloning) - with "
+        "everything else held fixed, so the two can be compared honestly. "
+        "Emits the mode-matched loss_fn itself; wire model+loss_fn to "
+        "TrainingLoop and the PushWorldDemos dataset to a DataLoader. "
+        "Defaults build ~3.2M params."
+    )
+
+    # A MODEL output is a live handle TrainingLoop mutates in place --
+    # the #253/#254 rule, same as CausalLMModel.
+    cacheable = False
+
+    # Every constructor input, so editing one honestly discards persisted
+    # weights. flow_steps / flow_time_dist are deliberately ABSENT: they are
+    # runtime behavior refreshed onto the module every run.
+    structural_params = (
+        "image_size",
+        "patch_size",
+        "d_model",
+        "n_layers",
+        "n_heads",
+        "expert_layers",
+        "chunk",
+        "action_dim",
+        "max_text_len",
+        "head_type",
+        "vision_stem",
+        "dropout",
+        "seed",
+    )
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return []
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="model",
+                data_type=DataType.MODEL,
+                description=(
+                    "The policy as an nn.Module: forward((image, tokens, "
+                    "actions)) for training, predict_action(image, tokens) "
+                    "for rollout. Carries chunk/action_dim/image_size/"
+                    "max_text_len/head_type as attributes."
+                ),
+            ),
+            PortDefinition(
+                name="loss_fn",
+                data_type=DataType.LOSS_FN,
+                description=(
+                    "The loss matched to head_type - emitted here so a "
+                    "mismatched generic loss cannot silently train the "
+                    "wrong objective. Wire straight to TrainingLoop."
+                ),
+            ),
+            PortDefinition(
+                name="param_count",
+                data_type=DataType.SCALAR,
+                description="Trainable parameters",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="head_type",
+                param_type=ParamType.SELECT,
+                default="flow_matching",
+                options=HEAD_TYPES,
+                description=(
+                    "flow_matching: pi0/SmolVLA-style velocity field over "
+                    "noised action chunks, Euler sampling at inference. "
+                    "regression: direct chunk prediction, MSE. The loss_fn "
+                    "output follows this choice automatically."
+                ),
+            ),
+            ParamDefinition(
+                name="d_model",
+                param_type=ParamType.INT,
+                default=192,
+                min_value=32,
+                max_value=2048,
+                description="Width of every token stream (must divide by n_heads)",
+            ),
+            ParamDefinition(
+                name="n_layers",
+                param_type=ParamType.INT,
+                default=4,
+                min_value=1,
+                max_value=48,
+                description="Trunk depth over [vision; text] tokens",
+            ),
+            ParamDefinition(
+                name="n_heads",
+                param_type=ParamType.INT,
+                default=6,
+                min_value=1,
+                max_value=32,
+                description="Attention heads, trunk and expert alike",
+            ),
+            ParamDefinition(
+                name="expert_layers",
+                param_type=ParamType.INT,
+                default=2,
+                min_value=1,
+                max_value=16,
+                description=(
+                    "Action-expert depth (self-attention over the chunk "
+                    "queries + cross-attention into the trunk)"
+                ),
+            ),
+            ParamDefinition(
+                name="chunk",
+                param_type=ParamType.INT,
+                default=8,
+                min_value=1,
+                max_value=64,
+                description=(
+                    "Actions predicted per call (the chunk horizon H) - "
+                    "must match PushWorldDemos' chunk"
+                ),
+            ),
+            ParamDefinition(
+                name="image_size",
+                param_type=ParamType.INT,
+                default=96,
+                min_value=32,
+                max_value=256,
+                description="Input frame size - must match PushWorldEnv's image_size",
+            ),
+            ParamDefinition(
+                name="vision_stem",
+                param_type=ParamType.SELECT,
+                default="conv",
+                options=VISION_STEMS,
+                description=(
+                    "conv: three stride-2 3x3 convs (fine localization; the "
+                    "'early convolutions help transformers see' result is "
+                    "measurable here). patchify: the classic ViT stem, kept "
+                    "for studying exactly that difference."
+                ),
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="patch_size",
+                param_type=ParamType.INT,
+                default=8,
+                min_value=4,
+                max_value=32,
+                description="Patchify stem only: square patch edge",
+                visible_when={"vision_stem": "patchify"},
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="action_dim",
+                param_type=ParamType.INT,
+                default=2,
+                min_value=1,
+                max_value=32,
+                description="Action vector width (PushWorld is 2: dx, dy)",
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="max_text_len",
+                param_type=ParamType.INT,
+                default=48,
+                min_value=8,
+                max_value=256,
+                description=(
+                    "Instruction length in BYTES - must match the dataset's "
+                    "encoding (PushWorldDemos uses 48)"
+                ),
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="flow_steps",
+                param_type=ParamType.INT,
+                default=10,
+                min_value=1,
+                max_value=100,
+                description=(
+                    "flow_matching only: Euler integration steps at "
+                    "inference (SmolVLA uses 10). Runtime knob - editing it "
+                    "keeps persisted weights."
+                ),
+                visible_when={"head_type": "flow_matching"},
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="flow_time_dist",
+                param_type=ParamType.SELECT,
+                default="uniform",
+                options=FLOW_TIME_DISTS,
+                description=(
+                    "flow_matching only: how training samples the flow time "
+                    "t. beta weights the noisier end of the path "
+                    "(pi0-style). Runtime knob - keeps persisted weights."
+                ),
+                visible_when={"head_type": "flow_matching"},
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="dropout",
+                param_type=ParamType.FLOAT,
+                default=0.0,
+                min_value=0.0,
+                max_value=0.9,
+                description="Dropout through trunk and expert",
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description="Weight-init seed",
+                advanced=True,
+            ),
+        ]
+
+    def build_module(self, params: dict[str, Any]) -> nn.Module:
+        config = _resolve_config(params)
+        if config["d_model"] % config["n_heads"]:
+            raise ValueError(
+                f"d_model ({config['d_model']}) must divide evenly by "
+                f"n_heads ({config['n_heads']})")
+        torch.manual_seed(max(0, int(params.get("seed", 0) or 0)))
+        return VLAModule(**config)
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        config = _resolve_config(params)
+        model = self.get_or_build_module(context, params)
+        # Runtime knobs refresh every run precisely BECAUSE they are not
+        # structural: a persisted module must still honor today's values.
+        model.flow_steps = max(1, int(params.get("flow_steps", 10) or 10))
+        model.flow_time_dist = str(
+            params.get("flow_time_dist", "uniform") or "uniform")
+
+        param_count = sum(
+            p.numel() for p in model.parameters() if p.requires_grad)
+        note = (
+            f"{param_count:,} trainable parameters: {config['n_layers']}-"
+            f"layer trunk + {config['expert_layers']}-layer action expert, "
+            f"d_model={config['d_model']}, {config['vision_stem']} stem, "
+            f"chunk {config['chunk']}, head {config['head_type']}."
+        )
+        logger.info("VLAModel: %s", note)
+        return {
+            "model": model,
+            "loss_fn": VLABehaviorLoss(config["head_type"]),
+            "param_count": param_count,
+            "__log__": note,
+        }

--- a/backend/app/nodes/vla/vla_rollout_node.py
+++ b/backend/app/nodes/vla/vla_rollout_node.py
@@ -1,0 +1,327 @@
+"""VLARollout node (#312) -- closed-loop evaluation, with the receipts.
+
+Rolls a trained VLAModel policy through fresh PushWorld episodes and
+reports what a VLA paper reports: closed-loop SUCCESS RATE, plus the
+rollout video (wire ``frames`` into VideoWrite). Two design points carry
+the science:
+
+**Receding horizon is a measured knob, not a detail.** The policy predicts
+a chunk of H actions; ``execute_k`` says how many to execute before
+re-planning from a fresh observation. Prototype measurement, same trained
+policy: execute_k=2 -> 46%, 4 -> 34%, 8 (full chunk, open loop) -> 20%.
+The default is 2; raising it toward H is the cheap way to STUDY the
+open-loop compounding-error effect rather than suffer it.
+
+**instruction_mode=swapped is the language-grounding ablation.** It hands
+the policy a deliberately mismatched instruction (a distractor puck's
+color). A policy that reads pixels only scores the same as normal mode; a
+policy that reads language collapses (46% -> 2% in the prototype). The gap
+IS the evidence that the instruction is load-bearing.
+
+Evaluation episodes come from a seed stream offset far from the
+demonstration nodes' defaults, so a default-wired graph never evaluates on
+initial states it trained on.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+
+from ...core.node_base import BaseNode, DataType, ParamDefinition, ParamType, PortDefinition
+from .pushworld_demos_node import encode_instruction
+from .pushworld_env_node import PushWorldFactory
+
+logger = logging.getLogger(__name__)
+
+INSTRUCTION_MODES = ["normal", "swapped"]
+
+#: Rollout seeds start here (plus the node's seed param), keeping them
+#: disjoint from PushWorldDemos' training stream (seed+0..) and holdout
+#: stream (seed+1_000_000..) at default settings.
+_ROLLOUT_SEED_OFFSET = 2_000_000
+
+#: Border tint painted onto recorded frames after the episode resolves.
+_TINT_SUCCESS = (40, 200, 60)
+_TINT_FAILURE = (210, 60, 50)
+_TINT_WIDTH = 2
+
+
+def _tint_border(frames: list[torch.Tensor], success: bool) -> None:
+    color = torch.tensor(
+        _TINT_SUCCESS if success else _TINT_FAILURE, dtype=torch.uint8)
+    for frame in frames:
+        frame[:, :_TINT_WIDTH, :] = color[:, None, None]
+        frame[:, -_TINT_WIDTH:, :] = color[:, None, None]
+        frame[:, :, :_TINT_WIDTH] = color[:, None, None]
+        frame[:, :, -_TINT_WIDTH:] = color[:, None, None]
+
+
+class VLARolloutNode(BaseNode):
+    NODE_NAME = "VLARollout"
+    CATEGORY = "VLA"
+    DESCRIPTION = (
+        "Closed-loop evaluation of a VLAModel in PushWorld: fresh episodes, "
+        "receding-horizon execution (predict a chunk, execute execute_k, "
+        "re-plan), success rate + per-episode metrics + a rollout video "
+        "tensor for VideoWrite (green/red border per outcome). "
+        "instruction_mode=swapped is the language ablation: a policy that "
+        "actually reads the instruction collapses when it lies."
+    )
+
+    # Consumes two live handles (model, env factory) and its outputs
+    # describe THIS run's policy weights -- nothing a cache key can see.
+    cacheable = False
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="model",
+                data_type=DataType.MODEL,
+                description="Trained VLAModel (needs predict_action)",
+            ),
+            PortDefinition(
+                name="env",
+                data_type=DataType.ANY,
+                description="PushWorldEnv handle",
+            ),
+        ]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [
+            PortDefinition(
+                name="success_rate",
+                data_type=DataType.SCALAR,
+                description="Episodes solved / episodes run, in [0, 1]",
+            ),
+            PortDefinition(
+                name="avg_steps",
+                data_type=DataType.SCALAR,
+                description=(
+                    "Mean episode length (timeouts count at the full "
+                    "budget, so lower is strictly better)"
+                ),
+            ),
+            PortDefinition(
+                name="frames",
+                data_type=DataType.TENSOR,
+                description=(
+                    "Recorded episodes, uint8 (T,3,S,S), border green/red "
+                    "by outcome - wire into VideoWrite"
+                ),
+            ),
+            PortDefinition(
+                name="report",
+                data_type=DataType.STRING,
+                description="Per-episode outcomes as text",
+            ),
+        ]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(
+                name="episodes",
+                param_type=ParamType.INT,
+                default=20,
+                min_value=1,
+                max_value=500,
+                description="Evaluation episodes (fresh seeds, disjoint from training)",
+            ),
+            ParamDefinition(
+                name="execute_k",
+                param_type=ParamType.INT,
+                default=2,
+                min_value=1,
+                max_value=64,
+                description=(
+                    "Actions executed per predicted chunk before re-planning "
+                    "(receding horizon). Measured on one trained policy: "
+                    "2 -> 46%, 4 -> 34%, full chunk 8 -> 20% - raise toward "
+                    "the chunk size to study open-loop compounding error."
+                ),
+            ),
+            ParamDefinition(
+                name="max_steps",
+                param_type=ParamType.INT,
+                default=100,
+                min_value=10,
+                max_value=1000,
+                description=(
+                    "Per-episode step budget (overrides the env's). Learned "
+                    "policies are slower than the scripted expert; a tight "
+                    "budget scores control errors as timeouts."
+                ),
+            ),
+            ParamDefinition(
+                name="instruction_mode",
+                param_type=ParamType.SELECT,
+                default="normal",
+                options=INSTRUCTION_MODES,
+                description=(
+                    "normal: the episode's true instruction. swapped: name a "
+                    "DISTRACTOR puck instead - the language-grounding "
+                    "ablation. A pixels-only policy scores the same either "
+                    "way; a language-reading one collapses under swapped."
+                ),
+            ),
+            ParamDefinition(
+                name="record_episodes",
+                param_type=ParamType.INT,
+                default=4,
+                min_value=0,
+                max_value=32,
+                description="First N episodes recorded into frames (0 = none)",
+            ),
+            ParamDefinition(
+                name="seed",
+                param_type=ParamType.INT,
+                default=0,
+                min_value=0,
+                description=(
+                    "Evaluation seed. Episode seeds run from an offset "
+                    "stream disjoint from PushWorldDemos' defaults."
+                ),
+                advanced=True,
+            ),
+            ParamDefinition(
+                name="device",
+                param_type=ParamType.SELECT,
+                default="auto",
+                options=["auto", "cpu", "cuda", "mps"],
+                description="auto follows the run's device",
+                advanced=True,
+            ),
+        ]
+
+    def execute(
+        self,
+        inputs: dict[str, Any],
+        params: dict[str, Any],
+        progress_callback: Any | None = None,
+        *,
+        context: Any = None,
+    ) -> dict[str, Any]:
+        from ...core.device_utils import resolve_node_device
+        from ...core.loop_control import ProgressThrottle, interrupted_result, stop_checker
+
+        model = inputs["model"]
+        factory = inputs["env"]
+        if not isinstance(factory, PushWorldFactory):
+            raise TypeError(
+                "VLARollout: the env input must come from PushWorldEnv "
+                f"(got {type(factory).__name__}).")
+        if not hasattr(model, "predict_action"):
+            raise TypeError(
+                "VLARollout: the model input must be a VLAModel (it has no "
+                "predict_action).")
+
+        episodes = max(1, int(params.get("episodes", 20) or 20))
+        execute_k = max(1, int(params.get("execute_k", 2) or 2))
+        max_steps = max(10, int(params.get("max_steps", 100) or 100))
+        mode = str(params.get("instruction_mode", "normal") or "normal")
+        record_episodes = max(0, int(params.get("record_episodes", 4) or 0))
+        seed = max(0, int(params.get("seed", 0) or 0))
+        if mode == "swapped" and factory.n_distractors < 1:
+            raise ValueError(
+                "instruction_mode=swapped needs at least one distractor "
+                "puck to name - set PushWorldEnv.n_distractors >= 1.")
+
+        device = resolve_node_device(params.get("device"), context)
+        model_device = next(model.parameters()).device
+        model.to(device)
+
+        should_stop = stop_checker(context)
+        throttle = ProgressThrottle(progress_callback)
+        max_text_len = int(getattr(model, "max_text_len", 48))
+
+        successes = 0
+        total_steps = 0
+        completed = 0
+        stopped_at: int | None = None
+        recorded: list[torch.Tensor] = []
+        lines: list[str] = []
+        try:
+            for index in range(episodes):
+                if should_stop():
+                    stopped_at = index
+                    break
+                episode = factory.episode(
+                    seed=seed + _ROLLOUT_SEED_OFFSET + index,
+                    max_steps=max_steps)
+                instruction = episode.instruction
+                if mode == "swapped":
+                    wrong_color = episode.puck_colors[1]
+                    instruction = (
+                        f"push the {wrong_color} puck to the "
+                        f"{episode.target_colors[episode.goal_target]} target")
+                tokens = encode_instruction(
+                    instruction, max_text_len).unsqueeze(0).to(device)
+
+                episode_frames: list[torch.Tensor] = []
+                done = False
+                while not done:
+                    frame = episode.render()
+                    if index < record_episodes:
+                        episode_frames.append(
+                            (frame.clamp(0, 1) * 255).round().to(torch.uint8))
+                    observation = frame.unsqueeze(0).to(device)
+                    chunk = model.predict_action(observation, tokens)[0]
+                    for k in range(min(execute_k, chunk.shape[0])):
+                        done = episode.step(chunk[k].float().cpu())
+                        if done:
+                            break
+                if index < record_episodes and episode_frames:
+                    _tint_border(episode_frames, episode.success)
+                    recorded.extend(episode_frames)
+
+                completed += 1
+                successes += int(episode.success)
+                total_steps += episode.steps
+                lines.append(
+                    f"episode {index + 1}: "
+                    f"{'success' if episode.success else 'timeout'} in "
+                    f"{episode.steps} steps -- \"{instruction}\"")
+                if context is not None:
+                    context.log_metric(
+                        "success_rate", successes / completed, completed)
+                    context.log_metric(
+                        "episode_steps", float(episode.steps), completed)
+                throttle.emit({
+                    "event": "progress",
+                    "episode": completed,
+                    "total_episodes": episodes,
+                    "success_rate": round(successes / completed, 4),
+                })
+        finally:
+            model.to(model_device)
+
+        if completed == 0:
+            raise RuntimeError("VLARollout: stopped before any episode ran.")
+
+        success_rate = successes / completed
+        avg_steps = total_steps / completed
+        frames = (
+            torch.stack(recorded) if recorded
+            else torch.zeros(0, 3, factory.image_size, factory.image_size,
+                             dtype=torch.uint8))
+        note = (
+            f"{mode} instructions: {successes}/{completed} solved "
+            f"(success_rate {success_rate:.2f}), avg {avg_steps:.1f} steps, "
+            f"execute_k {execute_k}, {frames.shape[0]} recorded frames."
+        )
+        logger.info("VLARollout: %s", note)
+        result: dict[str, Any] = {
+            "success_rate": success_rate,
+            "avg_steps": avg_steps,
+            "frames": frames,
+            "report": "\n".join(lines),
+            "__log__": note,
+        }
+        if stopped_at is not None:
+            result.update(interrupted_result(episode=stopped_at))
+        return result

--- a/backend/tests/test_vla_model_node.py
+++ b/backend/tests/test_vla_model_node.py
@@ -1,0 +1,332 @@
+"""VLAModel / VLARollout / VLAActionEval (#312), and the first REAL user of
+TrainingLoop's nested-batch device path.
+
+The training integration test at the bottom is a regression lock on a
+contract nothing exercised before: ``((image, tokens, actions), target)``
+batches move to the device through ``to_device``'s recursion, through all
+of TrainingLoop's batch sites, with ``model(data)`` receiving the tuple as
+one argument.
+"""
+
+import pickle
+
+import pytest
+import torch
+
+from app.core.execution_context import ExecutionContext
+from app.core.node_state_store import NodeStateStore
+from app.nodes.training.training_loop_node import TrainingLoopNode
+from app.nodes.vla.pushworld_demos_node import PushWorldDemosNode, encode_instruction
+from app.nodes.vla.pushworld_env_node import PushWorldFactory
+from app.nodes.vla.vla_action_eval_node import VLAActionEvalNode
+from app.nodes.vla.vla_model_node import VLABehaviorLoss, VLAModelNode, VLAModule
+from app.nodes.vla.vla_rollout_node import VLARolloutNode
+
+_SIZE = 32  # divisible by the conv stem's 8 and quick to render
+
+TINY = {
+    "image_size": _SIZE,
+    "d_model": 64,
+    "n_layers": 1,
+    "n_heads": 4,
+    "expert_layers": 1,
+    "chunk": 4,
+    "action_dim": 2,
+    "max_text_len": 48,
+    "seed": 0,
+}
+
+
+def _build(**overrides):
+    return VLAModelNode().execute({}, {**TINY, **overrides})
+
+
+def _batch(batch_size=3, chunk=4):
+    image = torch.rand(batch_size, 3, _SIZE, _SIZE)
+    tokens = torch.stack(
+        [encode_instruction("push the red puck to the blue target")]
+        * batch_size)
+    actions = torch.rand(batch_size, chunk, 2) * 2 - 1
+    return image, tokens, actions
+
+
+# ── forward contracts ───────────────────────────────────────────────────
+
+
+def test_regression_forward_predicts_the_chunk_shape():
+    model = _build(head_type="regression")["model"]
+    image, tokens, actions = _batch()
+    out = model((image, tokens, actions))
+    assert out.shape == (3, 4, 2)
+    assert torch.isfinite(out).all()
+
+
+def test_flow_forward_returns_a_residual_of_chunk_shape():
+    model = _build(head_type="flow_matching")["model"]
+    image, tokens, actions = _batch()
+    out = model((image, tokens, actions))
+    assert out.shape == (3, 4, 2)
+    assert torch.isfinite(out).all()
+
+
+def test_regression_tolerates_a_two_tuple_and_flow_refuses_it():
+    image, tokens, actions = _batch()
+    regression = _build(head_type="regression")["model"]
+    assert regression((image, tokens)).shape == (3, 4, 2)
+    flow = _build(head_type="flow_matching")["model"]
+    with pytest.raises(ValueError, match="action chunk inside data"):
+        flow((image, tokens))
+
+
+def test_forward_refuses_a_bare_tensor():
+    model = _build()["model"]
+    with pytest.raises(TypeError, match="one tuple"):
+        model(torch.rand(3, 3, _SIZE, _SIZE))
+
+
+def test_wrong_image_shape_is_a_clear_error():
+    model = _build()["model"]
+    _, tokens, actions = _batch()
+    with pytest.raises(ValueError, match="image must be"):
+        model((torch.rand(3, 1, _SIZE, _SIZE), tokens, actions))
+
+
+# ── the loss the node emits ─────────────────────────────────────────────
+
+
+def test_loss_fn_matches_the_head_and_the_flow_loss_is_the_residual_msq():
+    result = _build(head_type="flow_matching")
+    loss_fn = result["loss_fn"]
+    assert isinstance(loss_fn, VLABehaviorLoss)
+    assert loss_fn.head_type == "flow_matching"
+    residual = torch.tensor([[1.0, -1.0], [3.0, 0.0]])
+    ignored_targets = torch.zeros_like(residual)
+    assert loss_fn(residual, ignored_targets).item() == pytest.approx(2.75)
+
+    regression = _build(head_type="regression")["loss_fn"]
+    outputs = torch.tensor([[1.0, 0.0]])
+    targets = torch.tensor([[0.0, 0.0]])
+    assert regression(outputs, targets).item() == pytest.approx(0.5)
+    # never the classification gate's type
+    assert not isinstance(
+        regression, (torch.nn.CrossEntropyLoss, torch.nn.NLLLoss))
+
+
+def test_flow_training_step_reduces_the_flow_loss():
+    torch.manual_seed(0)
+    model = _build(head_type="flow_matching")["model"]
+    loss_fn = VLABehaviorLoss("flow_matching")
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    image, tokens, actions = _batch(batch_size=16)
+    losses = []
+    for _ in range(30):
+        out = model((image, tokens, actions))
+        loss = loss_fn(out, actions)
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        optimizer.step()
+        losses.append(loss.item())
+    assert losses[-1] < losses[0] * 0.8
+
+
+# ── predict_action ──────────────────────────────────────────────────────
+
+
+def test_predict_action_shapes_for_both_heads():
+    image, tokens, _ = _batch()
+    for head in ("regression", "flow_matching"):
+        model = _build(head_type=head)["model"]
+        out = model.predict_action(image, tokens)
+        assert out.shape == (3, 4, 2)
+        assert torch.isfinite(out).all()
+
+
+def test_flow_prediction_is_reproducible_under_a_seed():
+    model = _build(head_type="flow_matching")["model"]
+    image, tokens, _ = _batch(batch_size=1)
+    torch.manual_seed(7)
+    first = model.predict_action(image, tokens)
+    torch.manual_seed(7)
+    second = model.predict_action(image, tokens)
+    assert torch.equal(first, second)
+
+
+def test_predict_action_restores_training_mode():
+    model = _build()["model"]
+    model.train()
+    image, tokens, _ = _batch(batch_size=1)
+    model.predict_action(image, tokens)
+    assert model.training
+
+
+def test_flow_steps_refresh_without_a_rebuild():
+    node, context = VLAModelNode(), _persisting_context()
+    params = {**TINY, "head_type": "flow_matching", "flow_steps": 10}
+    first = node.execute({}, params, context=context)["model"]
+    second = node.execute(
+        {}, {**params, "flow_steps": 3}, context=context)["model"]
+    assert second is first  # runtime knob: same module...
+    assert second.flow_steps == 3  # ...new behavior
+
+
+# ── module hygiene ──────────────────────────────────────────────────────
+
+
+def test_the_module_pickles_whole():
+    """#283's lesson: module-scope classes or full_model saving breaks."""
+    model = _build()["model"]
+    clone = pickle.loads(pickle.dumps(model))
+    assert isinstance(clone, VLAModule)
+    image, tokens, actions = _batch(batch_size=1)
+    ours = model((image, tokens, actions) if model.head_type != "regression"
+                 else (image, tokens))
+    del ours  # the point is that forward runs on the clone at all
+    out = clone.predict_action(image, tokens)
+    assert out.shape == (1, 4, 2)
+
+
+def _persisting_context(**kwargs) -> ExecutionContext:
+    return ExecutionContext(
+        graph_id="g",
+        weights_persistent=True,
+        node_state_store=NodeStateStore(),
+        current_node_id="vla",
+        **kwargs,
+    )
+
+
+def test_persisted_weights_survive_and_structure_edits_drop_them():
+    node, context = VLAModelNode(), _persisting_context()
+    first = node.execute({}, dict(TINY), context=context)["model"]
+    with torch.no_grad():
+        first.head.weight.fill_(0.123)
+    again = node.execute({}, dict(TINY), context=context)["model"]
+    assert again is first
+    wider = node.execute(
+        {}, {**TINY, "d_model": 128, "n_heads": 4}, context=context)["model"]
+    assert wider is not first
+
+
+def test_patchify_stem_is_available_and_counts_differently():
+    conv = _build(vision_stem="conv")["param_count"]
+    patchify = _build(vision_stem="patchify", patch_size=8)["param_count"]
+    assert conv != patchify
+    model = _build(vision_stem="patchify", patch_size=8)["model"]
+    image, tokens, actions = _batch()
+    assert model((image, tokens, actions)).shape == (3, 4, 2)
+
+
+def test_bad_geometry_is_refused():
+    with pytest.raises(ValueError, match="divisible"):
+        _build(image_size=30)  # conv stem needs %8
+    with pytest.raises(ValueError, match="n_heads"):
+        _build(d_model=65, n_heads=4)
+
+
+# ── rollout + open-loop eval on a fresh (untrained) policy ──────────────
+
+
+def _factory(**overrides):
+    config = {"image_size": _SIZE, "n_distractors": 1, "max_steps": 30}
+    config.update(overrides)
+    return PushWorldFactory(**config)
+
+
+def test_rollout_runs_and_reports(monkeypatch):
+    model = _build()["model"]
+    result = VLARolloutNode().execute(
+        {"model": model, "env": _factory()},
+        {"episodes": 3, "execute_k": 2, "max_steps": 15,
+         "instruction_mode": "normal", "record_episodes": 2, "seed": 0,
+         "device": "cpu"},
+    )
+    assert 0.0 <= result["success_rate"] <= 1.0
+    assert result["avg_steps"] > 0
+    frames = result["frames"]
+    assert frames.dtype == torch.uint8
+    assert frames.dim() == 4 and frames.shape[1:] == (3, _SIZE, _SIZE)
+    assert frames.shape[0] > 0
+    assert len(result["report"].splitlines()) == 3
+
+
+def test_rollout_swapped_needs_a_distractor():
+    model = _build()["model"]
+    with pytest.raises(ValueError, match="distractor"):
+        VLARolloutNode().execute(
+            {"model": model, "env": _factory(n_distractors=0)},
+            {"episodes": 1, "instruction_mode": "swapped", "device": "cpu"},
+        )
+
+
+def test_rollout_refuses_a_model_without_predict_action():
+    with pytest.raises(TypeError, match="predict_action"):
+        VLARolloutNode().execute(
+            {"model": torch.nn.Linear(2, 2), "env": _factory()},
+            {"episodes": 1, "device": "cpu"},
+        )
+
+
+def _tiny_demos(chunk=4):
+    return PushWorldDemosNode().execute(
+        {"env": _factory()},
+        {"episodes": 2, "chunk": chunk, "demo_noise": 0.0,
+         "holdout_episodes": 2, "video_episodes": 0, "seed": 0},
+    )
+
+
+def test_action_eval_reports_a_reproducible_mse():
+    model = _build()["model"]
+    holdout = _tiny_demos()["holdout"]
+    params = {"max_samples": 16, "batch_size": 8, "seed": 3, "device": "cpu"}
+    first = VLAActionEvalNode().execute(
+        {"model": model, "dataset": holdout}, params)
+    second = VLAActionEvalNode().execute(
+        {"model": model, "dataset": holdout}, params)
+    assert first["evaluated"] == 16
+    assert first["action_mse"] > 0
+    assert first["action_mse"] == pytest.approx(second["action_mse"])
+
+
+def test_action_eval_refuses_an_empty_dataset():
+    model = _build()["model"]
+    empty = _tiny_demos()["holdout"]
+    empty.images_u8 = empty.images_u8[:0]
+    with pytest.raises(ValueError, match="empty"):
+        VLAActionEvalNode().execute(
+            {"model": model, "dataset": empty}, {"device": "cpu"})
+
+
+# ── the nested-batch TrainingLoop contract, exercised for real ──────────
+
+
+@pytest.mark.parametrize("head", ["regression", "flow_matching"])
+def test_training_loop_trains_a_vla_on_nested_batches(head):
+    """((image, tokens, actions), target) through the stock TrainingLoop:
+    device recursion, model(data)-as-one-tuple, the emitted loss, and a
+    val loader on the same nested shape. Fails before this wave if the
+    recursion contract regresses."""
+    result = _build(head_type=head)
+    model, loss_fn = result["model"], result["loss_fn"]
+    demos = _tiny_demos()
+    loader = torch.utils.data.DataLoader(
+        demos["dataset"], batch_size=8, shuffle=True)
+    val_loader = torch.utils.data.DataLoader(
+        demos["holdout"], batch_size=8, shuffle=False)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    before = model.head.weight.detach().clone()
+
+    out = TrainingLoopNode().execute(
+        {
+            "model": model,
+            "dataloader": loader,
+            "val_dataloader": val_loader,
+            "optimizer": optimizer,
+            "loss_fn": loss_fn,
+        },
+        {"epochs": 1, "device": "cpu"},
+    )
+    losses = out["losses"]
+    assert len(losses) == 1 and all(
+        torch.isfinite(torch.as_tensor(float(value))) for value in losses)
+    assert out["val_losses"], "the nested val pass must produce a loss"
+    assert not torch.equal(model.head.weight.detach(), before)

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -1026,6 +1026,60 @@ const zhTW: NodeTranslations = {
     },
   },
 
+  VLAModel: {
+    description:
+      '迷你視覺-語言-動作策略：視覺 stem + 位元組級指令嵌入 -> transformer 主幹 ' +
+      '-> 動作區塊 expert。head_type 選擇範式——flow_matching（pi0/SmolVLA 家族：' +
+      '對動作區塊加噪、學習速度場、推論時 Euler 積分）或 regression（直接 MSE 行為複製）' +
+      '——其他一切固定，兩者可誠實對比。loss_fn 由本節點配對輸出，' +
+      '接錯損失而靜默訓練錯目標的整類錯誤因此不存在。預設約 3.2M 參數',
+    params: {
+      head_type: 'flow_matching：pi0/SmolVLA 式速度場 + Euler 取樣。regression：直接預測區塊、MSE。loss_fn 輸出自動跟隨此選擇',
+      d_model: '所有 token 流的寬度（須能被 n_heads 整除）',
+      n_layers: '主幹深度（作用在 [視覺; 文字] token 上）',
+      n_heads: '注意力頭數（主幹與 expert 共用）',
+      expert_layers: '動作 expert 深度（區塊 query 自注意 + 對主幹交叉注意）',
+      chunk: '每次預測的動作數（區塊視野 H）——須與 PushWorldDemos 的 chunk 一致',
+      image_size: '輸入畫面邊長——須與 PushWorldEnv 的 image_size 一致',
+      vision_stem: 'conv：三層 stride-2 3x3 卷積（定位較精準，「early convolutions help transformers see」在此規模可量測）。patchify：經典 ViT stem，保留以研究這個差異',
+      patch_size: '僅 patchify stem：方形 patch 邊長',
+      action_dim: '動作向量寬度（PushWorld 為 2：dx, dy）',
+      max_text_len: '指令長度（位元組）——須與資料集編碼一致（PushWorldDemos 用 48）',
+      flow_steps: '僅 flow_matching：推論時的 Euler 積分步數（SmolVLA 用 10）。屬執行期旋鈕——修改不會丟棄已保存權重',
+      flow_time_dist: '僅 flow_matching：訓練取樣流時間 t 的分布。beta 偏重雜訊較大的一端（pi0 式）。執行期旋鈕——不影響已保存權重',
+      dropout: '主幹與 expert 全程的 dropout',
+      seed: '權重初始化種子',
+    },
+  },
+  VLARollout: {
+    description:
+      '在 PushWorld 中閉環評估 VLAModel：全新回合、後退視野執行' +
+      '（預測一個區塊、執行 execute_k 步、重新規劃），輸出成功率、逐回合指標、' +
+      '與可接 VideoWrite 的 rollout 影片張量（依結果鑲綠/紅邊框）。' +
+      'instruction_mode=swapped 是語言接地消融：真的在讀指令的策略，指令說謊時會崩潰',
+    params: {
+      episodes: '評估回合數（種子流與訓練資料不相交）',
+      execute_k: '每個預測區塊執行幾步後重新規劃（後退視野）。同一策略實測：2 -> 46%、4 -> 34%、整塊 8 -> 20%——往區塊長度調大即可研究 open-loop 誤差累積',
+      max_steps: '單回合步數預算（覆蓋 env 設定）。學到的策略比腳本專家慢，預算太緊會把控制誤差記成逾時',
+      instruction_mode: 'normal：回合真實指令。swapped：改講干擾 puck 的顏色——語言接地消融。只看畫面的策略兩者同分；讀語言的策略在 swapped 下崩潰',
+      record_episodes: '錄進 frames 的前 N 個回合（0 = 不錄）',
+      seed: '評估種子（回合種子取自與 PushWorldDemos 預設不相交的偏移流）',
+      device: 'auto 跟隨本次執行的裝置',
+    },
+  },
+  VLAActionEval: {
+    description:
+      '開環評估：在保留示範集（PushWorldDemos 的 holdout 輸出）上，' +
+      '計算策略預測動作區塊與專家動作的均方誤差。快速、每種子可重現——' +
+      '與 VLARollout 閉環成功率互補。MSE 低而成功率低，正是誤差累積的特徵',
+    params: {
+      max_samples: '最多評估的樣本數',
+      batch_size: '推論批次大小',
+      seed: '固定 flow head 的取樣噪聲讓數字可重現（regression 不受影響）',
+      device: 'auto 跟隨本次執行的裝置',
+    },
+  },
+
   // ── Custom ──
   AddScalar: {
     description: '將純量值加到張量上（自訂節點範例）',


### PR DESCRIPTION
> 中文摘要：#312 的策略與雙評估。VLAModel 是畫布規模的迷你 VLA：視覺 stem（預設三層 stride-2 卷積；patchify 保留作研究對照）+ 位元組級指令嵌入 -> transformer 主幹 -> 動作區塊 expert，head_type 一鍵切換 flow_matching（pi0/SmolVLA 式：加噪區塊、學速度場、推論 Euler 積分）與 regression（直接 MSE 行為複製），其餘全部固定，兩種範式可誠實對比。損失由節點自己的 loss_fn port 配對輸出——接錯泛用損失而「靜默訓練錯目標」這一類錯誤從結構上不可能發生（對 #312 原規格的刻意偏離：不設獨立 VLALoss 節點）。VLARollout 做閉環評估：後退視野執行（execute_k 實測 2 -> 46%、整塊 8 -> 20%）、instruction_mode=swapped 語言接地消融（46% -> 2%）、逐回合指標、與可直接接 VideoWrite 的結果鑲邊 rollout 影片張量。VLAActionEval 是開環互補（保留集上區塊 MSE）。同時以測試鎖定 TrainingLoop 巢狀 batch 裝置遞迴契約——VLA 是這條路徑的第一個真實使用者，訓練迴圈本身零修改。

Closes #312. Third slice of the VLA epic #309 (after #313 media I/O and
#314 env+demos). Deliberately does NOT touch training_loop_node.py /
lr_scheduler_node.py - the #308 fix belongs to #315.

## Design points

- **Two head paradigms, one model.** flow_matching trains on the residual
  `v_pred - v_target` (t ~ uniform | pi0-style beta), integrates Euler
  over `flow_steps` at inference; regression predicts the chunk directly.
  Same trunk, same data, same everything else - the comparison is the
  research feature.
- **The loss is a port, not a node.** VLAModel emits the mode-matched
  `loss_fn` (deviation from the issue's separate-VLALoss sketch, noted
  here): a generic loss wired to a flow head would train the wrong
  objective with no error anywhere. Making the pairing structural deletes
  the failure mode. `VLABehaviorLoss` reduces in float32 and is not a
  CrossEntropyLoss subclass (TrainingLoop's accuracy gate).
- **Runtime knobs stay runtime.** `flow_steps` / `flow_time_dist` refresh
  onto the persisted module every run - editing them never discards
  weights; everything constructor-shaping is in `structural_params` and
  honestly does.
- **VLARollout measures what the papers measure.** Success rate over
  fresh-seed episodes (offset stream, disjoint from training defaults),
  receding-horizon `execute_k` (measured 2 -> 46%, 4 -> 34%, 8 -> 20% on
  one policy - the open-loop compounding-error curve as a knob),
  `instruction_mode=swapped` as the language ablation (46% -> 2%),
  per-episode metric series, outcome-tinted rollout frames for VideoWrite.
- **VLAActionEval** is the fast deterministic complement; a low MSE beside
  a low success rate is the compounding-error signature, and now both
  numbers exist to see it.
- **Nested-batch contract locked.** `((image, tokens, actions), target)`
  through the STOCK TrainingLoop (train + val, both heads) - to_device's
  recursion had no real caller until now; the integration test fails if it
  regresses.

## Verification

```
cd backend
.venv/Scripts/python.exe -m pytest tests/test_vla_model_node.py -q       # 22 passed
.venv/Scripts/python.exe -m pytest tests/test_pushworld_nodes.py tests/test_api_nodes.py -q
uvx ruff@0.14.4 check .
```

Prototype evidence for the defaults (RTX 4080): conv stem vs patchify is
the difference between a 46% and a 20-24% policy at equal budget; the
numbers quoted in param descriptions are from those runs (epic #309 has
the full series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7hg6NttgDyNBcf49Na9kj
