### PR TITLE
fix(install): git still installs when winget's msstore source is unreachable

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/Cod
 
 By default this installs to `~/CodefyUI` (macOS/Linux) or `%USERPROFILE%\CodefyUI` (Windows). Override with the `CODEFYUI_DIR` environment variable.
 
-On Windows, `install.ps1` uses [winget](https://learn.microsoft.com/windows/package-manager/) to install `git` if it's missing. `winget` ships with Windows 11 and recent Windows 10 via the "App Installer" package.
+On Windows, `install.ps1` uses [winget](https://learn.microsoft.com/windows/package-manager/) to install `git` if it's missing. `winget` ships with Windows 11 and recent Windows 10 via the "App Installer" package. If `winget` is unavailable or its package sources can't be reached (corporate TLS interception makes the `msstore` source fail with `0x8a15005e`), the installer falls back to extracting [PortableGit](https://git-scm.com/download/win) into `%LOCALAPPDATA%\CodefyUI\PortableGit` — no administrator rights needed.
 
 The installer places a `cdui` launcher at `~/.local/bin/cdui` (Windows: `%USERPROFILE%\.local\bin\cdui.cmd`). **Restart your terminal**, then from any directory:
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/Cod
 
 By default this installs to `~/CodefyUI` (macOS/Linux) or `%USERPROFILE%\CodefyUI` (Windows). Override with the `CODEFYUI_DIR` environment variable.
 
-On Windows, `install.ps1` uses [winget](https://learn.microsoft.com/windows/package-manager/) to install `git` if it's missing. `winget` ships with Windows 11 and recent Windows 10 via the "App Installer" package. If `winget` is unavailable or its package sources can't be reached (corporate TLS interception makes the `msstore` source fail with `0x8a15005e`), the installer falls back to extracting [PortableGit](https://git-scm.com/download/win) into `%LOCALAPPDATA%\CodefyUI\PortableGit` — no administrator rights needed.
+On Windows, `install.ps1` uses [winget](https://learn.microsoft.com/windows/package-manager/) to install `git` if it's missing. `winget` ships with Windows 11 and recent Windows 10 via the "App Installer" package. If `winget` is unavailable or its package sources cannot be reached (corporate TLS interception makes the `msstore` source fail with `0x8a15005e`), the installer falls back to extracting [PortableGit](https://git-scm.com/download/win) into `%LOCALAPPDATA%\CodefyUI\PortableGit` — no administrator rights required.
 
 The installer places a `cdui` launcher at `~/.local/bin/cdui` (Windows: `%USERPROFILE%\.local\bin\cdui.cmd`). **Restart your terminal**, then from any directory:
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -27,7 +27,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/Cod
 
 預設安裝到 `~/CodefyUI`（macOS/Linux）或 `%USERPROFILE%\CodefyUI`（Windows）。可用環境變數 `CODEFYUI_DIR` 覆寫。
 
-在 Windows 上，`install.ps1` 會透過 [winget](https://learn.microsoft.com/windows/package-manager/) 安裝缺少的 `git`。`winget` 內建於 Windows 11 與較新的 Windows 10（透過「App Installer」套件）。
+在 Windows 上，`install.ps1` 會透過 [winget](https://learn.microsoft.com/windows/package-manager/) 安裝缺少的 `git`。`winget` 內建於 Windows 11 與較新的 Windows 10（透過「App Installer」套件）。若 `winget` 不存在，或它的套件來源連不上（公司網路 TLS 攔截會讓 `msstore` 來源噴 `0x8a15005e`），安裝程式會退而把 [PortableGit](https://git-scm.com/download/win) 解壓到 `%LOCALAPPDATA%\CodefyUI\PortableGit` —— 不需要系統管理員權限。
 
 安裝程式會把 `cdui` 啟動器放到 `~/.local/bin/cdui`（Windows 為 `%USERPROFILE%\.local\bin\cdui.cmd`）。**請重新開啟你的 terminal**，然後在任何目錄執行：
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -27,7 +27,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/Cod
 
 預設安裝到 `~/CodefyUI`（macOS/Linux）或 `%USERPROFILE%\CodefyUI`（Windows）。可用環境變數 `CODEFYUI_DIR` 覆寫。
 
-在 Windows 上，`install.ps1` 會透過 [winget](https://learn.microsoft.com/windows/package-manager/) 安裝缺少的 `git`。`winget` 內建於 Windows 11 與較新的 Windows 10（透過「App Installer」套件）。若 `winget` 不存在，或它的套件來源連不上（公司網路 TLS 攔截會讓 `msstore` 來源噴 `0x8a15005e`），安裝程式會退而把 [PortableGit](https://git-scm.com/download/win) 解壓到 `%LOCALAPPDATA%\CodefyUI\PortableGit` —— 不需要系統管理員權限。
+在 Windows 上，`install.ps1` 會透過 [winget](https://learn.microsoft.com/windows/package-manager/) 安裝缺少的 `git`。`winget` 內建於 Windows 11 與較新的 Windows 10（透過「App Installer」套件）。若 `winget` 不可用，或其套件來源無法連線（企業網路 TLS 攔截會使 `msstore` 來源回報 `0x8a15005e`），安裝程式會改以 [PortableGit](https://git-scm.com/download/win) 解壓至 `%LOCALAPPDATA%\CodefyUI\PortableGit` —— 不需系統管理員權限。
 
 安裝程式會把 `cdui` 啟動器放到 `~/.local/bin/cdui`（Windows 為 `%USERPROFILE%\.local\bin\cdui.cmd`）。**請重新開啟你的 terminal**，然後在任何目錄執行：
 

--- a/install.ps1
+++ b/install.ps1
@@ -39,13 +39,88 @@ function Refresh-Path {
     $env:Path = ($machine, $user, $env:Path | Where-Object { $_ }) -join ';'
 }
 
+function Add-UserPath($dir) {
+    $userPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($null -eq $userPath) { $userPath = '' }
+    $entries = $userPath -split ';' | Where-Object { $_ }
+    if ($entries -contains $dir) { return $false }
+    $newUserPath = if ($userPath) { "$userPath;$dir" } else { $dir }
+    [System.Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
+    return $true
+}
+
+# 回傳 $true/$false，讓呼叫端可以自己決定要不要走退路。
 function Install-Winget($id, $friendlyName) {
     if (-not (Test-Cmd winget)) {
-        Die "winget not found. Install '$friendlyName' manually or install 'App Installer' from Microsoft Store, then re-run."
+        Warn "winget 不存在（需要 Microsoft Store 的 'App Installer'），無法用 winget 安裝 $friendlyName"
+        return $false
     }
-    winget install --id $id --silent --accept-source-agreements --accept-package-agreements --exact
-    if ($LASTEXITCODE -ne 0) { Die "winget install $id failed (exit $LASTEXITCODE)" }
+    # `--source winget` 是必要的：部分機器（公司網路 TLS 攔截、憑證不符）連不上
+    # msstore 來源，會噴 0x8a15005e「The server certificate did not match any of
+    # the expected values」。此時 winget 認為結果不明確，回一句 "Please specify
+    # one of them using the --source option" 就整個失敗——即使 winget 來源本身
+    # 已經找到套件。明確指定來源就完全跳過 msstore。
+    # 輸出導到 Out-Host：原生指令的 stdout 會落進 pipeline，不擋掉的話會混進
+    # 這個函式的回傳值。
+    winget install --id $id --exact --source winget --silent `
+        --accept-source-agreements --accept-package-agreements | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        Warn "winget install $id failed (exit $LASTEXITCODE)"
+        return $false
+    }
     Refresh-Path
+    return $true
+}
+
+# winget 完全不能用時的退路：Git for Windows 的 PortableGit 是 7-Zip 自解壓檔，
+# 解到使用者目錄就能用，不需要系統管理員權限，也不碰 winget 的套件來源。
+function Install-GitPortable {
+    $arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+        'ARM64' { 'arm64' }
+        'x86'   { '32-bit' }
+        default { '64-bit' }
+    }
+    try {
+        $rel = Invoke-RestMethod -UseBasicParsing -TimeoutSec 30 `
+            -Uri 'https://api.github.com/repos/git-for-windows/git/releases/latest' `
+            -Headers @{ 'User-Agent' = 'CodefyUI-installer' }
+    } catch {
+        Warn "無法查詢 Git for Windows release：$($_.Exception.Message)"
+        return $false
+    }
+
+    $portable = @($rel.assets | Where-Object { $_.name -like 'PortableGit-*.7z.exe' })
+    $asset = $portable | Where-Object { $_.name -like "*-$arch.7z.exe" } | Select-Object -First 1
+    if (-not $asset) { $asset = $portable | Where-Object { $_.name -like '*-64-bit.7z.exe' } | Select-Object -First 1 }
+    if (-not $asset) {
+        Warn "Git for Windows release 裡找不到 PortableGit 自解壓檔"
+        return $false
+    }
+
+    $target = Join-Path $env:LOCALAPPDATA 'CodefyUI\PortableGit'
+    $tmp = Join-Path $env:TEMP "cdui-git-$([guid]::NewGuid().ToString('N')).exe"
+    Write-Host "  下載：$($asset.browser_download_url)"
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri $asset.browser_download_url -OutFile $tmp -TimeoutSec 600
+    } catch {
+        Warn "PortableGit 下載失敗：$($_.Exception.Message)"
+        return $false
+    }
+
+    if (Test-Path $target) { Remove-Item -Recurse -Force $target -ErrorAction SilentlyContinue }
+    New-Item -ItemType Directory -Path $target -Force | Out-Null
+    # 7-Zip SFX 旗標：-o<dir>（不能有空白）指定解壓目的地、-y 全部同意。
+    Start-Process -FilePath $tmp -ArgumentList "-o`"$target`" -y" -Wait -NoNewWindow | Out-Null
+    Remove-Item -Force $tmp -ErrorAction SilentlyContinue
+
+    $gitCmdDir = Join-Path $target 'cmd'
+    if (-not (Test-Path (Join-Path $gitCmdDir 'git.exe'))) {
+        Warn "PortableGit 解壓後找不到 git.exe"
+        return $false
+    }
+    $env:Path = "$gitCmdDir;$env:Path"
+    if (Add-UserPath $gitCmdDir) { Ok "已把 $gitCmdDir 加入使用者 PATH" }
+    return $true
 }
 
 function Install-NodeToolchain {
@@ -158,7 +233,14 @@ if ($ForceBuild) { Write-Host "  強制本地 build (CODEFYUI_FORCE_BUILD=1)" -F
 Step "git"
 if (-not (Test-Cmd git)) {
     Warn "Not installed, installing via winget..."
-    Install-Winget 'Git.Git' 'Git'
+    if (-not (Install-Winget 'Git.Git' 'Git')) {
+        Warn "winget 路徑失敗，改用免安裝的 PortableGit（不需管理員權限）..."
+        if (-not (Install-GitPortable)) {
+            Die "無法自動安裝 git。請手動安裝 Git for Windows（https://git-scm.com/download/win）後重跑安裝指令。"
+        }
+    }
+    Refresh-Path
+    if (-not (Test-Cmd git)) { Die "git not found on PATH after install. Open a new shell and re-run." }
 }
 Ok (git --version)
 
@@ -261,14 +343,7 @@ Set-Content -Path $Launcher -Value $stub -Encoding ASCII
 Ok "cdui -> $Launcher"
 
 # Ensure LauncherDir is on user PATH for future shells
-$userPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
-if ($null -eq $userPath) { $userPath = '' }
-$pathEntries = $userPath -split ';' | Where-Object { $_ }
-if ($pathEntries -notcontains $LauncherDir) {
-    $newUserPath = if ($userPath) { "$userPath;$LauncherDir" } else { $LauncherDir }
-    [System.Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
-    Ok "Added $LauncherDir to user PATH"
-}
+if (Add-UserPath $LauncherDir) { Ok "Added $LauncherDir to user PATH" }
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -49,19 +49,19 @@ function Add-UserPath($dir) {
     return $true
 }
 
-# 回傳 $true/$false，讓呼叫端可以自己決定要不要走退路。
+# 回傳 $true/$false，由呼叫端決定是否改用備援方案。
 function Install-Winget($id, $friendlyName) {
     if (-not (Test-Cmd winget)) {
-        Warn "winget 不存在（需要 Microsoft Store 的 'App Installer'），無法用 winget 安裝 $friendlyName"
+        Warn "winget 不可用（需先安裝 Microsoft Store 的 'App Installer'），無法透過 winget 安裝 $friendlyName"
         return $false
     }
-    # `--source winget` 是必要的：部分機器（公司網路 TLS 攔截、憑證不符）連不上
-    # msstore 來源，會噴 0x8a15005e「The server certificate did not match any of
-    # the expected values」。此時 winget 認為結果不明確，回一句 "Please specify
-    # one of them using the --source option" 就整個失敗——即使 winget 來源本身
-    # 已經找到套件。明確指定來源就完全跳過 msstore。
-    # 輸出導到 Out-Host：原生指令的 stdout 會落進 pipeline，不擋掉的話會混進
-    # 這個函式的回傳值。
+    # `--source winget` 為必要參數：部分環境（企業網路 TLS 攔截、憑證不符）無法
+    # 連線至 msstore 來源，會回報 0x8a15005e「The server certificate did not match
+    # any of the expected values」。此時 winget 會將結果視為不明確，輸出 "Please
+    # specify one of them using the --source option" 後即以非零狀態結束——即使
+    # winget 來源本身已成功解析到該套件。明確指定來源即可完全略過 msstore。
+    # 輸出導向 Out-Host：原生指令的 stdout 會進入 PowerShell 的成功管線，未加以
+    # 攔截時會混入本函式的回傳值。
     winget install --id $id --exact --source winget --silent `
         --accept-source-agreements --accept-package-agreements | Out-Host
     if ($LASTEXITCODE -ne 0) {
@@ -72,8 +72,8 @@ function Install-Winget($id, $friendlyName) {
     return $true
 }
 
-# winget 完全不能用時的退路：Git for Windows 的 PortableGit 是 7-Zip 自解壓檔，
-# 解到使用者目錄就能用，不需要系統管理員權限，也不碰 winget 的套件來源。
+# winget 不可用時的備援方案：Git for Windows 的 PortableGit 為 7-Zip 自解壓封存
+# 檔，解壓至使用者目錄即可使用，不需系統管理員權限，亦不經過 winget 的套件來源。
 function Install-GitPortable {
     $arch = switch ($env:PROCESSOR_ARCHITECTURE) {
         'ARM64' { 'arm64' }
@@ -85,7 +85,7 @@ function Install-GitPortable {
             -Uri 'https://api.github.com/repos/git-for-windows/git/releases/latest' `
             -Headers @{ 'User-Agent' = 'CodefyUI-installer' }
     } catch {
-        Warn "無法查詢 Git for Windows release：$($_.Exception.Message)"
+        Warn "無法查詢 Git for Windows release 資訊：$($_.Exception.Message)"
         return $false
     }
 
@@ -93,7 +93,7 @@ function Install-GitPortable {
     $asset = $portable | Where-Object { $_.name -like "*-$arch.7z.exe" } | Select-Object -First 1
     if (-not $asset) { $asset = $portable | Where-Object { $_.name -like '*-64-bit.7z.exe' } | Select-Object -First 1 }
     if (-not $asset) {
-        Warn "Git for Windows release 裡找不到 PortableGit 自解壓檔"
+        Warn "Git for Windows release 中未提供 PortableGit 自解壓封存檔"
         return $false
     }
 
@@ -109,17 +109,17 @@ function Install-GitPortable {
 
     if (Test-Path $target) { Remove-Item -Recurse -Force $target -ErrorAction SilentlyContinue }
     New-Item -ItemType Directory -Path $target -Force | Out-Null
-    # 7-Zip SFX 旗標：-o<dir>（不能有空白）指定解壓目的地、-y 全部同意。
+    # 7-Zip SFX 參數：-o<dir>（與路徑之間不可有空白）指定解壓目的地，-y 為全部同意。
     Start-Process -FilePath $tmp -ArgumentList "-o`"$target`" -y" -Wait -NoNewWindow | Out-Null
     Remove-Item -Force $tmp -ErrorAction SilentlyContinue
 
     $gitCmdDir = Join-Path $target 'cmd'
     if (-not (Test-Path (Join-Path $gitCmdDir 'git.exe'))) {
-        Warn "PortableGit 解壓後找不到 git.exe"
+        Warn "PortableGit 解壓完成後仍找不到 git.exe"
         return $false
     }
     $env:Path = "$gitCmdDir;$env:Path"
-    if (Add-UserPath $gitCmdDir) { Ok "已把 $gitCmdDir 加入使用者 PATH" }
+    if (Add-UserPath $gitCmdDir) { Ok "已將 $gitCmdDir 加入使用者 PATH" }
     return $true
 }
 
@@ -234,9 +234,9 @@ Step "git"
 if (-not (Test-Cmd git)) {
     Warn "Not installed, installing via winget..."
     if (-not (Install-Winget 'Git.Git' 'Git')) {
-        Warn "winget 路徑失敗，改用免安裝的 PortableGit（不需管理員權限）..."
+        Warn "winget 安裝路徑失敗，改用免安裝的 PortableGit（不需系統管理員權限）..."
         if (-not (Install-GitPortable)) {
-            Die "無法自動安裝 git。請手動安裝 Git for Windows（https://git-scm.com/download/win）後重跑安裝指令。"
+            Die "無法自動安裝 git。請手動安裝 Git for Windows（https://git-scm.com/download/win）後重新執行安裝指令。"
         }
     }
     Refresh-Path


### PR DESCRIPTION
> 中文摘要：部分 Windows 機器（電腦教室、企業網路）的 winget `msstore` 來源會因憑證釘選失敗而回報 `0x8a15005e`，一鍵安裝腳本便在第一步的 git 安裝中止。但從錯誤輸出可以看出，`winget` 來源其實已正常解析到 `Git.Git` —— 問題在於我們沒有指定 `--source`，winget 才把「其中一個來源查詢失敗」視為結果不明確而整個終止。本 PR 將安裝指令釘定為 `--source winget`（直接略過 msstore），並讓 `Install-Winget` 從「失敗即終止」改為回傳布林值；另外補上一條 winget 完全不可用時的備援方案：將 PortableGit 解壓至 `%LOCALAPPDATA%\CodefyUI\PortableGit`，不需系統管理員權限，也完全不經過 winget 的套件來源。

## What / Why

Running the documented one-liner on some lab machines fails at the very first step:

```
==> git
  !   Not installed, installing via winget...
Failed when searching source: msstore
An unexpected error occurred while executing the command:
0x8a15005e : The server certificate did not match any of the expected values.

The following packages were found among the working sources.
Please specify one of them using the --source option to proceed.
Name Id      Source
-------------------
Git  Git.Git winget

  X Error: winget install Git.Git failed (exit -1978335138)
```

Two things are going on, and only one of them is ours.

**Not ours:** the machine cannot validate the `msstore` source's pinned certificate. In a computer lab the usual cause is a proxy or antivirus performing TLS interception; a stale App Installer that predates Microsoft's certificate rotation, or a badly skewed system clock, produce the same code.

**Ours:** that failure should have been survivable. winget's own output shows `Git.Git` resolved fine in the working `winget` source. Because `Install-Winget` never passed `--source`, winget treated one dead source as an ambiguous result rather than a recoverable one, told the user to pick a source, and exited non-zero. `Install-Winget` called `Die`, and the installer stopped -- on a machine where every ingredient it needed was actually reachable. An environmental failure was turned into a hard failure by a missing flag.

## What changed

- **Pin the source.** `winget install --id $id --exact --source winget --silent ...` skips msstore entirely, so a broken msstore source is no longer consulted, let alone fatal.

  Native-command stdout lands in the PowerShell success pipeline, so the call is routed through `Out-Host`. Without it, winget's output would be concatenated into the function's return value and every `if (Install-Winget ...)` check would be meaninglessly truthy.

- **`Install-Winget` returns `$true`/`$false` instead of terminating,** so the caller decides what to do next. It also no longer terminates when `winget` itself is missing.

- **New `Install-GitPortable` fallback,** for machines where winget is absent, or where its own source is unreachable too. It resolves the correct PortableGit self-extracting archive for the machine's architecture (`64-bit` / `arm64` / `32-bit`) from the `git-for-windows/git` latest-release API, extracts it into `%LOCALAPPDATA%\CodefyUI\PortableGit`, and adds it to the user PATH.

  PortableGit rather than the regular Git for Windows installer, deliberately: the SFX requires no administrator rights, which matters on locked-down lab machines. And unlike winget, this path downloads through `Invoke-WebRequest`, which validates against the Windows certificate store -- so an inspection proxy whose root CA is already installed on the lab image does not break it. That is precisely the environment that broke winget in the first place.

- **`Add-UserPath` extracted** from the launcher step at the bottom of the script and reused by the fallback, replacing a second copy of the same read-split-append-write logic.

- **Docs updated** in both `docs/docs/getting-started/installation.md` and its zh-TW twin, describing the fallback and the failure it covers.

- **Wording normalised** in a follow-up commit. The script's pre-existing zh-TW messages are written in a formal register; the lines added here had drifted into colloquial usage (`噴 0x8a15005e`, `連不上`, `走退路`, `重跑安裝指令`). These are exactly the lines a user sees when the install fails, so they now match the rest of the file. Comments and string literals only -- no logic touched.

## Closes / relates to

No open issue -- reported directly from a failed install on lab machines.

## Test evidence

```
# 1. Script still parses (read as UTF-8; see the note below on why that matters)
[System.Management.Automation.Language.Parser]::ParseInput($utf8Text, ...)
  -> PATCHED PARSE OK (utf8)

# 2. Source pinning resolves Git.Git on its own, with no msstore query
winget show --id Git.Git --exact --source winget --accept-source-agreements
  -> found Git [Git.Git], version 2.55.0.3 -- single unambiguous hit, no
     "specify one of them using the --source option" prompt

# 3. PortableGit fallback, end to end, on a real machine
   asset resolution  -> v2.55.0.windows.5 / PortableGit-2.55.0.5-64-bit.7z.exe
   download          -> 58,960,208 bytes
   SFX extraction    -> into a target path containing a space, on purpose
   result            -> git version 2.55.0.windows.5

# 4. Repo checks
python scripts/check_control_bytes.py
  -> OK: no raw C0 control bytes in 1193 tracked files
cd docs && pnpm install --frozen-lockfile && pnpm build
  -> [SUCCESS] Generated static files in "build" and "build\zh-TW" (exit 0).
     Two broken-anchor warnings remain, both pre-existing and in unrelated
     zh-TW pages (advanced/python-script-node, usage/graph-as-a-function).
```

## What I deliberately did not do

- **Did not reproduce the msstore certificate failure itself.** No machine here has the broken source. The fix does not depend on reproducing it: winget's ambiguity behaviour when a source fails is what the `--source` flag exists for, and evidence item 2 confirms the pinned source resolves the package alone.

- **Did not add a UTF-8 BOM to `install.ps1`,** although there is a real latent bug in the same file. The file is UTF-8 **without** a BOM, so on a cp950 or cp936 machine, running it locally (`git clone` then `.\install.ps1`) makes PowerShell decode the Chinese comments as ANSI. Big5 trail bytes include `0x5C` and `0x22`, so the mojibake manufactures stray backslashes and quotes and the script fails to parse. Verified on a cp950 machine: it fails identically before and after this PR, so it is not a regression. The documented `irm | iex` path is unaffected, because the response body is decoded as UTF-8 over HTTP. Adding a BOM would fix the local case but put a `U+FEFF` at the head of the string `iex` receives, which warrants its own PR and its own testing rather than being included here.

- **Did not touch `install.sh`.** macOS and Linux go through brew and never had this failure mode.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its zh-TW twin in the same PR.
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do, if a reviewer might expect it.
