### PR TITLE
fix(plugins): a kebab-case plugin id reaches the registry as its manifest id

### DIFF
--- a/backend/app/api/routes_nodes.py
+++ b/backend/app/api/routes_nodes.py
@@ -24,17 +24,35 @@ router = APIRouter(prefix="/api/nodes", tags=["nodes"])
 _filter_device_options = device_options
 
 
-def _provider_for(cls: type[BaseNode]) -> str:
-    """Classify a node by where it was loaded from, via its module path."""
+def _provider_for(qualified_name: str, cls: type[BaseNode]) -> str:
+    """Classify a node by where it was loaded from.
+
+    The module path says WHICH KIND of source a node came from, and that is
+    all it is used for here. For a plugin node the id itself comes from the
+    registry key, because that key is the plugin's manifest id — hyphens
+    included — threaded through discovery by
+    ``plugin_loader.discover_plugin_nodes``. The module path cannot supply
+    it: ``official-template`` is imported as ``cdui_plugins.official_template``
+    because a hyphen is not legal in a Python module name, and reading the id
+    back off that string returns the snake_case spelling no other part of the
+    API uses. ``/api/plugins`` says ``official-template`` and
+    ``/api/examples`` tags graphs ``plugin:official-template``; ``provider``
+    has to say the same thing about the same pack.
+    """
     mod = cls.__module__ or ""
     if mod.startswith("app.nodes"):
         return "builtin"
     if mod.startswith("app.custom_nodes"):
         return "custom"
     if mod.startswith("cdui_plugins."):
-        # cdui_plugins.<py_id>.nodes.<file>  →  provider = "plugin:<py_id>"
-        # py_id may have underscores (from kebab-case → snake_case during load);
-        # callers wanting the original id should look at the lockfile.
+        plugin_id, sep, _node = qualified_name.partition(":")
+        if sep:
+            return f"plugin:{plugin_id}"
+        # No prefix on the key: the node was registered bare even though it
+        # lives under the plugin namespace (only reachable by discovering a
+        # plugin package with the prefix explicitly suppressed). Fall back to
+        # the import spelling — wrong for a kebab-case id, but it is the only
+        # signal left, and it beats reporting the node's own name as the pack.
         parts = mod.split(".")
         if len(parts) >= 2:
             return f"plugin:{parts[1]}"
@@ -54,7 +72,7 @@ def _node_to_definition(qualified_name: str, cls: type[BaseNode]) -> NodeDefinit
         node_name=qualified_name,
         category=cls.CATEGORY,
         description=cls.DESCRIPTION,
-        provider=_provider_for(cls),
+        provider=_provider_for(qualified_name, cls),
         inputs=[
             PortDefinitionSchema(
                 name=p.name,

--- a/backend/app/core/node_registry.py
+++ b/backend/app/core/node_registry.py
@@ -16,12 +16,37 @@ logger = logging.getLogger(__name__)
 _PLUGIN_NS_PREFIX = "cdui_plugins."  # synthetic namespace, see plugin_loader
 
 
+class _DeriveFromPackage:
+    """Type of the "caller said nothing" default for ``discover(plugin_id=)``.
+
+    A distinct sentinel rather than ``None`` because ``None`` is already a
+    meaningful value here: :func:`qualify` reads it as "builtin, keep the
+    bare name". So ``None`` cannot also mean "work it out yourself".
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid only
+        return "<derive from package name>"
+
+
+_DERIVE_FROM_PACKAGE = _DeriveFromPackage()
+
+
 def _plugin_id_from_package(package_name: str) -> str | None:
     """Return ``c2`` for ``cdui_plugins.c2.nodes`` etc., else ``None``.
 
     Builtin nodes are discovered with ``package_name="app.nodes"`` and don't
     match — they keep their bare ``NODE_NAME``. Plugin nodes are discovered
     under ``cdui_plugins.<plugin_id>.nodes`` and get the prefix.
+
+    LOSSY, and only a fallback. A plugin id may be kebab-case, and the
+    synthetic package name it is loaded under cannot be: ``official-template``
+    is imported as ``cdui_plugins.official_template``, and nothing in that
+    string records that the underscore used to be a hyphen. Callers that know
+    the manifest id — every plugin call site does, see
+    ``plugin_loader.discover_plugin_nodes`` — pass it to :meth:`discover`
+    explicitly instead of letting it be guessed from here. What is left for
+    this function is the builtin case (``app.nodes`` → ``None``) and ad-hoc
+    discoveries in tests.
     """
     if not package_name.startswith(_PLUGIN_NS_PREFIX):
         return None
@@ -103,6 +128,7 @@ class NodeRegistry:
         package_path: Path,
         package_name: str,
         *,
+        plugin_id: str | None | _DeriveFromPackage = _DERIVE_FROM_PACKAGE,
         force_reload: bool = False,
     ) -> int:
         """Walk *package_path* and register every ``BaseNode`` subclass.
@@ -120,11 +146,21 @@ class NodeRegistry:
         plugin id, so ``EduKNN`` from ``cdui_plugins.c2.nodes`` lands in
         the registry as ``c2:EduKNN``. Builtin discoveries (``app.nodes``,
         ``app.custom_nodes``) keep bare names.
+
+        ``plugin_id`` is how a caller that KNOWS the id says so. It must be
+        the id the plugin's manifest declares, hyphens and all, because that
+        is the id the rest of the system uses — the examples route's
+        ``plugin:<id>`` prefix, the install directory, ``cdui plugin list``
+        and the ``"type"`` string in saved graphs. Left unset, the id is
+        derived from ``package_name``, which is right for builtins (no
+        prefix) but can only ever return the snake_case spelling of a plugin
+        id; see :func:`_plugin_id_from_package`.
         """
         count = 0
         if not package_path.exists():
             return count
-        plugin_id = _plugin_id_from_package(package_name)
+        if isinstance(plugin_id, _DeriveFromPackage):
+            plugin_id = _plugin_id_from_package(package_name)
         for importer, modname, ispkg in pkgutil.walk_packages(
             [str(package_path)], prefix=package_name + "."
         ):

--- a/backend/app/core/plugin_loader.py
+++ b/backend/app/core/plugin_loader.py
@@ -22,7 +22,7 @@ import sys
 import types
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import Any, NamedTuple
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -220,17 +220,42 @@ def frontend_entry_rel(manifest: dict[str, Any]) -> str | None:
     return str(p)
 
 
+class PluginNamespace(NamedTuple):
+    """One installed plugin's nodes, ready to hand to ``NodeRegistry.discover``.
+
+    Carries THREE things, and the third is the one that used to go missing.
+    ``package_name`` and ``plugin_id`` are two different spellings of the same
+    pack and only one of them is the real name: ``official-template`` is
+    imported as ``cdui_plugins.official_template`` because a hyphen cannot
+    appear in a Python module path, but ``official-template`` is what the
+    manifest says, what the install directory is called, what
+    ``cdui plugin list`` prints, and what a saved graph's
+    ``"type": "official-template:HelloPlugin"`` has to say. Rebuilding the id
+    from the package name recovers only the snake_case spelling, so it is
+    carried rather than re-derived.
+
+    A named tuple rather than a bare 3-tuple precisely because two of the
+    three fields are strings: positional unpacking is exactly how the id was
+    dropped in the first place.
+    """
+
+    nodes_dir: Path
+    package_name: str
+    plugin_id: str
+
+
 def install_plugin_finder(
     builtin_root: Path,
     user_root: Path,
     lockfile: dict[str, Any],
-) -> list[tuple[Path, str]]:
-    """Register the synthetic namespace and return ``(nodes_dir, package_name)`` pairs.
+) -> list[PluginNamespace]:
+    """Register the synthetic namespace and return one entry per loadable pack.
 
-    The returned pairs are ready to pass straight to
-    :meth:`NodeRegistry.discover`. Plugins whose manifest is missing,
-    whose ``nodes/`` directory is absent, **or whose ``enabled`` flag is
-    false** are skipped silently — the caller is responsible for surfacing
+    The returned entries are ready to pass straight to
+    :meth:`NodeRegistry.discover` — see :func:`discover_plugin_nodes`, which
+    is what every caller in the app actually uses. Plugins whose manifest is
+    missing, whose ``nodes/`` directory is absent, **or whose ``enabled`` flag
+    is false** are skipped silently — the caller is responsible for surfacing
     those.
     """
     pkg = sys.modules.get(NAMESPACE_PACKAGE)
@@ -239,7 +264,7 @@ def install_plugin_finder(
         pkg.__path__ = []  # namespace package
         sys.modules[NAMESPACE_PACKAGE] = pkg
 
-    pairs: list[tuple[Path, str]] = []
+    found: list[PluginNamespace] = []
     for plugin_id, entry in lockfile.get("plugins", {}).items():
         if not is_enabled(entry):
             continue
@@ -260,9 +285,44 @@ def install_plugin_finder(
 
         nodes_dir = plugin_dir / "nodes"
         if nodes_dir.exists():
-            pairs.append((nodes_dir, f"{sub_name}.nodes"))
+            found.append(PluginNamespace(nodes_dir, f"{sub_name}.nodes", plugin_id))
 
-    return pairs
+    return found
+
+
+def discover_plugin_nodes(
+    registry: Any,
+    builtin_root: Path,
+    user_root: Path,
+    lockfile: dict[str, Any],
+    *,
+    force_reload: bool = False,
+) -> tuple[int, int]:
+    """Register every enabled pack's nodes; returns ``(nodes, packs)``.
+
+    The single place that turns installed packs into registry entries. The
+    server lifespan, ``POST /api/plugins/reload`` (via :func:`rediscover_all`)
+    and ``scripts/project.py`` all go through here instead of writing the
+    ``install_plugin_finder`` → ``discover`` loop themselves, so there is
+    exactly one line that has to remember to pass the manifest id along —
+    and three copies of it cannot drift apart, which is how plugin nodes came
+    to be registered under ``official_template:`` while every other subsystem
+    said ``official-template``.
+
+    Both counts are returned because the lifespan log reports "N nodes from M
+    plugins", and M is not derivable from N.
+    """
+    namespaces = install_plugin_finder(builtin_root, user_root, lockfile)
+    node_count = sum(
+        registry.discover(
+            ns.nodes_dir,
+            ns.package_name,
+            plugin_id=ns.plugin_id,
+            force_reload=force_reload,
+        )
+        for ns in namespaces
+    )
+    return node_count, len(namespaces)
 
 
 def purge_plugin_modules(plugin_id: str) -> None:
@@ -332,10 +392,9 @@ def rediscover_all(
     custom = registry.discover(custom_nodes_dir, "app.custom_nodes", force_reload=True)
 
     lockfile = load_lockfile()
-    pairs = install_plugin_finder(builtin_root, user_root, lockfile)
-    plugin_count = 0
-    for plug_nodes_dir, pkg_name in pairs:
-        plugin_count += registry.discover(plug_nodes_dir, pkg_name, force_reload=True)
+    plugin_count, _packs = discover_plugin_nodes(
+        registry, builtin_root, user_root, lockfile, force_reload=True
+    )
 
     preset_registry.clear()
     preset_count = preset_registry.discover(presets_dir, registry)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,7 +79,7 @@ from .core.port_stats import PortStatsCache
 from .core.version import get_version
 from .core import plugin_loader
 from .core.plugin_loader import (
-    install_plugin_finder,
+    discover_plugin_nodes,
     iter_plugin_dirs,
     load_lockfile,
     rediscover_all,
@@ -222,14 +222,14 @@ async def lifespan(app: FastAPI):
 
     # Discover plugin nodes (per-user installed packs + built-in direction packs)
     lockfile = load_lockfile()
-    pairs = install_plugin_finder(
-        plugin_loader.plugins_builtin_root(), plugin_loader.plugins_user_root(), lockfile
+    plugin_count, pack_count = discover_plugin_nodes(
+        registry,
+        plugin_loader.plugins_builtin_root(),
+        plugin_loader.plugins_user_root(),
+        lockfile,
     )
-    plugin_count = 0
-    for nodes_dir, pkg_name in pairs:
-        plugin_count += registry.discover(nodes_dir, pkg_name)
     logger.info(
-        "Discovered %d plugin nodes from %d active plugin(s)", plugin_count, len(pairs)
+        "Discovered %d plugin nodes from %d active plugin(s)", plugin_count, pack_count
     )
 
     for name in sorted(registry.nodes.keys()):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -73,7 +73,15 @@ def _discover_builtin_packs() -> None:
     for plugin_id in _BUILTIN_TEST_PACKS:
         plugin_nodes = _REPO_ROOT / "plugins" / plugin_id / "nodes"
         if plugin_nodes.exists():
-            registry.discover(plugin_nodes, f"cdui_plugins.{plugin_id}.nodes")
+            # ``plugin_id`` is passed rather than left to be derived from the
+            # package name: none of these packs has a hyphen in its id, so
+            # both routes agree today, but the suite should exercise the same
+            # call production makes.
+            registry.discover(
+                plugin_nodes,
+                f"cdui_plugins.{plugin_id}.nodes",
+                plugin_id=plugin_id,
+            )
 
 
 def _packs_missing_from_registry() -> bool:

--- a/backend/tests/test_chapter_examples.py
+++ b/backend/tests/test_chapter_examples.py
@@ -7,6 +7,11 @@ validates, and executes end-to-end without error.
 
 Parametrised by glob so adding a new example file is enough — no test
 code changes required.
+
+A second check runs over the same graphs: every node ``type`` must be an
+EXACT key in the node registry. ``validate_graph`` is deliberately lenient
+about that and the canvas is not — see
+``test_chapter_graph_node_types_match_the_palette_exactly``.
 """
 
 from __future__ import annotations
@@ -18,7 +23,10 @@ from pathlib import Path
 
 import pytest
 
+from app.config import settings
 from app.core.graph_engine import execute_graph, validate_graph
+from app.core.node_registry import NodeRegistry
+from app.core.plugin_loader import install_plugin_finder
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _PLUGIN_ROOT = _REPO_ROOT / "plugins"
@@ -88,3 +96,103 @@ def test_chapter_graph_executes(graph_path: Path):
         asyncio.run(execute_graph(nodes, edges, error_mode="fail_fast"))
     finally:
         os.chdir(prev_cwd)
+
+
+# ── every example type is a type the palette actually has ─────────────────
+
+#: Container node types that are not registry entries and are resolved
+#: elsewhere: presets come from ``preset_registry`` (with a graph-embedded
+#: fallback for presets the server has never seen), subgraph instances are
+#: expanded from the graph's own ``subgraphs`` list.
+_NON_REGISTRY_PREFIXES = ("preset:", "subgraph:")
+
+#: Every pack in the repo, by manifest directory — the same auto-discovery
+#: the graph glob above uses, so a new pack is covered without editing this
+#: file.
+_IN_REPO_PACKS = sorted(m.parent.name for m in _PLUGIN_ROOT.glob("*/cdui.plugin.toml"))
+
+
+@pytest.fixture(scope="module")
+def palette() -> set[str]:
+    """The registry keys an install of the in-repo packs would offer.
+
+    Built here rather than read off the session-wide registry singleton on
+    purpose. The singleton's contents depend on what earlier tests did to it
+    — ``test_plugin_api`` runs the app lifespan against a lockfile naming
+    three packs, which drops the others — and a check about whether examples
+    match the palette must not be able to pass or fail on collection order.
+
+    It is also the point of the check: the keys are produced by the real
+    discovery path, ``install_plugin_finder`` → ``discover``, so they are
+    exactly the strings ``/api/nodes`` would publish. Built-in nodes are
+    included because pack examples wire pack nodes to them; user custom nodes
+    are not, because a shipped example must never depend on one.
+    """
+    reg = NodeRegistry()
+    reg.discover(settings.NODES_DIR, "app.nodes")
+    lockfile = {
+        "schema": 1,
+        "plugins": {
+            pack: {"source_kind": "builtin", "source": pack, "enabled": True}
+            for pack in _IN_REPO_PACKS
+        },
+    }
+    for ns in install_plugin_finder(
+        _PLUGIN_ROOT,
+        _REPO_ROOT / "_phantom_user_root_for_tests",  # never read
+        lockfile,
+    ):
+        reg.discover(ns.nodes_dir, ns.package_name, plugin_id=ns.plugin_id)
+
+    keys = set(reg.nodes)
+    assert _IN_REPO_PACKS, "found no packs under plugins/ -- the scan is broken"
+    assert any(":" in k for k in keys), (
+        "no pack node was discovered -- this check would pass vacuously"
+    )
+    return keys
+
+
+@pytest.mark.parametrize(
+    "graph_path",
+    _GRAPHS,
+    ids=[p.relative_to(_PLUGIN_ROOT).as_posix() for p in _GRAPHS],
+)
+def test_chapter_graph_node_types_match_the_palette_exactly(
+    graph_path: Path, palette: set[str]
+):
+    """Every node type in a pack example is a key the palette actually has.
+
+    ``test_chapter_graph_executes`` above does NOT cover this.
+    ``registry.get`` falls back to a suffix scan, so a graph asking for a
+    bare ``Edu-KNN`` while the registry holds ``foundations:Edu-KNN``
+    validates and executes server-side and looks entirely healthy from here.
+
+    The canvas has no such fallback. ``resolveSerializedNodes`` does an exact
+    ``Map.get(node.type)`` over the definitions from ``/api/nodes`` and, on a
+    miss, substitutes an EMPTY definition: the node renders as a blank box
+    badged "Utility" with no ports at all, and because the handles do not
+    exist every edge touching it is silently dropped. Nothing is logged and
+    nothing fails — the student just gets a broken-looking example.
+
+    So this guards the whole class rather than one spelling of it: any pack
+    whose registry key stops agreeing with the id its examples were written
+    against — a rename, a typo, or an id that the loader spells one way and
+    the manifest another — fails here instead of on a student's screen.
+    """
+    payload = json.loads(graph_path.read_text(encoding="utf-8"))
+    unresolved = sorted(
+        {
+            node_type
+            for node in payload.get("nodes", [])
+            for node_type in [str(node.get("type", ""))]
+            if not node_type.startswith(_NON_REGISTRY_PREFIXES)
+            and node_type not in palette
+        }
+    )
+    assert not unresolved, (
+        f"{graph_path} uses node types that are not registry keys: "
+        f"{unresolved}. The canvas resolves a node type by exact match, so "
+        f"each of these renders as an empty box with no ports. Plugin nodes "
+        f"must be written qualified, as \"<plugin-id>:<NodeName>\" — the "
+        f"plugin id exactly as its cdui.plugin.toml spells it."
+    )

--- a/backend/tests/test_node_namespacing.py
+++ b/backend/tests/test_node_namespacing.py
@@ -19,11 +19,16 @@ from whatever the test session's plugin install state happens to be.
 
 from __future__ import annotations
 
+import json
 import logging
+from pathlib import Path
+from textwrap import dedent
 
 
+from app.core import plugin_loader
 from app.core.node_base import BaseNode, DataType, PortDefinition
 from app.core.node_registry import NodeRegistry, _plugin_id_from_package, qualify
+from app.core.preset_registry import PresetRegistry
 
 
 # ── helpers ───────────────────────────────────────────────────────────────
@@ -156,14 +161,160 @@ def test_exact_qualified_match_bypasses_fallback_path():
     assert reg.get("c2:EduKNN") is a
 
 
-# ── discover() autodetection ──────────────────────────────────────────────
+# ── discover(): where the plugin id comes from ────────────────────────────
+#
+# The id a node is registered under has to be the id the plugin's MANIFEST
+# declares, because that is the id every other subsystem already uses: the
+# examples route's ``plugin:<id>`` path prefix, the install directory,
+# ``cdui plugin list``, and the ``"type": "<id>:<NodeName>"`` that
+# :func:`qualify` documents as the saved-graph form.
+#
+# That id cannot be recovered from the Python package name. A kebab-case id
+# has to become snake_case to be importable at all (``official-template`` ->
+# ``cdui_plugins.official_template``), and nothing in the package name says
+# whether the underscore was a hyphen first. So the loader threads the real
+# id through to ``discover``, which only falls back to reading it off the
+# package name when no caller supplies one.
+
+
+def _write_kebab_pack(root: Path, plugin_id: str, node_name: str) -> Path:
+    """Install a minimal pack under *root* whose manifest id has a hyphen."""
+    plugin_dir = root / plugin_id
+    nodes = plugin_dir / "nodes"
+    nodes.mkdir(parents=True)
+    (plugin_dir / "cdui.plugin.toml").write_text(
+        dedent(f"""            [plugin]
+            id = "{plugin_id}"
+            name = "Kebab pack {plugin_id}"
+            version = "0.0.1"
+            description = ""
+            schema_version = 1
+            """),
+        encoding="utf-8",
+    )
+    (nodes / "__init__.py").write_text("", encoding="utf-8")
+    (nodes / "demo_node.py").write_text(
+        dedent(f"""            from app.core.node_base import BaseNode, DataType, PortDefinition
+
+
+            class DemoNode(BaseNode):
+                NODE_NAME = "{node_name}"
+                CATEGORY = "Test"
+                DESCRIPTION = ""
+
+                @classmethod
+                def define_inputs(cls):
+                    return [PortDefinition(name="x", data_type=DataType.ANY)]
+
+                @classmethod
+                def define_outputs(cls):
+                    return [PortDefinition(name="y", data_type=DataType.ANY)]
+
+                def execute(self, inputs, params, **_):
+                    return {{}}
+            """),
+        encoding="utf-8",
+    )
+    return plugin_dir
+
+
+def test_kebab_case_pack_registers_under_its_hyphenated_manifest_id(tmp_path):
+    """``official-template`` must not reach the registry as ``official_template``.
+
+    Driven through the production pair of calls — ``install_plugin_finder``
+    then ``discover`` — because the id is what gets lost between exactly
+    those two when the loader hands over only the package name.
+    """
+    plugin_id = "kebab-case-pack"
+    user_root = tmp_path / "userdata" / "plugins"
+    user_root.mkdir(parents=True)
+    _write_kebab_pack(user_root, plugin_id, "KebabDemo")
+    lockfile = {
+        "schema": 1,
+        "plugins": {plugin_id: {"source_kind": "user", "enabled": True}},
+    }
+
+    reg = NodeRegistry()
+    try:
+        namespaces = plugin_loader.install_plugin_finder(
+            tmp_path / "builtin", user_root, lockfile
+        )
+        assert [ns.plugin_id for ns in namespaces] == [plugin_id]
+        for ns in namespaces:
+            # The importable spelling and the real id travel together, which
+            # is the whole point: the package name still has to be snake_case.
+            assert ns.package_name == "cdui_plugins.kebab_case_pack.nodes"
+            reg.discover(ns.nodes_dir, ns.package_name, plugin_id=ns.plugin_id)
+    finally:
+        plugin_loader.purge_plugin_modules(plugin_id)
+
+    assert "kebab-case-pack:KebabDemo" in reg.nodes
+    # The snake_case spelling belongs to the Python import path and nowhere
+    # else — no graph, palette label, example path or CLI listing shows it.
+    assert "kebab_case_pack:KebabDemo" not in reg.nodes
+
+
+def test_plugin_discovery_wiring_keeps_the_hyphen_the_manifest_declares(
+    tmp_path, monkeypatch
+):
+    """The wiring, not just the API.
+
+    ``discover_plugin_nodes`` is the one loop the server lifespan, the
+    project CLI and ``POST /api/plugins/reload`` all run, so a call site that
+    stopped passing the id along would fail here rather than only on a
+    student's canvas.
+    """
+    plugin_id = "kebab-case-reload"
+    user_root = tmp_path / "userdata" / "plugins"
+    user_root.mkdir(parents=True)
+    _write_kebab_pack(user_root, plugin_id, "KebabReload")
+    (user_root / "installed.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "plugins": {plugin_id: {"source_kind": "user", "enabled": True}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    # rediscover_all reads the lockfile itself rather than taking one, so the
+    # user root has to be redirected as well as passed.
+    monkeypatch.setattr(plugin_loader, "plugins_user_root", lambda: user_root)
+
+    empty = tmp_path / "empty"  # no builtin nodes, custom nodes or presets
+    reg = NodeRegistry()
+    try:
+        counts = plugin_loader.rediscover_all(
+            reg,
+            PresetRegistry(),
+            nodes_dir=empty,
+            custom_nodes_dir=empty,
+            presets_dir=empty,
+            builtin_root=empty,
+            user_root=user_root,
+        )
+    finally:
+        plugin_loader.purge_plugin_modules(plugin_id)
+
+    assert counts["plugins"] == 1
+    assert list(reg.nodes) == ["kebab-case-reload:KebabReload"]
 
 
 # ── _plugin_id_from_package() ────────────────────────────────────────────
 
 
 def test_plugin_id_detection_from_cdui_plugins_namespace():
-    """Discoveries from ``cdui_plugins.<id>.nodes`` should detect ``<id>``."""
+    """Discoveries from ``cdui_plugins.<id>.nodes`` should detect ``<id>``.
+
+    This is the FALLBACK only — the path taken when a caller passes no
+    explicit ``plugin_id`` (builtin discovery, ad-hoc discovery in tests).
+    It reads the Python package name, so the best it can ever return is the
+    snake_case spelling: ``third_party_pack`` is the right answer here
+    whether the manifest said ``third_party_pack`` or ``third-party-pack``,
+    because the package name genuinely does not record which. The
+    hyphen-preserving path is the one above, where the loader supplies the
+    manifest id instead of leaving it to be guessed.
+    """
     assert _plugin_id_from_package("cdui_plugins.c2.nodes") == "c2"
     assert _plugin_id_from_package("cdui_plugins.c2") == "c2"
     assert _plugin_id_from_package("cdui_plugins.third_party_pack.nodes") == "third_party_pack"

--- a/backend/tests/test_plugin_api.py
+++ b/backend/tests/test_plugin_api.py
@@ -230,6 +230,58 @@ def test_provider_field_is_plugin_for_edu_nodes(client):
     assert by_name["deep:Edu-SelfAttention"]["provider"] == "plugin:deep"
 
 
+def test_provider_field_spells_a_plugin_id_the_way_its_manifest_does(client):
+    """A kebab-case pack's ``provider`` agrees with the rest of the API.
+
+    ``/api/plugins`` lists ``official-template`` and ``/api/examples/list``
+    tags its graphs ``plugin:official-template``, so a ``provider`` reading
+    ``plugin:official_template`` would be the single place in the API that
+    spells the same pack differently — and the underscore form is not an id
+    any other endpoint, the lockfile or the CLI will accept.
+
+    Every in-repo pack id is a single word, so the two spellings coincide for
+    all of them; this registers a node the way a kebab-case pack is loaded
+    (hyphenated registry key, snake_case module path) to tell them apart.
+    """
+    from app.core.node_base import BaseNode, DataType, PortDefinition
+    from app.core.node_registry import registry
+
+    class _KebabNode(BaseNode):
+        NODE_NAME = "KebabDemo"
+        CATEGORY = "Test"
+        DESCRIPTION = ""
+
+        @classmethod
+        def define_inputs(cls):
+            return [PortDefinition(name="x", data_type=DataType.ANY)]
+
+        @classmethod
+        def define_outputs(cls):
+            return [PortDefinition(name="y", data_type=DataType.ANY)]
+
+        def execute(self, inputs, params, **_):
+            return {}
+
+    # The import spelling a pack whose manifest id is "kebab-pack" is
+    # genuinely loaded under — the hyphen cannot survive into a module name.
+    _KebabNode.__module__ = "cdui_plugins.kebab_pack.nodes.demo_node"
+    key = "kebab-pack:KebabDemo"
+    registry._nodes[key] = _KebabNode
+    try:
+        listed = client.get("/api/nodes")
+        assert listed.status_code == 200
+        by_name = {n["node_name"]: n for n in listed.json()}
+        assert by_name[key]["provider"] == "plugin:kebab-pack"
+
+        # The single-node route builds the same definition, so it must not
+        # disagree with the list the palette was populated from.
+        one = client.get(f"/api/nodes/{key}")
+        assert one.status_code == 200, one.text
+        assert one.json()["provider"] == "plugin:kebab-pack"
+    finally:
+        registry._nodes.pop(key, None)
+
+
 def test_provider_field_is_builtin_for_production_nodes(client):
     r = client.get("/api/nodes")
     by_name = {n["node_name"]: n for n in r.json()}

--- a/backend/tests/test_plugin_enable_disable.py
+++ b/backend/tests/test_plugin_enable_disable.py
@@ -56,10 +56,10 @@ def test_install_plugin_finder_skips_disabled(tmp_path):
             "deep": {"source_kind": "builtin", "source": "deep", "enabled": False},
         },
     }
-    pairs = plugin_loader.install_plugin_finder(builtin, tmp_path, lockfile)
-    paths = {p[0].parent.name for p in pairs}
-    assert "foundations" in paths
-    assert "deep" not in paths
+    namespaces = plugin_loader.install_plugin_finder(builtin, tmp_path, lockfile)
+    ids = {ns.plugin_id for ns in namespaces}
+    assert "foundations" in ids
+    assert "deep" not in ids
 
 
 def test_iter_plugin_dirs_include_disabled_flag(tmp_path):

--- a/backend/tests/test_plugin_loader.py
+++ b/backend/tests/test_plugin_loader.py
@@ -111,9 +111,9 @@ def test_install_plugin_finder_registers_synthetic_namespace(tmp_path):
     assert "cdui_plugins" in sys.modules
     assert "cdui_plugins.c2" in sys.modules
     assert len(pairs) == 1
-    nodes_dir, pkg_name = pairs[0]
-    assert nodes_dir == plugin_dir / "nodes"
-    assert pkg_name == "cdui_plugins.c2.nodes"
+    assert pairs[0].nodes_dir == plugin_dir / "nodes"
+    assert pairs[0].package_name == "cdui_plugins.c2.nodes"
+    assert pairs[0].plugin_id == "c2"
 
 
 def test_install_plugin_finder_resolves_user_packs_from_user_root(tmp_path):
@@ -136,7 +136,13 @@ def test_install_plugin_finder_resolves_user_packs_from_user_root(tmp_path):
     # kebab-case "alice-extras" → snake-case "alice_extras" for the Python module name
     assert "cdui_plugins.alice_extras" in sys.modules
     assert len(pairs) == 1
-    assert pairs[0][1] == "cdui_plugins.alice_extras.nodes"
+    assert pairs[0].package_name == "cdui_plugins.alice_extras.nodes"
+    # ...and the manifest id travels alongside it UNCHANGED. The snake_case
+    # spelling exists only so the pack can be imported; every other subsystem
+    # — examples paths, the install directory, `cdui plugin list`, the
+    # `"type"` in a saved graph — says "alice-extras", so that is what the
+    # node registry has to be told.
+    assert pairs[0].plugin_id == "alice-extras"
 
 
 def test_install_plugin_finder_skips_plugins_without_manifest(tmp_path):
@@ -188,9 +194,9 @@ def test_install_plugin_finder_resolves_local_path_entries(tmp_path):
 
     assert "cdui_plugins.my_plugin" in sys.modules
     assert len(pairs) == 1
-    nodes_dir, pkg_name = pairs[0]
-    assert nodes_dir == work / "nodes"
-    assert pkg_name == "cdui_plugins.my_plugin.nodes"
+    assert pairs[0].nodes_dir == work / "nodes"
+    assert pairs[0].package_name == "cdui_plugins.my_plugin.nodes"
+    assert pairs[0].plugin_id == "my-plugin"
 
 
 def test_install_plugin_finder_local_without_path_is_skipped(tmp_path):

--- a/backend/tests/test_stats_pack.py
+++ b/backend/tests/test_stats_pack.py
@@ -129,15 +129,17 @@ def test_installing_twice_needs_force(isolated_lockfile):
 def test_an_installed_pack_exposes_all_eight_nodes(isolated_lockfile):
     assert _install() == 0
 
-    pairs = plugin_loader.install_plugin_finder(
+    namespaces = plugin_loader.install_plugin_finder(
         plugin_loader.plugins_builtin_root(),
         plugin_loader.plugins_user_root(),
         plugin_loader.load_lockfile(),
     )
-    nodes_dir, package = next(p for p in pairs if p[1].endswith("stats.nodes"))
+    ns = next(n for n in namespaces if n.plugin_id == "stats")
 
     registry = NodeRegistry()
-    assert registry.discover(nodes_dir, package) == 8
+    assert (
+        registry.discover(ns.nodes_dir, ns.package_name, plugin_id=ns.plugin_id) == 8
+    )
     assert sorted(registry.nodes) == [f"stats:{name}" for name in NODE_NAMES]
 
 
@@ -163,7 +165,7 @@ def test_hot_reload_picks_up_an_edit_to_a_node_file(tmp_path):
 
     The reload here is exactly what ``rediscover_all`` does — the function
     behind ``POST /api/plugins/reload`` — for a plugin:
-    ``install_plugin_finder`` then ``discover(force_reload=True)``. There is no
+    ``discover_plugin_nodes(force_reload=True)``. There is no
     ``purge_plugin_modules`` call because production does not make one:
     ``force_reload`` re-imports through ``importlib.reload``, which re-reads
     the file, and that is sufficient on its own.
@@ -193,14 +195,15 @@ def test_hot_reload_picks_up_an_edit_to_a_node_file(tmp_path):
 
     def reload_pack() -> int:
         """The plugin half of rediscover_all, verbatim."""
-        pairs = plugin_loader.install_plugin_finder(
-            plugin_loader.plugins_builtin_root(), user_root, lockfile
-        )
         registry.clear()
-        return sum(
-            registry.discover(nodes_dir, pkg, force_reload=True)
-            for nodes_dir, pkg in pairs
+        node_count, _packs = plugin_loader.discover_plugin_nodes(
+            registry,
+            plugin_loader.plugins_builtin_root(),
+            user_root,
+            lockfile,
+            force_reload=True,
         )
+        return node_count
 
     try:
         assert reload_pack() == 8

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -217,7 +217,7 @@ def _init_registries_like_server() -> None:
     import app.core.plugin_loader as plugin_loader
     from app.config import settings
     from app.core.node_registry import registry
-    from app.core.plugin_loader import install_plugin_finder
+    from app.core.plugin_loader import discover_plugin_nodes
     from app.core.preset_registry import preset_registry
 
     registry.discover(settings.NODES_DIR, "app.nodes")
@@ -225,8 +225,7 @@ def _init_registries_like_server() -> None:
     lockfile = load_lockfile()
     builtin_root = plugin_loader.plugins_builtin_root()
     user_root = plugin_loader.plugins_user_root()
-    for nodes_dir, pkg_name in install_plugin_finder(builtin_root, user_root, lockfile):
-        registry.discover(nodes_dir, pkg_name)
+    discover_plugin_nodes(registry, builtin_root, user_root, lockfile)
     preset_registry.discover(settings.PRESETS_DIR, registry)
     for _pid, pdir in iter_plugin_dirs(builtin_root, user_root, lockfile):
         preset_registry.discover(pdir / "presets", registry)


### PR DESCRIPTION
A plugin whose manifest `id` contains a hyphen registered its nodes under the
*Python package* spelling, which disagreed with the id every other subsystem uses.

```
official_template:HelloPlugin      <- registry (underscore)
official-template                  <- iter_plugin_dirs, /api/examples/list,
                                      /api/plugins, cdui plugin list, docs
```

`_py_id()` turning `-` into `_` is correct and necessary — it becomes a Python
module path (`cdui_plugins.official_template.nodes`). The bug is that
`install_plugin_finder` discarded the real `plugin_id` it already had in scope,
and `node_registry._plugin_id_from_package` then *re-derived* it from the package
name. Underscore does not map back to hyphen, so the manifest id was unrecoverable.

## Why nobody noticed

The backend and the canvas resolve a node type by two different rules:

- `registry.get()` falls back to a **suffix scan** (`node_registry.py:84-96`), so a
  graph asking for a bare or mis-spelled plugin type still resolves. `validate_graph`
  passes, `execute_graph` runs, every server-side check is green.
- The canvas does an exact `defMap.get(node.type)` (`frontend/src/utils/index.ts:342,470`)
  with **no** fallback. On a miss it substitutes an empty definition (`:479`), so the node
  renders as a blank box badged "Utility" with zero ports — and because those handles do
  not exist, every edge attached to it is silently dropped on load.

Net effect: an example that looks broken on screen while nothing anywhere reports a
problem. That is exactly how the official plugin template's two `Demo` examples shipped.

## What changed

- `install_plugin_finder` returns a `PluginNamespace(nodes_dir, package_name, plugin_id)`
  instead of a 2-tuple that threw the id away.
- `NodeRegistry.discover()` takes a keyword-only `plugin_id`. Its default is a sentinel,
  not `None`, because `None` already means "builtin, keep the bare name" in `qualify()`.
  `_plugin_id_from_package` stays as the fallback, now documented as lossy.
- New `discover_plugin_nodes()` owns the discover loop. `main.py`, `scripts/project.py`
  and `rediscover_all` had three hand-written copies of it — which is the mechanism that
  let one subsystem's spelling drift from the others in the first place.
- `_provider_for()` in `routes_nodes.py` now reads the qualified registry key instead of
  re-deriving from the module path, so `provider` and `node_name` agree inside one
  response. `/api/examples/list` already reported the hyphenated form.

## Regression guard

`test_chapter_examples.py` gains a check that every node `type` in every in-repo pack
example is an **exact** key in the registry — the same operation the canvas performs,
deliberately not `registry.get()`, whose suffix scan would mask the very mistake being
guarded. Packs are auto-discovered from `plugins/*/cdui.plugin.toml`, so a new pack is
covered without editing the test.

## Backward compatibility

Clean rename, no alias. `grep -rEn '"type"\s*:\s*"[a-z0-9]+_[a-z0-9_]+:' --include=*.json`
across the repo returns zero hits; all 35 in-repo pack examples use hyphen-free ids; the
only installed plugins with a hyphen are `official-template` and `graph-copilot`, and the
latter ships no backend nodes. An alias would duplicate every kebab-named node in the
palette for no real-world gain. Graphs saved before this that reference a *bare* plugin
type keep working via the suffix scan.

## Verification

- The two new namespacing tests fail on `main` (`'kebab_case_reload:KebabReload' !=
  'kebab-case-reload:KebabReload'`) and pass here. The provider test is likewise
  non-vacuous — reverting the branch to the module-path derivation fails it.
- Full backend suite: `5187 passed, 19 skipped`.
- `tests/test_codegen.py` is excluded from that run: it fails identically on a pristine
  tree because this worktree has no venv and the exported runner is spawned with
  `python -I`. Unrelated to this change; CI has a venv.
- Live registry, before and after:
  ```
  before: ['official_template:HelloPlugin',  'official_template:MovingAverage']
  after:  ['official-template:HelloPlugin',  'official-template:MovingAverage']
          provider=plugin:official-template
  ```

## Ordering note

This alone does not fix the user-visible symptom. The installed template's example graphs
use *bare* types, which the canvas cannot resolve either way. The companion fix is
CodefyUI/CodefyUI-Plugin-Official — both are needed, and the plugin-side change only
reaches users once a release carrying this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjjuvdbySV2p9UGPejEn4x
