### PR TITLE
fix(ui): one atomic door for opening a graph document, and a version gate that fails closed (#200)

### DIFF
--- a/frontend/src/components/Canvas/EmptyCanvasOverlay.test.tsx
+++ b/frontend/src/components/Canvas/EmptyCanvasOverlay.test.tsx
@@ -234,20 +234,26 @@ describe('EmptyCanvasOverlay', () => {
     // Existing preset to exercise the "already present, skip" branch.
     useNodeDefStore.setState({ definitions: [], presets: [{ preset_name: 'Existing' } as any] });
 
-    const setNodes = vi.fn();
-    const setEdges = vi.fn();
-    const renameTab = vi.fn();
-    useTabStore.setState({ setNodes, setEdges, renameTab });
+    // One spy, because the gallery path installs the whole document through
+    // one store action now (#200 items 4 and 8) instead of sequencing
+    // setNodes/setEdges/renameTab itself.
+    const loadGraphDocument = vi.fn();
+    useTabStore.setState({ loadGraphDocument });
 
     render(<EmptyCanvasOverlay />);
     fireEvent.click(await screen.findByText('Loadable'));
 
-    await waitFor(() => expect(setNodes).toHaveBeenCalled());
+    await waitFor(() => expect(loadGraphDocument).toHaveBeenCalled());
     expect(mockedRest.loadExample).toHaveBeenCalledWith('/examples/foo.json');
-    expect(setNodes).toHaveBeenCalledWith([{ id: 'n1' }]);
-    expect(setEdges).toHaveBeenCalledWith([{ id: 'e1' }]);
-    // trimmed example name used for rename
-    expect(renameTab).toHaveBeenCalledWith(useTabStore.getState().activeTabId, 'My Model');
+    expect(loadGraphDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodes: [{ id: 'n1' }],
+        edges: [{ id: 'e1' }],
+        // trimmed example name, carried on the document rather than applied
+        // by a separate renameTab
+        name: 'My Model',
+      }),
+    );
     // new preset merged into the store (Existing + NewPreset)
     await waitFor(() =>
       expect(useNodeDefStore.getState().presets.map((p) => p.preset_name)).toEqual([
@@ -266,7 +272,7 @@ describe('EmptyCanvasOverlay', () => {
       presets: [{ preset_name: 'Shared' }],
     });
     useNodeDefStore.setState({ definitions: [], presets: [{ preset_name: 'Shared' } as any] });
-    useTabStore.setState({ setNodes: vi.fn(), setEdges: vi.fn(), renameTab: vi.fn() });
+    useTabStore.setState({ loadGraphDocument: vi.fn() });
 
     render(<EmptyCanvasOverlay />);
     fireEvent.click(await screen.findByText('Dup'));
@@ -282,16 +288,14 @@ describe('EmptyCanvasOverlay', () => {
     // No nodes/edges/presets keys; name is blank whitespace.
     mockedRest.loadExample.mockResolvedValue({ name: '   ' });
 
-    const setNodes = vi.fn();
-    const setEdges = vi.fn();
-    const renameTab = vi.fn();
-    useTabStore.setState({ setNodes, setEdges, renameTab });
+    const loadGraphDocument = vi.fn();
+    useTabStore.setState({ loadGraphDocument });
     const before = useNodeDefStore.getState().presets;
 
     render(<EmptyCanvasOverlay />);
     fireEvent.click(await screen.findByText('Bare'));
 
-    await waitFor(() => expect(setNodes).toHaveBeenCalled());
+    await waitFor(() => expect(loadGraphDocument).toHaveBeenCalled());
     // resolveSerializedNodes/Edges were called with [] fallbacks; the edges
     // resolver also receives the resolved nodes for per-data-type coloring.
     // The trailing [] is the example's own subgraph definitions (core#137):
@@ -299,8 +303,10 @@ describe('EmptyCanvasOverlay', () => {
     // interface, so the resolver has to be given them.
     expect(mockedUtils.resolveSerializedNodes).toHaveBeenCalledWith([], [], expect.any(Array), []);
     expect(mockedUtils.resolveSerializedEdges).toHaveBeenCalledWith([], [{ id: 'n1' }]);
-    // blank name => no rename
-    expect(renameTab).not.toHaveBeenCalled();
+    // blank name => the document carries none, so the tab keeps its label
+    expect(loadGraphDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ name: null }),
+    );
     // no imported presets => store unchanged
     expect(useNodeDefStore.getState().presets).toBe(before);
   });
@@ -313,7 +319,7 @@ describe('EmptyCanvasOverlay', () => {
       edges: [],
       presets: 'not-an-array',
     });
-    useTabStore.setState({ setNodes: vi.fn(), setEdges: vi.fn(), renameTab: vi.fn() });
+    useTabStore.setState({ loadGraphDocument: vi.fn() });
     const before = useNodeDefStore.getState().presets;
 
     render(<EmptyCanvasOverlay />);
@@ -329,7 +335,7 @@ describe('EmptyCanvasOverlay', () => {
     mockedRest.loadExample.mockRejectedValue(new Error('load failed'));
     const addToast = vi.fn();
     useToastStore.setState({ addToast });
-    useTabStore.setState({ setNodes: vi.fn(), setEdges: vi.fn(), renameTab: vi.fn() });
+    useTabStore.setState({ loadGraphDocument: vi.fn() });
 
     render(<EmptyCanvasOverlay />);
     fireEvent.click(await screen.findByText('Broken'));

--- a/frontend/src/components/Sidebar/TemplatesTab.test.tsx
+++ b/frontend/src/components/Sidebar/TemplatesTab.test.tsx
@@ -148,28 +148,29 @@ describe('TemplatesTab', () => {
       nodes: [],
       edges: [],
     });
-    const setNodes = vi.fn();
-    const setEdges = vi.fn();
-    const renameTab = vi.fn();
-    useTabStore.setState({ setNodes, setEdges, renameTab });
+    // The whole document goes in through one store action (#200 items 4
+    // and 8), so there is one call to assert on instead of three.
+    const loadGraphDocument = vi.fn();
+    useTabStore.setState({ loadGraphDocument });
 
     render(<TemplatesTab />);
     fireEvent.click(await screen.findByText('Loadable'));
 
-    await waitFor(() => expect(setNodes).toHaveBeenCalled());
+    await waitFor(() => expect(loadGraphDocument).toHaveBeenCalled());
     expect(mockedRest.loadExample).toHaveBeenCalledWith('Usage_Example/Loadable');
-    expect(setEdges).toHaveBeenCalled();
     // The trimmed example name is mirrored onto the tab.
-    expect(renameTab).toHaveBeenCalledWith(useTabStore.getState().activeTabId, 'My Model');
+    expect(loadGraphDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ nodes: [], edges: [], name: 'My Model' }),
+    );
   });
 
   it('surfaces a load failure as a toast and leaves the graph alone', async () => {
     mockedRest.listExamples.mockResolvedValue([ex({ name: 'Broken' })]);
     mockedRest.loadExample.mockRejectedValue(new Error('nope'));
-    const setNodes = vi.fn();
+    const loadGraphDocument = vi.fn();
     const addToast = vi.fn();
     useToastStore.setState({ addToast });
-    useTabStore.setState({ setNodes, setEdges: vi.fn(), renameTab: vi.fn() });
+    useTabStore.setState({ loadGraphDocument });
 
     render(<TemplatesTab />);
     fireEvent.click(await screen.findByText('Broken'));
@@ -177,7 +178,7 @@ describe('TemplatesTab', () => {
     await waitFor(() =>
       expect(addToast).toHaveBeenCalledWith('Failed to load example', 'error'),
     );
-    expect(setNodes).not.toHaveBeenCalled();
+    expect(loadGraphDocument).not.toHaveBeenCalled();
   });
 
   it('offers a jump index across example categories', async () => {

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -11,7 +11,6 @@ import { subgraphIdOf } from '../../utils/subgraph';
 import { graphToSvg, svgToPngBlob } from '../../utils/exportDiagram';
 import { confirm, prompt } from '../../utils/dialog';
 import { saveActiveGraph } from '../../utils/saveActiveGraph';
-import { isFormatTooNew } from '../../utils/formatVersion';
 import { CustomNodeManager } from '../CustomNodeManager/CustomNodeManager';
 import { useToastStore } from '../../store/toastStore';
 import { useProjectStore } from '../../store/projectStore';
@@ -208,7 +207,9 @@ function LoadSubMenuPanel({
 
 export function Toolbar() {
   const { execute, stop } = useGraphExecution();
-  const { clear, getSerializedGraph, setNodes, setEdges, setDescription, setCurrentGraphFile, setSegmentGroups, setSubgraphs } = useTabStore();
+  // `loadGraphDocument` replaced the five setters both graph readers below
+  // used to call in sequence (#200 items 4 and 8).
+  const { clear, getSerializedGraph, setCurrentGraphFile, loadGraphDocument } = useTabStore();
   const activeTab = useTabStore((s) => s.tabs.find((t) => t.id === s.activeTabId)!);
   const status = activeTab.status;
   const { reload, fetchDefinitions } = useNodeDefStore();
@@ -303,21 +304,27 @@ export function Toolbar() {
         // Missing/incomplete layout (project mode): dagre-lay-out ALL nodes
         // directly -- NOT via applyLayout, which pushes an undo snapshot and a
         // toast -- then deterministically place unbound notes. The next save
-        // persists the computed layout (spec 6.3).
-        if (graphData.layout_missing) {
-          const laid = stackUnboundNotes(
-            autoLayout(resolvedNodes, resolvedEdges, 'all'),
-          ) as FlowNode<NodeData>[];
-          setNodes(laid);
-        } else {
-          setNodes(resolvedNodes);
-        }
-        setEdges(resolvedEdges);
-        setSubgraphs(loadedSubgraphs);
-        setDescription(typeof graphData.description === 'string' ? graphData.description : '');
-        setSegmentGroups(Array.isArray(graphData.segmentGroups) ? graphData.segmentGroups : []);
-        const tooNew = isFormatTooNew(graphData.format_version);
-        useTabStore.getState().setTabReadOnly(tooNew);
+        // persists the computed layout (spec 6.3). Laid out BEFORE the
+        // install, so the graph reaches the canvas already positioned.
+        const laidOutNodes = graphData.layout_missing
+          ? (stackUnboundNotes(
+              autoLayout(resolvedNodes, resolvedEdges, 'all'),
+            ) as FlowNode<NodeData>[])
+          : resolvedNodes;
+        // One call, not six (#200 items 4 and 8): the whole document lands in
+        // a single store update, so no subscriber sees the new nodes beside
+        // the old definitions, and the read-only gate is now the action's own
+        // return value rather than a line each reader has to remember --
+        // which is what the third reader of a document, `openExample`, did
+        // not.
+        const tooNew = loadGraphDocument({
+          nodes: laidOutNodes,
+          edges: resolvedEdges,
+          subgraphs: loadedSubgraphs,
+          segmentGroups: Array.isArray(graphData.segmentGroups) ? graphData.segmentGroups : [],
+          description: typeof graphData.description === 'string' ? graphData.description : '',
+          formatVersion: graphData.format_version,
+        });
         if (tooNew) {
           addToast(t('project.readOnly.loadNotice', { version: graphData.format_version }), 'warning');
         }
@@ -333,7 +340,7 @@ export function Toolbar() {
         addToast(t('toolbar.load.fail', { error: (e as Error).message }), 'error');
       }
     },
-    [setNodes, setEdges, setSubgraphs, setDescription, setSegmentGroups, setCurrentGraphFile, t, addToast],
+    [loadGraphDocument, setCurrentGraphFile, t, addToast],
   );
 
   const handleImportFile = useCallback(
@@ -360,17 +367,20 @@ export function Toolbar() {
           const importedSubgraphs = Array.isArray(data.subgraphs) ? data.subgraphs : [];
           const resolvedNodes = resolveSerializedNodes(rawNodes, store.definitions, mergedPresets, importedSubgraphs);
           const resolvedEdges = resolveSerializedEdges(edges, resolvedNodes);
-          setNodes(resolvedNodes);
-          setEdges(resolvedEdges);
-          setSubgraphs(importedSubgraphs);
-          setDescription(typeof data.description === 'string' ? data.description : '');
-          setSegmentGroups(Array.isArray(data.segmentGroups) ? data.segmentGroups : []);
-          // Same format-version gate as handleLoadGraph (ID8 fast-follow):
-          // importing a newer-format file must open it read-only too, and
-          // importing an ordinary file into a previously read-only tab must
-          // clear the stale flag -- called unconditionally either way.
-          const tooNew = isFormatTooNew(data.format_version);
-          useTabStore.getState().setTabReadOnly(tooNew);
+          // Same one-call install as handleLoadGraph (#200 items 4 and 8),
+          // which is the point: the format-version gate (ID8 fast-follow)
+          // now runs inside it, so importing a newer-format file opens it
+          // read-only and importing an ordinary file into a previously
+          // read-only tab clears the stale flag -- neither is a line a
+          // reader of a document can forget to write any more.
+          const tooNew = loadGraphDocument({
+            nodes: resolvedNodes,
+            edges: resolvedEdges,
+            subgraphs: importedSubgraphs,
+            segmentGroups: Array.isArray(data.segmentGroups) ? data.segmentGroups : [],
+            description: typeof data.description === 'string' ? data.description : '',
+            formatVersion: data.format_version,
+          });
           if (tooNew) {
             addToast(t('project.readOnly.loadNotice', { version: data.format_version }), 'warning');
           }
@@ -387,7 +397,7 @@ export function Toolbar() {
       reader.readAsText(file);
       event.target.value = '';
     },
-    [setNodes, setEdges, setSubgraphs, setDescription, setSegmentGroups, setCurrentGraphFile, t, addToast],
+    [loadGraphDocument, setCurrentGraphFile, t, addToast],
   );
 
   const handleExportJson = useCallback(() => {

--- a/frontend/src/store/tabStore.loadDocument.test.ts
+++ b/frontend/src/store/tabStore.loadDocument.test.ts
@@ -1,0 +1,188 @@
+/**
+ * `loadGraphDocument` -- the one door a whole graph document comes through
+ * (#200 items 4 and 8).
+ *
+ * Before it there were three readers (Toolbar's load, Toolbar's import,
+ * `openExample`) each hand-sequencing setNodes/setEdges/setSubgraphs/
+ * setSegmentGroups/setDescription/setTabReadOnly. Two of the three got the
+ * whole sequence right; the third dropped `description` and the
+ * format-version gate. These tests pin the properties that made that class
+ * of bug possible: ONE update, and every field of the document written
+ * whether the file carries it or not.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { Edge, Node } from '@xyflow/react';
+
+import { useTabStore } from './tabStore';
+import type { NodeData, SegmentGroup, SubgraphDefinition } from '../types';
+
+const store = () => useTabStore.getState();
+const tab = () => useTabStore.getState().getActiveTab();
+
+function node(id: string): Node<NodeData> {
+  return {
+    id,
+    type: 'baseNode',
+    position: { x: 0, y: 0 },
+    data: { label: id, type: 'Add', params: {} },
+  } as Node<NodeData>;
+}
+
+function edge(id: string, source: string, target: string): Edge {
+  return { id, source, target };
+}
+
+function definition(id: string): SubgraphDefinition {
+  return {
+    id,
+    name: id,
+    description: '',
+    nodes: [],
+    edges: [],
+    interface: { inputs: [], outputs: [], triggerTargets: [] },
+  } as unknown as SubgraphDefinition;
+}
+
+beforeEach(() => {
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  useTabStore.getState().addTab('Tab 1');
+  localStorage.clear();
+});
+
+describe('loadGraphDocument', () => {
+  it('installs the whole document in ONE store emission', () => {
+    let emissions = 0;
+    const unsubscribe = useTabStore.subscribe(() => {
+      emissions += 1;
+    });
+
+    store().loadGraphDocument({
+      nodes: [node('a')],
+      edges: [edge('e1', 'a', 'a')],
+      subgraphs: [definition('blk')],
+      segmentGroups: [{ id: 's1' } as unknown as SegmentGroup],
+      name: 'Doc',
+      description: 'a description',
+      formatVersion: 1,
+    });
+    unsubscribe();
+
+    // The point of the action: no window in which the tab holds the new
+    // nodes but the old definitions (or any other half-installed mix).
+    expect(emissions).toBe(1);
+    const t = tab();
+    expect(t.nodes.map((n) => n.id)).toEqual(['a']);
+    expect(t.edges.map((e) => e.id)).toEqual(['e1']);
+    expect(t.subgraphs.map((d) => d.id)).toEqual(['blk']);
+    expect(t.segmentGroups.map((s) => s.id)).toEqual(['s1']);
+    expect(t.name).toBe('Doc');
+    expect(t.description).toBe('a description');
+    expect(t.readOnly).toBe(false);
+  });
+
+  it('writes every field even for a document that omits them, so nothing survives from the previous graph', () => {
+    store().loadGraphDocument({
+      nodes: [node('old')],
+      edges: [],
+      subgraphs: [definition('old-blk')],
+      segmentGroups: [{ id: 'stale' } as unknown as SegmentGroup],
+      description: 'the previous graph',
+    });
+    store().setActiveSegment({ id: 'stale' } as unknown as SegmentGroup);
+
+    // A bare document -- exactly what a hand-written example file looks like.
+    store().loadGraphDocument({ nodes: [node('new')], edges: [] });
+
+    const t = tab();
+    expect(t.nodes.map((n) => n.id)).toEqual(['new']);
+    expect(t.subgraphs).toEqual([]);
+    // `description` and `segmentGroups` are both persisted through save: a
+    // leftover would be written to disk as if it belonged to the new graph.
+    expect(t.description).toBe('');
+    expect(t.segmentGroups).toEqual([]);
+    // The overlay the Teaching Inspector is pointing at names head/tail ids
+    // the new graph does not have.
+    expect(t.activeSegment).toBeNull();
+  });
+
+  it('keeps the tab name when the document ships none, and adopts a trimmed one when it does', () => {
+    store().loadGraphDocument({ nodes: [], edges: [] });
+    expect(tab().name).toBe('Tab 1');
+
+    store().loadGraphDocument({ nodes: [], edges: [], name: '  My Model  ' });
+    expect(tab().name).toBe('My Model');
+
+    // A blank name is not a name: it would leave the tab labelled "".
+    store().loadGraphDocument({ nodes: [], edges: [], name: '   ' });
+    expect(tab().name).toBe('My Model');
+  });
+
+  it('fails closed on a newer format_version: read-only, and the verdict is returned', () => {
+    const tooNew = store().loadGraphDocument({ nodes: [], edges: [], formatVersion: 999 });
+
+    expect(tooNew).toBe(true);
+    expect(tab().readOnly).toBe(true);
+  });
+
+  it('clears a stale read-only flag when a current-format document is loaded', () => {
+    store().loadGraphDocument({ nodes: [], edges: [], formatVersion: 999 });
+    expect(tab().readOnly).toBe(true);
+
+    const tooNew = store().loadGraphDocument({ nodes: [], edges: [], formatVersion: 1 });
+
+    expect(tooNew).toBe(false);
+    expect(tab().readOnly).toBe(false);
+  });
+
+  it('treats a missing format_version as current, not as too new', () => {
+    expect(store().loadGraphDocument({ nodes: [], edges: [] })).toBe(false);
+    expect(tab().readOnly).toBe(false);
+  });
+
+  it('normalizes definitions read off a file', () => {
+    // Same door `setSubgraphs` normalized through: an entry missing its
+    // interface must not reach the four walkers that later read one.
+    store().loadGraphDocument({
+      nodes: [],
+      edges: [],
+      subgraphs: [{ id: 'x' } as unknown as SubgraphDefinition],
+    });
+
+    const [installed] = tab().subgraphs;
+    expect(installed.id).toBe('x');
+    expect(installed.interface).toBeDefined();
+    expect(installed.nodes).toEqual([]);
+  });
+
+  it('drops an open sub-canvas and installs the document as the top level', () => {
+    // The ordering contract `setSubgraphs` documents, now enforced by
+    // construction: the incoming nodes ARE the top level, so an editing
+    // stack left standing would leave a dead block's insides on screen as
+    // if they were the whole graph -- and the next save would write them.
+    useTabStore.setState({
+      tabs: useTabStore.getState().tabs.map((t) => ({
+        ...t,
+        nodes: [node('inside-a-block')],
+        subgraphStack: [
+          {
+            subgraphId: 'blk',
+            nodes: [node('outer')],
+            edges: [],
+            undoStack: [],
+            redoStack: [],
+            selectedNodeId: null,
+            subgraphs: [definition('blk')],
+          },
+        ],
+      })) as never,
+    });
+
+    store().loadGraphDocument({ nodes: [node('top')], edges: [], subgraphs: [definition('blk')] });
+
+    const t = tab();
+    expect(t.subgraphStack).toEqual([]);
+    expect(t.nodes.map((n) => n.id)).toEqual(['top']);
+    // What a save/run sees is the document, not the block that was open.
+    expect(store().getSerializedGraph().nodes.map((n: { id: string }) => n.id)).toEqual(['top']);
+  });
+});

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -30,6 +30,7 @@ import {
   type CollapseResult,
 } from '../utils/subgraph';
 import { ExecutionWebSocket } from '../api/ws';
+import { isFormatTooNew } from '../utils/formatVersion';
 import { useToastStore } from './toastStore';
 import { useUIStore } from './uiStore';
 import { useI18n, type TranslationKey } from '../i18n';
@@ -344,6 +345,36 @@ function createTabState(id: string, name: string): TabState {
 
 // ── Store ──
 
+/**
+ * A whole graph document, in the shape every reader of one already holds
+ * after parsing a file (#200 items 4 and 8).
+ *
+ * Optional here means "the file may omit it", NOT "leave whatever the
+ * previous graph left": `loadGraphDocument` writes every field either way.
+ * That distinction is the bug this type exists to close -- opening an
+ * example used to leave the previous graph's `description` on the tab
+ * because the field was simply never mentioned on that path.
+ */
+export interface GraphDocument {
+  nodes: Node<NodeData>[];
+  edges: Edge[];
+  subgraphs?: SubgraphDefinition[];
+  segmentGroups?: SegmentGroup[];
+  /**
+   * Tab label to adopt. Absent/blank keeps the tab's current name -- a
+   * saved graph is bound to its file by `currentGraphFile`, not by the tab
+   * label, so `Toolbar`'s load path deliberately passes nothing here.
+   */
+  name?: string | null;
+  description?: string;
+  /**
+   * The document's raw `format_version` field, untrusted and unparsed. The
+   * read-only verdict is computed inside the action rather than by the
+   * caller, so a reader cannot forget the gate (ID8, #200 item 4).
+   */
+  formatVersion?: unknown;
+}
+
 interface TabStoreState {
   tabs: TabState[];
   activeTabId: string;
@@ -407,6 +438,15 @@ interface TabStoreState {
    */
   /** Replace the definition list wholesale (load / import). */
   setSubgraphs: (subgraphs: SubgraphDefinition[]) => void;
+  /**
+   * Install a whole graph document into the active tab in ONE update
+   * (#200 items 4 and 8) -- the single door for every reader of a document.
+   *
+   * Returns true when the document opened READ-ONLY because its
+   * `format_version` is newer than this build writes: the store owns the
+   * verdict, the caller owns the notice it shows for it.
+   */
+  loadGraphDocument: (doc: GraphDocument) => boolean;
   collapseSelectionToSubgraph: (name?: string) => CollapseResult;
   /** Put an instance's definition back on the canvas. One undo step. */
   expandSubgraphInstance: (nodeId: string) => boolean;
@@ -1973,9 +2013,15 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
   // `setNodes`/`setEdges` have installed the graph these definitions belong
   // to. It drops `subgraphStack` without putting a canvas back, so calling
   // it while the user is inside a block leaves the block's INSIDES on screen
-  // as if they were the whole graph. All three callers (`Toolbar`'s load and
-  // import, `openExample`) set nodes and edges first, so no path reaches
-  // that today.
+  // as if they were the whole graph.
+  //
+  // No document reader calls this any more (#200 item 8): all three go
+  // through `loadGraphDocument` below, which installs nodes, edges and
+  // definitions in ONE `set` and so has no order to get wrong. What is left
+  // here is the narrow primitive -- "replace only the definition list" --
+  // and the contract stays written down because it is still a live trap for
+  // anything that reaches for it. Prefer `loadGraphDocument` for anything
+  // that is installing a graph.
   //
   // Deliberately does NOT flush the stack itself, which would look like the
   // safer choice and is not: `flushSubgraphEditing` writes whatever is on
@@ -1996,6 +2042,65 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
         subgraphStack: [],
       })),
     }),
+
+  // ── Installing a whole document (#200 items 4 and 8) ──
+  //
+  // Three readers open a graph document: `Toolbar.handleLoadGraph`,
+  // `Toolbar.handleImportFile` and `openExample.applyToActiveTab`. Each used
+  // to hand-sequence five or six setters, and a sequence written out three
+  // times is only ever as right as its worst copy: the third one dropped
+  // `description` and skipped the format-version gate, so an example whose
+  // `format_version` was newer than this build opened EDITABLE -- failing
+  // OPEN, the one direction that gate must never fail -- with the previous
+  // graph's description still on the tab.
+  //
+  // The order of that sequence was load-bearing too, and lived only in the
+  // comment above `setSubgraphs`. Here there is no order: every field of the
+  // tab is computed and committed in ONE `set`, so no subscriber ever
+  // observes a half-installed graph and no caller can sequence it wrongly.
+  //
+  // Undo is deliberately untouched, matching what all three readers did
+  // before: opening a document pushes no snapshot and clears no stack.
+  // Making an open its own undo frame needs `UndoSnapshot` to carry
+  // `segmentGroups`/`description` first -- #200 item 2, which is its own
+  // change because it alters the shape of every frame in the store.
+  loadGraphDocument: (doc) => {
+    // Computed here, not by the caller: a reader that forgets the gate is
+    // exactly the bug this action closes, and `formatVersion` is untrusted
+    // input off a file, so a missing or non-numeric field reads as current.
+    const readOnly = isFormatTooNew(doc.formatVersion);
+    const name =
+      typeof doc.name === 'string' && doc.name.trim() ? doc.name.trim() : null;
+    set({
+      tabs: updateTab(get().tabs, get().activeTabId, () => ({
+        nodes: doc.nodes,
+        edges: doc.edges,
+        // Normalized on the way in, as `setSubgraphs` does: every reader
+        // hands over a list parsed out of a file and none of them validates
+        // the entries.
+        subgraphs: normalizeSubgraphs(doc.subgraphs ?? []),
+        // The document IS the top level, so an open sub-canvas was editing a
+        // definition this load just replaced. Not flushed, for the reason
+        // `setSubgraphs` records: a flush would write the incoming top level
+        // back into the incoming definition.
+        subgraphStack: [],
+        // Written even when the document ships none of them. Both are
+        // persisted through save, so a leftover from the graph that was here
+        // is not merely cosmetic: it gets written to disk as if it belonged
+        // to the graph that replaced it. `activeSegment` follows its list
+        // for the same reason `clear()` nulls it -- an overlay naming
+        // head/tail ids the new graph does not have.
+        segmentGroups: doc.segmentGroups ?? [],
+        activeSegment: null,
+        description: doc.description ?? '',
+        readOnly,
+        // Only when the document names one: a tab that was never renamed
+        // keeps the label the user is looking at.
+        ...(name ? { name } : {}),
+      })),
+    });
+    return readOnly;
+  },
 
   collapseSelectionToSubgraph: (name) => {
     const tab = get().getActiveTab();

--- a/frontend/src/utils/openExample.test.ts
+++ b/frontend/src/utils/openExample.test.ts
@@ -72,6 +72,82 @@ describe('openExample', () => {
     expect(activeTab().nodes.map((n) => n.id)).toEqual(['keep']);
     expect(useToastStore.getState().toasts[0].message).toBe('Failed to load example');
   });
+
+  // -- #200 item 4: the two fields this reader used to drop --
+
+  it('carries the example description onto the tab', async () => {
+    mockedRest.loadExample.mockResolvedValue({
+      nodes: [raw('a')], edges: [], description: 'What this template teaches',
+    });
+
+    await openExample('x');
+
+    expect(activeTab().description).toBe('What this template teaches');
+  });
+
+  it('clears the previous graph description for an example that ships none', async () => {
+    // `description` is persisted through save, so the leftover was not just
+    // cosmetic: it got written to disk as the new graph's description.
+    store().setDescription('the graph that was here before');
+    mockedRest.loadExample.mockResolvedValue({ nodes: [raw('a')], edges: [] });
+
+    await openExample('x');
+
+    expect(activeTab().description).toBe('');
+  });
+
+  it('opens an example written by a newer CodefyUI read-only, and says so', async () => {
+    // The gate must fail CLOSED. This path used to skip it entirely, so a
+    // plugin-shipped template from a newer build opened fully editable and
+    // the next save silently down-converted it.
+    mockedRest.loadExample.mockResolvedValue({
+      nodes: [raw('a')], edges: [], format_version: 999,
+    });
+
+    await expect(openExample('x')).resolves.toBe(true);
+
+    expect(activeTab().readOnly).toBe(true);
+    expect(
+      useToastStore.getState().toasts.some(
+        (t) => t.type === 'warning' && t.message.includes('v999'),
+      ),
+    ).toBe(true);
+  });
+
+  it('opening a current-format example into a read-only tab makes it editable again', async () => {
+    store().setTabReadOnly(true);
+    mockedRest.loadExample.mockResolvedValue({ nodes: [raw('a')], edges: [], format_version: 1 });
+
+    await openExample('x');
+
+    expect(activeTab().readOnly).toBe(false);
+    expect(useToastStore.getState().toasts.some((t) => t.type === 'warning')).toBe(false);
+  });
+
+  it('an example with no format_version opens editable', async () => {
+    mockedRest.loadExample.mockResolvedValue({ nodes: [raw('a')], edges: [] });
+    await openExample('x');
+    expect(activeTab().readOnly).toBe(false);
+  });
+
+  it('installs the whole example in ONE store update', async () => {
+    // #200 item 8: the ordering contract between setNodes and setSubgraphs
+    // is enforced by construction now -- there is no intermediate state in
+    // which the tab holds the new nodes and the old definitions.
+    mockedRest.loadExample.mockResolvedValue(exampleWithBlock());
+    let emissions = 0;
+    const unsubscribe = useTabStore.subscribe(() => {
+      emissions += 1;
+    });
+
+    await openExample('x');
+    unsubscribe();
+
+    expect(emissions).toBe(1);
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['plain', 'inst']);
+    expect(activeTab().subgraphs.map((d) => d.id)).toEqual(['blk']);
+    expect(activeTab().name).toBe('Blocky');
+  });
 });
 
 describe('openExampleInNewTab', () => {

--- a/frontend/src/utils/openExample.ts
+++ b/frontend/src/utils/openExample.ts
@@ -24,6 +24,20 @@ interface ResolvedExample {
   subgraphs: SubgraphDefinition[];
   /** Teaching Inspector segment overlays the example ships; often empty. */
   segmentGroups: SegmentGroup[];
+  /**
+   * The example's own description, or '' when it ships without one (#200
+   * item 4). Carried so opening an example REPLACES the tab's description
+   * instead of leaving the previous graph's on it -- `description` is
+   * persisted through save, so a leftover gets written to disk.
+   */
+  description: string;
+  /**
+   * The example's raw `format_version` (#200 item 4). An example -- or a
+   * plugin-shipped template -- written by a newer CodefyUI must open
+   * read-only here exactly as it does on the Toolbar's load and import
+   * paths; the verdict is `loadGraphDocument`'s to make.
+   */
+  formatVersion: unknown;
 }
 
 /**
@@ -72,28 +86,52 @@ async function fetchResolvedExample(path: string): Promise<ResolvedExample> {
   const segmentGroups: SegmentGroup[] = Array.isArray(data.segmentGroups)
     ? data.segmentGroups
     : [];
-  return { nodes, edges, name, subgraphs, segmentGroups };
+  const description =
+    typeof data.description === 'string' ? data.description : '';
+  return {
+    nodes,
+    edges,
+    name,
+    subgraphs,
+    segmentGroups,
+    description,
+    formatVersion: data.format_version,
+  };
 }
 
-/** Replace the active tab's graph with a resolved example. */
+/**
+ * Replace the active tab's graph with a resolved example.
+ *
+ * One call, because this is the third door onto the same state and the two
+ * in `Toolbar` were the reference (#200 items 4 and 8). Hand-sequencing the
+ * setters here is what lost `description` and the format-version gate on
+ * this path alone; `loadGraphDocument` installs the whole document in one
+ * update, so there is nothing left to forget and no order to get wrong.
+ *
+ * The name is passed through rather than applied by a separate `renameTab`:
+ * mirroring the example's name onto the tab is what gives saves, exports and
+ * the script header a meaningful name out of the box.
+ */
 function applyToActiveTab(example: ResolvedExample): void {
-  const tabs = useTabStore.getState();
-  tabs.setNodes(example.nodes);
-  tabs.setEdges(example.edges);
-  // After the nodes: `setSubgraphs` clears the editing stack and nothing
-  // else, so the canvas has to be in place first.
-  tabs.setSubgraphs(example.subgraphs);
-  // Unconditionally, even for an example that ships none. This REPLACES the
-  // tab's graph, so a segment left over from the graph that was there names
-  // head/tail ids nothing wears any more -- and `segmentGroups` is persisted
-  // through save, so the broken segment would be written to disk. Both
-  // Toolbar readers (`handleLoadGraph`, `handleImportFile`) already do this;
-  // this is the third door onto the same state.
-  tabs.setSegmentGroups(example.segmentGroups);
-  // Mirror the example name onto the active tab so saves, exports, and the
-  // script header all use a meaningful name out of the box.
-  if (example.name) {
-    tabs.renameTab(useTabStore.getState().activeTabId, example.name);
+  const openedReadOnly = useTabStore.getState().loadGraphDocument({
+    nodes: example.nodes,
+    edges: example.edges,
+    subgraphs: example.subgraphs,
+    segmentGroups: example.segmentGroups,
+    name: example.name,
+    description: example.description,
+    formatVersion: example.formatVersion,
+  });
+  // Same notice the Toolbar readers show, for the same reason: read-only is
+  // not a failure, and a user who is not told will read the refused Save as
+  // one.
+  if (openedReadOnly) {
+    useToastStore.getState().addToast(
+      useI18n.getState().t('project.readOnly.loadNotice', {
+        version: example.formatVersion as string | number,
+      }),
+      'warning',
+    );
   }
 }
 


### PR DESCRIPTION
## What

CodefyUI has three readers of a graph document -- `Toolbar.handleLoadGraph`,
`Toolbar.handleImportFile` and `openExample.applyToActiveTab` -- and each one
hand-sequenced five or six `tabStore` setters. A sequence written out three
times is only ever as right as its worst copy:

- **openExample dropped `description`.** Opening an example left the previous
  graph's description on the tab, and `description` is persisted through save,
  so the leftover was written to disk as the new graph's description.
- **openExample skipped the format-version gate.** An example, or a
  plugin-shipped template, whose `format_version` is newer than this build
  opened fully **editable** -- the gate failing OPEN, the one direction it must
  never fail. The next save silently down-converted a file written by a newer
  CodefyUI. The two Toolbar readers had the gate; the third did not.
- **The ordering was load-bearing and lived in a comment.** `setSubgraphs`
  drops `subgraphStack` without restoring a canvas, which is correct only if
  the new nodes are already installed. Nothing pinned that.

## The fix

One store action, `loadGraphDocument(doc)`, installs a whole document -- nodes,
edges, subgraphs, segmentGroups, name, description and the read-only verdict --
in a **single** state update, and all three readers now call it.

- The **format-version verdict is computed inside the action** from the raw,
  untrusted `format_version` and returned to the caller (which owns only the
  user-facing notice). A reader can no longer open a newer-format document
  editable by forgetting a line. A missing or non-numeric field reads as
  current-format.
- `description` and `segmentGroups` are written **whether or not the file
  carries them**, so nothing from the previous graph survives an open.
  `activeSegment` is nulled alongside its list, exactly as `clear()` already
  does -- an overlay naming head/tail ids the new graph does not have.
- **There is no order left to get wrong**: one `set`, so no subscriber ever
  observes the new nodes beside the old definitions. `setSubgraphs` keeps its
  contract comment because it survives as the narrow "replace only the
  definition list" primitive.

Undo is deliberately unchanged: opening a document pushes no snapshot, which is
what all three readers did before. Making an open its own undo frame requires
`UndoSnapshot` to carry `segmentGroups` first -- that is item 2, which alters
the shape of every frame in the store and wants its own change.

## Tests

- New `frontend/src/store/tabStore.loadDocument.test.ts` (8 cases): one store
  emission for a whole document, every field written for a document that omits
  them, name kept/trimmed/adopted, read-only set for a newer `format_version`
  and cleared for a current one, definitions normalized, and an open sub-canvas
  dropped so the document lands as the top level.
- `openExample.test.ts`: description carried and previous description cleared,
  a newer-format example opens read-only with the notice, a current-format one
  clears a stale read-only flag, and the whole example installs in one update.
- `EmptyCanvasOverlay.test.tsx` / `TemplatesTab.test.tsx`: call expectations
  moved from the three old setters to the one action.
- Gates: `pnpm exec tsc -b`, `pnpm test` (139 files, 3170 tests), `pnpm build`
  (contrast gate included), `python scripts/check_control_bytes.py`,
  `uvx ruff@0.14.4 check .` -- all green.

## Scope

Part of #200 -- items 4 and 8; the issue stays open for items 2 and 7 (and for
items 1, 3, 5, 6), which are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYmF5XjhQStu2K6swHp2XX
