### PR TITLE
ci: run backend and frontend checks on every PR, not just path-matched ones (#270)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -9,20 +9,13 @@ name: Backend Tests
 #   3. Test failures introduced in PRs that don't touch the install path
 #      (the existing install-check workflow only fires on releases).
 #   4. Plugin-SDK drift. `tests/test_plugin_dx.py` guards the scaffold and the
-#      vendored copy of the plugin contract, so it has to fire for changes to
-#      `scripts/` and to the contract itself — neither of which lives under
-#      `backend/`. Without those two paths the drift check could only ever
-#      fail locally, which is the same as not having it.
+#      vendored copy of the plugin contract, which live outside `backend/` —
+#      one more reason the workflow runs on every PR rather than a path subset.
 on:
+  # No path filter on pull_request: these checks are required by the main
+  # branch ruleset, and a filtered-out workflow never reports, which would
+  # leave the PR's merge button waiting forever. Every PR runs everything.
   pull_request:
-    paths:
-      - 'backend/**'
-      - 'examples/**'
-      - 'plugins/**'
-      - 'scripts/**'
-      - 'frontend/src/plugins/contract.ts'
-      - 'ruff.toml'
-      - '.github/workflows/backend-test.yml'
   push:
     branches:
       - main

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,13 +1,13 @@
 name: Frontend Build Check
 
-# Verify the frontend builds + types + tests cleanly on every PR touching it
-# and on every push to main. Catches regressions before they hit a release tag,
+# Verify the frontend builds + types + tests cleanly on every PR and on
+# every push to main. Catches regressions before they hit a release tag,
 # so `release-build.yml` is never the first place to discover a broken build.
 on:
+  # No path filter on pull_request: this check is required by the main
+  # branch ruleset, and a filtered-out workflow never reports, which would
+  # leave the PR's merge button waiting forever. Every PR runs everything.
   pull_request:
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-build.yml'
   push:
     branches:
       - main


### PR DESCRIPTION
The main-branch ruleset now requires all eight checks to report (the maintainer-side half of #270, done today). A required check that a path filter kept from running never reports, which leaves the merge button waiting forever - a docs-only PR would be unmergeable.

This drops the `pull_request` path filters on `backend-test.yml` and `frontend-build.yml` so every PR produces every required check. Push-to-main triggers keep their filters since nothing gates on those runs. Header comments updated where they explained the old path lists.

#270 stays open until this merges and is verified, then gets closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYmF5XjhQStu2K6swHp2XX