### PR TITLE
fix(api): a keyset cursor pages the runs list past a shared timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -393,6 +393,23 @@ received — each links to the release it was published as.
   traceback happens to name the class in its last line. The message itself
   never carried it: `str(KeyError('tensor'))` is just `"'tensor'"`.
 
+- **Paging through `GET /api/apps/{slug}/runs` no longer drops every run that
+  shares a timestamp with the cursor** ([#372]). The `before` cursor carried
+  the previous page's own `created_at` into `AND created_at < ?`, so a page
+  boundary landing inside a group of runs recorded in the same microsecond
+  tick excluded that whole group — including the runs the client had not seen
+  yet. Two invokes in quick succession share a tick often enough that this
+  endpoint's own test hit it about one run in five, and the affected rows were
+  unreachable through the API entirely: no page ever returned them. The list
+  now takes a composite keyset cursor, `before` plus `before_id`, which are
+  the `created_at` and `run_id` of the last row of the previous page and name
+  one row in the `created_at DESC, rowid DESC` ordering [#371] settled. An
+  anchor that no longer resolves — pruned by retention, or belonging to
+  another app — degrades to the old `created_at < ?`, which stays exact for
+  the retention case because retention deletes a timestamp whole. `before`
+  alone still works for clients written against the earlier contract and keeps
+  its original meaning; `before_id` without `before` is a 422.
+
 ## [2.4.1] — 2026-08-22
 
 Four fixes that landed on `main` in the hours after 2.4.0, and nothing else:
@@ -2440,6 +2457,8 @@ Release candidates before 1.0.0 are on the
 [#357]: https://github.com/CodefyUI/CodefyUI/pull/357
 [#359]: https://github.com/CodefyUI/CodefyUI/pull/359
 [#360]: https://github.com/CodefyUI/CodefyUI/issues/360
+[#371]: https://github.com/CodefyUI/CodefyUI/pull/371
+[#372]: https://github.com/CodefyUI/CodefyUI/issues/372
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...main

--- a/backend/app/api/routes_apps.py
+++ b/backend/app/api/routes_apps.py
@@ -995,12 +995,29 @@ async def list_runs(
     request: Request,
     limit: int = Query(default=50, ge=1, le=500),
     before: str | None = Query(default=None),
+    before_id: str | None = Query(default=None),
 ):
     """Newest-first METADATA-ONLY rows; IO lives on the detail endpoint.
 
     Either-credential read (Stage 3's editor UI uses the session token).
-    ``before`` is an ISO timestamp cursor over ``created_at``.
+
+    The cursor is the ``created_at`` and the ``run_id`` of the last row of
+    the previous page, sent back as ``before`` and ``before_id``. Together
+    they name one row in the ordering this endpoint sorts by, so a page
+    boundary that falls inside a group of runs sharing one timestamp
+    resumes at the right place.
+
+    ``before`` alone stays supported for clients written against the older
+    contract and keeps its original meaning, ``created_at < before``, which
+    skips every row sharing that exact timestamp. ``before_id`` alone is a
+    422: it has no timestamp to anchor against.
     """
+    if before is None and before_id is not None:
+        raise _manage_error(
+            422, "incomplete_cursor",
+            "before_id requires before -- send the created_at and the "
+            "run_id of the last row of the previous page",
+        )
     db = get_db(request)
 
     def _select(conn: sqlite3.Connection) -> list[dict[str, Any]] | None:
@@ -1015,7 +1032,36 @@ async def list_runs(
             "FROM runs WHERE app_id = ?"
         )
         params: list[Any] = [app_row["id"]]
-        if before is not None:
+        if before is not None and before_id is not None:
+            # Keyset pagination on the (created_at, rowid) tuple the ORDER
+            # BY below sorts on. `created_at < ?` alone excluded EVERY row
+            # sharing the cursor's timestamp, including the ones the client
+            # had not seen yet, and two invokes land in one microsecond tick
+            # often enough for that to drop runs out of the listing (#372).
+            #
+            # The subselect resolves to NULL when the anchor row is gone
+            # (retention) or belongs to another app, and `rowid < NULL` is
+            # NULL, so the predicate collapses to `created_at < ?` with no
+            # branch here. For a pruned anchor that fallback is exact:
+            # retention deletes with `created_at < cutoff`, so it takes a
+            # timestamp whole -- if the anchor went, everything sharing its
+            # timestamp went with it.
+            #
+            # `created_at <= ?` is implied by both arms of the OR and is
+            # therefore redundant to the RESULT; it is here for the query
+            # planner. Terms inside an OR cannot constrain an index seek, so
+            # without it idx_runs_app_created is entered on `app_id = ?`
+            # alone and the scan skips every row newer than the cursor.
+            # Measured on 20k runs in one app, 3 runs per timestamp,
+            # limit=50: 0.08 ms at page 1 either way, and at a cursor 19k
+            # rows deep 2.79 ms without the bound against 0.12 ms with it.
+            sql += (
+                " AND created_at <= ?"
+                " AND (created_at < ? OR (created_at = ? AND rowid < "
+                "(SELECT rowid FROM runs WHERE run_id = ? AND app_id = ?)))"
+            )
+            params.extend([before, before, before, before_id, app_row["id"]])
+        elif before is not None:
             sql += " AND created_at < ?"
             params.append(before)
         # rowid DESC is the tie-breaker for rows sharing a created_at
@@ -1026,7 +1072,8 @@ async def list_runs(
         # tick often enough to fail this endpoint's own test on CI (#370).
         # rowid rises with insertion, so it is deterministic AND actually
         # newest-first; it is what run_store.py's equivalent queries already
-        # use. The `before` cursor stays keyed on created_at alone.
+        # use. The `before`/`before_id` cursor keys on these same two
+        # columns, so the cursor keys and the sort keys are one tuple.
         sql += " ORDER BY created_at DESC, rowid DESC LIMIT ?"
         params.append(limit)
         return [dict(r) for r in conn.execute(sql, params).fetchall()]

--- a/backend/tests/test_api_apps_invoke.py
+++ b/backend/tests/test_api_apps_invoke.py
@@ -163,6 +163,33 @@ async def _run_rows(db: Database) -> list[dict[str, Any]]:
     return await db.run(_select)
 
 
+async def _invokes_at(client, token: str, stamps: list[str], monkeypatch,
+                      slug: str = SLUG) -> list[str]:
+    """One invoke per stamp, with each run's ``created_at`` pinned to it.
+
+    Returns the run_ids in insertion order. ``_record_run`` reads the clock
+    exactly once per recorded run, so the stamps line up one-for-one with
+    the invokes. Call this AFTER ``_publish`` -- the publish routes read the
+    same clock through the same name.
+    """
+    clock = iter(stamps)
+    monkeypatch.setattr("app.api.routes_apps.utc_now_iso",
+                        lambda: next(clock))
+    ids: list[str] = []
+    for n in range(len(stamps)):
+        resp = await client.post(f"/api/apps/{slug}/invoke",
+                                 json={"inputs": {"x": f"v{n}"}},
+                                 headers=_bearer(token))
+        assert resp.status_code == 200, resp.text
+        ids.append(resp.json()["run_id"])
+    return ids
+
+
+def _cursor(row: dict[str, Any]) -> str:
+    """The keyset cursor query string built from the last row of a page."""
+    return f"before={row['created_at']}&before_id={row['run_id']}"
+
+
 # ── envelope value rules + happy path ────────────────────────────────────
 
 
@@ -782,16 +809,21 @@ async def test_invoke_succeeds_after_queued_timeout(
 async def test_runs_list_metadata_only_newest_first(
     test_client, app_db, api_key, monkeypatch,
 ):
-    """Ordering, field set, and the limit/before cursor on distinct stamps.
+    """Ordering, field set, and the legacy ``before``-alone cursor.
 
-    The clock is stepped rather than left real. Two invokes this close
-    together often land in one ``created_at`` tick, and the `before` cursor
-    is keyed on ``created_at`` alone (``created_at < ?``) -- so on a tie the
-    cursor below excludes BOTH rows and this test fails with an empty list.
-    That is a real defect in the endpoint, tracked separately; it is not what
-    this test is about, and leaving it to chance made this file fail on CI at
-    random. Ordering under a genuine tie has its own test above
-    (``test_two_invokes_in_one_timestamp_tick_still_list_newest_first``).
+    ``before`` without ``before_id`` keeps the semantics it shipped with:
+    ``created_at < ?``, which skips every row sharing the cursor's
+    timestamp. The clock is stepped here so the two runs land in different
+    ticks and that cursor is exact -- two invokes this close together often
+    share a tick, and leaving it to chance made this file fail on CI at
+    random.
+
+    The composite ``before``/``before_id`` cursor is what pages through a
+    shared timestamp, in
+    ``test_runs_list_pages_through_runs_sharing_one_timestamp`` and the
+    three tests beside it (#372). Ordering under a genuine tie has its own
+    test above, in
+    ``test_two_invokes_in_one_timestamp_tick_still_list_newest_first``.
     """
     await _publish(test_client, SLUG, _echo_graph())
 
@@ -852,7 +884,8 @@ async def test_runs_list_tie_breaks_on_insertion_order_when_created_at_equal(
     ``rowid`` rises with insertion, so it is both deterministic AND the real
     answer to "which happened last" -- and it is what the same query in
     ``run_store.py`` (lines 520, 695, 1174) already tie-breaks on. The
-    ``before`` cursor stays keyed on ``created_at`` alone, unchanged.
+    ``before``/``before_id`` cursor added by #372 keys on these same two
+    columns, so the cursor keys and the sort keys are one tuple.
 
     The ids below are deliberately NOT in lexicographic order: inserted
     aaa, zzz, mmm, a run_id sort would answer zzz/mmm/aaa, and only an
@@ -919,6 +952,161 @@ async def test_two_invokes_in_one_timestamp_tick_still_list_newest_first(
     assert [r["run_id"] for r in rows] == [
         second.json()["run_id"], first.json()["run_id"],
     ]
+
+
+# ── keyset cursor: before + before_id (#372) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runs_list_pages_through_runs_sharing_one_timestamp(
+    test_client, app_db, api_key, monkeypatch,
+):
+    """Three runs in ONE ``created_at`` tick page through one at a time.
+
+    ``before`` alone is keyed on ``created_at`` and its predicate is
+    ``created_at < ?``, so it excludes every row sharing the cursor's
+    timestamp -- including the ones the client has not seen yet. Page 2 of
+    this walk used to come back empty and the other two runs were
+    unreachable through the API (#372). The composite cursor keys on the
+    same ``(created_at, rowid)`` tuple the ORDER BY sorts on, so each run is
+    visited exactly once.
+    """
+    await _publish(test_client, SLUG, _echo_graph())
+    stamp = "2026-04-04T00:00:00.000000Z"
+    ids = await _invokes_at(test_client, api_key["token"], [stamp] * 3,
+                            monkeypatch)
+
+    rows = (await test_client.get(f"/api/apps/{SLUG}/runs")).json()
+    assert {r["created_at"] for r in rows} == {stamp}, (
+        "the frozen clock did not take -- the tie this test exists for "
+        "never happened")
+
+    seen: list[str] = []
+    query = f"/api/apps/{SLUG}/runs?limit=1"
+    for page_no in (1, 2, 3):
+        page = (await test_client.get(query)).json()
+        assert len(page) == 1, f"page {page_no} came back as {page}"
+        seen.append(page[0]["run_id"])
+        query = f"/api/apps/{SLUG}/runs?limit=1&{_cursor(page[0])}"
+
+    assert seen == list(reversed(ids))   # newest first, each run exactly once
+    assert (await test_client.get(query)).json() == []
+
+
+@pytest.mark.asyncio
+async def test_runs_list_cursor_walks_mixed_and_shared_timestamps(
+    test_client, app_db, api_key, monkeypatch,
+):
+    """Four runs across two ticks; one query exercises both halves of the
+    predicate.
+
+    Page 2 anchors on the older of the two runs in the newer tick. That one
+    query has to keep the newer tick's other run out through
+    ``created_at = :ts AND rowid < ...`` and let both runs from the older
+    tick in through ``created_at < :ts``.
+    """
+    await _publish(test_client, SLUG, _echo_graph())
+    older = "2026-05-05T00:00:00.000000Z"
+    newer = "2026-05-05T00:00:01.000000Z"
+    r1, r2, r3, r4 = await _invokes_at(
+        test_client, api_key["token"], [older, older, newer, newer],
+        monkeypatch)
+
+    page1 = (await test_client.get(f"/api/apps/{SLUG}/runs?limit=2")).json()
+    assert [r["run_id"] for r in page1] == [r4, r3]
+
+    page2 = (await test_client.get(
+        f"/api/apps/{SLUG}/runs?limit=2&{_cursor(page1[-1])}")).json()
+    assert [r["run_id"] for r in page2] == [r2, r1]
+
+    assert (await test_client.get(
+        f"/api/apps/{SLUG}/runs?limit=2&{_cursor(page2[-1])}")).json() == []
+
+
+@pytest.mark.asyncio
+async def test_runs_list_cursor_survives_a_pruned_anchor_row(
+    test_client, app_db, api_key, monkeypatch,
+):
+    """A cursor whose anchor row is gone falls back to ``created_at < ts``.
+
+    Retention deletes with ``created_at < cutoff``, so it takes a timestamp
+    whole. When the anchor is one of the rows that went, every row sharing
+    its timestamp went with it, and ``created_at < ts`` is then the exact
+    next page. The subselect resolves a missing anchor to NULL and
+    ``rowid < NULL`` is NULL, so the fallback needs no branch in Python.
+    """
+    await _publish(test_client, SLUG, _echo_graph())
+    older = "2026-06-06T00:00:00.000000Z"
+    newer = "2026-06-06T00:00:01.000000Z"
+    r1, r2, r3 = await _invokes_at(
+        test_client, api_key["token"], [older, newer, newer], monkeypatch)
+
+    page1 = (await test_client.get(f"/api/apps/{SLUG}/runs?limit=2")).json()
+    assert [r["run_id"] for r in page1] == [r3, r2]
+    cursor = _cursor(page1[-1])                   # anchored on r2
+
+    def _prune(conn: sqlite3.Connection) -> None:
+        conn.execute("DELETE FROM runs WHERE created_at = ?", (newer,))
+
+    await app_db.run(_prune)
+
+    resp = await test_client.get(f"/api/apps/{SLUG}/runs?limit=2&{cursor}")
+    assert resp.status_code == 200
+    assert [r["run_id"] for r in resp.json()] == [r1]
+
+
+@pytest.mark.asyncio
+async def test_runs_list_ignores_a_before_id_from_another_app(
+    test_client, app_db, api_key, monkeypatch,
+):
+    """``before_id`` resolves only inside the app being listed.
+
+    The subselect carries ``AND app_id = :app_id``, so another app's run_id
+    -- or one that never existed -- resolves to NULL and the cursor falls
+    back to ``created_at < ts``. The two runs below share a timestamp, which
+    is what makes the difference visible: this app's own run_id pages to the
+    second run, anything else pages to nothing.
+    """
+    await _publish(test_client, SLUG, _echo_graph())
+    other_slug = "other-app"
+    await _publish(test_client, other_slug, _echo_graph(name="other-src"))
+    token = api_key["token"]
+    stamp = "2026-07-07T00:00:00.000000Z"
+    r1, r2 = await _invokes_at(test_client, token, [stamp] * 2, monkeypatch)
+    foreign = (await _invokes_at(test_client, token, [stamp], monkeypatch,
+                                 slug=other_slug))[0]
+
+    own = await test_client.get(
+        f"/api/apps/{SLUG}/runs?before={stamp}&before_id={r2}")
+    assert [r["run_id"] for r in own.json()] == [r1]
+
+    cross = await test_client.get(
+        f"/api/apps/{SLUG}/runs?before={stamp}&before_id={foreign}")
+    assert cross.status_code == 200
+    assert cross.json() == []
+
+    unknown = await test_client.get(
+        f"/api/apps/{SLUG}/runs?before={stamp}&before_id=never-ran")
+    assert unknown.json() == []
+
+    # The fallback is exactly what `before` alone answers.
+    assert (await test_client.get(
+        f"/api/apps/{SLUG}/runs?before={stamp}")).json() == []
+
+
+@pytest.mark.asyncio
+async def test_runs_list_rejects_before_id_without_before(
+    test_client, app_db, api_key,
+):
+    """``before_id`` alone has no timestamp to anchor against -> 422.
+
+    The management error shape this file uses everywhere, so the code is
+    machine-matchable the same way the endpoint's own ``app_not_found`` is.
+    """
+    await _publish(test_client, SLUG, _echo_graph())
+    resp = await test_client.get(f"/api/apps/{SLUG}/runs?before_id=whatever")
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "incomplete_cursor"
 
 
 @pytest.mark.asyncio

--- a/docs/docs/usage/publish.md
+++ b/docs/docs/usage/publish.md
@@ -118,9 +118,11 @@ curl -s -X POST "http://127.0.0.1:8000/api/apps/classifier/invoke" \
 Every invoke that resolves to an app version writes one row (status, error code, device, `total_s`, per-node timings, capped inputs/outputs, key id). Pre-resolution rejections (`invalid_key`, `app_not_found`, `app_unpublished`) write nothing. Recording is best-effort: a storage failure after execution is logged and the run result is still returned.
 
 ```text
-GET /api/apps/{slug}/runs?limit=50&before=<iso>   -- newest-first metadata only
-GET /api/apps/{slug}/runs/{run_id}                -- the full row incl. inputs/outputs/node_timings
+GET /api/apps/{slug}/runs?limit=50&before=<created_at>&before_id=<run_id>   -- newest-first metadata only
+GET /api/apps/{slug}/runs/{run_id}                                         -- the full row incl. inputs/outputs/node_timings
 ```
+
+`before` and `before_id` are the `created_at` and the `run_id` of the last row of the previous page. Together they name one row in the newest-first ordering, so a page boundary that falls inside a group of runs recorded in the same timestamp tick resumes at the right place. Sending only `before` is still accepted for clients written against the earlier contract, and keeps its original meaning: rows strictly older than that timestamp, which skips any run sharing it.
 
 Reads accept EITHER a valid API key or the editor session token (the editor UI reads runs without ever holding an API key), and reject requests with neither.
 


### PR DESCRIPTION
> 中文摘要：`GET /api/apps/{slug}/runs` 的 `before` 游標帶的是前一頁最後一列自己的 `created_at`，條件是 `AND created_at < ?`，所以只要翻頁的分界正好落在同一個微秒刻度內的一群 run 中間，那一整群都會被排除掉——包含使用者還沒讀到的那幾筆。那些 run 透過 API 完全拿不到：沒有任何一頁會回傳它們。連續兩次 invoke 落在同一刻度並不罕見，這個端點自己的測試大約五次就會中一次，#371 因此在測試裡刻意把時鐘錯開，並把游標本身留給這個 issue。這個 PR 改成複合式 keyset 游標：`before` 加上 `before_id`，也就是前一頁最後一列的 `created_at` 與 `run_id`。這兩個欄位在 `created_at DESC, rowid DESC` 這個由 #371 定案的排序中唯一指定一列，游標鍵與排序鍵因此是同一個 tuple。錨點列若已不存在（被 retention 清掉）或屬於別的 app，子查詢會是 NULL，`rowid < NULL` 也是 NULL，條件就自動退回舊的 `created_at < ?`——對 retention 而言這個退路是精確的，因為 retention 用 `created_at < cutoff` 刪除，一個時間戳一定整組刪掉。只送 `before` 的舊客戶端行為完全不變，文件現在明說它會跳過共用該時間戳的列；只送 `before_id` 則回 422。

## What / Why

From the issue: `GET /api/apps/{slug}/runs?before=<created_at>` skips every run that shares the cursor's timestamp, and the client never sees them.

The cursor value was the previous page's own `created_at`, and the predicate was `AND created_at < ?`. When a page boundary landed inside a group of runs recorded in one microsecond tick, that predicate excluded the whole group, including the rows the client had not read yet. The next page started below them. No page ever returned them, so those runs were unreachable through the API entirely.

`created_at` comes from `utc_now_iso()` at microsecond precision, and two invokes in quick succession land in one tick often enough that this endpoint's own test hit it about one run in five locally. [#371] fixed the *ordering* (the tie-break moved from `run_id DESC` to `rowid DESC`) and deliberately left the cursor alone, stepping the clock in the test and pointing at [#372] for the rest.

### The design

A composite keyset cursor. The client sends back the `created_at` and the `run_id` of the last row of the previous page:

```text
GET /api/apps/{slug}/runs?limit=50&before=<created_at>&before_id=<run_id>
```

Those two columns name exactly one row in the `created_at DESC, rowid DESC` ordering [#371] settled, so the cursor keys and the sort keys are one tuple. The predicate:

```sql
AND created_at <= :ts
AND (created_at < :ts
     OR (created_at = :ts
         AND rowid < (SELECT rowid FROM runs
                      WHERE run_id = :id AND app_id = :app_id)))
```

Three properties worth stating:

- **A missing anchor degrades on its own.** The subselect resolves to NULL when the anchor row was pruned by retention or belongs to another app, and `rowid < NULL` is NULL, so the predicate collapses to `created_at < :ts` with no branch in Python. For the retention case that fallback is *exact*: retention deletes with `created_at < cutoff`, so it takes a timestamp whole — if the anchor row went, every row sharing its timestamp went with it.
- **`app_id` is inside the subselect.** A `before_id` from another app resolves to NULL and is therefore ignored, the same as one that never existed. It cannot be used to read across apps.
- **`created_at <= :ts` is redundant to the result, and deliberate.** Both arms of the OR imply it, so it changes nothing that comes back. It is there for the query planner: terms inside an OR cannot constrain an index seek, so without it `idx_runs_app_created` is entered on `app_id = ?` alone and the scan has to skip every row newer than the cursor. Measured below.

`before` alone stays supported and keeps its original meaning. `before_id` alone is a 422 carrying `incomplete_cursor` in the `{"detail": {"code", "message", "details"}}` management shape this file uses everywhere (`_manage_error`), matching this endpoint's own `app_not_found` — the same choice `publish_app` documents for `invalid_git_commit`.

### Alternatives rejected

- **An opaque server-issued token.** It would have to travel somewhere, and this endpoint returns a bare JSON array. Adding a token means wrapping the response in an envelope (`{"items": [...], "next": "..."}`), which breaks every existing caller for a cursor change. The two-parameter cursor is built from fields the client already holds in the last row it read.
- **A `run_id`-only cursor.** It reads well until the anchor row is gone. Retention deletes runs continuously, and a cursor that cannot resolve its anchor has no timestamp to fall back to, so paging would either fail or restart from the top. Carrying `created_at` alongside is what makes the degradation safe.
- **A rowid sequence number as the cursor.** It exposes a storage detail in the public contract, and it would pin the ordering to insertion order — `created_at` and `rowid` agree today, and making `rowid` the contract would prevent that from ever being revisited.

## Closes / relates to

Closes #372

Relates to [#371], which fixed the ordering this cursor now keys on and left the cursor itself for this change.

## Test evidence

Five tests added to `backend/tests/test_api_apps_invoke.py`. Three of them fail on unmodified `main`.

**The tie test, run against unmodified `main` (this is the defect):**

```text
$ .venv/bin/python -m pytest -q tests/test_api_apps_invoke.py::test_runs_list_pages_through_runs_sharing_one_timestamp

        seen: list[str] = []
        query = f"/api/apps/{SLUG}/runs?limit=1"
        for page_no in (1, 2, 3):
            page = (await test_client.get(query)).json()
>           assert len(page) == 1, f"page {page_no} came back as {page}"
E           AssertionError: page 2 came back as []
E           assert 0 == 1
E            +  where 0 = len([])
tests/test_api_apps_invoke.py:982: AssertionError
1 failed in 0.72s
```

Three runs go into one frozen `created_at` tick; page 1 returns the newest, and page 2 comes back empty because `created_at < cursor` excluded all three.

**All five new tests against unmodified `main`:**

```text
FAILED test_runs_list_pages_through_runs_sharing_one_timestamp - page 2 came back as []
FAILED test_runs_list_ignores_a_before_id_from_another_app    - assert [] == ['dfda4c2af2b...']
FAILED test_runs_list_rejects_before_id_without_before        - assert 200 == 422
3 failed, 2 passed, 25 deselected in 0.81s
```

The two that pass on `main` are regression guards: `..._cursor_walks_mixed_and_shared_timestamps` and `..._cursor_survives_a_pruned_anchor_row` both degrade to `created_at < ts`, which is what `main` already does, so they pin the behaviour without failing first.

**After the fix:**

```text
python3 scripts/check_control_bytes.py
  -> OK: no raw C0 control bytes in 1282 tracked files

uvx ruff@0.14.4 check .
  -> All checks passed!

cd backend && .venv/bin/python -m pytest -q tests/test_api_apps_invoke.py
  -> 30 passed in 11.12s        (25 before this PR, +5 new)

cd backend && .venv/bin/python -m pytest -q tests/test_api_apps_invoke.py \
     tests/test_api_apps_manage.py tests/test_api_apps_openapi.py
  -> 59 passed in 11.32s

cd backend && .venv/bin/python -m pytest -q tests/
  -> 11 failed, 6127 passed, 50 skipped in 170.20s

cd docs && pnpm build
  -> exit 0, "Generated static files in build/" and build/zh-TW
```

The 11 full-suite failures are pre-existing on `origin/main` and unrelated to this change. Verified by stashing the branch and re-running the same five files on the clean tree: `11 failed, 483 passed` — the identical eleven test ids (`test_api_packs.py`, `test_device_index.py` x5, `test_packs_download.py` x3, `test_tiered_policy.py`, `test_timestep_embedding_node.py`; local environment, torch/hf/device probing).

The docs build's two broken-anchor warnings are on `zh-TW/advanced/python-script-node` and `zh-TW/usage/graph-as-a-function`, both pre-existing and untouched here.

**Determinism.** The tie test 20 times in a row:

```text
20x tie test -> pass=20 fail=0
```

The clock is frozen with `monkeypatch`, so the tie is guaranteed on every run.

### EXPLAIN QUERY PLAN

Real schema (`MIGRATIONS` applied to a scratch DB), 6000 runs across 3 apps, every timestamp shared by 3 runs, `limit=50`. Nothing in the backend runs `ANALYZE` (grepped: no occurrence in `backend/app/` or `scripts/`), so the no-stats plan is the production plan:

```text
-- no cursor (unchanged)
   SEARCH runs USING INDEX idx_runs_app_created (app_id=?)
   USE TEMP B-TREE FOR LAST TERM OF ORDER BY
-- before alone (unchanged)
   SEARCH runs USING INDEX idx_runs_app_created (app_id=? AND created_at<?)
   USE TEMP B-TREE FOR LAST TERM OF ORDER BY
-- before + before_id (new)
   SEARCH runs USING INDEX idx_runs_app_created (app_id=? AND created_at<?)
   SCALAR SUBQUERY 1
   SEARCH runs USING INDEX sqlite_autoindex_runs_1 (run_id=?)
   USE TEMP B-TREE FOR LAST TERM OF ORDER BY
```

(`sqlite 3.46.0`. The script that produced this asserts each SQL fragment appears verbatim in `routes_apps.py`, so the plan is for the shipped string.)

The outer scan stays on `idx_runs_app_created`, the subselect resolves through the `run_id` primary key's implicit unique index (`sqlite_autoindex_runs_1`), and it is a `SCALAR SUBQUERY`, evaluated once for the whole query. The temp b-tree for the last ORDER BY term is not new: the index supplies `(app_id, created_at DESC)` and the `rowid DESC` tie-break is sorted on top, exactly as `main` already does for the no-cursor and `before`-alone queries.

**Why the redundant `created_at <= ?` is there.** Without it the outer seek is `app_id=?` alone, because a term inside an OR cannot constrain an index. 20k runs in one app, 3 per timestamp, `limit=50`, timed over 100 iterations:

```text
depth     0  bare=  0.081 ms  bounded=  0.080 ms
depth  1000  bare=  0.218 ms  bounded=  0.081 ms
depth 10000  bare=  1.427 ms  bounded=  0.079 ms
depth 19000  bare=  2.786 ms  bounded=  0.118 ms
```

The bare form degrades linearly with cursor depth; the bounded form stays O(limit) at any depth. Both return identical rows — checked by walking all 20000 rows with `limit=7` under each form and comparing against `ORDER BY created_at DESC, rowid DESC` (2000/2000 and 20000/20000 rows, all distinct, exact order).

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its
      zh-TW twin in the same PR (docs/i18n/zh-TW/... or the matching
      nodeLocales entry).
- [x] No pictographic emoji in code, logs, UI strings, or this PR body
      (Windows consoles crash on them — ASCII markers like `[OK]` instead).
- [x] I explained what I deliberately did not do, if a reviewer might expect it.

On the zh-TW box: `docs/docs/usage/publish.md` has no zh-TW twin. `docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/usage/` contains 17 pages and `publish.md` is not among them, so the page already falls back to English and there is nothing to keep in sync. Ticked on that basis; no translation was written.

## What I deliberately did not do

- **No zh-TW translation of `publish.md`.** No twin exists (checked above). Creating one is a separate piece of work and does not belong in a cursor fix.
- **`before` alone is still accepted, unchanged.** Removing it would break clients written against the shipped contract for no benefit this fix needs. The docs now state plainly that it skips rows sharing the cursor timestamp and that new clients should send both parameters.
- **No change to `/api/runs`.** That is the Run Service listing, it pages by `limit`/`offset`, and it is a different endpoint with a different contract. The frontend's `runStore` reads that one; grepping `frontend/src`, the CLI and `plugins/` found no consumer of `/api/apps/{slug}/runs` at all, so this cursor change has no client to migrate.
- **No opaque cursor token and no response envelope.** Rejected above; it would be a breaking change to the response shape.
- **No index added.** The existing `idx_runs_app_created` covers the new query, as the plan above shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EwoZ9EbPynXbEHBcZZeTo

[#371]: https://github.com/CodefyUI/CodefyUI/pull/371
[#372]: https://github.com/CodefyUI/CodefyUI/issues/372

