### PR TITLE
fix(packs,cli): the Package Center backend and launcher follow-ups from #380

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -393,6 +393,19 @@ received — each links to the release it was published as.
   traceback happens to name the class in its last line. The message itself
   never carried it: `str(KeyError('tensor'))` is just `"'tensor'"`.
 
+- **A follow-up pass over the Package Center installer and its launcher**
+  ([#380]). The catalog now validates what its tests had only assumed; the
+  byte meter cannot freeze a bar or pass 100%; an asset's sentinel is
+  re-checked against its catalog entry; and an interrupted asset download
+  takes its `.part` file with it rather than leave behind 69 MB nothing
+  counts and nothing removes. A late event from a finished job no longer
+  stamps a step on the next one, a claim stamped in the future cannot wedge
+  a restart, a helper's pid stamp survives a concurrent read on Windows, and
+  a claim from another checkout is refused but left alone. An interrupted
+  helper waits for the old server before relaunching, a crash in it keeps its
+  own message, `cdui update` and `cdui dev` stand down while a restart
+  install is finishing, and two `cdui packs` prompts stop misreporting.
+
 ## [2.4.1] — 2026-08-22
 
 Four fixes that landed on `main` in the hours after 2.4.0, and nothing else:
@@ -2440,6 +2453,7 @@ Release candidates before 1.0.0 are on the
 [#357]: https://github.com/CodefyUI/CodefyUI/pull/357
 [#359]: https://github.com/CodefyUI/CodefyUI/pull/359
 [#360]: https://github.com/CodefyUI/CodefyUI/issues/360
+[#380]: https://github.com/CodefyUI/CodefyUI/issues/380
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...main

--- a/backend/app/core/asset_cache.py
+++ b/backend/app/core/asset_cache.py
@@ -193,7 +193,18 @@ def resolve(
         if progress_callback is not None:
             progress_callback(done, total)
     except BaseException:
-        tmp.unlink(missing_ok=True)
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            # The cleanup must never become the failure that gets reported.
+            # On Windows this unlink raises PermissionError whenever another
+            # process (an indexer, a scanner) still holds the .part open, and
+            # an unguarded one would travel out of here in place of the
+            # PackCancelled it is tidying up after -- turning a Stop the user
+            # asked for into a failed job. The leftover gets a log line and
+            # the original exception gets the raise.
+            log.warning("Could not remove partial download %s: %s",
+                        tmp, cleanup_error)
         raise
 
     if spec.sha256 is not None:

--- a/backend/app/core/asset_cache.py
+++ b/backend/app/core/asset_cache.py
@@ -167,20 +167,34 @@ def resolve(
 
     log.info("Downloading %s from %s", spec.name, spec.url)
     tmp = target.with_suffix(target.suffix + ".part")
-    with urllib.request.urlopen(spec.url, timeout=timeout) as resp:  # noqa: S310 — fixed URL set
-        total = _content_length(resp)
-        done = 0
-        with tmp.open("wb") as f:
-            while True:
-                chunk = resp.read(1 << 20)
-                if not chunk:
-                    break
-                f.write(chunk)
-                done += len(chunk)
-                if progress_callback is not None:
-                    progress_callback(done, total)
-    if progress_callback is not None:
-        progress_callback(done, total)
+    # A download that does not finish takes its own temp file with it. The
+    # rename below is the only thing that would ever have named these bytes,
+    # so an abandoned .part is pure residue -- nothing resumes it (the open
+    # is "wb", which truncates), nothing counts it in the disk precheck, and
+    # nothing removes it: the pack remover only knows the item's own
+    # filename. For GloVe that is 69 MB a user can never find.
+    #
+    # BaseException, not Exception: a cancelled install raises PackCancelled
+    # out of the progress callback (an Exception) and a Ctrl-C raises
+    # KeyboardInterrupt (not one), and both abandon the same file.
+    try:
+        with urllib.request.urlopen(spec.url, timeout=timeout) as resp:  # noqa: S310 — fixed URL set
+            total = _content_length(resp)
+            done = 0
+            with tmp.open("wb") as f:
+                while True:
+                    chunk = resp.read(1 << 20)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+                    done += len(chunk)
+                    if progress_callback is not None:
+                        progress_callback(done, total)
+        if progress_callback is not None:
+            progress_callback(done, total)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
 
     if spec.sha256 is not None:
         actual = sha256_of(tmp)

--- a/backend/app/core/packs/catalog.py
+++ b/backend/app/core/packs/catalog.py
@@ -15,6 +15,10 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+# Path is used for one pure-string question -- "is this filename a single
+# component?" -- and never to touch the filesystem, which stays a later
+# layer's job.
+from pathlib import Path
 
 #: How a pack's install finishes. "live" packs are usable the moment the
 #: install ends; "restart" packs replace something already imported into the
@@ -219,6 +223,22 @@ def _validate(packs: Sequence[Pack]) -> None:
                     f"{item.item_id!r} in pack {pack.pack_id!r} and by {owner}")
             repo_owner[item.repo_id] = f"{pack.pack_id}/{item.item_id}"
 
+    # The same argument one layer down: an asset item's bytes are ONE file in
+    # ONE flat directory, named by ``filename`` alone, so two items naming one
+    # filename share a file -- removing either would delete the other's
+    # download while the other's sentinel went on claiming it was there.
+    file_owner: dict[str, str] = {}
+    for pack in packs:
+        for item in pack.items:
+            if item.kind != "asset" or not item.filename:
+                continue
+            owner = file_owner.get(item.filename)
+            if owner is not None:
+                raise ValueError(
+                    f"asset filename {item.filename!r} is used by item "
+                    f"{item.item_id!r} in pack {pack.pack_id!r} and by {owner}")
+            file_owner[item.filename] = f"{pack.pack_id}/{item.item_id}"
+
     for pack in packs:
         if pack.install_mode not in INSTALL_MODES:
             raise ValueError(
@@ -236,12 +256,38 @@ def _validate(packs: Sequence[Pack]) -> None:
                 raise ValueError(
                     f"item {item.item_id!r} has kind {item.kind!r}; "
                     f"expected one of {sorted(ITEM_KINDS)}")
+            # Every surface that offers this item quotes a size and a
+            # licence: the confirm prompt, ``packs list``, the disk precheck,
+            # the progress meter's fallback total. A zero size makes the
+            # precheck wave through a download it cannot hold and the meter
+            # divide by nothing; an empty licence ships a model with no
+            # terms attached.
+            if item.approx_bytes <= 0:
+                raise ValueError(
+                    f"item {item.item_id!r} in pack {pack.pack_id!r} has "
+                    f"approx_bytes {item.approx_bytes!r}; expected a "
+                    f"positive size")
+            if not item.license:
+                raise ValueError(
+                    f"item {item.item_id!r} in pack {pack.pack_id!r} has no "
+                    f"license")
             if item.kind == "hf" and not item.repo_id:
                 raise ValueError(f"hf item {item.item_id!r} has no repo_id")
             if item.kind == "asset" and not item.url:
                 raise ValueError(f"asset item {item.item_id!r} has no url")
             if item.kind == "asset" and not item.filename:
                 raise ValueError(f"asset item {item.item_id!r} has no filename")
+            # The rule ``flows._asset_removal_target`` enforces at DELETE
+            # time, stated here so the catalog cannot ship a filename the
+            # remover will refuse -- which would be a download nothing can
+            # ever free. ``".."`` is named explicitly because pathlib does
+            # not resolve it away: ``Path("..").name`` is ``".."``.
+            if (item.kind == "asset" and item.filename
+                    and (item.filename in {".", ".."}
+                         or Path(item.filename).name != item.filename)):
+                raise ValueError(
+                    f"asset item {item.item_id!r} has filename "
+                    f"{item.filename!r}; expected one plain path component")
 
         for dep in pack.depends_on:
             if dep == pack.pack_id:
@@ -304,5 +350,15 @@ def get_item(pack: Pack, item_id: str) -> ModelItem:
 
 
 PACK_IDS: frozenset[str] = frozenset(pack.pack_id for pack in CATALOG)
+
+#: The one pack three other modules have to recognise BY ID rather than by
+#: anything in its record. ``state`` asks it about the installed wheel
+#: instead of about downloaded files, ``restart`` builds it a
+#: ``cdui install --gpu`` line instead of a ``cdui packs install`` one, and
+#: ``service`` picks the helper's command shape from it. Named here, once,
+#: because a pack id spelled privately in three files is three chances for
+#: one of them to be renamed alone -- and because the catalog is where "which
+#: pack is which" is decided.
+GPU_TORCH_PACK_ID: str = "gpu-torch"
 
 _validate(CATALOG)

--- a/backend/app/core/packs/download.py
+++ b/backend/app/core/packs/download.py
@@ -148,8 +148,21 @@ class _ByteMeter:
         meter past the *base* the next file is handed; a ceiling under
         ``done`` would then clamp the bar BACKWARDS, and a progress bar that
         goes down reads as a restart rather than as arithmetic.
+
+        Such a file is UNCAPPED rather than pinned at ``done``. Pinning it
+        there also satisfies "never clamp backwards" -- and freezes the bar
+        for the whole of that file, because every byte it then adds is
+        clamped to the ceiling it was already at. The panel showed a stopped
+        bar for a download that was running. An uncapped file cannot pull
+        the bar down either, so the guarantee survives; what goes is the
+        freeze.
         """
-        self._ceiling = max(base + size, self.done) if size else None
+        if not size:
+            self._ceiling = None
+        elif base + size <= self.done:
+            self._ceiling = None
+        else:
+            self._ceiling = base + size
         self._initial_seen = False
 
     def note_initial(self, initial: int) -> None:
@@ -168,7 +181,14 @@ class _ByteMeter:
     def _payload(self) -> dict:
         percent = None
         if self.total:
-            percent = round(100.0 * self.done / self.total, 1)
+            # Clamped, unlike ``bytes_done``/``bytes_total`` beside it.
+            # Those are MEASUREMENTS and are reported as they are; the
+            # percentage is a claim about completeness, and ``advance_to``
+            # is deliberately outside the per-file ceiling, so ``done`` can
+            # pass an ``approx_bytes`` total that was only ever an estimate.
+            # A panel reading 103% is wrong in a way "449 MB / 476 MB" is
+            # not.
+            percent = round(min(100.0, 100.0 * self.done / self.total), 1)
         return {"type": "progress", "item": self._item_id,
                 "bytes_done": self.done, "bytes_total": self.total,
                 "percent": percent}
@@ -591,6 +611,14 @@ def check_disk(items: Iterable[ModelItem]) -> None:
     for GloVe that second file is bigger than the first. Budgeting the
     download alone would pass the check on a disk that then fills during the
     convert step -- with the download already spent.
+
+    ONE volume is measured for both kinds of item, and it is the right one:
+    ``hf_cache_dir()`` is ``cache_dir() / "hf"``, a child of the directory
+    asset items land in, and ``_measurable_dir`` walks up to the nearest
+    ancestor that exists -- so on a machine that has never installed a pack
+    this already measures ``cache_dir()`` itself. The one arrangement that
+    would make the two differ is a separate mount at ``<cache>/hf``, which
+    nothing here creates.
     """
     approx = sum(item.approx_bytes + item.derived_bytes for item in items)
     if approx <= 0:

--- a/backend/app/core/packs/flows.py
+++ b/backend/app/core/packs/flows.py
@@ -41,7 +41,7 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from . import download, runner, state
@@ -603,6 +603,24 @@ def remove_item(pack: Pack, item_id: str) -> bool:
         target = _hf_removal_target(item)
     else:
         target = _asset_removal_target(item, recorded)
+        # The belt for a download abandoned BEFORE ``asset_cache.resolve``
+        # learned to take its own temp file with it. Nothing new lands here
+        # any more, but a cache that survived an interrupted install still
+        # holds one, and this is the only screen a user can reach it from.
+        # Named through the same helper -- with the ``.part`` filename
+        # standing in for the item's own -- rather than joined by hand, so
+        # the sibling gets exactly the checks the download itself gets and
+        # there is one answer to "which file may this delete". No
+        # ``recorded`` to compare against: the sentinel never named it.
+        part = _asset_removal_target(
+            replace(item, filename=f"{item.filename}.part"), None)
+        if part is not None:
+            try:
+                part.unlink()
+            except OSError:
+                log.warning("could not remove %s, an abandoned download of "
+                            "pack %s item %s; something is holding it open",
+                            part, pack.pack_id, item_id)
         # Before the download itself, because the sentinel that names these
         # goes away with it: a derived file left behind after its record has
         # been deleted is one nothing will ever find again.

--- a/backend/app/core/packs/restart.py
+++ b/backend/app/core/packs/restart.py
@@ -821,14 +821,26 @@ def _read_pending(path: Path) -> "PendingRestart | None":
 
 
 def _age_seconds(pending: PendingRestart) -> "float | None":
-    """How long ago the claim was made, or None when it does not say."""
+    """How long ago the claim was made, or None when it does not say.
+
+    A stamp in the FUTURE does not say either. It gives a negative age,
+    which :func:`_is_stale` would read as "very young" -- so a clock that
+    stepped back would refuse every restart-mode install with "one is
+    already pending" until the wall clock caught up, with no deadline. Both
+    the writer and the reader are processes on this machine, so a future
+    stamp is a clock that moved rather than a claim that is young; None,
+    which the rules below already read as "old", and no skew tolerance.
+
+    Mirrored by ``dev._iso_age_seconds``.
+    """
     try:
         created = datetime.fromisoformat(pending.created_at)
     except ValueError:
         return None
     if created.tzinfo is None:
         created = created.replace(tzinfo=timezone.utc)
-    return (datetime.now(timezone.utc) - created).total_seconds()
+    age = (datetime.now(timezone.utc) - created).total_seconds()
+    return None if age < 0 else age
 
 
 def _is_stale(pending: PendingRestart) -> bool:

--- a/backend/app/core/packs/restart.py
+++ b/backend/app/core/packs/restart.py
@@ -54,14 +54,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from . import runner, state
-from .catalog import Pack
+from .catalog import GPU_TORCH_PACK_ID, Pack
 from .errors import PackInstallError, PendingExists
 from .paths import job_log_dir, last_restart_file, pending_restart_file
 
 log = logging.getLogger(__name__)
-
-#: The pack whose install is a wheel swap rather than a download.
-_GPU_TORCH_PACK_ID = "gpu-torch"
 
 #: Kill switch. ``"0"`` refuses restart-mode installs even under
 #: ``cdui start``; anything else (including unset) leaves them on. A kill
@@ -371,7 +368,7 @@ def install_command_for(pack: Pack, variant: str | None = None) -> str:
         raise ValueError(
             f"unknown torch variant {variant!r}; expected one of "
             f"{', '.join(VARIANTS)}")
-    if pack.pack_id == _GPU_TORCH_PACK_ID:
+    if pack.pack_id == GPU_TORCH_PACK_ID:
         chosen = variant or gpu_info()["recommended_variant"]
         return f"cdui install --gpu {chosen}"
     return f"cdui packs install {pack.pack_id}"

--- a/backend/app/core/packs/service.py
+++ b/backend/app/core/packs/service.py
@@ -355,7 +355,7 @@ class PackService:
             self._cursor = 0
             self._broadcast = broadcast
             self._store({"type": "job_started", "pack_id": pack.pack_id,
-                         "items": list(job.items)})
+                         "items": list(job.items)}, job)
         # job_started is in the buffer before the flow can emit anything, so
         # a client that polls from cursor 0 always sees it first.
         self._task = asyncio.create_task(self._run(job, pack, loop, broadcast))
@@ -471,7 +471,7 @@ class PackService:
             self._cursor = 0
             self._broadcast = broadcast
             self._store({"type": "job_started", "pack_id": pack.pack_id,
-                         "items": []})
+                         "items": []}, job)
         # Terminal immediately, and under the lock like every other terminal
         # event: a client that sees ``needs_restart`` has already been handed
         # the event that names the command, the kind and the file.
@@ -556,7 +556,7 @@ class PackService:
         the job reaches a terminal state either way, which is the part that
         matters to anyone still watching it.
         """
-        emit = self._emitter(loop, broadcast)
+        emit = self._emitter(job, loop, broadcast)
         try:
             await asyncio.to_thread(
                 self._run_flow, pack, list(job.items),
@@ -605,12 +605,21 @@ class PackService:
             # dict drop.
             state.invalidate()
 
-    def _emitter(self, loop, broadcast: _Broadcast) -> Callable[[dict], None]:
-        """The ``emit`` the flow is handed. Called from the worker thread."""
+    def _emitter(self, job: PackJob, loop, broadcast: _Broadcast
+                 ) -> Callable[[dict], None]:
+        """The ``emit`` the flow is handed. Called from the worker thread.
+
+        Closes over the JOB as well as its generation's loop and broadcast,
+        so an event says which job produced it. A closure is the only thing
+        that can: the caller is a reader thread that may outlive the job --
+        ``runner._pump`` is a daemon thread joined with a timeout -- and by
+        the time its event reaches ``_store`` the service's idea of the
+        current job may already be somebody else's.
+        """
 
         def emit(event: dict) -> None:
             with self._lock:
-                self._store(event)
+                self._store(event, job)
             try:
                 loop.call_soon_threadsafe(broadcast.notify)
             except RuntimeError:
@@ -621,13 +630,22 @@ class PackService:
 
         return emit
 
-    def _store(self, event: dict) -> None:
-        """Stamp *event* and buffer it. CALLER HOLDS ``self._lock``."""
+    def _store(self, event: dict, job: PackJob | None) -> None:
+        """Stamp *event* and buffer it. CALLER HOLDS ``self._lock``.
+
+        *job* is the job that PRODUCED the event, which is not always the
+        current one: a finished job's reader thread can still be emitting.
+        Buffering is unconditional -- the buffer belongs to whatever job is
+        current, and a stray line in it is visible and harmless -- but the
+        step bookkeeping is not. ``current_step`` is what
+        ``GET /api/packs`` turns into an item's "downloading" badge, so a
+        late event stamping it on the next job would put that badge on an
+        item of a pack the old job never touched.
+        """
         self._cursor += 1
         self._events.append({**event, "cursor": self._cursor, "ts": _now_iso()})
 
-        job = self._job
-        if job is None:
+        if job is None or job is not self._job:
             return
         kind = event.get("type")
         if kind == "step_started":
@@ -655,7 +673,7 @@ class PackService:
         this is the only place its status is ever set.
         """
         with self._lock:
-            self._store(event)
+            self._store(event, job)
             job.status = status
             job.finished_at = time.time()
         self._broadcast.notify()

--- a/backend/app/core/packs/service.py
+++ b/backend/app/core/packs/service.py
@@ -51,7 +51,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 from . import download, flows, restart, state
-from .catalog import ModelItem, Pack, get_item
+from .catalog import GPU_TORCH_PACK_ID, ModelItem, Pack, get_item
 from .errors import (
     PackCancelled,
     PackInstallError,
@@ -491,10 +491,11 @@ class PackService:
         catalog to look the pack up in, so the decision is made here and
         written into the pending file.
 
-        ``restart._GPU_TORCH_PACK_ID`` rather than a second copy of the
-        literal: ``restart`` is already where "which pack is the wheel swap"
-        is decided (``install_command_for`` asks the same question), and one
-        pack id spelled in two files is one spelling too many.
+        ``catalog.GPU_TORCH_PACK_ID`` rather than a second copy of the
+        literal: the catalog is where "which pack is which" is decided, and
+        one pack id spelled in three files is two spellings too many.
+        ``restart.install_command_for`` and ``state.pack_state`` ask the same
+        question off the same constant.
 
         :raises ValueError: the pack has no packages to install. Stopping the
             server to install nothing is worse than refusing -- and it would
@@ -503,7 +504,7 @@ class PackService:
             case; this one runs first, before a job id has even been minted,
             so the client is answered by its own request.
         """
-        if pack.pack_id == restart._GPU_TORCH_PACK_ID:
+        if pack.pack_id == GPU_TORCH_PACK_ID:
             return "torch"
         if not pack.pip:
             raise ValueError(

--- a/backend/app/core/packs/state.py
+++ b/backend/app/core/packs/state.py
@@ -206,6 +206,19 @@ def item_state(pack: Pack, item: ModelItem) -> ItemState:
             return absent
         recorded = data.get("snapshot_dir")
     else:
+        # The same re-check the hf branch does, against what an asset item
+        # is identified BY. A catalog entry may move to a new URL, and the
+        # downloaded file cannot say where it came from -- it has no hub
+        # behind it, only this sentinel -- so without this the old bytes go
+        # on reporting themselves as the new item's model.
+        if data.get("url") != item.url:
+            return absent
+        # An install done before a digest was recorded wrote the digest it
+        # COMPUTED off the bytes that arrived, which is the one the catalog
+        # then records -- so recording a digest invalidates nothing already
+        # downloaded, and a mismatch really is different bytes.
+        if item.sha256 is not None and data.get("sha256") != item.sha256:
+            return absent
         recorded = data.get("path")
 
     if not isinstance(recorded, str) or not recorded:

--- a/backend/app/core/packs/state.py
+++ b/backend/app/core/packs/state.py
@@ -39,14 +39,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from .catalog import ModelItem, Pack, get_pack, iter_packs
+from .catalog import GPU_TORCH_PACK_ID, ModelItem, Pack, get_pack, iter_packs
 from .paths import sentinel_path
-
-#: The one pack whose "installed" is not "are its files there". Torch is
-#: always importable; this pack asks whether the ACCELERATED build is the one
-#: in place, which is a property of the wheel already installed rather than of
-#: anything the Package Center downloaded.
-_GPU_TORCH_PACK_ID = "gpu-torch"
 
 #: Both ids are interpolated straight into a sentinel FILENAME. Today they
 #: only ever come from the catalog; this is the guard for the day one arrives
@@ -159,6 +153,11 @@ def write_sentinel(pack_id: str, item_id: str, payload: dict) -> Path:
     crash mid-write leaves either the previous sentinel or none -- never a
     truncated one that a reader would have to guess about. *payload* is
     written verbatim; its shape is the schema in this module's docstring.
+
+    Explicit LF, like ``write_constraints_file``: the default would translate
+    every line ending to CRLF on Windows and the same sentinel would be a
+    different file on two platforms. Cosmetic -- JSON round-trips either way
+    -- but the two writers in this feature should not disagree about it.
     """
     _validate_id(pack_id, "pack_id")
     _validate_id(item_id, "item_id")
@@ -167,7 +166,8 @@ def write_sentinel(pack_id: str, item_id: str, payload: dict) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     staged = path.with_name(f"{path.name}.tmp-{os.getpid()}")
     try:
-        staged.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        staged.write_text(json.dumps(payload, indent=2), encoding="utf-8",
+                          newline="\n")
         os.replace(staged, path)
     finally:
         staged.unlink(missing_ok=True)
@@ -246,7 +246,7 @@ def pack_state(pack: Pack) -> PackState:
     ready = pip_ready(pack)
     items = tuple(item_state(pack, item) for item in pack.items)
 
-    if pack.pack_id == _GPU_TORCH_PACK_ID:
+    if pack.pack_id == GPU_TORCH_PACK_ID:
         # This pack downloads nothing, so the general rules below would call
         # it both installed and usable on any machine at all. Its readiness
         # lives in the installed WHEEL instead, and both answers come from

--- a/backend/tests/test_asset_cache.py
+++ b/backend/tests/test_asset_cache.py
@@ -1,13 +1,16 @@
 """The asset cache: bytes in, verified file out -- and now a progress report.
 
-Two properties are pinned here and nothing else in the suite pins them:
+Three properties are pinned here and nothing else in the suite pins them:
 
 * a caller can watch a download byte by byte (the Package Center draws a bar
   from it), and passing no callback leaves the old code path untouched;
 * a spec with NO recorded sha256 is UNVERIFIED, not verified. The GloVe table
   ships with ``sha256=None`` until a maintainer records the real digest, and
   the difference between "we could not check" and "we checked" must be an
-  explicit decision at the call site rather than a silently skipped ``if``.
+  explicit decision at the call site rather than a silently skipped ``if``;
+* cleaning up the abandoned ``.part`` cannot change what failed. The unlink
+  runs inside the handler for the exception it is tidying up after, so an
+  unlucky one of its own must not take that exception's place.
 
 Never touches the network: ``urllib.request.urlopen`` is replaced with a fake
 that serves bytes from memory.
@@ -17,7 +20,9 @@ from __future__ import annotations
 
 import hashlib
 import io
+import logging
 import urllib.request
+from pathlib import Path
 
 import pytest
 
@@ -177,3 +182,41 @@ def test_asset_cache_allow_fetch_false_still_refuses_to_download(served):
 
     with pytest.raises(AssetMissingError):
         resolve(_spec(), allow_fetch=False, progress_callback=lambda *_: None)
+
+
+def test_a_failed_cleanup_unlink_keeps_the_original_exception(served,
+                                                              monkeypatch,
+                                                              caplog):
+    """Deleting the abandoned ``.part`` cannot become the reported failure.
+
+    On Windows an ``unlink`` of a file another process holds open without
+    ``FILE_SHARE_DELETE`` -- an indexer, a backup agent, a scanner that
+    opened the growing file -- raises ``PermissionError``. That unlink runs
+    inside the ``except`` cleaning up after a cancel, so an unguarded one
+    propagates INSTEAD OF the ``PackCancelled`` (or ``KeyboardInterrupt``)
+    that was travelling: the user presses Stop and the job is reported
+    *failed* with ``[WinError 32]``, having also failed to delete anything.
+    The leftover is worth a warning naming it and nothing more.
+    """
+    served(PAYLOAD)
+    real_unlink = Path.unlink
+
+    def _unlink(self, *args, **kwargs):
+        if self.suffix == ".part":
+            raise PermissionError(32, "another process is using this file")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", _unlink)
+
+    class _Stopped(Exception):
+        """Stands in for the ``PackCancelled`` a real Stop raises."""
+
+    def _stop(done, total):
+        raise _Stopped("the user pressed Stop")
+
+    with caplog.at_level(logging.WARNING, logger="app.core.asset_cache"):
+        with pytest.raises(_Stopped):
+            resolve(_spec(), progress_callback=_stop)
+
+    assert any("thing.bin.part" in record.getMessage()
+               for record in caplog.records), caplog.text

--- a/backend/tests/test_dev_packs_cli.py
+++ b/backend/tests/test_dev_packs_cli.py
@@ -705,6 +705,48 @@ def test_dev_and_restart_agree_on_which_claims_are_still_alive(
         restart.PendingRestart.from_json(json.dumps(claim))) is not live
 
 
+def test_a_claim_stamped_in_the_future_is_not_believed_forever(monkeypatch,
+                                                               tmp_path):
+    """A clock that moved BACK must not wedge a claim until it catches up.
+
+    A ``created_at`` in the future gives a negative age, and both sides used
+    to read that as young: ``age <= HELPER_START_GRACE_S`` is true on the
+    dev side, ``age > HELPER_START_GRACE_S`` is false on the backend side.
+    So ``cdui start`` stood down and every restart-mode install was refused
+    with "one is already pending", with no deadline -- until the wall clock
+    caught up, which for a clock stepped back an hour is an hour.
+
+    A negative age is treated exactly like an unreadable one: None, which
+    every caller on both sides already reads as "old". No skew tolerance,
+    because a stamp written by a process on THIS machine and read by
+    another one on this machine is not a stamp that needs one -- and a
+    tolerance would be a number with no correct value.
+    """
+    restart = _restart_state()
+    monkeypatch.setattr(dev, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(restart, "_pid_alive", lambda pid: False)
+
+    claim = {
+        "schema": 1, "job_id": "j1", "pack_id": "gpu-torch", "kind": "torch",
+        "index_url": "https://download.pytorch.org/whl/cu128",
+        "packages": ["torch"], "specs": [],
+        "venv_python": "/nowhere/python", "server_pid": 4242,
+        "launcher": ["/py", "/dev.py"], "relaunch_argv": [],
+        "created_at": (datetime.now(timezone.utc)
+                       + timedelta(hours=1)).isoformat(),
+    }
+    path = tmp_path / "pending_restart.json"
+    path.write_text(json.dumps(claim), encoding="utf-8")
+    # The dev side falls back to the file's MTIME when created_at answers
+    # None, and that clock is the safer of the two -- so it has to be old
+    # for this to be about created_at at all.
+    os.utime(path, (0, 0))
+
+    assert dev._pending_state(path, claim) == "abandoned"
+    assert restart._is_stale(
+        restart.PendingRestart.from_json(json.dumps(claim))) is True
+
+
 def test_dev_and_restart_agree_on_where_the_two_files_live(tmp_path,
                                                            monkeypatch):
     """Not just the names — the whole path, derived from the same variable.
@@ -1130,12 +1172,22 @@ def test_run_pending_refuses_a_launcher_that_did_not_start_this_helper(
     assert helper["install"] is None
     assert helper["relaunch"] is None
     assert "interpreter" in capsys.readouterr().err
+    # The third ownership check, left alone for the same reason as the
+    # other two: another interpreter's claim is another install's claim.
+    assert path.exists()
+    assert not (helper["control"] / "last_restart_job.json").exists()
 
 
 def test_run_pending_refuses_a_foreign_venv_python(helper, capsys):
     """The interpreter to install INTO is the one field that decides which
     environment gets rewritten. A path outside this checkout's venv is a file
-    somebody else wrote."""
+    somebody else wrote.
+
+    An OWNERSHIP refusal, so the file is left exactly as found and no
+    outcome record is written -- see
+    ``test_a_claim_from_another_checkout_is_refused_but_left_alone`` for
+    why. The refusal reaches the user through the console only.
+    """
     path = _pending(helper, venv_python="/usr/bin/python3")
 
     assert dev._run_pending_job(path) == 2
@@ -1143,9 +1195,8 @@ def test_run_pending_refuses_a_foreign_venv_python(helper, capsys):
     assert helper["install"] is None
     assert helper["relaunch"] is None
     assert "venv_python" in capsys.readouterr().err
-    record = _outcome(helper)
-    assert record["status"] == "failed"
-    assert "refused" in record["message"]
+    assert path.exists()
+    assert not (helper["control"] / "last_restart_job.json").exists()
 
 
 def test_run_pending_refuses_a_launcher_that_is_not_this_dev_py(helper, capsys):
@@ -1824,6 +1875,64 @@ def test_the_helper_arms_the_sigterm_handler_before_it_runs_anything(
     assert order == ["armed", "ran"]
 
 
+def test_the_atomic_write_retries_a_sharing_violation(tmp_path, monkeypatch):
+    """A momentary Windows sharing violation is not a lost record.
+
+    CPython's `open()` on Windows does not request `FILE_SHARE_DELETE`, so
+    `os.replace` over a file another process merely has OPEN raises
+    `PermissionError`. The helper stamps `helper_pid` and then
+    `installer_pid` into the claim while a `cdui status` may be reading it,
+    and the loser of that sub-millisecond race is the claim: an unwritten
+    `helper_pid` makes the next `cdui start` read a live restart as
+    abandoned.
+
+    Only the replace is retried -- the write into the temp file is this
+    process's own file and has no such race.
+    """
+    calls: list = []
+    real = os.replace
+
+    def flaky(src, dst):
+        calls.append((src, dst))
+        if len(calls) < 3:
+            raise PermissionError(32, "being used by another process")
+        return real(src, dst)
+
+    monkeypatch.setattr(dev.os, "replace", flaky)
+    monkeypatch.setattr(dev.time, "sleep", lambda seconds: None)
+    path = tmp_path / "pending_restart.json"
+
+    assert dev._write_json_atomic(path, {"schema": 1}) is True
+
+    assert len(calls) == 3, calls
+    assert json.loads(path.read_text(encoding="utf-8")) == {"schema": 1}
+
+
+def test_the_atomic_write_still_gives_up_eventually(tmp_path, monkeypatch):
+    """Bounded, and still never raising. A destination that is genuinely
+    unwritable -- a read-only directory, not a passing reader -- must not
+    turn the helper into a process that sits there sleeping: the caller is
+    on its way to starting a server again and a record nobody could write
+    is not a reason to skip that."""
+    calls: list = []
+    slept: list = []
+
+    def always_locked(src, dst):
+        calls.append((src, dst))
+        raise PermissionError(32, "being used by another process")
+
+    monkeypatch.setattr(dev.os, "replace", always_locked)
+    monkeypatch.setattr(dev.time, "sleep", slept.append)
+    path = tmp_path / "pending_restart.json"
+
+    assert dev._write_json_atomic(path, {"schema": 1}) is False
+
+    assert len(calls) == dev.ATOMIC_REPLACE_ATTEMPTS, calls
+    assert sum(slept) <= 0.15, slept
+    assert not path.exists()
+    assert list(tmp_path.iterdir()) == [], "the temp file was left behind"
+
+
 def test_a_refused_claim_is_never_stamped_with_a_helper_pid(helper,
                                                             monkeypatch):
     """It is not ours. Writing into it would be claiming a job this process
@@ -1840,6 +1949,35 @@ def test_a_refused_claim_is_never_stamped_with_a_helper_pid(helper,
 
     assert path not in written, "the helper claimed a job that was not its own"
     assert written, "and the outcome record was still filed"
+
+
+def test_a_claim_from_another_checkout_is_refused_but_left_alone(helper,
+                                                                 capsys):
+    """A refusal that says "this is not mine" must not then act on it.
+
+    The three OWNERSHIP checks -- the launcher script, the launcher
+    interpreter and venv_python -- answer "did THIS installation write
+    this?", and a no means another installation did. Deleting that claim
+    takes it away from the live helper still acting on it, and that
+    installation's next `cdui start` then sees no claim and starts a second
+    server into a venv `uv` is mid-way through rewriting.
+
+    The outcome record goes the same way, and for a sharper reason: it lives
+    NEXT TO the claim, in the other installation's control directory, so
+    writing one would overwrite that install's last real report with a
+    refusal it did not ask for. A foreign claim gets a printed refusal and
+    nothing else.
+    """
+    path = _pending(helper, launcher=["/other/python", "/other/dev.py"])
+
+    assert dev._run_pending_job(path) == 2
+
+    assert "launcher" in capsys.readouterr().err
+    assert path.exists(), "the other installation's claim was deleted"
+    assert not (helper["control"] / "last_restart_job.json").exists(), (
+        "the other installation's last report was overwritten")
+    assert helper["install"] is None
+    assert helper["relaunch"] is None
 
 
 def test_a_refused_claim_is_deleted_rather_than_left_behind(helper):

--- a/backend/tests/test_dev_packs_cli.py
+++ b/backend/tests/test_dev_packs_cli.py
@@ -383,6 +383,31 @@ def test_cli_install_prompt_shows_the_download_size(
     assert "69" in "".join(asked), "the prompt must say how many MB this is"
 
 
+def test_the_size_prompt_skips_items_already_on_disk(probed, fake_flow,
+                                                     monkeypatch):
+    """The sentence shown to a human has to be about what will be fetched.
+
+    ``--items`` was quoted back verbatim, downloaded or not, so a user who
+    already had one of two named models was asked to approve both their
+    sizes -- and the flow then fetched only the missing one. The prompt
+    mirrors ``flows._resolve_items``, which skips what is present, or it is
+    not describing the install it is asking about.
+    """
+    probed(**{"sentence-embeddings": {"present": ["all-MiniLM-L6-v2"],
+                                      "pip_ready": True, "usable": True}})
+    asked: list[str] = []
+    monkeypatch.setattr(packs, "_stdin_is_interactive", lambda: True)
+    monkeypatch.setattr("builtins.input",
+                        lambda prompt="": asked.append(prompt) or "y")
+
+    assert packs.main(["install", "sentence-embeddings",
+                       "--items", "all-MiniLM-L6-v2,bge-small-zh-v1.5"]) == 0
+
+    prompt = "".join(asked)
+    assert "95.0" in prompt, prompt          # bge-small-zh-v1.5 alone
+    assert "185.0" not in prompt, prompt     # and not both of them
+
+
 def test_cli_install_needs_restart_exits_3_with_command(
         probed, fake_flow, capsys):
     from app.core.packs.errors import PackNeedsRestart
@@ -517,6 +542,32 @@ def test_cli_remove_an_item_that_was_never_downloaded_says_nothing_to_remove(
     assert "glove-50d" in text
     assert "not downloaded" in text.lower()
     assert "disk" not in text.lower()
+
+
+def test_remove_says_nothing_about_pip_when_there_was_nothing_to_remove(
+        probed, monkeypatch, capsys):
+    """No removal, no advice about what a removal did not do.
+
+    The ``uv pip uninstall`` hint is the answer to "your model is gone but
+    its Python packages are not". After "nothing to remove" it answers a
+    question nobody asked, and it is the longest line on the screen -- so
+    the one line that matters is the one competing for attention.
+
+    A pack WITH pip specs on purpose: ``word-vectors`` has none, so the hint
+    never printed for it and the same assertion there would pass without
+    testing anything.
+    """
+    from app.core.packs import flows
+
+    monkeypatch.setattr(flows, "remove_item", lambda pack, item_id: False)
+
+    assert packs.main(["remove", "sentence-embeddings",
+                       "all-MiniLM-L6-v2"]) == 0
+
+    captured = capsys.readouterr()
+    text = captured.out + captured.err
+    assert "not downloaded" in text.lower()
+    assert "uv pip uninstall" not in text, text
 
 
 def test_cli_remove_unknown_item_exits_2(probed, monkeypatch, capsys):

--- a/backend/tests/test_dev_packs_cli.py
+++ b/backend/tests/test_dev_packs_cli.py
@@ -1838,6 +1838,81 @@ def test_a_helper_killed_before_the_install_records_it_too(helper, monkeypatch,
     assert record["relaunch"] == "ok"
 
 
+def test_an_interrupt_during_the_server_wait_still_waits_before_relaunching(
+        helper, monkeypatch):
+    """The one interrupt that can leave a user with NO server at all.
+
+    The `finally` relaunches whatever happened -- but if the interrupt
+    landed inside `_wait_for_server_exit`, the old server is still there.
+    The relaunched `cdui start` then finds the pidfile, prints "already
+    running", exits 0, and the outcome record says `relaunch: ok` -- and
+    moments later the old server finishes exiting and there is no server
+    anywhere.
+
+    So the interrupt path waits for the old pid too, with the SAME wait: the
+    reason the first one exists (installing while the server still holds the
+    files open is the failure this whole mechanism prevents) is unchanged by
+    an interrupt, and a second, shorter grace would be a second rule for one
+    file. `_forget_stopped_server` follows it exactly as on the happy path,
+    or the relaunch reads a pidfile for a server that is gone.
+    """
+    order: list = []
+    real_relaunch = dev._relaunch_server
+
+    def _wait(pid):
+        order.append(("wait", pid))
+        if len(order) == 1:
+            raise KeyboardInterrupt("stopped")
+        return "exited"
+
+    def _counted(launcher, argv, log_path):
+        order.append(("relaunch", None))
+        return real_relaunch(launcher, argv, log_path)
+
+    monkeypatch.setattr(dev, "_wait_for_server_exit", _wait)
+    monkeypatch.setattr(dev, "_relaunch_server", _counted)
+    dev.SERVER_PIDFILE.write_text("4242", encoding="utf-8")
+    dev.SERVER_ADDRFILE.write_text("http://127.0.0.1:8000", encoding="utf-8")
+    path = _pending(helper)
+
+    with pytest.raises(KeyboardInterrupt):
+        dev._run_pending_job(path)
+
+    assert order == [("wait", 4242), ("wait", 4242), ("relaunch", None)]
+    assert not dev.SERVER_PIDFILE.exists(), "the relaunch would read a dead pid"
+    assert not dev.SERVER_ADDRFILE.exists()
+    assert helper["relaunch"] is not None
+
+
+def test_a_crash_in_the_helper_is_not_reported_as_an_interrupt(helper,
+                                                               monkeypatch,
+                                                               capsys):
+    """`except BaseException` catches everything, and everything used to be
+    written up as "the install was interrupted before it finished".
+
+    A KeyError on a claim field, a MemoryError, any genuine traceback: the
+    user read "interrupted" and went looking for the Ctrl-C they never
+    typed. The message now names the exception, and only a real
+    KeyboardInterrupt or SystemExit says interrupted.
+    """
+    def _boom(data):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(dev, "_pending_install_cmd", _boom)
+    path = _pending(helper)
+
+    with pytest.raises(RuntimeError):
+        dev._run_pending_job(path)
+
+    record = _outcome(helper)
+    assert record["status"] == "failed"
+    assert "RuntimeError" in record["message"], record["message"]
+    assert "interrupted" not in record["message"], record["message"]
+    assert "RuntimeError" in capsys.readouterr().err
+    # The promise the handler exists to keep, kept for a crash too.
+    assert helper["relaunch"] is not None
+
+
 def test_a_sigterm_at_the_helper_raises_the_way_a_ctrl_c_does(monkeypatch):
     """`End task`, a service stop, a shell's cleanup: POSIX default action is
     to die on the spot, which skips every `except` and `finally` the helper

--- a/backend/tests/test_dev_start_command.py
+++ b/backend/tests/test_dev_start_command.py
@@ -845,3 +845,125 @@ def test_a_failed_delete_does_not_stop_the_server_starting(started, monkeypatch,
     dev.start()
 
     assert started["popen"] is not None
+
+
+# ── the other two commands that run out of the venv a helper is rewriting ──
+#
+# `start` stands down at exit 0 -- the user asked for a running server and
+# one is on its way, so their request is being satisfied by somebody else.
+# Nobody else is going to run the user's `update`, so these two REFUSE, at
+# exit 1, matching `update`'s own "a server is running" refusal that scripts
+# already gate on.
+
+
+class _ReachedLaunch(Exception):
+    """Raised by a stubbed Popen: proof `dev()` got as far as launching."""
+
+
+def _update_argv(monkeypatch, *args):
+    monkeypatch.setattr(sys, "argv", ["cdui", "update", *args])
+
+
+def _updatable(monkeypatch, started) -> list:
+    """Stub everything `update()` does AFTER the preflight, and record the
+    call to `install` that ends it. `dev.run` is already a recorder, so the
+    git commands land in ``started["run"]``."""
+    (dev.ROOT / ".git").mkdir(parents=True, exist_ok=True)
+    installed: list = []
+    monkeypatch.setattr(dev, "_resolve_update_options",
+                        lambda argv: (None, False))
+    monkeypatch.setattr(dev, "install", lambda **kw: installed.append(kw))
+    monkeypatch.setattr(dev.shutil, "which", lambda name: "/fake/pnpm")
+    return installed
+
+
+def test_update_refuses_while_a_restart_is_finishing(started, monkeypatch,
+                                                     control, tmp_path,
+                                                     capsys):
+    """`update` hard-realigns the checkout, deletes frontend/dist and
+    rewrites the venv -- while a detached helper may be mid-`uv pip install`
+    into that same venv. Two writers in one site-packages, and the loser is
+    whichever finishes second."""
+    installed = _updatable(monkeypatch, started)
+    path = _write_pending(control, helper_pid=777)
+    monkeypatch.setattr(dev, "_pid_alive", lambda pid: pid == 777)
+    _update_argv(monkeypatch)
+
+    with pytest.raises(SystemExit) as leaving:
+        dev.update()
+
+    assert leaving.value.code == 1
+    assert started["run"] is None, "update reached git under a live install"
+    assert installed == []
+    assert path.exists(), "the helper still needs its own claim"
+    assert "cdui status" in capsys.readouterr().out
+    # The same sandbox guard as `test_the_sandbox_keeps_the_preflight_out_of
+    # _the_real_user_data`: the preflight DELETES what it finds, and a test
+    # that read the developer's own claim would delete that.
+    assert dev._pending_restart_file().is_relative_to(tmp_path)
+
+
+def test_update_proceeds_once_an_abandoned_claim_is_cleared(started,
+                                                            monkeypatch,
+                                                            control, tmp_path):
+    """The other half, or the fix would trade one wedge for another: a claim
+    nobody is acting on is cleared and the update runs."""
+    installed = _updatable(monkeypatch, started)
+    path = _write_pending(control, helper_pid=777,
+                          age_s=dev.STALE_PENDING_S + 60)
+    monkeypatch.setattr(dev, "_pid_alive", lambda pid: False)
+    _update_argv(monkeypatch)
+
+    dev.update()
+
+    assert not path.exists()
+    assert started["run"] is not None, "update never reached git"
+    assert installed == [{"gpu": None, "dev": False}]
+    assert dev._pending_restart_file().is_relative_to(tmp_path)
+
+
+def _devable(monkeypatch) -> None:
+    monkeypatch.setattr(dev.shutil, "which", lambda name: "/fake/pnpm")
+    monkeypatch.setattr(dev, "_install_frontend_deps_if_needed", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["cdui", "dev"])
+
+
+def test_dev_refuses_while_a_restart_is_finishing(started, monkeypatch,
+                                                 control, tmp_path):
+    """`cdui dev` starts a `--reload` uvicorn out of the venv the helper is
+    replacing. It checked nothing at all before this."""
+    _devable(monkeypatch)
+    monkeypatch.setattr(dev.subprocess, "Popen",
+                        lambda cmd, **kw: pytest.fail(f"launched {cmd}"))
+    path = _write_pending(control, helper_pid=777)
+    monkeypatch.setattr(dev, "_pid_alive", lambda pid: pid == 777)
+
+    with pytest.raises(SystemExit) as leaving:
+        dev.dev()
+
+    assert leaving.value.code == 1
+    assert path.exists()
+    assert dev._pending_restart_file().is_relative_to(tmp_path)
+
+
+def test_dev_proceeds_once_an_abandoned_claim_is_cleared(started, monkeypatch,
+                                                         control, tmp_path):
+    """A dead claim is cleared and `cdui dev` launches."""
+    _devable(monkeypatch)
+    launched: list = []
+
+    def _reached(cmd, **kw):
+        launched.append(list(cmd))
+        raise _ReachedLaunch
+
+    monkeypatch.setattr(dev.subprocess, "Popen", _reached)
+    path = _write_pending(control, helper_pid=777,
+                          age_s=dev.STALE_PENDING_S + 60)
+    monkeypatch.setattr(dev, "_pid_alive", lambda pid: False)
+
+    with pytest.raises(_ReachedLaunch):
+        dev.dev()
+
+    assert launched and launched[0][0] == "/fake/uvicorn", launched
+    assert not path.exists()
+    assert dev._pending_restart_file().is_relative_to(tmp_path)

--- a/backend/tests/test_glove_loader.py
+++ b/backend/tests/test_glove_loader.py
@@ -426,8 +426,12 @@ def test_a_lazy_conversion_records_the_npz_so_the_uninstall_finds_it():
     gz_path = _write_gz(asset_dir() / item.filename, _table_lines())
     state.write_sentinel(pack.pack_id, item.item_id, {
         "schema": 1, "pack_id": pack.pack_id, "item_id": item.item_id,
+        # The catalog's digest, which is what a real install records: the
+        # download stores the digest it computed off the bytes that
+        # arrived, and ``state.item_state`` re-checks the sentinel against
+        # the catalog entry the way it does an hf item's revision.
         "kind": "asset", "url": item.url, "path": str(gz_path),
-        "bytes": gz_path.stat().st_size, "sha256": None,
+        "bytes": gz_path.stat().st_size, "sha256": item.sha256,
         "at": "2026-08-28T00:00:00Z",
     })
 

--- a/backend/tests/test_packs_catalog.py
+++ b/backend/tests/test_packs_catalog.py
@@ -18,9 +18,10 @@ import pytest
 
 from app.config import _user_data_root
 from app.core.asset_cache import cache_dir
-from app.core.packs import PackMissingError
+from app.core.packs import PackMissingError, restart, state
 from app.core.packs.catalog import (
     CATALOG,
+    GPU_TORCH_PACK_ID,
     PACK_IDS,
     PYPROJECT_EXTRA_FOR_PACK,
     ModelItem,
@@ -99,9 +100,33 @@ def test_rag_depends_on_sentence_embeddings():
 
 
 def test_install_modes_are_valid():
+    """A GUARD, not a discovery: the restart pack and the GPU pack are one
+    pack, and two modules quietly rely on it.
+
+    ``routes_packs._install_command`` branches on ``install_mode ==
+    "restart"``; ``restart.install_command_for`` branches on ``pack_id ==
+    GPU_TORCH_PACK_ID``. They agree only because the two sets are equal
+    today. The day a second restart-mode pack is added, the two branches
+    disagree about it -- one would route it through the restart helper, the
+    other would print ``cdui packs install <id>`` -- and this is what says
+    so before anybody finds out from a stopped server.
+    """
     assert {pack.pack_id for pack in iter_packs()
-            if pack.install_mode == "restart"} == {"gpu-torch"}
+            if pack.install_mode == "restart"} == {GPU_TORCH_PACK_ID}
     assert all(pack.install_mode in {"live", "restart"} for pack in iter_packs())
+
+
+def test_the_gpu_torch_id_is_spelled_once():
+    """One public constant, not a private copy per module.
+
+    ``service`` used to reach across a module boundary for
+    ``restart._GPU_TORCH_PACK_ID`` -- a private name, so nothing stopped
+    ``restart`` from renaming it, and ``state`` carried a third copy of the
+    literal besides.
+    """
+    assert GPU_TORCH_PACK_ID in PACK_IDS
+    assert not hasattr(restart, "_GPU_TORCH_PACK_ID")
+    assert not hasattr(state, "_GPU_TORCH_PACK_ID")
 
 
 def test_hf_items_have_repo_ids_and_asset_items_have_urls():
@@ -207,6 +232,24 @@ def test_validate_rejects_dependency_cycle():
     pytest.param((_pack(items=(_item(kind="asset", repo_id=None,
                                      url="https://x/f.gz"),)),),
                  id="asset-without-filename"),
+    pytest.param((_pack(items=(_item(approx_bytes=0),)),),
+                 id="zero-approx-bytes"),
+    pytest.param((_pack(items=(_item(license=""),)),),
+                 id="no-license"),
+    # A filename the REMOVER would refuse (flows._asset_removal_target) --
+    # the catalog must not ship something that can be downloaded and then
+    # never deleted.
+    pytest.param((_pack(items=(_item(kind="asset", repo_id=None,
+                                     url="https://x/f.gz",
+                                     filename="sub/f.gz"),)),),
+                 id="asset-filename-with-a-separator"),
+    pytest.param((_pack("a", items=(_item("m", kind="asset", repo_id=None,
+                                          url="https://x/f.gz",
+                                          filename="f.gz"),)),
+                  _pack("b", items=(_item("n", kind="asset", repo_id=None,
+                                          url="https://y/f.gz",
+                                          filename="f.gz"),))),
+                 id="two-packs-one-asset-filename"),
     # Distinct repo ids on purpose: the repo-id-uniqueness rule runs FIRST,
     # so two items sharing ``_item``'s default repo would be rejected for
     # that instead and this case would never reach the rule it is named for.

--- a/backend/tests/test_packs_constraints.py
+++ b/backend/tests/test_packs_constraints.py
@@ -22,6 +22,7 @@ import importlib.metadata
 import pytest
 
 from app.core.packs.constraints import (
+    _canonical,
     constraints_text,
     installed_distributions,
     write_constraints_file,
@@ -79,15 +80,25 @@ def test_pins_torch_at_the_version_uv_resolves_against():
 
 def test_names_are_pep503_canonical():
     """``huggingface_hub`` and ``huggingface-hub`` are one distribution; the
-    keys are the canonical spelling so a caller can look one up."""
+    keys are the canonical spelling so a caller can look one up.
+
+    The underscore half is proved through ``_canonical`` on a synthesised
+    name rather than by naming a real package that happens to have one
+    today. It used to assert ``"huggingface-hub" in dists`` -- a TRANSITIVE
+    dependency, so the day a resolver stops pulling it this test would go
+    red about PEP 503 canonicalisation for a reason that has nothing to do
+    with it. What the real list is still asked is only that it exists.
+    """
     dists = installed_distributions()
 
+    assert dists, "this interpreter reported no distributions at all"
     for name in dists:
         assert name == name.lower()
         assert "_" not in name
         assert " " not in name
 
-    assert "huggingface-hub" in dists, "underscores were not canonicalised"
+    assert _canonical("Some_Name") == "some-name"
+    assert _canonical("zope.interface") == "zope-interface"
 
 
 def test_the_editable_project_is_never_pinned():
@@ -249,3 +260,16 @@ def test_write_constraints_file_defaults_to_this_interpreter(tmp_path):
 
     assert "\ntorch==" in "\n" + path.read_text(encoding="utf-8")
     assert "codefyui-backend==" not in path.read_text(encoding="utf-8")
+
+
+def test_write_constraints_file_does_not_create_its_directory(tmp_path):
+    """The CALLER owns the directory -- a per-job temporary one it makes and
+    cleans up -- so a missing one is the caller's bug and has to be raised
+    rather than papered over. A ``mkdir(parents=True)`` here would leave a
+    stray directory behind on every such bug, in a place nothing cleans."""
+    gone = tmp_path / "gone"
+
+    with pytest.raises(OSError):
+        write_constraints_file(gone)
+
+    assert not gone.exists()

--- a/backend/tests/test_packs_download.py
+++ b/backend/tests/test_packs_download.py
@@ -919,6 +919,28 @@ def test_download_asset_item_cancel_mid_download(served):
     assert not state.item_state(pack, item).present
 
 
+def test_a_cancelled_asset_download_leaves_no_part_file(served):
+    """The abandoned ``.part`` goes with the cancelled download.
+
+    ``resolve`` writes into ``<name>.part`` and renames it into place at the
+    end; a cancel raises out of the middle, so the rename never happens and
+    nothing else was ever going to name that file. For GloVe that is up to
+    69 MB of cache nothing counts, nothing shows and ``cdui packs remove``
+    does not free -- the remover only knows the item's own filename.
+
+    It is not a resumable download either: the next attempt reopens the same
+    path with ``"wb"``, which truncates.
+    """
+    pack, item = _asset_pack(DIGEST)
+    served(PAYLOAD)
+
+    with pytest.raises(PackCancelled):
+        download.download_asset_item(pack, item, emit=lambda event: None,
+                                     cancel_check=lambda: True)
+
+    assert not (cache_dir() / "thing.bin.part").exists()
+
+
 # -- the disk precheck -----------------------------------------------------
 
 

--- a/backend/tests/test_packs_download.py
+++ b/backend/tests/test_packs_download.py
@@ -489,6 +489,38 @@ def test_a_zero_size_file_cannot_drag_the_next_file_backwards():
     assert percents == sorted(percents), percents
 
 
+def test_a_file_after_an_unsized_one_still_moves_the_bar():
+    """Not clamping backwards must not mean not moving at all.
+
+    ``max(base + size, self.done)`` kept the bar from going down by pinning
+    the ceiling AT ``done`` -- which froze it there for the whole of the next
+    file, so the panel showed a stopped bar for a download that was running.
+    A file whose own ceiling is already below what has been counted is
+    uncapped instead: it cannot pull the bar down, and it can push it up.
+
+    The percentage is a separate claim from the byte counts. ``advance_to``
+    is deliberately outside the ceiling, so ``done`` can pass ``total`` and
+    the panel used to read over 100 per cent while the item still showed
+    449 MB of 476 MB.
+    """
+    events: list[dict] = []
+    meter = download._ByteMeter(emit=events.append, item_id="m", total=1000,
+                                min_interval_s=0.0)
+
+    meter.begin_file(0, 0)
+    meter.add(700)
+
+    meter.begin_file(0, 400)
+    meter.add(10)
+    meter.add(10)
+
+    assert meter.done > 700, "the bar froze for the whole of the next file"
+    meter.advance_to(5000)
+    meter.emit_now()
+    percents = [event["percent"] for event in _progress(events)]
+    assert all(percent <= 100.0 for percent in percents), percents
+
+
 # -- Hugging Face items ----------------------------------------------------
 
 

--- a/backend/tests/test_packs_flows.py
+++ b/backend/tests/test_packs_flows.py
@@ -841,6 +841,30 @@ def test_remove_item_deletes_an_asset_file(installer):
     assert asset_dir().exists(), "the cache root went with it"
 
 
+def test_remove_item_also_deletes_a_leftover_part_file(installer):
+    """The belt for ``.part`` files already on machines in the field.
+
+    ``asset_cache.resolve`` now takes its own ``.part`` with it when a
+    download is abandoned, so nothing new arrives here -- but a cache that
+    survived an interrupted install before that fix still holds one, up to
+    69 MB of it for GloVe, and "remove this model" is the only place a user
+    can reach it from. Named through ``_asset_removal_target`` rather than
+    joined by hand, so the sibling gets exactly the checks the download does.
+    """
+    pack = get_pack("word-vectors")
+    _install("word-vectors", None, installer)
+    item = get_item(pack, "glove-50d")
+    path = asset_dir() / item.filename
+    _asset_sentinel_for(pack, item, path)
+    leftover = asset_dir() / f"{item.filename}.part"
+    leftover.write_bytes(b"half a download")
+
+    assert flows.remove_item(pack, item.item_id) is True
+
+    assert not path.exists()
+    assert not leftover.exists(), "the abandoned .part outlived the pack"
+
+
 def test_remove_item_deletes_what_the_install_derived(installer):
     """Uninstalling has to free the CONVERSION too.
 

--- a/backend/tests/test_packs_service.py
+++ b/backend/tests/test_packs_service.py
@@ -281,6 +281,62 @@ async def test_current_step_tracks_step_started_and_step_done():
     await drain(service, job.job_id)
 
 
+class CapturingFlow(ScriptedFlow):
+    """A ``ScriptedFlow`` that hands the test back the ``emit`` it was given.
+
+    That is the handle a reader thread outliving its job has: ``emit`` is a
+    closure over one job's generation, and ``runner._pump`` is a DAEMON
+    thread that ``_stop_process`` joins with a TIMEOUT -- so a cancelled
+    install's reader can still be holding one after the job is over.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.emits: list = []
+
+    def __call__(self, pack: Pack, item_ids, *, emit, cancel_check):
+        self.emits.append(emit)
+        return super().__call__(pack, item_ids, emit=emit,
+                                cancel_check=cancel_check)
+
+
+async def test_a_late_event_from_a_finished_job_never_touches_the_next_one():
+    """A step stamped by whoever emitted it, not by whoever is current.
+
+    ``_store`` used to read ``self._job``, so an event arriving from a
+    finished job's reader thread set ``current_step`` on the job that had
+    replaced it -- and ``GET /api/packs`` then reported some item of the NEW
+    pack as "downloading" on the strength of the old one's log. The window
+    is real rather than theoretical: ``emit`` takes the same lock a submit
+    takes, so it can be blocked on it while the next job is being installed
+    into ``self._job``.
+
+    The event is still BUFFERED. The buffer belongs to whatever job is
+    current and a stray line in it is visible, explainable and harmless; a
+    wrong item badge is none of those.
+    """
+    flow = CapturingFlow()
+    flow.finish()
+    service = PackService(run_flow=flow)
+
+    first = await service.submit_install(get_pack(SENTENCE), [],
+                                         mode="live", variant=None)
+    await drain(service, first.job_id)
+    assert len(flow.emits) == 1, flow.emits
+    stale_emit = flow.emits[0]
+
+    second = await service.submit_install(get_pack("word-vectors"), [],
+                                          mode="live", variant=None)
+    stale_emit({"type": "step_started", "step": "download:ghost"})
+
+    assert service.current_job() is second
+    assert second.current_step is None
+    assert first.current_step is None
+
+    flow.finish()
+    await drain(service, second.job_id)
+
+
 # ── one job at a time, and the last one stays readable ────────────────────
 
 

--- a/backend/tests/test_packs_state.py
+++ b/backend/tests/test_packs_state.py
@@ -203,6 +203,24 @@ def test_write_sentinel_is_atomic_and_readable(user_data_dir):
     assert list(path.parent.iterdir()) == [path], "a .tmp file was left behind"
 
 
+def test_write_sentinel_uses_lf_endings(user_data_dir):
+    """One line ending on every platform.
+
+    ``write_text`` with no ``newline=`` translates ``json.dumps``'s ``\\n``
+    to ``os.linesep``, so the same sentinel is written differently on
+    Windows and on Linux. It round-trips either way -- this is cosmetic --
+    but ``write_constraints_file`` already pins LF for exactly this reason
+    and two files in one feature should not disagree about it.
+
+    RED ON WINDOWS ONLY. A green run on Linux proves nothing: there
+    ``os.linesep`` is already ``\\n``.
+    """
+    path = state.write_sentinel("rag", "qwen2.5-0.5b-instruct",
+                                {"schema": 1, "path": "x"})
+
+    assert b"\r\n" not in path.read_bytes()
+
+
 def test_remove_sentinel_reports_whether_there_was_one(user_data_dir):
     state.write_sentinel("rag", "qwen2.5-0.5b-instruct", {"schema": 1})
 

--- a/backend/tests/test_packs_state.py
+++ b/backend/tests/test_packs_state.py
@@ -74,17 +74,27 @@ def _install_qwen():
     return _install_hf("rag", "qwen2.5-0.5b-instruct")
 
 
+def _asset_sentinel(pack_id: str, item_id: str, *, url, path, sha256):
+    state.write_sentinel(pack_id, item_id, {
+        "schema": 1, "pack_id": pack_id, "item_id": item_id, "kind": "asset",
+        "url": url, "path": str(path), "bytes": 30, "sha256": sha256,
+        "at": "2026-08-28T00:00:00Z",
+    })
+
+
 def _install_glove():
-    """Make the word-vectors asset look downloaded. Returns the file path."""
+    """Make the word-vectors asset look downloaded. Returns the file path.
+
+    The digest recorded is the CATALOG's, which is what a real install
+    writes: ``download._finish_asset`` stores the digest it computed off the
+    bytes that arrived, and that download only succeeded because it matched.
+    """
     item = get_item(get_pack("word-vectors"), "glove-50d")
     path = asset_dir() / item.filename
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(b"not really a word vector table")
-    state.write_sentinel("word-vectors", item.item_id, {
-        "schema": 1, "pack_id": "word-vectors", "item_id": item.item_id,
-        "kind": "asset", "url": item.url, "path": str(path), "bytes": 30,
-        "sha256": None, "at": "2026-08-28T00:00:00Z",
-    })
+    _asset_sentinel("word-vectors", item.item_id, url=item.url, path=path,
+                    sha256=item.sha256)
     return path
 
 
@@ -188,6 +198,45 @@ def test_asset_item_points_at_the_file(user_data_dir):
     assert present.snapshot_dir == path
 
     path.unlink()
+    assert not state.item_state(pack, item).present
+
+
+def test_asset_sentinel_for_the_wrong_url_reads_as_missing(user_data_dir):
+    """An asset is re-checked against the catalog, exactly as an hf item is.
+
+    The catalog is allowed to move an asset to a new URL -- a rehosted
+    mirror, a new upstream release. Yesterday's bytes are then not this
+    item's file, however present they are on disk, and the file itself
+    cannot say so: unlike a hub snapshot it carries no record of where it
+    came from except this sentinel.
+    """
+    pack, item = get_pack("word-vectors"), get_item(get_pack("word-vectors"),
+                                                    "glove-50d")
+    path = _install_glove()
+    assert state.item_state(pack, item).present
+
+    _asset_sentinel(pack.pack_id, item.item_id, url="https://elsewhere/x.gz",
+                    path=path, sha256=item.sha256)
+
+    assert not state.item_state(pack, item).present
+
+
+def test_asset_sentinel_for_the_wrong_digest_reads_as_missing(user_data_dir):
+    """A digest the catalog now records and the download does not match is
+    the same fact: those are not the bytes this item names.
+
+    An install done BEFORE a digest was recorded is unaffected -- it wrote
+    the digest it computed off the bytes that arrived, which is the one the
+    catalog then records -- so adding a digest does not invalidate anything
+    already on disk.
+    """
+    pack, item = get_pack("word-vectors"), get_item(get_pack("word-vectors"),
+                                                    "glove-50d")
+    path = _install_glove()
+
+    _asset_sentinel(pack.pack_id, item.item_id, url=item.url, path=path,
+                    sha256="0" * 64)
+
     assert not state.item_state(pack, item).present
 
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1331,6 +1331,23 @@ def update() -> None:
     # this process already imported the old dev.py either way.
     gpu, dev = _resolve_update_options(sys.argv[2:])
 
+    # A restart-mode install is a detached helper running `uv pip install`
+    # into the very venv the lines below rewrite -- two writers in one
+    # site-packages, and the loser is whichever finishes second. Same claim
+    # file `cdui start` reads (`_packs_control_dir` resolves to one path for
+    # every command in one checkout), and it clears an abandoned one on the
+    # way, so a helper that died cannot wedge `update` either.
+    #
+    # Exit 1 where `start()` exits 0. `start()` stands down because the user
+    # asked for a running server and one is on its way -- their request is
+    # being satisfied by somebody else. Nobody else is going to run this
+    # user's update, so the honest answer is a refusal, and it matches the
+    # "a server is running" refusal immediately below that scripts already
+    # gate on. After option parsing, so `--help` still answers; before the
+    # git work, which is the first irreversible thing here.
+    if not _restart_preflight():
+        sys.exit(1)
+
     # Nothing below this line is survivable by a running server: the checkout
     # is hard-realigned under it, the frontend/dist it is serving is deleted,
     # and its dependencies are rewritten in the venv it imported from. The
@@ -3537,6 +3554,13 @@ def dev() -> None:
         sys.exit(1)
     _install_frontend_deps_if_needed()
     _apply_dev_env()
+    # After `_apply_dev_env`, which is what points `CODEFYUI_USER_DATA_DIR`
+    # at this checkout's `.codefyui_dev` -- the same claim file every other
+    # command here reads. `cdui dev` starts a `--reload` uvicorn out of the
+    # venv a restart helper may be mid-way through replacing; exit 1 for the
+    # same reason `update` does, and an abandoned claim is cleared on the way.
+    if not _restart_preflight():
+        sys.exit(1)
     project = _parse_project(sys.argv[2:])
     if project is not None:
         _activate_project(project)

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1989,6 +1989,20 @@ RESTART_LOG_TAIL_LINES = 40
 #: How long a finished restart stays worth mentioning in `cdui status`.
 RESTART_NOTICE_S = 60 * 60
 
+#: Attempts at the `os.replace` that puts a control file in place, and the
+#: pause between them. On Windows CPython's `open()` does not request
+#: `FILE_SHARE_DELETE`, so replacing a file another process merely has OPEN
+#: raises `PermissionError` -- and the helper stamps its pid and then the
+#: installer's into the claim while a `cdui status` may be reading it. The
+#: window is sub-millisecond and the loser of that race is the claim itself:
+#: an unwritten `helper_pid` makes the next `cdui start` read a live restart
+#: as abandoned. A retry rather than a lock because a lock would need both
+#: sides to take it, and one of the two sides here is a user typing a
+#: command; total sleep is capped at a tenth of a second, which nobody waits
+#: on and a genuinely unwritable directory does not turn into a hang.
+ATOMIC_REPLACE_ATTEMPTS = 3
+ATOMIC_REPLACE_PAUSE_S = 0.05
+
 
 def _packs_control_dir() -> Path:
     """`<user data>/packs` -- what `app.core.packs.paths.control_dir()` returns.
@@ -2048,12 +2062,28 @@ def _write_json_atomic(path: Path, data: dict) -> bool:
 
     Never raises: the caller is on its way to starting a server again, and a
     record nobody could write is not a reason to skip that.
+
+    The `os.replace` is RETRIED, and it is the only part that is. On Windows
+    CPython's `open()` does not request `FILE_SHARE_DELETE`, so replacing a
+    file another process merely has open raises `PermissionError` -- and
+    both of this file's writers stamp into a claim a `cdui status` may be
+    reading at that instant. The window is sub-millisecond, so a couple of
+    attempts a twentieth of a second apart close it; a lock would need both
+    sides to take it and one of the two sides is a user typing a command.
+    The temp write is not retried: that file is this process's own.
     """
     tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        os.replace(tmp, path)
+        for attempt in range(ATOMIC_REPLACE_ATTEMPTS):
+            try:
+                os.replace(tmp, path)
+                break
+            except OSError:
+                if attempt + 1 == ATOMIC_REPLACE_ATTEMPTS:
+                    raise
+                time.sleep(ATOMIC_REPLACE_PAUSE_S)
         return True
     except OSError:
         try:
@@ -2069,7 +2099,19 @@ def _iso_now() -> str:
 
 
 def _iso_age_seconds(stamp) -> "float | None":
-    """Seconds since an ISO-8601 timestamp, or None when it is not one."""
+    """Seconds since an ISO-8601 timestamp, or None when it is not one.
+
+    A stamp in the FUTURE is not one either. It gives a negative age, which
+    every rule below would read as "very young" -- so a clock that stepped
+    back would hold a dead claim alive until the wall clock caught up, with
+    no deadline. A `created_at` is written by a process on this machine and
+    read by another one on this machine: a stamp from the future is a clock
+    that moved, not a claim that is young. None, which every caller here
+    already reads as "old", and no skew tolerance -- that would be a number
+    with no correct value.
+
+    Mirrored by `app.core.packs.restart._age_seconds`.
+    """
     from datetime import datetime, timezone  # noqa: PLC0415 — only needed here
     if not isinstance(stamp, str):
         return None
@@ -2079,7 +2121,8 @@ def _iso_age_seconds(stamp) -> "float | None":
         return None
     if moment.tzinfo is None:
         moment = moment.replace(tzinfo=timezone.utc)
-    return (datetime.now(timezone.utc) - moment).total_seconds()
+    age = (datetime.now(timezone.utc) - moment).total_seconds()
+    return None if age < 0 else age
 
 
 def _pending_age_seconds(path: Path, data: "dict | None") -> "float | None":
@@ -2319,8 +2362,16 @@ def _is_plain_requirement(spec: str) -> bool:
     return not match.group("name").lower().endswith(_ARCHIVE_SUFFIXES)
 
 
-def _validate_pending(data: "dict | None") -> "str | None":
+def _validate_pending(data: "dict | None") -> "tuple[str, bool] | None":
     """Why this pending file must not be acted on, or None when it may be.
+
+    Returns `(problem, foreign)`. `foreign` is True for the three OWNERSHIP
+    refusals -- the launcher script, the launcher interpreter and
+    `venv_python` -- which do not say the file is malformed, they say
+    another installation wrote it. That distinction decides what
+    `_run_pending_steps` may do to the file afterwards, so it is answered
+    here, where the checks already are, rather than by a second function
+    re-running them: two readers of one rule drift.
 
     Every check answers one question: did THIS installation's server write
     this file? It names an interpreter to install into, a package index to
@@ -2332,26 +2383,28 @@ def _validate_pending(data: "dict | None") -> "str | None":
     starting one "back" would be starting a second one.
     """
     if data is None:
-        return "the pending file is missing, empty or unreadable"
+        return "the pending file is missing, empty or unreadable", False
 
     schema = data.get("schema")
     if isinstance(schema, bool) or schema != PENDING_SCHEMA:
-        return f"schema {schema!r} is not {PENDING_SCHEMA}"
+        return f"schema {schema!r} is not {PENDING_SCHEMA}", False
 
     kind = data.get("kind")
     if kind not in ("torch", "pip"):
-        return f"kind {kind!r} is not 'torch' or 'pip'"
+        return f"kind {kind!r} is not 'torch' or 'pip'", False
 
     launcher = data.get("launcher")
     if (not isinstance(launcher, list) or len(launcher) != 2
             or not all(isinstance(part, str) and part for part in launcher)):
-        return "launcher is not exactly an interpreter and a script"
+        # A SHAPE refusal, not an ownership one: nobody's launcher looks
+        # like this, so no live helper is acting on this file.
+        return "launcher is not exactly an interpreter and a script", False
     try:
         mine = Path(launcher[1]).resolve() == Path(__file__).resolve()
     except OSError:
         mine = False
     if not mine:
-        return f"launcher {launcher[1]!r} is not this installation's dev.py"
+        return f"launcher {launcher[1]!r} is not this installation's dev.py", True
     try:
         # THIS interpreter, not merely one that exists. `spawn_helper` starts
         # the helper as `[launcher[0], dev.py, packs-run-pending, <file>]`, so
@@ -2368,16 +2421,16 @@ def _validate_pending(data: "dict | None") -> "str | None":
         runnable = False
     if not runnable:
         return (f"launcher {launcher[0]!r} is not the interpreter this helper "
-                f"is running on")
+                f"is running on", True)
 
     relaunch = data.get("relaunch_argv")
     if (not isinstance(relaunch, list)
             or not all(isinstance(part, str) for part in relaunch)):
-        return "relaunch_argv is not a list of strings"
+        return "relaunch_argv is not a list of strings", False
 
     venv_python = data.get("venv_python")
     if not isinstance(venv_python, str) or not venv_python:
-        return "venv_python is not a path"
+        return "venv_python is not a path", False
     # The DIRECTORY is resolved and the leaf name is not. Resolving the whole
     # path would follow the interpreter itself, and on POSIX `uv venv`
     # symlinks `.venv/bin/python` straight at the uv-managed base interpreter
@@ -2393,27 +2446,27 @@ def _validate_pending(data: "dict | None") -> "str | None":
     except OSError:
         inside = False
     if not inside:
-        return f"venv_python {venv_python!r} is not inside {VENV}"
+        return f"venv_python {venv_python!r} is not inside {VENV}", True
 
     pid = data.get("server_pid")
     if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
-        return f"server_pid {pid!r} is not a process id"
+        return f"server_pid {pid!r} is not a process id", False
 
     if kind == "torch":
         index_url = data.get("index_url")
         if index_url is not None and index_url not in set(TORCH_INDEX_URLS.values()):
             return (f"index_url {index_url!r} is not one of the PyTorch wheel "
-                    f"indexes this launcher installs from")
+                    f"indexes this launcher installs from", False)
     else:
         specs = data.get("specs")
         if (not isinstance(specs, list)
                 or not all(isinstance(s, str) and s for s in specs)):
-            return "specs is not a list of package requirements"
+            return "specs is not a list of package requirements", False
         for spec in specs:
             if not _is_plain_requirement(spec):
                 return (f"spec {spec!r} is not a package requirement; only a "
                         f"name with an optional version range is installed "
-                        f"from here")
+                        f"from here", False)
     return None
 
 
@@ -2795,10 +2848,19 @@ def _run_pending_steps(pending_path: Path) -> int:
     down and has nothing to give back.
     """
     data = _read_json_file(pending_path)
-    problem = _validate_pending(data)
-    if problem is not None:
+    refusal = _validate_pending(data)
+    if refusal is not None:
+        problem, foreign = refusal
         err(f"拒絕執行這個重啟安裝：{problem}",
             f"refusing to run this restart install: {problem}")
+        if foreign:
+            # Not ours to write to. Both files below live in the control
+            # directory of the installation that WROTE this claim: its live
+            # helper may still be acting on the claim, and its outcome
+            # record is the last real report its user can read. A refusal
+            # that says "this is not mine" and then edits it anyway is the
+            # bug, not the fix. Printed and left exactly as found.
+            return 2
         if data is not None:
             # A file that could not even be parsed names no job, and writing
             # "refused" over `last_restart_job.json` would erase the report of

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -2914,9 +2914,16 @@ def _run_pending_steps(pending_path: Path) -> int:
     # Declared out here because the handler below is: an interrupt has to be
     # able to stop an installer that HAS started, from a phase that has not.
     installer: list = []
+    # Whether the wait for the old server ever ANSWERED. False only while an
+    # interrupt is inside it, and the `finally` needs to know: relaunching
+    # over a server that is still on its way out is how a user ends up with
+    # none. `alive` counts as answered -- that case is decided here, on
+    # purpose, and its pidfile is still true.
+    waited = False
 
     try:
         how = _wait_for_server_exit(data["server_pid"])
+        waited = True
         if how != "alive":
             _forget_stopped_server()
         if how == "exited":
@@ -2977,7 +2984,7 @@ def _run_pending_steps(pending_path: Path) -> int:
         _finish(status="failed", returncode=code,
                 message=f"the installer exited with {code}", log_tail=tail)
         return 1
-    except BaseException:
+    except BaseException as exc:
         # Ctrl-C, a SIGTERM (see `_raise_on_sigterm`), a closed console: this
         # process is going. It covers the WHOLE run, not just the install,
         # because `_raise_on_sigterm` does -- the server wait alone is up to
@@ -2988,14 +2995,40 @@ def _run_pending_steps(pending_path: Path) -> int:
         # status` will read it, and let the exception out: the `finally`
         # below still relaunches, and a server that comes back and reports
         # beats none at all.
+        #
+        # And it says WHICH of those happened. `BaseException` also catches a
+        # KeyError on a claim field, a MemoryError, any genuine traceback --
+        # all of which used to be written up as "interrupted", sending the
+        # user to look for a Ctrl-C they never typed.
         for proc in installer:
             _terminate_pid(proc.pid)
-        message = "the install was interrupted before it finished"
-        err("安裝被中斷，已停止安裝程式", message)
+        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            message = "the install was interrupted before it finished"
+            err("安裝被中斷，已停止安裝程式", message)
+        else:
+            message = f"the restart helper failed: {exc!r}"
+            err(f"重啟安裝程式發生錯誤：{exc!r}", message)
         _finish(status="failed", returncode=None, message=message,
                 log_tail=[])
         raise
     finally:
+        if not waited:
+            # The wait never answered -- an interrupt landed inside it -- so
+            # the old server may well still be on its way out. Relaunching
+            # now would find its pidfile, print "already running", exit 0
+            # and record `relaunch: ok`; the old server would then finish
+            # exiting and leave nothing behind it. The SAME wait, not a
+            # shorter one: what it is waiting for has not changed, and a
+            # bespoke grace would be a second rule for one file.
+            #
+            # Wrapped, because this runs in a `finally` on the way out of an
+            # exception that is already travelling: an error here would
+            # replace it, and the user would be told about the wrong thing.
+            try:
+                if _wait_for_server_exit(data["server_pid"]) != "alive":
+                    _forget_stopped_server()
+            except BaseException:
+                pass
         pid = _relaunch_server(list(data["launcher"]),
                                list(data["relaunch_argv"]), log_path)
         if record:

--- a/scripts/packs.py
+++ b/scripts/packs.py
@@ -321,14 +321,18 @@ def _pending_items(pack, probe, item_ids: list[str] | None) -> list:
     """What this install would download, for the size prompt.
 
     Mirrors ``flows._resolve_items``: named items, or everything not already
-    on disk. The flow decides again for itself from a fresh probe -- this
-    copy only ever feeds a sentence shown to a human.
+    on disk -- and either way, only what is not on disk. The flow decides
+    again for itself from a fresh probe; this copy only ever feeds a
+    sentence shown to a human, and that sentence has to be about what will
+    actually be fetched. Quoting a named item that is already here asks
+    somebody to approve megabytes nothing is going to download.
     """
     from app.core.packs import catalog
 
-    if item_ids is not None:
-        return [catalog.get_item(pack, item_id) for item_id in item_ids]
     present = {item.item_id for item in probe.items if item.present}
+    if item_ids is not None:
+        return [catalog.get_item(pack, item_id) for item_id in item_ids
+                if item_id not in present]
     return [item for item in pack.items if item.item_id not in present]
 
 
@@ -547,7 +551,12 @@ def cmd_remove(args: argparse.Namespace) -> int:
              f"{item.item_id} is no longer registered, but its files are "
              f"still on disk (something may be holding them open)")
 
-    names = _dist_names(pack)
+    # Only when a removal actually happened, or was attempted on something
+    # that was there. The hint answers "your model is gone but its Python
+    # packages are not"; after "nothing to remove" it answers a question
+    # nobody asked, in the longest line on the screen -- competing for
+    # attention with the one line that matters.
+    names = _dist_names(pack) if (removed or was_present) else []
     if names:
         info("Python 套件不會一併移除。要移除的話：",
              "Python packages are not removed. To remove them:")


### PR DESCRIPTION
> 中文摘要：套件中心後端與啟動器在 #380 裡延後的小項，一次收掉：目錄驗證補上測試早就假設的四條規則、`gpu-torch` 的 id 只寫一次、sentinel 用 LF；進度條不會卡住也不會超過 100%，資產 sentinel 會對照目錄裡的網址與雜湊；中斷的下載會把 `.part` 殘檔一起帶走；上一個工作晚到的事件不會蓋到下一個工作的步驟；待處理檔的規則兩邊一致——時鐘倒退不會把它卡住、Windows 上短暫的共用衝突不會讓 PID 登記失敗、別的安裝目錄的待處理檔只拒絕不刪除；被中斷的輔助程序會先等舊伺服器結束再重新啟動、程式錯誤保留自己的訊息；`cdui update` 與 `cdui dev` 在重啟安裝進行中會拒絕（exit 1）；兩個 CLI 提示修正。

## What this changes

Eight self-contained groups, safest first, each with its red-first test (full detail in the review trail):

1. **Catalog + data reads.** `catalog._validate` now enforces `approx_bytes > 0`, a non-empty licence, single-component asset filenames and asset-filename uniqueness across packs; one public `catalog.GPU_TORCH_PACK_ID` replaces two private copies; a guard pins that the only restart-mode pack is the GPU pack; sentinels are written with LF; two constraints-suite tests stop depending on a transitive package.
2. **Progress and state.** The byte meter no longer freezes a file's bar after an unsized file, and the reported percent is clamped to 100; an asset sentinel is re-checked against the catalog's URL and digest the way an HF sentinel is checked against its revision; `check_disk` documents which volume it measures.
3. **Downloads.** An interrupted or cancelled asset download deletes its `.part` file (in `asset_cache.resolve`, the one place that names it); `cdui packs remove` also sweeps a leftover `.part`.
4. **Job runner.** A late event from a finished job's reader thread can no longer stamp `current_step` on the next job.
5. **The claim file, both sides.** A `created_at` in the future reads as unreadable (no skew tolerance) in both `restart.py` and `dev.py`, with the parity test extended; `_write_json_atomic` retries `os.replace` a bounded number of times on a Windows sharing violation; a claim that belongs to another checkout is refused but neither deleted nor overwritten with an outcome record.
6. **The helper's exit paths.** An interrupt that lands during the server wait now waits for the old server (and forgets its pidfile) before relaunching, so the relaunch cannot collide with a server that is still leaving; a genuine crash keeps its own exception in the outcome record instead of being reported as an interrupt.
7. **`cdui update` and `cdui dev`** refuse (exit 1) while a restart-mode install is finishing — `update` would rewrite the venv `uv` is mid-way through, `dev` would start a reload server out of it — and still proceed when the claim is abandoned.
8. **Two console refusals.** The `--items` size prompt no longer counts items already on disk; `remove` stops printing the pip hint when there was nothing to remove.

Not changed: the allowlist, the remote-install gate, `test_auth_drift.py`, the frontend, the docs. The `later` list from the triage (venv-scoped claim, `--wait-for-restart`, a phase field for `cdui status`, the events-route note for the deployment docs, ...) stays in #380.

## Verification

- Backend: 6211 tests green on Windows (26 skipped; one pre-existing test that fails only on the Python 3.14 venv used here was deselected - CI's 3.10-3.12 jobs run it), ruff clean; a whole-diff review (approved; five minors) plus a one-line guard for the one minor worth taking - a cleanup unlink can no longer replace the exception it cleans up after - with its red-first test.
- Found on the way and filed separately: `uv.lock` pins `huggingface_hub` 1.10.1, below the 1.19 where the xet abort hook the cancel path uses first appears (CI resolves 1.29 fresh, so CI never sees it) - #386; one pre-existing test fails only on Python 3.14 - #387.
- No browser change; the percent clamp is visible in the Package Center and was left for the next Chrome pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jh5Fbd8CJdJ2wtva3ePr7C
