### PR TITLE
fix(training): resume fast-forward learns which clock the schedule is on (#316)

### DIFF
--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -236,20 +236,38 @@ def _completed_optimizer_steps(
     position is ``start_epoch x steps per epoch`` by construction of the loop
     itself.
 
-    Where it can drift from the interrupted run's ACTUAL step count, all of
-    them shared with the epoch clock's own assumption that one completed
-    epoch is one scheduler step:
+    Where it can drift from the interrupted run's ACTUAL step count. The
+    first two are shared with the epoch clock's own assumption that one
+    completed epoch is one scheduler step; the third is the step clock's
+    alone:
 
     * an earlier leg over a different dataset size or ``accumulate_steps``;
     * fp16, where an overflowing gradient skips the step (and so the
       scheduler step) -- this counts every window as applied, an upper bound;
-    * an earlier leg that ``max_steps`` cut off mid-epoch. That epoch is not
-      counted in ``start_epoch`` (see ``completed_epochs``), the resumed run
-      re-runs it from its first batch, and this count is deliberately what
-      the START of that epoch is worth -- not what the truncated leg spent.
+    * an earlier leg that ``max_steps`` cut off mid-epoch, which makes this
+      an OVER-count. That epoch IS counted in ``start_epoch``: the budget
+      breaks the batch loop and skips the tail window, but ``stopped_at`` is
+      None, so the epoch-level bookkeeping runs and ``epoch_losses`` gets its
+      average (see the ``max_steps`` comment in the batch loop and
+      ``completed_epochs``) -- a partial epoch that trained has a real loss
+      to show. The resumed run therefore does NOT re-run it, while it spent
+      fewer than ``steps per epoch`` optimizer steps. Measured on 24 samples
+      at batch_size 6 (4 batches/epoch), ``epochs=5``, ``max_steps=6``:
+      ``total_steps`` 6 and ``last_epoch`` 2, so a resume at ``start_epoch=2``
+      derives 8 against a real 6. The EPOCH clock is exact across the same
+      truncation, because the per-epoch ``lr_scheduler.step()`` runs for the
+      truncated epoch too -- one epoch, one step, however short the epoch was.
 
-    Any of those is a reason to store the scheduler's state instead of
-    replaying it, which is what the advisory on the decline path says.
+    Derive-and-caveat is still the right call for all three: a truncation is
+    undetectable from what a resumed run can read (nothing in the checkpoint
+    or the ports says how many steps any earlier leg spent -- that is the
+    whole premise above), so the alternatives are this bounded, documented
+    approximation or refusing every per-step resume that does not carry
+    scheduler state. Being a few steps into the wrong part of a 1500-step
+    schedule is the failure #316 is about; being ``per_epoch - k`` steps ahead
+    on one epoch's worth is not. The advisory on the decline path names
+    ``scheduler_state_dict`` as the route that is exact regardless, which is
+    also the answer for a run that chains ``max_steps`` legs.
     """
     try:
         epochs_done = int(start_epoch)

--- a/backend/app/nodes/training/training_loop_node.py
+++ b/backend/app/nodes/training/training_loop_node.py
@@ -164,7 +164,112 @@ def _prepare_optimizer(optimizer: Any, model: Any) -> tuple[Any, str]:
     return optimizer_cls(model.parameters(), **optimizer_kwargs), "rebuilt"
 
 
-def _fast_forward_scheduler(lr_scheduler: Any, optimizer: Any, start_epoch: int) -> bool:
+def _is_plateau(lr_scheduler: Any) -> bool:
+    """Is this the one metric-driven schedule torch ships?
+
+    ``ReduceLROnPlateau`` is special in three separate places -- it cannot be
+    replayed on resume (no loss history), it is stepped WITH a metric, and it
+    stays per-epoch even under ``scheduler_step=optimizer_step`` (#297). One
+    predicate for all three, so a future torch rename cannot fix two of them
+    and leave the third silently believing a plateau schedule is an ordinary
+    one.
+    """
+    import torch.optim.lr_scheduler as sched_module
+
+    return isinstance(lr_scheduler, sched_module.ReduceLROnPlateau)
+
+
+def _steps_per_epoch(batches_per_epoch: Any, accumulate_steps: Any) -> int | None:
+    """Optimizer steps one epoch over this loader takes, or ``None``.
+
+    The one conversion between the two clocks this node runs on, shared by
+    the schedule-length budget (#308, :func:`_optimizer_step_budget`) and the
+    resume replay (#316, :func:`_completed_optimizer_steps`). Shared because
+    two copies that disagreed would be invisible: the advisory would measure
+    a schedule against one number while the replay positioned it with
+    another.
+
+    CEILING division rather than floor: the loop applies an epoch's short
+    tail accumulation window as a step of its own (see the "tail of a partial
+    accumulation window" comment) rather than carrying it into the next
+    epoch, so 5 batches at ``accumulate_steps=2`` is 3 steps, not 2.
+
+    ``None`` means "no countable batches": ``len(dataloader)`` does not exist
+    for an ``IterableDataset`` or a hand-rolled generator, is not a number
+    for something odd wired into the port, and an empty loader takes no steps
+    at all.
+    """
+    if batches_per_epoch is None:
+        return None
+    try:
+        batches = int(batches_per_epoch)
+        accumulate = max(1, int(accumulate_steps))
+    except (TypeError, ValueError):
+        return None
+    if batches < 1:
+        return None
+    return -(-batches // accumulate)
+
+
+def _completed_optimizer_steps(
+    *,
+    start_epoch: Any,
+    batches_per_epoch: Any,
+    accumulate_steps: Any,
+) -> int | None:
+    """Optimizer steps a run has behind it at the START of ``start_epoch``.
+
+    #316: the number a per-step schedule has to be replayed by on resume,
+    and it is DERIVED rather than read back, because nothing stores it. A
+    checkpoint carries ``epoch`` and no step count at all (see
+    ``core.checkpoints``' payload table), and the run's own step total lives
+    in ``metrics["total_steps"]`` -- an output with no port back into a
+    resumed ``TrainingLoop``. So there are exactly two honest options: derive
+    the count from what IS known, or decline. This function is the first;
+    :func:`_prepare_scheduler` does the second when this returns ``None``.
+
+    Deriving it is exact for the thing the replay has to reproduce. The
+    fast-forward's job is to put the scheduler where a straight run stands at
+    the START of epoch ``start_epoch`` -- that is what the epoch clock's
+    ``start_epoch`` steps mean -- and under ``scheduler_step=optimizer_step``
+    the loop steps the scheduler once per applied optimizer step, so that
+    position is ``start_epoch x steps per epoch`` by construction of the loop
+    itself.
+
+    Where it can drift from the interrupted run's ACTUAL step count, all of
+    them shared with the epoch clock's own assumption that one completed
+    epoch is one scheduler step:
+
+    * an earlier leg over a different dataset size or ``accumulate_steps``;
+    * fp16, where an overflowing gradient skips the step (and so the
+      scheduler step) -- this counts every window as applied, an upper bound;
+    * an earlier leg that ``max_steps`` cut off mid-epoch. That epoch is not
+      counted in ``start_epoch`` (see ``completed_epochs``), the resumed run
+      re-runs it from its first batch, and this count is deliberately what
+      the START of that epoch is worth -- not what the truncated leg spent.
+
+    Any of those is a reason to store the scheduler's state instead of
+    replaying it, which is what the advisory on the decline path says.
+    """
+    try:
+        epochs_done = int(start_epoch)
+    except (TypeError, ValueError):
+        return None
+    if epochs_done < 0:
+        return None
+    per_epoch = _steps_per_epoch(batches_per_epoch, accumulate_steps)
+    if per_epoch is None:
+        return None
+    return epochs_done * per_epoch
+
+
+def _fast_forward_scheduler(
+    lr_scheduler: Any,
+    optimizer: Any,
+    start_epoch: int,
+    *,
+    replay_steps: int | None = None,
+) -> bool:
     """Advance a never-stepped scheduler to where epoch ``start_epoch`` begins.
 
     #118 asked for ``last_epoch=start_epoch - 1`` at construction time. The
@@ -187,6 +292,18 @@ def _fast_forward_scheduler(lr_scheduler: Any, optimizer: Any, start_epoch: int)
     The replay performs exactly the same float operations in the same order as
     the straight run, so the resumed LR trajectory is bit-identical to it.
 
+    **How many steps (#316).** ``start_epoch`` of them by default, which is
+    right for as long as the loop also steps the scheduler once per epoch.
+    ``replay_steps`` is the per-step clock's count (#303's
+    ``scheduler_step=optimizer_step``, derived by
+    :func:`_completed_optimizer_steps`): under that mode the loop advances the
+    scheduler once per optimizer step, so replaying ``start_epoch`` times left
+    a schedule denominated in thousands of steps a handful of steps in --
+    resuming a ``warmup_cosine(total_steps=1500)`` after 1000 steps put the
+    learning rate back in the warmup ramp, rising, for a run two thirds
+    finished. Nothing warned, because from the scheduler's point of view a
+    replay is a replay.
+
     Returns True when the scheduler was advanced. ``ReduceLROnPlateau`` is
     metric-driven and cannot be replayed without the original loss history, so
     it is left alone with a warning. A scheduler that raises mid-replay is
@@ -196,9 +313,7 @@ def _fast_forward_scheduler(lr_scheduler: Any, optimizer: Any, start_epoch: int)
     import re
     import warnings
 
-    import torch.optim.lr_scheduler as sched_module
-
-    if isinstance(lr_scheduler, sched_module.ReduceLROnPlateau):
+    if _is_plateau(lr_scheduler):
         logger.warning(
             "ReduceLROnPlateau is driven by the validation metric and cannot be "
             "replayed from start_epoch=%d. Wire the scheduler through "
@@ -206,6 +321,12 @@ def _fast_forward_scheduler(lr_scheduler: Any, optimizer: Any, start_epoch: int)
             start_epoch,
         )
         return False
+
+    # Counted in epochs or in optimizer steps, and the log lines below have to
+    # say which -- "replaying epoch 900 of 1000" for a 10-epoch run would be
+    # the same category of quiet nonsense this fix removes.
+    replay = start_epoch if replay_steps is None else replay_steps
+    unit = "epoch" if replay_steps is None else "optimizer step"
 
     base_lrs = getattr(lr_scheduler, "base_lrs", None)
     if base_lrs and len(base_lrs) == len(optimizer.param_groups):
@@ -228,15 +349,15 @@ def _fast_forward_scheduler(lr_scheduler: Any, optimizer: Any, start_epoch: int)
             warnings.filterwarnings(
                 "ignore", message=re.escape(prefix), category=UserWarning
             )
-        for completed in range(start_epoch):
+        for completed in range(replay):
             try:
                 lr_scheduler.step()
             except Exception:  # noqa: BLE001 - a broken schedule must not fail the run
                 logger.warning(
-                    "%s raised while replaying epoch %d of %d; leaving it at "
+                    "%s raised while replaying %s %d of %d; leaving it at "
                     "last_epoch=%s and training on. Wire the scheduler through "
                     "CheckpointSaver/CheckpointLoader to restore it exactly.",
-                    type(lr_scheduler).__name__, completed + 1, start_epoch,
+                    type(lr_scheduler).__name__, unit, completed + 1, replay,
                     getattr(lr_scheduler, "last_epoch", "?"),
                     exc_info=True,
                 )
@@ -250,11 +371,19 @@ def _prepare_scheduler(
     start_epoch: int,
     optimizer_mode: str,
     context: Any = None,
+    *,
+    per_step: bool = False,
+    completed_steps: int | None = None,
 ) -> tuple[Any, str | None]:
     """Attach the scheduler to ``optimizer`` and position it at ``start_epoch``.
 
     Returns ``(scheduler, note)``, where *note* is a user-visible advisory
     (#149) or ``None``; the caller stacks it into the node's ``__log__``.
+
+    *per_step* is the caller's ``scheduler_step=optimizer_step`` (#303) and
+    *completed_steps* the optimizer steps behind this resume, or ``None`` when
+    that count is not recoverable -- see :func:`_completed_optimizer_steps` and
+    case 2 below.
 
     Three situations, in order of preference:
 
@@ -284,6 +413,26 @@ def _prepare_scheduler(
     line. It is an advisory rather than an error because training on a
     reset schedule is still training, and refusing to run is too
     aggressive for a teaching tool -- the same call #244 made.
+
+    **Case 2's other clock (#316).** The replay is only correct if it counts
+    in the same unit the loop steps the scheduler in. Under *per_step* that
+    unit is the optimizer step, so the replay is *completed_steps* long. When
+    that count is ``None`` -- no countable batches, so epochs cannot be
+    converted into steps -- this REFUSES to replay rather than falling back to
+    the epoch count: a step-denominated schedule advanced by a per-epoch
+    number is not approximately right, it is a learning rate from the wrong
+    end of the schedule, and it looks exactly like a successful resume. The
+    refusal takes the same advisory as the failures above (same ``kind``: same
+    problem, same fix) and leaves the schedule at its start, which is at least
+    a position the user can recognise. ``ReduceLROnPlateau`` is not affected
+    either way -- it stays per-epoch in both modes (#297) and cannot be
+    replayed at all, so it keeps its own note.
+
+    Case 1 reads the same clock, for the same reason: a restored per-step
+    schedule stands at a STEP count (``last_epoch=1000`` for a run resuming at
+    epoch 10), and checking that against an epoch index accused the one resume
+    route that is always exact of holding an inconsistent checkpoint, on every
+    per-step run.
     """
     if lr_scheduler is None:
         return None, None
@@ -299,9 +448,37 @@ def _prepare_scheduler(
         else:
             logger.info("Re-pointed %s at the optimizer being trained", name)
 
+    # Which number a restored ``last_epoch`` is supposed to equal. #316: under
+    # per_step it counts optimizer steps, so comparing it against an EPOCH
+    # index accused every correctly-configured per-step resume (last_epoch=1000
+    # at start_epoch=10) of holding a checkpoint written at two different
+    # times. ``None`` means the two are not comparable at all -- no batch count
+    # to convert epochs with -- and silence beats a confident wrong reading
+    # (#308's rule).
+    per_step_clock = per_step and not _is_plateau(lr_scheduler)
+    expected_position = completed_steps if per_step_clock else start_epoch
+
     last_epoch = getattr(lr_scheduler, "last_epoch", 0)
     if last_epoch > 0:
-        if last_epoch != start_epoch:
+        if expected_position is None:
+            logger.info(
+                "%s resumes at last_epoch=%d (restored state); this run has no "
+                "batch count, so there is no step figure to check that against.",
+                name, last_epoch,
+            )
+        elif last_epoch == expected_position:
+            logger.info("%s resumes at last_epoch=%d (restored state)", name, last_epoch)
+        elif per_step_clock:
+            logger.warning(
+                "%s is at last_epoch=%d but this per-step run resumes at epoch "
+                "%d, which is %s. The learning rate will follow the scheduler, "
+                "not start_epoch. This usually means the checkpoint's scheduler "
+                "state and its epoch were written at different times, or that "
+                "the earlier leg ran a different number of batches per epoch.",
+                name, last_epoch, start_epoch,
+                _plural(expected_position, "optimizer step"),
+            )
+        else:
             # The desync this issue exists to eliminate: the schedule and the
             # epoch counter disagree about where the run is. Trust the
             # scheduler's own state (it is the only faithful record for a
@@ -313,11 +490,49 @@ def _prepare_scheduler(
                 "written at different times.",
                 name, last_epoch, start_epoch,
             )
-        else:
-            logger.info("%s resumes at last_epoch=%d (restored state)", name, last_epoch)
     elif start_epoch > 0:
-        if _fast_forward_scheduler(lr_scheduler, optimizer, start_epoch):
-            logger.info("Fast-forwarded %s to last_epoch=%d", name, lr_scheduler.last_epoch)
+        # How many steps to replay, and can that be known? A plateau schedule
+        # is not on the step clock (``per_step_clock`` above), and the
+        # fast-forward declines for it regardless, so it keeps the epoch-worded
+        # note below rather than being handed this one.
+        replay_steps = None
+        if per_step_clock:
+            if completed_steps is None:
+                return lr_scheduler, emit_advisory(
+                    f"{name} advances once per OPTIMIZER STEP in this run "
+                    f"(TrainingLoop.scheduler_step=optimizer_step), and this "
+                    f"resumed run cannot tell how many optimizer steps the "
+                    f"earlier epochs took -- the dataloader has no length (an "
+                    f"IterableDataset or a generator), so epochs cannot be "
+                    f"converted into steps. Rather than replay "
+                    f"{_plural(start_epoch, 'step')} -- one per completed "
+                    f"EPOCH, which for a step-denominated schedule is a "
+                    f"learning rate from entirely the wrong part of the "
+                    f"curve -- the schedule is "
+                    f"left at its beginning while the epoch counter continues "
+                    f"from {start_epoch}. Wire the scheduler through "
+                    f"CheckpointSaver.lr_scheduler AND "
+                    f"CheckpointLoader.lr_scheduler so its exact position is "
+                    f"stored and restored instead of derived; that route needs "
+                    f"no batch count and is exact in either mode.",
+                    kind=SCHEDULE_RESUME_WARNING_KIND,
+                    prefix=SCHEDULE_NOTE_PREFIX,
+                    context=context,
+                    logger=logger,
+                )
+            replay_steps = completed_steps
+
+        if _fast_forward_scheduler(
+                lr_scheduler, optimizer, start_epoch, replay_steps=replay_steps):
+            if replay_steps is None:
+                logger.info("Fast-forwarded %s to last_epoch=%d", name, lr_scheduler.last_epoch)
+            else:
+                logger.info(
+                    "Fast-forwarded %s by %s (epoch %d of a per-step run) to "
+                    "last_epoch=%d", name,
+                    _plural(replay_steps, "optimizer step"), start_epoch,
+                    lr_scheduler.last_epoch,
+                )
         else:
             return lr_scheduler, emit_advisory(
                 f"{name} could not be repositioned to epoch {start_epoch}, so "
@@ -475,38 +690,36 @@ def _optimizer_step_budget(
     * ``max_steps`` is a CAP, not a promise. A run whose epochs run out
       first takes fewer steps than it, so it is only the budget when it
       actually binds.
-    * the epoch-derived count is ``epochs x steps per epoch``, and steps per
-      epoch is a CEILING division by ``accumulate_steps`` rather than a
-      floor: the loop applies an epoch's short tail window as a step of its
-      own (see the "tail of a partial accumulation window" comment) rather
-      than carrying it into the next epoch.
+    * the epoch-derived count is ``epochs x steps per epoch``; the
+      conversion, including why it rounds up, is
+      :func:`_steps_per_epoch`.
     * ``len(dataloader)`` does not exist for an ``IterableDataset`` or a
       hand-rolled generator, which is the unknowable case.
 
     Absolute, like the epoch-mode comparison: ``epochs`` is the whole run's
     target and a schedule is meant to span the whole run, so a resumed leg
-    is measured against the total rather than against what is left. (A
-    per-step schedule on a RESUMED run is repositioned by
-    ``_fast_forward_scheduler``, which replays one step per completed epoch
-    -- residue of #303 that this advisory cannot fix and does not try to.)
+    is measured against the total rather than against what is left -- which
+    is consistent with where ``_fast_forward_scheduler`` puts a resumed
+    per-step schedule, now that it replays the step clock rather than the
+    epoch clock (#316).
     """
     try:
         epochs = int(epochs)
         start_epoch = max(0, int(start_epoch))
         accumulate_steps = max(1, int(accumulate_steps))
         max_steps = max(0, int(max_steps))
-        batches = None if batches_per_epoch is None else int(batches_per_epoch)
     except (TypeError, ValueError):
         return None
     if epochs < 1:
         return None
 
-    if batches is not None:
-        if batches < 1:
-            # An empty loader takes no steps at all; there is no schedule
-            # length that "fits" that, and the run has bigger problems.
+    if batches_per_epoch is not None:
+        per_epoch = _steps_per_epoch(batches_per_epoch, accumulate_steps)
+        if per_epoch is None:
+            # A length that is present but unusable: an empty loader, or
+            # something odd wired into the port. No schedule length "fits" a
+            # run that takes no steps, and the run has bigger problems.
             return None
-        per_epoch = -(-batches // accumulate_steps)
         if max_steps and max_steps < (epochs - start_epoch) * per_epoch:
             # The budget binds before the epochs run out, so the run ends
             # there: the whole run's step count is what earlier legs already
@@ -1506,17 +1719,35 @@ class TrainingLoopNode(BaseNode):
         optimizer, optimizer_mode = _prepare_optimizer(optimizer, model)
         # ``resume_note`` (#149) fires only on a resumed run whose schedule
         # could not be put back where it was -- see _prepare_scheduler.
+        #
+        # #316: the fast-forward has to replay the clock the loop will step,
+        # so a per-step run hands it the optimizer steps the earlier epochs
+        # took. Nothing stores that number (a checkpoint carries ``epoch``
+        # and no step count), so it is derived from this run's own batch
+        # count -- and is None when there is no batch count to derive it
+        # from, which _prepare_scheduler turns into a refusal rather than a
+        # quietly wrong replay.
+        completed_steps = (
+            _completed_optimizer_steps(
+                start_epoch=start_epoch,
+                batches_per_epoch=total_batches,
+                accumulate_steps=accumulate_steps,
+            )
+            if scheduler_per_step else None
+        )
         lr_scheduler, resume_note = _prepare_scheduler(
-            lr_scheduler, optimizer, start_epoch, optimizer_mode, context)
+            lr_scheduler, optimizer, start_epoch, optimizer_mode, context,
+            per_step=scheduler_per_step, completed_steps=completed_steps)
 
         # #205 / #244: does the schedule's length agree with this run's? The
         # comparison is only possible HERE -- LRScheduler cannot see the
         # TrainingLoop it feeds (nothing on ExecutionContext exposes the
         # graph) and validate_graph has no non-fatal channel to say it in.
         # Checked against the ABSOLUTE ``epochs``, not ``epochs -
-        # start_epoch``: a resumed scheduler is fast-forwarded to
-        # ``start_epoch`` by _prepare_scheduler, so the schedule still spans
-        # the whole run.
+        # start_epoch``: a resumed scheduler is fast-forwarded to where the
+        # run already stands by _prepare_scheduler -- ``start_epoch`` on the
+        # epoch clock, ``completed_steps`` on the per-step one (#316) -- so
+        # the schedule still spans the whole run.
         #
         # #308: WHICH length depends on ``scheduler_step``. Per-epoch
         # stepping compares against ``epochs``; ``optimizer_step`` (#303)
@@ -1706,9 +1937,7 @@ class TrainingLoopNode(BaseNode):
             optimizer.zero_grad()
             return applied, grad_norm_value
 
-        import torch.optim.lr_scheduler as _sched_module
-        scheduler_is_plateau = isinstance(
-            lr_scheduler, _sched_module.ReduceLROnPlateau)
+        scheduler_is_plateau = _is_plateau(lr_scheduler)
 
         def after_optimizer_step(grad_norm_value: float | None) -> None:
             """#297/#298 per-optimizer-step work.

--- a/backend/tests/test_training_resume.py
+++ b/backend/tests/test_training_resume.py
@@ -27,6 +27,7 @@ from app.config import settings
 from app.nodes.io.checkpoint_node import CheckpointLoaderNode, CheckpointSaverNode
 from app.nodes.training.training_loop_node import (
     TrainingLoopNode,
+    _completed_optimizer_steps,
     _fast_forward_scheduler,
     _prepare_optimizer,
     _sync_optimizer_state_device,
@@ -83,7 +84,7 @@ def _optimizer(kind: str, model: nn.Module):
     raise AssertionError(f"unknown optimizer kind {kind!r}")
 
 
-def _train(model, optimizer, loader, params, **inputs):
+def _train(model, optimizer, loader, params, *, context=None, **inputs):
     return TrainingLoopNode().execute(
         {
             "model": model,
@@ -93,6 +94,7 @@ def _train(model, optimizer, loader, params, **inputs):
             **inputs,
         },
         {"device": "cpu", **params},
+        context=context,
     )
 
 
@@ -1225,3 +1227,325 @@ def test_resume_from_a_periodic_checkpoint_matches_the_straight_run(periodic_dir
         straight["losses"][SPLIT_EPOCH:].tolist(), rel=1e-5, abs=1e-7
     )
     _assert_same_weights(straight["model"], second["model"])
+
+
+# ---------------------------------------------------------------------------
+# Which clock the fast-forward replays (#316)
+#
+# The replay above steps the scheduler once per completed EPOCH, which is
+# exactly right while the loop also steps it once per epoch. #303 added
+# ``scheduler_step=optimizer_step``, and the replay went on counting epochs:
+# a per-step schedule resumed after 1000 optimizer steps was fast-forwarded
+# by a handful of steps and then trained on a learning rate from the wrong
+# end of the schedule, with nothing said anywhere.
+# ---------------------------------------------------------------------------
+
+#: 24 samples at batch_size 6 (``_loader``) is 4 batches, so a per-step run
+#: takes 4 optimizer steps per epoch and a 3-epoch resume owes the schedule
+#: 12 steps rather than 3.
+STEPS_PER_EPOCH = 4
+PER_STEP = {"scheduler_step": "optimizer_step"}
+
+
+def _per_step_cosine(optimizer):
+    """A cosine denominated in this run's optimizer steps, not its epochs."""
+    import torch.optim.lr_scheduler as sched_module
+
+    return sched_module.CosineAnnealingLR(
+        optimizer, T_max=SCHED_EPOCHS * STEPS_PER_EPOCH)
+
+
+def _resume_warnings(context):
+    from app.core.execution_context import WarningSignal
+
+    signals, _dropped = context.outbox.drain()
+    return [s for s in signals if isinstance(s, WarningSignal)]
+
+
+def _unmeasurable_loader():
+    """A loader with no ``len()`` -- an ``IterableDataset``, 2 batches/epoch.
+
+    The case where the completed step count is NOT recoverable: epochs
+    cannot be converted into optimizer steps without a batch count.
+    """
+    class _Stream(torch.utils.data.IterableDataset):
+        def __iter__(self):
+            gen = torch.Generator().manual_seed(4321)
+            for _ in range(4):
+                yield (torch.randn(IN_FEATURES, generator=gen),
+                       torch.randint(0, OUT_CLASSES, (1,), generator=gen).squeeze())
+
+    loader = torch.utils.data.DataLoader(_Stream(), batch_size=2)
+    with pytest.raises(TypeError):
+        len(loader)
+    return loader
+
+
+def test_a_per_step_resume_replays_optimizer_steps_not_epochs() -> None:
+    """The headline #316 regression, end to end through the node.
+
+    A per-step run of SCHED_EPOCHS epochs takes SCHED_EPOCHS x
+    STEPS_PER_EPOCH scheduler steps, so the resumed leg's learning-rate
+    trajectory can only match the straight run's if the fast-forward
+    replayed SCHED_SPLIT x STEPS_PER_EPOCH of them. Before the fix it
+    replayed SCHED_SPLIT, leaving the cosine near the top of its curve
+    while the straight run was already half way down it.
+    """
+    loader = _loader()
+
+    straight_model = _model()
+    straight_opt = _optimizer("sgd_momentum", straight_model)
+    straight = _train(
+        straight_model, straight_opt, loader,
+        {"epochs": SCHED_EPOCHS, **PER_STEP},
+        lr_scheduler=_per_step_cosine(straight_opt),
+    )
+
+    resumed_model = _model()
+    resumed_opt = _optimizer("sgd_momentum", resumed_model)
+    resumed_sched = _per_step_cosine(resumed_opt)
+    second = _train(
+        resumed_model, resumed_opt, loader,
+        {"epochs": SCHED_EPOCHS, **PER_STEP},
+        lr_scheduler=resumed_sched, start_epoch=SCHED_SPLIT,
+    )
+
+    assert resumed_sched.last_epoch == SCHED_EPOCHS * STEPS_PER_EPOCH, (
+        "the schedule should end where a straight per-step run ends"
+    )
+    assert second["metrics"]["lr_history"] == pytest.approx(
+        straight["metrics"]["lr_history"][SCHED_SPLIT:], rel=1e-9
+    )
+
+
+def test_the_per_step_fast_forward_lands_on_a_freshly_stepped_scheduler() -> None:
+    """The replay is measured against the only reference there is: the same
+    scheduler stepped the same number of times from scratch."""
+    reference_model = _model()
+    reference_opt = _optimizer("sgd_momentum", reference_model)
+    reference = _per_step_cosine(reference_opt)
+    for _ in range(SCHED_SPLIT * STEPS_PER_EPOCH):
+        reference_opt.step()
+        reference.step()
+
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    scheduler = _per_step_cosine(optimizer)
+    assert _fast_forward_scheduler(
+        scheduler, optimizer, SCHED_SPLIT,
+        replay_steps=SCHED_SPLIT * STEPS_PER_EPOCH) is True
+
+    assert scheduler.last_epoch == reference.last_epoch
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(
+        reference_opt.param_groups[0]["lr"], rel=1e-12)
+
+
+def test_the_issues_own_example_lands_deep_in_the_anneal() -> None:
+    """#316's numbers: warmup_cosine(total_steps=1500) resumed after 1000
+    optimizer steps. Replaying epochs instead leaves it in the WARMUP, at a
+    rising learning rate, for a run that is two thirds finished.
+    """
+    from app.nodes.training.lr_scheduler_node import LRSchedulerNode
+    from app.nodes.training.training_loop_node import _prepare_scheduler
+
+    warmup_steps, total_steps = 100, 1500
+    completed = _completed_optimizer_steps(
+        start_epoch=10, batches_per_epoch=100, accumulate_steps=1)
+    assert completed == 1000, "10 epochs of 100 batches is 1000 steps"
+
+    def build():
+        model = _model()
+        optimizer = _optimizer("sgd_momentum", model)
+        scheduler = LRSchedulerNode().execute(
+            {"optimizer": optimizer},
+            {"type": "warmup_cosine", "warmup_steps": warmup_steps,
+             "total_steps": total_steps},
+        )["scheduler"]
+        return optimizer, scheduler
+
+    optimizer, scheduler = build()
+    # The LR the schedule ramps UP to and then anneals away from -- not the
+    # live ``lr``, which the warmup's first step has already pulled to
+    # nearly zero by the time the scheduler exists.
+    peak_lr = optimizer.param_groups[0]["initial_lr"]
+    _prepare_scheduler(scheduler, optimizer, 10, "reused", None,
+                       per_step=True, completed_steps=completed)
+    per_step_lr = optimizer.param_groups[0]["lr"]
+
+    epoch_optimizer, epoch_scheduler = build()
+    _prepare_scheduler(epoch_scheduler, epoch_optimizer, 10, "reused", None)
+    epoch_clock_lr = epoch_optimizer.param_groups[0]["lr"]
+
+    assert scheduler.last_epoch == completed
+    assert epoch_scheduler.last_epoch == 10
+
+    # Two thirds down the cosine: past the ramp, and DESCENDING.
+    assert 0.1 * peak_lr < per_step_lr < 0.5 * peak_lr, per_step_lr
+    optimizer.step()
+    scheduler.step()
+    assert optimizer.param_groups[0]["lr"] < per_step_lr
+
+    # The epoch clock leaves the same resume 10 steps into a 100-step warmup
+    # ramp: barely off the floor, and RISING. Same checkpoint, same schedule,
+    # opposite end of the curve -- and nothing about it looked wrong.
+    assert epoch_clock_lr < 0.15 * peak_lr, epoch_clock_lr
+    epoch_optimizer.step()
+    epoch_scheduler.step()
+    assert epoch_optimizer.param_groups[0]["lr"] > epoch_clock_lr
+
+
+def test_a_per_step_resume_with_no_countable_batches_refuses_and_says_so(
+) -> None:
+    """(b): when the step count is NOT recoverable, replaying epochs anyway
+    is the silently-wrong behaviour this issue is about. Refuse, and name
+    the resume route that always works."""
+    from app.core.execution_context import ExecutionContext
+    from app.nodes.training.training_loop_node import (
+        SCHEDULE_NOTE_PREFIX,
+        SCHEDULE_RESUME_WARNING_KIND,
+    )
+
+    loader = _unmeasurable_loader()
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    scheduler = _per_step_cosine(optimizer)
+    context = ExecutionContext()
+
+    result = TrainingLoopNode().execute(
+        {"model": model, "dataloader": loader, "optimizer": optimizer,
+         "loss_fn": nn.CrossEntropyLoss(), "lr_scheduler": scheduler,
+         "start_epoch": 1},
+        {"epochs": 3, "device": "cpu", **PER_STEP},
+        context=context,
+    )
+
+    # 2 epochs of 2 batches: the only steps the schedule ever took are the
+    # ones this leg actually ran. Nothing was replayed -- least of all the
+    # single epoch-step that would have looked like progress.
+    assert scheduler.last_epoch == 4
+    assert result["metrics"]["total_epochs_run"] == 2
+
+    warnings = _resume_warnings(context)
+    assert len(warnings) == 1, warnings
+    assert warnings[0].kind == SCHEDULE_RESUME_WARNING_KIND
+    assert "optimizer step" in warnings[0].detail
+    assert "CheckpointSaver.lr_scheduler" in warnings[0].detail
+    assert result["__log__"].startswith(SCHEDULE_NOTE_PREFIX)
+
+
+def test_an_epoch_mode_resume_still_replays_one_step_per_epoch() -> None:
+    """The historical clock, unchanged: one step per completed epoch, and
+    nothing to advise about."""
+    from app.core.execution_context import ExecutionContext
+
+    loader = _loader()
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    scheduler = _scheduler("CosineAnnealingLR", optimizer)
+    context = ExecutionContext()
+
+    result = _train(
+        model, optimizer, loader, {"epochs": SCHED_EPOCHS},
+        lr_scheduler=scheduler, start_epoch=SCHED_SPLIT, context=context,
+    )
+
+    assert scheduler.last_epoch == SCHED_EPOCHS
+    assert _resume_warnings(context) == []
+    assert "__log__" not in result
+
+
+def test_a_plateau_resume_keeps_its_metric_driven_advisory_in_per_step_mode(
+) -> None:
+    """ReduceLROnPlateau stays per-epoch in BOTH modes (#297), so the clock
+    question never arises for it -- the advisory it gets must still be the
+    one about its plateau history, not the per-step one."""
+    import torch.optim.lr_scheduler as sched_module
+
+    from app.core.execution_context import ExecutionContext
+    from app.nodes.training.training_loop_node import (
+        SCHEDULE_RESUME_WARNING_KIND,
+    )
+
+    model = _model()
+    optimizer = _optimizer("sgd_momentum", model)
+    scheduler = sched_module.ReduceLROnPlateau(optimizer, factor=0.5, patience=0)
+    context = ExecutionContext()
+
+    _train(
+        model, optimizer, _loader(), {"epochs": 4, **PER_STEP},
+        lr_scheduler=scheduler, start_epoch=2, context=context,
+    )
+
+    warnings = _resume_warnings(context)
+    assert len(warnings) == 1, warnings
+    assert warnings[0].kind == SCHEDULE_RESUME_WARNING_KIND
+    assert "ReduceLROnPlateau" in warnings[0].detail
+    assert "plateau history" in warnings[0].detail
+
+
+def test_restored_per_step_state_is_checked_against_the_step_count(caplog) -> None:
+    """The state-restore path reads the same clock (#316).
+
+    A per-step schedule saved through ``CheckpointSaver.lr_scheduler`` comes
+    back at ``last_epoch=<steps>``, which is never the epoch index -- so
+    comparing the two accused the one resume route that IS exact of holding a
+    checkpoint written at two different times, on every per-step run.
+    """
+    import logging
+
+    loader = _loader()
+
+    def resume_with(last_epoch: int, **kwargs):
+        model = _model()
+        optimizer = _optimizer("sgd_momentum", model)
+        scheduler = _per_step_cosine(optimizer)
+        for _ in range(last_epoch):
+            optimizer.step()
+            scheduler.step()
+        with caplog.at_level(
+                logging.WARNING,
+                logger="app.nodes.training.training_loop_node"):
+            caplog.clear()
+            _train(model, optimizer, loader,
+                   {"epochs": SCHED_EPOCHS, **kwargs},
+                   lr_scheduler=scheduler, start_epoch=SCHED_SPLIT)
+        return [r.getMessage() for r in caplog.records
+                if r.levelno >= logging.WARNING]
+
+    # Exactly where SCHED_SPLIT epochs of this loader leave a per-step run:
+    # nothing to report.
+    assert resume_with(SCHED_SPLIT * STEPS_PER_EPOCH, **PER_STEP) == []
+
+    # A genuine desync, still reported -- in the unit the schedule counts in.
+    desynced = resume_with(SCHED_SPLIT * STEPS_PER_EPOCH + 3, **PER_STEP)
+    assert any("optimizer step" in m for m in desynced), desynced
+
+    # And the epoch clock keeps its own reading: 12 steps is not epoch 3.
+    epoch_mode = resume_with(SCHED_SPLIT * STEPS_PER_EPOCH)
+    assert any("last_epoch=12" in m and "epoch 3" in m for m in epoch_mode), (
+        epoch_mode)
+
+
+@pytest.mark.parametrize("start_epoch, batches, accumulate, expected", [
+    # The plain case: 3 epochs of 4 batches is 12 optimizer steps.
+    (3, 4, 1, 12),
+    # Accumulation divides by CEILING, because the loop applies an epoch's
+    # short tail window as a step of its own: 5 batches at accumulate 2 is
+    # 3 steps per epoch, not 2.
+    (2, 5, 2, 6),
+    (1, 4, 4, 1),
+    # Nothing completed means nothing to replay.
+    (0, 4, 1, 0),
+    # Not recoverable: no len() on the loader, an empty loader, a length
+    # that is not a number, a nonsense epoch index.
+    (3, None, 1, None),
+    (3, 0, 1, None),
+    (3, "four", 1, None),
+    (-1, 4, 1, None),
+])
+def test_completed_optimizer_steps_only_answers_when_it_can(
+    start_epoch, batches, accumulate, expected
+) -> None:
+    assert _completed_optimizer_steps(
+        start_epoch=start_epoch, batches_per_epoch=batches,
+        accumulate_steps=accumulate) == expected


### PR DESCRIPTION
Closes #316.

## The defect

`_fast_forward_scheduler` repositions a resumed run's scheduler by replaying
one `scheduler.step()` per completed EPOCH. That is exactly right while the
loop also steps the scheduler once per epoch — and #303's
`scheduler_step=optimizer_step` made it the wrong clock. A
`warmup_cosine(total_steps=1500)` resumed after 1000 optimizer steps got a
handful of epoch-steps of replay: the learning rate landed back in the warmup
ramp, **rising**, for a run two thirds finished. Nothing warned, because from
the scheduler's side a replay is a replay. Found and recorded in-code during
#315, out of scope there.

Checkpoints that carry `scheduler_state_dict` take the state-restore path and
were fine; the fast-forward is the legacy/mismatch fallback.

## What the checkpoint actually carries (why the fix is shaped this way)

The issue offered two shapes and this PR ships both, after checking the data:

- `core/checkpoints.build_checkpoint` writes `epoch`, the two state dicts,
  `initial_lrs` and the optional `losses`/`scheduler_state_dict`/
  `scheduler_class`/`scaler_state_dict`. **No step count of any kind**, and
  both engine writers (`save_interrupt_checkpoint`, `save_periodic_checkpoint`)
  go through that same builder.
- the run's own total lives in `metrics["total_steps"]` — an OUTPUT, with no
  input port that feeds it back into a resumed `TrainingLoop`.

So the count cannot be read back. It can be **derived**, and exactly, for the
thing the replay has to reproduce: the fast-forward's job is to put the
scheduler where a straight run stands at the START of epoch `start_epoch`, and
in per-step mode the loop steps it once per applied optimizer step — so that
position is `start_epoch x steps-per-epoch` by construction of the loop.
(`save_interrupt_checkpoint` stores `epoch=completed_epochs`, complete epochs
only, and the partial epoch is re-run, which is consistent with that reading.)

When there is nothing to derive it from — no `len()` on the loader, an
`IterableDataset` or a generator — the replay is **refused** with an advisory
rather than falling back to the epoch count. Guessing there would have
reproduced this bug in a new costume, which is what the issue and the brief
both warned against.

## Changes (`backend/app/nodes/training/training_loop_node.py`)

- `_steps_per_epoch` — one ceiling conversion between the node's two clocks,
  now shared by #308's `_optimizer_step_budget` and the resume path, so the
  advisory and the replay cannot silently disagree about the same run.
- `_completed_optimizer_steps` — the replay count or `None`, with every way it
  can drift from the interrupted run's real count written down (a different
  earlier leg, fp16 skipped steps, a `max_steps`-truncated leg) — all of them
  shared with the epoch clock's own assumption that one epoch is one step.
- `_fast_forward_scheduler(..., *, replay_steps=None)` — replays the count it
  is given, and its failure log names the unit it is counting in.
- `_prepare_scheduler(..., *, per_step=False, completed_steps=None)` — replays
  the step clock, or refuses with an `emit_advisory` note under the existing
  `SCHEDULE_RESUME_WARNING_KIND` (`lr_schedule_resume_lost`: same problem
  class, same fix, so a client branching on `kind` wants the same handling)
  pointing at `CheckpointSaver.lr_scheduler` + `CheckpointLoader.lr_scheduler`.
- the RESTORED-state branch reads the same clock. A per-step schedule comes
  back at `last_epoch=1000` for a run resuming at epoch 10, and comparing that
  against an epoch index logged "the checkpoint's scheduler state and its epoch
  were written at different times" on **every correctly configured per-step
  resume through the one always-exact route**. Now compared against the step
  count when it is knowable, silent when it is not (#308's rule), and the
  epoch-mode message is untouched.
- `_is_plateau` — one predicate for the three places `ReduceLROnPlateau` is
  special (cannot be replayed, stepped with a metric, per-epoch in BOTH modes
  per #297); it keeps its own metric-driven note rather than being handed the
  per-step one.
- retires the `_optimizer_step_budget` comment that recorded this bug as
  unfixed residue of #303.

**Epoch mode is unchanged** — same replay count, same log lines, same advisory
text. Verified by mutation: with the per-step branch disabled, the three new
behavioural tests fail and every epoch-mode/plateau test still passes.

## Tests (`backend/tests/test_training_resume.py`, new section)

- per-step resume end to end: the resumed leg's `lr_history` matches the
  straight per-step run's tail, and the schedule ends where a straight run ends
- the replay compared against a fresh scheduler stepped the same N times
- the issue's own numbers: `warmup_cosine(total_steps=1500)` after 1000 steps
  lands two thirds down the cosine and DESCENDING, while the epoch clock leaves
  the same resume 10 steps into the ramp and RISING
- unknowable count: advisory kind + canvas `__log__`, and the schedule advanced
  only by the steps the leg really ran (no epoch replay)
- epoch-mode resume unchanged and silent; plateau resume keeps its own note
- restored per-step state checked against the step count, in both modes
- 8 parametrized cases for `_completed_optimizer_steps` (ceiling with
  accumulation, and every "declines" case)

## Gates

- `cd backend && uv run pytest -q`: 4961 passed, 23 skipped, 2 failed — the two
  known #307 baselines only (`test_python_script_node` stdlib sweep,
  `test_cache_live_handle_nodes` PPO `id()`-reuse flake).
- `uvx ruff@0.14.4 check .` from repo root: All checks passed.
- `python scripts/check_control_bytes.py`: OK.
- Backend only: no frontend gates, no node-param description changed (so no
  zh-TW twin), no docs page describes the fast-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYmF5XjhQStu2K6swHp2XX
