### PR TITLE
fix(ui): a media port shows its picture or clip, not its base64 or its repr

### DIFF
--- a/frontend/src/components/InspectorPanel/InspectorPanel.module.css
+++ b/frontend/src/components/InspectorPanel/InspectorPanel.module.css
@@ -185,6 +185,32 @@
 
 /* ── TensorGridView ── */
 
+/* A media port's picture, shown in place of its captured value. Bounded
+   rather than free-scaling because the panel is a narrow side column and the
+   modal's data column is not much wider — a full-size matplotlib figure would
+   push every other port off screen. */
+.portImage {
+  max-width: 100%;
+  max-height: 220px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-base);
+  background: var(--surface-canvas);
+  margin-top: var(--sp-2);
+  object-fit: contain;
+}
+
+/* A clip written by a video port. Taller than .portImage because playback
+   controls sit inside the element and 220px leaves them unusable. */
+.portVideo {
+  max-width: 100%;
+  max-height: 260px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-base);
+  background: var(--surface-canvas);
+  margin-top: var(--sp-2);
+  object-fit: contain;
+}
+
 .tensorView {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/InspectorPanel/InspectorPanel.tsx
+++ b/frontend/src/components/InspectorPanel/InspectorPanel.tsx
@@ -6,7 +6,12 @@ import { BackwardView } from './BackwardView';
 import { TokenChipsView } from './TokenChipsView';
 import { PortGroup, FlowDivider, keyOf } from './PortGroup';
 import type { PortTarget } from './PortGroup';
-import { portDataType, resolveSingleNodePorts, usePortFetches } from './portCaptures';
+import {
+  portDataType,
+  resolveSingleNodePorts,
+  usePortFetches,
+  usePortMedia,
+} from './portCaptures';
 import { isTensor, shapesEqual, makeHighlight } from './diff';
 import { computeSegmentNodes } from '../../utils/segmentPath';
 import styles from './InspectorPanel.module.css';
@@ -113,6 +118,9 @@ export function InspectorPanel() {
     [targets],
   );
   const fetches = usePortFetches(lastRunId, allPorts);
+  // Same source the Node Detail Modal's capture tabs read, so a media port
+  // shows the same picture or clip in the side panel and in the modal.
+  const media = usePortMedia();
 
   const collapseButton = (
     <button type="button"
@@ -181,6 +189,7 @@ export function InspectorPanel() {
             title={t('inspector.segment.inputs', { count: targets.inputs.length })}
             ports={targets.inputs}
             fetches={fetches}
+            media={media}
           />
           <FlowDivider />
           <PortGroup
@@ -188,6 +197,7 @@ export function InspectorPanel() {
             title={t('inspector.segment.outputs', { count: targets.outputs.length })}
             ports={targets.outputs}
             fetches={fetches}
+            media={media}
           />
         </div>
       </div>
@@ -268,6 +278,7 @@ export function InspectorPanel() {
                   ports={inputs}
                   fetches={fetches}
                   emptyText={t('inspector.node.inputsEmpty')}
+                  media={media}
                 />
                 <FlowDivider chip={shapeChip} />
                 <PortGroup
@@ -277,6 +288,7 @@ export function InspectorPanel() {
                   fetches={fetches}
                   emptyText={t('inspector.node.outputsEmpty')}
                   highlight={outHighlight}
+                  media={media}
                 />
               </>
             )}

--- a/frontend/src/components/InspectorPanel/PortGroup.test.tsx
+++ b/frontend/src/components/InspectorPanel/PortGroup.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { NonTensorView } from './PortGroup';
+import { NonTensorView, PortGroup, keyOf } from './PortGroup';
+import type { PortMedia } from './portCaptures';
 import { makeHighlight, shapesEqual } from './diff';
 import { useI18n } from '../../i18n';
 import type { OutputData, TensorOutput } from '../../types';
@@ -86,6 +87,128 @@ describe('NonTensorView', () => {
     const g = { type: 'weird', run_id: 'r', node_id: 'n', port: 'p' } as unknown as OutputData;
     render(<NonTensorView value={g} />);
     expect(screen.getAllByText('weird').length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ── A port that declared media renders what it produced, not its bytes ──────
+// The value on a `media=MEDIA_IMAGE` port is a base64 PNG, and on a
+// `media=MEDIA_VIDEO` port a reference dict. Neither survives the capture
+// path: `/api/execution/outputs` truncates every string at 4000 chars (a plot
+// is ~35 000), and a dict arrives as a `repr`. Both are drawn from the
+// node_status stream instead.
+
+describe('PortGroup — media ports', () => {
+  const PNG =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+  function imageMedia(data = PNG, format = 'png'): PortMedia {
+    return { kind: 'image', image: { format, encoding: 'base64', data } };
+  }
+
+  function videoMedia(format = 'mp4', url = '/api/media/clip.mp4'): PortMedia {
+    return { kind: 'video', video: { path: 'clip.mp4', url, format } };
+  }
+
+  function stringState(value: string) {
+    return {
+      loading: false,
+      error: null,
+      data: { type: 'string', run_id: 'r', node_id: 'n1', port: 'image', value } as OutputData,
+    };
+  }
+
+  function renderPort(media: PortMedia, fetches = {}, port = 'image', displayName?: string) {
+    return render(
+      <PortGroup
+        kind="output"
+        title="Outputs (1)"
+        ports={[{ nodeId: 'n1', port, ...(displayName ? { displayName } : {}) }]}
+        fetches={fetches}
+        media={{ [keyOf('n1', port)]: media }}
+      />,
+    );
+  }
+
+  it('renders the picture instead of the captured base64 string', () => {
+    renderPort(imageMedia(), {
+      [keyOf('n1', 'image')]: stringState('iVBORw0KGgoTRUNCATED'),
+    });
+    const img = screen.getByAltText('image') as HTMLImageElement;
+    expect(img.src).toBe(`data:image/png;base64,${PNG}`);
+    expect(screen.queryByText('iVBORw0KGgoTRUNCATED')).toBeNull();
+  });
+
+  it('honours the payload format rather than assuming png', () => {
+    renderPort(imageMedia(PNG, 'svg+xml'));
+    expect((screen.getByAltText('image') as HTMLImageElement).src).toContain(
+      'data:image/svg+xml;base64,',
+    );
+  });
+
+  it('shows the media with no capture at all (Record outputs off)', () => {
+    renderPort(imageMedia());
+    expect(screen.getByAltText('image')).toBeInTheDocument();
+    // No pending-capture ellipsis alongside it — the picture IS the value.
+    expect(screen.queryByText('…')).toBeNull();
+  });
+
+  it('replaces a capture error rather than stacking under it', () => {
+    renderPort(imageMedia(), {
+      [keyOf('n1', 'image')]: { loading: false, error: 'run data expired', data: null },
+    });
+    expect(screen.getByAltText('image')).toBeInTheDocument();
+    expect(screen.queryByText('run data expired')).toBeNull();
+  });
+
+  it('leaves ports with no media on the ordinary value path', () => {
+    render(
+      <PortGroup
+        kind="output"
+        title="Outputs (2)"
+        ports={[
+          { nodeId: 'n1', port: 'image' },
+          { nodeId: 'n1', port: 'caption' },
+        ]}
+        fetches={{ [keyOf('n1', 'caption')]: stringState('a loss curve') }}
+        media={{ [keyOf('n1', 'image')]: imageMedia() }}
+      />,
+    );
+    expect(screen.getByAltText('image')).toBeInTheDocument();
+    expect(screen.getByText('a loss curve')).toBeInTheDocument();
+  });
+
+  it('uses the row label for alt text when the port has one', () => {
+    renderPort(imageMedia(), {}, 'image', 'Plot.image');
+    expect(screen.getByAltText('Plot.image')).toBeInTheDocument();
+  });
+
+  it('plays a video port in a <video> element instead of showing its repr', () => {
+    renderPort(videoMedia(), {
+      [keyOf('n1', 'video')]: {
+        loading: false,
+        error: null,
+        data: {
+          type: 'dict',
+          run_id: 'r',
+          node_id: 'n1',
+          port: 'video',
+          repr: "{'path': 'clip.mp4', 'url': '/api/media/clip.mp4'}",
+        } as unknown as OutputData,
+      },
+    }, 'video');
+    const video = screen.getByLabelText('video') as HTMLVideoElement;
+    expect(video.tagName).toBe('VIDEO');
+    expect(video.getAttribute('src')).toBe('/api/media/clip.mp4');
+    expect(video.controls).toBe(true);
+    expect(screen.queryByText(/'path': 'clip.mp4'/)).toBeNull();
+  });
+
+  it('puts a gif in an <img> — browsers refuse it as a video source', () => {
+    renderPort(videoMedia('gif', '/api/media/clip.gif'), {}, 'video');
+    const img = screen.getByAltText('video') as HTMLImageElement;
+    expect(img.tagName).toBe('IMG');
+    expect(img.getAttribute('src')).toBe('/api/media/clip.gif');
+    expect(document.querySelector('video')).toBeNull();
   });
 });
 

--- a/frontend/src/components/InspectorPanel/PortGroup.tsx
+++ b/frontend/src/components/InspectorPanel/PortGroup.tsx
@@ -1,5 +1,6 @@
 import type { OutputData, TensorOutput } from '../../types';
 import { TensorGridView } from './TensorGridView';
+import type { PortMedia, PortMediaMap } from './portCaptures';
 import { getPortColor } from '../../utils';
 import styles from './InspectorPanel.module.css';
 
@@ -36,6 +37,7 @@ export function PortGroup({
   fetches,
   emptyText,
   highlight,
+  media,
 }: {
   kind: 'input' | 'output';
   title: string;
@@ -44,6 +46,14 @@ export function PortGroup({
   emptyText?: string;
   /** Per-cell heat for one specific port (the solo-output transform case). */
   highlight?: { portKey: string; fn: (i: number, j: number) => number };
+  /**
+   * What media ports produced last run, keyed by {@link keyOf} — from
+   * `usePortMedia`. A port with an entry here renders the picture or the clip
+   * INSTEAD of its captured value, because that value is not a readable one:
+   * an image port's is a base64 PNG the capture endpoint truncates at 4000
+   * chars, and a video port's is a reference dict that renders as a `repr`.
+   */
+  media?: PortMediaMap;
 }) {
   return (
     <div className={styles.portGroup}>
@@ -54,6 +64,7 @@ export function PortGroup({
         ports.map((p) => {
           const key = keyOf(p.nodeId, p.port);
           const state = fetches[key];
+          const portMedia = media?.[key];
           return (
             <div key={key} className={styles.portBlock}>
               <div className={styles.portHeader}>
@@ -66,22 +77,67 @@ export function PortGroup({
                 )}
                 <span className={styles.portName}>{p.displayName ?? p.port}</span>
               </div>
-              {state?.error && <div className={styles.portError}>{state.error}</div>}
-              {state?.data && state.data.type === 'tensor' && (
-                <TensorGridView
-                  tensor={state.data as TensorOutput}
-                  highlight={highlight && highlight.portKey === key ? highlight.fn : undefined}
-                />
+              {state?.error && !portMedia && (
+                <div className={styles.portError}>{state.error}</div>
               )}
-              {state?.data && state.data.type !== 'tensor' && (
-                <NonTensorView value={state.data} />
+              {portMedia ? (
+                <PortMediaView media={portMedia} label={p.displayName ?? p.port} />
+              ) : (
+                <>
+                  {state?.data && state.data.type === 'tensor' && (
+                    <TensorGridView
+                      tensor={state.data as TensorOutput}
+                      highlight={
+                        highlight && highlight.portKey === key ? highlight.fn : undefined
+                      }
+                    />
+                  )}
+                  {state?.data && state.data.type !== 'tensor' && (
+                    <NonTensorView value={state.data} />
+                  )}
+                  {!state?.data && !state?.error && (
+                    <div className={styles.diffMissing}>…</div>
+                  )}
+                </>
               )}
-              {!state?.data && !state?.error && <div className={styles.diffMissing}>…</div>}
             </div>
           );
         })
       )}
     </div>
+  );
+}
+
+/**
+ * A media port's own output: the picture it drew, or the clip it wrote.
+ *
+ * Kept in step with the results panel's log rows deliberately — a gif is an
+ * animated image and browsers refuse it as a `<video>` source, so it goes in
+ * an `<img>` there and here alike.
+ */
+export function PortMediaView({ media, label }: { media: PortMedia; label: string }) {
+  if (media.kind === 'image') {
+    return (
+      <img
+        className={styles.portImage}
+        src={`data:image/${media.image.format};base64,${media.image.data}`}
+        alt={label}
+      />
+    );
+  }
+  const { video } = media;
+  if (video.format === 'gif') {
+    return <img className={styles.portVideo} src={video.url} alt={label} />;
+  }
+  return (
+    <video
+      className={styles.portVideo}
+      src={video.url}
+      aria-label={label}
+      controls
+      loop
+      preload="metadata"
+    />
   );
 }
 

--- a/frontend/src/components/InspectorPanel/portCaptures.ts
+++ b/frontend/src/components/InspectorPanel/portCaptures.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   fetchOutput,
   RunDataExpiredError,
@@ -6,6 +6,12 @@ import {
 } from '../../api/executionOutputs';
 import type { NodeData, OutputData } from '../../types';
 import type { Edge, Node } from '@xyflow/react';
+import {
+  useTabStore,
+  type LogEntry,
+  type LogImagePayload,
+  type LogVideoPayload,
+} from '../../store/tabStore';
 import { keyOf, type FetchMap, type PortTarget } from './PortGroup';
 
 /**
@@ -68,6 +74,55 @@ export function resolveInputSources(
     result.push({ nodeId: e.source, port: e.sourceHandle });
   }
   return result;
+}
+
+/** Stable empty reference — a fresh `[]` from a zustand selector re-renders forever. */
+const NO_LOGS: LogEntry[] = [];
+
+/** What a media port produced, ready to render. */
+export type PortMedia =
+  | { kind: 'image'; image: LogImagePayload }
+  | { kind: 'video'; video: LogVideoPayload };
+
+export type PortMediaMap = Record<string, PortMedia>;
+
+/**
+ * What each media port produced last run, keyed by {@link keyOf}.
+ *
+ * The capture fetch cannot be the source for either kind. A port declaring
+ * `media=MEDIA_IMAGE` carries a base64 PNG and `/api/execution/outputs`
+ * truncates every string it serves at 4000 chars — two orders of magnitude
+ * under a plot — so what it returns for such a port is a fragment that decodes
+ * to nothing. A port declaring `media=MEDIA_VIDEO` carries a reference dict,
+ * which the capture path can only describe as a `repr`. Both ride the
+ * `node_status` stream instead, which is how the results panel has always
+ * drawn them, and the entry names the port it came from (see
+ * `build_node_output_entries`). Reading the log rather than the capture also
+ * means they still show with "Record outputs" off, the same property the chart
+ * block relies on.
+ *
+ * Later entries win, so a re-run replaces the previous run's media rather than
+ * stacking behind it.
+ */
+export function usePortMedia(): PortMediaMap {
+  const logs = useTabStore(
+    (s) => s.tabs.find((t) => t.id === s.activeTabId)?.logs ?? NO_LOGS,
+  );
+  return useMemo(() => {
+    const out: PortMediaMap = {};
+    for (const entry of logs) {
+      if (!entry.nodeId) continue;
+      // An entry with no `port` predates the named-port contract (or came
+      // from the legacy flat image field): it cannot be attributed to a row,
+      // and guessing would put one node's media on another node's port.
+      if (entry.kind === 'image' && entry.image?.data && entry.image.port) {
+        out[keyOf(entry.nodeId, entry.image.port)] = { kind: 'image', image: entry.image };
+      } else if (entry.kind === 'video' && entry.video?.url && entry.video.port) {
+        out[keyOf(entry.nodeId, entry.video.port)] = { kind: 'video', video: entry.video };
+      }
+    }
+    return out;
+  }, [logs]);
 }
 
 export interface NodePorts {

--- a/frontend/src/components/NodeDetailModal/CapturesTab.tsx
+++ b/frontend/src/components/NodeDetailModal/CapturesTab.tsx
@@ -2,7 +2,11 @@ import { useMemo } from 'react';
 import { useI18n } from '../../i18n';
 import type { OutputSummary } from '../../types';
 import { PortGroup } from '../InspectorPanel/PortGroup';
-import { resolveSingleNodePorts, usePortFetches } from '../InspectorPanel/portCaptures';
+import {
+  resolveSingleNodePorts,
+  usePortFetches,
+  usePortMedia,
+} from '../InspectorPanel/portCaptures';
 import { getPortColor } from '../../utils';
 import { useTabStore, type LogEntry } from '../../store/tabStore';
 import { ChartView } from '../shared/ChartView';
@@ -55,6 +59,9 @@ export function CapturesTab({
   }, [kind, ctx.nodeId, ctx.nodes, ctx.edges]);
 
   const fetches = usePortFetches(ctx.runId, ports);
+  // A port that declared media renders as what it produced — the picture or
+  // the clip — rather than as the string or dict the capture path serves.
+  const media = usePortMedia();
 
   // Charts this node emitted during the run (#130). They arrive on the
   // node_status stream rather than through the captures API, so they are read
@@ -138,6 +145,7 @@ export function CapturesTab({
         ports={ports}
         fetches={fetches}
         emptyText={emptyText}
+        media={media}
       />
     </div>
   );

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
@@ -1446,6 +1446,233 @@ describe('NodeDetailModal — chart outputs (#130)', () => {
   });
 });
 
+// ── A media port shows what it produced on the Outputs tab ──────────────────
+// Visualize declares `media=MEDIA_IMAGE`, so its `image` port carries a base64
+// PNG; VideoWrite declares `media=MEDIA_VIDEO` on `video` (and MEDIA_IMAGE on
+// `preview`), so that port carries a reference dict. The results panel has
+// always drawn both; the capture path never could — it truncates strings at
+// 4000 chars where a plot is ~35 000, and can only `repr` a dict. The rows
+// read from the same node_status stream the log does, which is also why they
+// survive Record outputs being off.
+
+describe('NodeDetailModal — media outputs', () => {
+  const PNG =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+  const OTHER_PNG = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+  function imageLog(nodeId: string, port: string | undefined, data: string) {
+    return {
+      timestamp: 1_700_000_000_000,
+      nodeId,
+      message: '',
+      type: 'info' as const,
+      kind: 'image' as const,
+      image: { format: 'png', encoding: 'base64', data, ...(port ? { port } : {}) },
+    };
+  }
+
+  /** What the capture endpoint actually serves for such a port: a fragment. */
+  function truncatedCapture(): OutputData {
+    return {
+      type: 'string',
+      run_id: 'run1',
+      node_id: 'n1',
+      port: 'image',
+      value: 'iVBORw0KGgoTRUNCATEDAT4000CHARS',
+    } as OutputData;
+  }
+
+  it('renders the picture at its port row instead of the base64 string', async () => {
+    mockOutput.mockResolvedValue(truncatedCapture());
+    seedTab({
+      nodes: [node('n1', { definition: outputsDef(['image']) })],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [imageLog('n1', 'image', PNG)],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+
+    const img = (await screen.findByAltText('image')) as HTMLImageElement;
+    expect(img.src).toBe(`data:image/png;base64,${PNG}`);
+    await waitFor(() => expect(mockOutput).toHaveBeenCalled());
+    expect(screen.queryByText('iVBORw0KGgoTRUNCATEDAT4000CHARS')).toBeNull();
+  });
+
+  it('shows the picture with Record outputs off, when nothing was captured', () => {
+    seedTab({
+      nodes: [node('n1', { definition: outputsDef(['image']) })],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      recordOutputs: false,
+      logs: [imageLog('n1', 'image', PNG)],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+    expect(screen.getByAltText('image')).toBeInTheDocument();
+  });
+
+  it('shows only the picture belonging to the node being inspected', () => {
+    seedTab({
+      nodes: [
+        node('n1', { definition: outputsDef(['image']) }),
+        node('n2', { definition: outputsDef(['image']) }),
+      ],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [imageLog('n1', 'image', PNG), imageLog('n2', 'image', OTHER_PNG)],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+    const img = screen.getByAltText('image') as HTMLImageElement;
+    expect(img.src).toContain(PNG);
+    expect(img.src).not.toContain(OTHER_PNG);
+  });
+
+  it('shows the latest picture logged for the port, not the first', () => {
+    seedTab({
+      nodes: [node('n1', { definition: outputsDef(['image']) })],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run2',
+      logs: [imageLog('n1', 'image', OTHER_PNG), imageLog('n1', 'image', PNG)],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+    expect(screen.getAllByAltText('image')).toHaveLength(1);
+    expect((screen.getByAltText('image') as HTMLImageElement).src).toContain(PNG);
+  });
+
+  it('ignores an entry that names no port — it cannot be attributed to a row', async () => {
+    mockOutput.mockResolvedValue(truncatedCapture());
+    seedTab({
+      nodes: [node('n1', { definition: outputsDef(['image']) })],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [imageLog('n1', undefined, PNG)],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+    expect(screen.queryByAltText('image')).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByText('iVBORw0KGgoTRUNCATEDAT4000CHARS')).toBeInTheDocument(),
+    );
+  });
+
+  it('draws the same picture in the side Inspector as in the modal', () => {
+    seedTab({
+      nodes: [node('n1', { definition: outputsDef(['image']) })],
+      selectedNodeId: 'n1',
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [imageLog('n1', 'image', PNG)],
+    });
+    render(
+      <>
+        <InspectorPanel />
+        <NodeDetailModal />
+      </>,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+    const srcs = screen
+      .getAllByAltText('image')
+      .map((el) => (el as HTMLImageElement).src);
+    expect(srcs).toHaveLength(2);
+    expect(new Set(srcs).size).toBe(1);
+  });
+
+  // ── VideoWrite's `video` port: a reference dict, not bytes (#310) ──────────
+
+  function videoLog(nodeId: string, port: string | undefined, over: Record<string, unknown> = {}) {
+    return {
+      timestamp: 1_700_000_000_000,
+      nodeId,
+      message: '',
+      type: 'info' as const,
+      kind: 'video' as const,
+      video: {
+        path: 'clip.mp4',
+        url: '/api/media/clip.mp4',
+        format: 'mp4',
+        ...over,
+        ...(port ? { port } : {}),
+      },
+    };
+  }
+
+  /** What the capture endpoint serves for a reference port: a repr. */
+  function dictCapture(): OutputData {
+    return {
+      type: 'dict',
+      run_id: 'run1',
+      node_id: 'n1',
+      port: 'video',
+      repr: "{'path': 'clip.mp4', 'url': '/api/media/clip.mp4', 'format': 'mp4'}",
+    } as unknown as OutputData;
+  }
+
+  it('plays the clip at its port row instead of showing the reference dict', async () => {
+    mockOutput.mockResolvedValue(dictCapture());
+    seedTab({
+      nodes: [node('n1', { definition: outputsDef(['video']) })],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [videoLog('n1', 'video')],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+
+    const video = (await screen.findByLabelText('video')) as HTMLVideoElement;
+    expect(video.tagName).toBe('VIDEO');
+    expect(video.getAttribute('src')).toBe('/api/media/clip.mp4');
+    await waitFor(() => expect(mockOutput).toHaveBeenCalled());
+    expect(screen.queryByText(/'path': 'clip.mp4'/)).toBeNull();
+  });
+
+  it('shows a gif clip as an image, since browsers refuse it as a video source', () => {
+    seedTab({
+      nodes: [node('n1', { definition: outputsDef(['video']) })],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [videoLog('n1', 'video', { format: 'gif', url: '/api/media/clip.gif' })],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+    expect((screen.getByAltText('video') as HTMLImageElement).getAttribute('src')).toBe(
+      '/api/media/clip.gif',
+    );
+    expect(document.querySelector('video')).toBeNull();
+  });
+
+  it('draws a clip and a preview picture side by side on the same node', () => {
+    seedTab({
+      nodes: [node('n1', { definition: outputsDef(['video', 'preview']) })],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [videoLog('n1', 'video'), imageLog('n1', 'preview', PNG)],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+    expect(screen.getByLabelText('video')).toBeInTheDocument();
+    expect((screen.getByAltText('preview') as HTMLImageElement).src).toContain(PNG);
+  });
+
+  it('ignores a clip entry that names no port', async () => {
+    mockOutput.mockResolvedValue(dictCapture());
+    seedTab({
+      nodes: [node('n1', { definition: outputsDef(['video']) })],
+      nodeDetailNodeId: 'n1',
+      lastRunId: 'run1',
+      logs: [videoLog('n1', undefined)],
+    });
+    render(<NodeDetailModal />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Outputs' }));
+    expect(screen.queryByLabelText('video')).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByText(/'path': 'clip.mp4'/)).toBeInTheDocument(),
+    );
+  });
+});
+
 describe('NodeDetailModal — tab registry', () => {
   function ctx(over: Partial<NodeDetailTabContext> = {}): NodeDetailTabContext {
     const n = node('n1');


### PR DESCRIPTION
> 中文摘要：雙擊 Visualize 打開節點詳細資訊，「輸出」分頁把 `image` port 印成一長串 base64 字串，但幾秒前同一張圖在執行紀錄裡明明畫得好好的；VideoWrite 的 `video` port 則是印出 Python dict 的 `repr`。宣告從來不是問題 —— 兩個節點都正確宣告了 media，後端也在 node_status 事件裡連同 port 名稱一起送出。問題是那些 port 列讀錯來源：它們讀的是 `/api/execution/outputs`，而那個端點把所有字串截斷在 4000 字元（一張 loss curve 是約 34,600 字元，拿到的是解不開的碎片），dict 也只能給 `repr`。這個 PR 讓 port 列改讀 tab 的 log —— 事件本來就標了來源 port —— 有 media 的 port 直接畫出圖片或影片，取代原本的值。後端零改動，資料早就是對的。

## What / Why

Open a `Visualize` node's details (double-click, or Enter on the selection), go
to **Outputs**, and its `image` port reads as a wall of base64 characters —
while the identical plot rendered as a picture in the execution log seconds
earlier. `VideoWrite`'s `video` port has the same bug wearing a different
costume: a Python dict `repr`.

The `media` declaration was never missing. `Visualize` declares
`media=MEDIA_IMAGE` on `image` (`visualize_node.py:31`), `VideoWrite` declares
`media=MEDIA_VIDEO` on `video` and `MEDIA_IMAGE` on `preview`
(`video_write_node.py:68,80`), and `build_node_output_entries` puts both on the
node_status stream with the originating port attached — a contract
`test_api_contract.py:833` already pins with `assert img["port"] == "image"`.

The port rows were reading the wrong source. They render whatever
`/api/execution/outputs` returns, and that endpoint **cannot carry either
payload**:

- It truncates every string it serves at 4000 chars
  (`routes_execution_outputs.py:167`). Measured against the node's own
  `figsize=(8,6), dpi=100`, a loss-curve PNG is **34 596 base64 chars**. So the
  captured value is not merely ugly to look at — it is a fragment that decodes
  to nothing. Wrapping it in an `<img>` would have shipped a broken-image icon
  and called it fixed.
- A `MEDIA_VIDEO` value is a reference dict (#310 — the bytes never ride the
  event stream), which the same endpoint can only describe as a `repr`.

So the rows now read the media from the tab's log instead. **No backend
change** — the data was already on the wire and already correct.

## What changed

- **`usePortMedia`** (`portCaptures.ts`) folds the tab's log into a
  `nodeId::port -> {kind, payload}` map. Later entries win, so a re-run
  replaces the previous run's media rather than stacking behind it.
- **`PortGroup`** takes an optional `media` map and, for a port that has an
  entry, renders `PortMediaView` **instead of** the captured value — including
  in place of a capture error, since for that row the media is the more
  truthful answer than "run data expired".
- **`PortMediaView`** draws an image port as an `<img>` (honouring the
  payload's `format` rather than assuming png) and a video port as a
  `<video controls loop preload="metadata">` — except a gif, which goes in an
  `<img>` because browsers refuse it as a video source. That is the same split
  the results panel already makes for its log rows.
- **Both surfaces wired**, not just the modal the bug was filed against.
  `portCaptures`' whole premise is that the side Inspector and the Node Detail
  Modal read run data through one path; a picture appearing in one but not the
  other is exactly the drift that module exists to prevent.

Decisions a reviewer might otherwise wonder about:

- **An entry with no `port` is skipped, not guessed at.** Legacy flat-field
  images carry no port, and attributing one to a row by position would put one
  node's picture on another node's port.
- **Nothing sniffs.** Which ports carry media is still only ever what the node
  declared, per the #117 contract that exists precisely because the old
  "long alphanumeric string => base64 PNG" heuristic mislabelled CJK prose and
  token dumps as broken images.
- **Reading the log rather than the capture has a second payoff:** the media
  shows with **Record outputs off**, when the port fetches have nothing at all.
  That is the same property #130's chart block relies on, and it is covered by
  a test.

## Closes / relates to

No open issue — reported directly from the running app.

Related in spirit to #117 (declared media kinds), #127 (the modal and the
Inspector sharing their capture-reading code), #130 (charts on the Outputs tab,
read from the log for the same reason) and #310 (video as a reference).

## Test evidence

```
cd frontend && npx tsc -b
  -> exit 0

cd frontend && npx vitest run
  -> 142 files, 3301 passed (was 3295 before this branch; +6 net)

cd frontend && node scripts/check-contrast.mjs
  -> Contrast gate passed - 403 colour relationships verified across 188 tokens

python scripts/check_control_bytes.py
  -> OK: no raw C0 control bytes in 1193 tracked files
```

New tests — 8 in `PortGroup.test.tsx`, 10 in `NodeDetailModal.test.tsx` (the
latter render the real modal against a real store and assert the rendered
element, not a prop):

- the picture replaces the captured base64 string, and that string is gone
- the payload's `format` is honoured rather than assumed to be png
- the media shows with no capture at all (Record outputs off)
- the media replaces a capture error rather than stacking under it
- ports with no media stay on the ordinary value path
- the row's display name becomes the alt text
- only the inspected node's media is shown
- the latest entry for a port wins over the first
- an entry naming no port is ignored, and the row falls back to its capture
- the modal and the side Inspector draw the same picture
- a video port plays in a `<video>` instead of showing its dict repr
- a gif goes in an `<img>`, with no `<video>` in the tree
- a clip and its `preview` picture render side by side on one node

Measurement backing the truncation claim, run against the node's own matplotlib
settings:

```
png bytes   : 25947
base64 chars: 34596      <- endpoint truncates at 4000
```

## What I deliberately did not do

- **Did not raise the 4000-char cap in `/api/execution/outputs`.** Carrying a
  35 KB base64 blob through the capture path to render what the event stream
  already delivers would be a second copy of the same picture on the wire, and
  the cap protects every other string port. The event stream is the right
  source for declared media; the capture path stays for data.
- **Did not verify in a live browser.** I ran the Forward Diffusion example
  against a dev server and confirmed the picture reaches the execution log, but
  could not drive the Node Details modal open through the automation layer
  (click coordinates did not map to the real viewport). The behaviour is
  covered by the integration tests above, which mount the real modal; a
  reviewer with the app in front of them can confirm in about thirty seconds.
- **Did not touch `MEDIA_CHART`.** Charts already render on the Outputs tab via
  #130's block. Whether they should ALSO move inline to their port row is a
  real question, but it is a design change to working behaviour, not a bug fix,
  so it does not belong in this PR.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its
      zh-TW twin in the same PR. (Neither changed — this is renderer behaviour
      only.)
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do, if a reviewer might expect it.
