### PR TITLE
fix(plugins): a missing pack names the catalog it is missing from (#363)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Open [http://localhost:8000](http://localhost:8000). The single uvicorn process 
 | `cdui test` | Run the backend (`pytest`) and frontend (`vitest`) tests; the frontend half is skipped, not failed, when pnpm is absent |
 | `cdui clean` | Remove virtualenv, `node_modules`, and `frontend/dist` |
 | `cdui uninstall` | Clean + remove the PATH launcher |
-| `cdui plugin install <name\|url>` | Install a plugin pack (catalog name like `C2`, `owner/repo[@ref]`, or full GitHub URL) |
+| `cdui plugin install <name\|url>` | Install a plugin pack (catalog name like `foundations`, `owner/repo[@ref]`, or full GitHub URL) |
 | `cdui plugin list` | List installed plugin packs |
 | `cdui plugin uninstall <id>` | Remove an installed plugin pack |
 
@@ -178,6 +178,7 @@ cumulatively as you progress:
 
 ```bash
 cdui plugin install foundations deep rl   # full textbook companion
+cdui plugin install edu stats             # hands-on labs + descriptive statistics
 cdui plugin list
 cdui plugin info deep                      # manifest, lessons covered, node names
 cdui plugin search attention              # query the catalog
@@ -196,6 +197,8 @@ and lets `cdui start` rediscover them on the next launch.
 | `foundations` | I1 資料表示 · I2 經典 ML | Edu-ColumnStats, Edu-KNN, Edu-LinearRegression, Edu-LogisticRegression, Edu-TokenEmbedding, Edu-FFN |
 | `deep` | I3 視覺 · I4 序列 | Edu-CrossAttention, Edu-ResBlock, Edu-SelfAttention, Edu-MultiHeadAttention, Edu-Patchify |
 | `rl` | I5 強化學習 | Edu-PolicyGradient |
+| `edu` | I1 資料表示 · I2 經典 ML（動手做版） | FilterRows, SlidingWindow2D, SentenceEmbedding, Classifier, AdvancedClassifier, FFNLayer, ActivationLayer, TrainAndEvaluate |
+| `stats` | — 任何資料集 | Stats-Describe, Stats-GroupByAggregate, Stats-Histogram, Stats-Percentile, Stats-Correlation, Stats-ConfusionMatrix, Stats-TableView, Stats-ChartView |
 
 Each Edu node decomposes a single lesson concept into a chain of named steps
 that the Teaching Inspector renders one row at a time — `Edu-ColumnStats`

--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -49,6 +49,54 @@ def test_parse_source_rejects_garbage():
         plugin_cli.parse_source("not a valid source spec")
 
 
+def test_parse_source_names_the_example_from_the_catalog():
+    # Hard-coding the example is how this line spent releases advertising "C2"
+    # after that pack was renamed away.
+    with pytest.raises(ValueError) as excinfo:
+        plugin_cli.parse_source("not a valid source spec")
+    example = sorted(plugin_cli.load_catalog()["plugins"])[0]
+    assert f"e.g. {example}" in str(excinfo.value)
+
+
+def test_parse_source_unknown_bare_name_lists_the_catalog(monkeypatch):
+    # A bare word is unambiguously a catalog name, so saying "expected a catalog
+    # name" back is a dead end: say which ones this install actually has.
+    monkeypatch.setenv("CODEFYUI_LANG", "en")
+    with pytest.raises(ValueError) as excinfo:
+        plugin_cli.parse_source("edo")
+    msg = str(excinfo.value)
+    assert "No plugin pack named 'edo'" in msg
+    for pack_id in plugin_cli.load_catalog()["plugins"]:
+        assert pack_id in msg
+    assert "cdui update" in msg  # the fix for the stale-install case
+
+
+def test_parse_source_unknown_bare_name_flags_an_unreadable_catalog(monkeypatch):
+    # An empty catalog fails every name, including the valid ones — say so
+    # instead of blaming the name the user typed.
+    monkeypatch.setenv("CODEFYUI_LANG", "en")
+    monkeypatch.setattr(plugin_cli, "load_catalog", lambda: {"schema": 1, "plugins": {}})
+    with pytest.raises(ValueError) as excinfo:
+        plugin_cli.parse_source("foundations")
+    msg = str(excinfo.value)
+    assert "(none)" in msg
+    assert str(plugin_cli._catalog_path()) in msg
+
+
+def test_parse_source_bare_name_error_is_localized(monkeypatch):
+    monkeypatch.setenv("CODEFYUI_LANG", "zh")
+    with pytest.raises(ValueError) as excinfo:
+        plugin_cli.parse_source("edo")
+    assert "內建包" in str(excinfo.value)
+
+
+def test_parse_source_accepts_every_catalog_pack():
+    # Regression for the report that `cdui plugin install edu` "could not parse
+    # plugin source" — every id the catalog ships must round-trip.
+    for pack_id in plugin_cli.load_catalog()["plugins"]:
+        assert plugin_cli.parse_source(pack_id) == ("catalog", pack_id, "", "")
+
+
 # ── validate_manifest ──────────────────────────────────────────────────────
 
 def _good_manifest(plugin_id: str = "test-pack") -> dict:

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -11,6 +11,7 @@ Educational ("Edu") nodes ship as installable **plugin packs**, organised **by d
 ```bash
 cdui plugin sync                           # install every built-in pack you have not decided about
 cdui plugin install foundations deep rl   # or pick them one by one
+cdui plugin install edu stats              # hands-on labs, descriptive statistics
 cdui plugin list
 cdui plugin info deep                      # manifest, lessons covered, node names
 cdui plugin search attention               # query the catalog
@@ -25,6 +26,7 @@ cdui plugin uninstall deep                 # remembered: sync will not re-add it
 | `foundations` | I1 Data Representation · I2 Classical ML | Edu-ColumnStats, Edu-KNN, Edu-LinearRegression, Edu-LogisticRegression, Edu-TokenEmbedding, Edu-FFN |
 | `deep` | I3 Vision · I4 Sequences | Edu-CrossAttention, Edu-ResBlock, Edu-SelfAttention, Edu-MultiHeadAttention, Edu-Patchify |
 | `rl` | I5 Reinforcement Learning | Edu-PolicyGradient |
+| `edu` | I1 Data Representation · I2 Classical ML (hands-on labs) | FilterRows, SlidingWindow2D, SentenceEmbedding, Classifier, AdvancedClassifier, FFNLayer, ActivationLayer, TrainAndEvaluate |
 | `stats` | — (any dataset) | Stats-Describe, Stats-GroupByAggregate, Stats-Histogram, Stats-Percentile, Stats-Correlation, Stats-ConfusionMatrix, Stats-TableView, Stats-ChartView |
 
 `stats` is the odd one out: not a textbook companion but a working reference for third-party pack authors. It is pure numpy + torch, installs at [Tier 0](#security--three-tiers) with **no `[security]` section at all**, and its [README](https://github.com/CodefyUI/CodefyUI/blob/main/plugins/stats/README.md) is the normative write-up of the two contracts a data pack needs — how a table travels between ports, and how a `chart` output is declared and drawn.

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -251,6 +251,46 @@ _GITHUB_SHORT = re.compile(r"^([\w.-]+)/([\w.-]+?)(?:@([\w./-]+))?$")
 _GITHUB_URL = re.compile(
     r"^https?://(?:www\.)?github\.com/([\w.-]+)/([\w.-]+?)(?:\.git)?/?(?:@(.+))?$"
 )
+# One word, no slash and no scheme: the only thing it can have been meant as is
+# a catalog name. See _unknown_catalog_name for why that deserves its own error.
+_BARE_NAME = re.compile(r"^[A-Za-z0-9][\w.-]*$")
+
+
+def _unknown_catalog_name(spec: str, known: list[str]) -> ValueError:
+    """The error for a bare word this install's catalog does not have (#363).
+
+    The generic "expected a catalog name, owner/repo, or a URL" is a dead end
+    here, because the user *did* type a catalog name — what they cannot see is
+    that their copy of ``plugins/registry.json`` has never heard of it. The
+    usual reason is an install old enough to predate the pack: a stale ``cdui``
+    reported exactly this for ``edu``, which only entered the catalog in 1.3.0,
+    and the message gave its user nothing to act on. So name the packs this
+    install really has, and point at the update that would add the missing one.
+    """
+    have = ", ".join(known) if known else t("（無）", "(none)")
+    lines = [
+        t(
+            f"這份安裝的內建外掛目錄裡沒有 {spec!r}。",
+            f"No plugin pack named {spec!r} in this install's catalog.",
+        ),
+        t(f"目前可裝的內建包：{have}", f"Built-in packs available here: {have}"),
+    ]
+    if not known:
+        lines.append(
+            t(
+                f"目錄檔讀不到或是空的：{_catalog_path()}",
+                f"The catalog file is missing or unreadable: {_catalog_path()}",
+            )
+        )
+    lines.append(
+        t(
+            "若這個包應該存在，代表你的 CodefyUI 比它舊 — 先執行 `cdui update` "
+            "再試一次；第三方外掛則要寫成 owner/repo[@ref] 或完整的 GitHub URL。",
+            "If the pack should exist, this install predates it — run `cdui update` "
+            "and try again. Third-party packs need owner/repo[@ref] or a full GitHub URL.",
+        )
+    )
+    return ValueError("\n    ".join(lines))
 
 
 def parse_source(spec: str) -> tuple[str, str, str, str]:
@@ -260,6 +300,7 @@ def parse_source(spec: str) -> tuple[str, str, str, str]:
     For github: ``a`` = owner, ``b`` = repo, ``ref`` = tag/branch/sha (may be empty).
     """
     catalog = load_catalog()
+    known = sorted(catalog.get("plugins", {}))
     if spec.lower() in catalog.get("plugins", {}):
         return ("catalog", spec.lower(), "", "")
 
@@ -271,9 +312,19 @@ def parse_source(spec: str) -> tuple[str, str, str, str]:
     if m:
         return ("github", m.group(1), m.group(2), m.group(3) or "")
 
+    if _BARE_NAME.match(spec):
+        raise _unknown_catalog_name(spec, known)
+
+    # Name the example from the catalog rather than hard-coding it: this line
+    # spent three releases telling people to try "C2" after that pack was gone.
+    example = known[0] if known else "foundations"
     raise ValueError(
-        f"Could not parse plugin source: {spec!r}. "
-        "Expected a catalog name (e.g. foundations), owner/repo[@ref], or a GitHub URL."
+        t(
+            f"無法解析外掛來源：{spec!r}。請輸入內建包名稱"
+            f"（例如 {example}）、owner/repo[@ref] 或 GitHub URL。",
+            f"Could not parse plugin source: {spec!r}. "
+            f"Expected a catalog name (e.g. {example}), owner/repo[@ref], or a GitHub URL.",
+        )
     )
 
 


### PR DESCRIPTION
Closes #363.

A user reported `cdui plugin install edu` failing with `Could not parse plugin source: 'edu'. Expected a catalog name (e.g. C2), owner/repo[@ref], or a GitHub URL.`

Their install predates the pack. Two fingerprints in the one screenshot date it to before tag 1.1.0: the message says `e.g. C2` (a literal that existed only between #21 and #30, and #30 landed before 1.1.0), and `scripts/dev.py:86` still raised the `locale.getdefaultlocale` DeprecationWarning that #39 fixed. `edu` entered the catalog in #49 and first shipped in 1.3.0, so their `registry.json` held `c1`–`c6` and the pack they were told to install genuinely did not exist for them. `edu` is fine on `main` — parse, manifest validation and the install-time AST gate all pass for every built-in pack.

The defect this PR fixes is the message. The user typed a catalog name; being told to type a catalog name answers a question they did not ask.

## Changes

**`scripts/plugins.py`**

`parse_source`'s single failure becomes two. A bare word — no slash, no scheme — can only ever have been meant as a catalog name, so it now gets an error that names the packs this install actually has and points at `cdui update`:

```
✗ No plugin pack named 'edo' in this install's catalog.
  Built-in packs available here: deep, edu, foundations, rl, stats
  If the pack should exist, this install predates it — run `cdui update` and try
  again. Third-party packs need owner/repo[@ref] or a full GitHub URL.
```

When the catalog comes back empty it additionally names the `registry.json` path. That case matters on its own: `load_catalog()` swallows `JSONDecodeError`/`OSError` and returns no plugins, after which *every* name fails to parse — the valid ones included — and blaming the name the user typed sends them looking in the wrong place.

Both errors are now localized; they were English-only in the zh half of `err(...)`. And the generic message's example pack id is read off the loaded catalog instead of being hard-coded — the hard-coded one advertised `C2` for three releases after that pack was renamed away, which is how a help string ended up naming a pack that did not exist.

**Docs**

`edu` appeared in no pack table: `README.md` lists only `foundations` / `deep` / `rl`, and the docs site adds `stats` but not `edu`. A user who hears about the pack has no way to confirm it is real. Added to both, `stats` added to README's, and README's CLI table no longer documents the catalog name as `` `C2` ``.

**Tests** — 5 added to `backend/tests/test_plugin_cli.py`: every catalog id round-trips through `parse_source` (the direct regression for the report), the bare-name error lists the catalog and mentions `cdui update`, an empty catalog names its own path, the zh message localizes, and the generic example comes from the catalog rather than a literal.

## Verification

`tests/test_plugin_cli.py` + catalog honesty + pack discovery: 110 passed. Full backend suite: 5247 passed, 7 failed — all 7 (`test_device_index`, `test_tiered_policy`, `test_timestep_embedding_node`) fail identically on a clean tree and are unrelated. `ruff check` clean on both changed Python files.

## Follow-up, not in this PR

The `edu` pack's eight nodes have no test coverage at all, and `test_plugin_catalog_honesty.py` cannot reach them: its `NODE_NAME_RE` matches only hyphenated `Edu-*` / `Stats-*` names while `edu`'s nodes are bare CamelCase (`Classifier`, `FFNLayer`, …). The pack currently has no automated defence of any kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmvwbefEGi2niy39dQmYk1
