### PR TITLE
fix(examples): the RL optimizers get the right model, MoE shows its mixture, four descriptions stop lying

### DIFF
--- a/backend/tests/test_example_graph_invariants.py
+++ b/backend/tests/test_example_graph_invariants.py
@@ -1,0 +1,97 @@
+"""Structural invariants every shipped example graph must hold.
+
+``test_builtin_examples.py`` and ``test_chapter_examples.py`` each execute
+their own half of the shipped graphs and assert per-example facts. This file
+is the other axis: one rule, checked across every graph in both roots, for
+the failure modes that are silent everywhere else.
+
+Silent is the operative word. ``validate_graph`` accepts two edges into one
+input port without a word, and the engine resolves it by last-writer-wins --
+so a graph with a duplicate can validate, execute, and print a plausible
+number that came from the wrong upstream node. The 2026-08-21 example audit
+found exactly that in ``DQN-Atari-RL`` and ``PPO-Robotics-RL``: an
+undocumented ``SequentialModel`` sitting off to one side, wired into
+``optimizer-1.model`` alongside the agent's own ``model`` output, so the
+optimizer in a Deep-Q-Network example may well have been handed a detached
+feed-forward stack instead of the DQN. Nothing failed. Nothing warned.
+
+These are graph-shape rules only. Whether a graph *runs* is the other two
+files' job, and deliberately not repeated here.
+"""
+
+from __future__ import annotations
+
+import collections
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ROOTS = (_REPO_ROOT / "examples", _REPO_ROOT / "plugins")
+
+
+def _discover_all_shipped_graphs() -> list[Path]:
+    """Every example graph an install can put in front of a user."""
+    found: list[Path] = []
+    found.extend((_REPO_ROOT / "examples").rglob("graph.json"))
+    found.extend((_REPO_ROOT / "plugins").glob("*/examples/**/graph.json"))
+    return sorted(found)
+
+
+_GRAPHS = _discover_all_shipped_graphs()
+assert _GRAPHS, "example invariant suite discovered no graphs"
+
+_IDS = [p.relative_to(_REPO_ROOT).as_posix() for p in _GRAPHS]
+
+
+def _data_edges(payload: dict) -> list[dict]:
+    """Edges that carry a value, so trigger wiring is out of scope.
+
+    A trigger port legitimately takes several inbound edges -- that is how a
+    Start node fans out to more than one entry point -- so counting them here
+    would flag correct graphs.
+    """
+    return [e for e in payload.get("edges", []) if e.get("type") != "trigger"]
+
+
+@pytest.mark.parametrize("graph_path", _GRAPHS, ids=_IDS)
+def test_no_input_port_is_fed_by_two_edges(graph_path: Path):
+    payload = json.loads(graph_path.read_text(encoding="utf-8"))
+
+    inbound = collections.Counter(
+        (e.get("target"), e.get("targetHandle")) for e in _data_edges(payload)
+    )
+    doubled = {port: n for port, n in inbound.items() if n > 1}
+
+    assert not doubled, (
+        f"{graph_path.name} feeds an input port from more than one source: "
+        f"{sorted(doubled)}. The engine takes the last edge and drops the "
+        f"rest without warning, so the graph runs and shows a number from an "
+        f"upstream node the reader cannot identify. Delete the edge that does "
+        f"not belong -- and the node behind it, if that leaves it orphaned."
+    )
+
+
+@pytest.mark.parametrize("graph_path", _GRAPHS, ids=_IDS)
+def test_every_edge_endpoint_is_a_node_in_the_graph(graph_path: Path):
+    """An edge to a deleted node id. Cheap to check, easy to hand-edit in.
+
+    ``validate_graph`` reports this one, but only when someone runs the
+    graph; a dangling edge in a file nobody has opened since the edit sits
+    there until a student hits it.
+    """
+    payload = json.loads(graph_path.read_text(encoding="utf-8"))
+    node_ids = {n["id"] for n in payload.get("nodes", [])}
+
+    dangling = [
+        f"{e.get('id')}.{side}={e.get(side)!r}"
+        for e in payload.get("edges", [])
+        for side in ("source", "target")
+        if e.get(side) not in node_ids
+    ]
+
+    assert not dangling, (
+        f"{graph_path.name} has edges pointing at ids that are not nodes in "
+        f"the file: {dangling}"
+    )

--- a/examples/Classical/Iris-Sklearn-KNN/graph.json
+++ b/examples/Classical/Iris-Sklearn-KNN/graph.json
@@ -1,6 +1,6 @@
 {
   "name": "Iris with sklearn KNN: same graph, production scale",
-  "description": "Identical pipeline shape to KNN-from-Scratch — CSV → ColumnSelector → Normalize → TrainTestSplit — but the classifier is the production KNN node (sklearn-backed) instead of EduKNN. Both nodes share the same input/output contract, so swapping is a one-edit change in the graph; the goal of the lesson is to show that the dual-track design lets you teach the math with EduKNN and ship with KNN. Distance-weighted voting + KD-tree internally means this same graph would still run at 100k+ rows.",
+  "description": "CSV → ColumnSelector → Normalize → TrainTestSplit → KNN: the production classifier (sklearn-backed), with distance-weighted voting and a KD-tree internally, so this same graph still runs at 100k+ rows. It is the second half of a dual-track pair — the teaching half is the `Edu-KNN` node, which computes every distance in the open where you can read it. Both share the same input/output contract, so swapping one for the other is a one-edit change to this graph. `Edu-KNN` and the matching `KNN-from-Scratch` example ship in the `foundations` chapter pack (`cdui plugin install foundations`), not in the base install.",
   "nodes": [
     { "id": "start-1",   "type": "Start",          "position": { "x": -260, "y": 0 }, "data": { "params": {} } },
     { "id": "csv",       "type": "CSVReader",      "position": { "x": -40,  "y": 0 }, "data": { "params": { "path": "data/samples/iris.csv", "target_column": "species", "include_columns": "", "skip_header": true } } },

--- a/examples/Diffusion/Mini-UNet-Compact/graph.json
+++ b/examples/Diffusion/Mini-UNet-Compact/graph.json
@@ -1,6 +1,6 @@
 {
   "name": "Mini U-Net (Compact): the same architecture in one node",
-  "description": "Counterpart to `Mini-UNet-Expanded`: instead of wiring every ResBlock + Upsample + Concat by hand, the entire U-Net is packaged into a single `DiffusionUNet` meta-node. Same teaching architecture, same hyperparameters, just collapsed into one block — the form you'd actually use when assembling a sampling pipeline. Run it: GaussianNoise feeds the model + DDPMSampler at one step to confirm the output shape is preserved.",
+  "description": "The whole U-Net packaged into a single `DiffusionUNet` meta-node, rather than every ResBlock + Upsample + Concat wired by hand — the form you'd actually use when assembling a sampling pipeline. Run it: GaussianNoise feeds the model + DDPMSampler at one step to confirm the output shape is preserved. If you want to see the same architecture opened up node by node, the `Mini-UNet-Expanded` counterpart ships in the `deep` chapter pack (`cdui plugin install deep`), not in the base install.",
   "nodes": [
     { "id": "start-1",  "type": "Start", "position": { "x": -260, "y": 0 }, "data": { "params": {} } },
     { "id": "noise",    "type": "GaussianNoise", "position": { "x": 0,    "y": 60 }, "data": { "params": { "shape": "1,3,16,16", "mean": 0, "std": 1, "seed": 42 } } },

--- a/examples/Model_Architecture/DQN-Atari-RL/graph.json
+++ b/examples/Model_Architecture/DQN-Atari-RL/graph.json
@@ -1,6 +1,6 @@
 {
   "name": "DQN with CNN Feature Extractor (Atari)",
-  "description": "Deep Q-Network with CNN backbone for Atari game playing - the landmark DeepMind architecture (2015) that demonstrated superhuman performance on Atari games. Conv layers extract visual features from stacked 84x84 frames, fed into a DQN head for action-value estimation. This example runs fully offline: a TensorCreate node supplies a synthetic batch of preprocessed observations (randn, shape 2x4x84x84) in place of a live Atari environment, so no gym/ale-py install is needed. Swap in an EnvWrapper to drive it from a real environment.",
+  "description": "Deep Q-Network with CNN backbone for Atari game playing - the landmark DeepMind architecture (2015) that demonstrated superhuman performance on Atari games. Conv layers extract visual features from stacked 84x84 frames, fed into a DQN head for action-value estimation. This example runs fully offline: a TensorCreate node supplies a synthetic batch of preprocessed observations (randn, shape 2x4x84x84) in place of a live Atari environment, so no gym/ale-py install is needed. Swap in an EnvWrapper to drive it from a real environment. The `seq-model` node off to the side is not part of the data path: it holds the same Conv/ReLU backbone the canvas builds node by node, packaged as one layer stack — double-click it to read the whole architecture in the layer editor. The optimizer is fed by `dqn-1.model`, the agent's own network, which is what gets trained.",
   "nodes": [
     {
       "id": "start-1",
@@ -201,6 +201,19 @@
           "plot_type": "histogram"
         }
       }
+    },
+    {
+      "id": "seq-model",
+      "type": "SequentialModel",
+      "position": {
+        "x": 400,
+        "y": 300
+      },
+      "data": {
+        "params": {
+          "layers": "{\"version\":2,\"nodes\":[{\"id\":\"in\",\"type\":\"Input\",\"ports\":[{\"id\":\"p_x\",\"name\":\"x\"}]},{\"id\":\"n0\",\"type\":\"Conv2d\",\"params\":{\"in_channels\":4,\"out_channels\":32,\"kernel_size\":8,\"stride\":4}},{\"id\":\"n1\",\"type\":\"ReLU\"},{\"id\":\"n2\",\"type\":\"Conv2d\",\"params\":{\"in_channels\":32,\"out_channels\":64,\"kernel_size\":4,\"stride\":2}},{\"id\":\"n3\",\"type\":\"ReLU\"},{\"id\":\"n4\",\"type\":\"Conv2d\",\"params\":{\"in_channels\":64,\"out_channels\":64,\"kernel_size\":3,\"stride\":1}},{\"id\":\"n5\",\"type\":\"ReLU\"},{\"id\":\"n6\",\"type\":\"Flatten\"},{\"id\":\"n7\",\"type\":\"Linear\",\"params\":{\"in_features\":3136,\"out_features\":512}},{\"id\":\"n8\",\"type\":\"ReLU\"},{\"id\":\"n9\",\"type\":\"Linear\",\"params\":{\"in_features\":512,\"out_features\":4}},{\"id\":\"out\",\"type\":\"Output\",\"ports\":[{\"id\":\"p_y\",\"name\":\"y\"}]}],\"edges\":[{\"id\":\"e0\",\"source\":\"in\",\"sourceHandle\":\"p_x\",\"target\":\"n0\"},{\"id\":\"e1\",\"source\":\"n0\",\"target\":\"n1\"},{\"id\":\"e2\",\"source\":\"n1\",\"target\":\"n2\"},{\"id\":\"e3\",\"source\":\"n2\",\"target\":\"n3\"},{\"id\":\"e4\",\"source\":\"n3\",\"target\":\"n4\"},{\"id\":\"e5\",\"source\":\"n4\",\"target\":\"n5\"},{\"id\":\"e6\",\"source\":\"n5\",\"target\":\"n6\"},{\"id\":\"e7\",\"source\":\"n6\",\"target\":\"n7\"},{\"id\":\"e8\",\"source\":\"n7\",\"target\":\"n8\"},{\"id\":\"e9\",\"source\":\"n8\",\"target\":\"n9\"},{\"id\":\"e10\",\"source\":\"n9\",\"target\":\"out\",\"targetHandle\":\"p_y\"}]}"
+        }
+      }
     }
   ],
   "edges": [
@@ -292,6 +305,13 @@
       "id": "e-trigger-1",
       "source": "start-1",
       "target": "obs-1",
+      "sourceHandle": "trigger",
+      "type": "trigger"
+    },
+    {
+      "id": "e-trigger-2",
+      "source": "start-1",
+      "target": "seq-model",
       "sourceHandle": "trigger",
       "type": "trigger"
     }

--- a/examples/Model_Architecture/DQN-Atari-RL/graph.json
+++ b/examples/Model_Architecture/DQN-Atari-RL/graph.json
@@ -201,19 +201,6 @@
           "plot_type": "histogram"
         }
       }
-    },
-    {
-      "id": "seq-model",
-      "type": "SequentialModel",
-      "position": {
-        "x": 400,
-        "y": 300
-      },
-      "data": {
-        "params": {
-          "layers": "{\"version\":2,\"nodes\":[{\"id\":\"in\",\"type\":\"Input\",\"ports\":[{\"id\":\"p_x\",\"name\":\"x\"}]},{\"id\":\"n0\",\"type\":\"Conv2d\",\"params\":{\"in_channels\":4,\"out_channels\":32,\"kernel_size\":8,\"stride\":4}},{\"id\":\"n1\",\"type\":\"ReLU\"},{\"id\":\"n2\",\"type\":\"Conv2d\",\"params\":{\"in_channels\":32,\"out_channels\":64,\"kernel_size\":4,\"stride\":2}},{\"id\":\"n3\",\"type\":\"ReLU\"},{\"id\":\"n4\",\"type\":\"Conv2d\",\"params\":{\"in_channels\":64,\"out_channels\":64,\"kernel_size\":3,\"stride\":1}},{\"id\":\"n5\",\"type\":\"ReLU\"},{\"id\":\"n6\",\"type\":\"Flatten\"},{\"id\":\"n7\",\"type\":\"Linear\",\"params\":{\"in_features\":3136,\"out_features\":512}},{\"id\":\"n8\",\"type\":\"ReLU\"},{\"id\":\"n9\",\"type\":\"Linear\",\"params\":{\"in_features\":512,\"out_features\":4}},{\"id\":\"out\",\"type\":\"Output\",\"ports\":[{\"id\":\"p_y\",\"name\":\"y\"}]}],\"edges\":[{\"id\":\"e0\",\"source\":\"in\",\"sourceHandle\":\"p_x\",\"target\":\"n0\"},{\"id\":\"e1\",\"source\":\"n0\",\"target\":\"n1\"},{\"id\":\"e2\",\"source\":\"n1\",\"target\":\"n2\"},{\"id\":\"e3\",\"source\":\"n2\",\"target\":\"n3\"},{\"id\":\"e4\",\"source\":\"n3\",\"target\":\"n4\"},{\"id\":\"e5\",\"source\":\"n4\",\"target\":\"n5\"},{\"id\":\"e6\",\"source\":\"n5\",\"target\":\"n6\"},{\"id\":\"e7\",\"source\":\"n6\",\"target\":\"n7\"},{\"id\":\"e8\",\"source\":\"n7\",\"target\":\"n8\"},{\"id\":\"e9\",\"source\":\"n8\",\"target\":\"n9\"},{\"id\":\"e10\",\"source\":\"n9\",\"target\":\"out\",\"targetHandle\":\"p_y\"}]}"
-        }
-      }
     }
   ],
   "edges": [
@@ -295,13 +282,6 @@
       "targetHandle": "value"
     },
     {
-      "id": "e-auto-12",
-      "source": "seq-model",
-      "target": "optimizer-1",
-      "sourceHandle": "model",
-      "targetHandle": "model"
-    },
-    {
       "id": "e-auto-14",
       "source": "dqn-1",
       "target": "visualize-q",
@@ -312,13 +292,6 @@
       "id": "e-trigger-1",
       "source": "start-1",
       "target": "obs-1",
-      "sourceHandle": "trigger",
-      "type": "trigger"
-    },
-    {
-      "id": "e-trigger-2",
-      "source": "start-1",
-      "target": "seq-model",
       "sourceHandle": "trigger",
       "type": "trigger"
     }

--- a/examples/Model_Architecture/PPO-Robotics-RL/graph.json
+++ b/examples/Model_Architecture/PPO-Robotics-RL/graph.json
@@ -98,19 +98,6 @@
           "plot_type": "heatmap"
         }
       }
-    },
-    {
-      "id": "seq-model",
-      "type": "SequentialModel",
-      "position": {
-        "x": 400,
-        "y": 300
-      },
-      "data": {
-        "params": {
-          "layers": "{\"version\":2,\"nodes\":[{\"id\":\"in\",\"type\":\"Input\",\"ports\":[{\"id\":\"p_x\",\"name\":\"x\"}]},{\"id\":\"n0\",\"type\":\"Linear\",\"params\":{\"in_features\":376,\"out_features\":256}},{\"id\":\"n1\",\"type\":\"ReLU\"},{\"id\":\"n2\",\"type\":\"Linear\",\"params\":{\"in_features\":256,\"out_features\":256}},{\"id\":\"n3\",\"type\":\"ReLU\"},{\"id\":\"n4\",\"type\":\"Linear\",\"params\":{\"in_features\":256,\"out_features\":17}},{\"id\":\"out\",\"type\":\"Output\",\"ports\":[{\"id\":\"p_y\",\"name\":\"y\"}]}],\"edges\":[{\"id\":\"e0\",\"source\":\"in\",\"sourceHandle\":\"p_x\",\"target\":\"n0\"},{\"id\":\"e1\",\"source\":\"n0\",\"target\":\"n1\"},{\"id\":\"e2\",\"source\":\"n1\",\"target\":\"n2\"},{\"id\":\"e3\",\"source\":\"n2\",\"target\":\"n3\"},{\"id\":\"e4\",\"source\":\"n3\",\"target\":\"n4\"},{\"id\":\"e5\",\"source\":\"n4\",\"target\":\"out\",\"targetHandle\":\"p_y\"}]}"
-        }
-      }
     }
   ],
   "edges": [
@@ -143,13 +130,6 @@
       "targetHandle": "value"
     },
     {
-      "id": "e-auto-5",
-      "source": "seq-model",
-      "target": "optimizer-1",
-      "sourceHandle": "model",
-      "targetHandle": "model"
-    },
-    {
       "id": "e-auto-6",
       "source": "ppo-1",
       "target": "visualize-actions",
@@ -160,13 +140,6 @@
       "id": "e-trigger-1",
       "source": "start-1",
       "target": "obs-1",
-      "sourceHandle": "trigger",
-      "type": "trigger"
-    },
-    {
-      "id": "e-trigger-2",
-      "source": "start-1",
-      "target": "seq-model",
       "sourceHandle": "trigger",
       "type": "trigger"
     }

--- a/examples/Model_Architecture/PPO-Robotics-RL/graph.json
+++ b/examples/Model_Architecture/PPO-Robotics-RL/graph.json
@@ -1,6 +1,6 @@
 {
   "name": "PPO Robotics Controller",
-  "description": "Proximal Policy Optimization for Robotics Control - PPO (OpenAI, 2017) is the default algorithm behind most modern RL deployments: OpenAI Five (Dota 2), ChatGPT RLHF fine-tuning, robotic manipulation, and autonomous driving. Uses a clipped surrogate objective for stable policy gradient updates with an Actor-Critic architecture. This example runs fully offline: a TensorCreate node supplies a synthetic batch of Humanoid-style observations (randn, shape 2x376) in place of a live MuJoCo environment, so no gym/mujoco install is needed. Swap in an EnvWrapper to drive it from a real environment.",
+  "description": "Proximal Policy Optimization for Robotics Control - PPO (OpenAI, 2017) is the default algorithm behind most modern RL deployments: OpenAI Five (Dota 2), ChatGPT RLHF fine-tuning, robotic manipulation, and autonomous driving. Uses a clipped surrogate objective for stable policy gradient updates with an Actor-Critic architecture. This example runs fully offline: a TensorCreate node supplies a synthetic batch of Humanoid-style observations (randn, shape 2x376) in place of a live MuJoCo environment, so no gym/mujoco install is needed. Swap in an EnvWrapper to drive it from a real environment. The `seq-model` node off to the side is not part of the data path: it holds the 376-256-256-17 policy stack as one layer spec — double-click it to read the whole architecture in the layer editor. The optimizer is fed by `ppo-1.model`, the agent's own network, which is what gets trained.",
   "nodes": [
     {
       "id": "start-1",
@@ -98,6 +98,19 @@
           "plot_type": "heatmap"
         }
       }
+    },
+    {
+      "id": "seq-model",
+      "type": "SequentialModel",
+      "position": {
+        "x": 400,
+        "y": 300
+      },
+      "data": {
+        "params": {
+          "layers": "{\"version\":2,\"nodes\":[{\"id\":\"in\",\"type\":\"Input\",\"ports\":[{\"id\":\"p_x\",\"name\":\"x\"}]},{\"id\":\"n0\",\"type\":\"Linear\",\"params\":{\"in_features\":376,\"out_features\":256}},{\"id\":\"n1\",\"type\":\"ReLU\"},{\"id\":\"n2\",\"type\":\"Linear\",\"params\":{\"in_features\":256,\"out_features\":256}},{\"id\":\"n3\",\"type\":\"ReLU\"},{\"id\":\"n4\",\"type\":\"Linear\",\"params\":{\"in_features\":256,\"out_features\":17}},{\"id\":\"out\",\"type\":\"Output\",\"ports\":[{\"id\":\"p_y\",\"name\":\"y\"}]}],\"edges\":[{\"id\":\"e0\",\"source\":\"in\",\"sourceHandle\":\"p_x\",\"target\":\"n0\"},{\"id\":\"e1\",\"source\":\"n0\",\"target\":\"n1\"},{\"id\":\"e2\",\"source\":\"n1\",\"target\":\"n2\"},{\"id\":\"e3\",\"source\":\"n2\",\"target\":\"n3\"},{\"id\":\"e4\",\"source\":\"n3\",\"target\":\"n4\"},{\"id\":\"e5\",\"source\":\"n4\",\"target\":\"out\",\"targetHandle\":\"p_y\"}]}"
+        }
+      }
     }
   ],
   "edges": [
@@ -140,6 +153,13 @@
       "id": "e-trigger-1",
       "source": "start-1",
       "target": "obs-1",
+      "sourceHandle": "trigger",
+      "type": "trigger"
+    },
+    {
+      "id": "e-trigger-2",
+      "source": "start-1",
+      "target": "seq-model",
       "sourceHandle": "trigger",
       "type": "trigger"
     }

--- a/examples/Transformer/MoE-TopK-Routing/graph.json
+++ b/examples/Transformer/MoE-TopK-Routing/graph.json
@@ -1,16 +1,18 @@
 {
   "name": "Mixture of Experts: top-k routing in 5 nodes",
-  "description": "What MoE actually does to a token batch. A 2 × 5 × 32 tensor (2 batches of 5 tokens, hidden dim 32) goes into MoELayer with N=4 experts and top_k=2. Each token picks its 2 best experts by softmax over a small gating network; the layer's output is the weighted sum of those 2 experts' FFN outputs. The Print on routing_weights shows the [B, T, k] tensor so students can read off which experts each token chose and how confident the gate was. Same architecture pattern as Switch Transformer, Mixtral, and DeepSeek-MoE — sized down so the routing decisions fit on one screen.",
+  "description": "What MoE actually does to a token batch. A 2 × 5 × 32 tensor (2 batches of 5 tokens, hidden dim 32) goes into MoELayer with N=4 experts and top_k=2. Each token picks its 2 best experts by softmax over a small gating network; the layer's output is the weighted sum of those 2 experts' FFN outputs. All three outputs are printed, and reading them together is the point: `expert_indices` says WHICH 2 experts each token chose, `routing_weights` says how confident the gate was about that choice, and `output` is the mixture those two produce — [B, T, H], the same shape that went in, which is what lets an MoE layer drop into a Transformer block where a plain FFN used to sit. Same architecture pattern as Switch Transformer, Mixtral, and DeepSeek-MoE — sized down so the routing decisions fit on one screen.",
   "nodes": [
     { "id": "start-1",   "type": "Start",        "position": { "x": -260, "y": 0    }, "data": { "params": {} } },
     { "id": "x",         "type": "TensorCreate", "position": { "x": -40,  "y": 0    }, "data": { "params": { "shape": "2,5,32", "fill": "randn", "value": 0, "requires_grad": false } } },
     { "id": "moe",       "type": "MoELayer",     "position": { "x": 240,  "y": 0    }, "data": { "params": { "num_experts": 4, "top_k": 2, "hidden_dim": 32, "expert_hidden_dim": 64, "seed": 42 } } },
-    { "id": "print_w",   "type": "Print",        "position": { "x": 540,  "y": -100 }, "data": { "params": { "label": "routing_weights [B, T, k]" } } },
-    { "id": "print_idx", "type": "Print",        "position": { "x": 540,  "y": 100  }, "data": { "params": { "label": "expert_indices [B, T, k]" } } }
+    { "id": "print_out", "type": "Print",        "position": { "x": 540,  "y": -220 }, "data": { "params": { "label": "output [B, T, H] — the mixture itself, same shape as the input" } } },
+    { "id": "print_w",   "type": "Print",        "position": { "x": 540,  "y": -20  }, "data": { "params": { "label": "routing_weights [B, T, k]" } } },
+    { "id": "print_idx", "type": "Print",        "position": { "x": 540,  "y": 180  }, "data": { "params": { "label": "expert_indices [B, T, k]" } } }
   ],
   "edges": [
     { "id": "trig_x",  "source": "start-1", "target": "x",         "sourceHandle": "trigger", "type": "trigger" },
     { "id": "e_x_moe", "source": "x",       "target": "moe",       "sourceHandle": "tensor",          "targetHandle": "x" },
+    { "id": "e_moe_o", "source": "moe",     "target": "print_out", "sourceHandle": "output",          "targetHandle": "value" },
     { "id": "e_moe_w", "source": "moe",     "target": "print_w",   "sourceHandle": "routing_weights", "targetHandle": "value" },
     { "id": "e_moe_i", "source": "moe",     "target": "print_idx", "sourceHandle": "expert_indices",  "targetHandle": "value" }
   ]

--- a/examples/Usage_Example/CNN-MNIST/InferenceCNN-MNIST/graph.json
+++ b/examples/Usage_Example/CNN-MNIST/InferenceCNN-MNIST/graph.json
@@ -1,6 +1,6 @@
 {
   "name": "Inference CNN on MNIST",
-  "description": "Load a trained CNN model and classify a single handwritten digit. Run 'Train CNN on MNIST' once first - it saves model_weights.pt, which this graph loads. ImageReader reads test_digit.png (a real MNIST digit bundled under backend/data/images/), SequentialModel rebuilds the same architecture, ModelLoader restores the saved weights, and Inference runs the forward pass to produce a prediction.",
+  "description": "PREREQUISITE: run 'Train CNN on MNIST' once first — it writes model_weights.pt, which this graph loads. Trained weights are never shipped with an install, so on a fresh machine this graph fails at ModelLoader until that training run has happened. After that: ImageReader reads test_digit.png (a real MNIST digit bundled under backend/data/images/), SequentialModel rebuilds the same architecture, ModelLoader restores the saved weights, and Inference runs the forward pass to classify a single handwritten digit.",
   "nodes": [
     {
       "id": "start-1",

--- a/examples/Usage_Example/GPT-Mini/TrainGPT-Mini/graph.json
+++ b/examples/Usage_Example/GPT-Mini/TrainGPT-Mini/graph.json
@@ -70,7 +70,7 @@
       },
       "data": {
         "params": {
-          "title": "GPT Language Modeling Loss",
+          "title": "Mini-GPT on MNIST — 10-class cross-entropy loss",
           "plot_type": "line"
         }
       }


### PR DESCRIPTION
> 中文摘要：2026-08-21 那次範例稽核記下的具體 bug，這輪全部修掉，並補上一個防止復發的測試。最嚴重的一個是 **DQN 與 PPO 兩個範例的 optimizer 可能拿到錯的模型**——各有兩條邊灌進同一個輸入埠，引擎「後寫的贏」而且不吭聲，所以圖能過驗證、能執行、印出看起來合理的數字。另外 **MoE 範例從來沒接上它自己的混合輸出**，以及四段指向使用者手上沒有的東西的描述。

四個 commit：前三個分別對應三類問題，第四個是我把 DQN/PPO 刪過頭之後的更正（CI 抓到的，細節寫在第 1 節）。

---

## 1. DQN / PPO 的 optimizer 拿到的可能不是那個 agent

兩張圖都有**兩條邊**進 `optimizer-1.model`：

```
DQN:  dqn-1.model     -> optimizer-1.model     (e-10)
      seq-model.model -> optimizer-1.model     (e-auto-12)

PPO:  ppo-1.model     -> optimizer-1.model     (e-3)
      seq-model.model -> optimizer-1.model     (e-auto-5)
```

`seq-model` 是一個 `SequentialModel`，除了 Start 的觸發線和這條邊之外**跟整張圖沒有任何連結**，兩份描述也從頭到尾沒提過它。引擎遇到同一個輸入埠有多條邊是**後寫的贏、而且完全不警告**，所以一個叫「Deep Q-Network」的範例，很可能一路把一疊沒接上任何東西的前饋網路交給 optimizer。驗證會過、執行會過、數字印得出來。

**只移除那條邊，`seq-model` 節點留著。** 我第一版把整個節點也刪了，CI 抓到那是刪過頭：`frontend/src/components/LayersEditor/graphSerialization.test.ts` 拿這兩個節點的 `layers` 參數當作「完全沒有座標的 GraphSpec」真實案例 fixture，用來守自動排版的迴歸行為，它的載入函式甚至寫明「若範例移動，請改指向這個測試而不要刪掉它」。刪掉之後兩個案例都變成 `no node with a string 'layers' param found`。

所以節點回來了，只有那條進 `optimizer-1.model` 的邊維持刪除 —— 那才是這個 bug 的全部。optimizer 現在明確收到 `dqn-1.model` / `ppo-1.model`。

順帶把它從「沒人解釋的佈景」變成有說明的教學物件：兩份描述現在都寫明 `seq-model` 是什麼（畫布上一個一個接出來的同一套架構，打包成一份可以在層編輯器裡打開來讀的 layer stack），以及 optimizer 實際訓練的是哪個模型。它當初看起來像可以刪，正是因為沒人說過它是幹嘛的。

### 防止復發

新增 `backend/tests/test_example_graph_invariants.py`，一個測試一條規則，跑遍**兩個目錄底下全部 68 張出貨的圖**（`examples/` 與 `plugins/*/examples/`）：

- 沒有任何輸入埠被兩條邊灌（**觸發埠排除** —— 一個 Start 分岔到多個進入點是正確的）
- 沒有任何邊的端點不是這個檔案裡的節點

已經對著它要防的 bug 驗過：把第二條邊加回 `optimizer-1.model`，測試會失敗並指名是哪個埠 ——

```
AssertionError: graph.json feeds an input port from more than one source: [('optimizer-1', 'model')].
```

而且**那張被植入 bug 的圖照樣能 parse、能驗證、能執行**。這正是為什麼這個檢查必須在檔案層級做，而不能指望執行期發現。

## 2. MoE 範例從來沒展示過「混合」

`MoE-TopK-Routing` 印了 `routing_weights` 和 `expert_indices`，卻**沒有接 `MoELayer.output`**。一個以「混合專家」為名的範例，從來沒讓學生看到混合出來的東西。學生讀得到每個 token 選了哪兩個專家、gate 有多確定，就是看不到那兩個數字在講的那個結果。

補上第三個 Print 接 `output`，描述也改成說明三個為什麼要一起讀：`expert_indices` 是**選了誰**、`routing_weights` 是**多有把握**、`output` 是**混出來的結果** —— [B, T, H]，跟進去時同一個形狀，而這正是 MoE 層能直接替換掉 Transformer block 裡原本那個 FFN 的原因。

## 3. 四段描述指向使用者手上沒有的東西

| 範例 | 問題 |
|---|---|
| `Iris-Sklearn-KNN` | 兩次把教學節點寫成 **`EduKNN`**，實際節點名是 **`Edu-KNN`**（有連字號）——照描述打進節點面板搜不到任何東西。也拿 `KNN-from-Scratch` 來對比卻沒說那在 `foundations` 包裡。|
| `Mini-UNet-Compact` | 第一句就是「Counterpart to `Mini-UNet-Expanded`」，而那個範例在 `deep` 包裡。內建範例的第一句不該建立在一個沒人裝的外掛上。|
| `InferenceCNN-MNIST` | 需要 `model_weights.pt`，而 `*.gitignore` 依設計就不會讓訓練權重進版控。描述本來有寫「先跑訓練範例」，但**埋在第一句之後**，而畫廊卡片大約八十字就截斷 —— 決定這張圖跑不跑得起來的那句話剛好被切掉。|
| `TrainGPT-Mini` | 另一種錯：loss 圖的標題是「GPT Language Modeling Loss」，但這張圖自己的描述結尾寫著「projects to 10 class logits」。它是拿 GPT 風格 decoder 當 MNIST 影像分類器，**整張圖裡沒有任何語言建模**。|

`InferenceCNN-MNIST` 現在以 **PREREQUISITE** 開頭，並明說在乾淨的機器上會卡在 ModelLoader 直到跑過訓練。其餘三處改成能自己站得住、並指出東西在哪個包。

這一節**沒有動任何圖的結構**，只有四個字串。

## 刻意沒做的事

- **`InferenceCNN-MNIST` 沒有改成自給自足。** 訓練權重不該進版控，這個判斷是對的；它就是一個「從 checkpoint 推論」的範例，本來就依賴先跑訓練。真正的底層問題是**描述在載入之後完全看不到**（稽核清單裡的第一順位工作），那是另一件事。我只做了零風險的部分：把前置條件搬到卡片截斷前看得到的位置。
- **沒有在 `validate_graph` 裡加警告。** 「同一個輸入埠兩條邊」如果變成驗證錯誤，會讓使用者手上已經這樣接的圖直接停掉；`advisories.py` 那套是給節點執行期用的，不是給圖驗證用的。改用檔案層級的測試 —— 只約束我們出貨的範例，碰不到使用者的圖。
- **沒有加新範例。** 這輪照約定只修既有的 bug。

## 測試

```
cd backend && pytest tests/ -q
  -> 5415 passed, 16 skipped, 19 failed

cd backend && pytest tests/test_example_graph_invariants.py          -> 136 passed
cd backend && pytest tests/test_builtin_examples.py
              tests/test_chapter_examples.py
              tests/test_example_graph_invariants.py                 -> 236 passed, 9 skipped
uvx ruff@0.14.4 check backend/app backend/tests                      -> All checks passed!
python scripts/check_control_bytes.py                                -> OK, 1193 tracked files
```

那 19 個 failed **全部在 `tests/test_codegen.py`，與本 PR 無關**——我把非 codegen 的失敗過濾一遍，結果是空的。它們是本機環境問題：匯出的腳本開子行程時 import 不到 `app`。前幾輪在未修改的 main 上驗過同樣的 19 個。本 PR 只動範例 JSON 和一個新測試檔，碰不到 codegen。CI 上這些是綠的。

```
cd frontend && npx vitest run  -> 142 檔, 3309 passed
```

第一版我以為「沒改前端檔就不用跑前端測試」而跳過，結果 CI 打臉：範例 JSON 本來就會被前端測試讀。這輪整套跑過。

## 尚未完成：瀏覽器實測

跟上一個 PR 同樣的狀況 —— Chrome 載不進本機開發伺服器（`localhost:5173`、`127.0.0.1:5173`、`5174` 都回 error page，curl 同網址都是 200），所以沒有在畫布上眼睛看過。

不過這輪的風險比上次低很多：改動全部是圖的結構與字串，而 `test_builtin_examples.py` 與 `test_chapter_examples.py` 會**實際執行**這些圖，DQN、PPO、MoE 三張都在執行範圍內。要用眼睛確認的只有「MoE 那個新的 Print 有畫出來、位置沒有跟另外兩個重疊」。DQN/PPO 現在只少一條邊，節點與座標都沒動。

## Closes

沒有對應的 issue —— 這些 bug 記在 2026-08-21 的範例稽核裡，沒有各自開單。

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its zh-TW twin in the same PR.（改的是範例圖的 description 欄位，不是文件頁或節點參數，沒有 zh-TW 對應檔）
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do, if a reviewer might expect it.
