### PR TITLE
chore(release): 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -428,6 +428,42 @@ operations. `Conv2dKernel` is retired; `Conv2dExplicit` picks its own kernel.
   restoring the node popped the modal back open by itself — and drops a
   segment highlight pointing at an overlay that is no longer in the list.
 
+- **Contributors are credited permanently and owe no royalty** ([#266]).
+  Every place the licensing story is told now states the maintainer's
+  contributor-terms ruling: contributors keep their copyright and their credit,
+  the inbound dual-license grant is voluntary and royalty-free, so no royalty or
+  revenue share is owed when a commercial license is sold, and a contributor who
+  considers a contribution outstanding can discuss recognition or separate terms
+  with the maintainers. Anything beyond those defaults needs explicit written
+  agreement.
+
+### Removed
+
+- **`Conv2dKernel` is retired; `Conv2dExplicit` picks its own kernel**
+  ([#362], contributed by [@oyea0801]). Applying one textbook filter used to
+  take two nodes and an edge — `Conv2dKernel` emitted a 3x3 matrix and
+  `Conv2dExplicit` convolved with it. Nothing else in the registry consumed a
+  kernel, so the split bought nothing and cost canvas in the one lesson whose
+  point is "look what this matrix does to an image". `Conv2dExplicit` now takes
+  a single `tensor` input and a `preset` param (EdgeDetection3x3 / Sharpen3x3 /
+  VerticalEdge3x3, or `Custom` with a hand-authored NxN grid), reading in the
+  order the decision is made: which filter, then how it is swept. The
+  convolution itself is unchanged — still depthwise with `groups=C` — and the
+  weight is now built on the input's device from the start, since the engine
+  aligns what arrives on a wire but cannot see what a node conjures inside
+  `execute` ([#359]).
+
+  **Breaking.** A saved graph containing `Conv2dKernel`, or an edge into
+  `Conv2dExplicit`'s `kernel` port, still opens on the canvas and keeps its
+  param values, but is stopped at Run by `validate_graph` with
+  `Unknown node type: Conv2dKernel` / `Invalid input port 'kernel' on
+  Conv2dExplicit`. Delete the `Conv2dKernel` node and pick the filter on
+  `Conv2dExplicit` instead. No example, plugin or gallery graph here or in
+  CodefyUI-Examples / CodefyUI-Plugin-Official / CodefyUI-Self-Learning used
+  either node, so only user-authored graphs are affected; this repository has
+  no node-type migration or alias facility, and one was not built for a single
+  node.
+
 ### Fixed
 
 - **The engine puts a node's inputs on the device that node runs on**
@@ -647,6 +683,25 @@ operations. `Conv2dKernel` is retired; `Conv2dExplicit` picks its own kernel.
   too, now pinned by a test; and `OpResult.node_id` comes from the ops that
   create or edit a node, not from "every op that names one", `remove_node`
   being the op that names one and returns none.
+
+- **Four gallery examples stop teaching the wrong thing** ([#369]).
+  `DQN-Atari-RL` and `PPO-Robotics-RL` each fed `optimizer-1.model` from two
+  places — the agent's own `model` output and a `SequentialModel` sitting off to
+  one side. The engine resolves a doubled input port by last-writer-wins and
+  says nothing, so a Deep-Q-Network example may well have been handing its
+  optimizer a detached feed-forward stack instead of the DQN: it validated, it
+  ran, it printed plausible numbers. The duplicate edges are gone, the
+  Mixture-of-Experts example shows its mixture, and four descriptions that
+  described something other than the graph beneath them were corrected.
+
+- **The kernel grid writes back the shape it is showing** ([#365], [#366],
+  [#367]). `TensorGridEditor` reshaped the value for display and stopped there,
+  so raising `Conv2dExplicit`'s `kernel_size` from 3 to 5 drew a filled 5x5 grid
+  over a param still holding 9 numbers and the run failed with "`weights` has 9
+  elements but kernel_size=5 expects 25". The reshape is now committed through
+  `onChange`; widening pads with zeros and keeps the numbers already typed. The
+  C1-3 kernel-effects example gets the figure it was demonstrating with, and
+  `Conv2dExplicit` gets its zh-TW entry.
 
 ### Internal
 
@@ -2734,6 +2789,12 @@ Release candidates before 1.0.0 are on the
 [#325]: https://github.com/CodefyUI/CodefyUI/issues/325
 [#337]: https://github.com/CodefyUI/CodefyUI/issues/337
 [#341]: https://github.com/CodefyUI/CodefyUI/issues/341
+[#266]: https://github.com/CodefyUI/CodefyUI/issues/266
+[#362]: https://github.com/CodefyUI/CodefyUI/pull/362
+[#365]: https://github.com/CodefyUI/CodefyUI/issues/365
+[#366]: https://github.com/CodefyUI/CodefyUI/issues/366
+[#367]: https://github.com/CodefyUI/CodefyUI/issues/367
+[#369]: https://github.com/CodefyUI/CodefyUI/pull/369
 [#342]: https://github.com/CodefyUI/CodefyUI/issues/342
 [#400]: https://github.com/CodefyUI/CodefyUI/issues/400
 [#396]: https://github.com/CodefyUI/CodefyUI/issues/396

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+## [2.5.0] — 2026-09-01
+
+Twenty-four commits since 2.4.1, around three themes. The Package Center
+installs the optional four hundred megabytes a lesson needs from inside the
+app, and the LLM, embedding and RAG nodes that need those megabytes arrive with
+it. Sweeps search a parameter space in one request and hand back a ranked table.
+The plugin frontend contract reaches `apiVersion 5`, where a plugin gets the tab
+strip, whole-tab snapshots, compare-and-swap writes and six more agent canvas
+operations. `Conv2dKernel` is retired; `Conv2dExplicit` picks its own kernel.
+
 ### Added
 
 - **Sweeps: search a parameter space in one request instead of babysitting
@@ -2731,7 +2741,8 @@ Release candidates before 1.0.0 are on the
 [#140]: https://github.com/CodefyUI/CodefyUI/issues/140
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
-[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...main
+[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.5.0...main
+[2.5.0]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...2.5.0
 [2.4.1]: https://github.com/CodefyUI/CodefyUI/compare/2.4.0...2.4.1
 [2.4.0]: https://github.com/CodefyUI/CodefyUI/compare/2.3.0...2.4.0
 [2.3.0]: https://github.com/CodefyUI/CodefyUI/compare/2.2.0...2.3.0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefyui-backend"
-version = "2.4.1"
+version = "2.5.0"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
 # Names the copyright holder in distribution metadata. Until this landed, no
 # file in the repository said who owns CodefyUI, which left the commercial

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "codefyui-backend"
-version = "2.4.1"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },

--- a/docs/docs/advanced/plugin-frontend-extensions.md
+++ b/docs/docs/advanced/plugin-frontend-extensions.md
@@ -11,7 +11,7 @@ A plugin pack can ship a JavaScript bundle alongside its Python nodes. When the 
 :::note Availability
 Frontend extensions are in CodefyUI **1.3.0** and later. Check `cdui --version`; if it reports an older version, run `cdui update`.
 
-Dock panels, toolbar buttons, execution events and the runs facade need **apiVersion 3** (CodefyUI 2.0.0 and later); `graph.getView` needs **apiVersion 4** (CodefyUI 2.3.0 and later); `api.workspace` and the six agent canvas operations need **apiVersion 5** (*next release (unreleased)* {/* stamp-on-release */} and later). Feature-check before you use them — see [API versions](#api-versions).
+Dock panels, toolbar buttons, execution events and the runs facade need **apiVersion 3** (CodefyUI 2.0.0 and later); `graph.getView` needs **apiVersion 4** (CodefyUI 2.3.0 and later); `api.workspace` and the six agent canvas operations need **apiVersion 5** (CodefyUI 2.5.0 and later). Feature-check before you use them — see [API versions](#api-versions).
 :::
 
 ## API versions
@@ -24,7 +24,7 @@ Dock panels, toolbar buttons, execution events and the runs facade need **apiVer
 | 2 | 1.3.0 | `nodes.registerRenderer` |
 | 3 | 2.0.0 | `ui.addPanel` / `removePanel`, `ui.addToolbarButton` / `removeToolbarButton`, `events.onExecution`, `runs.*` |
 | 4 | 2.3.0 | `graph.getView` — which level of the graph the user is looking at |
-| 5 | *next release (unreleased)* {/* stamp-on-release */} | `workspace.*` — tabs, snapshots and compare-and-swap writes; `move_node`, `set_segment` / `remove_segment`, `add_note` / `update_note`, `set_node_meta` |
+| 5 | 2.5.0 | `workspace.*` — tabs, snapshots and compare-and-swap writes; `move_node`, `set_segment` / `remove_segment`, `add_note` / `update_note`, `set_node_meta` |
 
 Check it before reaching for anything newer than the version you require, and degrade rather than throw:
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugin-frontend-extensions.md
@@ -11,7 +11,7 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 :::note 可用性
 前端擴充功能自 CodefyUI **1.3.0** 起內建。請執行 `cdui --version` 確認；若顯示更舊的版本，請執行 `cdui update`。
 
-停靠面板、工具列按鈕、執行事件與 runs 門面需要 **apiVersion 3**（CodefyUI 2.0.0 起）；`graph.getView` 需要 **apiVersion 4**（CodefyUI 2.3.0 起）；`api.workspace` 與六個代理畫布操作需要 **apiVersion 5**（*下一個版本（尚未發布）* {/* stamp-on-release */} 起）。使用前請先檢查版本——參見 [API 版本](#api-版本)。
+停靠面板、工具列按鈕、執行事件與 runs 門面需要 **apiVersion 3**（CodefyUI 2.0.0 起）；`graph.getView` 需要 **apiVersion 4**（CodefyUI 2.3.0 起）；`api.workspace` 與六個代理畫布操作需要 **apiVersion 5**（CodefyUI 2.5.0 起）。使用前請先檢查版本——參見 [API 版本](#api-版本)。
 :::
 
 ## API 版本
@@ -24,7 +24,7 @@ description: 隨外掛包附上一個 JavaScript bundle，讓外掛能新增 UI 
 | 2 | 1.3.0 | `nodes.registerRenderer` |
 | 3 | 2.0.0 | `ui.addPanel` / `removePanel`、`ui.addToolbarButton` / `removeToolbarButton`、`events.onExecution`、`runs.*` |
 | 4 | 2.3.0 | `graph.getView`——使用者正在看圖表的哪一層 |
-| 5 | *下一個版本（尚未發布）* {/* stamp-on-release */} | `workspace.*`——分頁、快照與比較後寫入；`move_node`、`set_segment` / `remove_segment`、`add_note` / `update_note`、`set_node_meta` |
+| 5 | 2.5.0 | `workspace.*`——分頁、快照與比較後寫入；`move_node`、`set_segment` / `remove_segment`、`add_note` / `update_note`、`set_node_meta` |
 
 在使用比你所要求的版本更新的功能之前先檢查它，而且是降級處理，不是直接拋錯：
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codefyui-frontend",
   "private": true,
-  "version": "2.4.1",
+  "version": "2.5.0",
   "license": "AGPL-3.0-only",
   "author": "CodefyUI (https://github.com/CodefyUI)",
   "packageManager": "pnpm@9.15.0",


### PR DESCRIPTION
Release prep for **2.5.0**, following `.github/RELEASING.md` step by step.

### Minor, not patch

The twenty-four commits since 2.4.1 include the Package Center and the
LLM/embedding/RAG nodes it exists to feed, the sweep runner, `cdui packs` and
`cdui cache`, and plugin `apiVersion 5`. `Conv2dKernel` is retired in favour of
`Conv2dExplicit` — the one removal in the set; nothing else changes an existing
signature.

### What is in here

- **`CHANGELOG.md`** — `## [Unreleased]` promoted to `## [2.5.0] — 2026-09-01`
  with a short intro naming the three themes, a fresh empty `[Unreleased]`
  above it, and the compare links repointed (`[Unreleased]` now compares from
  2.5.0; a new `[2.5.0]` row compares 2.4.1...2.5.0).
- **The three version fields** — edited by hand, nothing reconciles them, so all
  three were checked: `backend/pyproject.toml`, `backend/uv.lock` (regenerated
  with `uv lock`; only the `codefyui-backend` version line moved),
  `frontend/package.json`.
- **The docs placeholders** — `git grep stamp-on-release docs/` had four hits,
  all on the plugin `apiVersion` table and its availability note. The
  apiVersion 5 row and the prose now say `2.5.0` in both locales, and the
  `{/* stamp-on-release */}` markers are gone with the placeholder text. The
  grep is empty again.

### After merge

`git tag -a 2.5.0 --cleanup=verbatim -F notes.md` on `main`, then push the tag —
Release Build attaches `frontend-dist.tar.gz` to a draft release, and Install
Check runs once it is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhV83n94xYEZGYAqZRpis2
