### PR TITLE
chore(release): 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+## [2.4.0] — 2026-08-22
+
 ### Added
 
 - **Load now asks where the graph should land, and its list can be searched**
@@ -1991,7 +1993,8 @@ Release candidates before 1.0.0 are on the
 [#350]: https://github.com/CodefyUI/CodefyUI/pull/350
 [#352]: https://github.com/CodefyUI/CodefyUI/pull/352
 [@oyea0801]: https://github.com/oyea0801
-[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.3.0...main
+[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.0...main
+[2.4.0]: https://github.com/CodefyUI/CodefyUI/compare/2.3.0...2.4.0
 [2.3.0]: https://github.com/CodefyUI/CodefyUI/compare/2.2.0...2.3.0
 [2.2.0]: https://github.com/CodefyUI/CodefyUI/compare/2.1.1...2.2.0
 [2.1.1]: https://github.com/CodefyUI/CodefyUI/compare/2.1.0...2.1.1

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefyui-backend"
-version = "2.3.0"
+version = "2.4.0"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
 # Names the copyright holder in distribution metadata. Until this landed, no
 # file in the repository said who owns CodefyUI, which left the commercial

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -361,7 +361,7 @@ wheels = [
 
 [[package]]
 name = "codefyui-backend"
-version = "2.3.0"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codefyui-frontend",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "AGPL-3.0-only",
   "author": "CodefyUI (https://github.com/CodefyUI)",
   "packageManager": "pnpm@9.15.0",


### PR DESCRIPTION
> 中文摘要：切 2.4.0。把 CHANGELOG 的 `[Unreleased]` 升成 `## [2.4.0] — 2026-08-22`、重開一個空的 `[Unreleased]`、改好 compare 連結，並把三個手動維護的版本欄位（`backend/pyproject.toml`、`backend/uv.lock`、`frontend/package.json`）都改成 2.4.0。取 minor 而非 patch，是因為 #352 除了修捲不動的 bug 之外還加了新的載入目的地和搜尋框。合併後我會打 `2.4.0` tag。

## What / Why

Release prep for 2.4.0, following `.github/RELEASING.md`.

1. **`CHANGELOG.md`** — `## [Unreleased]` promoted to `## [2.4.0] — 2026-08-22`,
   a fresh empty `[Unreleased]` opened above it, compare links repointed
   (`[Unreleased]` at `2.4.0...main`, a new `[2.4.0]` at `2.3.0...2.4.0`). The
   section's two entries are [#352]'s, verbatim — nothing rewritten.
2. **The three version fields** — edited by hand, nothing reconciles them, and
   a mismatch ships silently with the frontend claiming one version and the
   backend another. All three now say 2.4.0: `backend/pyproject.toml`,
   `backend/uv.lock` (regenerated with `uv lock` — only the
   `codefyui-backend` version line moves; no dependency resolution changed),
   `frontend/package.json`.
3. **Docs placeholders** — `git grep stamp-on-release docs/` is empty, so
   nothing is waiting on this number.

**Minor, not patch.** [#352] adds a load destination and a search box over the
saved graphs. That is added functionality under SemVer, not only the
`overflow: hidden` fix that motivated it.

## Closes / relates to

Ships [#352].

## Test evidence

```
uv lock (in backend/)                    -> Resolved 134 packages; codefyui-backend 2.3.0 -> 2.4.0, nothing else
git grep -n stamp-on-release docs/       -> no matches
git diff --stat                          -> 4 files, +7/-4 (CHANGELOG, pyproject, uv.lock, package.json)
```

The code being released was tested in [#352]; this PR changes only version
strings and the changelog, and the same CI gates run on it.

## Checklist

- [ ] Commits are signed off — owner release PR; no DCO check runs on the repo.
- [x] Version consistent across all three files.
- [x] No pictographic emoji.
- [x] Nothing deliberately skipped: the tag push (`git tag -a 2.4.0
      --cleanup=verbatim -F notes.md`) is the next step once this lands.

[#352]: https://github.com/CodefyUI/CodefyUI/pull/352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtswbmtwirwHobBbDuvv6i
