### PR TITLE
feat(plugins): apiVersion 5 — a plugin can open, read and safely write any tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,36 @@ received — each links to the release it was published as.
 
 ### Added
 
+- **Plugin frontend contract apiVersion 5: a plugin gets the tab strip, and
+  an agent gets four more kinds of edit.** `api.workspace` lets a plugin open
+  a graph as a labelled, optionally read-only editor tab without moving the
+  user off the one they were on, read any tab whole, and write to a named tab
+  only if its `revision` still matches the one it was holding ([#341]). That
+  replaces the only guard a plugin had — stringifying the whole graph before
+  and after and comparing — which a settling auto-layout was enough to
+  invalidate, so a correct promotion got refused for no reason. The write
+  refuses in a fixed order and without a side effect at any step: an unknown
+  tab, then a read-only tab, then a tab whose canvas is showing a block's
+  insides, then a stale revision — and a mismatch hands back the CURRENT
+  revision, so the plugin re-arms without a second read that races the same
+  way. `atomic: true` is the all-or-nothing preflight the first consumer was
+  getting by re-implementing our own reducer; the real one already works on
+  copies, and the full-length results still say which op was wrong.
+  `onChanged` reports added tabs, document changes, activations and closes
+  across every tab, with the writing plugin's id attached so a plugin can
+  ignore its own edits. Tabs a plugin opens do not survive a reload unless it
+  asks for that, and the tab bar shows a read-only badge and names the plugin
+  that opened a tab. Six new graph operations come with it ([#342]):
+  `move_node` places one node and brings its bound notes along, so a model
+  can stop reaching for `auto_layout` — an op that throws away every position
+  the user arranged; `set_segment` / `remove_segment` mark a subsystem with
+  the overlay the Teaching Inspector already draws; `add_note` /
+  `update_note` write the sticky note the canvas already has; and
+  `set_node_meta` names a node. The whole batch is still one Ctrl+Z.
+  Feature-check with `api.apiVersion >= 5` or
+  `typeof api.workspace?.openGraphs === "function"`; apiVersion 4 is frozen
+  under its own contract assertion, as 3 and 2 were.
+
 - **Package Center — the optional four hundred megabytes a lesson needs now
   install from inside the app.** A stock CodefyUI is deliberately small
   enough to hand to a classroom, which means the parts a sentence-embedding
@@ -348,6 +378,25 @@ received — each links to the release it was published as.
   Dismiss reachable, and a node names its missing pack once — banner over hint,
   header badge over param chip, shorter option suffix.
 
+- **A read-only tab now refuses `api.graph.applyOperations` instead of
+  accepting it** ([#341]). Every op in the batch comes back
+  `{ ok: false, error: "tab is read-only" }` and nothing is written. Until
+  now `readOnly` — set when a graph file was written by a newer CodefyUI than
+  this one — stopped Save and stopped the editor's own structural actions,
+  but the plugin write path never consulted it, so a plugin could edit a
+  document this build had already said it does not fully understand. This is
+  the only behaviour an installed plugin can notice in apiVersion 5.
+
+- **A plugin's batch lands as one write, and takes the canvas state that
+  depends on it with it** ([#341]). `api.graph.applyOperations` set the nodes
+  and then set the edges, so a subscriber woken between the two saw a graph
+  whose edges named nodes that were not there yet; it is now the same single
+  commit the workspace path uses, writing nodes, edges and the top-level
+  segment overlays together. That commit also clears a detail modal or a
+  canvas selection naming a node the batch removed — otherwise an undo
+  restoring the node popped the modal back open by itself — and drops a
+  segment highlight pointing at an overlay that is no longer in the list.
+
 ### Fixed
 
 - **The engine puts a node's inputs on the device that node runs on**
@@ -521,6 +570,22 @@ received — each links to the release it was published as.
   store: all six open a portal modal, and restoring one after viewport
   culling would reopen it by itself, so #324 stays open with the real fix
   recorded there.
+
+- **A renamed node keeps its name through save and reload** ([#342]). The
+  reader has always looked for `data.label` and the writer never wrote it, so
+  renaming a node in the editor lasted exactly as long as the session and
+  `getGraph()` never saw it at all. The serializer now writes `label`
+  whenever it differs from the node's type, which is precisely what the
+  reader falls back to — so a graph nobody has renamed anything in still
+  serializes byte-for-byte as before. Start needed one line more: its branch
+  of the reader hardcoded `Start` rather than reading the key, which was
+  harmless only while nothing wrote it.
+- **The Delete key prunes the segment overlays naming the node it deleted**
+  ([#341]). The context menu's Delete already did; React Flow's Delete key
+  goes through a different path that unbound notes and closed modals but left
+  the segments alone. A segment whose head or tail is gone can never resolve
+  a path, so it drew nothing on the canvas while staying in the tab — and
+  getting written to the file on the next save.
 
 ## [2.4.1] — 2026-08-22
 
@@ -2578,6 +2643,8 @@ Release candidates before 1.0.0 are on the
 [#323]: https://github.com/CodefyUI/CodefyUI/issues/323
 [#325]: https://github.com/CodefyUI/CodefyUI/issues/325
 [#337]: https://github.com/CodefyUI/CodefyUI/issues/337
+[#341]: https://github.com/CodefyUI/CodefyUI/issues/341
+[#342]: https://github.com/CodefyUI/CodefyUI/issues/342
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...main

--- a/backend/tests/test_graph_label_roundtrip.py
+++ b/backend/tests/test_graph_label_roundtrip.py
@@ -1,0 +1,91 @@
+"""A renamed node keeps its name through save and load (#342).
+
+``data.label`` is written by the editor's serializer from plugin API v5 on,
+and the backend has to carry it. Nothing in ``schemas/models.py`` needs to
+change for that -- ``NodeData.data`` is ``dict[str, Any]`` with no ``extra=``
+config -- but "nothing needs to change" is a claim, and this is the test that
+makes it one you can check.
+
+Project mode gets its own case because ``split_graph`` DOES strip keys out of
+a node's ``data``: the four note-geometry keys, and only from note nodes. A
+regular node's ``label`` is logic and belongs in the reviewable graph file.
+"""
+
+import json
+
+import pytest
+
+from app.api import routes_graph
+
+
+@pytest.fixture
+def project_settings(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", tmp_path)
+    monkeypatch.setattr(routes_graph.settings, "GRAPHS_DIR", tmp_path / "graphs")
+    (tmp_path / "graphs").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "layout").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _graph(label=None, name="labelled"):
+    data = {"params": {"name": "MNIST"}}
+    if label is not None:
+        data["label"] = label
+    return {
+        "name": name,
+        "description": "",
+        "nodes": [
+            {"id": "a", "type": "Dataset", "position": {"x": 10, "y": 0}, "data": data},
+        ],
+        "edges": [],
+        "presets": [],
+        "segmentGroups": [],
+    }
+
+
+async def test_label_round_trips_in_single_file_mode(test_client, tmp_path, monkeypatch):
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", None)
+    monkeypatch.setattr(routes_graph.settings, "GRAPHS_DIR", tmp_path)
+
+    r = await test_client.post("/api/graph/save", json=_graph(label="Training set"))
+    assert r.status_code == 200
+
+    r = await test_client.get("/api/graph/load/labelled")
+    assert r.status_code == 200
+    assert r.json()["nodes"][0]["data"]["label"] == "Training set"
+
+
+async def test_a_graph_without_a_label_stays_without_one(test_client, tmp_path, monkeypatch):
+    monkeypatch.setattr(routes_graph.settings, "PROJECT_DIR", None)
+    monkeypatch.setattr(routes_graph.settings, "GRAPHS_DIR", tmp_path)
+
+    await test_client.post("/api/graph/save", json=_graph())
+    r = await test_client.get("/api/graph/load/labelled")
+    assert "label" not in r.json()["nodes"][0]["data"]
+
+
+async def test_label_is_logic_in_project_mode(project_settings, test_client):
+    await test_client.post("/api/graph/save", json=_graph(label="Training set"))
+
+    logic = json.loads((project_settings / "graphs" / "labelled.graph.json").read_text())
+    layout = json.loads((project_settings / "layout" / "labelled.layout.json").read_text())
+    # The reviewable file is where a rename belongs: it is a change to what the
+    # graph MEANS, not to where it sits.
+    assert logic["nodes"][0]["data"]["label"] == "Training set"
+    assert "label" not in json.dumps(layout)
+
+    r = await test_client.get("/api/graph/load/labelled")
+    assert r.json()["nodes"][0]["data"]["label"] == "Training set"
+
+
+async def test_renaming_a_node_dirties_only_the_logic_file(project_settings, test_client):
+    await test_client.post("/api/graph/save", json=_graph(label="Training set"))
+    logic1 = (project_settings / "graphs" / "labelled.graph.json").read_text()
+    layout1 = (project_settings / "layout" / "labelled.layout.json").read_text()
+
+    await test_client.post("/api/graph/save", json=_graph(label="Validation set"))
+    logic2 = (project_settings / "graphs" / "labelled.graph.json").read_text()
+    layout2 = (project_settings / "layout" / "labelled.layout.json").read_text()
+
+    assert layout1 == layout2
+    assert logic1 != logic2

--- a/docs/docs/advanced/plugin-frontend-extensions.md
+++ b/docs/docs/advanced/plugin-frontend-extensions.md
@@ -338,7 +338,7 @@ Each entry is validated in this order, and a failure produces a result with an `
 1. `title` must be a non-empty string — `invalid_graph`.
 2. `graph` must survive `JSON.stringify` — `invalid_graph`.
 3. That JSON must be at most 8 MiB — `too_large`.
-4. The graph must read through the editor's document reader, the same one opening a gallery example uses: node params are merged onto their definition's presets, unknown top-level keys are ignored, `subgraphs`, `segmentGroups` and `presets` are honoured, and a `format_version` newer than this editor opens the tab read-only exactly as a file would. A reader failure is `invalid_graph`, with the reader's own message.
+4. The graph must read through the editor's document reader, the same one opening a gallery example uses: a node's `params` are taken exactly as the entry wrote them, and nothing is filled in from its definition or its preset — a param you leave out stays out; unknown top-level keys are ignored, `subgraphs`, `segmentGroups` and `presets` are honoured, and a `format_version` newer than this editor opens the tab read-only exactly as a file would. A reader failure is `invalid_graph`, with the reader's own message.
 5. Opening must not take the editor past 32 tabs — `too_many_tabs`.
 
 The tab count is checked last, against the live count, so two entries in one call cannot both slip under a limit only one of them fits. The cost of that order is that an entry refused with `too_many_tabs` has already been read: presets it carries that this server has never seen are merged into the palette even though no tab was opened.

--- a/docs/docs/advanced/plugin-frontend-extensions.md
+++ b/docs/docs/advanced/plugin-frontend-extensions.md
@@ -11,12 +11,12 @@ A plugin pack can ship a JavaScript bundle alongside its Python nodes. When the 
 :::note Availability
 Frontend extensions are in CodefyUI **1.3.0** and later. Check `cdui --version`; if it reports an older version, run `cdui update`.
 
-Dock panels, toolbar buttons, execution events and the runs facade need **apiVersion 3** (CodefyUI 2.0.0 and later); `graph.getView` needs **apiVersion 4** (CodefyUI 2.3.0 and later). Feature-check before you use them — see [API versions](#api-versions).
+Dock panels, toolbar buttons, execution events and the runs facade need **apiVersion 3** (CodefyUI 2.0.0 and later); `graph.getView` needs **apiVersion 4** (CodefyUI 2.3.0 and later); `api.workspace` and the six agent canvas operations need **apiVersion 5** (*next release (unreleased)* {/* stamp-on-release */} and later). Feature-check before you use them — see [API versions](#api-versions).
 :::
 
 ## API versions
 
-`api.apiVersion` is a number that only ever grows, and every release so far has been **purely additive**: nothing that worked at an older version has been removed or changed shape. A plugin written for apiVersion 2 keeps working on an apiVersion 4 editor with no changes at all.
+`api.apiVersion` is a number that only ever grows, and every release has been **additive in shape**: nothing that worked at an older version has been removed or changed signature. A plugin written for apiVersion 2 keeps working on an apiVersion 5 editor with no changes at all, with one exception that apiVersion 5 introduces and that is written down in full below — [a read-only tab now refuses a write](#one-change-for-plugins-written-before-apiversion-5).
 
 | `apiVersion` | CodefyUI | Added |
 |--------------|----------|-------|
@@ -24,6 +24,7 @@ Dock panels, toolbar buttons, execution events and the runs facade need **apiVer
 | 2 | 1.3.0 | `nodes.registerRenderer` |
 | 3 | 2.0.0 | `ui.addPanel` / `removePanel`, `ui.addToolbarButton` / `removeToolbarButton`, `events.onExecution`, `runs.*` |
 | 4 | 2.3.0 | `graph.getView` — which level of the graph the user is looking at |
+| 5 | *next release (unreleased)* {/* stamp-on-release */} | `workspace.*` — tabs, snapshots and compare-and-swap writes; `move_node`, `set_segment` / `remove_segment`, `add_note` / `update_note`, `set_node_meta` |
 
 Check it before reaching for anything newer than the version you require, and degrade rather than throw:
 
@@ -189,7 +190,7 @@ Re-adding an id replaces the button. The remove function you get back belongs to
 
 #### GraphOp table
 
-All seven operation types share the property `op` (the discriminant string). Field names below are exact.
+All thirteen operation types share the property `op` (the discriminant string). Field names below are exact.
 
 | `op` | Fields | Description |
 |------|--------|-------------|
@@ -200,6 +201,12 @@ All seven operation types share the property `op` (the discriminant string). Fie
 | `"remove_edge"` | `source: string`, `target: string`, `source_handle?: string`, `target_handle?: string` | Disconnect matching edge(s) between two nodes. |
 | `"clear_graph"` | *(none)* | Remove all nodes and edges. |
 | `"auto_layout"` | *(none)* | Re-run the automatic graph layout. |
+| `"move_node"` | `node_id: string`, `position: { x: number; y: number }` | **apiVersion 5.** Put one node at an exact position. Any note bound to that node moves with it, exactly as it does when the user drags the node. |
+| `"set_segment"` | `segment_id?: string`, `head_node_id: string`, `tail_node_id: string` | **apiVersion 5.** Create or replace a segment overlay — the bubble the editor draws around every node on a data path from head to tail. Omit `segment_id` to create; pass an existing one to move it. The result carries the id either way, in `segment_id`. Fails when no data-edge path joins the two, and when either end is a note. |
+| `"remove_segment"` | `segment_id: string` | **apiVersion 5.** Remove a segment overlay. |
+| `"add_note"` | `ref?: string`, `text: string`, `position?: { x: number; y: number }`, `color?: string`, `bind_to?: string` | **apiVersion 5.** Add a text note. `text` is 1 to 4000 characters and may hold newlines and tabs but no other control characters; `color` is `#rrggbb`; `bind_to` attaches the note to a node so it follows that node, and defaults its position beside it. Notes are never executed, exported or validated. |
+| `"update_note"` | `node_id: string`, `text?: string`, `color?: string` | **apiVersion 5.** Rewrite an existing note. At least one of `text` and `color` is required, and `text` applies to a text note only — an image note's content is its data URL. |
+| `"set_node_meta"` | `node_id: string`, `label: string` | **apiVersion 5.** Name a node. 1 to 120 characters on one line, trimmed. The label is stored beside `params`, never inside it, and now survives save and reload. |
 
 #### ApplyResult shape
 
@@ -208,7 +215,8 @@ interface OpResult {
   index: number;      // the op's position in the batch
   ok: boolean;        // whether this op applied
   error?: string;     // failure reason when ok is false
-  node_id?: string;   // resolved node id (add_node / set_params)
+  node_id?: string;   // resolved node id, from every op that names or creates one
+  segment_id?: string; // apiVersion 5: the id set_segment created or replaced
 }
 
 interface ApplyResult {
@@ -262,6 +270,166 @@ Refusing is not the only honest answer — waiting, or scoping the edit to somet
 The view is **read-only**, and read live: each call is a fresh answer, and there is deliberately no way to navigate somebody's editor from a plugin. `onGraphChanged` fires when the user steps into or out of a block (the canvas changed, after all), so a panel that displays where it would write can re-read `getView()` from that callback.
 
 Where a write lands is the editor's long-standing behaviour, now written down rather than changed. A later revision may let an op name its target level explicitly; it will do that by adding something, not by quietly redirecting the writes that installed plugins already make.
+
+### `api.workspace` — tabs and compare-and-swap writes
+
+Requires `api.apiVersion >= 5`. On an older editor `api.workspace` is `undefined` — it is never stubbed with methods that throw, so `typeof api.workspace?.openGraphs === "function"` is an honest check.
+
+`api.graph` sees one graph: the one in front of the user. `api.workspace` sees the tab strip. It exists for the plugin that wants to put a proposal somewhere the user can look at it without touching what they were doing, and to write back only if they have not changed it meanwhile.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `openGraphs` | `(entries, options?) => WorkspaceOpenResult[]` | Open one or more graphs as editor tabs. The result is **positional**: `result[i]` describes `entries[i]`, and one bad entry never affects another. |
+| `tabs` | `() => WorkspaceTabInfo[]` | Every tab, in strip order, with `active` on the one the user is looking at. |
+| `snapshot` | `(tabId?) => WorkspaceSnapshot` | A tab's identity plus its whole graph. No id means the active tab. An unknown id returns `{ error: "unknown_tab" }` rather than throwing. |
+| `applyOperations` | `(request) => WorkspaceApplyResult` | Apply a batch to a named tab, optionally only if its revision still matches, optionally all-or-nothing. |
+| `onChanged` | `(callback) => () => void` | Subscribe to tab and document changes across every tab. Returns an unsubscribe function. |
+
+#### Revisions
+
+Every tab carries a `revision`: a number that starts at 1 and goes up by one every time the tab's document changes. Dragging a node changes it. So do undo and redo — they restore older content, which is still a change. Renaming the tab, switching to it, selecting a node, panning the canvas and highlighting a segment do not — and neither does a run, whose per-node status, error and progress are painted on the canvas but never written to the saved file. A compare-and-swap therefore does not expire several times a second while a model trains.
+
+The number only ever climbs, and it is saved with the tab, so a revision you stored before a reload still means something afterwards. That is the whole point: hold a revision, go away and think for two minutes, and hand it back with your write.
+
+```ts
+interface WorkspaceTabInfo {
+  tabId: string;
+  title: string;
+  revision: number;
+  readOnly: boolean;
+  transient: boolean;               // gone after a reload
+  source: WorkspaceSource | null;   // who opened it
+  active: boolean;
+}
+
+interface WorkspaceSource {
+  kind: string;         // your own label, e.g. "agent-variant"
+  pluginId: string;
+  jobId?: string;
+  variantId?: string;
+  [key: string]: unknown;   // opaque to the editor, handed back verbatim
+}
+```
+
+#### Opening graphs
+
+```ts
+const opened = api.workspace.openGraphs(
+  candidates.map((c) => ({
+    title: `${hypothesis} — ${c.label}`,
+    graph: c.graph,                 // the shape getGraph() answers with
+    readOnly: true,
+    source: { kind: "agent-variant", pluginId: api.pluginId, variantId: c.id },
+  })),
+  { activate: "first" },
+);
+
+for (const [i, result] of opened.entries()) {
+  if ("error" in result) {
+    api.ui.toast(`Candidate ${i + 1} not opened: ${result.error}`, "error");
+    continue;
+  }
+  remember(result.tabId, result.revision);
+}
+```
+
+Each entry is validated in this order, and a failure produces a result with an `error` sentence and a `code`:
+
+1. `title` must be a non-empty string — `invalid_graph`.
+2. `graph` must survive `JSON.stringify` — `invalid_graph`.
+3. That JSON must be at most 8 MiB — `too_large`.
+4. The graph must read through the editor's document reader, the same one opening a gallery example uses: node params are merged onto their definition's presets, unknown top-level keys are ignored, `subgraphs`, `segmentGroups` and `presets` are honoured, and a `format_version` newer than this editor opens the tab read-only exactly as a file would. A reader failure is `invalid_graph`, with the reader's own message.
+5. Opening must not take the editor past 32 tabs — `too_many_tabs`.
+
+The tab count is checked last, against the live count, so two entries in one call cannot both slip under a limit only one of them fits. The cost of that order is that an entry refused with `too_many_tabs` has already been read: presets it carries that this server has never seen are merged into the palette even though no tab was opened.
+
+`options.activate` is `"first"` (the default), `"last"`, or `"none"` to leave the user where they are.
+
+An opened tab is an ordinary tab afterwards. The user can rename it, close it, or Save As into a real graph file — and opening that file gives them an editable tab the usual way. `readOnly` belongs to the tab and lasts until the tab is closed.
+
+Tabs you open are **transient** by default: they are not written to the editor's autosave, so they are gone after a reload. Pass `persist: true` if a candidate is meant to survive one. There is deliberately no `closeTab`: a tab the user is looking at is theirs to close.
+
+#### Writing under a compare-and-swap
+
+```ts
+const before = api.workspace.snapshot();          // the active tab
+const armed = { tabId: before.tabId, revision: before.revision };
+
+// ...minutes pass, experiments run...
+
+const result = api.workspace.applyOperations({
+  tabId: armed.tabId,
+  expectedRevision: armed.revision,
+  operations: winner.operations,
+  atomic: true,
+});
+
+if (result.conflict === "revision_mismatch") {
+  // result.revision is the CURRENT one, so you can re-arm without re-reading.
+  api.ui.toast("The graph changed while the study was running.", "warning");
+} else if (result.conflict === "read_only") {
+  api.ui.toast("That tab is read-only — promote into an editable one.", "warning");
+} else if (result.conflict === "editing_subgraph") {
+  api.ui.toast("Step out of the block first — the write is waiting.", "warning");
+} else if (!result.committed) {
+  const failed = result.results.filter((r) => !r.ok);
+  api.ui.toast(`Nothing applied: ${failed.map((r) => r.error).join("; ")}`, "error");
+} else {
+  armed.revision = result.revision;                // continue the chain
+}
+```
+
+The checks run in this order, and each one returns without changing anything:
+
+1. `tabId` (or the active tab) must resolve, else `conflict: "unknown_tab"`, `results: []`, `committed: false`, `revision: 0`.
+2. The tab must not be read-only, else `conflict: "read_only"`, `results: []`, `committed: false`, and the tab's current `revision`.
+3. The tab must not be showing the inside of a block, else `conflict: "editing_subgraph"`. While a block is open the canvas holds that block's contents rather than the document `snapshot()` describes, so a write would land somewhere you never read; retry once the user steps back out.
+4. `expectedRevision`, if you passed one, must equal the tab's `revision`, else `conflict: "revision_mismatch"` and the **current** revision, so you can re-arm without a second read.
+5. The batch is applied to a copy.
+6. With `atomic: true`, if any op failed, nothing is written: `committed: false`, `revision` unchanged, and the **full-length** `results` so you can see which op was wrong.
+7. Otherwise, if anything changed: one undo snapshot, one write, `committed: true`, and the new `revision`. A batch that changes nothing writes nothing and pushes no undo step.
+
+On a refusal `node_count` and `edge_count` still describe the tab as it stands, so a plugin that logs them is not told the graph is empty when it is not. `unknown_tab` is the exception: there is no tab to count.
+
+Conflicts are **returned, never thrown**. A batch is still one undo step, and per-op semantics are unchanged from `api.graph.applyOperations`: without `atomic`, a failing op is skipped and reported while the rest apply. A commit that leaves the graph without the node a detail modal or the canvas selection names clears both, so an undo restoring that node cannot pop the modal open by itself.
+
+```ts
+type WorkspaceConflict =
+  "revision_mismatch" | "read_only" | "unknown_tab" | "editing_subgraph";
+
+interface WorkspaceApplyResult extends ApplyResult {
+  tabId: string;
+  revision: number;        // AFTER this call; unchanged on a conflict or a preflight failure
+  committed: boolean;
+  conflict?: WorkspaceConflict;
+}
+```
+
+#### Watching every tab
+
+```ts
+const off = api.workspace.onChanged((event) => {
+  if (event.type === "graph" && event.origin?.pluginId === api.pluginId) return;  // your own write
+  if (event.type === "tabs" && event.removed) forget(event.tabId);
+});
+```
+
+```ts
+type WorkspaceEvent =
+  | { type: "graph"; tabId: string; revision: number; origin?: { pluginId: string } }
+  | { type: "tabs"; tabId: string; revision: number; removed: boolean }
+  | { type: "active-tab"; tabId: string; revision: number };
+```
+
+Events arrive synchronously after the change, in a fixed order: tabs added, then documents changed, then the active tab, then tabs removed. `origin` is present on a `graph` event only when the change came from a plugin's `workspace.applyOperations`, which is how you tell your own writes from the user's.
+
+If your callback throws, the editor logs it and unsubscribes you — a plugin must not be able to break the tab store. `api.graph.onGraphChanged` is unchanged: still the active tab, still no payload.
+
+#### One change for plugins written before apiVersion 5
+
+A read-only tab now refuses `api.graph.applyOperations` too. Every op comes back `{ ok: false, error: "tab is read-only" }` and nothing is written. Before apiVersion 5 the write went through: `readOnly` was a UI affordance that the plugin write path did not consult. If your plugin writes to whatever tab is in front of the user, check `api.workspace.snapshot().readOnly` first, or read the `ok` flags you were already getting back.
+
+One further refusal is new rather than changed, because both ops it names are new in apiVersion 5: while the user is inside a block, a legacy batch containing `set_segment` or `remove_segment` is refused whole-batch, every op reporting `set_segment and remove_segment cannot apply while a block is open`. Segments are top-level state, so committing one from in there would write an overlay naming the block's inner node ids — it reaches the saved file, draws nothing, and the user cannot delete what never renders. Every other op still writes the open canvas from inside a block, exactly as before.
 
 ### `api.nodes` — custom node renderers
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
@@ -338,7 +338,7 @@ for (const [i, result] of opened.entries()) {
 1. `title` 必須是非空字串——`invalid_graph`。
 2. `graph` 必須能通過 `JSON.stringify`——`invalid_graph`。
 3. 該 JSON 最多 8 MiB——`too_large`。
-4. 圖表必須能通過編輯器的文件讀取器，也就是開啟藝廊範例所用的同一個：節點參數會與其定義的 preset 合併、未知的最上層鍵會被忽略、`subgraphs`、`segmentGroups` 與 `presets` 都會被採用，而 `format_version` 比這個編輯器新時，分頁會以唯讀開啟，和開檔案一模一樣。讀取器失敗是 `invalid_graph`，訊息就是讀取器自己的訊息。
+4. 圖表必須能通過編輯器的文件讀取器，也就是開啟藝廊範例所用的同一個：節點的 `params` 完全照該項目寫下來的樣子讀取，不會從它的定義或 preset 補進任何東西——你沒寫的參數就是沒有；未知的最上層鍵會被忽略、`subgraphs`、`segmentGroups` 與 `presets` 都會被採用，而 `format_version` 比這個編輯器新時，分頁會以唯讀開啟，和開檔案一模一樣。讀取器失敗是 `invalid_graph`，訊息就是讀取器自己的訊息。
 5. 開啟後不得讓編輯器超過 32 個分頁——`too_many_tabs`。
 
 分頁數是**最後**才檢查的，而且比對的是當下的即時數量，所以同一次呼叫裡的兩筆項目，不會一起擠進只夠一筆的額度。這個順序的代價是：一筆被 `too_many_tabs` 拒絕的項目其實已經被讀過了——它帶來而這台伺服器沒看過的 preset 已經併進節點面板，即使沒有任何分頁被開出來。

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
@@ -11,12 +11,12 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 :::note 可用性
 前端擴充功能自 CodefyUI **1.3.0** 起內建。請執行 `cdui --version` 確認；若顯示更舊的版本，請執行 `cdui update`。
 
-停靠面板、工具列按鈕、執行事件與 runs 門面需要 **apiVersion 3**（CodefyUI 2.0.0 起）；`graph.getView` 需要 **apiVersion 4**（CodefyUI 2.3.0 起）。使用前請先檢查版本——參見 [API 版本](#api-版本)。
+停靠面板、工具列按鈕、執行事件與 runs 門面需要 **apiVersion 3**（CodefyUI 2.0.0 起）；`graph.getView` 需要 **apiVersion 4**（CodefyUI 2.3.0 起）；`api.workspace` 與六個代理畫布操作需要 **apiVersion 5**（*下一個版本（尚未發布）* {/* stamp-on-release */} 起）。使用前請先檢查版本——參見 [API 版本](#api-版本)。
 :::
 
 ## API 版本
 
-`api.apiVersion` 是一個只增不減的數字，而目前每一次改版都是**純粹新增**：舊版能用的東西，沒有被移除過，也沒有被改過形狀。為 apiVersion 2 撰寫的外掛，在 apiVersion 4 的編輯器上不必改任何一行就能繼續運作。
+`api.apiVersion` 是一個只增不減的數字，而目前每一次改版在形狀上都是**純粹新增**：舊版能用的東西，沒有被移除過，簽名也沒有被改過。為 apiVersion 2 撰寫的外掛，在 apiVersion 5 的編輯器上不必改任何一行就能繼續運作，只有一個例外由 apiVersion 5 引入，而且完整寫在下面——[唯讀分頁現在會拒絕寫入](#apiversion-5-之前的外掛要注意的一件事)。
 
 | `apiVersion` | CodefyUI | 新增內容 |
 |--------------|----------|----------|
@@ -24,6 +24,7 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 | 2 | 1.3.0 | `nodes.registerRenderer` |
 | 3 | 2.0.0 | `ui.addPanel` / `removePanel`、`ui.addToolbarButton` / `removeToolbarButton`、`events.onExecution`、`runs.*` |
 | 4 | 2.3.0 | `graph.getView`——使用者正在看圖表的哪一層 |
+| 5 | *下一個版本（尚未發布）* {/* stamp-on-release */} | `workspace.*`——分頁、快照與比較後寫入；`move_node`、`set_segment` / `remove_segment`、`add_note` / `update_note`、`set_node_meta` |
 
 在使用比你所要求的版本更新的功能之前先檢查它，而且是降級處理，不是直接拋錯：
 
@@ -200,6 +201,12 @@ const remove = api.ui.addToolbarButton({
 | `"remove_edge"` | `source: string`、`target: string`、`source_handle?: string`、`target_handle?: string` | 中斷兩節點間相符的邊。 |
 | `"clear_graph"` | *（無）* | 移除所有節點與邊。 |
 | `"auto_layout"` | *（無）* | 重新執行自動圖表佈局。 |
+| `"move_node"` | `node_id: string`、`position: { x: number; y: number }` | **apiVersion 5。** 把一個節點放到精確的位置。綁在該節點上的便箋會一起移動，就跟使用者拖曳該節點時一樣。 |
+| `"set_segment"` | `segment_id?: string`、`head_node_id: string`、`tail_node_id: string` | **apiVersion 5。** 建立或取代一個區段標示——編輯器在從頭到尾的資料路徑上，為每個節點畫出的那個泡泡。省略 `segment_id` 就是建立；傳入既有的 id 就是移動它。不論哪一種，結果都會在 `segment_id` 帶回該 id。頭尾之間沒有資料邊路徑時會失敗，任一端是便箋時也會失敗。 |
+| `"remove_segment"` | `segment_id: string` | **apiVersion 5。** 移除一個區段標示。 |
+| `"add_note"` | `ref?: string`、`text: string`、`position?: { x: number; y: number }`、`color?: string`、`bind_to?: string` | **apiVersion 5。** 新增一張文字便箋。`text` 為 1 到 4000 個字元，可含換行與 tab，但不可含其他控制字元；`color` 為 `#rrggbb`；`bind_to` 把便箋綁到某個節點，使它跟著該節點移動，並預設把位置放在它旁邊。便箋永遠不會被執行、匯出或驗證。 |
+| `"update_note"` | `node_id: string`、`text?: string`、`color?: string` | **apiVersion 5。** 改寫既有的便箋。`text` 與 `color` 至少要有一個，而 `text` 只適用於文字便箋——圖片便箋的內容是它的 data URL。 |
+| `"set_node_meta"` | `node_id: string`、`label: string` | **apiVersion 5。** 為節點命名。1 到 120 個字元，單行，前後空白會被去除。標籤存放在 `params` 旁邊，永遠不會存進 `params` 裡面，而且現在存檔重新載入後也還在。 |
 
 #### ApplyResult 形狀
 
@@ -208,7 +215,8 @@ interface OpResult {
   index: number;      // 操作在批次中的位置
   ok: boolean;        // 此操作是否套用成功
   error?: string;     // ok 為 false 時的失敗原因
-  node_id?: string;   // 解析出的節點 id（add_node / set_params）
+  node_id?: string;   // 解析出的節點 id，凡是指名或建立節點的操作都會帶
+  segment_id?: string; // apiVersion 5：set_segment 建立或取代的那個 id
 }
 
 interface ApplyResult {
@@ -262,6 +270,166 @@ api.graph.applyOperations(ops);
 這個 view 是**唯讀**的，而且是即時讀取：每次呼叫都是當下的新答案；而且我們刻意沒有提供任何讓外掛帶著使用者跳到別層的方法。使用者走進或走出區塊時 `onGraphChanged` 會觸發（畢竟畫布真的換了），所以想顯示「我會寫到哪裡」的面板，可以在那個回呼裡重新讀一次 `getView()`。
 
 寫入會落在哪一層，是編輯器一直以來的行為，這次是把它寫下來，而不是把它改掉。未來的改版可能會讓操作自己指名目標層級；那也會是用「新增一個東西」的方式做到，而不是悄悄改寫既有外掛已經在做的那些寫入。
+
+### `api.workspace` — 分頁與比較後寫入
+
+需要 `api.apiVersion >= 5`。在更舊的編輯器上 `api.workspace` 會是 `undefined`——它不會被塞成一組會拋錯的方法，所以 `typeof api.workspace?.openGraphs === "function"` 是一個誠實的檢查。
+
+`api.graph` 看見的是一張圖表：使用者眼前的那一張。`api.workspace` 看見的是整條分頁列。它的存在，是為了讓外掛能把一個提案放到使用者可以去看、但又不會動到他手邊工作的地方，並且只在使用者這段期間沒有改過它時才寫回去。
+
+| 方法 | 簽名 | 說明 |
+|------|------|------|
+| `openGraphs` | `(entries, options?) => WorkspaceOpenResult[]` | 把一張或多張圖表開成編輯器分頁。結果是**依位置對應**的：`result[i]` 描述的就是 `entries[i]`，而且一筆壞掉的項目永遠不會影響另一筆。 |
+| `tabs` | `() => WorkspaceTabInfo[]` | 依分頁列順序列出每個分頁，使用者正在看的那一個帶有 `active`。 |
+| `snapshot` | `(tabId?) => WorkspaceSnapshot` | 一個分頁的身分，加上它的整張圖表。不給 id 就是作用中分頁。id 不存在時回傳 `{ error: "unknown_tab" }`，而不是拋錯。 |
+| `applyOperations` | `(request) => WorkspaceApplyResult` | 對指定分頁套用一個批次，可選擇只在版本號仍相符時才寫入，也可選擇全有全無。 |
+| `onChanged` | `(callback) => () => void` | 訂閱所有分頁的分頁與文件變更。回傳一個取消訂閱函式。 |
+
+#### 版本號
+
+每個分頁都帶著一個 `revision`：從 1 開始，每當該分頁的文件變更就加一。拖曳節點會讓它變。撤銷與重做也會——它們還原的是舊內容，那仍然是一次變更。重新命名分頁、切換到它、選取節點、平移畫布與標示區段都不會；執行也不會，因為執行畫在節點上的狀態、錯誤與進度從來不會寫進存檔。所以一次比較後寫入，不會在模型訓練時每秒過期好幾次。
+
+這個數字只增不減，而且會跟著分頁一起存起來，所以你在重新載入之前記下的版本號，載入之後仍然有意義。這正是重點：拿著一個版本號，離開去想個兩分鐘，然後連同你的寫入一起交回來。
+
+```ts
+interface WorkspaceTabInfo {
+  tabId: string;
+  title: string;
+  revision: number;
+  readOnly: boolean;
+  transient: boolean;               // gone after a reload
+  source: WorkspaceSource | null;   // who opened it
+  active: boolean;
+}
+
+interface WorkspaceSource {
+  kind: string;         // your own label, e.g. "agent-variant"
+  pluginId: string;
+  jobId?: string;
+  variantId?: string;
+  [key: string]: unknown;   // opaque to the editor, handed back verbatim
+}
+```
+
+#### 開啟圖表
+
+```ts
+const opened = api.workspace.openGraphs(
+  candidates.map((c) => ({
+    title: `${hypothesis} — ${c.label}`,
+    graph: c.graph,                 // the shape getGraph() answers with
+    readOnly: true,
+    source: { kind: "agent-variant", pluginId: api.pluginId, variantId: c.id },
+  })),
+  { activate: "first" },
+);
+
+for (const [i, result] of opened.entries()) {
+  if ("error" in result) {
+    api.ui.toast(`Candidate ${i + 1} not opened: ${result.error}`, "error");
+    continue;
+  }
+  remember(result.tabId, result.revision);
+}
+```
+
+每一筆項目依此順序驗證，失敗時產生一筆帶有 `error` 句子與 `code` 的結果：
+
+1. `title` 必須是非空字串——`invalid_graph`。
+2. `graph` 必須能通過 `JSON.stringify`——`invalid_graph`。
+3. 該 JSON 最多 8 MiB——`too_large`。
+4. 圖表必須能通過編輯器的文件讀取器，也就是開啟藝廊範例所用的同一個：節點參數會與其定義的 preset 合併、未知的最上層鍵會被忽略、`subgraphs`、`segmentGroups` 與 `presets` 都會被採用，而 `format_version` 比這個編輯器新時，分頁會以唯讀開啟，和開檔案一模一樣。讀取器失敗是 `invalid_graph`，訊息就是讀取器自己的訊息。
+5. 開啟後不得讓編輯器超過 32 個分頁——`too_many_tabs`。
+
+分頁數是**最後**才檢查的，而且比對的是當下的即時數量，所以同一次呼叫裡的兩筆項目，不會一起擠進只夠一筆的額度。這個順序的代價是：一筆被 `too_many_tabs` 拒絕的項目其實已經被讀過了——它帶來而這台伺服器沒看過的 preset 已經併進節點面板，即使沒有任何分頁被開出來。
+
+`options.activate` 可以是 `"first"`（預設）、`"last"`，或 `"none"` 讓使用者留在原地。
+
+開出來的分頁之後就是一個普通分頁。使用者可以重新命名、關掉它，或另存成一個真正的圖表檔案——而開啟那個檔案，會照平常的方式得到一個可編輯的分頁。`readOnly` 屬於分頁本身，直到分頁被關掉為止。
+
+你開的分頁預設是**暫時的**：它們不會被寫進編輯器的自動存檔，所以重新載入之後就不見了。如果某個候選方案應該撐過一次重新載入，請傳 `persist: true`。這裡刻意沒有 `closeTab`：使用者正在看的分頁，要關要留由他決定。
+
+#### 在比較後寫入
+
+```ts
+const before = api.workspace.snapshot();          // the active tab
+const armed = { tabId: before.tabId, revision: before.revision };
+
+// ...minutes pass, experiments run...
+
+const result = api.workspace.applyOperations({
+  tabId: armed.tabId,
+  expectedRevision: armed.revision,
+  operations: winner.operations,
+  atomic: true,
+});
+
+if (result.conflict === "revision_mismatch") {
+  // result.revision is the CURRENT one, so you can re-arm without re-reading.
+  api.ui.toast("The graph changed while the study was running.", "warning");
+} else if (result.conflict === "read_only") {
+  api.ui.toast("That tab is read-only — promote into an editable one.", "warning");
+} else if (result.conflict === "editing_subgraph") {
+  api.ui.toast("Step out of the block first — the write is waiting.", "warning");
+} else if (!result.committed) {
+  const failed = result.results.filter((r) => !r.ok);
+  api.ui.toast(`Nothing applied: ${failed.map((r) => r.error).join("; ")}`, "error");
+} else {
+  armed.revision = result.revision;                // continue the chain
+}
+```
+
+檢查依此順序進行，而且每一項都是「什麼都不改」地回傳：
+
+1. `tabId`（或作用中分頁）必須找得到，否則 `conflict: "unknown_tab"`、`results: []`、`committed: false`、`revision: 0`。
+2. 分頁不能是唯讀的，否則 `conflict: "read_only"`、`results: []`、`committed: false`，以及該分頁當下的 `revision`。
+3. 分頁不能正顯示某個區塊的內部，否則 `conflict: "editing_subgraph"`。區塊打開時，畫布上的是那個區塊的內容，而不是 `snapshot()` 所描述的文件，所以這時寫入會落在你從沒讀過的地方；等使用者走出來再重試。
+4. 若你有傳 `expectedRevision`，它必須等於分頁的 `revision`，否則 `conflict: "revision_mismatch"`，並回傳**當下**的版本號，讓你不必再讀一次就能重新持有。
+5. 批次會套用在一份副本上。
+6. 使用 `atomic: true` 時，只要有任何一個操作失敗就什麼都不寫：`committed: false`、`revision` 不變，而且回傳**完整長度**的 `results`，讓你看得出是哪個操作錯了。
+7. 否則，若有東西改變：一個撤銷快照、一次寫入、`committed: true`，以及新的 `revision`。什麼都沒改變的批次，不會寫入，也不會推入撤銷步驟。
+
+被拒絕時，`node_count` 與 `edge_count` 仍然描述該分頁當下的樣子，所以會把它們記進 log 的外掛，不會被告知圖表是空的而其實不是。`unknown_tab` 是例外：根本沒有分頁可數。
+
+衝突是**回傳的，永遠不會拋出**。一個批次仍然是一個撤銷步驟，而每個操作的語義與 `api.graph.applyOperations` 相同：沒有 `atomic` 時，失敗的操作會被跳過並回報，其餘照樣套用。若提交後的圖表已經沒有詳細資料視窗或畫布選取所指的那個節點，兩者都會被清掉，這樣還原該節點的撤銷就不會讓視窗自己彈回來。
+
+```ts
+type WorkspaceConflict =
+  "revision_mismatch" | "read_only" | "unknown_tab" | "editing_subgraph";
+
+interface WorkspaceApplyResult extends ApplyResult {
+  tabId: string;
+  revision: number;        // AFTER this call; unchanged on a conflict or a preflight failure
+  committed: boolean;
+  conflict?: WorkspaceConflict;
+}
+```
+
+#### 監看所有分頁
+
+```ts
+const off = api.workspace.onChanged((event) => {
+  if (event.type === "graph" && event.origin?.pluginId === api.pluginId) return;  // your own write
+  if (event.type === "tabs" && event.removed) forget(event.tabId);
+});
+```
+
+```ts
+type WorkspaceEvent =
+  | { type: "graph"; tabId: string; revision: number; origin?: { pluginId: string } }
+  | { type: "tabs"; tabId: string; revision: number; removed: boolean }
+  | { type: "active-tab"; tabId: string; revision: number };
+```
+
+事件在變更之後同步送達，順序固定：先是新增的分頁，接著是變更的文件，然後是作用中分頁，最後是移除的分頁。`origin` 只有在變更來自某個外掛的 `workspace.applyOperations` 時才會出現在 `graph` 事件上，這就是你分辨自己的寫入與使用者的寫入的方法。
+
+如果你的回呼拋錯，編輯器會記錄它並把你取消訂閱——外掛不能有能力弄壞分頁儲存。`api.graph.onGraphChanged` 不變：仍然是作用中分頁，仍然不帶任何內容。
+
+#### apiVersion 5 之前的外掛要注意的一件事
+
+唯讀分頁現在連 `api.graph.applyOperations` 也會拒絕。每個操作都會回傳 `{ ok: false, error: "tab is read-only" }`，而且什麼都不會寫入。apiVersion 5 之前這個寫入是會過的：`readOnly` 只是一個 UI 上的表現，外掛的寫入路徑從來不看它。如果你的外掛是往使用者眼前那個分頁寫，請先檢查 `api.workspace.snapshot().readOnly`，或是讀一讀你本來就會拿到的 `ok` 旗標。
+
+還有一個拒絕是新增的而不是變更的，因為它所指的兩個操作都是 apiVersion 5 才有的：使用者在區塊裡面時，含有 `set_segment` 或 `remove_segment` 的舊路徑批次會被整批拒絕，每個操作都回報 `set_segment and remove_segment cannot apply while a block is open`。區段是最上層的狀態，所以從區塊裡面提交一個區段，會寫出一個指名該區塊內部節點 id 的標示——它會進到存檔、畫不出任何東西，而使用者也刪不掉一個從來不會顯示的東西。其餘所有操作在區塊裡面仍然照樣寫入打開的那張畫布，跟以前一樣。
 
 ### `api.nodes` — 自訂 node 渲染
 

--- a/frontend/src/components/TabBar/TabBar.module.css
+++ b/frontend/src/components/TabBar/TabBar.module.css
@@ -40,6 +40,21 @@
   white-space: nowrap;
 }
 
+/* Read-only badge (#341). Density from padding; the 2xs size is the token
+   reserved for badges. Never shrinks to zero: an ellipsised "Read-o" would
+   read as a truncated name rather than as a state. */
+.badge {
+  flex-shrink: 0;
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  color: var(--text-muted);
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-tight);
+  white-space: nowrap;
+}
+
 /* Edit input inside tab */
 .editInput {
   background: var(--surface-input);

--- a/frontend/src/components/TabBar/TabBar.test.tsx
+++ b/frontend/src/components/TabBar/TabBar.test.tsx
@@ -391,4 +391,72 @@ describe('TabBar', () => {
     // Tab 1 was removed; active should not have become Tab 1.
     expect(useTabStore.getState().tabs.find((t) => t.id === firstId)).toBeUndefined();
   });
+
+  // ── Read-only badge and plugin provenance (#341) ───────────────────────────
+
+  /** Mark the tab at `index` read-only and, optionally, plugin-opened. */
+  function markTab(index: number, patch: Record<string, unknown>) {
+    const tabs = useTabStore.getState().tabs;
+    useTabStore.setState({
+      tabs: tabs.map((t, i) => (i === index ? { ...t, ...patch } : t)),
+    });
+  }
+
+  it('shows no badge on an ordinary tab', () => {
+    render(<TabBar />);
+    expect(screen.queryByText('Read-only')).toBeNull();
+  });
+
+  it('badges a read-only tab', () => {
+    markTab(0, { readOnly: true });
+    render(<TabBar />);
+    expect(screen.getByText('Read-only')).toBeTruthy();
+  });
+
+  it('names the plugin that opened a tab in its tooltip', () => {
+    markTab(0, { source: { kind: 'agent-variant', pluginId: 'graph-copilot' } });
+    render(<TabBar />);
+    expect(screen.getByTitle('Opened by graph-copilot')).toBeTruthy();
+  });
+
+  it('carries no tooltip on a tab the user opened', () => {
+    render(<TabBar />);
+    // The add button is the only titled control on a plain tab bar.
+    expect(screen.queryByTitle(/Opened by/)).toBeNull();
+  });
+
+  it('shows both at once without hiding the tab name', () => {
+    markTab(0, {
+      readOnly: true,
+      source: { kind: 'agent-variant', pluginId: 'graph-copilot' },
+    });
+    render(<TabBar />);
+    const tab = screen.getByTitle('Opened by graph-copilot');
+    expect(within(tab).getByText('Read-only')).toBeTruthy();
+    expect(within(tab).getByText('Tab 1')).toBeTruthy();
+  });
+
+  it('uses the zh-TW copy for both', () => {
+    useI18n.setState({ locale: 'zh-TW' });
+    markTab(0, {
+      readOnly: true,
+      source: { kind: 'agent-variant', pluginId: 'graph-copilot' },
+    });
+    render(<TabBar />);
+    expect(screen.getByText('唯讀')).toBeTruthy();
+    expect(screen.getByTitle('由 graph-copilot 開啟')).toBeTruthy();
+  });
+
+  it('renaming a read-only tab still works -- the badge is chrome, not a lock', () => {
+    // `readOnly` gates SAVING a newer-format file, and plugin writes. The tab
+    // label is the user's own, and nothing here should take it away.
+    markTab(0, { readOnly: true });
+    render(<TabBar />);
+    const id = useTabStore.getState().tabs[0].id;
+    fireEvent.doubleClick(screen.getByText('Tab 1'));
+    const input = screen.getByDisplayValue('Tab 1');
+    fireEvent.change(input, { target: { value: 'Candidate A' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(useTabStore.getState().tabs.find((t) => t.id === id)?.name).toBe('Candidate A');
+  });
 });

--- a/frontend/src/components/TabBar/TabBar.tsx
+++ b/frontend/src/components/TabBar/TabBar.tsx
@@ -83,6 +83,12 @@ export function TabBar() {
           const isActive = tab.id === activeTabId;
           const isRunning = tab.status === 'running';
           const isEditing = editingId === tab.id;
+          // A plugin-opened tab says so on hover rather than in the strip:
+          // the tab is 180px wide and already carries a name, a running dot
+          // and a close button.
+          const sourceTitle = tab.source
+            ? t('tabBar.sourceTitle', { plugin: tab.source.pluginId })
+            : undefined;
 
           return (
             <div
@@ -90,6 +96,7 @@ export function TabBar() {
               onClick={() => setActiveTab(tab.id)}
               onDoubleClick={() => startRename(tab.id, tab.name)}
               className={styles.tab}
+              title={sourceTitle}
               style={{
                 background: isActive ? 'var(--surface-raised)' : 'transparent',
                 borderBottom: isActive ? '2px solid var(--accent)' : '2px solid transparent',
@@ -131,6 +138,15 @@ export function TabBar() {
                 />
               ) : (
                 <span className={styles.tabName}>{tab.name}</span>
+              )}
+
+              {/* Read-only badge (#341). One word, after the name, so the
+                  name is what gets the room and the badge is what gets
+                  clipped last. `readOnly` means Save is refused and plugin
+                  writes are refused -- it does not mean the tab is frozen,
+                  so rename and close are untouched. */}
+              {tab.readOnly && (
+                <span className={styles.badge}>{t('tabBar.readOnly')}</span>
               )}
 
               {/* Close button */}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -269,6 +269,10 @@ const en = {
     'This tab has a graph in it ({count} nodes). Closing discards it, and there is no undo for a closed tab: anything you have not saved to a graph file is gone. Cancel and save it first if you want it back later.',
   'tabs.close.confirmButton': 'Close tab',
 
+  // Tab bar chrome (#341)
+  'tabBar.readOnly': 'Read-only',
+  'tabBar.sourceTitle': 'Opened by {plugin}',
+
   // Subgraph Editor (SequentialModel)
   'layersEditor.title': 'Model Architecture Editor',
   'layersEditor.palette': 'Layers',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -252,6 +252,10 @@ const zhTW: Record<TranslationKey, string> = {
     '這個分頁裡有圖表（{count} 個節點）。關閉分頁會把圖表一起丟棄，而且已關閉的分頁無法復原：尚未儲存成圖表檔案的內容都會消失。若想日後再使用，請先取消並儲存。',
   'tabs.close.confirmButton': '關閉分頁',
 
+  // Tab bar chrome (#341)
+  'tabBar.readOnly': '唯讀',
+  'tabBar.sourceTitle': '由 {plugin} 開啟',
+
   // Subgraph Editor (SequentialModel)
   'layersEditor.title': '模型架構編輯器',
   'layersEditor.palette': '層級',

--- a/frontend/src/plugins/api.test.ts
+++ b/frontend/src/plugins/api.test.ts
@@ -116,6 +116,17 @@ describe('graph surface', () => {
     expect(calls).toBe(1);
   });
 
+  it('applyOperations still answers with an ApplyResult and nothing more', () => {
+    // The legacy path now runs through the workspace commit, which knows
+    // about tab ids, revisions and conflicts. None of that may leak out
+    // here: an installed v1 plugin reads these four keys and no others.
+    const api = freshApi();
+    const result = api.graph.applyOperations([{ op: 'add_node', node_type: 'Source' }]);
+    expect(Object.keys(result).sort()).toEqual(
+      ['edge_count', 'node_count', 'refs', 'results'],
+    );
+  });
+
   it('onGraphChanged registers its unsubscribe with trackCleanup', () => {
     const tracked: Array<() => void> = [];
     const api = buildPluginAPI(

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -287,8 +287,11 @@ function tabInfoOf(tab: TabState, activeTabId: string): WorkspaceTabInfo {
  * knob a plugin can reach: the workspace path refuses outright, and the legacy
  * path keeps writing the open canvas because that is what it has always done
  * and moving an installed plugin's writes out from under it is not a change to
- * make silently (see `commitGraphOperations`). Its one carve-out is the two
- * segment ops, which are not canvas writes at all -- see the branch below.
+ * make silently (see `commitGraphOperations`). "The open canvas" is the whole
+ * of it, though: inside a block the legacy path refuses the two segment ops
+ * and drops the reducer's segment outcome, because `segmentGroups` is the
+ * GRAPH's list from in there and no legacy op ever wrote it before v5. Both
+ * halves are below.
  */
 function commitToTab(
   pluginId: string,
@@ -311,7 +314,10 @@ function commitToTab(
     return { ...empty, ...counts, tabId, revision: tab.revision,
              committed: false, conflict: 'read_only' };
   }
-  if (tab.subgraphStack.length > 0) {
+  // Read again at the commit below. Past the branch this opens, a non-empty
+  // stack can only be the legacy path: the workspace path has returned.
+  const insideBlock = tab.subgraphStack.length > 0;
+  if (insideBlock) {
     // While a block is open, `tab.nodes` / `tab.edges` are the BLOCK's
     // contents, and `snapshot()` answers with the flushed top level -- so a
     // workspace write here would land somewhere the plugin never read.
@@ -381,7 +387,18 @@ function commitToTab(
   store.commitDocument(tabId, {
     nodes: outcome.nodes,
     edges: outcome.edges,
-    segmentGroups: outcome.segmentGroups,
+    // The legacy path inside a block writes the open canvas and NOTHING else,
+    // which is what it did before v5 -- back then it wrote only nodes and
+    // edges, and the reducer's segments fell on the floor. They have to keep
+    // falling: `segmentGroups` is the GRAPH's list while a block is open
+    // (`enterSubgraph` captures it rather than swapping it), so committing
+    // the outcome would let `clear_graph` wipe every overlay on a canvas the
+    // user is not looking at, and `remove_node` prune one whose endpoint id
+    // an inner node happens to reuse. Neither is a canvas write, and both
+    // reach the next save. The two ops that mean to write segments are
+    // refused outright above; this is the same bar for the ops that would
+    // have done it by accident.
+    segmentGroups: insideBlock ? tab.segmentGroups : outcome.segmentGroups,
     dirtyIds: outcome.dirtyIds,
     origin: { pluginId },
   });

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -5,7 +5,10 @@
  * breaks installed plugins. Add, don't mutate; bump apiVersion on breaking
  * changes.
  */
-import { useTabStore } from '../store/tabStore';
+import {
+  useTabStore, lastCommitOrigin,
+  type GraphDocument, type TabState,
+} from '../store/tabStore';
 import { useNodeDefStore } from '../store/nodeDefStore';
 import { useToastStore } from '../store/toastStore';
 import type { ToastType } from '../store/toastStore';
@@ -14,7 +17,8 @@ import {
   getRun, getRunMetrics, listRuns,
   type RunInfo, type RunListPage, type RunMetrics, type RunStatus,
 } from '../api/rest';
-import type { NodeDefinition } from '../types';
+import type { NodeDefinition, WorkspaceSource } from '../types';
+import { resolveExample } from '../utils/openExample';
 import { subgraphViewPath } from '../utils/subgraph';
 import { applyGraphOps, type ApplyOutcome, type GraphOp, type OpResult } from './ops';
 import { registerNodeRenderer, type PluginNodeRenderer } from './nodeRenderers';
@@ -38,6 +42,89 @@ export interface ApplyResult {
 export type SerializedGraph = ReturnType<
   ReturnType<typeof useTabStore.getState>['getSerializedGraph']
 >;
+
+export type { WorkspaceSource };
+
+/**
+ * The document a plugin hands `workspace.openGraphs`.
+ *
+ * Deliberately looser than `SerializedGraph`, which is the store's exact
+ * RETURN type with every list non-optional: a plugin composes this object
+ * itself, and the honest shape of "whatever a graph file holds" is two
+ * required lists and a bag. Everything else is read defensively by the same
+ * document reader a file load uses.
+ */
+export interface WorkspaceGraphInput {
+  nodes: unknown[];
+  edges: unknown[];
+  presets?: unknown[];
+  segmentGroups?: unknown[];
+  subgraphs?: unknown[];
+  name?: string;
+  description?: string;
+  format_version?: unknown;
+  [key: string]: unknown;
+}
+
+export interface WorkspaceOpenEntry {
+  /** Shown on the tab. Stored whole; the tab bar ellipsises what will not fit. */
+  title: string;
+  graph: WorkspaceGraphInput;
+  /** Default false. A read-only tab refuses plugin writes on both paths. */
+  readOnly?: boolean;
+  source?: WorkspaceSource;
+  /** Default false: the tab is transient and is gone after a reload. */
+  persist?: boolean;
+}
+
+export type WorkspaceOpenResult =
+  | { tabId: string; revision: number }
+  | { error: string; code: 'invalid_graph' | 'too_many_tabs' | 'too_large' };
+
+export interface WorkspaceTabInfo {
+  tabId: string;
+  title: string;
+  revision: number;
+  readOnly: boolean;
+  transient: boolean;
+  source: WorkspaceSource | null;
+  active: boolean;
+}
+
+export type WorkspaceSnapshot =
+  | (WorkspaceTabInfo & { graph: SerializedGraph })
+  | { error: 'unknown_tab' };
+
+export interface WorkspaceApplyRequest {
+  /** Defaults to the active tab. */
+  tabId?: string;
+  /** Omitted: no compare. Present and stale: nothing is written. */
+  expectedRevision?: number;
+  operations: GraphOp[];
+  /** Default false. True: any failing op means nothing is committed. */
+  atomic?: boolean;
+}
+
+export type WorkspaceConflict =
+  | 'revision_mismatch' | 'read_only' | 'unknown_tab' | 'editing_subgraph';
+
+export interface WorkspaceApplyResult extends ApplyResult {
+  tabId: string;
+  /** The tab's revision AFTER this call; unchanged on a conflict or a preflight failure. */
+  revision: number;
+  committed: boolean;
+  conflict?: WorkspaceConflict;
+}
+
+export type WorkspaceEvent =
+  | { type: 'graph'; tabId: string; revision: number; origin?: { pluginId: string } }
+  | { type: 'tabs'; tabId: string; revision: number; removed: boolean }
+  | { type: 'active-tab'; tabId: string; revision: number };
+
+/** Serialized JSON a single `openGraphs` entry may carry. */
+const MAX_WORKSPACE_GRAPH_BYTES = 8 * 1024 * 1024;
+/** How many tabs the editor will hold before `openGraphs` starts refusing. */
+const MAX_WORKSPACE_TABS = 32;
 
 export interface RunListOptions {
   status?: readonly RunStatus[];
@@ -117,6 +204,22 @@ export interface CodefyUIPluginAPI {
     /** Read-only: which level of the graph the user is looking at (#200 item 7). */
     getView(): GraphView;
   };
+  /**
+   * Tabs, snapshots and compare-and-swap writes -- requires apiVersion >= 5.
+   *
+   * Absent on an older editor rather than stubbed, so
+   * `typeof api.workspace?.openGraphs === 'function'` is an honest check.
+   */
+  workspace: {
+    openGraphs(
+      entries: WorkspaceOpenEntry[],
+      options?: { activate?: 'first' | 'last' | 'none' },
+    ): WorkspaceOpenResult[];
+    tabs(): WorkspaceTabInfo[];
+    snapshot(tabId?: string): WorkspaceSnapshot;
+    applyOperations(request: WorkspaceApplyRequest): WorkspaceApplyResult;
+    onChanged(cb: (event: WorkspaceEvent) => void): () => void;
+  };
   nodes: {
     /** Register a custom renderer for a node type's card body. Returns an unregister fn. */
     registerRenderer(nodeType: string, renderer: PluginNodeRenderer): () => void;
@@ -140,6 +243,120 @@ export interface CodefyUIPluginAPI {
   };
 }
 
+function tabInfoOf(tab: TabState, activeTabId: string): WorkspaceTabInfo {
+  return {
+    tabId: tab.id,
+    title: tab.name,
+    revision: tab.revision,
+    readOnly: tab.readOnly,
+    transient: tab.transient,
+    source: tab.source,
+    active: tab.id === activeTabId,
+  };
+}
+
+/**
+ * Apply a plugin's batch to a NAMED tab, under a compare-and-swap (#341 4.4).
+ *
+ * The order of the refusals is the contract, and each returns without a side
+ * effect: an unknown tab, then a read-only tab, then a tab whose canvas is
+ * showing a block's insides, then a stale revision. Only after all four does
+ * the pure reducer run, and only after `atomic`'s preflight does anything get
+ * written.
+ *
+ * Conflicts are RETURNED, never thrown: the consumer treats a throw out of
+ * this call as "the canvas may hold a partial update", which is the one thing
+ * that is never true here.
+ *
+ * `refuseInsideBlock` is the ONE way the two callers differ, and it is not a
+ * knob a plugin can reach: the workspace path refuses, and the legacy path
+ * keeps writing the open canvas because that is what it has always done and
+ * moving an installed plugin's writes out from under it is not a change to
+ * make silently (see `commitGraphOperations`).
+ */
+function commitToTab(
+  pluginId: string,
+  request: WorkspaceApplyRequest,
+  options: { refuseInsideBlock: boolean },
+): WorkspaceApplyResult {
+  const store = useTabStore.getState();
+  const tabId = request.tabId ?? store.activeTabId;
+  const tab = store.getTab(tabId);
+  const empty = { results: [] as OpResult[], refs: {} as Record<string, string> };
+
+  if (!tab) {
+    return { ...empty, tabId, revision: 0, committed: false,
+             conflict: 'unknown_tab', node_count: 0, edge_count: 0 };
+  }
+  // The counts on a refusal describe the tab as it stands, so a plugin that
+  // logs them is not told the graph is empty when it is not.
+  const counts = { node_count: tab.nodes.length, edge_count: tab.edges.length };
+  if (tab.readOnly) {
+    return { ...empty, ...counts, tabId, revision: tab.revision,
+             committed: false, conflict: 'read_only' };
+  }
+  // While a block is open, `tab.nodes` / `tab.edges` are the BLOCK's contents,
+  // and `snapshot()` answers with the flushed top level -- so a write here
+  // would land somewhere the plugin never read. Refused rather than
+  // redirected: the plugin retries once the user steps back out, which is a
+  // wait it can see, unlike an edit that silently went into a definition.
+  if (options.refuseInsideBlock && tab.subgraphStack.length > 0) {
+    return { ...empty, ...counts, tabId, revision: tab.revision,
+             committed: false, conflict: 'editing_subgraph' };
+  }
+  if (
+    request.expectedRevision !== undefined
+    && request.expectedRevision !== tab.revision
+  ) {
+    return { ...empty, ...counts, tabId, revision: tab.revision,
+             committed: false, conflict: 'revision_mismatch' };
+  }
+
+  const definitions = useNodeDefStore.getState().definitions;
+  const outcome: ApplyOutcome = applyGraphOps(
+    { nodes: tab.nodes, edges: tab.edges, segmentGroups: tab.segmentGroups },
+    definitions,
+    request.operations,
+  );
+  const applied = {
+    tabId,
+    results: outcome.results,
+    refs: outcome.refs,
+    node_count: outcome.nodes.length,
+    edge_count: outcome.edges.length,
+  };
+
+  // The preflight `atomic` buys: the reducer already works on copies, so
+  // "discard the outcome" is the whole implementation. The results are still
+  // returned in full so the model can see WHICH op it got wrong.
+  if (request.atomic && outcome.results.some((r) => !r.ok)) {
+    return { ...applied, revision: tab.revision, committed: false };
+  }
+  if (!outcome.mutated) {
+    return { ...applied, revision: tab.revision, committed: false };
+  }
+
+  // One snapshot, then one write: that is what makes a batch one Ctrl+Z.
+  store.pushUndoSnapshotFor(tabId);
+  store.commitDocument(tabId, {
+    nodes: outcome.nodes,
+    edges: outcome.edges,
+    segmentGroups: outcome.segmentGroups,
+    dirtyIds: outcome.dirtyIds,
+    origin: { pluginId },
+  });
+  const after = useTabStore.getState().getTab(tabId)!;
+  return { ...applied, revision: after.revision, committed: true };
+}
+
+/** The tab-addressed write path, as `api.workspace.applyOperations` exposes it. */
+export function commitWorkspaceOperations(
+  pluginId: string,
+  request: WorkspaceApplyRequest,
+): WorkspaceApplyResult {
+  return commitToTab(pluginId, request, { refuseInsideBlock: true });
+}
+
 /**
  * Apply a plugin's batch to the canvas the user has open.
  *
@@ -160,29 +377,33 @@ export interface CodefyUIPluginAPI {
  * flushes and answers with the whole graph, so a plugin that reads, reasons and
  * writes can compute node ids that exist at the top level and apply them to a
  * canvas where they do not.
+ *
+ * Since v5 this is a thin shim over the tab-addressed path above: same target,
+ * same undo semantics, same `ApplyResult` shape, and none of the conflict
+ * channel -- a v1 plugin reads four keys and would not know what to do with a
+ * fifth. It keeps `refuseInsideBlock: false` precisely to preserve the
+ * behaviour this comment describes; `workspace.applyOperations` is where a
+ * plugin gets the refusal instead. The ONE behaviour change v5 makes to an
+ * installed plugin is the other one -- a read-only tab now refuses per op
+ * instead of being written through (#341 section 4.6).
  */
-export function commitGraphOperations(ops: GraphOp[]): ApplyResult {
-  const store = useTabStore.getState();
-  const tab = store.getActiveTab();
-  const definitions = useNodeDefStore.getState().definitions;
-  const outcome: ApplyOutcome = applyGraphOps(
-    { nodes: tab.nodes, edges: tab.edges, segmentGroups: tab.segmentGroups },
-    definitions,
-    ops,
-  );
-  if (outcome.mutated) {
-    store.pushUndoSnapshot();
-    store.setNodes(outcome.nodes);
-    store.setEdges(outcome.edges);
-    for (const id of outcome.dirtyIds) {
-      useTabStore.getState().markDirty(id);
-    }
+export function commitGraphOperations(ops: GraphOp[], pluginId = ''): ApplyResult {
+  const result = commitToTab(pluginId, { operations: ops }, { refuseInsideBlock: false });
+  if (result.conflict === 'read_only') {
+    return {
+      results: ops.map((_, index) => ({
+        index, ok: false, error: 'tab is read-only',
+      })),
+      refs: {},
+      node_count: result.node_count,
+      edge_count: result.edge_count,
+    };
   }
   return {
-    results: outcome.results,
-    refs: outcome.refs,
-    node_count: outcome.nodes.length,
-    edge_count: outcome.edges.length,
+    results: result.results,
+    refs: result.refs,
+    node_count: result.node_count,
+    edge_count: result.edge_count,
   };
 }
 
@@ -206,6 +427,180 @@ function subscribeGraphChanged(cb: () => void): () => void {
     prevTab = tab;
     if (changed) cb();
   });
+}
+
+/**
+ * Read a plugin's graph the way a file load reads a file, and hand back the
+ * document `loadGraphDocumentInto` installs. Throws the reader's own error.
+ */
+function workspaceDocument(graph: WorkspaceGraphInput): GraphDocument {
+  const resolved = resolveExample(graph);
+  return {
+    nodes: resolved.nodes,
+    edges: resolved.edges,
+    // A plugin's graph is bound to no file: the first Save has to ask where
+    // it should go, exactly as an example does.
+    boundFile: null,
+    subgraphs: resolved.subgraphs,
+    segmentGroups: resolved.segmentGroups,
+    // The TAB's label is the entry's `title`, already set by `createTab`. The
+    // graph's own `name` is deliberately not allowed to overwrite it.
+    name: null,
+    description: resolved.description,
+    formatVersion: resolved.formatVersion,
+  };
+}
+
+function openWorkspaceGraphs(
+  entries: WorkspaceOpenEntry[],
+  options?: { activate?: 'first' | 'last' | 'none' },
+): WorkspaceOpenResult[] {
+  const results: WorkspaceOpenResult[] = [];
+  const opened: string[] = [];
+
+  for (const entry of entries) {
+    const title = typeof entry?.title === 'string' ? entry.title.trim() : '';
+    if (!title) {
+      results.push({ error: 'openGraphs: title must be a non-empty string', code: 'invalid_graph' });
+      continue;
+    }
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(entry.graph);
+    } catch {
+      results.push({ error: 'openGraphs: graph is not JSON-serializable', code: 'invalid_graph' });
+      continue;
+    }
+    const bytes = new TextEncoder().encode(serialized).byteLength;
+    if (bytes > MAX_WORKSPACE_GRAPH_BYTES) {
+      results.push({
+        error: `openGraphs: the graph is ${Math.round(bytes / 1024 / 1024)} MiB; the limit is 8 MiB`,
+        code: 'too_large',
+      });
+      continue;
+    }
+    let doc: GraphDocument;
+    try {
+      doc = workspaceDocument(entry.graph);
+    } catch (error) {
+      results.push({
+        error: `openGraphs: ${error instanceof Error ? error.message : String(error)}`,
+        code: 'invalid_graph',
+      });
+      continue;
+    }
+    // Checked LAST, and against the live count, so two entries in one call
+    // cannot both slip past a limit only one of them fits under.
+    if (useTabStore.getState().tabs.length >= MAX_WORKSPACE_TABS) {
+      results.push({
+        error: `openGraphs: the editor already has ${MAX_WORKSPACE_TABS} tabs open`,
+        code: 'too_many_tabs',
+      });
+      continue;
+    }
+
+    const tabId = useTabStore.getState().createTab({ title, activate: false });
+    const tooNew = useTabStore.getState().loadGraphDocumentInto(tabId, doc);
+    useTabStore.getState().setTabMeta(tabId, {
+      // Either reason is enough: the plugin asked, or the document is from a
+      // build this one does not understand.
+      readOnly: entry.readOnly === true || tooNew,
+      source: entry.source ?? null,
+      transient: entry.persist !== true,
+    });
+    results.push({
+      tabId,
+      revision: useTabStore.getState().getTab(tabId)!.revision,
+    });
+    opened.push(tabId);
+  }
+
+  const activate = options?.activate ?? 'first';
+  if (activate !== 'none' && opened.length > 0) {
+    useTabStore.getState().setActiveTab(
+      activate === 'last' ? opened[opened.length - 1] : opened[0],
+    );
+  }
+  return results;
+}
+
+/**
+ * One store subscription, diffed element-wise, fanned out as ordered events
+ * (#341 section 4.5).
+ *
+ * The order -- added, changed, activated, removed -- is what lets a consumer
+ * process a batch in one pass: a tab it is told about has already been
+ * announced, and a tab it is told is gone was still there for everything
+ * before it.
+ */
+function subscribeWorkspaceChanged(
+  cb: (event: WorkspaceEvent) => void,
+): () => void {
+  let prevTabs = useTabStore.getState().tabs;
+  let prevActive = useTabStore.getState().activeTabId;
+  let alive = true;
+  const unsubscribe = useTabStore.subscribe((state) => {
+    if (!alive) return;
+    const { tabs, activeTabId } = state;
+    const before = new Map(prevTabs.map((t) => [t.id, t] as const));
+    const after = new Map(tabs.map((t) => [t.id, t] as const));
+    const events: WorkspaceEvent[] = [];
+
+    for (const t of tabs) {
+      if (!before.has(t.id)) {
+        events.push({ type: 'tabs', tabId: t.id, revision: t.revision, removed: false });
+      }
+    }
+    for (const t of tabs) {
+      const was = before.get(t.id);
+      if (was && was.revision !== t.revision) {
+        // Read inside the notification, which is the only window the store
+        // keeps it open for.
+        const origin = lastCommitOrigin();
+        events.push({
+          type: 'graph', tabId: t.id, revision: t.revision,
+          ...(origin ? { origin } : {}),
+        });
+      }
+    }
+    if (activeTabId !== prevActive) {
+      events.push({
+        type: 'active-tab', tabId: activeTabId,
+        revision: after.get(activeTabId)?.revision ?? 0,
+      });
+    }
+    for (const t of prevTabs) {
+      if (!after.has(t.id)) {
+        events.push({ type: 'tabs', tabId: t.id, revision: t.revision, removed: true });
+      }
+    }
+
+    // Advanced BEFORE the fan-out: a callback is allowed to write to the
+    // store, and a re-entrant notification must diff against what it sees.
+    prevTabs = tabs;
+    prevActive = activeTabId;
+
+    for (const event of events) {
+      try {
+        cb(event);
+      } catch (error) {
+        // A plugin must never be able to break the store, and a callback that
+        // throws once will throw on the next event too -- so it is dropped
+        // rather than left to fire into a burst of drag events.
+        console.error(
+          '[CodefyUI] a plugin workspace.onChanged callback threw; unsubscribing it',
+          error,
+        );
+        alive = false;
+        unsubscribe();
+        return;
+      }
+    }
+  });
+  return () => {
+    alive = false;
+    unsubscribe();
+  };
 }
 
 export function buildPluginAPI(
@@ -243,7 +638,7 @@ export function buildPluginAPI(
     graph: {
       getGraph: () => useTabStore.getState().getSerializedGraph(),
       getNodeDefinitions: () => useNodeDefStore.getState().definitions,
-      applyOperations: (ops) => commitGraphOperations(ops),
+      applyOperations: (ops) => commitGraphOperations(ops, pluginId),
       onGraphChanged: (cb) => {
         // Track the unsubscribe so the host can tear it down on a dev
         // hot-reload — otherwise re-activation would stack subscriptions.
@@ -252,6 +647,30 @@ export function buildPluginAPI(
         return unsubscribe;
       },
       getView: () => currentGraphView(),
+    },
+    workspace: {
+      openGraphs: (entries, options) => openWorkspaceGraphs(entries, options),
+      tabs: () => {
+        const { tabs, activeTabId } = useTabStore.getState();
+        return tabs.map((t) => tabInfoOf(t, activeTabId));
+      },
+      snapshot: (tabId) => {
+        const state = useTabStore.getState();
+        const tab = state.getTab(tabId ?? state.activeTabId);
+        if (!tab) return { error: 'unknown_tab' };
+        return {
+          ...tabInfoOf(tab, state.activeTabId),
+          graph: state.getSerializedGraphOf(tab),
+        };
+      },
+      applyOperations: (request) => commitWorkspaceOperations(pluginId, request),
+      onChanged: (cb) => {
+        // Tracked like `onGraphChanged`'s, so a dev hot-reload does not stack
+        // subscriptions.
+        const unsubscribe = subscribeWorkspaceChanged(cb);
+        trackCleanup?.(unsubscribe);
+        return unsubscribe;
+      },
     },
     nodes: {
       registerRenderer: (nodeType, renderer) => {

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -166,7 +166,7 @@ export function commitGraphOperations(ops: GraphOp[]): ApplyResult {
   const tab = store.getActiveTab();
   const definitions = useNodeDefStore.getState().definitions;
   const outcome: ApplyOutcome = applyGraphOps(
-    { nodes: tab.nodes, edges: tab.edges },
+    { nodes: tab.nodes, edges: tab.edges, segmentGroups: tab.segmentGroups },
     definitions,
     ops,
   );

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -189,7 +189,7 @@ export function currentGraphView(): GraphView {
 }
 
 export interface CodefyUIPluginAPI {
-  apiVersion: 4;
+  apiVersion: 5;
   pluginId: string;
   ui: {
     addFloatingWidget(opts: { id: string }): HTMLElement;
@@ -655,11 +655,13 @@ export function buildPluginAPI(
 ): CodefyUIPluginAPI {
   const ns = (key: string) => `plugin:${pluginId}:${key}`;
   return {
-    // Bumped for `graph.getView` (#200 item 7). The number is the only way a
-    // plugin can tell a host that has the new member from one that does not:
-    // on a 2.0-to-2.2 editor `api.graph.getView` is simply `undefined`, and the
-    // documented feature check is `api.apiVersion >= 4`.
-    apiVersion: 4,
+    // Bumped for `workspace` and the six agent canvas ops (#341, #342). The
+    // number is the only way a plugin can tell a host that has them from one
+    // that does not: on a 2.0-to-2.4 editor `api.workspace` is simply
+    // `undefined` -- never a stub whose methods throw -- and the documented
+    // feature checks are `api.apiVersion >= 5` and
+    // `typeof api.workspace?.openGraphs === 'function'`.
+    apiVersion: 5,
     pluginId,
     ui: {
       addFloatingWidget: ({ id }) => getWidgetContainer(id),

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -125,6 +125,16 @@ export type WorkspaceEvent =
 const MAX_WORKSPACE_GRAPH_BYTES = 8 * 1024 * 1024;
 /** How many tabs the editor will hold before `openGraphs` starts refusing. */
 const MAX_WORKSPACE_TABS = 32;
+/**
+ * Refusal for a legacy batch that would commit a top-level segment from
+ * inside a block (#341 section 4.6).
+ *
+ * Written once and in the same voice as `'tab is read-only'` -- what is
+ * wrong, not what to do about it. The contract does not freeze either
+ * literal; both are read by people, not matched on.
+ */
+const SEGMENT_INSIDE_BLOCK_ERROR =
+  'set_segment and remove_segment cannot apply while a block is open';
 
 export interface RunListOptions {
   status?: readonly RunStatus[];
@@ -243,6 +253,11 @@ export interface CodefyUIPluginAPI {
   };
 }
 
+/** The two ops that write `segmentGroups`, which is top-level state. */
+function isSegmentOp(op: GraphOp): boolean {
+  return op.op === 'set_segment' || op.op === 'remove_segment';
+}
+
 function tabInfoOf(tab: TabState, activeTabId: string): WorkspaceTabInfo {
   return {
     tabId: tab.id,
@@ -269,10 +284,11 @@ function tabInfoOf(tab: TabState, activeTabId: string): WorkspaceTabInfo {
  * that is never true here.
  *
  * `refuseInsideBlock` is the ONE way the two callers differ, and it is not a
- * knob a plugin can reach: the workspace path refuses, and the legacy path
- * keeps writing the open canvas because that is what it has always done and
- * moving an installed plugin's writes out from under it is not a change to
- * make silently (see `commitGraphOperations`).
+ * knob a plugin can reach: the workspace path refuses outright, and the legacy
+ * path keeps writing the open canvas because that is what it has always done
+ * and moving an installed plugin's writes out from under it is not a change to
+ * make silently (see `commitGraphOperations`). Its one carve-out is the two
+ * segment ops, which are not canvas writes at all -- see the branch below.
  */
 function commitToTab(
   pluginId: string,
@@ -295,14 +311,38 @@ function commitToTab(
     return { ...empty, ...counts, tabId, revision: tab.revision,
              committed: false, conflict: 'read_only' };
   }
-  // While a block is open, `tab.nodes` / `tab.edges` are the BLOCK's contents,
-  // and `snapshot()` answers with the flushed top level -- so a write here
-  // would land somewhere the plugin never read. Refused rather than
-  // redirected: the plugin retries once the user steps back out, which is a
-  // wait it can see, unlike an edit that silently went into a definition.
-  if (options.refuseInsideBlock && tab.subgraphStack.length > 0) {
-    return { ...empty, ...counts, tabId, revision: tab.revision,
-             committed: false, conflict: 'editing_subgraph' };
+  if (tab.subgraphStack.length > 0) {
+    // While a block is open, `tab.nodes` / `tab.edges` are the BLOCK's
+    // contents, and `snapshot()` answers with the flushed top level -- so a
+    // workspace write here would land somewhere the plugin never read.
+    // Refused rather than redirected: the plugin retries once the user steps
+    // back out, which is a wait it can see, unlike an edit that silently went
+    // into a definition.
+    if (options.refuseInsideBlock) {
+      return { ...empty, ...counts, tabId, revision: tab.revision,
+               committed: false, conflict: 'editing_subgraph' };
+    }
+    // The legacy path goes on writing the open canvas -- except for the two
+    // segment ops, which do not write the canvas at all. `enterSubgraph`
+    // CAPTURES `segmentGroups` instead of swapping them, so a segment
+    // committed from in here is a TOP-LEVEL overlay naming inner node ids: it
+    // survives the exit, reaches the saved file, and draws nothing -- which
+    // also means the user cannot remove it, the control being on the bubble.
+    // `remove_segment` is the mirror, deleting a real top-level overlay the
+    // user cannot even see from where they are standing.
+    //
+    // Refused whole-batch and shaped like the read-only refusal (#341 section
+    // 4.6). Not a behaviour change for anybody: both ops are new in v5, so no
+    // installed plugin sends them, and a batch without one is untouched.
+    if (request.operations.some(isSegmentOp)) {
+      return {
+        ...counts, tabId, revision: tab.revision, committed: false,
+        refs: {},
+        results: request.operations.map((_, index) => ({
+          index, ok: false, error: SEGMENT_INSIDE_BLOCK_ERROR,
+        })),
+      };
+    }
   }
   if (
     request.expectedRevision !== undefined
@@ -386,6 +426,11 @@ export function commitWorkspaceOperations(
  * plugin gets the refusal instead. The ONE behaviour change v5 makes to an
  * installed plugin is the other one -- a read-only tab now refuses per op
  * instead of being written through (#341 section 4.6).
+ *
+ * The segment carve-out above is not a third: `set_segment` and
+ * `remove_segment` are new in v5, so no installed plugin can send them, and
+ * refusing them inside a block keeps a top-level overlay naming inner node
+ * ids out of the saved file.
  */
 export function commitGraphOperations(ops: GraphOp[], pluginId = ''): ApplyResult {
   const result = commitToTab(pluginId, { operations: ops }, { refuseInsideBlock: false });

--- a/frontend/src/plugins/api.v5.test.ts
+++ b/frontend/src/plugins/api.v5.test.ts
@@ -569,6 +569,81 @@ describe('workspace.applyOperations while the user is inside a block', () => {
     expect(store().getTab(tabId)!.segmentGroups).toHaveLength(1);
     expect(store().getTab(tabId)!.nodes).toHaveLength(3);
   });
+
+  /**
+   * A graph with a real top-level overlay, standing inside a block.
+   *
+   * The overlay is installed through the real write path rather than pushed
+   * into the store by hand, so what the tests below assert against is a
+   * segment the editor itself produced.
+   */
+  function enterBlockOverSegmentedGraph() {
+    store().setNodes([
+      { id: 'a', type: 'baseNode', position: { x: 0, y: 0 },
+        data: { label: 'a', type: 'Source', params: {} } } as never,
+      { id: 'b', type: 'baseNode', position: { x: 200, y: 0 },
+        data: { label: 'b', type: 'Sink', params: {} } } as never,
+      { id: 'inst', type: 'baseNode', position: { x: 400, y: 0 },
+        data: { label: 'Encoder', type: 'subgraph:blk', params: {} } } as never,
+    ]);
+    store().setEdges([
+      { id: 'e1', source: 'a', target: 'b', sourceHandle: 'out', targetHandle: 'x' },
+    ]);
+    store().setSubgraphs([{
+      id: 'blk', name: 'Encoder', description: '',
+      nodes: [{ id: 'in1', type: 'Source', position: { x: 0, y: 0 }, data: { params: {} } }],
+      edges: [],
+      interface: { inputs: [], outputs: [], triggerTargets: [] },
+    } as never]);
+
+    const seeded = freshApi().workspace.applyOperations({
+      operations: [
+        { op: 'set_segment', segment_id: 's-top', head_node_id: 'a', tail_node_id: 'b' },
+      ],
+    });
+    expect(seeded.committed).toBe(true);
+    expect(store().getActiveTab().segmentGroups).toHaveLength(1);
+    expect(store().enterSubgraph('inst')).toBe(true);
+  }
+
+  it('a legacy clear_graph in a block leaves the TOP LEVEL overlays alone', () => {
+    // `clear_graph` empties the reducer's segment list, and while a block is
+    // open that list is the GRAPH's, not the block's -- so committing the
+    // outcome wholesale would delete every overlay on a canvas the user is not
+    // even looking at, and the next save would write the loss to disk. Before
+    // v5 the legacy commit never touched segments at all; from inside a block
+    // it still does not.
+    const api = freshApi();
+    enterBlockOverSegmentedGraph();
+    // The block's own canvas: one node, and no segments of its own.
+    expect(store().getActiveTab().nodes).toHaveLength(1);
+    expect(store().getActiveTab().segmentGroups).toHaveLength(1);
+
+    const result = api.graph.applyOperations([{ op: 'clear_graph' }]);
+    expect(result.results[0].ok).toBe(true);
+
+    // Emptied the block, exactly as before (api.view.test.ts pins this too).
+    expect(store().getActiveTab().nodes).toEqual([]);
+    // ...and left the graph's overlay standing, through the exit and into
+    // what the next save would write.
+    expect(store().getActiveTab().segmentGroups).toHaveLength(1);
+    store().exitSubgraph();
+    expect(store().getActiveTab().segmentGroups).toHaveLength(1);
+    expect(api.graph.getGraph().segmentGroups).toHaveLength(1);
+  });
+
+  it('the same clear_graph at the TOP level still empties the overlays', () => {
+    // The companion: nothing about the legacy path spares segments as such.
+    // Being inside a block is the whole of the difference.
+    const api = freshApi();
+    enterBlockOverSegmentedGraph();
+    store().exitSubgraph();
+    expect(store().getActiveTab().segmentGroups).toHaveLength(1);
+
+    api.graph.applyOperations([{ op: 'clear_graph' }]);
+    expect(store().getActiveTab().segmentGroups).toEqual([]);
+    expect(store().getActiveTab().nodes).toEqual([]);
+  });
 });
 
 describe('workspace.onChanged', () => {

--- a/frontend/src/plugins/api.v5.test.ts
+++ b/frontend/src/plugins/api.v5.test.ts
@@ -417,6 +417,30 @@ describe('workspace.applyOperations while the user is inside a block', () => {
     expect(store().enterSubgraph('inst')).toBe(true);
   }
 
+  /**
+   * The same, but with two connected nodes inside the block -- enough for a
+   * `set_segment` that WOULD be accepted on its merits, so what the test
+   * catches is the guard and not the op's own validation.
+   */
+  function enterBlockWithChain() {
+    store().setNodes([{
+      id: 'inst', type: 'baseNode', position: { x: 0, y: 0 },
+      data: { label: 'Encoder', type: 'subgraph:blk', params: {} },
+    } as never]);
+    store().setSubgraphs([{
+      id: 'blk', name: 'Encoder', description: '',
+      nodes: [
+        { id: 'in1', type: 'Source', position: { x: 0, y: 0 }, data: { params: {} } },
+        { id: 'in2', type: 'Sink', position: { x: 200, y: 0 }, data: { params: {} } },
+      ],
+      edges: [
+        { id: 'ie1', source: 'in1', target: 'in2', sourceHandle: 'out', targetHandle: 'x' },
+      ],
+      interface: { inputs: [], outputs: [], triggerTargets: [] },
+    } as never]);
+    expect(store().enterSubgraph('inst')).toBe(true);
+  }
+
   it('refuses with editing_subgraph instead of writing into the block', () => {
     const api = freshApi();
     enterEmptyBlock();
@@ -458,6 +482,55 @@ describe('workspace.applyOperations while the user is inside a block', () => {
     expect(result.results[0].ok).toBe(true);
     expect(store().getActiveTab().nodes).toHaveLength(1);
     expect(store().getActiveTab().subgraphStack).toHaveLength(1);
+  });
+
+  it('...but refuses a legacy batch holding a segment op, whole batch', () => {
+    // `enterSubgraph` captures `segmentGroups` rather than swapping them, so a
+    // segment committed from in here is a TOP-LEVEL overlay naming inner node
+    // ids: it survives the exit, is written to the saved file, and draws
+    // nothing -- so the user cannot delete it either. The whole batch goes,
+    // including the innocent op, because segments are committed wholesale and
+    // there is no half of this batch that lands safely.
+    const api = freshApi();
+    enterBlockWithChain();
+    const before = store().getActiveTab();
+    const nodesBefore = before.nodes.length;
+
+    const result = api.graph.applyOperations([
+      { op: 'add_node', node_type: 'Source' },
+      { op: 'set_segment', segment_id: 's1', head_node_id: 'in1', tail_node_id: 'in2' },
+    ]);
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results.every((r) => !r.ok)).toBe(true);
+    expect(result.results.map((r) => r.index)).toEqual([0, 1]);
+    expect(result.results[0].error).toContain('set_segment');
+
+    const after = store().getActiveTab();
+    expect(after.segmentGroups).toEqual([]);
+    expect(after.nodes).toHaveLength(nodesBefore);
+    expect(after.revision).toBe(before.revision);
+    expect(after.undoStack).toHaveLength(before.undoStack.length);
+  });
+
+  it('the same batch at the TOP level commits, segment and all', () => {
+    // The counterfactual: nothing is wrong with these two ops, and the legacy
+    // path has no quarrel with segments as such. It is standing inside a block
+    // -- where `segmentGroups` is still the top level's -- that makes the
+    // write unsafe.
+    const api = freshApi();
+    const [opened] = api.workspace.openGraphs(
+      [{ title: 'Top level', graph: candidateGraph() }], { activate: 'first' });
+    const { tabId } = opened as { tabId: string };
+
+    const result = api.graph.applyOperations([
+      { op: 'add_node', node_type: 'Source' },
+      { op: 'set_segment', segment_id: 's1', head_node_id: 'a', tail_node_id: 'b' },
+    ]);
+
+    expect(result.results.every((r) => r.ok)).toBe(true);
+    expect(store().getTab(tabId)!.segmentGroups).toHaveLength(1);
+    expect(store().getTab(tabId)!.nodes).toHaveLength(3);
   });
 });
 

--- a/frontend/src/plugins/api.v5.test.ts
+++ b/frontend/src/plugins/api.v5.test.ts
@@ -64,6 +64,43 @@ beforeEach(() => {
   window.localStorage.clear();
 });
 
+describe('meta', () => {
+  it('reports at least apiVersion 5', () => {
+    // The documented v5 feature check is `api.apiVersion >= 5`, so that is
+    // what this asserts; the exact number lives in `api.view.test.ts`.
+    expect(freshApi().apiVersion).toBeGreaterThanOrEqual(5);
+  });
+
+  it('offers the whole workspace surface as callable functions', () => {
+    const api = freshApi();
+    for (const member of ['openGraphs', 'tabs', 'snapshot', 'applyOperations', 'onChanged']) {
+      expect(
+        typeof (api.workspace as unknown as Record<string, unknown>)[member],
+        `workspace.${member}`,
+      ).toBe('function');
+    }
+  });
+
+  it('every apiVersion 4 member is still there', () => {
+    const V4_SHAPE: Record<string, string[]> = {
+      ui: ['addFloatingWidget', 'toast', 'addPanel', 'removePanel', 'addToolbarButton', 'removeToolbarButton'],
+      graph: ['getGraph', 'getNodeDefinitions', 'applyOperations', 'onGraphChanged', 'getView'],
+      nodes: ['registerRenderer'],
+      events: ['onExecution'],
+      runs: ['list', 'get', 'metrics'],
+      http: ['fetch'],
+      storage: ['get', 'set', 'remove'],
+    };
+    const api = freshApi() as unknown as Record<string, Record<string, unknown>>;
+    for (const [section, members] of Object.entries(V4_SHAPE)) {
+      expect(api[section], `section ${section}`).toBeDefined();
+      for (const member of members) {
+        expect(typeof api[section][member], `${section}.${member}`).toBe('function');
+      }
+    }
+  });
+});
+
 describe('workspace.openGraphs', () => {
   it('opens a labelled tab without disturbing the live graph', () => {
     const api = freshApi();

--- a/frontend/src/plugins/api.v5.test.ts
+++ b/frontend/src/plugins/api.v5.test.ts
@@ -1,0 +1,563 @@
+/**
+ * `api.workspace` — the apiVersion 5 surface (#341).
+ *
+ * Four things a plugin could not do before: open a graph as a tab without
+ * moving the user, read a tab that is not on screen, write to a named tab
+ * only if it has not changed since it last looked, and hear about all of it.
+ *
+ * The read-only refusal on the LEGACY path is here too, because it is the one
+ * behaviour an installed plugin can notice (#341 section 4.6).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useTabStore, _persistedTabsForTesting } from '../store/tabStore';
+import { useNodeDefStore } from '../store/nodeDefStore';
+import { buildPluginAPI } from './api';
+import type { NodeDefinition } from '../types';
+
+vi.mock('../store/tabPersistence', () => ({
+  readSnapshot: vi.fn(async () => null),
+  writeSnapshot: vi.fn(async () => {}),
+}));
+
+const store = () => useTabStore.getState();
+
+const DEFS: NodeDefinition[] = [
+  {
+    node_name: 'Source', category: 'Layer', description: '',
+    inputs: [],
+    outputs: [{ name: 'out', data_type: 'TENSOR', description: '', optional: false }],
+    params: [],
+  },
+  {
+    node_name: 'Sink', category: 'Layer', description: '',
+    inputs: [{ name: 'x', data_type: 'TENSOR', description: '', optional: false }],
+    outputs: [], params: [],
+  },
+];
+
+function freshApi(pluginId = 'test-plugin') {
+  return buildPluginAPI(pluginId, () => document.createElement('div'));
+}
+
+/** A serialized two-node chain, in the shape `getGraph()` answers with. */
+function candidateGraph(name = 'candidate') {
+  return {
+    name,
+    description: '',
+    nodes: [
+      { id: 'a', type: 'Source', position: { x: 0, y: 0 }, data: { params: {} } },
+      { id: 'b', type: 'Sink', position: { x: 200, y: 0 }, data: { params: {} } },
+    ],
+    edges: [
+      { id: 'e1', source: 'a', target: 'b', sourceHandle: 'out', targetHandle: 'x' },
+    ],
+    presets: [],
+    segmentGroups: [],
+    subgraphs: [],
+  };
+}
+
+beforeEach(() => {
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  store().addTab('live');
+  useNodeDefStore.setState({ definitions: DEFS, presets: [] } as never);
+  window.localStorage.clear();
+});
+
+describe('workspace.openGraphs', () => {
+  it('opens a labelled tab without disturbing the live graph', () => {
+    const api = freshApi();
+    const live = store().activeTabId;
+    const [result] = api.workspace.openGraphs(
+      [{ title: 'Variant A', graph: candidateGraph(), readOnly: true,
+         source: { kind: 'agent-variant', pluginId: 'test-plugin', jobId: 'j1' } }],
+      { activate: 'none' },
+    );
+    expect('tabId' in result).toBe(true);
+    if (!('tabId' in result)) return;
+
+    expect(store().activeTabId).toBe(live);
+    const tab = store().getTab(result.tabId)!;
+    expect(tab.name).toBe('Variant A');
+    expect(tab.nodes.map((n) => n.id)).toEqual(['a', 'b']);
+    expect(tab.edges).toHaveLength(1);
+    expect(tab.readOnly).toBe(true);
+    expect(tab.transient).toBe(true);
+    expect(tab.source).toEqual({ kind: 'agent-variant', pluginId: 'test-plugin', jobId: 'j1' });
+    expect(result.revision).toBe(tab.revision);
+  });
+
+  it('is positional: one bad entry does not sink its neighbours', () => {
+    const api = freshApi();
+    const results = api.workspace.openGraphs([
+      { title: 'Good one', graph: candidateGraph('one') },
+      { title: '   ', graph: candidateGraph('two') },
+      { title: 'Good two', graph: candidateGraph('three') },
+    ], { activate: 'none' });
+
+    expect(results).toHaveLength(3);
+    expect('tabId' in results[0]).toBe(true);
+    expect(results[1]).toMatchObject({ code: 'invalid_graph' });
+    expect('tabId' in results[2]).toBe(true);
+  });
+
+  it('refuses a graph over the 8 MiB limit with too_large', () => {
+    const api = freshApi();
+    const huge = candidateGraph();
+    huge.description = 'x'.repeat(9 * 1024 * 1024);
+    const [result] = api.workspace.openGraphs([{ title: 'Huge', graph: huge }], { activate: 'none' });
+    expect(result).toMatchObject({ code: 'too_large' });
+    expect(store().tabs).toHaveLength(1);
+  });
+
+  it('refuses past 32 tabs with too_many_tabs', () => {
+    const api = freshApi();
+    while (store().tabs.length < 32) store().createTab({ activate: false });
+    const [result] = api.workspace.openGraphs(
+      [{ title: 'One too many', graph: candidateGraph() }], { activate: 'none' },
+    );
+    expect(result).toMatchObject({ code: 'too_many_tabs' });
+    expect(store().tabs).toHaveLength(32);
+  });
+
+  it('reports a reader failure as invalid_graph and opens no tab', () => {
+    const api = freshApi();
+    const [result] = api.workspace.openGraphs(
+      // `nodes` is not a list, so the document reader cannot walk it.
+      [{ title: 'Broken', graph: { nodes: 'not-a-list', edges: [] } as never }],
+      { activate: 'none' },
+    );
+    expect(result).toMatchObject({ code: 'invalid_graph' });
+    expect(store().tabs).toHaveLength(1);
+  });
+
+  it('honours activate: first, last and none', () => {
+    const api = freshApi();
+    const live = store().activeTabId;
+
+    const none = api.workspace.openGraphs(
+      [{ title: 'n1', graph: candidateGraph() }], { activate: 'none' });
+    expect(store().activeTabId).toBe(live);
+
+    const first = api.workspace.openGraphs([
+      { title: 'f1', graph: candidateGraph() },
+      { title: 'f2', graph: candidateGraph() },
+    ]);
+    expect(store().activeTabId).toBe((first[0] as { tabId: string }).tabId);
+
+    const last = api.workspace.openGraphs([
+      { title: 'l1', graph: candidateGraph() },
+      { title: 'l2', graph: candidateGraph() },
+    ], { activate: 'last' });
+    expect(store().activeTabId).toBe((last[1] as { tabId: string }).tabId);
+    void none;
+  });
+
+  it('persist: true opts the tab back into surviving a reload', () => {
+    const api = freshApi();
+    const [kept] = api.workspace.openGraphs(
+      [{ title: 'Kept', graph: candidateGraph(), persist: true }], { activate: 'none' });
+    expect(store().getTab((kept as { tabId: string }).tabId)!.transient).toBe(false);
+  });
+
+  it('an ACTIVATED transient tab leaves the next reload on a real tab', () => {
+    // The one state where the persisted pointer names a tab that will not come
+    // back: `saveTabs` writes the unfiltered `activeTabId` alongside records
+    // `persistedTabsFor` has dropped the transient tab from. The reader's
+    // fallback -- `tabs[0]` when no record carries the id (`loadTabs`) -- is
+    // what keeps that from being a crash, so it is asserted here against the
+    // records this state really produces.
+    const api = freshApi();
+    const live = store().activeTabId;
+    const [opened] = api.workspace.openGraphs(
+      [{ title: 'Candidate', graph: candidateGraph() }], { activate: 'first' });
+    const { tabId } = opened as { tabId: string };
+    expect(store().activeTabId).toBe(tabId);
+
+    const records = _persistedTabsForTesting(store().tabs);
+    expect(records.map((r) => r.id)).not.toContain(tabId);
+    const restored = records.some((r) => r.id === store().activeTabId)
+      ? store().activeTabId
+      : records[0].id;
+    expect(restored).toBe(live);
+  });
+});
+
+describe('workspace.tabs and workspace.snapshot', () => {
+  it('lists every tab in bar order, marking the active one', () => {
+    const api = freshApi();
+    const live = store().activeTabId;
+    api.workspace.openGraphs([{ title: 'Second', graph: candidateGraph() }], { activate: 'none' });
+
+    const tabs = api.workspace.tabs();
+    expect(tabs).toHaveLength(2);
+    expect(tabs.map((t) => t.tabId)).toEqual(store().tabs.map((t) => t.id));
+    expect(tabs.filter((t) => t.active).map((t) => t.tabId)).toEqual([live]);
+    expect(tabs[1].title).toBe('Second');
+    expect(tabs[1].transient).toBe(true);
+  });
+
+  it('snapshots a background tab, whole graph included', () => {
+    const api = freshApi();
+    const [opened] = api.workspace.openGraphs(
+      [{ title: 'Background', graph: candidateGraph(), source: { kind: 'k', pluginId: 'p' } }],
+      { activate: 'none' },
+    );
+    const { tabId } = opened as { tabId: string };
+
+    const snap = api.workspace.snapshot(tabId);
+    expect('error' in snap).toBe(false);
+    if ('error' in snap) return;
+    expect(snap.tabId).toBe(tabId);
+    expect(snap.active).toBe(false);
+    expect(snap.source).toEqual({ kind: 'k', pluginId: 'p' });
+    expect(snap.graph.nodes.map((n: { id: string }) => n.id)).toEqual(['a', 'b']);
+    expect(snap.graph.edges).toHaveLength(1);
+  });
+
+  it('snapshot() with no id answers for the active tab', () => {
+    const api = freshApi();
+    const snap = api.workspace.snapshot();
+    expect('error' in snap).toBe(false);
+    if ('error' in snap) return;
+    expect(snap.tabId).toBe(store().activeTabId);
+    expect(snap.active).toBe(true);
+  });
+
+  it('an unknown id is an error result, never a throw', () => {
+    const api = freshApi();
+    expect(api.workspace.snapshot('no-such-tab')).toEqual({ error: 'unknown_tab' });
+  });
+});
+
+describe('workspace.applyOperations', () => {
+  function openEditable() {
+    const api = freshApi();
+    const [opened] = api.workspace.openGraphs(
+      [{ title: 'Target', graph: candidateGraph() }], { activate: 'none' });
+    return { api, tabId: (opened as { tabId: string }).tabId };
+  }
+
+  it('commits to a named tab and advances the revision by one', () => {
+    const { api, tabId } = openEditable();
+    const before = store().getTab(tabId)!.revision;
+
+    const result = api.workspace.applyOperations({
+      tabId,
+      expectedRevision: before,
+      operations: [{ op: 'add_node', node_type: 'Source' }],
+    });
+
+    expect(result.committed).toBe(true);
+    expect(result.conflict).toBeUndefined();
+    expect(result.tabId).toBe(tabId);
+    expect(result.revision).toBe(before + 1);
+    expect(result.node_count).toBe(3);
+    expect(store().getTab(tabId)!.nodes).toHaveLength(3);
+  });
+
+  it('refuses on a stale revision, and hands back the current one', () => {
+    const { api, tabId } = openEditable();
+    const stale = store().getTab(tabId)!.revision;
+    // Somebody else edits the tab in the meantime.
+    api.workspace.applyOperations({ tabId, operations: [{ op: 'add_node', node_type: 'Sink' }] });
+    const current = store().getTab(tabId)!.revision;
+
+    const result = api.workspace.applyOperations({
+      tabId,
+      expectedRevision: stale,
+      operations: [{ op: 'clear_graph' }],
+    });
+
+    expect(result.conflict).toBe('revision_mismatch');
+    expect(result.committed).toBe(false);
+    expect(result.results).toEqual([]);
+    // The plugin can re-arm without a second read, and the tab is untouched.
+    expect(result.revision).toBe(current);
+    expect(store().getTab(tabId)!.nodes.length).toBeGreaterThan(0);
+  });
+
+  it('refuses a read-only tab before it reduces anything', () => {
+    const api = freshApi();
+    const [opened] = api.workspace.openGraphs(
+      [{ title: 'Frozen', graph: candidateGraph(), readOnly: true }], { activate: 'none' });
+    const { tabId } = opened as { tabId: string };
+    const before = store().getTab(tabId)!.revision;
+
+    const result = api.workspace.applyOperations({
+      tabId, operations: [{ op: 'clear_graph' }],
+    });
+
+    expect(result.conflict).toBe('read_only');
+    expect(result.committed).toBe(false);
+    expect(result.results).toEqual([]);
+    expect(result.revision).toBe(before);
+    expect(store().getTab(tabId)!.nodes).toHaveLength(2);
+  });
+
+  it('an unknown tab is a conflict with revision 0', () => {
+    const api = freshApi();
+    const result = api.workspace.applyOperations({
+      tabId: 'gone', operations: [{ op: 'clear_graph' }],
+    });
+    expect(result).toMatchObject({
+      conflict: 'unknown_tab', committed: false, revision: 0, tabId: 'gone',
+    });
+    expect(result.results).toEqual([]);
+  });
+
+  it('atomic: one bad op in three commits nothing and still names the failure', () => {
+    const { api, tabId } = openEditable();
+    const before = store().getTab(tabId)!.revision;
+
+    const result = api.workspace.applyOperations({
+      tabId,
+      atomic: true,
+      operations: [
+        { op: 'add_node', node_type: 'Source' },
+        { op: 'add_node', node_type: 'Ghost' },
+        { op: 'add_node', node_type: 'Sink' },
+      ],
+    });
+
+    expect(result.committed).toBe(false);
+    expect(result.conflict).toBeUndefined();
+    // Full length, in input order: the model has to see WHICH op failed.
+    expect(result.results).toHaveLength(3);
+    expect(result.results.map((r) => r.ok)).toEqual([true, false, true]);
+    expect(result.revision).toBe(before);
+    expect(store().getTab(tabId)!.nodes).toHaveLength(2);
+  });
+
+  it('non-atomic still commits the ops that worked', () => {
+    const { api, tabId } = openEditable();
+    const result = api.workspace.applyOperations({
+      tabId,
+      operations: [
+        { op: 'add_node', node_type: 'Ghost' },
+        { op: 'add_node', node_type: 'Sink' },
+      ],
+    });
+    expect(result.committed).toBe(true);
+    expect(result.results.map((r) => r.ok)).toEqual([false, true]);
+    expect(store().getTab(tabId)!.nodes).toHaveLength(3);
+  });
+
+  it('a batch that mutates nothing commits nothing and pushes no undo step', () => {
+    const { api, tabId } = openEditable();
+    const before = store().getTab(tabId)!;
+    const result = api.workspace.applyOperations({
+      tabId, operations: [{ op: 'add_node', node_type: 'Ghost' }],
+    });
+    expect(result.committed).toBe(false);
+    expect(result.revision).toBe(before.revision);
+    expect(store().getTab(tabId)!.undoStack).toHaveLength(before.undoStack.length);
+  });
+
+  it('move + segment + note + label is ONE undo step', () => {
+    const { api, tabId } = openEditable();
+    const result = api.workspace.applyOperations({
+      tabId,
+      atomic: true,
+      operations: [
+        { op: 'move_node', node_id: 'a', position: { x: 640, y: 320 } },
+        { op: 'set_segment', segment_id: 's1', head_node_id: 'a', tail_node_id: 'b' },
+        { op: 'add_note', text: 'ablation: no warmup', bind_to: 'a' },
+        { op: 'set_node_meta', node_id: 'b', label: 'Readout' },
+      ],
+    });
+    expect(result.results.every((r) => r.ok)).toBe(true);
+    expect(result.committed).toBe(true);
+
+    const after = store().getTab(tabId)!;
+    expect(after.nodes.find((n) => n.id === 'a')!.position).toEqual({ x: 640, y: 320 });
+    expect(after.segmentGroups).toHaveLength(1);
+    expect(after.nodes.some((n) => n.type === 'noteNode')).toBe(true);
+    expect(after.nodes.find((n) => n.id === 'b')!.data.label).toBe('Readout');
+
+    // Undo is per tab, so activate it first -- exactly what the user does.
+    store().setActiveTab(tabId);
+    store().undo();
+    const undone = store().getTab(tabId)!;
+    expect(undone.nodes.find((n) => n.id === 'a')!.position).toEqual({ x: 0, y: 0 });
+    expect(undone.segmentGroups).toHaveLength(0);
+    expect(undone.nodes.some((n) => n.type === 'noteNode')).toBe(false);
+    expect(undone.nodes.find((n) => n.id === 'b')!.data.label).not.toBe('Readout');
+  });
+
+  it('with no tabId, writes to the active tab', () => {
+    const api = freshApi();
+    const live = store().activeTabId;
+    const result = api.workspace.applyOperations({
+      operations: [{ op: 'add_node', node_type: 'Source' }],
+    });
+    expect(result.tabId).toBe(live);
+    expect(store().getTab(live)!.nodes).toHaveLength(1);
+  });
+});
+
+describe('workspace.applyOperations while the user is inside a block', () => {
+  /**
+   * Put the active tab inside an empty block, through the real action.
+   *
+   * The canvas arrays are the BLOCK's contents from here on, which is the
+   * whole reason for the refusal below: `snapshot()` still describes the
+   * flushed top level, so a write that landed on those arrays would be a
+   * write to something the plugin never read (#341 section 4.4 step 3).
+   */
+  function enterEmptyBlock() {
+    store().setNodes([{
+      id: 'inst', type: 'baseNode', position: { x: 0, y: 0 },
+      data: { label: 'Encoder', type: 'subgraph:blk', params: {} },
+    } as never]);
+    store().setSubgraphs([{
+      id: 'blk', name: 'Encoder', description: '',
+      nodes: [], edges: [], interface: { inputs: [], outputs: [], triggerTargets: [] },
+    }]);
+    expect(store().enterSubgraph('inst')).toBe(true);
+  }
+
+  it('refuses with editing_subgraph instead of writing into the block', () => {
+    const api = freshApi();
+    enterEmptyBlock();
+    const before = store().getActiveTab().revision;
+
+    const result = api.workspace.applyOperations({
+      operations: [{ op: 'add_node', node_type: 'Source' }],
+    });
+
+    expect(result.conflict).toBe('editing_subgraph');
+    expect(result.committed).toBe(false);
+    expect(result.results).toEqual([]);
+    expect(result.revision).toBe(before);
+    // Nothing was written anywhere: the block is still empty.
+    expect(store().getActiveTab().nodes).toEqual([]);
+  });
+
+  it('read-only outranks it, and it outranks a stale revision', () => {
+    const api = freshApi();
+    enterEmptyBlock();
+    expect(api.workspace.applyOperations({
+      expectedRevision: 9999, operations: [{ op: 'clear_graph' }],
+    }).conflict).toBe('editing_subgraph');
+
+    store().setTabReadOnly(true);
+    expect(api.workspace.applyOperations({
+      operations: [{ op: 'clear_graph' }],
+    }).conflict).toBe('read_only');
+  });
+
+  it('the LEGACY path still writes into the open block, exactly as before', () => {
+    // The one place the two paths deliberately disagree. Moving an installed
+    // plugin's writes out from under it is the change #341 refused to make
+    // (core#200 item 7, maintainer decision); `workspace` is where a plugin
+    // gets the stricter promise instead.
+    const api = freshApi();
+    enterEmptyBlock();
+    const result = api.graph.applyOperations([{ op: 'add_node', node_type: 'Source' }]);
+    expect(result.results[0].ok).toBe(true);
+    expect(store().getActiveTab().nodes).toHaveLength(1);
+    expect(store().getActiveTab().subgraphStack).toHaveLength(1);
+  });
+});
+
+describe('workspace.onChanged', () => {
+  it('reports an added tab, a graph change, an activation and a close, in order', () => {
+    const api = freshApi();
+    const seen: string[] = [];
+    const off = api.workspace.onChanged((e) => seen.push(`${e.type}${e.type === 'tabs' ? `:${e.removed}` : ''}`));
+
+    const [opened] = api.workspace.openGraphs(
+      [{ title: 'Watched', graph: candidateGraph() }], { activate: 'none' });
+    const { tabId } = opened as { tabId: string };
+    expect(seen[0]).toBe('tabs:false');
+    expect(seen).toContain('graph');
+
+    seen.length = 0;
+    store().setActiveTab(tabId);
+    expect(seen).toEqual(['active-tab']);
+
+    seen.length = 0;
+    store().removeTab(tabId);
+    expect(seen).toContain('tabs:true');
+
+    off();
+  });
+
+  it('carries the tabId and the new revision on a graph event', () => {
+    const api = freshApi();
+    const events: Array<{ type: string; tabId: string; revision: number }> = [];
+    const off = api.workspace.onChanged((e) => events.push(e));
+    store().addNote('text', { x: 0, y: 0 });
+    const graphEvents = events.filter((e) => e.type === 'graph');
+    // Exactly one: `addNote` snapshots and then writes, and only the write
+    // touches a document field.
+    expect(graphEvents).toHaveLength(1);
+    expect(graphEvents[0].tabId).toBe(store().activeTabId);
+    expect(graphEvents[0].revision).toBe(store().getActiveTab().revision);
+    off();
+  });
+
+  it('attaches origin to a plugin write and to nothing else', () => {
+    const api = freshApi('graph-copilot');
+    const origins: Array<{ pluginId: string } | undefined> = [];
+    const off = api.workspace.onChanged((e) => {
+      if (e.type === 'graph') origins.push(e.origin);
+    });
+
+    api.workspace.applyOperations({ operations: [{ op: 'add_node', node_type: 'Source' }] });
+    expect(origins).toEqual([{ pluginId: 'graph-copilot' }]);
+
+    origins.length = 0;
+    store().addNote('text', { x: 0, y: 0 });
+    expect(origins).toEqual([undefined]);
+    off();
+  });
+
+  it('unsubscribes cleanly, and drops a callback that throws', () => {
+    const api = freshApi();
+    let calls = 0;
+    const off = api.workspace.onChanged(() => { calls += 1; });
+    store().addNote('text', { x: 0, y: 0 });
+    const seen = calls;
+    off();
+    store().addNote('text', { x: 0, y: 0 });
+    expect(calls).toBe(seen);
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let thrown = 0;
+    api.workspace.onChanged(() => { thrown += 1; throw new Error('plugin bug'); });
+    store().addNote('text', { x: 0, y: 0 });
+    store().addNote('text', { x: 0, y: 0 });
+    // Called once, then unsubscribed -- a plugin cannot break the store.
+    expect(thrown).toBe(1);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe('the legacy graph.applyOperations on a read-only tab (#341 section 4.6)', () => {
+  it('refuses every op instead of writing through', () => {
+    const api = freshApi();
+    store().setTabReadOnly(true);
+    const before = store().getActiveTab().nodes.length;
+
+    const result = api.graph.applyOperations([
+      { op: 'add_node', node_type: 'Source' },
+      { op: 'add_node', node_type: 'Sink' },
+    ]);
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results.every((r) => !r.ok)).toBe(true);
+    expect(result.results[0].error).toContain('read-only');
+    expect(result.results.map((r) => r.index)).toEqual([0, 1]);
+    expect(store().getActiveTab().nodes).toHaveLength(before);
+  });
+
+  it('still writes through on an editable tab', () => {
+    const api = freshApi();
+    const result = api.graph.applyOperations([{ op: 'add_node', node_type: 'Source' }]);
+    expect(result.results[0].ok).toBe(true);
+    expect(store().getActiveTab().nodes).toHaveLength(1);
+  });
+});

--- a/frontend/src/plugins/api.view.test.ts
+++ b/frontend/src/plugins/api.view.test.ts
@@ -277,17 +277,21 @@ describe('read/write asymmetry the view exists to expose', () => {
   });
 });
 
-describe('apiVersion 4', () => {
-  it('reports 4 and offers getView', () => {
+describe('apiVersion 5', () => {
+  it('reports 5 and offers the workspace namespace', () => {
+    // The exact number is pinned in ONE place per version, and this is the
+    // file that owns it -- `api.v3.test.ts:59-64` records why: a `toBe(N)`
+    // left behind in an older version's file fails every later additive
+    // release in a suite that is testing something else.
     const api = freshApi();
-    expect(api.apiVersion).toBe(4);
-    expect(typeof api.graph.getView).toBe('function');
+    expect(api.apiVersion).toBe(5);
+    expect(typeof api.workspace.openGraphs).toBe('function');
   });
 
   it('leaves every earlier graph member in place', () => {
-    // Additive: a v2/v3 plugin reaches for these four and nothing else.
+    // Additive: a v2/v3 plugin reaches for these four, a v4 one for getView.
     const api = freshApi();
-    for (const member of ['getGraph', 'getNodeDefinitions', 'applyOperations', 'onGraphChanged']) {
+    for (const member of ['getGraph', 'getNodeDefinitions', 'applyOperations', 'onGraphChanged', 'getView']) {
       expect(
         typeof (api.graph as unknown as Record<string, unknown>)[member],
         `graph.${member}`,

--- a/frontend/src/plugins/contract.assert.ts
+++ b/frontend/src/plugins/contract.assert.ts
@@ -15,6 +15,15 @@ import type {
   GraphView as HGraphView,
   GraphViewLevel as HGraphViewLevel,
   RunListOptions as HRunListOptions,
+  WorkspaceApplyRequest as HWorkspaceApplyRequest,
+  WorkspaceApplyResult as HWorkspaceApplyResult,
+  WorkspaceConflict as HWorkspaceConflict,
+  WorkspaceEvent as HWorkspaceEvent,
+  WorkspaceGraphInput as HWorkspaceGraphInput,
+  WorkspaceOpenEntry as HWorkspaceOpenEntry,
+  WorkspaceOpenResult as HWorkspaceOpenResult,
+  WorkspaceSource as HWorkspaceSource,
+  WorkspaceTabInfo as HWorkspaceTabInfo,
 } from './api';
 import type {
   NodeDefinition as HNodeDef,
@@ -62,6 +71,15 @@ import type {
   RunMetrics as CRunMetrics,
   RunStatus as CRunStatus,
   RunSummary as CRunSummary,
+  WorkspaceApplyRequest as CWorkspaceApplyRequest,
+  WorkspaceApplyResult as CWorkspaceApplyResult,
+  WorkspaceConflict as CWorkspaceConflict,
+  WorkspaceEvent as CWorkspaceEvent,
+  WorkspaceGraphInput as CWorkspaceGraphInput,
+  WorkspaceOpenEntry as CWorkspaceOpenEntry,
+  WorkspaceOpenResult as CWorkspaceOpenResult,
+  WorkspaceSource as CWorkspaceSource,
+  WorkspaceTabInfo as CWorkspaceTabInfo,
 } from './contract';
 
 type Extends<A, B> = A extends B ? true : false;
@@ -100,8 +118,30 @@ export type _RunMetrics = Expect<Mutual<HRunMetrics, CRunMetrics>>;
 export type _GraphViewLevel = Expect<Mutual<HGraphViewLevel, CGraphViewLevel>>;
 export type _GraphView = Expect<Mutual<HGraphView, CGraphView>>;
 
+// ── apiVersion 5 additions (#341, #342) ───────────────────────────────────
+export type _WorkspaceSource = Expect<Mutual<HWorkspaceSource, CWorkspaceSource>>;
+export type _WorkspaceGraphInput = Expect<Mutual<HWorkspaceGraphInput, CWorkspaceGraphInput>>;
+export type _WorkspaceOpenResult = Expect<Mutual<HWorkspaceOpenResult, CWorkspaceOpenResult>>;
+export type _WorkspaceTabInfo = Expect<Mutual<HWorkspaceTabInfo, CWorkspaceTabInfo>>;
+export type _WorkspaceApplyRequest = Expect<Mutual<HWorkspaceApplyRequest, CWorkspaceApplyRequest>>;
+export type _WorkspaceApplyResult = Expect<Mutual<HWorkspaceApplyResult, CWorkspaceApplyResult>>;
+export type _WorkspaceConflict = Expect<Mutual<HWorkspaceConflict, CWorkspaceConflict>>;
+export type _WorkspaceEvent = Expect<Mutual<HWorkspaceEvent, CWorkspaceEvent>>;
+// `WorkspaceOpenEntry.graph` is the ONE field deliberately not compared: the
+// host takes the loose `WorkspaceGraphInput` a plugin can actually build,
+// while the contract shows a plugin the `SerializedGraph` it read. `Omit`
+// keeps the rest of the entry honest — which is where a renamed or dropped
+// field would otherwise hide. Same carve-out `SerializedGraph` itself has had
+// since v1, and for the same reason.
+export type _WorkspaceOpenEntryMeta = Expect<
+  Mutual<Omit<HWorkspaceOpenEntry, 'graph'>, Omit<CWorkspaceOpenEntry, 'graph'>>
+>;
+export type _WorkspaceKeys = Expect<
+  Mutual<keyof HApi['workspace'], keyof CApi['workspace']>
+>;
+
 // ── API surface: same top-level sections; apiVersion is intentionally widened
-// from the host's literal `4` to `number` so plugins can defensively check it. ──
+// from the host's literal `5` to `number` so plugins can defensively check it. ──
 export type _ApiKeys = Expect<Mutual<keyof HApi, keyof CApi>>;
 export type _ApiVersion = Expect<Extends<HApi['apiVersion'], CApi['apiVersion']>>;
 export type _UiKeys = Expect<Mutual<keyof HApi['ui'], keyof CApi['ui']>>;

--- a/frontend/src/plugins/contract.assert.ts
+++ b/frontend/src/plugins/contract.assert.ts
@@ -22,6 +22,7 @@ import type {
   WorkspaceGraphInput as HWorkspaceGraphInput,
   WorkspaceOpenEntry as HWorkspaceOpenEntry,
   WorkspaceOpenResult as HWorkspaceOpenResult,
+  WorkspaceSnapshot as HWorkspaceSnapshot,
   WorkspaceSource as HWorkspaceSource,
   WorkspaceTabInfo as HWorkspaceTabInfo,
 } from './api';
@@ -78,6 +79,7 @@ import type {
   WorkspaceGraphInput as CWorkspaceGraphInput,
   WorkspaceOpenEntry as CWorkspaceOpenEntry,
   WorkspaceOpenResult as CWorkspaceOpenResult,
+  WorkspaceSnapshot as CWorkspaceSnapshot,
   WorkspaceSource as CWorkspaceSource,
   WorkspaceTabInfo as CWorkspaceTabInfo,
 } from './contract';
@@ -135,6 +137,17 @@ export type _WorkspaceEvent = Expect<Mutual<HWorkspaceEvent, CWorkspaceEvent>>;
 // since v1, and for the same reason.
 export type _WorkspaceOpenEntryMeta = Expect<
   Mutual<Omit<HWorkspaceOpenEntry, 'graph'>, Omit<CWorkspaceOpenEntry, 'graph'>>
+>;
+// The same carve-out, one level in. `Exclude` drops the graph-bearing branch —
+// whose other half `_WorkspaceTabInfo` already compares — and leaves
+// `{ error: 'unknown_tab' }`, which nothing else reaches: `_WorkspaceKeys`
+// compares the key NAMES of `workspace`, never the return type of `snapshot`,
+// so a re-typed error branch would drift in silence. `Omit` cannot stand in
+// here the way it does above: `keyof` a union is the INTERSECTION of its
+// branches' keys, which is `never` for this one, so `Omit<..., 'graph'>`
+// collapses to `{}` and would compare nothing at all.
+export type _WorkspaceSnapshotMeta = Expect<
+  Mutual<Exclude<HWorkspaceSnapshot, { graph: unknown }>, Exclude<CWorkspaceSnapshot, { graph: unknown }>>
 >;
 export type _WorkspaceKeys = Expect<
   Mutual<keyof HApi['workspace'], keyof CApi['workspace']>

--- a/frontend/src/plugins/contract.ts
+++ b/frontend/src/plugins/contract.ts
@@ -81,7 +81,22 @@ export type GraphOp =
    * either way. Head and tail must be joined by data edges.
    */
   | { op: 'set_segment'; segment_id?: string; head_node_id: string; tail_node_id: string }
-  | { op: 'remove_segment'; segment_id: string };
+  | { op: 'remove_segment'; segment_id: string }
+  /**
+   * Add a text note to the canvas — the sticky the editor already draws.
+   * `bind_to` attaches it to a node so it follows when that node moves.
+   * `text` is 1..4000 characters; `color` is `#rrggbb`.
+   */
+  | { op: 'add_note'; ref?: string; text: string;
+      position?: { x: number; y: number }; color?: string; bind_to?: string }
+  /** Rewrite an existing note's text and/or colour. Text notes only. */
+  | { op: 'update_note'; node_id: string; text?: string; color?: string }
+  /**
+   * Name one node — `data.label`, 1..120 characters on a single line. The
+   * label sits beside `params`, never inside it, so naming a node is not a
+   * parameter change to anything reading the graph.
+   */
+  | { op: 'set_node_meta'; node_id: string; label: string };
 
 export interface OpResult {
   index: number;

--- a/frontend/src/plugins/contract.ts
+++ b/frontend/src/plugins/contract.ts
@@ -359,6 +359,138 @@ export interface RunMetrics {
   metrics: RunMetricPoint[];
 }
 
+/* ── workspace tabs — requires apiVersion >= 5 ───────────────────────────── */
+
+/**
+ * Who opened a tab, and why. Opaque to the editor: whatever you put here
+ * comes back verbatim on `tabs()` and `snapshot()`, and persists with the tab
+ * when you open it with `persist: true`.
+ */
+export interface WorkspaceSource {
+  /** A short kind of your own choosing, e.g. `'agent-variant'`. */
+  kind: string;
+  pluginId: string;
+  jobId?: string;
+  variantId?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * The loosest shape `openGraphs` accepts for a graph document.
+ *
+ * `WorkspaceOpenEntry.graph` is declared as `SerializedGraph` below, because
+ * the graph you hand over usually came from `getGraph()`. This type is what
+ * the editor really reads: two required lists and a bag it walks defensively,
+ * so a document you composed yourself is accepted on the same terms as a
+ * file. Unknown top-level keys are ignored.
+ */
+export interface WorkspaceGraphInput {
+  nodes: unknown[];
+  edges: unknown[];
+  presets?: unknown[];
+  segmentGroups?: unknown[];
+  subgraphs?: unknown[];
+  name?: string;
+  description?: string;
+  format_version?: unknown;
+  [key: string]: unknown;
+}
+
+export interface WorkspaceOpenEntry {
+  /** Shown on the tab. Stored whole; the tab bar ellipsises what will not fit. */
+  title: string;
+  /**
+   * The document to open, normalised the way a file load normalises one:
+   * `subgraphs`, `segmentGroups` and `presets` are honoured, and a
+   * `format_version` newer than the editor opens the tab read-only.
+   */
+  graph: SerializedGraph;
+  /** Default false. A read-only tab refuses writes on BOTH write paths. */
+  readOnly?: boolean;
+  source?: WorkspaceSource;
+  /** Default false: the tab is transient and is gone after a reload. */
+  persist?: boolean;
+}
+
+/**
+ * One entry's outcome. Results are POSITIONAL — `result[i]` describes
+ * `entries[i]` — so one bad candidate never sinks the others.
+ */
+export type WorkspaceOpenResult =
+  | { tabId: string; revision: number }
+  | { error: string; code: 'invalid_graph' | 'too_many_tabs' | 'too_large' };
+
+export interface WorkspaceTabInfo {
+  tabId: string;
+  title: string;
+  /**
+   * The tab's compare-and-swap token. It starts at 1 and advances by one
+   * whenever the tab's document changes — from your writes, the user's edits,
+   * an undo, or a redo. Hand it back as `expectedRevision` to write only if
+   * nothing has moved since you read.
+   */
+  revision: number;
+  readOnly: boolean;
+  /** True for a tab that will not survive a reload (opened without `persist`). */
+  transient: boolean;
+  source: WorkspaceSource | null;
+  active: boolean;
+}
+
+export type WorkspaceSnapshot =
+  | (WorkspaceTabInfo & { graph: SerializedGraph })
+  | { error: 'unknown_tab' };
+
+export interface WorkspaceApplyRequest {
+  /** Defaults to the active tab. */
+  tabId?: string;
+  /** Omitted: no compare. Present and stale: nothing is written. */
+  expectedRevision?: number;
+  operations: GraphOp[];
+  /** Default false. True: any failing op means nothing is committed. */
+  atomic?: boolean;
+}
+
+/**
+ * Why a write was refused. Each is returned, never thrown, and each leaves
+ * the tab exactly as it was.
+ *
+ * `editing_subgraph` means the user has stepped inside a block, so the canvas
+ * arrays are that block's contents rather than the document `snapshot()`
+ * describes. Retry once they step back out — `graph.getView().atTopLevel`
+ * says when.
+ */
+export type WorkspaceConflict =
+  | 'revision_mismatch' | 'read_only' | 'unknown_tab' | 'editing_subgraph';
+
+export interface WorkspaceApplyResult extends ApplyResult {
+  tabId: string;
+  /**
+   * The tab's revision AFTER this call, and on `revision_mismatch` the
+   * CURRENT one — so you can re-arm without a second read that races the
+   * same way. Unchanged by a conflict or a failed `atomic` preflight.
+   */
+  revision: number;
+  committed: boolean;
+  conflict?: WorkspaceConflict;
+}
+
+/**
+ * One workspace change, as `workspace.onChanged` delivers it.
+ *
+ * Delivered synchronously, in the order `tabs` (added), `graph`,
+ * `active-tab`, `tabs` (removed), so a burst can be processed in one pass. A
+ * `graph` event carries `origin` when the change came from a plugin's
+ * `workspace.applyOperations`, which is how you ignore your own writes.
+ *
+ * If your callback throws, the editor logs it and unsubscribes you: a plugin
+ * cannot be allowed to break the editor's own state.
+ */
+export type WorkspaceEvent =
+  | { type: 'graph'; tabId: string; revision: number; origin?: { pluginId: string } }
+  | { type: 'tabs'; tabId: string; revision: number; removed: boolean }
+  | { type: 'active-tab'; tabId: string; revision: number };
+
 /** The object the editor hands every plugin frontend at activation. */
 export interface CodefyUIPluginAPI {
   apiVersion: number;
@@ -447,6 +579,55 @@ export interface CodefyUIPluginAPI {
      * `api.apiVersion >= 4` (or `typeof api.graph.getView === 'function'`).
      */
     getView(): GraphView;
+  };
+  /**
+   * Tabs, snapshots and compare-and-swap writes — requires apiVersion >= 5.
+   *
+   * This is the half of the API that does not assume the user is looking at
+   * what you are working on. You can open a candidate graph in its own
+   * labelled tab without moving anybody, read a tab that is not on screen,
+   * write to a tab only if it has not changed since you read it, and be told
+   * when any of that happens.
+   *
+   * On an older editor the whole member is `undefined` rather than a stub
+   * that throws, so `typeof api.workspace?.openGraphs === 'function'` is an
+   * honest feature check (`api.apiVersion >= 5` works too).
+   */
+  workspace: {
+    /**
+     * Open one tab per entry. Nothing is activated when `activate` is
+     * `'none'`; `'first'` (the default) and `'last'` activate one of the tabs
+     * that actually opened.
+     *
+     * Limits: 8 MiB of serialized JSON per graph, 32 tabs in the editor.
+     * A tab opened here is an ordinary tab afterwards — the user can rename
+     * it, close it, or Save As into a real graph file.
+     */
+    openGraphs(
+      entries: WorkspaceOpenEntry[],
+      options?: { activate?: 'first' | 'last' | 'none' },
+    ): WorkspaceOpenResult[];
+    /** Every tab, in tab-bar order. */
+    tabs(): WorkspaceTabInfo[];
+    /**
+     * A tab's info plus its WHOLE graph, flattened the way `getGraph()`
+     * flattens the active one. Defaults to the active tab. An unknown id
+     * answers `{ error: 'unknown_tab' }` rather than throwing.
+     */
+    snapshot(tabId?: string): WorkspaceSnapshot;
+    /**
+     * Apply a batch to a named tab, as one undo step, under an optional
+     * compare-and-swap.
+     *
+     * Checked in a fixed order, each refusal leaving the tab untouched:
+     * unknown tab, read-only tab, the user is inside a block, stale
+     * `expectedRevision`. Then the batch runs; with `atomic: true` a single
+     * failing op means nothing is committed, and `results` still comes back
+     * full-length so you can see which op was wrong.
+     */
+    applyOperations(request: WorkspaceApplyRequest): WorkspaceApplyResult;
+    /** Subscribe to workspace changes. Returns an unsubscribe function. */
+    onChanged(cb: (event: WorkspaceEvent) => void): () => void;
   };
   /** Custom node renderers — requires apiVersion >= 2. */
   nodes: {

--- a/frontend/src/plugins/contract.ts
+++ b/frontend/src/plugins/contract.ts
@@ -70,13 +70,26 @@ export type GraphOp =
   | { op: 'remove_edge'; source: string; target: string;
       source_handle?: string; target_handle?: string }
   | { op: 'clear_graph' }
-  | { op: 'auto_layout' };
+  | { op: 'auto_layout' }
+  /* ── requires apiVersion >= 5 ─────────────────────────────────────────── */
+  /** Put one node at an exact position. Notes bound to it move with it. */
+  | { op: 'move_node'; node_id: string; position: { x: number; y: number } }
+  /**
+   * Create or replace a segment overlay -- the orange bubble the canvas draws
+   * around every node on a data path from head to tail. Omit `segment_id` to
+   * create one; pass an existing id to move it. The result carries the id
+   * either way. Head and tail must be joined by data edges.
+   */
+  | { op: 'set_segment'; segment_id?: string; head_node_id: string; tail_node_id: string }
+  | { op: 'remove_segment'; segment_id: string };
 
 export interface OpResult {
   index: number;
   ok: boolean;
   error?: string;
   node_id?: string;
+  /** Set by `set_segment` — apiVersion 5. */
+  segment_id?: string;
 }
 
 export interface ApplyResult {

--- a/frontend/src/plugins/contract.v4.assert.ts
+++ b/frontend/src/plugins/contract.v4.assert.ts
@@ -1,0 +1,496 @@
+/**
+ * Frozen snapshot of the apiVersion 4 contract, and a compile-time proof that
+ * the host still satisfies it.
+ *
+ * apiVersion 5 (#341, #342) adds `api.workspace`, six `GraphOp` members and
+ * `OpResult.segment_id`, and the claim that it adds nothing else is worth
+ * exactly as much as the guard behind it -- the argument `contract.v3.assert.ts`
+ * makes one version down. v3 does not cover the v4-only surface
+ * (`graph.getView`, `GraphView`, `GraphViewLevel`, and the `option_packs` /
+ * `requires_pack` fields the node catalog grew alongside it), so without this
+ * file the members added in 2.3.0 had nothing frozen watching them:
+ * `contract.assert.ts` compares the host against the CURRENT contract, and a
+ * change that edits both drifts silently.
+ *
+ * Every plugin scaffolded by `cdui plugin new` since 2.3.0 vendored the
+ * contract below as its own `ui/src/sdk/types.ts` and declares
+ * `activate(api: CodefyUIPluginAPI)` against it. Those plugins keep working
+ * exactly as long as the host's real API object stays ASSIGNABLE to the
+ * interface below, which is what this file asserts.
+ *
+ * The body is `contract.ts` as it stood at apiVersion 4, verbatim. It is a
+ * historical record: DO NOT edit it to make a change compile. If a change
+ * makes this file fail, that change is breaking for every installed v4 plugin
+ * and needs an apiVersion bump and a migration note, not a patched snapshot.
+ */
+import type { CodefyUIPluginAPI as HostApi } from './api';
+
+/** Compile error unless the argument resolves to exactly `true`. */
+type Expect<T extends true> = T;
+type Extends<A, B> = A extends B ? true : false;
+
+/* ── BEGIN frozen apiVersion 4 contract ─────────────────────────────── */
+
+type ToastType = 'success' | 'error' | 'info' | 'warning';
+
+interface PortDefinition {
+  name: string;
+  data_type: string;
+  description: string;
+  optional: boolean;
+}
+
+interface ParamDefinition {
+  name: string;
+  param_type:
+    | 'int' | 'float' | 'string' | 'bool'
+    | 'select' | 'model_file' | 'image_file' | 'data_file' | 'tensor_grid' | 'secret'
+    | 'code';
+  default: unknown;
+  description: string;
+  options: string[];
+  min_value: number | null;
+  max_value: number | null;
+  /** Conditional visibility. A value may be an array, read as "any of". */
+  visible_when?: Record<string, unknown> | null;
+  /** Collected behind the collapsed "Advanced" section. Absent = basic. */
+  advanced?: boolean;
+  /** Package Center: maps a SELECT option to the optional pack it needs,
+   *  `"<pack_id>"` or `"<pack_id>:<item_id>"`. Absent = every option works. */
+  option_packs?: Record<string, string> | null;
+}
+
+interface NodeDefinition {
+  node_name: string;
+  category: string;
+  description: string;
+  inputs: PortDefinition[];
+  outputs: PortDefinition[];
+  params: ParamDefinition[];
+  /** Package Center: the optional pack this node needs before it can run at
+   *  all. Absent / null = covered by the base install. */
+  requires_pack?: string | null;
+}
+
+/** A batch operation accepted by `api.graph.applyOperations`. Field names are exact. */
+type GraphOp =
+  | { op: 'add_node'; node_type: string; ref?: string;
+      params?: Record<string, unknown>; position?: { x: number; y: number } }
+  | { op: 'connect'; source: string; source_handle: string;
+      target: string; target_handle: string }
+  | { op: 'set_params'; node_id: string; params: Record<string, unknown> }
+  | { op: 'remove_node'; node_id: string }
+  | { op: 'remove_edge'; source: string; target: string;
+      source_handle?: string; target_handle?: string }
+  | { op: 'clear_graph' }
+  | { op: 'auto_layout' };
+
+interface OpResult {
+  index: number;
+  ok: boolean;
+  error?: string;
+  node_id?: string;
+}
+
+interface ApplyResult {
+  results: OpResult[];
+  refs: Record<string, string>;
+  node_count: number;
+  edge_count: number;
+}
+
+interface SerializedGraphNode {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: { params: Record<string, unknown>; [key: string]: unknown };
+}
+
+interface SerializedGraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  sourceHandle: string;
+  targetHandle: string;
+}
+
+interface SerializedGraph {
+  nodes: SerializedGraphNode[];
+  edges: SerializedGraphEdge[];
+  presets?: unknown[];
+  segmentGroups?: unknown[];
+  name?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+/* ── view context (read-only) — requires apiVersion >= 4 ─────────────────── */
+
+/** One opened block on the path from the graph to the canvas the user sees. */
+interface GraphViewLevel {
+  /** The block definition's id — stable, and what `getGraph()` refers to it by. */
+  subgraphId: string;
+  /** The block's name, exactly as the editor's breadcrumb bar shows it. */
+  name: string;
+}
+
+/**
+ * Where the user is looking right now, from `api.graph.getView()`.
+ *
+ * A CodefyUI graph nests: a block (subgraph) has its own canvas, and the user
+ * can step inside one, then inside another. The editor shows this as the
+ * "Main > Encoder > Attention" bar above the canvas; `getView()` is the same
+ * information, for a plugin.
+ *
+ * Read-only, and read live — a fresh answer each call. There is no way to
+ * navigate the user somewhere through the plugin API, deliberately: moving
+ * somebody's editor under them is not something a plugin should be able to do
+ * quietly.
+ */
+interface GraphView {
+  /** 0 at the top level, 1 inside a block, 2 inside a block inside a block. */
+  depth: number;
+  /** The opened blocks, outermost first. Empty at the top level. */
+  path: GraphViewLevel[];
+  /** `depth === 0`, named so the check a plugin usually wants reads plainly. */
+  atTopLevel: boolean;
+}
+
+interface NodeRenderContext {
+  node: {
+    id: string;
+    type: string;
+    params: Record<string, unknown>;
+    definition?: unknown;
+  };
+}
+
+/**
+ * Imperative renderer for a node's card body. The SDK's `defineNodeRenderer`
+ * adapts a React component to this shape; the host calls mount once, update on
+ * param changes, and unmount when the node is removed.
+ */
+interface PluginNodeRenderer {
+  mount(container: HTMLElement, ctx: NodeRenderContext): void;
+  update?(container: HTMLElement, ctx: NodeRenderContext): void;
+  unmount?(container: HTMLElement): void;
+}
+
+/* ── panels, toolbar buttons — requires apiVersion >= 3 ─────────────────── */
+
+/** Where a panel lives: a tab in the bottom dock, or a right-hand section. */
+type PluginPanelDock = 'bottom' | 'right';
+
+interface PluginPanelOptions {
+  /** Unique within your plugin. The host namespaces it with your plugin id. */
+  id: string;
+  /** Tab label (bottom dock) or section heading (right dock). */
+  title: string;
+  /** Optional short glyph shown before the title. */
+  icon?: string;
+  /** Defaults to `'bottom'`. */
+  dock?: PluginPanelDock;
+  /**
+   * Called after the panel's element is attached to the document, and after
+   * it is detached. The element itself survives either way — these exist so
+   * you can stop doing work while nobody can see it.
+   */
+  onShow?: () => void;
+  onHide?: () => void;
+}
+
+interface PluginToolbarButtonOptions {
+  /** Unique within your plugin. */
+  id: string;
+  /** Short glyph — the toolbar has room for a glyph, not a sentence. */
+  icon: string;
+  /** Hover and accessible text. An icon on its own is not a label. */
+  tooltip: string;
+  onClick: () => void;
+}
+
+/* ── execution events — requires apiVersion >= 3 ────────────────────────── */
+
+/**
+ * One recorded scalar point.
+ *
+ * Declared here because BOTH halves of the run surface use it: the live
+ * `metric` event below, and `runs.metrics()` further down. One type for one
+ * concept is the whole reason a dashboard can share a fold between them.
+ */
+interface RunMetricPoint {
+  node_id: string | null;
+  name: string;
+  step: number;
+  /** `null` for a non-finite value (a diverged loss) — a gap, not a zero. */
+  value: number | null;
+  /**
+   * When the point was recorded, ISO-8601 UTC.
+   *
+   * Present on points from `runs.metrics()`, absent on points from a live
+   * `metric` event — the live path carries only what a chart needs to plot
+   * against `step`. Optional for exactly that reason; a fold that ignores it
+   * works on both halves unchanged.
+   */
+  ts?: string;
+}
+
+/** Terminal state of a run. */
+type ExecutionFinishStatus =
+  | 'succeeded' | 'failed' | 'cancelled' | 'interrupted';
+
+/**
+ * One run event, as `api.events.onExecution` delivers it.
+ *
+ * Every event carries TWO numbers, and they answer different questions.
+ *
+ * `cursor` is the event's position in the run's durable log — the same cursor
+ * `GET /api/runs/{id}/events` pages by and `runs.get(id).last_cursor` reports.
+ * Use it to line an event up against the REST side. It is strictly increasing
+ * within a run but **not dense**: the log also holds entries this stream does
+ * not publish (artifacts, run warnings, refused submits, entries the server
+ * collapsed because they were too large), and each of those consumes a cursor.
+ * A cursor jump is therefore ordinary — a run that saves a checkpoint produces
+ * one every time — and says nothing about whether you missed anything.
+ *
+ * `seq` is this stream's own counter, and it is the one to check for loss. It
+ * counts the events delivered to plugin subscribers for a run, densely: the
+ * next event you receive for a run always has `seq` exactly one higher than
+ * the last, unless the host dropped events under the buffering limit. So
+ * `seq` gapless means you have everything; `seq` jumping by N means N events
+ * were dropped and `runs.metrics()` is how to recover them.
+ *
+ * (The first `seq` you see for a run is your baseline, not necessarily 1: it
+ * counts from when the editor started streaming that run, which may predate
+ * your subscription.)
+ *
+ * A `metric` entry carries the whole batch it was recorded as, rather than
+ * being split into one event per point. That keeps the log entry atomic —
+ * `cursor` would otherwise say "you have this entry" when only part of it had
+ * been delivered — and makes `points` the SAME type `runs.metrics()` returns,
+ * so a dashboard can fold the live tail and the REST back-fill with one
+ * function. `value` is `null` for a non-finite number exactly as it is there.
+ *
+ * Events and their `points` are frozen: they are shared between every
+ * subscriber, so one plugin cannot mutate what another receives.
+ */
+type ExecutionEvent =
+  | { type: 'run_started'; run_id: string; cursor: number; seq: number }
+  | {
+      type: 'node_status'; run_id: string; cursor: number; seq: number;
+      node_id: string; status: string; error?: string;
+    }
+  | {
+      type: 'metric'; run_id: string; cursor: number; seq: number;
+      points: readonly RunMetricPoint[];
+    }
+  | {
+      type: 'run_finished'; run_id: string; cursor: number; seq: number;
+      status: ExecutionFinishStatus; error?: string;
+    };
+
+/* ── runs (read-only) — requires apiVersion >= 3 ────────────────────────── */
+
+type RunStatus =
+  | 'queued' | 'running' | 'succeeded'
+  | 'failed' | 'cancelled' | 'interrupted';
+
+/** One row of the run history. Timestamps are ISO-8601 UTC with a `Z`. */
+interface RunSummary {
+  id: string;
+  name: string | null;
+  status: RunStatus;
+  error: string | null;
+  /** Submit options verbatim — `device`, `seed`, `record_outputs`, ... */
+  options: Record<string, unknown>;
+  queue_key: string | null;
+  created_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+  git_commit: string | null;
+  git_dirty: boolean | null;
+  plugin_pins: Record<string, unknown> | null;
+  /** 1-based place in this run's own device queue; `null` is a real answer. */
+  queue_position: number | null;
+  /** Last recorded value of every series, e.g. `{ train_loss: 0.31 }`. */
+  final_metrics: Record<string, number>;
+  /** Whether the server is currently driving this run. */
+  active: boolean;
+}
+
+interface RunInfo extends RunSummary {
+  /** Highest event cursor issued so far — where a follower should resume. */
+  last_cursor: number;
+}
+
+interface RunListPage {
+  runs: RunSummary[];
+  /** Unpaged count for the active filter, so a table can size itself. */
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+interface RunListOptions {
+  status?: readonly RunStatus[];
+  limit?: number;
+  offset?: number;
+}
+
+interface RunMetrics {
+  run_id: string;
+  /** Every series name in the run, so a legend needs no scan of the points. */
+  names: string[];
+  metrics: RunMetricPoint[];
+}
+
+/** The object the editor hands every plugin frontend at activation. */
+interface CodefyUIPluginAPI {
+  apiVersion: number;
+  pluginId: string;
+  ui: {
+    /** Create (or reuse) a container `<div>` in the editor's widget stack. */
+    addFloatingWidget(opts: { id: string }): HTMLElement;
+    toast(message: string, type?: ToastType): void;
+    /**
+     * Register a dock panel and get its container element — requires
+     * apiVersion >= 3.
+     *
+     * The host owns the tab chrome and the placement; you own what goes
+     * inside the element. The element's identity is stable for the life of
+     * the panel, so mount into it once: the host attaches and detaches it as
+     * its tab becomes active, and never empties or replaces it. Calling
+     * `addPanel` again with the same id returns the same element and updates
+     * the title/icon/dock.
+     */
+    addPanel(opts: PluginPanelOptions): HTMLElement;
+    /** Remove a panel. Its element is detached from the editor. */
+    removePanel(id: string): void;
+    /**
+     * Add a toolbar button — requires apiVersion >= 3. Returns a remove
+     * function. Placement and overflow are the host's: buttons share one
+     * group and collapse into a menu when the window is too narrow.
+     *
+     * Re-adding an id replaces the button, and the returned remove function
+     * is scoped to the registration it came from: a disposer whose button has
+     * since been replaced does nothing, rather than removing the replacement.
+     * Use `removeToolbarButton(id)` to remove whatever currently holds an id.
+     */
+    addToolbarButton(opts: PluginToolbarButtonOptions): () => void;
+    removeToolbarButton(id: string): void;
+  };
+  /**
+   * The graph.
+   *
+   * Read and write are not aimed at the same place while the user is inside a
+   * block, and that difference is documented on each member below. `getView()`
+   * — apiVersion 4 — is how you find out where the user is before you write.
+   */
+  graph: {
+    /**
+     * The WHOLE graph, always: nodes and edges at the top level, plus the block
+     * definitions under `subgraphs`.
+     *
+     * Never affected by where the user is standing — the editor flattens its
+     * open sub-canvases into the answer first, exactly as Save and Run do. So a
+     * plugin reading the graph sees the same bytes the user would get by saving
+     * the file, whether or not a block is open on screen.
+     */
+    getGraph(): SerializedGraph;
+    getNodeDefinitions(): NodeDefinition[];
+    /**
+     * Synchronous — returns the result directly, committed as one undo step.
+     *
+     * **A batch applies to the canvas the user has open, which is not always
+     * the top level.** Entering a block replaces the canvas with that block's
+     * insides, so ops applied then land inside the block: `add_node` adds a
+     * node to the block, and `clear_graph` empties the block rather than the
+     * graph. Node ids from `getGraph()` — which always answers with the top
+     * level — will not be found there, and those ops fail with an error in
+     * their `results` entry.
+     *
+     * This is the editor's long-standing behaviour and it is not changing
+     * silently; it is written down here so you can code against it. If your
+     * plugin composes a read with a write, call `getView()` between the two and
+     * handle `atTopLevel === false` — refuse with a toast, wait for the user to
+     * step out, or scope your edit to what makes sense inside a block. Writing
+     * anyway is not corruption, but it lands somewhere the user is not looking.
+     */
+    applyOperations(ops: GraphOp[]): ApplyResult;
+    /**
+     * Called after the graph changes — including when the user steps into or
+     * out of a block, since that swaps the canvas. Re-read `getView()` from the
+     * callback if you track which level the user is on.
+     */
+    onGraphChanged(cb: () => void): () => void;
+    /**
+     * Where the user is looking — requires apiVersion >= 4.
+     *
+     * Read-only. It exists so a plugin can tell "the user is inside a block"
+     * from "the user is on the graph" before it writes; see `applyOperations`.
+     * On an older editor this member is `undefined`, so feature-check with
+     * `api.apiVersion >= 4` (or `typeof api.graph.getView === 'function'`).
+     */
+    getView(): GraphView;
+  };
+  /** Custom node renderers — requires apiVersion >= 2. */
+  nodes: {
+    registerRenderer(nodeType: string, renderer: PluginNodeRenderer): () => void;
+  };
+  /** Live run events — requires apiVersion >= 3. */
+  events: {
+    /**
+     * Subscribe to the run event stream. Returns an unsubscribe function.
+     *
+     * Events are batched onto animation frames, so a burst arrives as a burst
+     * of calls in one frame rather than one call per socket message, and a
+     * backgrounded editor delivers nothing until it is painted again. If your
+     * callback throws, the host contains it — no other subscriber is
+     * affected, but you will lose that event.
+     */
+    onExecution(cb: (event: ExecutionEvent) => void): () => void;
+  };
+  /**
+   * Read-only view of run history — requires apiVersion >= 3.
+   *
+   * The host performs the requests, with editor authentication attached; the
+   * session token is never handed to plugin code. Submitting and cancelling
+   * runs are deliberately absent: a plugin should not be able to start work
+   * on the user's machine behind a UI the user did not open.
+   */
+  runs: {
+    list(opts?: RunListOptions): Promise<RunListPage>;
+    /** `null` when the server has never heard of the run. */
+    get(id: string): Promise<RunInfo | null>;
+    metrics(id: string, name?: string): Promise<RunMetrics>;
+  };
+  http: {
+    /** Browser `fetch`, with the CodefyUI session token attached. */
+    fetch(url: string, init?: RequestInit): Promise<Response>;
+  };
+  storage: {
+    get(key: string): string | null;
+    set(key: string, value: string): void;
+    remove(key: string): void;
+  };
+}
+
+/** The default-export contract: the editor calls this once with the API. */
+type ActivateFn = (api: CodefyUIPluginAPI) => void;
+
+/* ── END frozen apiVersion 4 contract ───────────────────────────────── */
+
+/**
+ * The host's real API object still satisfies the v4 interface -- every member
+ * a v4 plugin can reach is present, with a compatible type.
+ */
+export type _V4SurfaceIntact = Expect<Extends<HostApi, CodefyUIPluginAPI>>;
+
+/**
+ * ...so a v4 plugin's exported `activate` is still callable with what the host
+ * hands it, which is the thing that actually has to keep working. (Parameters
+ * are contravariant, so this direction models the real call.)
+ */
+export type _V4ActivateStillCallable = Expect<
+  Extends<ActivateFn, (api: HostApi) => void>
+>;

--- a/frontend/src/plugins/ops.test.ts
+++ b/frontend/src/plugins/ops.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Node, Edge } from '@xyflow/react';
-import type { NodeData, NodeDefinition } from '../types';
+import type { NodeData, NodeDefinition, SegmentGroup } from '../types';
 import { applyGraphOps, type GraphOp } from './ops';
 import { buildFlowNode } from '../utils';
 
@@ -32,8 +32,13 @@ const DEFS: NodeDefinition[] = [
   }),
 ];
 
-function run(ops: GraphOp[], nodes: Node<NodeData>[] = [], edges: Edge[] = []) {
-  return applyGraphOps({ nodes, edges }, DEFS, ops);
+function run(
+  ops: GraphOp[],
+  nodes: Node<NodeData>[] = [],
+  edges: Edge[] = [],
+  segmentGroups: SegmentGroup[] = [],
+) {
+  return applyGraphOps({ nodes, edges, segmentGroups }, DEFS, ops);
 }
 
 describe('applyGraphOps — add_node', () => {
@@ -169,5 +174,138 @@ describe('applyGraphOps — set_params / remove_node / remove_edge / clear / lay
     const laid = run([{ op: 'auto_layout' }], nodes, edges);
     expect(laid.results[0].ok).toBe(true);
     expect(laid.nodes).toHaveLength(2);
+  });
+});
+
+describe('applyGraphOps — move_node', () => {
+  function seeded() {
+    const a = buildFlowNode(DEFS[0], { x: 0, y: 0 });
+    const note: Node<NodeData> = {
+      id: 'note1', type: 'noteNode', position: { x: 30, y: 40 },
+      data: {
+        label: 'Note', type: 'note', params: {},
+        noteKind: 'text', noteContent: 'hi', noteColor: '#3d3d1a',
+        boundToNodeId: a.id, boundOffset: { x: 30, y: 40 },
+        noteWidth: 200,
+      },
+    };
+    const loose: Node<NodeData> = { ...note, id: 'note2', data: { ...note.data, boundToNodeId: null, boundOffset: null } };
+    return { nodes: [a, note, loose], a };
+  }
+
+  it('moves a node to an exact position', () => {
+    const { nodes, a } = seeded();
+    const r = run([{ op: 'move_node', node_id: a.id, position: { x: 500, y: 250 } }], nodes);
+    expect(r.results[0]).toMatchObject({ ok: true, node_id: a.id });
+    expect(r.nodes.find((n) => n.id === a.id)!.position).toEqual({ x: 500, y: 250 });
+    expect(r.mutated).toBe(true);
+  });
+
+  it('carries a bound note along by the same delta, and leaves a loose one', () => {
+    const { nodes, a } = seeded();
+    const r = run([{ op: 'move_node', node_id: a.id, position: { x: 100, y: 60 } }], nodes);
+    expect(r.nodes.find((n) => n.id === 'note1')!.position).toEqual({ x: 130, y: 100 });
+    expect(r.nodes.find((n) => n.id === 'note2')!.position).toEqual({ x: 30, y: 40 });
+  });
+
+  it('rejects an unknown node and a non-finite position', () => {
+    const { nodes, a } = seeded();
+    const ghost = run([{ op: 'move_node', node_id: 'nope', position: { x: 0, y: 0 } }], nodes);
+    expect(ghost.results[0].ok).toBe(false);
+    expect(ghost.mutated).toBe(false);
+
+    const nan = run([{ op: 'move_node', node_id: a.id, position: { x: Number.NaN, y: 0 } }], nodes);
+    expect(nan.results[0].ok).toBe(false);
+    expect(nan.results[0].error).toContain('finite');
+  });
+
+  it('accepts a same-batch ref', () => {
+    const r = run([
+      { op: 'add_node', node_type: 'Source', ref: 's' },
+      { op: 'move_node', node_id: 's', position: { x: 12, y: 34 } },
+    ]);
+    expect(r.results[1].ok).toBe(true);
+    expect(r.nodes[0].position).toEqual({ x: 12, y: 34 });
+  });
+});
+
+describe('applyGraphOps — set_segment / remove_segment', () => {
+  function chain() {
+    const a = buildFlowNode(DEFS[0], { x: 0, y: 0 });
+    const b = buildFlowNode(DEFS[1], { x: 100, y: 0 });
+    const e: Edge = { id: 'e1', source: a.id, target: b.id, sourceHandle: 'out', targetHandle: 'x' };
+    return { nodes: [a, b], edges: [e], a, b };
+  }
+
+  it('appends a segment and reports the id it generated', () => {
+    const { nodes, edges, a, b } = chain();
+    const r = run([{ op: 'set_segment', head_node_id: a.id, tail_node_id: b.id }], nodes, edges);
+    expect(r.results[0].ok).toBe(true);
+    expect(typeof r.results[0].segment_id).toBe('string');
+    expect(r.segmentGroups).toEqual([
+      { id: r.results[0].segment_id, headNodeId: a.id, tailNodeId: b.id },
+    ]);
+  });
+
+  it('replaces by id rather than duplicating', () => {
+    const { nodes, edges, a, b } = chain();
+    const r = run(
+      [{ op: 'set_segment', segment_id: 's1', head_node_id: b.id, tail_node_id: b.id }],
+      nodes, edges,
+      [{ id: 's1', headNodeId: a.id, tailNodeId: b.id }],
+    );
+    expect(r.segmentGroups).toHaveLength(1);
+    expect(r.segmentGroups[0]).toEqual({ id: 's1', headNodeId: b.id, tailNodeId: b.id });
+  });
+
+  it('refuses head and tail with no data-edge path between them', () => {
+    const { nodes, edges, a, b } = chain();
+    const backwards = run(
+      [{ op: 'set_segment', head_node_id: b.id, tail_node_id: a.id }],
+      nodes, edges,
+    );
+    expect(backwards.results[0].ok).toBe(false);
+    expect(backwards.results[0].error).toContain('no data-edge path');
+    expect(backwards.segmentGroups).toHaveLength(0);
+    expect(backwards.mutated).toBe(false);
+  });
+
+  it('refuses a note as an endpoint and an unknown node', () => {
+    const { nodes, edges, a } = chain();
+    const note: Node<NodeData> = {
+      id: 'note1', type: 'noteNode', position: { x: 0, y: 0 },
+      data: { label: 'Note', type: 'note', params: {}, noteKind: 'text', noteContent: 'x', noteColor: '#3d3d1a', boundToNodeId: null, boundOffset: null, noteWidth: 200 },
+    };
+    const withNote = run(
+      [{ op: 'set_segment', head_node_id: a.id, tail_node_id: 'note1' }],
+      [...nodes, note], edges,
+    );
+    expect(withNote.results[0].ok).toBe(false);
+    expect(withNote.results[0].error).toContain('note');
+
+    const ghost = run([{ op: 'set_segment', head_node_id: a.id, tail_node_id: 'nope' }], nodes, edges);
+    expect(ghost.results[0].ok).toBe(false);
+  });
+
+  it('remove_segment drops a known id and reports an unknown one', () => {
+    const { nodes, edges, a, b } = chain();
+    const groups: SegmentGroup[] = [{ id: 's1', headNodeId: a.id, tailNodeId: b.id }];
+    const ok = run([{ op: 'remove_segment', segment_id: 's1' }], nodes, edges, groups);
+    expect(ok.results[0].ok).toBe(true);
+    expect(ok.segmentGroups).toHaveLength(0);
+
+    const miss = run([{ op: 'remove_segment', segment_id: 'nope' }], nodes, edges, groups);
+    expect(miss.results[0].ok).toBe(false);
+    expect(miss.mutated).toBe(false);
+  });
+
+  it('hands back the SAME segmentGroups array when no op touched it', () => {
+    // The persistence record cache compares this array by reference, so a
+    // batch of add_node that handed back a fresh (identical) segment list
+    // would rewrite the tab's IndexedDB record for nothing.
+    const { nodes, edges, a, b } = chain();
+    const groups: SegmentGroup[] = [{ id: 's1', headNodeId: a.id, tailNodeId: b.id }];
+    const r = run([{ op: 'add_node', node_type: 'Source' }], nodes, edges, groups);
+    expect(r.segmentGroups).toBe(groups);
   });
 });

--- a/frontend/src/plugins/ops.test.ts
+++ b/frontend/src/plugins/ops.test.ts
@@ -367,3 +367,132 @@ describe('applyGraphOps — set_segment / remove_segment', () => {
     expect(run([{ op: 'clear_graph' }], nodes, edges, empty).segmentGroups).toBe(empty);
   });
 });
+
+describe('applyGraphOps — add_note / update_note', () => {
+  function seeded() {
+    const a = buildFlowNode(DEFS[0], { x: 200, y: 100 });
+    return { nodes: [a], a };
+  }
+
+  it('adds a text note the canvas can already render', () => {
+    const r = run([{ op: 'add_note', text: 'branch B = ablation', ref: 'n' }]);
+    expect(r.results[0].ok).toBe(true);
+    const id = r.results[0].node_id!;
+    expect(r.refs.n).toBe(id);
+    const note = r.nodes.find((n) => n.id === id)!;
+    expect(note.type).toBe('noteNode');
+    expect(note.data).toMatchObject({
+      type: 'note', noteKind: 'text', noteContent: 'branch B = ablation',
+      noteColor: '#3d3d1a', boundToNodeId: null, boundOffset: null, noteWidth: 200,
+    });
+  });
+
+  it('binds to a node and records the offset that binding implies', () => {
+    const { nodes, a } = seeded();
+    const r = run([{ op: 'add_note', text: 'why', bind_to: a.id, position: { x: 260, y: 60 } }], nodes);
+    const note = r.nodes.find((n) => n.type === 'noteNode')!;
+    expect(note.data.boundToNodeId).toBe(a.id);
+    expect(note.data.boundOffset).toEqual({ x: 60, y: -40 });
+  });
+
+  it('places an unpositioned bound note beside its node', () => {
+    const { nodes, a } = seeded();
+    const r = run([{ op: 'add_note', text: 'why', bind_to: a.id }], nodes);
+    const note = r.nodes.find((n) => n.type === 'noteNode')!;
+    expect(note.position.x).toBeGreaterThan(a.position.x);
+  });
+
+  it('rejects empty text, over-long text, control characters and a bad colour', () => {
+    const long = 'x'.repeat(4001);
+    for (const op of [
+      { op: 'add_note', text: '' } as GraphOp,
+      { op: 'add_note', text: long } as GraphOp,
+      // A real NUL, built rather than typed: a literal escape in a test is
+      // the one thing that can silently stop being what it claims to be.
+      { op: 'add_note', text: `a${String.fromCharCode(0)}b` } as GraphOp,
+      { op: 'add_note', text: 'ok', color: 'red' } as GraphOp,
+      { op: 'add_note', text: 'ok', color: '#fff' } as GraphOp,
+    ]) {
+      const r = run([op]);
+      expect(r.results[0].ok, JSON.stringify(op)).toBe(false);
+      expect(r.nodes).toHaveLength(0);
+      expect(r.mutated).toBe(false);
+    }
+  });
+
+  it('accepts newlines and tabs, and every colour from the canvas palette', () => {
+    const r = run([
+      { op: 'add_note', text: 'line one\nline two\tindented' },
+      { op: 'add_note', text: 'blue', color: '#1a2d3d' },
+    ]);
+    expect(r.results.map((x) => x.ok)).toEqual([true, true]);
+  });
+
+  it('refuses to bind a note to another note', () => {
+    const r = run([
+      { op: 'add_note', text: 'first', ref: 'n1' },
+      { op: 'add_note', text: 'second', bind_to: 'n1' },
+    ]);
+    expect(r.results[1].ok).toBe(false);
+    expect(r.results[1].error).toContain('note');
+  });
+
+  it('update_note rewrites text and colour, and refuses a non-note', () => {
+    const { nodes, a } = seeded();
+    const added = run([{ op: 'add_note', text: 'draft' }], nodes);
+    const noteId = added.results[0].node_id!;
+
+    const r = run(
+      [{ op: 'update_note', node_id: noteId, text: 'final', color: '#1a3d1a' }],
+      added.nodes,
+    );
+    const note = r.nodes.find((n) => n.id === noteId)!;
+    expect(note.data.noteContent).toBe('final');
+    expect(note.data.noteColor).toBe('#1a3d1a');
+
+    const wrong = run([{ op: 'update_note', node_id: a.id, text: 'x' }], added.nodes);
+    expect(wrong.results[0].ok).toBe(false);
+    expect(wrong.results[0].error).toContain('not a note');
+  });
+
+  it('update_note with nothing to change is an error, not a silent no-op', () => {
+    const added = run([{ op: 'add_note', text: 'draft' }]);
+    const noteId = added.results[0].node_id!;
+    const r = run([{ op: 'update_note', node_id: noteId }], added.nodes);
+    expect(r.results[0].ok).toBe(false);
+    expect(r.mutated).toBe(false);
+  });
+});
+
+describe('applyGraphOps — set_node_meta', () => {
+  function seeded() {
+    const a = buildFlowNode(DEFS[0], { x: 0, y: 0 });
+    return { nodes: [a], a };
+  }
+
+  it('names a node', () => {
+    const { nodes, a } = seeded();
+    const r = run([{ op: 'set_node_meta', node_id: a.id, label: '  Encoder input  ' }], nodes);
+    expect(r.results[0]).toMatchObject({ ok: true, node_id: a.id });
+    expect(r.nodes[0].data.label).toBe('Encoder input');
+    // The label is metadata, not a param: an agent naming a node must not
+    // look to a consumer like a parameter change.
+    expect(r.nodes[0].data.params).toEqual(a.data.params);
+  });
+
+  it('rejects a blank, multi-line or over-long label and a note target', () => {
+    const { nodes, a } = seeded();
+    const added = run([{ op: 'add_note', text: 'n' }], nodes);
+    const noteId = added.results[0].node_id!;
+    for (const op of [
+      { op: 'set_node_meta', node_id: a.id, label: '   ' } as GraphOp,
+      { op: 'set_node_meta', node_id: a.id, label: 'a\nb' } as GraphOp,
+      { op: 'set_node_meta', node_id: a.id, label: 'x'.repeat(121) } as GraphOp,
+      { op: 'set_node_meta', node_id: noteId, label: 'Note name' } as GraphOp,
+    ]) {
+      const r = run([op], added.nodes);
+      expect(r.results[0].ok, JSON.stringify(op)).toBe(false);
+      expect(r.mutated).toBe(false);
+    }
+  });
+});

--- a/frontend/src/plugins/ops.test.ts
+++ b/frontend/src/plugins/ops.test.ts
@@ -227,6 +227,33 @@ describe('applyGraphOps — move_node', () => {
     expect(r.results[1].ok).toBe(true);
     expect(r.nodes[0].position).toEqual({ x: 12, y: 34 });
   });
+
+  it('re-derives the offset when the moved node IS the bound note', () => {
+    const { nodes, a } = seeded();
+    const r = run([{ op: 'move_node', node_id: 'note1', position: { x: 200, y: 100 } }], nodes);
+    const note = r.nodes.find((n) => n.id === 'note1')!;
+    expect(note.position).toEqual({ x: 200, y: 100 });
+    // `onNodesChange`'s FIRST pass: the offset follows the note that was moved.
+    expect(note.data.boundOffset).toEqual({ x: 200, y: 100 });
+
+    // The SECOND pass, replayed by hand -- what the store does on the next
+    // drag of the parent. A stale offset would snap the note back to where it
+    // sat before the plugin moved it, reading as if the edit had been undone.
+    const parent = r.nodes.find((n) => n.id === a.id)!;
+    const dragged = { x: parent.position.x + 40, y: parent.position.y + 15 };
+    const rederived = {
+      x: dragged.x + note.data.boundOffset!.x,
+      y: dragged.y + note.data.boundOffset!.y,
+    };
+    expect(rederived).toEqual({ x: 240, y: 115 });
+  });
+
+  it('leaves a plain node\'s data object untouched', () => {
+    const { nodes, a } = seeded();
+    const before = nodes.find((n) => n.id === a.id)!.data;
+    const r = run([{ op: 'move_node', node_id: a.id, position: { x: 7, y: 8 } }], nodes);
+    expect(r.nodes.find((n) => n.id === a.id)!.data).toBe(before);
+  });
 });
 
 describe('applyGraphOps — set_segment / remove_segment', () => {
@@ -307,5 +334,36 @@ describe('applyGraphOps — set_segment / remove_segment', () => {
     const groups: SegmentGroup[] = [{ id: 's1', headNodeId: a.id, tailNodeId: b.id }];
     const r = run([{ op: 'add_node', node_type: 'Source' }], nodes, edges, groups);
     expect(r.segmentGroups).toBe(groups);
+  });
+
+  it('remove_node drops the segments that named it, and only those', () => {
+    const { nodes, edges, a, b } = chain();
+    const groups: SegmentGroup[] = [
+      { id: 's1', headNodeId: a.id, tailNodeId: b.id },
+      { id: 's2', headNodeId: b.id, tailNodeId: b.id },
+    ];
+    const head = run([{ op: 'remove_node', node_id: a.id }], nodes, edges, groups);
+    expect(head.results[0].ok).toBe(true);
+    expect(head.segmentGroups).toEqual([{ id: 's2', headNodeId: b.id, tailNodeId: b.id }]);
+
+    // A delete that names no endpoint leaves the list alone -- by reference,
+    // so the autosave record is not rewritten for a list that did not move.
+    const note: Node<NodeData> = {
+      id: 'note1', type: 'noteNode', position: { x: 0, y: 0 },
+      data: { label: 'Note', type: 'note', params: {}, noteKind: 'text', noteContent: 'x', noteColor: '#3d3d1a', boundToNodeId: null, boundOffset: null, noteWidth: 200 },
+    };
+    const other = run([{ op: 'remove_node', node_id: 'note1' }], [...nodes, note], edges, groups);
+    expect(other.segmentGroups).toBe(groups);
+  });
+
+  it('clear_graph empties the segment list too', () => {
+    const { nodes, edges, a, b } = chain();
+    const groups: SegmentGroup[] = [{ id: 's1', headNodeId: a.id, tailNodeId: b.id }];
+    const r = run([{ op: 'clear_graph' }], nodes, edges, groups);
+    expect(r.results[0].ok).toBe(true);
+    expect(r.segmentGroups).toEqual([]);
+
+    const empty: SegmentGroup[] = [];
+    expect(run([{ op: 'clear_graph' }], nodes, edges, empty).segmentGroups).toBe(empty);
   });
 });

--- a/frontend/src/plugins/ops.ts
+++ b/frontend/src/plugins/ops.ts
@@ -9,7 +9,9 @@
  */
 import type { Edge, Node } from '@xyflow/react';
 import type { NodeData, NodeDefinition, ParamDefinition, SegmentGroup } from '../types';
-import { buildFlowNode, generateId, isValidConnection } from '../utils';
+import {
+  buildFlowNode, buildNoteNode, DEFAULT_NOTE_COLOR, generateId, isValidConnection,
+} from '../utils';
 import { autoLayout } from '../utils/autoLayout';
 import { computeSegmentNodes } from '../utils/segmentPath';
 
@@ -37,7 +39,16 @@ export type GraphOp =
    * data edges or the overlay would render nothing.
    */
   | { op: 'set_segment'; segment_id?: string; head_node_id: string; tail_node_id: string }
-  | { op: 'remove_segment'; segment_id: string };
+  | { op: 'remove_segment'; segment_id: string }
+  /**
+   * Add a text note -- the sticky the canvas already renders, and which the
+   * validator, the exporters and every fingerprint already skip (#342).
+   */
+  | { op: 'add_note'; ref?: string; text: string;
+      position?: { x: number; y: number }; color?: string; bind_to?: string }
+  | { op: 'update_note'; node_id: string; text?: string; color?: string }
+  /** Name one node. The label is metadata beside `params`, never inside it. */
+  | { op: 'set_node_meta'; node_id: string; label: string };
 
 export interface OpResult {
   index: number;
@@ -56,6 +67,79 @@ export interface ApplyOutcome {
   refs: Record<string, string>;
   dirtyIds: string[];
   mutated: boolean;
+}
+
+/** Longest note an op may write. An agent inlining a document is not a note. */
+const NOTE_TEXT_MAX = 4000;
+/** Longest node label. Long enough for a sentence fragment, short enough for a card. */
+const NODE_LABEL_MAX = 120;
+/**
+ * The six colours the canvas's note menu offers are all `#rrggbb`
+ * (`NodeContextMenu.tsx:33-40`), so one pattern covers "a palette colour" and
+ * "a hex colour" without importing a component's private constant.
+ */
+const NOTE_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+/** Where an unpositioned bound note lands, relative to the node it explains. */
+const NOTE_BIND_OFFSET = { x: 240, y: -20 };
+
+/**
+ * A bound note's offset from the node it explains, derived from where the
+ * note actually sits. One function so `add_note`'s initial binding and
+ * `move_node`'s re-derivation cannot drift: they are the same rule, and a
+ * disagreement between them shows up only as a note that jumps on the next
+ * drag of its parent.
+ */
+function boundOffsetFrom(
+  notePosition: { x: number; y: number },
+  parentPosition: { x: number; y: number },
+): { x: number; y: number } {
+  return { x: notePosition.x - parentPosition.x, y: notePosition.y - parentPosition.y };
+}
+
+/**
+ * True when `text` holds a C0 control character or DEL.
+ *
+ * Written as a codepoint scan rather than a regex character class on
+ * purpose: a class of `\u00xx` escapes is the kind of literal that gets
+ * mangled by one careless copy-paste and then silently accepts nothing, or
+ * everything. Tab, newline and carriage return are legitimate in a note and
+ * are the only three let through.
+ */
+function hasControlChars(text: string): boolean {
+  for (const ch of text) {
+    const code = ch.codePointAt(0)!;
+    if (code === 9 || code === 10 || code === 13) continue;
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function validateNoteText(text: unknown): string | null {
+  if (typeof text !== 'string') return 'text must be a string';
+  if (text.length < 1 || text.length > NOTE_TEXT_MAX) {
+    return `text must be 1..${NOTE_TEXT_MAX} characters`;
+  }
+  if (hasControlChars(text)) {
+    return 'text may not contain control characters (newline and tab are fine)';
+  }
+  return null;
+}
+
+function validateNoteColor(color: unknown): string | null {
+  if (typeof color !== 'string' || !NOTE_COLOR_RE.test(color)) {
+    return "color must be a '#rrggbb' hex string";
+  }
+  return null;
+}
+
+function validateNodeLabel(label: unknown): string | null {
+  if (typeof label !== 'string') return 'label must be a string';
+  if (/[\r\n]/.test(label)) return 'label must be a single line';
+  const trimmed = label.trim();
+  if (trimmed.length < 1 || trimmed.length > NODE_LABEL_MAX) {
+    return `label must be 1..${NODE_LABEL_MAX} characters`;
+  }
+  return null;
 }
 
 function validateParamValue(p: ParamDefinition, value: unknown): string | null {
@@ -333,10 +417,7 @@ export function applyGraphOps(
               if (parent) {
                 next.data = {
                   ...n.data,
-                  boundOffset: {
-                    x: target.x - parent.position.x,
-                    y: target.y - parent.position.y,
-                  },
+                  boundOffset: boundOffsetFrom(target, parent.position),
                 };
               }
             }
@@ -392,6 +473,105 @@ export function applyGraphOps(
         segmentGroups = segmentGroups.filter((s) => s.id !== op.segment_id);
         mutated = true;
         results.push({ index, ok: true });
+        return;
+      }
+
+      case 'add_note': {
+        const textError = validateNoteText(op.text);
+        if (textError) return fail(`add_note: ${textError}`);
+        if (op.color !== undefined) {
+          const colorError = validateNoteColor(op.color);
+          if (colorError) return fail(`add_note: ${colorError}`);
+        }
+        let bound: Node<NodeData> | undefined;
+        if (op.bind_to !== undefined) {
+          const boundId = resolveId(op.bind_to);
+          if (!boundId) return fail(`add_note: unknown node '${op.bind_to}'`);
+          bound = nodes.find((n) => n.id === boundId)!;
+          if (bound.type === 'noteNode') {
+            return fail('add_note: a note cannot be bound to another note');
+          }
+        }
+        const position = op.position
+          ?? (bound
+            ? {
+                x: bound.position.x + NOTE_BIND_OFFSET.x,
+                y: bound.position.y + NOTE_BIND_OFFSET.y,
+              }
+            : { x: 160 + (staggered % 4) * 90, y: 120 + staggered * 70 });
+        staggered += 1;
+        const note = buildNoteNode({
+          text: op.text,
+          position,
+          color: op.color ?? DEFAULT_NOTE_COLOR,
+          boundToNodeId: bound ? bound.id : null,
+          // Derived from where the note actually ends up, so an explicit
+          // `position` and the default one both leave a consistent binding.
+          boundOffset: bound ? boundOffsetFrom(position, bound.position) : null,
+        });
+        nodes = [...nodes, note];
+        if (op.ref) refs[op.ref] = note.id;
+        mutated = true;
+        results.push({ index, ok: true, node_id: note.id });
+        return;
+      }
+
+      case 'update_note': {
+        const id = resolveId(op.node_id);
+        if (!id) return fail(`update_note: unknown node '${op.node_id}'`);
+        const note = nodes.find((n) => n.id === id)!;
+        if (note.type !== 'noteNode') {
+          return fail(`update_note: node '${op.node_id}' is not a note`);
+        }
+        if (op.text === undefined && op.color === undefined) {
+          return fail('update_note: nothing to change — pass text, color, or both');
+        }
+        if (op.text !== undefined) {
+          const textError = validateNoteText(op.text);
+          if (textError) return fail(`update_note: ${textError}`);
+          // An image note's `noteContent` is its data URL. Writing prose over
+          // it would blank the picture, and the 4000-char cap is not a
+          // meaningful guard for a field that is meant to hold base64.
+          if (note.data.noteKind === 'image') {
+            return fail('update_note: cannot set text on an image note');
+          }
+        }
+        if (op.color !== undefined) {
+          const colorError = validateNoteColor(op.color);
+          if (colorError) return fail(`update_note: ${colorError}`);
+        }
+        nodes = nodes.map((n) =>
+          n.id === id
+            ? {
+                ...n,
+                data: {
+                  ...n.data,
+                  ...(op.text !== undefined ? { noteContent: op.text } : {}),
+                  ...(op.color !== undefined ? { noteColor: op.color } : {}),
+                },
+              }
+            : n,
+        );
+        mutated = true;
+        results.push({ index, ok: true, node_id: id });
+        return;
+      }
+
+      case 'set_node_meta': {
+        const id = resolveId(op.node_id);
+        if (!id) return fail(`set_node_meta: unknown node '${op.node_id}'`);
+        const target = nodes.find((n) => n.id === id)!;
+        if (target.type === 'noteNode') {
+          return fail('set_node_meta: a note has no label — use update_note');
+        }
+        const labelError = validateNodeLabel(op.label);
+        if (labelError) return fail(`set_node_meta: ${labelError}`);
+        const label = op.label.trim();
+        nodes = nodes.map((n) =>
+          n.id === id ? { ...n, data: { ...n.data, label } } : n,
+        );
+        mutated = true;
+        results.push({ index, ok: true, node_id: id });
         return;
       }
 

--- a/frontend/src/plugins/ops.ts
+++ b/frontend/src/plugins/ops.ts
@@ -8,9 +8,10 @@
  * errors.
  */
 import type { Edge, Node } from '@xyflow/react';
-import type { NodeData, NodeDefinition, ParamDefinition } from '../types';
+import type { NodeData, NodeDefinition, ParamDefinition, SegmentGroup } from '../types';
 import { buildFlowNode, generateId, isValidConnection } from '../utils';
 import { autoLayout } from '../utils/autoLayout';
+import { computeSegmentNodes } from '../utils/segmentPath';
 
 export type GraphOp =
   | { op: 'add_node'; node_type: string; ref?: string;
@@ -22,18 +23,35 @@ export type GraphOp =
   | { op: 'remove_edge'; source: string; target: string;
       source_handle?: string; target_handle?: string }
   | { op: 'clear_graph' }
-  | { op: 'auto_layout' };
+  | { op: 'auto_layout' }
+  /**
+   * Put one node at an exact position (#342). Notes bound to it ride along by
+   * the same delta, the way they do when the user drags it -- an agent that
+   * tidies a corner and strands three sticky notes has not tidied anything.
+   */
+  | { op: 'move_node'; node_id: string; position: { x: number; y: number } }
+  /**
+   * Create or replace a Teaching Inspector segment: the orange bubble the
+   * canvas draws around every node on a data path from head to tail (#342).
+   * Membership is derived, not stored, so head and tail have to be joined by
+   * data edges or the overlay would render nothing.
+   */
+  | { op: 'set_segment'; segment_id?: string; head_node_id: string; tail_node_id: string }
+  | { op: 'remove_segment'; segment_id: string };
 
 export interface OpResult {
   index: number;
   ok: boolean;
   error?: string;
   node_id?: string;
+  /** Set by `set_segment`, which may have generated the id itself. */
+  segment_id?: string;
 }
 
 export interface ApplyOutcome {
   nodes: Node<NodeData>[];
   edges: Edge[];
+  segmentGroups: SegmentGroup[];
   results: OpResult[];
   refs: Record<string, string>;
   dirtyIds: string[];
@@ -96,12 +114,17 @@ function validateParams(
 }
 
 export function applyGraphOps(
-  current: { nodes: Node<NodeData>[]; edges: Edge[] },
+  current: { nodes: Node<NodeData>[]; edges: Edge[]; segmentGroups: SegmentGroup[] },
   definitions: NodeDefinition[],
   ops: GraphOp[],
 ): ApplyOutcome {
   let nodes = [...current.nodes];
   let edges = [...current.edges];
+  // NOT copied, unlike the two above. The commit path writes whatever comes
+  // back, and the autosave record cache compares this array by reference, so
+  // a fresh (identical) list on every batch of add_node would rewrite the
+  // tab's stored record for nothing.
+  let segmentGroups = current.segmentGroups;
   const results: OpResult[] = [];
   const refs: Record<string, string> = {};
   const dirty = new Set<string>();
@@ -274,6 +297,75 @@ export function applyGraphOps(
         return;
       }
 
+      case 'move_node': {
+        const id = resolveId(op.node_id);
+        if (!id) return fail(`move_node: unknown node '${op.node_id}'`);
+        const target = op.position;
+        if (
+          !target
+          || !Number.isFinite(target.x)
+          || !Number.isFinite(target.y)
+        ) {
+          return fail('move_node: position must be two finite numbers');
+        }
+        const moved = nodes.find((n) => n.id === id)!;
+        const dx = target.x - moved.position.x;
+        const dy = target.y - moved.position.y;
+        nodes = nodes.map((n) => {
+          if (n.id === id) return { ...n, position: { x: target.x, y: target.y } };
+          // Mirrors `onNodesChange`'s second pass (tabStore.ts:2152-2178): a
+          // bound note follows its parent. By DELTA rather than by
+          // re-deriving from `boundOffset`, so a note the user has nudged
+          // keeps the offset they nudged it to.
+          if (n.type === 'noteNode' && n.data.boundToNodeId === id && n.data.boundOffset) {
+            return { ...n, position: { x: n.position.x + dx, y: n.position.y + dy } };
+          }
+          return n;
+        });
+        mutated = true;
+        results.push({ index, ok: true, node_id: id });
+        return;
+      }
+
+      case 'set_segment': {
+        const headId = resolveId(op.head_node_id);
+        const tailId = resolveId(op.tail_node_id);
+        if (!headId) return fail(`set_segment: unknown head node '${op.head_node_id}'`);
+        if (!tailId) return fail(`set_segment: unknown tail node '${op.tail_node_id}'`);
+        const head = nodes.find((n) => n.id === headId)!;
+        const tail = nodes.find((n) => n.id === tailId)!;
+        if (head.type === 'noteNode' || tail.type === 'noteNode') {
+          return fail('set_segment: a note node cannot be a segment endpoint');
+        }
+        // The overlay derives its members by BFS over data edges and draws
+        // nothing when the tail is unreachable, so an unreachable pair is a
+        // segment the user would never see. Refused with the reason rather
+        // than stored invisibly.
+        if (computeSegmentNodes(headId, tailId, nodes, edges).size === 0) {
+          return fail(
+            `set_segment: no data-edge path from '${op.head_node_id}' to '${op.tail_node_id}'`,
+          );
+        }
+        const id = op.segment_id ?? generateId();
+        segmentGroups = [
+          ...segmentGroups.filter((s) => s.id !== id),
+          { id, headNodeId: headId, tailNodeId: tailId },
+        ];
+        mutated = true;
+        results.push({ index, ok: true, segment_id: id });
+        return;
+      }
+
+      case 'remove_segment': {
+        if (!segmentGroups.some((s) => s.id === op.segment_id)) {
+          return fail(`remove_segment: unknown segment '${op.segment_id}'`);
+        }
+        segmentGroups = segmentGroups.filter((s) => s.id !== op.segment_id);
+        mutated = true;
+        results.push({ index, ok: true });
+        return;
+      }
+
       default:
         fail(`Unknown op '${(op as { op?: string }).op}'`);
     }
@@ -282,6 +374,7 @@ export function applyGraphOps(
   return {
     nodes,
     edges,
+    segmentGroups,
     results,
     refs,
     dirtyIds: [...dirty].filter((id) => nodes.some((n) => n.id === id)),

--- a/frontend/src/plugins/ops.ts
+++ b/frontend/src/plugins/ops.ts
@@ -257,6 +257,13 @@ export function applyGraphOps(
               : n,
           );
         edges = edges.filter((e) => e.source !== id && e.target !== id);
+        // The rule the Delete key follows (tabStore.ts:2206-2237): a group
+        // whose head or tail has just been deleted renders nothing and would
+        // otherwise be written to the saved file for good.
+        const keptSegments = segmentGroups.filter(
+          (s) => s.headNodeId !== id && s.tailNodeId !== id,
+        );
+        if (keptSegments.length !== segmentGroups.length) segmentGroups = keptSegments;
         mutated = true;
         results.push({ index, ok: true });
         return;
@@ -284,6 +291,9 @@ export function applyGraphOps(
       case 'clear_graph': {
         nodes = [];
         edges = [];
+        // Every group named nodes that are gone. Guarded so an already-empty
+        // list comes back by reference.
+        if (segmentGroups.length > 0) segmentGroups = [];
         for (const k of Object.keys(refs)) delete refs[k];
         mutated = true;
         results.push({ index, ok: true });
@@ -312,7 +322,26 @@ export function applyGraphOps(
         const dx = target.x - moved.position.x;
         const dy = target.y - moved.position.y;
         nodes = nodes.map((n) => {
-          if (n.id === id) return { ...n, position: { x: target.x, y: target.y } };
+          if (n.id === id) {
+            const next = { ...n, position: { x: target.x, y: target.y } };
+            // Mirrors `onNodesChange`'s FIRST pass (tabStore.ts:2133-2150): a
+            // bound note that is itself moved re-derives its offset, or the
+            // next drag of its parent would snap it back to where it sat
+            // before -- reading as if the plugin's edit had been undone.
+            if (n.type === 'noteNode' && n.data.boundToNodeId && n.data.boundOffset) {
+              const parent = nodes.find((p) => p.id === n.data.boundToNodeId);
+              if (parent) {
+                next.data = {
+                  ...n.data,
+                  boundOffset: {
+                    x: target.x - parent.position.x,
+                    y: target.y - parent.position.y,
+                  },
+                };
+              }
+            }
+            return next;
+          }
           // Mirrors `onNodesChange`'s second pass (tabStore.ts:2152-2178): a
           // bound note follows its parent. By DELTA rather than by
           // re-deriving from `boundOffset`, so a note the user has nudged

--- a/frontend/src/store/tabStore.idb.test.ts
+++ b/frontend/src/store/tabStore.idb.test.ts
@@ -134,6 +134,29 @@ describe('tab autosave - IndexedDB migration on first load', () => {
     expect(state.activeTabId).toBe('y');
   });
 
+  it('restores each tab revision, and a pre-#341 record as 1', async () => {
+    // The hydration path installs `tabFromPersisted` results through the RAW
+    // `useTabStore.setState`, so it never passes the revision wrapper -- this
+    // is the one place the stored number is proved to survive end to end
+    // rather than at the function boundary.
+    const first = await loadStore();
+    await first.persistence.writeSnapshot(
+      LEGACY_KEY,
+      [
+        { id: 'kept', name: 'Kept', nodes: [], edges: [], revision: 7 },
+        // Written before the counter existed: no `revision` key at all.
+        { id: 'old', name: 'Old', nodes: [], edges: [] },
+      ],
+      'kept',
+    );
+
+    const second = await loadStore();
+    expect(await second.store.whenTabsHydrated()).toBe('loaded');
+    const tabs = second.store.useTabStore.getState().tabs;
+    expect(tabs.find((t) => t.id === 'kept')!.revision).toBe(7);
+    expect(tabs.find((t) => t.id === 'old')!.revision).toBe(1);
+  });
+
   it('keeps the live socket of a tab the hydrate also names', async () => {
     localStorage.setItem(
       LEGACY_KEY,

--- a/frontend/src/store/tabStore.label.test.ts
+++ b/frontend/src/store/tabStore.label.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `data.label` survives serialization (#342).
+ *
+ * The deserializer has always read it (`utils/index.ts:505`,
+ * `label: raw.data?.label ?? nodeType`) and the serializer never wrote it, so
+ * a node renamed in the editor lost its name on save and `getGraph()` never
+ * showed it. That asymmetry is what #342's round-trip criterion runs into.
+ *
+ * The other half of the fix is the one that keeps it cheap: a node nobody has
+ * renamed serializes byte-identically to before, so this does not rewrite
+ * every graph file in the repository.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useTabStore } from './tabStore';
+import { useNodeDefStore } from './nodeDefStore';
+import { resolveSerializedNodes } from '../utils';
+import type { NodeDefinition } from '../types';
+
+vi.mock('./tabPersistence', () => ({
+  readSnapshot: vi.fn(async () => null),
+  writeSnapshot: vi.fn(async () => {}),
+}));
+
+const store = () => useTabStore.getState();
+
+const DEF: NodeDefinition = {
+  node_name: 'Dataset', category: 'data', description: '',
+  inputs: [], outputs: [], params: [],
+};
+
+beforeEach(() => {
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  store().addTab('test');
+  useNodeDefStore.setState({ definitions: [DEF], presets: [] } as never);
+});
+
+describe('label serialization', () => {
+  it('omits label on a node nobody renamed', () => {
+    store().addNode(DEF, { x: 0, y: 0 });
+    const [node] = store().getSerializedGraph().nodes;
+    expect(node.data.label).toBeUndefined();
+    expect(Object.keys(node.data)).toEqual(['params']);
+  });
+
+  it('emits label once the node is renamed', () => {
+    store().addNode(DEF, { x: 0, y: 0 });
+    const id = store().getActiveTab().nodes[0].id;
+    store().renameNode(id, 'Training set');
+    const [node] = store().getSerializedGraph().nodes;
+    expect(node.data.label).toBe('Training set');
+  });
+
+  it('round-trips: rename, serialize, resolve, still named', () => {
+    store().addNode(DEF, { x: 0, y: 0 });
+    const id = store().getActiveTab().nodes[0].id;
+    store().renameNode(id, 'Training set');
+    const serialized = store().getSerializedGraph();
+    const resolved = resolveSerializedNodes(serialized.nodes, [DEF], []);
+    expect(resolved[0].data.label).toBe('Training set');
+  });
+
+  it('a note carries no label field of its own', () => {
+    store().addNote('text', { x: 0, y: 0 });
+    const [note] = store().getSerializedGraph().nodes;
+    expect(note.type).toBe('note');
+    expect(note.data.label).toBeUndefined();
+  });
+});

--- a/frontend/src/store/tabStore.label.test.ts
+++ b/frontend/src/store/tabStore.label.test.ts
@@ -66,3 +66,47 @@ describe('label serialization', () => {
     expect(note.data.label).toBeUndefined();
   });
 });
+
+/**
+ * Start was the one node class the reader ignored a saved label on (review I1).
+ *
+ * `resolveSerializedNodes` has a dedicated Start branch, and it hardcoded
+ * `label: 'Start'` instead of reading `raw.data?.label`. So a renamed Start --
+ * by the canvas context menu, or by an agent's `set_node_meta`, which both
+ * write the same `data.label` -- serialized its new name, came back as 'Start'
+ * on the next load, and lost the key entirely on the save after that. The
+ * rename reported success at every step and reverted anyway.
+ */
+describe('label serialization — the Start node', () => {
+  const START: NodeDefinition = {
+    node_name: 'Start', category: 'Control', description: '',
+    inputs: [],
+    outputs: [{ name: 'trigger', data_type: 'TRIGGER', description: '', optional: false }],
+    params: [],
+  };
+
+  it('round-trips a renamed Start', () => {
+    store().addNode(START, { x: 0, y: 0 });
+    const id = store().getActiveTab().nodes[0].id;
+    store().renameNode(id, 'Entry');
+
+    const serialized = store().getSerializedGraph();
+    expect(serialized.nodes[0].type).toBe('Start');
+    expect(serialized.nodes[0].data.label).toBe('Entry');
+
+    const resolved = resolveSerializedNodes(serialized.nodes, [START], []);
+    expect(resolved[0].data.label).toBe('Entry');
+  });
+
+  it('falls back to Start when the file carries no label', () => {
+    store().addNode(START, { x: 0, y: 0 });
+    const serialized = store().getSerializedGraph();
+    expect(serialized.nodes[0].data.label).toBeUndefined();
+
+    const resolved = resolveSerializedNodes(serialized.nodes, [START], []);
+    expect(resolved[0].data.label).toBe('Start');
+    // The rest of the Start branch is untouched by the fix.
+    expect(resolved[0].type).toBe('start');
+    expect(resolved[0].data.type).toBe('Start');
+  });
+});

--- a/frontend/src/store/tabStore.revision.test.ts
+++ b/frontend/src/store/tabStore.revision.test.ts
@@ -1,0 +1,316 @@
+/**
+ * `TabState.revision` — the compare-and-swap token plugin API v5 hands out
+ * (#341).
+ *
+ * The rule under test is a construction rule, not a per-action one: the
+ * store's `set` is wrapped once, so a tab whose DOCUMENT changed in a
+ * transition comes out of it with `revision + 1`. These tests drive that
+ * through the PUBLIC actions, because "a new action forgot to bump" is
+ * exactly the failure the wrapper exists to make impossible -- and the only
+ * honest way to check it is to mutate the way the editor does.
+ *
+ * The other half of the contract, and the harder half, is what must NOT bump.
+ * React Flow rewrites `nodes` for reasons that have nothing to do with the
+ * document: selecting a card, and reporting a card's measured size when it
+ * remounts after being culled by `onlyRenderVisibleElements`. A counter that
+ * compared array references would climb while the user panned the canvas, and
+ * every plugin's compare-and-swap would fail against a graph nobody had
+ * touched. So the comparison is by CONTENT, and these tests are where that is
+ * pinned.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Edge, Node } from '@xyflow/react';
+import { useTabStore, _documentChangedForTesting } from './tabStore';
+import { useNodeDefStore } from './nodeDefStore';
+import type { NodeData, NodeDefinition } from '../types';
+
+vi.mock('./tabPersistence', () => ({
+  readSnapshot: vi.fn(async () => null),
+  writeSnapshot: vi.fn(async () => {}),
+}));
+
+const store = () => useTabStore.getState();
+const activeTab = () => useTabStore.getState().getActiveTab();
+const revision = () => activeTab().revision;
+
+function def(name: string): NodeDefinition {
+  return {
+    node_name: name, category: 'Layer', description: '',
+    inputs: [{ name: 'in', data_type: 'TENSOR', description: '', optional: false }],
+    outputs: [{ name: 'out', data_type: 'TENSOR', description: '', optional: false }],
+    params: [
+      { name: 'size', param_type: 'int', default: 8, description: '', options: [], min_value: 1, max_value: 64 },
+    ],
+  };
+}
+
+function node(id: string, x = 0): Node<NodeData> {
+  return {
+    id, type: 'baseNode', position: { x, y: 0 },
+    data: { label: id, type: 'A', params: {}, definition: def('A'), executionStatus: 'idle' },
+  };
+}
+
+function dataEdge(id: string, source: string, target: string): Edge {
+  return { id, source, target, sourceHandle: 'out', targetHandle: 'in' };
+}
+
+beforeEach(() => {
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  store().addTab('test');
+  useNodeDefStore.setState({ definitions: [def('A')] } as never);
+});
+
+describe('TabState.revision', () => {
+  it('starts at 1 on a fresh tab', () => {
+    expect(revision()).toBe(1);
+  });
+
+  it('bumps exactly once per document-changing action', () => {
+    // One `set` per action, one bump per `set`: the table is the contract.
+    const steps: Array<[string, () => void]> = [
+      ['setNodes', () => store().setNodes([node('a'), node('b', 200)])],
+      ['setEdges', () => store().setEdges([dataEdge('e1', 'a', 'b')])],
+      ['addNote', () => store().addNote('text', { x: 10, y: 10 })],
+      ['deleteNode', () => store().deleteNode('b')],
+      ['renameNode', () => store().renameNode('a', 'Renamed')],
+      ['addSegmentGroup', () => store().addSegmentGroup({ id: 's1', headNodeId: 'a', tailNodeId: 'a' })],
+      ['removeSegmentGroup', () => store().removeSegmentGroup('s1')],
+      ['setSegmentGroups', () => store().setSegmentGroups([{ id: 's2', headNodeId: 'a', tailNodeId: 'a' }])],
+      // A real definition, not `[]`: `documentChanged` compares definitions
+      // with `sameSubgraphs`, and an empty list replaced by another empty
+      // list is honestly not a change.
+      ['setSubgraphs', () => store().setSubgraphs([{
+        id: 'blk', name: 'Encoder', description: '',
+        nodes: [], edges: [], interface: { inputs: [], outputs: [], triggerTargets: [] },
+      }])],
+      ['renameSubgraph', () => store().renameSubgraph('blk', 'Decoder')],
+      ['updateNodeParams', () => store().updateNodeParams('a', { size: 16 })],
+      ['clear', () => store().clear()],
+    ];
+    for (const [name, run] of steps) {
+      const before = revision();
+      run();
+      expect(revision(), `${name} must bump revision by exactly 1`).toBe(before + 1);
+    }
+  });
+
+  it('bumps on undo and on redo -- the document changed either way', () => {
+    store().setNodes([node('a')]);
+    store().pushUndoSnapshot();
+    store().setNodes([node('a'), node('b', 200)]);
+    const afterEdit = revision();
+
+    store().undo();
+    expect(revision()).toBe(afterEdit + 1);
+    expect(activeTab().nodes).toHaveLength(1);
+
+    store().redo();
+    expect(revision()).toBe(afterEdit + 2);
+    expect(activeTab().nodes).toHaveLength(2);
+  });
+
+  it('bumps on loadGraphDocument and never goes backwards', () => {
+    store().setNodes([node('a')]);
+    const before = revision();
+    store().loadGraphDocument({ nodes: [], edges: [], boundFile: null });
+    expect(revision()).toBe(before + 1);
+    expect(revision()).toBeGreaterThan(1);
+  });
+
+  it('does NOT bump for rename, activate, a modal id or run status', () => {
+    const id = activeTab().id;
+    const before = revision();
+    store().renameTab(id, 'Renamed tab');
+    store().setActiveTab(id);
+    store().setSelectedNodeId(null);
+    store().openPresetModal('a');
+    store().closePresetModal();
+    store().closeNodeDetail();
+    store().setTabStatus(id, 'running');
+    expect(useTabStore.getState().getTab(id)!.revision).toBe(before);
+  });
+});
+
+describe('revision ignores what is not the document', () => {
+  beforeEach(() => {
+    store().setNodes([node('a'), node('b', 200)]);
+    store().setEdges([dataEdge('e1', 'a', 'b')]);
+  });
+
+  it('a plain click through setSelectedNodeId does not bump', () => {
+    const before = revision();
+    store().setSelectedNodeId('a');
+    expect(revision()).toBe(before);
+  });
+
+  it('selectNodeExclusively does not bump', () => {
+    // It writes `node.selected` onto every node, so the array reference moves
+    // and the objects are fresh. Selection is not the document.
+    const before = revision();
+    store().selectNodeExclusively('a');
+    expect(activeTab().nodes.find((n) => n.id === 'a')!.selected).toBe(true);
+    expect(activeTab().selectedNodeId).toBe('a');
+    expect(revision()).toBe(before);
+  });
+
+  it('openNodeDetail does not bump', () => {
+    // Same write as above plus four scalar fields and the request nonce.
+    const before = revision();
+    store().openNodeDetail('a');
+    expect(activeTab().nodeDetailNodeId).toBe('a');
+    expect(revision()).toBe(before);
+  });
+
+  it('a select-only onNodesChange batch does not bump', () => {
+    const before = revision();
+    store().onNodesChange([
+      { id: 'a', type: 'select', selected: true },
+      { id: 'b', type: 'select', selected: false },
+    ]);
+    expect(activeTab().nodes.find((n) => n.id === 'a')!.selected).toBe(true);
+    expect(revision()).toBe(before);
+  });
+
+  it('a select-only onEdgesChange batch does not bump', () => {
+    const before = revision();
+    store().onEdgesChange([{ id: 'e1', type: 'select', selected: true }]);
+    expect(activeTab().edges[0].selected).toBe(true);
+    expect(revision()).toBe(before);
+  });
+
+  it('a dimensions batch does not bump -- panning must not break a plugin CAS', () => {
+    // This is the shape React Flow sends when a card that was culled by
+    // `onlyRenderVisibleElements` remounts and re-measures itself: it sets
+    // `measured`, and with `setAttributes` also `width` and `height`. Under a
+    // reference-comparing counter, scrolling around a large graph would
+    // invalidate every revision a plugin was holding.
+    const before = revision();
+    store().onNodesChange([
+      { id: 'a', type: 'dimensions', dimensions: { width: 214, height: 88 }, setAttributes: true },
+      { id: 'b', type: 'dimensions', dimensions: { width: 214, height: 88 } },
+    ]);
+    expect(activeTab().nodes[0].measured).toEqual({ width: 214, height: 88 });
+    expect(revision()).toBe(before);
+  });
+
+  it('a resize flag on its own does not bump', () => {
+    const before = revision();
+    store().onNodesChange([{ id: 'a', type: 'dimensions', resizing: true }]);
+    expect(revision()).toBe(before);
+  });
+
+  it('a drag START, which carries no coordinates, does not bump', () => {
+    // `NodePositionChange.position` is optional; the first change of a drag
+    // sets only `dragging`. Nothing about the document has changed yet.
+    const before = revision();
+    store().onNodesChange([{ id: 'a', type: 'position', dragging: true }]);
+    expect(revision()).toBe(before);
+  });
+
+  it('a drag that actually moves a node bumps', () => {
+    const before = revision();
+    store().onNodesChange([
+      { id: 'a', type: 'position', position: { x: 40, y: 12 }, dragging: true },
+    ]);
+    expect(activeTab().nodes[0].position).toEqual({ x: 40, y: 12 });
+    expect(revision()).toBe(before + 1);
+  });
+
+  it('a position change to the SAME coordinates does not bump', () => {
+    // React Flow hands over a fresh position object either way, so this is
+    // only true because the comparison reads x and y rather than the
+    // reference.
+    const before = revision();
+    store().onNodesChange([
+      { id: 'a', type: 'position', position: { x: 0, y: 0 }, dragging: false },
+    ]);
+    expect(revision()).toBe(before);
+  });
+
+  it('a params edit bumps, because it replaces data', () => {
+    const before = revision();
+    store().updateNodeParams('a', { size: 16 });
+    expect(revision()).toBe(before + 1);
+  });
+
+  it('documentChanged reads position by value and data by reference', () => {
+    // The helper directly, since it is the whole rule.
+    const base = activeTab();
+    const sameShape = {
+      ...base,
+      nodes: base.nodes.map((n) => ({ ...n, position: { ...n.position }, selected: !n.selected })),
+    };
+    expect(_documentChangedForTesting(base, sameShape)).toBe(false);
+
+    const moved = {
+      ...base,
+      nodes: base.nodes.map((n, i) => (i === 0 ? { ...n, position: { x: 1, y: 0 } } : n)),
+    };
+    expect(_documentChangedForTesting(base, moved)).toBe(true);
+
+    const relabelled = {
+      ...base,
+      nodes: base.nodes.map((n, i) => (i === 0 ? { ...n, data: { ...n.data } } : n)),
+    };
+    expect(_documentChangedForTesting(base, relabelled)).toBe(true);
+
+    const shorter = { ...base, nodes: base.nodes.slice(0, 1) };
+    expect(_documentChangedForTesting(base, shorter)).toBe(true);
+  });
+});
+
+describe('TabState.revision, continued', () => {
+
+  it('does not bump a tab that did not change when a sibling tab does', () => {
+    const first = activeTab().id;
+    store().addTab('second');
+    const second = activeTab().id;
+    const firstRevision = useTabStore.getState().getTab(first)!.revision;
+    store().setNodes([node('a')]);
+    expect(useTabStore.getState().getTab(second)!.revision).toBeGreaterThan(1);
+    expect(useTabStore.getState().getTab(first)!.revision).toBe(firstRevision);
+  });
+
+  it('pushUndoSnapshot alone does not bump -- it changes no document field', () => {
+    store().setNodes([node('a')]);
+    const before = revision();
+    store().pushUndoSnapshot();
+    expect(revision()).toBe(before);
+  });
+
+  it('a whole drag session bumps, and only for the batches that moved it', () => {
+    // The real sequence: grab (no coordinates), two pointer moves, release
+    // (same coordinates as the last move). Three of the four batches are not
+    // document changes.
+    store().setNodes([node('a')]);
+    const before = revision();
+    store().onNodesChange([{ id: 'a', type: 'position', dragging: true }]);
+    store().onNodesChange([{ id: 'a', type: 'position', position: { x: 20, y: 5 }, dragging: true }]);
+    store().onNodesChange([{ id: 'a', type: 'position', position: { x: 40, y: 9 }, dragging: true }]);
+    store().onNodesChange([{ id: 'a', type: 'position', position: { x: 40, y: 9 }, dragging: false }]);
+    expect(activeTab().nodes[0].position).toEqual({ x: 40, y: 9 });
+    expect(revision()).toBe(before + 2);
+  });
+});
+
+describe('revision persistence', () => {
+  it('round-trips through buildPersistedTab / tabFromPersisted', async () => {
+    const { _buildPersistedTabForTesting, _tabFromPersistedForTesting } = await import('./tabStore');
+    store().setNodes([node('a')]);
+    store().setEdges([]);
+    const record = _buildPersistedTabForTesting(activeTab());
+    expect(record.revision).toBe(activeTab().revision);
+
+    const restored = _tabFromPersistedForTesting(record, activeTab());
+    expect(restored.revision).toBe(record.revision);
+  });
+
+  it('a record written before this feature restores as revision 1', async () => {
+    const { _buildPersistedTabForTesting, _tabFromPersistedForTesting } = await import('./tabStore');
+    const record = _buildPersistedTabForTesting(activeTab());
+    delete (record as { revision?: number }).revision;
+    const restored = _tabFromPersistedForTesting(record, activeTab());
+    expect(restored.revision).toBe(1);
+  });
+});

--- a/frontend/src/store/tabStore.revision.test.ts
+++ b/frontend/src/store/tabStore.revision.test.ts
@@ -17,10 +17,17 @@
  * every plugin's compare-and-swap would fail against a graph nobody had
  * touched. So the comparison is by CONTENT, and these tests are where that is
  * pinned.
+ *
+ * Node `data` is the same story one field deeper. A run rewrites `data` on
+ * every node it touches to paint status, an error and a progress bar, and
+ * `getSerializedGraph` writes none of those three into a saved file -- so a
+ * training run must leave the counter alone. That is `RUN_STATE_DATA_KEYS`,
+ * and the tests below pin both halves of it: run state does not bump, and a
+ * real edit arriving on a node that carries run state still does.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Edge, Node } from '@xyflow/react';
-import { useTabStore, _documentChangedForTesting } from './tabStore';
+import { useTabStore, _documentChangedForTesting, _setForTesting } from './tabStore';
 import { useNodeDefStore } from './nodeDefStore';
 import type { NodeData, NodeDefinition } from '../types';
 
@@ -234,7 +241,57 @@ describe('revision ignores what is not the document', () => {
     expect(revision()).toBe(before + 1);
   });
 
-  it('documentChanged reads position by value and data by reference', () => {
+  it('a run does not bump -- node status is not the document', () => {
+    // Spec rule 3. `setNodeExecutionStatus` replaces `data` wholesale, so
+    // under a plain data-REFERENCE comparison a run would bump the counter
+    // once per node per frame and expire every plugin's compare-and-swap
+    // against a graph the user never touched. None of these fields is
+    // written by `getSerializedGraph`, so none of them is the document.
+    const before = revision();
+    store().setNodeExecutionStatus('a', 'running');
+    store().setNodeExecutionStatus('a', 'completed');
+    expect(activeTab().nodes[0].data.executionStatus).toBe('completed');
+    expect(revision()).toBe(before);
+  });
+
+  it('a failure message does not bump, and neither does clearing it', () => {
+    // `error` is written unconditionally -- `undefined` when the node did not
+    // fail -- so it ADDS an own key to a node that never had one. The key-set
+    // equality check has to skip it, not merely compare it.
+    const before = revision();
+    store().setNodeExecutionStatus('a', 'error', 'boom');
+    expect(activeTab().nodes[0].data.error).toBe('boom');
+    store().clearExecutionStatus();
+    expect(activeTab().nodes[0].data.executionStatus).toBe('idle');
+    expect(revision()).toBe(before);
+  });
+
+  it('a streamed progress frame does not bump', () => {
+    // The live run path: `nodeUpdateQueue` batches WebSocket events into
+    // `applyTabNodeUpdates`, which rewrites `data` for every node named.
+    const before = revision();
+    store().setTabNodeProgress(activeTab().id, 'a', { event: 'epoch', epoch: 3, total_epochs: 10 });
+    expect(activeTab().nodes[0].data.progress).toEqual({ event: 'epoch', epoch: 3, total_epochs: 10 });
+    expect(revision()).toBe(before);
+  });
+
+  it('a params edit DURING a run still bumps', () => {
+    // The exclusion list must not swallow a real edit that happens to arrive
+    // on a node carrying run state.
+    store().setNodeExecutionStatus('a', 'running');
+    const before = revision();
+    store().updateNodeParams('a', { size: 32 });
+    expect(revision()).toBe(before + 1);
+  });
+
+  it('a label change on a node carrying run state still bumps', () => {
+    store().setNodeExecutionStatus('a', 'error', 'boom');
+    const before = revision();
+    store().renameNode('a', 'Renamed');
+    expect(revision()).toBe(before + 1);
+  });
+
+  it('documentChanged reads position by value, and data by content minus run state', () => {
     // The helper directly, since it is the whole rule.
     const base = activeTab();
     const sameShape = {
@@ -249,14 +306,65 @@ describe('revision ignores what is not the document', () => {
     };
     expect(_documentChangedForTesting(base, moved)).toBe(true);
 
-    const relabelled = {
+    // A bit-identical copy of `data` is NOT a change: every value still
+    // matches by reference, so only the wrapper object moved.
+    const recopied = {
       ...base,
       nodes: base.nodes.map((n, i) => (i === 0 ? { ...n, data: { ...n.data } } : n)),
     };
+    expect(_documentChangedForTesting(base, recopied)).toBe(false);
+
+    const relabelled = {
+      ...base,
+      nodes: base.nodes.map((n, i) =>
+        (i === 0 ? { ...n, data: { ...n.data, label: 'Renamed' } } : n)),
+    };
     expect(_documentChangedForTesting(base, relabelled)).toBe(true);
+
+    // All three run-state keys at once, including two the node did not have.
+    const running = {
+      ...base,
+      nodes: base.nodes.map((n, i) => (i === 0
+        ? {
+          ...n,
+          data: {
+            ...n.data,
+            executionStatus: 'running' as const,
+            error: 'boom',
+            progress: { event: 'epoch', epoch: 1 },
+          },
+        }
+        : n)),
+    };
+    expect(_documentChangedForTesting(base, running)).toBe(false);
+
+    // A real key the node did not carry before IS a change -- the skip list
+    // must not become "ignore any added key".
+    const bypassed = {
+      ...base,
+      nodes: base.nodes.map((n, i) =>
+        (i === 0 ? { ...n, data: { ...n.data, bypassed: true } } : n)),
+    };
+    expect(_documentChangedForTesting(base, bypassed)).toBe(true);
 
     const shorter = { ...base, nodes: base.nodes.slice(0, 1) };
     expect(_documentChangedForTesting(base, shorter)).toBe(true);
+  });
+
+  it('tolerates a node carrying neither position nor data', () => {
+    // `documentChanged` runs inside EVERY `set`, and node shapes are not
+    // trustworthy: localStorage is user-editable and IndexedDB records
+    // outlive format changes, which is why `tabFromPersisted` coerces rather
+    // than validates. A comparison that threw on a malformed node would take
+    // the workspace down on the next keystroke instead of just drawing it
+    // oddly.
+    const base = activeTab();
+    const bare = (ids: string[]) =>
+      ({ ...base, nodes: ids.map((id) => ({ id })) } as unknown as typeof base);
+
+    expect(_documentChangedForTesting(bare(['a']), bare(['a']))).toBe(false);
+    expect(_documentChangedForTesting(bare(['a']), bare(['b']))).toBe(true);
+    expect(_documentChangedForTesting(base, bare(['a', 'b']))).toBe(true);
   });
 });
 
@@ -295,22 +403,65 @@ describe('TabState.revision, continued', () => {
 });
 
 describe('revision persistence', () => {
+  // `tabFromPersisted` spreads `...base` FIRST, so handing it the same tab the
+  // record was built from would let both of these pass with the restore line
+  // deleted outright. The base is therefore held at a number neither the
+  // record nor a fresh tab can produce: 41 is the wrong answer to both
+  // questions, and the only way to the right one is through the record.
+  const BASE_REVISION = 41;
+
   it('round-trips through buildPersistedTab / tabFromPersisted', async () => {
     const { _buildPersistedTabForTesting, _tabFromPersistedForTesting } = await import('./tabStore');
     store().setNodes([node('a')]);
     store().setEdges([]);
     const record = _buildPersistedTabForTesting(activeTab());
     expect(record.revision).toBe(activeTab().revision);
+    // Guards the guard: a record still at 1 would not discriminate against a
+    // fresh tab's default.
+    expect(record.revision).toBeGreaterThan(1);
 
-    const restored = _tabFromPersistedForTesting(record, activeTab());
+    const base = { ...activeTab(), revision: BASE_REVISION };
+    const restored = _tabFromPersistedForTesting(record, base);
     expect(restored.revision).toBe(record.revision);
+    expect(restored.revision).not.toBe(BASE_REVISION);
   });
 
   it('a record written before this feature restores as revision 1', async () => {
     const { _buildPersistedTabForTesting, _tabFromPersistedForTesting } = await import('./tabStore');
     const record = _buildPersistedTabForTesting(activeTab());
     delete (record as { revision?: number }).revision;
-    const restored = _tabFromPersistedForTesting(record, activeTab());
+    const base = { ...activeTab(), revision: BASE_REVISION };
+    const restored = _tabFromPersistedForTesting(record, base);
+    // 1, not 41: "missing restores as 1" must mean 1, or a plugin's stored
+    // expectedRevision could match whatever placeholder tab the loader reused.
     expect(restored.revision).toBe(1);
+  });
+});
+
+describe('the wrapped set', () => {
+  it('forwards zustand replace instead of merging', () => {
+    // No action in the store passes `replace`, so the wrapper itself is the
+    // only place this is reachable -- and `TabSet` admits `set(x, true)` at
+    // every call site whether or not the wrapper honours it. Dropping the
+    // flag would turn a replace into a merge with nothing failing to say so.
+    expect(useTabStore.getState().clipboard).not.toBe(undefined);
+    const full = { ...useTabStore.getState() };
+    delete (full as { clipboard?: unknown }).clipboard;
+
+    _setForTesting(full as ReturnType<typeof useTabStore.getState>, true);
+
+    expect('clipboard' in useTabStore.getState()).toBe(false);
+  });
+
+  it('still bumps the revision through a replace', () => {
+    // `withRevisions` only ever rewrites `tabs`, so replace mode must not be
+    // a hole in the counter.
+    const before = revision();
+    const full = { ...useTabStore.getState() };
+    full.tabs = full.tabs.map((t) => ({ ...t, nodes: [node('a')] }));
+
+    _setForTesting(full as ReturnType<typeof useTabStore.getState>, true);
+
+    expect(revision()).toBe(before + 1);
   });
 });

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -850,7 +850,11 @@ describe('getSerializedGraph', () => {
       { id: 'e1', source: 'n1', target: 'n2' },
     ] as any);
     const g = store().getSerializedGraph();
-    expect(g.nodes[0]).toEqual({ id: 'n1', type: 'Dataset', position: { x: 1, y: 2 }, data: { params: { p: 1 } } });
+    // `label` is emitted because this node's label ('A') differs from its type
+    // -- which is what a rename looks like to the serializer (#342). The
+    // unrenamed case, where `data` is exactly `{ params }`, is pinned in
+    // tabStore.label.test.ts.
+    expect(g.nodes[0]).toEqual({ id: 'n1', type: 'Dataset', position: { x: 1, y: 2 }, data: { params: { p: 1 }, label: 'A' } });
     expect(g.edges[0]).toEqual({ id: 'e1', source: 'n1', target: 'n2', sourceHandle: '', targetHandle: '' });
     expect(g.presets).toEqual([]);
   });

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -256,8 +256,10 @@ export interface TabState {
    *
    * Starts at 1 and only ever climbs. It advances by exactly one whenever a
    * `set` changes this tab's `nodes`, `edges`, `subgraphs` or `segmentGroups`
-   * -- the four fields an undo frame captures, which is to say "the
-   * document". Undo and redo advance it too: they restore older CONTENT, and
+   * -- four of the five fields an undo frame captures, which is to say "the
+   * document". `activeSegment`, the fifth, is deliberately excluded: it is a
+   * view choice about which stretch of the graph is highlighted, not the
+   * document. Undo and redo advance it too: they restore older CONTENT, and
    * a plugin holding a revision from before the undo must not be told nothing
    * happened.
    *
@@ -1586,6 +1588,17 @@ function loadTabs(): { tabs: TabState[]; activeTabId: string } {
 type TabSet = Parameters<StateCreator<TabStoreState>>[0];
 
 /**
+ * Test seam: the store's WRAPPED `set`, assigned once inside `create()`.
+ *
+ * `useTabStore.setState` is the RAW setter and skips the revision bump
+ * entirely, so it cannot stand in for this. Exported as a `let` because the
+ * value does not exist until the factory runs.
+ */
+export let _setForTesting: TabSet = () => {
+  throw new Error('useTabStore has not been created yet');
+};
+
+/**
  * The plugin whose `applyOperations` produced the transition currently being
  * notified, or null (#341 section 4.5).
  *
@@ -1609,9 +1622,76 @@ export function _setCommitOriginForTesting(
 }
 
 /**
+ * Node `data` keys that describe a RUN, not the document (#341, spec rule 3).
+ *
+ * `getSerializedGraph` writes each node's `data` field by field -- `params`,
+ * `internalParams` for a preset, `bypassed` when muted, and the note fields
+ * for a note -- so none of these three reaches a saved file, an export or a
+ * plugin's `getGraph`. They exist only to paint a card while a run is in
+ * flight, and they are written by the hottest path in the store:
+ * `applyTabNodeUpdates` rebuilds `data` for every node named in every
+ * batched WebSocket frame.
+ *
+ * Without this list, "revision changes when the document changes" would mean
+ * "revision changes several times a second while training runs" -- every
+ * plugin's compare-and-swap would expire on a graph the user never touched,
+ * which is the same failure that made the comparison content-based in the
+ * first place, one field deeper.
+ */
+const RUN_STATE_DATA_KEYS: ReadonlySet<string> = new Set([
+  'executionStatus',
+  'error',
+  'progress',
+]);
+
+/**
+ * Do two node `data` objects differ in anything the DOCUMENT keeps? (#341)
+ *
+ * Reached only when the two references differ, which is why it can afford to
+ * walk keys: `data` is replaced wholesale by every writer in this store, so
+ * the reference is still the fast path and this is the slow one.
+ *
+ * Shallow and reference-wise per key, exactly as the whole-object comparison
+ * was: `params` is a fresh object on every param edit, `definition` and
+ * `presetDefinition` are swapped rather than mutated. The only judgement here
+ * is which keys to skip, and that list is `RUN_STATE_DATA_KEYS`.
+ *
+ * Key sets must otherwise match, so adding or removing a real field counts.
+ * `setNodeExecutionStatus` writes `error` unconditionally -- `undefined` when
+ * the node did not fail -- which ADDS an own `error` key to a node that never
+ * had one; that is exactly why `error` is on the skip list rather than merely
+ * compared.
+ */
+function nodeDataChanged(
+  a: NodeData | undefined,
+  b: NodeData | undefined,
+): boolean {
+  // A node reconstructed from a hand-edited localStorage record -- or built
+  // by a test double -- can be missing `data` altogether. This runs inside
+  // every `set`, so it coerces rather than throws: the same choice
+  // `tabFromPersisted` makes one layer up, and for the same reason.
+  if (a == null || b == null) return a !== b;
+  let aKeys = 0;
+  for (const key of Object.keys(a)) {
+    if (RUN_STATE_DATA_KEYS.has(key)) continue;
+    aKeys += 1;
+    if (!Object.prototype.hasOwnProperty.call(b, key)) return true;
+    if (a[key] !== b[key]) return true;
+  }
+  let bKeys = 0;
+  for (const key of Object.keys(b)) {
+    if (!RUN_STATE_DATA_KEYS.has(key)) bKeys += 1;
+  }
+  return aKeys !== bKeys;
+}
+
+/**
  * Did this tab's DOCUMENT change between two states? (#341)
  *
- * The four fields an undo frame captures are the document, but their array
+ * Four of the five fields an undo frame captures are the document --
+ * `activeSegment`, the fifth, is a view choice about which stretch of the
+ * graph is highlighted and is deliberately excluded, so a Teaching Inspector
+ * focus click does not expire a plugin's compare-and-swap. But their array
  * references are not a usable signal, because React Flow rewrites `nodes` for
  * things that are not the document at all:
  *
@@ -1632,10 +1712,13 @@ export function _setCommitOriginForTesting(
  *     Flow built, so the reference always moves -- even for a drag that ends
  *     where it started, and even on the drag-start change that carries no
  *     coordinates at all.
- *   - `data` BY REFERENCE. No change type touches `data`, and every writer in
- *     this store replaces it (`{...n.data, ...}`), so the reference IS the
- *     value. This is what makes a params edit or a rename a document change
- *     without a deep walk of every param on every pointer move.
+ *   - `data` BY REFERENCE FIRST. No change type touches `data`, and every
+ *     writer in this store replaces it (`{...n.data, ...}`), so an unchanged
+ *     reference is proof of an unchanged document and a pointer move costs
+ *     nothing. When the reference HAS moved, `nodeDataChanged` decides,
+ *     because "the reference moved" is not the same question as "the
+ *     document changed": a run rewrites `data` on every node it touches to
+ *     paint status and progress, and none of that is saved with the graph.
  *   - `id`, `type`, `parentId` by value -- structural, and never touched by a
  *     change.
  *   - `selected`, `dragging`, `measured`, `width`, `height`, `resizing`,
@@ -1661,12 +1744,19 @@ function documentChanged(prev: TabState, next: TabState): boolean {
         a.id !== b.id
         || a.type !== b.type
         || a.parentId !== b.parentId
-        || a.data !== b.data
-        || a.position.x !== b.position.x
-        || a.position.y !== b.position.y
+        // Optional-chained for the same reason `nodeDataChanged` tolerates a
+        // missing `data`: a node out of a hand-edited record may have no
+        // `position`, and a comparison that runs on every `set` must not be
+        // the thing that takes the workspace down. Absent on both sides
+        // compares equal; absent on one is a change.
+        || a.position?.x !== b.position?.x
+        || a.position?.y !== b.position?.y
       ) {
         return true;
       }
+      // Cheap scalars first; the key walk runs only for a node whose `data`
+      // was actually replaced, and then only to ask whether a run wrote it.
+      if (a.data !== b.data && nodeDataChanged(a.data, b.data)) return true;
     }
   }
 
@@ -1766,22 +1856,37 @@ function withRevisions(
 const initialState = loadTabs();
 
 export const useTabStore = create<TabStoreState>((rawSet, get) => {
-  // Every `set` in the body below is this one. `replace` is deliberately not
-  // forwarded: nothing in this store calls `set(x, true)`, and a wrapper that
-  // pretended to support a whole-state replace would have to decide what a
-  // revision means for a tab list that arrived without a predecessor.
-  const set: TabSet = (partial) => {
-    rawSet((state) =>
+  // Every `set` in the body below is this one.
+  //
+  // `replace` is FORWARDED rather than dropped. `TabSet` is zustand's
+  // two-overload setter, so `set(x, true)` type-checks at every call site
+  // whether or not this wrapper honours it; a wrapper that quietly ignored
+  // the flag would turn "replace the state, dropping these keys" into a
+  // merge that keeps them, with nothing failing to say so. Nothing in this
+  // store passes it today -- the point is that the day something does, it
+  // works. `withRevisions` needs no special case: it only ever rewrites
+  // `tabs`, and a replace partial is by type the whole state, so the
+  // comparison sees the same before/after tab lists either way.
+  const set: TabSet = (partial, replace) => {
+    const next = (state: TabStoreState) =>
       withRevisions(
         state,
         typeof partial === 'function' ? partial(state) : partial,
-      ),
-    );
+      );
+    if (replace === true) {
+      rawSet(next as (state: TabStoreState) => TabStoreState, true);
+    } else {
+      rawSet(next);
+    }
     // Cleared AFTER `rawSet` returns, i.e. after zustand has finished
     // notifying synchronously -- which is the only window a subscriber can
     // read it in.
     _lastCommitOrigin = null;
   };
+  // The wrapper is reachable from nowhere else: every action closes over it,
+  // and none of them passes `replace`. Handing it to the test is the only way
+  // to prove the flag survives the wrapping.
+  _setForTesting = set;
 
   return {
   tabs: initialState.tabs,

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand';
+import { create, type StateCreator } from 'zustand';
 import { applyNodeChanges, applyEdgeChanges } from '@xyflow/react';
 import type { Node, Edge, NodeChange, EdgeChange, Connection } from '@xyflow/react';
 import {
@@ -251,6 +251,28 @@ export interface TabState {
   // refuses to write it -- so an older CodefyUI build can never
   // destructively down-save a newer file.
   readOnly: boolean;
+  /**
+   * Compare-and-swap token for this tab's document (#341).
+   *
+   * Starts at 1 and only ever climbs. It advances by exactly one whenever a
+   * `set` changes this tab's `nodes`, `edges`, `subgraphs` or `segmentGroups`
+   * -- the four fields an undo frame captures, which is to say "the
+   * document". Undo and redo advance it too: they restore older CONTENT, and
+   * a plugin holding a revision from before the undo must not be told nothing
+   * happened.
+   *
+   * "Changes" is by CONTENT, not by array reference, and that distinction is
+   * the whole difficulty -- see `documentChanged`. React Flow rewrites the
+   * nodes array for selection and for remeasuring a card, neither of which is
+   * a document change, and a counter that climbed for those would expire a
+   * plugin's compare-and-swap every time the user panned the canvas.
+   *
+   * No action sets this by hand. The store's `set` is wrapped once, in
+   * `create()` below, so a mutating action added later cannot forget it. The
+   * one exception is the persistence loader, which restores the number a tab
+   * was saved with -- see `withRevisions`.
+   */
+  revision: number;
   // flow
   nodes: Node<NodeData>[];
   edges: Edge[];
@@ -347,6 +369,7 @@ function createTabState(id: string, name: string): TabState {
     currentGraphFile: null,
     projectOrigin: null,
     readOnly: false,
+    revision: 1,
     nodes: [],
     edges: [],
     subgraphs: [],
@@ -1246,6 +1269,13 @@ export interface PersistedTab {
   currentGraphFile?: string | null;
   projectOrigin?: string | null;
   readOnly?: boolean;
+  /**
+   * The tab's compare-and-swap counter (#341). Absent on a record written
+   * before this feature; such a record restores as 1, which is exactly what
+   * a fresh tab has, so a plugin's stored `expectedRevision` from a previous
+   * session fails closed rather than matching by accident.
+   */
+  revision?: number;
   nodes: Node<NodeData>[];
   edges: Edge[];
   segmentGroups?: SegmentGroup[];
@@ -1303,6 +1333,7 @@ function buildPersistedTab(input: TabState): PersistedTab {
   return {
     id: t.id,
     name: t.name,
+    revision: t.revision,
     description: t.description,
     currentGraphFile: t.currentGraphFile,
     // Only persisted when set, so non-project localStorage is byte-identical.
@@ -1381,6 +1412,7 @@ function scalarSignature(t: TabState): string {
     t.autoBackward ? '1' : '0',
     t.seed ?? '',
     t.deterministic ? '1' : '0',
+    String(t.revision),
   ]);
 }
 
@@ -1490,6 +1522,9 @@ function tabFromPersisted(t: PersistedTab, base: TabState): TabState {
     currentGraphFile: t.currentGraphFile ?? null,
     projectOrigin: t.projectOrigin ?? null,
     readOnly: t.readOnly ?? false,
+    // A record without the field is pre-#341: restore as 1 rather than as
+    // whatever the placeholder tab happened to be carrying.
+    revision: typeof t.revision === 'number' ? t.revision : 1,
     nodes,
     // Autosave stores each edge object as it stands, baked stroke and all, so
     // this is the one door a wire painted by an older palette comes back
@@ -1521,6 +1556,10 @@ function tabFromPersisted(t: PersistedTab, base: TabState): TabState {
   };
 }
 
+/** Test seams: the persistence record round-trip, without the debounce. */
+export const _buildPersistedTabForTesting = buildPersistedTab;
+export const _tabFromPersistedForTesting = tabFromPersisted;
+
 function loadTabs(): { tabs: TabState[]; activeTabId: string } {
   try {
     const raw = localStorage.getItem(_storageKey());
@@ -1543,9 +1582,208 @@ function loadTabs(): { tabs: TabState[]; activeTabId: string } {
   return { tabs: [createTabState(id, 'Tab 1')], activeTabId: id };
 }
 
+/** The `set` a zustand state creator is handed, named so it can be wrapped. */
+type TabSet = Parameters<StateCreator<TabStoreState>>[0];
+
+/**
+ * The plugin whose `applyOperations` produced the transition currently being
+ * notified, or null (#341 section 4.5).
+ *
+ * Module-level rather than a store field because it is not state: it exists
+ * for the duration of one `set`'s synchronous listener fan-out and is cleared
+ * by the wrapper the moment that fan-out returns, so `workspace.onChanged`
+ * can attach `origin` to a `graph` event without a plugin's write leaving a
+ * trace anybody can read afterwards.
+ */
+let _lastCommitOrigin: { pluginId: string } | null = null;
+
+export function lastCommitOrigin(): { pluginId: string } | null {
+  return _lastCommitOrigin;
+}
+
+/** Test seam: pretend a commit came from `origin` for the next notification. */
+export function _setCommitOriginForTesting(
+  origin: { pluginId: string } | null,
+): void {
+  _lastCommitOrigin = origin;
+}
+
+/**
+ * Did this tab's DOCUMENT change between two states? (#341)
+ *
+ * The four fields an undo frame captures are the document, but their array
+ * references are not a usable signal, because React Flow rewrites `nodes` for
+ * things that are not the document at all:
+ *
+ *   - selection -- `applyChange`'s `'select'` case sets `node.selected` on a
+ *     fresh shallow copy of the node;
+ *   - remeasuring -- a card culled by `onlyRenderVisibleElements` remounts
+ *     when it scrolls back into view and reports its size as a `'dimensions'`
+ *     change, which writes `measured`, `width` and `height`.
+ *
+ * A reference-comparing counter would therefore climb while the user simply
+ * PANNED THE CANVAS, and every plugin's compare-and-swap would expire against
+ * a graph nobody had touched. So this reads content.
+ *
+ * What it compares, and why each is safe (verified in @xyflow/react 12.10.1,
+ * `applyChanges` / `applyChange`, dist/esm/index.mjs:583-696):
+ *
+ *   - `position` BY VALUE. A `'position'` change assigns the object React
+ *     Flow built, so the reference always moves -- even for a drag that ends
+ *     where it started, and even on the drag-start change that carries no
+ *     coordinates at all.
+ *   - `data` BY REFERENCE. No change type touches `data`, and every writer in
+ *     this store replaces it (`{...n.data, ...}`), so the reference IS the
+ *     value. This is what makes a params edit or a rename a document change
+ *     without a deep walk of every param on every pointer move.
+ *   - `id`, `type`, `parentId` by value -- structural, and never touched by a
+ *     change.
+ *   - `selected`, `dragging`, `measured`, `width`, `height`, `resizing`,
+ *     `zIndex` are deliberately ABSENT. They are the viewport's opinion about
+ *     a node, not the graph's.
+ *
+ * Index-wise behind a length guard: `applyChanges` walks the array in place,
+ * so `select`, `position` and `dimensions` never reorder; only `add` and
+ * `remove` move anything, and both change the length or the ids at an index.
+ * A genuine reorder that preserved every id counts as a change, which is the
+ * conservative direction -- serialization writes nodes in array order.
+ */
+function documentChanged(prev: TabState, next: TabState): boolean {
+  if (prev === next) return false;
+
+  if (prev.nodes !== next.nodes) {
+    if (prev.nodes.length !== next.nodes.length) return true;
+    for (let i = 0; i < next.nodes.length; i += 1) {
+      const a = prev.nodes[i];
+      const b = next.nodes[i];
+      if (a === b) continue;
+      if (
+        a.id !== b.id
+        || a.type !== b.type
+        || a.parentId !== b.parentId
+        || a.data !== b.data
+        || a.position.x !== b.position.x
+        || a.position.y !== b.position.y
+      ) {
+        return true;
+      }
+    }
+  }
+
+  if (prev.edges !== next.edges) {
+    if (prev.edges.length !== next.edges.length) return true;
+    for (let i = 0; i < next.edges.length; i += 1) {
+      const a = prev.edges[i];
+      const b = next.edges[i];
+      if (a === b) continue;
+      if (
+        a.id !== b.id
+        || a.source !== b.source
+        || a.target !== b.target
+        || a.sourceHandle !== b.sourceHandle
+        || a.targetHandle !== b.targetHandle
+        || a.type !== b.type
+        || a.data !== b.data
+        || a.style !== b.style
+      ) {
+        return true;
+      }
+    }
+  }
+
+  // Definitions already have a by-value comparator, written for the undo
+  // frame (#200 item 2); a second one here would be the same drift risk this
+  // whole function exists to avoid.
+  if (prev.subgraphs !== next.subgraphs && !sameSubgraphs(prev.subgraphs, next.subgraphs)) {
+    return true;
+  }
+
+  if (prev.segmentGroups !== next.segmentGroups) {
+    if (prev.segmentGroups.length !== next.segmentGroups.length) return true;
+    for (let i = 0; i < next.segmentGroups.length; i += 1) {
+      const a = prev.segmentGroups[i];
+      const b = next.segmentGroups[i];
+      if (a === b) continue;
+      if (
+        a.id !== b.id
+        || a.headNodeId !== b.headNodeId
+        || a.tailNodeId !== b.tailNodeId
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/** Test seam: the bump rule, without having to drive a store transition. */
+export const _documentChangedForTesting = documentChanged;
+
+/**
+ * Advance `revision` on every tab whose document changed in this transition.
+ *
+ * ONE chokepoint rather than a bump in each of this file's dozens of mutating
+ * actions: a counter maintained by hand in fifty places is a counter that is
+ * wrong in one of them, and the one it is wrong in is the one a plugin's
+ * compare-and-swap silently trusts. Bumping inside the same `set` also closes
+ * the window a subscription-based bump would open, where subscribers briefly
+ * see new content carrying the old number.
+ *
+ * The reference guards are what keep this cheap: `documentChanged` returns on
+ * `prev === next` immediately, and each of the four field comparisons is
+ * skipped entirely unless that field's array was replaced. A drag frame
+ * therefore costs one pass over the nodes with six scalar compares each, on a
+ * path that was already allocating a whole new array.
+ *
+ * A tab whose `revision` the transition ITSELF changed is left alone. That is
+ * how the persistence loader states a restored tab's number
+ * (`rehydrateForProject` installs tabs rebuilt by `tabFromPersisted`, whose
+ * ids can collide with the ones already on screen) without the wrapper
+ * overwriting it with `previous + 1`.
+ */
+function withRevisions(
+  prev: TabStoreState,
+  next: Partial<TabStoreState>,
+): Partial<TabStoreState> {
+  const tabs = next.tabs;
+  if (!tabs || tabs === prev.tabs) return next;
+  const before = new Map(prev.tabs.map((t) => [t.id, t] as const));
+  let bumped = false;
+  const withBumps = tabs.map((t) => {
+    const was = before.get(t.id);
+    // A brand-new tab keeps the number `createTabState` gave it.
+    if (!was) return t;
+    // The loader spoke; do not argue with it.
+    if (t.revision !== was.revision) return t;
+    if (!documentChanged(was, t)) return t;
+    bumped = true;
+    return { ...t, revision: was.revision + 1 };
+  });
+  return bumped ? { ...next, tabs: withBumps } : next;
+}
+
 const initialState = loadTabs();
 
-export const useTabStore = create<TabStoreState>((set, get) => ({
+export const useTabStore = create<TabStoreState>((rawSet, get) => {
+  // Every `set` in the body below is this one. `replace` is deliberately not
+  // forwarded: nothing in this store calls `set(x, true)`, and a wrapper that
+  // pretended to support a whole-state replace would have to decide what a
+  // revision means for a tab list that arrived without a predecessor.
+  const set: TabSet = (partial) => {
+    rawSet((state) =>
+      withRevisions(
+        state,
+        typeof partial === 'function' ? partial(state) : partial,
+      ),
+    );
+    // Cleared AFTER `rawSet` returns, i.e. after zustand has finished
+    // notifying synchronously -- which is the only window a subscriber can
+    // read it in.
+    _lastCommitOrigin = null;
+  };
+
+  return {
   tabs: initialState.tabs,
   activeTabId: initialState.activeTabId,
 
@@ -3391,7 +3629,8 @@ export const useTabStore = create<TabStoreState>((set, get) => ({
         deterministic: !tab.deterministic,
       })),
     }),
-}));
+  };
+});
 
 // ── Loading the IndexedDB tier ──
 //

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -16,7 +16,7 @@ import { forgetViewport } from '../utils/viewportMemory';
 import { idbAvailable } from '../utils/idb';
 import { readSnapshot, writeSnapshot } from './tabPersistence';
 import { autoLayout, autoLayoutWithTargets, nodesBoundingBox, type LayoutMode } from '../utils/autoLayout';
-import type { NodeData, NodeDefinition, PresetDefinition, ExecutionStatus, OutputSummary, NodeProgress, SegmentGroup, SubgraphDefinition } from '../types';
+import type { NodeData, NodeDefinition, PresetDefinition, ExecutionStatus, OutputSummary, NodeProgress, SegmentGroup, SubgraphDefinition, WorkspaceSource } from '../types';
 import {
   collapseSelection,
   definitionFromCanvas,
@@ -275,6 +275,15 @@ export interface TabState {
    * was saved with -- see `withRevisions`.
    */
   revision: number;
+  /**
+   * True for a tab a plugin opened without asking for it to survive a reload
+   * (#341 section 4.8). Never persisted: `persistedTabsFor` skips the whole
+   * record, and a tab that came BACK from storage is by definition not
+   * transient.
+   */
+  transient: boolean;
+  /** Who opened this tab, or null for one the user opened. */
+  source: WorkspaceSource | null;
   // flow
   nodes: Node<NodeData>[];
   edges: Edge[];
@@ -372,6 +381,8 @@ function createTabState(id: string, name: string): TabState {
     projectOrigin: null,
     readOnly: false,
     revision: 1,
+    transient: false,
+    source: null,
     nodes: [],
     edges: [],
     subgraphs: [],
@@ -500,11 +511,34 @@ export interface GraphDocument {
   formatVersion?: unknown;
 }
 
+/** One document write, as `commitDocument` applies it. */
+export interface DocumentCommit {
+  nodes: Node<NodeData>[];
+  edges: Edge[];
+  segmentGroups: SegmentGroup[];
+  /** Node ids to add to the tab's partial-re-execution set. */
+  dirtyIds: string[];
+  /**
+   * The plugin this write came from, for `workspace.onChanged`'s `origin`.
+   * Lives only for the duration of this transition's listener fan-out.
+   */
+  origin?: { pluginId: string } | null;
+}
+
 interface TabStoreState {
   tabs: TabState[];
   activeTabId: string;
 
   // tab management
+  /**
+   * Create a tab and RETURN its id (#341).
+   *
+   * `addTab` delegates here and stays the UI's door: it always activates,
+   * because clicking `+` and landing somewhere else would be a bug. A plugin
+   * opening a candidate for review passes `activate: false` and gets the id
+   * back, which `addTab`'s `void` return could never give it.
+   */
+  createTab: (options?: { title?: string; activate?: boolean }) => string;
   addTab: (name?: string) => void;
   removeTab: (id: string) => void;
   setActiveTab: (id: string) => void;
@@ -555,6 +589,8 @@ interface TabStoreState {
     segmentGroups: SegmentGroup[];
     subgraphs: SubgraphDefinition[];
   };
+  /** The serializer as a pure function of a tab. `getSerializedGraph()` calls it with the active one. */
+  getSerializedGraphOf: (tab: TabState) => ReturnType<TabStoreState['getSerializedGraph']>;
   /**
    * Collapse the canvas selection into one subgraph instance (core#137).
    *
@@ -576,6 +612,8 @@ interface TabStoreState {
    * item 9). See the field's own note for why it is required.
    */
   loadGraphDocument: (doc: GraphDocument) => boolean;
+  /** `loadGraphDocument`, addressed by tab id. The active-tab wrapper calls this. */
+  loadGraphDocumentInto: (tabId: string, doc: GraphDocument) => boolean;
   collapseSelectionToSubgraph: (name?: string) => CollapseResult;
   /** Put an instance's definition back on the canvas. One undo step. */
   expandSubgraphInstance: (nodeId: string) => boolean;
@@ -639,6 +677,7 @@ interface TabStoreState {
 
   // undo/redo
   pushUndoSnapshot: () => void;
+  pushUndoSnapshotFor: (tabId: string) => void;
   undo: () => void;
   redo: () => void;
 
@@ -670,6 +709,18 @@ interface TabStoreState {
   // helpers
   getActiveTab: () => TabState;
   getTab: (id: string) => TabState | undefined;
+  /**
+   * The plugin write path: nodes, edges, segments and dirty marks in ONE
+   * transition, so the revision advances once and no subscriber ever sees
+   * nodes and edges disagree. The caller pushes its own undo snapshot first
+   * (`pushUndoSnapshotFor`) -- that is what makes a batch one undo step.
+   */
+  commitDocument: (tabId: string, patch: DocumentCommit) => void;
+  /** Set any subset of a tab's provenance flags. Absent keys are left alone. */
+  setTabMeta: (
+    tabId: string,
+    meta: { readOnly?: boolean; source?: WorkspaceSource | null; transient?: boolean },
+  ) => void;
 
   // execution actions for specific tab (used by WS handlers)
   applyTabNodeUpdates: (updates: PendingNodeUpdates) => void;
@@ -1278,6 +1329,8 @@ export interface PersistedTab {
    * session fails closed rather than matching by accident.
    */
   revision?: number;
+  /** Provenance for a tab a plugin opened and asked to keep (#341). */
+  source?: WorkspaceSource;
   nodes: Node<NodeData>[];
   edges: Edge[];
   segmentGroups?: SegmentGroup[];
@@ -1336,6 +1389,8 @@ function buildPersistedTab(input: TabState): PersistedTab {
     id: t.id,
     name: t.name,
     revision: t.revision,
+    // Only when set, so a tab the user opened persists byte-identically.
+    ...(t.source ? { source: t.source } : {}),
     description: t.description,
     currentGraphFile: t.currentGraphFile,
     // Only persisted when set, so non-project localStorage is byte-identical.
@@ -1415,12 +1470,17 @@ function scalarSignature(t: TabState): string {
     t.seed ?? '',
     t.deterministic ? '1' : '0',
     String(t.revision),
+    t.source ? JSON.stringify(t.source) : '',
   ]);
 }
 
 function persistedTabsFor(tabs: TabState[]): PersistedTab[] {
   const next = new Map<string, TabRecordCacheEntry>();
-  const records = tabs.map((t) => {
+  // A transient tab is skipped whole (#341 section 4.8): an agent's candidate
+  // is a proposal, and a proposal that quietly becomes a tab in tomorrow's
+  // workspace is worse than one that vanishes. It also keeps a materialized
+  // candidate carrying resolved secrets out of IndexedDB.
+  const records = tabs.filter((t) => !t.transient).map((t) => {
     const scalars = scalarSignature(t);
     const cached = _recordCache.get(t.id);
     const entry: TabRecordCacheEntry =
@@ -1527,6 +1587,9 @@ function tabFromPersisted(t: PersistedTab, base: TabState): TabState {
     // A record without the field is pre-#341: restore as 1 rather than as
     // whatever the placeholder tab happened to be carrying.
     revision: typeof t.revision === 'number' ? t.revision : 1,
+    source: t.source ?? null,
+    // A restored tab is, by definition, one that persisted.
+    transient: false,
     nodes,
     // Autosave stores each edge object as it stands, baked stroke and all, so
     // this is the one door a wire painted by an older palette comes back
@@ -1561,6 +1624,7 @@ function tabFromPersisted(t: PersistedTab, base: TabState): TabState {
 /** Test seams: the persistence record round-trip, without the debounce. */
 export const _buildPersistedTabForTesting = buildPersistedTab;
 export const _tabFromPersistedForTesting = tabFromPersisted;
+export const _persistedTabsForTesting = persistedTabsFor;
 
 function loadTabs(): { tabs: TabState[]; activeTabId: string } {
   try {
@@ -1894,13 +1958,22 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
 
   // ── Tab management ──
 
-  addTab: (name) => {
+  createTab: (options) => {
     const id = generateId();
     const tabCount = get().tabs.length;
     set({
-      tabs: [...get().tabs, createTabState(id, name ?? `Tab ${tabCount + 1}`)],
-      activeTabId: id,
+      tabs: [
+        ...get().tabs,
+        createTabState(id, options?.title ?? `Tab ${tabCount + 1}`),
+      ],
+      // `activate` defaults to true so `addTab` keeps its behaviour exactly.
+      ...(options?.activate === false ? {} : { activeTabId: id }),
     });
+    return id;
+  },
+
+  addTab: (name) => {
+    get().createTab({ title: name, activate: true });
   },
 
   removeTab: (id) => {
@@ -1958,6 +2031,53 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
   },
 
   getTab: (id) => get().tabs.find((t) => t.id === id),
+
+  setTabMeta: (tabId, meta) =>
+    set({
+      tabs: updateTab(get().tabs, tabId, () => ({
+        ...(meta.readOnly !== undefined ? { readOnly: meta.readOnly } : {}),
+        ...(meta.source !== undefined ? { source: meta.source } : {}),
+        ...(meta.transient !== undefined ? { transient: meta.transient } : {}),
+      })),
+    }),
+
+  commitDocument: (tabId, patch) => {
+    // Set BEFORE the `set`, read by subscribers during its synchronous
+    // fan-out, cleared by the `set` wrapper the moment that returns.
+    _lastCommitOrigin = patch.origin ?? null;
+    set({
+      tabs: updateTab(get().tabs, tabId, (tab) => {
+        const dirtyNodeIds = new Set(tab.dirtyNodeIds);
+        for (const id of patch.dirtyIds) dirtyNodeIds.add(id);
+        return {
+          nodes: patch.nodes,
+          edges: patch.edges,
+          segmentGroups: patch.segmentGroups,
+          dirtyNodeIds,
+          // The same rule `removeSegmentGroup` follows: a highlight that
+          // points into a list it is no longer in draws a bubble around
+          // nothing.
+          activeSegment:
+            tab.activeSegment
+            && !patch.segmentGroups.some((s) => s.id === tab.activeSegment!.id)
+              ? null
+              : tab.activeSegment,
+        };
+      }),
+    });
+  },
+
+  pushUndoSnapshotFor: (tabId) => {
+    const tab = get().getTab(tabId);
+    if (!tab) return;
+    const snapshot = undoFrameOf(tab);
+    set({
+      tabs: updateTab(get().tabs, tabId, (t) => ({
+        undoStack: [...t.undoStack.slice(-(MAX_UNDO - 1)), snapshot],
+        redoStack: [],
+      })),
+    });
+  },
 
   // ── Flow actions (active tab) ──
 
@@ -2076,6 +2196,15 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
         // — nothing is `.selected` once its node is gone.
         let nodeDetailNodeId = tab.nodeDetailNodeId;
         let selectedNodeId = tab.selectedNodeId;
+        // A segment whose head or tail is gone can never resolve a path, so
+        // `deleteNode` drops it. React Flow's own Delete key never reaches
+        // that action -- it emits a `remove` change straight into this
+        // reducer -- so until now the primary delete gesture left a dangling
+        // group behind, rendering nothing and still being written to the file
+        // on the next save. Same pruning, same place the notes are unbound
+        // (#341 section 5.5).
+        let segmentGroups = tab.segmentGroups;
+        let activeSegment = tab.activeSegment;
         if (hasRemove) {
           const removedIds = new Set(
             changes.filter((c) => c.type === 'remove').map((c) => c.id)
@@ -2091,9 +2220,23 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
           if (selectedNodeId !== null && removedIds.has(selectedNodeId)) {
             selectedNodeId = null;
           }
+          const kept = tab.segmentGroups.filter(
+            (s) => !removedIds.has(s.headNodeId) && !removedIds.has(s.tailNodeId),
+          );
+          // A delete that touches no segment hands back the SAME array. The
+          // revision counter compares segments by value and would not be
+          // fooled either way, but the persistence record cache compares
+          // references -- so a fresh array here is a rewritten IndexedDB
+          // record on every Delete keystroke, for nothing.
+          if (kept.length !== tab.segmentGroups.length) {
+            segmentGroups = kept;
+            if (activeSegment && !kept.some((s) => s.id === activeSegment!.id)) {
+              activeSegment = null;
+            }
+          }
         }
 
-        return { nodes: updatedNodes, nodeDetailNodeId, selectedNodeId };
+        return { nodes: updatedNodes, nodeDetailNodeId, selectedNodeId, segmentGroups, activeSegment };
       }),
     });
   },
@@ -2421,11 +2564,16 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
     });
   },
 
-  getSerializedGraph: () => {
+  getSerializedGraph: () => get().getSerializedGraphOf(get().getActiveTab()),
+
+  getSerializedGraphOf: (input) => {
     // A tab whose canvas is showing a subgraph's insides still SAVES and
     // RUNS the whole graph: flatten the editing stack first, so what is
     // serialized never depends on where the user happens to be standing.
-    const tab = flushSubgraphEditing(get().getActiveTab());
+    // Taking the tab as an argument rather than reading the active one is
+    // what lets a plugin snapshot a background tab (#341 section 4.3) -- and
+    // it costs nothing, because `flushSubgraphEditing` was already pure.
+    const tab = flushSubgraphEditing(input);
     // Computed AFTER the flush, so a block the user is editing right now --
     // whose instance is back on the canvas only because the flush put it
     // there -- is never mistaken for an orphan and dropped mid-edit.
@@ -2650,7 +2798,9 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
   // a frame still carries no `description`, no `readOnly` and no tab name, and
   // an undo that restored the previous graph's nodes under the new graph's
   // description would be a worse lie than not offering the step at all.
-  loadGraphDocument: (doc) => {
+  loadGraphDocument: (doc) => get().loadGraphDocumentInto(get().activeTabId, doc),
+
+  loadGraphDocumentInto: (tabId, doc) => {
     // Computed here, not by the caller: a reader that forgets the gate is
     // exactly the bug this action closes, and `formatVersion` is untrusted
     // input off a file, so a missing or non-numeric field reads as current.
@@ -2658,7 +2808,7 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
     const name =
       typeof doc.name === 'string' && doc.name.trim() ? doc.name.trim() : null;
     set({
-      tabs: updateTab(get().tabs, get().activeTabId, (tab) => ({
+      tabs: updateTab(get().tabs, tabId, (tab) => ({
         nodes: doc.nodes,
         edges: doc.edges,
         // Normalized on the way in, as `setSubgraphs` does: every reader
@@ -3323,13 +3473,7 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
   // snapshot's array to being the live one and a copy costs a pointer memcpy.
 
   pushUndoSnapshot: () => {
-    const snapshot = undoFrameOf(get().getActiveTab());
-    set({
-      tabs: updateTab(get().tabs, get().activeTabId, (t) => ({
-        undoStack: [...t.undoStack.slice(-(MAX_UNDO - 1)), snapshot],
-        redoStack: [],
-      })),
-    });
+    get().pushUndoSnapshotFor(get().activeTabId);
   },
 
   // Both consumers SPREAD the frame rather than listing its fields (#200

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -2051,8 +2051,24 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
       tabs: updateTab(get().tabs, tabId, (tab) => {
         const dirtyNodeIds = new Set(tab.dirtyNodeIds);
         for (const id of patch.dirtyIds) dirtyNodeIds.add(id);
+        // A detail modal or a selection naming a node this commit dropped is
+        // the same desync the Delete key exposed, one write path over
+        // (`onNodesChange`'s remove branch, #167): harmless while it renders
+        // nothing, and a modal that pops back open by itself the moment an
+        // undo restores the node. Decided by PRESENCE in the committed
+        // document rather than against a list of removals, because a batch can
+        // lose a node several ways -- `remove_node`, `clear_graph` -- and the
+        // document is the one answer that covers all of them.
+        const stillThere = (id: string | null) =>
+          id !== null && patch.nodes.some((n) => n.id === id);
         return {
           nodes: patch.nodes,
+          nodeDetailNodeId: stillThere(tab.nodeDetailNodeId)
+            ? tab.nodeDetailNodeId
+            : null,
+          selectedNodeId: stillThere(tab.selectedNodeId)
+            ? tab.selectedNodeId
+            : null,
           edges: patch.edges,
           segmentGroups: patch.segmentGroups,
           dirtyNodeIds,

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -4,6 +4,7 @@ import type { Node, Edge, NodeChange, EdgeChange, Connection } from '@xyflow/rea
 import {
   generateId,
   buildFlowNode,
+  buildNoteNode,
   isBypassable,
   resolveDynamicInputs,
   resolveDynamicOutputs,
@@ -28,6 +29,7 @@ import {
   refreshInstances,
   sameSubgraphs,
   subgraphIdOf,
+  SUBGRAPH_TYPE_PREFIX,
   type CollapseResult,
 } from '../utils/subgraph';
 import { ExecutionWebSocket } from '../api/ws';
@@ -2627,6 +2629,31 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
           // Written only when muted (core#128), so a graph nobody has
           // bypassed anything in serializes byte-identically to before.
           ...(n.data.bypassed ? { bypassed: true } : {}),
+          // Written only when the user (or an agent, via set_node_meta) has
+          // actually renamed the node (#342). `n.data.type` is exactly what
+          // the reader falls back to -- `label: raw.data?.label ?? nodeType`,
+          // utils/index.ts:505 -- so comparing against it both guarantees the
+          // round-trip and keeps an unrenamed graph's bytes unchanged.
+          //
+          // Deliberately skipped for a subgraph instance and a preset, whose
+          // labels come from the definition each time they are read and whose
+          // `data.type` therefore never equals the label: emitting for them
+          // would rewrite existing files to say something the reader ignores.
+          //
+          // `typeof n.data.type === 'string'` is not belt-and-braces: a node
+          // can reach here with no `type` at all (the field above writes it
+          // through unchecked), and serialization -- which every Run goes
+          // through -- is the last place that should throw over a missing
+          // optional. Such a node has no fallback for the reader to restore
+          // from either, so it is left exactly as it serialized before.
+          ...(!n.data.isPreset
+            && typeof n.data.type === 'string'
+            && !n.data.type.startsWith(SUBGRAPH_TYPE_PREFIX)
+            && typeof n.data.label === 'string'
+            && n.data.label !== ''
+            && n.data.label !== n.data.type
+            ? { label: n.data.label }
+            : {}),
         },
       };
     });
@@ -3303,23 +3330,7 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
 
   addNote: (kind, position) => {
     get().pushUndoSnapshot();
-    const node: Node<NodeData> = {
-      id: generateId(),
-      type: 'noteNode',
-      position,
-      data: {
-        label: 'Note',
-        type: 'note',
-        params: {},
-        noteKind: kind,
-        noteContent: '',
-        noteColor: '#3d3d1a',
-        boundToNodeId: null,
-        boundOffset: null,
-        noteWidth: 200,
-        noteHeight: kind === 'image' ? 150 : undefined,
-      },
-    };
+    const node = buildNoteNode({ kind, position });
     set({
       tabs: updateTab(get().tabs, get().activeTabId, (tab) => ({
         nodes: [...tab.nodes, node],

--- a/frontend/src/store/tabStore.workspace.test.ts
+++ b/frontend/src/store/tabStore.workspace.test.ts
@@ -1,0 +1,278 @@
+/**
+ * The tab-addressed half of the store, added for plugin API v5 (#341).
+ *
+ * Everything the editor does happens to the ACTIVE tab; everything a plugin
+ * does happens to a tab it names. These are the actions that make the second
+ * possible without duplicating the first -- each active-tab action now
+ * delegates to its tab-addressed twin, so the two cannot drift.
+ *
+ * Also here: the Delete-key segment pruning fix (#341 section 5.5), because it
+ * is the same "a tab's document must stay self-consistent" invariant one
+ * gesture over, and an agent writing segments at volume is what surfaces it.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Edge, Node } from '@xyflow/react';
+import {
+  useTabStore,
+  _buildPersistedTabForTesting,
+  _persistedTabsForTesting,
+} from './tabStore';
+import { useNodeDefStore } from './nodeDefStore';
+import type { NodeData, NodeDefinition } from '../types';
+
+vi.mock('./tabPersistence', () => ({
+  readSnapshot: vi.fn(async () => null),
+  writeSnapshot: vi.fn(async () => {}),
+}));
+
+const store = () => useTabStore.getState();
+const activeTab = () => useTabStore.getState().getActiveTab();
+
+function def(name: string): NodeDefinition {
+  return {
+    node_name: name, category: 'Layer', description: '',
+    inputs: [{ name: 'in', data_type: 'TENSOR', description: '', optional: false }],
+    outputs: [{ name: 'out', data_type: 'TENSOR', description: '', optional: false }],
+    params: [],
+  };
+}
+
+function node(id: string, x = 0): Node<NodeData> {
+  return {
+    id, type: 'baseNode', position: { x, y: 0 },
+    data: { label: id, type: 'A', params: {}, definition: def('A'), executionStatus: 'idle' },
+  };
+}
+
+function dataEdge(id: string, source: string, target: string): Edge {
+  return { id, source, target, sourceHandle: 'out', targetHandle: 'in' };
+}
+
+beforeEach(() => {
+  useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
+  store().addTab('test');
+  useNodeDefStore.setState({ definitions: [def('A')], presets: [] } as never);
+});
+
+describe('createTab', () => {
+  it('returns the new id and activates by default', () => {
+    const before = activeTab().id;
+    const id = store().createTab({ title: 'Candidate' });
+    expect(id).not.toBe(before);
+    expect(store().activeTabId).toBe(id);
+    expect(store().getTab(id)!.name).toBe('Candidate');
+    expect(store().getTab(id)!.revision).toBe(1);
+  });
+
+  it('can create a tab WITHOUT stealing the user focus', () => {
+    const before = store().activeTabId;
+    const id = store().createTab({ title: 'Background', activate: false });
+    expect(store().activeTabId).toBe(before);
+    expect(store().getTab(id)).toBeDefined();
+  });
+
+  it('addTab still activates and still numbers unnamed tabs', () => {
+    store().addTab();
+    expect(activeTab().name).toBe('Tab 2');
+  });
+});
+
+describe('loadGraphDocumentInto', () => {
+  it('installs a document into a NAMED tab, leaving the active one alone', () => {
+    store().setNodes([node('live')]);
+    const target = store().createTab({ title: 'Target', activate: false });
+    const activeBefore = store().activeTabId;
+
+    const readOnly = store().loadGraphDocumentInto(target, {
+      nodes: [node('a'), node('b', 200)],
+      edges: [dataEdge('e1', 'a', 'b')],
+      boundFile: null,
+      segmentGroups: [{ id: 's1', headNodeId: 'a', tailNodeId: 'b' }],
+      description: 'from a plugin',
+    });
+
+    expect(readOnly).toBe(false);
+    expect(store().activeTabId).toBe(activeBefore);
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['live']);
+    const loaded = store().getTab(target)!;
+    expect(loaded.nodes.map((n) => n.id)).toEqual(['a', 'b']);
+    expect(loaded.segmentGroups).toHaveLength(1);
+    expect(loaded.description).toBe('from a plugin');
+    expect(loaded.revision).toBe(2);
+  });
+
+  it('returns the read-only verdict for a newer format, on the named tab', () => {
+    const target = store().createTab({ title: 'Newer', activate: false });
+    const readOnly = store().loadGraphDocumentInto(target, {
+      nodes: [], edges: [], boundFile: null, formatVersion: 9_999,
+    });
+    expect(readOnly).toBe(true);
+    expect(store().getTab(target)!.readOnly).toBe(true);
+  });
+
+  it('loadGraphDocument still targets the active tab', () => {
+    store().createTab({ title: 'Other', activate: false });
+    store().loadGraphDocument({ nodes: [node('x')], edges: [], boundFile: null });
+    expect(activeTab().nodes.map((n) => n.id)).toEqual(['x']);
+  });
+});
+
+describe('getSerializedGraphOf', () => {
+  it('serializes a BACKGROUND tab while a block is open in the active one', () => {
+    // The active tab is inside a block; the background tab must still answer
+    // with its own whole graph rather than with what is on screen.
+    const target = store().createTab({ title: 'Background', activate: false });
+    store().loadGraphDocumentInto(target, {
+      nodes: [node('bg')], edges: [], boundFile: null,
+    });
+    store().setNodes([node('a'), node('b', 200)]);
+    // Both, not one: `checkCollapse` refuses a selection of fewer than two.
+    store().setNodes(activeTab().nodes.map((n) => ({ ...n, selected: true })));
+    expect(store().collapseSelectionToSubgraph('Blk').ok).toBe(true);
+    const instance = activeTab().nodes.find((n) => n.data.type.startsWith('subgraph:'))!;
+    expect(store().enterSubgraph(instance.id)).toBe(true);
+
+    const graph = store().getSerializedGraphOf(store().getTab(target)!);
+    expect(graph.nodes.map((n) => n.id)).toEqual(['bg']);
+    // Reading a background tab must not close the block the user is in.
+    expect(activeTab().subgraphStack).toHaveLength(1);
+  });
+
+  it('getSerializedGraph() still answers for the active tab', () => {
+    store().setNodes([node('a')]);
+    expect(store().getSerializedGraph().nodes.map((n) => n.id)).toEqual(['a']);
+  });
+});
+
+describe('commitDocument + pushUndoSnapshotFor', () => {
+  it('writes nodes, edges and segments in ONE transition and bumps once', () => {
+    const target = store().createTab({ title: 'Target', activate: false });
+    store().loadGraphDocumentInto(target, {
+      nodes: [node('a'), node('b', 200)], edges: [], boundFile: null,
+    });
+    const before = store().getTab(target)!.revision;
+
+    store().pushUndoSnapshotFor(target);
+    store().commitDocument(target, {
+      nodes: [node('a'), node('b', 200), node('c', 400)],
+      edges: [dataEdge('e1', 'a', 'b')],
+      segmentGroups: [{ id: 's1', headNodeId: 'a', tailNodeId: 'b' }],
+      dirtyIds: ['c'],
+    });
+
+    const tab = store().getTab(target)!;
+    expect(tab.revision).toBe(before + 1);
+    expect(tab.nodes).toHaveLength(3);
+    expect(tab.edges).toHaveLength(1);
+    expect(tab.segmentGroups).toHaveLength(1);
+    expect([...tab.dirtyNodeIds]).toContain('c');
+    expect(tab.undoStack).toHaveLength(1);
+  });
+
+  it('clears activeSegment when the commit drops the segment it named', () => {
+    const target = store().createTab({ title: 'Target', activate: false });
+    store().loadGraphDocumentInto(target, {
+      nodes: [node('a')], edges: [], boundFile: null,
+      segmentGroups: [{ id: 's1', headNodeId: 'a', tailNodeId: 'a' }],
+    });
+    // `setActiveSegment` is active-tab only, and this tab is deliberately in
+    // the background, so the highlight is installed directly.
+    useTabStore.setState({
+      tabs: store().tabs.map((t) =>
+        t.id === target ? { ...t, activeSegment: { id: 's1', headNodeId: 'a', tailNodeId: 'a' } } : t,
+      ),
+    });
+
+    store().commitDocument(target, {
+      nodes: [node('a')], edges: [], segmentGroups: [], dirtyIds: [],
+    });
+    expect(store().getTab(target)!.activeSegment).toBeNull();
+  });
+
+  it('pushUndoSnapshotFor on a background tab does not touch the active one', () => {
+    const target = store().createTab({ title: 'Target', activate: false });
+    store().pushUndoSnapshotFor(target);
+    expect(store().getTab(target)!.undoStack).toHaveLength(1);
+    expect(activeTab().undoStack).toHaveLength(0);
+  });
+});
+
+describe('setTabMeta and transient persistence', () => {
+  it('sets only the keys it was given', () => {
+    const id = store().createTab({ title: 'Meta', activate: false });
+    store().setTabMeta(id, { readOnly: true, source: { kind: 'agent-variant', pluginId: 'p' } });
+    expect(store().getTab(id)!.readOnly).toBe(true);
+    expect(store().getTab(id)!.transient).toBe(false);
+
+    store().setTabMeta(id, { transient: true });
+    expect(store().getTab(id)!.readOnly).toBe(true);
+    expect(store().getTab(id)!.source!.pluginId).toBe('p');
+    expect(store().getTab(id)!.transient).toBe(true);
+  });
+
+  it('a transient tab is never written to storage', () => {
+    const keep = store().createTab({ title: 'Keep', activate: false });
+    const drop = store().createTab({ title: 'Drop', activate: false });
+    store().setTabMeta(drop, { transient: true });
+
+    const records = _persistedTabsForTesting(store().tabs);
+    expect(records.map((r) => r.id)).toContain(keep);
+    expect(records.map((r) => r.id)).not.toContain(drop);
+  });
+
+  it('source persists with a non-transient tab; transient itself never does', () => {
+    const id = store().createTab({ title: 'Kept', activate: false });
+    store().setTabMeta(id, { source: { kind: 'agent-variant', pluginId: 'p', jobId: 'j' } });
+    const record = _buildPersistedTabForTesting(store().getTab(id)!);
+    expect(record.source).toEqual({ kind: 'agent-variant', pluginId: 'p', jobId: 'j' });
+    expect('transient' in record).toBe(false);
+  });
+
+  it('changing only the source still produces a fresh record', () => {
+    // The record cache compares node/edge references plus a scalar signature;
+    // setTabMeta moves neither array, so `source` has to be in the signature
+    // or the tab persists without it.
+    const id = store().createTab({ title: 'Cached', activate: false });
+    const first = _persistedTabsForTesting(store().tabs).find((r) => r.id === id)!;
+    store().setTabMeta(id, { source: { kind: 'agent-variant', pluginId: 'p' } });
+    const second = _persistedTabsForTesting(store().tabs).find((r) => r.id === id)!;
+    expect(second).not.toBe(first);
+    expect(second.source).toEqual({ kind: 'agent-variant', pluginId: 'p' });
+  });
+});
+
+describe('Delete key prunes segments (#341 section 5.5)', () => {
+  it('removing a segment head through onNodesChange drops the segment', () => {
+    store().setNodes([node('a'), node('b', 200)]);
+    store().setEdges([dataEdge('e1', 'a', 'b')]);
+    store().addSegmentGroup({ id: 's1', headNodeId: 'a', tailNodeId: 'b' });
+    store().setActiveSegment({ id: 's1', headNodeId: 'a', tailNodeId: 'b' });
+
+    store().onNodesChange([{ id: 'a', type: 'remove' }]);
+
+    expect(activeTab().segmentGroups).toHaveLength(0);
+    expect(activeTab().activeSegment).toBeNull();
+    // ...and it is gone from what the next save would write.
+    expect(store().getSerializedGraph().segmentGroups).toHaveLength(0);
+  });
+
+  it('leaves an unrelated segment, and its array identity, alone', () => {
+    store().setNodes([node('a'), node('b', 200), node('c', 400)]);
+    store().setEdges([dataEdge('e1', 'a', 'b')]);
+    store().addSegmentGroup({ id: 's1', headNodeId: 'a', tailNodeId: 'b' });
+    const groupsBefore = activeTab().segmentGroups;
+
+    store().onNodesChange([{ id: 'c', type: 'remove' }]);
+
+    expect(activeTab().segmentGroups).toBe(groupsBefore);
+  });
+
+  it('undo brings the segment back with the node', () => {
+    store().setNodes([node('a'), node('b', 200)]);
+    store().setEdges([dataEdge('e1', 'a', 'b')]);
+    store().addSegmentGroup({ id: 's1', headNodeId: 'a', tailNodeId: 'b' });
+    store().onNodesChange([{ id: 'a', type: 'remove' }]);
+    store().undo();
+    expect(activeTab().segmentGroups.map((s) => s.id)).toEqual(['s1']);
+  });
+});

--- a/frontend/src/store/tabStore.workspace.test.ts
+++ b/frontend/src/store/tabStore.workspace.test.ts
@@ -189,6 +189,41 @@ describe('commitDocument + pushUndoSnapshotFor', () => {
     expect(store().getTab(target)!.activeSegment).toBeNull();
   });
 
+  it('closes a detail modal the commit removed the node for', () => {
+    // The same cleanup `onNodesChange`'s remove branch does (#167). A plugin's
+    // `remove_node` never reaches that reducer, so without this the modal
+    // points at a node that is gone -- and pops back open on its own the
+    // moment an undo restores it (#341 section 4.4 step 7).
+    const live = store().activeTabId;
+    store().loadGraphDocumentInto(live, {
+      nodes: [node('a'), node('b', 200)], edges: [], boundFile: null,
+    });
+    store().openNodeDetail('b');
+    expect(activeTab().nodeDetailNodeId).toBe('b');
+    expect(activeTab().selectedNodeId).toBe('b');
+
+    store().commitDocument(live, {
+      nodes: [node('a')], edges: [], segmentGroups: [], dirtyIds: [],
+    });
+    expect(activeTab().nodeDetailNodeId).toBeNull();
+    expect(activeTab().selectedNodeId).toBeNull();
+  });
+
+  it('leaves both alone when the committed document still has the node', () => {
+    const live = store().activeTabId;
+    store().loadGraphDocumentInto(live, {
+      nodes: [node('a'), node('b', 200)], edges: [], boundFile: null,
+    });
+    store().openNodeDetail('b');
+
+    store().commitDocument(live, {
+      nodes: [node('a'), node('b', 200), node('c', 400)],
+      edges: [], segmentGroups: [], dirtyIds: [],
+    });
+    expect(activeTab().nodeDetailNodeId).toBe('b');
+    expect(activeTab().selectedNodeId).toBe('b');
+  });
+
   it('pushUndoSnapshotFor on a background tab does not touch the active one', () => {
     const target = store().createTab({ title: 'Target', activate: false });
     store().pushUndoSnapshotFor(target);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -57,6 +57,24 @@ export interface SegmentGroup {
 }
 
 /**
+ * Who opened a tab, and on whose behalf (#341).
+ *
+ * Written by a plugin through `api.workspace.openGraphs` and handed back
+ * verbatim by `tabs()` / `snapshot()`; the host reads only `pluginId`, for
+ * the tab's tooltip. Everything else is the plugin's own bookkeeping -- a
+ * study id, a variant id -- and it round-trips through persistence untouched
+ * so a plugin can re-attach to its own tabs after a reload.
+ */
+export interface WorkspaceSource {
+  /** A short plugin-chosen kind, e.g. `'agent-variant'`. */
+  kind: string;
+  pluginId: string;
+  jobId?: string;
+  variantId?: string;
+  [key: string]: unknown;
+}
+
+/**
  * One boundary port of a subgraph (core#137).
  *
  * `port` is the handle the INSTANCE node shows on the canvas; `innerNode` /

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -485,7 +485,11 @@ export function resolveSerializedNodes(
         type: 'start',
         position,
         data: {
-          label: 'Start',
+          // Same fallback the regular branch uses (`:505`). Start has its own
+          // branch, and hardcoding the name here was the one node class where
+          // a saved rename did not survive a reload -- the serializer wrote
+          // `data.label` (#342) and this read straight past it.
+          label: raw.data?.label ?? 'Start',
           type: 'Start',
           params,
           definition: defMap.get('Start') ?? { node_name: 'Start', category: 'Control', description: '', inputs: [], outputs: [{ name: 'trigger', data_type: 'TRIGGER', description: '', optional: false }], params: [] },

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -643,6 +643,61 @@ export function buildFlowNode(
   };
 }
 
+/** The canvas's default note colour, and the size a fresh note is given. */
+export const DEFAULT_NOTE_COLOR = '#3d3d1a';
+export const DEFAULT_NOTE_WIDTH = 200;
+export const DEFAULT_IMAGE_NOTE_HEIGHT = 150;
+
+export interface BuildNoteNodeOptions {
+  /** Omit to generate one. */
+  id?: string;
+  kind?: 'text' | 'image';
+  text?: string;
+  position: { x: number; y: number };
+  color?: string;
+  boundToNodeId?: string | null;
+  boundOffset?: { x: number; y: number } | null;
+}
+
+/**
+ * One note node, built the same way whoever asks for it (#342).
+ *
+ * A note bypasses `buildFlowNode` entirely -- it has no NodeDefinition, no
+ * ports and no params -- so before this there was exactly one literal that
+ * knew its shape, inside the store's `addNote`. The ops reducer cannot call
+ * that action (it pushes its own undo snapshot, which would turn one batch
+ * into N undo steps), so it needed the same literal; two copies of a shape
+ * that the serializer, the deserializer and the renderer all agree on is two
+ * copies that drift.
+ */
+export function buildNoteNode({
+  id,
+  kind = 'text',
+  text = '',
+  position,
+  color = DEFAULT_NOTE_COLOR,
+  boundToNodeId = null,
+  boundOffset = null,
+}: BuildNoteNodeOptions): Node<NodeData> {
+  return {
+    id: id ?? generateId(),
+    type: 'noteNode',
+    position,
+    data: {
+      label: 'Note',
+      type: 'note',
+      params: {},
+      noteKind: kind,
+      noteContent: text,
+      noteColor: color,
+      boundToNodeId,
+      boundOffset,
+      noteWidth: DEFAULT_NOTE_WIDTH,
+      noteHeight: kind === 'image' ? DEFAULT_IMAGE_NOTE_HEIGHT : undefined,
+    },
+  };
+}
+
 /**
  * Which target types each source type may feed, keyed by SOURCE.
  *

--- a/frontend/src/utils/openExample.ts
+++ b/frontend/src/utils/openExample.ts
@@ -8,8 +8,16 @@ import type { NodeData, SegmentGroup, SubgraphDefinition } from '../types';
 import { resolveSerializedNodes, resolveSerializedEdges } from '.';
 import { isFormatTooNew } from './formatVersion';
 
-/** A fetched example, resolved into live canvas nodes and edges. */
-interface ResolvedExample {
+/**
+ * A fetched example, resolved into live canvas nodes and edges.
+ *
+ * Exported since #341: `api.workspace.openGraphs` reads a plugin's graph
+ * through this same door, so a graph handed over by an agent is normalised
+ * exactly the way a file or an example is -- unknown presets merged, block
+ * definitions honoured, `format_version` carried through to the read-only
+ * verdict.
+ */
+export interface ResolvedExample {
   nodes: Node<NodeData>[];
   edges: Edge[];
   /** The example's own name, trimmed; null when it ships without one. */
@@ -62,7 +70,7 @@ async function fetchResolvedExample(path: string): Promise<ResolvedExample> {
  * unknown presets into the node-def store -- so a refusal decided after it
  * would already have left the palette holding a newer build's presets.
  */
-function resolveExample(data: any): ResolvedExample {
+export function resolveExample(data: any): ResolvedExample {
   const store = useNodeDefStore.getState();
   // An example may ship presets the running server has never seen. Merge the
   // unknown ones in by name so its nodes resolve, without clobbering the

--- a/frontend/src/utils/subgraph.contract.test.ts
+++ b/frontend/src/utils/subgraph.contract.test.ts
@@ -60,7 +60,12 @@ function toCanvas(raw: any[]): Node<NodeData>[] {
     type: n.type === 'Start' ? 'start' : 'baseNode',
     position: n.position,
     data: {
-      label: n.id,
+      // What the shipped reader puts here -- `label: raw.data?.label ??
+      // nodeType` (utils/index.ts) -- not the node's id. The serializer emits
+      // `label` only when it differs from the type (#342), so a harness that
+      // invented a per-node label would make every fixture node look renamed
+      // and the collapsed halves stop matching.
+      label: n.data?.label ?? n.type,
       type: n.type,
       params: n.data?.params ?? {},
       definition: definitionFor(n.type),

--- a/scripts/templates/plugin/ui/src/sdk/types.ts
+++ b/scripts/templates/plugin/ui/src/sdk/types.ts
@@ -54,13 +54,26 @@ export type GraphOp =
   | { op: 'remove_edge'; source: string; target: string;
       source_handle?: string; target_handle?: string }
   | { op: 'clear_graph' }
-  | { op: 'auto_layout' };
+  | { op: 'auto_layout' }
+  /* ── requires apiVersion >= 5 ─────────────────────────────────────────── */
+  /** Put one node at an exact position. Notes bound to it move with it. */
+  | { op: 'move_node'; node_id: string; position: { x: number; y: number } }
+  /**
+   * Create or replace a segment overlay -- the orange bubble the canvas draws
+   * around every node on a data path from head to tail. Omit `segment_id` to
+   * create one; pass an existing id to move it. The result carries the id
+   * either way. Head and tail must be joined by data edges.
+   */
+  | { op: 'set_segment'; segment_id?: string; head_node_id: string; tail_node_id: string }
+  | { op: 'remove_segment'; segment_id: string };
 
 export interface OpResult {
   index: number;
   ok: boolean;
   error?: string;
   node_id?: string;
+  /** Set by `set_segment` — apiVersion 5. */
+  segment_id?: string;
 }
 
 export interface ApplyResult {

--- a/scripts/templates/plugin/ui/src/sdk/types.ts
+++ b/scripts/templates/plugin/ui/src/sdk/types.ts
@@ -343,6 +343,138 @@ export interface RunMetrics {
   metrics: RunMetricPoint[];
 }
 
+/* ── workspace tabs — requires apiVersion >= 5 ───────────────────────────── */
+
+/**
+ * Who opened a tab, and why. Opaque to the editor: whatever you put here
+ * comes back verbatim on `tabs()` and `snapshot()`, and persists with the tab
+ * when you open it with `persist: true`.
+ */
+export interface WorkspaceSource {
+  /** A short kind of your own choosing, e.g. `'agent-variant'`. */
+  kind: string;
+  pluginId: string;
+  jobId?: string;
+  variantId?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * The loosest shape `openGraphs` accepts for a graph document.
+ *
+ * `WorkspaceOpenEntry.graph` is declared as `SerializedGraph` below, because
+ * the graph you hand over usually came from `getGraph()`. This type is what
+ * the editor really reads: two required lists and a bag it walks defensively,
+ * so a document you composed yourself is accepted on the same terms as a
+ * file. Unknown top-level keys are ignored.
+ */
+export interface WorkspaceGraphInput {
+  nodes: unknown[];
+  edges: unknown[];
+  presets?: unknown[];
+  segmentGroups?: unknown[];
+  subgraphs?: unknown[];
+  name?: string;
+  description?: string;
+  format_version?: unknown;
+  [key: string]: unknown;
+}
+
+export interface WorkspaceOpenEntry {
+  /** Shown on the tab. Stored whole; the tab bar ellipsises what will not fit. */
+  title: string;
+  /**
+   * The document to open, normalised the way a file load normalises one:
+   * `subgraphs`, `segmentGroups` and `presets` are honoured, and a
+   * `format_version` newer than the editor opens the tab read-only.
+   */
+  graph: SerializedGraph;
+  /** Default false. A read-only tab refuses writes on BOTH write paths. */
+  readOnly?: boolean;
+  source?: WorkspaceSource;
+  /** Default false: the tab is transient and is gone after a reload. */
+  persist?: boolean;
+}
+
+/**
+ * One entry's outcome. Results are POSITIONAL — `result[i]` describes
+ * `entries[i]` — so one bad candidate never sinks the others.
+ */
+export type WorkspaceOpenResult =
+  | { tabId: string; revision: number }
+  | { error: string; code: 'invalid_graph' | 'too_many_tabs' | 'too_large' };
+
+export interface WorkspaceTabInfo {
+  tabId: string;
+  title: string;
+  /**
+   * The tab's compare-and-swap token. It starts at 1 and advances by one
+   * whenever the tab's document changes — from your writes, the user's edits,
+   * an undo, or a redo. Hand it back as `expectedRevision` to write only if
+   * nothing has moved since you read.
+   */
+  revision: number;
+  readOnly: boolean;
+  /** True for a tab that will not survive a reload (opened without `persist`). */
+  transient: boolean;
+  source: WorkspaceSource | null;
+  active: boolean;
+}
+
+export type WorkspaceSnapshot =
+  | (WorkspaceTabInfo & { graph: SerializedGraph })
+  | { error: 'unknown_tab' };
+
+export interface WorkspaceApplyRequest {
+  /** Defaults to the active tab. */
+  tabId?: string;
+  /** Omitted: no compare. Present and stale: nothing is written. */
+  expectedRevision?: number;
+  operations: GraphOp[];
+  /** Default false. True: any failing op means nothing is committed. */
+  atomic?: boolean;
+}
+
+/**
+ * Why a write was refused. Each is returned, never thrown, and each leaves
+ * the tab exactly as it was.
+ *
+ * `editing_subgraph` means the user has stepped inside a block, so the canvas
+ * arrays are that block's contents rather than the document `snapshot()`
+ * describes. Retry once they step back out — `graph.getView().atTopLevel`
+ * says when.
+ */
+export type WorkspaceConflict =
+  | 'revision_mismatch' | 'read_only' | 'unknown_tab' | 'editing_subgraph';
+
+export interface WorkspaceApplyResult extends ApplyResult {
+  tabId: string;
+  /**
+   * The tab's revision AFTER this call, and on `revision_mismatch` the
+   * CURRENT one — so you can re-arm without a second read that races the
+   * same way. Unchanged by a conflict or a failed `atomic` preflight.
+   */
+  revision: number;
+  committed: boolean;
+  conflict?: WorkspaceConflict;
+}
+
+/**
+ * One workspace change, as `workspace.onChanged` delivers it.
+ *
+ * Delivered synchronously, in the order `tabs` (added), `graph`,
+ * `active-tab`, `tabs` (removed), so a burst can be processed in one pass. A
+ * `graph` event carries `origin` when the change came from a plugin's
+ * `workspace.applyOperations`, which is how you ignore your own writes.
+ *
+ * If your callback throws, the editor logs it and unsubscribes you: a plugin
+ * cannot be allowed to break the editor's own state.
+ */
+export type WorkspaceEvent =
+  | { type: 'graph'; tabId: string; revision: number; origin?: { pluginId: string } }
+  | { type: 'tabs'; tabId: string; revision: number; removed: boolean }
+  | { type: 'active-tab'; tabId: string; revision: number };
+
 /** The object the editor hands every plugin frontend at activation. */
 export interface CodefyUIPluginAPI {
   apiVersion: number;
@@ -431,6 +563,55 @@ export interface CodefyUIPluginAPI {
      * `api.apiVersion >= 4` (or `typeof api.graph.getView === 'function'`).
      */
     getView(): GraphView;
+  };
+  /**
+   * Tabs, snapshots and compare-and-swap writes — requires apiVersion >= 5.
+   *
+   * This is the half of the API that does not assume the user is looking at
+   * what you are working on. You can open a candidate graph in its own
+   * labelled tab without moving anybody, read a tab that is not on screen,
+   * write to a tab only if it has not changed since you read it, and be told
+   * when any of that happens.
+   *
+   * On an older editor the whole member is `undefined` rather than a stub
+   * that throws, so `typeof api.workspace?.openGraphs === 'function'` is an
+   * honest feature check (`api.apiVersion >= 5` works too).
+   */
+  workspace: {
+    /**
+     * Open one tab per entry. Nothing is activated when `activate` is
+     * `'none'`; `'first'` (the default) and `'last'` activate one of the tabs
+     * that actually opened.
+     *
+     * Limits: 8 MiB of serialized JSON per graph, 32 tabs in the editor.
+     * A tab opened here is an ordinary tab afterwards — the user can rename
+     * it, close it, or Save As into a real graph file.
+     */
+    openGraphs(
+      entries: WorkspaceOpenEntry[],
+      options?: { activate?: 'first' | 'last' | 'none' },
+    ): WorkspaceOpenResult[];
+    /** Every tab, in tab-bar order. */
+    tabs(): WorkspaceTabInfo[];
+    /**
+     * A tab's info plus its WHOLE graph, flattened the way `getGraph()`
+     * flattens the active one. Defaults to the active tab. An unknown id
+     * answers `{ error: 'unknown_tab' }` rather than throwing.
+     */
+    snapshot(tabId?: string): WorkspaceSnapshot;
+    /**
+     * Apply a batch to a named tab, as one undo step, under an optional
+     * compare-and-swap.
+     *
+     * Checked in a fixed order, each refusal leaving the tab untouched:
+     * unknown tab, read-only tab, the user is inside a block, stale
+     * `expectedRevision`. Then the batch runs; with `atomic: true` a single
+     * failing op means nothing is committed, and `results` still comes back
+     * full-length so you can see which op was wrong.
+     */
+    applyOperations(request: WorkspaceApplyRequest): WorkspaceApplyResult;
+    /** Subscribe to workspace changes. Returns an unsubscribe function. */
+    onChanged(cb: (event: WorkspaceEvent) => void): () => void;
   };
   /** Custom node renderers — requires apiVersion >= 2. */
   nodes: {

--- a/scripts/templates/plugin/ui/src/sdk/types.ts
+++ b/scripts/templates/plugin/ui/src/sdk/types.ts
@@ -65,7 +65,22 @@ export type GraphOp =
    * either way. Head and tail must be joined by data edges.
    */
   | { op: 'set_segment'; segment_id?: string; head_node_id: string; tail_node_id: string }
-  | { op: 'remove_segment'; segment_id: string };
+  | { op: 'remove_segment'; segment_id: string }
+  /**
+   * Add a text note to the canvas — the sticky the editor already draws.
+   * `bind_to` attaches it to a node so it follows when that node moves.
+   * `text` is 1..4000 characters; `color` is `#rrggbb`.
+   */
+  | { op: 'add_note'; ref?: string; text: string;
+      position?: { x: number; y: number }; color?: string; bind_to?: string }
+  /** Rewrite an existing note's text and/or colour. Text notes only. */
+  | { op: 'update_note'; node_id: string; text?: string; color?: string }
+  /**
+   * Name one node — `data.label`, 1..120 characters on a single line. The
+   * label sits beside `params`, never inside it, so naming a node is not a
+   * parameter change to anything reading the graph.
+   */
+  | { op: 'set_node_meta'; node_id: string; label: string };
 
 export interface OpResult {
   index: number;


### PR DESCRIPTION
> 中文摘要：外掛前端 API 升到第 5 版，讓外掛（例如 Graph Copilot 這種代理程式）能安全地同時操作多個分頁：每個分頁現在有自己的版本號，外掛可以一次開好幾個分頁（預設關掉就不見、可指定唯讀、會記下是誰開的）、讀取任一分頁的內容，並用「我讀到的版本號」下筆——中間如果使用者動過圖，這一批就整批退回並附上目前的版本號，不會覆蓋掉別人的修改。同時新增六個畫布操作：搬動節點、標記／取消標記鏈段、加註解（可綁在節點上）、改註解、幫節點改名——改名現在會存進檔案，重新載入還在（這是舊有的漏存 bug）。唯讀分頁在分頁列上會顯示「唯讀」，滑鼠移上去會說是哪個外掛開的。對既有外掛只有一個行為改變：寫入唯讀分頁會被拒絕。

Closes #341, closes #342.

## What this changes

`api.apiVersion` goes 4 -> 5. Detection stays `api.apiVersion >= 5`; there is no feature list.

- **Every tab counts its own revisions.** A tab's `revision` starts at 1 and climbs by one whenever its document identity changes - nodes by id/type/parentId/data/position, edges by id/endpoints/handles/type/data/style, subgraphs, segment groups. Selection, React Flow's `dimensions` on a culled card's remount, modal ids, the viewport and per-node run status are not the document and never bump it (a training run writing `executionStatus`/`error`/`progress` onto every node would otherwise bump it dozens of times a second). It only ever climbs, and it is persisted, so a plugin's compare-and-swap survives a reload.
- **`api.workspace`.** `openGraphs(entries, {activate})` opens several graphs in one call and answers positionally with `{tabId, revision}` or `{error, code}` (`invalid_graph` / `too_large` at 8 MiB / `too_many_tabs` at 32); entries are transient unless they ask to persist, may carry a `source` (who opened this, for which job) and become read-only exactly as a too-new file does. `tabs()` lists every tab; `snapshot(tabId?)` reads one - both without touching what the user is looking at. `applyOperations({tabId, expectedRevision, operations, atomic})` checks, in order, unknown tab -> read-only -> user is inside a block (`editing_subgraph`) -> revision mismatch, each returning without a side effect and with the tab's current revision, then reduces, then commits as ONE store transition: one undo frame, one revision bump, `origin` attached. `onChanged` reports tab, graph and activation events, with the writing plugin's id on its own writes.
- **Six new operations** on the same reducer both API paths share: `move_node` (a note bound to a node re-derives its offset, so the next parent drag does not snap it back), `set_segment` / `remove_segment` (validated against the same path rule the canvas uses, replace-by-id, and a removed node takes its segment with it), `add_note` / `update_note` (text only, 1..4000 characters, bound or free), `set_node_meta` (a label of 1..120 characters).
- **A renamed node survives saving.** The serializer never wrote `data.label`, so every rename - including the shipped context-menu one - was lost on reload. It is written now when it differs from the node's type, and the reader stopped hardcoding `Start`.
- **Tab chrome.** A read-only tab shows a `Read-only` / `唯讀` badge; a plugin-opened tab's tooltip says which plugin opened it. Tokens only; the strip stays one row.
- **The one behaviour change for existing plugins:** a read-only tab now refuses the legacy `graph.applyOperations` per op with `{ok: false, error: 'tab is read-only'}`. Before v5 that write went through. One guard is new but cannot change any installed plugin's behaviour, because the ops it names are new in v5: a legacy batch containing `set_segment`/`remove_segment` while the user is inside a block is refused whole-batch - committing it wrote a top-level segment naming inner node ids into the saved file, invisible on screen and impossible to remove from the UI. For the same reason a legacy batch inside a block no longer lets `clear_graph` or `remove_node` reach the graph's segment overlays.
- **Docs** (en + zh-TW, heading and line parity) carry the whole surface: the types, both check orders, the event order, every operation's ranges, the version row with its release stamp, and the quirks worth knowing (`openGraphs` reads an entry exactly as it was written and fills nothing in from a preset; an entry refused for the tab cap has still been read).
- `contract.v4.assert.ts` freezes the pre-v5 contract byte for byte, as v2 and v3 are frozen, and the vendored plugin SDK is re-synced in the same commits as the contract.

## Verification

- 14 commits, each red-first, each reviewed against the spec and for quality by a fresh reviewer, plus fix rounds and scoped re-reviews; then one whole-branch review that traced five invariants end to end (compare-and-swap, one-step undo, read-only on both paths, transient tabs never reaching disk, and every write path while a block is open) and found one real defect, fixed here.
- Frontend 3801 tests, `tsc -b`, `pnpm build` with the contrast gate; backend 6273 tests; `ruff` clean; docs build green in both locales.
- Chrome, against this branch's own server with a throwaway plugin driving the real API: apiVersion 5; two tabs opened in one call without stealing focus; the read-only badge earned from `format_version` alone, in zh-TW and English; compare-and-swap refused after a real concurrent edit, with the current revision returned; an atomic batch whose second op fails committing nothing; `editing_subgraph` and the legacy whole-batch refusal while inside a block; the segment bubble drawn and removed on the canvas; notes added, bound and rewritten; a whole plugin batch undone by one Ctrl+Z; and after a real reload the transient tabs gone, the persisted one back with its revision, its `source` and its renamed node intact in storage. At 860 px the tab strip stays one row with no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jh5Fbd8CJdJ2wtva3ePr7C
