### PR TITLE
fix(api,test,ci): runs list is really newest-first, two caps are proved not timed, and main stops skipping suites

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -25,6 +25,12 @@ on:
       - 'plugins/**'
       - 'scripts/**'
       - 'frontend/src/plugins/contract.ts'
+      # The zh-TW node catalog is a BACKEND test fixture: test_api_nodes.py's
+      # translation ratchet and test_causal_lm_model_node.py both read
+      # frontend/src/i18n/nodeLocales/zh-TW.ts off disk. Editing it with no
+      # backend file touched would otherwise skip the very checks that guard
+      # it. (Same class of gap as examples/** in frontend-build.yml.)
+      - 'frontend/src/i18n/**'
       - 'ruff.toml'
       - '.github/workflows/backend-test.yml'
   workflow_dispatch:

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -13,6 +13,19 @@ on:
       - main
     paths:
       - 'frontend/**'
+      # Frontend tests read these, so a change to them can break this check
+      # with no frontend file touched at all. That is not hypothetical: a
+      # PR editing only example graphs broke `graphSerialization.test.ts`,
+      # and the pull_request run (which has no path filter) was the only
+      # thing that caught it -- had it been pushed straight to main, this
+      # workflow would have been skipped and main would have gone green on
+      # a frontend suite that was red.
+      #   examples/**                     graphSerialization.test.ts,
+      #                                   resnetOverlap.test.ts,
+      #                                   SmartDataEdge.overlap.test.tsx
+      #   backend/tests/fixtures/**       subgraph.contract.test.ts
+      - 'examples/**'
+      - 'backend/tests/fixtures/**'
       - '.github/workflows/frontend-build.yml'
   workflow_dispatch:
 

--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -1018,10 +1018,16 @@ async def list_runs(
         if before is not None:
             sql += " AND created_at < ?"
             params.append(before)
-        # run_id DESC is a pure tie-breaker for rows sharing a created_at
-        # timestamp — determinism only, the `before` cursor stays keyed on
-        # created_at alone.
-        sql += " ORDER BY created_at DESC, run_id DESC LIMIT ?"
+        # rowid DESC is the tie-breaker for rows sharing a created_at
+        # timestamp. It was `run_id DESC`, which is deterministic but says
+        # nothing about when a run happened -- run_id is a uuid4().hex, so
+        # among rows in one timestamp tick the "newest first" list could put
+        # the older run first, and two invokes in quick succession share a
+        # tick often enough to fail this endpoint's own test on CI (#370).
+        # rowid rises with insertion, so it is deterministic AND actually
+        # newest-first; it is what run_store.py's equivalent queries already
+        # use. The `before` cursor stays keyed on created_at alone.
+        sql += " ORDER BY created_at DESC, rowid DESC LIMIT ?"
         params.append(limit)
         return [dict(r) for r in conn.execute(sql, params).fetchall()]
 

--- a/backend/tests/test_api_apps_invoke.py
+++ b/backend/tests/test_api_apps_invoke.py
@@ -780,9 +780,28 @@ async def test_invoke_succeeds_after_queued_timeout(
 
 @pytest.mark.asyncio
 async def test_runs_list_metadata_only_newest_first(
-    test_client, app_db, api_key,
+    test_client, app_db, api_key, monkeypatch,
 ):
+    """Ordering, field set, and the limit/before cursor on distinct stamps.
+
+    The clock is stepped rather than left real. Two invokes this close
+    together often land in one ``created_at`` tick, and the `before` cursor
+    is keyed on ``created_at`` alone (``created_at < ?``) -- so on a tie the
+    cursor below excludes BOTH rows and this test fails with an empty list.
+    That is a real defect in the endpoint, tracked separately; it is not what
+    this test is about, and leaving it to chance made this file fail on CI at
+    random. Ordering under a genuine tie has its own test above
+    (``test_two_invokes_in_one_timestamp_tick_still_list_newest_first``).
+    """
     await _publish(test_client, SLUG, _echo_graph())
+
+    stamps = iter([
+        "2026-03-03T00:00:01.000000Z",
+        "2026-03-03T00:00:02.000000Z",
+    ])
+    monkeypatch.setattr("app.api.routes_apps.utc_now_iso",
+                        lambda: next(stamps))
+
     key_headers = _bearer(api_key["token"])
     first = await test_client.post(f"/api/apps/{SLUG}/invoke",
                                    json={"inputs": {"x": "one"}},
@@ -817,11 +836,28 @@ async def test_runs_list_metadata_only_newest_first(
 
 
 @pytest.mark.asyncio
-async def test_runs_list_tie_breaks_on_run_id_desc_when_created_at_equal(
+async def test_runs_list_tie_breaks_on_insertion_order_when_created_at_equal(
     test_client, app_db,
 ):
-    """Rows sharing one created_at timestamp must still sort deterministically
-    (run_id DESC tie-break) — the `before` cursor design is unaffected."""
+    """Rows sharing one created_at timestamp still come back newest first.
+
+    The tie-break used to be ``run_id DESC``, chosen for determinism alone.
+    It is deterministic, but ``run_id`` is a ``uuid4().hex`` -- so among rows
+    that share a timestamp the order was arbitrary with respect to when they
+    actually happened, and an endpoint whose whole contract is "newest first"
+    could hand back the older run first. Two invokes in quick succession land
+    in the same timestamp tick often enough that
+    ``test_runs_list_metadata_only_newest_first`` failed on CI over it (#370).
+
+    ``rowid`` rises with insertion, so it is both deterministic AND the real
+    answer to "which happened last" -- and it is what the same query in
+    ``run_store.py`` (lines 520, 695, 1174) already tie-breaks on. The
+    ``before`` cursor stays keyed on ``created_at`` alone, unchanged.
+
+    The ids below are deliberately NOT in lexicographic order: inserted
+    aaa, zzz, mmm, a run_id sort would answer zzz/mmm/aaa, and only an
+    insertion-order sort answers mmm/zzz/aaa.
+    """
     await _publish(test_client, SLUG, _echo_graph())
 
     def _app_id(conn: sqlite3.Connection) -> int:
@@ -845,7 +881,43 @@ async def test_runs_list_tie_breaks_on_run_id_desc_when_created_at_equal(
     resp = await test_client.get(f"/api/apps/{SLUG}/runs")
     assert resp.status_code == 200
     assert [r["run_id"] for r in resp.json()] == [
-        "run-zzz", "run-mmm", "run-aaa",
+        "run-mmm", "run-zzz", "run-aaa",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_two_invokes_in_one_timestamp_tick_still_list_newest_first(
+    test_client, app_db, api_key, monkeypatch,
+):
+    """The flake in ``test_runs_list_metadata_only_newest_first``, made real.
+
+    That test invokes twice and asserts the newer run comes back first. On a
+    fast machine both rows land in the same ``created_at`` tick, and until
+    #370 the tie-break was ``run_id DESC`` over two uuid4 hexes -- a coin
+    flip, so CI failed it at random. Here the clock is frozen so the tie is
+    guaranteed rather than hoped for: if the ordering ever goes back to
+    something that is not insertion order, this fails every single time
+    instead of one run in N.
+    """
+    await _publish(test_client, SLUG, _echo_graph())
+    monkeypatch.setattr(
+        "app.api.routes_apps.utc_now_iso",
+        lambda: "2026-02-02T00:00:00.000000Z",
+    )
+
+    key_headers = _bearer(api_key["token"])
+    first = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                   json={"inputs": {"x": "one"}},
+                                   headers=key_headers)
+    second = await test_client.post(f"/api/apps/{SLUG}/invoke",
+                                    json={"inputs": {"x": "two"}},
+                                    headers=key_headers)
+
+    rows = (await test_client.get(f"/api/apps/{SLUG}/runs")).json()
+    assert {r["created_at"] for r in rows} == {"2026-02-02T00:00:00.000000Z"}, (
+        "the freeze did not take -- the tie this test exists for never happened")
+    assert [r["run_id"] for r in rows] == [
+        second.json()["run_id"], first.json()["run_id"],
     ]
 
 

--- a/backend/tests/test_run_queue.py
+++ b/backend/tests/test_run_queue.py
@@ -445,27 +445,56 @@ async def test_queue_position_counts_from_the_front(service):
     assert service.queue_position("nope") is None
 
 
+async def _two_run_at_once_third_queues(service, store, probe, *,
+                                        device: str, labels: list[str]):
+    """Assert a cap of two admits two AT ONCE and queues the third.
+
+    "At once" is the part worth being careful about. Sizing a sleep and then
+    reading ``probe.peak`` asks whether the two runs happened to overlap on
+    the wall clock, and on a loaded CI runner the first can finish before the
+    second even reaches ``enter`` -- peak stays 1 and the test fails having
+    found no defect at all (#370; observed on main and on two PR branches).
+
+    So both runs are held open on gates instead. ``wait_entered`` returns
+    only once a run is provably inside its slot, so by the time the second
+    returns, two are demonstrably in flight and the peak is a fact rather
+    than a race. This is what ``_Probe.hold`` was built for in #187.
+    """
+    release_a = probe.hold(labels[0])
+    release_b = probe.hold(labels[1])
+    try:
+        results = [await _submit(service, label, device=device)
+                   for label in labels]
+        assert [r.status for r in results] == [STATUS_RUNNING, STATUS_RUNNING,
+                                               STATUS_QUEUED]
+        # Both provably occupying a slot at the same moment.
+        await probe.wait_entered(labels[0])
+        await probe.wait_entered(labels[1])
+        assert probe.peak[device] == 2
+    finally:
+        release_a.set()
+        release_b.set()
+
+    for result in results:
+        await _await_terminal(store, result.run_id)
+    # The third only ever ran after a slot came free, so the cap held for
+    # the whole test, not just at the moment it was sampled above.
+    assert probe.peak[device] == 2
+
+
 async def test_cpu_admits_two_at_once_and_queues_the_third(service, store,
                                                            probe):
     """The cap is per key, and ``cpu``'s is two — contention, not death."""
-    results = [await _submit(service, f"cpu-{i}", seconds=0.25)
-               for i in range(3)]
-    assert [r.status for r in results] == [STATUS_RUNNING, STATUS_RUNNING,
-                                           STATUS_QUEUED]
-    for result in results:
-        await _await_terminal(store, result.run_id)
-    assert probe.peak["cpu"] == 2
+    await _two_run_at_once_third_queues(
+        service, store, probe, device="cpu",
+        labels=["cpu-0", "cpu-1", "cpu-2"])
 
 
 async def test_an_override_raises_one_devices_cap(make_service, store, probe):
     service = make_service(gpu=1, overrides=(("cuda:0", 2),))
-    results = [await _submit(service, f"gpu-{i}", device="cuda:0",
-                             seconds=0.2) for i in range(3)]
-    assert [r.status for r in results] == [STATUS_RUNNING, STATUS_RUNNING,
-                                           STATUS_QUEUED]
-    for result in results:
-        await _await_terminal(store, result.run_id)
-    assert probe.peak["cuda:0"] == 2
+    await _two_run_at_once_third_queues(
+        service, store, probe, device="cuda:0",
+        labels=["gpu-0", "gpu-1", "gpu-2"])
 
 
 async def test_a_freed_slot_promotes_the_next_run(service, store, probe):


### PR DESCRIPTION
> 中文摘要：修 #370 的兩個不穩定測試，過程中發現**兩個更嚴重的東西**。一是 runs 列表的排序在同一時間刻度內真的是錯的（tie-break 用 `run_id DESC`，而 run_id 是 uuid4，等於擲銅板）。二是 CI 的 push-to-main 路徑過濾器沒涵蓋測試實際會讀的檔案 —— **#369 的合併 commit 根本沒有跑過 Frontend Build Check**，而那個 PR 正是靠前端測試抓到問題的。另外還查出一個我沒修、另外開單的分頁 bug 和一個 Windows 崩潰。

三個 commit 分開對應三件事。

---

## 1. runs 列表在同一時間刻度內排序是錯的

`GET /api/apps/{slug}/runs` 的 tie-break 是 `run_id DESC`。程式碼註解說這是「determinism only」—— 確實有決定性，但 `run_id` 是 `uuid4().hex`，所以**同一個 `created_at` 刻度內的順序跟事情實際發生的先後毫無關係**。一個契約寫著「newest first」的端點，會把舊的排在前面。

連續兩次 invoke 落在同一刻度的機率不低，本機重現大約**五次會壞一次**。

改用 `rowid DESC` —— 隨插入遞增，所以既有決定性、又真的回答了「哪個比較晚」。而且 `run_store.py` 的同類查詢（520、695、1174 行）**本來就都用 rowid**，只有這一處不一樣。`before` cursor 維持以 `created_at` 為鍵，沒動。

### 動到一個刻意釘住舊行為的測試

`test_runs_list_tie_breaks_on_run_id_desc_when_created_at_equal` 是刻意把 `run_id DESC` 釘住的，所以我**改寫而不是刪掉**：同樣三筆、同樣共用時間戳，改成斷言插入順序。它的 id 本來就選得讓兩種答案不同（插入 aaa/zzz/mmm —— run_id 排序給 zzz/mmm/aaa，插入順序給 mmm/zzz/aaa），所以它仍然能分辨這兩種設計。

**這是刻意改變一個有測試釘住的行為，值得你看一眼再決定。** 我的理由是：端點契約與它自己的測試名稱都寫著 newest first，而 UUID 的字典序對使用者沒有任何意義。

### 新增／強化的測試

- **`test_two_invokes_in_one_timestamp_tick_still_list_newest_first`** —— 把時鐘凍住，讓平手**保證發生**而不是碰運氣。以後排序若不再是插入順序，這個會**每次都失敗**，而不是 N 次壞一次。
- **`test_runs_list_metadata_only_newest_first`** 改成讓時鐘遞增，兩次 run 拿到不同時間戳。這不是為了迴避平手（上面那個測試專門測平手），而是因為它的 `before` cursor 斷言有**第二個平手敏感點**，見下。

## 2. 順帶查出、但我沒修的分頁 bug

`before` cursor 是 `created_at < ?`。兩筆共用同一刻度時，`before=<該刻度>` 會**把兩筆都排除**，回傳空陣列。

也就是說**使用者用 `before` 翻頁時，同一刻度的 run 會整批消失**。這是真的資料遺漏，不只是測試問題。

我沒有在這個 PR 修，因為正確的修法是把 cursor 改成複合鍵（created_at + rowid），那會**改變對外的 cursor 格式**，是一個該獨立決定的 API 契約變更。已另開 **#372** 追蹤，並在測試裡寫明為什麼那兩個時間戳是刻意錯開的。

## 3. 兩個不穩定的併發測試

`test_cpu_admits_two_at_once_and_queues_the_third` 與 `test_an_override_raises_one_devices_cap` 送三個帶固定 `seconds=` 睡眠的 run，然後讀 `probe.peak` —— 這是在問「那兩個 run 有沒有剛好在牆上時鐘上重疊」。runner 一慢，第一個在第二個進到 `_Probe.enter` 之前就跑完，峰值停在 1，測試就在**沒有發現任何缺陷的情況下失敗**。

### 一個值得記下的不對稱

這個檔案另外還有兩個峰值斷言（432、538 行）是 `peak == 1`，也就是**上界**。runner 越慢越不容易重疊，所以那兩個在高負載下反而更安全，只有上限真的漏掉時才會失敗 —— 那正是它們存在的目的。**會壞的只有「斷言峰值有達到 N」這個方向。**

兩個都改成用 gate 撐住那兩個被接納的 run，再用 `wait_entered` 等到它們**確實同時待在各自的 slot 裡**才斷言。峰值變成事實而不是競態。這正是 `_Probe.hold` 在 #187 建立時的用途 —— 工具早就在手邊，只是這兩個測試沒有搬過去。

驗證：把 override 改成 `("cuda:0", 1)`，測試會失敗（證明它仍抓得到錯的上限）；連跑 8 次全綠。

## 4. CI 的 push-to-main 路徑過濾器沒涵蓋測試實際讀的檔案

**這是你說「Actions 沒有完整跑完」的原因。**

兩套測試都會讀 repo 另外一半的 fixture 檔，但兩個 workflow 的 push 過濾器都沒寫進去。在 PR 上看不出來 —— 兩個 workflow 都刻意不對 `pull_request` 設過濾器（因為分支規則要求它們回報）。但 **push 到 main 時過濾器是生效的**，所以 main 可能在一套從未執行的測試上顯示綠燈。

這不是假設。**#369 只改了 `examples/**`，而它破壞了 `graphSerialization.test.ts`** —— PR 的那次 run 抓到了，但同一個 workflow 的 push-to-main 那次被整個跳過，因為 `frontend-build.yml` 只列了 `frontend/**`。合併 commit `2a1bba4` 底下**完全沒有 Frontend Build Check**。

`frontend-build.yml` 補上它的測試實際讀的：

| 路徑 | 讀它的測試 |
|---|---|
| `examples/**` | `graphSerialization.test.ts`、`resnetOverlap.test.ts`、`SmartDataEdge.overlap.test.tsx` |
| `backend/tests/fixtures/**` | `subgraph.contract.test.ts` |

`backend-test.yml` 有**對稱的同一個問題** —— zh-TW 節點目錄其實是**後端**的測試 fixture，被 `test_api_nodes.py` 的翻譯 ratchet 和 `test_causal_lm_model_node.py` 直接讀檔，但過濾器只列了 `frontend/src/plugins/contract.ts`：

| 路徑 | 讀它的測試 |
|---|---|
| `frontend/src/i18n/**` | `test_api_nodes.py`、`test_causal_lm_model_node.py` |

兩份清單都是**掃出來的不是猜的**：走過每一個呼叫 `readFileSync` / `Path(...).parents[2]` 的測試並解析路徑，目前會跨出自己那一半的就是這四個檔案加一個目錄。

## 順帶更正：main 上的兩次 CI 失敗不是不穩定測試

我先前跟你說 8/25 那次 main 失敗是併發測試不穩 —— **那是錯的**，我當時沒抓到日誌就下了結論。實際查證後：

| commit | 失敗原因 |
|---|---|
| `8d8393e8`（8/25）| `Windows fatal exception: 0xc000001d` |
| `2a1bba46`（8/26）| 同上 |

`0xc000001d` 是 **STATUS_ILLEGAL_INSTRUCTION** —— CPU 執行了它不支援的指令，發生在 torch 的 `nn.Linear.forward`，由 `causal_lm_model_node.py:216` 呼叫，而且是在背景執行緒裡。

兩次的依賴完全相同（`torch==2.13.0`、`numpy==2.5.2`，跟通過那次一模一樣），所以不是版本漂移；重跑同一個 commit 就過。最可能是 GitHub Windows runner 的 CPU 型號不一致，torch 的指令集分派踩到不支援的機器。已另開 **#373** 記錄（含往下查的方向），我沒有能力在這個 repo 裡修 runner 硬體。

真正的併發測試不穩只發生在 PR #368 的分支上（我讀到了 `assert probe.peak["cuda:0"] == 2` 的斷言文字），那個由本 PR 第 3 節修掉。

## 測試

```
cd backend && pytest tests/ -q
  -> 5416 passed, 16 skipped, 19 failed

cd backend && pytest tests/test_api_apps_invoke.py  -> 25 passed（連跑 6 次全綠，原本約 1/5 失敗）
cd backend && pytest tests/test_run_queue.py        -> 40 passed（那兩個連跑 8 次全綠）
cd frontend && npx vitest run                       -> 142 檔, 3309 passed
uvx ruff@0.14.4 check backend/app backend/tests     -> All checks passed!
python scripts/check_control_bytes.py               -> OK, 1193 tracked files
```

那 19 個 failed 全部在 `tests/test_codegen.py`，與本 PR 無關 —— 我把非 codegen 的失敗過濾一遍是空的。本機環境問題（匯出腳本的子行程 import 不到 `app`），前幾輪在未修改的 main 上驗過同樣的 19 個。

兩個 workflow YAML 都用 `yaml.safe_load` 解析驗證過，路徑清單如預期。

## Closes

Closes #370

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its zh-TW twin in the same PR.（本 PR 沒有動文件頁或節點參數）
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do, if a reviewer might expect it.（沒修 `before` cursor 的分頁 bug → #372、沒修 Windows 崩潰 → #373）
