### PR TITLE
docs(changelog): remove the conflict markers left in the link-definition footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2569,18 +2569,15 @@ Release candidates before 1.0.0 are on the
 [#357]: https://github.com/CodefyUI/CodefyUI/pull/357
 [#359]: https://github.com/CodefyUI/CodefyUI/pull/359
 [#360]: https://github.com/CodefyUI/CodefyUI/issues/360
-<<<<<<< HEAD
 [#380]: https://github.com/CodefyUI/CodefyUI/issues/380
 [#386]: https://github.com/CodefyUI/CodefyUI/issues/386
 [#387]: https://github.com/CodefyUI/CodefyUI/issues/387
-=======
 [#371]: https://github.com/CodefyUI/CodefyUI/pull/371
 [#372]: https://github.com/CodefyUI/CodefyUI/issues/372
 [#305]: https://github.com/CodefyUI/CodefyUI/issues/305
 [#323]: https://github.com/CodefyUI/CodefyUI/issues/323
 [#325]: https://github.com/CodefyUI/CodefyUI/issues/325
 [#337]: https://github.com/CodefyUI/CodefyUI/issues/337
->>>>>>> origin/main
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...main


### PR DESCRIPTION
> 中文摘要：CHANGELOG.md 檔尾的連結定義區從 #388 合併時就留著一組衝突標記（那次把 main 併進分支時衝突有兩處，我只處理了 Unreleased 區段那一處，第二處被誤判成引用範例而提交了），之後 #389、#391、#392、#393 的定義都插在那個舊區塊裡面。這個 PR 拿掉三行標記，九個定義全部保留。

The merge of main into the backend follow-ups branch (#388) conflicted in two places in `CHANGELOG.md`. The resolver handled the Unreleased bullets; the second block - the `[#nnn]: url` link definitions at the end of the file - was committed with its markers and squash-merged as b66a4a0. Every PR since (#389, #391, #392, #393) inserted its definitions inside that stale block, which is why the block now spans nine definitions.

Change: the three marker lines go (`<<<<<<< HEAD`, `=======`, `>>>>>>> origin/main`); all nine definitions stay. Whole-file marker grep is 0, `git diff --check` is clean, CRLF intact. No other file.

Lesson recorded for the session's process: after any merge, grep the whole file for markers and treat every `git diff --check` hit as a defect until read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jh5Fbd8CJdJ2wtva3ePr7C