### PR TITLE
feat(ui): the health numbers the backend was already sending finally have somewhere to be seen (#193)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -100,8 +100,12 @@ beforeEach(() => {
   mockedFetchHealth.mockReset();
   mockedFetchHealth.mockResolvedValue({
     status: 'ok',
+    // version / caches are read by the settings popover, not by App (#193
+    // item 2); present here because HealthInfo now carries them.
+    version: '2.2.0',
     nodes_loaded: 0,
     presets_loaded: 0,
+    caches: {},
     project: null,
   });
 });
@@ -309,8 +313,10 @@ describe('App', () => {
     );
     mockedFetchHealth.mockResolvedValueOnce({
       status: 'ok',
+      version: '2.2.0',
       nodes_loaded: 0,
       presets_loaded: 0,
+      caches: {},
       project: '/proj',
     });
     render(<App />);

--- a/frontend/src/api/rest.test.ts
+++ b/frontend/src/api/rest.test.ts
@@ -288,12 +288,16 @@ describe('GET endpoints', () => {
 describe('fetchHealth', () => {
   it('passes through the project path string when present (project mode)', async () => {
     const fetchMock = mockFetch(200, {
-      status: 'ok', nodes_loaded: 3, presets_loaded: 1, project: '/home/me/my-service',
+      status: 'ok', version: '2.2.0', nodes_loaded: 3, presets_loaded: 1,
+      caches: { execution_cache: { instances: 1, entries: 2, bytes: 2048, max_bytes_each: 4096 } },
+      project: '/home/me/my-service',
     });
     const out = await fetchHealth();
     expect(fetchMock).toHaveBeenCalledWith('/api/health');
     expect(out).toEqual({
-      status: 'ok', nodes_loaded: 3, presets_loaded: 1, project: '/home/me/my-service',
+      status: 'ok', version: '2.2.0', nodes_loaded: 3, presets_loaded: 1,
+      caches: { execution_cache: { instances: 1, entries: 2, bytes: 2048, max_bytes_each: 4096 } },
+      project: '/home/me/my-service',
     });
   });
 
@@ -302,6 +306,35 @@ describe('fetchHealth', () => {
     const out = await fetchHealth();
     expect(out.project).toBeNull();
     expect('project' in out).toBe(true);
+  });
+
+  // #193 item 2: the settings panel maps over `caches` on every render and
+  // prints `version` into a value column, so neither may arrive as undefined.
+  it('normalizes an absent caches block to an empty map and an absent version to null', async () => {
+    mockFetch(200, { status: 'ok', nodes_loaded: 3, presets_loaded: 1 });
+    const out = await fetchHealth();
+    expect(out.caches).toEqual({});
+    expect(out.version).toBeNull();
+  });
+
+  it('passes the per-store cache usage through untouched', async () => {
+    // Each store reports a DIFFERENT set of keys (see CacheUsage); the client
+    // must not narrow them to some common subset.
+    mockFetch(200, {
+      status: 'ok', version: '2.2.0', nodes_loaded: 3, presets_loaded: 1,
+      caches: {
+        execution_cache: { instances: 2, entries: 5, bytes: 1024, max_bytes_each: 2048 },
+        run_output_store: { runs: 1, max_runs: 20, bytes: 4096, max_bytes: 8192 },
+        node_state_store: { modules: 3, max_modules: 64, bytes: 512, max_bytes: 1024 },
+      },
+    });
+    const out = await fetchHealth();
+    expect(out.caches.run_output_store).toEqual({
+      runs: 1, max_runs: 20, bytes: 4096, max_bytes: 8192,
+    });
+    expect(Object.keys(out.caches)).toEqual([
+      'execution_cache', 'run_output_store', 'node_state_store',
+    ]);
   });
 
   it('throws on a non-ok response', async () => {

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -31,10 +31,31 @@ export async function fetchPresetDefinitions(): Promise<PresetDefinition[]> {
   return res.json();
 }
 
+/**
+ * One cache store's line in the health payload's `caches` block.
+ *
+ * Deliberately an open map of numbers rather than a named-field interface: the
+ * three stores do NOT share a shape. `bytes` is the only key all of them
+ * carry; the budget is `max_bytes` for the run-output and node-state stores
+ * but `max_bytes_each` for the execution cache (there is one instance per
+ * WebSocket, so a single total has no single ceiling), and the item count is
+ * `entries` / `runs` / `modules` respectively. A store added backend-side
+ * therefore needs no change here (#193 item 2).
+ */
+export type CacheUsage = Record<string, number>;
+
 export interface HealthInfo {
   status: string;
+  /** The running server's version. Unconditional since #135 -- normalized to
+   *  `null` only so a pre-#135 server, or a partial test double, renders a
+   *  placeholder instead of "undefined". */
+  version: string | null;
   nodes_loaded: number;
   presets_loaded: number;
+  /** Per-store memory usage, keyed by store name (`execution_cache`,
+   *  `run_output_store`, `node_state_store`). Empty when the server reports
+   *  none -- see `CacheUsage` for why the inner shape is open. */
+  caches: Record<string, CacheUsage>;
   project: string | null;
 }
 
@@ -47,6 +68,12 @@ export interface HealthInfo {
  * `useProjectStore.setProject` / `isProjectMode` key off a strict
  * `!== null` check, which `undefined` would satisfy and misreport project
  * mode as active.
+ *
+ * `caches` is normalized to `{}` rather than left absent for the same reason:
+ * the settings panel maps over it on every render, and a missing key would be
+ * a crash rather than an empty list. The backend also omits an individual
+ * store that is not running (a test client reaches the endpoint with nothing
+ * on `app.state`), so an empty map is a reachable, valid answer.
  */
 export async function fetchHealth(): Promise<HealthInfo> {
   const res = await fetch(`${BASE_URL}/health`);
@@ -54,8 +81,10 @@ export async function fetchHealth(): Promise<HealthInfo> {
   const data = await res.json();
   return {
     status: data.status,
+    version: data.version ?? null,
     nodes_loaded: data.nodes_loaded,
     presets_loaded: data.presets_loaded,
+    caches: data.caches ?? {},
     project: data.project ?? null,
   };
 }

--- a/frontend/src/components/Toolbar/HealthSection.test.tsx
+++ b/frontend/src/components/Toolbar/HealthSection.test.tsx
@@ -76,6 +76,19 @@ describe('HealthSection', () => {
     expect(hint).toHaveTextContent(/for the weight cache that means training time/);
   });
 
+  it('treats a configured budget of 0 as unbounded, not as an exhausted ceiling', async () => {
+    // Every store reads a falsy max as "no cap" (run_output_store.py:93,
+    // node_state_store.py:149, cache.py:140/156), and the MAX_MB env vars are
+    // unvalidated ints, so 0 is reachable. "1.5 GB of 0 B" would say
+    // catastrophically over budget when it means the opposite.
+    mockedFetchHealth.mockResolvedValue(
+      healthBody({ caches: { run_output_store: { runs: 3, bytes: 1536, max_bytes: 0 } } }),
+    );
+    render(<HealthSection />);
+    expect(await screen.findByText('1.5 KB')).toBeInTheDocument();
+    expect(screen.queryByText(/of 0 B/)).not.toBeInTheDocument();
+  });
+
   it('shows a store with no reported budget as a bare size', async () => {
     mockedFetchHealth.mockResolvedValue(
       healthBody({ caches: { run_output_store: { runs: 1, bytes: 4096 } } }),

--- a/frontend/src/components/Toolbar/HealthSection.test.tsx
+++ b/frontend/src/components/Toolbar/HealthSection.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { HealthSection } from './HealthSection';
+import { useI18n } from '../../i18n';
+import { useToastStore } from '../../store/toastStore';
+import { fetchHealth } from '../../api/rest';
+
+vi.mock('../../api/rest', () => ({
+  fetchHealth: vi.fn(),
+}));
+
+const mockedFetchHealth = vi.mocked(fetchHealth);
+
+/** A full /api/health body, shaped exactly like backend/app/main.py health()
+ *  (three stores, each with its OWN key set — see CacheUsage). */
+function healthBody(overrides: Record<string, unknown> = {}) {
+  return {
+    status: 'ok',
+    version: '2.2.0',
+    nodes_loaded: 137,
+    presets_loaded: 12,
+    caches: {
+      execution_cache: {
+        instances: 1,
+        entries: 4,
+        bytes: 2 * 1024 * 1024,
+        max_bytes_each: 512 * 1024 * 1024,
+      },
+      run_output_store: { runs: 2, max_runs: 20, bytes: 0, max_bytes: 256 * 1024 * 1024 },
+      node_state_store: { modules: 3, max_modules: 64, bytes: 1024 ** 3, max_bytes: 2 * 1024 ** 3 },
+    },
+    project: null,
+    ...overrides,
+  } as never;
+}
+
+describe('HealthSection', () => {
+  beforeEach(() => {
+    useI18n.setState({ locale: 'en' });
+    useToastStore.setState({ toasts: [] });
+    mockedFetchHealth.mockReset();
+    mockedFetchHealth.mockResolvedValue(healthBody());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reads the server once on mount and shows the version and registry counts', async () => {
+    render(<HealthSection />);
+    // Mounting IS "on open": SettingsPopover renders nothing while closed, so
+    // this component only exists while the popover is on screen.
+    expect(mockedFetchHealth).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('2.2.0')).toBeInTheDocument();
+    expect(screen.getByText('137')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('lists every cache store with human-readable bytes against its budget', async () => {
+    render(<HealthSection />);
+    expect(await screen.findByText('Node outputs (per editor connection)')).toBeInTheDocument();
+    // The execution cache reports max_bytes_each, the other two max_bytes;
+    // both have to resolve to the same "used of budget" line.
+    expect(screen.getByText('2.0 MB of 512.0 MB')).toBeInTheDocument();
+    expect(screen.getByText('Recorded run outputs')).toBeInTheDocument();
+    expect(screen.getByText('0 B of 256.0 MB')).toBeInTheDocument();
+    expect(screen.getByText('Layer weights kept between runs')).toBeInTheDocument();
+    expect(screen.getByText('1.0 GB of 2.0 GB')).toBeInTheDocument();
+  });
+
+  it('explains what a cache is, once, without naming a delete button that does not exist yet', async () => {
+    render(<HealthSection />);
+    const hint = await screen.findByText(/hold results the server already computed/);
+    // The honest version of "it is only derived data": the weight store holds
+    // TRAINED weights, so clearing it costs training time, not a recompute.
+    expect(hint).toHaveTextContent(/for the weight cache that means training time/);
+  });
+
+  it('shows a store with no reported budget as a bare size', async () => {
+    mockedFetchHealth.mockResolvedValue(
+      healthBody({ caches: { run_output_store: { runs: 1, bytes: 4096 } } }),
+    );
+    render(<HealthSection />);
+    expect(await screen.findByText('4.0 KB')).toBeInTheDocument();
+  });
+
+  it('lists an unknown store under its raw name rather than dropping it', async () => {
+    // The payload can grow a store this build has never heard of (a fourth
+    // cache, a plugin's own); it must still be counted on screen.
+    mockedFetchHealth.mockResolvedValue(
+      healthBody({ caches: { asset_cache: { bytes: 1536, max_bytes: 1024 * 1024 } } }),
+    );
+    render(<HealthSection />);
+    expect(await screen.findByText('asset_cache')).toBeInTheDocument();
+    expect(screen.getByText('1.5 KB of 1.0 MB')).toBeInTheDocument();
+  });
+
+  it('says so plainly when the server reports no caches at all', async () => {
+    // Reachable: the backend omits a store that is not running.
+    mockedFetchHealth.mockResolvedValue(healthBody({ caches: {} }));
+    render(<HealthSection />);
+    expect(await screen.findByText('No caches are running yet.')).toBeInTheDocument();
+  });
+
+  it('renders a placeholder rather than "null" when the server sends no version', async () => {
+    mockedFetchHealth.mockResolvedValue(healthBody({ version: null }));
+    render(<HealthSection />);
+    expect(await screen.findByText('unknown')).toBeInTheDocument();
+  });
+
+  // ── failure path ──────────────────────────────────────────────────
+
+  it('reports an unreachable server inline, not as a toast', async () => {
+    mockedFetchHealth.mockRejectedValue(new Error('offline'));
+    render(<HealthSection />);
+    expect(
+      await screen.findByText('Could not read the server status. Press Refresh to try again.'),
+    ).toBeInTheDocument();
+    // A toast would outlive the popover the user opened to read this.
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+    // Nothing invented in place of the numbers.
+    expect(screen.queryByText('Version')).not.toBeInTheDocument();
+  });
+
+  it('keeps the numbers it already had when a REFRESH fails', async () => {
+    render(<HealthSection />);
+    expect(await screen.findByText('137')).toBeInTheDocument();
+
+    mockedFetchHealth.mockRejectedValueOnce(new Error('offline'));
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh server status' }));
+
+    await screen.findByText('Could not read the server status. Press Refresh to try again.');
+    // Stale counts plus the warning beat a blank panel: the reader can see
+    // WHICH half is untrustworthy.
+    expect(screen.getByText('137')).toBeInTheDocument();
+  });
+
+  // ── refresh ───────────────────────────────────────────────────────
+
+  it('refetches on Refresh and renders the new numbers', async () => {
+    render(<HealthSection />);
+    expect(await screen.findByText('137')).toBeInTheDocument();
+
+    mockedFetchHealth.mockResolvedValue(
+      healthBody({
+        nodes_loaded: 140,
+        caches: { execution_cache: { bytes: 3 * 1024 * 1024, max_bytes_each: 512 * 1024 * 1024 } },
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh server status' }));
+
+    await waitFor(() => expect(mockedFetchHealth).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('140')).toBeInTheDocument();
+    expect(screen.getByText('3.0 MB of 512.0 MB')).toBeInTheDocument();
+  });
+
+  it('clears a previous failure once a refresh succeeds', async () => {
+    mockedFetchHealth.mockRejectedValueOnce(new Error('offline'));
+    render(<HealthSection />);
+    await screen.findByText('Could not read the server status. Press Refresh to try again.');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh server status' }));
+
+    expect(await screen.findByText('137')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Could not read the server status. Press Refresh to try again.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables Refresh while a read is in flight', async () => {
+    let release: (() => void) | undefined;
+    mockedFetchHealth.mockImplementationOnce(
+      () => new Promise((resolve) => { release = () => resolve(healthBody()); }),
+    );
+    render(<HealthSection />);
+    expect(screen.getByRole('button', { name: 'Refresh server status' })).toBeDisabled();
+    expect(screen.getByText('Reading the server…')).toBeInTheDocument();
+
+    release!();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Refresh server status' })).not.toBeDisabled());
+  });
+
+  it('does not write state after the popover closes mid-read', async () => {
+    let release: ((body: unknown) => void) | undefined;
+    mockedFetchHealth.mockImplementationOnce(
+      () => new Promise((resolve) => { release = resolve as (body: unknown) => void; }),
+    );
+    const { unmount } = render(<HealthSection />);
+    unmount();
+    // Resolving after unmount must be inert; a throw here would surface as an
+    // unhandled rejection in the run.
+    release!(healthBody());
+    await Promise.resolve();
+    expect(screen.queryByText('137')).not.toBeInTheDocument();
+  });
+
+  // ── zh-TW ─────────────────────────────────────────────────────────
+
+  it('renders the zh-TW strings, including the cache caption', async () => {
+    useI18n.setState({ locale: 'zh-TW' });
+    render(<HealthSection />);
+    expect(await screen.findByText('這台伺服器載入了什麼')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '重新讀取伺服器狀態' })).toBeInTheDocument();
+    expect(screen.getByText('版本')).toBeInTheDocument();
+    expect(screen.getByText('節點輸出（每個編輯器連線一份）')).toBeInTheDocument();
+    // The unit itself stays Latin: "2.0 MB" is how the budget is configured.
+    expect(screen.getByText('2.0 MB / 上限 512.0 MB')).toBeInTheDocument();
+    expect(screen.getByText(/這些存放伺服器已經算過的結果/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Toolbar/HealthSection.tsx
+++ b/frontend/src/components/Toolbar/HealthSection.tsx
@@ -62,6 +62,10 @@ export function HealthSection() {
   // fetch (different error handling, a missed cancel, etc.).
   const [attempt, setAttempt] = useState(0);
 
+  // StrictMode's double mount does issue this twice in dev; the first pass is
+  // cancelled by its own cleanup, so only the second writes state. Not worth a
+  // ref guard: two idempotent GETs of a status endpoint cost nothing, and the
+  // guard would be a second code path to keep correct.
   useEffect(() => {
     let cancelled = false;
     setBusy(true);

--- a/frontend/src/components/Toolbar/HealthSection.tsx
+++ b/frontend/src/components/Toolbar/HealthSection.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react';
+import { useI18n } from '../../i18n';
+import type { TranslationKey } from '../../i18n/locales/en';
+import { fetchHealth, type CacheUsage, type HealthInfo } from '../../api/rest';
+import { formatBytes } from '../../utils/formatBytes';
+import { SettingsRow } from './SettingsRow';
+import styles from './SettingsPopover.module.css';
+
+/**
+ * Human names for the stores `/api/health` reports.
+ *
+ * A map rather than a `settings.health.cache.${name}` template because `t()`
+ * takes a typed key, and because an unknown store must still be listed: the
+ * payload can grow a fourth store (the unbounded lm_blocks cache of #306 is
+ * one candidate), and a store this table has never heard of is more useful
+ * shown under its raw name than silently dropped from the list.
+ */
+const CACHE_LABEL_KEYS: Record<string, TranslationKey> = {
+  execution_cache: 'settings.health.cache.execution_cache',
+  run_output_store: 'settings.health.cache.run_output_store',
+  node_state_store: 'settings.health.cache.node_state_store',
+};
+
+/**
+ * First numeric value among `keys`, or undefined.
+ *
+ * The three stores do not agree on a budget key -- `max_bytes` for the
+ * run-output and node-state stores, `max_bytes_each` for the execution cache
+ * (one instance per WebSocket, so the total has no single ceiling). Checked at
+ * runtime rather than typed, because `CacheUsage` is deliberately an open map
+ * of whatever that store chose to report.
+ */
+function pick(usage: CacheUsage, ...keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = usage[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+/**
+ * The "This Server" section of the settings popover (#193 item 2).
+ *
+ * `/api/health` has reported the version, the registry counts and per-store
+ * cache bytes since #135, and the frontend read exactly one field of it
+ * (`project`, once, at bootstrap). Users on a bounded memory budget had no way
+ * to see how close they were.
+ *
+ * Fetched when this mounts, which is when the popover opens -- SettingsPopover
+ * returns null while closed, so "on open" needs no extra plumbing. No polling:
+ * the numbers do move during a run, but a panel that refetches on a timer
+ * while sitting open costs a request per interval for information nobody is
+ * necessarily reading. The Refresh button is the explicit ask instead.
+ */
+export function HealthSection() {
+  const { t } = useI18n();
+  const [health, setHealth] = useState<HealthInfo | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  // Bumped by Refresh. Re-running the same effect keeps one code path for the
+  // first read and every later one, so a refresh cannot drift from the mount
+  // fetch (different error handling, a missed cancel, etc.).
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setBusy(true);
+    fetchHealth()
+      .then((info) => {
+        if (cancelled) return;
+        setHealth(info);
+        setFailed(false);
+      })
+      .catch(() => {
+        // Inline, not a toast: the user is looking at this panel, and a toast
+        // for a number they opened a popover to read would outlive the popover.
+        if (!cancelled) setFailed(true);
+      })
+      .finally(() => {
+        if (!cancelled) setBusy(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [attempt]);
+
+  const caches = Object.entries(health?.caches ?? {});
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionTitle}>{t('toolbar.settings.section.system')}</div>
+
+      <SettingsRow
+        name={t('settings.health.name')}
+        desc={t('settings.health.desc')}
+        ctrl={
+          <button
+            type="button"
+            // The LLM section's button reads "Refresh" too; the sections tell
+            // them apart visually, an accessible name has to do it in words.
+            aria-label={t('settings.health.refreshAria')}
+            className={styles.action}
+            disabled={busy}
+            onClick={(e) => {
+              e.stopPropagation();
+              setAttempt((n) => n + 1);
+            }}
+          >
+            {t('settings.health.refresh')}
+          </button>
+        }
+      />
+
+      <div className={styles.health}>
+        {/* A failed refresh keeps the numbers it already had on screen: stale
+            counts plus "could not read" is more informative than a blank
+            panel, and says which half of the panel is untrustworthy. */}
+        {failed && (
+          <div className={styles.healthError} role="status">
+            {t('settings.health.failed')}
+          </div>
+        )}
+
+        {health === null ? (
+          !failed && <div className={styles.healthNote}>{t('settings.health.loading')}</div>
+        ) : (
+          <>
+            <div className={styles.healthStats}>
+              <Stat label={t('settings.health.version')} value={health.version ?? t('settings.health.unknown')} />
+              <Stat label={t('settings.health.nodes')} value={String(health.nodes_loaded)} />
+              <Stat label={t('settings.health.presets')} value={String(health.presets_loaded)} />
+            </div>
+
+            <div className={styles.healthLabel}>{t('settings.health.caches')}</div>
+            {caches.length === 0 ? (
+              // Reachable, not an error: the backend omits a store that is not
+              // running rather than reporting it as empty.
+              <div className={styles.healthNote}>{t('settings.health.cachesEmpty')}</div>
+            ) : (
+              <ul className={styles.cacheList}>
+                {caches.map(([name, usage]) => {
+                  const labelKey = CACHE_LABEL_KEYS[name];
+                  const used = formatBytes(pick(usage, 'bytes') ?? 0);
+                  const budget = pick(usage, 'max_bytes', 'max_bytes_each');
+                  return (
+                    <li key={name} className={styles.cacheRow}>
+                      <span className={styles.cacheName}>{labelKey ? t(labelKey) : name}</span>
+                      <span className={styles.cacheValue}>
+                        {budget === undefined
+                          ? used
+                          : t('settings.health.cacheOf', { used, budget: formatBytes(budget) })}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            <div className={styles.healthHint}>{t('settings.health.cachesHint')}</div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className={styles.healthStat}>
+      <span className={styles.healthStatLabel}>{label}</span>
+      <span className={styles.healthStatValue}>{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/Toolbar/HealthSection.tsx
+++ b/frontend/src/components/Toolbar/HealthSection.tsx
@@ -39,6 +39,23 @@ function pick(usage: CacheUsage, ...keys: string[]): number | undefined {
 }
 
 /**
+ * The store's configured ceiling, or undefined when it has none.
+ *
+ * Zero is NOT an exhausted budget: every store reads a falsy max as "no cap"
+ * -- `if not self._max_bytes: return` (run_output_store.py:93), `while
+ * (self._max_bytes and ...)` (node_state_store.py:149, cache.py:140/156) -- and
+ * `CODEFYUI_RUN_OUTPUT_STORE_MAX_MB` is a documented env var declared as a
+ * plain `int` with no lower bound, so a user can genuinely configure it. Read
+ * as a budget it would print "1.5 GB of 0 B", which says catastrophically over
+ * the limit when it means the exact opposite. Unbounded falls through to the
+ * bare-size rendering instead.
+ */
+function pickBudget(usage: CacheUsage): number | undefined {
+  const value = pick(usage, 'max_bytes', 'max_bytes_each');
+  return value !== undefined && value > 0 ? value : undefined;
+}
+
+/**
  * The "This Server" section of the settings popover (#193 item 2).
  *
  * `/api/health` has reported the version, the registry counts and per-store
@@ -145,7 +162,7 @@ export function HealthSection() {
                 {caches.map(([name, usage]) => {
                   const labelKey = CACHE_LABEL_KEYS[name];
                   const used = formatBytes(pick(usage, 'bytes') ?? 0);
-                  const budget = pick(usage, 'max_bytes', 'max_bytes_each');
+                  const budget = pickBudget(usage);
                   return (
                     <li key={name} className={styles.cacheRow}>
                       <span className={styles.cacheName}>{labelKey ? t(labelKey) : name}</span>

--- a/frontend/src/components/Toolbar/SettingsPopover.module.css
+++ b/frontend/src/components/Toolbar/SettingsPopover.module.css
@@ -318,3 +318,91 @@
   color: var(--text-disabled);
   font-weight: var(--fw-medium);
 }
+
+/* ----- "This Server" section (#193 item 2) -----
+   Shared with HealthSection.tsx, which renders that section: one stylesheet
+   per panel, one component per section (same split as InspectorPanel).
+   Read-only figures, so the whole block sits below the row's control column
+   rather than in it — a three-line cache list has nowhere to fit on the right
+   of a settings row. */
+.health {
+  padding: 0 var(--sp-5) var(--sp-2);
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+
+.healthStats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2) var(--sp-5);
+  padding-bottom: var(--sp-3);
+}
+
+.healthStat {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-2);
+}
+
+.healthStatLabel {
+  color: var(--text-muted);
+}
+
+.healthStatValue {
+  color: var(--text-primary);
+  font-weight: var(--fw-semibold);
+  /* Same-width digits so a refresh that changes a count does not shift the
+     labels beside it. */
+  font-variant-numeric: tabular-nums;
+}
+
+.healthLabel {
+  color: var(--text-secondary);
+  font-weight: var(--fw-semibold);
+  padding-bottom: var(--sp-2);
+}
+
+.cacheList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.cacheRow {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--sp-4);
+  align-items: baseline;
+}
+
+.cacheName {
+  color: var(--text-muted);
+  line-height: var(--lh-snug);
+}
+
+.cacheValue {
+  color: var(--text-secondary);
+  font-weight: var(--fw-medium);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.healthHint {
+  margin-top: var(--sp-3);
+  color: var(--text-muted);
+  line-height: var(--lh-normal);
+}
+
+.healthNote {
+  color: var(--text-muted);
+  padding-bottom: var(--sp-2);
+}
+
+.healthError {
+  color: var(--status-error);
+  line-height: var(--lh-normal);
+  padding-bottom: var(--sp-3);
+}

--- a/frontend/src/components/Toolbar/SettingsPopover.test.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.test.tsx
@@ -13,11 +13,21 @@ import {
   fetchCodexStatus,
   startCodexLogin,
   logoutCodex,
+  fetchHealth,
 } from '../../api/rest';
 import { computeSegmentNodes } from '../../utils/segmentPath';
 
 vi.mock('../../api/rest', () => ({
   resetWeights: vi.fn(),
+  // The "This Server" section reads /api/health when the popover opens
+  // (#193 item 2); its own behaviour is covered in HealthSection.test.tsx.
+  fetchHealth: vi.fn(() =>
+    Promise.resolve({
+      status: 'ok', version: '2.2.0', nodes_loaded: 137, presets_loaded: 12,
+      caches: { run_output_store: { runs: 0, bytes: 0, max_bytes: 1024 * 1024 } },
+      project: null,
+    }),
+  ),
   fetchCodexStatus: vi.fn(() => Promise.resolve({ status: 'logged_out' })),
   startCodexLogin: vi.fn(() => Promise.resolve({ auth_url: 'https://auth.example' })),
   logoutCodex: vi.fn(() => Promise.resolve({ status: 'logged_out' })),
@@ -95,6 +105,12 @@ describe('SettingsPopover', () => {
       globalDevice: 'cpu',
       edgeStyle: 'circuit',
     });
+    vi.mocked(fetchHealth).mockReset();
+    vi.mocked(fetchHealth).mockResolvedValue({
+      status: 'ok', version: '2.2.0', nodes_loaded: 137, presets_loaded: 12,
+      caches: { run_output_store: { runs: 0, bytes: 0, max_bytes: 1024 * 1024 } },
+      project: null,
+    });
     mockedFetchCodexStatus.mockResolvedValue({ status: 'logged_out' });
     mockedStartCodexLogin.mockResolvedValue({ auth_url: 'https://auth.example' });
     mockedLogoutCodex.mockResolvedValue({ status: 'logged_out' });
@@ -128,7 +144,22 @@ describe('SettingsPopover', () => {
     expect(screen.getByText('Recording & Inspection')).toBeInTheDocument();
     expect(screen.getByText('Training Behavior')).toBeInTheDocument();
     expect(screen.getByText('Editor')).toBeInTheDocument();
+    expect(screen.getByText('This Server')).toBeInTheDocument();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('the server section reads /api/health when the popover opens, not before', async () => {
+    // "Fetch on open" needs no plumbing: the popover renders nothing while
+    // closed, so the section does not exist to fetch (#193 item 2).
+    const { unmount } = render(
+      <SettingsPopover open={false} onClose={vi.fn()} triggerRef={makeTriggerRef()} />,
+    );
+    expect(vi.mocked(fetchHealth)).not.toHaveBeenCalled();
+    unmount();
+
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+    await waitFor(() => expect(vi.mocked(fetchHealth)).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('137')).toBeInTheDocument();
   });
 
 

--- a/frontend/src/components/Toolbar/SettingsPopover.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.tsx
@@ -15,6 +15,8 @@ import {
 import { computeSegmentNodes } from '../../utils/segmentPath';
 import { generateId } from '../../utils';
 import { confirm } from '../../utils/dialog';
+import { HealthSection } from './HealthSection';
+import { SettingsRow as Row } from './SettingsRow';
 import styles from './SettingsPopover.module.css';
 
 interface Props {
@@ -610,39 +612,11 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
             }
           />
         </section>
-      </div>
-    </div>
-  );
-}
 
-interface RowProps {
-  name: string;
-  desc: string;
-  ctrl: React.ReactNode;
-  onClick?: () => void;
-  disabled?: boolean;
-}
-
-function Row({ name, desc, ctrl, onClick, disabled }: RowProps) {
-  const interactive = onClick !== undefined;
-  return (
-    <div
-      className={`${styles.row} ${interactive ? styles.interactive : ''} ${disabled ? styles.disabled : ''}`}
-      onClick={onClick}
-      role={interactive ? 'button' : undefined}
-      tabIndex={interactive ? 0 : undefined}
-      onKeyDown={(e) => {
-        if (interactive && (e.key === 'Enter' || e.key === ' ')) {
-          e.preventDefault();
-          onClick?.();
-        }
-      }}
-    >
-      <div>
-        <div className={styles.name}>{name}</div>
-        <div className={styles.desc}>{desc}</div>
+        {/* Last, and read-only: everything above changes how a run behaves,
+            this only reports what the server already is (#193 item 2). */}
+        <HealthSection />
       </div>
-      <div className={styles.ctrl}>{ctrl}</div>
     </div>
   );
 }

--- a/frontend/src/components/Toolbar/SettingsRow.tsx
+++ b/frontend/src/components/Toolbar/SettingsRow.tsx
@@ -1,0 +1,43 @@
+import styles from './SettingsPopover.module.css';
+
+interface RowProps {
+  name: string;
+  desc: string;
+  ctrl: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * One "name / description / control" line of the settings popover.
+ *
+ * Extracted from SettingsPopover.tsx when the "This Server" section moved into
+ * its own component (#193 item 2): both files need this row, and importing it
+ * back out of SettingsPopover would have made the two modules import each
+ * other. The markup is unchanged — a row with no `onClick` stays
+ * non-interactive (no role, no tab stop), which is what the panel's
+ * read-only rows rely on.
+ */
+export function SettingsRow({ name, desc, ctrl, onClick, disabled }: RowProps) {
+  const interactive = onClick !== undefined;
+  return (
+    <div
+      className={`${styles.row} ${interactive ? styles.interactive : ''} ${disabled ? styles.disabled : ''}`}
+      onClick={onClick}
+      role={interactive ? 'button' : undefined}
+      tabIndex={interactive ? 0 : undefined}
+      onKeyDown={(e) => {
+        if (interactive && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
+    >
+      <div>
+        <div className={styles.name}>{name}</div>
+        <div className={styles.desc}>{desc}</div>
+      </div>
+      <div className={styles.ctrl}>{ctrl}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/Toolbar/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.test.tsx
@@ -40,6 +40,13 @@ vi.mock('../../api/rest', () => ({
   fetchCodexStatus: vi.fn(() => Promise.resolve({ status: 'logged_out' })),
   startCodexLogin: vi.fn(() => Promise.resolve({ auth_url: 'https://auth.example' })),
   logoutCodex: vi.fn(() => Promise.resolve({ status: 'logged_out' })),
+  // Used by the popover's "This Server" section (#193 item 2)
+  fetchHealth: vi.fn(() =>
+    Promise.resolve({
+      status: 'ok', version: '2.2.0', nodes_loaded: 0, presets_loaded: 0,
+      caches: {}, project: null,
+    }),
+  ),
 }));
 
 const mockedRest = vi.mocked(rest);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -480,6 +480,7 @@ const en = {
   'toolbar.settings.section.training': 'Training Behavior',
   'toolbar.settings.section.editor': 'Editor',
   'toolbar.settings.section.llm': 'LLM Providers',
+  'toolbar.settings.section.system': 'This Server',
   'settings.device.name': 'Compute device',
   'settings.device.desc': 'Run the graph on this device. Nodes set to "auto" follow it.',
 
@@ -536,6 +537,29 @@ const en = {
   'settings.codex.signInFailed': 'Codex sign-in failed',
   'settings.codex.logoutFailed': 'Codex sign-out failed',
   'settings.codex.statusFailed': 'Codex status check failed',
+
+  // "This Server" section (#193 item 2). /api/health has reported all of this
+  // since #135; until now nothing in the editor showed it.
+  'settings.health.name': 'What this server has loaded',
+  'settings.health.desc': 'The version you are running, and how much memory its caches are holding right now.',
+  'settings.health.refresh': 'Refresh',
+  // The Codex row's button is also called "Refresh", and the two are only
+  // distinguishable by which section they sit in — which a screen reader does
+  // not read out. The accessible name says which one this is.
+  'settings.health.refreshAria': 'Refresh server status',
+  'settings.health.loading': 'Reading the server…',
+  'settings.health.failed': 'Could not read the server status. Press Refresh to try again.',
+  'settings.health.version': 'Version',
+  'settings.health.nodes': 'Nodes',
+  'settings.health.presets': 'Presets',
+  'settings.health.unknown': 'unknown',
+  'settings.health.caches': 'Caches',
+  'settings.health.cachesEmpty': 'No caches are running yet.',
+  'settings.health.cachesHint': 'These hold results the server already computed so a re-run can skip the work; none of it is your saved graphs or files. Clearing one costs recompute time — for the weight cache that means training time, unless you saved a checkpoint.',
+  'settings.health.cache.execution_cache': 'Node outputs (per editor connection)',
+  'settings.health.cache.run_output_store': 'Recorded run outputs',
+  'settings.health.cache.node_state_store': 'Layer weights kept between runs',
+  'settings.health.cacheOf': '{used} of {budget}',
   // LLM
   'tokenizer.tokenCount': '{count} tokens',
   'tokenizer.emptyOutput': 'No tokens — input text was empty.',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -465,6 +465,7 @@ const zhTW: Record<TranslationKey, string> = {
   'toolbar.settings.section.training': '訓練行為',
   'toolbar.settings.section.editor': '編輯器',
   'toolbar.settings.section.llm': 'LLM 提供者',
+  'toolbar.settings.section.system': '這台伺服器',
   'settings.device.name': '運算裝置',
   'settings.device.desc': '在此裝置上執行圖。設為「auto」的節點會跟隨此設定。',
 
@@ -521,6 +522,26 @@ const zhTW: Record<TranslationKey, string> = {
   'settings.codex.signInFailed': 'Codex 登入失敗',
   'settings.codex.logoutFailed': 'Codex 登出失敗',
   'settings.codex.statusFailed': 'Codex 狀態檢查失敗',
+
+  // 「這台伺服器」區塊（#193 第 2 項）。這些數字 /api/health 從 #135 就一直在
+  // 回報，只是編輯器裡一直沒有地方顯示。
+  'settings.health.name': '這台伺服器載入了什麼',
+  'settings.health.desc': '你正在使用的版本，以及它的快取目前占用了多少記憶體。',
+  'settings.health.refresh': '重新讀取',
+  'settings.health.refreshAria': '重新讀取伺服器狀態',
+  'settings.health.loading': '正在讀取伺服器資訊…',
+  'settings.health.failed': '讀不到伺服器狀態。按「重新讀取」再試一次。',
+  'settings.health.version': '版本',
+  'settings.health.nodes': '節點',
+  'settings.health.presets': '預設組合',
+  'settings.health.unknown': '未知',
+  'settings.health.caches': '快取',
+  'settings.health.cachesEmpty': '目前沒有任何快取在運作。',
+  'settings.health.cachesHint': '這些存放伺服器已經算過的結果，讓下次執行可以跳過重算；裡面不會有你存下來的圖或檔案。清掉的代價是重算的時間 — 權重那一項則是重新訓練的時間，除非你存過 checkpoint。',
+  'settings.health.cache.execution_cache': '節點輸出（每個編輯器連線一份）',
+  'settings.health.cache.run_output_store': '已錄製的執行輸出',
+  'settings.health.cache.node_state_store': '在多次執行間保留的層權重',
+  'settings.health.cacheOf': '{used} / 上限 {budget}',
   // LLM
   'tokenizer.tokenCount': '{count} 個 token',
   'tokenizer.emptyOutput': '沒有 token — 輸入文字為空。',

--- a/frontend/src/utils/formatBytes.test.ts
+++ b/frontend/src/utils/formatBytes.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from './formatBytes';
+
+describe('formatBytes', () => {
+  it('reads an empty store as zero bytes, not as an empty string', () => {
+    // The health panel renders this straight into a value column, so "nothing
+    // cached" has to look like a number the reader can compare against the
+    // budget next to it.
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('keeps sub-kilobyte sizes in whole bytes', () => {
+    expect(formatBytes(1)).toBe('1 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('switches to KB at exactly 1024 bytes', () => {
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('switches to MB at exactly 1024 KB', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(512 * 1024 * 1024)).toBe('512.0 MB');
+  });
+
+  it('switches to GB at exactly 1024 MB, and to TB above that', () => {
+    expect(formatBytes(1024 ** 3)).toBe('1.0 GB');
+    expect(formatBytes(3 * 1024 ** 3 + 512 * 1024 ** 2)).toBe('3.5 GB');
+    expect(formatBytes(1024 ** 4)).toBe('1.0 TB');
+  });
+
+  it('promotes a value that would round up into the next unit', () => {
+    // 1048575 B is 1023.999… KB. One decimal place prints that as
+    // "1024.0 KB" -- a number nobody expects to see in a KB column, so the
+    // unit is promoted once more instead.
+    expect(formatBytes(1024 * 1024 - 1)).toBe('1.0 MB');
+    expect(formatBytes(1024 - 1)).toBe('1023 B');
+  });
+
+  it('stays in TB rather than inventing a unit it has no name for', () => {
+    expect(formatBytes(1024 ** 5)).toBe('1024.0 TB');
+  });
+
+  it('renders a missing or nonsensical number as zero rather than NaN', () => {
+    // /api/health omits a store that is not running, so a caller can hand this
+    // `undefined.bytes`; "NaN B" in the panel would read as a bug in the
+    // server rather than a gap in the payload.
+    expect(formatBytes(Number.NaN)).toBe('0 B');
+    expect(formatBytes(Number.POSITIVE_INFINITY)).toBe('0 B');
+    expect(formatBytes(-1)).toBe('0 B');
+  });
+});

--- a/frontend/src/utils/formatBytes.ts
+++ b/frontend/src/utils/formatBytes.ts
@@ -1,0 +1,38 @@
+/** Byte counts, for humans.
+ *
+ * Binary steps (1024) with the short KB/MB/GB names rather than KiB/MiB/GiB,
+ * because the numbers this formats come from `/api/health`, and the budgets
+ * there are configured in the same units: `EXECUTION_CACHE_MAX_MB * 1024 *
+ * 1024` (backend/app/core/cache.py). Dividing by 1000 instead would render a
+ * configured 512 MB ceiling as "536.9 MB", which reads as the app
+ * misreporting the setting rather than as a unit convention.
+ *
+ * There is no house formatter to reuse -- this is the first place in the
+ * frontend that shows a size (#193 item 2).
+ */
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB'] as const;
+
+export function formatBytes(bytes: number): string {
+  // A store that is not running is omitted from the health payload entirely,
+  // so a caller reading `caches.x?.bytes` can land here with undefined ->
+  // NaN. "NaN B" in a settings panel reads as a broken server; zero is the
+  // honest rendering of "nothing to report".
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+
+  let value = bytes;
+  let unit = 0;
+  while (unit < UNITS.length - 1 && value >= 1024) {
+    value /= 1024;
+    unit += 1;
+  }
+  // 1048575 B settles at 1023.999… KB, and one decimal place would print that
+  // as "1024.0 KB". Promote on the ROUNDED value, not the raw one, so the
+  // printed number never reaches the next unit's threshold.
+  if (unit < UNITS.length - 1 && Number(value.toFixed(1)) >= 1024) {
+    value /= 1024;
+    unit += 1;
+  }
+  // Whole bytes below 1 KB: a tenth of a byte is not a quantity, and every
+  // byte count the backend sends is an integer.
+  return unit === 0 ? `${Math.round(value)} B` : `${value.toFixed(1)} ${UNITS[unit]}`;
+}


### PR DESCRIPTION
## What

`/api/health` has reported the running version, the registry counts and a per-store cache byte breakdown since #135. The frontend read exactly **one** field of it — `project`, once, at bootstrap — and dropped the rest. A user on a bounded memory budget had no way to see how close they were; a bug reporter had no way to state their version from inside the editor.

This adds a **"This Server"** section at the bottom of the settings popover (the gear), showing the version, node count, preset count, and each cache store's usage against its budget. Backend untouched.

Closes #193 — item 2 was the last one open (items 1 and 3-6 were settled in #281).

## Design decisions

- **Fetch on open, not a poll.** `SettingsPopover` renders nothing while closed, so the section only exists while the popover is on screen — "on open" needed no extra plumbing. The numbers do move during a run, but a timer costs a request per interval for figures nobody is necessarily reading; Refresh is the explicit ask instead.
- **A failed read keeps the numbers it already had**, with an inline line above them. Stale counts plus "could not read" says *which half* of the panel is untrustworthy; a blank panel says nothing. Inline rather than a toast, which would outlive the popover it belongs to.
- **`CacheUsage` is an open map of numbers, not a named-field interface.** The three stores do not share a shape: the budget is `max_bytes` for the run-output and node-state stores but `max_bytes_each` for the execution cache (one instance per WebSocket, so the total has no single ceiling), and the item count is `entries` / `runs` / `modules`. An unknown store name is listed under its raw name rather than dropped, so a fourth cache needs no change here.
- **`formatBytes` steps by 1024 and still says KB/MB/GB**, because the budgets it prints are configured that way (`EXECUTION_CACHE_MAX_MB * 1024 * 1024`). Dividing by 1000 would render a configured 512 MB ceiling as "536.9 MB", which reads as the app misreporting the setting. It promotes on the *rounded* value, so 1048575 B prints `1.0 MB` rather than `1024.0 KB`.
- **The caption stops short of the tidy version of "it's only derived data".** The node-state store holds *trained* weights, so clearing that one costs training time, not a recompute — the caption says so, and points at checkpoints.
- **`Row` moved to `SettingsRow.tsx`.** Both the popover and the new section need it; importing it back out of `SettingsPopover` would have made the two modules import each other. Markup unchanged, so the existing row tests still pin the same DOM.
- **The Refresh button carries an `aria-label`.** The LLM section's button is also called "Refresh", and only the section they sit in tells them apart — which a screen reader does not read out.

## Tests

- `formatBytes.test.ts` — 0 / sub-KB / KB / MB / GB / TB boundaries, the round-up promotion, the TB cap, and NaN/negative rendering as `0 B` (a missing store key must not print "NaN B").
- `HealthSection.test.tsx` — renders version + counts + all three stores from a mocked fetch; `max_bytes` and `max_bytes_each` both resolve to one "used of budget" line; a store with no budget; an unknown store name; an empty `caches` map; a missing `version`; the failure path (inline, no toast); a failed *refresh* keeping the old numbers; refresh refetching and re-rendering; Refresh disabled in flight; no state write after unmount; the zh-TW strings including the caption.
- `SettingsPopover.test.tsx` — the section is not fetched while the popover is closed, and is once it opens.
- `rest.test.ts` — `caches` normalizes to `{}` and `version` to `null` when absent; per-store keys pass through untouched.

## Gates

`pnpm exec tsc -b`, `pnpm test` (142 files / 3259 tests), `pnpm build` (includes `check-contrast`), `python scripts/check_control_bytes.py`, `uvx ruff@0.14.4 check .` — all green.

## Verified in Chrome

Against a live server started from this worktree (`CODEFYUI_PORT=8199`, freshly built dist):

- gear → the section shows `Version 2.2.0 / Nodes 139 / Presets 3` and the three real budgets (`0 B of 1.0 GB`, `0 B of 2.0 GB`, `0 B of 1.0 GB`), matching the raw `/api/health` body;
- Refresh issues exactly one new `/api/health` (counted with a `fetch` wrapper);
- both locales render (zh-TW `這台伺服器` … `0 B / 上限 1.0 GB`, and English);
- killing the backend and pressing Refresh shows the inline failure with the previous numbers left in place, and no toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYmF5XjhQStu2K6swHp2XX
