### PR TITLE
docs(vla): vision_stem describes the measured picture, not the confounded one

### DIFF
--- a/backend/app/nodes/vla/vla_model_node.py
+++ b/backend/app/nodes/vla/vla_model_node.py
@@ -477,10 +477,13 @@ class VLAModelNode(StatefulModuleMixin, BaseNode):
                 default="conv",
                 options=VISION_STEMS,
                 description=(
-                    "conv: three stride-2 3x3 convs (fine localization; the "
-                    "'early convolutions help transformers see' result is "
-                    "measurable here). patchify: the classic ViT stem, kept "
-                    "for studying exactly that difference."
+                    "conv: three stride-2 3x3 convs. patchify: the classic "
+                    "ViT stem. A controlled A/B at a 1200-episode/45-epoch "
+                    "budget measured patchify AHEAD (0.85 vs 0.45 success, "
+                    "same data/seed) - the opposite of the NeurIPS'21 "
+                    "conv-stem result and of this node's earlier confounded "
+                    "notes; at the full 2400/110 budget only conv has been "
+                    "run (0.97). The knob exists to settle exactly this."
                 ),
                 advanced=True,
             ),

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -1041,7 +1041,7 @@ const zhTW: NodeTranslations = {
       expert_layers: '動作 expert 深度（區塊 query 自注意 + 對主幹交叉注意）',
       chunk: '每次預測的動作數（區塊視野 H）——須與 PushWorldDemos 的 chunk 一致',
       image_size: '輸入畫面邊長——須與 PushWorldEnv 的 image_size 一致',
-      vision_stem: 'conv：三層 stride-2 3x3 卷積（定位較精準，「early convolutions help transformers see」在此規模可量測）。patchify：經典 ViT stem，保留以研究這個差異',
+      vision_stem: 'conv：三層 stride-2 3x3 卷積。patchify：經典 ViT stem。1200 回合／45 epochs 預算下的控制 A/B 量到 patchify 領先（成功率 0.85 vs 0.45，同資料同 seed）——與 NeurIPS 2021 的 conv-stem 結論及本節點早先的混淆筆記相反；2400／110 完整預算目前只跑過 conv（0.97）。這顆旋鈕存在的目的就是把這件事定案',
       patch_size: '僅 patchify stem：方形 patch 邊長',
       action_dim: '動作向量寬度（PushWorld 為 2：dx, dy）',
       max_text_len: '指令長度（位元組）——須與資料集編碼一致（PushWorldDemos 用 48）',


### PR DESCRIPTION
> 中文摘要：vision_stem 參數描述更正為控制實驗的實測結果——1200 回合／45 epochs 預算下 patchify 0.85 vs conv 0.45(同資料同 seed、唯一變因是 stem),與參數原引用的 NeurIPS'21 結論及早先混淆的原型筆記相反(當時同一次迭代同時改了 stem 與資料量)。註明 2400／110 完整預算目前僅跑過 conv(0.97),把裁決留給這顆旋鈕。zh-TW 同步。研究出處:copilot repo 的 paper-early-convs 文件頁。

Verification: `pytest tests/test_vla_model_node.py tests/test_api_nodes.py -q` (52 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7hg6NttgDyNBcf49Na9kj