### PR TITLE
feat(plugins): one command to catch up on builtin packs, and an uninstall that is finally remembered (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,37 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+### Added
+
+- **`cdui plugin sync` — one command to catch up on built-in packs, and an
+  uninstall that is finally remembered** ([#175]). A built-in pack is activated
+  by a lockfile entry, and an update never writes one. So a release that *adds*
+  a pack — `stats` did — puts its files on every machine and loads them on
+  none: the nodes are installable and invisible at the same time, a class
+  follows the update instructions, the new chapter's palette is empty, and the
+  only cure was typing an id list nobody knew existed. `cdui plugin sync`
+  installs every built-in pack this install has made no decision about, with
+  `--dry-run` to just list them, `--yes` for scripts and classroom images, and
+  `--prune` to drop lockfile entries for packs that no longer ship (which
+  discovery had been skipping in silence). Failures are per pack: one pack whose
+  `python_deps` will not download on a school network reports and the rest still
+  install, because a batch that aborts on the first failure is a batch nobody
+  can use offline.
+
+  Two shapes were rejected on the way here, and the reason is the same one:
+  syncing at startup, and prompting during `cdui update`, both activate code the
+  user never asked for because a release shipped it. That is a consent decision,
+  so it stays a verb they type. Which exposed the real bug — `uninstall` popped
+  the lockfile entry outright, making "this install has never heard of the pack"
+  and "the user threw it away" the same state, and those are precisely the two
+  states a catch-up command has to tell apart. Uninstalling a built-in pack now
+  leaves a **tombstone** (a `removed` map beside `plugins`, so every existing
+  reader of `plugins` keeps its exact meaning), `sync` names it as skipped
+  rather than re-installing it, the `cdui start` and `cdui plugin list` notices
+  stop nagging about it, and installing the pack by name clears the record. A
+  lockfile written before this field loads unchanged; only built-in packs are
+  tombstoned, since they are the only ones sync could ever put back uninvited.
+
 ### Fixed
 
 - **An unhandled `/api` path answered `405 Method Not Allowed` on every real
@@ -954,6 +985,7 @@ Release candidates before 1.0.0 are on the
 [#291]: https://github.com/CodefyUI/CodefyUI/issues/291
 [#288]: https://github.com/CodefyUI/CodefyUI/issues/288
 [#292]: https://github.com/CodefyUI/CodefyUI/issues/292
+[#175]: https://github.com/CodefyUI/CodefyUI/issues/175
 [@oyea0801]: https://github.com/oyea0801
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.2.0...main
 [2.2.0]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...2.2.0

--- a/backend/app/core/plugin_loader.py
+++ b/backend/app/core/plugin_loader.py
@@ -140,6 +140,64 @@ def is_enabled(entry: dict[str, Any]) -> bool:
     return bool(entry.get("enabled", True))
 
 
+def removed_ids(lockfile: dict[str, Any]) -> set[str]:
+    """Pack ids the user uninstalled on purpose — the #175 "tombstones".
+
+    ``cdui plugin uninstall`` used to only pop the entry, which made "this
+    install has never heard of the pack" and "the user threw it away"
+    the same state — and those are the only two states a catch-up command has
+    to tell apart. So the removal is recorded in a top-level ``removed`` map
+    rather than as a retained ``plugins`` entry: everything that walks
+    ``plugins`` (discovery, the plugin list API, presets, examples) keeps its
+    exact meaning, and an uninstalled pack cannot come back to life through a
+    field one of those readers forgets to check.
+
+    A missing or malformed field reads as "no tombstones", so a lockfile
+    written before #175 loads unchanged — the same legacy-tolerant default as
+    :func:`is_enabled`.
+    """
+    removed = lockfile.get("removed")
+    if not isinstance(removed, dict):
+        return set()
+    return set(removed)
+
+
+def mark_removed(
+    lockfile: dict[str, Any],
+    plugin_id: str,
+    *,
+    source_kind: str | None = None,
+) -> None:
+    """Record ``plugin_id`` as deliberately removed. The caller saves."""
+    removed = lockfile.get("removed")
+    if not isinstance(removed, dict):
+        removed = {}
+        lockfile["removed"] = removed
+    entry: dict[str, Any] = {"removed_at": now_iso()}
+    if source_kind:
+        entry["source_kind"] = source_kind
+    removed[plugin_id] = entry
+
+
+def clear_removed(lockfile: dict[str, Any], plugin_id: str) -> bool:
+    """Forget a tombstone; returns whether there was one. The caller saves.
+
+    Installing a pack by name is the undo for having uninstalled it, so the
+    record of the removal has to go with it — otherwise ``sync`` would keep
+    skipping a pack that is now installed, and a later uninstall/install cycle
+    would read as "still removed".
+    """
+    removed = lockfile.get("removed")
+    if not isinstance(removed, dict) or plugin_id not in removed:
+        return False
+    del removed[plugin_id]
+    if not removed:
+        # Don't leave an empty map behind: a lockfile that records no removals
+        # should look exactly like one written before this field existed.
+        lockfile.pop("removed", None)
+    return True
+
+
 def frontend_entry_rel(manifest: dict[str, Any]) -> str | None:
     """Validated ``[frontend].entry`` path from a plugin manifest, or ``None``.
 

--- a/backend/tests/test_builtin_pack_discovery.py
+++ b/backend/tests/test_builtin_pack_discovery.py
@@ -6,30 +6,54 @@ re-syncs it. The pack is fully installable and completely invisible — the
 class updates as instructed, the new chapter's nodes are not in the palette,
 and nothing anywhere says why. `stats` shipped exactly this way.
 
-Discoverability only: nothing here installs or enables a pack. Running code a
-user did not ask for because a release shipped it is a consent decision, and
-it stays theirs.
+Discoverability first: nothing is installed or enabled behind the user's back.
+Running code a user did not ask for because a release shipped it is a consent
+decision, and it stays theirs — which is why the cure is a verb they type,
+`cdui plugin sync`, and why a pack they uninstalled is remembered as removed
+instead of offered again on the next start.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
+from textwrap import dedent
+from types import SimpleNamespace
 
 import pytest
 
 import dev  # scripts/dev.py -- conftest puts scripts/ on sys.path
 import plugins as plugin_cli  # scripts/plugins.py
+from app.core import plugin_loader
+
+
+@pytest.fixture(autouse=True)
+def _english_cli_messages(monkeypatch):
+    """Pin the CLI's language so the message assertions below are deterministic.
+
+    `plugins.py` picks zh from `LANG`/`LC_ALL`, so a maintainer whose shell is
+    Traditional Chinese would otherwise see these tests fail on strings that are
+    perfectly correct. Same trick as test_plugin_dx.py's subprocess env.
+    """
+    monkeypatch.setenv("CODEFYUI_LANG", "en")
 
 
 @pytest.fixture
 def catalog_of(monkeypatch):
-    """Install a fake catalog + lockfile pair."""
+    """Install a fake catalog + lockfile pair.
 
-    def _apply(catalog: dict, installed: dict):
+    ``removed`` is passed as a plain id list for brevity and stored in the
+    lockfile shape the CLI actually writes (a map of id -> record), so these
+    tests exercise the same read path as a real tombstone.
+    """
+
+    def _apply(catalog: dict, installed: dict, removed: list[str] | None = None):
+        lockfile: dict = {"plugins": installed}
+        if removed is not None:
+            lockfile["removed"] = {pid: {"removed_at": "2026-08-12T00:00:00+00:00"}
+                                   for pid in removed}
         monkeypatch.setattr(plugin_cli, "load_catalog", lambda: {"plugins": catalog})
-        monkeypatch.setattr(
-            plugin_cli, "load_lockfile", lambda: {"plugins": installed}
-        )
+        monkeypatch.setattr(plugin_cli, "load_lockfile", lambda: lockfile)
 
     return _apply
 
@@ -70,6 +94,27 @@ def test_result_is_sorted(catalog_of):
     assert [pid for pid, _ in plugin_cli.available_builtin_packs()] == ["a", "z"]
 
 
+def test_a_pack_the_user_uninstalled_is_not_offered_again(catalog_of):
+    """The #175 consent crux: "removed on purpose" is not "never seen"."""
+    catalog_of({"a": BUILTIN_A, "b": BUILTIN_B}, {}, removed=["a"])
+    assert plugin_cli.available_builtin_packs() == [("b", "Pack B")]
+
+
+def test_a_legacy_lockfile_without_the_removed_field_is_read_unchanged(catalog_of):
+    """Backward compat: pre-#175 lockfiles have no ``removed`` key at all."""
+    catalog_of({"a": BUILTIN_A}, {})  # no `removed` passed -> key absent
+    assert plugin_cli.available_builtin_packs() == [("a", "Pack A")]
+
+
+def test_a_malformed_removed_field_is_read_as_no_tombstones(monkeypatch):
+    """A hand-edited lockfile must not hide every pack behind a typo."""
+    monkeypatch.setattr(plugin_cli, "load_catalog", lambda: {"plugins": {"a": BUILTIN_A}})
+    monkeypatch.setattr(
+        plugin_cli, "load_lockfile", lambda: {"plugins": {}, "removed": ["a"]}
+    )
+    assert plugin_cli.available_builtin_packs() == [("a", "Pack A")]
+
+
 def test_a_broken_lockfile_yields_no_notice_rather_than_raising(monkeypatch):
     def boom():
         raise OSError("lockfile is a directory")
@@ -87,7 +132,8 @@ def test_plugin_list_names_available_packs_when_none_are_installed(
     assert plugin_cli.cmd_list(argparse.Namespace()) == 0
     out = capsys.readouterr().out
     assert "stats" in out
-    assert "cdui plugin install stats" in out
+    # The notice points at the verb, not at an id list that grows per release.
+    assert "cdui plugin sync" in out
 
 
 def test_plugin_list_names_available_packs_alongside_installed_ones(
@@ -100,8 +146,9 @@ def test_plugin_list_names_available_packs_alongside_installed_ones(
     )
     assert plugin_cli.cmd_list(argparse.Namespace()) == 0
     out = capsys.readouterr().out
-    assert "Pack A" in out           # the installed one
-    assert "cdui plugin install b" in out  # and the one that is not
+    assert "Pack A" in out            # the installed one
+    assert "Pack B" in out            # and the one that is not
+    assert "cdui plugin sync" in out  # with the one command that fixes it
 
 
 def test_plugin_list_says_nothing_extra_when_everything_is_installed(
@@ -113,7 +160,9 @@ def test_plugin_list_says_nothing_extra_when_everything_is_installed(
                "manifest": {"name": "Pack A"}}},
     )
     plugin_cli.cmd_list(argparse.Namespace())
-    assert "cdui plugin install" not in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "cdui plugin install" not in out
+    assert "cdui plugin sync" not in out
 
 
 # ── the `cdui start` banner ──────────────────────────────────────────────────
@@ -125,7 +174,7 @@ def test_start_banner_names_available_packs(monkeypatch, capsys):
     dev._print_uninstalled_builtin_packs()
     out = capsys.readouterr().out
     assert "stats (Stats)" in out
-    assert "cdui plugin install stats" in out
+    assert "cdui plugin sync" in out
 
 
 def test_start_banner_is_silent_when_nothing_is_pending(monkeypatch, capsys):
@@ -143,3 +192,275 @@ def test_start_banner_never_breaks_startup(monkeypatch, capsys):
     monkeypatch.setattr(plugin_cli, "available_builtin_packs", boom)
     dev._print_uninstalled_builtin_packs()  # must not raise
     assert capsys.readouterr().out == ""
+
+
+# ── `cdui plugin sync` (#175, option D) ──────────────────────────────────────
+
+def _write_pack(root, pack_id: str) -> None:
+    nodes = root / pack_id / "nodes"
+    nodes.mkdir(parents=True, exist_ok=True)
+    (nodes / "__init__.py").write_text("", encoding="utf-8")
+    (root / pack_id / "cdui.plugin.toml").write_text(
+        dedent(f"""\
+            [plugin]
+            id = "{pack_id}"
+            name = "Pack {pack_id}"
+            version = "0.1.0"
+            schema_version = 1
+            """),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def fake_packs(tmp_path, monkeypatch):
+    """A fake built-in root (registry.json + three pack dirs) and a tmp lockfile.
+
+    The real catalog cannot be used for the install path: `edu` declares
+    `python_deps`, so syncing it would shell out to `uv pip install` from a unit
+    test. Everything else is real — `cmd_sync` calls the same
+    `_install_catalog` the CLI does, and the lockfile is written and re-read
+    from disk, so the tombstone round-trips through JSON exactly as it will in
+    a user's `installed.json`.
+    """
+    user_root = tmp_path / "user" / "plugins"
+    user_root.mkdir(parents=True)
+    builtin_root = tmp_path / "repo" / "plugins"
+    builtin_root.mkdir(parents=True)
+
+    for pack_id in ("alpha", "beta", "gamma"):
+        _write_pack(builtin_root, pack_id)
+    (builtin_root / "registry.json").write_text(
+        json.dumps({
+            "schema": 1,
+            "plugins": {
+                pack_id: {
+                    "kind": "builtin",
+                    "name": f"Pack {pack_id}",
+                    "path": f"plugins/{pack_id}",
+                }
+                for pack_id in ("alpha", "beta", "gamma")
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(plugin_loader, "plugins_user_root", lambda: user_root)
+    monkeypatch.setattr(plugin_cli, "plugins_user_root", lambda: user_root)
+    monkeypatch.setattr(plugin_cli, "plugins_builtin_root", lambda: builtin_root)
+    monkeypatch.setattr(plugin_cli, "_backend_reload", lambda: False)
+    return SimpleNamespace(user_root=user_root, builtin_root=builtin_root)
+
+
+def _locked() -> dict:
+    return plugin_loader.load_lockfile()
+
+
+def _installed_ids() -> set[str]:
+    return set(_locked().get("plugins", {}))
+
+
+def test_sync_installs_every_pending_pack(fake_packs):
+    assert plugin_cli.main(["sync", "--yes"]) == 0
+    assert _installed_ids() == {"alpha", "beta", "gamma"}
+
+
+def test_sync_installs_exactly_the_missing_ones(fake_packs):
+    assert plugin_cli.main(["install", "beta", "--no-confirm"]) == 0
+    installed_at = _locked()["plugins"]["beta"]["installed_at"]
+
+    assert plugin_cli.main(["sync", "--yes"]) == 0
+    assert _installed_ids() == {"alpha", "beta", "gamma"}
+    # beta was not reinstalled on top of itself -- sync skips, it does not force.
+    assert _locked()["plugins"]["beta"]["installed_at"] == installed_at
+
+
+def test_sync_is_a_no_op_once_everything_is_decided(fake_packs, capsys):
+    assert plugin_cli.main(["sync", "--yes"]) == 0
+    capsys.readouterr()
+    assert plugin_cli.main(["sync", "--yes"]) == 0
+    out = capsys.readouterr().out
+    assert "nothing to sync" in out
+
+
+def test_sync_never_re_adds_a_pack_the_user_uninstalled(fake_packs, capsys):
+    """The consent crux (#175, option E): sync respects a removal."""
+    assert plugin_cli.main(["install", "alpha", "--no-confirm"]) == 0
+    assert plugin_cli.main(["uninstall", "alpha"]) == 0
+    capsys.readouterr()
+
+    assert plugin_cli.main(["sync", "--yes"]) == 0
+    assert _installed_ids() == {"beta", "gamma"}
+    out = capsys.readouterr().out
+    assert "Skipping packs you removed: alpha" in out
+
+
+def test_installing_by_name_clears_the_tombstone(fake_packs):
+    assert plugin_cli.main(["install", "alpha", "--no-confirm"]) == 0
+    assert plugin_cli.main(["uninstall", "alpha"]) == 0
+    assert plugin_loader.removed_ids(_locked()) == {"alpha"}
+
+    assert plugin_cli.main(["install", "alpha", "--no-confirm"]) == 0
+    assert plugin_loader.removed_ids(_locked()) == set()
+    # And a pack whose tombstone is gone counts as decided again, not pending.
+    assert plugin_cli.available_builtin_packs() == [("beta", "Pack beta"),
+                                                   ("gamma", "Pack gamma")]
+
+
+def test_dry_run_lists_the_pending_packs_and_installs_nothing(fake_packs, capsys):
+    assert plugin_cli.main(["sync", "--dry-run"]) == 0
+    assert _installed_ids() == set()
+    out = capsys.readouterr().out
+    for pack_id in ("alpha", "beta", "gamma"):
+        assert pack_id in out
+    assert "--dry-run" in out
+
+
+def test_dry_run_omits_a_pack_the_user_uninstalled(fake_packs, capsys):
+    assert plugin_cli.main(["install", "alpha", "--no-confirm"]) == 0
+    assert plugin_cli.main(["uninstall", "alpha"]) == 0
+    capsys.readouterr()
+
+    assert plugin_cli.main(["sync", "--dry-run"]) == 0
+    out = capsys.readouterr().out
+    assert "Skipping packs you removed: alpha" in out
+    # alpha appears only in that skip line, never in the would-install list.
+    assert out.count("alpha") == 1
+
+
+def test_one_pack_that_fails_does_not_stop_the_others(fake_packs, monkeypatch, capsys):
+    """An offline `python_deps` download must cost one pack, not the batch."""
+    real_install = plugin_cli._install_catalog
+
+    def flaky(pack_id, args, lockfile):
+        if pack_id == "beta":
+            plugin_cli.err("下載相依套件失敗", "dependency download failed")
+            return 1
+        return real_install(pack_id, args, lockfile)
+
+    monkeypatch.setattr(plugin_cli, "_install_catalog", flaky)
+
+    assert plugin_cli.main(["sync", "--yes"]) == 1  # the failure is reported
+    assert _installed_ids() == {"alpha", "gamma"}   # and the rest still landed
+    captured = capsys.readouterr()
+    assert "beta failed" in captured.out
+    assert "1 failed (beta)" in captured.err
+
+
+def test_sync_refuses_to_install_without_a_terminal_or_yes(fake_packs, capsys):
+    """Fails closed like the capability gate: never install on a guess."""
+    assert plugin_cli.main(["sync"]) == 1
+    assert _installed_ids() == set()
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_sync_fails_when_stdin_closes_under_a_terminal(fake_packs, monkeypatch, capsys):
+    """`cdui plugin sync < /dev/null` on Windows: isatty() says yes, EOF anyway.
+
+    Found in the #175 smoke run. The first version asked `_stdin_is_interactive()`
+    a second time to pick the exit code, so this path printed "pass --yes" and
+    then exited 0 — an unanswerable question reported as a completed command.
+    """
+    monkeypatch.setattr(plugin_cli, "_stdin_is_interactive", lambda: True)
+
+    def _eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof)
+    assert plugin_cli.main(["sync"]) == 1
+    assert _installed_ids() == set()
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_an_interactive_no_installs_nothing_and_is_not_an_error(
+    fake_packs, monkeypatch, capsys
+):
+    monkeypatch.setattr(plugin_cli, "_stdin_is_interactive", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _p: "n")
+    assert plugin_cli.main(["sync"]) == 0  # a decision, not a failure
+    assert _installed_ids() == set()
+    assert "Cancelled" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("answer", ["y", "Y", "yes", " YES "])
+def test_an_interactive_yes_installs(fake_packs, monkeypatch, answer):
+    monkeypatch.setattr(plugin_cli, "_stdin_is_interactive", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _p: answer)
+    assert plugin_cli.main(["sync"]) == 0
+    assert _installed_ids() == {"alpha", "beta", "gamma"}
+
+
+def test_yes_never_prompts(fake_packs, monkeypatch):
+    def _explode(*_a, **_k):  # pragma: no cover - only runs on a bug
+        raise AssertionError("--yes must not prompt")
+
+    monkeypatch.setattr("builtins.input", _explode)
+    assert plugin_cli.main(["sync", "--yes"]) == 0
+    assert _installed_ids() == {"alpha", "beta", "gamma"}
+
+
+def test_dry_run_never_prompts(fake_packs, monkeypatch):
+    def _explode(*_a, **_k):  # pragma: no cover - only runs on a bug
+        raise AssertionError("--dry-run must not prompt")
+
+    monkeypatch.setattr(plugin_cli, "_stdin_is_interactive", lambda: True)
+    monkeypatch.setattr("builtins.input", _explode)
+    assert plugin_cli.main(["sync", "--dry-run"]) == 0
+    assert _installed_ids() == set()
+
+
+def test_sync_prunes_only_orphaned_builtin_keys(fake_packs, capsys):
+    assert plugin_cli.main(["sync", "--yes"]) == 0
+    lockfile = _locked()
+    # A pack a past release shipped and this one does not: still in the
+    # lockfile, silently skipped by discovery, invisible to every command.
+    lockfile["plugins"]["ghost"] = {"source_kind": "builtin", "source": "ghost",
+                                   "enabled": True}
+    # Two entries prune must NOT touch: a local link whose checkout may just be
+    # unmounted, and a downloaded pack whose files are the user's own data.
+    lockfile["plugins"]["mylink"] = {"source_kind": "local",
+                                     "path": str(fake_packs.user_root / "nope"),
+                                     "enabled": True}
+    lockfile["plugins"]["third"] = {"source_kind": "github_url", "source": "a/b",
+                                    "enabled": True}
+    lockfile.setdefault("removed", {})["vanished"] = {"removed_at": "2026-01-01T00:00:00+00:00"}
+    plugin_loader.save_lockfile(lockfile)
+    capsys.readouterr()
+
+    assert plugin_cli.main(["sync", "--prune"]) == 0
+    after = _locked()
+    assert set(after["plugins"]) == {"alpha", "beta", "gamma", "mylink", "third"}
+    assert plugin_loader.removed_ids(after) == set()
+    out = capsys.readouterr().out
+    assert "ghost" in out and "vanished" in out
+    assert "mylink" not in out and "third" not in out
+
+
+def test_prune_under_dry_run_changes_nothing(fake_packs, capsys):
+    """`--dry-run` promises to change nothing, including with `--prune`."""
+    lockfile = plugin_loader.empty_lockfile()
+    lockfile["plugins"]["ghost"] = {"source_kind": "builtin", "source": "ghost"}
+    plugin_loader.save_lockfile(lockfile)
+
+    assert plugin_cli.main(["sync", "--prune", "--dry-run"]) == 0
+    assert "ghost" in _installed_ids()  # still there
+    out = capsys.readouterr().out
+    assert "would prune" in out
+
+
+def test_sync_without_prune_leaves_a_stale_key_alone(fake_packs):
+    lockfile = plugin_loader.empty_lockfile()
+    lockfile["plugins"]["ghost"] = {"source_kind": "builtin", "source": "ghost"}
+    plugin_loader.save_lockfile(lockfile)
+
+    assert plugin_cli.main(["sync", "--yes"]) == 0
+    assert "ghost" in _installed_ids()
+
+
+def test_sync_parser_wiring():
+    parser = plugin_cli.build_parser()
+    a = parser.parse_args(["sync"])
+    assert a._func is plugin_cli.cmd_sync
+    assert a.dry_run is False and a.yes is False and a.prune is False
+    a = parser.parse_args(["sync", "--dry-run", "-y", "--prune"])
+    assert a.dry_run is True and a.yes is True and a.prune is True

--- a/backend/tests/test_plugin_uninstall_builtin.py
+++ b/backend/tests/test_plugin_uninstall_builtin.py
@@ -7,6 +7,12 @@ file copy. Uninstall should:
     1. Remove the lockfile entry (deactivation).
     2. **Leave the repo directory intact** — it's checked-in code, not user
        data, and a follow-up ``install`` must be able to re-activate it.
+    3. **Record that the removal happened** (#175) — a tombstone in the
+       lockfile's ``removed`` map. Popping the entry alone made "this install
+       never heard of the pack" and "the user threw it away" the same state,
+       and those are precisely the two states ``cdui plugin sync`` has to tell
+       apart. The tombstone lives beside ``plugins`` rather than inside it so
+       every existing reader of ``plugins`` keeps its exact meaning.
 
 A regression here would either (a) refuse to uninstall builtins as "you
 can't remove what you didn't download", or (b) accidentally try to
@@ -102,3 +108,87 @@ def test_uninstall_does_not_touch_other_builtins(isolated_lockfile):
     # And every repo dir still in place.
     for pid in ("foundations", "deep", "rl"):
         assert (plugin_loader.plugins_builtin_root() / pid).is_dir()
+
+
+# ── the uninstall tombstone (#175, option E) ─────────────────────────────────
+
+def test_uninstall_records_the_removal(isolated_lockfile, capsys):
+    assert plugin_cli.main(["install", "rl", "--no-confirm"]) == 0
+    assert plugin_cli.main(["uninstall", "rl"]) == 0
+
+    data = _read_lockfile(isolated_lockfile)
+    assert "rl" not in data["plugins"]          # gone from the active set
+    assert plugin_loader.removed_ids(data) == {"rl"}  # but the decision is kept
+    entry = data["removed"]["rl"]
+    assert entry["source_kind"] == "builtin"
+    assert entry["removed_at"]                 # when, so the record is auditable
+
+    # And the user is told what the tombstone means, since nothing else shows it.
+    out = capsys.readouterr().out
+    assert "cdui plugin sync" in out or "cdui plugin sync" in out.lower()
+    assert "cdui plugin install rl" in out
+
+
+def test_a_reinstall_clears_the_tombstone(isolated_lockfile):
+    assert plugin_cli.main(["install", "rl", "--no-confirm"]) == 0
+    assert plugin_cli.main(["uninstall", "rl"]) == 0
+    assert plugin_cli.main(["install", "rl", "--no-confirm"]) == 0
+
+    data = _read_lockfile(isolated_lockfile)
+    assert "rl" in data["plugins"]
+    # Cleared entirely, not left as an empty map: a lockfile that records no
+    # removals should look exactly like one written before this field existed.
+    assert plugin_loader.removed_ids(data) == set()
+    assert "removed" not in data
+
+
+def test_a_tombstone_records_only_the_pack_that_was_removed(isolated_lockfile):
+    for pid in ("foundations", "deep", "rl"):
+        assert plugin_cli.main(["install", pid, "--no-confirm"]) == 0
+    assert plugin_cli.main(["uninstall", "deep"]) == 0
+
+    data = _read_lockfile(isolated_lockfile)
+    assert plugin_loader.removed_ids(data) == {"deep"}
+    assert set(data["plugins"]) == {"foundations", "rl"}
+
+
+def test_unlinking_a_local_plugin_leaves_no_tombstone(isolated_lockfile, tmp_path):
+    """Only built-in packs need one — nothing re-adds a local link uninvited."""
+    work = tmp_path / "work" / "my-local-pack"
+    (work / "nodes").mkdir(parents=True)
+    (work / "nodes" / "__init__.py").write_text("", encoding="utf-8")
+    (work / "cdui.plugin.toml").write_text(
+        '[plugin]\nid = "my-local-pack"\nname = "Local"\n'
+        'version = "0.1.0"\nschema_version = 1\n',
+        encoding="utf-8",
+    )
+    assert plugin_cli.main(["link", str(work)]) == 0
+    assert plugin_cli.main(["uninstall", "my-local-pack"]) == 0
+
+    data = _read_lockfile(isolated_lockfile)
+    assert "my-local-pack" not in data["plugins"]
+    assert plugin_loader.removed_ids(data) == set()
+
+
+def test_a_pre_175_lockfile_loads_and_gains_a_tombstone_in_place(isolated_lockfile):
+    """Backward compat: a lockfile with no ``removed`` key at all is untouched
+    until something is actually removed, and every other field survives."""
+    lockfile_dir = isolated_lockfile / "plugins"
+    lockfile_dir.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "schema": 1,
+        "plugins": {
+            "rl": {"source_kind": "builtin", "source": "rl"},  # no `enabled` either
+        },
+    }
+    (lockfile_dir / "installed.json").write_text(json.dumps(legacy), encoding="utf-8")
+
+    loaded = plugin_loader.load_lockfile()
+    assert loaded == legacy                      # read back verbatim
+    assert plugin_loader.removed_ids(loaded) == set()
+    assert plugin_loader.is_enabled(loaded["plugins"]["rl"]) is True
+
+    assert plugin_cli.main(["uninstall", "rl"]) == 0
+    data = _read_lockfile(isolated_lockfile)
+    assert data["schema"] == 1
+    assert plugin_loader.removed_ids(data) == {"rl"}

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -9,12 +9,13 @@ description: Install plugin packs of educational nodes, and learn how to write a
 Educational ("Edu") nodes ship as installable **plugin packs**, organised **by direction** so each maps onto a hands-on textbook module and installs cumulatively as you progress.
 
 ```bash
-cdui plugin install foundations deep rl   # full textbook companion
+cdui plugin sync                           # install every built-in pack you have not decided about
+cdui plugin install foundations deep rl   # or pick them one by one
 cdui plugin list
 cdui plugin info deep                      # manifest, lessons covered, node names
 cdui plugin search attention               # query the catalog
 cdui plugin install foo/bar                # third-party pack from GitHub
-cdui plugin uninstall deep
+cdui plugin uninstall deep                 # remembered: sync will not re-add it
 ```
 
 ## What's available
@@ -37,6 +38,19 @@ Each Edu node decomposes a single lesson concept into a chain of named steps tha
 - A lockfile at `<USER_DATA>/plugins/installed.json` records every install — including which capabilities you granted — so `cdui start` rediscovers them on the next launch.
 
 Plugin nodes are namespaced to avoid collisions and to self-document graphs — built-in nodes use a bare name like `Conv2d`, while plugin nodes are qualified like `foundations:Edu-KNN`.
+
+### Catching up after an update — `cdui plugin sync`
+
+The lockfile is what activates a pack, and an update does not write it. So when a release **adds** a built-in pack, its files land on your disk and nothing loads them: the nodes are installable and invisible at the same time. `cdui plugin sync` is the catch-up — it installs every built-in pack this install has not made a decision about, asks once before doing it, and reports per pack so one pack whose `python_deps` cannot be downloaded on a school network does not take the others down with it.
+
+```bash
+cdui plugin sync --dry-run   # just tell me what is pending
+cdui plugin sync             # install it all (one confirmation)
+cdui plugin sync --yes        # no prompt — scripts, CI, classroom images
+cdui plugin sync --prune      # also drop lockfile entries for packs that no longer ship
+```
+
+Two things it deliberately does **not** do. It does not run at startup, and `cdui update` does not offer to run it: activating code you never asked for because a release shipped it is a consent decision, not an update detail. And it never re-adds a pack you uninstalled — `cdui plugin uninstall` records the removal in the lockfile (a `removed` map beside `plugins`), so "I have never seen this pack" and "I threw this pack away" stop being the same state. `cdui start` and `cdui plugin list` stop mentioning a removed pack for the same reason. To undo a removal, install the pack by name: `cdui plugin install stats` clears the record and sync counts it again.
 
 ## Security — three tiers
 

--- a/docs/docs/getting-started/cli-commands.md
+++ b/docs/docs/getting-started/cli-commands.md
@@ -28,10 +28,11 @@ description: The cdui launcher commands — install, start, status, dev, build, 
 | Command | Description |
 |---------|-------------|
 | `cdui plugin install <name\|url>` | Install a plugin pack (catalog name like `foundations`, `owner/repo[@ref]`, or a full GitHub URL). |
-| `cdui plugin list` | List installed plugin packs. |
+| `cdui plugin sync` | Install every **built-in** pack this install has not decided about yet — the one command to run after an update that shipped a new pack. Asks for confirmation once (`--yes` skips it, and is required when there is no terminal); `--dry-run` only lists; `--prune` also drops lockfile entries for built-in packs that no longer ship. Packs you uninstalled are left alone. |
+| `cdui plugin list` | List installed plugin packs, plus any built-in pack still waiting for a decision. |
 | `cdui plugin info <id>` | Show a pack's manifest, lessons covered, and node names. |
 | `cdui plugin search <query>` | Query the plugin catalog. |
-| `cdui plugin uninstall <id>` | Remove an installed plugin pack. |
+| `cdui plugin uninstall <id>` | Remove an installed plugin pack. For a built-in pack the removal is remembered, so `cdui plugin sync` will not bring it back; `cdui plugin install <id>` undoes that. |
 
 See **[Plugins](/advanced/plugins)** for the full plugin workflow.
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -9,12 +9,13 @@ description: 安裝教育節點的外掛包，並學習如何撰寫與發布你�
 教育（「Edu」）節點以可安裝的**外掛包**形式提供，**依方向**組織，因此每一個都對應到一個動手實作的教科書模組，並在你逐步學習時累進安裝。
 
 ```bash
-cdui plugin install foundations deep rl   # full textbook companion
+cdui plugin sync                           # 安裝所有你還沒決定過的內建外掛包
+cdui plugin install foundations deep rl   # 或者一個一個挑
 cdui plugin list
 cdui plugin info deep                      # manifest, lessons covered, node names
 cdui plugin search attention               # query the catalog
 cdui plugin install foo/bar                # third-party pack from GitHub
-cdui plugin uninstall deep
+cdui plugin uninstall deep                 # 會被記住：sync 不會再把它裝回來
 ```
 
 ## 有哪些可用的外掛包
@@ -37,6 +38,19 @@ cdui plugin uninstall deep
 - 位於 `<USER_DATA>/plugins/installed.json` 的 lockfile 會記錄每一次安裝——包含你授權了哪些能力——因此 `cdui start` 會在下次啟動時重新探索它們。
 
 外掛節點會加上命名空間，以避免衝突並讓圖能自我說明——內建節點使用像 `Conv2d` 這樣的裸名稱，而外掛節點則會像 `foundations:Edu-KNN` 這樣加上限定。
+
+### 升級後補上新外掛包——`cdui plugin sync`
+
+真正啟用一個外掛包的是 lockfile，而升級並不會去寫它。所以當某個版本**新增**了內建外掛包時，它的檔案會隨升級落到你的磁碟上，卻沒有任何東西去載入它：那些節點同時處於「可以安裝」與「完全看不到」的狀態。`cdui plugin sync` 就是這個補課動作——它會安裝所有你還沒做過決定的內建外掛包，動手前先確認一次，並且逐一回報結果，所以某個外掛包的 `python_deps` 在學校網路下載不下來時，不會把其他外掛包一起拖垮。
+
+```bash
+cdui plugin sync --dry-run   # 只告訴我還有哪些沒裝
+cdui plugin sync             # 全部安裝（確認一次）
+cdui plugin sync --yes        # 不詢問——腳本、CI、教室映像檔
+cdui plugin sync --prune      # 順手清掉已不再發行的外掛 lockfile 項目
+```
+
+有兩件事它刻意不做。它不會在啟動時自動執行，`cdui update` 也不會主動問你要不要跑：因為某個版本剛好帶了某段程式碼就替你啟用它，是一個關於同意的決定，不是升級的細節。它也絕不會把你移除過的外掛包裝回來——`cdui plugin uninstall` 會把這次移除記錄在 lockfile 裡（`plugins` 旁邊的 `removed` 對應表），讓「我從沒見過這個外掛包」與「我把這個外掛包丟掉了」不再是同一個狀態。`cdui start` 與 `cdui plugin list` 也因為同樣的理由，不會再提起你移除過的外掛包。想反悔就用名稱重新安裝：`cdui plugin install stats` 會清掉那筆記錄，sync 之後也會重新把它算進去。
 
 ## 安全性——三個層級
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/cli-commands.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/cli-commands.md
@@ -28,10 +28,11 @@ description: cdui 啟動器指令 —— install、start、status、dev、build�
 | 指令 | 說明 |
 |------|------|
 | `cdui plugin install <name\|url>` | 安裝一個外掛包（型錄名稱如 `foundations`、`owner/repo[@ref]`，或完整的 GitHub URL）。 |
-| `cdui plugin list` | 列出已安裝的外掛包。 |
+| `cdui plugin sync` | 安裝所有你還沒做過決定的**內建**外掛包——升級後多了新外掛包時，只要跑這一個指令。會先確認一次（`--yes` 可略過確認；沒有終端時必須加）；`--dry-run` 只列出清單；`--prune` 會順手清掉已不再隨版本發行的內建外掛 lockfile 項目。你自己移除過的外掛包不會被裝回來。 |
+| `cdui plugin list` | 列出已安裝的外掛包，以及還在等你決定的內建外掛包。 |
 | `cdui plugin info <id>` | 顯示某個外掛包的 manifest、涵蓋的課程與節點名稱。 |
 | `cdui plugin search <query>` | 查詢外掛型錄。 |
-| `cdui plugin uninstall <id>` | 移除一個已安裝的外掛包。 |
+| `cdui plugin uninstall <id>` | 移除一個已安裝的外掛包。若是內建外掛包，這個移除會被記住，`cdui plugin sync` 不會再把它裝回來；要拿回它就執行 `cdui plugin install <id>`。 |
 
 完整的外掛工作流程請見 **[外掛](/advanced/plugins)**。
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -75,10 +75,13 @@
                 pack 預設不會安裝，需要時逐一裝即可。範例：
                     python scripts/dev.py plugin install deep
                     python scripts/dev.py plugin install owner/repo@main
+                    python scripts/dev.py plugin sync --dry-run  # 列出尚未決定的內建包
+                    python scripts/dev.py plugin sync            # 全部安裝（會先確認）
                     python scripts/dev.py plugin list
                     python scripts/dev.py plugin enable deep     # 啟用
                     python scripts/dev.py plugin disable deep    # 停用（檔案保留）
                     python scripts/dev.py plugin uninstall deep  # 從 lockfile 移除
+                                                                # （sync 之後不會再裝回）
 
 環境變數：
     CODEFYUI_RELEASE_TAG    指定要下載的 release tag（預設：latest）
@@ -1493,7 +1496,10 @@ def _print_uninstalled_builtin_packs() -> None:
 
     This is discoverability only. Nothing is enabled on the user's behalf —
     running code someone did not ask for because a release shipped it is a
-    consent decision, not a startup detail, so the pack still installs by hand.
+    consent decision, not a startup detail, so the pack still installs by hand
+    (`cdui plugin sync`, one verb for all of them, #175). A pack the user
+    uninstalled is not listed: `available_builtin_packs` subtracts the
+    uninstall tombstones, so this notice stops nagging once you have said no.
 
     `cdui start` has already hopped into the venv (`_SKIP_VENV_EXEC` excludes
     it), so scripts/plugins.py's `app.core.*` imports resolve here. Guarded
@@ -1510,15 +1516,17 @@ def _print_uninstalled_builtin_packs() -> None:
         return
     if not available:
         return
-    ids = " ".join(pack_id for pack_id, _ in available)
     names = ", ".join(f"{pack_id} ({name})" for pack_id, name in available)
     print(t(
         f"    有尚未安裝的內建外掛：{names}",
         f"    Built-in packs available but not installed: {names}",
     ))
+    # One verb, not the id list this used to print (#175). The list grows with
+    # every release, and retyping it is the step people skip — after which the
+    # chapter's nodes are missing and this notice was the only warning.
     print(t(
-        f"    安裝：cdui plugin install {ids}",
-        f"    Install with: cdui plugin install {ids}",
+        "    安裝：cdui plugin sync",
+        "    Install them with: cdui plugin sync",
     ))
 
 

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -1,4 +1,4 @@
-"""``cdui plugin <subcommand>`` — install, list, uninstall CodefyUI plugin packs.
+"""``cdui plugin <subcommand>`` — install, sync, list, uninstall CodefyUI plugin packs.
 
 Two install sources, one command::
 
@@ -6,6 +6,7 @@ Two install sources, one command::
     cdui plugin install foo/bar                         # GitHub short form, default branch
     cdui plugin install foo/bar@v1.2.3                  # GitHub, tagged release
     cdui plugin install https://github.com/foo/bar      # full URL
+    cdui plugin sync                                    # every built-in pack you have not decided about
 
 Built-in catalog packs (kind=builtin in plugins/registry.json) are
 activated in place — discovery walks ``<REPO>/plugins/<id>/`` directly,
@@ -43,9 +44,12 @@ else:
 
 from app.core.plugin_loader import (
     MANIFEST_FILENAME,
+    clear_removed,
     load_lockfile,
+    mark_removed,
     plugins_builtin_root,
     plugins_user_root,
+    removed_ids,
     save_lockfile,
 )
 from app.core.plugin_validator import PluginValidationError, validate_python_source
@@ -200,24 +204,41 @@ def load_catalog() -> dict[str, Any]:
         return {"schema": 1, "plugins": {}}
 
 
+def builtin_catalog_packs() -> dict[str, dict[str, Any]]:
+    """The ``kind = "builtin"`` half of the catalog — packs that ship in-repo."""
+    return {
+        pack_id: entry
+        for pack_id, entry in load_catalog().get("plugins", {}).items()
+        if isinstance(entry, dict) and entry.get("kind") == "builtin"
+    }
+
+
 def available_builtin_packs() -> list[tuple[str, str]]:
-    """Built-in packs shipped on disk that this install has never installed.
+    """Built-in packs shipped on disk that this install has made no decision about.
 
     A release can add a pack (``stats`` did), and its files land on disk with
     the update — but the server only loads what the lockfile records, and
     nothing re-syncs it. So the pack is fully installable and completely
     invisible: the nodes never appear, and no message anywhere says why.
 
+    "No decision" is the operative phrase (#175): a pack the user uninstalled
+    is subtracted too. Before uninstall left a tombstone, the entry was simply
+    popped, so a removed pack was indistinguishable from one this install had
+    never seen — which is why the notices used to nag about a pack the user had
+    already thrown away, once per start, forever.
+
     Returns ``(id, display name)`` pairs, sorted, so callers can name them.
     """
     try:
-        catalog = load_catalog().get("plugins", {})
-        installed = load_lockfile().get("plugins", {})
+        catalog = builtin_catalog_packs()
+        lockfile = load_lockfile()
+        installed = lockfile.get("plugins", {})
+        tombstoned = removed_ids(lockfile)
     except Exception:  # never let discoverability break a caller
         return []
     out: list[tuple[str, str]] = []
     for pack_id, entry in catalog.items():
-        if entry.get("kind") != "builtin" or pack_id in installed:
+        if pack_id in installed or pack_id in tombstoned:
             continue
         out.append((pack_id, str(entry.get("name") or pack_id)))
     return sorted(out)
@@ -1028,6 +1049,17 @@ def _install_catalog(plugin_id: str, args, lockfile) -> int:
         if rc != 0:
             return rc
 
+    # Installing a pack by name is how you undo having uninstalled it, so the
+    # tombstone goes with it (#175). Said out loud rather than silently, because
+    # the state it clears is invisible: nothing else would tell the user that
+    # `cdui plugin sync` has started counting this pack again.
+    if clear_removed(lockfile, plugin_id):
+        info(
+            f"已清除先前的移除記錄（cdui plugin sync 之後會把 {plugin_id} 一併納入）",
+            f"Cleared the earlier uninstall record — `cdui plugin sync` counts "
+            f"{plugin_id} again from now on",
+        )
+
     lockfile.setdefault("plugins", {})[plugin_id] = {
         "source_kind": "builtin",
         "source": plugin_id,
@@ -1244,8 +1276,14 @@ def _print_available_builtins() -> None:
     width = max(len(pid) for pid, _ in available) + 2
     for pack_id, name in available:
         print(f"  {BOLD}{pack_id.ljust(width)}{RESET}{name}")
-    ids = " ".join(pid for pid, _ in available)
-    info(f"安裝：cdui plugin install {ids}", f"Install with: cdui plugin install {ids}")
+    # One verb instead of a hand-typed id list (#175): the list grows with every
+    # release, and copying five ids off a terminal is exactly the step people
+    # skip — after which the nodes are missing and nothing says why.
+    info(
+        "全部安裝：cdui plugin sync（單獨安裝：cdui plugin install <id>）",
+        "Install them all with: cdui plugin sync  "
+        "(or one at a time: cdui plugin install <id>)",
+    )
 
 
 def cmd_list(args: argparse.Namespace) -> int:
@@ -1288,6 +1326,232 @@ def cmd_list(args: argparse.Namespace) -> int:
                 f"  {DIM}{plugin_id.ljust(width)}{name}  [disabled]  {'  '.join(bits)}{RESET}"
             )
     _print_available_builtins()
+    return 0
+
+
+# ── sync (#175) ────────────────────────────────────────────────────────────
+
+def _prune_stale_lockfile_keys(lockfile: dict[str, Any]) -> list[tuple[str, str]]:
+    """Drop lockfile keys for built-in packs that no longer exist.
+
+    ``install_plugin_finder`` skips an entry whose manifest is missing without
+    a word (plugin_loader.py), which is right for discovery and useless for the
+    user: a pack a release dropped lingers in the lockfile forever as an entry
+    that loads nothing and explains nothing. Dead tombstones go the same way —
+    remembering that someone removed a pack that no longer ships is not a
+    decision worth keeping.
+
+    Only ``builtin`` entries are pruned. Their files ship with the release, so
+    "not on disk" is final; a ``local`` link points at the author's own checkout,
+    which can be missing today and back tomorrow, and a ``github_url`` pack's
+    directory is user data this command has no business deleting behind a flag
+    named ``--prune``.
+
+    Returns ``(id, reason)`` pairs. The caller saves and reports.
+    """
+    catalog = builtin_catalog_packs()
+    builtin_root = plugins_builtin_root()
+    dropped: list[tuple[str, str]] = []
+
+    for plugin_id, entry in sorted(lockfile.get("plugins", {}).items()):
+        if not isinstance(entry, dict) or entry.get("source_kind") != "builtin":
+            continue
+        if plugin_id not in catalog:
+            dropped.append((plugin_id, t("已不在內建型錄中", "no longer in the catalog")))
+        elif not (builtin_root / plugin_id / MANIFEST_FILENAME).exists():
+            dropped.append((plugin_id, t("磁碟上找不到 manifest", "no manifest on disk")))
+    for plugin_id, _reason in dropped:
+        lockfile["plugins"].pop(plugin_id, None)
+
+    for plugin_id in sorted(removed_ids(lockfile)):
+        if plugin_id not in catalog:
+            clear_removed(lockfile, plugin_id)
+            dropped.append(
+                (plugin_id, t("移除記錄已無對應外掛", "removal record for a pack that is gone"))
+            )
+    return dropped
+
+
+#: Sentinel for "there was no way to ask" — no terminal, or stdin closed
+#: under one. Distinct from a plain ``False``, which is a human answering no:
+#: a decision is a success (exit 0) and an unanswerable question is not
+#: (exit 1), and conflating them made `cdui plugin sync </dev/null` print
+#: "pass --yes" and then exit 0 as though it had done what was asked.
+SYNC_UNANSWERABLE = None
+
+
+def _confirm_sync(count: int) -> bool | None:
+    """Ask once before installing ``count`` packs.
+
+    ``True`` proceed, ``False`` the user said no, :data:`SYNC_UNANSWERABLE`
+    nobody could be asked.
+
+    Fails closed with no terminal, like :func:`capability_gate`: a sync in a CI
+    job or behind a pipe must not block on an ``input()`` nobody will answer,
+    and must not silently decide yes on the user's behalf either — installing
+    code someone did not ask for is the exact thing #175 refused to automate.
+    On Windows the prompt is reachable at all only because ``dev.py`` re-execs
+    the venv interpreter through ``subprocess.run`` (see ``_reexec``); with
+    ``os.execv`` the console was orphaned and every prompt read EOF.
+    """
+    def _no_terminal() -> None:
+        err(
+            "沒有終端可確認。要直接安裝請加 --yes，只想看清單請用 --dry-run。",
+            "No terminal to confirm at. Pass --yes to install, "
+            "or --dry-run to just see the list.",
+        )
+
+    if not _stdin_is_interactive():
+        _no_terminal()
+        return SYNC_UNANSWERABLE
+    prompt = t(f"要安裝以上 {count} 個外掛嗎？", f"Install these {count} pack(s)?")
+    try:
+        answer = input(f"  {prompt} [y/N]: ").strip().lower()
+    except EOFError:
+        # ``isatty()`` said yes and stdin was closed anyway — `sync < /dev/null`
+        # on Windows does exactly this. Same fail-closed answer as the branch
+        # above, and the same exit code, because the question was never asked.
+        print()
+        _no_terminal()
+        return SYNC_UNANSWERABLE
+    if answer not in ("y", "yes"):
+        warn("已取消（未安裝任何東西）", "Cancelled (nothing was installed)")
+        return False
+    return True
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    """Install every built-in pack this install has not yet decided about.
+
+    The gap this closes (#175): built-in packs ship on disk with an update, but
+    only a lockfile entry activates them and nothing re-syncs it — so a pack a
+    release added is installable and invisible at the same time, and the only
+    cure was typing an id list nobody knew existed. Two shapes were rejected on
+    the way here, both for the same reason: activating packs at startup, and
+    prompting during `cdui update`, would install code the user never asked for
+    because a release shipped it. That is a consent decision, and this command
+    is where it is given — once, deliberately, for everything pending.
+
+    A pack the user uninstalled is not pending: uninstall leaves a tombstone
+    (see :func:`cmd_uninstall`) and sync names it as skipped rather than
+    quietly re-installing it. Per-pack exit codes, so one pack whose
+    ``python_deps`` cannot be downloaded on a school network does not decide
+    the fate of the other four.
+    """
+    section("同步內建外掛", "Syncing built-in packs")
+    lockfile = load_lockfile()
+
+    dry_run = bool(getattr(args, "dry_run", False))
+    if getattr(args, "prune", False):
+        # The in-memory prune happens either way so the pending list below is a
+        # faithful preview, but under --dry-run nothing is saved: a flag whose
+        # whole promise is "changes nothing" must not quietly edit the lockfile
+        # because a second flag was also passed.
+        pruned = _prune_stale_lockfile_keys(lockfile)
+        if not pruned:
+            info("沒有需要清除的 lockfile 項目", "Nothing stale to prune")
+        elif dry_run:
+            for plugin_id, reason in pruned:
+                info(
+                    f"--dry-run：會清除 lockfile 項目 {plugin_id}（{reason}）",
+                    f"--dry-run: would prune lockfile entry '{plugin_id}' ({reason})",
+                )
+        else:
+            save_lockfile(lockfile)
+            for plugin_id, reason in pruned:
+                ok(
+                    f"已清除 lockfile 項目 {plugin_id}（{reason}）",
+                    f"Pruned lockfile entry '{plugin_id}' ({reason})",
+                )
+
+    catalog = builtin_catalog_packs()
+    installed = lockfile.get("plugins", {})
+    tombstoned = removed_ids(lockfile)
+
+    pending = sorted(
+        (pack_id, str(entry.get("name") or pack_id))
+        for pack_id, entry in catalog.items()
+        if pack_id not in installed and pack_id not in tombstoned
+    )
+    skipped = sorted(
+        pack_id for pack_id in catalog
+        if pack_id in tombstoned and pack_id not in installed
+    )
+    if skipped:
+        info(
+            f"略過你先前移除的外掛：{', '.join(skipped)}"
+            f"（要裝回請執行 cdui plugin install <id>）",
+            f"Skipping packs you removed: {', '.join(skipped)} "
+            f"(bring one back with `cdui plugin install <id>`)",
+        )
+
+    if not pending:
+        ok(
+            "每個內建外掛都已有決定，沒有要同步的項目",
+            "Every built-in pack is accounted for — nothing to sync",
+        )
+        return 0
+
+    width = max(len(pack_id) for pack_id, _ in pending) + 2
+    for pack_id, name in pending:
+        print(f"  {BOLD}{pack_id.ljust(width)}{RESET}{name}")
+
+    if dry_run:
+        info(
+            f"--dry-run：以上 {len(pending)} 個都不會安裝",
+            f"--dry-run: none of these {len(pending)} pack(s) were installed",
+        )
+        return 0
+
+    if not getattr(args, "yes", False):
+        answer = _confirm_sync(len(pending))
+        if answer is SYNC_UNANSWERABLE:
+            # Nothing was installed and the message named --yes: that is a
+            # failure to carry out the command, and scripts have to see it.
+            return 1
+        if not answer:
+            # "No" is a complete answer, not an error.
+            return 0
+
+    done: list[str] = []
+    failed: list[str] = []
+    for pack_id, _name in pending:
+        # Re-read per pack: _install_catalog saves the lockfile object it is
+        # handed, so carrying one copy across the loop would write the state
+        # from before the previous pack straight back over it.
+        lockfile = load_lockfile()
+        rc = _install_catalog(
+            pack_id,
+            argparse.Namespace(
+                force=False,
+                no_confirm=True,
+                trust_author=False,
+                accept_capabilities=False,
+                prior_capabilities=[],
+            ),
+            lockfile,
+        )
+        if rc == 0:
+            done.append(pack_id)
+            continue
+        failed.append(pack_id)
+        warn(
+            f"{pack_id} 安裝失敗，繼續處理其餘外掛",
+            f"{pack_id} failed — continuing with the rest",
+        )
+
+    if failed:
+        err(
+            f"完成：成功 {len(done)} 個，失敗 {len(failed)} 個"
+            f"（{', '.join(failed)}）。修正原因後可再執行 cdui plugin sync。",
+            f"Done: {len(done)} installed, {len(failed)} failed "
+            f"({', '.join(failed)}). Re-run `cdui plugin sync` once the cause is fixed.",
+        )
+        return 1
+    ok(
+        f"完成：已安裝 {len(done)} 個內建外掛",
+        f"Done: installed {len(done)} built-in pack(s)",
+    )
     return 0
 
 
@@ -1359,6 +1623,19 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
                 return 1
 
     lockfile["plugins"].pop(plugin_id, None)
+
+    # Remember the decision instead of merely forgetting the pack (#175).
+    # Popping the entry made "never installed" and "removed on purpose" the
+    # same state, so `cdui plugin sync` would have to either re-install what the
+    # user just threw away or nag about it forever. Only built-in packs are
+    # tombstoned: they are the only ones sync can put back uninvited, and a
+    # tombstone nothing reads is dead data the user would still have to explain.
+    is_builtin = (
+        entry.get("source_kind") == "builtin"
+        or plugin_id in builtin_catalog_packs()
+    )
+    if is_builtin:
+        mark_removed(lockfile, plugin_id, source_kind=entry.get("source_kind"))
     save_lockfile(lockfile)
 
     if _backend_reload():
@@ -1367,6 +1644,13 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
         info("伺服器未運行", "Server not running")
 
     ok(f"已移除 {plugin_id}", f"Removed {plugin_id}")
+    if is_builtin:
+        info(
+            f"cdui plugin sync 不會再把 {plugin_id} 裝回來；"
+            f"要拿回它請執行 cdui plugin install {plugin_id}",
+            f"`cdui plugin sync` will not bring {plugin_id} back. When you want "
+            f"it again, run `cdui plugin install {plugin_id}`.",
+        )
     return 0
 
 
@@ -2017,10 +2301,38 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_inst.set_defaults(_func=cmd_install)
 
+    p_sync = sub.add_parser(
+        "sync",
+        help=(
+            "Install every built-in pack this install has not decided about yet "
+            "(packs you uninstalled stay uninstalled)"
+        ),
+    )
+    p_sync.add_argument("--dry-run", action="store_true",
+                        help="list what would be installed and change nothing")
+    p_sync.add_argument("--yes", "-y", action="store_true",
+                        help="install without the confirmation prompt (required with no terminal)")
+    p_sync.add_argument(
+        "--prune",
+        action="store_true",
+        help=(
+            "also drop lockfile entries for built-in packs that no longer ship, "
+            "which discovery otherwise skips in silence"
+        ),
+    )
+    p_sync.set_defaults(_func=cmd_sync)
+
     p_list = sub.add_parser("list", help="List installed plugins")
     p_list.set_defaults(_func=cmd_list)
 
-    p_un = sub.add_parser("uninstall", help="Remove an installed plugin")
+    p_un = sub.add_parser(
+        "uninstall",
+        help=(
+            "Remove an installed plugin. A built-in pack is also remembered as "
+            "removed, so `cdui plugin sync` leaves it alone until you install it "
+            "by name again"
+        ),
+    )
     p_un.add_argument("plugin_id")
     p_un.set_defaults(_func=cmd_uninstall)
 


### PR DESCRIPTION
Closes #175.

## The bug

A built-in pack is activated by an entry in `<USER_DATA>/plugins/installed.json`, and an update never writes one. So a release that **adds** a pack — `stats` did, in #130 — puts its files on every machine and loads them on none. The pack is installable and invisible at the same time: a class follows the update instructions, the new chapter's palette is empty, and the only cure was typing an id list nobody knew existed. Five built-in packs ship today, and a fresh install activates zero of them.

## What this does — maintainer decision D + E (2026-08-12)

**D — `cdui plugin sync`.** Installs every built-in pack this install has made no decision about, looping the existing `_install_catalog` with a per-pack exit code.

```
cdui plugin sync --dry-run   # list what is pending, change nothing
cdui plugin sync             # one confirmation, then install
cdui plugin sync --yes       # no prompt: scripts, CI, classroom images
cdui plugin sync --prune     # also drop lockfile entries for packs that no longer ship
```

Per-pack failure was the requirement that shaped the loop: one pack whose `python_deps` will not download on a school network reports and the rest still install, because a batch that aborts on the first failure is a batch nobody can use offline. `--prune` cleans up the entries `install_plugin_finder` had been skipping in total silence (a pack a past release shipped and this one does not), and only for `source_kind = "builtin"` — a `local` link can point at a checkout that is merely not mounted today, and a downloaded pack's directory is user data this flag has no business deleting.

**E — an uninstall that is remembered.** `cmd_uninstall` popped the lockfile entry outright, which made *"this install has never heard of the pack"* and *"the user threw it away"* the same state — and those are precisely the two states a catch-up command has to tell apart. Uninstalling a built-in pack now leaves a **tombstone**: a `removed` map beside `plugins`, not a retained `plugins` entry, so every existing reader of `plugins` (discovery, the plugin list API, presets, examples) keeps its exact meaning and a removed pack cannot come back to life through a field one of them forgets to check. `sync` names it as skipped, the `cdui start` and `cdui plugin list` notices stop nagging about it, and `cdui plugin install <id>` clears the record — which uninstall's own output now says, since nothing else would reveal that state.

Backward compatibility follows the established `is_enabled` precedent: a missing *or malformed* `removed` field reads as "no tombstones", so a pre-#175 lockfile loads byte-identically, and clearing the last tombstone removes the empty map so a lockfile recording no removals looks exactly like one written before the field existed.

## Why not A or B

Not **A** (silent auto-sync at startup) and not **B** (a prompt during `cdui update`), for the same reason: both activate code the user never asked for because a release shipped it. That is a consent decision, not a startup detail or an update step — so it stays a verb they type. And that decision is exactly what exposed E: a command that respects "no" needs somewhere for "no" to be recorded, and there wasn't one.

## Notices

Both sites now point at the verb instead of a hand-typed id list (`scripts/dev.py`'s start banner and `_print_available_builtins`). The list grows with every release, and retyping five ids off a terminal is the step people skip.

## Found by the smoke run

The confirmation's exit code was wrong in the first draft. `cdui plugin sync </dev/null` on Windows passes `isatty()` and then raises `EOFError`; asking `_stdin_is_interactive()` a second time to choose the exit code reported that unanswerable question as a completed command (printed "pass `--yes`", exited 0). The refusal now carries a sentinel: "the user said no" exits 0, "nobody could be asked" exits 1. Pinned by a test.

## Verification

- `cd backend && uv run pytest -q` → **5014 passed**, 2 failed — only the two known #307 baselines (`test_cache_live_handle_nodes.py::test_a_network_constructor_hands_out_a_fresh_network_every_run[PPO-params1]`, `test_python_script_node.py::test_no_reachable_callable_takes_a_file_path`).
- `uvx ruff@0.14.4 check .` → clean. `python scripts/check_control_bytes.py` → clean.
- 30 new/updated tests across `test_builtin_pack_discovery.py` and `test_plugin_uninstall_builtin.py`: tombstone written (with `removed_at` + `source_kind`) and cleared, malformed/absent field compatibility, sync installs exactly the missing non-tombstoned set without re-forcing an installed pack, `--dry-run` installs nothing (and `--prune --dry-run` writes nothing), per-pack failure continues, `--prune` drops only orphaned builtin keys and dead tombstones, all four confirmation outcomes. Mutation-checked: removing the tombstone subtraction or the `mark_removed` call fails 7 of them.
- **Real CLI smoke** in a temp `CODEFYUI_USER_DATA_DIR` against `backend/.venv`: `sync --dry-run` listed all five packs; `sync --yes` with the network disabled installed four and failed only `edu` (whose `python_deps` is `model2vec`), exit 1 naming it — per-pack failure with a genuine offline dependency, not a stub; `uninstall stats` wrote `removed: {"stats": {...}}`; `sync --dry-run` then reported `Skipping packs you removed: stats` with `stats` absent from the pending list; `install stats` printed the cleared-record notice and left no `removed` key; `sync --prune --yes` pruned a seeded ghost entry and a dead tombstone and installed `edu` for real (5/5); a final `sync --dry-run` reported nothing to sync. The venv was restored (`model2vec` uninstalled) before the suite ran.

No frontend or API surface is touched — there is no "available packs" endpoint — so there is nothing to verify in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYmF5XjhQStu2K6swHp2XX
