### PR TITLE
fix(plugins,ui): a renamed node survives a collapse, notes undo, and three v5 guards get teeth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,6 +580,23 @@ received — each links to the release it was published as.
   serializes byte-for-byte as before. Start needed one line more: its branch
   of the reader hardcoded `Start` rather than reading the key, which was
   harmless only while nothing wrote it.
+- **…and keeps it when it is collapsed into a block** ([#400]). The serializer
+  that writes a node INTO a block never learned the rule above, so collapsing
+  a renamed node reverted it to its type name — permanently, because the
+  original node is gone and the definition is the only record of the name
+  left. The inner writer now follows the same rule clause for clause, and both
+  readers of a definition — entering a block, expanding one — already restore
+  the key. A block nobody has renamed anything inside still serializes
+  byte-for-byte as before.
+- **Typing in a note can be undone** ([#400]). `updateNoteData` pushed no undo
+  snapshot, so a note's text was the one thing a user could write onto a graph
+  and not take back — while the same edit made by a plugin's `update_note`
+  could be. Every caller commits at a boundary (blurring the note, picking a
+  colour from the context menu, choosing an image), never per keystroke, so
+  one snapshot is one undo step per finished edit. An edit that changes
+  nothing records none: blurring a note commits whether or not anything was
+  typed, and an undo step that restores the state you were already in would
+  push real history off a capped stack.
 - **The Delete key prunes the segment overlays naming the node it deleted**
   ([#341]). The context menu's Delete already did; React Flow's Delete key
   goes through a different path that unbound notes and closed modals but left
@@ -2645,6 +2662,7 @@ Release candidates before 1.0.0 are on the
 [#337]: https://github.com/CodefyUI/CodefyUI/issues/337
 [#341]: https://github.com/CodefyUI/CodefyUI/issues/341
 [#342]: https://github.com/CodefyUI/CodefyUI/issues/342
+[#400]: https://github.com/CodefyUI/CodefyUI/issues/400
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -603,6 +603,19 @@ received — each links to the release it was published as.
   the segments alone. A segment whose head or tail is gone can never resolve
   a path, so it drew nothing on the canvas while staying in the tab — and
   getting written to the file on the next save.
+- **A discarded `atomic` batch reports the graph that is still there, and the
+  v5 reference stops overstating two more things** ([#396]). `node_count` and
+  `edge_count` were built from the reducer outcome, so a three-op atomic batch
+  with one failure answered `node_count = tab + 2` for a tab it had just
+  committed nothing to — a plugin logging the counts was told the size of a
+  graph that no longer exists anywhere. Every return that writes nothing now
+  reports the tab as it stands, which is what the four conflict refusals
+  already did. Two documentation claims go with it: `origin` is stamped on
+  BOTH plugin write paths, not only `workspace.applyOperations` — they share
+  one commit — so a plugin filtering on it can ignore its own legacy writes
+  too, now pinned by a test; and `OpResult.node_id` comes from the ops that
+  create or edit a node, not from "every op that names one", `remove_node`
+  being the op that names one and returns none.
 
 ## [2.4.1] — 2026-08-22
 
@@ -2663,6 +2676,7 @@ Release candidates before 1.0.0 are on the
 [#341]: https://github.com/CodefyUI/CodefyUI/issues/341
 [#342]: https://github.com/CodefyUI/CodefyUI/issues/342
 [#400]: https://github.com/CodefyUI/CodefyUI/issues/400
+[#396]: https://github.com/CodefyUI/CodefyUI/issues/396
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,6 +617,35 @@ received — each links to the release it was published as.
   create or edit a node, not from "every op that names one", `remove_node`
   being the op that names one and returns none.
 
+### Internal
+
+- **Three apiVersion 5 guards passed even when the thing they guarded was
+  broken** ([#398]). All three came with the workspace work above, and all
+  three had the same shape: the assertion was real, and what it pointed at
+  was not.
+
+  `workspace.onChanged` fans a transition out as added tabs, then document
+  changes, then the activation, then closes — an order a consumer relies on
+  to process a batch in one pass. It was only ever asserted ACROSS
+  transitions, one event in each, so reversing the four loops that build the
+  batch left the suite green. It is now pinned against a single transition
+  that does all four at once.
+
+  The transient-tab reload case restated the reader's "fall back to the first
+  record" rule inside the test instead of calling the readers, so a
+  regression in either real one would have failed nothing. It now drives the
+  autosave for real and asks both tiers that have to survive an active tab
+  which was never persisted: `loadTabs` for localStorage and `readSnapshot`
+  for IndexedDB.
+
+  And the cross-side check on `WorkspaceSnapshot` used `Exclude` to isolate
+  the `{ error: 'unknown_tab' }` branch — which isolates it by dropping the
+  graph-bearing branch, so a host-only field added next to `graph` was
+  compared against nothing. Both branches are now compared member for member
+  through a distributive omit: `Omit` applied to each union member
+  separately, which plain `Omit` cannot do, because `keyof` a union is the
+  intersection of its branches' keys and collapses this one to `{}`.
+
 ## [2.4.1] — 2026-08-22
 
 Four fixes that landed on `main` in the hours after 2.4.0, and nothing else:
@@ -2677,6 +2706,7 @@ Release candidates before 1.0.0 are on the
 [#342]: https://github.com/CodefyUI/CodefyUI/issues/342
 [#400]: https://github.com/CodefyUI/CodefyUI/issues/400
 [#396]: https://github.com/CodefyUI/CodefyUI/issues/396
+[#398]: https://github.com/CodefyUI/CodefyUI/issues/398
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...main

--- a/docs/docs/advanced/plugin-frontend-extensions.md
+++ b/docs/docs/advanced/plugin-frontend-extensions.md
@@ -215,7 +215,7 @@ interface OpResult {
   index: number;      // the op's position in the batch
   ok: boolean;        // whether this op applied
   error?: string;     // failure reason when ok is false
-  node_id?: string;   // resolved node id, from every op that names or creates one
+  node_id?: string;   // resolved node id, from ops that create or edit one; not remove_node
   segment_id?: string; // apiVersion 5: the id set_segment created or replaced
 }
 
@@ -389,7 +389,7 @@ The checks run in this order, and each one returns without changing anything:
 6. With `atomic: true`, if any op failed, nothing is written: `committed: false`, `revision` unchanged, and the **full-length** `results` so you can see which op was wrong.
 7. Otherwise, if anything changed: one undo snapshot, one write, `committed: true`, and the new `revision`. A batch that changes nothing writes nothing and pushes no undo step.
 
-On a refusal `node_count` and `edge_count` still describe the tab as it stands, so a plugin that logs them is not told the graph is empty when it is not. `unknown_tab` is the exception: there is no tab to count.
+Whenever a call commits nothing — a refusal, a failed `atomic` preflight, a batch that changed nothing — `node_count` and `edge_count` describe the tab as it stands, so a plugin that logs them is never handed the counts of a graph that was thrown away. `unknown_tab` is the exception: there is no tab to count.
 
 Conflicts are **returned, never thrown**. A batch is still one undo step, and per-op semantics are unchanged from `api.graph.applyOperations`: without `atomic`, a failing op is skipped and reported while the rest apply. A commit that leaves the graph without the node a detail modal or the canvas selection names clears both, so an undo restoring that node cannot pop the modal open by itself.
 
@@ -421,7 +421,7 @@ type WorkspaceEvent =
   | { type: "active-tab"; tabId: string; revision: number };
 ```
 
-Events arrive synchronously after the change, in a fixed order: tabs added, then documents changed, then the active tab, then tabs removed. `origin` is present on a `graph` event only when the change came from a plugin's `workspace.applyOperations`, which is how you tell your own writes from the user's.
+Events arrive synchronously after the change, in a fixed order: tabs added, then documents changed, then the active tab, then tabs removed. `origin` is present on a `graph` event only when the change came from a plugin write — either `workspace.applyOperations` or the legacy `graph.applyOperations`, both of which stamp it — which is how you tell your own writes from the user's.
 
 If your callback throws, the editor logs it and unsubscribes you — a plugin must not be able to break the tab store. `api.graph.onGraphChanged` is unchanged: still the active tab, still no payload.
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
@@ -215,7 +215,7 @@ interface OpResult {
   index: number;      // 操作在批次中的位置
   ok: boolean;        // 此操作是否套用成功
   error?: string;     // ok 為 false 時的失敗原因
-  node_id?: string;   // 解析出的節點 id，凡是指名或建立節點的操作都會帶
+  node_id?: string;   // 解析出的節點 id，凡是建立或修改節點的操作都會帶；remove_node 不帶
   segment_id?: string; // apiVersion 5：set_segment 建立或取代的那個 id
 }
 
@@ -389,7 +389,7 @@ if (result.conflict === "revision_mismatch") {
 6. 使用 `atomic: true` 時，只要有任何一個操作失敗就什麼都不寫：`committed: false`、`revision` 不變，而且回傳**完整長度**的 `results`，讓你看得出是哪個操作錯了。
 7. 否則，若有東西改變：一個撤銷快照、一次寫入、`committed: true`，以及新的 `revision`。什麼都沒改變的批次，不會寫入，也不會推入撤銷步驟。
 
-被拒絕時，`node_count` 與 `edge_count` 仍然描述該分頁當下的樣子，所以會把它們記進 log 的外掛，不會被告知圖表是空的而其實不是。`unknown_tab` 是例外：根本沒有分頁可數。
+只要這次呼叫什麼都沒提交——被拒絕、`atomic` 前置檢查失敗、批次什麼都沒改——`node_count` 與 `edge_count` 就描述該分頁當下的樣子，所以會把它們記進 log 的外掛，拿到的絕不會是一份已經被丟掉的圖表的數字。`unknown_tab` 是例外：根本沒有分頁可數。
 
 衝突是**回傳的，永遠不會拋出**。一個批次仍然是一個撤銷步驟，而每個操作的語義與 `api.graph.applyOperations` 相同：沒有 `atomic` 時，失敗的操作會被跳過並回報，其餘照樣套用。若提交後的圖表已經沒有詳細資料視窗或畫布選取所指的那個節點，兩者都會被清掉，這樣還原該節點的撤銷就不會讓視窗自己彈回來。
 
@@ -421,7 +421,7 @@ type WorkspaceEvent =
   | { type: "active-tab"; tabId: string; revision: number };
 ```
 
-事件在變更之後同步送達，順序固定：先是新增的分頁，接著是變更的文件，然後是作用中分頁，最後是移除的分頁。`origin` 只有在變更來自某個外掛的 `workspace.applyOperations` 時才會出現在 `graph` 事件上，這就是你分辨自己的寫入與使用者的寫入的方法。
+事件在變更之後同步送達，順序固定：先是新增的分頁，接著是變更的文件，然後是作用中分頁，最後是移除的分頁。`origin` 只有在變更來自外掛的寫入時才會出現在 `graph` 事件上——`workspace.applyOperations` 與舊有的 `graph.applyOperations` 兩條路徑都會蓋上它——這就是你分辨自己的寫入與使用者的寫入的方法。
 
 如果你的回呼拋錯，編輯器會記錄它並把你取消訂閱——外掛不能有能力弄壞分頁儲存。`api.graph.onGraphChanged` 不變：仍然是作用中分頁，仍然不帶任何內容。
 

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -374,12 +374,15 @@ function commitToTab(
 
   // The preflight `atomic` buys: the reducer already works on copies, so
   // "discard the outcome" is the whole implementation. The results are still
-  // returned in full so the model can see WHICH op it got wrong.
+  // returned in full so the model can see WHICH op it got wrong -- but the
+  // COUNTS come from the tab, because the outcome they would describe is the
+  // one being thrown away (#396). Every return that commits nothing now says
+  // the same thing the four refusals above say: the graph as it stands.
   if (request.atomic && outcome.results.some((r) => !r.ok)) {
-    return { ...applied, revision: tab.revision, committed: false };
+    return { ...applied, ...counts, revision: tab.revision, committed: false };
   }
   if (!outcome.mutated) {
-    return { ...applied, revision: tab.revision, committed: false };
+    return { ...applied, ...counts, revision: tab.revision, committed: false };
   }
 
   // One snapshot, then one write: that is what makes a batch one Ctrl+Z.

--- a/frontend/src/plugins/api.v5.test.ts
+++ b/frontend/src/plugins/api.v5.test.ts
@@ -366,6 +366,32 @@ describe('workspace.applyOperations', () => {
     expect(store().getTab(tabId)!.nodes).toHaveLength(2);
   });
 
+  it('atomic: the counts on a discarded batch describe the TAB, not the outcome', () => {
+    const { api, tabId } = openEditable();
+    const before = store().getTab(tabId)!;
+    expect(before.nodes).toHaveLength(2);
+    expect(before.edges).toHaveLength(1);
+
+    const result = api.workspace.applyOperations({
+      tabId,
+      atomic: true,
+      operations: [
+        { op: 'remove_edge', source: 'a', target: 'b' },
+        { op: 'add_node', node_type: 'Ghost' },
+        { op: 'add_node', node_type: 'Sink' },
+      ],
+    });
+
+    // Nothing was written, so the counts a plugin logs have to be the graph it
+    // can still see -- the same promise the four conflict refusals keep. The
+    // discarded outcome would have said 3 nodes and 0 edges (#396).
+    expect(result.committed).toBe(false);
+    expect(result.node_count).toBe(2);
+    expect(result.edge_count).toBe(1);
+    expect(store().getTab(tabId)!.nodes).toHaveLength(2);
+    expect(store().getTab(tabId)!.edges).toHaveLength(1);
+  });
+
   it('non-atomic still commits the ops that worked', () => {
     const { api, tabId } = openEditable();
     const result = api.workspace.applyOperations({
@@ -696,6 +722,22 @@ describe('workspace.onChanged', () => {
     origins.length = 0;
     store().addNote('text', { x: 0, y: 0 });
     expect(origins).toEqual([undefined]);
+    off();
+  });
+
+  it('attaches origin to the LEGACY write path too, not just the workspace one', () => {
+    // Both paths run through the same `commitToTab`, so both stamp `origin`.
+    // Pinned because the reference used to name only `workspace.applyOperations`
+    // (#396): a plugin filtering on `origin` must be able to ignore its own
+    // legacy writes as well, or it hears its own echo.
+    const api = freshApi('graph-copilot');
+    const origins: Array<{ pluginId: string } | undefined> = [];
+    const off = api.workspace.onChanged((e) => {
+      if (e.type === 'graph') origins.push(e.origin);
+    });
+
+    api.graph.applyOperations([{ op: 'add_node', node_type: 'Source' }]);
+    expect(origins).toEqual([{ pluginId: 'graph-copilot' }]);
     off();
   });
 

--- a/frontend/src/plugins/api.v5.test.ts
+++ b/frontend/src/plugins/api.v5.test.ts
@@ -742,9 +742,11 @@ describe('workspace.onChanged', () => {
   it('orders added, changed, activated and removed WITHIN one transition', () => {
     // The sibling above only ever sees one event per store transition, so it
     // pins the order ACROSS transitions: reordering the four loops in
-    // `subscribeWorkspaceChanged` leaves it green (#398). These two
-    // assertions are the other half -- the sequence a consumer actually has
-    // to be able to process in one pass.
+    // `subscribeWorkspaceChanged` leaves it green (#398). The SECOND
+    // assertion here is the half with teeth -- one transition carrying all
+    // four kinds at once, which is the only shape that constrains the loop
+    // order. The `openGraphs` assertion first is the sequence a consumer has
+    // to process in one pass; it spans several commits, so it does not.
     const api = freshApi();
     const seen: string[] = [];
     const off = api.workspace.onChanged((e) =>

--- a/frontend/src/plugins/api.v5.test.ts
+++ b/frontend/src/plugins/api.v5.test.ts
@@ -9,8 +9,11 @@
  * behaviour an installed plugin can notice (#341 section 4.6).
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { useTabStore, _persistedTabsForTesting } from '../store/tabStore';
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
+import { useTabStore, type PersistedTab } from '../store/tabStore';
 import { useNodeDefStore } from '../store/nodeDefStore';
+import { useProjectStore } from '../store/projectStore';
+import { _resetIdbForTests } from '../utils/idb';
 import { buildPluginAPI } from './api';
 import type { NodeDefinition } from '../types';
 
@@ -58,6 +61,9 @@ function candidateGraph(name = 'candidate') {
 }
 
 beforeEach(() => {
+  // Reset FIRST: a case that opened a project would otherwise leave the
+  // autosave scoped to it for every case after.
+  useProjectStore.setState({ projectDir: null, projectName: null, loaded: false });
   useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
   store().addTab('live');
   useNodeDefStore.setState({ definitions: DEFS, presets: [] } as never);
@@ -197,26 +203,64 @@ describe('workspace.openGraphs', () => {
     expect(store().getTab((kept as { tabId: string }).tabId)!.transient).toBe(false);
   });
 
-  it('an ACTIVATED transient tab leaves the next reload on a real tab', () => {
-    // The one state where the persisted pointer names a tab that will not come
-    // back: `saveTabs` writes the unfiltered `activeTabId` alongside records
-    // `persistedTabsFor` has dropped the transient tab from. The reader's
-    // fallback -- `tabs[0]` when no record carries the id (`loadTabs`) -- is
-    // what keeps that from being a crash, so it is asserted here against the
-    // records this state really produces.
+  it('an ACTIVATED transient tab leaves the next reload on a real tab', async () => {
+    // The one state where the persisted pointer names a tab that will not
+    // come back: `saveTabs` writes the unfiltered `activeTabId` alongside
+    // records `persistedTabsFor` has dropped the transient tab from. Two
+    // readers have to survive that -- `loadTabs` for the localStorage tier
+    // and `readSnapshot` for the IndexedDB one -- and BOTH are driven here
+    // rather than restated, so a regression in either fails this test (#398).
+    const PROJECT = '/proj';
+    const scope = `codefyui-tabs::${PROJECT}`;
+    useProjectStore.getState().setProject(PROJECT);
     const api = freshApi();
     const live = store().activeTabId;
-    const [opened] = api.workspace.openGraphs(
-      [{ title: 'Candidate', graph: candidateGraph() }], { activate: 'first' });
-    const { tabId } = opened as { tabId: string };
-    expect(store().activeTabId).toBe(tabId);
 
-    const records = _persistedTabsForTesting(store().tabs);
-    expect(records.map((r) => r.id)).not.toContain(tabId);
-    const restored = records.some((r) => r.id === store().activeTabId)
-      ? store().activeTabId
-      : records[0].id;
-    expect(restored).toBe(live);
+    let tabId!: string;
+    let saved!: { activeTabId: string; tabs: PersistedTab[] };
+    vi.useFakeTimers();
+    try {
+      const [opened] = api.workspace.openGraphs(
+        [{ title: 'Candidate', graph: candidateGraph() }], { activate: 'first' });
+      ({ tabId } = opened as { tabId: string });
+      expect(store().activeTabId).toBe(tabId);
+      // The real autosave, on its real trailing-edge debounce.
+      vi.advanceTimersByTime(300);
+      saved = JSON.parse(localStorage.getItem(scope)!);
+    } finally {
+      vi.useRealTimers();
+    }
+    // The hazard, as the writer really leaves it on disk.
+    expect(saved.activeTabId).toBe(tabId);
+    expect(saved.tabs.map((r) => r.id)).toEqual([live]);
+
+    // Reader 1: `loadTabs`, through the action a resolved project calls it
+    // from. A reload lands on the surviving tab, not on the pointer.
+    store().rehydrateForProject(PROJECT);
+    expect(store().tabs.map((t) => t.id)).toEqual([live]);
+    expect(store().activeTabId).toBe(live);
+
+    // Reader 2: `readSnapshot`, the tier that is the store of record since
+    // #125. This file mocks that module for the store's own use, so the real
+    // one is imported here and driven against a real IDB state machine.
+    const persistence = await vi.importActual<typeof import('../store/tabPersistence')>(
+      '../store/tabPersistence',
+    );
+    vi.stubGlobal('indexedDB', new IDBFactory());
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange);
+    _resetIdbForTests();
+    persistence._resetTabPersistenceForTests();
+    try {
+      await persistence.writeSnapshot(scope, saved.tabs, tabId);
+      persistence._resetTabPersistenceForTests(); // a fresh page load
+      const snapshot = await persistence.readSnapshot(scope);
+      expect(snapshot!.tabs.map((t) => t.id)).toEqual([live]);
+      expect(snapshot!.activeTabId).toBe(live);
+    } finally {
+      vi.unstubAllGlobals();
+      _resetIdbForTests();
+      persistence._resetTabPersistenceForTests();
+    }
   });
 });
 
@@ -691,6 +735,55 @@ describe('workspace.onChanged', () => {
     seen.length = 0;
     store().removeTab(tabId);
     expect(seen).toContain('tabs:true');
+
+    off();
+  });
+
+  it('orders added, changed, activated and removed WITHIN one transition', () => {
+    // The sibling above only ever sees one event per store transition, so it
+    // pins the order ACROSS transitions: reordering the four loops in
+    // `subscribeWorkspaceChanged` leaves it green (#398). These two
+    // assertions are the other half -- the sequence a consumer actually has
+    // to be able to process in one pass.
+    const api = freshApi();
+    const seen: string[] = [];
+    const off = api.workspace.onChanged((e) =>
+      seen.push(e.type === 'tabs'
+        ? `tabs${e.removed ? '-' : '+'}:${e.tabId}`
+        : `${e.type}:${e.tabId}`),
+    );
+    const live = store().activeTabId;
+
+    // Two entries in ONE call. `openGraphs` creates each tab and fills it in
+    // separate commits and activates once at the end, so the whole call is a
+    // fixed five-event sequence with nothing interleaved.
+    const opened = api.workspace.openGraphs([
+      { title: 'One', graph: candidateGraph() },
+      { title: 'Two', graph: candidateGraph() },
+    ], { activate: 'last' });
+    const [first, second] = opened.map((r) => (r as { tabId: string }).tabId);
+    expect(seen).toEqual([
+      `tabs+:${first}`, `graph:${first}`,
+      `tabs+:${second}`, `graph:${second}`,
+      `active-tab:${second}`,
+    ]);
+
+    // And one transition that does all four at once. `setState` rather than
+    // an action because no single action does: this is the commit shape
+    // `hydrateTabsFromPersistence` makes when a reload comes back with a
+    // different tab set -- one tab gone, one back, a survivor on a new
+    // revision, the user landed elsewhere.
+    const secondTab = store().getTab(second)!;
+    store().removeTab(second);
+    const liveTab = store().getTab(live)!;
+    seen.length = 0;
+    useTabStore.setState({
+      tabs: [{ ...liveTab, revision: liveTab.revision + 1 }, secondTab],
+      activeTabId: second,
+    });
+    expect(seen).toEqual([
+      `tabs+:${second}`, `graph:${live}`, `active-tab:${second}`, `tabs-:${first}`,
+    ]);
 
     off();
   });

--- a/frontend/src/plugins/contract.assert.ts
+++ b/frontend/src/plugins/contract.assert.ts
@@ -89,6 +89,19 @@ type Extends<A, B> = A extends B ? true : false;
 type Mutual<A, B> = Extends<A, B> extends true ? Extends<B, A> : false;
 /** Compile error unless the argument resolves to exactly `true`. */
 type Expect<T extends true> = T;
+/**
+ * `Omit`, applied to each member of a union SEPARATELY.
+ *
+ * A conditional type over a naked type parameter distributes, so every branch
+ * is omitted from on its own and the union is put back together with all of
+ * them still in it. Plain `Omit` cannot do that on a union: `keyof (A | B)` is
+ * the INTERSECTION of the two key sets, so `Omit<A | B, K>` keeps only the
+ * keys A and B share — `never` for a union whose branches have nothing in
+ * common, which collapses the whole thing to `{}` and compares nothing at all.
+ */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
 
 // ── data contracts: must match the host structurally, both directions ──
 // (ParamDefinition.default is `any` on the host and `unknown` in the contract;
@@ -138,16 +151,21 @@ export type _WorkspaceEvent = Expect<Mutual<HWorkspaceEvent, CWorkspaceEvent>>;
 export type _WorkspaceOpenEntryMeta = Expect<
   Mutual<Omit<HWorkspaceOpenEntry, 'graph'>, Omit<CWorkspaceOpenEntry, 'graph'>>
 >;
-// The same carve-out, one level in. `Exclude` drops the graph-bearing branch —
-// whose other half `_WorkspaceTabInfo` already compares — and leaves
-// `{ error: 'unknown_tab' }`, which nothing else reaches: `_WorkspaceKeys`
-// compares the key NAMES of `workspace`, never the return type of `snapshot`,
-// so a re-typed error branch would drift in silence. `Omit` cannot stand in
-// here the way it does above: `keyof` a union is the INTERSECTION of its
-// branches' keys, which is `never` for this one, so `Omit<..., 'graph'>`
-// collapses to `{}` and would compare nothing at all.
+// The same carve-out, one level in — and applied to BOTH branches of the
+// union, which is the part `Exclude` could not do (#398). Nothing else
+// reaches either branch: `_WorkspaceKeys` compares the key NAMES of
+// `workspace`, never the return type of `snapshot`. `Exclude<..., { graph:
+// unknown }>` closed the `{ error: 'unknown_tab' }` half by isolating it, but
+// it isolates by DROPPING the graph-bearing half, so a host-only field added
+// next to `graph` was compared against nothing at all. Omitting `graph` from
+// each branch separately leaves both of them in the comparison, member for
+// member. (`graph` itself stays out for the reason above: the host's
+// `SerializedGraph` and the contract's are the one deliberate divergence.)
 export type _WorkspaceSnapshotMeta = Expect<
-  Mutual<Exclude<HWorkspaceSnapshot, { graph: unknown }>, Exclude<CWorkspaceSnapshot, { graph: unknown }>>
+  Mutual<
+    DistributiveOmit<HWorkspaceSnapshot, 'graph'>,
+    DistributiveOmit<CWorkspaceSnapshot, 'graph'>
+  >
 >;
 export type _WorkspaceKeys = Expect<
   Mutual<keyof HApi['workspace'], keyof CApi['workspace']>

--- a/frontend/src/plugins/contract.ts
+++ b/frontend/src/plugins/contract.ts
@@ -480,8 +480,9 @@ export interface WorkspaceApplyResult extends ApplyResult {
  *
  * Delivered synchronously, in the order `tabs` (added), `graph`,
  * `active-tab`, `tabs` (removed), so a burst can be processed in one pass. A
- * `graph` event carries `origin` when the change came from a plugin's
- * `workspace.applyOperations`, which is how you ignore your own writes.
+ * `graph` event carries `origin` when the change came from a plugin write —
+ * either `workspace.applyOperations` or the legacy `graph.applyOperations`,
+ * both of which stamp it — which is how you ignore your own writes.
  *
  * If your callback throws, the editor logs it and unsubscribes you: a plugin
  * cannot be allowed to break the editor's own state.

--- a/frontend/src/store/tabStore.label.test.ts
+++ b/frontend/src/store/tabStore.label.test.ts
@@ -110,3 +110,42 @@ describe('label serialization — the Start node', () => {
     expect(resolved[0].data.type).toBe('Start');
   });
 });
+
+/**
+ * The name has to survive being collapsed into a block, too (#400).
+ *
+ * Collapse is the one place where losing it is PERMANENT: the renamed node
+ * leaves the canvas and the definition becomes the only record of it, so a
+ * name dropped by `serializeInnerNode` cannot be recovered by any later edit.
+ * The whole round trip is exercised here rather than in the pure unit tests
+ * because it takes both halves -- the inner serializer writing the key and
+ * `resolveSerializedNodes` reading it back on entry -- for the user to see
+ * their own name again.
+ */
+describe('label serialization — a node collapsed into a block', () => {
+  it('keeps a renamed node named through collapse, save and re-entry', () => {
+    store().addNode(DEF, { x: 0, y: 0 });
+    store().addNode(DEF, { x: 200, y: 0 });
+    const [first, second] = store().getActiveTab().nodes;
+    store().renameNode(first.id, 'Training set');
+    store().setNodes(
+      store().getActiveTab().nodes.map((n) => ({ ...n, selected: true })),
+    );
+    expect(store().collapseSelectionToSubgraph('Block').ok).toBe(true);
+
+    // The saved FILE carries the key -- and only for the renamed node.
+    const serialized = store().getSerializedGraph();
+    const inner = serialized.subgraphs[0].nodes as any[];
+    expect(inner.find((n) => n.id === first.id).data.label).toBe('Training set');
+    expect(inner.find((n) => n.id === second.id).data).not.toHaveProperty('label');
+
+    // ...and the name is on screen again when the user opens the block.
+    const instance = store()
+      .getActiveTab()
+      .nodes.find((n) => String(n.data.type).startsWith('subgraph:'))!;
+    expect(store().enterSubgraph(instance.id)).toBe(true);
+    const opened = store().getActiveTab().nodes;
+    expect(opened.find((n) => n.id === first.id)!.data.label).toBe('Training set');
+    expect(opened.find((n) => n.id === second.id)!.data.label).toBe('Dataset');
+  });
+});

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -1533,6 +1533,41 @@ describe('notes', () => {
     expect(activeTab().nodes[0].data.noteContent).toBe('');
   });
 
+  // ── Note edits are undoable (#400) ──
+  //
+  // `updateNoteData` pushed no snapshot, so text typed into a note could not
+  // be undone -- while the same edit made by a plugin's `update_note` could.
+  // The note's editor commits on blur (and on the unmount rescue), never per
+  // keystroke, so one snapshot per call is one undo step per finished edit,
+  // exactly the shape `renameNode` has.
+  it('updateNoteData records one undo step per committed edit', () => {
+    store().addNote('text', { x: 0, y: 0 });
+    const id = activeTab().nodes[0].id;
+    const before = activeTab().undoStack.length;
+
+    store().updateNoteData(id, { noteContent: 'hello' });
+    expect(activeTab().undoStack.length).toBe(before + 1);
+
+    store().undo();
+    expect(activeTab().nodes[0].data.noteContent).toBe('');
+  });
+
+  it('updateNoteData records nothing when the edit changes nothing', () => {
+    // Blurring a note commits whether or not anything was typed, so without
+    // this a double-click and a click away would spend an undo slot on a
+    // step that restores the state it was already in.
+    store().addNote('text', { x: 0, y: 0 });
+    const id = activeTab().nodes[0].id;
+    store().updateNoteData(id, { noteContent: 'hello' });
+    const after = activeTab().undoStack.length;
+
+    store().updateNoteData(id, { noteContent: 'hello' });
+    expect(activeTab().undoStack.length).toBe(after);
+
+    store().updateNoteData('nope', { noteContent: 'x' });
+    expect(activeTab().undoStack.length).toBe(after);
+  });
+
   it('bindNoteToNode stores the relative offset', () => {
     store().setNodes([
       { id: 'comp', type: 'baseNode', position: { x: 10, y: 20 }, data: { label: 'C', type: 'C', params: {} } },

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -3355,6 +3355,32 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
   },
 
   updateNoteData: (nodeId, updates) => {
+    // A note edit is undoable (#400). It was the one text the user could type
+    // into a graph and not take back -- while the SAME edit made by a
+    // plugin's `update_note` went through the ops batch and could be.
+    //
+    // One snapshot per call is one undo step per finished edit, the shape
+    // `renameNode` has: every caller commits at a boundary (blur, the
+    // unmount rescue in NoteNode, a colour picked from the context menu, an
+    // image chosen), never per keystroke, so there is nothing to coalesce.
+    //
+    // Guarded on the edit actually changing something, which the callers do
+    // NOT guarantee: blur commits whether or not anything was typed, so
+    // double-clicking a note to read it and clicking away would otherwise
+    // spend an undo slot on a step that restores the state it was already in
+    // -- and the stack is capped, so dead frames push real history out.
+    // Shallow comparison: only `boundOffset` is an object, and no caller
+    // passes it through here; a fresh one would compare unequal and take the
+    // snapshot, which is the safe side to err on.
+    {
+      const note = get().getActiveTab().nodes.find((n) => n.id === nodeId);
+      const changed =
+        !!note
+        && (Object.keys(updates) as (keyof typeof updates)[]).some(
+          (key) => note.data[key] !== updates[key],
+        );
+      if (changed) get().pushUndoSnapshot();
+    }
     set({
       tabs: updateTab(get().tabs, get().activeTabId, (tab) => ({
         nodes: tab.nodes.map((n) =>

--- a/frontend/src/utils/subgraph.test.ts
+++ b/frontend/src/utils/subgraph.test.ts
@@ -399,6 +399,83 @@ describe('definitionFromCanvas', () => {
   });
 });
 
+// ── Inner-node labels (#400) ────────────────────────────────────────────
+
+/**
+ * A renamed node keeps its name when it is collapsed into a block.
+ *
+ * #395 made `data.label` survive a save at the TOP level: the serializer
+ * writes it when it differs from the node's type, and the reader restores it
+ * (`label: raw.data?.label ?? nodeType`). `serializeInnerNode` never learned
+ * the rule, so collapsing a renamed node threw its name away for good -- the
+ * original node is gone, and the definition is the only record left of it.
+ *
+ * The rule is copied rather than loosened. Emitting a label that EQUALS the
+ * type would make every existing definition grow a key the reader would have
+ * defaulted to anyway; emitting one for a preset or a nested block would
+ * write a name the reader ignores, since those two read their label off their
+ * definition on every load.
+ */
+describe('inner nodes keep the name the user gave them', () => {
+  const renamed = (id: string, type: string, label: string, x = 0) =>
+    node(id, type, { x, y: 0 }, { label });
+
+  const block: SubgraphDefinition = {
+    id: 'sg',
+    name: 'Block',
+    description: '',
+    nodes: [{ id: 'x', type: 'X', position: { x: 0, y: 0 }, data: { params: {} } }],
+    edges: [],
+    interface: { inputs: [], outputs: [], triggerTargets: [] },
+  };
+
+  it('collapse writes a renamed member into the definition', () => {
+    const nodes = [renamed('b', 'B', 'Encoder'), renamed('c', 'C', 'C', 100)];
+    const result = collapseSelection(nodes, [edge('e', 'b', 'c')], [], ['b', 'c'], {
+      id: 'sg1', instanceId: 'inst',
+    });
+    if (!result.ok) throw new Error('expected collapse to succeed');
+    const inner = result.definition.nodes as any[];
+    expect(inner.find((n) => n.id === 'b').data.label).toBe('Encoder');
+    // ...and leaves the member nobody renamed byte-identical to before.
+    expect(inner.find((n) => n.id === 'c').data).not.toHaveProperty('label');
+  });
+
+  it('carries a rename made INSIDE the block back into the definition', () => {
+    const next = definitionFromCanvas(block, [renamed('x', 'X', 'Latent')], []);
+    expect((next.nodes[0] as any).data.label).toBe('Latent');
+  });
+
+  it('writes no label for a preset or a nested block', () => {
+    // Both read their name off their own definition every time they are
+    // resolved, so `data.type` never equals the label and an unguarded rule
+    // would emit for every one of them -- a key the reader then ignores.
+    const preset = renamed('p', 'preset:KeyedChat', 'KeyedChat');
+    const nodes = [
+      { ...preset, type: 'presetNode', data: { ...preset.data, isPreset: true } },
+      renamed('g', 'subgraph:inner', 'Inner Block', 100),
+    ];
+    const result = collapseSelection(nodes, [edge('e', 'p', 'g')], [], ['p', 'g'], {
+      id: 'sg1', instanceId: 'inst',
+    });
+    if (!result.ok) throw new Error('expected collapse to succeed');
+    for (const inner of result.definition.nodes as any[]) {
+      expect(inner.data).not.toHaveProperty('label');
+    }
+  });
+
+  it('writes no label for an inner node that has no type to compare against', () => {
+    // Serialization is on the path of every Run and every save, so a node
+    // that reached the canvas without a `data.type` must not throw here --
+    // and it has no fallback for the reader to restore from either.
+    const typeless = node('t', 'T', { x: 0, y: 0 }, {
+      label: 'Named', type: undefined as unknown as string,
+    });
+    const next = definitionFromCanvas(block, [typeless], []);
+    expect((next.nodes[0] as any).data).not.toHaveProperty('label');
+  });
+});
+
 describe('refreshInstances', () => {
   it('rewrites every instance of the definition, and nothing else', () => {
     const definition: SubgraphDefinition = {

--- a/frontend/src/utils/subgraph.ts
+++ b/frontend/src/utils/subgraph.ts
@@ -612,6 +612,24 @@ function serializeInnerNode(
         ? { internalParams: node.data.internalParams ?? {} }
         : {}),
       ...(node.data.bypassed ? { bypassed: true } : {}),
+      // The name the user (or an agent's `set_node_meta`) gave the node, on
+      // exactly the terms the TOP-LEVEL serializer writes it (#342, and
+      // `getSerializedGraphOf` in the store, where every clause of this rule
+      // is spelled out). Dropping it here was #400: a collapsed node leaves
+      // the canvas, so the definition is the only record of its name left and
+      // losing it is permanent.
+      //
+      // Read back by `resolveSerializedNodes`, which both readers of a
+      // definition go through -- `enterSubgraph` and `expandInstance` -- so
+      // the key restores the name on screen with no reader change.
+      ...(!node.data.isPreset
+        && typeof node.data.type === 'string'
+        && !node.data.type.startsWith(SUBGRAPH_TYPE_PREFIX)
+        && typeof node.data.label === 'string'
+        && node.data.label !== ''
+        && node.data.label !== node.data.type
+        ? { label: node.data.label }
+        : {}),
     },
   };
 }

--- a/scripts/templates/plugin/ui/src/sdk/types.ts
+++ b/scripts/templates/plugin/ui/src/sdk/types.ts
@@ -464,8 +464,9 @@ export interface WorkspaceApplyResult extends ApplyResult {
  *
  * Delivered synchronously, in the order `tabs` (added), `graph`,
  * `active-tab`, `tabs` (removed), so a burst can be processed in one pass. A
- * `graph` event carries `origin` when the change came from a plugin's
- * `workspace.applyOperations`, which is how you ignore your own writes.
+ * `graph` event carries `origin` when the change came from a plugin write —
+ * either `workspace.applyOperations` or the legacy `graph.applyOperations`,
+ * both of which stamp it — which is how you ignore your own writes.
  *
  * If your callback throws, the editor logs it and unsubscribes you: a plugin
  * cannot be allowed to break the editor's own state.


### PR DESCRIPTION
> 中文摘要：上一個外掛 API v5 的 PR 留下的三筆尾巴。一是把節點改名後收合進區塊會被吃掉的老問題修好（v5 只修了最上層的存檔，收合成區塊那條路徑還會掉），順手讓便箋的文字編輯可以用 Ctrl+Z 復原——原本外掛改便箋可以復原，使用者自己打字反而不行。二是文件講錯的三件事：`origin` 兩條寫入路徑都會附上（不是只有 workspace 那條）、`remove_node` 其實不回傳 `node_id`、以及原子批次被拒絕時回報的節點數是「本來要變成的樣子」而不是現況——最後這個直接改行為，改成回報現況。三是三個「就算壞掉也不會失敗」的測試與型別防護，現在會失敗了。

Closes #396, closes #398, closes #400.

## What this changes

- **A renamed node survives being collapsed into a block.** v5 made `data.label` survive saving at the top level, but `serializeInnerNode` still dropped it, so collapsing a renamed node lost the name for good — the original node is gone, and nothing could bring it back. The inner serializer now emits `label` under the same rule as the top level (only when it differs from the node's type) and the inner reader restores it.
- **A note's text edit is undoable.** `updateNoteData` pushed no undo snapshot, so a plugin's `update_note` could be undone while a user typing in the same note could not. One edit is now one undo step, and a blur that changed nothing adds none. Note text reaches the store on blur (or once at unmount while editing), never per keystroke, so this cannot spam the stack.
- **The reference stops overstating three things.** `origin` is attached on both plugin write paths, not only `workspace.applyOperations` — corrected in the docs (both locales), the contract and the vendored SDK, and pinned by a test so it cannot drift again. `OpResult.node_id` no longer claims to come from "every op that names or creates one" (`remove_node` names one and returns none).
- **A discarded atomic batch reports the graph that is still there.** The counts after a failed `atomic` preflight described the reducer's discarded outcome, so a batch of three adds with one failure reported two extra nodes while committing nothing. They now describe the tab as it stands, like the four conflict refusals do.
- **Three guards that passed while broken now bite.** `onChanged`'s loop order is asserted within ONE transition (the previous assertions all spanned separate transitions, so reversing the four loops kept the suite green); the transient-tab reload test drives the real readers instead of re-implementing their `tabs[0]` fallback, and each reader now fails it independently; and `WorkspaceSnapshot`'s cross-side guard uses a distributive omit so a host-only field added to EITHER branch fails `tsc -b` — `Exclude` dropped the graph-bearing branch wholesale, and `Omit` cannot be used at all because `keyof` a union intersects its branches.

## Verification

- Frontend 3811 tests, `tsc -b`, docs build green in both locales (pages stay at 708 lines / 30 headings each); backend `test_plugin_dx.py` and the cross-language subgraph contract green. Each change red-first; where a fix corrected only prose, the test's teeth were proved by mutating the code, watching it fail, and restoring the file byte-identically.
- Each commit reviewed against its issue and for quality by a fresh reviewer. The third commit's reviewer re-ran every teeth-proof independently: reversing the event loops, breaking each reload fallback in turn, and adding, removing and retyping a field on each branch of the snapshot type — all fail now, and the `Exclude` counterfactual reproduces the old hole exactly.
- Chrome, against this branch's own server: renamed a node through the context menu and saw the new name on the card; typed into a note, clicked away, and one Ctrl+Z put the old text back. Not verified in the browser: the collapse round trip itself — this environment cannot hold Shift for a multi-select — so it rests on the unit tests that drive the real serializer and reader plus the reviewer's code trace.

Two things deliberately left for their own issues rather than folded in here: a plugin-opened tab's provenance is a tooltip and therefore mouse-only (#402), and the separate clone-and-own plugin template repository still carries the old `origin` sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jh5Fbd8CJdJ2wtva3ePr7C
