### PR TITLE
fix(ui): the quick-add palette is dismissable by click and by Escape

### DIFF
--- a/frontend/src/components/Canvas/FlowCanvas.tsx
+++ b/frontend/src/components/Canvas/FlowCanvas.tsx
@@ -610,7 +610,9 @@ export function FlowCanvas({ tabId }: { tabId?: string } = {}) {
     setContextMenu(null);
     setPaneMenu(null);
     setEdgeTooltip(null);
-    // quickSearch is closed by QuickNodeSearch's own outside-click handler
+    // quickSearch is closed by QuickNodeSearch's own dismissal effect, which
+    // listens in the capture phase precisely because this pane swallows
+    // mousedown before it can bubble to the document.
   }, [selectNodeExclusively]);
 
   const handlePaneContextMenu = useCallback(

--- a/frontend/src/components/Canvas/QuickNodeSearch.test.tsx
+++ b/frontend/src/components/Canvas/QuickNodeSearch.test.tsx
@@ -321,6 +321,67 @@ describe('QuickNodeSearch', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  // ── Dismissal on a surface that owns the pointer ─────────────────────────
+  // React Flow's pane is dragged by d3-zoom, whose mousedown handler calls
+  // `nopropagation(event)` so it can own panning. A bubble-phase document
+  // listener never sees that event, which is why clicking the canvas used to
+  // leave the palette open; and because clicking also blurred the input, the
+  // Escape key that lived on the input stopped working too, leaving no way
+  // out at all.
+
+  /** A stand-in for the React Flow pane: swallows mousedown like d3-zoom. */
+  function paneThatSwallowsMouseDown(): HTMLElement {
+    const pane = document.createElement('div');
+    pane.addEventListener('mousedown', (e) => e.stopImmediatePropagation());
+    document.body.appendChild(pane);
+    return pane;
+  }
+
+  it('closes on a click that the surface underneath stops propagating', () => {
+    setStore([def('Aaa')], []);
+    const onClose = vi.fn();
+    render(<QuickNodeSearch screenPos={SCREEN} flowPos={FLOW} onClose={onClose} />);
+
+    const pane = paneThatSwallowsMouseDown();
+    fireEvent.mouseDown(pane);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    pane.remove();
+  });
+
+  it('Escape still closes after the input has lost focus', () => {
+    setStore([def('Aaa')], []);
+    const onClose = vi.fn();
+    const { getByPlaceholderText } = render(
+      <QuickNodeSearch screenPos={SCREEN} flowPos={FLOW} onClose={onClose} />,
+    );
+    // What clicking the canvas does to the palette: the input is no longer
+    // where keys are routed.
+    (getByPlaceholderText('Search nodes...') as HTMLInputElement).blur();
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('a key other than Escape does not close it', () => {
+    setStore([def('Aaa')], []);
+    const onClose = vi.fn();
+    render(<QuickNodeSearch screenPos={SCREEN} flowPos={FLOW} onClose={onClose} />);
+    fireEvent.keyDown(document.body, { key: 'a' });
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('stops listening once unmounted', () => {
+    setStore([def('Aaa')], []);
+    const onClose = vi.fn();
+    const { unmount } = render(
+      <QuickNodeSearch screenPos={SCREEN} flowPos={FLOW} onClose={onClose} />,
+    );
+    unmount();
+    fireEvent.mouseDown(document.body);
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it('clamps the panel position to stay on screen', () => {
     // Force a large screenPos so Math.min picks the (innerWidth/Height - margin) branch.
     const big = { x: 99999, y: 99999 };

--- a/frontend/src/components/Canvas/QuickNodeSearch.tsx
+++ b/frontend/src/components/Canvas/QuickNodeSearch.tsx
@@ -91,12 +91,11 @@ export function QuickNodeSearch({ screenPos, flowPos, onClose }: QuickNodeSearch
     [addNode, addPresetNode, flowPos, onClose],
   );
 
+  // Navigation only. Escape is deliberately NOT here -- see the dismissal
+  // effect below for why it has to survive the input losing focus.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose();
-      } else if (e.key === 'ArrowDown') {
+      if (e.key === 'ArrowDown') {
         e.preventDefault();
         setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
       } else if (e.key === 'ArrowUp') {
@@ -109,19 +108,42 @@ export function QuickNodeSearch({ screenPos, flowPos, onClose }: QuickNodeSearch
         }
       }
     },
-    [results, selectedIndex, handleSelect, onClose],
+    [results, selectedIndex, handleSelect],
   );
 
-  // Close on outside click
+  // Dismissal: outside click or Escape, the same pair the toolbar's own menus
+  // give. Both listeners sit on the document, and each is there for a reason
+  // the obvious placement got wrong.
+  //
+  // The pointer listener runs in the CAPTURE phase because the surface this
+  // palette floats over is React Flow's pane, and d3-zoom's mousedown handler
+  // calls `nopropagation(event)` -- `stopImmediatePropagation` -- so it can
+  // own panning (d3-zoom/src/zoom.js). A bubble-phase document listener
+  // therefore never sees a click on the canvas: the palette closed for a click
+  // on the toolbar or the sidebar, but not for a click on the canvas, which is
+  // the first place someone dismissing it will click. Capture runs before the
+  // pane's own handler, so stopping propagation there cannot hide the event.
+  //
+  // Escape is on the document because it used to be the input's own onKeyDown.
+  // Clicking the canvas blurs the input, so after one such click the palette
+  // had no dismissal left at all -- neither the click (swallowed above) nor
+  // the key (no longer routed to the input) could close it.
   const panelRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
+    const onPointerDown = (e: MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         onClose();
       }
     };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', onPointerDown, true);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown, true);
+      document.removeEventListener('keydown', onKeyDown);
+    };
   }, [onClose]);
 
   // Position: try to keep on screen


### PR DESCRIPTION
> 中文摘要：在畫布上雙擊會開啟快速新增節點的搜尋面板，但點畫布其他地方關不掉，而且點過一次之後連 Esc 也失效，等於面板卡在畫面上沒有任何出路。兩個症狀是同一個根因：React Flow 的 pane 由 d3-zoom 驅動平移，它的 mousedown handler 會呼叫 `nopropagation(event)`（也就是 `stopImmediatePropagation`），事件在 pane 就死了，面板掛在 document 冒泡階段的 outside-click listener 根本收不到 —— 所以點工具列、點側邊欄都關得掉，唯獨點畫布不行。Esc 則是下游後果：它原本掛在 input 的 `onKeyDown` 上，而點畫布會讓 input 失焦，於是點擊被吞掉、按鍵沒人接。修法是把兩個 listener 合併成一個 effect 掛在 document 上，其中指標事件走**捕獲階段** —— 捕獲比 pane 自己的 handler 更早跑，下游怎麼擋都藏不住事件。

## What / Why

Double-click the canvas to open the quick node search, then try to dismiss it
by clicking the canvas: nothing happens. Worse, after that click **Escape stops
working too**, so the palette sits there with no way out at all.

Two symptoms, one root cause wearing two hats.

**The outside-click handler was never broken — it simply never saw the event.**
React Flow's pane is panned by d3-zoom, whose mousedown handler calls
`nopropagation(event)` (i.e. `stopImmediatePropagation`) so it can own the drag
— `d3-zoom/src/zoom.js:280`. The event dies at the pane, so the bubble-phase
`document` listener the palette registered (`QuickNodeSearch.tsx:117`) never
fires. That is exactly why the palette closed for a click on the toolbar or the
sidebar but not for a click on the canvas — the first place someone dismissing
it is going to click.

**Escape was the downstream consequence.** It lived on the input's own
`onKeyDown`, and clicking the canvas blurs the input, so keys stopped being
routed there. With the click swallowed and the key unrouted, nothing at all
could close the panel. That is the "click somewhere first and then Escape does
not work either" half of the report.

## What changed

One effect registering both listeners on the document — the shape
`SettingsPopover` and `PluginToolbarButtons` already use for their menus, so a
palette does not behave like a different application from the toolbar:

- **The pointer listener runs in the CAPTURE phase.** Capture reaches the
  document *before* the pane's own handler runs, so stopping propagation down
  there cannot hide the event. This is deliberately more general than
  special-casing the pane (e.g. closing it from `onPaneClick`): any surface
  that owns the pointer is covered by construction, not by enumeration.
- **Escape moves to the document,** so it no longer depends on where focus
  sits. The input keeps ArrowUp / ArrowDown / Enter, which are genuinely about
  the field.
- **`FlowCanvas`'s comment is corrected.** It claimed `quickSearch is closed by
  QuickNodeSearch's own outside-click handler` — precisely the thing that was
  not happening. It now says what actually closes it and why the phase matters,
  so the next reader does not re-derive this.

## Closes / relates to

No open issue — reported directly from the running app.

## Test evidence

Both regressions are covered by tests that **fail without this change**. I
reverted the fix and re-ran to confirm they reproduce the reported bugs rather
than merely describing the new code:

```
with the fix reverted:
  2 failed | 20 passed (22)
  FAIL  closes on a click that the surface underneath stops propagating
  FAIL  Escape still closes after the input has lost focus

with the fix restored:
  22 passed (22)
```

The click test uses a stand-in pane that really calls
`stopImmediatePropagation` rather than a mock, so it exercises the actual
mechanism d3-zoom uses. Four tests added in total, the other two covering
"a key other than Escape does not close it" and listener teardown on unmount.

```
cd frontend && npx tsc -b
  -> exit 0

cd frontend && npx vitest run
  -> 142 files, 3305 passed

python scripts/check_control_bytes.py
  -> OK: no raw C0 control bytes in 1193 tracked files
```

**Also verified in the running app** (Vite dev server against a live backend,
driving the real pane rather than a fixture):

```
start            : 1   (sidebar search only)
afterDblclick    : 2   -> palette opened
afterCanvasClick : 1   -> canvas click dismisses it        <- was broken
reopened         : 2
focusAfterBlur   : BODY  (input has lost focus - the state where Escape died)
afterEscape      : 1   -> Escape still dismisses it        <- was broken
```

## What I deliberately did not do

- **Did not close the palette from `FlowCanvas`'s `onPaneClick`.** That would
  have fixed the reported click and left the general bug in place: any other
  surface that owns the pointer would swallow the dismissal the same way, and
  the palette's own dismissal contract would be split across two files.
- **Did not touch the `100ms` `setTimeout` that attaches the dblclick listener**
  in `FlowCanvas`. It is a separate piece of mount-timing debt, unrelated to
  dismissal, and changing it here would put an untested behaviour change in a
  bug-fix PR.
- **Did not memoize the `onClose` prop.** It is an inline arrow, so the effect
  re-registers on every `FlowCanvas` render. That is pre-existing, harmless
  (the listeners are equivalent), and out of scope.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its
      zh-TW twin in the same PR. (Neither changed — no user-facing string was
      added or altered.)
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do, if a reviewer might expect it.
