### PR TITLE
fix(ui): sidebar examples are dragged onto the canvas, not detonated on it (#348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,24 @@ received — each links to the release it was published as.
 
 ### Fixed
 
+- **Clicking a sidebar example destroyed the graph you were working on, with
+  nothing to undo** ([#348]). The Templates tab sent every click through
+  `openExample`, which replaces the active tab's nodes, edges, subgraphs,
+  description, save binding and tab name in one commit and — by design —
+  pushes no undo frame. So a stray click on a list of ~30 examples took
+  however long you had spent on the canvas with it, and Ctrl+Z did nothing,
+  because from the undo stack's point of view nothing had happened. The hint
+  under the list advertised exactly that behaviour: "Click an example to open
+  it". Examples now **join** the canvas the way every other palette item
+  does. Drag one out of the sidebar and it lands where you release the
+  pointer, without the camera moving off the gesture that just finished;
+  click one and it lands clear of the graph already there, with the viewport
+  brought onto it. Either way the ids are remapped so nothing on the canvas
+  can be overwritten, the tab keeps its own name, description and save
+  target, and one Ctrl+Z takes the whole block back off. A template written
+  by a newer CodefyUI is still refused, on the drag path as well as the
+  click.
+
 - **An unhandled `/api` path answered `405 Method Not Allowed` on every real
   installation, and `404` in CI** ([#285]). The catch-all that serves the built
   frontend is registered only when `frontend/dist/index.html` exists, and it
@@ -1040,6 +1058,7 @@ Release candidates before 1.0.0 are on the
 [#288]: https://github.com/CodefyUI/CodefyUI/issues/288
 [#292]: https://github.com/CodefyUI/CodefyUI/issues/292
 [#175]: https://github.com/CodefyUI/CodefyUI/issues/175
+[#348]: https://github.com/CodefyUI/CodefyUI/issues/348
 [#200]: https://github.com/CodefyUI/CodefyUI/issues/200
 [@oyea0801]: https://github.com/oyea0801
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.2.0...main

--- a/frontend/src/components/Canvas/EmptyCanvasOverlay.tsx
+++ b/frontend/src/components/Canvas/EmptyCanvasOverlay.tsx
@@ -153,8 +153,10 @@ export function EmptyCanvasOverlay() {
 
   const sections = groupExamples(examples);
 
-  // Loading an example lives in `utils/openExample` so the sidebar's
-  // Templates tab (#126) opens one identically.
+  // Still the REPLACING reader, and the only one left (#348): this overlay
+  // is shown when the canvas is empty, so there is nothing for a replace to
+  // take. The sidebar's Templates tab and the gallery modal both insert
+  // instead, because they are reachable while a graph is on screen.
   const handleClick = useCallback(
     (example: ExampleSummary) => void openExample(example.path),
     [],

--- a/frontend/src/components/Sidebar/TemplatesTab.test.tsx
+++ b/frontend/src/components/Sidebar/TemplatesTab.test.tsx
@@ -8,15 +8,28 @@ import { useI18n } from '../../i18n';
 import * as rest from '../../api/rest';
 import type { ExampleSummary } from '../../api/rest';
 
-// Only the two network calls are stubbed; `openExample` runs for real so the
-// "opens an example the same way the gallery does" contract is exercised end
-// to end rather than mocked away.
+// Only the two network calls are stubbed; `insertExample` runs for real so
+// the "an example joins the canvas the same way the gallery inserts one"
+// contract is exercised end to end rather than mocked away.
 vi.mock('../../api/rest', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../api/rest')>();
   return { ...actual, listExamples: vi.fn(), loadExample: vi.fn() };
 });
 
 const mockedRest = vi.mocked(rest);
+
+const activeTab = () => useTabStore.getState().getActiveTab();
+
+/** A serialized example node, in the shape `/api/examples/load` returns. */
+function rawNode(id: string) {
+  return { id, type: 'Dropout', position: { x: 0, y: 0 }, data: { params: {} } };
+}
+
+/** A single empty tab named "Tab 1", so insertion assertions start from zero. */
+function freshTab() {
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string });
+  useTabStore.getState().addTab('Tab 1');
+}
 
 function ex(overrides: Partial<ExampleSummary> = {}): ExampleSummary {
   return {
@@ -76,7 +89,9 @@ describe('TemplatesTab', () => {
     await waitFor(() => expect(screen.queryByText('Loading examples...')).toBeNull());
     expect(screen.getByText('Templates')).toBeTruthy();
     expect(screen.getByPlaceholderText('Search examples...')).toBeTruthy();
-    expect(screen.getByText('Click an example to open it')).toBeTruthy();
+    expect(
+      screen.getByText('Drag an example onto the canvas, or click to add it'),
+    ).toBeTruthy();
   });
 
   it('lists examples grouped by category, with the node count', async () => {
@@ -139,38 +154,94 @@ describe('TemplatesTab', () => {
     await screen.findByText('Newly installed');
   });
 
-  it('clicking an example loads it into the active tab (same path as the gallery)', async () => {
+  // -- #348: an example JOINS the canvas; it never replaces it --
+
+  it('clicking an example inserts it into the canvas instead of replacing it', async () => {
+    freshTab();
+    useTabStore.getState().setNodes([
+      { id: 'mine', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'MINE', type: 'K', params: {} } },
+    ] as never);
     mockedRest.listExamples.mockResolvedValue([
       ex({ name: 'Loadable', path: 'Usage_Example/Loadable' }),
     ]);
     mockedRest.loadExample.mockResolvedValue({
       name: '  My Model  ',
-      nodes: [],
+      nodes: [rawNode('a'), rawNode('b')],
       edges: [],
     });
-    // The whole document goes in through one store action (#200 items 4
-    // and 8), so there is one call to assert on instead of three.
-    const loadGraphDocument = vi.fn();
-    useTabStore.setState({ loadGraphDocument });
 
     render(<TemplatesTab />);
     fireEvent.click(await screen.findByText('Loadable'));
 
-    await waitFor(() => expect(loadGraphDocument).toHaveBeenCalled());
+    await waitFor(() => expect(activeTab().nodes).toHaveLength(3));
     expect(mockedRest.loadExample).toHaveBeenCalledWith('Usage_Example/Loadable');
-    // The trimmed example name is mirrored onto the tab.
-    expect(loadGraphDocument).toHaveBeenCalledWith(
-      expect.objectContaining({ nodes: [], edges: [], name: 'My Model' }),
+    // The user's own node is still there, still under its own id.
+    expect(activeTab().nodes.find((n) => n.id === 'mine')!.data.label).toBe('MINE');
+    // ...and the example's name did NOT take over the tab, because the tab
+    // still holds the user's graph.
+    expect(activeTab().name).toBe('Tab 1');
+  });
+
+  it('a click is one undo step away from the canvas that was there', async () => {
+    freshTab();
+    useTabStore.getState().setNodes([
+      { id: 'mine', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'MINE', type: 'K', params: {} } },
+    ] as never);
+    mockedRest.listExamples.mockResolvedValue([ex({ name: 'Loadable' })]);
+    mockedRest.loadExample.mockResolvedValue({
+      nodes: [rawNode('a'), rawNode('b')],
+      edges: [{ id: 'e1', source: 'a', target: 'b', sourceHandle: 'tensor', targetHandle: 'tensor' }],
+    });
+
+    render(<TemplatesTab />);
+    fireEvent.click(await screen.findByText('Loadable'));
+    await waitFor(() => expect(activeTab().nodes).toHaveLength(3));
+
+    useTabStore.getState().undo();
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['mine']);
+    expect(activeTab().edges).toHaveLength(0);
+  });
+
+  it('inserts from the keyboard, so the drag is an enhancement and not the way in', async () => {
+    freshTab();
+    mockedRest.listExamples.mockResolvedValue([ex({ name: 'Reachable' })]);
+    mockedRest.loadExample.mockResolvedValue({ nodes: [rawNode('a')], edges: [] });
+
+    render(<TemplatesTab />);
+    const item = (await screen.findByRole('button', { name: /Reachable/ }));
+    fireEvent.keyDown(item, { key: 'Enter' });
+
+    await waitFor(() => expect(activeTab().nodes).toHaveLength(1));
+  });
+
+  it('makes every example draggable, carrying its path', async () => {
+    mockedRest.listExamples.mockResolvedValue([
+      ex({ name: 'Draggable', path: 'Usage_Example/Drag' }),
+    ]);
+    render(<TemplatesTab />);
+    const item = (await screen.findByText('Draggable')).closest('[draggable]') as HTMLElement;
+    expect(item).toBeTruthy();
+
+    const setData = vi.fn();
+    const dt: any = { setData, effectAllowed: '' };
+    fireEvent.dragStart(item, { dataTransfer: dt });
+
+    expect(setData).toHaveBeenCalledWith(
+      'application/codefyui-example',
+      'Usage_Example/Drag',
     );
+    expect(dt.effectAllowed).toBe('move');
   });
 
   it('surfaces a load failure as a toast and leaves the graph alone', async () => {
+    freshTab();
+    useTabStore.getState().setNodes([
+      { id: 'mine', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'MINE', type: 'K', params: {} } },
+    ] as never);
     mockedRest.listExamples.mockResolvedValue([ex({ name: 'Broken' })]);
     mockedRest.loadExample.mockRejectedValue(new Error('nope'));
-    const loadGraphDocument = vi.fn();
     const addToast = vi.fn();
     useToastStore.setState({ addToast });
-    useTabStore.setState({ loadGraphDocument });
 
     render(<TemplatesTab />);
     fireEvent.click(await screen.findByText('Broken'));
@@ -178,7 +249,7 @@ describe('TemplatesTab', () => {
     await waitFor(() =>
       expect(addToast).toHaveBeenCalledWith('Failed to load example', 'error'),
     );
-    expect(loadGraphDocument).not.toHaveBeenCalled();
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['mine']);
   });
 
   it('offers a jump index across example categories', async () => {

--- a/frontend/src/components/Sidebar/TemplatesTab.tsx
+++ b/frontend/src/components/Sidebar/TemplatesTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { listExamples, type ExampleSummary } from '../../api/rest';
-import { openExample } from '../../utils/openExample';
+import { insertExample } from '../../utils/openExample';
 import { useUIStore } from '../../store/uiStore';
 import { useI18n } from '../../i18n';
 import { EXAMPLE_CATEGORY_COLORS, EXAMPLE_CATEGORY_FALLBACK } from '../../styles/theme';
@@ -47,13 +47,53 @@ export function groupExamplesByCategory(
 
 // ── Example item ──
 
+/**
+ * One example, as a drag source (#348).
+ *
+ * Both gestures INSERT: dragging drops the block where the pointer was
+ * released, clicking puts it below the graph already on the canvas. Neither
+ * replaces anything, and either is one Ctrl+Z from the canvas as it was.
+ *
+ * This used to call `openExample`, which routes to `loadGraphDocument` — an
+ * action that swaps out the tab's nodes, edges, subgraphs, description and
+ * save binding in one commit and, by design, pushes no undo frame. So a
+ * stray click on a list of ~30 examples destroyed however long the user had
+ * spent on the graph, with nothing to undo. Nothing about the sidebar
+ * suggested that; the hint underneath it read "Click an example to open it".
+ *
+ * A `<div>` carrying button semantics rather than a real `<button>`, which is
+ * what this was: `draggable` is reliable on a plain div in every engine (it
+ * is how the Nodes and Presets tabs have always dragged), and is not on a
+ * button — Firefox has ignored the attribute there for years. The semantics
+ * a button was providing are restored explicitly, because clicking is a real
+ * action here and the drag has to stay an enhancement rather than the only
+ * way in: `role`, `tabIndex`, and Enter/Space activation.
+ */
 function ExampleItem({ example }: { example: ExampleSummary }) {
   const { t } = useI18n();
+  const insert = () => void insertExample(example.path);
+  const handleDragStart = (event: React.DragEvent) => {
+    // The path, not the resolved graph: the drop handler does the fetch, so
+    // opening the Templates tab does not pull ~30 example files off the
+    // server just in case one of them gets dragged.
+    event.dataTransfer.setData('application/codefyui-example', example.path);
+    event.dataTransfer.effectAllowed = 'move';
+  };
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
+      draggable
+      onDragStart={handleDragStart}
       className={tabStyles.exampleItem}
-      onClick={() => void openExample(example.path)}
+      onClick={insert}
+      onKeyDown={(event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        // Space would scroll the panel out from under the list otherwise,
+        // which is the default a real <button> was suppressing for us.
+        event.preventDefault();
+        insert();
+      }}
       title={example.description}
     >
       <div className={tabStyles.exampleName}>{example.name}</div>
@@ -63,7 +103,7 @@ function ExampleItem({ example }: { example: ExampleSummary }) {
       <div className={tabStyles.exampleMeta}>
         {t('empty.nodeCount', { count: example.node_count })}
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -75,10 +115,10 @@ function ExampleItem({ example }: { example: ExampleSummary }) {
  *
  * Deliberately thumbnail-less: this is the always-available list view, and the
  * richer gallery is the empty-canvas overlay's job — and core#128's modal,
- * which the footer button below opens. Both call the same `openExample`
- * helper this does, so an example opens the same way from every surface, and
- * both group by category through `groupExamplesByCategory` (exported for
- * exactly that reason) so the two never drift out of order.
+ * which the footer button below opens. All three group by category through
+ * `groupExamplesByCategory` (exported for exactly that reason) so they never
+ * drift out of order, and this tab and the modal now share `insertExample`
+ * (#348) so an example joins the canvas the same way from either.
  *
  * Examples are fetched per mount rather than cached in a store: the sidebar
  * only mounts this tab while it is the selected one, and the list changes

--- a/frontend/src/hooks/useDragAndDrop.test.ts
+++ b/frontend/src/hooks/useDragAndDrop.test.ts
@@ -1,8 +1,20 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useDragAndDrop } from './useDragAndDrop';
 import { useTabStore } from '../store/tabStore';
 import { useNodeDefStore } from '../store/nodeDefStore';
+import * as rest from '../api/rest';
+
+// Only the example fetch is stubbed. The drop then runs the real
+// `insertExample` -> `insertGraph` chain, which is the point: what this hook
+// has to get right is the POSITION it hands over, and a mocked insert would
+// assert nothing about where the block actually lands.
+vi.mock('../api/rest', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/rest')>();
+  return { ...actual, loadExample: vi.fn() };
+});
+
+const mockedRest = vi.mocked(rest);
 
 // Mock @xyflow/react so useReactFlow returns a controllable screenToFlowPosition.
 // Identity transform keeps the asserted positions simple.
@@ -49,6 +61,7 @@ function makeDragEvent(data: Record<string, string> = {}) {
 
 beforeEach(() => {
   screenToFlowPosition.mockClear();
+  mockedRest.loadExample.mockReset();
   // Seed node-def store with one preset + one definition.
   useNodeDefStore.setState({
     definitions: [defA],
@@ -136,8 +149,61 @@ describe('useDragAndDrop - onDrop node branch', () => {
     result.current.onDrop(event);
 
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
-    // Both keys consulted, but no node added.
-    expect(event.dataTransfer.getData).toHaveBeenCalledTimes(2);
+    // All three keys consulted, but no node added.
+    expect(event.dataTransfer.getData).toHaveBeenCalledTimes(3);
+    expect(activeNodes()).toHaveLength(0);
+  });
+});
+
+describe('useDragAndDrop - onDrop example branch (#348)', () => {
+  it('inserts the dropped example with its top-left at the pointer', async () => {
+    mockedRest.loadExample.mockResolvedValue({
+      nodes: [
+        { id: 'a', type: 'Dropout', position: { x: 700, y: 700 }, data: { params: {} } },
+      ],
+      edges: [],
+    });
+    const { result } = renderHook(() => useDragAndDrop());
+    const event = makeDragEvent({ 'application/codefyui-example': 'Usage_Example/Foo' });
+
+    result.current.onDrop(event);
+
+    await waitFor(() => expect(activeNodes()).toHaveLength(1));
+    expect(mockedRest.loadExample).toHaveBeenCalledWith('Usage_Example/Foo');
+    // clientX/clientY are 10/20 and screenToFlowPosition is the identity.
+    expect(activeNodes()[0].position).toEqual({ x: 10, y: 20 });
+  });
+
+  it('reads the path and the point BEFORE awaiting the fetch', async () => {
+    // A DataTransfer is only readable during the event that carries it, so an
+    // implementation that reaches for `event.dataTransfer` after its first
+    // await gets nothing -- and the drop silently does nothing.
+    mockedRest.loadExample.mockResolvedValue({
+      nodes: [{ id: 'a', type: 'Dropout', position: { x: 0, y: 0 }, data: { params: {} } }],
+      edges: [],
+    });
+    const { result } = renderHook(() => useDragAndDrop());
+    const event = makeDragEvent({ 'application/codefyui-example': 'Usage_Example/Foo' });
+
+    result.current.onDrop(event);
+    // The handler has returned; the browser would have emptied the transfer
+    // by now and the pointer would have moved on.
+    (event.dataTransfer.getData as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('dataTransfer read outside its own event');
+    });
+    Object.defineProperty(event, 'clientX', { value: NaN });
+
+    await waitFor(() => expect(activeNodes()).toHaveLength(1));
+    expect(activeNodes()[0].position).toEqual({ x: 10, y: 20 });
+  });
+
+  it('leaves the canvas alone when the dropped example fails to load', async () => {
+    mockedRest.loadExample.mockRejectedValue(new Error('nope'));
+    const { result } = renderHook(() => useDragAndDrop());
+
+    result.current.onDrop(makeDragEvent({ 'application/codefyui-example': 'bad' }));
+
+    await waitFor(() => expect(mockedRest.loadExample).toHaveBeenCalled());
     expect(activeNodes()).toHaveLength(0);
   });
 });

--- a/frontend/src/hooks/useDragAndDrop.ts
+++ b/frontend/src/hooks/useDragAndDrop.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useReactFlow } from '@xyflow/react';
 import { useTabStore } from '../store/tabStore';
 import { useNodeDefStore } from '../store/nodeDefStore';
+import { insertExample } from '../utils/openExample';
 
 export function useDragAndDrop() {
   const { screenToFlowPosition } = useReactFlow();
@@ -36,7 +37,25 @@ export function useDragAndDrop() {
       if (nodeType) {
         const definition = definitions.find((d) => d.node_name === nodeType);
         if (definition) addNode(definition, position);
+        return;
       }
+
+      // Check for example drop (#348). The odd one out: the graph being
+      // dropped is not in memory yet, so this branch is asynchronous where
+      // the two above are not.
+      //
+      // `path` and `position` are both read off the event BEFORE that await
+      // and closed over, which is not a style choice. A DataTransfer is
+      // readable only while the event carrying it is being dispatched, and
+      // `event.clientX/Y` describe a pointer that has moved on by the time
+      // the fetch resolves — so reaching for either afterwards gets a drop
+      // that lands nowhere, or lands wrong.
+      //
+      // Deliberately not awaited: `insertExample` reports failure with its
+      // own toast and never throws, and an event handler that returns a
+      // promise is a promise nobody is watching.
+      const examplePath = event.dataTransfer.getData('application/codefyui-example');
+      if (examplePath) void insertExample(examplePath, position);
     },
     [definitions, presets, screenToFlowPosition, addNode, addPresetNode]
   );

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -107,7 +107,7 @@ const en = {
   'templates.loadFail': 'Failed to load examples: {error}',
   'templates.empty': 'No examples available',
   'templates.noMatch': 'No matching examples',
-  'templates.hint': 'Click an example to open it',
+  'templates.hint': 'Drag an example onto the canvas, or click to add it',
 
   // Template gallery modal (core#128)
   'gallery.open': 'Templates',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -105,7 +105,7 @@ const zhTW: Record<TranslationKey, string> = {
   'templates.loadFail': '載入範例失敗：{error}',
   'templates.empty': '沒有可用的範例',
   'templates.noMatch': '找不到符合的範例',
-  'templates.hint': '點選範例即可開啟',
+  'templates.hint': '把範例拖曳到畫布上，或點一下加入',
 
   // 範例圖庫彈窗 (core#128)
   'gallery.open': '範例圖庫',

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -2822,6 +2822,48 @@ describe('insertGraph', () => {
   });
 });
 
+// -- #348: a dropped example lands under the pointer, not below the graph --
+
+describe('insertGraph — explicit drop point (#348)', () => {
+  beforeEach(resetToSingleTab);
+
+  it('puts the block top-left at the drop point, ignoring the existing graph', () => {
+    // The auto placement would put this BELOW n1. A drop must not: the user
+    // released the pointer somewhere specific and that is where it goes.
+    store().setNodes([bnode('n1', { position: { x: 0, y: 0 } })]);
+    store().insertGraph([bnode('t1', { position: { x: 500, y: 500 } })], [], [], { x: -80, y: 40 });
+
+    const inserted = activeTab().nodes.find((n) => n.selected)!;
+    expect(inserted.position).toEqual({ x: -80, y: 40 });
+  });
+
+  it('preserves the template layout around the drop point', () => {
+    store().insertGraph(
+      [
+        bnode('t1', { position: { x: 100, y: 100 } }),
+        bnode('t2', { position: { x: 340, y: 180 } }),
+      ],
+      [],
+      [],
+      { x: 0, y: 0 },
+    );
+    // The bounding box origin lands on the point; the second node keeps its
+    // offset from the first.
+    expect(activeTab().nodes.map((n) => n.position)).toEqual([
+      { x: 0, y: 0 },
+      { x: 240, y: 80 },
+    ]);
+  });
+
+  it('is still one undo step', () => {
+    store().setNodes([bnode('n1')]);
+    store().insertGraph([bnode('t1'), bnode('t2')], [], [], { x: 5, y: 5 });
+    expect(activeTab().nodes).toHaveLength(3);
+    store().undo();
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['n1']);
+  });
+});
+
 
 describe('bypass — graph I/O contract nodes (core#128 review)', () => {
   beforeEach(resetToSingleTab);
@@ -2878,6 +2920,15 @@ describe('insertGraph — viewport fit (core#128 review)', () => {
 
   it('does not request a fit for an empty template', () => {
     store().insertGraph([], []);
+    expect(useUIStore.getState().layoutFitRequest).toBeNull();
+  });
+
+  it('does not move the viewport when the caller named a drop point (#348)', () => {
+    // The fit exists because the auto placement can land off-screen. A drop
+    // cannot: the pointer was on screen, so moving the camera would yank the
+    // canvas out from under the gesture that just finished.
+    store().setNodes([bnode('n1', { position: { x: 0, y: 0 } })]);
+    store().insertGraph([bnode('t1')], [], [], { x: 900, y: 900 });
     expect(useUIStore.getState().layoutFitRequest).toBeNull();
   });
 });

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -591,11 +591,17 @@ interface TabStoreState {
    * ids are NOT remapped the way node ids are -- an id is what an instance
    * node names -- so a collision is resolved the way paste resolves it: the
    * definition already in this tab wins.
+   *
+   * `at` is a flow-space point to put the block's top-left corner on (#348),
+   * for the one caller that knows better than the automatic placement: a
+   * drag-and-drop, where the user released the pointer somewhere specific.
+   * Omitted, the block lands below the existing graph as it always has.
    */
   insertGraph: (
     nodes: Node<NodeData>[],
     edges: Edge[],
     subgraphs?: SubgraphDefinition[],
+    at?: { x: number; y: number },
   ) => void;
 
   // note actions
@@ -1012,9 +1018,15 @@ const INSERT_GAP = 96;
 function insertionOffset(
   existing: Node<NodeData>[],
   incoming: Node<NodeData>[],
+  at?: { x: number; y: number },
 ): { x: number; y: number } {
-  const target = nodesBoundingBox(existing as Node[]);
   const source = nodesBoundingBox(incoming as Node[]);
+  // A named drop point (#348) answers the question outright: put the block's
+  // top-left there. The existing graph is not consulted, so a drop CAN land
+  // on top of a node that is already there -- which is the user's call to
+  // make, and one Ctrl+Z away either way.
+  if (at) return source ? { x: at.x - source.x, y: at.y - source.y } : { x: 0, y: 0 };
+  const target = nodesBoundingBox(existing as Node[]);
   // An empty canvas (or a template with nothing in it) needs no move at all.
   if (!target || !source) return { x: 0, y: 0 };
   return {
@@ -2659,7 +2671,7 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
 
   // ── Template insertion (core#128) ──
 
-  insertGraph: (incomingNodes, incomingEdges, incomingSubgraphs = []) => {
+  insertGraph: (incomingNodes, incomingEdges, incomingSubgraphs = [], at) => {
     if (incomingNodes.length === 0) return;
     const tab = get().getActiveTab();
     get().pushUndoSnapshot();
@@ -2671,7 +2683,7 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
     const idMap = new Map<string, string>();
     for (const node of incomingNodes) idMap.set(node.id, generateId());
 
-    const offset = insertionOffset(tab.nodes, incomingNodes);
+    const offset = insertionOffset(tab.nodes, incomingNodes, at);
 
     const newNodes: Node<NodeData>[] = incomingNodes.map((node) => {
       const data: NodeData = { ...node.data, executionStatus: 'idle', error: undefined };
@@ -2728,6 +2740,13 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
     // user has panned or zoomed into can be entirely off-screen — an insert
     // that looks like it did nothing. Reuse auto-layout's one-shot fit
     // request so the viewport lands on what just arrived.
+    //
+    // Skipped for a drop (#348), and only for a drop: the pointer was on
+    // screen when it was released, so the block cannot have landed out of
+    // sight — and moving the camera would pull the canvas out from under the
+    // gesture that just finished, which reads as the drop having gone
+    // somewhere else.
+    if (at) return;
     const inserted = nodesBoundingBox(newNodes as Node[]);
     if (inserted && inserted.width > 0 && inserted.height > 0) {
       useUIStore.getState().requestLayoutFit(inserted);

--- a/frontend/src/utils/openExample.test.ts
+++ b/frontend/src/utils/openExample.test.ts
@@ -223,6 +223,34 @@ describe('insertExample', () => {
     expect(tab.name).toBe('Tab 1');
   });
 
+  it('lands the template at a drop point when one is given (#348)', async () => {
+    store().setNodes([
+      { id: 'mine', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'k', type: 'K', params: {} } },
+    ] as never);
+    mockedRest.loadExample.mockResolvedValue({
+      nodes: [raw('a', { position: { x: 900, y: 900 } })],
+      edges: [],
+    });
+
+    await expect(insertExample('x', { x: -50, y: 25 })).resolves.toBe(true);
+
+    const inserted = activeTab().nodes.find((n) => n.selected)!;
+    expect(inserted.position).toEqual({ x: -50, y: 25 });
+  });
+
+  it('still refuses a too-new template on the drop path (#348)', async () => {
+    // The gate lives before resolution on BOTH paths, or a drop installs a
+    // newer build's presets that the click path would have refused.
+    mockedRest.loadExample.mockResolvedValue({
+      nodes: [raw('a')],
+      edges: [],
+      format_version: 999,
+    });
+
+    await expect(insertExample('x', { x: 0, y: 0 })).resolves.toBe(false);
+    expect(activeTab().nodes).toHaveLength(0);
+  });
+
   it('reports false for a template with no nodes', async () => {
     mockedRest.loadExample.mockResolvedValue({ nodes: [], edges: [] });
     await expect(insertExample('x')).resolves.toBe(false);

--- a/frontend/src/utils/openExample.ts
+++ b/frontend/src/utils/openExample.ts
@@ -217,8 +217,17 @@ export async function openExampleInNewTab(path: string): Promise<boolean> {
  * editable graph reaches the same place by a shorter road, since the next
  * save writes the result. So the merge does not happen at all, and the user
  * is told why rather than left wondering why nothing appeared.
+ *
+ * `at` is the flow-space point a DROP released on (#348). It is the only
+ * difference between dragging an example out of the sidebar and clicking it:
+ * everything above -- the id remap, the definition merge, the format gate --
+ * is the same work either way, which is why there is one function and not
+ * two.
  */
-export async function insertExample(path: string): Promise<boolean> {
+export async function insertExample(
+  path: string,
+  at?: { x: number; y: number },
+): Promise<boolean> {
   try {
     // Read off the raw payload, BEFORE resolving: resolution merges the
     // example's unknown presets into the node-def store, so a refusal after
@@ -240,6 +249,7 @@ export async function insertExample(path: string): Promise<boolean> {
       example.nodes,
       example.edges,
       example.subgraphs,
+      at,
     );
     return true;
   } catch {


### PR DESCRIPTION
Fixes #348.

## The bug

`ExampleItem` in the sidebar's Templates tab called `openExample`, which routes to `tabStore.loadGraphDocument` — an action that replaces the active tab's nodes, edges, subgraphs, segment groups, description, save binding and tab name in one commit, and by its own comment touches neither undo stack:

```
// Undo is deliberately untouched, matching what all three readers did
// before: opening a document pushes no snapshot and clears no stack.
```

So: build a graph, click "Train CNN on MNIST" in the sidebar out of curiosity, and the graph is gone. Ctrl+Z does nothing, because from the undo stack's point of view nothing happened. The hint under the list promised exactly that behaviour — "Click an example to open it".

## The fix

An example now **joins** the canvas instead of replacing it, by both gestures.

**Drag.** Each row is a drag source carrying `application/codefyui-example`, and `useDragAndDrop` grows a third branch beside the node and preset ones. It is the only asynchronous branch — the graph is not in memory yet — so the path and the flow-space point are read off the event *before* the fetch is awaited: a `DataTransfer` is readable only while its own event is dispatching, and `clientX/Y` describe a pointer that has moved on by the time the graph arrives.

**Placement.** `insertGraph` takes an optional drop point. With one, the incoming block's top-left lands there and the viewport is left alone — the pointer was on screen when it was released, so nothing can have landed out of sight, and moving the camera would read as the drop having gone somewhere else. Without one, it places the block below the existing graph and requests a fit, exactly as it always has, so the gallery modal's "Insert into this canvas" is unchanged.

**Click.** Now `insertExample` as well, which means the id remap, the subgraph-definition merge and the too-new-`format_version` refusal are shared by both gestures — and both are one `pushUndoSnapshot()`, so one Ctrl+Z takes the whole block back off.

**The element.** The row became a `<div>` with button semantics rather than a `<button>`: Firefox has ignored `draggable` on buttons for years, and it is a supported target (`docs/package.json` browserslist carries `last 3 firefox version`). `role="button"`, `tabIndex={0}` and Enter/Space activation put back what the button was providing.

**Scope.** `loadGraphDocument` is untouched and still not undoable. The empty-canvas overlay is now the only reader that replaces, and it is only shown when the canvas is empty, so there is nothing there for a replace to take. The gallery modal already offered only non-destructive actions.

## Verification

`pnpm test` — 3276 pass (142 files), `pnpm exec tsc -b` clean, contrast gate passes (403 relationships / 188 tokens), `scripts/check_control_bytes.py` clean.

New tests: drop-point placement and its suppressed viewport fit (`tabStore`), point pass-through and the format gate on the drop path (`openExample`), the example drop branch including a regression test that the handler reads the transfer *before* awaiting (`useDragAndDrop`), and click-inserts / one-step-undo / draggable / keyboard activation (`TemplatesTab`).

Browser e2e in Chrome against a build of this branch, on a canvas holding a 4-node graph:

| step | result |
|---|---|
| click "Api-Function" | 0 → 4 nodes, tab still named "Tab 2" |
| drag "Train CNN on MNIST" to a point on the canvas | 4 → 11 nodes, block top-left at the release point, viewport transform byte-identical before and after |
| Ctrl+Z | 11 → 4 nodes, 3 edges — only the dropped block left |
| Ctrl+Z | 4 → 0 nodes, 0 edges |
| focus a row, press Enter | 0 → 4 nodes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
