### PR TITLE
fix(ui): an example never inherits another file's save target, and a merge refuses a future format (#200)

### DIFF
--- a/frontend/src/components/Toolbar/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.test.tsx
@@ -760,6 +760,17 @@ describe('Toolbar', () => {
     expect(fileInput().value).toBe('');
   });
 
+  // #200 item 9 folded this assignment into the document install; the
+  // behavior it pins is unchanged, which is the point of pinning it.
+  it('Import: unbinds the tab so the imported graph cannot be saved over the file that was open', async () => {
+    setActiveTab({ currentGraphFile: 'bound-graph' });
+    render(<Toolbar />);
+    const payload = JSON.stringify({ nodes: [], edges: [] });
+    const file = new File([payload], 'imported.json', { type: 'application/json' });
+    fireEvent.change(fileInput(), { target: { files: [file] } });
+    await waitFor(() => expect(useTabStore.getState().tabs[0].currentGraphFile).toBeNull());
+  });
+
   it('Import: JSON without presets / missing arrays uses fallbacks, no preset write', async () => {
     render(<Toolbar />);
     const payload = JSON.stringify({}); // nodes/edges absent -> ?? [] ; presets not array

--- a/frontend/src/components/Toolbar/Toolbar.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.tsx
@@ -208,8 +208,9 @@ function LoadSubMenuPanel({
 export function Toolbar() {
   const { execute, stop } = useGraphExecution();
   // `loadGraphDocument` replaced the five setters both graph readers below
-  // used to call in sequence (#200 items 4 and 8).
-  const { clear, getSerializedGraph, setCurrentGraphFile, loadGraphDocument } = useTabStore();
+  // used to call in sequence (#200 items 4 and 8) -- and, since #200 item 9,
+  // the `setCurrentGraphFile` call each of them made right after it.
+  const { clear, getSerializedGraph, loadGraphDocument } = useTabStore();
   const activeTab = useTabStore((s) => s.tabs.find((t) => t.id === s.activeTabId)!);
   const status = activeTab.status;
   const { reload, fetchDefinitions } = useNodeDefStore();
@@ -320,6 +321,12 @@ export function Toolbar() {
         const tooNew = loadGraphDocument({
           nodes: laidOutNodes,
           edges: resolvedEdges,
+          // `name` is the sanitized file stem — bind the tab to it so
+          // re-saving under the same name doesn't trigger the overwrite
+          // warning. Part of the document install since #200 item 9, not a
+          // line after it: the binding says which file the graph on screen
+          // writes to, so the two must never be set apart.
+          boundFile: name,
           subgraphs: loadedSubgraphs,
           segmentGroups: Array.isArray(graphData.segmentGroups) ? graphData.segmentGroups : [],
           description: typeof graphData.description === 'string' ? graphData.description : '',
@@ -328,9 +335,6 @@ export function Toolbar() {
         if (tooNew) {
           addToast(t('project.readOnly.loadNotice', { version: graphData.format_version }), 'warning');
         }
-        // `name` is the sanitized file stem — bind the tab to it so re-saving
-        // under the same name doesn't trigger the overwrite warning.
-        setCurrentGraphFile(name);
         const projectDir = useProjectStore.getState().projectDir;
         if (projectDir !== null) useTabStore.getState().stampActiveTabProject(projectDir);
         if (savedPresets.length > 0) {
@@ -340,7 +344,7 @@ export function Toolbar() {
         addToast(t('toolbar.load.fail', { error: (e as Error).message }), 'error');
       }
     },
-    [loadGraphDocument, setCurrentGraphFile, t, addToast],
+    [loadGraphDocument, t, addToast],
   );
 
   const handleImportFile = useCallback(
@@ -376,6 +380,11 @@ export function Toolbar() {
           const tooNew = loadGraphDocument({
             nodes: resolvedNodes,
             edges: resolvedEdges,
+            // An imported file is a fresh, unsaved graph — not bound to any
+            // saved file yet, so the next save always runs the overwrite
+            // check (#200 item 9 moved this into the install; it used to be
+            // an assignment after it).
+            boundFile: null,
             subgraphs: importedSubgraphs,
             segmentGroups: Array.isArray(data.segmentGroups) ? data.segmentGroups : [],
             description: typeof data.description === 'string' ? data.description : '',
@@ -384,9 +393,6 @@ export function Toolbar() {
           if (tooNew) {
             addToast(t('project.readOnly.loadNotice', { version: data.format_version }), 'warning');
           }
-          // An imported file is a fresh, unsaved graph — not bound to any
-          // saved file yet, so the next save always runs the overwrite check.
-          setCurrentGraphFile(null);
           if (importedPresets.length > 0) {
             useNodeDefStore.setState({ presets: mergedPresets });
           }
@@ -397,7 +403,7 @@ export function Toolbar() {
       reader.readAsText(file);
       event.target.value = '';
     },
-    [loadGraphDocument, setCurrentGraphFile, t, addToast],
+    [loadGraphDocument, t, addToast],
   );
 
   const handleExportJson = useCallback(() => {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -599,9 +599,13 @@ const en = {
   'project.save.crossProjectRefused': 'This graph belongs to another project ({origin}) and cannot be saved into the open project.',
 
   // format_version read policy (ID8): newer-than-this-build graphs open
-  // read-only, never blocked on load.
+  // read-only, never blocked on load. The third string is the one case where
+  // read-only is not an available answer (#200 item 10): MERGING a too-new
+  // template into an editable graph has no document to mark read-only, so
+  // that path refuses the merge and explains the two ways forward.
   'project.readOnly.loadNotice': 'Opened read-only: this graph uses a newer format (v{version}) than this CodefyUI build.',
   'project.readOnly.saveBlocked': 'Save is disabled: this graph was written by a newer CodefyUI. Update CodefyUI to edit it.',
+  'project.formatTooNew.insertRefused': 'Nothing was inserted: this template uses a newer format (v{version}) than this CodefyUI build, so merging it into your graph could quietly drop parts of it. Open it instead to view it read-only, or update CodefyUI to use it.',
 
   // Plugin API v3 chrome (#132). Plugin panels and toolbar buttons supply
   // their own titles, so the host only labels the containers around them.

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -576,9 +576,12 @@ const zhTW: Record<TranslationKey, string> = {
   'project.badge.title': '目前的專案目錄',
   'project.save.crossProjectRefused': '此圖屬於另一個專案（{origin}），無法儲存到目前開啟的專案。',
 
-  // format_version 讀取政策（ID8）：比目前版本更新的圖只會以唯讀開啟，載入時絕不阻擋
+  // format_version 讀取政策（ID8）：比目前版本更新的圖只會以唯讀開啟，載入時絕不阻擋。
+  // 第三句是唯獨無法用「唯讀」回應的情況（#200 項目 10）：把較新格式的範本「合併」
+  // 進可編輯的圖時，沒有一份文件可以標成唯讀，所以那條路徑直接拒絕合併，並說明兩種做法。
   'project.readOnly.loadNotice': '以唯讀開啟：此圖使用比目前版本更新的格式（v{version}）。',
   'project.readOnly.saveBlocked': '儲存已停用：此圖由較新版本的 CodefyUI 寫入，請更新 CodefyUI 後再編輯。',
+  'project.formatTooNew.insertRefused': '沒有插入任何內容：此範本使用比目前版本更新的格式（v{version}），合併進你的圖可能會悄悄遺失其中一部分。可以改用開啟的方式以唯讀檢視，或更新 CodefyUI 後再使用。',
 
   // 外掛 API v3 的外框（#132）。外掛面板與工具列按鈕自帶標題，主程式只負責
   // 標示包在外面的容器。

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -577,7 +577,7 @@ const zhTW: Record<TranslationKey, string> = {
   'project.save.crossProjectRefused': '此圖屬於另一個專案（{origin}），無法儲存到目前開啟的專案。',
 
   // format_version 讀取政策（ID8）：比目前版本更新的圖只會以唯讀開啟，載入時絕不阻擋。
-  // 第三句是唯獨無法用「唯讀」回應的情況（#200 項目 10）：把較新格式的範本「合併」
+  // 第三句是唯一無法用「唯讀」回應的情況（#200 項目 10）：把較新格式的範本「合併」
   // 進可編輯的圖時，沒有一份文件可以標成唯讀，所以那條路徑直接拒絕合併，並說明兩種做法。
   'project.readOnly.loadNotice': '以唯讀開啟：此圖使用比目前版本更新的格式（v{version}）。',
   'project.readOnly.saveBlocked': '儲存已停用：此圖由較新版本的 CodefyUI 寫入，請更新 CodefyUI 後再編輯。',

--- a/frontend/src/store/tabStore.loadDocument.test.ts
+++ b/frontend/src/store/tabStore.loadDocument.test.ts
@@ -9,6 +9,11 @@
  * format-version gate. These tests pin the properties that made that class
  * of bug possible: ONE update, and every field of the document written
  * whether the file carries it or not.
+ *
+ * #200 item 9 added the save binding (`boundFile` -> `currentGraphFile`) to
+ * that set for the same reason, one field later: it was the last piece of
+ * "which graph is this" still being assigned OUTSIDE the install, and the
+ * reader that never assigned it opened examples onto another file's binding.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { Edge, Node } from '@xyflow/react';
@@ -59,6 +64,7 @@ describe('loadGraphDocument', () => {
     store().loadGraphDocument({
       nodes: [node('a')],
       edges: [edge('e1', 'a', 'a')],
+      boundFile: 'doc-file',
       subgraphs: [definition('blk')],
       segmentGroups: [{ id: 's1' } as unknown as SegmentGroup],
       name: 'Doc',
@@ -78,20 +84,27 @@ describe('loadGraphDocument', () => {
     expect(t.name).toBe('Doc');
     expect(t.description).toBe('a description');
     expect(t.readOnly).toBe(false);
+    // The save target lands in the SAME emission as the graph it belongs to
+    // (#200 item 9) -- there is no window in which the tab holds this
+    // document and the previous graph's file.
+    expect(t.currentGraphFile).toBe('doc-file');
   });
 
   it('writes every field even for a document that omits them, so nothing survives from the previous graph', () => {
     store().loadGraphDocument({
       nodes: [node('old')],
       edges: [],
+      boundFile: 'the-previous-file',
       subgraphs: [definition('old-blk')],
       segmentGroups: [{ id: 'stale' } as unknown as SegmentGroup],
       description: 'the previous graph',
     });
     store().setActiveSegment({ id: 'stale' } as unknown as SegmentGroup);
+    // Really bound, so the clear below is not passing vacuously.
+    expect(tab().currentGraphFile).toBe('the-previous-file');
 
     // A bare document -- exactly what a hand-written example file looks like.
-    store().loadGraphDocument({ nodes: [node('new')], edges: [] });
+    store().loadGraphDocument({ nodes: [node('new')], edges: [], boundFile: null });
 
     const t = tab();
     expect(t.nodes.map((n) => n.id)).toEqual(['new']);
@@ -103,39 +116,68 @@ describe('loadGraphDocument', () => {
     // The overlay the Teaching Inspector is pointing at names head/tail ids
     // the new graph does not have.
     expect(t.activeSegment).toBeNull();
+    // The save target is the sharpest case of "written either way": the
+    // previous file's binding under the new graph is what made an example
+    // overwrite it on the next Save (#200 item 9).
+    expect(t.currentGraphFile).toBeNull();
+  });
+
+  // -- #200 item 9: the save binding is part of installing a document --
+
+  it('binds the tab to the file the document names, and unbinds when it names none', () => {
+    store().loadGraphDocument({ nodes: [], edges: [], boundFile: 'classifier' });
+    expect(tab().currentGraphFile).toBe('classifier');
+
+    // A template/import: bound to nothing, so the next Save has to ask.
+    store().loadGraphDocument({ nodes: [], edges: [], boundFile: null });
+    expect(tab().currentGraphFile).toBeNull();
+
+    // ...and back again, so this is a real write and not a one-way clear.
+    store().loadGraphDocument({ nodes: [], edges: [], boundFile: 'other' });
+    expect(tab().currentGraphFile).toBe('other');
+  });
+
+  it('never lets a document inherit the previous graph binding', () => {
+    store().setCurrentGraphFile('foo');
+
+    store().loadGraphDocument({ nodes: [node('example')], edges: [], boundFile: null });
+
+    // The whole of item 9: the graph on screen is the example, so the file
+    // Save would overwrite must not still be foo.
+    expect(tab().currentGraphFile).toBeNull();
   });
 
   it('keeps the tab name when the document ships none, and adopts a trimmed one when it does', () => {
-    store().loadGraphDocument({ nodes: [], edges: [] });
+    store().loadGraphDocument({ nodes: [], edges: [], boundFile: null });
     expect(tab().name).toBe('Tab 1');
 
-    store().loadGraphDocument({ nodes: [], edges: [], name: '  My Model  ' });
+    store().loadGraphDocument({ nodes: [], edges: [], boundFile: null, name: '  My Model  ' });
     expect(tab().name).toBe('My Model');
 
     // A blank name is not a name: it would leave the tab labelled "".
-    store().loadGraphDocument({ nodes: [], edges: [], name: '   ' });
+    store().loadGraphDocument({ nodes: [], edges: [], boundFile: null, name: '   ' });
     expect(tab().name).toBe('My Model');
   });
 
   it('fails closed on a newer format_version: read-only, and the verdict is returned', () => {
-    const tooNew = store().loadGraphDocument({ nodes: [], edges: [], formatVersion: 999 });
+    const tooNew = store().loadGraphDocument({ nodes: [], edges: [], boundFile: null, formatVersion: 999 });
 
     expect(tooNew).toBe(true);
     expect(tab().readOnly).toBe(true);
   });
 
   it('clears a stale read-only flag when a current-format document is loaded', () => {
-    store().loadGraphDocument({ nodes: [], edges: [], formatVersion: 999 });
+    store().loadGraphDocument({ nodes: [], edges: [], boundFile: null, formatVersion: 999 });
     expect(tab().readOnly).toBe(true);
 
-    const tooNew = store().loadGraphDocument({ nodes: [], edges: [], formatVersion: 1 });
+    const tooNew = store().loadGraphDocument({ nodes: [], edges: [], boundFile: null, formatVersion: 1 });
 
     expect(tooNew).toBe(false);
     expect(tab().readOnly).toBe(false);
   });
 
   it('treats a missing format_version as current, not as too new', () => {
-    expect(store().loadGraphDocument({ nodes: [], edges: [] })).toBe(false);
+    expect(store().loadGraphDocument({ nodes: [], edges: [], boundFile: null })).toBe(false);
     expect(tab().readOnly).toBe(false);
   });
 
@@ -145,6 +187,7 @@ describe('loadGraphDocument', () => {
     store().loadGraphDocument({
       nodes: [],
       edges: [],
+      boundFile: null,
       subgraphs: [{ id: 'x' } as unknown as SubgraphDefinition],
     });
 
@@ -177,7 +220,12 @@ describe('loadGraphDocument', () => {
       })) as never,
     });
 
-    store().loadGraphDocument({ nodes: [node('top')], edges: [], subgraphs: [definition('blk')] });
+    store().loadGraphDocument({
+      nodes: [node('top')],
+      edges: [],
+      boundFile: null,
+      subgraphs: [definition('blk')],
+    });
 
     const t = tab();
     expect(t.subgraphStack).toEqual([]);

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -397,6 +397,21 @@ function createTabState(id: string, name: string): TabState {
 export interface GraphDocument {
   nodes: Node<NodeData>[];
   edges: Edge[];
+  /**
+   * The saved-graph file the tab is bound to AFTER this load -- the file a
+   * plain Save overwrites in place -- or null for "bound to nothing, so ask
+   * where this should go" (#200 item 9).
+   *
+   * REQUIRED, and the only field here the caller does not read out of the
+   * document: it is the reader's binding decision, and there is no safe
+   * default for it. Omitting it meant "keep whatever the PREVIOUS graph was
+   * bound to", which is how opening an example into a tab holding `foo.json`
+   * made the next Save write the example over `foo.json` with no overwrite
+   * warning. Required so the compiler asks every reader -- the two in
+   * `Toolbar` always answered it (they assigned it right after the call);
+   * the third, `openExample`, never knew there was a question.
+   */
+  boundFile: string | null;
   subgraphs?: SubgraphDefinition[];
   segmentGroups?: SegmentGroup[];
   /**
@@ -484,6 +499,10 @@ interface TabStoreState {
    * Returns true when the document opened READ-ONLY because its
    * `format_version` is newer than this build writes: the store owns the
    * verdict, the caller owns the notice it shows for it.
+   *
+   * The tab's save target comes from `doc.boundFile` and is always written,
+   * so no document can be installed onto another file's binding (#200
+   * item 9). See the field's own note for why it is required.
    */
   loadGraphDocument: (doc: GraphDocument) => boolean;
   collapseSelectionToSubgraph: (name?: string) => CollapseResult;
@@ -2166,6 +2185,16 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
   // tab is computed and committed in ONE `set`, so no subscriber ever
   // observes a half-installed graph and no caller can sequence it wrongly.
   //
+  // The save binding (`currentGraphFile`) joined the update in #200 item 9.
+  // It looked like it did not belong here -- it is not read off the file --
+  // but leaving it outside was the same shape of bug one field over: the
+  // example reader never assigned it, so a template opened into a tab bound
+  // to foo.json inherited foo.json as its save target and the next Save
+  // overwrote that file, silently, without the overwrite prompt (the prompt
+  // is skipped precisely BECAUSE the tab claims to be bound to it). Which
+  // file a graph writes to is part of installing a graph, so `boundFile` is
+  // required rather than optional.
+  //
   // Undo is deliberately untouched, matching what all three readers did
   // before: opening a document pushes no snapshot and clears no stack.
   // #200 item 2 has since put `segmentGroups`/`activeSegment` in every frame,
@@ -2203,6 +2232,11 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
         activeSegment: null,
         description: doc.description ?? '',
         readOnly,
+        // The save target, stated by the reader and never inherited (#200
+        // item 9). This is the field whose absence made an example opened
+        // into a tab bound to foo.json overwrite foo.json on the next Save:
+        // the graph on screen had been replaced and the binding had not.
+        currentGraphFile: doc.boundFile,
         // Only when the document names one: a tab that was never renamed
         // keeps the label the user is looking at.
         ...(name ? { name } : {}),

--- a/frontend/src/utils/openExample.test.ts
+++ b/frontend/src/utils/openExample.test.ts
@@ -130,6 +130,26 @@ describe('openExample', () => {
     expect(activeTab().readOnly).toBe(false);
   });
 
+  // -- #200 item 9: an example is a template, bound to no file --
+
+  it('unbinds the tab so the example cannot be saved over the file that was open', async () => {
+    // The bug: the tab still claimed to be bound to my_graph, and a bound tab
+    // is exactly the case Save skips the overwrite prompt for -- so the next
+    // Save wrote the EXAMPLE into my_graph without asking.
+    store().setCurrentGraphFile('my_graph');
+    mockedRest.loadExample.mockResolvedValue({ nodes: [raw('a')], edges: [] });
+
+    await openExample('x');
+
+    expect(activeTab().currentGraphFile).toBeNull();
+  });
+
+  it('leaves an already-unbound tab unbound', async () => {
+    mockedRest.loadExample.mockResolvedValue({ nodes: [raw('a')], edges: [] });
+    await openExample('x');
+    expect(activeTab().currentGraphFile).toBeNull();
+  });
+
   it('installs the whole example in ONE store update', async () => {
     // #200 item 8: the ordering contract between setNodes and setSubgraphs
     // is enforced by construction now -- there is no intermediate state in
@@ -216,6 +236,55 @@ describe('insertExample', () => {
     await expect(insertExample('x')).resolves.toBe(false);
     expect(activeTab().nodes.map((n) => n.id)).toEqual(['keep']);
     expect(useToastStore.getState().toasts[0].message).toBe('Failed to load example');
+  });
+
+  // -- #200 item 10: a merge cannot be answered with read-only, so it refuses --
+
+  it('refuses a template written by a newer CodefyUI, leaving the canvas untouched', async () => {
+    store().setNodes([
+      { id: 'mine', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'k', type: 'K', params: {} } },
+    ] as never);
+    mockedRest.loadExample.mockResolvedValue({
+      nodes: [raw('a'), raw('b')],
+      edges: [],
+      format_version: 999,
+    });
+
+    await expect(insertExample('x')).resolves.toBe(false);
+
+    // Nothing merged: the node count is the user's own graph, unchanged.
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['mine']);
+    expect(activeTab().edges).toEqual([]);
+    // ...and the tab is NOT dragged into read-only for what the template is.
+    expect(activeTab().readOnly).toBe(false);
+    const toasts = useToastStore.getState().toasts;
+    const toast = toasts[toasts.length - 1];
+    expect(toast.type).toBe('error');
+    expect(toast.message).toContain('v999');
+  });
+
+  it("does not install a refused template's presets on the way to refusing it", async () => {
+    // Resolution merges unknown presets into the palette, so the gate has to
+    // run on the RAW payload -- before anything is resolved.
+    const preset = { preset_name: 'FromTheFuture', category: 'c', description: '', tags: [], nodes: [], edges: [], exposed_inputs: [], exposed_outputs: [], exposed_params: [] };
+    mockedRest.loadExample.mockResolvedValue({
+      nodes: [raw('a')], edges: [], presets: [preset], format_version: 999,
+    });
+
+    await expect(insertExample('x')).resolves.toBe(false);
+
+    expect(useNodeDefStore.getState().presets).toEqual([]);
+  });
+
+  it('inserts a current-format template, and one with no format_version', async () => {
+    mockedRest.loadExample.mockResolvedValue({ nodes: [raw('a')], edges: [], format_version: 1 });
+    await expect(insertExample('x')).resolves.toBe(true);
+    expect(activeTab().nodes).toHaveLength(1);
+
+    mockedRest.loadExample.mockResolvedValue({ nodes: [raw('b')], edges: [] });
+    await expect(insertExample('x')).resolves.toBe(true);
+    expect(activeTab().nodes).toHaveLength(2);
+    expect(useToastStore.getState().toasts).toEqual([]);
   });
 
   it('round-trips a bypassed node from the example file onto the canvas', async () => {

--- a/frontend/src/utils/openExample.ts
+++ b/frontend/src/utils/openExample.ts
@@ -6,6 +6,7 @@ import { useToastStore } from '../store/toastStore';
 import { useI18n } from '../i18n';
 import type { NodeData, SegmentGroup, SubgraphDefinition } from '../types';
 import { resolveSerializedNodes, resolveSerializedEdges } from '.';
+import { isFormatTooNew } from './formatVersion';
 
 /** A fetched example, resolved into live canvas nodes and edges. */
 interface ResolvedExample {
@@ -49,8 +50,19 @@ interface ResolvedExample {
  * means for the graph in front of the user.
  */
 async function fetchResolvedExample(path: string): Promise<ResolvedExample> {
-  const data = await loadExample(path);
+  return resolveExample(await loadExample(path));
+}
 
+/**
+ * Resolve an already-fetched example payload.
+ *
+ * Split out of the fetch for `insertExample` (#200 item 10), which has to
+ * read `format_version` off the RAW payload and refuse before anything is
+ * resolved: resolution is not a pure function -- it merges the example's
+ * unknown presets into the node-def store -- so a refusal decided after it
+ * would already have left the palette holding a newer build's presets.
+ */
+function resolveExample(data: any): ResolvedExample {
   const store = useNodeDefStore.getState();
   // An example may ship presets the running server has never seen. Merge the
   // unknown ones in by name so its nodes resolve, without clobbering the
@@ -116,6 +128,13 @@ function applyToActiveTab(example: ResolvedExample): void {
   const openedReadOnly = useTabStore.getState().loadGraphDocument({
     nodes: example.nodes,
     edges: example.edges,
+    // An example is a TEMPLATE, not a file the user owns: it is bound to
+    // nothing, so the first Save has to ask for a name (#200 item 9). This
+    // reader used to leave the binding alone, which meant an example opened
+    // into a tab holding `foo.json` inherited it -- and the next Save wrote
+    // the example over foo.json without the overwrite prompt, because a
+    // bound tab is exactly the case that prompt is skipped for.
+    boundFile: null,
     subgraphs: example.subgraphs,
     segmentGroups: example.segmentGroups,
     name: example.name,
@@ -188,10 +207,34 @@ export async function openExampleInNewTab(path: string): Promise<boolean> {
  * `insertGraph`, so inserting into a populated canvas can never clobber a
  * node that is already there. Unlike `openExample` this does not rename the
  * tab: the tab still holds the user's own graph, which the template joined.
+ *
+ * REFUSES a template written by a newer CodefyUI (#200 item 10). The other
+ * two paths answer a too-new `format_version` by opening the graph read-only,
+ * and that answer does not translate here: a merge has no separate document
+ * to mark, and marking the tab read-only would punish the user's own graph
+ * for what the template is. Read-only exists so an older build can never
+ * write back fields it does not understand -- merging those fields INTO an
+ * editable graph reaches the same place by a shorter road, since the next
+ * save writes the result. So the merge does not happen at all, and the user
+ * is told why rather than left wondering why nothing appeared.
  */
 export async function insertExample(path: string): Promise<boolean> {
   try {
-    const example = await fetchResolvedExample(path);
+    // Read off the raw payload, BEFORE resolving: resolution merges the
+    // example's unknown presets into the node-def store, so a refusal after
+    // it would have already installed a newer build's presets.
+    const data = await loadExample(path);
+    const formatVersion = data.format_version;
+    if (isFormatTooNew(formatVersion)) {
+      useToastStore.getState().addToast(
+        useI18n.getState().t('project.formatTooNew.insertRefused', {
+          version: formatVersion as string | number,
+        }),
+        'error',
+      );
+      return false;
+    }
+    const example = resolveExample(data);
     if (example.nodes.length === 0) return false;
     useTabStore.getState().insertGraph(
       example.nodes,

--- a/frontend/src/utils/saveActiveGraph.test.ts
+++ b/frontend/src/utils/saveActiveGraph.test.ts
@@ -64,6 +64,24 @@ describe('saveActiveGraph', () => {
     expect(saveGraph).toHaveBeenCalledWith(expect.objectContaining({ name: 'fresh' }));
   });
 
+  // #200 item 9. The binding is the whole of what decides "overwrite in
+  // place, no prompt", so a document installed with no binding has to take
+  // the prompt path even when the tab was bound a moment earlier -- which is
+  // what opening an example into a tab bound to a file now does.
+  it('project mode: a document opened with no file binding prompts instead of overwriting the file that was open', async () => {
+    useProjectStore.setState({ projectDir: '/proj', projectName: 'proj', loaded: true });
+    useTabStore.getState().setCurrentGraphFile('classifier');
+    // Exactly what `openExample` hands the store now.
+    useTabStore.getState().loadGraphDocument({ nodes: [], edges: [], boundFile: null });
+    (prompt as unknown as ReturnType<typeof vi.fn>).mockResolvedValue('from-template');
+
+    await saveActiveGraph();
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(saveGraph).toHaveBeenCalledWith(expect.objectContaining({ name: 'from-template' }));
+    expect(saveGraph).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'classifier' }));
+  });
+
   it('empty prompt aborts the save', async () => {
     (prompt as unknown as ReturnType<typeof vi.fn>).mockResolvedValue('');
     await saveActiveGraph();


### PR DESCRIPTION
Part of #200 — items 9 and 10; the issue stays open for item 7 (the plugin
op surface). Both are residues the #319 review surfaced on the
example/template paths.

## Item 9 — an example inherited the previous graph's save target

Opening an example into a tab bound to `foo.json` left the tab bound to
`foo.json`. The graph on screen had been replaced and the save target had
not, so the next Save wrote the example over `foo.json` — with no overwrite
prompt, because a bound tab is precisely the case Save is allowed to
overwrite in place.

`loadGraphDocument` now takes a **required** `boundFile` and writes
`currentGraphFile` inside the same single `set` as the graph it belongs to.
Both Toolbar readers already assigned the binding on the line after the
call, so their behavior is unchanged (load binds to the sanitized file
stem, import unbinds); what changes is that the question is now asked by
the compiler — which is the part the third reader, `openExample`, was
never asked.

## Item 10 — the merge path ignored `format_version`

`insertExample` never looked at `format_version`, so a template written by
a newer CodefyUI merged straight into an editable graph. The other two
paths answer "too new" with read-only, and that answer does not translate
to a merge: there is no separate document to mark, and marking the tab
would punish the user's own graph for what the template is. Read-only
exists so an older build can never write back fields it does not
understand — merging those fields into an editable graph gets to the same
place by a shorter road, since the next save writes the result.

So the merge is refused, with an educational toast (en + zh-TW) that names
the version and both ways forward: open it to view it read-only, or update
CodefyUI. The gate reads the **raw** payload before resolution, because
resolution is not pure — it merges the template's unknown presets into the
palette, which a refusal decided any later would already have done.

## Tests

- store level: bind / unbind / never inherit, and the binding lands in the
  same single emission as the graph
- `openExample` clears the binding; the save path then prompts instead of
  overwriting the file that was open
- Toolbar import still unbinds, Toolbar load still binds (unchanged
  behavior, now pinned)
- the merge refusal leaves nodes, edges, `readOnly` and the preset list
  untouched, and a current-format / version-less template still inserts

Every new assertion was checked against a mutated implementation (gate
disabled, binding write removed) and observed to fail.

Gates: `pnpm exec tsc -b`, `pnpm test` (139 files / 3204 tests), `pnpm build`,
`scripts/check_control_bytes.py`, `ruff check .` — all green. Frontend only.

Browser e2e for the controller:
1. Load a saved graph (File > Load) so the tab is bound to it, open a
   gallery example over it, then File > Save — it must ask for a name
   instead of silently overwriting the loaded file.
2. Insert a doctored template whose `format_version` is 999 from the
   Template Gallery — the canvas must not change and an error toast must
   name v999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYmF5XjhQStu2K6swHp2XX
