### PR TITLE
feat(plugins): the op surface learns which level the user is looking at (#200)

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -6,8 +6,9 @@ maintainer's job is to push the tag and check the result before publishing.
 ## TL;DR — happy path
 
 ```bash
-# 1. Promote CHANGELOG.md's [Unreleased] section to the new version, and
-#    bump the three version fields (see "Before you tag" below).
+# 1. Promote CHANGELOG.md's [Unreleased] section to the new version, bump the
+#    three version fields, and stamp any "unreleased" docs placeholder with the
+#    new number (see "Before you tag" below).
 # 2. From main, once that commit is in:
 git tag 1.0.0rcN
 git push origin 1.0.0rcN
@@ -15,7 +16,7 @@ git push origin 1.0.0rcN
 
 ## Before you tag
 
-Two things are done by hand, and nothing else in the pipeline checks them for
+Three things are done by hand, and nothing else in the pipeline checks them for
 you:
 
 1. **Promote `CHANGELOG.md`.** Rename `## [Unreleased]` to
@@ -30,6 +31,18 @@ you:
    with `uv lock`), and `frontend/package.json`. A mismatch between them ships
    silently — the frontend claiming one version while the backend claims
    another — so check all three before tagging.
+
+3. **Stamp any "unreleased" version placeholder in the docs.**
+   `git grep -n "unreleased" docs/` — a docs page that promises a feature "from
+   the next release" has to name the release once there is one. Today that is the
+   plugin `apiVersion` table in
+   `docs/docs/advanced/plugin-frontend-extensions.md` (and its zh-TW twin), whose
+   rightmost column says which CodefyUI version shipped each `apiVersion`; a new
+   row lands as *next release (unreleased)* because the number does not exist
+   when the PR is written. **Both locales.** This is a real failure, not a
+   hypothetical: the apiVersion 3 row said "1.5.0" for three releases — a version
+   that was never tagged — because it was written before 2.0.0 was the number,
+   and nothing ever came back to correct it.
 
 Then on GitHub:
 1. Wait for **Release Build** to finish (≈2 min) — produces a draft release.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -32,17 +32,37 @@ you:
    silently — the frontend claiming one version while the backend claims
    another — so check all three before tagging.
 
-3. **Stamp any "unreleased" version placeholder in the docs.**
-   `git grep -n "unreleased" docs/` — a docs page that promises a feature "from
-   the next release" has to name the release once there is one. Today that is the
-   plugin `apiVersion` table in
-   `docs/docs/advanced/plugin-frontend-extensions.md` (and its zh-TW twin), whose
-   rightmost column says which CodefyUI version shipped each `apiVersion`; a new
-   row lands as *next release (unreleased)* because the number does not exist
-   when the PR is written. **Both locales.** This is a real failure, not a
-   hypothetical: the apiVersion 3 row said "1.5.0" for three releases — a version
-   that was never tagged — because it was written before 2.0.0 was the number,
-   and nothing ever came back to correct it.
+3. **Stamp every docs placeholder that is waiting for this version number.**
+
+   ```bash
+   git grep -n "stamp-on-release" docs/
+   ```
+
+   A docs page that promises a feature "from the next release" has to name the
+   release once there is one, so every such spot carries the marker
+   `{/* stamp-on-release */}` — an **MDX** comment, which renders to nothing at
+   all (verified: the string does not appear in the built HTML of either locale).
+   Replace the placeholder with the version you are tagging and delete the marker
+   with it.
+
+   > Use `{/* ... */}`, not `<!-- ... -->`. Docusaurus compiles these `.md` pages
+   > as MDX, where an HTML comment is a syntax error — `pnpm build` in `docs/`
+   > fails with "MDX compilation failed" rather than quietly ignoring it.
+
+   The marker is ASCII **on purpose**: the placeholder text itself is
+   translated (`*next release (unreleased)*` in `docs/docs/`,
+   `*下一個版本（尚未發布）*` in `docs/i18n/zh-TW/`), so grepping for the English
+   words finds the English row and silently walks past the Chinese one — which
+   reproduces the bug in the locale nobody proofreads. One marker, both locales,
+   one command. Add it to any new placeholder you write, in every locale.
+
+   Today the marker sits on the plugin `apiVersion` table and its availability
+   note (`docs/.../advanced/plugin-frontend-extensions.md` + the zh-TW twin),
+   whose version column says which CodefyUI release shipped each `apiVersion`;
+   a new row lands as a placeholder because the number does not exist when the
+   PR is written. That is not hypothetical: the apiVersion 3 row said "1.5.0"
+   from 2.0.0 through 2.2.0 — a version never tagged — because it was written
+   before 2.0.0 was the number, and nothing brought anyone back to it.
 
 Then on GitHub:
 1. Wait for **Release Build** to finish (≈2 min) — produces a draft release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@ received — each links to the release it was published as.
   lockfile written before this field loads unchanged; only built-in packs are
   tombstoned, since they are the only ones sync could ever put back uninvited.
 
+- **Plugin apiVersion 4: `api.graph.getView()` — a plugin can now tell which
+  level of the graph the user is looking at** ([#200] item 7). A graph nests, and
+  entering a block swaps its insides onto the one canvas. `getGraph()` has always
+  flattened that and answered with the whole graph; `applyOperations()` has always
+  written to the canvas in front of the user. Both are defensible, but a plugin
+  had no way to tell the two apart, so a batch issued while a block happened to be
+  open landed inside the block — `clear_graph` emptied the block instead of the
+  graph — and nothing in the API said so. `getView()` returns `{ depth, path,
+  atTopLevel }`, read-only and live, so a plugin can refuse, warn, or wait
+  instead of writing blind, and the write rule is now documented API rather than
+  an accident. Purely additive: nothing about where writes land changed, no
+  installed plugin needs a line, and `apiVersion` is how you feature-check
+  (`api.apiVersion >= 4`). The apiVersion 3 contract is now frozen under test
+  too, the same way v2 already was.
+
 ### Fixed
 
 - **An unhandled `/api` path answered `405 Method Not Allowed` on every real
@@ -986,6 +1001,7 @@ Release candidates before 1.0.0 are on the
 [#288]: https://github.com/CodefyUI/CodefyUI/issues/288
 [#292]: https://github.com/CodefyUI/CodefyUI/issues/292
 [#175]: https://github.com/CodefyUI/CodefyUI/issues/175
+[#200]: https://github.com/CodefyUI/CodefyUI/issues/200
 [@oyea0801]: https://github.com/oyea0801
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.2.0...main
 [2.2.0]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...2.2.0

--- a/docs/docs/advanced/plugin-frontend-extensions.md
+++ b/docs/docs/advanced/plugin-frontend-extensions.md
@@ -11,7 +11,7 @@ A plugin pack can ship a JavaScript bundle alongside its Python nodes. When the 
 :::note Availability
 Frontend extensions are in CodefyUI **1.3.0** and later. Check `cdui --version`; if it reports an older version, run `cdui update`.
 
-Dock panels, toolbar buttons, execution events and the runs facade need **apiVersion 3** (CodefyUI 2.0.0 and later); `graph.getView` needs **apiVersion 4** (unreleased at the time of writing — the next release after 2.2.0). Feature-check before you use them — see [API versions](#api-versions).
+Dock panels, toolbar buttons, execution events and the runs facade need **apiVersion 3** (CodefyUI 2.0.0 and later); `graph.getView` needs **apiVersion 4** (unreleased at the time of writing — the next release after 2.2.0). Feature-check before you use them — see [API versions](#api-versions). {/* stamp-on-release */}
 :::
 
 ## API versions
@@ -23,7 +23,7 @@ Dock panels, toolbar buttons, execution events and the runs facade need **apiVer
 | 1 | 1.3.0 | `ui.addFloatingWidget`, `ui.toast`, `graph.*`, `http.fetch`, `storage.*` |
 | 2 | 1.3.0 | `nodes.registerRenderer` |
 | 3 | 2.0.0 | `ui.addPanel` / `removePanel`, `ui.addToolbarButton` / `removeToolbarButton`, `events.onExecution`, `runs.*` |
-| 4 | *next release (unreleased)* | `graph.getView` — which level of the graph the user is looking at |
+| 4 | *next release (unreleased)* {/* stamp-on-release */} | `graph.getView` — which level of the graph the user is looking at |
 
 Check it before reaching for anything newer than the version you require, and degrade rather than throw:
 

--- a/docs/docs/advanced/plugin-frontend-extensions.md
+++ b/docs/docs/advanced/plugin-frontend-extensions.md
@@ -11,18 +11,19 @@ A plugin pack can ship a JavaScript bundle alongside its Python nodes. When the 
 :::note Availability
 Frontend extensions are in CodefyUI **1.3.0** and later. Check `cdui --version`; if it reports an older version, run `cdui update`.
 
-Dock panels, toolbar buttons, execution events and the runs facade need **apiVersion 3** (CodefyUI 1.5.0 and later). Feature-check before you use them — see [API versions](#api-versions).
+Dock panels, toolbar buttons, execution events and the runs facade need **apiVersion 3** (CodefyUI 1.5.0 and later); `graph.getView` needs **apiVersion 4** (CodefyUI 2.3.0 and later). Feature-check before you use them — see [API versions](#api-versions).
 :::
 
 ## API versions
 
-`api.apiVersion` is a number that only ever grows, and every release so far has been **purely additive**: nothing that worked at an older version has been removed or changed shape. A plugin written for apiVersion 2 keeps working on an apiVersion 3 editor with no changes at all.
+`api.apiVersion` is a number that only ever grows, and every release so far has been **purely additive**: nothing that worked at an older version has been removed or changed shape. A plugin written for apiVersion 2 keeps working on an apiVersion 4 editor with no changes at all.
 
 | `apiVersion` | CodefyUI | Added |
 |--------------|----------|-------|
 | 1 | 1.3.0 | `ui.addFloatingWidget`, `ui.toast`, `graph.*`, `http.fetch`, `storage.*` |
 | 2 | 1.3.0 | `nodes.registerRenderer` |
 | 3 | 1.5.0 | `ui.addPanel` / `removePanel`, `ui.addToolbarButton` / `removeToolbarButton`, `events.onExecution`, `runs.*` |
+| 4 | 2.3.0 | `graph.getView` — which level of the graph the user is looking at |
 
 Check it before reaching for anything newer than the version you require, and degrade rather than throw:
 
@@ -180,10 +181,11 @@ Re-adding an id replaces the button. The remove function you get back belongs to
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `getGraph` | `() => GraphSnapshot` | Return a deep copy of the current graph state (nodes, edges, params). |
+| `getGraph` | `() => GraphSnapshot` | Return a deep copy of the **whole** graph state (nodes, edges, params, plus block definitions under `subgraphs`) — always the top level, whatever the user has open. |
 | `getNodeDefinitions` | `() => NodeDefinition[]` | Return the full node palette: types, port schemas, param schemas. |
-| `applyOperations` | `(ops: GraphOp[]) => ApplyResult` | Apply a batch of graph operations **synchronously** (returns the result directly — not a Promise). The whole batch is committed as a **single undo snapshot**. |
-| `onGraphChanged` | `(callback: (snapshot: GraphSnapshot) => void) => () => void` | Subscribe to graph changes. Returns an unsubscribe function. |
+| `applyOperations` | `(ops: GraphOp[]) => ApplyResult` | Apply a batch of graph operations **synchronously** (returns the result directly — not a Promise). The whole batch is committed as a **single undo snapshot**, and it applies to the canvas the user has open — see [Which level the user is looking at](#which-level-the-user-is-looking-at). |
+| `onGraphChanged` | `(callback: () => void) => () => void` | Subscribe to graph changes — including the user stepping into or out of a block. The callback takes no arguments; call `getGraph()` from it. Returns an unsubscribe function. |
+| `getView` | `() => GraphView` | **apiVersion 4.** Read-only: which level of the graph the user is looking at. |
 
 #### GraphOp table
 
@@ -218,6 +220,48 @@ interface ApplyResult {
 ```
 
 **Batch semantics:** All ops in a single `applyOperations` call form one undo snapshot — pressing Ctrl+Z after an AI edit undoes the entire batch at once. Ops are applied in order; a failing op is skipped and reported in its `results` entry (`ok: false` plus an `error`), while the remaining ops continue. A `ref` alias created by an earlier `add_node` in the same batch is available to later ops, and is echoed back in `refs`.
+
+#### Which level the user is looking at
+
+Requires `api.apiVersion >= 4`.
+
+A CodefyUI graph nests. A **block** (subgraph) has a canvas of its own, and the user can step inside one — the bar above the canvas then reads `Main > Encoder`. There is only ever one canvas: stepping inside *swaps* the block's insides onto it, which is exactly why every editing tool works the same inside a block as outside it.
+
+For a plugin that has one consequence, and it decides where your edits land:
+
+- **`getGraph()` always answers with the whole graph.** The editor folds whatever is open back in before serializing, the same way Save and Run do, so you read the same bytes the user would get by saving the file.
+- **`applyOperations()` writes to the canvas the user has open.** Inside a block, `add_node` adds a node *to that block*, and `clear_graph` empties *the block* rather than the graph. Node ids you read from `getGraph()` do not exist there, so ops naming them come back `ok: false` with an error.
+
+So a plugin that reads, reasons, then writes can be right about the graph and still write somewhere the user is not looking. `getView()` is how you tell the two situations apart first:
+
+```ts
+interface GraphViewLevel {
+  subgraphId: string;  // the block definition's id, as getGraph() refers to it
+  name: string;        // the block's name, as the breadcrumb bar shows it
+}
+
+interface GraphView {
+  depth: number;           // 0 at the top level, 1 inside a block, 2 inside a block inside a block
+  path: GraphViewLevel[];  // the open blocks, outermost first; empty at the top level
+  atTopLevel: boolean;     // depth === 0, for the check you usually want
+}
+```
+
+```js
+const view = api.graph.getView();
+if (!view.atTopLevel) {
+  const inside = view.path[view.path.length - 1].name;
+  api.ui.toast(`Step out of "${inside}" first — an edit now would land inside that block.`, "warning");
+  return;
+}
+api.graph.applyOperations(ops);
+```
+
+Refusing is not the only honest answer — waiting, or scoping the edit to something that makes sense inside a block, are both fine. The point is that the choice is now yours to make instead of a coin flip.
+
+The view is **read-only**, and read live: each call is a fresh answer, and there is deliberately no way to navigate somebody's editor from a plugin. `onGraphChanged` fires when the user steps into or out of a block (the canvas changed, after all), so a panel that displays where it would write can re-read `getView()` from that callback.
+
+Where a write lands is the editor's long-standing behaviour, now written down rather than changed. A later revision may let an op name its target level explicitly; it will do that by adding something, not by quietly redirecting the writes that installed plugins already make.
 
 ### `api.nodes` — custom node renderers
 

--- a/docs/docs/advanced/plugin-frontend-extensions.md
+++ b/docs/docs/advanced/plugin-frontend-extensions.md
@@ -11,7 +11,7 @@ A plugin pack can ship a JavaScript bundle alongside its Python nodes. When the 
 :::note Availability
 Frontend extensions are in CodefyUI **1.3.0** and later. Check `cdui --version`; if it reports an older version, run `cdui update`.
 
-Dock panels, toolbar buttons, execution events and the runs facade need **apiVersion 3** (CodefyUI 1.5.0 and later); `graph.getView` needs **apiVersion 4** (CodefyUI 2.3.0 and later). Feature-check before you use them — see [API versions](#api-versions).
+Dock panels, toolbar buttons, execution events and the runs facade need **apiVersion 3** (CodefyUI 2.0.0 and later); `graph.getView` needs **apiVersion 4** (unreleased at the time of writing — the next release after 2.2.0). Feature-check before you use them — see [API versions](#api-versions).
 :::
 
 ## API versions
@@ -22,8 +22,8 @@ Dock panels, toolbar buttons, execution events and the runs facade need **apiVer
 |--------------|----------|-------|
 | 1 | 1.3.0 | `ui.addFloatingWidget`, `ui.toast`, `graph.*`, `http.fetch`, `storage.*` |
 | 2 | 1.3.0 | `nodes.registerRenderer` |
-| 3 | 1.5.0 | `ui.addPanel` / `removePanel`, `ui.addToolbarButton` / `removeToolbarButton`, `events.onExecution`, `runs.*` |
-| 4 | 2.3.0 | `graph.getView` — which level of the graph the user is looking at |
+| 3 | 2.0.0 | `ui.addPanel` / `removePanel`, `ui.addToolbarButton` / `removeToolbarButton`, `events.onExecution`, `runs.*` |
+| 4 | *next release (unreleased)* | `graph.getView` — which level of the graph the user is looking at |
 
 Check it before reaching for anything newer than the version you require, and degrade rather than throw:
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
@@ -11,18 +11,19 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 :::note 可用性
 前端擴充功能自 CodefyUI **1.3.0** 起內建。請執行 `cdui --version` 確認；若顯示更舊的版本，請執行 `cdui update`。
 
-停靠面板、工具列按鈕、執行事件與 runs 門面需要 **apiVersion 3**（CodefyUI 1.5.0 起）。使用前請先檢查版本——參見 [API 版本](#api-版本)。
+停靠面板、工具列按鈕、執行事件與 runs 門面需要 **apiVersion 3**（CodefyUI 1.5.0 起）；`graph.getView` 需要 **apiVersion 4**（CodefyUI 2.3.0 起）。使用前請先檢查版本——參見 [API 版本](#api-版本)。
 :::
 
 ## API 版本
 
-`api.apiVersion` 是一個只增不減的數字，而目前每一次改版都是**純粹新增**：舊版能用的東西，沒有被移除過，也沒有被改過形狀。為 apiVersion 2 撰寫的外掛，在 apiVersion 3 的編輯器上不必改任何一行就能繼續運作。
+`api.apiVersion` 是一個只增不減的數字，而目前每一次改版都是**純粹新增**：舊版能用的東西，沒有被移除過，也沒有被改過形狀。為 apiVersion 2 撰寫的外掛，在 apiVersion 4 的編輯器上不必改任何一行就能繼續運作。
 
 | `apiVersion` | CodefyUI | 新增內容 |
 |--------------|----------|----------|
 | 1 | 1.3.0 | `ui.addFloatingWidget`、`ui.toast`、`graph.*`、`http.fetch`、`storage.*` |
 | 2 | 1.3.0 | `nodes.registerRenderer` |
 | 3 | 1.5.0 | `ui.addPanel` / `removePanel`、`ui.addToolbarButton` / `removeToolbarButton`、`events.onExecution`、`runs.*` |
+| 4 | 2.3.0 | `graph.getView`——使用者正在看圖表的哪一層 |
 
 在使用比你所要求的版本更新的功能之前先檢查它，而且是降級處理，不是直接拋錯：
 
@@ -180,10 +181,11 @@ const remove = api.ui.addToolbarButton({
 
 | 方法 | 簽名 | 說明 |
 |------|------|------|
-| `getGraph` | `() => GraphSnapshot` | 回傳目前圖表狀態（節點、邊、參數）的深層副本。 |
+| `getGraph` | `() => GraphSnapshot` | 回傳**整張**圖表狀態（節點、邊、參數，以及 `subgraphs` 底下的區塊定義）的深層副本——不論使用者當下打開哪一層，讀到的永遠是最上層。 |
 | `getNodeDefinitions` | `() => NodeDefinition[]` | 回傳完整的節點面板：型別、連接埠 schema、參數 schema。 |
-| `applyOperations` | `(ops: GraphOp[]) => ApplyResult` | **同步**套用一批圖表操作（直接回傳結果，非 Promise）。整個批次以**單一撤銷快照**的形式提交。 |
-| `onGraphChanged` | `(callback: (snapshot: GraphSnapshot) => void) => () => void` | 訂閱圖表變更事件。回傳一個取消訂閱函式。 |
+| `applyOperations` | `(ops: GraphOp[]) => ApplyResult` | **同步**套用一批圖表操作（直接回傳結果，非 Promise）。整個批次以**單一撤銷快照**的形式提交，而且會寫進使用者當下打開的那張畫布——參見[使用者正在看哪一層](#使用者正在看哪一層)。 |
+| `onGraphChanged` | `(callback: () => void) => () => void` | 訂閱圖表變更事件，包含使用者走進或走出一個區塊。回呼不帶任何參數；需要內容時請在回呼裡呼叫 `getGraph()`。回傳一個取消訂閱函式。 |
+| `getView` | `() => GraphView` | **apiVersion 4。** 唯讀：使用者正在看圖表的哪一層。 |
 
 #### GraphOp 表
 
@@ -218,6 +220,48 @@ interface ApplyResult {
 ```
 
 **批次語義：** 單次 `applyOperations` 呼叫中的所有操作形成一個撤銷快照——在 AI 編輯後按 Ctrl+Z 會一次撤銷整個批次。操作依序套用；失敗的操作會被跳過並回報於其 `results` 條目（`ok: false` 加上 `error`），其餘操作仍會繼續。同一批次中先前 `add_node` 建立的 `ref` 別名可供後續操作使用，並會回傳於 `refs`。
+
+#### 使用者正在看哪一層
+
+需要 `api.apiVersion >= 4`。
+
+CodefyUI 的圖表是可以嵌套的。一個**區塊**（subgraph）有它自己的畫布，使用者可以走進去——畫布上方那條列就會顯示成 `Main > Encoder`。而且從頭到尾只有一張畫布：走進區塊是把區塊的內容**換**到那張畫布上，這也正是為什麼每個編輯工具在區塊裡和在區塊外的行為完全一樣。
+
+對外掛來說，這件事有一個後果，而且它決定了你的編輯會落在哪裡：
+
+- **`getGraph()` 讀到的永遠是整張圖。** 編輯器會先把打開的層折回去再序列化，跟存檔與執行走的是同一條路，所以你讀到的位元組，和使用者按存檔會得到的檔案一致。
+- **`applyOperations()` 寫進的是使用者當下打開的那張畫布。** 在區塊裡面，`add_node` 是把節點加進*那個區塊*，`clear_graph` 清空的是*那個區塊*而不是整張圖。你從 `getGraph()` 讀到的節點 id 在那裡並不存在，所以指名它們的操作會回傳 `ok: false` 與一段錯誤說明。
+
+也就是說，一個先讀、再推理、然後寫的外掛，可以對整張圖的判斷完全正確，卻把結果寫到使用者根本沒在看的地方。`getView()` 就是讓你在寫之前先分辨這兩種處境：
+
+```ts
+interface GraphViewLevel {
+  subgraphId: string;  // 區塊定義的 id，與 getGraph() 中指涉它的方式相同
+  name: string;        // 區塊的名稱，與畫布上方麵包屑顯示的一致
+}
+
+interface GraphView {
+  depth: number;           // 最上層是 0，在一個區塊裡是 1，在區塊裡的區塊裡是 2
+  path: GraphViewLevel[];  // 已打開的區塊，由外而內；在最上層時為空陣列
+  atTopLevel: boolean;     // depth === 0，也就是你通常真正想做的那個判斷
+}
+```
+
+```js
+const view = api.graph.getView();
+if (!view.atTopLevel) {
+  const inside = view.path[view.path.length - 1].name;
+  api.ui.toast(`請先離開「${inside}」——現在編輯會寫進那個區塊裡面。`, "warning");
+  return;
+}
+api.graph.applyOperations(ops);
+```
+
+拒絕並不是唯一誠實的答案——等使用者走出來，或是把編輯縮小到在區塊裡也說得通的範圍，都同樣可以。重點是這個選擇現在由你來做，而不是丟一次硬幣。
+
+這個 view 是**唯讀**的，而且是即時讀取：每次呼叫都是當下的新答案；而且我們刻意沒有提供任何讓外掛帶著使用者跳到別層的方法。使用者走進或走出區塊時 `onGraphChanged` 會觸發（畢竟畫布真的換了），所以想顯示「我會寫到哪裡」的面板，可以在那個回呼裡重新讀一次 `getView()`。
+
+寫入會落在哪一層，是編輯器一直以來的行為，這次是把它寫下來，而不是把它改掉。未來的改版可能會讓操作自己指名目標層級；那也會是用「新增一個東西」的方式做到，而不是悄悄改寫既有外掛已經在做的那些寫入。
 
 ### `api.nodes` — 自訂 node 渲染
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
@@ -11,7 +11,7 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 :::note 可用性
 前端擴充功能自 CodefyUI **1.3.0** 起內建。請執行 `cdui --version` 確認；若顯示更舊的版本，請執行 `cdui update`。
 
-停靠面板、工具列按鈕、執行事件與 runs 門面需要 **apiVersion 3**（CodefyUI 1.5.0 起）；`graph.getView` 需要 **apiVersion 4**（CodefyUI 2.3.0 起）。使用前請先檢查版本——參見 [API 版本](#api-版本)。
+停靠面板、工具列按鈕、執行事件與 runs 門面需要 **apiVersion 3**（CodefyUI 2.0.0 起）；`graph.getView` 需要 **apiVersion 4**（撰寫此文時尚未發布——2.2.0 之後的下一個版本）。使用前請先檢查版本——參見 [API 版本](#api-版本)。
 :::
 
 ## API 版本
@@ -22,8 +22,8 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 |--------------|----------|----------|
 | 1 | 1.3.0 | `ui.addFloatingWidget`、`ui.toast`、`graph.*`、`http.fetch`、`storage.*` |
 | 2 | 1.3.0 | `nodes.registerRenderer` |
-| 3 | 1.5.0 | `ui.addPanel` / `removePanel`、`ui.addToolbarButton` / `removeToolbarButton`、`events.onExecution`、`runs.*` |
-| 4 | 2.3.0 | `graph.getView`——使用者正在看圖表的哪一層 |
+| 3 | 2.0.0 | `ui.addPanel` / `removePanel`、`ui.addToolbarButton` / `removeToolbarButton`、`events.onExecution`、`runs.*` |
+| 4 | *下一個版本（尚未發布）* | `graph.getView`——使用者正在看圖表的哪一層 |
 
 在使用比你所要求的版本更新的功能之前先檢查它，而且是降級處理，不是直接拋錯：
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
@@ -11,7 +11,7 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 :::note 可用性
 前端擴充功能自 CodefyUI **1.3.0** 起內建。請執行 `cdui --version` 確認；若顯示更舊的版本，請執行 `cdui update`。
 
-停靠面板、工具列按鈕、執行事件與 runs 門面需要 **apiVersion 3**（CodefyUI 2.0.0 起）；`graph.getView` 需要 **apiVersion 4**（撰寫此文時尚未發布——2.2.0 之後的下一個版本）。使用前請先檢查版本——參見 [API 版本](#api-版本)。
+停靠面板、工具列按鈕、執行事件與 runs 門面需要 **apiVersion 3**（CodefyUI 2.0.0 起）；`graph.getView` 需要 **apiVersion 4**（撰寫此文時尚未發布——2.2.0 之後的下一個版本）。使用前請先檢查版本——參見 [API 版本](#api-版本)。 {/* stamp-on-release */}
 :::
 
 ## API 版本
@@ -23,7 +23,7 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 | 1 | 1.3.0 | `ui.addFloatingWidget`、`ui.toast`、`graph.*`、`http.fetch`、`storage.*` |
 | 2 | 1.3.0 | `nodes.registerRenderer` |
 | 3 | 2.0.0 | `ui.addPanel` / `removePanel`、`ui.addToolbarButton` / `removeToolbarButton`、`events.onExecution`、`runs.*` |
-| 4 | *下一個版本（尚未發布）* | `graph.getView`——使用者正在看圖表的哪一層 |
+| 4 | *下一個版本（尚未發布）* {/* stamp-on-release */} | `graph.getView`——使用者正在看圖表的哪一層 |
 
 在使用比你所要求的版本更新的功能之前先檢查它，而且是降級處理，不是直接拋錯：
 

--- a/frontend/src/components/Canvas/SubgraphBreadcrumb.tsx
+++ b/frontend/src/components/Canvas/SubgraphBreadcrumb.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { useI18n } from '../../i18n';
 import { useTabStore } from '../../store/tabStore';
+import { subgraphViewPath } from '../../utils/subgraph';
 import styles from './SubgraphBreadcrumb.module.css';
 
 /**
@@ -25,10 +26,10 @@ export function SubgraphBreadcrumb() {
   const stack = tab?.subgraphStack ?? [];
   if (!tab || stack.length === 0) return null;
 
-  const names = stack.map((frame) => {
-    const definition = tab.subgraphs.find((d) => d.id === frame.subgraphId);
-    return definition?.name || frame.subgraphId;
-  });
+  // Shared with `api.graph.getView` (core#200 item 7): a plugin that warns the
+  // user about the block they are standing in must name the same block this bar
+  // names, so both read one derivation instead of two that can drift.
+  const names = subgraphViewPath(stack, tab.subgraphs).map((level) => level.name);
   const currentId = stack[stack.length - 1].subgraphId;
   // Renaming is a MUTATION, so it follows the same readOnly rule the store
   // applies to `renameSubgraph`: offering the input on a graph whose rename

--- a/frontend/src/plugins/api.test.ts
+++ b/frontend/src/plugins/api.test.ts
@@ -148,7 +148,11 @@ describe('storage surface', () => {
 describe('meta', () => {
   it('exposes apiVersion and pluginId', () => {
     const api = freshApi();
-    expect(api.apiVersion).toBe(3);
+    // A floor, not an exact number: this file predates the versions that
+    // followed, and what it is really asserting is that `apiVersion` is
+    // present and has not gone BACKWARDS. The exact value is pinned once, in
+    // the test file for the version that set it.
+    expect(api.apiVersion).toBeGreaterThanOrEqual(3);
     expect(api.pluginId).toBe('test-plugin');
   });
 });

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -15,6 +15,7 @@ import {
   type RunInfo, type RunListPage, type RunMetrics, type RunStatus,
 } from '../api/rest';
 import type { NodeDefinition } from '../types';
+import { subgraphViewPath } from '../utils/subgraph';
 import { applyGraphOps, type ApplyOutcome, type GraphOp, type OpResult } from './ops';
 import { registerNodeRenderer, type PluginNodeRenderer } from './nodeRenderers';
 import {
@@ -44,8 +45,46 @@ export interface RunListOptions {
   offset?: number;
 }
 
+/** One opened block on the path from the graph to the canvas the user sees. */
+export interface GraphViewLevel {
+  subgraphId: string;
+  /** The block's name, exactly as the breadcrumb bar shows it. */
+  name: string;
+}
+
+/**
+ * Where the user is looking, as `api.graph.getView()` answers (core#200 item 7).
+ *
+ * READ-ONLY, and read live: nothing here can be set through the plugin API, and
+ * the object is a fresh snapshot of the moment it was asked for.
+ */
+export interface GraphView {
+  /** 0 at the top level, 1 inside a block, 2 inside a block inside a block. */
+  depth: number;
+  /** The opened blocks, outermost first. Empty at the top level. */
+  path: GraphViewLevel[];
+  /** `depth === 0`, named so the common check reads as a sentence. */
+  atTopLevel: boolean;
+}
+
+/**
+ * The current view context, derived from the active tab's editing stack.
+ *
+ * Optional-chained through the tab because a plugin may call this at any time,
+ * including from an activation that runs before the editor has restored its
+ * tabs -- and "no tab" is honestly reported as the top level rather than as a
+ * thrown error inside third-party code.
+ */
+export function currentGraphView(): GraphView {
+  const tab = useTabStore.getState().getActiveTab() as
+    | ReturnType<ReturnType<typeof useTabStore.getState>['getActiveTab']>
+    | undefined;
+  const path = subgraphViewPath(tab?.subgraphStack, tab?.subgraphs);
+  return { depth: path.length, path, atTopLevel: path.length === 0 };
+}
+
 export interface CodefyUIPluginAPI {
-  apiVersion: 3;
+  apiVersion: 4;
   pluginId: string;
   ui: {
     addFloatingWidget(opts: { id: string }): HTMLElement;
@@ -58,10 +97,15 @@ export interface CodefyUIPluginAPI {
     removeToolbarButton(id: string): void;
   };
   graph: {
+    /** Always the WHOLE graph, from the top level down. See `getView`. */
     getGraph(): SerializedGraph;
     getNodeDefinitions(): NodeDefinition[];
+    /** Applies to the canvas the user has open, which is not always the top
+     * level. See `getView` before writing. */
     applyOperations(ops: GraphOp[]): ApplyResult;
     onGraphChanged(cb: () => void): () => void;
+    /** Read-only: which level of the graph the user is looking at (#200 item 7). */
+    getView(): GraphView;
   };
   nodes: {
     /** Register a custom renderer for a node type's card body. Returns an unregister fn. */
@@ -86,6 +130,27 @@ export interface CodefyUIPluginAPI {
   };
 }
 
+/**
+ * Apply a plugin's batch to the canvas the user has open.
+ *
+ * `tab.nodes` / `tab.edges` are the canvas in FRONT OF THE USER, which while a
+ * block is open are the block's insides rather than the graph -- so a batch
+ * applied then lands inside the block, and `clear_graph` empties the block
+ * instead of the graph (core#200 item 7).
+ *
+ * That is deliberately left as it stands (maintainer decision, 2026-08-12).
+ * Changing where a write lands would silently redirect every installed plugin's
+ * edits, and both answers are defensible; what was missing was any way for a
+ * plugin to KNOW. So the gradual step is `api.graph.getView()` -- read-only
+ * view context, above -- letting a plugin refuse, warn, or ask instead of
+ * writing blind. A future revision can add an explicit write target on top of
+ * it without having moved anybody's writes in the meantime.
+ *
+ * Note the asymmetry this leaves, and why `getView` matters: `getGraph()`
+ * flushes and answers with the whole graph, so a plugin that reads, reasons and
+ * writes can compute node ids that exist at the top level and apply them to a
+ * canvas where they do not.
+ */
 export function commitGraphOperations(ops: GraphOp[]): ApplyResult {
   const store = useTabStore.getState();
   const tab = store.getActiveTab();
@@ -140,7 +205,11 @@ export function buildPluginAPI(
 ): CodefyUIPluginAPI {
   const ns = (key: string) => `plugin:${pluginId}:${key}`;
   return {
-    apiVersion: 3,
+    // Bumped for `graph.getView` (#200 item 7). The number is the only way a
+    // plugin can tell a host that has the new member from one that does not:
+    // on a 1.5-era editor `api.graph.getView` is simply `undefined`, and the
+    // documented feature check is `api.apiVersion >= 4`.
+    apiVersion: 4,
     pluginId,
     ui: {
       addFloatingWidget: ({ id }) => getWidgetContainer(id),
@@ -165,6 +234,7 @@ export function buildPluginAPI(
       getGraph: () => useTabStore.getState().getSerializedGraph(),
       getNodeDefinitions: () => useNodeDefStore.getState().definitions,
       applyOperations: (ops) => commitGraphOperations(ops),
+      getView: () => currentGraphView(),
       onGraphChanged: (cb) => {
         // Track the unsubscribe so the host can tear it down on a dev
         // hot-reload — otherwise re-activation would stack subscriptions.

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -217,7 +217,7 @@ export function buildPluginAPI(
   return {
     // Bumped for `graph.getView` (#200 item 7). The number is the only way a
     // plugin can tell a host that has the new member from one that does not:
-    // on a 1.5-era editor `api.graph.getView` is simply `undefined`, and the
+    // on a 2.0-to-2.2 editor `api.graph.getView` is simply `undefined`, and the
     // documented feature check is `api.apiVersion >= 4`.
     apiVersion: 4,
     pluginId,

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -45,7 +45,13 @@ export interface RunListOptions {
   offset?: number;
 }
 
-/** One opened block on the path from the graph to the canvas the user sees. */
+/**
+ * One opened block on the path from the graph to the canvas the user sees.
+ *
+ * Structurally the `SubgraphPathEntry` the shared derivation returns; declared
+ * separately because the published contract (`contract.ts`) has to declare it
+ * with no imports, and `contract.assert.ts` proves the two stay identical.
+ */
 export interface GraphViewLevel {
   subgraphId: string;
   /** The block's name, exactly as the breadcrumb bar shows it. */
@@ -102,8 +108,10 @@ export interface CodefyUIPluginAPI {
     /** Always the WHOLE graph, from the top level down. See `getView`. */
     getGraph(): SerializedGraph;
     getNodeDefinitions(): NodeDefinition[];
-    /** Applies to the canvas the user has open, which is not always the top
-     * level. See `getView` before writing. */
+    /**
+     * Applies to the canvas the user has open, which is not always the top
+     * level. See `getView` -- and `commitGraphOperations` below for why.
+     */
     applyOperations(ops: GraphOp[]): ApplyResult;
     onGraphChanged(cb: () => void): () => void;
     /** Read-only: which level of the graph the user is looking at (#200 item 7). */
@@ -236,7 +244,6 @@ export function buildPluginAPI(
       getGraph: () => useTabStore.getState().getSerializedGraph(),
       getNodeDefinitions: () => useNodeDefStore.getState().definitions,
       applyOperations: (ops) => commitGraphOperations(ops),
-      getView: () => currentGraphView(),
       onGraphChanged: (cb) => {
         // Track the unsubscribe so the host can tear it down on a dev
         // hot-reload — otherwise re-activation would stack subscriptions.
@@ -244,6 +251,7 @@ export function buildPluginAPI(
         trackCleanup?.(unsubscribe);
         return unsubscribe;
       },
+      getView: () => currentGraphView(),
     },
     nodes: {
       registerRenderer: (nodeType, renderer) => {

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -76,9 +76,11 @@ export interface GraphView {
  * thrown error inside third-party code.
  */
 export function currentGraphView(): GraphView {
-  const tab = useTabStore.getState().getActiveTab() as
-    | ReturnType<ReturnType<typeof useTabStore.getState>['getActiveTab']>
-    | undefined;
+  // `getTab` rather than `getActiveTab`: the latter is typed as always
+  // returning a tab (it asserts the lookup with `!`), so asking it would mean
+  // casting the answer back to something that can be missing.
+  const { activeTabId, getTab } = useTabStore.getState();
+  const tab = getTab(activeTabId);
   const path = subgraphViewPath(tab?.subgraphStack, tab?.subgraphs);
   return { depth: path.length, path, atTopLevel: path.length === 0 };
 }

--- a/frontend/src/plugins/api.v3.test.ts
+++ b/frontend/src/plugins/api.v3.test.ts
@@ -56,8 +56,12 @@ afterEach(() => {
 });
 
 describe('meta', () => {
-  it('reports apiVersion 3', () => {
-    expect(freshApi().apiVersion).toBe(3);
+  it('reports at least apiVersion 3', () => {
+    // The documented v3 feature check is `api.apiVersion >= 3`, so that is
+    // what this asserts. It was `toBe(3)` until apiVersion 4 (#200 item 7)
+    // added `graph.getView`; pinning the number here would have made every
+    // later additive release fail in the file that tests the release before it.
+    expect(freshApi().apiVersion).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/frontend/src/plugins/api.view.test.ts
+++ b/frontend/src/plugins/api.view.test.ts
@@ -1,0 +1,288 @@
+/**
+ * `api.graph.getView()` — the read-only view context added at apiVersion 4
+ * (core#200 item 7), and the write behaviour it exists to warn a plugin about.
+ *
+ * The item: the op surface reads `tab.nodes` / `tab.edges`, which while the
+ * user is inside a block are the BLOCK's insides. A plugin could not tell, so
+ * `clear_graph` issued at the wrong moment emptied a block instead of the
+ * graph. The maintainer's decision (2026-08-12) was the gradual one: publish
+ * where the user is, leave where writes land alone, and let a plugin choose.
+ *
+ * So the write tests below are not aspirational — they PIN today's behaviour,
+ * which this change turns from an accident into documented API.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Edge, Node } from '@xyflow/react';
+
+import { useTabStore } from '../store/tabStore';
+import { useNodeDefStore } from '../store/nodeDefStore';
+import { buildPluginAPI } from './api';
+import { subgraphIdOf, subgraphViewPath } from '../utils/subgraph';
+import type { NodeData, NodeDefinition } from '../types';
+
+vi.mock('../store/tabPersistence', () => ({
+  readSnapshot: vi.fn(async () => null),
+  writeSnapshot: vi.fn(async () => {}),
+}));
+
+const store = () => useTabStore.getState();
+const tab = () => useTabStore.getState().getActiveTab();
+
+function def(name: string): NodeDefinition {
+  return {
+    node_name: name, category: 'x', description: '',
+    inputs: [{ name: 'in', data_type: 'TENSOR', description: '', optional: false }],
+    outputs: [{ name: 'out', data_type: 'TENSOR', description: '', optional: false }],
+    params: [],
+  };
+}
+
+function node(id: string, type: string, x = 0): Node<NodeData> {
+  return {
+    id, type: 'baseNode', position: { x, y: 0 },
+    data: { label: id, type, params: {}, definition: def(type), executionStatus: 'idle' },
+  };
+}
+
+function dataEdge(id: string, source: string, target: string): Edge {
+  return { id, source, target, sourceHandle: 'out', targetHandle: 'in' };
+}
+
+function freshApi() {
+  return buildPluginAPI('test-plugin', () => document.createElement('div'));
+}
+
+function select(...ids: string[]) {
+  store().setNodes(tab().nodes.map((n) => ({ ...n, selected: ids.includes(n.id) })));
+}
+
+/** a -> b -> c -> d, with b/c/d collapsed into a block. Returns its instance id. */
+function seedOneBlock(name = 'Block'): string {
+  store().setNodes([node('a', 'A', 0), node('b', 'B', 100), node('c', 'C', 200), node('d', 'D', 300)]);
+  store().setEdges([dataEdge('e1', 'a', 'b'), dataEdge('e2', 'b', 'c'), dataEdge('e3', 'c', 'd')]);
+  select('b', 'c', 'd');
+  expect(store().collapseSelectionToSubgraph(name).ok).toBe(true);
+  return tab().nodes.find((n) => subgraphIdOf(n.data.type))!.id;
+}
+
+/** Enters `Block`, then collapses c/d inside it into `Inner` and enters that too. */
+function seedTwoDeep(): void {
+  store().enterSubgraph(seedOneBlock('Block'));
+  select('c', 'd');
+  expect(store().collapseSelectionToSubgraph('Inner').ok).toBe(true);
+  const inner = tab().nodes.find((n) => subgraphIdOf(n.data.type))!.id;
+  expect(store().enterSubgraph(inner)).toBe(true);
+}
+
+beforeEach(() => {
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  store().addTab('test');
+  useNodeDefStore.setState({
+    definitions: [def('A'), def('B'), def('C'), def('D'), def('S')],
+    presets: [], categorized: {}, presetCategorized: {}, loading: false, error: null,
+  } as never);
+});
+
+describe('graph.getView', () => {
+  it('reports the top level when no block is open', () => {
+    seedOneBlock();
+    expect(freshApi().graph.getView()).toEqual({
+      depth: 0, path: [], atTopLevel: true,
+    });
+  });
+
+  it('reports one level deep, with the block name the breadcrumb shows', () => {
+    const instanceId = seedOneBlock('Encoder');
+    store().enterSubgraph(instanceId);
+
+    const view = freshApi().graph.getView();
+    expect(view.depth).toBe(1);
+    expect(view.atTopLevel).toBe(false);
+    expect(view.path).toHaveLength(1);
+    expect(view.path[0].name).toBe('Encoder');
+    expect(view.path[0].subgraphId).toBe(tab().subgraphStack[0].subgraphId);
+  });
+
+  it('reports two levels deep, outermost first', () => {
+    seedTwoDeep();
+
+    const view = freshApi().graph.getView();
+    expect(view.depth).toBe(2);
+    expect(view.atTopLevel).toBe(false);
+    expect(view.path.map((level) => level.name)).toEqual(['Block', 'Inner']);
+    expect(view.path.map((level) => level.subgraphId)).toEqual(
+      tab().subgraphStack.map((frame) => frame.subgraphId),
+    );
+  });
+
+  it('follows the user back out, one level at a time', () => {
+    const api = freshApi();
+    seedTwoDeep();
+    expect(api.graph.getView().depth).toBe(2);
+
+    store().exitSubgraph();
+    expect(api.graph.getView().depth).toBe(1);
+    expect(api.graph.getView().path.map((l) => l.name)).toEqual(['Block']);
+
+    store().exitSubgraph();
+    expect(api.graph.getView()).toEqual({ depth: 0, path: [], atTopLevel: true });
+  });
+
+  it('is back at the top level after exitAllSubgraphs', () => {
+    seedTwoDeep();
+    store().exitAllSubgraphs();
+    expect(freshApi().graph.getView().atTopLevel).toBe(true);
+  });
+
+  it('answers live, so a rename while inside is reflected immediately', () => {
+    const api = freshApi();
+    const instanceId = seedOneBlock('Encoder');
+    store().enterSubgraph(instanceId);
+    // The name comes from the live definition list, not from the copy the
+    // frame captured on entry (which exists for undo).
+    store().renameSubgraph(tab().subgraphStack[0].subgraphId, 'Decoder');
+    expect(api.graph.getView().path[0].name).toBe('Decoder');
+  });
+
+  it('falls back to the id when the definition has gone missing', () => {
+    // Tested on the pure derivation rather than through the store, because no
+    // store action can produce the state: `setSubgraphs` drops `subgraphStack`
+    // as it installs a new list (the deliberate ordering contract of #200 item
+    // 8), so "stack pointing at a definition that is gone" is unreachable from
+    // outside. The fallback is still the right answer -- `exitSubgraph` guards
+    // the same possibility, and an empty name would be worse than an ugly one:
+    // a plugin's warning has to name something.
+    expect(subgraphViewPath([{ subgraphId: 'gone' }], [])).toEqual([
+      { subgraphId: 'gone', name: 'gone' },
+    ]);
+  });
+
+  it('reports the top level again once a new document replaces the list', () => {
+    const api = freshApi();
+    store().enterSubgraph(seedOneBlock('Encoder'));
+    // `setSubgraphs` is one of the two actions that drop the editing stack
+    // (#200 item 8). Whatever else that does, the view must not go on claiming
+    // the user is inside a block that no longer exists.
+    store().setSubgraphs([]);
+    expect(api.graph.getView()).toEqual({ depth: 0, path: [], atTopLevel: true });
+  });
+
+  it('is a fresh object each call, so nothing a plugin keeps goes stale silently', () => {
+    const api = freshApi();
+    const instanceId = seedOneBlock();
+    const before = api.graph.getView();
+    store().enterSubgraph(instanceId);
+    expect(before.depth).toBe(0);
+    expect(api.graph.getView().depth).toBe(1);
+    expect(api.graph.getView()).not.toBe(before);
+  });
+
+  it('mutating the returned view cannot move the editor', () => {
+    const api = freshApi();
+    const instanceId = seedOneBlock();
+    store().enterSubgraph(instanceId);
+    const view = api.graph.getView();
+    view.depth = 0;
+    view.path.length = 0;
+    view.atTopLevel = true;
+    // Read-only means read-only: the editor is exactly where it was.
+    expect(tab().subgraphStack).toHaveLength(1);
+    expect(api.graph.getView().depth).toBe(1);
+  });
+});
+
+describe('read/write asymmetry the view exists to expose', () => {
+  it('getGraph answers with the whole graph while a block is open', () => {
+    const instanceId = seedOneBlock();
+    const api = freshApi();
+    store().enterSubgraph(instanceId);
+
+    const graph = api.graph.getGraph();
+    expect(graph.nodes.map((n: { id: string }) => n.id).sort()).toEqual(
+      ['a', instanceId].sort(),
+    );
+    // Reading must not close the editor behind the user.
+    expect(api.graph.getView().depth).toBe(1);
+  });
+
+  it('applyOperations lands in the OPEN canvas, not at the top level', () => {
+    const instanceId = seedOneBlock();
+    const api = freshApi();
+    store().enterSubgraph(instanceId);
+    const topLevelBefore = api.graph.getGraph().nodes.map((n: { id: string }) => n.id).sort();
+
+    const result = api.graph.applyOperations([{ op: 'add_node', node_type: 'S' }]);
+    expect(result.results[0].ok).toBe(true);
+
+    // The new node is on the canvas the user is looking at -- inside the block.
+    const added = result.results[0].node_id!;
+    expect(tab().nodes.map((n) => n.id)).toContain(added);
+    expect(tab().subgraphStack).toHaveLength(1);
+    // ...and the graph a plugin READS is unchanged, which is the whole trap:
+    // read the graph, reason about it, write, and the write goes elsewhere.
+    expect(api.graph.getGraph().nodes.map((n: { id: string }) => n.id).sort())
+      .toEqual(topLevelBefore);
+    // Exactly what `getView` is for: the plugin could have known.
+    expect(api.graph.getView().atTopLevel).toBe(false);
+  });
+
+  it('clear_graph inside a block empties the block, not the graph', () => {
+    const instanceId = seedOneBlock();
+    const api = freshApi();
+    store().enterSubgraph(instanceId);
+
+    api.graph.applyOperations([{ op: 'clear_graph' }]);
+    expect(tab().nodes).toEqual([]);
+    // The graph itself still has its top-level nodes, block instance included.
+    expect(api.graph.getGraph().nodes.map((n: { id: string }) => n.id).sort())
+      .toEqual(['a', instanceId].sort());
+  });
+
+  it('an op naming a top-level node fails while a block is open', () => {
+    const instanceId = seedOneBlock();
+    const api = freshApi();
+    store().enterSubgraph(instanceId);
+
+    // 'a' exists at the top level and nowhere inside the block, so a plugin
+    // that read `getGraph()` and wrote back blind gets a refusal per op.
+    const result = api.graph.applyOperations([
+      { op: 'set_params', node_id: 'a', params: { scale: 2 } },
+    ]);
+    expect(result.results[0].ok).toBe(false);
+    expect(result.results[0].error).toBeTruthy();
+  });
+
+  it('onGraphChanged fires on the level change, so the view can be re-read', () => {
+    const instanceId = seedOneBlock();
+    const api = freshApi();
+    let depthSeen = -1;
+    const off = api.graph.onGraphChanged(() => {
+      depthSeen = api.graph.getView().depth;
+    });
+
+    store().enterSubgraph(instanceId);
+    expect(depthSeen).toBe(1);
+    store().exitSubgraph();
+    expect(depthSeen).toBe(0);
+    off();
+  });
+});
+
+describe('apiVersion 4', () => {
+  it('reports 4 and offers getView', () => {
+    const api = freshApi();
+    expect(api.apiVersion).toBe(4);
+    expect(typeof api.graph.getView).toBe('function');
+  });
+
+  it('leaves every earlier graph member in place', () => {
+    // Additive: a v2/v3 plugin reaches for these four and nothing else.
+    const api = freshApi();
+    for (const member of ['getGraph', 'getNodeDefinitions', 'applyOperations', 'onGraphChanged']) {
+      expect(
+        typeof (api.graph as unknown as Record<string, unknown>)[member],
+        `graph.${member}`,
+      ).toBe('function');
+    }
+  });
+});

--- a/frontend/src/plugins/api.view.test.ts
+++ b/frontend/src/plugins/api.view.test.ts
@@ -167,6 +167,15 @@ describe('graph.getView', () => {
     expect(api.graph.getView()).toEqual({ depth: 0, path: [], atTopLevel: true });
   });
 
+  it('answers the top level rather than throwing when there is no tab', () => {
+    // A plugin can call this whenever it likes, including from an activation
+    // that runs before the editor has restored its tabs. Throwing inside
+    // third-party code over a state the host owns would be the host's bug.
+    const api = freshApi();
+    useTabStore.setState({ tabs: [], activeTabId: null as unknown as string });
+    expect(api.graph.getView()).toEqual({ depth: 0, path: [], atTopLevel: true });
+  });
+
   it('is a fresh object each call, so nothing a plugin keeps goes stale silently', () => {
     const api = freshApi();
     const instanceId = seedOneBlock();

--- a/frontend/src/plugins/contract.assert.ts
+++ b/frontend/src/plugins/contract.assert.ts
@@ -12,6 +12,8 @@ import type { GraphOp as HGraphOp, OpResult as HOpResult } from './ops';
 import type {
   ApplyResult as HApplyResult,
   CodefyUIPluginAPI as HApi,
+  GraphView as HGraphView,
+  GraphViewLevel as HGraphViewLevel,
   RunListOptions as HRunListOptions,
 } from './api';
 import type {
@@ -43,6 +45,8 @@ import type {
   ExecutionEvent as CExecutionEvent,
   ExecutionFinishStatus as CFinishStatus,
   GraphOp as CGraphOp,
+  GraphView as CGraphView,
+  GraphViewLevel as CGraphViewLevel,
   NodeDefinition as CNodeDef,
   OpResult as COpResult,
   ParamDefinition as CParamDef,
@@ -92,10 +96,18 @@ export type _RunListOptions = Expect<Mutual<HRunListOptions, CRunListOptions>>;
 export type _RunMetricPoint = Expect<Mutual<HRunMetricPoint, CRunMetricPoint>>;
 export type _RunMetrics = Expect<Mutual<HRunMetrics, CRunMetrics>>;
 
+// ── apiVersion 4 additions (#200 item 7) ──────────────────────────────────
+export type _GraphViewLevel = Expect<Mutual<HGraphViewLevel, CGraphViewLevel>>;
+export type _GraphView = Expect<Mutual<HGraphView, CGraphView>>;
+
 // ── API surface: same top-level sections; apiVersion is intentionally widened
-// from the host's literal `3` to `number` so plugins can defensively check it. ──
+// from the host's literal `4` to `number` so plugins can defensively check it. ──
 export type _ApiKeys = Expect<Mutual<keyof HApi, keyof CApi>>;
 export type _ApiVersion = Expect<Extends<HApi['apiVersion'], CApi['apiVersion']>>;
 export type _UiKeys = Expect<Mutual<keyof HApi['ui'], keyof CApi['ui']>>;
+// `graph` was the one section with no key check of its own, which is how a
+// member could have been published on the host and never reach the contract
+// plugins read (#200 item 7 added the first new member since).
+export type _GraphKeys = Expect<Mutual<keyof HApi['graph'], keyof CApi['graph']>>;
 export type _EventsKeys = Expect<Mutual<keyof HApi['events'], keyof CApi['events']>>;
 export type _RunsKeys = Expect<Mutual<keyof HApi['runs'], keyof CApi['runs']>>;

--- a/frontend/src/plugins/contract.v3.assert.ts
+++ b/frontend/src/plugins/contract.v3.assert.ts
@@ -1,33 +1,44 @@
 /**
- * CodefyUI plugin frontend API — the CANONICAL, self-contained type contract.
+ * Frozen snapshot of the apiVersion 3 contract, and a compile-time proof that
+ * the host still satisfies it.
  *
- * This is the single source of truth for the public plugin surface. It has NO
- * imports, so it drops verbatim into any plugin's `ui/src/sdk/types.ts`:
+ * apiVersion 4 (#200 item 7) adds `graph.getView` and nothing else, and the
+ * claim that it adds nothing else is worth exactly as much as the guard behind
+ * it -- which is the same argument `contract.v2.assert.ts` makes one version
+ * down. v2 does not cover the v3-only surface (panels, toolbar buttons,
+ * execution events, the runs facade), so without this file the members added in
+ * 1.5.0 had nothing frozen watching them: `contract.assert.ts` compares the host
+ * against the CURRENT contract, and a change that edits both drifts silently.
  *
- *   - `scripts/sync_plugin_sdk.py` copies it into the `cdui plugin new` scaffold
- *     payload (`scripts/templates/plugin/ui/src/sdk/types.ts`); a backend test
- *     (`tests/test_plugin_dx.py`) fails if that copy drifts.
- *   - The clone-and-own template `CodefyUI-Plugin-Official/ui/src/sdk/types.ts`
- *     is refreshed from this file too.
+ * Every plugin scaffolded by `cdui plugin new` since 1.5.0 vendored the contract
+ * below as its own `ui/src/sdk/types.ts` and declares
+ * `activate(api: CodefyUIPluginAPI)` against it. Those plugins keep working
+ * exactly as long as the host's real API object stays ASSIGNABLE to the
+ * interface below, which is what this file asserts.
  *
- * `contract.assert.ts` (next to this file) statically asserts that the host's
- * real implementation types (`./api`, `./ops`, `../types`, `./nodeRenderers`)
- * stay structurally compatible with the declarations here, so `tsc -b` fails the
- * moment the host drifts from the published contract. A future hardening step
- * could have the host import these types directly to make drift impossible
- * rather than merely detected.
+ * The body is `contract.ts` as it stood at apiVersion 3, verbatim. It is a
+ * historical record: DO NOT edit it to make a change compile. If a change makes
+ * this file fail, that change is breaking for every installed v3 plugin and
+ * needs an apiVersion bump and a migration note, not a patched snapshot.
  */
+import type { CodefyUIPluginAPI as HostApi } from './api';
 
-export type ToastType = 'success' | 'error' | 'info' | 'warning';
+/** Compile error unless the argument resolves to exactly `true`. */
+type Expect<T extends true> = T;
+type Extends<A, B> = A extends B ? true : false;
 
-export interface PortDefinition {
+/* ── BEGIN frozen apiVersion 3 contract ─────────────────────────────── */
+
+type ToastType = 'success' | 'error' | 'info' | 'warning';
+
+interface PortDefinition {
   name: string;
   data_type: string;
   description: string;
   optional: boolean;
 }
 
-export interface ParamDefinition {
+interface ParamDefinition {
   name: string;
   param_type:
     | 'int' | 'float' | 'string' | 'bool'
@@ -44,7 +55,7 @@ export interface ParamDefinition {
   advanced?: boolean;
 }
 
-export interface NodeDefinition {
+interface NodeDefinition {
   node_name: string;
   category: string;
   description: string;
@@ -54,7 +65,7 @@ export interface NodeDefinition {
 }
 
 /** A batch operation accepted by `api.graph.applyOperations`. Field names are exact. */
-export type GraphOp =
+type GraphOp =
   | { op: 'add_node'; node_type: string; ref?: string;
       params?: Record<string, unknown>; position?: { x: number; y: number } }
   | { op: 'connect'; source: string; source_handle: string;
@@ -66,28 +77,28 @@ export type GraphOp =
   | { op: 'clear_graph' }
   | { op: 'auto_layout' };
 
-export interface OpResult {
+interface OpResult {
   index: number;
   ok: boolean;
   error?: string;
   node_id?: string;
 }
 
-export interface ApplyResult {
+interface ApplyResult {
   results: OpResult[];
   refs: Record<string, string>;
   node_count: number;
   edge_count: number;
 }
 
-export interface SerializedGraphNode {
+interface SerializedGraphNode {
   id: string;
   type: string;
   position: { x: number; y: number };
   data: { params: Record<string, unknown>; [key: string]: unknown };
 }
 
-export interface SerializedGraphEdge {
+interface SerializedGraphEdge {
   id: string;
   source: string;
   target: string;
@@ -95,7 +106,7 @@ export interface SerializedGraphEdge {
   targetHandle: string;
 }
 
-export interface SerializedGraph {
+interface SerializedGraph {
   nodes: SerializedGraphNode[];
   edges: SerializedGraphEdge[];
   presets?: unknown[];
@@ -105,39 +116,7 @@ export interface SerializedGraph {
   [key: string]: unknown;
 }
 
-/* ── view context (read-only) — requires apiVersion >= 4 ─────────────────── */
-
-/** One opened block on the path from the graph to the canvas the user sees. */
-export interface GraphViewLevel {
-  /** The block definition's id — stable, and what `getGraph()` refers to it by. */
-  subgraphId: string;
-  /** The block's name, exactly as the editor's breadcrumb bar shows it. */
-  name: string;
-}
-
-/**
- * Where the user is looking right now, from `api.graph.getView()`.
- *
- * A CodefyUI graph nests: a block (subgraph) has its own canvas, and the user
- * can step inside one, then inside another. The editor shows this as the
- * "Main > Encoder > Attention" bar above the canvas; `getView()` is the same
- * information, for a plugin.
- *
- * Read-only, and read live — a fresh answer each call. There is no way to
- * navigate the user somewhere through the plugin API, deliberately: moving
- * somebody's editor under them is not something a plugin should be able to do
- * quietly.
- */
-export interface GraphView {
-  /** 0 at the top level, 1 inside a block, 2 inside a block inside a block. */
-  depth: number;
-  /** The opened blocks, outermost first. Empty at the top level. */
-  path: GraphViewLevel[];
-  /** `depth === 0`, named so the check a plugin usually wants reads plainly. */
-  atTopLevel: boolean;
-}
-
-export interface NodeRenderContext {
+interface NodeRenderContext {
   node: {
     id: string;
     type: string;
@@ -151,7 +130,7 @@ export interface NodeRenderContext {
  * adapts a React component to this shape; the host calls mount once, update on
  * param changes, and unmount when the node is removed.
  */
-export interface PluginNodeRenderer {
+interface PluginNodeRenderer {
   mount(container: HTMLElement, ctx: NodeRenderContext): void;
   update?(container: HTMLElement, ctx: NodeRenderContext): void;
   unmount?(container: HTMLElement): void;
@@ -160,9 +139,9 @@ export interface PluginNodeRenderer {
 /* ── panels, toolbar buttons — requires apiVersion >= 3 ─────────────────── */
 
 /** Where a panel lives: a tab in the bottom dock, or a right-hand section. */
-export type PluginPanelDock = 'bottom' | 'right';
+type PluginPanelDock = 'bottom' | 'right';
 
-export interface PluginPanelOptions {
+interface PluginPanelOptions {
   /** Unique within your plugin. The host namespaces it with your plugin id. */
   id: string;
   /** Tab label (bottom dock) or section heading (right dock). */
@@ -180,7 +159,7 @@ export interface PluginPanelOptions {
   onHide?: () => void;
 }
 
-export interface PluginToolbarButtonOptions {
+interface PluginToolbarButtonOptions {
   /** Unique within your plugin. */
   id: string;
   /** Short glyph — the toolbar has room for a glyph, not a sentence. */
@@ -199,7 +178,7 @@ export interface PluginToolbarButtonOptions {
  * `metric` event below, and `runs.metrics()` further down. One type for one
  * concept is the whole reason a dashboard can share a fold between them.
  */
-export interface RunMetricPoint {
+interface RunMetricPoint {
   node_id: string | null;
   name: string;
   step: number;
@@ -217,7 +196,7 @@ export interface RunMetricPoint {
 }
 
 /** Terminal state of a run. */
-export type ExecutionFinishStatus =
+type ExecutionFinishStatus =
   | 'succeeded' | 'failed' | 'cancelled' | 'interrupted';
 
 /**
@@ -255,7 +234,7 @@ export type ExecutionFinishStatus =
  * Events and their `points` are frozen: they are shared between every
  * subscriber, so one plugin cannot mutate what another receives.
  */
-export type ExecutionEvent =
+type ExecutionEvent =
   | { type: 'run_started'; run_id: string; cursor: number; seq: number }
   | {
       type: 'node_status'; run_id: string; cursor: number; seq: number;
@@ -272,12 +251,12 @@ export type ExecutionEvent =
 
 /* ── runs (read-only) — requires apiVersion >= 3 ────────────────────────── */
 
-export type RunStatus =
+type RunStatus =
   | 'queued' | 'running' | 'succeeded'
   | 'failed' | 'cancelled' | 'interrupted';
 
 /** One row of the run history. Timestamps are ISO-8601 UTC with a `Z`. */
-export interface RunSummary {
+interface RunSummary {
   id: string;
   name: string | null;
   status: RunStatus;
@@ -299,12 +278,12 @@ export interface RunSummary {
   active: boolean;
 }
 
-export interface RunInfo extends RunSummary {
+interface RunInfo extends RunSummary {
   /** Highest event cursor issued so far — where a follower should resume. */
   last_cursor: number;
 }
 
-export interface RunListPage {
+interface RunListPage {
   runs: RunSummary[];
   /** Unpaged count for the active filter, so a table can size itself. */
   total: number;
@@ -312,13 +291,13 @@ export interface RunListPage {
   offset: number;
 }
 
-export interface RunListOptions {
+interface RunListOptions {
   status?: readonly RunStatus[];
   limit?: number;
   offset?: number;
 }
 
-export interface RunMetrics {
+interface RunMetrics {
   run_id: string;
   /** Every series name in the run, so a legend needs no scan of the points. */
   names: string[];
@@ -326,7 +305,7 @@ export interface RunMetrics {
 }
 
 /** The object the editor hands every plugin frontend at activation. */
-export interface CodefyUIPluginAPI {
+interface CodefyUIPluginAPI {
   apiVersion: number;
   pluginId: string;
   ui: {
@@ -360,59 +339,12 @@ export interface CodefyUIPluginAPI {
     addToolbarButton(opts: PluginToolbarButtonOptions): () => void;
     removeToolbarButton(id: string): void;
   };
-  /**
-   * The graph.
-   *
-   * Read and write are not aimed at the same place while the user is inside a
-   * block, and that difference is documented on each member below. `getView()`
-   * — apiVersion 4 — is how you find out where the user is before you write.
-   */
   graph: {
-    /**
-     * The WHOLE graph, always: nodes and edges at the top level, plus the block
-     * definitions under `subgraphs`.
-     *
-     * Never affected by where the user is standing — the editor flattens its
-     * open sub-canvases into the answer first, exactly as Save and Run do. So a
-     * plugin reading the graph sees the same bytes the user would get by saving
-     * the file, whether or not a block is open on screen.
-     */
     getGraph(): SerializedGraph;
     getNodeDefinitions(): NodeDefinition[];
-    /**
-     * Synchronous — returns the result directly, committed as one undo step.
-     *
-     * **A batch applies to the canvas the user has open, which is not always
-     * the top level.** Entering a block replaces the canvas with that block's
-     * insides, so ops applied then land inside the block: `add_node` adds a
-     * node to the block, and `clear_graph` empties the block rather than the
-     * graph. Node ids from `getGraph()` — which always answers with the top
-     * level — will not be found there, and those ops fail with an error in
-     * their `results` entry.
-     *
-     * This is the editor's long-standing behaviour and it is not changing
-     * silently; it is written down here so you can code against it. If your
-     * plugin composes a read with a write, call `getView()` between the two and
-     * handle `atTopLevel === false` — refuse with a toast, wait for the user to
-     * step out, or scope your edit to what makes sense inside a block. Writing
-     * anyway is not corruption, but it lands somewhere the user is not looking.
-     */
+    /** Synchronous — returns the result directly, committed as one undo step. */
     applyOperations(ops: GraphOp[]): ApplyResult;
-    /**
-     * Called after the graph changes — including when the user steps into or
-     * out of a block, since that swaps the canvas. Re-read `getView()` from the
-     * callback if you track which level the user is on.
-     */
     onGraphChanged(cb: () => void): () => void;
-    /**
-     * Where the user is looking — requires apiVersion >= 4.
-     *
-     * Read-only. It exists so a plugin can tell "the user is inside a block"
-     * from "the user is on the graph" before it writes; see `applyOperations`.
-     * On an older editor this member is `undefined`, so feature-check with
-     * `api.apiVersion >= 4` (or `typeof api.graph.getView === 'function'`).
-     */
-    getView(): GraphView;
   };
   /** Custom node renderers — requires apiVersion >= 2. */
   nodes: {
@@ -457,4 +389,21 @@ export interface CodefyUIPluginAPI {
 }
 
 /** The default-export contract: the editor calls this once with the API. */
-export type ActivateFn = (api: CodefyUIPluginAPI) => void;
+type ActivateFn = (api: CodefyUIPluginAPI) => void;
+
+/* ── END frozen apiVersion 3 contract ───────────────────────────────── */
+
+/**
+ * The host's real API object still satisfies the v3 interface -- every member a
+ * v3 plugin can reach is present, with a compatible type.
+ */
+export type _V3SurfaceIntact = Expect<Extends<HostApi, CodefyUIPluginAPI>>;
+
+/**
+ * ...so a v3 plugin's exported `activate` is still callable with what the host
+ * hands it, which is the thing that actually has to keep working. (Parameters
+ * are contravariant, so this direction models the real call.)
+ */
+export type _V3ActivateStillCallable = Expect<
+  Extends<ActivateFn, (api: HostApi) => void>
+>;

--- a/frontend/src/plugins/contract.v3.assert.ts
+++ b/frontend/src/plugins/contract.v3.assert.ts
@@ -7,10 +7,10 @@
  * it -- which is the same argument `contract.v2.assert.ts` makes one version
  * down. v2 does not cover the v3-only surface (panels, toolbar buttons,
  * execution events, the runs facade), so without this file the members added in
- * 1.5.0 had nothing frozen watching them: `contract.assert.ts` compares the host
+ * 2.0.0 had nothing frozen watching them: `contract.assert.ts` compares the host
  * against the CURRENT contract, and a change that edits both drifts silently.
  *
- * Every plugin scaffolded by `cdui plugin new` since 1.5.0 vendored the contract
+ * Every plugin scaffolded by `cdui plugin new` since 2.0.0 vendored the contract
  * below as its own `ui/src/sdk/types.ts` and declares
  * `activate(api: CodefyUIPluginAPI)` against it. Those plugins keep working
  * exactly as long as the host's real API object stays ASSIGNABLE to the

--- a/frontend/src/utils/subgraph.ts
+++ b/frontend/src/utils/subgraph.ts
@@ -33,6 +33,41 @@ export function isSubgraphInstance(node: Node<NodeData> | undefined): boolean {
   return !!node && subgraphIdOf(node.data?.type) !== null;
 }
 
+/** One opened block on the trail from a graph's top level to the canvas on screen. */
+export interface SubgraphPathEntry {
+  subgraphId: string;
+  /** The block's name; its id when the definition has gone missing. */
+  name: string;
+}
+
+/**
+ * The trail of opened blocks, outermost first, named the way a human reads it.
+ *
+ * One derivation, two consumers: the breadcrumb bar the user reads
+ * (`components/Canvas/SubgraphBreadcrumb`) and the view a plugin reads
+ * (`api.graph.getView`, core#200 item 7). They have to agree -- a plugin that
+ * warns "you are inside Encoder" while the bar above the canvas says "Decoder"
+ * is worse than a plugin that says nothing -- and the only way to guarantee
+ * that is to let one function answer both.
+ *
+ * Names come from the LIVE definition list rather than from the list each frame
+ * captured on entry, so a rename shows up immediately; the frame's copy exists
+ * for undo, not for display. Falling back to the id keeps the answer non-empty
+ * for a definition that has gone missing (the case `exitSubgraph` guards), and
+ * that fallback is what the breadcrumb has always shown.
+ */
+export function subgraphViewPath(
+  stack: readonly { subgraphId: string }[] | undefined,
+  subgraphs: readonly SubgraphDefinition[] | undefined,
+): SubgraphPathEntry[] {
+  return (stack ?? []).map((frame) => ({
+    subgraphId: frame.subgraphId,
+    name:
+      (subgraphs ?? []).find((d) => d.id === frame.subgraphId)?.name
+      || frame.subgraphId,
+  }));
+}
+
 /**
  * An untrusted `subgraphs` list, coerced to the shape every consumer assumes.
  *

--- a/scripts/templates/plugin/README.md
+++ b/scripts/templates/plugin/README.md
@@ -36,7 +36,7 @@ the editor's bottom dock that lists a run's metrics live, using
 `api.events.onExecution` for the live tail and the read-only `api.runs` facade
 to back-fill what happened before the panel opened. Nothing imports it by
 default — copy it, or call `mountRunMetricsPanel(api)` from
-`ui/src/index.tsx`. It needs `api.apiVersion >= 3` (CodefyUI 1.5+).
+`ui/src/index.tsx`. It needs `api.apiVersion >= 3` (CodefyUI 2.0+).
 
 ## Test
 

--- a/scripts/templates/plugin/ui/src/examples/run-metrics-panel.tsx
+++ b/scripts/templates/plugin/ui/src/examples/run-metrics-panel.tsx
@@ -157,7 +157,7 @@ function RunMetricsPanel() {
 /** Add the panel as a tab in the editor's bottom dock. */
 export function mountRunMetricsPanel(api: CodefyUIPluginAPI): void {
   if (api.apiVersion < 3) {
-    api.ui.toast('This panel needs CodefyUI 1.5 or newer', 'warning');
+    api.ui.toast('This panel needs CodefyUI 2.0 or newer', 'warning');
     return;
   }
   mountPanel(

--- a/scripts/templates/plugin/ui/src/sdk/types.ts
+++ b/scripts/templates/plugin/ui/src/sdk/types.ts
@@ -89,6 +89,38 @@ export interface SerializedGraph {
   [key: string]: unknown;
 }
 
+/* ── view context (read-only) — requires apiVersion >= 4 ─────────────────── */
+
+/** One opened block on the path from the graph to the canvas the user sees. */
+export interface GraphViewLevel {
+  /** The block definition's id — stable, and what `getGraph()` refers to it by. */
+  subgraphId: string;
+  /** The block's name, exactly as the editor's breadcrumb bar shows it. */
+  name: string;
+}
+
+/**
+ * Where the user is looking right now, from `api.graph.getView()`.
+ *
+ * A CodefyUI graph nests: a block (subgraph) has its own canvas, and the user
+ * can step inside one, then inside another. The editor shows this as the
+ * "Main > Encoder > Attention" bar above the canvas; `getView()` is the same
+ * information, for a plugin.
+ *
+ * Read-only, and read live — a fresh answer each call. There is no way to
+ * navigate the user somewhere through the plugin API, deliberately: moving
+ * somebody's editor under them is not something a plugin should be able to do
+ * quietly.
+ */
+export interface GraphView {
+  /** 0 at the top level, 1 inside a block, 2 inside a block inside a block. */
+  depth: number;
+  /** The opened blocks, outermost first. Empty at the top level. */
+  path: GraphViewLevel[];
+  /** `depth === 0`, named so the check a plugin usually wants reads plainly. */
+  atTopLevel: boolean;
+}
+
 export interface NodeRenderContext {
   node: {
     id: string;
@@ -312,12 +344,59 @@ export interface CodefyUIPluginAPI {
     addToolbarButton(opts: PluginToolbarButtonOptions): () => void;
     removeToolbarButton(id: string): void;
   };
+  /**
+   * The graph.
+   *
+   * Read and write are not aimed at the same place while the user is inside a
+   * block, and that difference is documented on each member below. `getView()`
+   * — apiVersion 4 — is how you find out where the user is before you write.
+   */
   graph: {
+    /**
+     * The WHOLE graph, always: nodes and edges at the top level, plus the block
+     * definitions under `subgraphs`.
+     *
+     * Never affected by where the user is standing — the editor flattens its
+     * open sub-canvases into the answer first, exactly as Save and Run do. So a
+     * plugin reading the graph sees the same bytes the user would get by saving
+     * the file, whether or not a block is open on screen.
+     */
     getGraph(): SerializedGraph;
     getNodeDefinitions(): NodeDefinition[];
-    /** Synchronous — returns the result directly, committed as one undo step. */
+    /**
+     * Synchronous — returns the result directly, committed as one undo step.
+     *
+     * **A batch applies to the canvas the user has open, which is not always
+     * the top level.** Entering a block replaces the canvas with that block's
+     * insides, so ops applied then land inside the block: `add_node` adds a
+     * node to the block, and `clear_graph` empties the block rather than the
+     * graph. Node ids from `getGraph()` — which always answers with the top
+     * level — will not be found there, and those ops fail with an error in
+     * their `results` entry.
+     *
+     * This is the editor's long-standing behaviour and it is not changing
+     * silently; it is written down here so you can code against it. If your
+     * plugin composes a read with a write, call `getView()` between the two and
+     * handle `atTopLevel === false` — refuse with a toast, wait for the user to
+     * step out, or scope your edit to what makes sense inside a block. Writing
+     * anyway is not corruption, but it lands somewhere the user is not looking.
+     */
     applyOperations(ops: GraphOp[]): ApplyResult;
+    /**
+     * Called after the graph changes — including when the user steps into or
+     * out of a block, since that swaps the canvas. Re-read `getView()` from the
+     * callback if you track which level the user is on.
+     */
     onGraphChanged(cb: () => void): () => void;
+    /**
+     * Where the user is looking — requires apiVersion >= 4.
+     *
+     * Read-only. It exists so a plugin can tell "the user is inside a block"
+     * from "the user is on the graph" before it writes; see `applyOperations`.
+     * On an older editor this member is `undefined`, so feature-check with
+     * `api.apiVersion >= 4` (or `typeof api.graph.getView === 'function'`).
+     */
+    getView(): GraphView;
   };
   /** Custom node renderers — requires apiVersion >= 2. */
   nodes: {


### PR DESCRIPTION
A CodefyUI graph nests: a block (subgraph) has its own canvas, and entering one
*swaps* its insides onto the single canvas the editor has. Two consequences
followed for the plugin surface, and a plugin could see neither:

- `graph.getGraph()` flushes the editing stack and answers with the **whole**
  graph, whatever is open on screen (the same path Save and Run take).
- `graph.applyOperations()` writes to the canvas **in front of the user**. Inside
  a block that means the block: `add_node` adds a node to the block, and
  `clear_graph` empties the block rather than the graph (#200 item 7).

So a plugin could read the graph, reason about it entirely correctly, and write
into a block the user happened to have open — with node ids that do not exist
there, so half the batch also fails.

## What this does

Per the maintainer's decision (2026-08-12) this is the **gradual** shape:
publish where the user is, leave where writes land exactly as it is, and turn
that rule from an accident into documented API. A future revision can add an
explicit write target on top without having moved anybody's writes first.

- **`api.graph.getView()`** returns
  `{ depth, path: [{ subgraphId, name }, ...], atTopLevel }` — `depth` 0 at the
  top level, `path` outermost-first, `atTopLevel` for the check a plugin usually
  wants. Read-only and read live: nothing here can be set, and there is
  deliberately no way for a plugin to navigate somebody's editor.
  `onGraphChanged` already fires on a level change (the canvas swaps), so a panel
  can re-read it from that callback.
- **One derivation, two consumers.** The path comes from a new pure
  `subgraphViewPath(stack, subgraphs)`, which `SubgraphBreadcrumb` now uses too.
  A plugin that warns "you are inside Encoder" has to name the block the bar
  above the canvas names; two copies of that mapping would eventually disagree.
- **apiVersion 3 -> 4.** The number is the only way a plugin can tell a host that
  has `graph.getView` from one where it is `undefined`, and the docs' own rule is
  that additions arrive with a version. Purely additive — `contract.v2.assert.ts`
  still passes untouched.
- **The v3 contract is now frozen under test** (`contract.v3.assert.ts`), the way
  v2 already was. v2 does not cover the members 2.0.0 added (panels, toolbar
  buttons, execution events, the runs facade), so those had nothing frozen
  watching them: `contract.assert.ts` compares the host against the *current*
  contract, and a change that edits both drifts in silence. Verified non-vacuous
  by mutation (giving `ui.addPanel` a second required parameter fails it).
- **`contract.assert.ts` gains `_GraphKeys`.** `graph` was the one section whose
  key set was never compared, which is how a host member could have been
  published and never reached the contract plugins read. Also verified by
  mutation: deleting `getView` from `contract.ts` fails `tsc -b`.
- **Docs (en + zh-TW)**: a "Which level the user is looking at" section stating
  the read/write asymmetry plainly plus the refuse-or-warn pattern, the
  apiVersion table row 4, and a `getGraph`/`applyOperations` row rewrite. It also
  corrects `onGraphChanged`'s documented signature, which advertised a snapshot
  argument it has never passed.
- Vendored SDK types re-synced with `scripts/sync_plugin_sdk.py` (`--check`
  green; `backend/tests/test_plugin_dx.py` passes).

### One thing to know about the brief this was written from

The task brief said the write rule was already "always the top level". It is
not, and the code says so: `commitGraphOperations` reads `tab.nodes` / `tab.edges`
and calls `setNodes` / `setEdges`, all of which are the *open* canvas. That was
confirmed by probe before anything was written, and the read/write asymmetry is
documented as it actually behaves — which is also the only version in which this
field is useful, since a write that always landed at the top level would never
have needed a warning. Nothing about where writes land was changed.

## Tests

New `frontend/src/plugins/api.view.test.ts` (18 cases): the view at the top
level, one level deep, two deep, back out one at a time, after
`exitAllSubgraphs`, live under a rename, the id fallback for a missing
definition, freshness, and that mutating the returned object cannot move the
editor. Then the behaviour the field exists for, pinned: `getGraph` answers with
the whole graph while a block is open; `applyOperations` lands in the open
canvas and leaves the top level untouched; `clear_graph` inside a block empties
the block; an op naming a top-level node is refused with an error; and
`onGraphChanged` fires on the level change. The suite is non-vacuous — stubbing
`currentGraphView` to always report the top level fails 9 of them.

The two existing exact `apiVersion` assertions became `>= 3` floors (an additive
release must not fail the test file for the release before it); the exact number
is pinned once, in the new file.

Gates: `pnpm exec tsc -b`, `pnpm test` (140 files / 3233 tests), `pnpm build`,
`python scripts/check_control_bytes.py`, `uvx ruff@0.14.4 check .`,
`python scripts/sync_plugin_sdk.py --check`, `backend/tests/test_plugin_dx.py`
— all green.

## Item recount for #200

Closes #200 — item 7 was the last one open. Ten items were filed across the
round-2, round-3 and #319-review passes:

| Item | Status |
|------|--------|
| 1 — indistinguishable convexity blockers | done in #279 |
| 2 — undo dropped Teaching Inspector segments | done in #328 |
| 3 — `onGraphChanged` blind to definition-only changes | done in #279 |
| 4 — `openExample` skipped `description` + the version gate | done in #319 |
| 5 — publish pre-flight did not scan preset definitions | done in #279 |
| 6 — `AttributeError` on an explicitly-null node `"type"` | done in #279 |
| 7 — the plugin op surface was not sub-canvas aware | **this PR** |
| 8 — `setSubgraphs` ordering wanted an atomic `loadGraphDocument` | done in #319 |
| 9 — `openExample` did not rebind `currentGraphFile` | done in #329 |
| 10 — `insertExample` ignored `format_version` | done in #329 |

(Also noted in the issue's history: #200 was once closed by GitHub reading
"does not close #200" in #279's body as a closing keyword — this PR closes it on
purpose.)

## Notes for the reviewer

- **The apiVersion table's version column carried a pre-existing wrong number**,
  and review caught the new row about to repeat it. Row 3 said 1.5.0 — a version
  never tagged (tags go 1.4.2 -> 2.0.0); `git tag --contains` on the commit that
  set `apiVersion: 3` (d046bc2, #184) answers **2.0.0**, which is what the row
  says now, in both locales. The new row 4 says *next release (unreleased)*
  rather than inventing a number, and `.github/RELEASING.md` gains a third
  by-hand step telling the releaser to stamp it — `git grep -n "stamp-on-release"
  docs/`. The grep target is an **ASCII marker** (`{/* stamp-on-release */}`, an
  MDX comment on all four placeholder spots) rather than the prose, because the
  placeholder text is translated: grepping the English words finds the English
  row and walks past `*下一個版本（尚未發布）*`, which would reproduce the class
  in the locale nobody proofreads. One marker, both locales, one command — and
  `{/* */}` not `<!-- -->`, since Docusaurus compiles these `.md` pages as MDX
  where an HTML comment fails the build (it did, on the first attempt). The same never-released number is corrected in two
  plugin-author-facing spots in the scaffold (README, run-metrics example toast)
  and in the two host comments that copied it. One sibling is deliberately left
  alone: `docs/docs/usage/data-augmentation.md` says "Before CodefyUI 1.5" about
  a different feature — same root, another page, not this PR's business.
- Nothing here changes runtime behaviour for an existing plugin: `getView` is a
  new member, and no existing member changed shape or target. The only visible
  change is `api.apiVersion` reporting 4.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYmF5XjhQStu2K6swHp2XX
