### PR TITLE
fix(ui,examples,i18n): the kernel grid tells the truth, C1-3 gets its figure, Conv2dExplicit speaks zh-TW

### DIFF
--- a/backend/tests/test_api_nodes.py
+++ b/backend/tests/test_api_nodes.py
@@ -349,8 +349,11 @@ async def test_loss_and_dataloader_advertise_their_new_params(test_client):
 #: core#136's: the review found that this test was still hardcoded to the
 #: original four, so eleven new nodes and twenty-three new param keys were
 #: translated correctly and pinned by nothing -- the same gap the test was
-#: written for.
+#: written for. ``Conv2dExplicit`` is #367's: #362 gave it three new
+#: user-facing params in English on the node that C1-3 §C1.3.4.1 teaches
+#: from, so it was translated and moved up here out of the debt list below.
 TRANSLATED_NODES = (
+    "Conv2dExplicit",
     "Optimizer",
     "Loss",
     "DataLoader",
@@ -373,10 +376,11 @@ TRANSLATED_NODES = (
 #: older than core#136 -- listed rather than fixed because translating
 #: sixteen nodes is its own change. The point of the list is the ratchet in
 #: ``test_no_new_node_ships_without_a_zh_tw_entry``: this set may shrink,
-#: never grow. Delete a name from here when you translate it.
+#: never grow. Delete a name from here when you translate it. Two are gone
+#: already: ``Conv2dKernel`` with the node itself (#362), and
+#: ``Conv2dExplicit`` by being translated (#367) -- thirteen left.
 UNTRANSLATED_NODES = frozenset({
     "Argmax",
-    "Conv2dExplicit",
     "DatasetBatch",
     "DecisionBoundary",
     "DiffusionTrainingLoop",

--- a/frontend/src/components/ConfigPanel/TensorGridEditor.test.tsx
+++ b/frontend/src/components/ConfigPanel/TensorGridEditor.test.tsx
@@ -382,3 +382,155 @@ describe('TensorGridEditor — setCell guard', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 });
+
+describe('TensorGridEditor — the value follows the shape (#365)', () => {
+  // The grid used to reshape for DISPLAY only: `normalized` padded the value
+  // out to the new shape so a k×k grid could be drawn, but nothing wrote that
+  // back. Change Conv2dExplicit's kernel_size from 3 to 5 and the panel showed
+  // a filled 5×5 grid while the param still held 9 numbers -- then the run
+  // failed with "`weights` has 9 elements but kernel_size=5 expects 25". What
+  // the student saw and what the graph stored had quietly diverged.
+
+  function renderWithProps(props: {
+    value?: any;
+    siblingParams?: Record<string, any>;
+    onChange: (name: string, value: any) => void;
+  }) {
+    const element = (p: typeof props) => (
+      <TensorGridEditor
+        param={makeParam()}
+        value={p.value}
+        onChange={p.onChange}
+        displayLabel="My Tensor"
+        siblingParams={p.siblingParams}
+      />
+    );
+    const utils = render(element(props));
+    return {
+      ...utils,
+      update: (next: typeof props) => utils.rerender(element(next)),
+    };
+  }
+
+  const identity3 = [
+    [0, 0, 0],
+    [0, 1, 0],
+    [0, 0, 0],
+  ];
+
+  it('writes the resized value back when kernel_size grows', () => {
+    const onChange = vi.fn();
+    const { update } = renderWithProps({
+      value: identity3,
+      siblingParams: { kernel_size: 3 },
+      onChange,
+    });
+    // Steady state: the value already matches the shape, so nothing is written.
+    expect(onChange).not.toHaveBeenCalled();
+
+    update({ value: identity3, siblingParams: { kernel_size: 5 }, onChange });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [name, written] = onChange.mock.calls[0];
+    expect(name).toBe('weights');
+    expect(written).toHaveLength(5);
+    expect(written.flat()).toHaveLength(25);
+  });
+
+  it('keeps the numbers the user already typed and pads the rest with zeros', () => {
+    const onChange = vi.fn();
+    const { update } = renderWithProps({
+      value: identity3,
+      siblingParams: { kernel_size: 3 },
+      onChange,
+    });
+    update({ value: identity3, siblingParams: { kernel_size: 5 }, onChange });
+
+    // Row-major refill: the nine originals lead, zeros follow. Padding rather
+    // than clearing means widening a kernel is not a silent wipe of the work.
+    expect(onChange.mock.calls[0][1].flat()).toEqual([
+      0, 0, 0, 0, 1,
+      0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0,
+    ]);
+  });
+
+  it('truncates when kernel_size shrinks', () => {
+    const onChange = vi.fn();
+    const five = Array.from({ length: 5 }, (_, r) =>
+      Array.from({ length: 5 }, (_, c) => r * 5 + c),
+    );
+    const { update } = renderWithProps({
+      value: five,
+      siblingParams: { kernel_size: 5 },
+      onChange,
+    });
+    update({ value: five, siblingParams: { kernel_size: 3 }, onChange });
+
+    expect(onChange.mock.calls[0][1]).toEqual([
+      [0, 1, 2],
+      [3, 4, 5],
+      [6, 7, 8],
+    ]);
+  });
+
+  it('stays quiet when the value already has the right number of cells', () => {
+    const onChange = vi.fn();
+    const { update } = renderWithProps({
+      value: identity3,
+      siblingParams: { kernel_size: 3 },
+      onChange,
+    });
+    // A re-render that changes nothing about the shape must not write, or the
+    // effect would fight the store on every keystroke elsewhere in the panel.
+    update({ value: identity3, siblingParams: { kernel_size: 3 }, onChange });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing while the grid is disabled', () => {
+    const onChange = vi.fn();
+    const { update } = renderWithProps({
+      value: [[1, 2]],
+      siblingParams: { shape: '1,2', value_mode: 'random' },
+      onChange,
+    });
+    // TensorInput in random mode: the editor is not the source of truth, so a
+    // shape change must not rewrite values the backend is about to generate.
+    update({ value: [[1, 2]], siblingParams: { shape: '4,4', value_mode: 'random' }, onChange });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing when there is no value yet', () => {
+    const onChange = vi.fn();
+    const { update } = renderWithProps({
+      value: null,
+      siblingParams: { shape: '2,2', value_mode: 'explicit' },
+      onChange,
+    });
+    // TensorInput's `values` defaults to null. Filling it with zeros the
+    // moment the panel opens would turn "not set" into "explicitly zero".
+    update({ value: null, siblingParams: { shape: '3,3', value_mode: 'explicit' }, onChange });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('follows a TensorInput-style `shape` sibling too', () => {
+    const onChange = vi.fn();
+    const { update } = renderWithProps({
+      value: [[1, 2], [3, 4]],
+      siblingParams: { shape: '2,2', value_mode: 'explicit' },
+      onChange,
+    });
+    update({
+      value: [[1, 2], [3, 4]],
+      siblingParams: { shape: '2,3', value_mode: 'explicit' },
+      onChange,
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][1]).toEqual([
+      [1, 2, 3],
+      [4, 0, 0],
+    ]);
+  });
+});

--- a/frontend/src/components/ConfigPanel/TensorGridEditor.tsx
+++ b/frontend/src/components/ConfigPanel/TensorGridEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { ParamDefinition } from '../../types';
 import styles from './TensorGridEditor.module.css';
 
@@ -60,6 +60,13 @@ function fillFlat(shape: number[], flat: number[], offset = 0): [any, number] {
     cur = next;
   }
   return [out, cur];
+}
+
+/** How many numbers a (possibly nested) value holds, counted the way
+ *  ``reshapeValues`` flattens it. */
+function flatLength(value: any): number {
+  if (!Array.isArray(value)) return 1;
+  return value.reduce((n, v) => n + flatLength(v), 0);
 }
 
 function reshapeValues(value: any, shape: number[]): any {
@@ -162,6 +169,26 @@ export function TensorGridEditor({ param, value, onChange, displayLabel, sibling
     if (total > MAX_INLINE_NUMEL) return null;
     return reshapeValues(value ?? zerosOf(shape), shape);
   }, [value, shape, valueMode, total]);
+
+  // `normalized` reshapes for DISPLAY. Left at that, the panel and the stored
+  // param drift apart the moment the shape changes: raise Conv2dExplicit's
+  // kernel_size from 3 to 5 and a filled 5×5 grid appears over a param that
+  // still holds 9 numbers, until the run fails with "`weights` has 9 elements
+  // but kernel_size=5 expects 25" (#365). So commit the reshape — what the
+  // student sees is what the graph stores.
+  //
+  // Only on a cell-count change: a value that is already the right size is
+  // left exactly as it is, including its nesting, so opening a panel never
+  // rewrites a graph. The three ways this stays quiet matter as much as when
+  // it fires — a disabled grid is not the source of truth (TensorInput in
+  // random mode is about to have its values generated), and a null value is
+  // "not set", which is not the same as "explicitly zero".
+  useEffect(() => {
+    if (disabled || normalized === null) return;
+    if (value === null || value === undefined) return;
+    if (flatLength(value) === total) return;
+    onChange(param.name, normalized);
+  }, [disabled, normalized, value, total, onChange, param.name]);
 
   const grid = useMemo(
     () => (normalized ? drill2D(normalized, leading) : []),

--- a/frontend/src/i18n/nodeLocales/zh-TW.ts
+++ b/frontend/src/i18n/nodeLocales/zh-TW.ts
@@ -70,6 +70,16 @@ const zhTW: NodeTranslations = {
       padding: '兩側的零填充',
     },
   },
+  Conv2dExplicit: {
+    description: '用你指定的 kernel 做 2D 卷積 —— 不是網路學出來的那種，沒有可學參數、也沒有隨機初始化。可以選內建的 3×3 濾波器（邊緣偵測 / 銳化 / 垂直邊緣），或把 preset 設成 Custom 自己填一個 NxN 矩陣。同一個 kernel 會套用到每個輸入通道（depthwise 分組卷積），所以 (N, C, H, W) 進去就是 (N, C, H, W) 出來，通道數不變。',
+    params: {
+      preset: '內建的 3×3 kernel，或選 Custom 自己寫一個矩陣。',
+      kernel_size: 'NxN kernel 的邊長 N（只有 Custom 會用到）。',
+      weights: '自訂的 kernel 矩陣（NxN）；格子大小跟著 kernel_size 走。',
+      stride: '卷積步幅',
+      padding: '空間維度兩側的零填充',
+    },
+  },
   MaxPool2d: {
     description: '對輸入張量套用 2D 最大池化（封裝 nn.MaxPool2d）',
     params: {

--- a/plugins/foundations/cdui.plugin.toml
+++ b/plugins/foundations/cdui.plugin.toml
@@ -2,7 +2,7 @@
 id              = "foundations"
 name            = "Foundations — 資料表示與經典 ML"
 version         = "0.1.0"
-description     = "Educational nodes for the I1–I2 hands-on track: data representation (column stats, token embedding) and classical ML (KNN, linear / logistic regression, feed-forward network), plus 11 worked example graphs for lessons C1-2 through C2-4. Every node exposes its intermediate steps in verbose mode."
+description     = "Educational nodes for the I1–I2 hands-on track: data representation (column stats, token embedding) and classical ML (KNN, linear / logistic regression, feed-forward network), plus 12 worked example graphs for lessons C1-3 through C2-5. Every node exposes its intermediate steps in verbose mode."
 schema_version  = 1
 requires_codefyui = ">=0.2.0"
 

--- a/plugins/foundations/examples/C1-3/Kernel-Effects/graph.json
+++ b/plugins/foundations/examples/C1-3/Kernel-Effects/graph.json
@@ -1,0 +1,44 @@
+{
+  "name": "C1-3 the same image through four different 3×3 kernels",
+  "description": "Figure C1-3-e made runnable: one (1, 1, 8, 8) image, four Conv2dExplicit nodes, four completely different outputs — from an operator that never changes. §C1.3.4.1 makes the claim that 'the arithmetic is always the same; the nine weights decide what the window is looking for', and this graph is where a student checks it. The image is built by hand rather than randomly: columns 0–3 are 100 and columns 4–7 are 200 (one vertical edge down the middle), with a single bright 200 at row 6, column 1 (one isolated dot in the dark half). Every kernel then reports on the same two features. EdgeDetection returns exactly 800 at the dot — the number worked out by hand in §C1.3.4.1 Example 3-2 — and 0 across both flat regions, which is the 'flat → 0, different → large' property that section claims. Sharpen leaves the flat regions at their own value (100 stays 100, 200 stays 200) and pushes the dot to 600. VerticalEdge answers 300 on the two boundary columns and 0 at the dot, since an isolated point is not a vertical edge. The blur is the Custom preset with all nine weights at 1/9: flat regions unchanged, the dot smeared down to 111.11, the edge softened into a 133 → 167 ramp. Swap any preset, or edit the Custom matrix, and only the output changes — the graph does not.",
+  "nodes": [
+    { "id": "start", "type": "Start",           "position": { "x": -340, "y":    0 }, "data": { "params": {} } },
+    { "id": "img",   "type": "TensorInput",     "position": { "x":  -60, "y":    0 }, "data": { "params": { "shape": "1,1,8,8", "dtype": "float32", "value_mode": "explicit", "values": [[[
+        [100, 100, 100, 100, 200, 200, 200, 200],
+        [100, 100, 100, 100, 200, 200, 200, 200],
+        [100, 100, 100, 100, 200, 200, 200, 200],
+        [100, 100, 100, 100, 200, 200, 200, 200],
+        [100, 100, 100, 100, 200, 200, 200, 200],
+        [100, 100, 100, 100, 200, 200, 200, 200],
+        [100, 200, 100, 100, 200, 200, 200, 200],
+        [100, 100, 100, 100, 200, 200, 200, 200]
+      ]]] } } },
+
+    { "id": "k_edge",  "type": "Conv2dExplicit", "position": { "x": 320, "y": -390 }, "data": { "params": { "preset": "EdgeDetection3x3", "stride": 1, "padding": 1 } } },
+    { "id": "k_sharp", "type": "Conv2dExplicit", "position": { "x": 320, "y": -130 }, "data": { "params": { "preset": "Sharpen3x3",       "stride": 1, "padding": 1 } } },
+    { "id": "k_vert",  "type": "Conv2dExplicit", "position": { "x": 320, "y":  130 }, "data": { "params": { "preset": "VerticalEdge3x3",  "stride": 1, "padding": 1 } } },
+    { "id": "k_blur",  "type": "Conv2dExplicit", "position": { "x": 320, "y":  390 }, "data": { "params": { "preset": "Custom", "kernel_size": 3, "stride": 1, "padding": 1, "weights": [
+        [0.1111111111111111, 0.1111111111111111, 0.1111111111111111],
+        [0.1111111111111111, 0.1111111111111111, 0.1111111111111111],
+        [0.1111111111111111, 0.1111111111111111, 0.1111111111111111]
+      ] } } },
+
+    { "id": "p_edge",  "type": "Print", "position": { "x": 700, "y": -390 }, "data": { "params": { "label": "邊緣偵測 EdgeDetection — flat regions 0, the isolated dot 800 (§C1.3.4.1 Example 3-2)" } } },
+    { "id": "p_sharp", "type": "Print", "position": { "x": 700, "y": -130 }, "data": { "params": { "label": "銳化 Sharpen — flat regions keep their own value (100, 200), the dot rises to 600" } } },
+    { "id": "p_vert",  "type": "Print", "position": { "x": 700, "y":  130 }, "data": { "params": { "label": "垂直邊緣 VerticalEdge — 300 on the two boundary columns, 0 at the dot" } } },
+    { "id": "p_blur",  "type": "Print", "position": { "x": 700, "y":  390 }, "data": { "params": { "label": "模糊 Blur (Custom, all 1/9) — the dot smears to 111.11, the edge ramps 133 → 167" } } }
+  ],
+  "edges": [
+    { "id": "et", "source": "start", "target": "img", "sourceHandle": "trigger", "type": "trigger" },
+
+    { "id": "e_edge",  "source": "img", "target": "k_edge",  "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_sharp", "source": "img", "target": "k_sharp", "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_vert",  "source": "img", "target": "k_vert",  "sourceHandle": "tensor", "targetHandle": "tensor" },
+    { "id": "e_blur",  "source": "img", "target": "k_blur",  "sourceHandle": "tensor", "targetHandle": "tensor" },
+
+    { "id": "o_edge",  "source": "k_edge",  "target": "p_edge",  "sourceHandle": "tensor", "targetHandle": "value" },
+    { "id": "o_sharp", "source": "k_sharp", "target": "p_sharp", "sourceHandle": "tensor", "targetHandle": "value" },
+    { "id": "o_vert",  "source": "k_vert",  "target": "p_vert",  "sourceHandle": "tensor", "targetHandle": "value" },
+    { "id": "o_blur",  "source": "k_blur",  "target": "p_blur",  "sourceHandle": "tensor", "targetHandle": "value" }
+  ]
+}


### PR DESCRIPTION
> 中文摘要：#362 審核時留下的三個追蹤項，一次做完。**#365** 格子編輯器只把矩陣「畫」成新的大小、沒有存回去，所以畫面顯示 5x5、實際還是 9 個數字，一按執行就報錯 —— 現在看到什麼就存什麼。**#366** 補上 C1-3 §C1.3.4.1 的範例圖：一張手工影像穿過四個不同的 3x3 kernel，數字對得上課本的手算結果；**沒有**去改 C3-1 那個範例，原因寫在下面。**#367** `Conv2dExplicit` 補完中文翻譯，並移進 `TRANSLATED_NODES`，讓檢查機制從此守住它。

三個 commit 各對一個 issue，分開審比較好讀。

---

## #365 格子編輯器顯示的大小與存下來的矩陣不一致

`TensorGridEditor` 裡的 `normalized` 只負責「畫」：它把值補零撐到新的形狀好讓 k×k 的格子畫得出來，但從來沒有寫回 param。把 `Conv2dExplicit` 的 `kernel_size` 從 3 改成 5，畫面上出現一個填好的 5×5 格子，存的卻還是 9 個數字，執行時就報：

```
`weights` has 9 elements but kernel_size=5 expects 25 (5x5). Adjust kernel_size or re-fill the grid.
```

現在這個 reshape 會透過 `onChange` 存回去，**畫面上是什麼，跑的就是什麼**。變大時補零、並保留使用者已經填的數字（row-major，原本那九個排在前面），而不是整個清空重來。

**不做什麼跟做什麼一樣重要**，這三個守衛也是它不會無限迴圈的原因（寫回之後數量就對了，下一輪直接 return）：

| 情況 | 行為 | 為什麼 |
|---|---|---|
| 格子數量本來就對 | 不動 | 連巢狀結構都原封不動，開個面板不會改到別人的圖 |
| 格子是 disabled | 不寫 | `TensorInput` 在 random 模式下值是後端生的，編輯器不是那個真相來源 |
| 值是 null | 不寫 | 「還沒設定」跟「明確設成 0」是兩件事（`TensorInput` 的 `values` 預設就是 null）|

後端 `_resolve_kernel` 拒絕猜測的行為**保留不動** —— 靜靜補零或截斷等於拿一個使用者沒寫過的濾波器去做卷積。這次修的是說謊的那一側。

## #366 C1-3 §C1.3.4.1 的範例圖

**先說一件事：這個 issue 原本的方向是錯的，我沒有照著做。**

Issue 說「C3-1 那個『kernel 效果』範例用的是會學習的 `Conv2d`，該換成 `Conv2dExplicit`」。實際去看 `plugins/deep/examples/C3-1/Conv2D-Kernel-Effects/graph.json` 的 description，它已經寫明白了：

> The kernels are random here because training is what teaches them to detect edges / textures / parts

它教的是 §C3.1.5 的「多 kernel 特徵圖堆疊」跟 §C3.1.4.2 的參數量計算，隨機是刻意的。**那個範例沒有錯，不該動。**

真正缺的東西在更前面。C1-3 §C1.3.4.1 整節都在講「同一個滑動視窗，換九個權重就變成完全不同的工具」，用 Example 3-2 手算邊緣偵測，最後收在圖 C1-3-e —— 同一張原圖配四個 kernel，四張完全不同的輸出。**這一整節一張可執行的圖都沒有**，而 `foundations` 的 manifest 從一開始就宣告了 `C1-3` 這個 lesson，底下卻沒有對應的目錄。

新的 `plugins/foundations/examples/C1-3/Kernel-Effects/graph.json` 就是那張圖：一張 (1, 1, 8, 8) 的手工影像進去，四個 `Conv2dExplicit` 出來。影像是手寫的不是隨機的，因為下面每個數字都要能對得起來 —— 第 0-3 欄 100、第 4-7 欄 200（一條垂直邊），再在第 6 列第 1 欄放一個 200（暗區裡的孤立亮點）。四個 kernel 對同樣這兩個特徵各自作答：

| Kernel | 孤立亮點 | 平坦區 | 邊界兩欄 |
|---|---|---|---|
| 邊緣偵測 EdgeDetection | **800** | 0 | ±300 |
| 銳化 Sharpen | 600 | 100 / 200（原值不變）| 0 / 300 |
| 垂直邊緣 VerticalEdge | **0** | 0 | 300 / 300 |
| 模糊 Blur（Custom，九格都 1/9）| 111.11 | 100 / 200（原值不變）| 133 → 167 |

那個 **800 正是課本 §C1.3.4.1 Example 3-2 手算出來的答案**；平坦區 0 就是該節主張的「平坦 → 0、有差異 → 大數」；垂直邊緣在孤立亮點上回 0，剛好說明它只認垂直邊、不認孤立的點。

這也是 `Conv2dExplicit` 的**第一個範例圖**。

C1-3 教「kernel 是人手寫的」，C3-1 教「kernel 交給網路學」，兩個都該存在。

## #367 Conv2dExplicit 的中文翻譯

`Conv2dExplicit` 待在 `UNTRANSLATED_NODES` 裡，而那份名單自己的註解寫著「只能變短，不能變長」。#362 給它加了三個使用者看得到的新參數（`preset`、`kernel_size`、`weights`），全英文，而且**沒有任何檢查抓得到** —— ratchet 只問「這個節點有沒有條目」，逐參數的檢查又只涵蓋 `TRANSLATED_NODES` 裡列的節點。於是債務悄悄長在一個學生讀 C1-3 §C1.3.4.1 時真的會去點的 CNN 節點上，而那一節的主題正是「哪個濾波器做什麼」。

說明加五個參數全部翻完，並從債務名單**移進 `TRANSLATED_NODES`** —— 後面這半才是重點：從現在起，這個節點多一個沒翻的參數會直接讓測試失敗，而不是頂著中文標籤送出英文說明。

名單上還剩十三個節點，註解也更新成正確的數字，並記錄了離開的那兩個各自去了哪裡。

## 測試

```
cd backend && pytest tests/ -q
  -> 5278 passed, 16 skipped, 19 failed

cd backend && pytest tests/test_chapter_examples.py -k C1-3   -> 2 passed
cd backend && pytest tests/test_api_nodes.py                  -> 30 passed
cd frontend && npx vitest run TensorGridEditor.test.tsx       -> 27 passed（7 個新的）
cd frontend && npx vitest run                                 -> 142 檔, 3309 passed
cd frontend && npx tsc -b                                     -> exit 0
uvx ruff@0.14.4 check backend/app backend/tests               -> All checks passed!
python scripts/check_control_bytes.py                         -> OK, 1192 tracked files
```

那 19 個 failed **全部在 `tests/test_codegen.py`，與本 PR 無關**。它們是本機環境問題：匯出的腳本會開子行程，那個子行程 import 不到 `app`（`CodefyUI backend runtime is unavailable (failed import: app)`）。上一輪在**未修改的 main** 上跑同一個檔案得到一模一樣的 19 個失敗，而本 PR 的 diff 完全沒有碰 codegen。CI 上這些是綠的。

新範例不需要新測試：`test_chapter_examples.py` 用 glob 掃出範例，所以那張圖會被實際執行、node type 也會逐一對照 registry，一行測試碼都不用改。

## 尚未完成：瀏覽器實測

**這個 PR 還沒有做過瀏覽器實測，合併前應該補。** 不是跳過，是做不了：Chrome 這次載不進本機的開發伺服器，`localhost:5173`、`127.0.0.1:5173`、`5174` 三個位址都回 error page，但同樣的網址用 curl 都是 200，換新分頁也一樣。試了三次就停手，沒有繼續繞。看起來是擴充套件的站台權限狀態，不是程式的問題。

要看的東西很具體，權限一好就能補：

1. **#365** —— 放一個 `Conv2dExplicit`，`preset` 設 `Custom`，把 `kernel_size` 從 3 改成 5，直接執行。修好之後應該**成功**，而不是報 9 elements 的錯。
2. **#367** —— 同一個面板上確認說明與五個參數都是中文。
3. **#366** —— 這張圖的 UI 新元素只有一個：`TensorInput` 用 explicit 模式帶 64 格的值。要確認 64 格的格子**不會**被 #365 那個新的寫回邏輯多事改掉（`flatLength === total`，照設計不該寫，但值得眼睛看一次）。

範例圖本身的執行正確性已經由 `test_chapter_examples.py` 實跑保證了。

另外 `plugins/foundations` 這個章節包**沒有安裝在我這邊的環境**（只有 official-template），所以範例不會出現在畫廊裡。要在畫廊看到它得先裝那個包 —— 那會動到你的環境，我沒有自作主張。

## Closes

Closes #365
Closes #366
Closes #367

#366 的做法與 issue 原本寫的不同，理由在上面那一節，我也會在該 issue 上留言說明。

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its zh-TW twin in the same PR.（#367 本身就是這件事；`cdui.plugin.toml` 的範例數量 11 → 12 也一併更正）
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do, if a reviewer might expect it.（沒有改 C3-1 範例、沒有安裝章節包、瀏覽器實測未做）
