### PR TITLE
fix(ui/export): differentiate light-theme DATASET vs TRANSFORM ambers and extend contrast gate

### DIFF
--- a/frontend/scripts/check-contrast.mjs
+++ b/frontend/scripts/check-contrast.mjs
@@ -548,8 +548,8 @@ for (const theme of DIAGRAM_THEMES) {
         the export stops agreeing with the app a reader is looking at, and the
         colour coding silently means two different things in two places. */
 for (const slug of DIAGRAM_CATEGORIES) {
-  const [, da, db] = lab(t(`--cat-${slug}`));
-  const [, la, lb] = lab(t(`--diagram-light-${slug}`));
+  const [dL, da, db] = lab(t(`--cat-${slug}`));
+  const [lL, la, lb] = lab(t(`--diagram-light-${slug}`));
   const drift = Math.abs(
     ((Math.atan2(lb, la) - Math.atan2(db, da)) * 180) / Math.PI
   );
@@ -561,11 +561,18 @@ for (const slug of DIAGRAM_CATEGORIES) {
         `(needs <= 12) — the light export must be the same colour, darkened, not a different one`
     );
   }
+  checked += 1;
+  if (lL > dL + 0.5) {
+    failures.push(
+      `--diagram-light-${slug} (L* ${lL.toFixed(1)}) is lighter than --cat-${slug} (L* ${dL.toFixed(1)}) — ` +
+        `the light export must be darkened for a white page, not lightened`
+    );
+  }
 }
 
 for (const slug of DIAGRAM_TYPES) {
-  const [, da, db] = lab(t(`--type-${slug}`));
-  const [, la, lb] = lab(t(`--diagram-light-type-${slug}`));
+  const [dL, da, db] = lab(t(`--type-${slug}`));
+  const [lL, la, lb] = lab(t(`--diagram-light-type-${slug}`));
   const drift = Math.abs(
     ((Math.atan2(lb, la) - Math.atan2(db, da)) * 180) / Math.PI
   );
@@ -575,6 +582,13 @@ for (const slug of DIAGRAM_TYPES) {
     failures.push(
       `--diagram-light-type-${slug} sits ${wrapped.toFixed(1)} degrees of hue from --type-${slug} ` +
         `(needs <= 12) — the light export must be the same colour, darkened, not a different one`
+    );
+  }
+  checked += 1;
+  if (lL > dL + 0.5) {
+    failures.push(
+      `--diagram-light-type-${slug} (L* ${lL.toFixed(1)}) is lighter than --type-${slug} (L* ${dL.toFixed(1)}) — ` +
+        `the light export must be darkened for a white page, not lightened`
     );
   }
 }

--- a/frontend/scripts/check-contrast.mjs
+++ b/frontend/scripts/check-contrast.mjs
@@ -563,6 +563,22 @@ for (const slug of DIAGRAM_CATEGORIES) {
   }
 }
 
+for (const slug of DIAGRAM_TYPES) {
+  const [, da, db] = lab(t(`--type-${slug}`));
+  const [, la, lb] = lab(t(`--diagram-light-type-${slug}`));
+  const drift = Math.abs(
+    ((Math.atan2(lb, la) - Math.atan2(db, da)) * 180) / Math.PI
+  );
+  const wrapped = drift > 180 ? 360 - drift : drift;
+  checked += 1;
+  if (wrapped > 12) {
+    failures.push(
+      `--diagram-light-type-${slug} sits ${wrapped.toFixed(1)} degrees of hue from --type-${slug} ` +
+        `(needs <= 12) — the light export must be the same colour, darkened, not a different one`
+    );
+  }
+}
+
 /* ---------- report ---------- */
 
 if (failures.length) {

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -108,7 +108,7 @@ export const CATEGORY_LIGHT_VARS: Record<string, string> = {
 export const DATA_TYPE_COLORS_ON_LIGHT: Record<string, string> = {
   TENSOR: '#40a445',
   MODEL: '#2095f2',
-  DATASET: '#d27c00',
+  DATASET: '#a56100',
   DATALOADER: '#9c27b0',
   OPTIMIZER: '#f44336',
   LOSS_FN: '#e91e63',

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -414,7 +414,7 @@
      twelve already cleared the bar and keep their canvas value. */
   --diagram-light-type-tensor: #40a445; /* 3.18 */
   --diagram-light-type-model: #2095f2; /* 3.16 */
-  --diagram-light-type-dataset: #d27c00; /* 3.17 */
+  --diagram-light-type-dataset: #a56100; /* 4.67 */
   --diagram-light-type-dataloader: #9c27b0; /* 6.30 — unchanged */
   --diagram-light-type-optimizer: #f44336; /* 3.68 — unchanged */
   --diagram-light-type-loss-fn: #e91e63; /* 4.35 — unchanged */


### PR DESCRIPTION
Fixes #323

### Summary of Changes
1. **Lightness Separation**: Updated `--diagram-light-type-dataset` (and its mirror `DATA_TYPE_COLORS_ON_LIGHT.DATASET` in `frontend/src/styles/theme.ts`) from `#d27c00` to `#a56100`. This introduces a clear L* lightness gap against `TRANSFORM` (`#b78901`), resolving the lightness collision for dichromats while keeping 4.67:1 contrast on white.
2. **Contrast Gate Extension**: Updated `frontend/scripts/check-contrast.mjs` to include an automated hue-drift / lightness check for all `DIAGRAM_TYPES` alongside `DIAGRAM_CATEGORIES`.
3. **Verification**: Ran `node frontend/scripts/check-contrast.mjs` — all 405 color relationships verified cleanly.