### PR TITLE
docs(licensing): contributor credit and royalty-free commercial grant

### DIFF
--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -12,6 +12,14 @@ contributions are accepted under the Developer Certificate of Origin 1.1 plus
 the dual-licensing term stated in [CONTRIBUTING.md](CONTRIBUTING.md), so that
 contributed code can be offered on either path.
 
+That inbound grant is royalty-free: contributors are credited and retain
+copyright in their own work, and no royalty, revenue share, or other
+compensation is owed to them when a commercial license is granted. A
+commercial licensee therefore deals with a single licensor and inherits no
+payment obligations toward individual contributors. A contributor who
+considers a contribution outstanding may discuss separate recognition or
+terms with the maintainers; see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Open Source Path
 
 The default public license is AGPL-3.0-only. This path is intended for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for wanting to help. This document covers the three things you need before your first pull request: how to sign your commits, how to get a working development environment, and what the review conventions in this repository actually are.
 
-> 中文摘要：送 PR 前請先讀「Signing your work」一節——每個 commit 都要用 `git commit -s` 加上 DCO 簽署，否則因為本專案採雙軌授權，你的程式碼無法被納入商業授權路徑。開發環境設定與各項檢查指令列在下面，指令都是從 `scripts/dev.py` 與 CI workflow 直接核對過的，不是憑印象寫的。
+> 中文摘要：送 PR 前請先讀「Signing your work」一節——每個 commit 都要用 `git commit -s` 加上 DCO 簽署，否則因為本專案採雙軌授權，你的程式碼無法被納入商業授權路徑。貢獻是自願的無償授權：每位貢獻者都會被永久記錄並保有著作權，但著作權人銷售商業授權時不向貢獻者分潤；認為自己的貢獻特別重大的人，歡迎直接與維護者討論——見「Credit, compensation, and outstanding contributions」。開發環境設定與各項檢查指令列在下面，指令都是從 `scripts/dev.py` 與 CI workflow 直接核對過的，不是憑印象寫的。
 
 **Table of contents**
 
@@ -56,6 +56,16 @@ Two things are true when you sign off on a commit here.
 Point 2 is stated here as an inbound term of contributing, not as a separate agreement you sign. It is spelled out explicitly because the DCO on its own certifies *provenance* and submission under the project's open source license; it does not by itself say anything about a second, proprietary license. Rather than leave that gap implicit, the project states its position where you can read it before you contribute.
 
 If you are contributing on behalf of an employer, make sure you actually have the authority to agree to both points. If you are not comfortable with point 2, say so in the pull request before doing the work and the maintainers will discuss it with you rather than merge something on an unclear basis.
+
+### Credit, compensation, and outstanding contributions
+
+Three ground rules apply to every contribution. Read them before you contribute.
+
+1. **Every contributor is credited.** Your name and email stay with your commits in the git history permanently, and GitHub's contributors graph is derived from the same record. You also retain copyright in your own work (see [NOTICE](NOTICE)); nothing in this document assigns ownership to the project.
+
+2. **The grant is voluntary and royalty-free.** The inbound terms above license your contribution to the project on both paths without payment. If the copyright holder sells a commercial license that includes your code, no royalty, revenue share, or other compensation is owed to you for it. Contributing is voluntary; if that term does not work for you, raise it before doing the work.
+
+3. **Outstanding contributions can be discussed.** If you believe a contribution you have made, or are about to make, is substantial enough that different recognition or terms should apply, open an issue or contact the maintainers and discuss it. Any arrangement beyond the defaults above requires explicit written agreement with the copyright holder; the size of a merged PR does not imply one.
 
 ### Developer Certificate of Origin 1.1
 
@@ -317,4 +327,4 @@ Browse the [issue tracker](https://github.com/CodefyUI/CodefyUI/issues) for some
 
 ## License
 
-By contributing you agree that your contributions are licensed as described in [Signing your work](#signing-your-work-dco) above: AGPL-3.0-only, and available to the copyright holder for the commercial path. See [LICENSE](LICENSE), [NOTICE](NOTICE), and [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md).
+By contributing you agree that your contributions are licensed as described in [Signing your work](#signing-your-work-dco) above: AGPL-3.0-only, and available to the copyright holder, royalty-free, for the commercial path. Contributors are credited and retain copyright, and outstanding contributions can always be discussed with the maintainers — see [Credit, compensation, and outstanding contributions](#credit-compensation-and-outstanding-contributions). See also [LICENSE](LICENSE), [NOTICE](NOTICE), and [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md).

--- a/NOTICE
+++ b/NOTICE
@@ -43,3 +43,12 @@ CONTRIBUTIONS
 Contributions are accepted under the Developer Certificate of Origin 1.1 and
 the inbound licensing terms stated in CONTRIBUTING.md. Contributors retain
 copyright in their own contributions.
+
+The inbound grant is voluntary and royalty-free. It permits the copyright
+holder to offer contributed code on both licensing paths, including under
+commercial licenses, with no royalty, revenue share, or other compensation
+owed to any contributor. Every contributor is credited through the
+project's git history and GitHub's contributors graph. A contributor who
+considers a contribution outstanding may discuss recognition or terms with
+the maintainers; any arrangement beyond these defaults requires explicit
+written agreement with the copyright holder.

--- a/docs/docs/licensing.md
+++ b/docs/docs/licensing.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 title: Licensing FAQ
-description: What AGPL-3.0 actually requires of CodefyUI users, whether running it internally triggers section 13, how custom nodes and plugins are treated, and what the commercial license covers.
+description: What AGPL-3.0 actually requires of CodefyUI users, whether running it internally triggers section 13, how custom nodes and plugins are treated, what the commercial license covers, and what contributors agree to.
 ---
 
 # Licensing FAQ
@@ -82,6 +82,16 @@ The one thing to keep separate is the training *data* you feed in and any pretra
 **What it does not do:** it does not take anything away from the open source path, and it is not a support contract. Terms and pricing are negotiated per case.
 
 Start the conversation on the [issue tracker](https://github.com/CodefyUI/CodefyUI/issues). See also [COMMERCIAL-LICENSE.md](https://github.com/CodefyUI/CodefyUI/blob/main/COMMERCIAL-LICENSE.md).
+
+## What do contributors agree to? Do they share in commercial revenue?
+
+Three ground rules, stated in full in [CONTRIBUTING.md](https://github.com/CodefyUI/CodefyUI/blob/main/CONTRIBUTING.md):
+
+- **Every contributor is credited.** The git history keeps each contributor's name and email permanently, GitHub's contributors graph is derived from it, and contributors retain copyright in their own work.
+- **The grant is voluntary and royalty-free.** Contributions are licensed to the project on both paths — AGPL-3.0-only and the commercial license. When the copyright holder sells a commercial license that includes contributed code, no royalty, revenue share, or other compensation is owed to the contributors whose code is in it.
+- **Outstanding contributions can be discussed.** A contributor who believes a contribution is substantial enough that different recognition or terms should apply can raise it with the maintainers, before or after contributing. Anything beyond the defaults requires explicit written agreement with the copyright holder.
+
+For a commercial licensee this means a single licensor, and a license that carries no payment claims from individual contributors.
 
 ## Third-party components
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/licensing.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/licensing.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 title: 授權常見問題
-description: AGPL-3.0 對 CodefyUI 使用者實際的要求是什麼、內部執行會不會觸發第 13 條、自訂節點與外掛怎麼算，以及商業授權涵蓋哪些範圍。
+description: AGPL-3.0 對 CodefyUI 使用者實際的要求是什麼、內部執行會不會觸發第 13 條、自訂節點與外掛怎麼算、商業授權涵蓋哪些範圍，以及貢獻者同意了什麼。
 ---
 
 # 授權常見問題
@@ -88,6 +88,16 @@ AGPL-3.0 第 2 條（*Basic Permissions*）寫著：
 **它不做什麼：** 它不會從開源路徑拿走任何東西，也不是技術支援合約。條款與價格逐案商議。
 
 請從[問題追蹤器](https://github.com/CodefyUI/CodefyUI/issues)開始接洽。另見 [COMMERCIAL-LICENSE.md](https://github.com/CodefyUI/CodefyUI/blob/main/COMMERCIAL-LICENSE.md)。
+
+## 貢獻者同意了什麼？商業授權收入會分給貢獻者嗎？
+
+三條基本規則，完整內容見 [CONTRIBUTING.md](https://github.com/CodefyUI/CodefyUI/blob/main/CONTRIBUTING.md)：
+
+- **每一位貢獻者都會被記錄。** git 歷史會永久保留每位貢獻者的名字與 email，GitHub 的 contributors 圖表也由同一份記錄產生，而且貢獻者保有自己作品的著作權。
+- **授權是自願且無償的。** 貢獻以雙軌授權給專案——AGPL-3.0-only 與商業授權。當著作權人銷售包含貢獻程式碼的商業授權時，不需要向這些程式碼的貢獻者支付權利金、分潤或任何其他報酬。
+- **重大貢獻可以另行討論。** 若貢獻者認為某項貢獻夠重大、應該有不同的表彰或條件，可以在貢獻前後向維護者提出討論。任何超出上述預設的安排，都需要與著作權人明確書面約定。
+
+對商業授權買方而言，這代表只有單一授權人，且授權不附帶任何來自個別貢獻者的付款主張。
 
 ## 第三方元件
 


### PR DESCRIPTION
> 中文摘要：把維護者對第三方貢獻授權的裁定寫進文件：（一）所有貢獻者都會被永久記錄（git 歷史與 GitHub contributors）並保有著作權；（二）貢獻是自願的無償授權——著作權人銷售商業授權時，不需向貢獻者支付權利金或分潤；（三）認為自己有重大貢獻的人，可以在貢獻前後與維護者討論表彰或另訂條件，但任何超出預設的安排都必須有明確書面約定。此裁定取代 #266 原本的追蹤計畫，該 issue 隨本 PR 關閉。

CONTRIBUTING.md already carries the DCO plus an explicit inbound dual-licensing term (point 2 of "Inbound licensing"), and NOTICE says contributors retain copyright. Neither states whether the grant is paid or whether credit is guaranteed, which are the two questions a contributor or a commercial licensee will ask first.

This PR states the maintainer's ruling in every place the licensing story is told:

- **CONTRIBUTING.md** — new section "Credit, compensation, and outstanding contributions" with the three ground rules: permanent credit and retained copyright; a voluntary, royalty-free grant on both paths with no revenue share when a commercial license is sold; and an open path to discuss recognition or separate terms for outstanding contributions, with anything beyond the defaults requiring explicit written agreement. The zh-TW summary at the top and the closing License section say the same thing.
- **NOTICE** — the CONTRIBUTIONS section states the royalty-free grant, the credit policy, and the discussion path, since NOTICE ships in the release tarball.
- **COMMERCIAL-LICENSE.md** — states the buyer-facing consequence: a commercial licensee deals with a single licensor and inherits no payment obligations toward individual contributors.
- **docs licensing FAQ** (en + zh-TW) — new question "What do contributors agree to? Do they share in commercial revenue?".

This documents policy only and makes no factual claims about the pre-DCO historical grants #266 was tracking. Per the maintainer's ruling, that tracking plan is superseded and the issue closes with this PR.

Verified: `python3 scripts/check_control_bytes.py` (OK, 1193 files), `uvx ruff@0.14.4 check .` (all checks passed), `cd docs && pnpm build` (SUCCESS for both locales; the two broken-anchor warnings are pre-existing on unrelated pages). No code paths touched, so `cdui test` does not apply.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EwoZ9EbPynXbEHBcZZeTo
