### PR TITLE
chore(community): issue and PR templates that ask for the graph up front (#141)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,127 @@
+name: Bug report
+description: Something in CodefyUI is broken.
+title: "fix: <short summary of the problem>"
+labels:
+  - type:bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. The single most useful thing you can attach
+        is the graph JSON — most bug reports here turn into "please attach
+        your graph" as the first reply, which wastes a round trip. Export it
+        from the canvas toolbar (匯出 / Export) before you start filling this
+        in, then drag the file into the field below.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: >-
+        Describe the bug plainly. Include exact error text if the console or
+        server.log showed one — do not paraphrase it.
+        （請具體描述問題，錯誤訊息請照原文貼上，不要用自己的話重述。）
+      placeholder: |
+        Example: clicking Run on a graph with a LRScheduler node crashes the
+        backend with "AttributeError: 'NoneType' object has no attribute
+        'step'".
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      description: >-
+        Numbered steps, starting from a fresh graph if possible. If it only
+        reproduces on a specific graph, that graph is what the field below is
+        for.
+      placeholder: |
+        1. Open CodefyUI and load the attached graph
+        2. Set TrainingLoop.epochs to 5
+        3. Click Run
+        4. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: graph-json
+    attributes:
+      label: Graph JSON
+      description: >-
+        Paste the exported graph JSON here, or drag-and-drop the exported
+        .json file to attach it. Export it from the canvas toolbar's 匯出
+        (Export) button. Without this, a maintainer usually cannot reproduce
+        the bug at all — please do not skip this field even if you think the
+        problem is "obvious".
+        （請從畫布工具列的「匯出」按鈕匯出圖檔並貼上或附加，這是重現問題最重要的資訊。）
+      placeholder: |
+        Paste JSON here, or drag the exported .json file onto this box.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: CodefyUI version
+      description: >-
+        Run `cdui --version` (or `./cdui --version` on Linux/macOS,
+        `.\cdui.cmd --version` on Windows). If that is unavailable, check
+        frontend/dist/build-info.json instead.
+      placeholder: e.g. 1.4.2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-flavor
+    attributes:
+      label: Install flavor
+      description: How is CodefyUI installed on your machine?
+      options:
+        - "uv only, no Node (cdui start, prebuilt frontend-dist.tar.gz)"
+        - "Dev install with pnpm (cdui install --dev, cdui dev)"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: input
+    id: os-python
+    attributes:
+      label: OS and Python version
+      description: >-
+        e.g. "Windows 11, Python 3.11" or "Ubuntu 24.04, Python 3.12". Run
+        `python --version` inside the backend virtualenv if unsure.
+      placeholder: Windows 11, Python 3.11
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: >-
+        If `cdui start` is running the server, the backend log is at
+        `.codefyui_dev/server.log` in the repo/install directory. Paste the
+        last 30-50 lines around the failure, not the whole file. Browser
+        console output is also useful for frontend bugs.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I attached the graph JSON above, or explained why none applies.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+# Keep the blank issue option. A lot of the house issues in this repo are
+# free-form technical write-ups (root-cause analysis, a residue found while
+# fixing something else) that don't fit either structured form below —
+# templates are here to guide outsiders, not to gate people who already know
+# what they're reporting.
+blank_issues_enabled: true
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/CodefyUI/CodefyUI/blob/main/CONTRIBUTING.md
+    about: Dev setup, DCO sign-off, PR conventions — read this before your first PR.
+  - name: Documentation
+    url: https://docs.codefyui.com
+    about: Getting-started, architecture tour, and node reference.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Propose a new capability or improvement.
+title: "feat: <short summary of the capability>"
+labels:
+  - type:feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Lead with the problem, not the solution. "I want a Foo node" is
+        harder to evaluate than "I cannot do X, here is who runs into it, and
+        here is why the existing nodes don't cover it" — the second gives a
+        maintainer enough to design a better fix than the one you had in mind.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What can't you do today
+      description: >-
+        Describe the concrete task you were trying to accomplish and where
+        CodefyUI stopped you. Prefer a real graph or workflow over an
+        abstract description.
+        （請描述你實際想完成的工作，以及目前 CodefyUI 卡在哪一步。）
+    validations:
+      required: true
+
+  - type: textarea
+    id: who-hits-it
+    attributes:
+      label: Who runs into this
+      description: >-
+        A student working through a specific chapter, an instructor building
+        a demo, someone integrating a plugin, etc. This is what separates a
+        niche request from one worth prioritizing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-shape
+    attributes:
+      label: Proposed shape (optional)
+      description: >-
+        If you have an idea of what the fix could look like — a new node, a
+        new parameter, a UI change — sketch it here. It is fine to leave this
+        blank; the problem statement above matters more.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Workarounds you've tried (optional)
+      description: >-
+        Any existing node combination or manual step that partially covers
+        this. Helps a reviewer see exactly what gap remains.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--
+Delete this comment block before submitting. See CONTRIBUTING.md#pr-bodies
+for the full convention this template is a shortcut for.
+-->
+
+> 中文摘要：（一段中文摘要，說明改了什麼、為什麼要改）
+
+## What / Why
+
+<!-- What changed, and the concrete problem it fixes. "From the issue: ..." -->
+
+## Closes / relates to
+
+<!--
+Use a closing keyword ONLY when this PR fully resolves the issue:
+  Closes #NNN
+For partial work, say so plainly and do NOT use a closing keyword nearby —
+GitHub closes the issue on merge regardless of surrounding negation, e.g.
+"does not close #NNN" still closes #NNN. Write instead:
+  Part of #NNN (stays open — <what remains>)
+-->
+
+## Test evidence
+
+<!--
+The commands you actually ran and their outcome, not "tests pass". e.g.:
+  python scripts/check_control_bytes.py   -> clean
+  uvx ruff@0.14.4 check .                 -> clean
+  cd backend && uv run pytest -q          -> N passed
+  cd frontend && pnpm test                -> N passed
+If this genuinely can't be tested, say why instead of leaving it blank.
+-->
+
+## Checklist
+
+- [ ] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
+- [ ] If I changed a docs page or a node-param description, I updated its
+      zh-TW twin in the same PR (docs/i18n/zh-TW/... or the matching
+      nodeLocales entry).
+- [ ] No pictographic emoji in code, logs, UI strings, or this PR body
+      (Windows consoles crash on them — ASCII markers like `[OK]` instead).
+- [ ] I explained what I deliberately did not do, if a reviewer might expect it.


### PR DESCRIPTION
> 中文摘要：新增四份 `.github` 範本檔案——bug report、feature request、`config.yml`（保留自由格式 issue）以及 PR 範本。之前完全沒有這些檔案，回報 bug 常常因為沒附上 graph JSON 而白跑一趟；新的 bug 範本把 graph JSON 設為必填欄位，並提示從畫布「匯出」取得。這是 #141 的第 4 項，第 3 項（good-first-issue 整理）維持獨立處理，本 issue 保持開啟。

## What / Why

`.github/` had workflows and RELEASING.md but no issue forms and no PR
template. #141's controller re-scope comment (2026-08-11) narrowed the
issue to two remaining items; this PR delivers item 4.

The concrete failure this fixes: a bug report with no graph JSON attached is
close to useless for reproduction, and until now nothing on the issue-open
path even asked for it. `bug_report.yml` makes the graph JSON field
`required: true` and puts a note right at the top pointing at the canvas
toolbar's 匯出 (Export) button, since that's the step people skip.

## What changed

- `.github/ISSUE_TEMPLATE/bug_report.yml` -- structured form: what happened,
  expected behavior, repro steps, graph JSON (required), CodefyUI version
  (`cdui --version` / `build-info.json`), install flavor (uv-only vs. dev
  with pnpm), OS + Python, and an optional logs field pointing at
  `.codefyui_dev/server.log`. Labeled `type:bug`.
- `.github/ISSUE_TEMPLATE/feature_request.yml` -- problem-first: what you
  can't do today, who runs into it, proposed shape and workarounds are both
  optional. Labeled `type:feature`.
- `.github/ISSUE_TEMPLATE/config.yml` -- `blank_issues_enabled: true` (a lot
  of house issues here are free-form root-cause write-ups that don't fit a
  structured form) plus two `contact_links` pointing at CONTRIBUTING.md and
  the docs site.
- `.github/PULL_REQUEST_TEMPLATE.md` -- what/why, a closes-# section that
  spells out the negation trap explicitly ("does not close #N" still closes
  #N on GitHub -- say "Part of #N (stays open)" instead), a test-evidence
  section asking for actual commands run, and a checklist for DCO sign-off,
  zh-TW docs/node-description twins, and no pictographic emoji.

Fields are bilingual-lite per the brief: English labels throughout, with a
one-line zh-TW hint added only where a student reporter benefits (how to
export the graph, what to describe) rather than on every line.

## What I deliberately did not do

The original epic text (#141 item 4) also mentioned a "plugin-idea"
template; the controller's 2026-08-11 re-scope comment narrowed item 4 to
bug + feature + config + PR template only, so I did not add a third issue
form. Also skipped: no CI wiring for these files -- the brief and
CONTRIBUTING both note nothing validates issue-form YAML today, and this PR
does not add a validator, just eyeballs the schema by hand plus a PyYAML
parse.

## Test evidence

Repo-meta-only change (no code), so the applicable gates are:

```
python scripts/check_control_bytes.py   -> OK: no raw C0 control bytes in 1159 tracked files
uvx ruff@0.14.4 check .                  -> All checks passed!
```

Additionally parsed all three YAML files with PyYAML and asserted every
non-markdown body item has `type` in {input, textarea, dropdown,
checkboxes} plus an `id` and a `label` -- the closest thing to a schema
check available without `gh`'s (nonexistent) local validator.

No pytest/tsc/pnpm gates apply -- nothing under `backend/` or `frontend/`
changed.

## Closes / relates to

Part of #141 (stays open -- item 3, good-first-issue curation, is being
handled outside this task; the controller's 2026-08-11 comment already
tracks 5 of the 10 curated items there).

Generated with [Claude Code](https://claude.ai/code/session_01WYmF5XjhQStu2K6swHp2XX)

https://claude.ai/code/session_01WYmF5XjhQStu2K6swHp2XX
