### PR TITLE
test(run,cache): gate the shutdown test and keep the PPO modules alive

### DIFF
--- a/backend/tests/test_cache_live_handle_nodes.py
+++ b/backend/tests/test_cache_live_handle_nodes.py
@@ -818,7 +818,7 @@ async def test_a_network_constructor_hands_out_a_fresh_network_every_run(
     edges = _trigger("net")
 
     cache = ExecutionCache()
-    # The MODULES, not their ``id()``s (#307). An id is unique only among
+    # Keep the modules themselves (#307). An id is unique only among
     # objects that are alive at the same moment: recording ``id(model)``
     # and then rebinding ``model`` on the next iteration left the previous
     # network collectable, and CPython hands the next allocation the

--- a/backend/tests/test_cache_live_handle_nodes.py
+++ b/backend/tests/test_cache_live_handle_nodes.py
@@ -818,18 +818,32 @@ async def test_a_network_constructor_hands_out_a_fresh_network_every_run(
     edges = _trigger("net")
 
     cache = ExecutionCache()
-    identities, weights = [], []
+    # The MODULES, not their ``id()``s (#307). An id is unique only among
+    # objects that are alive at the same moment: recording ``id(model)``
+    # and then rebinding ``model`` on the next iteration left the previous
+    # network collectable, and CPython hands the next allocation the
+    # address it just freed. Two distinct networks then carried one id and
+    # this test reported a cache hit that had not happened -- observed with
+    # the first and third ids equal on PPO.
+    models, weights = [], []
     for _ in range(3):
         outputs = await execute_graph(nodes, edges, cache=cache)
         model = outputs["net"]["model"]
-        identities.append(id(model))
+        models.append(model)
         weights.append(_first_weight(model))
         with torch.no_grad():
             next(model.parameters()).fill_(99.0)
 
-    assert len(set(identities)) == 3, (
-        f"{node_type} handed back the same module object on "
-        f"{4 - len(set(identities))} of 3 runs. A cached network is the "
+    # ``is``, pairwise, with all three still referenced by ``models``: this
+    # compares the objects themselves, so no address the allocator is free
+    # to reuse can decide the outcome.
+    repeats = [(a + 1, b + 1)
+               for a in range(len(models))
+               for b in range(a + 1, len(models))
+               if models[a] is models[b]]
+    assert not repeats, (
+        f"{node_type} handed back one module object on more than one run: "
+        f"runs {repeats} got the same object. A cached network is the "
         "previous run's network, including whatever training did to it."
     )
     assert 99.0 not in weights, (

--- a/backend/tests/test_run_queue.py
+++ b/backend/tests/test_run_queue.py
@@ -262,14 +262,20 @@ async def make_service(store):
     the policy it is testing (``gpu=1`` and a five-deep queue is the whole
     acceptance criterion) instead of depending on a default that config is
     free to change.
+
+    ``shutdown_grace_s`` is a named parameter for the same reason, and
+    because a test that actually drains a run through ``shutdown`` should
+    be free to say "however long a loaded runner needs" rather than inherit
+    a five-second budget it never meant to assert (#318).
     """
     built: list[RunService] = []
 
     def _make(*, cpu: int = 2, gpu: int = 1, interactive: int = 2,
               overrides: tuple[tuple[str, int], ...] = (),
+              shutdown_grace_s: float = 5.0,
               **kwargs: Any) -> RunService:
         service = RunService(
-            store, shutdown_grace_s=5.0,
+            store, shutdown_grace_s=shutdown_grace_s,
             limits=QueueLimits(cpu=cpu, gpu=gpu, interactive=interactive,
                                overrides=overrides),
             **kwargs)
@@ -960,13 +966,56 @@ async def test_shutdown_retires_the_whole_queue_as_interrupted(make_service,
 
     Identical to what the next boot's ``recover_interrupted`` would write for
     the same rows — the two paths converge, this one just does not wait.
-    """
-    service = make_service()
-    running = await _submit(service, "running", device="cuda:0", seconds=0.05)
-    waiting = [await _submit(service, f"waiting-{i}", device="cuda:0",
-                             seconds=0.05) for i in range(3)]
 
-    await service.shutdown()
+    Everything below rests on one precondition: the three runs behind
+    ``running`` must still be WAITING at the moment ``shutdown`` starts. A
+    0.05s sleep only made that likely, which is #318 — measured on this
+    branch, 0.1s of extra delay between the last submit and the shutdown
+    call is already enough for the slot to free, promote ``waiting-0`` and
+    fail ``started_at is None``; at 0.3s the whole queue has drained and
+    every row comes back ``succeeded``. A loaded runner spends 0.1s without
+    noticing, which is how this failed once on Windows under load and then
+    passed four times in a row.
+
+    So ``running`` is held open on a gate (#187) instead: it provably
+    cannot finish until this test says so, and the hold is released only
+    after ``shutdown`` has been observed retiring the queue.
+    """
+    # The grace covers the drain of one released probe node with room to
+    # spare. Past it ``shutdown`` hard-cancels, a hard-cancelled task skips
+    # ``_finalize`` entirely, and the row keeps ``finished_at`` NULL — so
+    # the default five seconds would leave the last assertion here as one
+    # more thing measuring the runner's load.
+    service = make_service(shutdown_grace_s=30.0)
+    release_running = probe.hold("running")
+    stopping = None
+    try:
+        # ``seconds`` is omitted: a gated label never reaches the sleep.
+        running = await _submit(service, "running", device="cuda:0")
+        waiting = [await _submit(service, f"waiting-{i}", device="cuda:0",
+                                 seconds=0.05) for i in range(3)]
+        # Provably occupying the only cuda:0 slot, so the three behind it
+        # are provably still queued rather than merely expected to be.
+        await probe.wait_entered("running")
+        assert service.queue_snapshot() == {
+            "cuda:0": [result.run_id for result in waiting]}
+
+        stopping = asyncio.create_task(service.shutdown())
+        # ``shutdown`` sets ``_shutting_down`` and empties both queue
+        # indexes before its first await, and ``_pump`` refuses to promote
+        # anything once that flag is set — so an empty snapshot is the
+        # observable "the queue has been retired", and releasing the hold
+        # after it cannot start a fourth run. Polled against a deadline, so
+        # load costs this test time and nothing else.
+        await _wait_until(lambda: not service.queue_snapshot(),
+                          what="the shutdown retired the queue")
+    finally:
+        # However this exits: the hold must be let go, or ``shutdown`` sits
+        # out its whole grace waiting for a task that cannot finish and the
+        # real failure arrives half a minute late behind a timeout.
+        release_running.set()
+        if stopping is not None:
+            await stopping
 
     for result in waiting:
         row = await store.get_run(result.run_id)

--- a/backend/tests/test_run_queue.py
+++ b/backend/tests/test_run_queue.py
@@ -263,10 +263,10 @@ async def make_service(store):
     acceptance criterion) instead of depending on a default that config is
     free to change.
 
-    ``shutdown_grace_s`` is a named parameter for the same reason, and
-    because a test that actually drains a run through ``shutdown`` should
-    be free to say "however long a loaded runner needs" rather than inherit
-    a five-second budget it never meant to assert (#318).
+    ``shutdown_grace_s`` is a named parameter for the same reason: a test
+    that actually drains a run through ``shutdown`` can set the budget a
+    loaded runner needs, and the five-second default stays with the tests
+    that never meant to assert it (#318).
     """
     built: list[RunService] = []
 
@@ -977,8 +977,8 @@ async def test_shutdown_retires_the_whole_queue_as_interrupted(make_service,
     noticing, which is how this failed once on Windows under load and then
     passed four times in a row.
 
-    So ``running`` is held open on a gate (#187) instead: it provably
-    cannot finish until this test says so, and the hold is released only
+    So ``running`` is held open on a gate (#187): it provably cannot
+    finish until this test says so, and the hold is released only
     after ``shutdown`` has been observed retiring the queue.
     """
     # The grace covers the drain of one released probe node with room to


### PR DESCRIPTION
> 中文摘要：這個 PR 移除兩個後端測試自身的時序依賴，只動測試檔，沒有碰到任何 production code。#318 的 shutdown 測試需要三個排隊中的 run 在 `shutdown` 開始的當下仍然在排隊，原本靠一個 0.05 秒的 sleep 撐住唯一的 `cuda:0` slot；實測在最後一次 submit 與 `shutdown` 之間多 0.1 秒，slot 就會釋出、`waiting-0` 被提升，`started_at is None` 這條斷言即失敗，多 0.3 秒則整條佇列跑完、每一列都回報 `succeeded`。現在改用這個檔案既有的 probe gate（#187）把那個 run 卡在原地，等到觀察到 `shutdown` 已經把佇列退休之後才放行；等待條件走既有的 `_wait_until`，以 deadline 輪詢可觀察的事實，並讓這個測試向 `make_service` 要 30 秒的 shutdown grace，避免收尾階段落到 hard-cancel 路徑。#307 item 2 的 PPO freshness 斷言先記下 `id(model)`、下一圈再重新綁定 `model`，前一個 module 因此變成可回收，CPython 會把剛釋出的位址交給下一次配置，兩個不同的 module 就共用同一個 id。現在把三個 module 本身留在 list 裡，在三個都還活著的時候用 `is` 兩兩比較。兩個測試的斷言強度維持不變。

## What / Why

**#318 — `test_shutdown_retires_the_whole_queue_as_interrupted` is load-sensitive.**
The test submits one run and three more behind it on a queue with `gpu=1`,
calls `shutdown()`, and asserts that all three queued rows come back
`interrupted` with `started_at is None`. Every one of those assertions rests
on one precondition: the three must still be waiting at the moment
`shutdown` starts. The old shape got that from `seconds=0.05` on the run
holding the only `cuda:0` slot.

That window is about 100 ms wide. Measured on this branch with a throwaway
parametrized copy of the test (see Test evidence), injecting a delay between
the last submit and the `shutdown()` call:

| injected delay | `probe.started` at shutdown | queue depth | outcome |
| --- | --- | --- | --- |
| 0.0s | `[]` | 3 | pass |
| 0.1s | `['running', 'waiting-0']` | 2 | FAIL — `waiting-0` had started |
| 0.3s | all four | 0 | FAIL — status was `succeeded` |
| 1.0s | all four | 0 | FAIL — status was `succeeded` |
| 3.0s | all four | 0 | FAIL — status was `succeeded` |

A loaded Windows runner spends 100 ms without noticing, which is what #318
observed: one failure during a full-suite run, then green in isolation, at
the same baseline, and in two subsequent full runs.

The fix uses the mechanism this file already built for exactly this class of
problem. `running` is held open on a `_Probe` gate (#187), so it provably
occupies the slot and the three behind it are provably queued;
`probe.wait_entered` confirms the node reached the hold, and a new assertion
pins the queue at exactly those three run ids before shutdown begins.
`shutdown()` then runs as a task, and the hold is released once the empty
`queue_snapshot()` shows the queue has been retired — `shutdown` sets
`_shutting_down` and clears both queue indexes before its first `await`, and
`_pump` refuses to promote anything while that flag is set, so no fourth run
can start after the release. That wait goes through the file's existing
`_wait_until` deadline poll, so load costs the test time and nothing else.

One timing dependency remained after that: `shutdown` waits
`shutdown_grace_s` for the drain and then hard-cancels, and a hard-cancelled
task skips `_finalize`, leaving `finished_at` NULL and failing the last
assertion in the test. `make_service` now takes `shutdown_grace_s` as a named
parameter (default unchanged at 5.0s) and this test asks for 30s.

**#307 item 2 — the PPO freshness assertion compares `id()` of collectable
objects.** The old body appended `id(model)` and rebound `model` on the next
iteration, which dropped the previous module. `id()` is unique only among
objects alive at the same moment, and CPython hands a freed address to the
next allocation, so two distinct networks could report one id and the test
would announce a cache hit that never happened.

The shape is confirmed with weakrefs on this branch: at the start of run 3
the run-1 module is already dead while its id is still sitting in the list,
so runs 1 and 3 can share an address — exactly the "first and third ids
equal" in the issue. The fix keeps the three modules in a list and compares
them pairwise with `is` while all three are alive. No `id()` remains in the
assertion, so nothing there depends on an address the allocator may reuse.
The failure message now names the run pairs that shared an object.

Neither change weakens what is asserted. #318 keeps all six assertions and
gains one (the queue holds exactly the three expected ids when shutdown
starts). #307's `len(set(...)) == 3` and pairwise `is not` are equivalent
while every object is alive; the change removes only the false-failure mode.

## Closes / relates to

Closes #318
Closes #307

#307 was narrowed to item 2 on 2026-08-27 (item 1, the `collections.abc`
stdlib sweep hit, no longer reproduces), so item 2 closes it.

## Test evidence

Gates, from the repository root:

```
python3 scripts/check_control_bytes.py
  -> OK: no raw C0 control bytes in 1193 tracked files
uvx ruff@0.14.4 check .
  -> All checks passed!  (exit 0)
```

Both files in full, from `backend/`:

```
.venv/bin/python -m pytest -q -p no:cacheprovider \
    tests/test_run_queue.py tests/test_cache_live_handle_nodes.py
  -> 62 passed in 10.4s
```

Repeat runs of the two target tests on the final code:

```
20x tests/test_run_queue.py::test_shutdown_retires_the_whole_queue_as_interrupted
  -> 20 pass, 0 fail
20x tests/test_cache_live_handle_nodes.py::test_a_network_constructor_hands_out_a_fresh_network_every_run
  -> 20 pass, 0 fail   (3 parametrizations each, so 60 test runs)
```

An earlier 25x round on each, before a comment-only polish, was also 25/25
and 25/25.

**#318 — the race, demonstrated.** A throwaway file (not committed) held the
old body and the new body side by side, parametrized over an injected delay
in the place a loaded runner adds one for free. Old body: pass at 0.0s, fail
at 0.1s, 0.3s, 1.0s and 3.0s. New body, with the same delay injected twice
(before the shutdown and again mid-shutdown): pass at all five, and
`probe.started` was `['running']` with the queue exactly 3 deep at shutdown
in every case. The table above is that run's output.

**#318 — under CPU load.** 12 busy-loop Python processes on an 8-core macOS
box, load average peaking around 225:

```
old body, 12 runs of the target test  -> 12 pass, 0 fail
new body, 12 runs of the target test  -> 12 pass, 0 fail
both whole files, 3 runs              -> 62 passed each (12.0s, 12.2s, 12.2s)
```

Reported plainly: CPU load alone did not reproduce the #318 failure here.
The submits complete in about 2 ms in a single-test process, so the 100 ms
window survives even a load average of 225 on this machine. The injected-delay
experiment is what characterises the window, and the issue's own report is a
full-suite xdist run on Windows, where a scheduling or GC pause of that size
between two statements is ordinary.

**#307 — the id reuse, demonstrated.** Three measurements, on `PPO` with the
issue's parameters:

1. Liveness, with weakrefs and the old body's references: at entry to run 3
   the run-1 module is dead and the run-2 module is alive
   (`previous modules alive at entry = [False, True]`). Run 3 therefore
   allocates while run 1's address is free.
2. Forced collection. Dropping the references the old body did not hold and
   calling `gc.collect()` each iteration, the old assertion failed 2 of 10
   trials, both with two of the three ids identical, e.g.
   `[4627238800, 4627245264, 4627245264]`. The new assertion passed 10 of 10
   under identical forcing.
3. Unforced, the old assertion passed 200 of 200 trials in one process. The
   flake needs a GC pass to land in the right window, which is consistent
   with it being seen in a full-suite run and never in isolation. The fix
   holds regardless of when the collector runs, because no `id()` is
   compared at all.

## What I deliberately did not do

- No production code is touched. Both issues are defects in the tests'
  structure; `run_service.py` and the RL nodes behave correctly under both
  the old and the new assertions.
- #307 item 1 (`test_no_reachable_callable_takes_a_file_path` hitting
  `collections.abc.ABCMeta._dump_registry`) is untouched. It was narrowed out
  of the issue on 2026-08-27 as no longer reproducing.
- `make_service`'s default `shutdown_grace_s` stays at 5.0s, so no other test
  in the file changes behaviour. Only the #318 test asks for a longer grace.
- No sweep of other tests. `id(` was checked across `backend/tests/`: the
  remaining uses are visited-sets in `test_python_script_node.py` over
  modules and classes that stay reachable for the whole walk, and a cosmetic
  class-name suffix in `test_node_namespacing.py`. Neither is an identity
  assertion over a collectable object.
- The full backend suite was not run; the two files plus the repeat and load
  rounds above are the evidence for this change.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its
      zh-TW twin in the same PR (docs/i18n/zh-TW/... or the matching
      nodeLocales entry). — no docs or node-param descriptions changed.
- [x] No pictographic emoji in code, logs, UI strings, or this PR body
      (Windows consoles crash on them — ASCII markers like `[OK]` instead).
      The diff and the commit message are ASCII plus em dashes; the only
      marker below is the standard Claude Code attribution footer.
- [x] I explained what I deliberately did not do, if a reviewer might expect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EwoZ9EbPynXbEHBcZZeTo
