### PR TITLE
fix(ui): connection handles big enough to hit on the first try

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -85,6 +85,22 @@ body {
   background: var(--surface-canvas);
 }
 
+/* Press target around every connection handle — port dots, Start's trigger
+   diamond, the layers editor's handles. The dot stays as small as the diagram
+   wants; this transparent ring, sized by --handle-hit, is what the mouse has
+   to land on. Applied here rather than per node component so a handle cannot
+   be added without one. */
+.react-flow__handle::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: var(--handle-hit);
+  height: var(--handle-hit);
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+}
+
 .react-flow__edge-path {
   stroke: var(--wire);
   stroke-width: 2;

--- a/frontend/src/components/LayersEditor/InputNode.tsx
+++ b/frontend/src/components/LayersEditor/InputNode.tsx
@@ -57,11 +57,11 @@ function InputNodeComponent({ data, selected }: NodeProps<Node<LayerNodeData>>) 
             position={Position.Bottom}
             style={{
               background: color,
-              width: 10,
-              height: 10,
+              width: 'var(--handle-size)',
+              height: 'var(--handle-size)',
               border: '2px solid var(--surface-raised)',
               left: `${left}%`,
-              bottom: -5,
+              bottom: 'calc(var(--handle-size) / -2)',
             }}
           />
         );

--- a/frontend/src/components/LayersEditor/LayerNode.tsx
+++ b/frontend/src/components/LayersEditor/LayerNode.tsx
@@ -94,10 +94,10 @@ function LayerNodeComponent({ data, selected }: NodeProps<Node<LayerNodeData>>) 
         position={Position.Top}
         style={{
           background: 'var(--border-strong)',
-          width: 8,
-          height: 8,
+          width: 'var(--handle-size)',
+          height: 'var(--handle-size)',
           border: '2px solid var(--surface-raised)',
-          top: -4,
+          top: 'calc(var(--handle-size) / -2)',
         }}
       />
       <Handle
@@ -105,10 +105,10 @@ function LayerNodeComponent({ data, selected }: NodeProps<Node<LayerNodeData>>) 
         position={Position.Bottom}
         style={{
           background: 'var(--border-strong)',
-          width: 8,
-          height: 8,
+          width: 'var(--handle-size)',
+          height: 'var(--handle-size)',
           border: '2px solid var(--surface-raised)',
-          bottom: -4,
+          bottom: 'calc(var(--handle-size) / -2)',
         }}
       />
     </div>

--- a/frontend/src/components/LayersEditor/OutputNode.tsx
+++ b/frontend/src/components/LayersEditor/OutputNode.tsx
@@ -32,11 +32,11 @@ function OutputNodeComponent({ data, selected }: NodeProps<Node<LayerNodeData>>)
             position={Position.Top}
             style={{
               background: color,
-              width: 10,
-              height: 10,
+              width: 'var(--handle-size)',
+              height: 'var(--handle-size)',
               border: '2px solid var(--surface-raised)',
               left: `${left}%`,
-              top: -5,
+              top: 'calc(var(--handle-size) / -2)',
             }}
           />
         );

--- a/frontend/src/components/Nodes/BaseNode.module.css
+++ b/frontend/src/components/Nodes/BaseNode.module.css
@@ -133,9 +133,14 @@
 }
 
 /* ── Port row ── */
+/* The vertical padding is sized by the dot, not by the label: at
+   --handle-size 20px a 4px pad left only 4px of clear space between one
+   port's dot and the next one's, which is exactly the miss-the-target
+   problem the bigger dot was meant to fix. 8px puts the row pitch at ~32px,
+   i.e. a 12px gap between dots and room for the --handle-hit ring. */
 .portRowInput {
   position: relative;
-  padding: var(--sp-2) var(--sp-4) var(--sp-2) var(--sp-5);
+  padding: var(--sp-3) var(--sp-4) var(--sp-3) var(--sp-5);
   display: flex;
   align-items: center;
   gap: var(--sp-3);
@@ -143,7 +148,7 @@
 
 .portRowOutput {
   position: relative;
-  padding: var(--sp-2) var(--sp-5) var(--sp-2) var(--sp-4);
+  padding: var(--sp-3) var(--sp-5) var(--sp-3) var(--sp-4);
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -164,23 +169,25 @@
 }
 
 /* ── Port handle base ── */
-/* Note: background, position offsets injected inline because they depend on data_type and I/O side */
+/* Note: background is injected inline because it depends on data_type. */
 .portHandle {
-  width: 10px !important;
-  height: 10px !important;
+  width: var(--handle-size) !important;
+  height: var(--handle-size) !important;
   border: 2px solid var(--surface-raised) !important;
   border-radius: 50% !important;
   cursor: crosshair !important;
 }
 
+/* Half the dot hangs outside the card edge (the extra 0.5px keeps the old
+   hairline overhang), so its size and its offset stay tied to one token. */
 .portHandleInput {
-  left: -5.5px !important;
+  left: calc(var(--handle-size) / -2 - 0.5px) !important;
   top: 50% !important;
   transform: translateY(-50%) !important;
 }
 
 .portHandleOutput {
-  right: -5.5px !important;
+  right: calc(var(--handle-size) / -2 - 0.5px) !important;
   top: 50% !important;
   transform: translateY(-50%) !important;
 }
@@ -469,16 +476,30 @@
   transition: all var(--transition-fast);
 }
 
+/* This handle exists on every node but is 0x0 and invisible until a trigger
+   drag starts, while React Flow still marks it connectable (pointer-events:
+   all). The global press ring in App.css would therefore park an invisible
+   28px hotspot on every node's top-left corner and swallow drags there, so
+   the ring is withheld until the diamond is actually on screen. */
+.triggerHandle::before {
+  display: none;
+}
+
+.triggerHandleActive::before,
+.triggerHandleDetaching::before {
+  display: block;
+}
+
 .triggerHandleActive {
   /* Visible when user drags from Start trigger. var(--flow-trigger) is the app's
      recurring "trigger / control-flow" green (Start node, entry-point
      marker) — a deliberately different hue from --status-completed's green,
      and tokens.css has no dedicated trigger-flow colour yet (see migration
      report). */
-  width: 14px !important;
-  height: 14px !important;
-  min-width: 14px !important;
-  min-height: 14px !important;
+  width: var(--handle-size-trigger) !important;
+  height: var(--handle-size-trigger) !important;
+  min-width: var(--handle-size-trigger) !important;
+  min-height: var(--handle-size-trigger) !important;
   background: var(--flow-trigger) !important;
   border: 2px solid var(--text-primary) !important;
   opacity: 1;
@@ -492,10 +513,10 @@
    both apply (during a trigger reconnect every node shows the green diamond;
    the originally-connected one must show red instead). */
 .triggerHandleDetaching {
-  width: 14px !important;
-  height: 14px !important;
-  min-width: 14px !important;
-  min-height: 14px !important;
+  width: var(--handle-size-trigger) !important;
+  height: var(--handle-size-trigger) !important;
+  min-width: var(--handle-size-trigger) !important;
+  min-height: var(--handle-size-trigger) !important;
   background: var(--surface-raised) !important;
   border: 2px solid var(--status-error) !important;
   opacity: 1;

--- a/frontend/src/components/Nodes/PresetNode.module.css
+++ b/frontend/src/components/Nodes/PresetNode.module.css
@@ -53,9 +53,11 @@
   padding-bottom: var(--sp-3);
 }
 
+/* Vertical padding matches BaseNode's port rows — see the comment there for
+   why the dot, not the label, sets it. */
 .inputRow {
   position: relative;
-  padding: var(--sp-2) var(--sp-4) var(--sp-2) var(--sp-5);
+  padding: var(--sp-3) var(--sp-4) var(--sp-3) var(--sp-5);
   display: flex;
   align-items: center;
   gap: var(--sp-3);
@@ -63,7 +65,7 @@
 
 .outputRow {
   position: relative;
-  padding: var(--sp-2) var(--sp-5) var(--sp-2) var(--sp-4);
+  padding: var(--sp-3) var(--sp-5) var(--sp-3) var(--sp-4);
   display: flex;
   align-items: center;
   justify-content: flex-end;

--- a/frontend/src/components/Nodes/PresetNode.test.tsx
+++ b/frontend/src/components/Nodes/PresetNode.test.tsx
@@ -270,11 +270,11 @@ describe('PresetNode', () => {
     expect(detaching).toHaveLength(1);
     const handle = detaching[0] as HTMLElement;
     expect(handle.getAttribute('data-handleid')).toBe('x');
-    // The class coexists with PresetNode's inline handle styles — the class's
-    // !important border-color/box-shadow win the cascade over inline styles,
-    // while the untouched inline properties (background, size) remain.
+    // The class coexists with the shared port-dot styling — portDetaching is
+    // declared after portHandle, so its !important border-color/box-shadow win
+    // the cascade, while the inline data-type background remains.
     expect(handle.style.background).not.toBe('');
-    expect(handle.style.width).toBe('10px');
+    expect(handle.className).toMatch(/portHandle/);
   });
 
   it('adds portDetaching to the matching exposed output handle', () => {

--- a/frontend/src/components/Nodes/PresetNode.tsx
+++ b/frontend/src/components/Nodes/PresetNode.tsx
@@ -25,9 +25,9 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
   );
 
   // True when this exact handle is the originally-connected endpoint of an
-  // in-progress edge-reconnect drag; it shows the red "detaching" ring. The
-  // shared baseStyles.portDetaching class uses !important declarations, which
-  // beat this component's inline handle styles per the CSS cascade.
+  // in-progress edge-reconnect drag; it shows the red "detaching" ring.
+  // baseStyles.portDetaching is declared after baseStyles.portHandle, so its
+  // !important border-color/box-shadow win the cascade over the base dot.
   const isDetaching = (handleId: string, type: 'source' | 'target') =>
     reconnectingHandle !== null &&
     reconnectingHandle.nodeId === id &&
@@ -145,18 +145,10 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
               position={Position.Left}
               id={input.name}
               onMouseDownCapture={(e) => interceptConnectedInputMouseDown(e, input.name)}
-              className={isDetaching(input.name, 'target') ? baseStyles.portDetaching : undefined}
-              style={{
-                background: getPortColor(input.data_type),
-                width: 10,
-                height: 10,
-                border: '2px solid var(--surface-raised)',
-                left: -5.5,
-                top: '50%',
-                transform: 'translateY(-50%)',
-                borderRadius: '50%',
-                cursor: 'crosshair',
-              }}
+              className={`${baseStyles.portHandle} ${baseStyles.portHandleInput}${
+                isDetaching(input.name, 'target') ? ` ${baseStyles.portDetaching}` : ''
+              }`}
+              style={{ background: getPortColor(input.data_type) }}
             />
             <span
               className={styles.portLabel}
@@ -189,18 +181,10 @@ function PresetNode({ id, data, selected }: NodeProps<AppNode>) {
               type="source"
               position={Position.Right}
               id={output.name}
-              className={isDetaching(output.name, 'source') ? baseStyles.portDetaching : undefined}
-              style={{
-                background: getPortColor(output.data_type),
-                width: 10,
-                height: 10,
-                border: '2px solid var(--surface-raised)',
-                right: -5.5,
-                top: '50%',
-                transform: 'translateY(-50%)',
-                borderRadius: '50%',
-                cursor: 'crosshair',
-              }}
+              className={`${baseStyles.portHandle} ${baseStyles.portHandleOutput}${
+                isDetaching(output.name, 'source') ? ` ${baseStyles.portDetaching}` : ''
+              }`}
+              style={{ background: getPortColor(output.data_type) }}
             />
           </div>
         ))}

--- a/frontend/src/components/Nodes/StartNode.module.css
+++ b/frontend/src/components/Nodes/StartNode.module.css
@@ -30,8 +30,8 @@
 
 .handle {
   background: var(--flow-trigger) !important;
-  width: 12px !important;
-  height: 12px !important;
+  width: var(--handle-size-trigger) !important;
+  height: var(--handle-size-trigger) !important;
   border: 2px solid var(--text-primary) !important;
   border-radius: 0 !important;
   transform: rotate(45deg) !important;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -196,6 +196,27 @@
   --h-control-lg: 40px; /* primary actions, menu rows, dialog buttons */
   --h-row: 36px; /* list row in the node palette */
 
+  /* Graph connection handles. The dots are the smallest thing on the canvas
+     that has to be hit with a mouse, and teachers reported missing them.
+
+     --handle-size is the OUTER diameter; the dot carries a 2px ring in
+     --surface-raised, the same colour as the node card, so what actually
+     reads as "the dot" is 4px smaller than this. That is why the trigger
+     diamond looked so much bigger at nominally similar numbers: its ring is
+     --text-primary, i.e. part of the shape, and rotating a square by 45deg
+     stretches its widest span to 1.41x its side. The two sizes below are held
+     at a ratio where the dot's visible 13px core and the 13px diamond read as
+     the same weight; move one and the other has to follow.
+
+     --handle-hit is a transparent press target drawn around every handle
+     (App.css, .react-flow__handle::before) so the target can outgrow the dot.
+     20px keeps it inside the dot's own former footprint, i.e. clear of the
+     port label; the port row pitch (~32px, see .portRowInput) is the hard
+     ceiling, past which neighbouring ports steal each other's presses. */
+  --handle-size: 17px; /* port dot, 13px of it visible */
+  --handle-size-trigger: 13px; /* Start / trigger diamond */
+  --handle-hit: 20px;
+
   --radius-sm: 4px;
   --radius: 6px;
   --radius-lg: 8px;


### PR DESCRIPTION
> 中文摘要：老師們反映節點上的連接點太難點到。原因不只是尺寸小——圓點的 2px 邊框用的是 `--surface-raised`，跟節點卡片同色，所以 10px 的圓點實際只有 6px 的色芯看得出來。這個 PR 把 handle 幾何集中成三個 token（圓點 17px／色芯 13px、Start 與 trigger 菱形 13px、每個 handle 外圍 20px 的透明點擊圈），並把 port row 的上下 padding 從 4px 拉到 8px，避免相鄰 port 的點擊圈互相搶按。順帶修掉一個連帶問題：隱藏的 trigger handle 是 0x0 但仍被標成 connectable，若不排除就會在每個節點左上角留下一個吃掉拖曳的隱形熱區。

## What / Why

A port dot is 10px across with a 2px ring in `--surface-raised` — the same
colour as the node card behind it — so only a 6px core ever reads as the dot.
Making the dot nominally bigger does not fix that on its own: the ring grows
with it and stays camouflaged.

What changed:

- **Three tokens own handle geometry** (`--handle-size`, `--handle-size-trigger`,
  `--handle-hit` in `tokens.css`). The dot is 17px with a 13px visible core.
- **A transparent 20px press ring on every handle**, via a single
  `.react-flow__handle::before` rule in `App.css` rather than per component, so
  a handle cannot be added without one. It stops at 20px — the dot's own former
  footprint — to stay clear of the port label next to it.
- **Port rows go from 4px to 8px of vertical padding.** At the old 24px row
  pitch the press rings of neighbouring ports overlap and steal each other's
  presses, which is the same miss-the-target problem in a new form.
- **The Start and trigger diamonds come down from 12px and 14px to 13px.**
  Rotating a square 45 degrees stretches its widest span to 1.41x its side, and
  its ring is `--text-primary`, i.e. part of the shape rather than camouflage.
  At nominally similar numbers the diamond read about five times heavier than
  the dot; measured in the running app the two are now 169 px2 against 133 px2.
- **The hidden trigger handle is excluded from the press ring.** It is 0x0 until
  a trigger drag starts, but React Flow still marks it connectable, so the
  global rule would otherwise park an invisible 20px hotspot on every node's
  top-left corner and swallow drags there. The ring comes back with the diamond.
- **PresetNode and the layers editor nodes stop carrying their own sizes.**
  PresetNode had a duplicate of the dot's inline geometry; it uses the shared
  `portHandle` class now. Its test asserted the inline `10px` width and asserts
  the shared class instead.

Reviewers should start at `frontend/src/styles/tokens.css` (the numbers and why
they are tied together) and `frontend/src/App.css` (the press ring).

## Closes / relates to

No issue — reported directly by teachers using the app.

## Test evidence

Run under Node 22.17.0 (the repo's default Node on this machine, v26, cannot
load the jsdom test environment):

```
cd frontend && pnpm test              -> 3283 passed (142 files)
cd frontend && pnpm exec tsc --noEmit -> clean
cd frontend && pnpm build             -> built in 4.80s
                                         (contrast gate: 403 relationships,
                                          191 tokens, passed)
```

Measured in the running app (`pnpm dev`, backend on :8000, example graph
"Train CNN on MNIST"), reading computed styles off the live DOM:

```
port dot   outer 17px, visible core 13px, area 133 px2
diamond    side 13px,  span 18.4px,       area 169 px2
press ring 20px on port dots; display:none on the hidden trigger handle,
           and block once its active class is applied
port row   pitch 32.3px
```

## Impact and risks

Nodes grow about 8px taller per port row, so saved graphs will look slightly
airier; positions are unaffected. Auto-layout reads measured node sizes, not
constants, so it follows the new heights on its own.

Deliberately not done: `connectionRadius` stays at React Flow's default 20.
Raising it would make dropping an edge on empty canvas snap to a nearby port
instead of opening the quick-node search, which trades one usability problem
for another.

Generated with [Claude Code](https://claude.com/claude-code)

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] No docs page or node-param description changed, so there is no zh-TW twin
      to update.
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] What I deliberately did not do is stated above (`connectionRadius`).
