### PR TITLE
feat(sweeps): queue a parameter search and compare the results (backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,27 @@ received — each links to the release it was published as.
 
 ### Added
 
+- **Sweeps: search a parameter space in one request instead of babysitting
+  thirty runs.** Hand CodefyUI one graph and the values you want to try —
+  learning rates, weight decays, layer widths, anything a node parameter can
+  hold — and it builds a complete graph per combination, queues every one of
+  them on the device queue you already use, and gives you back a single table
+  ranked by whichever metric you said to optimise ([#140]). A grid tries every
+  combination; a random search takes a seeded sample of them, and the same seed
+  always produces the same list, so a result you report is a result someone else
+  can reproduce — the search runs on your own machine, with no model deciding
+  anything. Up to 32 variants over at most 4 parameters at a time, so a typo in
+  a range cannot fill a disk. Download the table as a spreadsheet with one row
+  per variant to compare, chart or hand in. Ask a sweep to stop and its queued
+  and running variants stop, keeping whatever numbers they had already recorded,
+  so a search you cut short is still a search you can read. Each variant is an
+  ordinary run you can open and inspect — and its score stays on the table even
+  after retention deletes that run, which is the difference between a comparison
+  you keep and one that quietly empties. A parameter the sweep cannot actually
+  reach is refused up front and named, rather than run as a batch of identical
+  variants that all silently ignored it. The Runs panel for driving this from
+  the canvas is still to come; for now it is the HTTP API.
+
 - **Plugin frontend contract apiVersion 5: a plugin gets the tab strip, and
   an agent gets four more kinds of edit.** `api.workspace` lets a plugin open
   a graph as a labelled, optionally read-only editor tab without moving the
@@ -2707,6 +2728,7 @@ Release candidates before 1.0.0 are on the
 [#400]: https://github.com/CodefyUI/CodefyUI/issues/400
 [#396]: https://github.com/CodefyUI/CodefyUI/issues/396
 [#398]: https://github.com/CodefyUI/CodefyUI/issues/398
+[#140]: https://github.com/CodefyUI/CodefyUI/issues/140
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...main

--- a/backend/app/api/routes_sweeps.py
+++ b/backend/app/api/routes_sweeps.py
@@ -1,9 +1,9 @@
 """REST surface for parameter sweeps (#140).
 
     POST   /api/sweeps                compile + queue N variants  -> 201
+    GET    /api/sweeps/{id}           the ranked table, JSON or CSV
 
-``GET /api/sweeps/{id}`` (the ranked comparison table, JSON or CSV) and
-``POST /api/sweeps/{id}/cancel`` land in their own commits. The conventions
+``POST /api/sweeps/{id}/cancel`` lands in its own commit. The conventions
 below are the module's rather than one route's, so they are stated once here.
 
 Conventions are ``routes_runs.py``'s, deliberately: plain ``dict`` returns
@@ -37,12 +37,15 @@ variants, and a caller who wants live progress long-polls each child's
 from __future__ import annotations
 
 import asyncio
+import csv
+import io
 import logging
 import sys
 from typing import Any, Literal
 from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import Response
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -68,14 +71,29 @@ from ..core.run_service import (
     # that already uses it.
     _swallow_task_result,
 )
-from ..core.run_store import RunProvenance
+from ..core.run_store import TERMINAL_STATUSES, RunProvenance, RunRecord
 from ..core.sweep_compiler import (
     CompiledSweep,
     CompiledVariant,
     SweepCompileError,
     compile_sweep,
 )
-from ..core.sweep_store import SweepRecord, SweepStore, SweepVariant
+from ..core.sweep_store import (
+    SWEEP_STATE_FAILED,
+    SWEEP_STATE_FINISHED,
+    HarvestEntry,
+    SweepRecord,
+    SweepStore,
+    SweepVariant,
+    rank_variants,
+    variant_is_terminal,
+)
+# The CSV helpers are REUSED, not re-derived: one BOM decision and one
+# formula-injection guard for the whole product. Importing a sibling
+# router's private helper is the house pattern (`routes_graph_run.py:47`
+# takes `_graph_path` and `_sanitize_name` from `routes_graph`), and there
+# is no cycle -- `routes_runs` imports nothing from here.
+from .routes_runs import _CSV_BOM, _csv_text_cell
 
 logger = logging.getLogger(__name__)
 
@@ -518,3 +536,251 @@ async def create_sweep(body: CreateSweepRequest, request: Request):
         "params": _spec_param_payload(sweep),
         "variants": submitted,
     }
+
+
+# ── the read side ─────────────────────────────────────────────────────────
+
+#: States a harvest must never re-write. ``failed`` is the submit loop's
+#: own record of what went wrong and outranks any later observation;
+#: ``finished`` is stamped once, so re-stamping it would move
+#: ``finished_at`` on every poll. ``SweepStore._write_variants`` enforces
+#: both itself -- this set is what lets the read side skip the write
+#: ENTIRELY when there is nothing else to say, which is the difference
+#: between three database round trips and four on every poll of a settled
+#: sweep.
+_SETTLED_STATES = frozenset({SWEEP_STATE_FINISHED, SWEEP_STATE_FAILED})
+
+
+async def _harvested_sweep(
+    service: RunService, store: SweepStore, sweep_id: str,
+) -> tuple[SweepRecord, dict[str, RunRecord], dict[str, dict[str, float]]]:
+    """Seam A: harvest, then hand back everything a read needs.
+
+    Exactly three database round trips regardless of variant count — the
+    sweep row, its children in one indexed range, and ONE grouped
+    ``latest_metrics`` call — plus a fourth only when the harvest has
+    something to write.
+
+    A variant is harvested when it has not been harvested before, its child
+    row still exists, and that row is terminal. Writing rather than merely
+    computing is RULING 4: retention deletes finished runs, and a value
+    computed for one response is gone with it.
+    """
+    sweep = await store.get_sweep(sweep_id)
+    if sweep is None:
+        raise HTTPException(status_code=404,
+                            detail=f"sweep '{sweep_id}' not found")
+    children = {record.id: record
+                for record in await service.store.list_runs_by_sweep(sweep_id)}
+    metrics = await service.store.latest_metrics(list(children))
+
+    metric = sweep.objective.get("metric")
+    entries: dict[int, HarvestEntry] = {}
+    for variant in sweep.variants:
+        if variant.harvested_at is not None or variant.run_id is None:
+            continue
+        child = children.get(variant.run_id)
+        if child is None or child.status not in TERMINAL_STATUSES:
+            continue
+        entries[variant.index] = HarvestEntry(
+            objective=metrics.get(variant.run_id, {}).get(metric),
+            status=child.status)
+
+    # `variant.index in entries` stands in for the patched variant's
+    # harvested status, so the terminal check sees the post-harvest world
+    # without materialising it.
+    finished = all(
+        variant.index in entries
+        or variant_is_terminal(
+            variant,
+            children[variant.run_id].status
+            if variant.run_id in children else None,
+            child_exists=variant.run_id in children)
+        for variant in sweep.variants)
+
+    if entries or (finished and sweep.state not in _SETTLED_STATES):
+        # ONE closure, so the read-modify-write of the variants blob is
+        # atomic against every other database operation in the process.
+        # Splitting it into a read here and a write there would silently
+        # drop a concurrent harvest -- a finishing run's, or a second
+        # poller's -- while still reporting success.
+        updated = await store.harvest(sweep.id, entries=entries,
+                                      finished=finished)
+        if updated is not None:
+            sweep = updated
+    return sweep, children, metrics
+
+
+_COUNT_KEYS = ("queued", "running", "succeeded", "failed", "cancelled",
+               "interrupted", _STATUS_MISSING)
+
+
+def _variant_payload(variant: SweepVariant, rank: int | None,
+                     children: dict[str, RunRecord],
+                     metrics: dict[str, dict[str, float]]) -> dict[str, Any]:
+    child = children.get(variant.run_id) if variant.run_id else None
+    payload: dict[str, Any] = {
+        "index": variant.index,
+        "domain_index": variant.domain_index,
+        "run_id": variant.run_id,
+        # The LIVE status wins, then the harvested one, then the literal
+        # "missing" -- what a client sees for a variant whose run was
+        # pruned or hand-deleted before any read harvested it.
+        "status": (child.status if child is not None
+                   else variant.status or _STATUS_MISSING),
+        "params": variant.params,
+        "seed": variant.seed,
+        "objective": variant.objective,
+        "rank": rank,
+        # RULING 4: the run id stays as a link that MAY BE DEAD, and this is
+        # how a client knows not to follow it.
+        "run_exists": child is not None,
+    }
+    if child is not None:
+        # OMITTED entirely, not {}, when the row is gone: an empty map reads
+        # as "this run recorded nothing" rather than "this run is no longer
+        # here".
+        payload["final_metrics"] = metrics.get(variant.run_id, {})
+    return payload
+
+
+def _counts(payloads: list[dict[str, Any]]) -> dict[str, int]:
+    """Per-status tallies that always sum to the variant count."""
+    counts = {key: 0 for key in _COUNT_KEYS}
+    for payload in payloads:
+        status = payload["status"]
+        counts[status if status in counts else _STATUS_MISSING] += 1
+    return counts
+
+
+def _objective_warning(sweep: SweepRecord,
+                       payloads: list[dict[str, Any]]) -> str | None:
+    """Absent when at least one variant ranked.
+
+    Otherwise it turns the single most likely user error — asking for
+    ``val_loss`` from a graph with no validation loader — into a message
+    that names the fix, instead of a table of empty cells. The series list
+    is the union of ``final_metrics`` keys across the children that still
+    exist, sorted so the message is the same twice, and omitted when none
+    of them do.
+    """
+    if any(payload["rank"] is not None for payload in payloads):
+        return None
+    names = sorted({name for payload in payloads
+                    for name in payload.get("final_metrics", {})})
+    warning = ("no variant recorded a metric named "
+               f"'{sweep.objective.get('metric')}'")
+    if names:
+        warning += ("; the series recorded across this sweep were: "
+                    + ", ".join(names))
+    return warning
+
+
+_CSV_COLUMNS = ("rank", "variant_index", "domain_index", "run_id", "status",
+                "objective")
+
+
+def _comparison_csv(sweep: SweepRecord,
+                    payloads: list[dict[str, Any]]) -> str:
+    """One row per variant — #140's fourth acceptance criterion.
+
+    ``rank``, ``variant_index``, ``domain_index`` and ``objective`` are
+    NUMERIC cells and are deliberately not routed through
+    ``_csv_text_cell``: a negative value leads with ``-`` by nature, and
+    quoting it would turn the column into text and break every chart built
+    on the export (``routes_runs.py:473-475``). ``run_id``, ``status`` and
+    every param cell ARE text cells — a ``select`` or ``string`` param's
+    value is caller-supplied. So is a node id, which is why the per-param
+    HEADER cells go through the same guard: ``=cmd.lr`` is a formula wearing
+    a column name.
+
+    An absent ``objective`` or ``rank`` is an EMPTY cell, which is what
+    every spreadsheet reads as a gap; ``"None"`` would read as text and
+    poison the column's type. An unranked variant still gets its row.
+    """
+    addresses = [(entry["node_id"], entry["param"])
+                 for entry in _spec_param_payload(sweep)]
+    buffer = io.StringIO(newline="")
+    # Explicit lineterminator: csv defaults to \r\n, and newline="" means
+    # that would survive verbatim into the body.
+    writer = csv.writer(buffer, lineterminator="\n")
+    writer.writerow([*_CSV_COLUMNS,
+                     *(_csv_text_cell(f"{node_id}.{param}")
+                       for node_id, param in addresses)])
+    for payload in payloads:
+        values = {(entry["node_id"], entry["param"]): entry["value"]
+                  for entry in payload["params"]}
+        writer.writerow([
+            "" if payload["rank"] is None else payload["rank"],
+            payload["index"],
+            payload["domain_index"],
+            _csv_text_cell(payload["run_id"] or ""),
+            _csv_text_cell(payload["status"]),
+            "" if payload["objective"] is None else payload["objective"],
+            *(_csv_text_cell(values.get(address, ""))
+              for address in addresses),
+        ])
+    return _CSV_BOM + buffer.getvalue()
+
+
+def _csv_filename(sweep_id: str) -> str:
+    """A filename that cannot break out of the header.
+
+    Sweep ids are our own uuid4 hex, but this endpoint's id comes off the
+    URL, so the value is whitelisted rather than trusted.
+    """
+    safe = "".join(c for c in sweep_id if c.isalnum() or c in "-_")[:64]
+    return f"sweep-{safe}-comparison.csv" if safe else "sweep-comparison.csv"
+
+
+@router.get("/{sweep_id}")
+async def get_sweep(
+    sweep_id: str,
+    request: Request,
+    format: str = Query(default="json", pattern="^(json|csv)$"),
+):
+    """The ranked comparison table, as JSON or as a spreadsheet download.
+
+    ``variants`` comes back in RANK order, best first, so a table renders it
+    without sorting and the best row is row one. The pre-rank identity is
+    never lost: ``index`` is the compiled variant number and
+    ``domain_index`` the cartesian cell, so a client can re-sort back to
+    submission order.
+
+    Harvests before answering, so a freshly-finished variant's objective is
+    STORED, not merely computed for this one response.
+    """
+    service = _get_service(request)
+    store = _get_sweep_store(request)
+    sweep, children, metrics = await _harvested_sweep(service, store,
+                                                      sweep_id)
+    ranked = rank_variants(
+        sweep.variants,
+        direction=sweep.objective.get("direction", "minimize"))
+    payloads = [_variant_payload(variant, rank, children, metrics)
+                for variant, rank in ranked]
+
+    if format == "csv":
+        return Response(
+            content=_comparison_csv(sweep, payloads),
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition":
+                     f'attachment; filename="{_csv_filename(sweep_id)}"'})
+
+    best = next((payload for payload in payloads if payload["rank"] == 1),
+                None)
+    body: dict[str, Any] = {
+        "sweep_id": sweep.id, "name": sweep.name, "state": sweep.state,
+        "method": sweep.method, "seed": sweep.seed,
+        "seed_variants": sweep.seed_variants, "objective": sweep.objective,
+        "created_at": sweep.created_at, "finished_at": sweep.finished_at,
+        "error": sweep.error, "counts": _counts(payloads),
+        "params": _spec_param_payload(sweep), "variants": payloads,
+        "best": None if best is None else {
+            "index": best["index"], "run_id": best["run_id"],
+            "objective": best["objective"]},
+    }
+    warning = _objective_warning(sweep, payloads)
+    if warning is not None:
+        body["objective_warning"] = warning
+    return body

--- a/backend/app/api/routes_sweeps.py
+++ b/backend/app/api/routes_sweeps.py
@@ -37,7 +37,10 @@ variants, and a caller who wants live progress long-polls each child's
 from __future__ import annotations
 
 import asyncio
+import logging
+import sys
 from typing import Any, Literal
+from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import (
@@ -59,6 +62,11 @@ from ..core.run_service import (
     normalize_graph,
     normalize_name,
     normalize_options,
+    # Private, and imported on purpose: retrieving a detached task's outcome
+    # so asyncio does not log it is ONE two-line implementation, and
+    # `_mark_failed_on_the_way_out` below is modelled on the RunGate release
+    # that already uses it.
+    _swallow_task_result,
 )
 from ..core.run_store import RunProvenance
 from ..core.sweep_compiler import (
@@ -68,6 +76,8 @@ from ..core.sweep_compiler import (
     compile_sweep,
 )
 from ..core.sweep_store import SweepRecord, SweepStore, SweepVariant
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/sweeps", tags=["sweeps"])
 
@@ -233,6 +243,58 @@ def _spec_param_payload(sweep: SweepRecord) -> list[dict[str, Any]]:
             for entry in sweep.spec.get("params", [])]
 
 
+#: Strong references to the detached writes fired by
+#: ``_mark_failed_on_the_way_out``. asyncio holds only a WEAK reference to a
+#: running task, so without this a settle fired while the request is being
+#: cancelled could be garbage-collected mid-flight. Mirrors ``RunGate``'s own
+#: ``self._wakes`` (``run_service.py:1038-1040``).
+_PENDING_MARKS: set[asyncio.Task[Any]] = set()
+
+
+async def _mark_failed_on_the_way_out(store: SweepStore, sweep_id: str,
+                                      error: str) -> None:
+    """Settle the sweep row while this request may itself be cancelled.
+
+    Shaped exactly like ``RunGate._release``'s notification
+    (``run_service.py:1029-1049``) and for the same reason: a bare
+    ``await store.mark_failed(...)`` inside a ``finally`` IS a cancellation
+    point, and Starlette runs a handler inside an anyio cancel scope where
+    every checkpoint after a cancel raises again -- so the write would never
+    be reached. Firing it as its OWN task and shielding the wait lets the
+    cancel take this await while the write runs on to completion.
+
+    Two properties, both required:
+
+    * **the CancelledError still propagates.** ``shield`` re-raises the
+      cancel that landed on this await, and ``except Exception`` does not
+      catch a ``BaseException``, so the request still ends cancelled. This
+      write is a side effect on the way out, never a recovery.
+    * **a failure here never replaces the exception on its way out.** This
+      runs in a ``finally``, so a raise would substitute itself for whatever
+      the handler was already failing with and the original would be gone.
+      Swallowing costs nothing that was not already lost -- the row is
+      unsettled either way -- while losing the caller's own error is new
+      damage.
+
+    Not durable against the loop itself going away: a process-wide shutdown
+    cancels every task and can take the detached write with it. Recovering a
+    sweep across a restart is RULING 2's explicit hand-off to #343.
+    """
+    try:
+        task = asyncio.ensure_future(store.mark_failed(sweep_id, error))
+    except RuntimeError:  # pragma: no cover - the loop is already gone
+        return
+    _PENDING_MARKS.add(task)
+    task.add_done_callback(_PENDING_MARKS.discard)
+    task.add_done_callback(_swallow_task_result)
+    try:
+        await asyncio.shield(task)
+    except Exception:  # noqa: BLE001 - see above; CancelledError is a
+        # BaseException and so still propagates, which is required.
+        logger.warning("sweep %s: settling it as failed on the way out of "
+                       "the submit loop failed", sweep_id, exc_info=True)
+
+
 def _refuse_unrecordable_outputs(request: Request, options: dict[str, Any],
                                  variant_count: int) -> None:
     """RULE 5 of spec 5.2 -- the only one that needs the compiled count.
@@ -336,77 +398,117 @@ async def create_sweep(body: CreateSweepRequest, request: Request):
     # answer. tests/test_run_store.py:123-127 skips it the same way.
     provenance = await asyncio.to_thread(RunProvenance.capture)
 
-    # The sweep row goes FIRST: exec_runs.sweep_id has an enforced foreign
-    # key, so inserting a child before its parent exists fails.
-    #
-    # The seed comes off the COMPILED sweep, not off `spec`: CompiledSweep
-    # .seed is the planner seed the sampler actually used, and reading it
-    # from there is what stops the stored seed and the sampled variant list
-    # from ever drifting apart (sweep_compiler.CompiledSweep.seed says so).
-    sweep = await store.create_sweep(
-        method=spec["method"], seed=compiled.seed,
-        seed_variants=body.seed_variants,
-        spec=_compiled_spec(spec, compiled),
-        objective=body.objective.model_dump(),
-        variants=[_placeholder_variant(compiled, variant)
-                  for variant in compiled.variants],
-        name=name)
-
+    # Minted HERE rather than left to create_sweep, so the settle-on-the-way-
+    # out `finally` below knows the id even when this frame never sees the
+    # record: Database.run finishes its worker before re-raising a
+    # cancellation (db.py:225-243), so a cancel delivered at create_sweep's
+    # own await leaves the row written and this coroutine unwinding past it.
+    sweep_id = uuid4().hex
     submitted: list[dict[str, Any]] = []
-    for variant in compiled.variants:
-        variant_options = dict(options)
-        seed: int | None = None
-        if body.seed_variants:
-            # The modulo is mandatory: normalize_options rejects a seed
-            # above MAX_SEED, so a base seed near the top of the range would
-            # make late variants fail submission with an error the caller
-            # never wrote. `compiled.seed` is not None here -- rule 3 above
-            # refused that case, and the compiler records the seed verbatim.
-            # When seed_variants is off the seed stays None -- the unseeded
-            # case, which takes the SHARED exclusion and lets variants
-            # overlap up to the device's concurrency limit.
-            seed = (compiled.seed + variant.index) % (MAX_SEED + 1)
-            variant_options["seed"] = seed
-        try:
-            result = await service.submit(
-                variant.graph, options=variant_options, name=name,
-                provenance=provenance, sweep_id=sweep.id,
-                sweep_variant=variant.index)
-            # Patched once per variant, not once at the end: a single
-            # patch at the end would lose every id if the loop broke
-            # half-way, which is precisely the case RULING 2 says must
-            # stay visible.
-            #
-            # INSIDE the guard, not after it. The duty is that every path
-            # out of this loop either fills in every run id or marks the
-            # sweep failed, and a store fault here would otherwise take a
-            # third path: a transient fault can fail one write and allow
-            # the next, so it would exit with neither -- leaving a
-            # `running` row that no harvest seam can ever settle, because
-            # a run_id-None variant is not terminal (spec 4.3).
-            await store.set_variant_run(sweep.id, variant.index,
-                                        run_id=result.run_id, seed=seed)
-        except Exception as exc:
-            # The children already created are LEFT ALONE. They are real
-            # queued runs and shutdown/startup recovery retires them as
-            # `interrupted` -- visible, not vanished, per RULING 2. The
-            # sweep id goes in the body so nothing is unfindable, and the
-            # row leaves `running`: a variant with run_id None is not
-            # terminal, so without this the sweep would never settle.
-            await store.mark_failed(sweep.id, str(exc))
-            status = 503 if isinstance(exc, RunServiceUnavailable) else 500
-            raise HTTPException(
-                status_code=status,
-                detail=(f"{exc}; sweep {sweep.id} was created with "
-                        f"{len(submitted)} of {len(compiled.variants)} "
-                        "variants and is marked failed")) from exc
-        # Appended only once the patch landed, so `len(submitted)` in the
-        # message above counts variants FULLY recorded on the row. A child
-        # whose patch failed is still findable by exec_runs.sweep_id.
-        submitted.append({
-            "index": variant.index, "domain_index": variant.domain_index,
-            "run_id": result.run_id, "status": result.status, "seed": seed,
-            "params": _variant_params(compiled, variant)})
+    marked_failed = False
+    try:
+        # The sweep row goes FIRST: exec_runs.sweep_id has an enforced
+        # foreign key, so inserting a child before its parent exists fails.
+        #
+        # The seed comes off the COMPILED sweep, not off `spec`:
+        # CompiledSweep.seed is the planner seed the sampler actually used,
+        # and reading it from there is what stops the stored seed and the
+        # sampled variant list from ever drifting apart
+        # (sweep_compiler.CompiledSweep.seed says so).
+        sweep = await store.create_sweep(
+            sweep_id=sweep_id,
+            method=spec["method"], seed=compiled.seed,
+            seed_variants=body.seed_variants,
+            spec=_compiled_spec(spec, compiled),
+            objective=body.objective.model_dump(),
+            variants=[_placeholder_variant(compiled, variant)
+                      for variant in compiled.variants],
+            name=name)
+
+        for variant in compiled.variants:
+            variant_options = dict(options)
+            seed: int | None = None
+            if body.seed_variants:
+                # The modulo is mandatory: normalize_options rejects a seed
+                # above MAX_SEED, so a base seed near the top of the range
+                # would make late variants fail submission with an error the
+                # caller never wrote. `compiled.seed` is not None here --
+                # rule 3 above refused that case, and the compiler records
+                # the seed verbatim. When seed_variants is off the seed
+                # stays None -- the unseeded case, which takes the SHARED
+                # exclusion and lets variants overlap up to the device's
+                # concurrency limit.
+                seed = (compiled.seed + variant.index) % (MAX_SEED + 1)
+                variant_options["seed"] = seed
+            try:
+                result = await service.submit(
+                    variant.graph, options=variant_options, name=name,
+                    provenance=provenance, sweep_id=sweep.id,
+                    sweep_variant=variant.index)
+                # Patched once per variant, not once at the end: a single
+                # patch at the end would lose every id if the loop broke
+                # half-way, which is precisely the case RULING 2 says must
+                # stay visible.
+                #
+                # INSIDE the guard, not after it. The duty is that every
+                # path out of this loop either fills in every run id or
+                # marks the sweep failed, and a store fault here would
+                # otherwise take a third path: a transient fault can fail
+                # one write and allow the next, so it would exit with
+                # neither -- leaving a `running` row that no harvest seam
+                # can ever settle, because a run_id-None variant is not
+                # terminal (spec 4.3).
+                await store.set_variant_run(sweep.id, variant.index,
+                                            run_id=result.run_id, seed=seed)
+            except Exception as exc:
+                # The children already created are LEFT ALONE. They are real
+                # queued runs and shutdown/startup recovery retires them as
+                # `interrupted` -- visible, not vanished, per RULING 2. The
+                # sweep id goes in the body so nothing is unfindable, and
+                # the row leaves `running`: a variant with run_id None is
+                # not terminal, so without this the sweep would never
+                # settle.
+                await store.mark_failed(sweep.id, str(exc))
+                marked_failed = True
+                status = (503 if isinstance(exc, RunServiceUnavailable)
+                          else 500)
+                raise HTTPException(
+                    status_code=status,
+                    detail=(f"{exc}; sweep {sweep.id} was created with "
+                            f"{len(submitted)} of {len(compiled.variants)} "
+                            "variants and is marked failed")) from exc
+            # Appended only once the patch landed, so `len(submitted)` in
+            # the message above counts variants FULLY recorded on the row. A
+            # child whose patch failed is still findable by
+            # exec_runs.sweep_id.
+            submitted.append({
+                "index": variant.index, "domain_index": variant.domain_index,
+                "run_id": result.run_id, "status": result.status,
+                "seed": seed, "params": _variant_params(compiled, variant)})
+    finally:
+        # EVERY other way out of the block above. There is no `return`,
+        # `break` or `continue` in it, so "every other way" means an
+        # exception this handler did not raise itself -- and the `except
+        # Exception` above cannot see the BaseException ones. The important
+        # one is not exotic: a browser tab closing during a 32-variant
+        # submit cancels the request task, which lands a CancelledError
+        # between two submits.
+        #
+        # `failed` is the honest end state then, and it is the spec's own
+        # words for it (4.3: "the submit loop broke part-way and some
+        # variants have no run at all"). Without this the row keeps
+        # `running` forever -- a variant holding a null run id is not
+        # terminal, so no harvest seam can ever settle it -- while the
+        # children already submitted keep running and stay inspectable,
+        # which is RULING 2's promise.
+        if not marked_failed and len(submitted) < len(compiled.variants):
+            cause = sys.exc_info()[1]
+            cause_name = "no error" if cause is None else type(cause).__name__
+            await _mark_failed_on_the_way_out(
+                store, sweep_id,
+                f"the submit loop did not finish ({cause_name}); "
+                f"{len(submitted)} of {len(compiled.variants)} variants "
+                "were created")
 
     return {
         "sweep_id": sweep.id, "state": sweep.state, "method": sweep.method,

--- a/backend/app/api/routes_sweeps.py
+++ b/backend/app/api/routes_sweeps.py
@@ -2,9 +2,10 @@
 
     POST   /api/sweeps                compile + queue N variants  -> 201
     GET    /api/sweeps/{id}           the ranked table, JSON or CSV
+    POST   /api/sweeps/{id}/cancel    stop the queued and running children
 
-``POST /api/sweeps/{id}/cancel`` lands in its own commit. The conventions
-below are the module's rather than one route's, so they are stated once here.
+The conventions below are the module's rather than one route's, so they are
+stated once here.
 
 Conventions are ``routes_runs.py``'s, deliberately: plain ``dict`` returns
 and no ``response_model``, request models declared locally with
@@ -79,6 +80,7 @@ from ..core.sweep_compiler import (
     compile_sweep,
 )
 from ..core.sweep_store import (
+    SWEEP_STATE_CANCELLING,
     SWEEP_STATE_FAILED,
     SWEEP_STATE_FINISHED,
     HarvestEntry,
@@ -784,3 +786,85 @@ async def get_sweep(
     if warning is not None:
         body["objective_warning"] = warning
     return body
+
+
+# ── cancel (spec 7) ───────────────────────────────────────────────────────
+
+
+@router.post("/{sweep_id}/cancel")
+async def cancel_sweep(sweep_id: str, request: Request):
+    """Ask every queued and running child of a sweep to stop.
+
+    There is no bulk cancel in ``RunService`` — ``CancelOutcome`` is
+    single-run — so this is N awaited cancels, each with its own database
+    write. NO transaction spans them, so a partially-cancelled sweep is a
+    reachable state and the response reports per-variant outcomes rather
+    than one boolean.
+
+    ``variants`` comes back in INDEX order, not rank order: a cancel is
+    about the submission, and the caller is matching rows against what they
+    just sent. Each entry mirrors ``POST /api/runs/{id}/cancel``'s own three
+    keys, which is what makes ``status: "running"`` with ``cancelled: true``
+    readable — cancellation is cooperative, so the reply is an
+    acknowledgement and the outcome is observed later on the row.
+
+    Asking twice is a 200, not an error: ``RunService.cancel`` re-reads the
+    row and reports ``cancelled=False`` for anything already terminal, so
+    the second call is ``cancelled: 0`` with the state unchanged. A cancel
+    racing a completion is normal (the user hits Stop as the last epoch
+    lands).
+    """
+    service = _get_service(request)
+    store = _get_sweep_store(request)
+    sweep = await store.get_sweep(sweep_id)
+    if sweep is None:
+        raise HTTPException(status_code=404,
+                            detail=f"sweep '{sweep_id}' not found")
+
+    results: list[dict[str, Any]] = []
+    cancelled = 0
+    already_finished = 0
+    for variant in sorted(sweep.variants, key=lambda entry: entry.index):
+        if variant.run_id is None:
+            # The failed-submit-loop case: there is nothing to cancel, and
+            # nothing FINISHED either, so it is counted in neither tally
+            # (spec 5.4: `already_finished` counts the rest that had a run).
+            results.append({"index": variant.index, "run_id": None,
+                            "status": _STATUS_MISSING, "cancelled": False})
+            continue
+        outcome = await service.cancel(variant.run_id)
+        if outcome is None:
+            # The row is gone -- pruned, or DELETE /api/runs/{id}. It had a
+            # run, so it counts as already finished.
+            results.append({"index": variant.index, "run_id": variant.run_id,
+                            "status": variant.status or _STATUS_MISSING,
+                            "cancelled": False})
+            already_finished += 1
+            continue
+        results.append({"index": variant.index, "run_id": variant.run_id,
+                        "status": outcome.status,
+                        "cancelled": outcome.cancelled})
+        if outcome.cancelled:
+            cancelled += 1
+        else:
+            already_finished += 1
+
+    if cancelled:
+        # `cancelling` ONLY when at least one child was still active. If
+        # every child was already terminal the state is left as it is, and
+        # it is never set to `cancelled`: a sweep where 30 of 32 variants
+        # finished and 2 were stopped is not a cancelled sweep, and
+        # per-variant status carries that truth. set_state refuses to
+        # overwrite `failed`.
+        await store.set_state(sweep.id, SWEEP_STATE_CANCELLING)
+
+    # Harvest before answering, so the sweep's own state is current rather
+    # than one request stale -- a queued child cancelled a moment ago is
+    # already terminal. It is also what keeps a cancel from LOSING results:
+    # whatever a stopped child had logged is copied onto the sweep row here
+    # rather than waiting for a read that may never come.
+    sweep, _children, _metrics = await _harvested_sweep(service, store,
+                                                        sweep_id)
+    return {"sweep_id": sweep.id, "state": sweep.state,
+            "cancelled": cancelled, "already_finished": already_finished,
+            "variants": results}

--- a/backend/app/api/routes_sweeps.py
+++ b/backend/app/api/routes_sweeps.py
@@ -290,7 +290,18 @@ async def create_sweep(body: CreateSweepRequest, request: Request):
             status_code=400,
             detail="options.seed is owned by the sweep; set sweep_spec.seed "
                    "and seed_variants instead")
-    if raw_options.get("lane") == LANE_INTERACTIVE:
+    # The STRIPPED value, not the raw one: normalize_options strips
+    # `lane` (run_service.py:596), so a padded " interactive " would pass
+    # a raw comparison, normalise INTO the interactive lane, and be caught
+    # only by submit's own guard inside the loop -- a 500 plus a permanent
+    # `failed` sweeps row, where this rule promises a 400 and no rows at
+    # all. NOT lowercased, because normalize_options does not lowercase
+    # either: lanes are case-sensitive labels and an unrecognised one
+    # QUEUES rather than bypassing (run_service.py:242-244), so
+    # "Interactive" is an ordinary queued lane and refusing it here would
+    # refuse a legal sweep.
+    raw_lane = raw_options.get("lane")
+    if isinstance(raw_lane, str) and raw_lane.strip() == LANE_INTERACTIVE:
         raise HTTPException(
             status_code=400,
             detail="a sweep cannot use the interactive lane; interactive "
@@ -361,6 +372,20 @@ async def create_sweep(body: CreateSweepRequest, request: Request):
                 variant.graph, options=variant_options, name=name,
                 provenance=provenance, sweep_id=sweep.id,
                 sweep_variant=variant.index)
+            # Patched once per variant, not once at the end: a single
+            # patch at the end would lose every id if the loop broke
+            # half-way, which is precisely the case RULING 2 says must
+            # stay visible.
+            #
+            # INSIDE the guard, not after it. The duty is that every path
+            # out of this loop either fills in every run id or marks the
+            # sweep failed, and a store fault here would otherwise take a
+            # third path: a transient fault can fail one write and allow
+            # the next, so it would exit with neither -- leaving a
+            # `running` row that no harvest seam can ever settle, because
+            # a run_id-None variant is not terminal (spec 4.3).
+            await store.set_variant_run(sweep.id, variant.index,
+                                        run_id=result.run_id, seed=seed)
         except Exception as exc:
             # The children already created are LEFT ALONE. They are real
             # queued runs and shutdown/startup recovery retires them as
@@ -375,11 +400,9 @@ async def create_sweep(body: CreateSweepRequest, request: Request):
                 detail=(f"{exc}; sweep {sweep.id} was created with "
                         f"{len(submitted)} of {len(compiled.variants)} "
                         "variants and is marked failed")) from exc
-        # Patched once per variant, not once at the end: a single patch at
-        # the end would lose every id if the loop broke half-way, which is
-        # precisely the case RULING 2 says must stay visible.
-        await store.set_variant_run(sweep.id, variant.index,
-                                    run_id=result.run_id, seed=seed)
+        # Appended only once the patch landed, so `len(submitted)` in the
+        # message above counts variants FULLY recorded on the row. A child
+        # whose patch failed is still findable by exec_runs.sweep_id.
         submitted.append({
             "index": variant.index, "domain_index": variant.domain_index,
             "run_id": result.run_id, "status": result.status, "seed": seed,

--- a/backend/app/api/routes_sweeps.py
+++ b/backend/app/api/routes_sweeps.py
@@ -1,0 +1,395 @@
+"""REST surface for parameter sweeps (#140).
+
+    POST   /api/sweeps                compile + queue N variants  -> 201
+
+``GET /api/sweeps/{id}`` (the ranked comparison table, JSON or CSV) and
+``POST /api/sweeps/{id}/cancel`` land in their own commits. The conventions
+below are the module's rather than one route's, so they are stated once here.
+
+Conventions are ``routes_runs.py``'s, deliberately: plain ``dict`` returns
+and no ``response_model``, request models declared locally with
+``extra="forbid"``, every error a ``{"detail": ...}`` (the 9-key run envelope
+belongs to ``routes_graph_run`` / ``routes_apps``), and a 503 when the
+service is not on ``app.state`` -- the lifespan does not run under httpx's
+``ASGITransport``.
+
+Auth follows the house rule in ``main.py`` exactly: ``auth_guard`` requires
+the session token for the mutating routes and lets the GET through like every
+other GET in the app. This router is deliberately NOT added to
+``_AUTH_EXEMPT_PREFIXES`` -- that list exists for ``/api/apps`` and
+``/api/keys``, which carry per-route auth dependencies instead, and joining
+it without one would silently drop authentication entirely
+(``test_api_sweeps.test_sweeps_routes_are_not_under_an_auth_exempt_prefix``
+guards it).
+
+**One deliberate deviation from ``routes_runs.py``: ``POST /api/sweeps``
+answers 201, not 200.** A sweep submit creates a new addressable resource
+with its own URL that the caller goes on to poll, which is what 201 means.
+``POST /api/runs`` answers 200 and predates any such resource-shaped
+surface; it is not worth changing now, and this note exists so a later
+reviewer does not "fix" one to match the other.
+
+No long poll and no pagination: a sweep has at most ``MAX_SWEEP_RUNS``
+variants, and a caller who wants live progress long-polls each child's
+``GET /api/runs/{id}/events``, which already works.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictFloat,
+    StrictInt,
+    field_validator,
+)
+
+from ..config import settings
+from ..core.run_service import (
+    LANE_INTERACTIVE,
+    MAX_SEED,
+    RunService,
+    RunServiceUnavailable,
+    RunSubmitError,
+    normalize_graph,
+    normalize_name,
+    normalize_options,
+)
+from ..core.run_store import RunProvenance
+from ..core.sweep_compiler import (
+    CompiledSweep,
+    CompiledVariant,
+    SweepCompileError,
+    compile_sweep,
+)
+from ..core.sweep_store import SweepRecord, SweepStore, SweepVariant
+
+router = APIRouter(prefix="/api/sweeps", tags=["sweeps"])
+
+#: A variant whose run cannot be reached: it never got one (the failed
+#: submit loop), or its row was pruned or deleted before any read harvested
+#: it. Not an ``exec_runs.status`` -- it is the absence of one.
+_STATUS_MISSING = "missing"
+
+
+def _get_service(request: Request) -> RunService:
+    service = getattr(request.app.state, "run_service", None)
+    if service is None:
+        raise HTTPException(status_code=503,
+                            detail="run service not initialised")
+    return service
+
+
+def _get_sweep_store(request: Request) -> SweepStore:
+    store = getattr(request.app.state, "sweep_store", None)
+    if store is None:
+        raise HTTPException(status_code=503,
+                            detail="sweep store not initialised")
+    return store
+
+
+# ── request models ────────────────────────────────────────────────────────
+#
+# extra="forbid" on every one of them is load-bearing, the same way it is in
+# routes_packs.py:80-86: it is what makes "the client cannot smuggle in an
+# unknown key" a guarantee of the schema rather than of every handler
+# remembering. OPTION_KEYS enforces the same closed-key discipline for run
+# options.
+
+
+class SweepRangeModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # StrictInt | StrictFloat rather than a plain `float`. Measured on
+    # pydantic 2.12: a lax `float` field accepts JSON `true` and coerces it
+    # to 1.0, which would smuggle a bool past the bool-is-not-a-number rule
+    # this design applies everywhere else. The union still accepts a JSON
+    # integer, which {min: 16, max: 128} needs.
+    min: StrictInt | StrictFloat
+    max: StrictInt | StrictFloat
+    count: int = Field(strict=True)
+    scale: Literal["linear", "log"]
+    type: Literal["int", "float"]
+
+
+class SweepParamModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str
+    param: str
+    # Exact JSON types survive this union (measured): 1 stays int, true
+    # stays bool, 2.0 stays float. That is what lets the compiler's type
+    # matrix see what the caller actually wrote rather than a coercion.
+    values: list[int | float | bool | str] | None = None
+    range: SweepRangeModel | None = None
+
+
+class SweepSpecModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    method: Literal["grid", "random"]
+    # strict, for the same reason `count` is: on a lax int field
+    # `seed: true` is silently the integer 1 and `seed: "7"` is 7.
+    seed: int | None = Field(default=None, strict=True)
+    samples: int | None = Field(default=None, strict=True)
+    params: list[SweepParamModel]
+
+
+class SweepObjectiveModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    metric: str = Field(min_length=1, max_length=128)
+    direction: Literal["minimize", "maximize"]
+
+    @field_validator("metric")
+    @classmethod
+    def _strip_metric(cls, value: str) -> str:
+        """Validated as a non-empty bounded string and NOTHING else.
+
+        Deliberately not checked against a known-series list: the name is
+        whatever a node computes, plugins and custom nodes can log anything,
+        and at submit time no variant has run so there is nothing to check
+        against.
+        """
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("objective.metric must not be blank")
+        return stripped
+
+
+class CreateSweepRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    base_graph: dict[str, Any]
+    sweep_spec: SweepSpecModel
+    #: REQUIRED, with no default. A default of "val_loss" would produce an
+    #: all-empty ranking for the majority of graphs a user is likely to
+    #: sweep first (spec 6.5), with nothing on screen explaining why, and
+    #: `direction` cannot be inferred from a user-chosen string either.
+    objective: SweepObjectiveModel
+    #: Run options for EVERY variant, passed verbatim to normalize_options.
+    #: `objective` and `seed_variants` are top-level rather than options
+    #: keys: OPTION_KEYS is a closed set, so smuggling one in there would be
+    #: a 400 from the wrong validator with the wrong message.
+    options: Any = None
+    name: str | None = None
+    #: RULING 1. A run carrying options["seed"] takes a PROCESS-WIDE
+    #: exclusive lock, so seeding all 32 variants would serialise the sweep
+    #: regardless of the queue's concurrency AND freeze every interactive
+    #: canvas run for the sweep's whole duration.
+    seed_variants: bool = False
+
+
+# ── payload helpers ───────────────────────────────────────────────────────
+
+
+def _variant_params(compiled: CompiledSweep,
+                    variant: CompiledVariant) -> list[dict[str, Any]]:
+    """``[{node_id, param, value}]`` in DECLARED order -- which is the order
+    the CSV columns and the comparison table use."""
+    return [{"node_id": param.node_id, "param": param.param, "value": value}
+            for param, value in zip(compiled.params, variant.assignment)]
+
+
+def _placeholder_variant(compiled: CompiledSweep,
+                         variant: CompiledVariant) -> SweepVariant:
+    """The stored entry before its run exists; ``run_id`` and ``seed`` are
+    patched in as each submit returns (spec 5.2 step 7)."""
+    return SweepVariant(
+        index=variant.index, domain_index=variant.domain_index, run_id=None,
+        params=_variant_params(compiled, variant), seed=None, objective=None,
+        status=None, harvested_at=None)
+
+
+def _compiled_spec(spec: dict[str, Any],
+                   compiled: CompiledSweep) -> dict[str, Any]:
+    """The normalised spec with each param's EXPANDED domain folded in.
+
+    ``sweeps.spec`` is documented as "the compiled, normalised sweep_spec",
+    and this is what makes it so. The read side needs the expanded,
+    deduplicated domain -- it is what shows a caller that an int range
+    collapsed -- and it cannot recompute it: recompiling needs the base
+    graph, which lives only on each child's snapshot and may have been
+    pruned, and it would re-resolve every address against a registry that
+    may have changed since submit.
+    """
+    return {
+        **spec,
+        "params": [{**raw, "domain": list(param.domain),
+                    "param_type": param.param_type}
+                   for raw, param in zip(spec["params"], compiled.params)],
+    }
+
+
+def _spec_param_payload(sweep: SweepRecord) -> list[dict[str, Any]]:
+    """The swept addresses with their expanded domains, for both routes."""
+    return [{"node_id": entry.get("node_id"), "param": entry.get("param"),
+             "domain": list(entry.get("domain") or [])}
+            for entry in sweep.spec.get("params", [])]
+
+
+def _refuse_unrecordable_outputs(request: Request, options: dict[str, Any],
+                                 variant_count: int) -> None:
+    """RULE 5 of spec 5.2 -- the only one that needs the compiled count.
+
+    ``RunOutputStore`` keeps only the newest ``max_runs`` runs (20 by
+    default), so a 32-variant sweep with ``record_outputs`` on evicts its
+    own earliest variants before it finishes -- silently, with nothing
+    erroring and ``/api/execution/outputs`` simply answering nothing.
+
+    Best-effort by design: the store is shared with the canvas, so even a
+    sweep under the cap can be evicted by concurrent captures. The job here
+    is to refuse the case that CANNOT work, not to promise the rest will.
+    The bound is read from the live store rather than a literal 20, so
+    raising it raises this limit with it.
+
+    The store is absent under httpx's ASGITransport and in any embedded host
+    without one; SKIP the rule then rather than refusing -- with no output
+    store there is nothing to evict and nothing to warn about. The same
+    tolerance ``routes_runs.delete_run`` shows for the same object.
+    """
+    if not options.get("record_outputs"):
+        return
+    store = getattr(request.app.state, "run_output_store", None)
+    if store is None:
+        return
+    if variant_count > store.max_runs:
+        raise HTTPException(
+            status_code=400,
+            detail=(f"options.record_outputs cannot be used for a sweep of "
+                    f"{variant_count} variants: captured outputs are kept "
+                    f"for only the newest {store.max_runs} runs, so the "
+                    "earliest variants' outputs would be evicted before the "
+                    "sweep finished. Submit the variants you want to "
+                    "inspect as individual runs instead."))
+
+
+@router.post("", status_code=201)
+async def create_sweep(body: CreateSweepRequest, request: Request):
+    """Compile a ``sweep_spec`` into N variant graphs and queue every one.
+
+    Nothing is written until compilation has finished, and compilation is
+    pure, so every 400 below leaves no rows at all. The order of the checks
+    is the whole transaction story (spec 5.2).
+    """
+    service = _get_service(request)
+    store = _get_sweep_store(request)
+    spec = body.sweep_spec.model_dump()
+
+    # Rules 1-3: cross-field refusals the option validator cannot see.
+    # `options` may legitimately be None or a non-dict; normalize_options
+    # below is what refuses the non-dict, with its own message.
+    raw_options = body.options if isinstance(body.options, dict) else {}
+    if "seed" in raw_options:
+        raise HTTPException(
+            status_code=400,
+            detail="options.seed is owned by the sweep; set sweep_spec.seed "
+                   "and seed_variants instead")
+    if raw_options.get("lane") == LANE_INTERACTIVE:
+        raise HTTPException(
+            status_code=400,
+            detail="a sweep cannot use the interactive lane; interactive "
+                   "submits are capped at RUN_INTERACTIVE_MAX_CONCURRENT "
+                   "and refused past it, never queued")
+    if body.seed_variants and spec.get("seed") is None:
+        raise HTTPException(
+            status_code=400,
+            detail="sweep_spec.seed is required when seed_variants is true; "
+                   "the per-variant execution seeds are derived from it")
+
+    try:
+        # Rule 4, then the envelope, then the compiler. The caps are read
+        # from settings PER REQUEST, never captured into a module constant,
+        # so CODEFYUI_MAX_SWEEP_RUNS actually reaches them.
+        options = normalize_options(body.options)
+        name = normalize_name(body.name)
+        graph = normalize_graph(body.base_graph)
+        compiled = compile_sweep(
+            graph, spec,
+            max_runs=settings.MAX_SWEEP_RUNS,
+            max_params=settings.MAX_SWEEP_PARAMS,
+            max_domain=settings.MAX_SWEEP_DOMAIN)
+    except (RunSubmitError, SweepCompileError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    _refuse_unrecordable_outputs(request, options, len(compiled.variants))
+
+    # ONE capture for all N. create_run's default runs RunProvenance.capture
+    # in a thread -- two git subprocesses plus a lockfile read in project
+    # mode -- and thirty-two of those is thirty-two times the cost for one
+    # answer. tests/test_run_store.py:123-127 skips it the same way.
+    provenance = await asyncio.to_thread(RunProvenance.capture)
+
+    # The sweep row goes FIRST: exec_runs.sweep_id has an enforced foreign
+    # key, so inserting a child before its parent exists fails.
+    #
+    # The seed comes off the COMPILED sweep, not off `spec`: CompiledSweep
+    # .seed is the planner seed the sampler actually used, and reading it
+    # from there is what stops the stored seed and the sampled variant list
+    # from ever drifting apart (sweep_compiler.CompiledSweep.seed says so).
+    sweep = await store.create_sweep(
+        method=spec["method"], seed=compiled.seed,
+        seed_variants=body.seed_variants,
+        spec=_compiled_spec(spec, compiled),
+        objective=body.objective.model_dump(),
+        variants=[_placeholder_variant(compiled, variant)
+                  for variant in compiled.variants],
+        name=name)
+
+    submitted: list[dict[str, Any]] = []
+    for variant in compiled.variants:
+        variant_options = dict(options)
+        seed: int | None = None
+        if body.seed_variants:
+            # The modulo is mandatory: normalize_options rejects a seed
+            # above MAX_SEED, so a base seed near the top of the range would
+            # make late variants fail submission with an error the caller
+            # never wrote. `compiled.seed` is not None here -- rule 3 above
+            # refused that case, and the compiler records the seed verbatim.
+            # When seed_variants is off the seed stays None -- the unseeded
+            # case, which takes the SHARED exclusion and lets variants
+            # overlap up to the device's concurrency limit.
+            seed = (compiled.seed + variant.index) % (MAX_SEED + 1)
+            variant_options["seed"] = seed
+        try:
+            result = await service.submit(
+                variant.graph, options=variant_options, name=name,
+                provenance=provenance, sweep_id=sweep.id,
+                sweep_variant=variant.index)
+        except Exception as exc:
+            # The children already created are LEFT ALONE. They are real
+            # queued runs and shutdown/startup recovery retires them as
+            # `interrupted` -- visible, not vanished, per RULING 2. The
+            # sweep id goes in the body so nothing is unfindable, and the
+            # row leaves `running`: a variant with run_id None is not
+            # terminal, so without this the sweep would never settle.
+            await store.mark_failed(sweep.id, str(exc))
+            status = 503 if isinstance(exc, RunServiceUnavailable) else 500
+            raise HTTPException(
+                status_code=status,
+                detail=(f"{exc}; sweep {sweep.id} was created with "
+                        f"{len(submitted)} of {len(compiled.variants)} "
+                        "variants and is marked failed")) from exc
+        # Patched once per variant, not once at the end: a single patch at
+        # the end would lose every id if the loop broke half-way, which is
+        # precisely the case RULING 2 says must stay visible.
+        await store.set_variant_run(sweep.id, variant.index,
+                                    run_id=result.run_id, seed=seed)
+        submitted.append({
+            "index": variant.index, "domain_index": variant.domain_index,
+            "run_id": result.run_id, "status": result.status, "seed": seed,
+            "params": _variant_params(compiled, variant)})
+
+    return {
+        "sweep_id": sweep.id, "state": sweep.state, "method": sweep.method,
+        "seed": sweep.seed, "seed_variants": sweep.seed_variants,
+        "objective": sweep.objective,
+        "total_combinations": compiled.total_combinations,
+        "params": _spec_param_payload(sweep),
+        "variants": submitted,
+    }

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -150,6 +150,21 @@ class Settings(BaseSettings):
     # user in front of it who can retry, and a silently queued click looks
     # exactly like a hang.
     RUN_INTERACTIVE_MAX_CONCURRENT: int = 2
+    # ── Sweeps (#140) ──────────────────────────────────────────────────
+    # Hard ceiling on the variants ONE sweep may compile. A sweep is queued
+    # unattended, and every variant is a full graph snapshot plus a real
+    # training run: 32 is what a classroom machine can work through in a
+    # session without the queue outliving the lesson. A spec that compiles
+    # more is REFUSED, never truncated -- a silently shortened grid is a
+    # comparison table with invisible missing rows.
+    MAX_SWEEP_RUNS: int = 32
+    # Most params one sweep may vary. Four is Graph Copilot's own limit
+    # (MAX_OPTIMIZER_BINDINGS) and it is also the width past which a
+    # comparison table stops fitting on a laptop screen.
+    MAX_SWEEP_PARAMS: int = 4
+    # Most values in ONE param's domain, after range expansion and dedup.
+    # Mirrors MAX_OPTIMIZER_DOMAIN_VALUES.
+    MAX_SWEEP_DOMAIN: int = 32
     # Comma-separated extra Host-whitelist entries, e.g.
     # "192.168.1.20:8000,mybox:8000". A str, not list[str]: pydantic list
     # env vars demand JSON-in-env quote hell; split in init_allowed_hosts.

--- a/backend/app/core/migrations.py
+++ b/backend/app/core/migrations.py
@@ -216,32 +216,67 @@ MIGRATION_004 = """
 CREATE TABLE sweeps (
   id            TEXT PRIMARY KEY,   -- uuid4().hex, same shape as exec_runs.id
   name          TEXT,               -- user label. NULL = unnamed, per normalize_name
-  state         TEXT NOT NULL,      -- running|cancelling|finished|failed
+  state         TEXT NOT NULL,      -- running|cancelling|finished|failed. READ-REPAIRED,
+                                    -- never pushed: nothing wakes up to advance it, so a
+                                    -- sweep that finished while nobody was looking still
+                                    -- reads 'running' HERE until the next read, cancel or
+                                    -- prune runs the harvest. And 'failed' means the SWEEP
+                                    -- broke (the submit loop gave some variant no run at
+                                    -- all), never that the training did: a sweep whose
+                                    -- variants all failed is 'finished'. Per-variant
+                                    -- outcomes live in `variants`, not here.
   method        TEXT NOT NULL,      -- grid|random
-  seed          INTEGER,            -- the sweep's OWN planner seed. NULL only for a
-                                    -- grid sweep that sent none
-  seed_variants INTEGER NOT NULL,   -- 0/1. Per-variant EXECUTION seeds, opt-in
+  seed          INTEGER,            -- the sweep's own PLANNER seed: it selects WHICH
+                                    -- COMBINATIONS EXIST and is not by itself what seeds
+                                    -- a graph. Required for random; optional for grid,
+                                    -- which enumerates everything and so consumes none.
+                                    -- NULL only for a grid sweep that sent none -- RULING
+                                    -- 1 records it whenever there is one, because it is
+                                    -- also the base the per-variant execution seeds below
+                                    -- are derived from.
+  seed_variants INTEGER NOT NULL,   -- 0/1. Per-variant EXECUTION seeds -- the kind that
+                                    -- reach a run and seed the graph itself -- opt-in and
+                                    -- default OFF (RULING 1): seeding every variant would
+                                    -- serialise the whole sweep and stall interactive runs
+                                    -- alongside it.
   spec          TEXT NOT NULL,      -- JSON. the compiled, normalised sweep_spec
-  objective     TEXT NOT NULL,      -- JSON {"metric": str, "direction": str}
-  variants      TEXT NOT NULL,      -- JSON list, one entry per variant
+  objective     TEXT NOT NULL,      -- JSON {"metric": str, "direction": "minimize"|"maximize"}.
+                                    -- Both keys required at submit; there is NO default
+                                    -- metric and no inferred direction, and the pair is
+                                    -- immutable in v1 (re-ranking would need child series
+                                    -- that retention may already have deleted).
+  variants      TEXT NOT NULL,      -- JSON list, one entry per variant, holding that
+                                    -- variant's chosen params and its harvested objective.
+                                    -- RULING 4: this is what keeps the sweep answerable
+                                    -- after retention has deleted its children, which is
+                                    -- also why the run id inside an entry is a link that
+                                    -- MAY BE DEAD rather than a foreign key.
   error         TEXT,               -- failure summary. NULL unless state = 'failed'
   created_at    TEXT NOT NULL,      -- submit time; the list ordering key
-  finished_at   TEXT                -- NULL until state is finished or failed
+  finished_at   TEXT                -- NULL until state is finished or failed, and written
+                                    -- by the same read repair that moves `state`
 );
 -- ASC deliberately, for the reason spelled out above idx_exec_runs_created:
 -- a (created_at DESC, rowid DESC) read is served by scanning an ASC index
 -- backwards. Do not "fix" this to DESC.
 CREATE INDEX idx_sweeps_created ON sweeps(created_at);
 
--- Both columns are nullable and NULL together: NULL means "not part of a
--- sweep", the same tri-state convention git_commit / git_dirty use. A
--- `sweep_variant INTEGER NOT NULL DEFAULT 0` would be legal SQLite and
--- would tell every pre-existing run it is variant 0 of nothing.
+-- Both columns are nullable, and a writer sets both or neither: NULL means
+-- "not part of a sweep", the same NULL-is-unknown convention git_commit /
+-- git_dirty already use. A `sweep_variant INTEGER NOT NULL DEFAULT 0` would
+-- be legal SQLite and would tell every pre-existing run it is variant 0 of
+-- nothing.
+--
+-- They are NOT always NULL together once written, and a reader must not
+-- assume it: ON DELETE SET NULL clears `sweep_id` alone, so a run whose
+-- sweep row was deleted keeps its `sweep_variant`. Find a sweep's children
+-- by `sweep_id IS NOT NULL`, never by `sweep_variant IS NOT NULL`.
 --
 -- ON DELETE SET NULL, never CASCADE: deleting a sweep row must not delete
 -- run history. SQLite cannot add a UNIQUE column via ADD COLUMN, so the
 -- (sweep_id, sweep_variant) pairing is a read index, not a constraint;
--- uniqueness is the writer's job (one create_sweep assigns each index once).
+-- uniqueness is the writer's job -- the submit loop that creates a sweep's
+-- children is the only assigner, and gives out each index exactly once.
 ALTER TABLE exec_runs ADD COLUMN sweep_id TEXT
   REFERENCES sweeps(id) ON DELETE SET NULL;
 ALTER TABLE exec_runs ADD COLUMN sweep_variant INTEGER;

--- a/backend/app/core/migrations.py
+++ b/backend/app/core/migrations.py
@@ -5,7 +5,8 @@ Append-only: NEVER edit a shipped migration — add a new list entry.
 Timestamps are ISO-8601 UTC TEXT (``app.core.db.utc_now_iso``).
 
 001/002 are the Stage-2 publish subsystem; 003 is the Run Service store
-(see the naming-decision block above ``MIGRATION_003``).
+(see the naming-decision block above ``MIGRATION_003``); 004 is the sweep
+schema (#140).
 """
 
 from __future__ import annotations
@@ -187,7 +188,68 @@ CREATE TABLE exec_run_artifacts (
 CREATE INDEX idx_exec_run_artifacts_run ON exec_run_artifacts(run_id, created_at);
 """
 
-MIGRATIONS: list[str] = [MIGRATION_001, MIGRATION_002, MIGRATION_003]
+# ── Migration 004: sweeps (#140) ──────────────────────────────────────────
+#
+# A sweep is a parent of N variant runs. What is load-bearing here is that
+# the CREATE and the ALTERs ship in ONE entry -- not their order inside it.
+# Measured on SQLite 3.50.4 with PRAGMA foreign_keys=ON: both orders commit
+# and every subsequent DML behaves identically, because a REFERENCES clause
+# added by ADD COLUMN is resolved at DML time, not at DDL time. The real
+# hazard is SPLITTING them: an ALTER-only migration commits happily and then
+# every INSERT INTO exec_runs -- and, worse, every DELETE FROM exec_runs --
+# fails with "no such table: main.sweeps", forever, until the CREATE ships.
+# Measured statement by statement: SELECT succeeds, UPDATE of a non-FK
+# column succeeds, INSERT and DELETE both fail. The DELETE half is the bad
+# one: RunStore.prune's DELETE runs after EVERY run reaches a terminal state
+# (run_service.py:2005) and at every startup (main.py:364), so a split
+# migration would not merely refuse new runs -- it would raise inside
+# retention on every finishing run in the process. Do not write a test
+# asserting the ORDER matters -- both orders migrate successfully, so it
+# would fail.
+#
+# RULING 4 is why `variants` is a column and not a pointer: RunStore.prune
+# deletes finished runs after EVERY terminal transition, so a sweep that
+# only held run ids would rot into dangling references. Each variant's
+# chosen params and harvested objective live on this row; the run id stays
+# as a link that MAY BE DEAD.
+MIGRATION_004 = """
+CREATE TABLE sweeps (
+  id            TEXT PRIMARY KEY,   -- uuid4().hex, same shape as exec_runs.id
+  name          TEXT,               -- user label. NULL = unnamed, per normalize_name
+  state         TEXT NOT NULL,      -- running|cancelling|finished|failed
+  method        TEXT NOT NULL,      -- grid|random
+  seed          INTEGER,            -- the sweep's OWN planner seed. NULL only for a
+                                    -- grid sweep that sent none
+  seed_variants INTEGER NOT NULL,   -- 0/1. Per-variant EXECUTION seeds, opt-in
+  spec          TEXT NOT NULL,      -- JSON. the compiled, normalised sweep_spec
+  objective     TEXT NOT NULL,      -- JSON {"metric": str, "direction": str}
+  variants      TEXT NOT NULL,      -- JSON list, one entry per variant
+  error         TEXT,               -- failure summary. NULL unless state = 'failed'
+  created_at    TEXT NOT NULL,      -- submit time; the list ordering key
+  finished_at   TEXT                -- NULL until state is finished or failed
+);
+-- ASC deliberately, for the reason spelled out above idx_exec_runs_created:
+-- a (created_at DESC, rowid DESC) read is served by scanning an ASC index
+-- backwards. Do not "fix" this to DESC.
+CREATE INDEX idx_sweeps_created ON sweeps(created_at);
+
+-- Both columns are nullable and NULL together: NULL means "not part of a
+-- sweep", the same tri-state convention git_commit / git_dirty use. A
+-- `sweep_variant INTEGER NOT NULL DEFAULT 0` would be legal SQLite and
+-- would tell every pre-existing run it is variant 0 of nothing.
+--
+-- ON DELETE SET NULL, never CASCADE: deleting a sweep row must not delete
+-- run history. SQLite cannot add a UNIQUE column via ADD COLUMN, so the
+-- (sweep_id, sweep_variant) pairing is a read index, not a constraint;
+-- uniqueness is the writer's job (one create_sweep assigns each index once).
+ALTER TABLE exec_runs ADD COLUMN sweep_id TEXT
+  REFERENCES sweeps(id) ON DELETE SET NULL;
+ALTER TABLE exec_runs ADD COLUMN sweep_variant INTEGER;
+CREATE INDEX idx_exec_runs_sweep ON exec_runs(sweep_id, sweep_variant);
+"""
+
+MIGRATIONS: list[str] = [MIGRATION_001, MIGRATION_002, MIGRATION_003,
+                         MIGRATION_004]
 
 
 def _is_comment_only(statement: str) -> bool:

--- a/backend/app/core/run_output_store.py
+++ b/backend/app/core/run_output_store.py
@@ -53,6 +53,18 @@ class RunOutputStore:
         self._writes = 0
         self._lock = asyncio.Lock()
 
+    @property
+    def max_runs(self) -> int:
+        """The run-count bound, read-only.
+
+        A sweep refuses ``record_outputs`` when it would compile more
+        variants than this (#140, spec 8.3), read from the LIVE store rather
+        than from a literal 20 -- so raising the bound raises that limit with
+        it. Already surfaced in ``stats()``; this is the same number without
+        the async hop.
+        """
+        return self._max_runs
+
     async def put(self, run_id: str, node_id: str, port: str, value: Any) -> None:
         # Measured OUTSIDE the lock: walking a captured value is pure
         # reading, and doing it under the lock would serialise every

--- a/backend/app/core/run_service.py
+++ b/backend/app/core/run_service.py
@@ -1433,11 +1433,12 @@ class RunService:
         behaves statefully while its stored row says ``queued``.
 
         *provenance*, *sweep_id* and *sweep_variant* are passed straight
-        through to ``create_run`` and interpreted nowhere else (#140). A
-        sweep captures ONE ``RunProvenance`` and hands the same object to
-        all N variants: the default capture shells out to git twice per run
-        in project mode, and thirty-two of those is thirty-two times the
-        cost for one answer.
+        through to ``create_run``, and read here only by the lane check
+        below — which is *sweep_id*'s single other use (#140). A sweep
+        captures ONE ``RunProvenance`` and hands the same object to all N
+        variants: the default capture shells out to git twice per run in
+        project mode, and thirty-two of those is thirty-two times the cost
+        for one answer.
         """
         if self._shutting_down:
             raise RunServiceUnavailable("run service is shutting down")

--- a/backend/app/core/run_service.py
+++ b/backend/app/core/run_service.py
@@ -155,6 +155,7 @@ from .run_store import (
     STATUS_SUCCEEDED,
     EventRecord,
     MetricPoint,
+    RunProvenance,
     RunStore,
     json_safe,
 )
@@ -1402,6 +1403,9 @@ class RunService:
         options: Any = None,
         name: str | None = None,
         session: InteractiveSession | None = None,
+        provenance: RunProvenance | None = None,
+        sweep_id: str | None = None,
+        sweep_variant: int | None = None,
     ) -> SubmitResult:
         """Persist a run, then SCHEDULE it. Raises ``RunSubmitError`` on input.
 
@@ -1427,6 +1431,13 @@ class RunService:
         :class:`InteractiveSession`. Passing one on any other lane is a
         submit error rather than a silent no-op: it would mean a run that
         behaves statefully while its stored row says ``queued``.
+
+        *provenance*, *sweep_id* and *sweep_variant* are passed straight
+        through to ``create_run`` and interpreted nowhere else (#140). A
+        sweep captures ONE ``RunProvenance`` and hands the same object to
+        all N variants: the default capture shells out to git twice per run
+        in project mode, and thirty-two of those is thirty-two times the
+        cost for one answer.
         """
         if self._shutting_down:
             raise RunServiceUnavailable("run service is shutting down")
@@ -1438,6 +1449,15 @@ class RunService:
             raise RunSubmitError(
                 f"an interactive session requires lane={LANE_INTERACTIVE!r}, "
                 f"got {lane!r}")
+        if sweep_id is not None and lane == LANE_INTERACTIVE:
+            # Refused for the same reason a session on the wrong lane is:
+            # _submit_interactive admits against RUN_INTERACTIVE_MAX_CONCURRENT
+            # and REFUSES past it rather than queuing, so a 32-variant
+            # interactive sweep would be two runs and thirty 503s.
+            raise RunSubmitError(
+                f"a sweep cannot use lane={LANE_INTERACTIVE!r}; its variants "
+                "are queued, and the interactive lane refuses past its cap "
+                "instead of queuing")
         queue_key = canonical_queue_key(
             resolve_device(normalized_options.get("device")))
 
@@ -1456,6 +1476,9 @@ class RunService:
             name=normalized_name,
             status=STATUS_QUEUED,
             queue_key=queue_key,
+            provenance=provenance,
+            sweep_id=sweep_id,
+            sweep_variant=sweep_variant,
         )
         if self._shutting_down:
             # The same re-check ``_start`` makes, for the same reason and at

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -1256,7 +1256,26 @@ class RunStore:
                 # ImportError depending on which one loaded first.
                 from .sweep_store import harvest_doomed
 
-                harvest_doomed(conn, where_clause, params)
+                # Best-effort FROM RETENTION'S POINT OF VIEW, and only
+                # from there. Retention is unattended, irreversible and
+                # irreplaceable -- it is the only thing bounding this
+                # table, its cascaded children, checkpoint files and
+                # TensorBoard logdirs -- and it runs behind the run task's
+                # blanket `except Exception`, so an exception raised in
+                # here would abort the prune for EVERY run, on every later
+                # pass, and surface as one log line rather than a failed
+                # request. One unreadable `sweeps.variants` cell must not
+                # fill the user's disk. Same shape, and the same log level,
+                # as `unlink_checkpoint`/`remove_logdir` swallowing a file
+                # they could not remove: the row goes either way.
+                try:
+                    harvest_doomed(conn, where_clause, params)
+                except Exception:
+                    logger.warning(
+                        "retention: could not harvest the sweep objectives "
+                        "of the runs about to be deleted; their variants "
+                        "keep whatever was harvested before and the delete "
+                        "proceeds", exc_info=True)
                 deleted = conn.execute(
                     f"DELETE FROM exec_runs WHERE {where_clause}", params,
                 ).rowcount

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -1268,6 +1268,12 @@ class RunStore:
                 # fill the user's disk. Same shape, and the same log level,
                 # as `unlink_checkpoint`/`remove_logdir` swallowing a file
                 # they could not remove: the row goes either way.
+                #
+                # This is the BACKSTOP, not the isolation. `harvest_doomed`
+                # already catches per sweep, so one bad row costs only its
+                # own sweep its results; what is left for this to catch is
+                # the work outside that loop (the doomed SELECT and the
+                # grouping), where there is no single sweep to blame.
                 try:
                     harvest_doomed(conn, where_clause, params)
                 except Exception:

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -106,7 +106,7 @@ ARTIFACT_KIND_TENSORBOARD = "tensorboard"
 
 _RUN_COLUMNS = (
     "id, name, options, status, error, queue_key, created_at, started_at, "
-    "finished_at, git_commit, git_dirty, plugin_pins"
+    "finished_at, git_commit, git_dirty, plugin_pins, sweep_id, sweep_variant"
 )
 _METRIC_COLUMNS = "run_id, node_id, name, step, value, ts"
 _EVENT_COLUMNS = "run_id, cursor, type, payload, ts"
@@ -209,6 +209,16 @@ class RunRecord:
     git_commit: str | None
     git_dirty: bool | None
     plugin_pins: dict[str, Any] | None
+    #: The parent sweep (#140), or None for an ordinary run. Written
+    #: together by ``create_run``, but they do NOT stay a pair: the FK's
+    #: ``ON DELETE SET NULL`` clears ``sweep_id`` alone when a ``sweeps``
+    #: row is deleted and leaves ``sweep_variant`` behind, so ``sweep_id``
+    #: is the only field that answers "is this run part of a sweep". They
+    #: flow onto every run payload for free, because ``_run_payload`` is
+    #: ``dataclasses.asdict(record)`` plus four keys, which is what lets the
+    #: Runs panel group a sweep's children without a new endpoint.
+    sweep_id: str | None = None
+    sweep_variant: int | None = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "RunRecord":
@@ -232,6 +242,8 @@ class RunRecord:
             git_commit=row["git_commit"],
             git_dirty=_tri_state(row["git_dirty"]),
             plugin_pins=_loads(row["plugin_pins"]),
+            sweep_id=row["sweep_id"],
+            sweep_variant=row["sweep_variant"],
         )
 
 
@@ -402,6 +414,8 @@ class RunStore:
         queue_key: str | None = None,
         run_id: str | None = None,
         provenance: RunProvenance | None = None,
+        sweep_id: str | None = None,
+        sweep_variant: int | None = None,
     ) -> RunRecord:
         """Insert a run and return its row.
 
@@ -413,6 +427,12 @@ class RunStore:
         *provenance* defaults to a fresh ``RunProvenance.capture()`` in a
         worker thread. Pass an explicit one (even an empty
         ``RunProvenance()``) to skip the git/lockfile work.
+
+        *sweep_id* / *sweep_variant* link the run to a sweep (#140). Pass
+        both or neither: the FK is enforced (``PRAGMA foreign_keys=ON``), so
+        the ``sweeps`` row must already exist. They are a pair only at
+        INSERT time — ``ON DELETE SET NULL`` later clears ``sweep_id`` alone
+        and leaves ``sweep_variant`` behind on the orphaned row.
         """
         if status not in RUN_STATUSES:
             raise ValueError(
@@ -441,6 +461,8 @@ class RunStore:
             git_commit=provenance.git_commit,
             git_dirty=provenance.git_dirty,
             plugin_pins=_json_safe(provenance.plugin_pins),
+            sweep_id=sweep_id,
+            sweep_variant=sweep_variant,
         )
         params = (
             record.id, record.name, _dumps(graph_snapshot),
@@ -448,13 +470,15 @@ class RunStore:
             record.created_at, record.git_commit,
             None if record.git_dirty is None else int(record.git_dirty),
             None if record.plugin_pins is None else _dumps(record.plugin_pins),
+            record.sweep_id, record.sweep_variant,
         )
 
         def _insert(conn: sqlite3.Connection) -> None:
             conn.execute(
                 "INSERT INTO exec_runs (id, name, graph_snapshot, options, "
                 "status, queue_key, created_at, git_commit, git_dirty, "
-                "plugin_pins) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "plugin_pins, sweep_id, sweep_variant) VALUES "
+                "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 params,
             )
 
@@ -470,6 +494,25 @@ class RunStore:
 
         row = await self.db.run(_select)
         return None if row is None else RunRecord.from_row(row)
+
+    async def list_runs_by_sweep(self, sweep_id: str) -> list[RunRecord]:
+        """Every child of one sweep, in variant order (#140).
+
+        A NEW method rather than a composition of ``list_runs``:
+        ``_status_filter`` is the only WHERE builder ``list_runs`` has, and
+        calling one store method from inside another's ``fn(conn)`` closure
+        deadlocks on the non-reentrant lock (see the module docstring).
+
+        Served by ``idx_exec_runs_sweep (sweep_id, sweep_variant)``, so the
+        whole sweep is one index range and the ORDER BY needs no sort.
+        """
+        def _select(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+            return conn.execute(
+                f"SELECT {_RUN_COLUMNS} FROM exec_runs WHERE sweep_id = ? "
+                "ORDER BY sweep_variant", (sweep_id,),
+            ).fetchall()
+
+        return [RunRecord.from_row(row) for row in await self.db.run(_select)]
 
     async def get_graph_snapshot(self, run_id: str) -> dict[str, Any] | None:
         """The submitted graph, fetched on demand (not part of ``RunRecord``).

--- a/backend/app/core/run_store.py
+++ b/backend/app/core/run_store.py
@@ -1246,6 +1246,17 @@ class RunStore:
                         (ARTIFACT_KIND_TENSORBOARD, *params),
                     ).fetchall()
                 ]
+                # A sweep's results must outlive its children (#140,
+                # RULING 4). Deferred import, in the method body, for the
+                # reason the checkpoint and tensorboard imports below
+                # already are -- plus a real cycle: sweep_store imports
+                # TERMINAL_STATUSES from this module, which is bound AFTER
+                # this module's own imports run, so a module-level import
+                # here would find a partially-initialised module and raise
+                # ImportError depending on which one loaded first.
+                from .sweep_store import harvest_doomed
+
+                harvest_doomed(conn, where_clause, params)
                 deleted = conn.execute(
                     f"DELETE FROM exec_runs WHERE {where_clause}", params,
                 ).rowcount

--- a/backend/app/core/sweep_compiler.py
+++ b/backend/app/core/sweep_compiler.py
@@ -1,0 +1,619 @@
+"""Grid / random sweep compilation (#140) — pure, LLM-free, deterministic.
+
+Turns a ``sweep_spec`` plus a base graph into an ordered list of complete
+variant graphs. No database, no HTTP, no node execution, and the input graph
+is NEVER modified: every variant is an independent ``deepcopy`` with its
+overrides written into ``data.params``.
+
+Ported bit-exactly from Graph Copilot's browser-side planner
+(``CodefyUI-Plugin-Graph-Copilot/ui/src/agent/optimizer.ts``): ``mulberry32``
+(:307-317), ``sampleUniqueRanks`` (:319-336) and the mixed-radix decode
+``assignmentAt`` (:285-294). Range expansion and per-variant execution seeds
+have no reference implementation there and are new design (spec 2.5, 2.9).
+
+RULING 3: an address that cannot be set is REFUSED, never guessed. A preset
+instance's params live in ``data.internalParams`` and a subgraph instance's
+come from its definition, so neither is reachable by a ``{node_id, param}``
+address; both are 400s that say why.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .node_base import ParamDefinition, ParamType
+from .node_registry import registry
+
+_GRID = "grid"
+_RANDOM = "random"
+_METHODS = (_GRID, _RANDOM)
+_SCALES = ("linear", "log")
+_RANGE_TYPES = ("int", "float")
+
+#: The planner seed space, matching optimizer.ts:462-466's own bound.
+MAX_PLANNER_SEED = 0xFFFFFFFF
+
+#: The param types a sweep can enumerate (spec 3.4, check 7).
+SWEEPABLE_PARAM_TYPES = (ParamType.INT, ParamType.FLOAT, ParamType.BOOL,
+                         ParamType.STRING, ParamType.SELECT)
+
+
+class SweepCompileError(ValueError):
+    """A sweep_spec that cannot be compiled. REST maps this to 400.
+
+    Mirrors ``RunSubmitError`` (``run_service.py:435-436``), which
+    ``routes_runs.py:264-265`` maps the same way.
+    """
+
+
+def planner_prng(seed: int) -> Callable[[], int]:
+    """``createPlannerPrng`` (optimizer.ts:307-317), ported.
+
+    Returns RAW uint32 draws, not floats in ``[0, 1)``. The JS original has
+    no ``/ 4294967296`` and its only consumer is ``next() % remaining``; a
+    textbook mulberry32 that divides and multiplies back would diverge on
+    some draws, giving the same seed a different variant list.
+
+    Translation: ``x >>> 0`` is ``x & 0xFFFFFFFF``; ``Math.imul(a, b)`` is
+    ``(a * b) & 0xFFFFFFFF`` once both operands are masked non-negative.
+    """
+    state = seed & 0xFFFFFFFF
+
+    def next_uint32() -> int:
+        nonlocal state
+        state = (state + 0x6D2B79F5) & 0xFFFFFFFF
+        value = state
+        value = ((value ^ (value >> 15)) * (value | 1)) & 0xFFFFFFFF
+        value = (value ^ (value + (((value ^ (value >> 7))
+                                    * (value | 61)) & 0xFFFFFFFF))) & 0xFFFFFFFF
+        return (value ^ (value >> 14)) & 0xFFFFFFFF
+
+    return next_uint32
+
+
+def sample_unique_ranks(total: int, count: int, seed: int) -> list[int]:
+    """``count`` distinct ranks out of ``0..total-1``, in DRAW order.
+
+    Sparse Fisher-Yates (``sampleUniqueRanks``, optimizer.ts:319-336): one
+    draw per VARIANT rather than per param, so uniqueness is structural and
+    there is no draw-and-reject loop. Draw order is preserved deliberately —
+    sorting would throw away the reproducibility the pinned vectors prove.
+    """
+    nxt = planner_prng(seed)
+    swaps: dict[int, int] = {}
+    selected: list[int] = []
+    for draw_index in range(count):
+        remaining = total - draw_index
+        draw = nxt() % remaining
+        chosen = swaps.get(draw, draw)
+        last_position = remaining - 1
+        last_value = swaps.get(last_position, last_position)
+        if draw != last_position:
+            swaps[draw] = last_value
+        else:
+            swaps.pop(draw, None)
+        swaps.pop(last_position, None)
+        selected.append(chosen)
+    return selected
+
+
+@dataclass(frozen=True)
+class CompiledParam:
+    """One swept address plus its final, deduplicated, coerced domain."""
+
+    node_id: str
+    param: str
+    #: The ``ParamType`` value: "int"|"float"|"bool"|"string"|"select".
+    param_type: str
+    domain: tuple[Any, ...]
+
+
+@dataclass(frozen=True)
+class CompiledVariant:
+    """One variant: a whole, independent graph with its overrides applied."""
+
+    #: 0-based position in ``CompiledSweep.variants``.
+    index: int
+    #: Which cell of the cartesian product this is. Equal to ``index`` for a
+    #: grid; for a random sweep it is the drawn rank, recorded so a reader
+    #: can verify the draw.
+    domain_index: int
+    #: One value per ``CompiledSweep.params``, in the same order.
+    assignment: tuple[Any, ...]
+    graph: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CompiledSweep:
+    params: tuple[CompiledParam, ...]
+    variants: tuple[CompiledVariant, ...]
+    #: prod(len(p.domain)). May exceed len(variants) for a random sweep.
+    total_combinations: int
+
+
+def _round_half_away_from_zero(value: float) -> int:
+    """NOT Python's ``round``, which is banker's rounding: ``round(0.5)`` is
+    0 and ``round(2.5)`` is 2, so a batch-size domain would silently skip
+    values by a rule nobody reading the spec would predict."""
+    return math.floor(value + 0.5) if value >= 0 else math.ceil(value - 0.5)
+
+
+def _expand_range(lo: float, hi: float, count: int, scale: str,
+                  range_type: str) -> list[Any]:
+    """Spec 2.5, to the last float.
+
+    Both endpoints are pinned by EXPLICIT ASSIGNMENT after the
+    interpolation, never by trusting the arithmetic: ``10 ** log10(1e-4)``
+    is not bit-identical to ``1e-4``, and a learning-rate column reading
+    ``0.00010000000000000009`` in a classroom table is a bug report. This is
+    ``numpy.linspace``'s own endpoint discipline.
+
+    Base **10** for the log scale, not ``e``. The interpolation is
+    mathematically base-independent and NOT so in IEEE-754: the ``ln`` form
+    gives ``[0.00010000000000000009, ...]`` where ``log10`` gives
+    ``[0.0001, 0.001, 0.01, 0.1]``. The base is observable, so it is pinned.
+    """
+    if count == 1:
+        values: list[float] = [lo]
+    elif scale == "log":
+        a, b = math.log10(lo), math.log10(hi)
+        values = [10 ** (a + (b - a) * i / (count - 1)) for i in range(count)]
+        values[0], values[-1] = lo, hi
+    else:
+        values = [lo + (hi - lo) * i / (count - 1) for i in range(count)]
+        values[0], values[-1] = lo, hi
+
+    typed: list[Any] = ([_round_half_away_from_zero(v) for v in values]
+                        if range_type == "int" else list(values))
+
+    # Dedup by exact equality, first-seen order. The DEDUPLICATED length is
+    # the domain size everywhere afterwards -- a cap computed on the
+    # pre-dedup count would lie. A range that collapses is not an error:
+    # {1, 3, count 10, linear, int} genuinely has three integer points.
+    out: list[Any] = []
+    for value in typed:
+        if value not in out:
+            out.append(value)
+    return out
+
+
+def _coerce(value: Any, param_type: ParamType) -> Any | None:
+    """Spec 3.4.1's matrix. The coerced value, or None when unacceptable.
+
+    None is unambiguous as a rejection because ``null`` is not a sweepable
+    scalar in the first place (spec 2.1).
+    """
+    if param_type is ParamType.BOOL:
+        return value if isinstance(value, bool) else None
+    if param_type in (ParamType.STRING, ParamType.SELECT):
+        return value if isinstance(value, str) else None
+    if isinstance(value, bool):
+        # bool subclasses int and True == 1: without this guard `true`
+        # silently becomes the integer 1. Same rule normalize_options
+        # already applies to `seed` (run_service.py:544).
+        return None
+    if param_type is ParamType.INT:
+        if isinstance(value, int):
+            return int(value)
+        if (isinstance(value, float) and math.isfinite(value)
+                and value.is_integer()):
+            return int(value)
+        return None
+    if param_type is ParamType.FLOAT:
+        if isinstance(value, (int, float)) and math.isfinite(value):
+            return float(value)
+        return None
+    return None
+
+
+def _validate_seed(spec: dict[str, Any], method: str) -> int | None:
+    """The sweep's own PLANNER seed: it selects which combinations exist.
+
+    Required for ``random``, optional for ``grid`` (a grid enumerates
+    everything, so the seed selects nothing) — but still recorded, because
+    RULING 1 makes it the base for per-variant execution seeds. The
+    ``seed_variants`` interaction is the ROUTE's rule (spec 5.2 rule 3), not
+    this function's: the compiler never sees that flag.
+    """
+    seed = spec.get("seed")
+    if seed is None:
+        if method == _RANDOM:
+            raise SweepCompileError(
+                "sweep_spec.seed is required for method 'random' and must "
+                "be an integer from 0 to 4294967295")
+        return None
+    if isinstance(seed, bool) or not isinstance(seed, int) \
+            or not 0 <= seed <= MAX_PLANNER_SEED:
+        # Its OWN wording, not the "required for method 'random'" one: a
+        # grid sweep carrying seed=2**32 has an out-of-range seed, not a
+        # missing one.
+        raise SweepCompileError(
+            "sweep_spec.seed must be an integer from 0 to 4294967295")
+    return seed
+
+
+def _validate_samples(spec: dict[str, Any], method: str,
+                      max_runs: int) -> int | None:
+    """FORBIDDEN for a grid: on a grid `samples` could only mean truncate,
+    and a truncated grid is a table whose missing rows are invisible."""
+    samples = spec.get("samples")
+    if method == _GRID:
+        if samples is not None:
+            raise SweepCompileError(
+                "sweep_spec.samples is only allowed for method 'random'")
+        return None
+    if samples is None:
+        raise SweepCompileError(
+            "sweep_spec.samples is required for method 'random'")
+    if isinstance(samples, bool) or not isinstance(samples, int) \
+            or not 1 <= samples <= max_runs:
+        raise SweepCompileError(
+            f"sweep_spec.samples must be an integer from 1 to {max_runs}")
+    return samples
+
+
+def _validated_range(i: int, spec: Any, *, max_domain: int) -> list[Any]:
+    if not isinstance(spec, dict):
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}] needs either 'values' or 'range'")
+    lo, hi = spec.get("min"), spec.get("max")
+    if not all(isinstance(v, (int, float)) and not isinstance(v, bool)
+               and math.isfinite(v) for v in (lo, hi)):
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}].range bounds must be finite numbers")
+    count = spec.get("count")
+    if isinstance(count, bool) or not isinstance(count, int) \
+            or not 1 <= count <= max_domain:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}].range.count must be an integer from 1 "
+            f"to {max_domain}")
+    if hi < lo:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}].range.max must be >= range.min")
+    scale = spec.get("scale")
+    if scale not in _SCALES:
+        raise SweepCompileError(
+            f"unknown range scale {scale!r}; expected 'linear' or 'log'")
+    range_type = spec.get("type")
+    if range_type not in _RANGE_TYPES:
+        raise SweepCompileError(
+            f"unknown range type {range_type!r}; expected 'int' or 'float'")
+    if scale == "log" and lo <= 0:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}].range needs a positive min for a log "
+            "scale (log of 0 or a negative number is undefined)")
+    if range_type == "int" and not (float(lo).is_integer()
+                                    and float(hi).is_integer()):
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}].range needs whole-number bounds for "
+            "type 'int'")
+    return _expand_range(float(lo), float(hi), count, scale, range_type)
+
+
+def _raw_domain(i: int, entry: dict[str, Any], *,
+                max_domain: int) -> list[Any]:
+    """The pre-coercion domain. Runs for EVERY param before any address is
+    resolved, so a NaN is refused with the envelope message naming
+    ``values[j]`` rather than with a type message (spec 3.4.1)."""
+    values = entry.get("values")
+    range_spec = entry.get("range")
+    if values is not None and range_spec is not None:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}] may not carry both 'values' and 'range'")
+    if values is None and range_spec is None:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}] needs either 'values' or 'range'")
+    if values is None:
+        return _validated_range(i, range_spec, max_domain=max_domain)
+
+    if not isinstance(values, list) or not 1 <= len(values) <= max_domain:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}].values must contain 1 to {max_domain} "
+            "values")
+    for j, value in enumerate(values):
+        if value is None or isinstance(value, (list, dict)):
+            raise SweepCompileError(
+                f"sweep_spec.params[{i}].values must contain only numbers, "
+                "booleans or strings")
+        if isinstance(value, (int, float)) and not math.isfinite(value):
+            # A non-finite passes every other check and then corrupts things
+            # quietly: RunStore._dumps rewrites it to null in the stored
+            # snapshot, and Starlette's JSONResponse renders with
+            # allow_nan=False, so a survivor wedges every later read of the
+            # sweep with a 500 inside the renderer.
+            raise SweepCompileError(
+                f"sweep_spec.params[{i}].values[{j}] must be a finite "
+                "number; NaN and Infinity are not sweepable")
+    return list(values)
+
+
+def _node_index(base_graph: dict[str, Any]) -> dict[str, list[dict]]:
+    """Every addressable node keyed by id, ids mapping to a LIST.
+
+    NON-DICT entries are SKIPPED rather than indexed. ``normalize_graph``
+    (``run_service.py:619-655``) validates that ``nodes`` is a non-empty
+    list and nothing about its contents, so ``{"nodes": ["x"]}`` reaches
+    here intact; ``node["id"]`` on a ``str`` raises ``TypeError``, which on
+    an in-request compiler is an uncaught 500 on a surface that promises
+    400s. A non-dict entry simply matches no ``node_id``, which is the
+    honest answer -- the graph really does not contain an addressable node
+    with that id.
+
+    Values are lists so check 1 can tell one node from two: a ``node_id``
+    over a duplicated id would set one node and leave the other alone, with
+    no way to say which (the hazard ``secret_params.py:37-41`` names).
+    """
+    out: dict[str, list[dict]] = {}
+    for node in base_graph.get("nodes") or []:
+        if isinstance(node, dict) and isinstance(node.get("id"), str):
+            out.setdefault(node["id"], []).append(node)
+    return out
+
+
+def _coerced_domain(i: int, node_id: str, param_name: str,
+                    definition: ParamDefinition, domain: list[Any], *,
+                    from_values: bool) -> list[Any]:
+    """Checks 8-10, in the order spec 3.4.1 rule 4 fixes: coerce every
+    value, THEN duplicates, THEN bounds.
+
+    Duplicates first would reintroduce the ``1 == True`` collision; bounds
+    first would compare a bound against a value the sweep will not use.
+    Coercion is what makes a domain type-homogeneous, which is what makes
+    the exact-equality dedup correct.
+    """
+    address = f"{node_id}.{param_name}"
+    coerced: list[Any] = []
+    for value in domain:
+        out = _coerce(value, definition.param_type)
+        if out is None:
+            raise SweepCompileError(
+                f"sweep_spec.params[{i}]: '{address}' is a "
+                f"{definition.param_type.value} param but the domain "
+                f"contains {value!r}")
+        if definition.param_type is ParamType.SELECT \
+                and out not in definition.options:
+            raise SweepCompileError(
+                f"sweep_spec.params[{i}]: '{address}' does not accept "
+                f"{out!r}; its options are {definition.options}")
+        coerced.append(out)
+
+    if from_values:
+        # A range that collapses is arithmetic and is deduped (spec 2.5
+        # step 3); a hand-written list that repeats a value is a typo the
+        # caller can fix.
+        seen: list[Any] = []
+        for value in coerced:
+            if value in seen:
+                raise SweepCompileError(
+                    f"sweep_spec.params[{i}].values repeats {value!r}; "
+                    "list each value once")
+            seen.append(value)
+
+    if definition.param_type in (ParamType.INT, ParamType.FLOAT):
+        for value in coerced:
+            if definition.min_value is not None \
+                    and value < definition.min_value:
+                raise SweepCompileError(
+                    f"sweep_spec.params[{i}]: '{address}' must be >= "
+                    f"{definition.min_value}, got {value}")
+            if definition.max_value is not None \
+                    and value > definition.max_value:
+                raise SweepCompileError(
+                    f"sweep_spec.params[{i}]: '{address}' must be <= "
+                    f"{definition.max_value}, got {value}")
+    return coerced
+
+
+def _compile_param(i: int, entry: dict[str, Any], domain: list[Any],
+                   index: dict[str, list[dict]]) -> CompiledParam:
+    """Checks 1-10 of spec 3.4 for one address. RULING 3 lives here."""
+    node_id = entry.get("node_id")
+    param_name = entry.get("param")
+    matches = index.get(node_id, []) if isinstance(node_id, str) else []
+    if not matches:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}]: no node with id {node_id!r} in "
+            "base_graph")
+    if len(matches) > 1:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}]: base_graph has {len(matches)} nodes "
+            f"with id {node_id!r}; ids must be unique for a sweep to "
+            "address them")
+    node = matches[0]
+
+    data = node.get("data")
+    if data is not None and not isinstance(data, dict):
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}]: node {node_id!r} has no 'data' object "
+            "to set params on")
+    stored = (data or {}).get("params")
+    if stored is not None and not isinstance(stored, dict):
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}]: node {node_id!r} has a 'data.params' "
+            "that is not an object")
+
+    node_type = node.get("type")
+    if isinstance(node_type, str) and node_type.startswith("preset:"):
+        # A preset node's inner params live in
+        # data.internalParams[<inner id>][<param>] (graph_engine.py:102);
+        # writing data.params[name] on the preset node reaches nothing.
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}]: node {node_id!r} is a preset "
+            "instance; its inner params live in data.internalParams, which "
+            "a {node_id, param} address cannot reach")
+    if isinstance(node_type, str) and node_type.startswith("subgraph:"):
+        # graph_engine.py:466-467: "Params ride along verbatim from the
+        # definition. v1 has no per-instance overrides".
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}]: node {node_id!r} is a subgraph "
+            "instance; a subgraph's params come from its definition and "
+            "cannot be overridden per instance")
+
+    node_cls = registry.get(node_type) if isinstance(node_type, str) else None
+    if node_cls is None:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}]: node {node_id!r} has type "
+            f"{node_type!r}, which is not a known node type; a sweep can "
+            "only set params on registered nodes")
+
+    definition = next((p for p in node_cls.define_params()
+                       if p.name == param_name), None)
+    if definition is None:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}]: node {node_id!r} (type {node_type!r}) "
+            f"has no param named {param_name!r}")
+    if definition.param_type is ParamType.SECRET:
+        # RULING 4 stores each variant's chosen params on the DURABLE sweeps
+        # row, so a swept secret would be written there in the clear --
+        # while every other persisting path scrubs it.
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}]: '{node_id}.{param_name}' is a secret "
+            "parameter and cannot be swept")
+    if definition.param_type not in SWEEPABLE_PARAM_TYPES:
+        raise SweepCompileError(
+            f"sweep_spec.params[{i}]: '{node_id}.{param_name}' has param "
+            f"type '{definition.param_type.value}', which a sweep cannot "
+            "enumerate")
+
+    return CompiledParam(
+        node_id=node_id, param=param_name,
+        param_type=definition.param_type.value,
+        domain=tuple(_coerced_domain(
+            i, node_id, param_name, definition, domain,
+            from_values=entry.get("values") is not None)))
+
+
+def _assignment_at(params: tuple[CompiledParam, ...],
+                   domain_index: int) -> tuple[Any, ...]:
+    """Mixed-radix decode (``assignmentAt``, optimizer.ts:285-294).
+
+    The LAST-declared param varies fastest and the first varies slowest --
+    row-major / C order -- so a comparison table is reproducible from the
+    spec alone. The cartesian product is never materialised as tuples.
+    """
+    values: list[Any] = [None] * len(params)
+    remainder = domain_index
+    for i in range(len(params) - 1, -1, -1):
+        domain = params[i].domain
+        values[i] = domain[remainder % len(domain)]
+        remainder //= len(domain)
+    return tuple(values)
+
+
+def _build_variant(base_graph: dict[str, Any],
+                   params: tuple[CompiledParam, ...],
+                   index: int, domain_index: int) -> CompiledVariant:
+    """One independent deep copy with its overrides written in.
+
+    The base graph is NEVER modified: deepcopy first, then write — the same
+    contract ``split_graph_secrets`` states (``secret_params.py:388-392``).
+    The compiler must NOT pre-scrub secrets: ``RunService.submit`` runs
+    ``normalize_graph`` and ``split_graph_secrets`` on each copy itself.
+    """
+    assignment = _assignment_at(params, domain_index)
+    graph = copy.deepcopy(base_graph)
+    nodes = {node["id"]: node for node in graph["nodes"]
+             if isinstance(node, dict) and isinstance(node.get("id"), str)}
+    for param, value in zip(params, assignment):
+        node = nodes[param.node_id]      # present: check 1 used this filter
+        data = node.get("data")
+        if not isinstance(data, dict):
+            # An explicit "data": null passes check 2 as "absent", so
+            # setdefault alone would call a method on None.
+            data = {}
+            node["data"] = data
+        stored = data.get("params")
+        if not isinstance(stored, dict):
+            stored = {}
+            data["params"] = stored
+        stored[param.param] = value
+    return CompiledVariant(index=index, domain_index=domain_index,
+                           assignment=assignment, graph=graph)
+
+
+def compile_sweep(base_graph: dict[str, Any], spec: dict[str, Any], *,
+                  max_runs: int, max_params: int,
+                  max_domain: int) -> CompiledSweep:
+    """Validate, expand and enumerate. Raises ``SweepCompileError`` (-> 400).
+
+    Pure: nothing is written anywhere and ``base_graph`` is not touched, so
+    a 400 never leaves a partial sweep behind.
+
+    The caps are PASSED IN rather than read from ``settings`` here, so a
+    caller states the policy it is enforcing and a test can override it --
+    the rule ``QueueLimits.from_settings`` follows for the same reason
+    (``run_service.py:383-397``).
+    """
+    method = spec.get("method")
+    if method not in _METHODS:
+        raise SweepCompileError(
+            f"unknown sweep method {method!r}; expected 'grid' or 'random'")
+
+    raw_params = spec.get("params")
+    if not isinstance(raw_params, list) \
+            or not 1 <= len(raw_params) <= max_params:
+        raise SweepCompileError(
+            f"sweep_spec.params must contain 1 to {max_params} entries")
+
+    seed = _validate_seed(spec, method)
+    samples = _validate_samples(spec, method, max_runs)
+
+    # Phase 1: the envelope, for every param, before any address exists.
+    seen: set[tuple[Any, Any]] = set()
+    domains: list[list[Any]] = []
+    for i, entry in enumerate(raw_params):
+        if not isinstance(entry, dict):
+            raise SweepCompileError(
+                f"sweep_spec.params[{i}] needs either 'values' or 'range'")
+        address = (entry.get("node_id"), entry.get("param"))
+        if address in seen:
+            raise SweepCompileError(
+                f"sweep_spec.params[{i}] repeats the address "
+                f"'{address[0]}.{address[1]}'; each address may appear once")
+        seen.add(address)
+        domains.append(_raw_domain(i, entry, max_domain=max_domain))
+
+    # Phase 2: resolve each address, then coerce against its ParamDefinition.
+    index = _node_index(base_graph)
+    params = tuple(_compile_param(i, raw_params[i], domains[i], index)
+                   for i in range(len(raw_params)))
+
+    total = 1
+    for param in params:
+        total *= len(param.domain)
+
+    if method == _RANDOM:
+        assert samples is not None      # _validate_samples guarantees it
+        if samples > total:
+            raise SweepCompileError(
+                f"sweep_spec.samples asks for {samples} distinct "
+                f"combinations but the search space has only {total}")
+        variant_count = samples
+    else:
+        variant_count = total
+
+    # Checked BEFORE any variant is built, so a 10x10x10 grid costs one
+    # multiplication rather than a thousand deep copies. Never truncate: a
+    # truncated grid is a table whose missing rows are invisible.
+    if variant_count > max_runs:
+        raise SweepCompileError(
+            f"sweep would compile {variant_count} variants but "
+            f"MAX_SWEEP_RUNS is {max_runs}; narrow the domains or lower "
+            "'samples' instead of truncating the sweep")
+
+    if method == _RANDOM:
+        # Draw order, NOT sorted order -- that is what the pinned vectors
+        # prove, and sorting would throw the proof away. No baseline shift:
+        # optimizer.ts:474-475's remap exists only to skip a baseline slot,
+        # and v1 has no baseline (spec 3.1).
+        domain_indices = sample_unique_ranks(total, samples, seed or 0)
+    else:
+        domain_indices = list(range(total))
+
+    variants = tuple(_build_variant(base_graph, params, i, domain_index)
+                     for i, domain_index in enumerate(domain_indices))
+    return CompiledSweep(params=params, variants=variants,
+                         total_combinations=total)

--- a/backend/app/core/sweep_compiler.py
+++ b/backend/app/core/sweep_compiler.py
@@ -187,6 +187,31 @@ def _expand_range(lo: float, hi: float, count: int, scale: str,
     return out
 
 
+def _is_finite_number(value: Any) -> bool:
+    """Is this number usable at all -- a finite float, or an int a float can
+    hold?
+
+    ``math.isfinite`` alone is not enough, and the gap is reachable from an
+    ordinary JSON body. Python ints are UNBOUNDED, so ``json.loads`` parses a
+    400-digit integer literal into an ``int`` no float can represent, and
+    ``math.isfinite`` then RAISES ``OverflowError: int too large to convert
+    to float`` rather than returning False. On an in-request compiler that is
+    an uncaught 500 on a surface whose whole contract is that a bad spec is a
+    400 -- the integer sibling of the ``json.loads("1e999")`` case spec 2.7
+    already refuses by design, and the same class as a non-dict node entry.
+
+    Callers refuse with the SPEC'S EXISTING non-finite message rather than a
+    dedicated "too large" one: a caller does not need to know whether their
+    number was too big or not a number, only that it cannot be used. This is
+    the single finiteness predicate for the module, so every entry point --
+    both envelope checks and the type matrix -- is covered by construction.
+    """
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False
+
+
 def _coerce(value: Any, param_type: ParamType) -> Any | None:
     """Spec 3.4.1's matrix. The coerced value, or None when unacceptable.
 
@@ -205,12 +230,14 @@ def _coerce(value: Any, param_type: ParamType) -> Any | None:
     if param_type is ParamType.INT:
         if isinstance(value, int):
             return int(value)
-        if (isinstance(value, float) and math.isfinite(value)
+        if (isinstance(value, float) and _is_finite_number(value)
                 and value.is_integer()):
             return int(value)
         return None
     if param_type is ParamType.FLOAT:
-        if isinstance(value, (int, float)) and math.isfinite(value):
+        # _is_finite_number, not math.isfinite: this is also what stops the
+        # float(value) below raising OverflowError on an unbounded int.
+        if isinstance(value, (int, float)) and _is_finite_number(value):
             return float(value)
         return None
     return None
@@ -268,7 +295,7 @@ def _validated_range(i: int, spec: Any, *, max_domain: int) -> list[Any]:
             f"sweep_spec.params[{i}] needs either 'values' or 'range'")
     lo, hi = spec.get("min"), spec.get("max")
     if not all(isinstance(v, (int, float)) and not isinstance(v, bool)
-               and math.isfinite(v) for v in (lo, hi)):
+               and _is_finite_number(v) for v in (lo, hi)):
         raise SweepCompileError(
             f"sweep_spec.params[{i}].range bounds must be finite numbers")
     count = spec.get("count")
@@ -325,7 +352,7 @@ def _raw_domain(i: int, entry: dict[str, Any], *,
             raise SweepCompileError(
                 f"sweep_spec.params[{i}].values must contain only numbers, "
                 "booleans or strings")
-        if isinstance(value, (int, float)) and not math.isfinite(value):
+        if isinstance(value, (int, float)) and not _is_finite_number(value):
             # A non-finite passes every other check and then corrupts things
             # quietly: RunStore._dumps rewrites it to null in the stored
             # snapshot, and Starlette's JSONResponse renders with

--- a/backend/app/core/sweep_compiler.py
+++ b/backend/app/core/sweep_compiler.py
@@ -132,6 +132,13 @@ class CompiledSweep:
     variants: tuple[CompiledVariant, ...]
     #: prod(len(p.domain)). May exceed len(variants) for a random sweep.
     total_combinations: int
+    #: The PLANNER seed, exactly as ``_validate_seed`` accepted it: the seed
+    #: that drove the sampling for a ``random`` sweep, whatever the caller
+    #: sent for a ``grid``, and None when a grid sent nothing. RULING 1
+    #: records it either way, and the route fills ``sweeps.seed`` from HERE
+    #: rather than re-reading ``spec["seed"]`` -- so the seed the sampler
+    #: used and the seed the row stores cannot drift apart.
+    seed: int | None
 
 
 def _round_half_away_from_zero(value: float) -> int:
@@ -616,4 +623,4 @@ def compile_sweep(base_graph: dict[str, Any], spec: dict[str, Any], *,
     variants = tuple(_build_variant(base_graph, params, i, domain_index)
                      for i, domain_index in enumerate(domain_indices))
     return CompiledSweep(params=params, variants=variants,
-                         total_combinations=total)
+                         total_combinations=total, seed=seed)

--- a/backend/app/core/sweep_store.py
+++ b/backend/app/core/sweep_store.py
@@ -27,10 +27,11 @@ from __future__ import annotations
 import json
 import sqlite3
 from dataclasses import dataclass, replace
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 from uuid import uuid4
 
 from .db import Database, transaction, utc_now_iso
+from .run_store import TERMINAL_STATUSES
 
 # ── state vocabulary ──────────────────────────────────────────────────────
 #
@@ -309,3 +310,209 @@ class SweepStore:
                 (state, sweep_id, SWEEP_STATE_FAILED)).rowcount
 
         return await self.db.run(_update) > 0
+
+    async def harvest(self, sweep_id: str, *,
+                      entries: Mapping[int, HarvestEntry],
+                      finished: bool) -> SweepRecord | None:
+        """Seam A: patch harvested objectives in and settle the state.
+
+        SELECT-patch-UPDATE inside ONE ``fn(conn)``, which is atomic against
+        every other database operation in the process. Returns the row as it
+        now stands, so a caller never needs a second read.
+
+        Safe against a race with a finishing run because of ``_finalize``'s
+        documented ordering: metrics are flushed with ``force=True`` BEFORE
+        the terminal event and before ``mark_finished``, so by the time a
+        row reads terminal its series are durable.
+        """
+        stamp = utc_now_iso()
+
+        def _patch(conn: sqlite3.Connection) -> SweepRecord | None:
+            with transaction(conn):
+                record = _select_sweep(conn, sweep_id)
+                if record is None:
+                    return None
+                _write_variants(
+                    conn, record,
+                    _apply_entries(record.variants, entries, stamp),
+                    finished=finished, stamp=stamp)
+                return _select_sweep(conn, sweep_id)
+
+        return await self.db.run(_patch)
+
+
+# ── the harvest (spec 6.3) ────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class HarvestEntry:
+    """What one terminal child contributes to its sweep row."""
+
+    objective: float | None
+    status: str
+
+
+def variant_is_terminal(variant: SweepVariant, child_status: str | None, *,
+                        child_exists: bool) -> bool:
+    """Spec 4.3's "terminal outcome", defined ONCE and used by both seams.
+
+    True when the variant has **no reachable run** (``run_id`` is None — the
+    failed-submit-loop case — or its row is gone and it was never
+    harvested), or it carries a harvested terminal status, or its live child
+    row is terminal.
+
+    The no-reachable-run clause is load-bearing: without it a variant whose
+    run someone deleted by hand would keep its sweep at ``running`` forever.
+    """
+    if variant.run_id is None:
+        return True
+    if variant.status is not None:
+        return True
+    if not child_exists:
+        return True
+    return child_status in TERMINAL_STATUSES
+
+
+def rank_variants(
+    variants: Sequence[SweepVariant], *, direction: str,
+) -> list[tuple[SweepVariant, int | None]]:
+    """``(variant, rank)`` in DISPLAY order — best first, then the rest.
+
+    Rankable means ``objective is not None``. Note the important
+    NON-exclusion: a **failed** variant that did log the objective before it
+    died IS ranked, on the value it reached — hiding a real number because
+    the run ended badly is the silent disappearance #140's third acceptance
+    criterion forbids.
+
+    Ties break on ``index`` **ascending** in both directions, so the order is
+    total and the table does not reshuffle between polls. Unrankable
+    variants keep their row with ``rank`` None and are appended in ``index``
+    order — never dropped, and never sorted as if None were a number.
+    """
+    sign = -1 if direction == "maximize" else 1
+    rankable = sorted((v for v in variants if v.objective is not None),
+                      key=lambda v: (sign * v.objective, v.index))
+    unranked = sorted((v for v in variants if v.objective is None),
+                      key=lambda v: v.index)
+    return ([(variant, i + 1) for i, variant in enumerate(rankable)]
+            + [(variant, None) for variant in unranked])
+
+
+def _apply_entries(variants: Sequence[SweepVariant],
+                   entries: Mapping[int, HarvestEntry],
+                   stamp: str) -> list[SweepVariant]:
+    """Patch harvested values in. Already-harvested variants are left alone,
+    which is what makes both seams idempotent."""
+    return [
+        replace(variant, objective=entries[variant.index].objective,
+                status=entries[variant.index].status, harvested_at=stamp)
+        if variant.index in entries and variant.harvested_at is None
+        else variant
+        for variant in variants
+    ]
+
+
+def _write_variants(conn: sqlite3.Connection, record: SweepRecord,
+                    variants: Sequence[SweepVariant], *, finished: bool,
+                    stamp: str) -> None:
+    """One UPDATE: the patched blob plus, when the sweep has just become
+    finished, its terminal state.
+
+    ``failed`` is NEVER overwritten, ``finished`` is never re-stamped, and a
+    sweep in ``cancelling`` lands on ``finished`` — the cancel is over once
+    nothing is active.
+    """
+    state = record.state
+    finished_at = record.finished_at
+    if finished and state not in (SWEEP_STATE_FAILED, SWEEP_STATE_FINISHED):
+        state = SWEEP_STATE_FINISHED
+        finished_at = finished_at or stamp
+    conn.execute(
+        "UPDATE sweeps SET variants = ?, state = ?, finished_at = ? "
+        "WHERE id = ?",
+        (_dumps([v.as_json() for v in variants]), state, finished_at,
+         record.id))
+
+
+def _last_metric_value(conn: sqlite3.Connection, run_id: str,
+                       name: str | None) -> float | None:
+    """The LAST point of one series.
+
+    ``ORDER BY step DESC, id DESC LIMIT 1`` is the identical rule
+    ``RunStore.latest_metrics`` uses (``_LATEST_METRICS_SQL``), so seam A
+    and seam B can never disagree about a variant's objective. Covered by
+    ``idx_exec_run_metrics_series``, so this is one seek per doomed child.
+
+    A NULL value is a non-finite point (a diverged loss) and reads back as
+    None — exactly as ``latest_metrics`` omits that series.
+    """
+    if not name:
+        return None
+    row = conn.execute(
+        "SELECT value FROM exec_run_metrics WHERE run_id = ? AND name = ? "
+        "ORDER BY step DESC, id DESC LIMIT 1", (run_id, name)).fetchone()
+    return None if row is None else row["value"]
+
+
+def harvest_doomed(conn: sqlite3.Connection, where_clause: str,
+                   params: tuple) -> int:
+    """Seam B: copy the final objective + status of every run about to be
+    deleted into its sweep row. Returns how many variants were harvested.
+
+    Runs INSIDE the caller's transaction and takes a CONNECTION, never a
+    ``Database``: a second ``Database.run`` here would deadlock on the
+    non-reentrant lock (``run_store``'s module docstring). A function
+    operating on an already-open connection does not violate that rule.
+
+    *where_clause* and *params* are ``RunStore.prune``'s own, verbatim, and
+    this runs immediately before its DELETE — the same discipline the
+    checkpoint-path read already uses, so a row cannot become eligible
+    between the two statements and be seen by one and deleted by the other.
+    **Retention cannot delete a child its sweep has not already harvested.**
+
+    Covers retention ONLY. ``DELETE /api/runs/{id}`` calls ``delete_run``,
+    not ``prune``, so a hand-deleted child that no read had harvested loses
+    its objective; the design then reports that variant honestly as
+    ``missing`` with a null objective (spec 10.12 files the fix).
+    """
+    doomed = conn.execute(
+        "SELECT id, sweep_id, sweep_variant, status FROM exec_runs "
+        f"WHERE {where_clause} AND sweep_id IS NOT NULL", params).fetchall()
+    if not doomed:
+        return 0
+
+    doomed_ids = {row["id"] for row in doomed}
+    by_sweep: dict[str, list[sqlite3.Row]] = {}
+    for row in doomed:
+        by_sweep.setdefault(row["sweep_id"], []).append(row)
+
+    stamp = utc_now_iso()
+    harvested = 0
+    for sweep_id, rows in by_sweep.items():
+        record = _select_sweep(conn, sweep_id)
+        if record is None:
+            continue
+        metric = record.objective.get("metric")
+        entries = {
+            row["sweep_variant"]: HarvestEntry(
+                objective=_last_metric_value(conn, row["id"], metric),
+                status=row["status"])
+            for row in rows if row["sweep_variant"] is not None
+        }
+        patched = _apply_entries(record.variants, entries, stamp)
+        # Every child that will STILL EXIST after the DELETE. The doomed
+        # ones are excluded on purpose: they are terminal by definition
+        # (prune never deletes an active run) and they have just been
+        # harvested, so `variant.status is not None` already answers for
+        # them.
+        live = {row["id"]: row["status"] for row in conn.execute(
+            "SELECT id, status FROM exec_runs WHERE sweep_id = ?",
+            (sweep_id,)) if row["id"] not in doomed_ids}
+        finished = all(
+            variant_is_terminal(variant, live.get(variant.run_id),
+                                child_exists=variant.run_id in live)
+            for variant in patched)
+        _write_variants(conn, record, patched, finished=finished,
+                        stamp=stamp)
+        harvested += len(entries)
+    return harvested

--- a/backend/app/core/sweep_store.py
+++ b/backend/app/core/sweep_store.py
@@ -1,0 +1,311 @@
+"""Durable sweep rows (#140) — the parent of a set of variant runs.
+
+Built to ``run_store``'s rules, for the same reasons: every method goes
+through ``Database.run``; each method is individually atomic; **methods do
+not compose** — calling one from inside another's ``fn(conn)`` closure
+deadlocks on the non-reentrant lock (``run_store``'s module docstring).
+Reads return frozen dataclasses, never ``sqlite3.Row``.
+
+RULING 4: this row OWNS its results. ``RunStore.prune`` deletes finished
+runs after every terminal transition and at startup, so a sweep that only
+pointed at run ids would rot into dangling references. Each variant's chosen
+params and harvested objective live here; the run id stays as a link that
+MAY BE DEAD.
+
+``variants`` is a JSON list on the row rather than a ``sweep_variants``
+table: ``MAX_SWEEP_RUNS`` bounds it at 32 entries, this codebase already
+stores bounded structured JSON in a column (``options``, ``plugin_pins``,
+``exec_run_artifacts.meta``), and ranking 32 rows happens in Python, not SQL.
+The cost is that a harvest is a read-modify-write of the whole array — safe
+because ``Database.run`` is one connection on one worker thread behind one
+``asyncio.Lock``, so a SELECT-patch-UPDATE inside a SINGLE ``fn(conn)`` is
+atomic against every other database operation in the process.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, replace
+from typing import Any, Sequence
+from uuid import uuid4
+
+from .db import Database, transaction, utc_now_iso
+
+# ── state vocabulary ──────────────────────────────────────────────────────
+#
+# Enforced in Python, the way RUN_STATUSES is: `sweeps.state` carries no SQL
+# CHECK constraint, following exec_runs.status' own policy (SQLite cannot
+# ALTER one away).
+#
+# There is deliberately no `cancelled`. A sweep is a CONTAINER, not a run:
+# collapsing 32 outcomes into one word loses the only information a
+# comparison table exists to show, and a sweep where 30 variants finished and
+# 2 were stopped is not "a cancelled sweep". Per-variant detail lives in
+# variants[].status.
+SWEEP_STATE_RUNNING = "running"
+SWEEP_STATE_CANCELLING = "cancelling"
+SWEEP_STATE_FINISHED = "finished"
+SWEEP_STATE_FAILED = "failed"
+SWEEP_STATES: frozenset[str] = frozenset({
+    SWEEP_STATE_RUNNING, SWEEP_STATE_CANCELLING,
+    SWEEP_STATE_FINISHED, SWEEP_STATE_FAILED,
+})
+
+_SWEEP_COLUMNS = (
+    "id, name, state, method, seed, seed_variants, spec, objective, "
+    "variants, error, created_at, finished_at"
+)
+
+
+def _dumps(value: Any) -> str:
+    """JSON for a sweep column. ``allow_nan=False`` deliberately.
+
+    Nothing that reaches this row may be non-finite: the compiler refuses a
+    NaN domain value at the door (spec 2.7) and a non-finite metric is
+    stored as SQL NULL and read back as None. If one ever did arrive, a
+    loud failure here beats ``_json_safe``'s silent rewrite to ``null`` in a
+    DURABLE row that nothing deletes.
+    """
+    return json.dumps(value, ensure_ascii=False, allow_nan=False)
+
+
+@dataclass(frozen=True)
+class SweepVariant:
+    """One entry of ``sweeps.variants``. Everything here is JSON-safe."""
+
+    #: 0-based; the variant's position in the list.
+    index: int
+    #: Which cell of the cartesian product this is.
+    domain_index: int
+    #: The child run. None only if creation failed part-way (spec 5.2).
+    run_id: str | None
+    #: [{"node_id":.., "param":.., "value":..}] in declared order.
+    params: list[dict[str, Any]]
+    #: The EXECUTION seed, when seed_variants is on. RULING 1.
+    seed: int | None
+    #: Harvested final objective. None = absent.
+    objective: float | None
+    #: HARVESTED terminal status. None = not harvested yet. NOT the same
+    #: field as a response's "status", which prefers the child's LIVE status
+    #: and falls back to this one.
+    status: str | None
+    #: ISO-8601 Z. None = not harvested yet. This is what stops a variant
+    #: that legitimately produced no objective from being re-read forever:
+    #: "harvested, no value" is a recorded fact, not a retry.
+    harvested_at: str | None
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "index": self.index, "domain_index": self.domain_index,
+            "run_id": self.run_id, "params": self.params, "seed": self.seed,
+            "objective": self.objective, "status": self.status,
+            "harvested_at": self.harvested_at,
+        }
+
+    @classmethod
+    def from_json(cls, raw: dict[str, Any]) -> "SweepVariant":
+        return cls(
+            index=raw["index"], domain_index=raw["domain_index"],
+            run_id=raw.get("run_id"), params=list(raw.get("params") or []),
+            seed=raw.get("seed"), objective=raw.get("objective"),
+            status=raw.get("status"), harvested_at=raw.get("harvested_at"),
+        )
+
+
+@dataclass(frozen=True)
+class SweepRecord:
+    """One ``sweeps`` row."""
+
+    id: str
+    name: str | None
+    state: str
+    method: str
+    seed: int | None
+    seed_variants: bool
+    spec: dict[str, Any]
+    objective: dict[str, Any]
+    variants: list[SweepVariant]
+    error: str | None
+    created_at: str
+    finished_at: str | None
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "SweepRecord":
+        variants = json.loads(row["variants"])
+        if not isinstance(variants, list):
+            # `or []` would quietly turn a corrupt value into a plausible
+            # empty sweep; an explicit check keeps damage loud, the rule
+            # RunRecord.from_row applies to `options`.
+            raise ValueError(
+                f"sweeps.variants for sweep {row['id']!r} is "
+                f"{type(variants).__name__}, expected a JSON array")
+        return cls(
+            id=row["id"], name=row["name"], state=row["state"],
+            method=row["method"], seed=row["seed"],
+            seed_variants=bool(row["seed_variants"]),
+            spec=json.loads(row["spec"]),
+            objective=json.loads(row["objective"]),
+            variants=[SweepVariant.from_json(v) for v in variants],
+            error=row["error"], created_at=row["created_at"],
+            finished_at=row["finished_at"],
+        )
+
+
+def _select_sweep(conn: sqlite3.Connection,
+                  sweep_id: str) -> SweepRecord | None:
+    """One row, off an already-open connection.
+
+    A plain function, not a method: it is called both from ``SweepStore``'s
+    own ``Database.run`` closures and from ``harvest_doomed``, which runs
+    inside ``RunStore.prune``'s transaction and must never open a second
+    ``Database.run``.
+    """
+    row = conn.execute(
+        f"SELECT {_SWEEP_COLUMNS} FROM sweeps WHERE id = ?",
+        (sweep_id,)).fetchone()
+    return None if row is None else SweepRecord.from_row(row)
+
+
+@dataclass
+class SweepStore:
+    """Typed CRUD over the ``sweeps`` table.
+
+    Holds no state beyond the ``Database`` it was handed, so it is safe to
+    construct per request or once on ``app.state`` — the same contract
+    ``RunStore`` states.
+    """
+
+    db: Database
+
+    async def create_sweep(
+        self,
+        *,
+        method: str,
+        seed: int | None,
+        seed_variants: bool,
+        spec: dict[str, Any],
+        objective: dict[str, Any],
+        variants: Sequence[SweepVariant],
+        name: str | None = None,
+        sweep_id: str | None = None,
+    ) -> SweepRecord:
+        """Insert a sweep and return its row, ``state='running'``.
+
+        The sweep row is written BEFORE its children: ``exec_runs.sweep_id``
+        has an enforced foreign key, so inserting a child first fails with
+        ``FOREIGN KEY constraint failed``.
+
+        *variants* carry ``run_id: None`` placeholders; the caller patches
+        each id in with :meth:`set_variant_run` as its submit returns.
+
+        **Each variant's ``index`` is assigned here, not taken on trust,
+        and this method is the only place that can be.** MIGRATION_004
+        spells out why: SQLite cannot add a UNIQUE column via
+        ``ADD COLUMN``, so ``(sweep_id, sweep_variant)`` is a read index and
+        not a constraint — the database will store two variant 3s without a
+        murmur, ``set_variant_run`` would then write one run id into both,
+        and two children would answer to the same ``sweep_variant``. There
+        is nothing below this line that would notice. Deriving the value
+        from the position is not a guess: spec 4.2 defines ``index`` AS the
+        entry's position in the list, which makes a duplicate unrepresentable
+        rather than merely detectable. ``domain_index`` — which cell of the
+        cartesian product this is — is the caller's own datum and is left
+        exactly as handed in.
+        """
+        record = SweepRecord(
+            id=sweep_id or uuid4().hex,
+            name=name,
+            state=SWEEP_STATE_RUNNING,
+            method=method,
+            seed=seed,
+            seed_variants=bool(seed_variants),
+            spec=spec,
+            objective=objective,
+            variants=[replace(v, index=i) for i, v in enumerate(variants)],
+            error=None,
+            created_at=utc_now_iso(),
+            finished_at=None,
+        )
+        params = (
+            record.id, record.name, record.state, record.method, record.seed,
+            int(record.seed_variants), _dumps(record.spec),
+            _dumps(record.objective),
+            _dumps([v.as_json() for v in record.variants]),
+            record.created_at,
+        )
+
+        def _insert(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                "INSERT INTO sweeps (id, name, state, method, seed, "
+                "seed_variants, spec, objective, variants, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", params)
+
+        await self.db.run(_insert)
+        return record
+
+    async def get_sweep(self, sweep_id: str) -> SweepRecord | None:
+        return await self.db.run(
+            lambda conn: _select_sweep(conn, sweep_id))
+
+    async def set_variant_run(self, sweep_id: str, index: int, *,
+                              run_id: str, seed: int | None) -> bool:
+        """Patch one variant's ``run_id`` and execution ``seed``.
+
+        Called once per variant as its submit returns, rather than once at
+        the end: patching in one call would lose every id if the loop broke
+        half-way, which is precisely the case RULING 2 says must stay
+        visible. Thirty-two small writes is milliseconds.
+
+        False when the sweep or the index does not exist.
+        """
+        def _patch(conn: sqlite3.Connection) -> bool:
+            with transaction(conn):
+                record = _select_sweep(conn, sweep_id)
+                if record is None:
+                    return False
+                patched = [replace(v, run_id=run_id, seed=seed)
+                           if v.index == index else v
+                           for v in record.variants]
+                if patched == record.variants:
+                    return False
+                conn.execute(
+                    "UPDATE sweeps SET variants = ? WHERE id = ?",
+                    (_dumps([v.as_json() for v in patched]), sweep_id))
+                return True
+
+        return await self.db.run(_patch)
+
+    async def mark_failed(self, sweep_id: str, error: str) -> bool:
+        """The submit loop broke part-way: some variants have no run at all.
+
+        ``failed`` on a sweep means something went wrong with the SWEEP, not
+        with the training — a sweep whose variants all failed is
+        ``finished``, with the detail in ``variants[].status``.
+        """
+        def _update(conn: sqlite3.Connection) -> int:
+            return conn.execute(
+                "UPDATE sweeps SET state = ?, error = ?, finished_at = ? "
+                "WHERE id = ?",
+                (SWEEP_STATE_FAILED, error, utc_now_iso(), sweep_id),
+            ).rowcount
+
+        return await self.db.run(_update) > 0
+
+    async def set_state(self, sweep_id: str, state: str) -> bool:
+        """Move the sweep to *state*. False when nothing changed.
+
+        Guarded on ``state != 'failed'``: a cancel must never overwrite a
+        failed submit loop's record of what went wrong.
+        """
+        if state not in SWEEP_STATES:
+            raise ValueError(
+                f"unknown sweep state {state!r}; expected one of "
+                f"{sorted(SWEEP_STATES)}")
+
+        def _update(conn: sqlite3.Connection) -> int:
+            return conn.execute(
+                "UPDATE sweeps SET state = ? WHERE id = ? AND state != ?",
+                (state, sweep_id, SWEEP_STATE_FAILED)).rowcount
+
+        return await self.db.run(_update) > 0

--- a/backend/app/core/sweep_store.py
+++ b/backend/app/core/sweep_store.py
@@ -25,6 +25,7 @@ atomic against every other database operation in the process.
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from dataclasses import dataclass, replace
 from typing import Any, Mapping, Sequence
@@ -32,6 +33,8 @@ from uuid import uuid4
 
 from .db import Database, transaction, utc_now_iso
 from .run_store import TERMINAL_STATUSES
+
+logger = logging.getLogger(__name__)
 
 # ── state vocabulary ──────────────────────────────────────────────────────
 #
@@ -375,17 +378,19 @@ def variant_is_terminal(variant: SweepVariant, child_status: str | None, *,
     whose run someone deleted by hand would keep its sweep at ``running``
     forever.
 
-    **A variant with no ``run_id`` at all is NOT terminal**, and that is a
-    deliberate narrowing of spec 4.3, whose "no reachable run" wording also
-    covered it. During ``POST /api/sweeps`` the later variants legitimately
-    carry ``run_id: null`` until the submit loop reaches them, and a prune
-    fires on the same event loop after every run finishes — so counting
-    them as done stamps a sweep ``finished`` on its first child, and
-    ``_write_variants`` never re-stamps a sweep that already reads
-    ``finished``. The wrong answer would be permanent. The submit loop
-    BREAKING is the other case, and it does not need this clause: spec 5.2
-    has the route call :meth:`SweepStore.mark_failed` itself, and neither
-    seam ever overwrites ``failed``.
+    **A variant with no ``run_id`` at all is NOT terminal** (spec 4.3, as
+    corrected during this task — the earlier "no reachable run" wording
+    covered it and that was a real bug). During ``POST /api/sweeps`` the
+    later variants legitimately carry ``run_id: null`` until the submit loop
+    reaches them, and a prune fires on the same event loop after every run
+    finishes — so counting them as done stamps a sweep ``finished`` on its
+    first child, and ``_write_variants`` never re-stamps a sweep that
+    already reads ``finished``. The wrong answer would be permanent. The
+    submit loop BREAKING is the other case, and it does not need this
+    clause: spec 5.2 has the route call :meth:`SweepStore.mark_failed`
+    itself, and neither seam ever overwrites ``failed``. That makes it a
+    DUTY on the route — a submit loop that neither fills in every ``run_id``
+    nor calls ``mark_failed`` leaves its sweep at ``running`` for good.
 
     The harvested-status check comes FIRST so a variant seam B harvested by
     ``sweep_variant`` before its ``set_variant_run`` landed still counts.
@@ -523,30 +528,58 @@ def harvest_doomed(conn: sqlite3.Connection, where_clause: str,
     stamp = utc_now_iso()
     harvested = 0
     for sweep_id, rows in by_sweep.items():
-        record = _select_sweep(conn, sweep_id)
-        if record is None:
-            continue
-        metric = record.objective.get("metric")
-        entries = {
-            row["sweep_variant"]: HarvestEntry(
-                objective=_last_metric_value(conn, row["id"], metric),
-                status=row["status"])
-            for row in rows if row["sweep_variant"] is not None
-        }
-        patched = _apply_entries(record.variants, entries, stamp)
-        # Every child that will STILL EXIST after the DELETE. The doomed
-        # ones are excluded on purpose: they are terminal by definition
-        # (prune never deletes an active run) and they have just been
-        # harvested, so `variant.status is not None` already answers for
-        # them.
-        live = {row["id"]: row["status"] for row in conn.execute(
-            "SELECT id, status FROM exec_runs WHERE sweep_id = ?",
-            (sweep_id,)) if row["id"] not in doomed_ids}
-        finished = all(
-            variant_is_terminal(variant, live.get(variant.run_id),
-                                child_exists=variant.run_id in live)
-            for variant in patched)
-        _write_variants(conn, record, patched, finished=finished,
-                        stamp=stamp)
-        harvested += len(entries)
+        # ISOLATED PER SWEEP. `prune` sweeps the whole table in one pass, so
+        # the sweeps in this loop have nothing to do with one another: one
+        # unreadable `variants` cell must cost its own sweep its results and
+        # NOTHING ELSE. Catching one level up instead would keep retention
+        # alive but unwind the loop, and every healthy sweep in the pass
+        # would lose the numbers RULING 4 exists to preserve while its
+        # children were deleted in the same transaction. The DELETE proceeds
+        # either way: retention is unattended and irreplaceable, and must
+        # never be blocked by bookkeeping.
+        try:
+            harvested += _harvest_one_sweep(conn, sweep_id, rows, doomed_ids,
+                                            stamp)
+        except Exception:
+            logger.warning(
+                "retention: could not harvest sweep %s, so its variants keep "
+                "whatever was harvested before; every other sweep in this "
+                "pass is unaffected and the delete proceeds", sweep_id,
+                exc_info=True)
     return harvested
+
+
+def _harvest_one_sweep(conn: sqlite3.Connection, sweep_id: str,
+                       rows: Sequence[sqlite3.Row], doomed_ids: set[str],
+                       stamp: str) -> int:
+    """One sweep's share of seam B; returns how many entries it harvested.
+
+    Split out so :func:`harvest_doomed` can isolate a failure to the sweep
+    that caused it. The only write is the single ``_write_variants`` UPDATE
+    at the end, so a sweep that raises anywhere above leaves its row exactly
+    as it was rather than half-patched.
+    """
+    record = _select_sweep(conn, sweep_id)
+    if record is None:
+        return 0
+    metric = record.objective.get("metric")
+    entries = {
+        row["sweep_variant"]: HarvestEntry(
+            objective=_last_metric_value(conn, row["id"], metric),
+            status=row["status"])
+        for row in rows if row["sweep_variant"] is not None
+    }
+    patched = _apply_entries(record.variants, entries, stamp)
+    # Every child that will STILL EXIST after the DELETE. The doomed ones
+    # are excluded on purpose: they are terminal by definition (prune never
+    # deletes an active run) and they have just been harvested, so
+    # `variant.status is not None` already answers for them.
+    live = {row["id"]: row["status"] for row in conn.execute(
+        "SELECT id, status FROM exec_runs WHERE sweep_id = ?",
+        (sweep_id,)) if row["id"] not in doomed_ids}
+    finished = all(
+        variant_is_terminal(variant, live.get(variant.run_id),
+                            child_exists=variant.run_id in live)
+        for variant in patched)
+    _write_variants(conn, record, patched, finished=finished, stamp=stamp)
+    return len(entries)

--- a/backend/app/core/sweep_store.py
+++ b/backend/app/core/sweep_store.py
@@ -53,6 +53,19 @@ SWEEP_STATES: frozenset[str] = frozenset({
     SWEEP_STATE_FINISHED, SWEEP_STATE_FAILED,
 })
 
+# The objective's ranking direction, enforced the same way and in the same
+# place, so a route validating the submitted field imports this rather than
+# re-spelling the two strings. There is no default and none is inferred:
+# spec 6.2 requires the field because `val_loss` and `val_accuracy` are both
+# plausible objectives and rank in OPPOSITE directions, and guessing from a
+# user-chosen series name is exactly the heuristic that would be wrong
+# silently.
+SWEEP_DIRECTION_MINIMIZE = "minimize"
+SWEEP_DIRECTION_MAXIMIZE = "maximize"
+SWEEP_DIRECTIONS: frozenset[str] = frozenset({
+    SWEEP_DIRECTION_MINIMIZE, SWEEP_DIRECTION_MAXIMIZE,
+})
+
 _SWEEP_COLUMNS = (
     "id, name, state, method, seed, seed_variants, spec, objective, "
     "variants, error, created_at, finished_at"
@@ -356,18 +369,31 @@ def variant_is_terminal(variant: SweepVariant, child_status: str | None, *,
                         child_exists: bool) -> bool:
     """Spec 4.3's "terminal outcome", defined ONCE and used by both seams.
 
-    True when the variant has **no reachable run** (``run_id`` is None — the
-    failed-submit-loop case — or its row is gone and it was never
-    harvested), or it carries a harvested terminal status, or its live child
-    row is terminal.
+    True when the variant carries a harvested terminal status, or its run
+    row is **gone** (spec 5.3's ``missing``), or its live child row is
+    terminal. The gone-row clause is load-bearing: without it a variant
+    whose run someone deleted by hand would keep its sweep at ``running``
+    forever.
 
-    The no-reachable-run clause is load-bearing: without it a variant whose
-    run someone deleted by hand would keep its sweep at ``running`` forever.
+    **A variant with no ``run_id`` at all is NOT terminal**, and that is a
+    deliberate narrowing of spec 4.3, whose "no reachable run" wording also
+    covered it. During ``POST /api/sweeps`` the later variants legitimately
+    carry ``run_id: null`` until the submit loop reaches them, and a prune
+    fires on the same event loop after every run finishes — so counting
+    them as done stamps a sweep ``finished`` on its first child, and
+    ``_write_variants`` never re-stamps a sweep that already reads
+    ``finished``. The wrong answer would be permanent. The submit loop
+    BREAKING is the other case, and it does not need this clause: spec 5.2
+    has the route call :meth:`SweepStore.mark_failed` itself, and neither
+    seam ever overwrites ``failed``.
+
+    The harvested-status check comes FIRST so a variant seam B harvested by
+    ``sweep_variant`` before its ``set_variant_run`` landed still counts.
     """
-    if variant.run_id is None:
-        return True
     if variant.status is not None:
         return True
+    if variant.run_id is None:
+        return False
     if not child_exists:
         return True
     return child_status in TERMINAL_STATUSES
@@ -388,8 +414,16 @@ def rank_variants(
     total and the table does not reshuffle between polls. Unrankable
     variants keep their row with ``rank`` None and are appended in ``index``
     order — never dropped, and never sorted as if None were a number.
+
+    An unrecognised *direction* RAISES, as ``set_state`` does for its own
+    vocabulary. Falling back to minimize would present the worst variant of
+    a ``maximize`` sweep as the best one, with nothing on screen to say so.
     """
-    sign = -1 if direction == "maximize" else 1
+    if direction not in SWEEP_DIRECTIONS:
+        raise ValueError(
+            f"unknown sweep direction {direction!r}; expected one of "
+            f"{sorted(SWEEP_DIRECTIONS)}")
+    sign = -1 if direction == SWEEP_DIRECTION_MAXIMIZE else 1
     rankable = sorted((v for v in variants if v.objective is not None),
                       key=lambda v: (sign * v.objective, v.index))
     unranked = sorted((v for v in variants if v.objective is None),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,6 +56,7 @@ from .api import (
     routes_plugins,
     routes_presets,
     routes_runs,
+    routes_sweeps,
     routes_system,
     ws_execution,
 )
@@ -91,6 +92,7 @@ from .core.preset_registry import preset_registry
 from .core.run_output_store import RunOutputStore
 from .core.run_service import RunService
 from .core.run_store import RunStore
+from .core.sweep_store import SweepStore
 
 logger = logging.getLogger(__name__)
 
@@ -350,6 +352,11 @@ async def lifespan(app: FastAPI):
         retention_keep_last=settings.RUN_RETENTION_KEEP_LAST,
     )
     app.state.run_service = run_service
+    # Sweeps (#140) read and write their own table through the same
+    # Database. Built here, next to the run service, only so the routes can
+    # 503 honestly when it is absent -- the lifespan does not run under
+    # httpx's ASGITransport, and tests set app.state directly.
+    app.state.sweep_store = SweepStore(db)
     # Order matters. Recovery FIRST: nothing resumes a `running` row after a
     # restart, and retention never deletes an active run — so an abandoned
     # one would keep its events and metrics forever. Retiring it is what
@@ -563,6 +570,7 @@ app.include_router(routes_data_files.router)
 app.include_router(routes_execution_outputs.router)
 app.include_router(routes_execution_state.router)
 app.include_router(routes_runs.router)
+app.include_router(routes_sweeps.router)
 app.include_router(routes_packs.router)
 app.include_router(routes_system.router)
 app.include_router(routes_llm.router)

--- a/backend/tests/test_api_sweeps.py
+++ b/backend/tests/test_api_sweeps.py
@@ -16,6 +16,7 @@ independent.
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 import threading
 import time
 from typing import Any
@@ -430,23 +431,24 @@ async def test_the_route_captures_provenance_once_for_the_whole_sweep(
     assert {c.git_commit for c in children} == {"sweep-sentinel"}
 
 
-def _raise_on_nth(real: Any, *, n: int) -> Any:
-    """Wrap ``RunService.submit`` so its *n*th call raises instead.
+def _raise_on_nth(real: Any, *, n: int,
+                  error: BaseException | None = None) -> Any:
+    """Wrap an async method so its *n*th call raises instead of running.
 
-    Calls before *n* run the REAL submit, so they create genuine queued rows
-    -- the point of the test is what happens to children that already
-    exist.
+    Calls before *n* run the REAL method, so they land genuine rows -- what
+    both callers are about is the work that already succeeded.
     """
     calls = 0
 
-    async def _submit(self: RunService, *args: Any, **kwargs: Any) -> Any:
+    async def _wrapped(self: Any, *args: Any, **kwargs: Any) -> Any:
         nonlocal calls
         calls += 1
         if calls == n:
-            raise RunServiceUnavailable("run service is shutting down")
+            raise (error if error is not None else
+                   RunServiceUnavailable("run service is shutting down"))
         return await real(self, *args, **kwargs)
 
-    return _submit
+    return _wrapped
 
 
 async def test_the_submit_loop_failing_part_way_leaves_a_failed_sweep(
@@ -506,6 +508,44 @@ async def test_the_submit_loop_failing_part_way_leaves_a_failed_sweep(
         release_filler.set()
 
 
+async def test_a_store_failure_while_patching_a_run_id_still_fails_the_sweep(
+        client, store, sweep_store, db, monkeypatch):
+    """The patch is the loop's THIRD exit, and it needs the same duty.
+
+    `set_variant_run` runs AFTER its variant's child was created, so a store
+    fault there used to leave the loop having neither filled in every run id
+    nor marked the sweep failed -- and a run_id-None variant is not terminal
+    (spec 4.3), so the row sat at `running` with no seam able to settle it.
+    A transient fault is real here: one write can fail and the next succeed.
+    """
+    monkeypatch.setattr(
+        SweepStore, "set_variant_run",
+        _raise_on_nth(SweepStore.set_variant_run, n=2,
+                      error=sqlite3.OperationalError("database is locked")))
+    response = await client.post("/api/sweeps", json=_body(
+        _values("lr", [0.001, 0.002, 0.003])))
+    assert response.status_code == 500, response.text   # not RunService-shaped
+    detail = response.json()["detail"]
+    assert "1 of 3 variants" in detail
+
+    rows = db._conn.execute("SELECT id FROM sweeps").fetchall()
+    assert len(rows) == 1
+    sweep_id = rows[0][0]
+    assert sweep_id in detail
+
+    record = await sweep_store.get_sweep(sweep_id)
+    assert record is not None
+    assert record.state == "failed"          # NOT still "running"
+    assert record.error
+    assert record.finished_at is not None
+    # Variant 1's PATCH is what failed, so the row under-reports it ...
+    assert [v.run_id is not None for v in record.variants] == [
+        True, False, False]
+    # ... while its child still exists and stays findable by sweep_id.
+    children = await store.list_runs_by_sweep(sweep_id)
+    assert [c.sweep_variant for c in children] == [0, 1]
+
+
 async def test_seed_variants_off_leaves_every_variant_unseeded(client, store):
     """RULING 1: an unseeded run takes the SHARED exclusion and overlaps up
     to the device limit. A seeded one takes a process-wide exclusive lock."""
@@ -553,6 +593,39 @@ async def test_the_interactive_lane_is_refused(client, db):
     assert response.status_code == 400
     assert "interactive lane" in response.json()["detail"]
     assert db._conn.execute("SELECT COUNT(*) FROM sweeps").fetchone()[0] == 0
+
+
+async def test_a_padded_interactive_lane_is_refused_before_any_row(client, db):
+    """normalize_options STRIPS `lane`, so comparing the RAW string lets
+    " interactive " walk past this rule, normalise INTO the interactive lane
+    and be refused only by submit's own guard inside the loop -- a 500 plus a
+    permanent `failed` sweeps row, where the rule promises a 400 and no rows
+    at all. Nothing in v1 deletes a sweeps row, so that one is forever.
+    """
+    response = await client.post("/api/sweeps", json=_body(
+        _values("lr", [0.1]),
+        options={"device": "cpu", "lane": " interactive "}))
+    assert response.status_code == 400, response.text
+    assert "interactive lane" in response.json()["detail"]
+    assert db._conn.execute("SELECT COUNT(*) FROM sweeps").fetchone()[0] == 0
+    assert db._conn.execute(
+        "SELECT COUNT(*) FROM exec_runs").fetchone()[0] == 0
+
+
+async def test_an_unrecognised_lane_label_queues_instead_of_being_refused(
+        client, store):
+    """The rule strips but must NOT lowercase, because normalize_options does
+    not lowercase either: an unrecognised lane label QUEUES rather than
+    bypassing (run_service.py:242-244), so "Interactive" is an ordinary
+    queued sweep and refusing it would refuse a legal one. Here to stop the
+    strip from being "fixed" into a casefold.
+    """
+    response = await client.post("/api/sweeps", json=_body(
+        _values("lr", [0.1]),
+        options={"device": "cpu", "lane": "Interactive"}))
+    assert response.status_code == 201, response.text
+    children = await store.list_runs_by_sweep(response.json()["sweep_id"])
+    assert [c.options["lane"] for c in children] == ["Interactive"]
 
 
 async def test_seed_variants_without_a_seed_is_refused(client, db):

--- a/backend/tests/test_api_sweeps.py
+++ b/backend/tests/test_api_sweeps.py
@@ -1,0 +1,607 @@
+"""Tests for /api/sweeps — the Sweep v1 REST surface (#140).
+
+#140's acceptance criteria at the level a user actually meets them (HTTP),
+on top of the compiler- and store-level versions in test_sweeps.py. Two test
+names deliberately appear in both modules —
+`test_a_failed_variant_that_logged_the_objective_is_still_ranked` and
+`test_a_diverged_variant_is_unranked` — because the property is worth
+proving at both levels; test_sweeps.py's are unit tests over `rank_variants`
+and these run a real graph through the queue.
+
+The probe node and the gate machinery are DUPLICATED from test_run_queue.py
+on purpose, the way test_api_runs.py duplicates its own: test modules stay
+independent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import settings
+from app.core import run_service as run_service_module
+from app.core.auth import TOKEN_HEADER, session_token
+from app.core.db import Database
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.node_registry import registry
+from app.core.run_service import QueueLimits, RunService, RunServiceUnavailable
+from app.core.run_store import RunProvenance, RunStore
+from app.core.sweep_store import SweepStore
+from app.main import app
+
+BASE_URL = f"http://127.0.0.1:{settings.PORT}"
+
+
+# ── the probe node (a trimmed copy of test_run_queue.py's) ────────────────
+
+
+class _Probe:
+    """Start order and per-variant gates. Mutated from ENGINE WORKER
+    THREADS, hence the lock."""
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.started: list[str] = []
+        self.gates: dict[str, tuple[threading.Event, threading.Event]] = {}
+
+    def enter(self, label: str) -> None:
+        with self.lock:
+            self.started.append(label)
+
+    def hold(self, label: str) -> threading.Event:
+        """Register *label* to block on a gate instead of returning.
+
+        A gate, never a sleep: the test controls exactly when a run may
+        finish, deterministically, rather than sizing a sleep against
+        wall-clock timing on a loaded runner. Must be called BEFORE the run
+        is submitted -- the node looks its label up on entry.
+        """
+        entered, release = threading.Event(), threading.Event()
+        self.gates[label] = (entered, release)
+        return release
+
+    async def wait_entered(self, label: str, timeout: float = 5.0) -> None:
+        """Block until *label*'s node has actually reached its hold point.
+
+        Runs the wait in a THREAD: this is awaited from the test's own
+        coroutine, which runs on the event loop, and the node's dispatch
+        chain needs that same loop to keep turning to reach the gate at all.
+        A direct Event.wait would deadlock against the thing it waits for.
+        """
+        entered, _release = self.gates[label]
+        if not await asyncio.to_thread(entered.wait, timeout):
+            raise AssertionError(
+                f"{label!r} never reached its hold point within {timeout}s")
+
+
+_probe = _Probe()
+
+
+class _SweepProbeNode(BaseNode):
+    """Logs ``val_loss = lr * 10 + weight_decay`` — a KNOWN function of the
+    swept params, which is what lets a ranking test assert the exact winner
+    instead of "some ordering happened".
+
+    The shipped examples cannot stand in for this (spec 6.5): only two wire
+    a val_dataloader at all and both are heavyweight.
+    """
+
+    NODE_NAME = "_SweepProbe"
+    CATEGORY = "Test"
+    DESCRIPTION = "Logs val_loss derived from its swept params"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(name="lr", param_type=ParamType.FLOAT,
+                            default=0.001, min_value=0.0, max_value=1.0),
+            ParamDefinition(name="weight_decay", param_type=ParamType.FLOAT,
+                            default=0.0),
+            ParamDefinition(name="silent", param_type=ParamType.BOOL,
+                            default=False),
+            ParamDefinition(name="diverge", param_type=ParamType.BOOL,
+                            default=False),
+            ParamDefinition(name="fail", param_type=ParamType.BOOL,
+                            default=False),
+            # A free-text param, so the CSV test can sweep a value that
+            # LOOKS LIKE A FORMULA. An explicitly enumerated values list on
+            # a string param is a legitimate domain, not a search over
+            # strings (spec 3.4.1).
+            ParamDefinition(name="note", param_type=ParamType.STRING,
+                            default=""),
+            ParamDefinition(name="api_key", param_type=ParamType.SECRET,
+                            default=""),
+        ]
+
+    def execute(self, inputs: dict[str, Any], params: dict[str, Any], *,
+                context: Any = None) -> dict[str, Any]:
+        # The engine injects the ExecutionContext when and only when the
+        # parameter is NAMED `context` (graph_engine.py:1576-1577).
+        lr = float(params.get("lr", 0.001))
+        weight_decay = float(params.get("weight_decay", 0.0))
+        label = _label(lr, weight_decay)
+        _probe.enter(label)
+        gate = _probe.gates.get(label)
+        if gate is not None:
+            entered, release = gate
+            entered.set()
+            # Bounded as a safety net only: a test that forgets to release
+            # should fail loudly, not hang the suite.
+            if not release.wait(timeout=10.0):
+                raise TimeoutError(f"probe hold for {label!r} never released")
+        if context is not None and not params.get("silent"):
+            value = (float("nan") if params.get("diverge")
+                     else lr * 10 + weight_decay)
+            context.log_metric("val_loss", value, step=0)
+            context.log_metric("train_loss", value * 2, step=0)
+        if params.get("fail"):
+            # AFTER the log_metric above: a failed variant that DID log the
+            # objective must still be rankable (AC 3).
+            raise RuntimeError("probe failed on purpose")
+        return {"value": inputs.get("value")}
+
+
+def _label(lr: float, weight_decay: float = 0.0) -> str:
+    """The gate key. Distinct per variant because a sweep's whole point is
+    that its variants differ in exactly these numbers."""
+    return f"lr={lr},wd={weight_decay}"
+
+
+_TEST_NODES = {"_SweepProbe": _SweepProbeNode}
+
+
+@pytest.fixture(autouse=True)
+def _register_test_nodes():
+    registry._nodes.update(_TEST_NODES)
+    yield
+    for name in _TEST_NODES:
+        registry._nodes.pop(name, None)
+
+
+@pytest.fixture(autouse=True)
+def probe():
+    """A clean probe per test. Returned so a test can read it directly."""
+    global _probe
+    _probe = _Probe()
+    return _probe
+
+
+@pytest.fixture(autouse=True)
+def fake_devices(monkeypatch):
+    """Every device string resolves to itself.
+
+    resolve_device degrades cuda/mps to cpu on a machine without them, which
+    on CI collapses every queue into one and makes the FIFO assertions
+    vacuous. Patching is honest here: the scheduler only ever handles the
+    result as an opaque string.
+    """
+    monkeypatch.setattr(
+        run_service_module, "resolve_device",
+        lambda requested: (requested or "cpu").strip().lower() or "cpu")
+    monkeypatch.setattr(run_service_module, "_current_cuda_index",
+                        lambda: 0)
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = Database(tmp_path / "codefyui.db")
+    database.connect()
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+@pytest.fixture
+def store(db):
+    return RunStore(db)
+
+
+@pytest.fixture
+def sweep_store(db):
+    return SweepStore(db)
+
+
+@pytest.fixture
+async def make_service(store, db, sweep_store):
+    """Build services with explicit limits, wire app.state, drain them all.
+
+    Limits are passed in rather than read from settings so a test states the
+    policy it is testing. The lifespan does not run under ASGITransport, so
+    app.state is set here (main.py:326-328 is the precedent) and torn down
+    in the REAL order: drain the service, then close the database.
+    """
+    built: list[RunService] = []
+
+    def _make(*, cpu: int = 2, gpu: int = 1, interactive: int = 2,
+              shutdown_grace_s: float = 5.0, **kwargs: Any) -> RunService:
+        service = RunService(
+            store, shutdown_grace_s=shutdown_grace_s,
+            limits=QueueLimits(cpu=cpu, gpu=gpu, interactive=interactive,
+                               overrides=()),
+            **kwargs)
+        built.append(service)
+        app.state.db = db
+        app.state.run_service = service
+        app.state.sweep_store = sweep_store
+        return service
+
+    try:
+        yield _make
+    finally:
+        for service in built:
+            await service.shutdown()
+        for attribute in ("db", "run_service", "sweep_store"):
+            if hasattr(app.state, attribute):
+                delattr(app.state, attribute)
+
+
+@pytest.fixture
+async def service(make_service):
+    return make_service()
+
+
+@pytest.fixture
+async def client(service):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url=BASE_URL,
+        headers={TOKEN_HEADER: session_token()},
+    ) as http:
+        yield http
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _graph(**params: Any) -> dict[str, Any]:
+    """Start --trigger--> _TestSource --value--> _SweepProbe."""
+    return {
+        "nodes": [
+            {"id": "start", "type": "Start", "data": {"params": {}}},
+            {"id": "src", "type": "_TestSource",
+             "data": {"params": {"val": "hi"}}},
+            {"id": "probe", "type": "_SweepProbe", "data": {"params": params}},
+        ],
+        "edges": [
+            {"id": "et", "source": "start", "target": "src",
+             "sourceHandle": "trigger", "type": "trigger"},
+            {"id": "e1", "source": "src", "target": "probe",
+             "sourceHandle": "value", "targetHandle": "value"},
+        ],
+    }
+
+
+def _values(param: str, values: list[Any]) -> dict[str, Any]:
+    return {"node_id": "probe", "param": param, "values": values}
+
+
+def _body(*params: dict[str, Any], graph: dict[str, Any] | None = None,
+          **overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "base_graph": graph if graph is not None else _graph(),
+        "sweep_spec": {"method": "grid", "params": list(params)},
+        "objective": {"metric": "val_loss", "direction": "minimize"},
+        "options": {"device": "cpu"},
+        "name": "lr sweep",
+    }
+    body.update(overrides)
+    return body
+
+
+async def _await_terminal(store: RunStore, run_id: str, *,
+                          timeout: float = 15.0):
+    """Poll the STORE (never the in-process registry) until the row is
+    done."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        record = await store.get_run(run_id)
+        assert record is not None, f"run {run_id} vanished"
+        if record.finished_at is not None:
+            return record
+        await asyncio.sleep(0.02)
+    raise AssertionError(f"run {run_id} did not finish within {timeout}s")
+
+
+# ── auth / openapi surface (spec 9.6) ─────────────────────────────────────
+
+
+def test_sweeps_routes_are_not_under_an_auth_exempt_prefix():
+    """/api/sweeps relies on auth_guard, so it must NOT be prefix-exempt —
+    otherwise its two POSTs would sail through with no auth at all. The
+    exemption exists for /api/apps and /api/keys, which carry per-route
+    dependencies instead."""
+    from app.main import _prefix_exempt
+
+    for path in ("/api/sweeps", "/api/sweeps/abc", "/api/sweeps/abc/cancel"):
+        assert not _prefix_exempt(path), path
+
+
+def test_sweeps_routes_appear_in_the_openapi_document():
+    # `/api/sweeps/{sweep_id}` and `/api/sweeps/{sweep_id}/cancel` are
+    # asserted by the tasks that add them; a route this module does not
+    # serve yet cannot be pinned here without leaving the tree red.
+    paths = app.openapi()["paths"]
+    assert "/api/sweeps" in paths
+    assert set(paths["/api/sweeps"]) == {"post"}
+
+
+async def test_a_mutating_sweep_route_without_a_token_is_403(service):
+    async with AsyncClient(transport=ASGITransport(app=app),
+                           base_url=BASE_URL) as http:
+        created = await http.post("/api/sweeps", json=_body(
+            _values("lr", [0.1])))
+        assert created.status_code == 403
+        assert TOKEN_HEADER in created.json()["detail"]
+        # auth_guard runs as middleware, ahead of routing, so every mutating
+        # /api/sweeps path is covered by the same rule whether or not it has
+        # a handler yet.
+        cancelled = await http.post("/api/sweeps/abc/cancel")
+        assert cancelled.status_code == 403
+        # The GET is open, like every other GET in the app.
+        assert (await http.get("/api/sweeps/abc")).status_code == 404
+
+
+# ── submit (spec 5.2, 9.7) ────────────────────────────────────────────────
+
+
+async def test_a_grid_sweep_queues_every_variant_in_fifo_order(
+        make_service, store, probe):
+    """3x2 -> 6 rows, every one carrying the sweep's id and its own variant
+    index, started in submission order. #140 acceptance criterion 1."""
+    service = make_service(cpu=1)          # one slot: start order IS FIFO
+    async with AsyncClient(transport=ASGITransport(app=app),
+                           base_url=BASE_URL,
+                           headers={TOKEN_HEADER: session_token()}) as http:
+        response = await http.post("/api/sweeps", json=_body(
+            _values("lr", [0.001, 0.002, 0.003]),
+            _values("weight_decay", [0.0, 0.5])))
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["total_combinations"] == 6
+        assert len(body["variants"]) == 6
+        assert [v["index"] for v in body["variants"]] == [0, 1, 2, 3, 4, 5]
+
+        children = await store.list_runs_by_sweep(body["sweep_id"])
+        assert [c.sweep_variant for c in children] == [0, 1, 2, 3, 4, 5]
+        assert {c.sweep_id for c in children} == {body["sweep_id"]}
+
+        for child in children:
+            await _await_terminal(store, child.id)
+    # The LAST-declared param varies fastest, so start order is the
+    # compiled order.
+    assert probe.started == [
+        _label(0.001, 0.0), _label(0.001, 0.5),
+        _label(0.002, 0.0), _label(0.002, 0.5),
+        _label(0.003, 0.0), _label(0.003, 0.5),
+    ]
+    assert service is not None
+
+
+async def test_the_route_captures_provenance_once_for_the_whole_sweep(
+        client, store, monkeypatch):
+    """ONE capture for all N variants (spec 4.5).
+
+    The counter sees BOTH call sites, which is what makes this a real
+    guard: the route's own `asyncio.to_thread(RunProvenance.capture)` and
+    `RunStore.create_run`'s default, which captures per run when nothing is
+    passed. So a route that forgot to capture, or captured inside the loop,
+    reads 6 here rather than 1 -- and the sentinel on every child row is
+    what stops "captured once" from also meaning "captured once and then
+    dropped on the floor".
+    """
+    captures: list[int] = []
+    sentinel = RunProvenance(git_commit="sweep-sentinel", git_dirty=False,
+                             plugin_pins={})
+
+    def _capture(*_args: Any, **_kwargs: Any) -> RunProvenance:
+        captures.append(1)
+        return sentinel
+
+    monkeypatch.setattr(RunProvenance, "capture", _capture)
+    response = await client.post("/api/sweeps", json=_body(
+        _values("lr", [0.001, 0.002, 0.003]),
+        _values("weight_decay", [0.0, 0.5])))
+    assert response.status_code == 201, response.text
+    assert len(captures) == 1, f"expected one capture, got {len(captures)}"
+    children = await store.list_runs_by_sweep(response.json()["sweep_id"])
+    assert len(children) == 6
+    assert {c.git_commit for c in children} == {"sweep-sentinel"}
+
+
+def _raise_on_nth(real: Any, *, n: int) -> Any:
+    """Wrap ``RunService.submit`` so its *n*th call raises instead.
+
+    Calls before *n* run the REAL submit, so they create genuine queued rows
+    -- the point of the test is what happens to children that already
+    exist.
+    """
+    calls = 0
+
+    async def _submit(self: RunService, *args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls == n:
+            raise RunServiceUnavailable("run service is shutting down")
+        return await real(self, *args, **kwargs)
+
+    return _submit
+
+
+async def test_the_submit_loop_failing_part_way_leaves_a_failed_sweep(
+        make_service, store, sweep_store, db, probe, monkeypatch):
+    """A sweep leaves `running` only if every variant got a run_id or the
+    route marked it failed (spec 4.3, 5.2). A variant with run_id null is
+    NOT terminal, so a loop that breaks and does neither would leave the row
+    at `running` forever, with no seam able to settle it.
+
+    §9.7.2's last assertion is a GET, which arrives with that route; the
+    rest of it is here, where the failure path is written.
+
+    The queue is saturated first, or the assertion that the two created
+    children are still `queued` could never pass: the default cpu cap is 2
+    and `submit` pumps immediately, so both would already be running.
+    """
+    service = make_service(cpu=1)             # one slot on the cpu queue
+    release_filler = probe.hold(_label(0.9))
+    await service.submit(_graph(lr=0.9), options={"device": "cpu"})
+    await probe.wait_entered(_label(0.9))     # the slot is provably occupied
+    # Only NOW install the failure, so the filler's own submit is not
+    # counted: calls 1 and 2 are variants 0 and 1, call 3 raises.
+    monkeypatch.setattr(RunService, "submit",
+                        _raise_on_nth(RunService.submit, n=3))
+    try:
+        async with AsyncClient(
+                transport=ASGITransport(app=app), base_url=BASE_URL,
+                headers={TOKEN_HEADER: session_token()}) as http:
+            response = await http.post("/api/sweeps", json=_body(
+                _values("lr", [0.001, 0.002, 0.003]),
+                _values("weight_decay", [0.0, 0.5])))
+
+        assert response.status_code == 503, response.text
+        detail = response.json()["detail"]
+        assert "2 of 6 variants" in detail
+
+        rows = db._conn.execute("SELECT id FROM sweeps").fetchall()
+        assert len(rows) == 1
+        sweep_id = rows[0][0]
+        # The id is in the body, so a partial sweep is never unfindable.
+        assert sweep_id in detail
+
+        record = await sweep_store.get_sweep(sweep_id)
+        assert record is not None
+        assert record.state == "failed"      # NOT still "running"
+        assert record.error
+        assert record.finished_at is not None
+        assert [v.run_id is not None for v in record.variants] == [
+            True, True, False, False, False, False]
+
+        # Nothing unwinds or deletes the children that were created.
+        children = await store.list_runs_by_sweep(sweep_id)
+        assert [c.sweep_variant for c in children] == [0, 1]
+        assert [c.status for c in children] == ["queued", "queued"]
+    finally:
+        # Held gates make the fixture's drain wait out shutdown_grace_s.
+        release_filler.set()
+
+
+async def test_seed_variants_off_leaves_every_variant_unseeded(client, store):
+    """RULING 1: an unseeded run takes the SHARED exclusion and overlaps up
+    to the device limit. A seeded one takes a process-wide exclusive lock."""
+    response = await client.post("/api/sweeps",
+                                 json=_body(_values("lr", [0.1, 0.2])))
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert all(v["seed"] is None for v in body["variants"])
+    for child in await store.list_runs_by_sweep(body["sweep_id"]):
+        assert child.options["seed"] is None
+
+
+async def test_seed_variants_on_derives_seed_plus_index_mod_2_32(
+        client, store):
+    """The modulo is mandatory: normalize_options rejects a seed above
+    MAX_SEED, so a base seed near the top of the range would make late
+    variants fail submission for a reason the caller never wrote."""
+    # sweep_spec is passed as an override rather than positionally, because
+    # it needs a `seed` and _body's positional form does not carry one.
+    response = await client.post("/api/sweeps", json=_body(
+        seed_variants=True,
+        sweep_spec={"method": "grid", "seed": 2 ** 32 - 3,
+                    "params": [_values("lr", [0.1, 0.2, 0.3, 0.4, 0.5])]}))
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert [v["seed"] for v in body["variants"]] == [
+        4294967293, 4294967294, 4294967295, 0, 1]
+    children = await store.list_runs_by_sweep(body["sweep_id"])
+    assert [c.options["seed"] for c in children] == [
+        4294967293, 4294967294, 4294967295, 0, 1]
+
+
+async def test_options_seed_is_refused(client, db):
+    response = await client.post("/api/sweeps", json=_body(
+        _values("lr", [0.1]), options={"device": "cpu", "seed": 7}))
+    assert response.status_code == 400
+    assert "seed_variants" in response.json()["detail"]
+    assert db._conn.execute("SELECT COUNT(*) FROM sweeps").fetchone()[0] == 0
+
+
+async def test_the_interactive_lane_is_refused(client, db):
+    response = await client.post("/api/sweeps", json=_body(
+        _values("lr", [0.1]),
+        options={"device": "cpu", "lane": "interactive"}))
+    assert response.status_code == 400
+    assert "interactive lane" in response.json()["detail"]
+    assert db._conn.execute("SELECT COUNT(*) FROM sweeps").fetchone()[0] == 0
+
+
+async def test_seed_variants_without_a_seed_is_refused(client, db):
+    """The route's rule, not the compiler's: a grid never needs a planner
+    seed, so nothing below this line would refuse it."""
+    response = await client.post("/api/sweeps", json=_body(
+        _values("lr", [0.1, 0.2]), seed_variants=True))
+    assert response.status_code == 400
+    assert "sweep_spec.seed is required" in response.json()["detail"]
+    assert db._conn.execute("SELECT COUNT(*) FROM sweeps").fetchone()[0] == 0
+
+
+async def test_record_outputs_over_the_output_store_bound_is_refused(
+        client, db):
+    from app.core.run_output_store import RunOutputStore
+
+    # Set and removed by hand rather than with monkeypatch, the way
+    # `make_service` does it: `app.state` is a starlette State, whose
+    # __delattr__ raises KeyError (not AttributeError) on a missing key, so
+    # monkeypatch's undo of a raising=False setattr dies in teardown.
+    app.state.run_output_store = RunOutputStore(max_runs=4, max_bytes=1024)
+    try:
+        response = await client.post("/api/sweeps", json=_body(
+            _values("lr", [0.1, 0.2, 0.3, 0.4, 0.5]),
+            options={"device": "cpu", "record_outputs": True}))
+        assert response.status_code == 400
+        detail = response.json()["detail"]
+        assert "5 variants" in detail and "newest 4 runs" in detail
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM sweeps").fetchone()[0] == 0
+    finally:
+        if hasattr(app.state, "run_output_store"):
+            delattr(app.state, "run_output_store")
+
+
+async def test_non_finite_values_are_refused(client, db):
+    """json.loads("NaN") is nan and json.loads("1e999") is inf, and both
+    pass every other check before corrupting a stored row. The body is sent
+    as raw text so the literals survive to the parser."""
+    body = _body(_values("lr", [0.1]))
+    raw = (
+        '{"base_graph": %s, "objective": {"metric": "val_loss", '
+        '"direction": "minimize"}, "options": {"device": "cpu"}, '
+        '"sweep_spec": {"method": "grid", "params": [{"node_id": "probe", '
+        '"param": "lr", "values": [0.1, NaN]}]}}'
+        % __import__("json").dumps(body["base_graph"]))
+    response = await client.post(
+        "/api/sweeps", content=raw.encode(),
+        headers={"Content-Type": "application/json"})
+    assert response.status_code == 400
+    assert "finite" in response.json()["detail"]
+    assert db._conn.execute("SELECT COUNT(*) FROM sweeps").fetchone()[0] == 0

--- a/backend/tests/test_api_sweeps.py
+++ b/backend/tests/test_api_sweeps.py
@@ -362,14 +362,19 @@ def test_sweeps_routes_are_not_under_an_auth_exempt_prefix():
 
 
 def test_sweeps_routes_appear_in_the_openapi_document():
-    # `/api/sweeps/{sweep_id}/cancel` is asserted by the task that adds it;
-    # a route this module does not serve yet cannot be pinned here without
-    # leaving the tree red.
+    """All three of spec 5's routes, and only the verb each one serves.
+
+    The verb sets are asserted, not just the paths: a `get` appearing on
+    `/api/sweeps/{sweep_id}/cancel` would be a route that mutates on a
+    method every crawler and prefetcher issues unasked.
+    """
     paths = app.openapi()["paths"]
     assert "/api/sweeps" in paths
     assert set(paths["/api/sweeps"]) == {"post"}
     assert "/api/sweeps/{sweep_id}" in paths
     assert set(paths["/api/sweeps/{sweep_id}"]) == {"get"}
+    assert "/api/sweeps/{sweep_id}/cancel" in paths
+    assert set(paths["/api/sweeps/{sweep_id}/cancel"]) == {"post"}
 
 
 async def test_a_mutating_sweep_route_without_a_token_is_403(service):
@@ -384,6 +389,11 @@ async def test_a_mutating_sweep_route_without_a_token_is_403(service):
         # a handler yet.
         cancelled = await http.post("/api/sweeps/abc/cancel")
         assert cancelled.status_code == 403
+        assert TOKEN_HEADER in cancelled.json()["detail"]
+        # Now that cancel HAS a handler, 403-not-404 is the load-bearing
+        # part: the handler would answer "sweep 'abc' not found", so a 403
+        # proves auth_guard ran ahead of it rather than the route simply
+        # being absent.
         # The GET is open, like every other GET in the app. The DETAIL is
         # asserted, not just the code: an unauthenticated GET must reach the
         # handler and be told the sweep does not exist, where a routing 404
@@ -1122,3 +1132,165 @@ async def test_an_unknown_format_is_a_422(client, store):
     sweep_id = await _run_sweep(client, store, _values("lr", [0.1]))
     assert (await client.get(
         f"/api/sweeps/{sweep_id}?format=xlsx")).status_code == 422
+
+
+# ── cancel (spec 5.4, 7, 9.7) ─────────────────────────────────────────────
+
+
+async def test_cancelling_a_sweep_stops_queued_and_running_children(
+        make_service, store, probe):
+    """#140 acceptance criterion 3: the stragglers stop and the partial
+    results stay inspectable."""
+    make_service(cpu=1)
+    release = probe.hold(_label(0.1))
+    async with AsyncClient(transport=ASGITransport(app=app),
+                           base_url=BASE_URL,
+                           headers={TOKEN_HEADER: session_token()}) as http:
+        created = await http.post("/api/sweeps", json=_body(
+            _values("lr", [0.1, 0.2, 0.3, 0.4, 0.5])))
+        sweep_id = created.json()["sweep_id"]
+        await probe.wait_entered(_label(0.1))
+
+        response = await http.post(f"/api/sweeps/{sweep_id}/cancel")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        # index order, not rank order: a cancel is about the submission.
+        assert [v["index"] for v in body["variants"]] == [0, 1, 2, 3, 4]
+        assert body["cancelled"] == 5
+        assert body["already_finished"] == 0
+        assert body["state"] == "cancelling"
+        # The running child's reply is an ACKNOWLEDGEMENT: cooperative
+        # cancellation sets a flag, and the row flips when it unwinds.
+        assert body["variants"][0]["status"] == "running"
+        assert body["variants"][0]["cancelled"] is True
+        assert all(v["status"] == "cancelled" for v in body["variants"][1:])
+
+        release.set()
+        for child in await store.list_runs_by_sweep(sweep_id):
+            await _await_terminal(store, child.id)
+        # A cancelled child that already logged points KEEPS them: its
+        # series are flushed by _finalize like any other terminal run.
+        after = (await http.get(f"/api/sweeps/{sweep_id}")).json()
+        assert after["variants"][0]["index"] == 0
+        assert after["variants"][0]["objective"] == pytest.approx(1.0)
+        assert after["variants"][0]["rank"] == 1
+        assert after["variants"][0]["final_metrics"]["train_loss"] == \
+            pytest.approx(2.0)
+        # ALL FIVE, including the one that was still `running` in the reply:
+        # spec 7.2's acknowledgement flips on the row when the run unwinds,
+        # and the engine's post-last-level checkpoint catches a stop that
+        # arrived while the final node was working. The partial result
+        # survives the flip -- that is acceptance criterion 3, and it is why
+        # a cancelled variant is ranked rather than blanked.
+        assert after["counts"] == {"queued": 0, "running": 0, "succeeded": 0,
+                                   "failed": 0, "cancelled": 5,
+                                   "interrupted": 0, "missing": 0}
+        # A container, never a run: `cancelled` is not a sweep state.
+        assert after["state"] == "finished"
+
+
+async def test_a_second_cancel_is_a_200_no_op(client, store):
+    """Asking twice is not an error, and a cancel that raced a completion
+    is normal -- the user hits Stop as the last epoch lands."""
+    sweep_id = await _run_sweep(client, store, _values("lr", [0.1, 0.2]))
+    first = (await client.post(f"/api/sweeps/{sweep_id}/cancel")).json()
+    assert first["cancelled"] == 0
+    assert first["already_finished"] == 2
+    state = first["state"]
+
+    second = await client.post(f"/api/sweeps/{sweep_id}/cancel")
+    assert second.status_code == 200
+    body = second.json()
+    assert body["cancelled"] == 0
+    assert body["already_finished"] == 2
+    assert body["state"] == state
+
+
+async def test_cancelling_flips_the_sweep_to_finished_at_the_next_harvest(
+        make_service, store, sweep_store, probe):
+    """Spec 7.3: a sweep is a container, not a run. It is NEVER set to
+    `cancelled` -- a sweep where most variants finished and two were
+    stopped is not a cancelled sweep."""
+    make_service(cpu=1)
+    release = probe.hold(_label(0.1))
+    async with AsyncClient(transport=ASGITransport(app=app),
+                           base_url=BASE_URL,
+                           headers={TOKEN_HEADER: session_token()}) as http:
+        created = await http.post("/api/sweeps", json=_body(
+            _values("lr", [0.1, 0.2])))
+        sweep_id = created.json()["sweep_id"]
+        await probe.wait_entered(_label(0.1))
+
+        await http.post(f"/api/sweeps/{sweep_id}/cancel")
+        assert (await sweep_store.get_sweep(sweep_id)).state == "cancelling"
+
+        release.set()
+        for child in await store.list_runs_by_sweep(sweep_id):
+            await _await_terminal(store, child.id)
+        body = (await http.get(f"/api/sweeps/{sweep_id}")).json()
+        assert body["state"] == "finished"
+        assert body["finished_at"] is not None
+        stored = await sweep_store.get_sweep(sweep_id)
+        assert stored.state == "finished"
+
+
+async def test_cancelling_a_failed_sweep_keeps_failed_and_skips_null_runs(
+        make_service, store, sweep_store, db, probe, monkeypatch):
+    """Spec 7.3's last line and 7.4's last paragraph, neither of which any
+    other test reaches.
+
+    `failed` is the submit loop's own record of what went wrong and outranks
+    a later cancel, so `set_state` is guarded on it -- a cancel that
+    downgraded a failed sweep to `cancelling` would erase the only
+    explanation the user has. And a variant that never got a run is
+    `missing` with nothing to cancel: it is counted in NEITHER tally, so
+    `cancelled + already_finished` is the number of variants that had a run,
+    not the variant count.
+    """
+    service = make_service(cpu=1)
+    release_filler = probe.hold(_label(0.9))
+    await service.submit(_graph(lr=0.9), options={"device": "cpu"})
+    await probe.wait_entered(_label(0.9))     # the one cpu slot is occupied
+    # Installed only NOW, so the filler's own submit is not counted: call 1
+    # is variant 0 and call 2 raises. Exactly one variant gets a run and two
+    # are left at run_id null.
+    monkeypatch.setattr(RunService, "submit",
+                        _raise_on_nth(RunService.submit, n=2))
+    try:
+        async with AsyncClient(
+                transport=ASGITransport(app=app), base_url=BASE_URL,
+                headers={TOKEN_HEADER: session_token()}) as http:
+            created = await http.post("/api/sweeps", json=_body(
+                _values("lr", [0.001, 0.002, 0.003])))
+            assert created.status_code == 503, created.text
+            sweep_id = db._conn.execute(
+                "SELECT id FROM sweeps").fetchone()[0]
+            assert (await sweep_store.get_sweep(sweep_id)).state == "failed"
+
+            body = (await http.post(
+                f"/api/sweeps/{sweep_id}/cancel")).json()
+
+        assert body["state"] == "failed"     # NOT downgraded to cancelling
+        assert body["cancelled"] == 1        # the one queued child
+        assert body["already_finished"] == 0  # a null run is neither
+        assert body["variants"] == [
+            {"index": 0, "run_id": body["variants"][0]["run_id"],
+             "status": "cancelled", "cancelled": True},
+            {"index": 1, "run_id": None, "status": "missing",
+             "cancelled": False},
+            {"index": 2, "run_id": None, "status": "missing",
+             "cancelled": False}]
+        assert body["variants"][0]["run_id"] is not None
+        # The harvest the cancel ran did not overwrite it either.
+        assert (await sweep_store.get_sweep(sweep_id)).state == "failed"
+        child = (await store.list_runs_by_sweep(sweep_id))[0]
+        assert (await store.get_run(child.id)).status == "cancelled"
+    finally:
+        # Held gates make the fixture's drain wait out shutdown_grace_s.
+        release_filler.set()
+
+
+async def test_cancelling_an_unknown_sweep_is_a_404(client):
+    response = await client.post("/api/sweeps/nope/cancel")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "sweep 'nope' not found"

--- a/backend/tests/test_api_sweeps.py
+++ b/backend/tests/test_api_sweeps.py
@@ -311,6 +311,25 @@ def _body(*params: dict[str, Any], graph: dict[str, Any] | None = None,
     return body
 
 
+async def _await_sweep_state(sweep_store: SweepStore, sweep_id: str,
+                             state: str, *, timeout: float = 5.0):
+    """Wait for a DETACHED settle to land.
+
+    `_mark_failed_on_the_way_out` fires its write as its own task, precisely
+    so a cancelled request cannot take the write with it -- which means the
+    row settles a tick or two after the handler has already unwound. A
+    bounded wait on an observed fact, never a sleep.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        record = await sweep_store.get_sweep(sweep_id)
+        if record is not None and record.state == state:
+            return record
+        await asyncio.sleep(0.02)
+    raise AssertionError(
+        f"sweep {sweep_id} never reached state {state!r} within {timeout}s")
+
+
 async def _await_terminal(store: RunStore, run_id: str, *,
                           timeout: float = 15.0):
     """Poll the STORE (never the in-process registry) until the row is
@@ -678,3 +697,111 @@ async def test_non_finite_values_are_refused(client, db):
     assert response.status_code == 400
     assert "finite" in response.json()["detail"]
     assert db._conn.execute("SELECT COUNT(*) FROM sweeps").fetchone()[0] == 0
+
+
+async def test_a_cancelled_submit_loop_still_settles_the_sweep(
+        make_service, store, sweep_store, db, probe, monkeypatch):
+    """A browser tab closing mid-POST cancels the request task, landing a
+    CancelledError between two submits. `except Exception` cannot see a
+    BaseException, so without the loop's `finally` the row keeps `running`
+    forever: a variant holding a null run id is not terminal, so no harvest
+    seam can ever settle it.
+
+    `failed` is the spec's own end state for exactly this (4.3: "the submit
+    loop broke part-way and some variants have no run at all"), and the
+    children already submitted keep running and stay inspectable (RULING 2).
+    """
+    service = make_service(cpu=1)
+    release_filler = probe.hold(_label(0.9))
+    await service.submit(_graph(lr=0.9), options={"device": "cpu"})
+    await probe.wait_entered(_label(0.9))
+
+    reached_third = asyncio.Event()
+    let_go = asyncio.Event()
+    real_submit = RunService.submit
+    calls = 0
+
+    async def _hang_on_the_third(self: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            # A gate, not a sleep: the cancel lands provably INSIDE the loop,
+            # with variants 0 and 1 already submitted and patched.
+            reached_third.set()
+            await let_go.wait()
+        return await real_submit(self, *args, **kwargs)
+
+    monkeypatch.setattr(RunService, "submit", _hang_on_the_third)
+    try:
+        async with AsyncClient(
+                transport=ASGITransport(app=app), base_url=BASE_URL,
+                headers={TOKEN_HEADER: session_token()}) as http:
+            posting = asyncio.ensure_future(http.post(
+                "/api/sweeps", json=_body(
+                    _values("lr", [0.001, 0.002, 0.003]),
+                    _values("weight_decay", [0.0, 0.5]))))
+            await asyncio.wait_for(reached_third.wait(), timeout=5.0)
+            posting.cancel()
+            # The cancellation must still propagate: the settle is a side
+            # effect on the way out, not a recovery.
+            with pytest.raises(asyncio.CancelledError):
+                await posting
+
+        rows = db._conn.execute("SELECT id FROM sweeps").fetchall()
+        assert len(rows) == 1
+        sweep_id = rows[0][0]
+        record = await _await_sweep_state(sweep_store, sweep_id, "failed")
+        assert record.error and "CancelledError" in record.error
+        assert record.finished_at is not None
+        assert [v.run_id is not None for v in record.variants] == [
+            True, True, False, False, False, False]
+
+        # The two children already submitted are untouched and still theirs.
+        children = await store.list_runs_by_sweep(sweep_id)
+        assert [c.sweep_variant for c in children] == [0, 1]
+        assert all(child.status in {"queued", "running"}
+                   for child in children), [c.status for c in children]
+    finally:
+        let_go.set()
+        release_filler.set()
+
+
+async def test_a_cancel_while_the_sweep_row_is_written_still_settles_it(
+        client, sweep_store, db, monkeypatch):
+    """The one window outside the loop, closed by the same guard.
+
+    `Database.run` finishes its worker before re-raising a cancellation
+    (db.py:225-243), so a cancel delivered at `create_sweep`'s own await
+    leaves the row WRITTEN while this handler unwinds straight past it,
+    never holding the record. The route therefore mints the sweep id itself,
+    so the `finally` knows which row to settle even then.
+    """
+    real_create = SweepStore.create_sweep
+    written = asyncio.Event()
+    let_go = asyncio.Event()
+
+    async def _write_then_hang(self: Any, **kwargs: Any) -> Any:
+        record = await real_create(self, **kwargs)
+        written.set()
+        await let_go.wait()      # the cancel lands here, row already in
+        return record
+
+    monkeypatch.setattr(SweepStore, "create_sweep", _write_then_hang)
+    try:
+        posting = asyncio.ensure_future(client.post(
+            "/api/sweeps", json=_body(_values("lr", [0.1, 0.2]))))
+        await asyncio.wait_for(written.wait(), timeout=5.0)
+        posting.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await posting
+
+        rows = db._conn.execute("SELECT id FROM sweeps").fetchall()
+        assert len(rows) == 1
+        record = await _await_sweep_state(sweep_store, rows[0][0], "failed")
+        assert record.finished_at is not None
+        assert [v.run_id for v in record.variants] == [None, None]
+        # Nothing was submitted, so nothing is left running either.
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM exec_runs").fetchone()[0] == 0
+    finally:
+        let_go.set()

--- a/backend/tests/test_api_sweeps.py
+++ b/backend/tests/test_api_sweeps.py
@@ -16,6 +16,8 @@ independent.
 from __future__ import annotations
 
 import asyncio
+import csv
+import io
 import sqlite3
 import threading
 import time
@@ -24,6 +26,7 @@ from typing import Any
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.api.routes_runs import _CSV_BOM
 from app.config import settings
 from app.core import run_service as run_service_module
 from app.core.auth import TOKEN_HEADER, session_token
@@ -37,7 +40,7 @@ from app.core.node_base import (
 )
 from app.core.node_registry import registry
 from app.core.run_service import QueueLimits, RunService, RunServiceUnavailable
-from app.core.run_store import RunProvenance, RunStore
+from app.core.run_store import TERMINAL_STATUSES, RunProvenance, RunStore
 from app.core.sweep_store import SweepStore
 from app.main import app
 
@@ -359,12 +362,14 @@ def test_sweeps_routes_are_not_under_an_auth_exempt_prefix():
 
 
 def test_sweeps_routes_appear_in_the_openapi_document():
-    # `/api/sweeps/{sweep_id}` and `/api/sweeps/{sweep_id}/cancel` are
-    # asserted by the tasks that add them; a route this module does not
-    # serve yet cannot be pinned here without leaving the tree red.
+    # `/api/sweeps/{sweep_id}/cancel` is asserted by the task that adds it;
+    # a route this module does not serve yet cannot be pinned here without
+    # leaving the tree red.
     paths = app.openapi()["paths"]
     assert "/api/sweeps" in paths
     assert set(paths["/api/sweeps"]) == {"post"}
+    assert "/api/sweeps/{sweep_id}" in paths
+    assert set(paths["/api/sweeps/{sweep_id}"]) == {"get"}
 
 
 async def test_a_mutating_sweep_route_without_a_token_is_403(service):
@@ -379,8 +384,13 @@ async def test_a_mutating_sweep_route_without_a_token_is_403(service):
         # a handler yet.
         cancelled = await http.post("/api/sweeps/abc/cancel")
         assert cancelled.status_code == 403
-        # The GET is open, like every other GET in the app.
-        assert (await http.get("/api/sweeps/abc")).status_code == 404
+        # The GET is open, like every other GET in the app. The DETAIL is
+        # asserted, not just the code: an unauthenticated GET must reach the
+        # handler and be told the sweep does not exist, where a routing 404
+        # would look identical from the outside.
+        unknown = await http.get("/api/sweeps/abc")
+        assert unknown.status_code == 404
+        assert unknown.json()["detail"] == "sweep 'abc' not found"
 
 
 # ── submit (spec 5.2, 9.7) ────────────────────────────────────────────────
@@ -470,15 +480,16 @@ def _raise_on_nth(real: Any, *, n: int,
     return _wrapped
 
 
-async def test_the_submit_loop_failing_part_way_leaves_a_failed_sweep(
+async def test_the_submit_loop_failing_part_way_leaves_a_failed_sweep_and_intact_children(
         make_service, store, sweep_store, db, probe, monkeypatch):
-    """A sweep leaves `running` only if every variant got a run_id or the
+    """Spec 9.7.2, in full.
+
+    A sweep leaves `running` only if every variant got a run_id or the
     route marked it failed (spec 4.3, 5.2). A variant with run_id null is
     NOT terminal, so a loop that breaks and does neither would leave the row
-    at `running` forever, with no seam able to settle it.
-
-    §9.7.2's last assertion is a GET, which arrives with that route; the
-    rest of it is here, where the failure path is written.
+    at `running` forever, with no seam able to settle it. Nothing else fails
+    if an implementer forgets the row patch or the `k of n` suffix, both of
+    which are pure design.
 
     The queue is saturated first, or the assertion that the two created
     children are still `queued` could never pass: the default cpu cap is 2
@@ -522,6 +533,19 @@ async def test_the_submit_loop_failing_part_way_leaves_a_failed_sweep(
         children = await store.list_runs_by_sweep(sweep_id)
         assert [c.sweep_variant for c in children] == [0, 1]
         assert [c.status for c in children] == ["queued", "queued"]
+
+        # §9.7.2's last assertion: the partial sweep is READABLE, and the
+        # four variants that never got a run report `missing` rather than
+        # vanishing from the table.
+        async with AsyncClient(
+                transport=ASGITransport(app=app), base_url=BASE_URL,
+                headers={TOKEN_HEADER: session_token()}) as http:
+            readback = await http.get(f"/api/sweeps/{sweep_id}")
+        assert readback.status_code == 200, readback.text
+        body = readback.json()
+        assert len(body["variants"]) == 6
+        assert body["counts"]["missing"] == 4
+        assert body["state"] == "failed"      # never overwritten by a harvest
     finally:
         # Held gates make the fixture's drain wait out shutdown_grace_s.
         release_filler.set()
@@ -805,3 +829,296 @@ async def test_a_cancel_while_the_sweep_row_is_written_still_settles_it(
             "SELECT COUNT(*) FROM exec_runs").fetchone()[0] == 0
     finally:
         let_go.set()
+
+
+# ── the ranked table (spec 5.3, 9.7) ──────────────────────────────────────
+
+
+async def _run_sweep(http: AsyncClient, store: RunStore,
+                     *params: dict[str, Any], **overrides: Any) -> str:
+    """POST a sweep and wait for every child to reach a terminal status."""
+    response = await http.post("/api/sweeps", json=_body(*params,
+                                                         **overrides))
+    assert response.status_code == 201, response.text
+    sweep_id = response.json()["sweep_id"]
+    for child in await store.list_runs_by_sweep(sweep_id):
+        await _await_terminal(store, child.id)
+    return sweep_id
+
+
+async def test_every_variant_completes_unattended_and_the_table_ranks_them(
+        client, store):
+    """#140 acceptance criterion 1: 3x2 completes unattended and the table
+    ranks by final val_loss. val_loss = lr * 10 + weight_decay, so the
+    winner is knowable in advance rather than merely "some ordering"."""
+    sweep_id = await _run_sweep(client, store,
+                                _values("lr", [0.003, 0.001, 0.002]),
+                                _values("weight_decay", [0.5, 0.0]))
+    body = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    assert body["state"] == "finished"
+    assert body["counts"]["succeeded"] == 6
+    assert [v["rank"] for v in body["variants"]] == [1, 2, 3, 4, 5, 6]
+    assert body["variants"][0]["objective"] == pytest.approx(0.01)
+    assert body["variants"][0]["params"] == [
+        {"node_id": "probe", "param": "lr", "value": 0.001},
+        {"node_id": "probe", "param": "weight_decay", "value": 0.0}]
+    assert body["best"]["index"] == body["variants"][0]["index"]
+    assert body["variants"][0]["final_metrics"]["train_loss"] == \
+        pytest.approx(0.02)
+    assert all(v["run_exists"] for v in body["variants"])
+    assert "objective_warning" not in body
+    # The pre-rank identity survives the sort, so a client can put the table
+    # back into submission order (spec 5.3).
+    assert sorted(v["index"] for v in body["variants"]) == [0, 1, 2, 3, 4, 5]
+
+
+async def test_the_ranked_order_is_stable_across_polls(client, store):
+    """A polled table must not reshuffle between reads.
+
+    Two variants are given the SAME objective on purpose -- val_loss is
+    lr * 10 + weight_decay, so (0.1, 0.0) and (0.05, 0.5) both land on 1.0 --
+    because a tie is the only case where a sort with no total order can
+    legally return either. Ties break on `index`, so the two reads below are
+    identical rather than merely sorted.
+    """
+    sweep_id = await _run_sweep(client, store,
+                                _values("lr", [0.1, 0.05]),
+                                _values("weight_decay", [0.0, 0.5]))
+    first = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    second = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    assert [v["index"] for v in first["variants"]] == \
+        [v["index"] for v in second["variants"]]
+    tied = [v["index"] for v in first["variants"]
+            if v["objective"] == pytest.approx(1.0)]
+    assert tied == sorted(tied) and len(tied) == 2
+
+
+async def test_a_failed_variant_that_logged_the_objective_is_still_ranked(
+        client, store):
+    """The HTTP sibling of test_sweeps.py's unit version. AC 3: hiding a
+    real number because the run ended badly is the silent disappearance
+    that criterion forbids."""
+    sweep_id = await _run_sweep(
+        client, store, _values("lr", [0.1]),
+        graph=_graph(fail=True))
+    body = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    variant = body["variants"][0]
+    assert variant["status"] == "failed"
+    assert variant["objective"] == pytest.approx(1.0)
+    assert variant["rank"] == 1
+    assert body["counts"]["failed"] == 1
+    assert body["state"] == "finished"      # a container, not a run
+
+
+async def test_a_variant_with_no_objective_is_unranked_but_present(
+        client, store):
+    sweep_id = await _run_sweep(
+        client, store, _values("lr", [0.1]), graph=_graph(silent=True))
+    body = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    assert body["variants"][0]["objective"] is None
+    assert body["variants"][0]["rank"] is None
+    assert body["best"] is None
+    csv_body = (await client.get(
+        f"/api/sweeps/{sweep_id}?format=csv")).text
+    rows = list(csv.reader(io.StringIO(csv_body.lstrip(_CSV_BOM))))
+    assert len(rows) == 2                    # header + the unranked row
+
+
+async def test_a_diverged_variant_is_unranked(client, store):
+    """A non-finite last point is stored as SQL NULL and omitted from the
+    series map: a diverged loss must not render as a suspiciously good
+    one. The HTTP sibling of test_sweeps.py's unit version."""
+    sweep_id = await _run_sweep(
+        client, store, _values("lr", [0.1]), graph=_graph(diverge=True))
+    body = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    assert body["variants"][0]["status"] == "succeeded"
+    assert body["variants"][0]["objective"] is None
+    assert body["variants"][0]["rank"] is None
+
+
+async def test_no_variant_produced_the_objective(client, store):
+    """The single most likely user error -- asking for val_loss from a
+    graph that never logs it -- becomes a message naming the fix instead of
+    a table of empty cells."""
+    sweep_id = await _run_sweep(
+        client, store, _values("lr", [0.1, 0.2]),
+        objective={"metric": "accuracy", "direction": "maximize"})
+    body = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    assert body["best"] is None
+    assert all(v["rank"] is None for v in body["variants"])
+    warning = body["objective_warning"]
+    assert "accuracy" in warning
+    assert "train_loss" in warning and "val_loss" in warning
+
+
+async def test_the_objective_survives_its_child_being_pruned(client, store):
+    """RULING 4: the run id stays as a link that may be dead, and the
+    numbers stay."""
+    sweep_id = await _run_sweep(client, store, _values("lr", [0.1, 0.2]))
+    before = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    assert before["variants"][0]["objective"] == pytest.approx(1.0)
+
+    assert await store.prune(keep_last=0) == 2
+    after = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    assert after["variants"][0]["objective"] == pytest.approx(1.0)
+    assert after["variants"][0]["status"] == "succeeded"   # the harvested one
+    assert after["variants"][0]["run_exists"] is False
+    assert "final_metrics" not in after["variants"][0]
+    assert after["variants"][0]["run_id"] is not None      # a dead link
+
+
+async def test_a_child_deleted_before_any_read_is_missing_not_a_wedged_sweep(
+        client, store, sweep_store):
+    """Spec 6.3's accepted hole, reported honestly rather than hidden.
+
+    `DELETE /api/runs/{id}` goes through `delete_run`, not `prune`, so seam
+    B's inside-the-transaction guarantee does not cover it: a child deleted
+    before any GET harvested it loses its objective permanently. What must
+    NOT happen is the sweep wedging at `running` forever with no seam able
+    to settle it -- which is exactly what the "row is gone" clause of
+    `variant_is_terminal` prevents, and this is the only place it fires.
+    """
+    sweep_id = await _run_sweep(client, store, _values("lr", [0.1]))
+    child = (await store.list_runs_by_sweep(sweep_id))[0]
+    # No GET yet, so nothing has been harvested.
+    assert (await sweep_store.get_sweep(sweep_id)).variants[0].status is None
+    assert await store.delete_run(child.id) is True
+
+    body = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    variant = body["variants"][0]
+    assert variant["status"] == "missing"
+    assert variant["objective"] is None
+    assert variant["rank"] is None
+    assert variant["run_exists"] is False
+    assert "final_metrics" not in variant
+    assert body["counts"]["missing"] == 1
+    assert body["state"] == "finished"      # NOT wedged at "running"
+    assert (await sweep_store.get_sweep(sweep_id)).state == "finished"
+
+
+async def test_the_sweep_finishes_through_seam_a(client, store, sweep_store):
+    sweep_id = await _run_sweep(client, store, _values("lr", [0.1, 0.2]))
+    first = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    assert first["state"] == "finished"
+    assert first["finished_at"] is not None
+    # The STORED row, not just the response: read repair means nothing else
+    # would ever write it.
+    stored = await sweep_store.get_sweep(sweep_id)
+    assert stored.state == "finished"
+    assert stored.finished_at == first["finished_at"]
+
+    second = (await client.get(f"/api/sweeps/{sweep_id}")).json()
+    assert second["finished_at"] == first["finished_at"]   # stamped once
+
+
+async def test_a_restart_leaves_variants_interrupted_and_the_sweep_inspectable(
+        make_service, store, probe):
+    """RULING 2. `recover_interrupted` is a STARTUP call and raises when
+    runs are in flight, so this uses spec 9.7.1 recipe (a): a graceful
+    shutdown, whose phase 0 files every WAITING run `interrupted` -- the
+    same status and the same rows a restart would write.
+    """
+    service = make_service(cpu=1)
+    release = probe.hold(_label(0.1))
+    async with AsyncClient(transport=ASGITransport(app=app),
+                           base_url=BASE_URL,
+                           headers={TOKEN_HEADER: session_token()}) as http:
+        response = await http.post("/api/sweeps", json=_body(
+            _values("lr", [0.1, 0.2, 0.3, 0.4])))
+        sweep_id = response.json()["sweep_id"]
+        await probe.wait_entered(_label(0.1))
+
+        # Release the RUNNING child, then shut down with NO await in
+        # between. The probe blocks on a threading.Event, not on a
+        # context.should_stop() poll, so shutdown's cooperative phase cannot
+        # reach a HELD node: it would sit there until phase 2 hard-cancels
+        # it after shutdown_grace_s, and shutdown's own docstring says that
+        # leaves the row reading `running`.
+        #
+        # The missing `await` between the two lines is the load-bearing
+        # part, not a shortcut. `shutdown` sets `_shutting_down` and empties
+        # both pending indexes BEFORE its first await
+        # (run_service.py:2637, :2674-2680), and entering a coroutine does
+        # not yield -- so the event loop cannot promote a queued child into
+        # the slot the released one just freed. Awaiting the released child
+        # to terminal first, as the obvious reading of the recipe suggests,
+        # hands the loop exactly that chance and makes "three children never
+        # started" a race instead of a fact.
+        release.set()
+        await service.shutdown()
+
+        statuses = {c.sweep_variant: c.status
+                    for c in await store.list_runs_by_sweep(sweep_id)}
+        # Variant 0 was drained by shutdown's phase 1, so it is terminal --
+        # `succeeded` normally, `interrupted` if the stop reason won the
+        # race with the node's own return. Either is a real restart outcome;
+        # what RULING 2 is about is the three that never started.
+        assert statuses[0] in TERMINAL_STATUSES, statuses
+        assert all(statuses[i] == "interrupted" for i in (1, 2, 3)), statuses
+
+        body = (await http.get(f"/api/sweeps/{sweep_id}")).json()
+        assert len(body["variants"]) == 4
+        assert sum(body["counts"].values()) == 4
+        assert body["counts"]["interrupted"] >= 3
+        assert body["state"] == "finished"     # every variant is terminal
+        # The harvest keeps whatever a stopped child had logged: variant 0
+        # logged val_loss before the gate released it, and _finalize flushes
+        # metrics with force=True whatever the outcome.
+        by_index = {v["index"]: v for v in body["variants"]}
+        assert by_index[0]["objective"] == pytest.approx(1.0)
+        assert all(by_index[i]["objective"] is None for i in (1, 2, 3))
+
+
+# ── the comparison CSV (spec 5.3, 9.8) ────────────────────────────────────
+
+
+async def test_the_comparison_csv_has_one_row_per_variant(client, store):
+    """#140 acceptance criterion 4. `note` is swept with a value that looks
+    like a FORMULA, because Excel, LibreOffice and Sheets all evaluate a
+    cell whose first character is '=' and a string param's value is
+    caller-supplied."""
+    sweep_id = await _run_sweep(
+        client, store,
+        _values("lr", [0.1, 0.2]),
+        _values("note", ["=HYPERLINK(1)", "ok"]),
+        graph=_graph(silent=True))          # unranked rows, on purpose
+    response = await client.get(f"/api/sweeps/{sweep_id}?format=csv")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    disposition = response.headers["content-disposition"]
+    assert "attachment" in disposition
+    assert f"sweep-{sweep_id}-comparison.csv" in disposition
+
+    text = response.text
+    # U+FEFF: text/csv; charset=utf-8 is not enough for Excel on Windows,
+    # which reads a BOM-less CSV in the ANSI codepage -- in a product that
+    # ships zh-TW.
+    assert text.startswith(_CSV_BOM)
+    rows = list(csv.reader(io.StringIO(text.lstrip(_CSV_BOM))))
+    assert rows[0] == ["rank", "variant_index", "domain_index", "run_id",
+                       "status", "objective", "probe.lr", "probe.note"]
+    assert len(rows) == 5                    # header + 4 variants
+    # Every variant is silent, so every rank and objective cell is EMPTY --
+    # not "None", which would read as text and poison the column's type --
+    # and no row disappears for being unranked.
+    assert all(row[0] == "" and row[5] == "" for row in rows[1:])
+    assert sorted(row[1] for row in rows[1:]) == ["0", "1", "2", "3"]
+    assert all(row[3] and row[4] == "succeeded" for row in rows[1:])
+    # The formula guard: a leading apostrophe, the convention every
+    # spreadsheet understands as "this is text".
+    assert {row[7] for row in rows[1:]} == {"'=HYPERLINK(1)", "ok"}
+    # Numeric cells are NOT quoted into text: a chart built on the export
+    # would break.
+    assert {row[6] for row in rows[1:]} == {"0.1", "0.2"}
+
+
+async def test_an_unknown_sweep_is_a_404(client):
+    response = await client.get("/api/sweeps/nope")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "sweep 'nope' not found"
+
+
+async def test_an_unknown_format_is_a_422(client, store):
+    sweep_id = await _run_sweep(client, store, _values("lr", [0.1]))
+    assert (await client.get(
+        f"/api/sweeps/{sweep_id}?format=xlsx")).status_code == 422

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -26,19 +26,20 @@ def test_connect_migrates_empty_file(tmp_path):
     db.connect()
     try:
         assert db._conn.execute("PRAGMA user_version").fetchone()[0] \
-            == len(MIGRATIONS) == 3
+            == len(MIGRATIONS) == 4
         names = {
             r[0] for r in db._conn.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table'"
             ).fetchall()
         }
-        # Publish (001/002) plus the Run Service store (003). The literal
-        # count above is a deliberate tripwire: adding a migration should
-        # make someone extend this set too. Per-table schema assertions
-        # live with each subsystem (test_provenance / test_run_store).
+        # Publish (001/002), the Run Service store (003) and sweeps (004).
+        # The literal count above is a deliberate tripwire: adding a
+        # migration should make someone extend this set too. Per-table
+        # schema assertions live with each subsystem (test_provenance /
+        # test_run_store).
         assert {"apps", "app_versions", "api_keys", "runs"} <= names
         assert {"exec_runs", "exec_run_metrics", "exec_run_events",
-                "exec_run_artifacts"} <= names
+                "exec_run_artifacts", "sweeps"} <= names
     finally:
         db.close()
 

--- a/backend/tests/test_run_queue.py
+++ b/backend/tests/test_run_queue.py
@@ -50,6 +50,7 @@ from app.core.run_service import (
     QueueLimits,
     RunService,
     RunServiceUnavailable,
+    RunSubmitError,
     canonical_queue_key,
     parse_queue_overrides,
 )
@@ -1082,3 +1083,34 @@ async def test_a_restart_retires_rows_a_hard_kill_left_queued(make_service,
     row = await store.get_run(orphan.id)
     assert row.status == STATUS_INTERRUPTED
     assert row.started_at is None
+
+
+# ── the sweep columns (#140) ──────────────────────────────────────────────
+
+
+async def test_submit_writes_the_sweep_columns_onto_the_row(db, store,
+                                                            service):
+    """The cheapest direct guard for the plumbing: submit is what a route
+    calls, and it is the only thing that can route the two columns from the
+    request into create_run."""
+    now = "2026-01-01T00:00:00.000000Z"
+    db._conn.execute(
+        "INSERT INTO sweeps (id, state, method, seed_variants, spec, "
+        "objective, variants, created_at) VALUES ('s1', 'running', 'grid', "
+        "0, '{}', '{}', '[]', ?)", (now,))
+    result = await service.submit(_graph("v2"), options={"device": "cpu"},
+                                  sweep_id="s1", sweep_variant=2)
+    record = await store.get_run(result.run_id)
+    assert record.sweep_id == "s1"
+    assert record.sweep_variant == 2
+
+
+async def test_submit_refuses_a_sweep_id_on_the_interactive_lane(service):
+    """A sweep never uses that lane: _submit_interactive admits against
+    RUN_INTERACTIVE_MAX_CONCURRENT and REFUSES past it rather than queuing,
+    so a 32-variant interactive sweep would be two runs and thirty 503s."""
+    with pytest.raises(RunSubmitError, match="interactive"):
+        await service.submit(_graph("x"),
+                             options={"device": "cpu",
+                                      "lane": LANE_INTERACTIVE},
+                             sweep_id="s1", sweep_variant=0)

--- a/backend/tests/test_run_queue.py
+++ b/backend/tests/test_run_queue.py
@@ -1085,7 +1085,7 @@ async def test_a_restart_retires_rows_a_hard_kill_left_queued(make_service,
     assert row.started_at is None
 
 
-# ── the sweep columns (#140) ──────────────────────────────────────────────
+# ── submit's sweep plumbing (#140) ────────────────────────────────────────
 
 
 async def test_submit_writes_the_sweep_columns_onto_the_row(db, store,
@@ -1114,3 +1114,38 @@ async def test_submit_refuses_a_sweep_id_on_the_interactive_lane(service):
                              options={"device": "cpu",
                                       "lane": LANE_INTERACTIVE},
                              sweep_id="s1", sweep_variant=0)
+
+
+async def test_submit_hands_the_callers_provenance_to_create_run(
+        service, store, monkeypatch):
+    """The third plumbed parameter, and the ONLY test that would notice it
+    being dropped.
+
+    Asserting the row merely "has provenance" would prove nothing: without
+    the pass-through, create_run's `provenance is None` fallback captures
+    its own and writes an equally valid-looking row. So this asserts
+    IDENTITY -- a commit string capture() cannot produce -- and then that
+    capture() was not called at all, which is the property #140 actually
+    buys: one git shell-out per SWEEP, not one per variant.
+
+    `capture` is replaced with a fresh recorder per test (monkeypatch undoes
+    it), never wrapped, so nothing carries over into another test.
+    """
+    captures: list[tuple] = []
+
+    def _record_capture(*args, **kwargs) -> RunProvenance:
+        captures.append(args)
+        return RunProvenance()
+
+    monkeypatch.setattr(RunProvenance, "capture", _record_capture)
+    pinned = RunProvenance(git_commit="beefcafe" * 5, git_dirty=True,
+                           plugin_pins={"c1": {"sha": "0ff1ce"}})
+
+    result = await service.submit(_graph("prov"), options={"device": "cpu"},
+                                  provenance=pinned)
+
+    record = await store.get_run(result.run_id)
+    assert record.git_commit == "beefcafe" * 5
+    assert record.git_dirty is True
+    assert record.plugin_pins == {"c1": {"sha": "0ff1ce"}}
+    assert captures == []       # not once -- let alone once per variant

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -705,6 +705,29 @@ def test_status_constants_partition_the_vocabulary():
                             "cancelled", "interrupted"}
 
 
+async def test_sweep_id_is_null_for_a_run_created_outside_a_sweep(store):
+    created = await _make_run(store)
+    assert created.sweep_id is None and created.sweep_variant is None
+    fetched = await store.get_run(created.id)
+    assert fetched.sweep_id is None and fetched.sweep_variant is None
+
+
+async def test_list_runs_by_sweep_returns_the_children_in_variant_order(
+        db, store):
+    now = "2026-01-01T00:00:00.000000Z"
+    db._conn.execute(
+        "INSERT INTO sweeps (id, state, method, seed_variants, spec, "
+        "objective, variants, created_at) VALUES ('s1', 'running', 'grid', "
+        "0, '{}', '{}', '[]', ?)", (now,))
+    for variant in (2, 0, 1):
+        await _make_run(store, sweep_id="s1", sweep_variant=variant)
+    await _make_run(store)                       # not part of the sweep
+    children = await store.list_runs_by_sweep("s1")
+    assert [c.sweep_variant for c in children] == [0, 1, 2]
+    assert {c.sweep_id for c in children} == {"s1"}
+    assert await store.list_runs_by_sweep("nope") == []
+
+
 # ── 3. events: the gapless cursor ─────────────────────────────────────────
 
 

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -177,6 +177,18 @@ def test_required_indexes_exist(db):
     names = _index_names(db)
     assert "idx_exec_runs_created" in names
     assert "idx_exec_runs_status_created" in names
+    # MIGRATION_004's two (#140). Nothing else under backend/ names either
+    # index, so without these a dropped CREATE INDEX line -- lost in a
+    # rebase, or dropped by a later migration -- leaves the whole suite
+    # green, and the index is then gone forever behind the append-only
+    # rule while list_runs_by_sweep full-scans exec_runs. The name check
+    # catches a deletion; the column tuples below catch a reshape, e.g.
+    # narrowing the sweep index to (sweep_id) alone, which still answers
+    # the filter but no longer orders by variant.
+    assert "idx_sweeps_created" in names
+    assert "idx_exec_runs_sweep" in names
+    assert ("created_at",) in _indexed_columns(db, "sweeps")
+    assert ("sweep_id", "sweep_variant") in _indexed_columns(db, "exec_runs")
 
 
 def test_upgrade_from_shipped_v2_db_preserves_publish_data(tmp_path, monkeypatch):
@@ -407,14 +419,32 @@ def test_the_sweep_columns_arrived_without_a_table_rebuild(db):
     COLUMN. This test used to perform that ALTER itself, as a stand-in for
     "the sweep column arrives without a table rebuild"; now that
     MIGRATION_004 ships it, it asserts what the stand-in was a proxy for."""
+    from app.core.migrations import MIGRATION_003, iter_statements
+
     assert _columns(db, "exec_runs")[-2:] == ["sweep_id", "sweep_variant"]
     ddl = db._conn.execute(
         "SELECT sql FROM sqlite_master WHERE name = 'exec_runs'").fetchone()[0]
-    # ADD COLUMN appends to the stored CREATE TABLE text and leaves
-    # migration 003's own body -- aligned comments and all -- byte-intact. A
-    # 12-step table rebuild would have replaced it with freshly written DDL.
-    assert "-- uuid4().hex, like runs.run_id" in ddl
-    assert "sweep_id" in ddl and "sweep_variant" in ddl
+    # THE rebuild detector, and it has to be structural rather than a
+    # comment match. A 12-step rebuild is normally written by copy-pasting
+    # migration 003's CREATE body out of this repo, so every comment in it
+    # survives the rebuild and any single comment string still matches --
+    # measured. What a rebuild cannot reproduce is the byte-for-byte
+    # PREFIX: adding columns to a hand-written CREATE means putting a comma
+    # after `plugin_pins TEXT`, and CREATE-new/RENAME-back re-quotes the
+    # table name to `CREATE TABLE "exec_runs"`. ADD COLUMN instead drops the
+    # stored text's final `)` and re-appends it after the new column
+    # definitions, leaving every byte before it untouched.
+    #
+    # Derived from MIGRATION_003 rather than duplicated from it, so it
+    # cannot drift, and so an edit to a shipped migration is reported as
+    # what it is instead of being misdiagnosed as a table rebuild.
+    create = next(s for s in iter_statements(MIGRATION_003)
+                  if s.lstrip().upper().startswith("CREATE TABLE EXEC_RUNS"))
+    create = create.strip().rstrip(";").strip()
+    body = create[:create.rindex(")")]
+    assert ddl.startswith(body)
+    appended = ddl[len(body):]
+    assert "sweep_id" in appended and "sweep_variant" in appended
     # A row written without the sweep columns reads back NULL in both, not
     # 0/''; ADD COLUMN with no DEFAULT is what makes that true for new rows
     # as well as for the ones that predate the migration.

--- a/backend/tests/test_run_store.py
+++ b/backend/tests/test_run_store.py
@@ -130,9 +130,12 @@ async def _make_run(store: RunStore, **kwargs) -> RunRecord:
 # ── 1. migrations ─────────────────────────────────────────────────────────
 
 
-def test_fresh_install_creates_the_four_exec_tables(db):
-    assert _user_version(db) == len(MIGRATIONS) == 3
+def test_fresh_install_creates_the_exec_tables_and_sweeps(db):
+    assert _user_version(db) == len(MIGRATIONS) == 4
     assert EXEC_TABLES <= _tables(db)
+    # NOT in EXEC_TABLES: that set is the `exec_`-prefixed namespace and
+    # `sweeps` is not in it.
+    assert "sweeps" in _tables(db)
 
 
 def test_fresh_install_keeps_the_publish_tables_untouched(db):
@@ -152,6 +155,9 @@ def test_exec_runs_has_the_full_column_list(db):
         "id", "name", "graph_snapshot", "options", "status", "error",
         "queue_key", "created_at", "started_at", "finished_at",
         "git_commit", "git_dirty", "plugin_pins",
+        # Appended by MIGRATION_004's ALTERs, in ALTER order -- SQLite puts
+        # an added column at the end of the table.
+        "sweep_id", "sweep_variant",
     ]
 
 
@@ -199,7 +205,7 @@ def test_upgrade_from_shipped_v2_db_preserves_publish_data(tmp_path, monkeypatch
     new = Database(tmp_path / "u.db")
     new.connect()
     try:
-        assert _user_version(new) == 3
+        assert _user_version(new) == len(MIGRATIONS)
         assert EXEC_TABLES <= _tables(new)
         row = new._conn.execute(
             "SELECT status, created_at FROM runs WHERE run_id = 'legacy-invoke'"
@@ -212,7 +218,102 @@ def test_upgrade_from_shipped_v2_db_preserves_publish_data(tmp_path, monkeypatch
         new.close()
 
 
-def test_reconnecting_a_v3_db_is_a_noop(tmp_path):
+def test_migration_004_upgrades_a_v3_db(tmp_path, monkeypatch):
+    """The sweep schema lands on a populated v3 database in place.
+
+    Pre-migration rows must survive the ALTER and read back with BOTH new
+    columns NULL (unknown) -- never 0, False or '': `sweep_variant = 0`
+    would tell every pre-existing run it is variant 0 of nothing.
+    """
+    from app.core import db as dbmod
+    from app.core.migrations import (
+        MIGRATION_001,
+        MIGRATION_002,
+        MIGRATION_003,
+    )
+
+    old_list = [MIGRATION_001, MIGRATION_002, MIGRATION_003]
+    monkeypatch.setattr(dbmod, "MIGRATIONS", old_list)
+    old = Database(tmp_path / "s.db")
+    old.connect()
+    assert _user_version(old) == 3
+    assert "sweep_id" not in _columns(old, "exec_runs")
+    assert "sweeps" not in _tables(old)
+
+    now = "2026-01-01T00:00:00.000000Z"
+    old._conn.execute(
+        "INSERT INTO exec_runs (id, name, graph_snapshot, options, status, "
+        "created_at) VALUES ('legacy-run', 'pre-sweep', '{}', '{}', "
+        "'succeeded', ?)", (now,),
+    )
+    old._conn.execute(
+        "INSERT INTO exec_run_metrics (run_id, name, step, value, ts) "
+        "VALUES ('legacy-run', 'train_loss', 0, 0.5, ?)", (now,),
+    )
+    old.close()
+
+    monkeypatch.setattr(dbmod, "MIGRATIONS", list(MIGRATIONS))
+    new = Database(tmp_path / "s.db")
+    new.connect()
+    try:
+        assert _user_version(new) == 4
+        assert "sweeps" in _tables(new)
+        assert EXEC_TABLES <= _tables(new)
+        columns = _columns(new, "exec_runs")
+        assert "sweep_id" in columns and "sweep_variant" in columns
+
+        row = new._conn.execute(
+            "SELECT name, status, created_at, sweep_id, sweep_variant "
+            "FROM exec_runs WHERE id = 'legacy-run'").fetchone()
+        assert row["name"] == "pre-sweep"          # old data byte-intact
+        assert row["status"] == "succeeded"
+        assert row["created_at"] == now
+        assert row["sweep_id"] is None             # NULL = not part of a sweep
+        assert row["sweep_variant"] is None
+        assert new._conn.execute(
+            "SELECT COUNT(*) FROM exec_run_metrics").fetchone()[0] == 1
+        assert new._conn.execute(
+            "SELECT COUNT(*) FROM sweeps").fetchone()[0] == 0
+    finally:
+        new.close()
+
+
+def test_creating_a_child_before_its_sweep_is_refused(db):
+    """The FK clause added by ALTER TABLE is resolved at DML time and is
+    live under PRAGMA foreign_keys=ON (db.py:106), so a child row cannot
+    name a sweep that does not exist. Says nothing about statement order
+    inside the migration -- spec 4.1 measured both orders working, so a
+    test asserting CREATE-before-ALTER would fail."""
+    with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
+        db._conn.execute(
+            "INSERT INTO exec_runs (id, graph_snapshot, options, status, "
+            "created_at, sweep_id, sweep_variant) VALUES ('orphan', '{}', "
+            "'{}', 'queued', '2026-01-01T00:00:00.000000Z', 'nope', 0)")
+
+
+def test_deleting_a_sweep_row_nulls_its_children(db):
+    """ON DELETE SET NULL, not CASCADE: deleting a sweep row must never
+    delete run history. v1 exposes no route that deletes one (spec 10.2), so
+    this exercises the clause with direct SQL."""
+    now = "2026-01-01T00:00:00.000000Z"
+    db._conn.execute(
+        "INSERT INTO sweeps (id, state, method, seed_variants, spec, "
+        "objective, variants, created_at) VALUES ('s1', 'running', 'grid', "
+        "0, '{}', '{}', '[]', ?)", (now,))
+    db._conn.execute(
+        "INSERT INTO exec_runs (id, graph_snapshot, options, status, "
+        "created_at, sweep_id, sweep_variant) VALUES ('child', '{}', '{}', "
+        "'queued', ?, 's1', 0)", (now,))
+    db._conn.execute("DELETE FROM sweeps WHERE id = 's1'")
+    row = db._conn.execute(
+        "SELECT status, sweep_id, sweep_variant FROM exec_runs "
+        "WHERE id = 'child'").fetchone()
+    assert row["status"] == "queued"            # history survives
+    assert row["sweep_id"] is None
+    assert row["sweep_variant"] == 0            # only the FK column is nulled
+
+
+def test_reconnecting_a_migrated_db_is_a_noop(tmp_path):
     first = Database(tmp_path / "idem.db")
     first.connect()
     first.close()
@@ -301,11 +402,30 @@ def test_status_vocabulary_is_not_pinned_in_sql(db):
     assert "CHECK" not in ddl.upper()
 
 
-def test_schema_stays_additive_for_the_sweep_column(db):
-    """#140 will add `sweep_id` -- prove a plain ALTER TABLE ADD COLUMN is
-    enough (no table rebuild, no data migration)."""
-    db._conn.execute("ALTER TABLE exec_runs ADD COLUMN sweep_id TEXT")
-    assert "sweep_id" in _columns(db, "exec_runs")
+def test_the_sweep_columns_arrived_without_a_table_rebuild(db):
+    """#140 added `sweep_id`/`sweep_variant` with a plain ALTER TABLE ADD
+    COLUMN. This test used to perform that ALTER itself, as a stand-in for
+    "the sweep column arrives without a table rebuild"; now that
+    MIGRATION_004 ships it, it asserts what the stand-in was a proxy for."""
+    assert _columns(db, "exec_runs")[-2:] == ["sweep_id", "sweep_variant"]
+    ddl = db._conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name = 'exec_runs'").fetchone()[0]
+    # ADD COLUMN appends to the stored CREATE TABLE text and leaves
+    # migration 003's own body -- aligned comments and all -- byte-intact. A
+    # 12-step table rebuild would have replaced it with freshly written DDL.
+    assert "-- uuid4().hex, like runs.run_id" in ddl
+    assert "sweep_id" in ddl and "sweep_variant" in ddl
+    # A row written without the sweep columns reads back NULL in both, not
+    # 0/''; ADD COLUMN with no DEFAULT is what makes that true for new rows
+    # as well as for the ones that predate the migration.
+    db._conn.execute(
+        "INSERT INTO exec_runs (id, graph_snapshot, options, status, "
+        "created_at) VALUES ('solo', '{}', '{}', 'queued', "
+        "'2026-01-01T00:00:00.000000Z')")
+    row = db._conn.execute(
+        "SELECT sweep_id, sweep_variant FROM exec_runs "
+        "WHERE id = 'solo'").fetchone()
+    assert row["sweep_id"] is None and row["sweep_variant"] is None
 
 
 # ── 2. run CRUD ───────────────────────────────────────────────────────────

--- a/backend/tests/test_sweeps.py
+++ b/backend/tests/test_sweeps.py
@@ -7,6 +7,7 @@ test_run_queue.py's, so test modules stay independent.
 
 from __future__ import annotations
 
+import asyncio
 import copy
 from typing import Any
 
@@ -611,6 +612,25 @@ async def test_create_sweep_assigns_each_variant_index_exactly_once(sweeps):
     assert [v.run_id for v in patched.variants] == [None, "r1", None]
 
 
+async def test_a_non_finite_objective_never_reaches_the_blob(sweeps):
+    """``_dumps``' ``allow_nan=False``, and why it must never be relaxed.
+
+    Python's json emits the bare tokens ``NaN`` / ``Infinity``, which are a
+    CPython extension and not JSON. Starlette renders every response with
+    ``allow_nan=False``, so one of those inside the durable blob is a 500 on
+    EVERY later read of the sweep -- permanently, because retention deletes
+    finished runs but never a sweeps row. Refusing at the door costs one
+    loud failure on the write instead, and the write is a single autocommit
+    INSERT, so nothing is stored.
+    """
+    for bad, unwritten in ((float("nan"), "nan-sweep"),
+                           (float("inf"), "inf-sweep")):
+        with pytest.raises(ValueError, match="not JSON compliant"):
+            await _new_sweep(sweeps, sweep_id=unwritten,
+                             variants=[_variant(0, objective=bad)])
+        assert await sweeps.get_sweep(unwritten) is None
+
+
 async def test_set_variant_run_patches_one_entry_and_leaves_the_rest(sweeps):
     created = await _new_sweep(sweeps, count=3)
     assert await sweeps.set_variant_run(created.id, 1, run_id="r1", seed=42)
@@ -623,6 +643,33 @@ async def test_set_variant_run_patches_one_entry_and_leaves_the_rest(sweeps):
                                             seed=None)
 
 
+async def test_concurrent_variant_patches_do_not_lose_each_other(sweeps):
+    """The single-closure rule, asserted rather than merely documented.
+
+    ``set_variant_run`` is the only read-modify-write in this module, and it
+    is safe ONLY because its SELECT, its patch and its UPDATE all live in
+    one ``fn(conn)``. Split into a ``Database.run`` read plus a separate
+    ``Database.run`` write -- the tidy-looking refactor a maintainer reaches
+    for when they notice ``get_sweep`` already does the read -- every call
+    still returns True and every patch but the last is silently lost, because
+    all of them read the same blob before any of them writes.
+
+    Spec 5.2's submit loop patches one variant per submit, so a real sweep can
+    have several of these in flight at once; a lost update there is a
+    sweep-to-child link gone for good, reported as ``status: "missing"``
+    forever while the child run sits in ``exec_runs`` with a correct
+    ``sweep_id``.
+    """
+    created = await _new_sweep(sweeps, count=4)
+    patched = await asyncio.gather(*(
+        sweeps.set_variant_run(created.id, i, run_id=f"r{i}", seed=i)
+        for i in range(4)))
+    assert all(patched)
+    fetched = await sweeps.get_sweep(created.id)
+    assert [v.run_id for v in fetched.variants] == ["r0", "r1", "r2", "r3"]
+    assert [v.seed for v in fetched.variants] == [0, 1, 2, 3]
+
+
 async def test_mark_failed_records_the_error_and_stamps_finished_at(sweeps):
     created = await _new_sweep(sweeps)
     assert await sweeps.mark_failed(created.id, "run service is shutting down")
@@ -630,6 +677,20 @@ async def test_mark_failed_records_the_error_and_stamps_finished_at(sweeps):
     assert fetched.state == SWEEP_STATE_FAILED
     assert fetched.error == "run service is shutting down"
     assert fetched.finished_at is not None
+
+
+async def test_set_state_moves_a_running_sweep(sweeps):
+    """The positive half, which the two negative tests never observe.
+
+    Spec 7.3's cancel is built entirely on this call, so a ``set_state`` that
+    quietly moves nothing would surface a task later as a cancelled sweep
+    that keeps reporting ``running`` to the panel.
+    """
+    created = await _new_sweep(sweeps)
+    assert await sweeps.set_state(created.id, SWEEP_STATE_CANCELLING)
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched.state == SWEEP_STATE_CANCELLING
+    assert not await sweeps.set_state("nope", SWEEP_STATE_CANCELLING)
 
 
 async def test_set_state_never_overwrites_failed(sweeps):

--- a/backend/tests/test_sweeps.py
+++ b/backend/tests/test_sweeps.py
@@ -1,0 +1,448 @@
+"""Sweep compilation and storage (#140).
+
+The REST surface has its own module (test_api_sweeps.py); the probe node is
+duplicated there on purpose, the way test_api_runs.py duplicates
+test_run_queue.py's, so test modules stay independent.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+
+from app.core.node_base import (
+    BaseNode,
+    DataType,
+    ParamDefinition,
+    ParamType,
+    PortDefinition,
+)
+from app.core.node_registry import registry
+from app.core.sweep_compiler import (
+    SweepCompileError,
+    compile_sweep,
+    planner_prng,
+    sample_unique_ranks,
+)
+
+
+class _SweepProbeNode(BaseNode):
+    """Every param type a sweep can meet, plus the ones it must refuse."""
+
+    NODE_NAME = "_SweepProbe"
+    CATEGORY = "Test"
+    DESCRIPTION = "Logs a val_loss derived from its swept params"
+
+    @classmethod
+    def define_inputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_outputs(cls) -> list[PortDefinition]:
+        return [PortDefinition(name="value", data_type=DataType.ANY)]
+
+    @classmethod
+    def define_params(cls) -> list[ParamDefinition]:
+        return [
+            ParamDefinition(name="lr", param_type=ParamType.FLOAT,
+                            default=0.001, min_value=0.0, max_value=1.0),
+            ParamDefinition(name="weight_decay", param_type=ParamType.FLOAT,
+                            default=0.0),
+            ParamDefinition(name="epochs", param_type=ParamType.INT,
+                            default=1),
+            ParamDefinition(name="shuffle", param_type=ParamType.BOOL,
+                            default=False),
+            ParamDefinition(name="optimizer", param_type=ParamType.SELECT,
+                            default="adam", options=["adam", "sgd"]),
+            ParamDefinition(name="note", param_type=ParamType.STRING,
+                            default=""),
+            ParamDefinition(name="api_key", param_type=ParamType.SECRET,
+                            default=""),
+            ParamDefinition(name="weights", param_type=ParamType.MODEL_FILE,
+                            default=""),
+        ]
+
+    def execute(self, inputs: dict[str, Any],
+                params: dict[str, Any]) -> dict[str, Any]:
+        return {"value": inputs.get("value")}
+
+
+@pytest.fixture(autouse=True)
+def _register_probe():
+    registry._nodes["_SweepProbe"] = _SweepProbeNode
+    yield
+    registry._nodes.pop("_SweepProbe", None)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _base_graph(*extra_nodes: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "nodes": [
+            {"id": "start", "type": "Start", "data": {"params": {}}},
+            {"id": "probe", "type": "_SweepProbe", "data": {"params": {}}},
+            *extra_nodes,
+        ],
+        "edges": [],
+    }
+
+
+def _compile(spec, graph=None, *, max_runs=32, max_params=4, max_domain=32):
+    return compile_sweep(graph if graph is not None else _base_graph(), spec,
+                         max_runs=max_runs, max_params=max_params,
+                         max_domain=max_domain)
+
+
+def _values(param: str, values: list[Any], node_id: str = "probe"):
+    return {"node_id": node_id, "param": param, "values": values}
+
+
+def _range(param: str, node_id: str = "probe", **fields: Any):
+    return {"node_id": node_id, "param": param, "range": fields}
+
+
+def _grid(*params: dict[str, Any]) -> dict[str, Any]:
+    return {"method": "grid", "params": list(params)}
+
+
+def _domain(param_spec: dict[str, Any]) -> tuple[Any, ...]:
+    return _compile(_grid(param_spec)).params[0].domain
+
+
+def _refusal(spec, graph=None, **kw) -> str:
+    with pytest.raises(SweepCompileError) as excinfo:
+        _compile(spec, graph, **kw)
+    return str(excinfo.value)
+
+
+# ── determinism (spec 2.10, 9.5) ──────────────────────────────────────────
+
+
+def test_mulberry32_matches_the_javascript_stream():
+    """Raw uint32 streams, computed from optimizer.ts:307-317's algorithm.
+    The tightest fixture there is: independent of the sampler, and the one
+    that catches a float-returning port immediately."""
+    def draws(seed: int, n: int) -> list[int]:
+        nxt = planner_prng(seed)
+        return [nxt() for _ in range(n)]
+
+    assert draws(0, 4) == [1144304738, 1416247, 958946056, 627933444]
+    assert draws(42, 4) == [2581720956, 1925393290, 3661312704, 2876485805]
+    assert draws(123456789, 6) == [1107202814, 4169434471, 3372958138,
+                                   885470128, 1301683845, 3208624240]
+
+
+def test_mulberry32_returns_a_raw_uint32_not_a_float():
+    """The JS original has no `/ 4294967296`; its only consumer is
+    `next() % remaining`. A textbook port that divides diverges on some
+    draws and silently produces a different variant list (spec 2.9)."""
+    nxt = planner_prng(2026)
+    for _ in range(64):
+        value = nxt()
+        assert isinstance(value, int) and not isinstance(value, bool)
+        assert 0 <= value < 2 ** 32
+
+
+def test_sample_unique_ranks_matches_the_copilot_fixture():
+    # optimizer.test.ts:192-220 uses domains [5, 2] with a baseline at
+    # index 3, so it draws 7 of the 9 non-baseline slots and shifts them:
+    # [9, 8, 5, 7, 0, 6, 2] after `rank >= 3 ? rank + 1 : rank`. v1 has no
+    # baseline (spec 3.1), so it uses the unshifted form below.
+    assert sample_unique_ranks(9, 7, 123456789) == [8, 7, 4, 6, 0, 5, 2]
+
+
+def test_sample_unique_ranks_is_a_permutation_when_exhaustive():
+    """count == total proves the sparse Fisher-Yates bookkeeping rather
+    than just the PRNG."""
+    drawn = sample_unique_ranks(6, 6, 7)
+    assert drawn == [4, 0, 2, 3, 1, 5]
+    assert sorted(drawn) == list(range(6))
+
+
+def test_the_same_seed_reproduces_the_identical_variant_list():
+    """#140 acceptance criterion 2."""
+    spec = {"method": "random", "seed": 123456789, "samples": 6,
+            "params": [_values("lr", [0.1, 0.01, 0.001, 0.0001, 0.5]),
+                       _values("epochs", [1, 2])]}
+    first = _compile(spec)
+    second = _compile(spec)
+    assert [v.assignment for v in first.variants] == \
+           [v.assignment for v in second.variants]
+    assert [v.domain_index for v in first.variants] == \
+           [v.domain_index for v in second.variants]
+
+
+def test_a_different_seed_produces_a_different_variant_list():
+    # Inequality only, mirroring optimizer.test.ts:222-227 -- pinning a
+    # second exact sequence buys nothing the first one has not already.
+    def order(seed: int) -> list[int]:
+        return [v.domain_index for v in _compile(
+            {"method": "random", "seed": seed, "samples": 6,
+             "params": [_values("lr", [0.1, 0.01, 0.001, 0.0001, 0.5]),
+                        _values("epochs", [1, 2])]}).variants]
+
+    assert order(123456789) != order(987654321)
+
+
+def test_random_never_repeats_a_combination():
+    compiled = _compile({"method": "random", "seed": 20260831, "samples": 5,
+                         "params": [_values("lr", [0.1, 0.01, 0.001, 0.5]),
+                                    _values("epochs", [1, 2, 3])]})
+    indices = [v.domain_index for v in compiled.variants]
+    assert len(set(indices)) == 5
+    assert compiled.total_combinations == 12
+
+
+def test_samples_above_the_space_is_refused():
+    message = _refusal({"method": "random", "seed": 1, "samples": 9,
+                        "params": [_values("epochs", [1, 2, 3])]})
+    assert "9" in message and "3" in message
+
+
+# ── grid shape (spec 3.1, 9.3) ────────────────────────────────────────────
+
+
+def test_grid_cardinality_is_the_product_of_the_domains():
+    """3x2 compiles exactly 6 variants -- no baseline subtraction.
+    #140 acceptance criterion 1."""
+    compiled = _compile(_grid(_values("lr", [0.0001, 0.001, 0.01]),
+                              _values("weight_decay", [0.0, 0.0001])))
+    assert compiled.total_combinations == 6
+    assert len(compiled.variants) == 6
+    assert [v.index for v in compiled.variants] == [0, 1, 2, 3, 4, 5]
+    assert [v.domain_index for v in compiled.variants] == [0, 1, 2, 3, 4, 5]
+
+
+def test_grid_varies_the_last_param_fastest():
+    """Row-major / C order, so a comparison table is reproducible from the
+    spec alone. The exact table is spec 3.1's, over this module's params."""
+    compiled = _compile(_grid(_values("epochs", [3, 4]),
+                              _values("shuffle", [False, True]),
+                              _values("optimizer", ["adam", "sgd"])))
+    assert [v.assignment for v in compiled.variants] == [
+        (3, False, "adam"), (3, False, "sgd"),
+        (3, True, "adam"), (3, True, "sgd"),
+        (4, False, "adam"), (4, False, "sgd"),
+        (4, True, "adam"), (4, True, "sgd"),
+    ]
+
+
+def test_the_cap_errors_and_never_truncates():
+    message = _refusal(_grid(_values("lr", [0.1, 0.2, 0.3, 0.4, 0.5]),
+                             _values("weight_decay", [0.0, 0.1, 0.2, 0.3, 0.4]),
+                             _values("epochs", [1, 2, 3, 4, 5])))
+    assert "125" in message and "32" in message
+    assert "narrow the domains" in message
+
+
+# ── range expansion (spec 2.5, 2.6, 9.3) ──────────────────────────────────
+
+
+def test_linear_float_range_includes_both_endpoints_exactly():
+    # `==` against the literals, never `is`: identity is meaningless on
+    # floats after a round-trip and vacuously true for `float(x) is x`.
+    assert _domain(_range("lr", min=0.0, max=1.0, count=5,
+                          scale="linear", type="float")) == \
+        (0.0, 0.25, 0.5, 0.75, 1.0)
+
+
+def test_log_float_range_hits_the_decades_exactly():
+    assert _domain(_range("lr", min=1e-4, max=1e-1, count=4,
+                          scale="log", type="float")) == \
+        (0.0001, 0.001, 0.01, 0.1)
+
+
+def test_log_int_range_doubles():
+    assert _domain(_range("epochs", min=16, max=128, count=4,
+                          scale="log", type="int")) == (16, 32, 64, 128)
+
+
+def test_int_range_rounds_half_away_from_zero():
+    """The midpoint is chosen so the two rules DIFFER: 1..4 in 3 points
+    interpolates [1.0, 2.5, 4.0], and Python's banker's `round(2.5)` is 2
+    while half-away-from-zero is 3. A 1.5-style midpoint is identical under
+    both rules and would satisfy a wrong implementation."""
+    assert _domain(_range("epochs", min=1, max=4, count=3,
+                          scale="linear", type="int")) == (1, 3, 4)
+
+
+def test_a_collapsed_int_range_dedupes_and_shrinks_the_grid():
+    compiled = _compile(_grid(_range("epochs", min=1, max=3, count=10,
+                                     scale="linear", type="int")))
+    assert compiled.params[0].domain == (1, 2, 3)
+    assert compiled.total_combinations == 3
+    assert len(compiled.variants) == 3
+
+
+def test_count_one_returns_the_min():
+    for scale in ("linear", "log"):
+        assert _domain(_range("lr", min=0.01, max=0.5, count=1,
+                              scale=scale, type="float")) == (0.01,)
+
+
+def test_log_range_with_a_non_positive_min_is_refused():
+    message = _refusal(_grid(_range("lr", min=0.0, max=0.1, count=3,
+                                    scale="log", type="float")))
+    assert "params[0]" in message and "positive min" in message
+
+
+def test_duplicate_values_are_refused():
+    assert "repeats" in _refusal(_grid(_values("epochs", [1, 1, 2])))
+
+
+def test_non_finite_values_are_refused():
+    """json.loads("NaN") is nan and json.loads("1e999") is inf, and both
+    pass every other check in the spec before corrupting a stored row."""
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        message = _refusal(_grid(_values("lr", [0.1, bad])))
+        assert "values[1]" in message and "finite" in message
+
+
+def test_non_finite_range_bounds_are_refused():
+    message = _refusal(_grid(_range("lr", min=0.1, max=float("inf"), count=3,
+                                    scale="linear", type="float")))
+    assert "bounds must be finite" in message
+
+
+# ── the type-acceptance matrix (spec 3.4.1, 9.3) ──────────────────────────
+
+
+def test_a_float_param_accepts_an_integer_and_stores_a_float():
+    compiled = _compile(_grid(_values("lr", [1, 0.1])))
+    assert compiled.params[0].domain == (1.0, 0.1)
+    stored = compiled.variants[0].graph["nodes"][1]["data"]["params"]["lr"]
+    assert stored == 1.0 and isinstance(stored, float)
+
+
+def test_an_int_param_accepts_a_whole_float_and_stores_an_int():
+    compiled = _compile(_grid(_values("epochs", [2.0])))
+    stored = compiled.variants[0].graph["nodes"][1]["data"]["params"]["epochs"]
+    assert stored == 2 and isinstance(stored, int)
+
+
+def test_true_is_not_a_number_for_an_int_or_float_param():
+    """bool subclasses int and True == 1, so a naive isinstance check would
+    silently accept `true` as 1 -- not a 400, and not a domain of size 2."""
+    assert "contains True" in _refusal(_grid(_values("lr", [1, True])))
+    assert "contains True" in _refusal(_grid(_values("epochs", [1, True])))
+
+
+def test_a_bool_param_refuses_1_and_0():
+    assert "bool param" in _refusal(_grid(_values("shuffle", [0, 1])))
+
+
+def test_coercion_makes_the_domain_homogeneous_before_dedup():
+    """Both coerce to 1.0, so this is a DUPLICATE error and not a domain of
+    size 2 -- which proves the coerce/dedup/bounds ordering (rule 4)."""
+    assert "repeats" in _refusal(_grid(_values("lr", [1, 1.0])))
+
+
+# ── graph handling (spec 3.5, 9.3) ────────────────────────────────────────
+
+
+def test_a_non_dict_node_entry_is_a_400_not_a_500():
+    """normalize_graph validates that `nodes` is a non-empty list and
+    nothing about its contents, so {"nodes": ["x"]} reaches the compiler
+    intact and `node["id"]` on a str would be an uncaught 500."""
+    graph = {"nodes": ["x", {"id": "probe", "type": "_SweepProbe",
+                             "data": {"params": {}}}], "edges": []}
+    message = _refusal(_grid(_values("lr", [0.1], node_id="ghost")), graph)
+    assert "no node with id 'ghost'" in message
+
+
+def test_compile_never_mutates_the_base_graph():
+    graph = _base_graph()
+    before = copy.deepcopy(graph)
+    _compile(_grid(_values("lr", [0.1, 0.2])), graph)
+    assert graph == before
+
+
+def test_each_variant_graph_is_independent():
+    compiled = _compile(_grid(_values("lr", [0.1, 0.2])))
+    compiled.variants[0].graph["nodes"][1]["data"]["params"]["lr"] = 99.0
+    assert compiled.variants[1].graph["nodes"][1]["data"]["params"]["lr"] == 0.2
+
+
+def test_overrides_land_in_data_params():
+    compiled = _compile(_grid(_values("lr", [0.0001, 0.001, 0.01]),
+                              _values("weight_decay", [0.0, 0.0001])))
+    params = compiled.variants[3].graph["nodes"][1]["data"]["params"]
+    assert params == {"lr": 0.001, "weight_decay": 0.0001}
+
+
+def test_a_param_absent_from_data_params_is_still_settable():
+    """Nodes read params.get(name, default), so writing a key that was not
+    there takes effect. Only unreachable CONTAINERS are refused."""
+    graph = {"nodes": [{"id": "probe", "type": "_SweepProbe", "data": {}}],
+             "edges": []}
+    compiled = _compile(_grid(_values("lr", [0.25])), graph)
+    assert compiled.variants[0].graph["nodes"][0]["data"]["params"] == \
+        {"lr": 0.25}
+
+
+# ── RULING 3: one test per reachability failure (spec 3.4, 9.4) ───────────
+
+
+def test_unknown_node_id_is_refused():
+    assert "no node with id 'nope'" in \
+        _refusal(_grid(_values("lr", [0.1], node_id="nope")))
+
+
+def test_duplicate_node_id_is_refused():
+    graph = _base_graph({"id": "probe", "type": "_SweepProbe",
+                         "data": {"params": {}}})
+    message = _refusal(_grid(_values("lr", [0.1])), graph)
+    assert "2 nodes with id 'probe'" in message
+    assert "ids must be unique" in message
+
+
+def test_preset_node_param_is_refused():
+    graph = {"nodes": [{"id": "pipe", "type": "preset:Training Pipeline",
+                        "data": {"params": {}}}], "edges": []}
+    message = _refusal(_grid(_values("lr", [0.1], node_id="pipe")), graph)
+    assert "preset instance" in message
+    assert "data.internalParams" in message
+
+
+def test_subgraph_node_param_is_refused():
+    graph = {"nodes": [{"id": "blk", "type": "subgraph:blk",
+                        "data": {"params": {}}}], "edges": []}
+    message = _refusal(_grid(_values("lr", [0.1], node_id="blk")), graph)
+    assert "subgraph instance" in message
+    assert "cannot be overridden per instance" in message
+
+
+def test_unknown_param_name_is_refused():
+    message = _refusal(_grid(_values("momentum", [0.9])))
+    assert "'probe'" in message and "'momentum'" in message
+
+
+def test_secret_param_is_refused():
+    """RULING 4 stores each variant's chosen params on the durable sweeps
+    row, so a swept SECRET would be written there in the clear."""
+    message = _refusal(_grid(_values("api_key", ["sk-1", "sk-2"])))
+    assert "'probe.api_key' is a secret parameter" in message
+
+
+def test_unsupported_param_type_is_refused():
+    message = _refusal(_grid(_values("weights", ["a.pt", "b.pt"])))
+    assert "param type 'model_file'" in message
+
+
+def test_value_outside_min_value_is_refused():
+    message = _refusal(_grid(_values("lr", [0.1, -1.0])))
+    assert "'probe.lr' must be >= 0.0, got -1.0" in message
+
+
+def test_select_value_not_in_options_is_refused():
+    message = _refusal(_grid(_values("optimizer", ["adam", "rmsprop"])))
+    assert "does not accept 'rmsprop'" in message
+    assert "['adam', 'sgd']" in message
+
+
+def test_wrong_scalar_type_for_an_int_param_is_refused():
+    assert "int param but the domain contains 0.5" in \
+        _refusal(_grid(_values("epochs", [1, 0.5])))

--- a/backend/tests/test_sweeps.py
+++ b/backend/tests/test_sweeps.py
@@ -719,12 +719,20 @@ async def test_an_unknown_sweep_state_is_refused(sweeps):
 
 async def _child(store: RunStore, sweep_id: str, index: int, *,
                  status: str = "succeeded",
-                 metrics: dict[str, float] | None = None) -> str:
+                 metrics: dict[str, float] | None = None,
+                 series: dict[str, list[tuple[int, float]]] | None = None,
+                 ) -> str:
+    """One child run. *metrics* logs a single point per series at step 0;
+    *series* logs a whole ``[(step, value), ...]`` in the order given, so a
+    test can pin which point of a series the harvest actually reads."""
     record = await store.create_run(
         graph_snapshot={"nodes": [], "edges": []}, options={},
         provenance=RunProvenance(), sweep_id=sweep_id, sweep_variant=index)
     for name, value in (metrics or {}).items():
         await store.log_metrics(record.id, [MetricPoint(name, value, 0)])
+    for name, points in (series or {}).items():
+        for step, value in points:
+            await store.log_metrics(record.id, [MetricPoint(name, value, step)])
     if status != "queued":
         await store.mark_finished(record.id, status)
     return record.id
@@ -875,6 +883,42 @@ async def test_concurrent_harvests_do_not_lose_each_other(sweeps):
     fetched = await sweeps.get_sweep(created.id)
     assert [v.index for v in fetched.variants] == [0, 1, 2, 3]   # order kept
     assert [v.objective for v in fetched.variants] == [0.0, 1.0, 2.0, 3.0]
+
+
+async def test_seam_b_harvests_the_LAST_point_of_the_objective_series(
+        db, sweeps):
+    """Spec 6.1: the objective is the series' LAST point by ``step``.
+
+    Not the first, not the best epoch, and not the last one WRITTEN. Every
+    other sweep test logs exactly one point per series, so the ordering in
+    ``_last_metric_value`` changes none of their answers and its
+    ``ORDER BY step DESC, id DESC`` could be flipped with nothing noticing.
+    Seam B is a SECOND implementation of the rule ``latest_metrics``
+    already implements -- that one is pinned in test_run_store.py, this one
+    was not -- and spec 6.1 requires the two to agree.
+
+    The blast radius is why this matters more here than in a chart: a sweep
+    pruned before its first GET is harvested only by seam B, and RULING 4
+    makes whatever it stored the PERMANENT answer. The children are gone
+    and nothing recomputes it.
+
+    Three points, arriving out of step order, give four implementations
+    four different answers: last-by-step 0.5 (correct), first-by-step 0.9,
+    best 0.1, last-WRITTEN 0.9. A run that overfits after its best epoch
+    therefore ranks on where it ended up, which is the honest reading of
+    #140's "final metric".
+    """
+    store = RunStore(db)
+    created = await _new_sweep(sweeps, count=1)
+    run_id = await _child(store, created.id, 0, series={
+        "val_loss": [(1, 0.1), (2, 0.5), (0, 0.9)]})
+    await sweeps.set_variant_run(created.id, 0, run_id=run_id, seed=None)
+
+    # No GET first, so seam A never runs and seam B is the only path.
+    assert await store.prune(keep_last=0) == 1
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched.variants[0].objective == 0.5
+    assert fetched.variants[0].harvested_at is not None
 
 
 async def test_the_objective_is_harvested_before_the_delete(db, sweeps):

--- a/backend/tests/test_sweeps.py
+++ b/backend/tests/test_sweeps.py
@@ -202,6 +202,51 @@ def test_samples_above_the_space_is_refused():
     assert "9" in message and "3" in message
 
 
+# ── the recorded planner seed (RULING 1, spec 2.2) ────────────────────────
+
+
+def test_the_compiled_sweep_records_the_planner_seed():
+    """The route fills sweeps.seed from the compiled object rather than
+    re-reading and re-validating spec['seed'], so the seed the sampler used
+    and the seed the row records cannot drift apart."""
+    compiled = _compile({"method": "random", "seed": 20260831, "samples": 3,
+                         "params": [_values("epochs", [1, 2, 3])]})
+    assert compiled.seed == 20260831
+
+
+def test_a_grid_without_a_seed_records_none():
+    """A grid enumerates everything, so it consumes no seed. None is the
+    honest record of 'the caller asked for nothing' -- not 0, which is a
+    real seed a caller may have meant."""
+    assert _compile(_grid(_values("epochs", [1, 2]))).seed is None
+
+
+def test_a_grid_with_a_seed_records_it():
+    """RULING 1: the seed is still recorded even though the planner never
+    draws with it, because it is the base for per-variant execution seeds
+    and because a stored spec should say what was asked for."""
+    spec = _grid(_values("epochs", [1, 2]))
+    spec["seed"] = 7
+    assert _compile(spec).seed == 7
+
+
+def test_the_recorded_seed_agrees_with_the_variant_list_it_produced():
+    """The one with teeth: re-draw the ranks from the RECORDED seed with the
+    public sampler and demand the compiler's own variant order back. A
+    compiler that recorded one seed and sampled with another passes every
+    other test in this section and fails this one."""
+    spec = {"method": "random", "seed": 123456789, "samples": 6,
+            "params": [_values("lr", [0.1, 0.01, 0.001, 0.0001, 0.5]),
+                       _values("epochs", [1, 2])]}
+    first = _compile(spec)
+    second = _compile(spec)
+    assert first.seed == second.seed == 123456789
+    assert [v.assignment for v in first.variants] == \
+           [v.assignment for v in second.variants]
+    assert [v.domain_index for v in first.variants] == \
+        sample_unique_ranks(first.total_combinations, 6, first.seed)
+
+
 # ── grid shape (spec 3.1, 9.3) ────────────────────────────────────────────
 
 

--- a/backend/tests/test_sweeps.py
+++ b/backend/tests/test_sweeps.py
@@ -954,6 +954,74 @@ async def test_a_failing_harvest_does_not_stop_retention(db, caplog,
     assert "sweeps.variants" in caplog.text      # the cause, not just "oops"
 
 
+async def _corrupt_variants(db: Database, sweep_id: str) -> None:
+    """Make one ``sweeps`` row unreadable — a JSON object where the blob
+    must be an array, which ``SweepRecord.from_row`` deliberately refuses
+    to paper over rather than turning into a plausible empty sweep."""
+    await db.run(lambda conn: conn.execute(
+        "UPDATE sweeps SET variants = ? WHERE id = ?",
+        ('{"not": "a list"}', sweep_id)))
+
+
+async def test_one_unharvestable_sweep_does_not_cost_the_others_their_results(
+        db, sweeps):
+    """Per-sweep isolation: one bad row costs only its OWN sweep.
+
+    Catching around the whole harvest keeps retention alive but unwinds the
+    loop, so every other sweep in the same pass loses its harvested numbers
+    too. ``prune`` sweeps the entire table in one call, so those sweeps are
+    unrelated to the broken one — a single corrupt row would quietly cost a
+    healthy sweep the results RULING 4 exists to preserve, and the children
+    holding them are deleted in the same transaction.
+    """
+    store = RunStore(db)
+    broken = await _new_sweep(sweeps, count=1, name="broken")
+    healthy = await _new_sweep(sweeps, count=1, name="healthy")
+    # Children created in this order so the doomed SELECT — a table scan,
+    # therefore rowid order — hands the broken sweep to the loop FIRST, and
+    # the healthy one is harvested strictly after the failure.
+    for sweep, value in ((broken, 0.7), (healthy, 0.25)):
+        run_id = await _child(store, sweep.id, 0, metrics={"val_loss": value})
+        await sweeps.set_variant_run(sweep.id, 0, run_id=run_id, seed=None)
+    await _corrupt_variants(db, broken.id)
+
+    assert await store.prune(keep_last=0) == 2
+    fetched = await sweeps.get_sweep(healthy.id)
+    assert fetched.variants[0].objective == 0.25
+    assert fetched.variants[0].status == "succeeded"
+    assert fetched.state == SWEEP_STATE_FINISHED
+
+
+async def test_an_unharvestable_sweep_is_logged_with_its_id(db, sweeps,
+                                                            caplog):
+    """A swallowed failure nobody can trace is barely better than a silent
+    one: the id is what makes the row findable afterwards."""
+    store = RunStore(db)
+    broken = await _new_sweep(sweeps, count=1)
+    run_id = await _child(store, broken.id, 0, metrics={"val_loss": 0.7})
+    await sweeps.set_variant_run(broken.id, 0, run_id=run_id, seed=None)
+    await _corrupt_variants(db, broken.id)
+
+    with caplog.at_level(logging.WARNING):
+        assert await store.prune(keep_last=0) == 1
+
+    # Asserted on the RECORD, not on caplog.text: the outer backstop in
+    # prune logs `exc_info=True`, and the ValueError's own message already
+    # names the sweep, so a substring check over the rendered traceback
+    # would pass with no per-sweep isolation at all.
+    isolated = [record for record in caplog.records
+                if record.name == "app.core.sweep_store"
+                and record.levelno >= logging.WARNING]
+    assert len(isolated) == 1
+    assert broken.id in isolated[0].getMessage()     # findable, not "a sweep"
+    assert "expected a JSON array" in str(isolated[0].exc_info[1])
+    # The blanket catch one level up never had to fire.
+    assert not [record for record in caplog.records
+                if record.name == "app.core.run_store"
+                and "could not harvest" in record.getMessage()]
+    assert await store.get_run(run_id) is None       # the delete proceeded
+
+
 async def test_the_sweep_finishes_through_seam_b_without_a_read(db, sweeps):
     """Catches a seam-B harvest that copies values but forgets the state."""
     store = RunStore(db)

--- a/backend/tests/test_sweeps.py
+++ b/backend/tests/test_sweeps.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import logging
 from typing import Any
 
 import pytest
@@ -730,20 +731,49 @@ async def _child(store: RunStore, sweep_id: str, index: int, *,
 
 
 def test_rank_variants_sorts_by_objective_and_keeps_the_unrankable():
-    variants = [_variant(0, objective=0.5), _variant(1, objective=None),
-                _variant(2, objective=0.2), _variant(3, objective=0.5)]
+    """Fed OUT of index order on purpose, both halves of the list.
+
+    ``sorted`` is stable, so an input that already arrives index-ordered
+    lets a key with NO ``index`` component agree with a correct one by
+    accident -- and then nothing pins the tiebreak that makes the ordering
+    total. Variants 0 and 3 tie at 0.5 and arrive 3-before-0; the unranked
+    4 and 1 arrive 4-before-1.
+    """
+    variants = [_variant(3, objective=0.5), _variant(4, objective=None),
+                _variant(0, objective=0.5), _variant(1, objective=None),
+                _variant(2, objective=0.2)]
     ranked = rank_variants(variants, direction="minimize")
     assert [(v.index, rank) for v, rank in ranked] == [
         (2, 1), (0, 2), (3, 3),      # ties break on index ASCENDING
-        (1, None),                   # unrankable, appended, never dropped
+        (1, None), (4, None),        # unrankable, appended in index order
     ]
 
 
 def test_rank_variants_maximize_still_breaks_ties_on_index_ascending():
-    variants = [_variant(0, objective=0.5), _variant(1, objective=0.9),
-                _variant(2, objective=0.5)]
+    """The tie arrives 2-before-0, so this pins the tiebreak and not just
+    the direction. ``sorted(..., reverse=True)`` is documented STABLE and
+    does not reverse equal elements, so a ``reverse=True`` implementation
+    with no index key answers [(1,1),(2,2),(0,3)] here and fails.
+    """
+    variants = [_variant(2, objective=0.5), _variant(1, objective=0.9),
+                _variant(0, objective=0.5)]
     ranked = rank_variants(variants, direction="maximize")
     assert [(v.index, rank) for v, rank in ranked] == [(1, 1), (0, 2), (2, 3)]
+
+
+def test_an_unknown_rank_direction_is_refused():
+    """``set_state`` raises on ITS unknown vocabulary; this matches it.
+
+    Silently minimizing on ``"Maximize"``, ``"max"`` or ``""`` would present
+    the WORST variant as `best` -- a confidently inverted answer, which is
+    worse than an error. Spec 6.2 makes `direction` required precisely
+    because inferring it would be a heuristic on a user-chosen string; the
+    route validates it too, and this is the half that does not depend on a
+    caller getting it right.
+    """
+    for bad in ("Maximize", "max", ""):
+        with pytest.raises(ValueError, match="unknown sweep direction"):
+            rank_variants([_variant(0, objective=0.5)], direction=bad)
 
 
 def test_a_failed_variant_that_logged_the_objective_is_still_ranked():
@@ -755,15 +785,33 @@ def test_a_failed_variant_that_logged_the_objective_is_still_ranked():
     assert [(v.index, rank) for v, rank in ranked] == [(0, 1), (1, 2)]
 
 
-def test_variant_is_terminal_covers_a_variant_with_no_reachable_run():
-    """Without this clause a variant whose run someone deleted by hand
-    would keep a sweep at `running` forever."""
-    assert variant_is_terminal(_variant(0, run_id=None), None,
-                               child_exists=False)
+def test_variant_is_terminal_answers_each_clause_with_a_LIVE_child_row():
+    """Every clause, exercised where ``child_exists=True``.
+
+    Asserting only ``child_exists=False`` cases lets the row-is-gone clause
+    answer all of them, and then the function can be collapsed to
+    ``not child_exists or child_status in TERMINAL_STATUSES`` with nothing
+    noticing. Seam B never reaches the earlier clauses -- it removes the
+    doomed ids from ``live`` first -- so Task 7's seam A, where the child
+    row is still there, is the only caller that will, which is exactly why
+    they need pinning now rather than then.
+    """
+    # A harvested status is the answer even while the child row is alive
+    # and says something else. This is what a `missing` variant relies on.
+    assert variant_is_terminal(_variant(0, run_id="r", status="succeeded"),
+                               "running", child_exists=True)
     assert variant_is_terminal(_variant(0, run_id="r", status="succeeded"),
                                None, child_exists=False)
+    # No run at all is NOT terminal -- see the sweep-level test below.
+    assert not variant_is_terminal(_variant(0, run_id=None), "running",
+                                   child_exists=True)
+    assert not variant_is_terminal(_variant(0, run_id=None), None,
+                                   child_exists=False)
+    # The row is gone and nothing harvested it: spec 5.3's "missing", and
+    # the clause that stops a hand-deleted child wedging a sweep forever.
     assert variant_is_terminal(_variant(0, run_id="r"), None,
-                               child_exists=False)      # gone -> "missing"
+                               child_exists=False)
+    # A live child answers on its own status.
     assert variant_is_terminal(_variant(0, run_id="r"), "succeeded",
                                child_exists=True)
     assert not variant_is_terminal(_variant(0, run_id="r"), "running",
@@ -844,6 +892,66 @@ async def test_the_objective_is_harvested_before_the_delete(db, sweeps):
     assert [v.objective for v in fetched.variants] == [0.4, 0.30000000000000004]
     assert [v.status for v in fetched.variants] == ["succeeded", "succeeded"]
     assert all(v.harvested_at is not None for v in fetched.variants)
+
+
+async def test_a_sweep_mid_submit_loop_is_never_stamped_finished(db, sweeps):
+    """A variant with NO run yet is not a variant that is done.
+
+    ``prune_retention()`` runs after every ``_finalize``, on the same event
+    loop that ``POST /api/sweeps`` is still submitting on, so the first
+    child of a sweep can finish and be pruned while the later variants
+    legitimately still carry ``run_id: null``. Counting those as terminal
+    stamps the sweep ``finished`` on its FIRST child -- at
+    ``RUN_RETENTION_KEEP_LAST = 0``, a documented setting, every time and
+    not as a race. It never recovers, because ``_write_variants`` refuses
+    to re-stamp a sweep that already reads ``finished``, so a polling table
+    would stop polling and a half-empty comparison table would be read as
+    the sweep's answer.
+
+    The submit loop BREAKING is a different case and does not need this:
+    spec 5.2 has the route call ``mark_failed`` itself, and neither seam
+    ever overwrites ``failed``.
+    """
+    store = RunStore(db)
+    created = await _new_sweep(sweeps, count=3)
+    run_id = await _child(store, created.id, 0, metrics={"val_loss": 0.4})
+    await sweeps.set_variant_run(created.id, 0, run_id=run_id, seed=None)
+
+    assert await store.prune(keep_last=0) == 1
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched.variants[0].objective == 0.4      # harvested all the same
+    assert fetched.state == SWEEP_STATE_RUNNING      # ... but NOT finished
+    assert fetched.finished_at is None
+
+
+async def test_a_failing_harvest_does_not_stop_retention(db, caplog,
+                                                         monkeypatch):
+    """Retention is unattended and irreplaceable; the harvest is not.
+
+    ``prune`` is the only thing bounding ``exec_runs``, its cascaded
+    children, checkpoint files and TensorBoard logdirs, and it runs behind
+    the run task's blanket ``except Exception`` -- so an exception raised
+    inside its transaction aborts retention for EVERY run, on every later
+    pass, permanently, and surfaces as one log line rather than a failed
+    request. One unreadable ``sweeps.variants`` cell must not fill the
+    user's disk.
+    """
+    store = RunStore(db)
+    record = await store.create_run(
+        graph_snapshot={"nodes": [], "edges": []}, options={},
+        provenance=RunProvenance())
+    await store.mark_finished(record.id, "succeeded")
+
+    def _boom(conn, where_clause, params):
+        raise ValueError("sweeps.variants for sweep 'x' is dict, expected "
+                         "a JSON array")
+
+    monkeypatch.setattr("app.core.sweep_store.harvest_doomed", _boom)
+    with caplog.at_level(logging.WARNING, logger="app.core.run_store"):
+        assert await store.prune(keep_last=0) == 1
+    assert await store.get_run(record.id) is None
+    assert "harvest" in caplog.text
+    assert "sweeps.variants" in caplog.text      # the cause, not just "oops"
 
 
 async def test_the_sweep_finishes_through_seam_b_without_a_read(db, sweeps):

--- a/backend/tests/test_sweeps.py
+++ b/backend/tests/test_sweeps.py
@@ -352,6 +352,41 @@ def test_non_finite_range_bounds_are_refused():
     assert "bounds must be finite" in message
 
 
+def test_a_huge_integer_in_values_is_refused_not_an_overflow():
+    """Python ints are UNBOUNDED, so json.loads happily parses a 400-digit
+    integer literal and `math.isfinite` RAISES OverflowError on it instead
+    of returning False. Uncaught, that is a 500 from one crafted body on a
+    surface whose whole contract is that a bad spec is a 400 -- the integer
+    sibling of the json.loads("1e999") case, and the same defect class as
+    test_a_non_dict_node_entry_is_a_400_not_a_500.
+
+    Both an INT and a FLOAT param, because the value never reaches the
+    param's type at all: the envelope refuses it before any address is
+    resolved."""
+    for param in ("epochs", "weight_decay"):
+        message = _refusal(_grid(_values(param, [1, 10 ** 400])))
+        assert "values[1]" in message and "finite" in message
+
+
+def test_a_huge_integer_range_bound_is_refused_not_an_overflow():
+    """Same hazard through the other door: range bounds are checked for
+    finiteness before anything else in the range envelope."""
+    message = _refusal(_grid(_range("weight_decay", min=1, max=10 ** 400,
+                                    count=3, scale="linear", type="float")))
+    assert "bounds must be finite" in message
+
+
+def test_a_large_but_representable_number_still_compiles():
+    """The guard refuses what cannot become a float AT ALL, not what is
+    merely large -- otherwise it would be a blanket size limit nobody asked
+    for. 10**300 and 1e308 are both ordinary finite floats and a sweep may
+    use them."""
+    compiled = _compile(_grid(_values("epochs", [1, 10 ** 300]),
+                              _values("weight_decay", [1e308])))
+    assert compiled.params[0].domain == (1, 10 ** 300)
+    assert compiled.params[1].domain == (1e308,)
+
+
 # ── the type-acceptance matrix (spec 3.4.1, 9.3) ──────────────────────────
 
 

--- a/backend/tests/test_sweeps.py
+++ b/backend/tests/test_sweeps.py
@@ -22,6 +22,7 @@ from app.core.node_base import (
     PortDefinition,
 )
 from app.core.node_registry import registry
+from app.core.run_store import MetricPoint, RunProvenance, RunStore
 from app.core.sweep_compiler import (
     SweepCompileError,
     compile_sweep,
@@ -31,9 +32,13 @@ from app.core.sweep_compiler import (
 from app.core.sweep_store import (
     SWEEP_STATE_CANCELLING,
     SWEEP_STATE_FAILED,
+    SWEEP_STATE_FINISHED,
     SWEEP_STATE_RUNNING,
+    HarvestEntry,
     SweepStore,
     SweepVariant,
+    rank_variants,
+    variant_is_terminal,
 )
 
 
@@ -706,3 +711,168 @@ async def test_an_unknown_sweep_state_is_refused(sweeps):
     created = await _new_sweep(sweeps)
     with pytest.raises(ValueError, match="unknown sweep state"):
         await sweeps.set_state(created.id, "cancelled")
+
+
+# ── harvest + ranking (spec 6.3, 6.4, 9.7) ────────────────────────────────
+
+
+async def _child(store: RunStore, sweep_id: str, index: int, *,
+                 status: str = "succeeded",
+                 metrics: dict[str, float] | None = None) -> str:
+    record = await store.create_run(
+        graph_snapshot={"nodes": [], "edges": []}, options={},
+        provenance=RunProvenance(), sweep_id=sweep_id, sweep_variant=index)
+    for name, value in (metrics or {}).items():
+        await store.log_metrics(record.id, [MetricPoint(name, value, 0)])
+    if status != "queued":
+        await store.mark_finished(record.id, status)
+    return record.id
+
+
+def test_rank_variants_sorts_by_objective_and_keeps_the_unrankable():
+    variants = [_variant(0, objective=0.5), _variant(1, objective=None),
+                _variant(2, objective=0.2), _variant(3, objective=0.5)]
+    ranked = rank_variants(variants, direction="minimize")
+    assert [(v.index, rank) for v, rank in ranked] == [
+        (2, 1), (0, 2), (3, 3),      # ties break on index ASCENDING
+        (1, None),                   # unrankable, appended, never dropped
+    ]
+
+
+def test_rank_variants_maximize_still_breaks_ties_on_index_ascending():
+    variants = [_variant(0, objective=0.5), _variant(1, objective=0.9),
+                _variant(2, objective=0.5)]
+    ranked = rank_variants(variants, direction="maximize")
+    assert [(v.index, rank) for v, rank in ranked] == [(1, 1), (0, 2), (2, 3)]
+
+
+def test_a_failed_variant_that_logged_the_objective_is_still_ranked():
+    """#140 acceptance criterion 3: hiding a real number because the run
+    ended badly is exactly the silent disappearance it forbids."""
+    variants = [_variant(0, objective=0.3, status="failed"),
+                _variant(1, objective=0.9, status="succeeded")]
+    ranked = rank_variants(variants, direction="minimize")
+    assert [(v.index, rank) for v, rank in ranked] == [(0, 1), (1, 2)]
+
+
+def test_variant_is_terminal_covers_a_variant_with_no_reachable_run():
+    """Without this clause a variant whose run someone deleted by hand
+    would keep a sweep at `running` forever."""
+    assert variant_is_terminal(_variant(0, run_id=None), None,
+                               child_exists=False)
+    assert variant_is_terminal(_variant(0, run_id="r", status="succeeded"),
+                               None, child_exists=False)
+    assert variant_is_terminal(_variant(0, run_id="r"), None,
+                               child_exists=False)      # gone -> "missing"
+    assert variant_is_terminal(_variant(0, run_id="r"), "succeeded",
+                               child_exists=True)
+    assert not variant_is_terminal(_variant(0, run_id="r"), "running",
+                                   child_exists=True)
+
+
+async def test_harvest_is_idempotent_and_records_an_absent_objective(sweeps):
+    created = await _new_sweep(sweeps, count=2)
+    await sweeps.set_variant_run(created.id, 0, run_id="r0", seed=None)
+    await sweeps.set_variant_run(created.id, 1, run_id="r1", seed=None)
+
+    first = await sweeps.harvest(
+        created.id,
+        entries={0: HarvestEntry(objective=0.25, status="succeeded"),
+                 1: HarvestEntry(objective=None, status="failed")},
+        finished=True)
+    assert first.state == SWEEP_STATE_FINISHED
+    assert first.finished_at is not None
+    assert first.variants[0].objective == 0.25
+    assert first.variants[1].objective is None
+    assert first.variants[1].status == "failed"
+    assert first.variants[1].harvested_at is not None
+
+    # "harvested, no value" is a recorded fact, not a retry.
+    second = await sweeps.harvest(
+        created.id, entries={1: HarvestEntry(objective=9.9, status="failed")},
+        finished=True)
+    assert second.variants[1].objective is None
+    assert second.finished_at == first.finished_at    # stamped once
+
+    # A sweep that is gone answers None rather than inventing a row.
+    assert await sweeps.harvest("nope", entries={}, finished=True) is None
+
+
+async def test_concurrent_harvests_do_not_lose_each_other(sweeps):
+    """The single-closure rule again, for the SECOND writer of the blob.
+
+    ``set_variant_run``'s own atomicity test cannot cover ``harvest``: they
+    are different methods, and the tidy-looking refactor -- read with
+    ``get_sweep``, patch in Python, write with a second ``Database.run`` --
+    is available to each of them separately. Split that way, all four calls
+    below read the same blob before any of them writes, every one still
+    returns a full record, and only the last patch survives.
+
+    Spec 6.3 runs a harvest on every GET and every cancel, so several are
+    genuinely in flight at once whenever a sweep is being polled; a lost
+    update there silently discards a harvested objective and, because
+    ``harvested_at`` was written for it, nothing ever retries.
+    """
+    created = await _new_sweep(sweeps, count=4)
+    for index in range(4):
+        await sweeps.set_variant_run(created.id, index, run_id=f"r{index}",
+                                     seed=None)
+    patched = await asyncio.gather(*(
+        sweeps.harvest(created.id,
+                       entries={index: HarvestEntry(objective=float(index),
+                                                    status="succeeded")},
+                       finished=False)
+        for index in range(4)))
+    assert all(record is not None for record in patched)
+    fetched = await sweeps.get_sweep(created.id)
+    assert [v.index for v in fetched.variants] == [0, 1, 2, 3]   # order kept
+    assert [v.objective for v in fetched.variants] == [0.0, 1.0, 2.0, 3.0]
+
+
+async def test_the_objective_is_harvested_before_the_delete(db, sweeps):
+    """RULING 4, seam B: prune with NO prior read, and the value survives."""
+    store = RunStore(db)
+    created = await _new_sweep(sweeps, count=2)
+    for index in range(2):
+        run_id = await _child(store, created.id, index,
+                              metrics={"val_loss": 0.4 - 0.1 * index})
+        await sweeps.set_variant_run(created.id, index, run_id=run_id,
+                                     seed=None)
+
+    assert await store.prune(keep_last=0) == 2
+    fetched = await sweeps.get_sweep(created.id)
+    assert [v.objective for v in fetched.variants] == [0.4, 0.30000000000000004]
+    assert [v.status for v in fetched.variants] == ["succeeded", "succeeded"]
+    assert all(v.harvested_at is not None for v in fetched.variants)
+
+
+async def test_the_sweep_finishes_through_seam_b_without_a_read(db, sweeps):
+    """Catches a seam-B harvest that copies values but forgets the state."""
+    store = RunStore(db)
+    created = await _new_sweep(sweeps, count=2)
+    for index in range(2):
+        run_id = await _child(store, created.id, index,
+                              metrics={"val_loss": 0.5})
+        await sweeps.set_variant_run(created.id, index, run_id=run_id,
+                                     seed=None)
+    await store.prune(keep_last=0)
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched.state == SWEEP_STATE_FINISHED
+    assert fetched.finished_at is not None
+
+
+async def test_a_diverged_variant_is_unranked(db, sweeps):
+    """A non-finite last point is stored as SQL NULL and omitted from the
+    series map, so a diverged loss must not render as a suspiciously good
+    one -- it is unranked, never ranked at 0.0."""
+    store = RunStore(db)
+    created = await _new_sweep(sweeps, count=1)
+    run_id = await _child(store, created.id, 0,
+                          metrics={"val_loss": float("nan")})
+    await sweeps.set_variant_run(created.id, 0, run_id=run_id, seed=None)
+    await store.prune(keep_last=0)
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched.variants[0].objective is None
+    assert fetched.variants[0].status == "succeeded"
+    assert rank_variants(fetched.variants, direction="minimize") == \
+        [(fetched.variants[0], None)]

--- a/backend/tests/test_sweeps.py
+++ b/backend/tests/test_sweeps.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from app.core.db import Database
 from app.core.node_base import (
     BaseNode,
     DataType,
@@ -25,6 +26,13 @@ from app.core.sweep_compiler import (
     compile_sweep,
     planner_prng,
     sample_unique_ranks,
+)
+from app.core.sweep_store import (
+    SWEEP_STATE_CANCELLING,
+    SWEEP_STATE_FAILED,
+    SWEEP_STATE_RUNNING,
+    SweepStore,
+    SweepVariant,
 )
 
 
@@ -526,3 +534,114 @@ def test_select_value_not_in_options_is_refused():
 def test_wrong_scalar_type_for_an_int_param_is_refused():
     assert "int param but the domain contains 0.5" in \
         _refusal(_grid(_values("epochs", [1, 0.5])))
+
+
+# ── SweepStore (spec 4.2, 4.3) ────────────────────────────────────────────
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = Database(tmp_path / "codefyui.db")
+    database.connect()
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+@pytest.fixture
+def sweeps(db):
+    return SweepStore(db)
+
+
+def _variant(index: int, **overrides) -> SweepVariant:
+    fields = {"index": index, "domain_index": index, "run_id": None,
+              "params": [{"node_id": "probe", "param": "lr",
+                          "value": 0.1 * (index + 1)}],
+              "seed": None, "objective": None, "status": None,
+              "harvested_at": None}
+    fields.update(overrides)
+    return SweepVariant(**fields)
+
+
+async def _new_sweep(store: SweepStore, count: int = 2, **overrides):
+    fields = {"method": "grid", "seed": 123456789, "seed_variants": False,
+              "spec": {"method": "grid", "params": []},
+              "objective": {"metric": "val_loss", "direction": "minimize"},
+              "variants": [_variant(i) for i in range(count)],
+              "name": "lr sweep"}
+    fields.update(overrides)
+    return await store.create_sweep(**fields)
+
+
+async def test_create_and_get_a_sweep_round_trip(sweeps):
+    created = await _new_sweep(sweeps)
+    assert created.state == SWEEP_STATE_RUNNING
+    assert created.finished_at is None and created.error is None
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched == created
+    assert fetched.seed_variants is False        # 0/1 comes back as a bool
+    assert [v.index for v in fetched.variants] == [0, 1]
+    assert fetched.variants[0].run_id is None
+    assert await sweeps.get_sweep("nope") is None
+
+
+async def test_create_sweep_assigns_each_variant_index_exactly_once(sweeps):
+    """The store is the ONLY thing that can guarantee this.
+
+    ``(sweep_id, sweep_variant)`` is an INDEX, not a constraint -- SQLite
+    cannot add a UNIQUE column via ``ADD COLUMN`` (MIGRATION_004) -- so the
+    database accepts two variant 3s without complaint, and every later
+    reader of the sweep would then see one of them twice. ``index`` IS the
+    entry's position in the list (spec 4.2), so the writer derives it and
+    never trusts what it was handed; ``domain_index``, which is the
+    caller's own datum, is left exactly as given.
+    """
+    created = await _new_sweep(sweeps, variants=[
+        _variant(3, domain_index=7), _variant(3, domain_index=2),
+        _variant(0, domain_index=5)])
+    assert [v.index for v in created.variants] == [0, 1, 2]
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched.variants == created.variants   # returned == stored
+    assert [v.domain_index for v in fetched.variants] == [7, 2, 5]
+    # With a duplicate index in the blob this patch would have hit two
+    # entries, and two children would claim the same sweep_variant.
+    assert await sweeps.set_variant_run(created.id, 1, run_id="r1", seed=None)
+    patched = await sweeps.get_sweep(created.id)
+    assert [v.run_id for v in patched.variants] == [None, "r1", None]
+
+
+async def test_set_variant_run_patches_one_entry_and_leaves_the_rest(sweeps):
+    created = await _new_sweep(sweeps, count=3)
+    assert await sweeps.set_variant_run(created.id, 1, run_id="r1", seed=42)
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched.variants[1].run_id == "r1"
+    assert fetched.variants[1].seed == 42
+    assert fetched.variants[0].run_id is None
+    assert fetched.variants[2].run_id is None
+    assert not await sweeps.set_variant_run(created.id, 9, run_id="x",
+                                            seed=None)
+
+
+async def test_mark_failed_records_the_error_and_stamps_finished_at(sweeps):
+    created = await _new_sweep(sweeps)
+    assert await sweeps.mark_failed(created.id, "run service is shutting down")
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched.state == SWEEP_STATE_FAILED
+    assert fetched.error == "run service is shutting down"
+    assert fetched.finished_at is not None
+
+
+async def test_set_state_never_overwrites_failed(sweeps):
+    """`failed` on a sweep means something went wrong with the SWEEP, not
+    with the training, and a later cancel must not paper over it."""
+    created = await _new_sweep(sweeps)
+    await sweeps.mark_failed(created.id, "boom")
+    assert not await sweeps.set_state(created.id, SWEEP_STATE_CANCELLING)
+    assert (await sweeps.get_sweep(created.id)).state == SWEEP_STATE_FAILED
+
+
+async def test_an_unknown_sweep_state_is_refused(sweeps):
+    created = await _new_sweep(sweeps)
+    with pytest.raises(ValueError, match="unknown sweep state"):
+        await sweeps.set_state(created.id, "cancelled")

--- a/backend/tests/test_sweeps.py
+++ b/backend/tests/test_sweeps.py
@@ -721,18 +721,24 @@ async def _child(store: RunStore, sweep_id: str, index: int, *,
                  status: str = "succeeded",
                  metrics: dict[str, float] | None = None,
                  series: dict[str, list[tuple[int, float]]] | None = None,
+                 points: list[MetricPoint] | None = None,
                  ) -> str:
     """One child run. *metrics* logs a single point per series at step 0;
     *series* logs a whole ``[(step, value), ...]`` in the order given, so a
-    test can pin which point of a series the harvest actually reads."""
+    test can pin which point of a series the harvest actually reads;
+    *points* logs raw ``MetricPoint``s one at a time, for the cases that
+    need a ``node_id`` or two points sharing a step (write order is the
+    tie-break, so they must not be batched into one flush)."""
     record = await store.create_run(
         graph_snapshot={"nodes": [], "edges": []}, options={},
         provenance=RunProvenance(), sweep_id=sweep_id, sweep_variant=index)
     for name, value in (metrics or {}).items():
         await store.log_metrics(record.id, [MetricPoint(name, value, 0)])
-    for name, points in (series or {}).items():
-        for step, value in points:
+    for name, series_points in (series or {}).items():
+        for step, value in series_points:
             await store.log_metrics(record.id, [MetricPoint(name, value, step)])
+    for point in (points or []):
+        await store.log_metrics(record.id, [point])
     if status != "queued":
         await store.mark_finished(record.id, status)
     return record.id
@@ -919,6 +925,120 @@ async def test_seam_b_harvests_the_LAST_point_of_the_objective_series(
     fetched = await sweeps.get_sweep(created.id)
     assert fetched.variants[0].objective == 0.5
     assert fetched.variants[0].harvested_at is not None
+
+
+async def test_seam_b_records_no_objective_when_the_series_was_never_logged(
+        db, sweeps):
+    """The child logged something — just not the sweep's objective.
+
+    A regression here does not LOSE a number, it INVENTS one, and that is
+    strictly worse: under ``minimize`` a fabricated ``0.0`` ranks BEST, so
+    the sweep would present a variant that never reported the metric as its
+    winner. RULING 4 makes it permanent — the child is gone and nothing
+    recomputes it. Same failure §6.1 guards against with "a diverged loss
+    must not render as a suspiciously good one", reached by another door.
+
+    test_api_sweeps.py's ``test_no_variant_produced_the_objective`` only
+    LOOKS like coverage for this: it asks for an unlogged metric over seam
+    A (a GET, so ``latest_metrics``) and never prunes.
+    """
+    store = RunStore(db)
+    created = await _new_sweep(sweeps, count=1)        # objective: val_loss
+    run_id = await _child(store, created.id, 0, metrics={"train_loss": 0.9})
+    await sweeps.set_variant_run(created.id, 0, run_id=run_id, seed=None)
+
+    assert await store.prune(keep_last=0) == 1
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched.variants[0].objective is None
+    assert fetched.variants[0].status == "succeeded"   # harvested, no value
+    assert fetched.variants[0].harvested_at is not None
+    # Unrankable, and emphatically not rank 1.
+    assert rank_variants(fetched.variants, direction="minimize") == \
+        [(fetched.variants[0], None)]
+
+
+async def test_seam_b_records_no_objective_when_the_sweep_names_no_metric(
+        db, sweeps):
+    """A ``sweeps`` row whose ``objective`` carries no usable ``metric``.
+
+    Defence in depth rather than a live path — the route requires a
+    non-empty metric — but the sweeps row is DURABLE (RULING 4) and
+    outlives the validation that wrote it, while ``harvest_doomed`` reads
+    ``objective.get("metric")`` off whatever the column happens to hold.
+    Inventing a number here would be the same permanent, best-ranked
+    fabrication as above. The child DOES log ``val_loss``, so a fallback
+    that guessed a metric name would be caught too, not just a bare 0.0.
+    """
+    store = RunStore(db)
+    for objective in ({"direction": "minimize"},                  # no key
+                      {"metric": "", "direction": "minimize"}):   # empty
+        created = await _new_sweep(sweeps, count=1, objective=objective)
+        run_id = await _child(store, created.id, 0,
+                              metrics={"val_loss": 0.4})
+        await sweeps.set_variant_run(created.id, 0, run_id=run_id, seed=None)
+
+        assert await store.prune(keep_last=0) == 1
+        fetched = await sweeps.get_sweep(created.id)
+        assert fetched.variants[0].objective is None
+        assert fetched.variants[0].status == "succeeded"
+
+
+async def test_seam_b_breaks_a_step_tie_by_write_order(db, sweeps):
+    """Two producers, one series name, one step — a decision, not luck.
+
+    §6.1 documents that the last-point rule collapses one name logged by
+    several nodes into a SINGLE number, and ``id DESC`` is what decides
+    which: the last one written. Without the tie-break sqlite may return
+    either row, so a sweep's PERMANENT objective would depend on the query
+    plan. ``latest_metrics`` pins this for seam A
+    (``test_latest_metrics_breaks_a_step_tie_by_write_order``); this is
+    seam B's half, so the two implementations cannot drift apart on exactly
+    the case §6.1 calls out.
+    """
+    store = RunStore(db)
+    created = await _new_sweep(sweeps, count=1)
+    run_id = await _child(store, created.id, 0, points=[
+        MetricPoint("val_loss", 9.0, 1, "node-a"),
+        MetricPoint("val_loss", 1.0, 1, "node-b"),   # written last, wins
+    ])
+    await sweeps.set_variant_run(created.id, 0, run_id=run_id, seed=None)
+
+    assert await store.prune(keep_last=0) == 1
+    fetched = await sweeps.get_sweep(created.id)
+    assert fetched.variants[0].objective == 1.0
+
+
+async def test_both_seams_read_the_same_objective_from_one_series(db, sweeps):
+    """§6.1's cross-seam guarantee, asserted instead of assumed.
+
+    ``latest_metrics`` (seam A — a recursive CTE in run_store) and
+    ``_last_metric_value`` (seam B — one seek in sweep_store) are two
+    implementations of ONE rule, and nothing held them to the same answer.
+    That is how seam B's ordering drifted out of coverage in the first
+    place: every test fed it a single-point series, on which every
+    plausible implementation agrees by accident.
+
+    So the series here is built to DISTINGUISH them: five points, steps
+    arriving out of order, the best value at neither end, and a tie on the
+    last step. Both seams must say 0.5 — the later-written of the two
+    points at step 3. The literal is asserted as well as the equality, so
+    the test cannot pass by both seams being wrong the same way.
+    """
+    store = RunStore(db)
+    created = await _new_sweep(sweeps, count=1)
+    run_id = await _child(store, created.id, 0, points=[
+        MetricPoint("val_loss", 0.9, 1),
+        MetricPoint("val_loss", 0.1, 3, "node-a"),   # best, and NOT the last
+        MetricPoint("val_loss", 0.7, 0),
+        MetricPoint("val_loss", 0.5, 3, "node-b"),   # same step, written later
+        MetricPoint("val_loss", 0.3, 2),
+    ])
+    await sweeps.set_variant_run(created.id, 0, run_id=run_id, seed=None)
+
+    seam_a = (await store.latest_metrics([run_id]))[run_id]["val_loss"]
+    assert await store.prune(keep_last=0) == 1   # seam B, with no prior GET
+    seam_b = (await sweeps.get_sweep(created.id)).variants[0].objective
+    assert seam_b == seam_a == 0.5
 
 
 async def test_the_objective_is_harvested_before_the_delete(db, sweeps):


### PR DESCRIPTION
> 中文摘要：參數掃描（Sweep）的後端。你給一組要試的參數（像學習率三個值 × weight decay 兩個值），伺服器把它展開成六份圖、排進既有的執行佇列跑完，再用一張比較表把每個組合的最終指標排名列出來，也能匯出 CSV。三個 API：建立、查詢、取消。設計上刻意保守的三件事：每個變體「各自的隨機種子」預設關閉（有種子的執行會拿全域獨占鎖，全開會讓整個掃描一次只能跑一組、還會卡住畫布上的互動執行）；這版不做重啟續跑（佇列只在記憶體裡，重啟中斷的子執行仍然看得見）；指不到的參數（藏在 preset 或子圖裡的）直接回 400 說是哪一個，不會編出一個改了等於沒改的變體。掃描結果存在掃描自己的資料列上，所以子執行被保留策略刪掉之後，表格還答得出來。前端與 issue 收尾在另一個 PR。

Part of #140 — the backend half. The frontend (the New sweep dialog, the comparison table and the chart overlay) is a separate spec and PR, so this one deliberately carries no closing keyword.

## What this adds

- **`POST /api/sweeps`** compiles a `sweep_spec` into variants and queues one run each. Grid or random, with a recorded seed; `values` for an enumerated domain or `range{min, max, count, scale, type}` for a generated one, linear or logarithmic, integer or float. The compiler is pure — no database, no HTTP — so the same spec and seed always produce the same list, and the sampler is a bit-exact port of the one Graph Copilot already uses (verified against the real JavaScript, not reimplemented from its description).
- **`GET /api/sweeps/{id}`** answers with every variant's chosen parameters, its status and its final objective metric, ranked, plus a CSV export of the same table. It repairs its own row as it reads: any variant that has finished since the last look is harvested before the answer goes out.
- **`POST /api/sweeps/{id}/cancel`** stops the queued children and asks the running one to stop, and loses nothing that was already measured.
- A `sweeps` table and two nullable columns on `exec_runs`, added by one migration; `RunService.submit` learns to carry them, and to accept a provenance object captured once for the whole sweep instead of thirty-two times.

## The four decisions worth knowing

- **Per-variant execution seeds are opt-in, off by default.** A seeded run takes a process-wide exclusive lock, so seeding every variant would serialise the sweep and freeze every interactive canvas run for its duration — unacceptable in a classroom. The sweep's own seed, which decides *which* variants exist, is always recorded and always used, and that is what the reproducibility criterion actually tests.
- **This version does not resume across a restart.** The run queue lives in memory, so a restart retires the queued children as interrupted. They stay visible and the sweep stays inspectable; durable, restart-surviving studies are #343's job.
- **A parameter that cannot be set is refused, never guessed.** Parameters living inside a preset instance or a block definition are not addressable by node id, so the whole request is refused with a 400 naming the address, rather than compiling a variant whose override would silently do nothing.
- **The sweep row owns its results.** Finished runs are pruned by retention, so each variant's parameters and final objective are copied onto the sweep itself before its children can be deleted — the table still answers months later, with the dead run links shown as dead.

`range` gained a `count` field the issue never named: an interval is not a finite domain, and no default was safe (every guess silently multiplies how many models get trained).

## Verification

- 8 tasks, 20 commits, each written test-first; each task reviewed against the spec and for quality by a fresh reviewer, with 9 fix rounds and their own re-reviews. Then a whole-branch review that re-implemented all four of the issue's acceptance criteria independently and ran them live against the real app.
- Backend 6393 tests (was 6274 on main), ruff clean, on Windows and in CI's Linux matrix. The frontend is untouched.
- Things a reviewer proved rather than assumed: the migration upgrades a real pre-existing database with every row intact and retention still working; 80 hostile request bodies produce a 4xx and write no rows, never a 5xx; a sweep's answer survives its children being deleted by three different routes; a 3×2 grid queues exactly 6 runs in order; and the same seed reproduces the identical variant list over HTTP.
- The reviews kept finding the same class of defect and it is worth naming: code that was correct but unguarded. A split read/write that silently lost concurrent writes while reporting success; a sweep that could be stamped finished while it was still creating its children; a padded `lane` string that smuggled a sweep onto the interactive lane and returned a 500; a "final metric" rule that would have recorded epoch-zero numbers if anyone reversed one `ORDER BY`. Each is now pinned by a test that was proven to fail when the behaviour is reverted.

Loose ends are filed as #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jh5Fbd8CJdJ2wtva3ePr7C
