### PR TITLE
ci: cap oneDNN below AMX on the Windows job so EMR runners stop crashing

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -120,6 +120,51 @@ jobs:
     defaults:
       run:
         shell: pwsh
+    # ── 0xc000001d on Emerald Rapids runners (core#373) ────────────────────
+    #
+    # Seven of the 105 Windows job attempts between 2026-08-11 and 2026-08-29
+    # died with `Windows fatal exception: code 0xc000001d`
+    # (STATUS_ILLEGAL_INSTRUCTION) -- about one attempt in fifteen, on the same
+    # resolved wheel (torch==2.13.0), and twice on the same commit, since one
+    # re-run crashed as well. Every one has the same top frames: torch's
+    # `linear.py:134 in forward` called from `causal_lm_model_node.py` at the
+    # fused QKV projection. The only bfloat16 work in that test file is
+    # `test_the_forward_survives_bf16_autocast`, so what dies is a CPU bf16
+    # GEMM. The ubuntu jobs have never seen it.
+    #
+    # Some `windows-2025` VMs land on Intel Xeon Platinum 8573C (Emerald
+    # Rapids) hosts that advertise AMX in CPUID leaf 7 and in XCR0 while
+    # reporting the tile palettes in CPUID leaf 0x1D as all zeros. oneDNN
+    # decides `mayiuse(amx_tile)` from leaf 7 and XCR0, emits an AMX tile
+    # kernel for the bf16 GEMM, and the CPU answers with #UD. torch 2.13.0
+    # bundles oneDNN v3.12 (third_party/ideep -> mkl-dnn 80afa71, which is tag
+    # v3.12) and that version has no palette check. Upstream:
+    #   * actions/runner-images#14483 -- the CPUID misreport itself. Open since
+    #     2026-07-30, no ETA.
+    #   * uxlfoundation/oneDNN#5689 -- the crash report. PR oneDNN#5801 added
+    #     the missing palette check and was closed unmerged.
+    #
+    # `ONEDNN_MAX_CPU_ISA` is oneDNN's own runtime dispatcher control, tested
+    # at the top of `mayiuse()` before any CPUID query. `AVX512_CORE_BF16` is
+    # the lowest value that still carries bfloat16 and it sits below every AMX
+    # value, so the bf16 GEMM keeps a native AVX-512 path and the AMX kernels
+    # leave the dispatch table. Reading the variable is a build-time option
+    # (`DNNL_ENABLE_MAX_CPU_ISA`, ON by default in oneDNN) that PyTorch's
+    # cmake/Modules/FindMKLDNN.cmake leaves alone, so the released wheel
+    # honours it.
+    #
+    # `ATEN_CPU_CAPABILITY`, the knob core#373 first suggested, does not reach
+    # this. It selects among ATen's own vectorised kernels, and the crashing
+    # code is JIT-generated inside oneDNN.
+    #
+    # Job-level so the smoke-import step is covered too. On runners with no AMX
+    # -- the AMD Zen and Ice Lake pools -- it changes nothing, because nothing
+    # above AVX512_CORE_BF16 was reachable there in the first place.
+    #
+    # Remove when either side is fixed upstream: actions/runner-images#14483
+    # lands, or torch ships a oneDNN carrying oneDNN#5801's palette check.
+    env:
+      ONEDNN_MAX_CPU_ISA: AVX512_CORE_BF16
     steps:
       - uses: actions/checkout@v6
 
@@ -146,6 +191,55 @@ jobs:
         run: |
           uv venv --python 3.12
           uv pip install -e ".[dev]"
+
+      # The evidence that the cap above is in effect on the machine that
+      # actually ran the job. On an 8573C runner the isa line has to name
+      # bfloat16 without naming AMX; on any other runner it records which CPU
+      # the job landed on, so the correlation in core#373 stays checkable from
+      # a log months from now.
+      #
+      # oneDNN writes verbose output with printf to STDOUT (v3.12
+      # src/common/verbose.cpp), so capturing stdout is enough and no `2>&1`
+      # merge is needed -- a Python traceback goes straight to the step log
+      # instead. The header is emitted once, at the first primitive execution,
+      # as `onednn_verbose,v1,info,cpu,isa:<description>`.
+      #
+      # A positive AMX match is the only thing that fails the step. A missing
+      # isa line means the bf16 GEMM never reached oneDNN (an AVX2-only runner,
+      # or ATen keeping the op in its own kernels); that is reported as [WARN]
+      # and left alone, so a change in oneDNN's verbose format cannot turn this
+      # job red on its own. The trailing `exit 0` is what makes that true: the
+      # runner appends `exit $LASTEXITCODE` to every pwsh step, so a probe that
+      # died would otherwise decide the step's result. A probe that dies is
+      # reported as [WARN] and left for the pytest step below to fail on, which
+      # is the same crash under the same conditions.
+      - name: Report the runner CPU and the oneDNN ISA actually in effect
+        working-directory: backend
+        run: |
+          $cpu = (Get-CimInstance Win32_Processor -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name) -join ' | '
+          if (-not $cpu) { $cpu = '<unavailable>' }
+          Write-Host "[INFO] CPU: $cpu"
+          Write-Host "[INFO] ONEDNN_MAX_CPU_ISA=$env:ONEDNN_MAX_CPU_ISA"
+          $probe = 'import torch; print("[INFO] torch", torch.__version__); print("[INFO] mkldnn available:", torch.backends.mkldnn.is_available()); x = torch.randn(256, 512).bfloat16(); w = torch.randn(512, 512).bfloat16(); y = torch.nn.functional.linear(x, w); print("[INFO] bf16 linear ->", tuple(y.shape), y.dtype, "finite:", bool(torch.isfinite(y.float()).all()))'
+          $env:ONEDNN_VERBOSE = '1'
+          $out = & .venv\Scripts\python.exe -c $probe
+          $code = $LASTEXITCODE
+          $out | ForEach-Object { Write-Host $_ }
+          if ($code -ne 0) {
+            Write-Host "[WARN] the bf16 probe exited with $code; -1073741795 there is 0xc000001d, which would mean the ISA cap did not take effect"
+          }
+          $isa = @($out | Where-Object { $_ -match 'isa:' })
+          if ($isa.Count -eq 0) {
+            Write-Host "[WARN] oneDNN printed no isa: line - the bf16 GEMM did not reach oneDNN on this runner, so there is nothing to assert"
+          } else {
+            $isa | ForEach-Object { Write-Host "[ISA] $_" }
+            if ($isa -match 'AMX') {
+              Write-Host "[FAIL] oneDNN still dispatches to AMX; ONEDNN_MAX_CPU_ISA did not take effect"
+              exit 1
+            }
+            Write-Host "[OK] oneDNN is capped below AMX on this runner"
+          }
+          exit 0
 
       - name: pytest
         working-directory: backend

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -204,15 +204,25 @@ jobs:
       # instead. The header is emitted once, at the first primitive execution,
       # as `onednn_verbose,v1,info,cpu,isa:<description>`.
       #
+      # The probe does two ops. The bf16 `F.linear` is the operation that
+      # crashes. The fp32 conv2d is there because the bf16 one is not enough on
+      # its own: ATen only hands a CPU bf16 GEMM to oneDNN on machines whose
+      # bf16 support it recognises, so on an AMD runner it stays in ATen's own
+      # kernels, oneDNN is never entered and no isa line appears (observed on
+      # this job's first green run, an EPYC 7763). A CPU fp32 convolution goes
+      # through `mkldnn_convolution` on every machine as long as the shapes
+      # clear the heuristics in ATen's `use_mkldnn()` -- batch 2 and a 5x5
+      # kernel clear both of its clauses -- so the header prints wherever the
+      # job lands.
+      #
       # A positive AMX match is the only thing that fails the step. A missing
-      # isa line means the bf16 GEMM never reached oneDNN (an AVX2-only runner,
-      # or ATen keeping the op in its own kernels); that is reported as [WARN]
-      # and left alone, so a change in oneDNN's verbose format cannot turn this
-      # job red on its own. The trailing `exit 0` is what makes that true: the
-      # runner appends `exit $LASTEXITCODE` to every pwsh step, so a probe that
-      # died would otherwise decide the step's result. A probe that dies is
-      # reported as [WARN] and left for the pytest step below to fail on, which
-      # is the same crash under the same conditions.
+      # isa line is reported as [WARN] and left alone, so a change in oneDNN's
+      # verbose format cannot turn this job red on its own. The trailing
+      # `exit 0` is what makes that true: the runner appends
+      # `exit $LASTEXITCODE` to every pwsh step, so a probe that died would
+      # otherwise decide the step's result. A probe that dies is reported as
+      # [WARN] and left for the pytest step below to fail on, which is the same
+      # crash under the same conditions.
       - name: Report the runner CPU and the oneDNN ISA actually in effect
         working-directory: backend
         run: |
@@ -220,7 +230,7 @@ jobs:
           if (-not $cpu) { $cpu = '<unavailable>' }
           Write-Host "[INFO] CPU: $cpu"
           Write-Host "[INFO] ONEDNN_MAX_CPU_ISA=$env:ONEDNN_MAX_CPU_ISA"
-          $probe = 'import torch; print("[INFO] torch", torch.__version__); print("[INFO] mkldnn available:", torch.backends.mkldnn.is_available()); x = torch.randn(256, 512).bfloat16(); w = torch.randn(512, 512).bfloat16(); y = torch.nn.functional.linear(x, w); print("[INFO] bf16 linear ->", tuple(y.shape), y.dtype, "finite:", bool(torch.isfinite(y.float()).all()))'
+          $probe = 'import torch; print("[INFO] torch", torch.__version__); print("[INFO] mkldnn available:", torch.backends.mkldnn.is_available()); x = torch.randn(256, 512).bfloat16(); w = torch.randn(512, 512).bfloat16(); y = torch.nn.functional.linear(x, w); print("[INFO] bf16 linear ->", tuple(y.shape), y.dtype, "finite:", bool(torch.isfinite(y.float()).all())); c = torch.nn.functional.conv2d(torch.randn(2, 8, 32, 32), torch.randn(8, 8, 5, 5)); print("[INFO] fp32 conv2d ->", tuple(c.shape), c.dtype, "finite:", bool(torch.isfinite(c).all()))'
           $env:ONEDNN_VERBOSE = '1'
           $out = & .venv\Scripts\python.exe -c $probe
           $code = $LASTEXITCODE

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -204,21 +204,29 @@ jobs:
       # instead. The header is emitted once, at the first primitive execution,
       # as `onednn_verbose,v1,info,cpu,isa:<description>`.
       #
-      # The probe does two ops. The bf16 `F.linear` is the operation that
-      # crashes. The fp32 conv2d is there because the bf16 one is not enough on
-      # its own: ATen only hands a CPU bf16 GEMM to oneDNN on machines whose
-      # bf16 support it recognises, so on an AMD runner it stays in ATen's own
-      # kernels, oneDNN is never entered and no isa line appears (observed on
-      # this job's first green run, an EPYC 7763). A CPU fp32 convolution goes
-      # through `mkldnn_convolution` on every machine as long as the shapes
-      # clear the heuristics in ATen's `use_mkldnn()` -- batch 2 and a 5x5
-      # kernel clear both of its clauses -- so the header prints wherever the
-      # job lands.
+      # The probe runs a fp32 conv2d and then the bf16 `F.linear`. The linear is
+      # the operation that crashes; the conv2d is what guarantees an isa line.
+      # ATen only hands a CPU bf16 GEMM to oneDNN on machines whose bf16 support
+      # it recognises, so on an AMD runner the linear stays in ATen's own
+      # kernels and oneDNN is never entered -- the first green run of this step
+      # landed on an EPYC 7763 and printed nothing. A CPU fp32 convolution goes
+      # through `mkldnn_convolution` on any machine once the shapes clear the
+      # two heuristic clauses in ATen's `use_mkldnn()`, which batch 2 with a 5x5
+      # kernel does. It runs first so the header is already out when the bf16
+      # op executes.
       #
-      # A positive AMX match is the only thing that fails the step. A missing
-      # isa line is reported as [WARN] and left alone, so a change in oneDNN's
-      # verbose format cannot turn this job red on its own. The trailing
-      # `exit 0` is what makes that true: the runner appends
+      # The step measures twice: once with `ONEDNN_MAX_CPU_ISA=DEFAULT`, which
+      # is oneDNN's spelling for no cap, and once with the job's value. On a
+      # runner with no AMX both lines read the same and the cap is shown to be
+      # the no-op it is meant to be there. On an EMR runner the two lines differ
+      # and that difference is the proof that the wheel honours the variable.
+      # The control uses fp32 only, so it cannot hit the illegal instruction it
+      # is measuring.
+      #
+      # A positive AMX match in the capped line is the only thing that fails the
+      # step. A missing isa line is reported as [WARN] and left alone, so a
+      # change in oneDNN's verbose format cannot turn this job red on its own.
+      # The trailing `exit 0` is what makes that true: the runner appends
       # `exit $LASTEXITCODE` to every pwsh step, so a probe that died would
       # otherwise decide the step's result. A probe that dies is reported as
       # [WARN] and left for the pytest step below to fail on, which is the same
@@ -230,24 +238,41 @@ jobs:
           if (-not $cpu) { $cpu = '<unavailable>' }
           Write-Host "[INFO] CPU: $cpu"
           Write-Host "[INFO] ONEDNN_MAX_CPU_ISA=$env:ONEDNN_MAX_CPU_ISA"
-          $probe = 'import torch; print("[INFO] torch", torch.__version__); print("[INFO] mkldnn available:", torch.backends.mkldnn.is_available()); x = torch.randn(256, 512).bfloat16(); w = torch.randn(512, 512).bfloat16(); y = torch.nn.functional.linear(x, w); print("[INFO] bf16 linear ->", tuple(y.shape), y.dtype, "finite:", bool(torch.isfinite(y.float()).all())); c = torch.nn.functional.conv2d(torch.randn(2, 8, 32, 32), torch.randn(8, 8, 5, 5)); print("[INFO] fp32 conv2d ->", tuple(c.shape), c.dtype, "finite:", bool(torch.isfinite(c).all()))'
+          $control = 'import torch; torch.nn.functional.conv2d(torch.randn(2, 8, 32, 32), torch.randn(8, 8, 5, 5))'
+          $probe = 'import torch; print("[INFO] torch", torch.__version__); print("[INFO] mkldnn available:", torch.backends.mkldnn.is_available()); c = torch.nn.functional.conv2d(torch.randn(2, 8, 32, 32), torch.randn(8, 8, 5, 5)); print("[INFO] fp32 conv2d ->", tuple(c.shape), c.dtype, "finite:", bool(torch.isfinite(c).all())); x = torch.randn(256, 512).bfloat16(); w = torch.randn(512, 512).bfloat16(); y = torch.nn.functional.linear(x, w); print("[INFO] bf16 linear ->", tuple(y.shape), y.dtype, "finite:", bool(torch.isfinite(y.float()).all()))'
           $env:ONEDNN_VERBOSE = '1'
+
+          $capped = $env:ONEDNN_MAX_CPU_ISA
+          $env:ONEDNN_MAX_CPU_ISA = 'DEFAULT'
+          $ctlOut = & .venv\Scripts\python.exe -c $control
+          $env:ONEDNN_MAX_CPU_ISA = $capped
+          $ctlIsa = @($ctlOut | Where-Object { $_ -match 'isa:' })
+          if ($ctlIsa.Count -eq 0) {
+            Write-Host "[WARN] the uncapped control run printed no isa: line"
+          } else {
+            $ctlIsa | ForEach-Object { Write-Host "[ISA uncapped] $_" }
+          }
+
           $out = & .venv\Scripts\python.exe -c $probe
           $code = $LASTEXITCODE
           $out | ForEach-Object { Write-Host $_ }
           if ($code -ne 0) {
-            Write-Host "[WARN] the bf16 probe exited with $code; -1073741795 there is 0xc000001d, which would mean the ISA cap did not take effect"
+            Write-Host "[WARN] the probe exited with $code; -1073741795 there is 0xc000001d, which would mean the ISA cap did not take effect"
           }
           $isa = @($out | Where-Object { $_ -match 'isa:' })
           if ($isa.Count -eq 0) {
-            Write-Host "[WARN] oneDNN printed no isa: line - the bf16 GEMM did not reach oneDNN on this runner, so there is nothing to assert"
+            Write-Host "[WARN] oneDNN printed no isa: line under the cap, so there is nothing to assert"
+            exit 0
+          }
+          $isa | ForEach-Object { Write-Host "[ISA capped  ] $_" }
+          if ($isa -match 'AMX') {
+            Write-Host "[FAIL] oneDNN still dispatches to AMX; ONEDNN_MAX_CPU_ISA did not take effect"
+            exit 1
+          }
+          if ($ctlIsa -match 'AMX') {
+            Write-Host "[OK] this runner has AMX and the cap removed it"
           } else {
-            $isa | ForEach-Object { Write-Host "[ISA] $_" }
-            if ($isa -match 'AMX') {
-              Write-Host "[FAIL] oneDNN still dispatches to AMX; ONEDNN_MAX_CPU_ISA did not take effect"
-              exit 1
-            }
-            Write-Host "[OK] oneDNN is capped below AMX on this runner"
+            Write-Host "[OK] oneDNN is below AMX under the cap; this runner had no AMX either way"
           }
           exit 0
 


### PR DESCRIPTION
> 中文摘要：`pytest (Windows, Python 3.12)` 從 2026-08-11 到 2026-08-29 的 105 次執行中，有 7 次以 `0xc000001d`（STATUS_ILLEGAL_INSTRUCTION）整個行程被殺掉，堆疊每次都一樣：torch 的 `linear.py:134 in forward`，由 `causal_lm_model_node.py:216` 的 QKV 投影呼叫，而該測試檔唯一使用 bfloat16 的地方是 `test_the_forward_survives_bf16_autocast`。原因在上游：部分 `windows-2025` runner 落在 Intel Xeon Platinum 8573C（Emerald Rapids）主機上，CPUID leaf 7 與 XCR0 宣告支援 AMX，CPUID leaf 0x1D 的 tile palette 卻全為 0；torch 2.13.0 內含的 oneDNN v3.12 只看 leaf 7 與 XCR0 就判定 `mayiuse(amx_tile)` 為真，對 bf16 GEMM 發出 AMX tile 指令，CPU 便回以 #UD。本 PR 在 `test-windows` job 的 `env:` 加上 `ONEDNN_MAX_CPU_ISA: AVX512_CORE_BF16`，把 oneDNN 的執行期分派上限壓在 AMX 之下、bfloat16 之上；並新增一個診斷步驟，印出 runner 的 CPU 型號，並分別在「無上限」與「有上限」兩種設定下量測 oneDNN 實際生效的 ISA，兩行都印出來，只有在有上限那行出現 AMX 時才讓步驟失敗。這樣即使 job 落在沒有 AMX 的機器上，日誌仍然說明得了狀況；落在 8573C 上時，兩行的差異就是這個環境變數確實生效的證據。測試沒有被跳過，torch 沒有被釘版本，ubuntu 的 job 一行都沒動。

## What / Why

`pytest (Windows, Python 3.12)` has been dying outright, roughly one attempt in fifteen, with no test failure and no pytest summary line -- the process is killed:

```
Windows fatal exception: code 0xc000001d
Current thread 0x00001e60 (most recent call first):
  File "...\torch\nn\modules\linear.py", line 134 in forward
  File "...\torch\nn\modules\module.py", line 1789 in _call_impl
  File "...\torch\nn\modules\module.py", line 1778 in _wrapped_call_impl
  File "...\backend\app\nodes\llm\causal_lm_model_node.py", line 216 in forward
```

**The census.** I enumerated every attempt of the Windows job (`filter=all`, so re-runs count separately) across all 101 `backend-test.yml` runs created since 2026-08-11, downloaded the log of each of the 12 that failed, and grepped for the exception code. Seven carry it:

| job id | date | branch | attempt |
|---|---|---|---|
| 93925583338 | 2026-08-11 | main | 1 |
| 94021019464 | 2026-08-12 | feat/full-model-functionals | 1 |
| 96955919200 | 2026-08-22 | feat/load-menu-destinations | 1 |
| 97811516823 | 2026-08-25 | main | 1 |
| 98262984424 | 2026-08-26 | main | 1 |
| 98950966734 | 2026-08-28 | test/flaky-queue-shutdown-and-ppo-identity (#378) | 1 |
| 99057958970 | 2026-08-28 | test/flaky-queue-shutdown-and-ppo-identity (#378) | 2 |

Seven of 105 Windows attempts, 6.7%. The other five Windows failures in that window are four ordinary single-test failures and one `setup-uv` network error. The top three frames are byte-identical in all seven, the fourth is always `causal_lm_model_node.py:216 in forward` (the fused QKV `nn.Linear`; line 216 at those commits, 217 today), and pytest's progress bar is at 14-15% in every one. #378 is the clearest illustration: run 33201249673, commit `140c2461`, three attempts -- attempt 1 crashed, attempt 2 crashed, attempt 3 passed, same commit and same workflow every time. The ubuntu jobs have never seen it. Job 98950966734 reports `torch==2.13.0` and `numpy==2.5.2`, the same versions passing runs resolve -- this is not dependency drift.

**Root cause, upstream.** `0xc000001d` is `STATUS_ILLEGAL_INSTRUCTION` -- `#UD`. Some `windows-2025` VMs land on Intel Xeon Platinum 8573C (Emerald Rapids) hosts whose CPUID is self-contradictory. From [actions/runner-images#14483](https://github.com/actions/runner-images/issues/14483), verbatim:

```
INTEL(R) XEON(R) PLATINUM 8573C
CPUID.7.0:EBX = 0xF1BF2FB9      <- AMX-TILE advertised
XCR0: 0x00000000000600E7        <- AMX state advertised

CPUID.1D.0:EAX = 0x00000000     <- zero tile palettes
CPUID.1D.1:EBX = 0x00000000
CPUID.1D.1:ECX = 0x00000000
```

torch 2.13.0 bundles oneDNN v3.12 (`pytorch@v2.13.0` -> `third_party/ideep` at `e087b6e` -> `mkl-dnn` at `80afa71`, which is oneDNN's `v3.12` tag). In that version `src/cpu/x64/cpu_isa_traits.hpp` decides:

```cpp
case amx_tile:
    REG_AMX_ISA(return cpu().has(Cpu::tAMX_TILE)
            && x64::amx::is_available());
```

Leaf 7 and XCR0 only. So `mayiuse(amx_tile)` is true on these hosts, oneDNN's brgemm path emits an AMX tile kernel for the bf16 GEMM, and the CPU raises `#UD`. The missing palette check was written -- [uxlfoundation/oneDNN#5801](https://github.com/uxlfoundation/oneDNN/pull/5801) adds `&& x64::amx::get_max_palette() != 0` to exactly that line, with a comment describing this exact hypervisor bug -- and was closed unmerged three hours after it was opened. The crash report [uxlfoundation/oneDNN#5689](https://github.com/uxlfoundation/oneDNN/issues/5689) ("Illegal instruction on EMR + Windows") is open (closed once, reopened). runner-images#14483 has been open since 2026-07-30 with two comments and no ETA. Both sides are stalled, so the fix has to be local.

Which line of ours pulls the trigger: `test_the_forward_survives_bf16_autocast` is the only bfloat16 work in `test_causal_lm_model_node.py`, and it wraps the model forward in `torch.autocast("cpu", dtype=torch.bfloat16)`. It landed in 7afbcddf; torch 2.13.0 was already in use and passing before that, which matches the 2026-08-11 start date.

**The change.** Two edits, both confined to the `test-windows` job.

1. `ONEDNN_MAX_CPU_ISA: AVX512_CORE_BF16` on the job's `env:`. This is oneDNN's [CPU dispatcher control](https://uxlfoundation.github.io/oneDNN/dev_guide_cpu_dispatcher_control.html). `mayiuse()` tests the cap first, before any CPUID query:

   ```cpp
   unsigned cpu_isa_mask = x64::get_max_cpu_isa_mask(soft);
   ...
   if ((cpu_isa_mask & cpu_isa_no_hints) != cpu_isa_no_hints) return false;
   ```

   so capping below AMX removes those kernels from the dispatch table entirely. `AVX512_CORE_BF16` is the lowest documented value that still carries bfloat16 ("Intel AVX-512 with Intel DL Boost and bfloat16 support"), so the bf16 GEMM keeps a native AVX-512 path and the job does not get slower on the runners that were already fine. Reading the variable is gated on the build-time option `DNNL_ENABLE_MAX_CPU_ISA`, which oneDNN defaults to `ON` (`cmake/options.cmake`) and PyTorch's `cmake/Modules/FindMKLDNN.cmake` does not override -- I checked the v2.13.0 file, and `MAX_CPU_ISA` does not appear in it. oneDNN lowercases the value before matching, so the documented uppercase spelling works. On runners with no AMX (the AMD Zen and Ice Lake pools) the cap changes nothing, because nothing above it was reachable there anyway. The variable sits on the job's `env:` so the smoke-import step is covered too.

2. A diagnostic step, `Report the runner CPU and the oneDNN ISA actually in effect`, between the install and pytest. It prints the CPU model (`Get-CimInstance Win32_Processor`) and then measures the effective oneDNN ISA **twice** under `ONEDNN_VERBOSE=1`: once with `ONEDNN_MAX_CPU_ISA=DEFAULT`, which is oneDNN's spelling for no cap (`cpu_isa_traits_t<isa_all>::user_option_env == "default"`), and once with the job's value. Both `onednn_verbose,v1,info,cpu,isa:...` lines are printed, as `[ISA uncapped]` and `[ISA capped  ]`. A positive `AMX` match in the capped line is the only thing that fails the step.

   Two measurements because one is a tautology on a runner with no AMX. The first green version of this step landed on an AMD EPYC 7763 and reported `isa:Intel AVX2`, which says nothing about whether the wheel honours the variable. With the control, the log answers the question either way: on an EMR runner the two lines differ and the difference is the proof, on any other runner they match and the cap is shown to be the no-op it is meant to be there. The control runs fp32 only, so it cannot execute the AMX bf16 kernel it is measuring.

   Details that came out of reading source or CI logs:

   - The probe runs a fp32 conv2d before the bf16 `F.linear`. ATen only hands a CPU bf16 GEMM to oneDNN on machines whose bf16 support it recognises, so on an AMD runner the linear stays in ATen's own kernels and oneDNN is never entered -- the first version of this step printed `mkldnn available: True` and no isa line at all. A CPU fp32 convolution goes through `mkldnn_convolution` on any machine once the shapes clear the two heuristic clauses in ATen's `use_mkldnn()` (`aten/src/ATen/native/Convolution.cpp`), which batch 2 with a 5x5 kernel does. It runs first so the header is already out before the bf16 op executes; oneDNN prints its header at the first primitive execution, so with the linear first a crash would take the isa line with it.
   - oneDNN writes verbose output to **stdout** (`printf` + `fflush(stdout)`, `src/common/verbose.cpp`), so the step captures stdout only. No `2>&1` merge, which keeps native stderr out of PowerShell's error stream under the runner's `$ErrorActionPreference = 'stop'`, and a Python traceback still lands in the step log directly.
   - A missing `isa:` line is a `[WARN]`, and the script ends in an explicit `exit 0`, because the runner appends `exit $LASTEXITCODE` to every pwsh step. Without that line a probe that died would decide the step's result. A probe that dies is reported as `[WARN]` and left for the pytest step below to fail on, which is the same crash under the same conditions.

   This is what turns "the env var should work" into evidence. On an 8573C runner the capped line has to name bfloat16 without naming AMX while the uncapped line names AMX. On any other runner it records which CPU the job landed on -- the first thing core#373 asked for, and what makes the correlation re-checkable from a log months from now.

**Why not `ATEN_CPU_CAPABILITY`.** core#373 suggested it, and it does not reach this crash. It limits ATen's own vectorised kernels; the faulting instruction is JIT-generated inside oneDNN, which never consults it. Setting it would have made the job slower and left the crash in place.

## Closes / relates to

Closes #373.

The latest instance is PR #378's Windows job: run 33201249673 on commit `140c2461`, where attempt 1 (job 98950966734) and attempt 2 (job 99057958970) both crashed with this and attempt 3 (job 99058302290) passed.

This is a workaround for an upstream defect, and it has a removal condition: take the `env:` entry out when [actions/runner-images#14483](https://github.com/actions/runner-images/issues/14483) is fixed, or when torch ships a oneDNN that carries oneDNN#5801's palette check. The diagnostic step is what tells you which state you are in, so the decision stays mechanical.

## Test evidence

Local, from the repository root:

```
python3 scripts/check_control_bytes.py
  -> OK: no raw C0 control bytes in 1217 tracked files

uvx ruff@0.14.4 check .
  -> All checks passed!

backend/.venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/backend-test.yml'))"
  -> parses; test-windows env == {'ONEDNN_MAX_CPU_ISA': 'AVX512_CORE_BF16'},
     the new step sits immediately before 'pytest', and the env of the
     'test', 'test-with-frontend' and 'lint' jobs is still None
```

Both probe strings were extracted from the YAML with PyYAML and run against the local venv, to catch Python-level typos before pushing:

```
ONEDNN_VERBOSE=1 ONEDNN_MAX_CPU_ISA=DEFAULT backend/.venv/bin/python -c '<$control from the step>'
  -> rc=0, no output (no oneDNN in this wheel)
ONEDNN_VERBOSE=1 ONEDNN_MAX_CPU_ISA=AVX512_CORE_BF16 backend/.venv/bin/python -c '<$probe from the step>'
  [INFO] torch 2.11.0
  [INFO] mkldnn available: False
  [INFO] fp32 conv2d -> (2, 8, 28, 28) torch.float32 finite: True
  [INFO] bf16 linear -> (256, 512) torch.bfloat16 finite: True
  -> rc=0
```

That is the honest limit of local verification. The dev venv here is a macOS wheel built with `USE_MKLDNN=OFF` (`mkldnn available: False` above), so there is no oneDNN to cap and no isa line to read; locally the step takes its `[WARN]` branch. There is no `pwsh` on this machine either, so the PowerShell in the step was verified only by running it in CI.

### CI, on this PR

Run 33237868538 on `6f93538`: all six `Backend Tests` jobs green, plus `Byte Scan` and `Frontend Build Check`. The Windows job's new step, copied verbatim from job 99061921816:

```
[INFO] CPU: AMD EPYC 7763 64-Core Processor
[INFO] ONEDNN_MAX_CPU_ISA=AVX512_CORE_BF16
[ISA uncapped] onednn_verbose,v1,info,cpu,isa:Intel AVX2
onednn_verbose,v1,info,oneDNN v3.12.0 (commit 80afa71049cd69a3df32adcccb623b12cd7baa22)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:2
onednn_verbose,v1,info,cpu,isa:Intel AVX2
[INFO] torch 2.13.0+cpu
[INFO] mkldnn available: True
[INFO] fp32 conv2d -> (2, 8, 28, 28) torch.float32 finite: True
[INFO] bf16 linear -> (256, 512) torch.bfloat16 finite: True
[ISA capped  ] onednn_verbose,v1,info,cpu,isa:Intel AVX2
[OK] oneDNN is below AMX under the cap; this runner had no AMX either way
```

I then re-ran that job to draw a different machine (attempt 2, job 99062756745). Same AMD EPYC 7763, same two isa lines, same `[OK]`. Four Windows jobs across this branch's three commits all landed on EPYC 7763.

What this establishes and what it does not:

- The step runs, produces both measurements, and passes. The earlier iterations of it are in the branch history: `ec964f9` printed `[WARN] oneDNN printed no isa: line` on an EPYC 7763 (the bf16 linear never reached oneDNN), which is why `54ca14a` added the fp32 conv2d and `6f93538` added the uncapped control.
- The `ONEDNN_MAX_CPU_ISA` value reaches the process and is spelled in a form oneDNN accepts; the run does not error on it and both probes complete.
- The verbose header from the actual wheel reads `oneDNN v3.12.0 (commit 80afa71...)`, which confirms at runtime what I had derived from submodule pins: torch 2.13.0 ships oneDNN v3.12 at exactly the commit whose `mayiuse(amx_tile)` has no palette check.
- **What it does not yet show** is the cap removing AMX on a live 8573C, because none of the four draws had AMX. That is the nature of the bug -- roughly one Windows job in fifteen lands on an affected host. The two-measurement design is there precisely so that the first job which does land on one records the answer in its own log: `[ISA uncapped] ...AMX...` next to `[ISA capped  ] ...bfloat16...`, and the `[OK] this runner has AMX and the cap removed it` branch. If the cap were somehow ignored on such a host, the capped line would name AMX and the step would fail with `[FAIL]` before pytest ever starts.

## What I deliberately did not do

- **No test skipped or weakened.** `test_the_forward_survives_bf16_autocast` still runs on Windows, in bf16, unchanged. Skipping it would have removed the only coverage of the dtype bug it exists to catch.
- **No torch pin.** The wheel is not at fault, and pinning would freeze the backend's most important dependency to route around a hypervisor misconfiguration.
- **No change to the ubuntu jobs, `test-with-frontend`, or `lint`.** They have never hit this and an ISA cap there would only mask real dispatch behaviour.
- **No change to app code**, even though `backend/app/core/amp.py` offers bf16 to CPU users (`supported_precisions("cpu")` returns all of `("fp32", "bf16", "fp16")`), which means a Windows user on a similarly misconfigured VM would hit the same crash in a real training run. That is a real gap. It belongs in the deployment documentation and deserves its own issue.
- **No claim that a green run proves the fix.** At 6.7% per attempt a green Windows job is the expected outcome with or without this change. I did re-run this PR's own Windows job once, to sample a second machine from the runner pool, and I am reporting that both draws were AMD. The isa line is the proof, which is why it is the hard check.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its
      zh-TW twin in the same PR (docs/i18n/zh-TW/... or the matching
      nodeLocales entry). -- n/a, no docs or node-param text changed.
- [x] No pictographic emoji in code, logs, UI strings, or this PR body
      (Windows consoles crash on them -- ASCII markers like `[OK]` instead).
      The new step prints `[INFO]` / `[ISA]` / `[OK]` / `[WARN]` / `[FAIL]`.
- [x] I explained what I deliberately did not do, if a reviewer might expect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EwoZ9EbPynXbEHBcZZeTo
