### PR TITLE
fix(engine): the cache key names the edge, not just the upstream node (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two nodes reading different ports of the same upstream no longer share one
+  cache entry** ([#360]). Running CF201 a second time drew the *same* picture in
+  both `Visualize` nodes hanging off a `Split` — vertical edges where the
+  horizontal-edge map belonged — and reported both as `cached`. The execution
+  cache key was built from the *source node ids* of the incoming edges and
+  nothing else, so `Split.chunk_0` and `Split.chunk_1` contributed the identical
+  `split` key: two same-typed, same-param siblings hashed to one entry, and
+  whichever executed first became the answer for both. `compute_key` then
+  `sorted()` those ids, which erased input-port order too, so
+  `MatMul(a=A, b=B)` and `MatMul(a=B, b=A)` collided as well — that one returned
+  each other's numbers on every re-run, silently and with no error. Each entry
+  now names its whole edge (target handle, source handle, source key) via the
+  new `ExecutionCache.upstream_ref`, so the sort still normalises the order
+  edges are listed in while the ports stay part of the identity. Cold runs were
+  always correct; only re-runs were wrong, which is why this survived so long.
+
 ## [2.4.1] — 2026-08-22
 
 Four fixes that landed on `main` in the hours after 2.4.0, and nothing else:
@@ -2067,6 +2085,7 @@ Release candidates before 1.0.0 are on the
 [#355]: https://github.com/CodefyUI/CodefyUI/pull/355
 [#356]: https://github.com/CodefyUI/CodefyUI/pull/356
 [#357]: https://github.com/CodefyUI/CodefyUI/pull/357
+[#360]: https://github.com/CodefyUI/CodefyUI/issues/360
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...main

--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -90,6 +90,18 @@ class ExecutionCache:
         the point on a multi-GPU box, where serving one card's tensors to a
         run on the other is a device-mismatch crash rather than a slow path.
 
+        ``upstream_keys`` is one entry PER INCOMING EDGE, and each entry must
+        identify the edge's ports as well as its source -- build them with
+        :meth:`upstream_ref`. The bare source keys are not enough (#360):
+        they say which upstream NODES feed this one, and ``sorted()`` below
+        then reduces even that to an unordered bag, so two different wirings
+        hash the same. ``Split.chunk_0`` and ``Split.chunk_1`` both reduce to
+        the one ``split`` key, and ``MatMul(a=A, b=B)`` and
+        ``MatMul(a=B, b=A)`` both reduce to ``{A, B}`` -- in each case the
+        second node gets served the first one's outputs on a re-run. The
+        ``sorted()`` is still right in INTENT (edge iteration order must not
+        change the key) as long as what it sorts keeps the port pair.
+
         ``fingerprint`` is ``node_cls.cache_fingerprint(params)`` (#144,
         #145): ``None`` for the overwhelming majority of nodes, whose
         params already describe their output completely. A node that reads
@@ -115,6 +127,25 @@ class ExecutionCache:
             default=str,
         )
         return hashlib.sha256(payload.encode()).hexdigest()
+
+    @staticmethod
+    def upstream_ref(
+        target_handle: str, source_handle: str, source_key: str
+    ) -> str:
+        """One ``upstream_keys`` entry: an edge, not just its source node.
+
+        JSON rather than a delimiter-joined string so no handle name can
+        forge a boundary -- ``json.dumps`` escapes whatever is in a port
+        name, where a ``"a<-b"`` separator would let a handle literally
+        called ``a<-b`` collide with a different pair. The list order
+        ``(target, source, key)`` puts the receiving port first so that
+        ``compute_key``'s ``sorted()`` groups a node's edges by the input
+        they land on, which is the reading order a human debugging a key
+        wants.
+        """
+        return json.dumps(
+            [target_handle, source_handle, source_key], separators=(",", ":")
+        )
 
     def get(self, key: str) -> dict[str, Any] | None:
         entry = self._store.get(key)

--- a/backend/app/core/graph_engine.py
+++ b/backend/app/core/graph_engine.py
@@ -2131,9 +2131,18 @@ async def execute_graph(
             for src_id, _, _ in incoming.get(node_id, [])
         )
         if cache is not None and node_cacheable and upstream_all_cached:
+            # One entry per EDGE, carrying both handles -- not one per
+            # upstream node (#360). A bare source key says only WHICH node
+            # feeds this one, so two sibling Visualizes reading `chunk_0`
+            # and `chunk_1` off the same Split hashed identically and the
+            # second was served the first's image on every re-run; ditto
+            # MatMul(a=A,b=B) vs MatMul(a=B,b=A), which returned each
+            # other's numbers with no error. compute_key still sorts these,
+            # which normalises edge ORDER while the port pair survives.
             upstream_keys = [
-                node_cache_keys[src_id]
-                for src_id, _, _ in incoming.get(node_id, [])
+                cache.upstream_ref(tgt_handle, src_handle,
+                                   node_cache_keys[src_id])
+                for src_id, src_handle, tgt_handle in incoming.get(node_id, [])
             ]
             # #144/#145: a node whose output depends on external state a
             # path param only NAMES (not contains) folds a cheap descriptor

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -1,5 +1,7 @@
 """Tests for node-level execution caching (Phase 5)."""
 
+from typing import Any
+
 import pytest
 
 from app.core.cache import ExecutionCache
@@ -278,3 +280,182 @@ async def test_non_cacheable_upstream_invalidates_downstream_cache():
     finally:
         registry._nodes.pop("_NonCacheable", None)
         registry._nodes.pop("_Passthrough", None)
+
+
+# ── #360: the key must identify EDGES, not just upstream nodes ───────────
+
+
+class _TwoOutNode(BaseNode):
+    """Cacheable source with two DIFFERENT output ports, like ``Split``."""
+
+    NODE_NAME = "_TwoOut"
+    CATEGORY = "Test"
+    DESCRIPTION = "Two distinguishable outputs"
+
+    @classmethod
+    def define_inputs(cls):
+        return []
+
+    @classmethod
+    def define_outputs(cls):
+        return [
+            PortDefinition(name="left", data_type=DataType.ANY),
+            PortDefinition(name="right", data_type=DataType.ANY),
+        ]
+
+    def execute(self, inputs, params):
+        return {"left": "LEFT", "right": "RIGHT"}
+
+
+class _PairNode(BaseNode):
+    """Cacheable node whose two inputs are NOT interchangeable, like ``MatMul``."""
+
+    NODE_NAME = "_Pair"
+    CATEGORY = "Test"
+    DESCRIPTION = "Order-sensitive over two inputs"
+
+    @classmethod
+    def define_inputs(cls):
+        return [
+            PortDefinition(name="a", data_type=DataType.ANY),
+            PortDefinition(name="b", data_type=DataType.ANY),
+        ]
+
+    @classmethod
+    def define_outputs(cls):
+        return [PortDefinition(name="out", data_type=DataType.ANY)]
+
+    def execute(self, inputs, params):
+        return {"out": f"{inputs.get('a')}->{inputs.get('b')}"}
+
+
+def test_compute_key_distinguishes_source_handles():
+    """Two nodes reading different OUTPUT ports of one upstream differ."""
+    left = ExecutionCache.upstream_ref("data", "chunk_0", "split-key")
+    right = ExecutionCache.upstream_ref("data", "chunk_1", "split-key")
+    assert ExecutionCache.compute_key(
+        "Visualize", {}, [left]
+    ) != ExecutionCache.compute_key("Visualize", {}, [right])
+
+
+def test_compute_key_distinguishes_swapped_target_handles():
+    """Same two upstreams wired into swapped INPUT ports differ."""
+    ab = [
+        ExecutionCache.upstream_ref("tensor_a", "tensor", "A"),
+        ExecutionCache.upstream_ref("tensor_b", "tensor", "B"),
+    ]
+    ba = [
+        ExecutionCache.upstream_ref("tensor_a", "tensor", "B"),
+        ExecutionCache.upstream_ref("tensor_b", "tensor", "A"),
+    ]
+    assert ExecutionCache.compute_key(
+        "MatMul", {}, ab
+    ) != ExecutionCache.compute_key("MatMul", {}, ba)
+
+
+def test_compute_key_ignores_edge_order():
+    """The port pair is what matters; the order edges are listed in is not."""
+    refs = [
+        ExecutionCache.upstream_ref("tensor_a", "tensor", "A"),
+        ExecutionCache.upstream_ref("tensor_b", "tensor", "B"),
+    ]
+    assert ExecutionCache.compute_key(
+        "MatMul", {}, refs
+    ) == ExecutionCache.compute_key("MatMul", {}, list(reversed(refs)))
+
+
+def test_upstream_ref_handle_cannot_forge_a_boundary():
+    """A handle containing the separator must not collide with another pair."""
+    assert ExecutionCache.upstream_ref("a", "b,c", "k") != \
+        ExecutionCache.upstream_ref("a,b", "c", "k")
+
+
+@pytest.mark.asyncio
+async def test_siblings_off_one_multi_output_node_keep_separate_entries():
+    """Regression (#360): the CF201 shape.
+
+    ``_TwoOut`` fans ``left``/``right`` into two same-typed, same-param
+    ``_Passthrough`` siblings. Before the fix both hashed to the SAME key
+    (only the shared source node id reached the key), so on the second run
+    both were served whichever one landed in the cache first -- in CF201
+    that meant two ``Visualize`` nodes rendering one identical image.
+    """
+    registry._nodes["_TwoOut"] = _TwoOutNode
+    registry._nodes["_Passthrough"] = _PassthroughNode
+    try:
+        cache = ExecutionCache()
+        nodes = [
+            _start_node(),
+            {"id": "src", "type": "_TwoOut", "data": {"params": {}}},
+            {"id": "l", "type": "_Passthrough", "data": {"params": {}}},
+            {"id": "r", "type": "_Passthrough", "data": {"params": {}}},
+        ]
+        edges = [
+            _trigger("et", "start", "src"),
+            {"id": "e1", "source": "src", "target": "l", "sourceHandle": "left", "targetHandle": "in_value"},
+            {"id": "e2", "source": "src", "target": "r", "sourceHandle": "right", "targetHandle": "in_value"},
+        ]
+
+        for run in (1, 2, 3):
+            seen: dict[str, tuple[str, Any]] = {}
+
+            async def capture(node_id, status, data):
+                if status in ("completed", "cached"):
+                    seen[node_id] = (status, data)
+
+            await execute_graph(nodes, edges, cache=cache, on_progress=capture)
+            assert seen["l"][1]["out"] == "LEFT", f"run {run}: {seen['l']}"
+            assert seen["r"][1]["out"] == "RIGHT", f"run {run}: {seen['r']}"
+
+        # ...and caching is still doing its job on the re-runs.
+        assert seen["l"][0] == "cached"
+        assert seen["r"][0] == "cached"
+    finally:
+        registry._nodes.pop("_TwoOut", None)
+        registry._nodes.pop("_Passthrough", None)
+
+
+@pytest.mark.asyncio
+async def test_swapped_input_ports_keep_separate_entries():
+    """Regression (#360): the silent-wrong-numbers shape.
+
+    Two ``_Pair`` nodes fed by the same two upstreams with ``a``/``b``
+    swapped. Before the fix ``sorted(upstream_keys)`` erased the
+    difference, so the second node returned the first one's result on
+    every re-run -- for ``MatMul`` that is ``A@B`` answering ``B@A`` with
+    no error raised.
+    """
+    registry._nodes["_Pair"] = _PairNode
+    try:
+        cache = ExecutionCache()
+        nodes = [
+            _start_node(),
+            {"id": "A", "type": "_CacheTest", "data": {"params": {"val": "A"}}},
+            {"id": "B", "type": "_CacheTest", "data": {"params": {"val": "B"}}},
+            {"id": "ab", "type": "_Pair", "data": {"params": {}}},
+            {"id": "ba", "type": "_Pair", "data": {"params": {}}},
+        ]
+        edges = [
+            _trigger("t1", "start", "A"),
+            _trigger("t2", "start", "B"),
+            {"id": "e1", "source": "A", "target": "ab", "sourceHandle": "out", "targetHandle": "a"},
+            {"id": "e2", "source": "B", "target": "ab", "sourceHandle": "out", "targetHandle": "b"},
+            {"id": "e3", "source": "B", "target": "ba", "sourceHandle": "out", "targetHandle": "a"},
+            {"id": "e4", "source": "A", "target": "ba", "sourceHandle": "out", "targetHandle": "b"},
+        ]
+
+        for run in (1, 2, 3):
+            seen: dict[str, tuple[str, Any]] = {}
+
+            async def capture(node_id, status, data):
+                if status in ("completed", "cached"):
+                    seen[node_id] = (status, data)
+
+            await execute_graph(nodes, edges, cache=cache, on_progress=capture)
+            assert seen["ab"][1]["out"] == "A->B", f"run {run}: {seen['ab']}"
+            assert seen["ba"][1]["out"] == "B->A", f"run {run}: {seen['ba']}"
+
+        assert seen["ab"][0] == "cached"
+        assert seen["ba"][0] == "cached"
+    finally:
+        registry._nodes.pop("_Pair", None)


### PR DESCRIPTION
Fixes #360.

## The bug

`upstream_keys` was built from the **source node ids** of a node's incoming edges and nothing else — both handles were dropped at the comprehension (`for src_id, _, _ in ...`). `ExecutionCache.compute_key` then `sorted()` those ids, reducing a node's wiring to an unordered bag of upstream node keys. Two distinct wirings collapse to one key:

1. **Same source, different output port.** `Split.chunk_0` and `Split.chunk_1` both contribute the single `split` key, so two same-typed, same-param siblings hash identically — whichever runs first becomes the answer for both on every re-run.
2. **Same sources, swapped input ports.** `MatMul(a=A, b=B)` and `MatMul(a=B, b=A)` both contribute `{A_key, B_key}`; the `sorted()` erases the difference. That one returns each other's *numbers*, silently, with no error raised.

Reported from CF201 (邊緣特徵圖堆疊): `MaxPool2d → Split(chunks=2, dim=1) → Visualize(chunk_0) / Visualize(chunk_1)`.

## The fix

Each `upstream_keys` entry now names its whole edge — `(target_handle, source_handle, source_key)` — via a new `ExecutionCache.upstream_ref`. JSON-serialised rather than delimiter-joined so no handle name can forge a boundary (a port literally called `a,b` would otherwise collide with a different pair).

The `sorted()` stays. It was right in *intent* — edge iteration order must not change the key — and now normalises only that, while the port pair survives into the hash.

`ExecutionCache` is in-memory and per-WebSocket-connection, never persisted, so the key shape changing has no stale on-disk cache to migrate.

## Verification

Real CF201 graph (`CF201_答案圖_Visual_cache污染.json`), same cache across three runs, sha of each `Visualize` node's base64 PNG:

**Before**
```
[run 1] [['running','completed'], ['running','completed']]  ['4572e41ec5e5', '0e5b1ed5bbf7']  SAME=False
[run 2] [['cached'], ['cached']]                            ['0e5b1ed5bbf7', '0e5b1ed5bbf7']  SAME=True
[run 3] [['cached'], ['cached']]                            ['0e5b1ed5bbf7', '0e5b1ed5bbf7']  SAME=True
```

**After**
```
[run 1] [['running','completed'], ['running','completed']]  ['4572e41ec5e5', '0e5b1ed5bbf7']  SAME=False
[run 2] [['cached'], ['cached']]                            ['4572e41ec5e5', '0e5b1ed5bbf7']  SAME=False
[run 3] [['cached'], ['cached']]                            ['4572e41ec5e5', '0e5b1ed5bbf7']  SAME=False
```

Both nodes still report `cached` — caching is intact, they just no longer share an entry.

Run 1 was correct before the fix only because the two siblings sit on the same level and race each other to a miss. The moment either one lands in the cache, both read it.

## Tests

Six new tests in `backend/tests/test_cache.py`, all of which fail without the source change (verified by stashing the fix and re-running):

- `test_compute_key_distinguishes_source_handles` — the `Split` shape at key level
- `test_compute_key_distinguishes_swapped_target_handles` — the `MatMul` shape at key level
- `test_compute_key_ignores_edge_order` — the order-insensitivity the `sorted()` still owes
- `test_upstream_ref_handle_cannot_forge_a_boundary` — the delimiter case
- `test_siblings_off_one_multi_output_node_keep_separate_entries` — end-to-end through `execute_graph`, three runs
- `test_swapped_input_ports_keep_separate_entries` — end-to-end, three runs

Full backend suite: **5223 passed**, 36 skipped. The 7 failures (`test_device_index.py` ×5, `test_tiered_policy.py`, `test_timestep_embedding_node.py`) are pre-existing on `main` — confirmed by running them against a clean tree — and unrelated to this change. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtswbmtwirwHobBbDuvv6i
