### PR TITLE
fix(ui): a tab with a graph in it asks before it dies (#331)

### DIFF
--- a/frontend/src/components/TabBar/TabBar.test.tsx
+++ b/frontend/src/components/TabBar/TabBar.test.tsx
@@ -233,6 +233,153 @@ describe('TabBar', () => {
     expect(useTabStore.getState().tabs).toHaveLength(2);
   });
 
+  // ── Close confirm for a tab with a graph in it (#331) ──────────────────────
+
+  /**
+   * Give the tab at `index` some content without going through the canvas:
+   * `tabHasContent` only reads nodes/edges/subgraphs, so two nodes is enough
+   * to make it the "would lose work" case.
+   */
+  function fillTab(index: number) {
+    const tabs = useTabStore.getState().tabs;
+    useTabStore.setState({
+      tabs: tabs.map((t, i) =>
+        i === index
+          ? {
+              ...t,
+              nodes: [
+                { id: 'n1', type: 'default', position: { x: 0, y: 0 }, data: { type: 'Dataset', params: {} } },
+                { id: 'n2', type: 'default', position: { x: 90, y: 0 }, data: { type: 'Model', params: {} } },
+              ] as never,
+            }
+          : t,
+      ),
+    });
+  }
+
+  it('closing an EMPTY tab does not ask (closes immediately)', () => {
+    useTabStore.getState().addTab('Tab 2');
+    render(<TabBar />);
+    fireEvent.click(screen.getAllByText('×')[0]);
+    expect(useDialogStore.getState().active).toBeNull();
+    expect(useTabStore.getState().tabs).toHaveLength(1);
+  });
+
+  it('closing a tab holding a graph asks first, with the tab name and node count', async () => {
+    useTabStore.getState().addTab('Tab 2');
+    fillTab(0);
+    render(<TabBar />);
+    fireEvent.click(screen.getAllByText('×')[0]);
+    await waitFor(() => {
+      expect(useDialogStore.getState().active).not.toBeNull();
+    });
+    const active = useDialogStore.getState().active!;
+    expect(active.kind).toBe('confirm');
+    expect(active.title).toBe('Close "Tab 1"?');
+    expect(active.message).toContain('2 nodes');
+    // Destructive action, so the danger styling the overwrite confirm uses.
+    expect(active.kind === 'confirm' && active.variant).toBe('danger');
+    expect(active.confirmText).toBe('Close tab');
+    // Nothing removed while the dialog is up.
+    expect(useTabStore.getState().tabs).toHaveLength(2);
+  });
+
+  it('cancelling the confirm keeps the tab and everything in it', async () => {
+    useTabStore.getState().addTab('Tab 2');
+    fillTab(0);
+    const before = useTabStore.getState().tabs[0];
+    render(<TabBar />);
+    fireEvent.click(screen.getAllByText('×')[0]);
+    await waitFor(() => {
+      expect(useDialogStore.getState().active).not.toBeNull();
+    });
+    useDialogStore.getState().close(false);
+    await waitFor(() => {
+      expect(useDialogStore.getState().active).toBeNull();
+    });
+    const after = useTabStore.getState().tabs[0];
+    expect(useTabStore.getState().tabs).toHaveLength(2);
+    // Same tab object: nodes, file binding and undo stacks all untouched.
+    expect(after).toBe(before);
+    expect(after.nodes).toHaveLength(2);
+    expect(screen.getByText('Tab 1')).toBeTruthy();
+  });
+
+  it('confirming the dialog removes the tab', async () => {
+    useTabStore.getState().addTab('Tab 2');
+    fillTab(0);
+    const firstId = useTabStore.getState().tabs[0].id;
+    render(<TabBar />);
+    fireEvent.click(screen.getAllByText('×')[0]);
+    await waitFor(() => {
+      expect(useDialogStore.getState().active).not.toBeNull();
+    });
+    useDialogStore.getState().close(true);
+    await waitFor(() => {
+      expect(useTabStore.getState().tabs).toHaveLength(1);
+    });
+    expect(useTabStore.getState().tabs.find((t) => t.id === firstId)).toBeUndefined();
+  });
+
+  it('a tab bound to a saved file still asks: dirty tracking cannot prove it is unchanged', async () => {
+    // `dirtyNodeIds` is the partial-re-execution hint -- cleared at the start
+    // of every run and never set by addNode -- so "clean and bound to a file"
+    // does not mean "identical to what is on disk". Asking anyway is the only
+    // answer that cannot silently discard work (#331).
+    useTabStore.getState().addTab('Tab 2');
+    fillTab(0);
+    const tabs = useTabStore.getState().tabs;
+    useTabStore.setState({
+      tabs: tabs.map((t, i) =>
+        i === 0 ? { ...t, currentGraphFile: 'saved-graph', dirtyNodeIds: new Set<string>() } : t,
+      ),
+    });
+    render(<TabBar />);
+    fireEvent.click(screen.getAllByText('×')[0]);
+    await waitFor(() => {
+      expect(useDialogStore.getState().active).not.toBeNull();
+    });
+    expect(useTabStore.getState().tabs).toHaveLength(2);
+  });
+
+  it('a running tab with a graph gets ONE dialog carrying both warnings', async () => {
+    useTabStore.getState().addTab('Tab 2');
+    fillTab(0);
+    const tabs = useTabStore.getState().tabs;
+    useTabStore.setState({
+      tabs: tabs.map((t, i) => (i === 0 ? { ...t, status: 'running' as const } : t)),
+    });
+    render(<TabBar />);
+    fireEvent.click(screen.getAllByText('×')[0]);
+    await waitFor(() => {
+      expect(useDialogStore.getState().active).not.toBeNull();
+    });
+    const active = useDialogStore.getState().active!;
+    expect(active.title).toBe('This tab is still running. Close it anyway?');
+    expect(active.message).toContain('2 nodes');
+    useDialogStore.getState().close(true);
+    await waitFor(() => {
+      expect(useTabStore.getState().tabs).toHaveLength(1);
+    });
+    // Only the one dialog: nothing re-opened behind it.
+    expect(useDialogStore.getState().active).toBeNull();
+  });
+
+  it('uses the zh-TW copy when that locale is active', async () => {
+    useI18n.setState({ locale: 'zh-TW' });
+    useTabStore.getState().addTab('Tab 2');
+    fillTab(0);
+    render(<TabBar />);
+    fireEvent.click(screen.getAllByText('×')[0]);
+    await waitFor(() => {
+      expect(useDialogStore.getState().active).not.toBeNull();
+    });
+    const active = useDialogStore.getState().active!;
+    expect(active.title).toBe('要關閉「Tab 1」嗎？');
+    expect(active.confirmText).toBe('關閉分頁');
+    expect(active.message).toContain('2 個節點');
+  });
+
   it('clicking the close button stops propagation (does not activate the tab)', () => {
     useTabStore.getState().addTab('Tab 2');
     const firstId = useTabStore.getState().tabs[0].id;

--- a/frontend/src/components/TabBar/TabBar.tsx
+++ b/frontend/src/components/TabBar/TabBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { useTabStore } from '../../store/tabStore';
+import { useTabStore, tabHasContent, tabNodeCount } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
 import { confirm } from '../../utils/dialog';
 import styles from './TabBar.module.css';
@@ -36,9 +36,37 @@ export function TabBar() {
       if (tabs.length <= 1) return;
       /* v8 ignore stop */
       const tab = tabs.find((t) => t.id === id);
-      if (tab && tab.status === 'running') {
+      // Only reachable if the tab vanished between render and click.
+      /* v8 ignore start */
+      if (!tab) return;
+      /* v8 ignore stop */
+      const hasContent = tabHasContent(tab);
+      // The graph warning, reused by both branches below so a running tab with
+      // a graph in it is still told what it is about to lose.
+      const lossMessage = hasContent
+        ? t('tabs.close.confirmMessage', { count: tabNodeCount(tab) })
+        : undefined;
+      if (tab.status === 'running') {
+        // A running tab already asked before #331, and its question is the
+        // stronger one (closing kills the run too). Chaining the content
+        // confirm after it would mean two dialogs for one click, so the run
+        // question just carries the graph warning as its body.
         const ok = await confirm({
           title: t('tabs.closeRunning'),
+          message: lossMessage,
+          variant: 'danger',
+        });
+        if (!ok) return;
+      } else if (hasContent) {
+        // #331: one misclick used to discard a whole graph with no undo --
+        // `removeTab` drops the tab's undo/redo stacks along with it, so there
+        // was nothing left to undo from. An empty tab still closes silently:
+        // asking about nothing is the noise that trains people to click
+        // through the dialog that matters.
+        const ok = await confirm({
+          title: t('tabs.close.confirmTitle', { name: tab.name }),
+          message: lossMessage,
+          confirmText: t('tabs.close.confirmButton'),
           variant: 'danger',
         });
         if (!ok) return;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -254,6 +254,10 @@ const en = {
   // Tabs
   'tabs.add': 'New tab',
   'tabs.closeRunning': 'This tab is still running. Close it anyway?',
+  'tabs.close.confirmTitle': 'Close "{name}"?',
+  'tabs.close.confirmMessage':
+    'This tab has a graph in it ({count} nodes). Closing discards it, and there is no undo for a closed tab: anything you have not saved to a graph file is gone. Cancel and save it first if you want it back later.',
+  'tabs.close.confirmButton': 'Close tab',
 
   // Subgraph Editor (SequentialModel)
   'layersEditor.title': 'Model Architecture Editor',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -239,6 +239,10 @@ const zhTW: Record<TranslationKey, string> = {
   // Tabs
   'tabs.add': '新增分頁',
   'tabs.closeRunning': '此分頁仍在執行中，確定要關閉嗎？',
+  'tabs.close.confirmTitle': '要關閉「{name}」嗎？',
+  'tabs.close.confirmMessage':
+    '這個分頁裡有圖表（{count} 個節點）。關閉分頁會把圖表一起丟棄，而且已關閉的分頁無法復原：尚未儲存成圖表檔案的內容都會消失。若想日後再使用，請先取消並儲存。',
+  'tabs.close.confirmButton': '關閉分頁',
 
   // Subgraph Editor (SequentialModel)
   'layersEditor.title': '模型架構編輯器',

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { useTabStore } from './tabStore';
+import { useTabStore, tabHasContent, tabNodeCount } from './tabStore';
 import { useToastStore } from './toastStore';
 import { useUIStore } from './uiStore';
 import type { NodeDefinition, PresetDefinition } from '../types';
@@ -2924,5 +2924,100 @@ describe('seed and deterministic', () => {
     expect(store().getActiveTab().deterministic).toBe(true);
     store().toggleDeterministic();
     expect(store().getActiveTab().deterministic).toBe(false);
+  });
+});
+
+// ── tabHasContent / tabNodeCount (#331) ─────────────────────────────────────
+
+describe('tabHasContent / tabNodeCount (#331)', () => {
+  beforeEach(() => {
+    resetToSingleTab();
+  });
+
+  it('a brand-new tab has no content (its close x may skip the confirm)', () => {
+    const tab = activeTab();
+    expect(tabNodeCount(tab)).toBe(0);
+    expect(tabHasContent(tab)).toBe(false);
+  });
+
+  it('one dropped node is content', () => {
+    store().addNode(makeDef(), { x: 0, y: 0 });
+    const tab = activeTab();
+    expect(tabNodeCount(tab)).toBe(1);
+    expect(tabHasContent(tab)).toBe(true);
+  });
+
+  it('counts the nodes stashed in the subgraph editing stack, not just the visible canvas', () => {
+    // Standing inside an empty block leaves `tab.nodes` empty while the whole
+    // graph waits in a stack frame -- the case a naive nodes.length check
+    // would wave through as "empty tab, close it".
+    store().addNode(makeDef(), { x: 0, y: 0 });
+    store().addNode(makeDef({ node_name: 'Model' }), { x: 100, y: 0 });
+    const outer = activeTab().nodes;
+    const tabs = useTabStore.getState().tabs;
+    useTabStore.setState({
+      tabs: tabs.map((t, i) =>
+        i === 0
+          ? {
+              ...t,
+              nodes: [],
+              edges: [],
+              subgraphStack: [
+                {
+                  subgraphId: 'sg1',
+                  nodes: outer,
+                  edges: [],
+                  undoStack: [],
+                  redoStack: [],
+                  selectedNodeId: null,
+                  subgraphs: [],
+                  segmentGroups: [],
+                  activeSegment: null,
+                },
+              ],
+            }
+          : t,
+      ),
+    });
+    const tab = useTabStore.getState().tabs[0];
+    expect(tab.nodes).toHaveLength(0);
+    expect(tabNodeCount(tab)).toBe(2);
+    expect(tabHasContent(tab)).toBe(true);
+  });
+
+  it('a leftover block definition with no nodes still counts as content', () => {
+    const tabs = useTabStore.getState().tabs;
+    useTabStore.setState({
+      tabs: tabs.map((t, i) =>
+        i === 0
+          ? {
+              ...t,
+              nodes: [],
+              edges: [],
+              subgraphs: [
+                {
+                  id: 'sg1',
+                  name: 'Block',
+                  description: '',
+                  nodes: [],
+                  edges: [],
+                  interface: { inputs: [], outputs: [], triggerTargets: [] },
+                },
+              ],
+            }
+          : t,
+      ),
+    });
+    const tab = useTabStore.getState().tabs[0];
+    expect(tabNodeCount(tab)).toBe(0);
+    expect(tabHasContent(tab)).toBe(true);
+  });
+
+  it('tolerates a tab record built before these fields existed', () => {
+    // Called from the tab bar on whatever the store holds; a record missing
+    // `subgraphStack` must read as empty rather than throw on the close path.
+    expect(
+      tabHasContent({ nodes: [], edges: [] } as unknown as Parameters<typeof tabHasContent>[0]),
+    ).toBe(false);
   });
 });

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -382,6 +382,51 @@ function createTabState(id: string, name: string): TabState {
   };
 }
 
+/**
+ * How many nodes this tab would take with it if it closed right now (#331).
+ *
+ * Counting `tab.nodes` alone is wrong while a block is open: `enterSubgraph`
+ * SWAPS the graph's nodes out into a `subgraphStack` frame and puts the
+ * definition's insides on the canvas, so a user standing inside a freshly
+ * created (empty) block has `tab.nodes.length === 0` with a whole graph
+ * stashed one level up. Every open frame is added back here for the same
+ * reason `buildPersistedTab` flushes the stack before persisting: the tab is
+ * the whole document, not the sub-canvas currently on screen.
+ */
+export function tabNodeCount(
+  tab: Pick<TabState, 'nodes' | 'subgraphStack'>,
+): number {
+  return (
+    (tab.nodes?.length ?? 0) +
+    (tab.subgraphStack ?? []).reduce((n, frame) => n + frame.nodes.length, 0)
+  );
+}
+
+/**
+ * Would closing this tab throw work away? Drives the confirm on the tab's
+ * close x (#331).
+ *
+ * Deliberately NOT derived from `dirtyNodeIds`. That set is the
+ * partial-re-execution hint and answers a different question: `clearDirty`
+ * empties it at the start of every run, and `addNode` never adds to it at
+ * all — so a graph that was dragged together and run but never saved reads as
+ * perfectly clean, which is exactly the tab whose loss hurts most. Nothing in
+ * the store records "matches what is on disk" (there is no snapshot of the
+ * last save to compare against), so the only honest question available is "is
+ * there anything in here", and a tab with anything in it always asks.
+ */
+export function tabHasContent(
+  tab: Pick<TabState, 'nodes' | 'edges' | 'subgraphs' | 'subgraphStack'>,
+): boolean {
+  if (tabNodeCount(tab) > 0) return true;
+  // An edge or a leftover block definition without any node is not reachable
+  // through normal editing, but it is still authored content — and a tab that
+  // has one is not the "brand-new empty tab" the silent close is for.
+  if (tab.edges?.length) return true;
+  if (tab.subgraphs?.length) return true;
+  return false;
+}
+
 // ── Store ──
 
 /**


### PR DESCRIPTION
Clicking the x on a canvas tab removed it on the spot. `removeTab` takes the
tab's undo/redo stacks with it, so there was nothing left to undo from either:
one misclick on the wrong tab discarded a whole graph, permanently.

## What changed

The tab bar now asks before closing a tab that has anything in it, using the
house confirm (`dialogStore` / `DialogContainer`, `variant: 'danger'`) -- the
same modal family as the save-name prompt (`請輸入圖表名稱`) and the overwrite
confirm. No new dependency: the request named "swal fire" as a style
reference, and the repo is CSP-self-contained with this family already in
place.

An **empty** tab still closes silently. Asking about nothing is the noise that
trains people to click through the dialog that matters.

## The shape I shipped, and why

**Asks for every non-empty tab**, not only the unsaved ones. The issue offered
the narrower shape if dirty tracking could support it; it cannot:

- `dirtyNodeIds` looks like a dirty flag but answers a different question. It
  is the partial-re-execution hint fed to the backend as `changed_nodes`, and
  `clearDirty()` empties it at the start of **every run**
  (`useGraphExecution.ts`).
- `addNode` never adds to it at all -- only param edits, connects and
  disconnects do.
- So a graph that was dragged together and run but never saved reads as
  perfectly clean. That is precisely the tab whose loss hurts most.
- Nothing in the store records "matches what is on disk". `currentGraphFile`
  says which file the tab is *bound* to, not that the two are identical; there
  is no snapshot of the last save to diff against. "Saved and unchanged" is
  not a state this codebase can currently prove.

Guessing that wrong is unrecoverable, and the hard requirement is that one
misclick never discards content -- so the confirm fires whenever there is
content. A future change that records a saved-state signature per tab could
narrow this to the lose-work case; until then the extra dialog on a
genuinely-saved tab is the cheap side of the trade.

## Details

- `tabHasContent` / `tabNodeCount` live in `tabStore` next to the state they
  read, and are exported so both the store test and the tab bar use the same
  answer.
- The node count sums the `subgraphStack` frames as well as the visible
  canvas, for the same reason `buildPersistedTab` flushes the stack before
  persisting: `enterSubgraph` swaps the graph's nodes out into a frame, so
  standing inside a freshly created (empty) block leaves `tab.nodes` empty
  with the whole graph stashed one level up. A naive `nodes.length` check
  would wave that tab through as empty.
- A **running** tab keeps its existing single question
  (`tabs.closeRunning` -- the stronger one, since closing kills the run too)
  and now carries the graph warning as the dialog body. One click never
  produces two dialogs.
- Keyboard follows the house convention unchanged: `DialogContainer`
  auto-focuses the confirm button and Enter submits, same as the overwrite
  confirm; Escape and the backdrop cancel.
- Only the explicit per-tab x is intercepted. There is no middle-click close
  in `TabBar`, and window unload is untouched.
- Copy is in `tabs.close.*` in both `locales/en.ts` and `locales/zh-TW.ts`,
  educational tone, naming the tab and its node count so the user can tell
  they clicked the wrong x.

## Tests

`tabStore.test.ts` -- new-tab/one-node/stack-frame/leftover-definition cases
for the two helpers, plus a field-missing record on the close path.
`TabBar.test.tsx` -- empty tab closes with no dialog; a tab with a graph opens
a danger confirm carrying the tab name, node count and `Close tab` button;
cancel keeps the **same tab object** (nodes, binding and undo stacks
untouched); confirm removes it; a file-bound tab with an empty `dirtyNodeIds`
still asks; a running tab with a graph gets exactly one dialog with both
warnings; zh-TW copy renders under that locale.

Mutation-checked: disabling the new branch fails 5 of them.

Gates: `pnpm exec tsc -b` clean, `pnpm test` 3216 passed / 139 files,
`pnpm build` clean, `check_control_bytes.py` OK, `ruff` clean.

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
