### PR TITLE
feat(ui): Plugin Center plumbing: REST client, job follower, plugin store and host reload (frontend)

### DIFF
--- a/frontend/src/api/rest.test.ts
+++ b/frontend/src/api/rest.test.ts
@@ -47,6 +47,7 @@ import {
   removePackItem,
   PackApiError,
   ApiError,
+  errorDetail,
   listPluginCatalog,
   inspectPluginSource,
   installPlugin,
@@ -1358,6 +1359,49 @@ describe('plugin center endpoints', () => {
       const pluginErr = await apiErr(listPluginCatalog());
       expect(pluginErr).not.toBeInstanceOf(PackApiError);
       expect(pluginErr.name).toBe('ApiError');
+    });
+  });
+
+  // The unwrapper every plugin caller shares. A pack route answers a flat
+  // body and is read with `err.body?.command`; a plugin route nests the same
+  // kind of keys one level down, where that read finds nothing.
+  describe('errorDetail', () => {
+    it('hands back the coded object a plugin refusal nests', async () => {
+      mockFetch(400, {
+        detail: { code: 'consent_required', missing_capabilities: ['network'] },
+      });
+      const err = await apiErr(installPlugin({ inspection_id: 'insp-1' }));
+      expect(errorDetail(err)).toEqual({
+        code: 'consent_required', missing_capabilities: ['network'],
+      });
+    });
+
+    it('answers null for a plain-text detail', async () => {
+      // `{detail: "Not Found"}` carries no keys to read: the message is the
+      // whole of it, and a caller must not get a string where it asked for a
+      // record.
+      mockFetch(404, { detail: 'Not Found' });
+      expect(errorDetail(await apiErr(listPluginCatalog()))).toBeNull();
+    });
+
+    it('answers null for a body with no detail at all', async () => {
+      // A pack-shaped body reaching a plugin caller: flat, so there is
+      // nothing nested to return.
+      const err = new ApiError(409, 'busy', { command: 'cdui update', job_id: 'j1' });
+      expect(errorDetail(err)).toBeNull();
+    });
+
+    it('answers null for a list detail', async () => {
+      // FastAPI's 422 puts a LIST under `detail`. It is an object by
+      // `typeof`, and reading `.code` off it would be a silent undefined.
+      const err = new ApiError(422, 'invalid', { detail: [{ loc: ['body'] }] });
+      expect(errorDetail(err)).toBeNull();
+    });
+
+    it('answers null for anything that is not an ApiError', () => {
+      expect(errorDetail(new Error('Failed to fetch'))).toBeNull();
+      expect(errorDetail('consent_required')).toBeNull();
+      expect(errorDetail(null)).toBeNull();
     });
   });
 

--- a/frontend/src/api/rest.test.ts
+++ b/frontend/src/api/rest.test.ts
@@ -1651,6 +1651,22 @@ describe('plugin center endpoints', () => {
       expect(err.body).toEqual({ status: 'moved' });
     });
 
+    it('throws on a 202 with no job to follow', async () => {
+      // Falling back to '' would start a follower on `/jobs//events`, which
+      // spends its retry budget and then reports the install as lost.
+      mockFetch(202, {});
+      const err = await apiErr(updatePlugin('c1-tokenizer'));
+      expect(err.status).toBe(202);
+      expect(err.message).toContain('job_id');
+    });
+
+    it('throws on an up_to_date with no sha', async () => {
+      // "Up to date at ''" is a version the panel would show as fact.
+      mockFetch(200, { status: 'up_to_date' });
+      const err = await apiErr(updatePlugin('c1-tokenizer'));
+      expect(err.message).toContain('sha');
+    });
+
     it('encodes an id that needs it', async () => {
       const fetchMock = mockFetch(202, { job_id: 'j2' });
       await updatePlugin('scope/name');

--- a/frontend/src/api/rest.test.ts
+++ b/frontend/src/api/rest.test.ts
@@ -1271,8 +1271,8 @@ describe('plugin center endpoints', () => {
       plugin_id: 'c1-tokenizer',
       catalog_id: null,
       official: true,
-      source: 'treeleaves30760/CodefyUI-Plugin-C1',
-      url: 'https://github.com/treeleaves30760/CodefyUI-Plugin-C1',
+      source: 'CodefyUI/CodefyUI-Plugin-C1',
+      url: 'https://github.com/CodefyUI/CodefyUI-Plugin-C1',
       ref: 'main',
       sha: 'abc123',
       name: 'Chapter 1',
@@ -1416,7 +1416,7 @@ describe('plugin center endpoints', () => {
           name: 'Chapter 1',
           description: 'Tokenizer nodes',
           kind: 'github',
-          source: 'treeleaves30760/CodefyUI-Plugin-C1',
+          source: 'CodefyUI/CodefyUI-Plugin-C1',
           homepage: 'https://example.invalid/c1',
         }],
       });
@@ -1432,7 +1432,7 @@ describe('plugin center endpoints', () => {
           // No status at all is a plugin nothing has installed.
           status: 'available',
           source_kind: null,
-          source: 'treeleaves30760/CodefyUI-Plugin-C1',
+          source: 'CodefyUI/CodefyUI-Plugin-C1',
           repo: null,
           ref: null,
           sha: null,
@@ -1500,11 +1500,11 @@ describe('plugin center endpoints', () => {
         official: true,
         status: 'installed',
         source_kind: 'github_url',
-        source: 'treeleaves30760/CodefyUI-Plugin-C1',
-        repo: 'treeleaves30760/CodefyUI-Plugin-C1',
+        source: 'CodefyUI/CodefyUI-Plugin-C1',
+        repo: 'CodefyUI/CodefyUI-Plugin-C1',
         ref: 'main',
         sha: 'abc123',
-        url: 'https://github.com/treeleaves30760/CodefyUI-Plugin-C1',
+        url: 'https://github.com/CodefyUI/CodefyUI-Plugin-C1',
         homepage: 'https://example.invalid/c1',
         version: '1.0.0',
         installed_at: '2026-09-01T10:00:00Z',
@@ -1545,14 +1545,14 @@ describe('plugin center endpoints', () => {
   describe('inspectPluginSource', () => {
     it('POSTs the source with the session token', async () => {
       const fetchMock = mockFetch(200, inspection());
-      const out = await inspectPluginSource('treeleaves30760/CodefyUI-Plugin-C1');
+      const out = await inspectPluginSource('CodefyUI/CodefyUI-Plugin-C1');
       expect(out).toEqual(inspection());
       const [url, init] = fetchMock.mock.calls[0];
       expect(url).toBe('/api/plugins/inspect');
       expect(init.method).toBe('POST');
       expect(new Headers(init.headers).get('X-CodefyUI-Token')).toBe('test-token');
       expect(JSON.parse(init.body)).toEqual({
-        source: 'treeleaves30760/CodefyUI-Plugin-C1',
+        source: 'CodefyUI/CodefyUI-Plugin-C1',
       });
     });
 

--- a/frontend/src/api/rest.test.ts
+++ b/frontend/src/api/rest.test.ts
@@ -46,6 +46,17 @@ import {
   getPackJobEvents,
   removePackItem,
   PackApiError,
+  ApiError,
+  listPluginCatalog,
+  inspectPluginSource,
+  installPlugin,
+  updatePlugin,
+  uninstallPlugin,
+  setPluginEnabled,
+  getPluginJobEvents,
+  cancelPluginJob,
+  type PluginCatalogEntry,
+  type PluginInspection,
 } from './rest';
 import { _setSessionTokenForTesting } from './_auth';
 
@@ -1235,6 +1246,470 @@ describe('pack endpoints', () => {
       const err = await packError(removePackItem('word-vectors', 'glove-6b-100d'));
       expect(err.status).toBe(409);
       expect(err.body).toEqual({ detail: 'an install is running', job_id: 'j1' });
+    });
+  });
+});
+
+// ── Plugin Center ────────────────────────────────────────────────────────
+
+describe('plugin center endpoints', () => {
+  /** Await a call that must fail, and hand back the ApiError it threw. */
+  async function apiErr(call: Promise<unknown>): Promise<ApiError> {
+    const err = await call.then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    return err as ApiError;
+  }
+
+  /** A complete inspection, so a test only states the field it is about. */
+  function inspection(overrides: Partial<PluginInspection> = {}): PluginInspection {
+    return {
+      inspection_id: 'insp-1',
+      expires_at: '2026-09-03T12:00:00Z',
+      kind: 'github',
+      mode: 'install',
+      plugin_id: 'c1-tokenizer',
+      catalog_id: null,
+      official: true,
+      source: 'treeleaves30760/CodefyUI-Plugin-C1',
+      url: 'https://github.com/treeleaves30760/CodefyUI-Plugin-C1',
+      ref: 'main',
+      sha: 'abc123',
+      name: 'Chapter 1',
+      version: '1.0.0',
+      description: 'Tokenizer nodes',
+      homepage: 'https://example.invalid/c1',
+      manifest: { id: 'c1-tokenizer', api_version: 5 },
+      capabilities: ['network'],
+      allowed_modules: ['requests'],
+      python_deps: { requests: '>=2' },
+      has_frontend: true,
+      chapters: ['C1'],
+      lessons: [],
+      consent_required: true,
+      installed: null,
+      up_to_date: false,
+      capabilities_added: ['network'],
+      allowed_modules_added: ['requests'],
+      warnings: [],
+      ...overrides,
+    };
+  }
+
+  describe('ApiError', () => {
+    it('keeps the status and the parsed body of a coded refusal', async () => {
+      const body = { detail: { code: 'busy', job_id: 'j-running' } };
+      mockFetch(409, body);
+      const err = await apiErr(installPlugin({ inspection_id: 'insp-1' }));
+      expect(err.status).toBe(409);
+      // No `message` in the detail, so the code is the readable half of it.
+      expect(err.message).toBe('busy');
+      // The panel offers "follow that job instead", which needs its id.
+      expect(err.body).toEqual(body);
+    });
+
+    it('prefers a coded detail\'s message over its code', async () => {
+      mockFetch(409, {
+        detail: { code: 'files_locked', message: 'a file is open', hint: 'close it' },
+      });
+      const err = await apiErr(uninstallPlugin('c1-tokenizer'));
+      expect(err.message).toBe('a file is open');
+    });
+
+    it('reads a string detail as the message', async () => {
+      // What a server with no `/api/plugins/catalog` route answers: FastAPI's
+      // own not-found body. The ONE status the store reads as "this build
+      // predates the Plugin Center".
+      mockFetch(404, { detail: 'Not Found' });
+      const err = await apiErr(listPluginCatalog());
+      expect(err.status).toBe(404);
+      expect(err.message).toBe('Not Found');
+    });
+
+    it('falls back to the status text when the body is not JSON', async () => {
+      mockFetchJsonThrows(503);
+      const err = await apiErr(listPluginCatalog());
+      expect(err.status).toBe(503);
+      expect(err.message).toBe('mock');
+      expect(err.body).toBeNull();
+    });
+
+    it('falls back to the status text for a detail with neither key', async () => {
+      // `400 {code: unknown_catalog_name, known: [...]}` without a code is not
+      // a shape the backend sends, but a body this client cannot read must
+      // still leave a message rather than "undefined".
+      mockFetch(400, { detail: { known: ['c1-tokenizer'] } });
+      const err = await apiErr(listPluginCatalog());
+      expect(err.message).toBe('mock');
+      expect(err.body).toEqual({ detail: { known: ['c1-tokenizer'] } });
+    });
+
+    // PackApiError is now a SUBCLASS of ApiError rather than the same class,
+    // so packStore's `err instanceof PackApiError` narrowing keeps meaning
+    // "a PACK call refused" instead of widening to every center at once.
+    it('is what a pack refusal extends, and not the other way round', async () => {
+      mockFetch(404, { detail: 'Not Found' });
+      const packErr = await listPacks().then(() => null, (e: unknown) => e);
+      expect(packErr).toBeInstanceOf(PackApiError);
+      expect(packErr).toBeInstanceOf(ApiError);
+      // Unchanged from before there was a base class.
+      expect((packErr as Error).name).toBe('PackApiError');
+
+      mockFetch(404, { detail: 'Not Found' });
+      const pluginErr = await apiErr(listPluginCatalog());
+      expect(pluginErr).not.toBeInstanceOf(PackApiError);
+      expect(pluginErr.name).toBe('ApiError');
+    });
+  });
+
+  describe('listPluginCatalog', () => {
+    // The panel maps over `chapters`, `nodes` and `capabilities` on every
+    // render, so an absent key has to arrive as an empty list rather than as
+    // a crash halfway through a repaint.
+    it('normalizes a sparse payload', async () => {
+      const fetchMock = mockFetch(200, {
+        entries: [{
+          id: 'c1-tokenizer',
+          name: 'Chapter 1',
+          description: 'Tokenizer nodes',
+          kind: 'github',
+          source: 'treeleaves30760/CodefyUI-Plugin-C1',
+          homepage: 'https://example.invalid/c1',
+        }],
+      });
+      const out = await listPluginCatalog();
+      expect(fetchMock).toHaveBeenCalledWith('/api/plugins/catalog');
+      expect(out).toEqual({
+        entries: [{
+          id: 'c1-tokenizer',
+          name: 'Chapter 1',
+          description: 'Tokenizer nodes',
+          kind: 'github',
+          official: false,
+          // No status at all is a plugin nothing has installed.
+          status: 'available',
+          source_kind: null,
+          source: 'treeleaves30760/CodefyUI-Plugin-C1',
+          repo: null,
+          ref: null,
+          sha: null,
+          url: null,
+          homepage: 'https://example.invalid/c1',
+          version: null,
+          installed_at: null,
+          enabled: false,
+          chapters: [],
+          lessons: [],
+          tags: [],
+          nodes: [],
+          node_count: 0,
+          capabilities: [],
+          trusted_modules: [],
+          python_deps: {},
+          has_frontend: false,
+          consent_required: false,
+          frontend_entry: null,
+          job: null,
+        }],
+        active_job: null,
+        // Absent is read as "allowed": the server is what actually refuses a
+        // remote install, with a 403 the panel then reports.
+        remote_install_allowed: true,
+        generation: 0,
+      });
+    });
+
+    it('derives enabled from the status when the server omits it', async () => {
+      mockFetch(200, {
+        entries: [
+          { id: 'a', status: 'installed' },
+          { id: 'b', status: 'disabled' },
+          // An explicit false survives: only an ABSENT key is derived.
+          { id: 'c', status: 'installed', enabled: false },
+        ],
+      });
+      const out = await listPluginCatalog();
+      expect(out.entries.map((e) => e.enabled)).toEqual([true, false, false]);
+    });
+
+    it('reads a value outside its union as the safe member', async () => {
+      // A newer server's vocabulary must degrade to something the panel can
+      // render, not arrive as an unhandled case: an unknown status is a
+      // plugin the user may install, and an unknown kind has no source this
+      // client could re-fetch.
+      mockFetch(200, {
+        entries: [{ id: 'a', status: 'quarantined', kind: 'sideloaded', source_kind: 'ftp' }],
+      });
+      const [entry] = (await listPluginCatalog()).entries;
+      expect(entry.status).toBe('available');
+      expect(entry.kind).toBe('external');
+      expect(entry.source_kind).toBeNull();
+    });
+
+    // The other half of normalizing: a mapped payload is also a payload a
+    // forgotten key can silently vanish from.
+    it('carries a full payload through unchanged', async () => {
+      const entry: PluginCatalogEntry = {
+        id: 'c1-tokenizer',
+        name: 'Chapter 1',
+        description: 'Tokenizer nodes',
+        kind: 'github',
+        official: true,
+        status: 'installed',
+        source_kind: 'github_url',
+        source: 'treeleaves30760/CodefyUI-Plugin-C1',
+        repo: 'treeleaves30760/CodefyUI-Plugin-C1',
+        ref: 'main',
+        sha: 'abc123',
+        url: 'https://github.com/treeleaves30760/CodefyUI-Plugin-C1',
+        homepage: 'https://example.invalid/c1',
+        version: '1.0.0',
+        installed_at: '2026-09-01T10:00:00Z',
+        enabled: true,
+        chapters: ['C1'],
+        lessons: ['C1L1'],
+        tags: ['edu'],
+        nodes: ['Tokenizer'],
+        node_count: 3,
+        capabilities: ['network'],
+        trusted_modules: ['requests'],
+        python_deps: { requests: '>=2' },
+        has_frontend: true,
+        consent_required: false,
+        frontend_entry: 'index.js',
+        job: { job_id: 'j1', status: 'running', current_step: 'download' },
+      };
+      mockFetch(200, {
+        entries: [entry],
+        active_job: {
+          job_id: 'j1', plugin_id: 'c1-tokenizer', kind: 'install',
+          status: 'running', current_step: 'download',
+        },
+        remote_install_allowed: false,
+        generation: 7,
+      });
+      const out = await listPluginCatalog();
+      expect(out.entries).toEqual([entry]);
+      expect(out.active_job).toEqual({
+        job_id: 'j1', plugin_id: 'c1-tokenizer', kind: 'install',
+        status: 'running', current_step: 'download',
+      });
+      expect(out.remote_install_allowed).toBe(false);
+      expect(out.generation).toBe(7);
+    });
+  });
+
+  describe('inspectPluginSource', () => {
+    it('POSTs the source with the session token', async () => {
+      const fetchMock = mockFetch(200, inspection());
+      const out = await inspectPluginSource('treeleaves30760/CodefyUI-Plugin-C1');
+      expect(out).toEqual(inspection());
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/plugins/inspect');
+      expect(init.method).toBe('POST');
+      expect(new Headers(init.headers).get('X-CodefyUI-Token')).toBe('test-token');
+      expect(JSON.parse(init.body)).toEqual({
+        source: 'treeleaves30760/CodefyUI-Plugin-C1',
+      });
+    });
+
+    it('surfaces the 400 a source it could not parse answers', async () => {
+      const body = { detail: { code: 'unknown_catalog_name', known: ['c1-tokenizer'] } };
+      mockFetch(400, body);
+      const err = await apiErr(inspectPluginSource('c1-tokeniser'));
+      expect(err.status).toBe(400);
+      expect(err.message).toBe('unknown_catalog_name');
+      expect(err.body).toEqual(body);
+    });
+  });
+
+  describe('installPlugin', () => {
+    it('posts the request and omits undefined keys', async () => {
+      const fetchMock = mockFetch(202, { job_id: 'j1' });
+      // `trust_author: undefined` is what a caller spreading a partly filled
+      // request sends; it must not reach the wire as `trust_author: null`.
+      expect(
+        await installPlugin({
+          inspection_id: 'insp-1',
+          accept_capabilities: ['network'],
+          trust_author: undefined,
+          force: undefined,
+        }),
+      ).toEqual({ job_id: 'j1' });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/plugins/install');
+      expect(init.method).toBe('POST');
+      expect(new Headers(init.headers).get('X-CodefyUI-Token')).toBe('test-token');
+      expect(JSON.parse(init.body)).toEqual({
+        inspection_id: 'insp-1',
+        accept_capabilities: ['network'],
+      });
+    });
+
+    it('sends only the inspection id when the caller accepts nothing', async () => {
+      const fetchMock = mockFetch(202, { job_id: 'j1' });
+      await installPlugin({ inspection_id: 'insp-1' });
+      expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+        inspection_id: 'insp-1',
+      });
+    });
+
+    it('surfaces the consent refusal with what is missing', async () => {
+      const body = {
+        detail: { code: 'consent_required', missing_capabilities: ['network'] },
+      };
+      mockFetch(400, body);
+      const err = await apiErr(installPlugin({ inspection_id: 'insp-1' }));
+      expect(err.status).toBe(400);
+      expect(err.body).toEqual(body);
+    });
+  });
+
+  describe('updatePlugin', () => {
+    it('reads a 202 as a job to follow', async () => {
+      const fetchMock = mockFetch(202, { job_id: 'j2' });
+      expect(await updatePlugin('c1-tokenizer')).toEqual({ kind: 'job', job_id: 'j2' });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/plugins/c1-tokenizer/update');
+      expect(init.method).toBe('POST');
+      expect(new Headers(init.headers).get('X-CodefyUI-Token')).toBe('test-token');
+    });
+
+    it('reads a 200 up_to_date as nothing to do', async () => {
+      mockFetch(200, { status: 'up_to_date', sha: 'abc123' });
+      expect(await updatePlugin('c1-tokenizer')).toEqual({
+        kind: 'up_to_date', sha: 'abc123',
+      });
+    });
+
+    it('reads a 200 needs_consent as the inspection to show', async () => {
+      const insp = inspection({ mode: 'update', up_to_date: false });
+      mockFetch(200, {
+        status: 'needs_consent',
+        inspection: insp,
+        capabilities_added: ['network'],
+        allowed_modules_added: ['requests'],
+      });
+      expect(await updatePlugin('c1-tokenizer')).toEqual({
+        kind: 'needs_consent',
+        inspection: insp,
+        capabilities_added: ['network'],
+        allowed_modules_added: ['requests'],
+      });
+    });
+
+    it('throws rather than guessing at a 200 that is neither shape', async () => {
+      // Both guesses -- "there was nothing to do", "a job is running" -- would
+      // leave the panel telling the user something that did not happen.
+      mockFetch(200, { status: 'moved' });
+      const err = await apiErr(updatePlugin('c1-tokenizer'));
+      expect(err.status).toBe(200);
+      expect(err.message).toContain('moved');
+      expect(err.body).toEqual({ status: 'moved' });
+    });
+
+    it('encodes an id that needs it', async () => {
+      const fetchMock = mockFetch(202, { job_id: 'j2' });
+      await updatePlugin('scope/name');
+      expect(fetchMock.mock.calls[0][0]).toBe('/api/plugins/scope%2Fname/update');
+    });
+  });
+
+  describe('uninstallPlugin', () => {
+    it('issues DELETE and reports what it left behind', async () => {
+      const result = {
+        id: 'c1-tokenizer',
+        removed: true,
+        tombstoned: false,
+        files_removed: true,
+        python_deps_left: ['requests'],
+        uninstall_command: 'uv pip uninstall requests',
+        reinstall_hint: 'cdui plugin install c1-tokenizer',
+      };
+      const fetchMock = mockFetch(200, result);
+      expect(await uninstallPlugin('c1-tokenizer')).toEqual(result);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/plugins/c1-tokenizer');
+      expect(init.method).toBe('DELETE');
+      expect(new Headers(init.headers).get('X-CodefyUI-Token')).toBe('test-token');
+    });
+
+    it('surfaces the 409 sent while a job targets the plugin', async () => {
+      const body = { detail: { code: 'busy', job_id: 'j1' } };
+      mockFetch(409, body);
+      const err = await apiErr(uninstallPlugin('c1-tokenizer'));
+      expect(err.status).toBe(409);
+      expect(err.body).toEqual(body);
+    });
+  });
+
+  describe('setPluginEnabled', () => {
+    it('POSTs enable with the session token', async () => {
+      const fetchMock = mockFetch(200, { id: 'c1-tokenizer', enabled: true });
+      expect(await setPluginEnabled('c1-tokenizer', true)).toEqual({
+        id: 'c1-tokenizer', enabled: true,
+      });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/plugins/c1-tokenizer/enable');
+      expect(init.method).toBe('POST');
+      expect(new Headers(init.headers).get('X-CodefyUI-Token')).toBe('test-token');
+    });
+
+    it('POSTs disable for the other half', async () => {
+      const fetchMock = mockFetch(200, { id: 'c1-tokenizer', enabled: false });
+      await setPluginEnabled('c1-tokenizer', false);
+      expect(fetchMock.mock.calls[0][0]).toBe('/api/plugins/c1-tokenizer/disable');
+    });
+  });
+
+  describe('getPluginJobEvents', () => {
+    it('passes cursor, wait, limit and the signal', async () => {
+      const fetchMock = mockFetch(200, {
+        job_id: 'j1', status: 'running', events: [], cursor: 7,
+      });
+      const controller = new AbortController();
+      await getPluginJobEvents('j1', {
+        cursor: 7, wait: 25, limit: 100, signal: controller.signal,
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/plugins/jobs/j1/events?cursor=7&wait=25&limit=100',
+        { signal: controller.signal },
+      );
+    });
+
+    it('sends no query when following from the beginning', async () => {
+      const fetchMock = mockFetch(200, {
+        job_id: 'j1',
+        status: 'needs_restart',
+        events: [{ type: 'needs_restart', cursor: 1, command: 'cdui start' }],
+        cursor: 1,
+      });
+      const page = await getPluginJobEvents('j1');
+      expect(fetchMock).toHaveBeenCalledWith('/api/plugins/jobs/j1/events', {
+        signal: undefined,
+      });
+      expect(page.status).toBe('needs_restart');
+      expect(page.events[0].command).toBe('cdui start');
+    });
+
+    it('throws when the job is gone mid-follow', async () => {
+      mockFetch(404, { detail: "job 'j1' not found" });
+      expect((await apiErr(getPluginJobEvents('j1'))).status).toBe(404);
+    });
+  });
+
+  describe('cancelPluginJob', () => {
+    it('POSTs to the job with the session token', async () => {
+      const fetchMock = mockFetch(200, { job_id: 'j1', cancelled: true });
+      expect(await cancelPluginJob('j1')).toEqual({ job_id: 'j1', cancelled: true });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/plugins/jobs/j1/cancel');
+      expect(init.method).toBe('POST');
+      expect(new Headers(init.headers).get('X-CodefyUI-Token')).toBe('test-token');
+    });
+
+    it('throws when the job is already forgotten', async () => {
+      mockFetch(404, { detail: "job 'j1' not found" });
+      expect((await apiErr(cancelPluginJob('j1'))).status).toBe(404);
     });
   });
 });

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -897,10 +897,11 @@ export class ApiError extends Error {
     body: Record<string, unknown> | null = null,
   ) {
     super(message);
-    // `new.target` is the class actually being constructed, so `PackApiError`
-    // reports its own name -- unchanged from before it had a base class --
-    // without restating this line.
-    this.name = new.target.name;
+    // Spelled out rather than taken from `new.target.name`, which is the
+    // MINIFIED identifier in a built bundle: what the console shows a user
+    // reporting a bug has to be the name in this file, not `e2`. A subclass
+    // restates its own (see `PackApiError`).
+    this.name = 'ApiError';
     this.body = body;
   }
 }
@@ -1132,10 +1133,15 @@ export interface PackJobEventsPage extends JobEventsPage {
  *
  * Its own class rather than a bare `ApiError` so that the pack store's
  * `err instanceof PackApiError` keeps meaning "a PACK call refused" now that
- * the Plugin Center throws the same base error, and so that `err.name` still
- * reads `PackApiError` in a console.
+ * the Plugin Center throws the same base error.
+ *
+ * The name is a field rather than a line in a constructor this class does not
+ * otherwise need: a field initializer runs after `super()`, so it wins over
+ * the base's own assignment.
  */
-export class PackApiError extends ApiError {}
+export class PackApiError extends ApiError {
+  override name = 'PackApiError';
+}
 
 /** Build the error for a refused pack request, body and all. */
 async function packApiError(res: Response): Promise<PackApiError> {

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -873,9 +873,13 @@ export async function downloadImageFile(filename: string) {
  *
  * The Package Center and the Plugin Center both answer with a status-coded
  * error vocabulary -- 403 remote, 404 gone, 409 busy, 507 out of disk -- and
- * each status carries extra keys the panel shows (`job_id`, `command`,
- * `blocked_by`, `missing_capabilities`). `body` is the parsed JSON, so none of
- * that has to be recovered from the message.
+ * each status carries extra keys the panel shows. `body` is the parsed JSON,
+ * so none of that has to be recovered from the message -- but the two centers
+ * put those keys in different places, and reading the wrong one gets
+ * `undefined` rather than an error: a pack route answers a FLAT body
+ * (`{detail: "...", command, blocked_by}`), a plugin route nests everything
+ * under `detail` (`{detail: {code, missing_capabilities}}`), which is what
+ * `errorDetail()` below reads.
  */
 export class ApiError extends Error {
   /**
@@ -929,6 +933,26 @@ async function readApiError(
 export async function apiError(res: Response): Promise<ApiError> {
   const { message, body } = await readApiError(res);
   return new ApiError(res.status, message, body);
+}
+
+/**
+ * The coded object out of a refusal: the keys a plugin route puts under
+ * `detail`, or null when there are none.
+ *
+ * Here rather than in each store because the nesting is the trap. `detail` is
+ * a plain object only for a coded refusal -- `{detail: {code:
+ * consent_required, missing_capabilities: [...]}}` -- and is the whole message
+ * for a plain one (`{detail: "Not Found"}`), so a caller that reached for
+ * `err.body?.missing_capabilities` the way the pack routes allow would read
+ * one level too high and get `undefined` with no error to say why.
+ */
+export function errorDetail(err: unknown): Record<string, unknown> | null {
+  if (!(err instanceof ApiError) || err.body === null) return null;
+  const detail = err.body.detail;
+  if (detail === null || typeof detail !== 'object' || Array.isArray(detail)) {
+    return null;
+  }
+  return detail as Record<string, unknown>;
 }
 
 /**

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -993,6 +993,25 @@ export interface JobEventsPage {
   cursor: number;
 }
 
+/**
+ * Where a job-events poll goes. One builder for both centers: the two routes
+ * differ by a single path segment and their query does not differ at all, so
+ * a second copy could only ever drift -- an omitted `limit` on one side, an
+ * unencoded id on the other.
+ */
+function jobEventsUrl(
+  base: string,
+  jobId: string,
+  opts: { cursor?: number; wait?: number; limit?: number },
+): string {
+  const params = new URLSearchParams();
+  if (opts.cursor !== undefined) params.set('cursor', String(opts.cursor));
+  if (opts.wait !== undefined) params.set('wait', String(opts.wait));
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  const query = params.toString();
+  return `${base}/jobs/${encodeURIComponent(jobId)}/events${query ? `?${query}` : ''}`;
+}
+
 // ── Optional packs / Package Center ──────────────────────────────────────
 
 /**
@@ -1250,14 +1269,8 @@ export async function getPackJobEvents(
   jobId: string,
   opts: { cursor?: number; wait?: number; limit?: number; signal?: AbortSignal } = {},
 ): Promise<PackJobEventsPage> {
-  const params = new URLSearchParams();
-  if (opts.cursor !== undefined) params.set('cursor', String(opts.cursor));
-  if (opts.wait !== undefined) params.set('wait', String(opts.wait));
-  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
-  const query = params.toString();
   const res = await fetch(
-    `${BASE_URL}/packs/jobs/${encodeURIComponent(jobId)}/events${query ? `?${query}` : ''}`,
-    { signal: opts.signal },
+    jobEventsUrl(`${BASE_URL}/packs`, jobId, opts), { signal: opts.signal },
   );
   if (!res.ok) throw await packApiError(res);
   return res.json();
@@ -1716,14 +1729,8 @@ export async function getPluginJobEvents(
   jobId: string,
   opts: { cursor?: number; wait?: number; limit?: number; signal?: AbortSignal } = {},
 ): Promise<JobEventsPage> {
-  const params = new URLSearchParams();
-  if (opts.cursor !== undefined) params.set('cursor', String(opts.cursor));
-  if (opts.wait !== undefined) params.set('wait', String(opts.wait));
-  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
-  const query = params.toString();
   const res = await fetch(
-    `${BASE_URL}/plugins/jobs/${encodeURIComponent(jobId)}/events${query ? `?${query}` : ''}`,
-    { signal: opts.signal },
+    jobEventsUrl(`${BASE_URL}/plugins`, jobId, opts), { signal: opts.signal },
   );
   if (!res.ok) throw await apiError(res);
   return res.json();

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -1251,3 +1251,456 @@ export async function removePackItem(
   if (!res.ok) throw await packApiError(res);
   return res.json();
 }
+
+// ── Plugin Center ────────────────────────────────────────────────────────
+
+/** Where an INSTALLED plugin's files came from. */
+export type PluginSourceKind = 'builtin' | 'github_url' | 'local';
+
+/**
+ * Where a catalog entry stands right now. `removed` is a builtin the user
+ * uninstalled (tombstoned, so it does not come back on the next reload);
+ * `missing_files` is a plugin the registry knows about whose directory is
+ * gone.
+ */
+export type PluginStatus =
+  | 'installed'
+  | 'disabled'
+  | 'available'
+  | 'removed'
+  | 'installing'
+  | 'missing_files';
+
+/**
+ * What a catalog entry IS. `builtin` ships with CodefyUI, `github` is
+ * installable from a repository, `external` is already on disk and has no
+ * source this client could re-fetch.
+ */
+export type PluginKind = 'builtin' | 'github' | 'external';
+
+/** The two things a plugin job can be doing. */
+export type PluginJobKind = 'install' | 'update';
+
+/**
+ * The install or update running right now, across the whole server. A
+ * FINISHED job keeps its events but is not reported here.
+ */
+export interface PluginJobRef {
+  job_id: string;
+  plugin_id: string;
+  kind: PluginJobKind;
+  status?: JobStatus;
+  current_step?: string | null;
+}
+
+/** One row of `GET /api/plugins/catalog`: installed, installable, or gone. */
+export interface PluginCatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  kind: PluginKind;
+  /** Published by the CodefyUI project rather than by a third party. */
+  official: boolean;
+  status: PluginStatus;
+  /** null for an entry that is not installed. */
+  source_kind: PluginSourceKind | null;
+  /** What a user would type to install this: a name, a repo, or a path. */
+  source: string;
+  repo: string | null;
+  ref: string | null;
+  sha: string | null;
+  url: string | null;
+  homepage: string;
+  version: string | null;
+  installed_at: string | null;
+  enabled: boolean;
+  chapters: string[];
+  lessons: string[];
+  tags: string[];
+  /** The node types this plugin registers. Empty while it is disabled. */
+  nodes: string[];
+  /** How many nodes it registers WHEN enabled -- `nodes.length` is not it. */
+  node_count: number;
+  capabilities: string[];
+  trusted_modules: string[];
+  python_deps: Record<string, string>;
+  has_frontend: boolean;
+  /** The install needs the user to accept capabilities before it can run. */
+  consent_required: boolean;
+  frontend_entry: string | null;
+  /** The job targeting THIS plugin, if any -- narrower than `active_job`. */
+  job: { job_id: string; status: JobStatus; current_step: string | null } | null;
+}
+
+export interface PluginCatalog {
+  entries: PluginCatalogEntry[];
+  active_job: PluginJobRef | null;
+  remote_install_allowed: boolean;
+  /**
+   * Bumped every time the node registry reloads. The panel compares it with
+   * what it last saw to know that an install actually landed.
+   */
+  generation: number;
+}
+
+/**
+ * What `POST /api/plugins/inspect` found at a source, and what installing it
+ * would cost -- the whole consent screen in one object.
+ */
+export interface PluginInspection {
+  /** Hand this back to `installPlugin`; the server forgets it after
+   *  `expires_at`, which is a 404 `inspection_expired`. */
+  inspection_id: string;
+  expires_at: string;
+  /** An `external` plugin has no source to inspect, so it never appears. */
+  kind: 'builtin' | 'github';
+  /** The same two values as a job's kind: a fresh install, or an update. */
+  mode: PluginJobKind;
+  plugin_id: string;
+  /** The builtin catalog name this resolved to, when it was one. */
+  catalog_id: string | null;
+  official: boolean;
+  source: string;
+  url: string | null;
+  ref: string | null;
+  sha: string | null;
+  name: string;
+  version: string;
+  description: string;
+  homepage: string;
+  /** The manifest as read, echoed whole: this client only shows it. */
+  manifest: Record<string, unknown>;
+  capabilities: string[];
+  allowed_modules: string[];
+  python_deps: Record<string, string>;
+  has_frontend: boolean;
+  chapters: string[];
+  lessons: string[];
+  consent_required: boolean;
+  /** What is on disk today, for an update; null for a fresh install. */
+  installed: {
+    sha: string;
+    version: string;
+    capabilities: string[];
+    trusted_modules: string[];
+    enabled: boolean;
+    source_kind: PluginSourceKind;
+  } | null;
+  up_to_date: boolean;
+  /** What this version asks for that the installed one did not: the ONLY
+   *  thing an update has to ask the user about. */
+  capabilities_added: string[];
+  allowed_modules_added: string[];
+  warnings: string[];
+}
+
+/**
+ * The body of `POST /api/plugins/install`.
+ *
+ * `accept_capabilities` echoes back exactly what the user ticked -- the
+ * server refuses with `consent_required` if anything is missing rather than
+ * trusting a blanket yes.
+ */
+export interface PluginInstallRequest {
+  inspection_id: string;
+  accept_capabilities?: string[];
+  trust_author?: boolean;
+  force?: boolean;
+}
+
+export interface PluginUninstallResult {
+  id: string;
+  /**
+   * Typed `boolean` rather than the literal `true` the route always answers
+   * with: a client that hand-mirrors a contract should still let its caller
+   * check, not be told by the compiler that there is nothing to check.
+   */
+  removed: boolean;
+  /** A builtin's files stay; a marker keeps it from coming back on reload. */
+  tombstoned: boolean;
+  /** null when the server could not tell -- Windows keeps an open file. */
+  files_removed: boolean | null;
+  /** Nothing uninstalls a plugin's pip packages; these are what it left. */
+  python_deps_left: string[];
+  uninstall_command: string | null;
+  reinstall_hint: string;
+}
+
+/**
+ * The three answers `POST /api/plugins/{id}/update` can give, told apart by
+ * HTTP status first (202 started a job) and then by the 200 body's `status`.
+ */
+export type PluginUpdateResult =
+  | { kind: 'job'; job_id: string }
+  | { kind: 'up_to_date'; sha: string }
+  | {
+      kind: 'needs_consent';
+      inspection: PluginInspection;
+      capabilities_added: string[];
+      allowed_modules_added: string[];
+    };
+
+/**
+ * A catalog entry as it ARRIVES: every key optional, and the enum-ish ones
+ * widened to `string`, because deciding what an absent or unrecognised value
+ * means is exactly what normalising is.
+ */
+type RawCatalogEntry = Omit<
+  Partial<PluginCatalogEntry>,
+  'status' | 'kind' | 'source_kind'
+> & {
+  status?: string;
+  kind?: string;
+  source_kind?: string | null;
+};
+
+type RawCatalog = {
+  entries?: RawCatalogEntry[];
+  active_job?: PluginJobRef | null;
+  remote_install_allowed?: boolean;
+  generation?: number;
+};
+
+const PLUGIN_STATUSES: readonly string[] = [
+  'installed',
+  'disabled',
+  'available',
+  'removed',
+  'installing',
+  'missing_files',
+];
+const PLUGIN_KINDS: readonly string[] = ['builtin', 'github', 'external'];
+const PLUGIN_SOURCE_KINDS: readonly string[] = ['builtin', 'github_url', 'local'];
+
+/**
+ * One catalog row, field by field.
+ *
+ * Normalised rather than passed through for the same reason `listPacks` is:
+ * the panel maps over `chapters`, `nodes` and `capabilities` on every
+ * repaint, so an absent key has to arrive as an empty list rather than as a
+ * crash mid-render. A value outside its union becomes the safe member --
+ * `available` is a plugin the user can install, `external` is one with no
+ * source to re-fetch -- so a newer server's vocabulary degrades instead of
+ * rendering as an unhandled case.
+ */
+function normalizePluginEntry(raw: RawCatalogEntry): PluginCatalogEntry {
+  const status: PluginStatus = PLUGIN_STATUSES.includes(raw.status ?? '')
+    ? (raw.status as PluginStatus)
+    : 'available';
+  return {
+    id: raw.id ?? '',
+    name: raw.name ?? '',
+    description: raw.description ?? '',
+    kind: PLUGIN_KINDS.includes(raw.kind ?? '')
+      ? (raw.kind as PluginKind)
+      : 'external',
+    official: raw.official ?? false,
+    status,
+    source_kind: PLUGIN_SOURCE_KINDS.includes(raw.source_kind ?? '')
+      ? (raw.source_kind as PluginSourceKind)
+      : null,
+    source: raw.source ?? '',
+    repo: raw.repo ?? null,
+    ref: raw.ref ?? null,
+    sha: raw.sha ?? null,
+    url: raw.url ?? null,
+    homepage: raw.homepage ?? '',
+    version: raw.version ?? null,
+    installed_at: raw.installed_at ?? null,
+    // A server that does not say reports the only thing its status can mean:
+    // `installed` is enabled, and every other status is not.
+    enabled: raw.enabled ?? status === 'installed',
+    chapters: raw.chapters ?? [],
+    lessons: raw.lessons ?? [],
+    tags: raw.tags ?? [],
+    nodes: raw.nodes ?? [],
+    node_count: raw.node_count ?? 0,
+    capabilities: raw.capabilities ?? [],
+    trusted_modules: raw.trusted_modules ?? [],
+    python_deps: raw.python_deps ?? {},
+    has_frontend: raw.has_frontend ?? false,
+    consent_required: raw.consent_required ?? false,
+    frontend_entry: raw.frontend_entry ?? null,
+    job: raw.job ?? null,
+  };
+}
+
+/**
+ * Every plugin this server knows about: installed, installable, and gone.
+ * The one route the Plugin Center polls.
+ *
+ * A 404 here is a server too old to have the route at all, which the store
+ * reads as "no Plugin Center" rather than as a failure to report.
+ * `remote_install_allowed` defaults to ALLOWED for the same reason it does in
+ * `listPacks`: the server is what refuses a remote install, with a 403 this
+ * then reports, so a missing key must not hide a button that works.
+ */
+export async function listPluginCatalog(): Promise<PluginCatalog> {
+  const res = await fetch(`${BASE_URL}/plugins/catalog`);
+  if (!res.ok) throw await apiError(res);
+  const data = (await res.json()) as RawCatalog;
+  return {
+    entries: (data.entries ?? []).map(normalizePluginEntry),
+    active_job: data.active_job ?? null,
+    remote_install_allowed: data.remote_install_allowed ?? true,
+    generation: data.generation ?? 0,
+  };
+}
+
+/**
+ * Resolve a source -- a builtin name, a GitHub URL, a local path -- and
+ * report what installing it would mean, WITHOUT installing anything.
+ *
+ * The `inspection_id` it hands back is what `installPlugin` acts on, so the
+ * user consents to exactly the manifest that was read rather than to whatever
+ * the source holds by the time the install starts.
+ */
+export async function inspectPluginSource(source: string): Promise<PluginInspection> {
+  const res = await apiFetch(`${BASE_URL}/plugins/inspect`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ source }),
+  });
+  if (!res.ok) throw await apiError(res);
+  return res.json();
+}
+
+/**
+ * Start installing an inspected plugin. 202 and a `job_id` to follow with
+ * `getPluginJobEvents`.
+ *
+ * `JSON.stringify` drops undefined values, so a caller spreading a partly
+ * filled request sends only the keys it actually set -- which matters because
+ * the backend's request model forbids anything it did not declare.
+ */
+export async function installPlugin(
+  body: PluginInstallRequest,
+): Promise<{ job_id: string }> {
+  const res = await apiFetch(`${BASE_URL}/plugins/install`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw await apiError(res);
+  return res.json();
+}
+
+/** The 200 and 202 bodies of `/update`, before they are told apart. */
+type RawUpdateResponse = {
+  job_id?: string;
+  status?: string;
+  sha?: string;
+  inspection?: PluginInspection;
+  capabilities_added?: string[];
+  allowed_modules_added?: string[];
+};
+
+/**
+ * Update an installed plugin to its source's newest commit.
+ *
+ * Three answers, so a union rather than a shape the caller has to re-derive:
+ * a job started (202), there was nothing to do, or the new version asks for
+ * capabilities the user has not accepted and the panel must ask first.
+ */
+export async function updatePlugin(pluginId: string): Promise<PluginUpdateResult> {
+  const res = await apiFetch(
+    `${BASE_URL}/plugins/${encodeURIComponent(pluginId)}/update`,
+    { method: 'POST' },
+  );
+  if (!res.ok) throw await apiError(res);
+  const data = (await res.json()) as RawUpdateResponse;
+  // 202 is the ONLY status that means a job started; both 200s carry a
+  // `status` that says which of the other two answers this is.
+  if (res.status === 202) return { kind: 'job', job_id: data.job_id ?? '' };
+  if (data.status === 'up_to_date') return { kind: 'up_to_date', sha: data.sha ?? '' };
+  if (data.status === 'needs_consent' && data.inspection !== undefined) {
+    return {
+      kind: 'needs_consent',
+      inspection: data.inspection,
+      capabilities_added: data.capabilities_added ?? [],
+      allowed_modules_added: data.allowed_modules_added ?? [],
+    };
+  }
+  // Neither 200 shape. Reported rather than guessed at: both guesses ("there
+  // was nothing to do", "a job is running") would leave the panel telling the
+  // user something that did not happen.
+  throw new ApiError(
+    res.status,
+    `Unexpected update response: ${String(data.status)}`,
+    data,
+  );
+}
+
+/**
+ * Remove a plugin. A builtin cannot be deleted, only tombstoned so it does
+ * not come back on the next reload -- `tombstoned` says which happened.
+ *
+ * Nothing removes a plugin's pip packages, here or anywhere:
+ * `python_deps_left` and `uninstall_command` are what the panel shows instead.
+ */
+export async function uninstallPlugin(
+  pluginId: string,
+): Promise<PluginUninstallResult> {
+  const res = await apiFetch(`${BASE_URL}/plugins/${encodeURIComponent(pluginId)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw await apiError(res);
+  return res.json();
+}
+
+/**
+ * Enable or disable an installed plugin. Two routes rather than a body, which
+ * is what the backend has offered since the plugin system shipped.
+ */
+export async function setPluginEnabled(
+  pluginId: string,
+  enabled: boolean,
+): Promise<{ id: string; enabled: boolean }> {
+  const res = await apiFetch(
+    `${BASE_URL}/plugins/${encodeURIComponent(pluginId)}/${enabled ? 'enable' : 'disable'}`,
+    { method: 'POST' },
+  );
+  if (!res.ok) throw await apiError(res);
+  return res.json();
+}
+
+/**
+ * A plugin job's events strictly after `cursor`, oldest first.
+ *
+ * `wait` turns this into a long poll exactly as it does for a pack job: the
+ * request parks server-side and returns the moment an event lands, the job
+ * ends, or the deadline passes. Pass a `signal` so a closing panel can
+ * abandon a parked request instead of holding a connection open.
+ */
+export async function getPluginJobEvents(
+  jobId: string,
+  opts: { cursor?: number; wait?: number; limit?: number; signal?: AbortSignal } = {},
+): Promise<JobEventsPage> {
+  const params = new URLSearchParams();
+  if (opts.cursor !== undefined) params.set('cursor', String(opts.cursor));
+  if (opts.wait !== undefined) params.set('wait', String(opts.wait));
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  const query = params.toString();
+  const res = await fetch(
+    `${BASE_URL}/plugins/jobs/${encodeURIComponent(jobId)}/events${query ? `?${query}` : ''}`,
+    { signal: opts.signal },
+  );
+  if (!res.ok) throw await apiError(res);
+  return res.json();
+}
+
+/**
+ * Ask the running plugin job to stop. `cancelled` reports whether the request
+ * did anything -- false for a job that had already finished, which is a
+ * normal answer rather than an error.
+ */
+export async function cancelPluginJob(
+  jobId: string,
+): Promise<{ job_id: string; cancelled: boolean }> {
+  const res = await apiFetch(
+    `${BASE_URL}/plugins/jobs/${encodeURIComponent(jobId)}/cancel`,
+    { method: 'POST' },
+  );
+  if (!res.ok) throw await apiError(res);
+  return res.json();
+}

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -866,6 +866,108 @@ export async function downloadImageFile(filename: string) {
   URL.revokeObjectURL(url);
 }
 
+// ── Shared: refused requests, and jobs to follow ─────────────────────────
+
+/**
+ * An `/api` call the server refused, with the status AND the parsed body kept.
+ *
+ * The Package Center and the Plugin Center both answer with a status-coded
+ * error vocabulary -- 403 remote, 404 gone, 409 busy, 507 out of disk -- and
+ * each status carries extra keys the panel shows (`job_id`, `command`,
+ * `blocked_by`, `missing_capabilities`). `body` is the parsed JSON, so none of
+ * that has to be recovered from the message.
+ */
+export class ApiError extends Error {
+  /**
+   * The parsed error body, or null when it was not JSON.
+   *
+   * Assignable rather than `readonly`: a caller (a test building a refusal to
+   * hand a store, say) constructs the error first and attaches the body it
+   * should carry second.
+   */
+  body: Record<string, unknown> | null;
+
+  constructor(
+    public readonly status: number,
+    message: string,
+    body: Record<string, unknown> | null = null,
+  ) {
+    super(message);
+    // `new.target` is the class actually being constructed, so `PackApiError`
+    // reports its own name -- unchanged from before it had a base class --
+    // without restating this line.
+    this.name = new.target.name;
+    this.body = body;
+  }
+}
+
+/**
+ * Read a refused response once, for every error factory below.
+ *
+ * The two bodies the backend sends are `{detail: "text"}` and `{detail:
+ * {code, ...}}`. `code` is what a panel switches on, so a coded detail with
+ * no `message` still yields something worth showing rather than a bare
+ * "Conflict".
+ */
+async function readApiError(
+  res: Response,
+): Promise<{ message: string; body: Record<string, unknown> | null }> {
+  const raw = await res.json().catch(() => null);
+  const body =
+    raw !== null && typeof raw === 'object' ? (raw as Record<string, unknown>) : null;
+  const detail = body?.detail;
+  if (typeof detail === 'string') return { message: detail, body };
+  if (detail !== null && typeof detail === 'object') {
+    const coded = detail as Record<string, unknown>;
+    const message = coded.message ?? coded.code;
+    if (typeof message === 'string') return { message, body };
+  }
+  return { message: res.statusText, body };
+}
+
+/** Build the error for a refused request, body and all. */
+export async function apiError(res: Response): Promise<ApiError> {
+  const { message, body } = await readApiError(res);
+  return new ApiError(res.status, message, body);
+}
+
+/**
+ * Where a background job -- a pack install, a plugin install or update -- has
+ * got to. `needs_restart` is a job that finished everything it could do from
+ * inside the running server.
+ */
+export type JobStatus =
+  | 'running'
+  | 'done'
+  | 'failed'
+  | 'cancelled'
+  | 'needs_restart';
+
+/**
+ * One line of a job's log.
+ *
+ * Deliberately open rather than a union: the payload keys differ per `type`
+ * (`log{line}`, `progress{item, bytes_done, ...}`, `job_done{sha, nodes}`),
+ * and a closed union would have to be edited every time the backend grows a
+ * step. Consumers narrow on `type`.
+ */
+export interface JobEvent {
+  type: string;
+  /** 1-based and monotonic. Resume from the PAGE's cursor, not from this. */
+  cursor?: number;
+  ts?: string;
+  [k: string]: unknown;
+}
+
+/** One page of a job's events, oldest first. */
+export interface JobEventsPage {
+  job_id: string;
+  status: JobStatus;
+  events: JobEvent[];
+  /** Where to resume; never moves backwards on an empty page. */
+  cursor: number;
+}
+
 // ── Optional packs / Package Center ──────────────────────────────────────
 
 /**
@@ -884,12 +986,11 @@ export type PackStatus =
 
 export type PackItemStatus = 'missing' | 'present' | 'downloading';
 
-export type PackJobStatus =
-  | 'running'
-  | 'done'
-  | 'failed'
-  | 'cancelled'
-  | 'needs_restart';
+/**
+ * The pack panel's name for `JobStatus`. One alias rather than a second copy
+ * of the union, so the two centers cannot drift apart.
+ */
+export type PackJobStatus = JobStatus;
 
 /**
  * How the server was launched (`CODEFYUI_MANAGED`). `unknown` is a bare
@@ -976,18 +1077,10 @@ export interface PackCatalog {
 }
 
 /**
- * One line of an install job's log.
- *
- * Deliberately open rather than a union: the payload keys differ per `type`
- * (`log{line}`, `progress{item, bytes_done, ...}`, `needs_restart{command}`),
- * and a closed union would have to be edited every time the backend grows a
- * step. Consumers narrow on `type`.
+ * One line of a pack install job's log: a `JobEvent` plus the two keys the
+ * restart contract adds.
  */
-export interface PackJobEvent {
-  type: string;
-  /** 1-based and monotonic. Resume from the PAGE's cursor, not from this. */
-  cursor?: number;
-  ts?: string;
+export interface PackJobEvent extends JobEvent {
   /**
    * `needs_restart` only: which helper finishes the install (`torch`, `pip`).
    *
@@ -1003,47 +1096,27 @@ export interface PackJobEvent {
    * the server cannot restart itself, so its presence is the whole check.
    */
   retry_mode?: string;
-  [k: string]: unknown;
 }
 
-export interface PackJobEventsPage {
-  job_id: string;
-  status: PackJobStatus;
+/** A page of pack events -- `JobEventsPage` narrowed to `PackJobEvent`. */
+export interface PackJobEventsPage extends JobEventsPage {
   events: PackJobEvent[];
-  /** Where to resume; never moves backwards on an empty page. */
-  cursor: number;
 }
 
 /**
- * A `/api/packs` call the server refused, with the status kept.
+ * A `/api/packs` call the server refused.
  *
- * The Package Center's error vocabulary is status-coded -- 403 remote, 409
- * busy or restart-refused, 507 out of disk -- and each carries extra keys the
- * panel shows (`job_id`, `command`, `blocked_by`, `needed`/`free`). `body` is
- * the parsed JSON, so none of that has to be recovered from the message.
+ * Its own class rather than a bare `ApiError` so that the pack store's
+ * `err instanceof PackApiError` keeps meaning "a PACK call refused" now that
+ * the Plugin Center throws the same base error, and so that `err.name` still
+ * reads `PackApiError` in a console.
  */
-export class PackApiError extends Error {
-  /** The parsed error body, or null when it was not JSON. */
-  body: Record<string, unknown> | null = null;
-
-  constructor(public readonly status: number, message: string) {
-    super(message);
-    this.name = 'PackApiError';
-  }
-}
+export class PackApiError extends ApiError {}
 
 /** Build the error for a refused pack request, body and all. */
 async function packApiError(res: Response): Promise<PackApiError> {
-  const raw = await res.json().catch(() => null);
-  const body =
-    raw !== null && typeof raw === 'object' ? (raw as Record<string, unknown>) : null;
-  const detail = body?.detail;
-  const err = new PackApiError(
-    res.status,
-    typeof detail === 'string' ? detail : res.statusText,
-  );
-  err.body = body;
-  return err;
+  const { message, body } = await readApiError(res);
+  return new PackApiError(res.status, message, body);
 }
 
 /**

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -1507,7 +1507,7 @@ function normalizePluginEntry(raw: RawCatalogEntry): PluginCatalogEntry {
     homepage: raw.homepage ?? '',
     version: raw.version ?? null,
     installed_at: raw.installed_at ?? null,
-    // A server that does not say reports the only thing its status can mean:
+    // A server that does not say gets the only answer its status supports:
     // `installed` is enabled, and every other status is not.
     enabled: raw.enabled ?? status === 'installed',
     chapters: raw.chapters ?? [],

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -1639,10 +1639,27 @@ export async function updatePlugin(pluginId: string): Promise<PluginUpdateResult
   );
   if (!res.ok) throw await apiError(res);
   const data = (await res.json()) as RawUpdateResponse;
+  // An answer this client cannot act on. Reported rather than guessed at:
+  // every guess ("there was nothing to do", "a job is running", "follow the
+  // job with no id") would leave the panel telling the user something that
+  // did not happen.
+  const unexpected = (detail: string) => new ApiError(
+    res.status, `Unexpected update response: ${detail}`, data,
+  );
+
   // 202 is the ONLY status that means a job started; both 200s carry a
   // `status` that says which of the other two answers this is.
-  if (res.status === 202) return { kind: 'job', job_id: data.job_id ?? '' };
-  if (data.status === 'up_to_date') return { kind: 'up_to_date', sha: data.sha ?? '' };
+  if (res.status === 202) {
+    // An empty id is worse than no answer: it would seed a follower on
+    // `/api/plugins/jobs//events`, which burns its whole retry budget before
+    // ending the install nobody started as `lost`.
+    if (!data.job_id) throw unexpected('202 without job_id');
+    return { kind: 'job', job_id: data.job_id };
+  }
+  if (data.status === 'up_to_date') {
+    if (!data.sha) throw unexpected('up_to_date without sha');
+    return { kind: 'up_to_date', sha: data.sha };
+  }
   if (data.status === 'needs_consent' && data.inspection !== undefined) {
     return {
       kind: 'needs_consent',
@@ -1651,14 +1668,7 @@ export async function updatePlugin(pluginId: string): Promise<PluginUpdateResult
       allowed_modules_added: data.allowed_modules_added ?? [],
     };
   }
-  // Neither 200 shape. Reported rather than guessed at: both guesses ("there
-  // was nothing to do", "a job is running") would leave the panel telling the
-  // user something that did not happen.
-  throw new ApiError(
-    res.status,
-    `Unexpected update response: ${String(data.status)}`,
-    data,
-  );
+  throw unexpected(String(data.status));
 }
 
 /**

--- a/frontend/src/components/Sidebar/NodePalette.tsx
+++ b/frontend/src/components/Sidebar/NodePalette.tsx
@@ -8,6 +8,7 @@ import {
 import { useI18n } from '../../i18n';
 import { useNodeDefinitionsBootstrap } from '../../hooks/useNodeDefinitionsBootstrap';
 import { usePackCatalogBootstrap } from '../../hooks/usePackCatalogBootstrap';
+import { usePluginCatalogBootstrap } from '../../hooks/usePluginCatalogBootstrap';
 import { SidebarRail } from './SidebarRail';
 import { NodesTab } from './NodesTab';
 import { PresetsTab } from './PresetsTab';
@@ -60,6 +61,10 @@ export function NodePalette() {
   // Same shell, same reason: the pack catalog decides which LLM nodes are
   // usable, so it cannot hang off a tab that may never be opened.
   usePackCatalogBootstrap();
+  // And the plugin catalog, which says which plugins this server has and
+  // whether an install is still running from before this page load. A server
+  // without the route answers 404 and the store goes quiet.
+  usePluginCatalogBootstrap();
 
   // Ends an in-flight resize drag: set while dragging, null otherwise.
   const endDragRef = useRef<(() => void) | null>(null);

--- a/frontend/src/hooks/usePluginCatalogBootstrap.test.ts
+++ b/frontend/src/hooks/usePluginCatalogBootstrap.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as rest from '../api/rest';
+import type { PluginCatalog } from '../api/rest';
+import { ApiError } from '../api/rest';
+
+vi.mock('../api/rest', async (importOriginal) => {
+  const actual = await importOriginal<typeof rest>();
+  return {
+    ...actual,
+    listPluginCatalog: vi.fn(),
+    getPluginJobEvents: vi.fn(),
+  };
+});
+
+// The store calls it after a settled change; nothing here settles one, but a
+// real import of the host would pull the whole widget stack into this file.
+vi.mock('../plugins/PluginHost', () => ({
+  reloadPluginFrontends: vi.fn(),
+}));
+
+import { usePluginCatalogBootstrap } from './usePluginCatalogBootstrap';
+import { _resetPluginStoreForTesting, usePluginStore } from '../store/pluginStore';
+import { useToastStore } from '../store/toastStore';
+
+const api = vi.mocked(rest);
+
+const catalog: PluginCatalog = {
+  entries: [],
+  active_job: null,
+  remote_install_allowed: true,
+  generation: 1,
+};
+
+beforeEach(() => {
+  _resetPluginStoreForTesting();
+  useToastStore.setState({ toasts: [] });
+  api.listPluginCatalog.mockResolvedValue(catalog);
+});
+
+afterEach(() => {
+  _resetPluginStoreForTesting();
+  vi.clearAllMocks();
+});
+
+describe('usePluginCatalogBootstrap', () => {
+  it('reads the catalog once on mount', async () => {
+    renderHook(() => usePluginCatalogBootstrap());
+
+    await waitFor(() => expect(usePluginStore.getState().loaded).toBe(true));
+    expect(api.listPluginCatalog).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads it once even when two callers mount', async () => {
+    // StrictMode mounts every effect twice, and the sidebar shell can be
+    // remounted by a layout change; neither may cost a second catalog read.
+    renderHook(() => usePluginCatalogBootstrap());
+    renderHook(() => usePluginCatalogBootstrap());
+
+    await waitFor(() => expect(usePluginStore.getState().loaded).toBe(true));
+    expect(api.listPluginCatalog).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-read a catalog that is already loaded', () => {
+    usePluginStore.setState({ loaded: true });
+
+    renderHook(() => usePluginCatalogBootstrap());
+
+    expect(api.listPluginCatalog).not.toHaveBeenCalled();
+  });
+
+  it('does not start a second read while one is in flight', () => {
+    usePluginStore.setState({ loading: true });
+
+    renderHook(() => usePluginCatalogBootstrap());
+
+    expect(api.listPluginCatalog).not.toHaveBeenCalled();
+  });
+
+  it('says nothing at all on a server without the route', async () => {
+    // The whole point of booting this at all costs on an old server: a 404 is
+    // an answer, not a failure, and the user never hears about it.
+    api.listPluginCatalog.mockRejectedValue(new ApiError(404, 'Not Found'));
+
+    renderHook(() => usePluginCatalogBootstrap());
+
+    await waitFor(() => expect(usePluginStore.getState().unsupported).toBe(true));
+    expect(useToastStore.getState().toasts).toEqual([]);
+    expect(usePluginStore.getState().error).toBeNull();
+  });
+});

--- a/frontend/src/hooks/usePluginCatalogBootstrap.ts
+++ b/frontend/src/hooks/usePluginCatalogBootstrap.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { usePluginStore } from '../store/pluginStore';
+
+/**
+ * Kick off the one-time plugin catalog read.
+ *
+ * Called from the sidebar SHELL, beside `usePackCatalogBootstrap`, for the
+ * same reason that one is: the shell is mounted whatever tab is open and
+ * whether or not the sidebar is collapsed, and this catalog is not the
+ * sidebar's — it is what tells the whole app which plugins exist, whether the
+ * server has a Plugin Center at all, and whether an install started before
+ * this page load is still running.
+ *
+ * It goes through `checkInProgress` rather than `refresh` because the boot
+ * read is where the thing that only makes sense at boot happens: adopting an
+ * install that outlived the last page, and saying so.
+ *
+ * A server without the route answers 404, which the store records as
+ * `unsupported` and nothing reports — this build talks to older servers too,
+ * and a missing feature is not an error the user did anything about.
+ *
+ * Deliberately returns nothing: consumers read the catalog straight from
+ * `usePluginStore`, so nothing subscribes to store slices just to get the
+ * fetch started. Idempotent twice over — it reads the LATEST store state
+ * rather than closure-captured flags, and `checkInProgress` keeps its own
+ * once-per-page flag — so StrictMode's double mount cannot double fetch.
+ */
+export function usePluginCatalogBootstrap(): void {
+  useEffect(() => {
+    const state = usePluginStore.getState();
+    if (!state.loaded && !state.loading) void state.checkInProgress();
+  }, []);
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1063,6 +1063,12 @@ const en = {
   'pluginCenter.toast.enabled': '{plugin} enabled.',
   'pluginCenter.toast.disabled': '{plugin} disabled.',
   'pluginCenter.toast.toggleFailed': 'Could not change {plugin}: {message}',
+  // The change itself landed; re-reading the catalog, the node definitions
+  // or the plugin UIs did not. Its own sentence, because saying "install
+  // failed" about a successful uninstall is the one reading that is flatly
+  // wrong.
+  'pluginCenter.toast.refreshFailed':
+    'Could not refresh the editor after the change: {message}',
   // The files are in place; the running server could not pick them up.
   'pluginCenter.toast.needsRestart': 'Restart the server to load {plugin}.',
   'pluginCenter.toast.inProgress':
@@ -1076,7 +1082,8 @@ const en = {
   'pluginCenter.uninstallConfirm':
     'Uninstall {plugin}? Graphs that use its nodes will stop running. '
     + 'Its Python packages stay installed.',
-  'pluginCenter.source.invalid': 'Enter owner/repo[@ref] or a GitHub URL.',
+  'pluginCenter.source.invalid':
+    'Enter a catalog name, owner/repo[@ref] or a GitHub URL.',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1049,11 +1049,34 @@ const en = {
   'node.paramNeedsPack': 'needs pack',
   'error.missingPack': 'This node needs the {pack} pack. Install it from the Package Center.',
 
-  // Plugin Center. Only the plugin HOST's own toasts so far: one for a plugin
-  // whose UI bundle would not load, one for the dev hot-reload. The panel's
-  // copy arrives with the panel.
+  // Plugin Center. The host's own two toasts (a UI bundle that would not
+  // load, the dev hot-reload) and everything the store says about an install,
+  // an update, a removal or a switch. The panel's own copy arrives with the
+  // panel.
   'pluginCenter.toast.frontendFailed': 'The UI of plugin "{plugin}" failed to load.',
   'pluginCenter.toast.frontendsReloaded': 'Plugin UI reloaded.',
+  'pluginCenter.toast.installed': '{plugin} installed.',
+  'pluginCenter.toast.updated': '{plugin} updated.',
+  'pluginCenter.toast.upToDate': '{plugin} is up to date.',
+  'pluginCenter.toast.removed': '{plugin} uninstalled.',
+  'pluginCenter.toast.removeFailed': 'Could not remove {plugin}: {message}',
+  'pluginCenter.toast.enabled': '{plugin} enabled.',
+  'pluginCenter.toast.disabled': '{plugin} disabled.',
+  'pluginCenter.toast.toggleFailed': 'Could not change {plugin}: {message}',
+  // The files are in place; the running server could not pick them up.
+  'pluginCenter.toast.needsRestart': 'Restart the server to load {plugin}.',
+  'pluginCenter.toast.inProgress':
+    'A plugin is still installing. Open the Plugin Center to watch it.',
+  'pluginCenter.toast.openCenter': 'Open Plugin Center',
+  'pluginCenter.updateFailed': 'Update failed: {message}',
+  'pluginCenter.uninstall': 'Uninstall',
+  // Says what is lost AND what is not: nothing uninstalls a plugin's pip
+  // packages, and a user who expects the disk space back should hear so here
+  // rather than after saying yes.
+  'pluginCenter.uninstallConfirm':
+    'Uninstall {plugin}? Graphs that use its nodes will stop running. '
+    + 'Its Python packages stay installed.',
+  'pluginCenter.source.invalid': 'Enter owner/repo[@ref] or a GitHub URL.',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1048,6 +1048,12 @@ const en = {
   'node.needsPack.title': 'Needs the {pack} pack. Click to open the Package Center.',
   'node.paramNeedsPack': 'needs pack',
   'error.missingPack': 'This node needs the {pack} pack. Install it from the Package Center.',
+
+  // Plugin Center. Only the plugin HOST's own toasts so far: one for a plugin
+  // whose UI bundle would not load, one for the dev hot-reload. The panel's
+  // copy arrives with the panel.
+  'pluginCenter.toast.frontendFailed': 'The UI of plugin "{plugin}" failed to load.',
+  'pluginCenter.toast.frontendsReloaded': 'Plugin UI reloaded.',
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -976,7 +976,7 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.uninstall': '解除安裝',
   'pluginCenter.uninstallConfirm':
     '要解除安裝「{plugin}」嗎？使用它節點的圖將無法執行；它安裝的 Python 套件會保留。',
-  'pluginCenter.source.invalid': '請輸入目錄名稱、owner/repo[@ref] 或 GitHub URL。',
+  'pluginCenter.source.invalid': '請輸入內建套件名稱、owner/repo[@ref] 或 GitHub URL。',
 };
 
 export default zhTW;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -959,6 +959,22 @@ const zhTW: Record<TranslationKey, string> = {
   // Plugin Center.
   'pluginCenter.toast.frontendFailed': '外掛「{plugin}」的介面載入失敗。',
   'pluginCenter.toast.frontendsReloaded': '已重新載入外掛介面。',
+  'pluginCenter.toast.installed': '已安裝 {plugin}。',
+  'pluginCenter.toast.updated': '已更新 {plugin}。',
+  'pluginCenter.toast.upToDate': '{plugin} 已是最新。',
+  'pluginCenter.toast.removed': '已解除安裝 {plugin}。',
+  'pluginCenter.toast.removeFailed': '無法解除安裝 {plugin}：{message}',
+  'pluginCenter.toast.enabled': '已啟用 {plugin}。',
+  'pluginCenter.toast.disabled': '已停用 {plugin}。',
+  'pluginCenter.toast.toggleFailed': '無法變更 {plugin}：{message}',
+  'pluginCenter.toast.needsRestart': '請重新啟動伺服器以載入 {plugin}。',
+  'pluginCenter.toast.inProgress': '有外掛仍在安裝中，可在外掛中心查看進度。',
+  'pluginCenter.toast.openCenter': '開啟外掛中心',
+  'pluginCenter.updateFailed': '更新失敗：{message}',
+  'pluginCenter.uninstall': '解除安裝',
+  'pluginCenter.uninstallConfirm':
+    '要解除安裝「{plugin}」嗎？使用它節點的圖將無法執行；它安裝的 Python 套件會保留。',
+  'pluginCenter.source.invalid': '請輸入 owner/repo[@ref] 或 GitHub URL。',
 };
 
 export default zhTW;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -967,6 +967,8 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.toast.enabled': '已啟用 {plugin}。',
   'pluginCenter.toast.disabled': '已停用 {plugin}。',
   'pluginCenter.toast.toggleFailed': '無法變更 {plugin}：{message}',
+  'pluginCenter.toast.refreshFailed':
+    '變更後無法重新整理編輯器：{message}',
   'pluginCenter.toast.needsRestart': '請重新啟動伺服器以載入 {plugin}。',
   'pluginCenter.toast.inProgress': '有外掛仍在安裝中，可在外掛中心查看進度。',
   'pluginCenter.toast.openCenter': '開啟外掛中心',
@@ -974,7 +976,7 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.uninstall': '解除安裝',
   'pluginCenter.uninstallConfirm':
     '要解除安裝「{plugin}」嗎？使用它節點的圖將無法執行；它安裝的 Python 套件會保留。',
-  'pluginCenter.source.invalid': '請輸入 owner/repo[@ref] 或 GitHub URL。',
+  'pluginCenter.source.invalid': '請輸入目錄名稱、owner/repo[@ref] 或 GitHub URL。',
 };
 
 export default zhTW;

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -955,6 +955,10 @@ const zhTW: Record<TranslationKey, string> = {
   'node.needsPack.title': '需要 {pack} 套件。點一下開啟套件中心。',
   'node.paramNeedsPack': '需套件',
   'error.missingPack': '這個節點需要 {pack} 套件，請到套件中心安裝。',
+
+  // Plugin Center.
+  'pluginCenter.toast.frontendFailed': '外掛「{plugin}」的介面載入失敗。',
+  'pluginCenter.toast.frontendsReloaded': '已重新載入外掛介面。',
 };
 
 export default zhTW;

--- a/frontend/src/plugins/PluginHost.test.tsx
+++ b/frontend/src/plugins/PluginHost.test.tsx
@@ -384,13 +384,17 @@ describe('reloadPluginFrontends', () => {
   afterEach(reset);
 
   it('cache-busts the import with the reload generation', async () => {
-    mockPluginHostFetch({ pluginPayloads: [[A]], generation: 7 });
+    const { calls } = mockPluginHostFetch({ pluginPayloads: [[A]], generation: 7 });
     const activate = vi.fn();
     const importer = vi.fn(async () => ({ default: activate }));
 
     expect(await reloadPluginFrontends(container, importer)).toEqual(['a']);
     expect(importer).toHaveBeenCalledTimes(1);
     expect(importer).toHaveBeenCalledWith('/plugins/a/frontend/index.js?v=7');
+    // The list is read ONCE and activated from that same answer. A second
+    // read would be a second truth: a plugin uninstalled between the two
+    // would be torn down and then activated again from the older list.
+    expect(calls.filter((url) => url === '/api/plugins')).toHaveLength(1);
   });
 
   it('busts with a timestamp when the server has no generation route', async () => {
@@ -560,6 +564,39 @@ describe('reloadPluginFrontends', () => {
     expect(executionEventSubscriberCount()).toBe(1);
     expect(getPluginPanels()).toHaveLength(1);
     expect(getPluginToolbarButtons()).toHaveLength(1);
+  });
+
+  it('does not stack the boot on a load that threw part way through', async () => {
+    // The half-activation: the plugin registered its panel, its button and
+    // its subscription and THEN threw, so it never joined `activatedIds`
+    // while its cleanups stayed on the list. A boot that asked only about
+    // the ids would find "nothing activated here" and stack a second copy
+    // of all three on top of the first.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      mockPluginHostFetch({ pluginPayloads: [[A]], generation: 2 });
+      const halfway = vi.fn((api: CodefyUIPluginAPI) => {
+        smallPlugin(api);
+        throw new Error('activate exploded');
+      });
+
+      expect(await startPluginFrontends(
+        container, vi.fn(async () => ({ default: halfway })),
+      )).toEqual([]);
+      expect(executionEventSubscriberCount()).toBe(1);
+
+      await startPluginFrontends(
+        container, vi.fn(async () => ({ default: smallPlugin })),
+      );
+
+      // The subscription is the one that cannot hide a duplicate: two
+      // registrations of the same panel id replace each other.
+      expect(executionEventSubscriberCount()).toBe(1);
+      expect(getPluginPanels()).toHaveLength(1);
+      expect(getPluginToolbarButtons()).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('keeps serving later callers after an activation rejects', async () => {

--- a/frontend/src/plugins/PluginHost.test.tsx
+++ b/frontend/src/plugins/PluginHost.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { loadPluginFrontends, unloadPluginFrontends } from './PluginHost';
+import { render } from '@testing-library/react';
+import {
+  PluginHost, _resetPluginHostForTesting, loadPluginFrontends,
+  reloadPluginFrontends, startPluginFrontends, unloadPluginFrontends,
+} from './PluginHost';
+import { useI18n } from '../i18n';
+import en from '../i18n/locales/en';
+import zhTW from '../i18n/locales/zh-TW';
 import { useNodeDefStore } from '../store/nodeDefStore';
 import { useToastStore } from '../store/toastStore';
 import { useTabStore } from '../store/tabStore';
@@ -303,5 +310,308 @@ describe('plugin unload leaves nothing behind', () => {
     unloadPluginFrontends();
     expect(() => unloadPluginFrontends()).not.toThrow();
     expect(residue()).toEqual(EMPTY);
+  });
+});
+
+/** One node definition, in the shape `waitForNodeDefinitions` counts. */
+const ONE_DEFINITION = [{
+  node_name: 'X', category: 'c', description: '',
+  inputs: [], outputs: [], params: [],
+}];
+
+/**
+ * A fetch that answers the two URLs the host asks for.
+ *
+ * `/api/plugins` walks the payload list, one per call, and repeats the last
+ * one -- that is how "the second answer no longer lists this plugin" is set
+ * up. `/api/plugins/generation` answers `generation`, or 404s when it is null
+ * (a server too old to have the route).
+ */
+function mockPluginHostFetch(options: {
+  pluginPayloads: unknown[];
+  generation: number | null;
+}) {
+  const calls: string[] = [];
+  let index = 0;
+  const fetchMock = vi.fn(async (url: string) => {
+    calls.push(url);
+    if (url === '/api/plugins/generation') {
+      return options.generation === null
+        ? { ok: false, json: async () => ({}) }
+        : { ok: true, json: async () => ({ generation: options.generation }) };
+    }
+    const payload = options.pluginPayloads[
+      Math.min(index, options.pluginPayloads.length - 1)
+    ];
+    index += 1;
+    return { ok: true, json: async () => payload };
+  });
+  vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch);
+  return { calls };
+}
+
+/**
+ * Re-activation without a page reload: the Plugin Center installs, enables or
+ * removes a plugin and the editor has to show the result at once, without
+ * ever running two activations over the same module-level registries.
+ */
+describe('reloadPluginFrontends', () => {
+  const A = { id: 'a', enabled: true, frontend_entry: '/plugins/a/frontend/index.js' };
+  const B = { id: 'b', enabled: true, frontend_entry: '/plugins/b/frontend/index.js' };
+
+  const container = () => document.createElement('div');
+
+  /**
+   * A plugin that registers one of everything a reload has to clear first.
+   * The execution subscriber is the one that cannot hide a duplicate: two
+   * registrations of the same panel id replace each other, two subscriptions
+   * stack.
+   */
+  function smallPlugin(api: CodefyUIPluginAPI) {
+    api.ui.addPanel({ id: 'dock', title: 'Dock' });
+    api.ui.addToolbarButton({ id: 'go', icon: '*', tooltip: 'Go', onClick: () => {} });
+    api.events.onExecution(() => {});
+  }
+
+  function reset() {
+    _resetPluginHostForTesting();
+    _clearPluginPanels();
+    _clearPluginToolbarButtons();
+    _resetExecutionEvents();
+  }
+
+  beforeEach(reset);
+  afterEach(reset);
+
+  it('cache-busts the import with the reload generation', async () => {
+    mockPluginHostFetch({ pluginPayloads: [[A]], generation: 7 });
+    const activate = vi.fn();
+    const importer = vi.fn(async () => ({ default: activate }));
+
+    expect(await reloadPluginFrontends(container, importer)).toEqual(['a']);
+    expect(importer).toHaveBeenCalledTimes(1);
+    expect(importer).toHaveBeenCalledWith('/plugins/a/frontend/index.js?v=7');
+  });
+
+  it('busts with a timestamp when the server has no generation route', async () => {
+    mockPluginHostFetch({ pluginPayloads: [[A]], generation: null });
+    const urls: string[] = [];
+    const importer = vi.fn(async (url: string) => {
+      urls.push(url);
+      return { default: vi.fn() };
+    });
+
+    const before = Date.now();
+    await reloadPluginFrontends(container, importer);
+    const url = urls[0] ?? '';
+
+    expect(url).toMatch(/^\/plugins\/a\/frontend\/index\.js\?v=\d+$/);
+    const stamp = Number(url.split('?v=')[1]);
+    expect(stamp).toBeGreaterThanOrEqual(before);
+    expect(stamp).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('tears the old frontends down before activating the new ones', async () => {
+    mockPluginHostFetch({ pluginPayloads: [[A]], generation: 3 });
+    await loadPluginFrontends(container, vi.fn(async () => ({ default: smallPlugin })));
+    expect(getPluginPanels()).toHaveLength(1);
+    expect(getPluginToolbarButtons()).toHaveLength(1);
+
+    // What the registries hold at the moment the new bundle arrives: if the
+    // unload ran, nothing.
+    const whenImported: number[] = [];
+    const importer = vi.fn(async () => {
+      whenImported.push(getPluginPanels().length, getPluginToolbarButtons().length);
+      return { default: smallPlugin };
+    });
+
+    await reloadPluginFrontends(container, importer);
+
+    expect(whenImported).toEqual([0, 0]);
+    // One copy of each, not two.
+    expect(getPluginPanels()).toHaveLength(1);
+    expect(getPluginToolbarButtons()).toHaveLength(1);
+    expect(executionEventSubscriberCount()).toBe(1);
+  });
+
+  it('does not re-activate a plugin the server no longer lists', async () => {
+    mockPluginHostFetch({ pluginPayloads: [[A, B], [A]], generation: 4 });
+    const importer = vi.fn(async () => ({ default: smallPlugin }));
+
+    await loadPluginFrontends(container, importer);
+    expect(getPluginPanels().map((p) => p.pluginId)).toEqual(['a', 'b']);
+
+    // 'b' was uninstalled (or disabled) between the two answers.
+    expect(await reloadPluginFrontends(container, importer)).toEqual(['a']);
+    expect(getPluginPanels().map((p) => p.pluginId)).toEqual(['a']);
+    expect(getPluginToolbarButtons().map((b) => b.pluginId)).toEqual(['a']);
+  });
+
+  it('hosts widgets in the document body when the stack is not mounted', async () => {
+    mockPluginHostFetch({ pluginPayloads: [[A]], generation: 5 });
+    const importer = vi.fn(async () => ({
+      default: (api: CodefyUIPluginAPI) => { api.ui.addFloatingWidget({ id: 'fab' }); },
+    }));
+
+    // No <PluginHost /> has mounted: a reload fired from the Plugin Center
+    // before the stack exists must still activate.
+    await reloadPluginFrontends(undefined, importer);
+
+    const widget = document.getElementById('plugin-widget-a-fab');
+    expect(widget?.parentElement).toBe(document.body);
+    widget?.remove();
+  });
+
+  /**
+   * The race the promise chain exists for: an install settles while the boot
+   * load is still parked in `waitForNodeDefinitions()`. Unserialised, the
+   * reload would tear down nothing (the boot has registered nothing yet) and
+   * both loads would then activate every plugin.
+   */
+  it('queues a reload issued during the boot load behind it', async () => {
+    vi.useFakeTimers();
+    try {
+      useNodeDefStore.setState({ definitions: [] });
+      mockPluginHostFetch({ pluginPayloads: [[A]], generation: 9 });
+
+      const order: string[] = [];
+      const activate = vi.fn((api: CodefyUIPluginAPI) => {
+        order.push('activate');
+        smallPlugin(api);
+      });
+      const importer = vi.fn(async (url: string) => {
+        order.push(url);
+        return { default: activate };
+      });
+
+      const boot = startPluginFrontends(container, importer);
+      const reload = reloadPluginFrontends(container, importer);
+
+      await vi.advanceTimersByTimeAsync(300);
+      expect(importer, 'the boot is still waiting for node definitions')
+        .not.toHaveBeenCalled();
+
+      useNodeDefStore.setState({ definitions: ONE_DEFINITION });
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(await boot).toEqual(['a']);
+      expect(await reload).toEqual(['a']);
+      expect(activate).toHaveBeenCalledTimes(2);
+      expect(order).toEqual([
+        '/plugins/a/frontend/index.js', 'activate',
+        '/plugins/a/frontend/index.js?v=9', 'activate',
+      ]);
+      // Twice activated, once registered: the reload's teardown ran between
+      // the two passes. Unserialised, the reload would have torn down an
+      // empty registry before the boot filled it, and both passes would have
+      // stacked -- two of every subscription, panel and button.
+      expect(executionEventSubscriberCount()).toBe(1);
+      expect(getPluginPanels()).toHaveLength(1);
+      expect(getPluginToolbarButtons()).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps serving later callers after an activation rejects', async () => {
+    // The queue is shared with the boot and the dev poller, so a task that
+    // throws must not be the end of it. Driven through the one call the host
+    // does not guard: the toast it fires for a plugin that failed to load.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const realAddToast = useToastStore.getState().addToast;
+    mockPluginHostFetch({ pluginPayloads: [[A]], generation: 6 });
+    try {
+      useToastStore.setState({
+        addToast: () => { throw new Error('toast exploded'); },
+      });
+      await expect(
+        reloadPluginFrontends(container, vi.fn(async () => { throw new Error('boom'); })),
+      ).rejects.toThrow('toast exploded');
+    } finally {
+      useToastStore.setState({ addToast: realAddToast });
+      warn.mockRestore();
+    }
+
+    expect(
+      await reloadPluginFrontends(container, vi.fn(async () => ({ default: vi.fn() }))),
+    ).toEqual(['a']);
+  });
+});
+
+describe('plugin host toasts', () => {
+  beforeEach(_resetPluginHostForTesting);
+  afterEach(_resetPluginHostForTesting);
+
+  it('names a plugin whose UI failed in the reader language', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const locale = useI18n.getState().locale;
+    try {
+      mockPluginsResponse([
+        { id: 'a', enabled: true, frontend_entry: '/plugins/a/frontend/index.js' },
+      ]);
+      useI18n.setState({ locale: 'zh-TW' });
+      await loadPluginFrontends(
+        () => document.createElement('div'),
+        vi.fn(async () => { throw new Error('boom'); }),
+      );
+
+      const [toast] = useToastStore.getState().toasts;
+      expect(toast.type).toBe('error');
+      expect(toast.message).toBe(
+        zhTW['pluginCenter.toast.frontendFailed'].replace('{plugin}', 'a'),
+      );
+      expect(toast.message).not.toContain('{plugin}');
+    } finally {
+      useI18n.setState({ locale });
+      warn.mockRestore();
+    }
+  });
+});
+
+/**
+ * The dev-only hot reload: still armed by a linked plugin at boot, still
+ * triggered by a generation bump, now going through the same reload the
+ * Plugin Center uses.
+ */
+describe('dev hot-reload poller', () => {
+  beforeEach(_resetPluginHostForTesting);
+  afterEach(_resetPluginHostForTesting);
+
+  it('reloads the frontends when the generation bumps', async () => {
+    vi.useFakeTimers();
+    try {
+      let generation = 1;
+      const calls: string[] = [];
+      // A linked plugin with no frontend bundle: enough to arm the poller,
+      // and nothing for the reload to import.
+      const linked = [{
+        id: 'linked', enabled: true, source_kind: 'local', frontend_entry: null,
+      }];
+      vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+        calls.push(url);
+        return url === '/api/plugins/generation'
+          ? { ok: true, json: async () => ({ generation }) }
+          : { ok: true, json: async () => linked };
+      }) as unknown as typeof fetch);
+
+      render(<PluginHost />);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(calls, 'the poller read the generation at boot')
+        .toContain('/api/plugins/generation');
+
+      await vi.advanceTimersByTimeAsync(1600);
+      expect(useToastStore.getState().toasts, 'no bump, no reload').toHaveLength(0);
+
+      generation = 2;
+      const before = calls.length;
+      await vi.advanceTimersByTimeAsync(1600);
+
+      expect(calls.slice(before), 'the reload re-read the plugin list')
+        .toContain('/api/plugins');
+      expect(useToastStore.getState().toasts.map((t) => t.message))
+        .toEqual([en['pluginCenter.toast.frontendsReloaded']]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/plugins/PluginHost.test.tsx
+++ b/frontend/src/plugins/PluginHost.test.tsx
@@ -513,6 +513,55 @@ describe('reloadPluginFrontends', () => {
     }
   });
 
+  /**
+   * The failure that would hurt most: a reload runs right after an install,
+   * which is exactly when the backend may be mid re-import and answer 503 (or
+   * not at all). Tearing down first would leave the editor with no plugin UI
+   * whatever, and nothing polls in production to put it back.
+   */
+  it('keeps the current activations when the plugin list cannot be read', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      mockPluginHostFetch({ pluginPayloads: [[A]], generation: 3 });
+      const activate = vi.fn(smallPlugin);
+      const importer = vi.fn(async () => ({ default: activate }));
+      expect(await reloadPluginFrontends(container, importer)).toEqual(['a']);
+
+      for (const [reason, failing] of [
+        ['a 503', vi.fn(async () => ({ ok: false, status: 503, json: async () => ({}) }))],
+        ['a dead socket', vi.fn(async () => { throw new Error('net'); })],
+      ] as const) {
+        vi.stubGlobal('fetch', failing as unknown as typeof fetch);
+
+        expect(await reloadPluginFrontends(container, importer), reason).toEqual(['a']);
+        expect(activate, reason).toHaveBeenCalledTimes(1);
+        expect(getPluginPanels(), reason).toHaveLength(1);
+        expect(getPluginToolbarButtons(), reason).toHaveLength(1);
+        expect(executionEventSubscriberCount(), reason).toBe(1);
+        // The store's own refresh already tells the user the server is down.
+        expect(useToastStore.getState().toasts, reason).toHaveLength(0);
+      }
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not stack the boot on frontends a reload activated first', async () => {
+    mockPluginHostFetch({ pluginPayloads: [[A]], generation: 8 });
+    const activate = vi.fn(smallPlugin);
+    const importer = vi.fn(async () => ({ default: activate }));
+
+    // The Plugin Center can act from a page whose host has not mounted yet.
+    await reloadPluginFrontends(container, importer);
+    await startPluginFrontends(container, importer);
+
+    expect(activate).toHaveBeenCalledTimes(2);
+    expect(executionEventSubscriberCount()).toBe(1);
+    expect(getPluginPanels()).toHaveLength(1);
+    expect(getPluginToolbarButtons()).toHaveLength(1);
+  });
+
   it('keeps serving later callers after an activation rejects', async () => {
     // The queue is shared with the boot and the dev poller, so a task that
     // throws must not be the end of it. Driven through the one call the host

--- a/frontend/src/plugins/PluginHost.tsx
+++ b/frontend/src/plugins/PluginHost.tsx
@@ -278,10 +278,12 @@ export async function reloadPluginFrontends(
 
 /**
  * Dev-only: if a linked (local) plugin is installed, poll the reload
- * generation and re-activate plugin frontends whenever it bumps. The bundle is
- * re-imported with a `?v=<generation>` cache-buster (the browser keeps the ESM
- * module registry keyed by URL, so the query bump is required even though the
- * server already sends Cache-Control: no-cache). No-ops in production.
+ * generation and re-activate plugin frontends whenever it bumps, so a linked
+ * plugin's frontend edits land without a browser refresh. The re-activation
+ * (and its cache-buster) is `reloadPluginFrontends` above.
+ *
+ * Armed once, at boot, from the plugin list as it was then: a machine with no
+ * linked plugin never polls, which is every production install.
  */
 async function maybeStartDevHotReload(): Promise<void> {
   if (pollTimer !== null) return;

--- a/frontend/src/plugins/PluginHost.tsx
+++ b/frontend/src/plugins/PluginHost.tsx
@@ -381,7 +381,7 @@ async function maybeStartDevHotReload(): Promise<void> {
       useToastStore.getState().addToast(
         useI18n.getState().t('pluginCenter.toast.frontendsReloaded'), 'info',
       );
-    })();
+    })().catch(console.warn);
   }, DEV_POLL_MS);
 }
 
@@ -392,7 +392,12 @@ export function PluginHost() {
     stackEl = ref.current;
     if (hostStarted) return;
     hostStarted = true;
-    void startPluginFrontends().then(() => maybeStartDevHotReload());
+    // Caught, not swallowed: a rejection here (an activation that reached the
+    // toast store and threw, a queued task that rejected) would otherwise
+    // surface as an unhandled rejection in a console the user never opens.
+    void startPluginFrontends()
+      .then(() => maybeStartDevHotReload())
+      .catch(console.warn);
     return () => { stackEl = null; };
   }, []);
 

--- a/frontend/src/plugins/PluginHost.tsx
+++ b/frontend/src/plugins/PluginHost.tsx
@@ -288,7 +288,11 @@ export async function startPluginFrontends(
   importer: Importer = dynamicImporter,
 ): Promise<string[]> {
   return serialized(() => {
-    if (activatedIds.length > 0) unloadPluginFrontends();
+    // `cleanups` as well as `activatedIds`: a load that threw part way
+    // through registered its cleanups and never got to record the ids, so
+    // reading only the ids would leave that half-activation in place and
+    // stack a second copy of every panel on top of it.
+    if (cleanups.length > 0 || activatedIds.length > 0) unloadPluginFrontends();
     return loadPluginFrontends(getContainer, importer);
   });
 }

--- a/frontend/src/plugins/PluginHost.tsx
+++ b/frontend/src/plugins/PluginHost.tsx
@@ -14,6 +14,7 @@
  * installs (no linked plugin) never poll.
  */
 import { useEffect, useRef } from 'react';
+import { useI18n } from '../i18n';
 import { useNodeDefStore } from '../store/nodeDefStore';
 import { useToastStore } from '../store/toastStore';
 import { buildPluginAPI } from './api';
@@ -167,7 +168,8 @@ export async function loadPluginFrontends(
     } catch (err) {
       console.warn(`[plugins] failed to activate '${p.id}' frontend:`, err);
       useToastStore.getState().addToast(
-        `Plugin "${p.id}" UI failed to load`, 'error',
+        useI18n.getState().t('pluginCenter.toast.frontendFailed', { plugin: p.id }),
+        'error',
       );
     }
   }
@@ -235,7 +237,9 @@ async function maybeStartDevHotReload(): Promise<void> {
         widgetContainer,
         (url) => import(/* @vite-ignore */ `${url}?v=${gen}`),
       );
-      useToastStore.getState().addToast('Plugin frontends reloaded', 'info');
+      useToastStore.getState().addToast(
+        useI18n.getState().t('pluginCenter.toast.frontendsReloaded'), 'info',
+      );
     })();
   }, DEV_POLL_MS);
 }

--- a/frontend/src/plugins/PluginHost.tsx
+++ b/frontend/src/plugins/PluginHost.tsx
@@ -2,16 +2,23 @@
  * Loads installed plugins' frontend bundles and hosts their floating
  * widgets in a fixed bottom-right stack.
  *
- * Activation is once per page load (module-level guard — React StrictMode
- * double-mounts effects in dev). A plugin that throws during import or
- * activate() is reported and skipped; it cannot break the app or other
+ * Boot activation is once per page load (module-level guard — React
+ * StrictMode double-mounts effects in dev). A plugin that throws during import
+ * or activate() is reported and skipped; it cannot break the app or other
  * plugins.
  *
+ * After boot, `reloadPluginFrontends()` re-activates on demand: the Plugin
+ * Center calls it once an install, update, uninstall, enable or disable has
+ * settled, so the new UI appears without a page reload. Boot, reload and the
+ * dev poller below all run on ONE promise chain, because the registries they
+ * touch (`cleanups`, `activatedIds`) are module-wide: two loads overlapping
+ * would tear down half of one and activate two copies of the other.
+ *
  * Dev hot-reload: when a linked (source_kind="local") plugin is present, the
- * host polls /api/plugins/generation and, on a bump, tears down and
- * re-activates plugin frontends with a cache-busted import — so a linked
- * plugin's frontend edits appear without a manual browser refresh. Production
- * installs (no linked plugin) never poll.
+ * host polls /api/plugins/generation and, on a bump, reloads the frontends
+ * with a cache-busted import, so a linked plugin's frontend edits appear
+ * without a manual browser refresh. Production installs (no linked plugin)
+ * never poll; there, re-entry is explicit from the Plugin Center.
  */
 import { useEffect, useRef } from 'react';
 import { useI18n } from '../i18n';
@@ -37,9 +44,13 @@ interface ActivatablePlugin {
 }
 
 type Importer = (url: string) => Promise<{ default?: unknown }>;
+type GetContainer = (pluginId: string, widgetId: string) => HTMLElement;
 
 const IMPORT_TIMEOUT_MS = 10000;
 const DEV_POLL_MS = 1500;
+
+/** The real thing, named so tests can substitute it at every entry point. */
+const dynamicImporter: Importer = (url) => import(/* @vite-ignore */ url);
 
 let hostStarted = false;
 let stackEl: HTMLElement | null = null;
@@ -47,6 +58,29 @@ let cleanups: Array<() => void> = [];
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 /** Ids activated by the last load — what a teardown has to unregister. */
 let activatedIds: string[] = [];
+
+/**
+ * The single queue every activation runs on.
+ *
+ * `loadPluginFrontends` is not atomic: it awaits a fetch, then up to 15 s of
+ * `waitForNodeDefinitions()`, then one import per plugin. An install that
+ * settles inside any of those gaps would otherwise start a second load that
+ * unloads nothing (the first has not registered anything yet) and then
+ * activates every plugin a second time: duplicate dock tabs, duplicate toolbar
+ * buttons, two createRoot() calls on one node.
+ *
+ * A rejected task must not poison the queue, so the chain stored for the next
+ * caller is the swallowed one, while the caller still gets the real promise.
+ */
+let chain: Promise<unknown> = Promise.resolve();
+
+function serialized<T>(task: () => Promise<T>): Promise<T> {
+  // Both handlers are `task`: the next activation runs whether the previous
+  // one resolved or threw.
+  const next = chain.then(task, task);
+  chain = next.catch(() => undefined);
+  return next;
+}
 
 function widgetContainer(pluginId: string, widgetId: string): HTMLElement {
   const host = stackEl ?? document.body;
@@ -118,9 +152,8 @@ async function waitForNodeDefinitions(timeoutMs = 15000): Promise<void> {
 }
 
 export async function loadPluginFrontends(
-  getContainer: (pluginId: string, widgetId: string) => HTMLElement
-    = widgetContainer,
-  importer: Importer = (url) => import(/* @vite-ignore */ url),
+  getContainer: GetContainer = widgetContainer,
+  importer: Importer = dynamicImporter,
 ): Promise<string[]> {
   let plugins: unknown;
   try {
@@ -178,9 +211,9 @@ export async function loadPluginFrontends(
 }
 
 /**
- * Tear every activated plugin frontend down. Exported for the host's own
- * tests and for a future explicit unload path; the dev hot-reload below is
- * the only production caller today.
+ * Tear every activated plugin frontend down. Call it on the chain (see
+ * `reloadPluginFrontends`) rather than on its own: an unload that lands in the
+ * middle of a load takes the cleanups registered so far with it.
  */
 export function unloadPluginFrontends(): void {
   teardownPlugins(activatedIds);
@@ -196,6 +229,51 @@ async function fetchGeneration(): Promise<number | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * The boot activation: one load, on the chain, with nothing torn down first
+ * (nothing is up yet). Kept separate from `reloadPluginFrontends` because boot
+ * must not cache-bust: the very first import of a bundle should hit the HTTP
+ * cache like any other module.
+ *
+ * The parameters exist so the host's tests can drive the boot path the mount
+ * effect drives; production always calls it with none.
+ */
+export async function startPluginFrontends(
+  getContainer: GetContainer = widgetContainer,
+  importer: Importer = dynamicImporter,
+): Promise<string[]> {
+  return serialized(() => loadPluginFrontends(getContainer, importer));
+}
+
+/**
+ * Tear down and re-activate every plugin frontend. The Plugin Center calls
+ * this after an install, update, uninstall, enable or disable has settled.
+ *
+ * Queued behind whatever is already activating, so a reload that arrives
+ * mid-boot runs after it rather than alongside it.
+ *
+ * The import is cache-busted with the reload generation because the browser
+ * keeps its ESM module registry keyed by URL: without a fresh query a rebuilt
+ * bundle would re-run the module instance already in memory. `Date.now()` is
+ * the fallback for a server too old to serve /api/plugins/generation: a
+ * needlessly fresh import is a far smaller cost than a stale one.
+ *
+ * Whatever the next /api/plugins answer omits (uninstalled, or disabled) is
+ * simply not activated again; its panels, buttons and widgets went with the
+ * teardown.
+ */
+export async function reloadPluginFrontends(
+  getContainer: GetContainer = widgetContainer,
+  importer: Importer = dynamicImporter,
+): Promise<string[]> {
+  return serialized(async () => {
+    unloadPluginFrontends();
+    const gen = await fetchGeneration();
+    const version = gen ?? Date.now();
+    return loadPluginFrontends(getContainer, (url) => importer(`${url}?v=${version}`));
+  });
 }
 
 /**
@@ -232,11 +310,11 @@ async function maybeStartDevHotReload(): Promise<void> {
       const gen = await fetchGeneration();
       if (gen === null || gen === lastGen) return;
       lastGen = gen;
-      unloadPluginFrontends();
-      await loadPluginFrontends(
-        widgetContainer,
-        (url) => import(/* @vite-ignore */ `${url}?v=${gen}`),
-      );
+      // The reload reads the generation again for its cache-buster. That
+      // second read is deliberate: it is the one the import is stamped with,
+      // so a build that lands between the tick and the teardown is picked up
+      // instead of being pinned to a number that is already old.
+      await reloadPluginFrontends();
       useToastStore.getState().addToast(
         useI18n.getState().t('pluginCenter.toast.frontendsReloaded'), 'info',
       );
@@ -251,9 +329,26 @@ export function PluginHost() {
     stackEl = ref.current;
     if (hostStarted) return;
     hostStarted = true;
-    void loadPluginFrontends().then(() => maybeStartDevHotReload());
+    void startPluginFrontends().then(() => maybeStartDevHotReload());
     return () => { stackEl = null; };
   }, []);
 
   return <div ref={ref} className={styles.stack} data-testid="plugin-widget-stack" />;
+}
+
+/**
+ * Test helper: put the module back to its pre-boot state, meaning the boot
+ * guard, the dev poller, the activation queue and everything a load leaves
+ * behind.
+ */
+export function _resetPluginHostForTesting(): void {
+  hostStarted = false;
+  if (pollTimer !== null) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  stackEl = null;
+  cleanups = [];
+  activatedIds = [];
+  chain = Promise.resolve();
 }

--- a/frontend/src/plugins/PluginHost.tsx
+++ b/frontend/src/plugins/PluginHost.tsx
@@ -2,7 +2,7 @@
  * Loads installed plugins' frontend bundles and hosts their floating
  * widgets in a fixed bottom-right stack.
  *
- * Boot activation is once per page load (module-level guard — React
+ * Boot activation is once per page load (module-level guard -- React
  * StrictMode double-mounts effects in dev). A plugin that throws during import
  * or activate() is reported and skipped; it cannot break the app or other
  * plugins.
@@ -151,21 +151,43 @@ async function waitForNodeDefinitions(timeoutMs = 15000): Promise<void> {
   }
 }
 
-export async function loadPluginFrontends(
-  getContainer: GetContainer = widgetContainer,
-  importer: Importer = dynamicImporter,
-): Promise<string[]> {
-  let plugins: unknown;
+/**
+ * The installed plugin list, or `null` when the server did not give us one.
+ *
+ * The distinction is the whole reason this is separate: `[]` is the server
+ * saying nothing is installed, `null` is us not knowing. A reload that tore
+ * down on `null` would wipe every plugin panel, button and widget over a
+ * transient 503, and the window right after an install or update, when the
+ * backend has just re-imported its modules, is exactly when a reload runs.
+ *
+ * A 2xx body that is not an array counts as `null` for the same reason: a
+ * body we cannot read is not a statement that nothing is installed. The
+ * elements themselves are NOT validated here; `activateFrontends` filters
+ * them, because a server can put anything in that array.
+ */
+async function fetchPluginList(): Promise<PluginListItem[] | null> {
   try {
     const res = await fetch('/api/plugins');
-    if (!res.ok) return [];
-    plugins = await res.json();
+    if (!res.ok) return null;
+    const data: unknown = await res.json();
+    return Array.isArray(data) ? (data as PluginListItem[]) : null;
   } catch {
-    return [];
+    return null;
   }
+}
 
-  if (!Array.isArray(plugins)) return [];
-
+/**
+ * Activate every entry of an already-fetched list.
+ *
+ * Split from `loadPluginFrontends` so the reload can decide what to do about
+ * an unreachable server BEFORE it tears the current frontends down, and then
+ * activate from that same answer instead of asking the server twice.
+ */
+async function activateFrontends(
+  plugins: PluginListItem[],
+  getContainer: GetContainer,
+  importer: Importer,
+): Promise<string[]> {
   const activatable = plugins.filter(
     (p): p is ActivatablePlugin =>
       !!p && typeof p === 'object'
@@ -200,6 +222,10 @@ export async function loadPluginFrontends(
       activated.push(p.id);
     } catch (err) {
       console.warn(`[plugins] failed to activate '${p.id}' frontend:`, err);
+      // Deliberately unguarded: a throw from the toast store propagates out
+      // of the activation and rejects the queued task, which is how the
+      // host's own test drives a rejected task through `serialized`. Wrapping
+      // this in a try/catch would gut that test without failing it.
       useToastStore.getState().addToast(
         useI18n.getState().t('pluginCenter.toast.frontendFailed', { plugin: p.id }),
         'error',
@@ -208,6 +234,18 @@ export async function loadPluginFrontends(
   }
   activatedIds = activated;
   return activated;
+}
+
+export async function loadPluginFrontends(
+  getContainer: GetContainer = widgetContainer,
+  importer: Importer = dynamicImporter,
+): Promise<string[]> {
+  const plugins = await fetchPluginList();
+  // An unreachable server costs nothing here: this path has activated
+  // nothing yet, so there is nothing to protect. The reload is where the
+  // difference between "no plugins" and "no answer" matters.
+  if (plugins === null) return [];
+  return activateFrontends(plugins, getContainer, importer);
 }
 
 /**
@@ -232,10 +270,15 @@ async function fetchGeneration(): Promise<number | null> {
 }
 
 /**
- * The boot activation: one load, on the chain, with nothing torn down first
- * (nothing is up yet). Kept separate from `reloadPluginFrontends` because boot
- * must not cache-bust: the very first import of a bundle should hit the HTTP
- * cache like any other module.
+ * The boot activation: one load, on the chain. Kept separate from
+ * `reloadPluginFrontends` because boot must not cache-bust: the very first
+ * import of a bundle should hit the HTTP cache like any other module.
+ *
+ * "Nothing is up yet" is nearly always true and not worth assuming: the
+ * Plugin Center can act from a page whose host has not mounted, so a reload
+ * can win the queue before this ever runs. If it did, its activations are
+ * live and the boot has to replace them rather than stack a second copy on
+ * top.
  *
  * The parameters exist so the host's tests can drive the boot path the mount
  * effect drives; production always calls it with none.
@@ -244,7 +287,10 @@ export async function startPluginFrontends(
   getContainer: GetContainer = widgetContainer,
   importer: Importer = dynamicImporter,
 ): Promise<string[]> {
-  return serialized(() => loadPluginFrontends(getContainer, importer));
+  return serialized(() => {
+    if (activatedIds.length > 0) unloadPluginFrontends();
+    return loadPluginFrontends(getContainer, importer);
+  });
 }
 
 /**
@@ -263,16 +309,35 @@ export async function startPluginFrontends(
  * Whatever the next /api/plugins answer omits (uninstalled, or disabled) is
  * simply not activated again; its panels, buttons and widgets went with the
  * teardown.
+ *
+ * A server that cannot answer at all is the one case where nothing happens:
+ * see `fetchPluginList`. Tearing down what we cannot restore would leave the
+ * editor with no plugin UI whatever until the user happened to trigger
+ * another reload, and in production nothing polls.
  */
 export async function reloadPluginFrontends(
   getContainer: GetContainer = widgetContainer,
   importer: Importer = dynamicImporter,
 ): Promise<string[]> {
   return serialized(async () => {
+    // The list comes FIRST, before anything is torn down.
+    const plugins = await fetchPluginList();
+    if (plugins === null) {
+      // No toast: the caller (the Plugin Center's own refresh) is already
+      // showing the user that the server is not answering, and a second
+      // message about it would be the same fact twice.
+      console.warn(
+        '[plugins] reload skipped: could not read the plugin list; '
+        + 'keeping the frontends already activated',
+      );
+      return [...activatedIds];
+    }
     unloadPluginFrontends();
     const gen = await fetchGeneration();
     const version = gen ?? Date.now();
-    return loadPluginFrontends(getContainer, (url) => importer(`${url}?v=${version}`));
+    return activateFrontends(
+      plugins, getContainer, (url) => importer(`${url}?v=${version}`),
+    );
   });
 }
 
@@ -288,16 +353,8 @@ export async function reloadPluginFrontends(
 async function maybeStartDevHotReload(): Promise<void> {
   if (pollTimer !== null) return;
 
-  let plugins: PluginListItem[];
-  try {
-    const res = await fetch('/api/plugins');
-    if (!res.ok) return;
-    const data = await res.json();
-    if (!Array.isArray(data)) return;
-    plugins = data;
-  } catch {
-    return;
-  }
+  const plugins = await fetchPluginList();
+  if (plugins === null) return;
 
   const hasLocal = plugins.some(
     (p) => p && p.source_kind === 'local' && p.enabled === true,

--- a/frontend/src/store/jobFollower.test.ts
+++ b/frontend/src/store/jobFollower.test.ts
@@ -1,0 +1,634 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { JobEvent, JobEventsPage } from '../api/rest';
+import {
+  FOLLOW_IDLE_MS,
+  FOLLOW_RETRY_MS,
+  EVENT_WAIT_S,
+  MAX_FOLLOW_FAILURES,
+  MAX_LOG_LINES,
+  createJobFollower,
+  emptyJob,
+  reduceJobEvents,
+  type Job,
+  type JobFollowerOptions,
+} from './jobFollower';
+
+/**
+ * A domain job, the way `PackJob` and `PluginJob` are: the generic shape plus
+ * a field this module knows nothing about. It is here so the tests can prove
+ * that a fold preserves the extra field and that `onExtra` can write it.
+ */
+interface TestJob extends Job {
+  tag: string | null;
+}
+
+function makeJob(partial: Partial<TestJob> = {}): TestJob {
+  return { ...emptyJob('j1'), tag: null, ...partial };
+}
+
+function page(partial: Partial<JobEventsPage> = {}): JobEventsPage {
+  return { job_id: 'j1', status: 'running', events: [], cursor: 0, ...partial };
+}
+
+// ── the pure reducer ──────────────────────────────────────────────────────
+
+describe('reduceJobEvents', () => {
+  it('records steps in order and marks the previous one done when the next starts', () => {
+    const next = reduceJobEvents(makeJob(), page({
+      cursor: 2,
+      events: [
+        { type: 'step_started', cursor: 1, ts: 't', step: 'download', label: 'Downloading' },
+        { type: 'step_started', cursor: 2, ts: 't', step: 'verify', label: 'Verifying' },
+      ],
+    }));
+
+    expect(next.steps).toEqual([
+      { step: 'download', label: 'Downloading', state: 'done' },
+      { step: 'verify', label: 'Verifying', state: 'running' },
+    ]);
+    expect(next.log.map((entry) => entry.text)).toEqual(['Downloading', 'Verifying']);
+  });
+
+  it('falls back to the step id when the server sent no label', () => {
+    const next = reduceJobEvents(makeJob(), page({
+      cursor: 1,
+      events: [{ type: 'step_started', cursor: 1, ts: 't', step: 'deps' }],
+    }));
+
+    expect(next.steps).toEqual([{ step: 'deps', label: 'deps', state: 'running' }]);
+  });
+
+  it('marks a step done on its own step_done event', () => {
+    const started = reduceJobEvents(makeJob(), page({
+      cursor: 1,
+      events: [{ type: 'step_started', cursor: 1, ts: 't', step: 'deps', label: 'Deps' }],
+    }));
+    const next = reduceJobEvents(started, page({
+      cursor: 2,
+      events: [{ type: 'step_done', cursor: 2, ts: 't', step: 'deps' }],
+    }));
+
+    expect(next.steps).toEqual([{ step: 'deps', label: 'Deps', state: 'done' }]);
+    // `step_done` is bookkeeping, not something to print: the line that named
+    // the step was already written when it started.
+    expect(next.log).toHaveLength(1);
+  });
+
+  it('drops an empty log line instead of printing a blank row', () => {
+    const next = reduceJobEvents(makeJob(), page({
+      cursor: 3,
+      events: [
+        { type: 'log', cursor: 1, ts: 't', line: '' },
+        { type: 'log', cursor: 2, ts: 't', line: '   ' },
+        { type: 'log', cursor: 3, ts: 't', line: 'real' },
+      ],
+    }));
+
+    expect(next.log.map((entry) => entry.text)).toEqual(['real']);
+  });
+
+  it('keeps per-item byte progress and never turns it into a log line', () => {
+    const next = reduceJobEvents(makeJob(), page({
+      cursor: 2,
+      events: [
+        {
+          type: 'progress', cursor: 1, ts: 't',
+          item: 'wheel', bytes_done: 25, bytes_total: 100,
+        },
+        {
+          type: 'progress', cursor: 2, ts: 't',
+          item: 'wheel', bytes_done: 50, bytes_total: 100,
+        },
+      ],
+    }));
+
+    expect(next.items).toEqual({
+      wheel: { bytesDone: 50, bytesTotal: 100, percent: 50 },
+    });
+    expect(next.log).toEqual([]);
+  });
+
+  it('leaves the percent unknown when there is no total to divide by', () => {
+    const next = reduceJobEvents(makeJob(), page({
+      cursor: 1,
+      events: [{ type: 'progress', cursor: 1, ts: 't', item: 'wheel', bytes_done: 9 }],
+    }));
+
+    expect(next.items.wheel).toEqual({ bytesDone: 9, bytesTotal: null, percent: null });
+  });
+
+  it('clamps a percent the server reported outside 0..100, both ways', () => {
+    const next = reduceJobEvents(makeJob(), page({
+      cursor: 2,
+      events: [
+        { type: 'progress', cursor: 1, ts: 't', item: 'a', bytes_done: 0, percent: 140 },
+        { type: 'progress', cursor: 2, ts: 't', item: 'b', bytes_done: 0, percent: -3 },
+      ],
+    }));
+
+    expect(next.items.a.percent).toBe(100);
+    expect(next.items.b.percent).toBe(0);
+  });
+
+  it('closes a still-running step when the job finishes', () => {
+    const started = reduceJobEvents(makeJob(), page({
+      cursor: 1,
+      events: [{ type: 'step_started', cursor: 1, ts: 't', step: 'deps', label: 'Deps' }],
+    }));
+    const next = reduceJobEvents(started, page({
+      status: 'done',
+      cursor: 2,
+      events: [{ type: 'job_done', cursor: 2, ts: 't' }],
+    }));
+
+    expect(next.status).toBe('done');
+    expect(next.steps.every((step) => step.state === 'done')).toBe(true);
+    expect(next.log[next.log.length - 1]).toMatchObject({ kind: 'step', text: 'done' });
+  });
+
+  it('captures the job_failed message and hint', () => {
+    const next = reduceJobEvents(makeJob(), page({
+      status: 'failed',
+      cursor: 1,
+      events: [{
+        type: 'job_failed', cursor: 1, ts: 't',
+        message: 'uv exited 1', hint: 'check the network',
+      }],
+    }));
+
+    expect(next.status).toBe('failed');
+    expect(next.error).toEqual({ message: 'uv exited 1', hint: 'check the network' });
+    expect(next.log[0]).toMatchObject({ kind: 'error', text: 'uv exited 1' });
+  });
+
+  it('stores the restart command so a banner can print it', () => {
+    const next = reduceJobEvents(makeJob(), page({
+      status: 'needs_restart',
+      cursor: 1,
+      events: [{
+        type: 'needs_restart', cursor: 1, ts: 't', command: 'cdui install --gpu cu128',
+      }],
+    }));
+
+    expect(next.status).toBe('needs_restart');
+    expect(next.restartCommand).toBe('cdui install --gpu cu128');
+    // A `needs_restart` event is not a transcript line either: the command
+    // has a block of its own to live in.
+    expect(next.log).toEqual([]);
+  });
+
+  it('skips an unknown event type rather than rendering a mystery line', () => {
+    const next = reduceJobEvents(makeJob(), page({
+      cursor: 2,
+      events: [
+        { type: 'quantum_entangled', cursor: 1, ts: 't', payload: 42 },
+        { type: 'log', cursor: 2, ts: 't', line: 'after' },
+      ],
+    }));
+
+    expect(next.log.map((entry) => entry.text)).toEqual(['after']);
+  });
+
+  it('skips events at or below the cursor already applied', () => {
+    const first = reduceJobEvents(makeJob(), page({
+      cursor: 2,
+      events: [
+        { type: 'log', cursor: 1, ts: 't', line: 'one' },
+        { type: 'log', cursor: 2, ts: 't', line: 'two' },
+      ],
+    }));
+    // The same page again — a reconnect that resumed from the wrong cursor.
+    const replayed = reduceJobEvents(first, page({
+      cursor: 3,
+      events: [
+        { type: 'log', cursor: 1, ts: 't', line: 'one' },
+        { type: 'log', cursor: 2, ts: 't', line: 'two' },
+        { type: 'log', cursor: 3, ts: 't', line: 'three' },
+      ],
+    }));
+
+    expect(replayed.log.map((entry) => entry.text)).toEqual(['one', 'two', 'three']);
+  });
+
+  it('caps the log at MAX_LOG_LINES, keeping the newest', () => {
+    const events: JobEvent[] = [];
+    for (let index = 1; index <= MAX_LOG_LINES + 20; index += 1) {
+      events.push({ type: 'log', cursor: index, ts: 't', line: `line ${index}` });
+    }
+    const next = reduceJobEvents(makeJob(), page({ cursor: events.length, events }));
+
+    expect(next.log).toHaveLength(MAX_LOG_LINES);
+    expect(next.log[0].text).toBe('line 21');
+    expect(next.log[next.log.length - 1].text).toBe(`line ${MAX_LOG_LINES + 20}`);
+  });
+
+  it('takes the status from the page and never moves the cursor backwards', () => {
+    const applied = reduceJobEvents(makeJob({ cursor: 9 }), page({ status: 'done', cursor: 4 }));
+
+    expect(applied.status).toBe('done');
+    expect(applied.cursor).toBe(9);
+  });
+
+  it('gives every log line a distinct seq so React keys never collide', () => {
+    const next = reduceJobEvents(makeJob(), page({
+      cursor: 2,
+      events: [
+        // No cursor at all: the line still needs a key nothing else holds.
+        { type: 'log', ts: 't', line: 'first' },
+        { type: 'log', cursor: 1, ts: 't', line: 'second' },
+        { type: 'log', cursor: 2, ts: 't', line: 'third' },
+      ],
+    }));
+
+    const seqs = next.log.map((entry) => entry.seq);
+    expect(new Set(seqs).size).toBe(seqs.length);
+  });
+
+  it('carries a domain field through untouched and lets onExtra write it', () => {
+    const next = reduceJobEvents<TestJob>(
+      makeJob({ tag: 'kept' }),
+      page({
+        cursor: 2,
+        events: [
+          { type: 'log', cursor: 1, ts: 't', line: 'noise' },
+          { type: 'needs_restart', cursor: 2, ts: 't', command: 'cdui start', flavour: 'gpu' },
+        ],
+      }),
+      (event, draft) => {
+        if (event.type === 'needs_restart') draft.tag = String(event.flavour);
+      },
+    );
+
+    expect(next.tag).toBe('gpu');
+    expect(next.restartCommand).toBe('cdui start');
+    expect(next.log.map((entry) => entry.text)).toEqual(['noise']);
+  });
+
+  it('does not let onExtra clobber the fields the reducer owns', () => {
+    const next = reduceJobEvents<TestJob>(
+      makeJob({ tag: null }),
+      page({ cursor: 1, events: [{ type: 'log', cursor: 1, ts: 't', line: 'kept' }] }),
+      (_event, draft) => {
+        draft.log = [];
+        draft.cursor = -5;
+      },
+    );
+
+    expect(next.log.map((entry) => entry.text)).toEqual(['kept']);
+    expect(next.cursor).toBe(1);
+  });
+
+  it('skips an onExtra call for an event the cursor guard dropped', () => {
+    const seen: string[] = [];
+    reduceJobEvents<TestJob>(
+      makeJob({ cursor: 2 }),
+      page({
+        cursor: 3,
+        events: [
+          { type: 'log', cursor: 1, ts: 't', line: 'old' },
+          { type: 'log', cursor: 3, ts: 't', line: 'new' },
+        ],
+      }),
+      (event) => { seen.push(String(event.line)); },
+    );
+
+    expect(seen).toEqual(['new']);
+  });
+
+  it('returns the job untouched when the page carried nothing', () => {
+    const job = makeJob({ cursor: 4 });
+    const next = reduceJobEvents(job, page({ cursor: 4 }));
+
+    // Same arrays, not copies: an empty poll must not re-render every
+    // subscriber that memoises on the log.
+    expect(next.log).toBe(job.log);
+    expect(next.steps).toBe(job.steps);
+    expect(next.items).toBe(job.items);
+  });
+});
+
+// ── the long-poll follower ────────────────────────────────────────────────
+
+describe('createJobFollower', () => {
+  /**
+   * Timers are faked throughout: the loop's only real waits are its idle and
+   * retry sleeps, and asserting "it did NOT poll again" by sleeping 10 ms of
+   * wall clock proves nothing when the next turn was 500 ms away regardless.
+   */
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Let queued microtasks (a resolved fetch, a patch) run to completion. */
+  const settle = () => vi.advanceTimersByTimeAsync(0);
+
+  /**
+   * One follower over a one-field store, wired the way a real store wires it:
+   * `patchJob` writes only when the id still matches the open job.
+   */
+  function bench(options: Partial<JobFollowerOptions<TestJob>> = {}) {
+    let open: TestJob | null = makeJob();
+
+    // The default answer is a running, empty page, so a test that forgets to
+    // arrange one parks on the idle timer instead of settling.
+    const fetchPage = vi.fn(async (
+      _jobId: string, _cursor: number, _signal: AbortSignal, _waitS: number,
+    ): Promise<JobEventsPage> => page());
+    const patchJob = vi.fn((jobId: string, next: TestJob) => {
+      if (open !== null && open.jobId === jobId) open = next;
+    });
+    const onSettled = vi.fn();
+
+    const follower = createJobFollower<TestJob>({
+      fetchPage, getOpenJob: () => open, patchJob, onSettled, ...options,
+    });
+
+    // Read off the recorded calls rather than from inside the implementation:
+    // a test that installs its own `mockImplementation` would otherwise
+    // silently stop recording.
+    const args = () => fetchPage.mock.calls;
+    return {
+      follower, fetchPage, patchJob, onSettled,
+      cursors: () => args().map((call) => call[1]),
+      signals: () => args().map((call) => call[2]),
+      waits: () => args().map((call) => call[3]),
+      job: () => open,
+      setJob: (next: TestJob | null) => { open = next; },
+    };
+  }
+
+  it('folds pages into the job and stops once terminal and the cursor stops moving', async () => {
+    const app = bench();
+    app.fetchPage
+      .mockResolvedValueOnce(page({
+        cursor: 2,
+        events: [
+          { type: 'step_started', cursor: 1, ts: 't', step: 'deps', label: 'Deps' },
+          { type: 'log', cursor: 2, ts: 't', line: 'uv pip install' },
+        ],
+      }))
+      .mockResolvedValue(page({
+        status: 'done',
+        cursor: 3,
+        events: [{ type: 'job_done', cursor: 3, ts: 't' }],
+      }));
+
+    app.follower.start('j1', 0);
+    await settle();
+
+    const job = app.job()!;
+    expect(job.status).toBe('done');
+    expect(job.cursor).toBe(3);
+    // The terminal page is replayed once; its event is applied exactly once.
+    expect(job.log.filter((line) => line.text === 'done')).toHaveLength(1);
+    expect(app.fetchPage).toHaveBeenCalledTimes(3);
+    expect(app.onSettled).toHaveBeenCalledTimes(1);
+    expect(app.onSettled).toHaveBeenCalledWith('j1', 'done', job);
+    expect(app.follower.followingJobId()).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(app.fetchPage).toHaveBeenCalledTimes(3);
+  });
+
+  it('resumes each request from the cursor already applied, parking for waitS', async () => {
+    const app = bench();
+    app.fetchPage.mockResolvedValue(page({
+      cursor: 5, events: [{ type: 'log', cursor: 5, ts: 't', line: 'five' }],
+    }));
+
+    app.follower.start('j1', 2);
+    await settle();
+    await vi.advanceTimersByTimeAsync(FOLLOW_IDLE_MS + 10);
+
+    expect(app.cursors().slice(0, 2)).toEqual([2, 5]);
+    expect(app.waits()[0]).toBe(EVENT_WAIT_S);
+  });
+
+  it('idles for FOLLOW_IDLE_MS when a running page returned nothing', async () => {
+    const app = bench();
+
+    app.follower.start('j1', 0);
+    await settle();
+    expect(app.fetchPage).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(FOLLOW_IDLE_MS - 1);
+    expect(app.fetchPage).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(2);
+    expect(app.fetchPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('asks again immediately while the cursor keeps moving', async () => {
+    const app = bench();
+    let cursor = 0;
+    app.fetchPage.mockImplementation(async () => {
+      if (cursor < 3) cursor += 1;
+      return page({ cursor });
+    });
+
+    app.follower.start('j1', 0);
+    await settle();
+
+    // Three advancing pages back to back with no idle sleep between them —
+    // the long poll is the wait — and a fourth that stood still, which is
+    // where the loop parked on the timer.
+    expect(app.fetchPage).toHaveBeenCalledTimes(4);
+    expect(app.cursors()).toEqual([0, 1, 2, 3]);
+  });
+
+  it('retries a failed fetch and marks the job lost after MAX_FOLLOW_FAILURES', async () => {
+    const app = bench();
+    app.fetchPage.mockRejectedValue(new Error('Failed to fetch'));
+
+    app.follower.start('j1', 0);
+    await settle();
+    expect(app.fetchPage).toHaveBeenCalledTimes(1);
+    expect(app.job()!.status).toBe('running');
+
+    await vi.advanceTimersByTimeAsync(FOLLOW_RETRY_MS * MAX_FOLLOW_FAILURES);
+    expect(app.fetchPage).toHaveBeenCalledTimes(MAX_FOLLOW_FAILURES);
+    expect(app.job()!.status).toBe('lost');
+    expect(app.follower.followingJobId()).toBeNull();
+
+    // Given up means given up: no further polling.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(app.fetchPage).toHaveBeenCalledTimes(MAX_FOLLOW_FAILURES);
+  });
+
+  it('recovers from a transient failure without losing the job', async () => {
+    const app = bench();
+    app.fetchPage
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
+      .mockResolvedValue(page());
+
+    app.follower.start('j1', 0);
+    await settle();
+    await vi.advanceTimersByTimeAsync(FOLLOW_RETRY_MS + 10);
+
+    expect(app.fetchPage).toHaveBeenCalledTimes(2);
+    expect(app.job()!.status).toBe('running');
+  });
+
+  it('hands the last error to onGiveUp and lets it settle the job itself', async () => {
+    const boom = new Error('Failed to fetch');
+    const onGiveUp = vi.fn(() => true);
+    const app = bench({ onGiveUp });
+    app.fetchPage.mockRejectedValue(boom);
+
+    app.follower.start('j1', 0);
+    await settle();
+    await vi.advanceTimersByTimeAsync(FOLLOW_RETRY_MS * MAX_FOLLOW_FAILURES);
+
+    expect(onGiveUp).toHaveBeenCalledTimes(1);
+    expect(onGiveUp).toHaveBeenCalledWith('j1', boom, app.job());
+    // It said it handled the ending, so nothing overwrote its verdict.
+    expect(app.job()!.status).toBe('running');
+  });
+
+  it('falls back to lost when onGiveUp declines the ending', async () => {
+    const onGiveUp = vi.fn(() => false);
+    const app = bench({ onGiveUp });
+    app.fetchPage.mockRejectedValue(new Error('Failed to fetch'));
+
+    app.follower.start('j1', 0);
+    await settle();
+    await vi.advanceTimersByTimeAsync(FOLLOW_RETRY_MS * MAX_FOLLOW_FAILURES);
+
+    expect(app.job()!.status).toBe('lost');
+  });
+
+  it('honours the timing overrides instead of the defaults', async () => {
+    const onGiveUp = vi.fn(() => true);
+    const app = bench({ waitS: 3, idleMs: 50, retryMs: 10, maxFailures: 2, onGiveUp });
+    app.fetchPage.mockRejectedValue(new Error('Failed to fetch'));
+
+    app.follower.start('j1', 0);
+    await settle();
+    await vi.advanceTimersByTimeAsync(10 + 5);
+
+    expect(app.fetchPage).toHaveBeenCalledTimes(2);
+    expect(app.waits()[0]).toBe(3);
+    expect(onGiveUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the parked request when following stops', async () => {
+    // A 25 s long poll left dangling holds a connection open on a server with
+    // a small pool, so stopping must cancel it rather than wait it out.
+    const app = bench();
+    // Parked, the way the server parks a long poll that has nothing yet.
+    app.fetchPage.mockImplementation(() => new Promise<JobEventsPage>(() => {}));
+
+    app.follower.start('j1', 0);
+    await settle();
+    expect(app.signals()).toHaveLength(1);
+    expect(app.signals()[0].aborted).toBe(false);
+
+    app.follower.stop();
+    expect(app.signals()[0].aborted).toBe(true);
+    expect(app.follower.followingJobId()).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(app.fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends a stale loop whose page arrives after the generation moved on', async () => {
+    // The abort only rejects the request in flight; on a fetch that ignores
+    // the signal (or answers in the same tick it was aborted) the generation
+    // is the whole guard.
+    const app = bench();
+    let deliver: (value: JobEventsPage) => void = () => {};
+    app.fetchPage.mockImplementation(() => new Promise<JobEventsPage>((resolve) => {
+      deliver = resolve;
+    }));
+
+    app.follower.start('j1', 0);
+    await settle();
+
+    app.follower.stop();
+    deliver(page({ cursor: 9, events: [{ type: 'log', cursor: 9, ts: 't', line: 'late' }] }));
+    await settle();
+
+    expect(app.patchJob).not.toHaveBeenCalled();
+    expect(app.job()!.log).toEqual([]);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(app.fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the parked request alone when the same job is started again', async () => {
+    // Adoption runs on every catalog poll. Restarting the follower each time
+    // would abort a long poll that was about to answer and re-ask from the
+    // same cursor — a request per poll, which is the entire cost the long
+    // poll exists to avoid.
+    const app = bench();
+    app.fetchPage.mockImplementation(() => new Promise<JobEventsPage>(() => {}));
+
+    app.follower.start('j1', 0);
+    await settle();
+    expect(app.signals()).toHaveLength(1);
+
+    app.follower.start('j1', 0);
+    await settle();
+
+    expect(app.signals()).toHaveLength(1);
+    expect(app.signals()[0].aborted).toBe(false);
+    expect(app.follower.followingJobId()).toBe('j1');
+  });
+
+  it('switches to another job, abandoning the first', async () => {
+    const app = bench();
+    app.fetchPage.mockImplementation(() => new Promise<JobEventsPage>(() => {}));
+
+    app.follower.start('j1', 0);
+    await settle();
+    app.follower.start('j2', 4);
+    await settle();
+
+    expect(app.signals()[0].aborted).toBe(true);
+    expect(app.follower.followingJobId()).toBe('j2');
+    expect(app.cursors()).toEqual([0, 4]);
+  });
+
+  it('drops a page for a job that is no longer the open one', async () => {
+    const app = bench();
+    app.fetchPage.mockResolvedValue(page({
+      cursor: 1, events: [{ type: 'log', cursor: 1, ts: 't', line: 'stale' }],
+    }));
+
+    app.follower.start('j1', 0);
+    app.setJob(makeJob({ jobId: 'other' }));
+    await settle();
+
+    expect(app.patchJob).not.toHaveBeenCalled();
+    expect(app.job()!.log).toEqual([]);
+  });
+
+  it('settles with a null job when the open one has moved on', async () => {
+    const app = bench();
+    app.fetchPage.mockResolvedValue(page({ status: 'failed', cursor: 0 }));
+
+    app.follower.start('j1', 0);
+    app.setJob(null);
+    await settle();
+
+    expect(app.onSettled).toHaveBeenCalledWith('j1', 'failed', null);
+  });
+
+  it('keeps polling a terminal job while its backlog is still arriving', async () => {
+    // A job that finished with a hundred queued lines still has pages to hand
+    // over; stopping on `status` alone would truncate its log.
+    const app = bench();
+    app.fetchPage
+      .mockResolvedValueOnce(page({ status: 'done', cursor: 1 }))
+      .mockResolvedValueOnce(page({ status: 'done', cursor: 2 }))
+      .mockResolvedValue(page({ status: 'done', cursor: 2 }));
+
+    app.follower.start('j1', 0);
+    await settle();
+
+    expect(app.fetchPage).toHaveBeenCalledTimes(3);
+    expect(app.onSettled).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/store/jobFollower.test.ts
+++ b/frontend/src/store/jobFollower.test.ts
@@ -265,17 +265,25 @@ describe('reduceJobEvents', () => {
   });
 
   it('does not let onExtra clobber the fields the reducer owns', () => {
+    const job = makeJob({ tag: null });
     const next = reduceJobEvents<TestJob>(
-      makeJob({ tag: null }),
+      job,
       page({ cursor: 1, events: [{ type: 'log', cursor: 1, ts: 't', line: 'kept' }] }),
       (_event, draft) => {
         draft.log = [];
         draft.cursor = -5;
+        // The identity fields too: the follower matches every page against
+        // `jobId`, so a fold that renamed the job would strand it — nothing
+        // would patch it again and nothing would settle it.
+        draft.jobId = 'hijacked';
+        draft.startedAt = 0;
       },
     );
 
     expect(next.log.map((entry) => entry.text)).toEqual(['kept']);
     expect(next.cursor).toBe(1);
+    expect(next.jobId).toBe('j1');
+    expect(next.startedAt).toBe(job.startedAt);
   });
 
   it('skips an onExtra call for an event the cursor guard dropped', () => {
@@ -394,6 +402,26 @@ describe('createJobFollower', () => {
     expect(app.fetchPage).toHaveBeenCalledTimes(3);
   });
 
+  it('folds with the reducer the domain passed instead of the default', async () => {
+    // How a center that reads keys of its own gets them read on a LIVE page
+    // and not only in its unit tests: one composed reducer, passed once.
+    const reduce = vi.fn((job: TestJob, folded: JobEventsPage): TestJob => ({
+      ...reduceJobEvents(job, folded), tag: 'domain',
+    }));
+    const app = bench({ reduce });
+    app.fetchPage.mockResolvedValue(page({
+      status: 'done', cursor: 1,
+      events: [{ type: 'log', cursor: 1, ts: 't', line: 'one' }],
+    }));
+
+    app.follower.start('j1', 0);
+    await settle();
+
+    expect(reduce).toHaveBeenCalled();
+    expect(app.job()!.tag).toBe('domain');
+    expect(app.job()!.log.map((entry) => entry.text)).toEqual(['one']);
+  });
+
   it('resumes each request from the cursor already applied, parking for waitS', async () => {
     const app = bench();
     app.fetchPage.mockResolvedValue(page({
@@ -498,6 +526,26 @@ describe('createJobFollower', () => {
     await vi.advanceTimersByTimeAsync(FOLLOW_RETRY_MS * MAX_FOLLOW_FAILURES);
 
     expect(app.job()!.status).toBe('lost');
+  });
+
+  it('keeps what a declining onGiveUp wrote to the job', async () => {
+    // Declining is about the ENDING, not about the job: a callback is
+    // entitled to record what it learned (a hint, a command it recovered
+    // elsewhere) and still leave `lost` to the follower. Building the patch
+    // from the snapshot taken before the callback ran would undo that write.
+    const onGiveUp = vi.fn(() => false);
+    const app = bench({ onGiveUp });
+    onGiveUp.mockImplementation(() => {
+      app.setJob({ ...app.job()!, tag: 'noted' });
+      return false;
+    });
+    app.fetchPage.mockRejectedValue(new Error('Failed to fetch'));
+
+    app.follower.start('j1', 0);
+    await settle();
+    await vi.advanceTimersByTimeAsync(FOLLOW_RETRY_MS * MAX_FOLLOW_FAILURES);
+
+    expect(app.job()).toMatchObject({ status: 'lost', tag: 'noted' });
   });
 
   it('honours the timing overrides instead of the defaults', async () => {
@@ -614,6 +662,39 @@ describe('createJobFollower', () => {
     await settle();
 
     expect(app.onSettled).toHaveBeenCalledWith('j1', 'failed', null);
+  });
+
+  it('starts from the beginning when the caller passes no cursor', async () => {
+    const app = bench();
+
+    app.follower.start('j1');
+    await settle();
+
+    expect(app.cursors()[0]).toBe(0);
+  });
+
+  it('does nothing when stopped before it was ever started', () => {
+    // `_reset...ForTesting` and an unmount both call `stop()` unconditionally.
+    const app = bench();
+
+    expect(() => app.follower.stop()).not.toThrow();
+    expect(app.follower.followingJobId()).toBeNull();
+    expect(app.fetchPage).not.toHaveBeenCalled();
+  });
+
+  it('counts a fetchPage that throws synchronously as a failed turn', async () => {
+    // A client that rejects before it ever awaits — a URL that will not
+    // build, a mock a test forgot to make async — must not escape the retry
+    // budget as an unhandled throw out of the loop.
+    const app = bench({ retryMs: 10, maxFailures: 2 });
+    app.fetchPage.mockImplementation(() => { throw new Error('boom'); });
+
+    app.follower.start('j1', 0);
+    await settle();
+    await vi.advanceTimersByTimeAsync(15);
+
+    expect(app.fetchPage).toHaveBeenCalledTimes(2);
+    expect(app.job()!.status).toBe('lost');
   });
 
   it('keeps polling a terminal job while its backlog is still arriving', async () => {

--- a/frontend/src/store/jobFollower.test.ts
+++ b/frontend/src/store/jobFollower.test.ts
@@ -582,6 +582,33 @@ describe('createJobFollower', () => {
     expect(app.fetchPage).toHaveBeenCalledTimes(1);
   });
 
+  it('stops one follower without touching another on its own job', async () => {
+    // Two centers follow two jobs at once -- a pack install and a plugin
+    // install -- from two instances of this factory. The generation counter
+    // that ends a loop is per instance, closure state rather than module
+    // state, and this is what says so: a shared counter would have the Pack
+    // Center's `stop()` silently end the Plugin Center's poll.
+    const packs = bench();
+    const plugins = bench();
+    plugins.setJob(makeJob({ jobId: 'j2' }));
+
+    packs.follower.start('j1', 0);
+    plugins.follower.start('j2', 0);
+    await settle();
+    expect(packs.fetchPage).toHaveBeenCalledTimes(1);
+    expect(plugins.fetchPage).toHaveBeenCalledTimes(1);
+
+    packs.follower.stop();
+    await vi.advanceTimersByTimeAsync(FOLLOW_IDLE_MS + 10);
+
+    expect(packs.fetchPage, 'the stopped follower').toHaveBeenCalledTimes(1);
+    expect(plugins.fetchPage, 'the untouched follower').toHaveBeenCalledTimes(2);
+    expect(packs.follower.followingJobId()).toBeNull();
+    expect(plugins.follower.followingJobId()).toBe('j2');
+
+    plugins.follower.stop();
+  });
+
   it('ends a stale loop whose page arrives after the generation moved on', async () => {
     // The abort only rejects the request in flight; on a fetch that ignores
     // the signal (or answers in the same tick it was aborted) the generation

--- a/frontend/src/store/jobFollower.ts
+++ b/frontend/src/store/jobFollower.ts
@@ -152,8 +152,9 @@ function sleep(ms: number): Promise<void> {
  * *onExtra* is how a domain reads the keys this reducer has no opinion about
  * (a pack's `retry_mode`, a plugin's `sha`): it runs once per applied event,
  * after the switch, on a shallow copy of the job whose DOMAIN fields it may
- * write. The generic fields are written back afterwards from this function's
- * own locals, so a careless callback cannot corrupt the log or the cursor.
+ * write. EVERY generic field is written back afterwards from this function's
+ * own locals, so a careless callback cannot corrupt the log, the cursor, or
+ * the identity the follower patches this job by.
  */
 export function reduceJobEvents<J extends Job>(
   job: J,
@@ -264,12 +265,18 @@ export function reduceJobEvents<J extends Job>(
 
   return {
     ...draft,
+    // `jobId` and `startedAt` are restated for the same reason the rest are:
+    // `draft` is the object `onExtra` was handed, and these two are what the
+    // follower matches a page against and what a "running for 4 min" label
+    // counts from. A callback that wrote either would re-key a job mid-fold.
+    jobId: job.jobId,
     status: page.status,
     steps,
     items,
     log,
     error,
     restartCommand,
+    startedAt: job.startedAt,
     // Never moves backwards: an empty page returns the cursor we sent.
     cursor: Math.max(job.cursor, page.cursor),
   };
@@ -309,10 +316,22 @@ export interface JobFollowerOptions<J extends Job> {
    * callback out, and the follower marks the job `lost`. *error* is the last
    * rejection, and the difference between a dropped connection and a server
    * that answered with a status code is usually the whole decision.
+   *
+   * A callback that writes to the job AND returns false keeps its write: the
+   * `lost` patch is built from a fresh `getOpenJob()` read taken after this
+   * returns, not from the *job* snapshot handed in above.
    */
   onGiveUp?: (jobId: string, error: unknown, job: J | null) => boolean;
-  /** Passed straight to `reduceJobEvents` on every page. */
-  onExtra?: (event: JobEvent, draft: J) => void;
+  /**
+   * Fold a page into the job. Defaults to `reduceJobEvents`.
+   *
+   * A domain that reads keys of its own composes ONE reducer — `packStore`'s
+   * `reducePackEvents` is `reduceJobEvents` with its `retry_mode` extras
+   * bound — and passes it here, so the panel's exported reducer and the one
+   * the follower runs are the same function rather than two wirings that can
+   * drift.
+   */
+  reduce?: (job: J, page: JobEventsPage) => J;
   waitS?: number;
   idleMs?: number;
   retryMs?: number;
@@ -346,12 +365,17 @@ export function createJobFollower<J extends Job>(
   options: JobFollowerOptions<J>,
 ): JobFollower {
   const {
-    fetchPage, getOpenJob, patchJob, onSettled, onGiveUp, onExtra,
+    fetchPage, getOpenJob, patchJob, onSettled, onGiveUp,
     waitS = EVENT_WAIT_S,
     idleMs = FOLLOW_IDLE_MS,
     retryMs = FOLLOW_RETRY_MS,
     maxFailures = MAX_FOLLOW_FAILURES,
   } = options;
+
+  // Annotated rather than defaulted in the destructuring above, which would
+  // leave `reduce` a union with the still-generic `reduceJobEvents` and fold
+  // a `J` into a `Job | J`. Written once here, the loop keeps its `J`.
+  const reduce: (job: J, page: JobEventsPage) => J = options.reduce ?? reduceJobEvents;
 
   /** Bumped by every `stop`; a loop whose generation is stale exits. */
   let generation = 0;
@@ -407,8 +431,15 @@ export function createJobFollower<J extends Job>(
           const open = getOpenJob();
           const held = open !== null && open.jobId === jobId ? open : null;
           const handled = onGiveUp?.(jobId, error, held) === true;
-          if (!handled && held !== null) {
-            patchJob(jobId, { ...held, status: 'lost' });
+          if (!handled) {
+            // Re-read rather than patch `held`: a callback that declined the
+            // ending may still have written something to the job (a hint, a
+            // command it recovered from elsewhere), and building the patch
+            // from the snapshot taken BEFORE it ran would silently undo that.
+            const latest = getOpenJob();
+            if (latest !== null && latest.jobId === jobId) {
+              patchJob(jobId, { ...latest, status: 'lost' });
+            }
           }
           return;
         }
@@ -421,7 +452,7 @@ export function createJobFollower<J extends Job>(
       let folded: J | null = null;
       const open = getOpenJob();
       if (open !== null && open.jobId === jobId) {
-        folded = reduceJobEvents(open, page, onExtra);
+        folded = reduce(open, page);
         patchJob(jobId, folded);
       }
 

--- a/frontend/src/store/jobFollower.ts
+++ b/frontend/src/store/jobFollower.ts
@@ -1,0 +1,440 @@
+import type { JobEvent, JobEventsPage, JobStatus } from '../api/rest';
+
+/**
+ * The long-poll job model, shared by every center that watches one.
+ *
+ * A pack install and a plugin install are the same shape of thing: a server
+ * -side job that outlives the panel it was started from, reports itself as a
+ * stream of cursor-numbered events, and has to survive the modal closing, a
+ * second browser tab, and a page reload. This module owns the two halves of
+ * that which have no domain in them — the pure fold of a page of events into
+ * a job, and the loop that keeps asking for the next page — so the stores
+ * above it are left with only the part that IS about packs or plugins.
+ *
+ * Deliberately domain-free: it imports the three wire types and nothing else.
+ * A follower's in-flight request and generation counter live in the closure
+ * `createJobFollower` returns, never at module scope, so two centers can
+ * follow two jobs at once without either one's `stop()` reaching the other.
+ */
+
+/** Long-poll parking time for a job follower, in SECONDS (server caps it). */
+export const EVENT_WAIT_S = 25;
+
+/**
+ * Floor between follower turns that made no progress.
+ *
+ * The long poll is supposed to park server-side, so an unadvanced page
+ * normally means its deadline passed and 500 ms of extra latency is noise. It
+ * is also the thing standing between this loop and a busy-wait if a server
+ * ever answers instantly without moving the cursor.
+ */
+export const FOLLOW_IDLE_MS = 500;
+
+/** Wait between retries after a failed events request. */
+export const FOLLOW_RETRY_MS = 2000;
+
+/**
+ * Consecutive failures before the follower gives up on a job.
+ *
+ * Five retries across ten seconds outlast a restarting dev server and a
+ * flaky Wi-Fi hop, which are the two things that interrupt an install on a
+ * developer's machine. Beyond that the honest thing to say is that we no
+ * longer know what the job is doing.
+ */
+export const MAX_FOLLOW_FAILURES = 5;
+
+/** Ring-buffer bound on a rendered job log. */
+export const MAX_LOG_LINES = 400;
+
+/**
+ * One line of a job's log.
+ *
+ * `text` is the server's own message (English, and often a pip line), kept
+ * verbatim rather than translated: it is a transcript of what ran, and the
+ * step LABELS the UI translates come from `JobStep.step` ids instead.
+ */
+export interface LogLine {
+  /** Unique, ascending, and stable — the React key for the line. */
+  seq: number;
+  ts: string | null;
+  kind: 'step' | 'log' | 'error';
+  text: string;
+}
+
+/** How far one item has downloaded. */
+export interface ItemProgress {
+  bytesDone: number;
+  /** null when the server never learned the size (a chunked response). */
+  bytesTotal: number | null;
+  /** 0..100, or null when there is no total to divide by. */
+  percent: number | null;
+}
+
+export interface JobStep {
+  /** The server's step id (`pip`, `download:<item>`, `verify`). */
+  step: string;
+  /** The server's English label — a fallback for a step the UI cannot name. */
+  label: string;
+  state: 'running' | 'done';
+}
+
+/**
+ * A job's status as the UI knows it.
+ *
+ * `lost` is ours, not the server's: after enough failed polls we no longer
+ * know what the job is doing, and saying "running" about a job nobody is
+ * watching is the one answer that is definitely wrong.
+ */
+export type JobPhase = JobStatus | 'lost';
+
+/**
+ * What every followed job has. A domain adds its own fields on top —
+ * `PackJob` its pack id and install mode, `PluginJob` its plugin id and kind
+ * — and passes itself as `J` to the two functions below.
+ */
+export interface Job {
+  jobId: string;
+  status: JobPhase;
+  steps: JobStep[];
+  /** Keyed by item id, so a replayed frame overwrites instead of appending. */
+  items: Record<string, ItemProgress>;
+  log: LogLine[];
+  /** Highest event cursor applied — where the follower resumes. */
+  cursor: number;
+  error: { message: string; hint: string | null } | null;
+  /** Set by a `needs_restart` event: what to run when we cannot restart. */
+  restartCommand: string | null;
+  startedAt: number;
+}
+
+/** A job with nothing in it yet — what an adopted or just-started job starts as. */
+export function emptyJob(jobId: string): Job {
+  return {
+    jobId,
+    status: 'running',
+    steps: [],
+    items: {},
+    log: [],
+    cursor: 0,
+    error: null,
+    restartCommand: null,
+    startedAt: Date.now(),
+  };
+}
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function num(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fold one page of events into a job.
+ *
+ * Pure and exported so the interesting part — what each event type does to
+ * the steps, the per-item bars and the log — is testable without a server, a
+ * timer or a React tree.
+ *
+ * A `progress` event NEVER becomes a log line. A 2 GB download emits
+ * thousands of them; one line each would bury every message that actually
+ * says something, and the bytes already have a bar of their own.
+ *
+ * *onExtra* is how a domain reads the keys this reducer has no opinion about
+ * (a pack's `retry_mode`, a plugin's `sha`): it runs once per applied event,
+ * after the switch, on a shallow copy of the job whose DOMAIN fields it may
+ * write. The generic fields are written back afterwards from this function's
+ * own locals, so a careless callback cannot corrupt the log or the cursor.
+ */
+export function reduceJobEvents<J extends Job>(
+  job: J,
+  page: JobEventsPage,
+  onExtra?: (event: JobEvent, draft: J) => void,
+): J {
+  let steps = job.steps;
+  let items = job.items;
+  let error = job.error;
+  let restartCommand = job.restartCommand;
+  const lines: LogLine[] = [];
+  const draft: J = { ...job };
+
+  // Log keys have to be unique for React and ascending for the reader. Event
+  // cursors are both, so they are used as-is; a frame that arrived without
+  // one (a hand-written double, an older backend) gets the next number after
+  // everything seen so far rather than a colliding zero.
+  let lastSeq = job.log.length > 0 ? job.log[job.log.length - 1].seq : 0;
+  if (job.cursor > lastSeq) lastSeq = job.cursor;
+
+  const line = (
+    seq: number, ts: string | null, kind: LogLine['kind'], text: string,
+  ) => lines.push({ seq, ts, kind, text });
+
+  const markStepDone = (predicate: (step: JobStep) => boolean) => {
+    if (!steps.some((step) => step.state === 'running' && predicate(step))) return;
+    steps = steps.map((step) => (
+      step.state === 'running' && predicate(step) ? { ...step, state: 'done' } : step
+    ));
+  };
+
+  for (const event of page.events) {
+    const cursor = num(event.cursor);
+    // Idempotent by cursor. `/events` returns events strictly AFTER the
+    // cursor we sent, so this only fires on a replay — but a replayed log
+    // line would be a duplicate React key as well as a duplicate line, and
+    // the reducer is cheaper to make safe than every caller is.
+    if (cursor !== null && cursor <= job.cursor) continue;
+    const seq = cursor !== null ? Math.max(cursor, lastSeq + 1) : lastSeq + 1;
+    lastSeq = seq;
+    const ts = str(event.ts);
+
+    switch (event.type) {
+      case 'step_started': {
+        const step = str(event.step);
+        if (step === null) break;
+        const label = str(event.label) ?? step;
+        // The server emits `step_done` for every step it finishes, but a step
+        // that ended by raising never gets one; closing the previous step
+        // here keeps the list from showing two spinners at once.
+        markStepDone(() => true);
+        steps = [...steps, { step, label, state: 'running' }];
+        line(seq, ts, 'step', label);
+        break;
+      }
+      case 'step_done': {
+        const step = str(event.step);
+        if (step === null) break;
+        markStepDone((entry) => entry.step === step);
+        break;
+      }
+      case 'log': {
+        const text = str(event.line);
+        // Blank lines are real in pip output and are nothing to render.
+        if (text === null || text.trim() === '') break;
+        line(seq, ts, 'log', text);
+        break;
+      }
+      case 'progress': {
+        const item = str(event.item);
+        if (item === null) break;
+        const bytesDone = num(event.bytes_done) ?? 0;
+        const bytesTotal = num(event.bytes_total);
+        const reported = num(event.percent);
+        const percent = reported !== null
+          ? clampPercent(reported)
+          : bytesTotal !== null && bytesTotal > 0
+            ? clampPercent((100 * bytesDone) / bytesTotal)
+            : null;
+        items = { ...items, [item]: { bytesDone, bytesTotal, percent } };
+        break;
+      }
+      case 'job_done':
+        markStepDone(() => true);
+        line(seq, ts, 'step', 'done');
+        break;
+      case 'job_failed': {
+        const message = str(event.message) ?? '';
+        error = { message, hint: str(event.hint) };
+        line(seq, ts, 'error', message);
+        break;
+      }
+      case 'needs_restart':
+        restartCommand = str(event.command);
+        break;
+      default:
+        // An unknown type from a newer backend is skipped, never rendered as
+        // a mystery line — the log is a transcript, not a protocol dump.
+        break;
+    }
+
+    onExtra?.(event, draft);
+  }
+
+  const log = lines.length > 0
+    ? [...job.log, ...lines].slice(-MAX_LOG_LINES)
+    : job.log;
+
+  return {
+    ...draft,
+    status: page.status,
+    steps,
+    items,
+    log,
+    error,
+    restartCommand,
+    // Never moves backwards: an empty page returns the cursor we sent.
+    cursor: Math.max(job.cursor, page.cursor),
+  };
+}
+
+export interface JobFollowerOptions<J extends Job> {
+  /**
+   * Ask for the page after *cursor*, parking for up to *waitS* seconds.
+   *
+   * The signal is the follower's, and abandoning a parked request is the only
+   * way to release the connection it is holding, so an implementation that
+   * drops it turns `stop()` into a lie.
+   */
+  fetchPage: (
+    jobId: string, cursor: number, signal: AbortSignal, waitS: number,
+  ) => Promise<JobEventsPage>;
+  /** The job the store is showing, whatever it is. May be null, or another job. */
+  getOpenJob: () => J | null;
+  /**
+   * Record *next* — but only if *jobId* is still the open job. Following is
+   * asynchronous, and a page for a job the user has moved on from must not
+   * overwrite the one they are looking at.
+   */
+  patchJob: (jobId: string, next: J) => void;
+  /**
+   * The job reached an ending. *job* is the freshly folded job when it is
+   * still the open one and null when it is not, which is the caller's cue
+   * that there is nothing on screen to talk about.
+   */
+  onSettled: (jobId: string, status: JobStatus, job: J | null) => void;
+  /**
+   * The events endpoint failed *maxFailures* times in a row.
+   *
+   * Return true to say the ending has been handled — a domain that can read
+   * something into the silence (a pack whose server was always going to stop
+   * answering mid-restart) settles the job itself. Return false, or leave the
+   * callback out, and the follower marks the job `lost`. *error* is the last
+   * rejection, and the difference between a dropped connection and a server
+   * that answered with a status code is usually the whole decision.
+   */
+  onGiveUp?: (jobId: string, error: unknown, job: J | null) => boolean;
+  /** Passed straight to `reduceJobEvents` on every page. */
+  onExtra?: (event: JobEvent, draft: J) => void;
+  waitS?: number;
+  idleMs?: number;
+  retryMs?: number;
+  maxFailures?: number;
+}
+
+export interface JobFollower {
+  /** Follow *jobId* from *cursor*, unless it is already being followed. */
+  start: (jobId: string, cursor?: number) => void;
+  /** Abandon the current follower, if any. */
+  stop: () => void;
+  /** The job this follower is on, or null. Makes adoption idempotent. */
+  followingJobId: () => string | null;
+}
+
+/**
+ * A loop that tails one job at a time until it can produce no more.
+ *
+ * The stop condition is "terminal AND the cursor did not move", which is the
+ * only one that is actually true: a finished job with a backlog still has
+ * pages to hand over, and a running job that returned nothing is simply
+ * between events. Phrasing it in terms of the CURSOR rather than
+ * `events.length` also makes a server that answers without making progress a
+ * bounded loop instead of a busy-wait.
+ *
+ * In-flight requests and timers are closure state, not store state: putting
+ * them in a store would make every turn of the loop a re-render for
+ * subscribers that only care about the data.
+ */
+export function createJobFollower<J extends Job>(
+  options: JobFollowerOptions<J>,
+): JobFollower {
+  const {
+    fetchPage, getOpenJob, patchJob, onSettled, onGiveUp, onExtra,
+    waitS = EVENT_WAIT_S,
+    idleMs = FOLLOW_IDLE_MS,
+    retryMs = FOLLOW_RETRY_MS,
+    maxFailures = MAX_FOLLOW_FAILURES,
+  } = options;
+
+  /** Bumped by every `stop`; a loop whose generation is stale exits. */
+  let generation = 0;
+  let inFlight: AbortController | null = null;
+  let following: string | null = null;
+
+  /**
+   * Two mechanisms, and both are needed. `abort()` releases the parked HTTP
+   * request immediately — a 25 s long poll left dangling holds a connection
+   * open on a server with a small pool. The generation bump is what stops the
+   * LOOP: an abort only rejects the request in flight, and without it the
+   * follower would simply issue the next one.
+   */
+  function stop(): void {
+    generation += 1;
+    inFlight?.abort();
+    inFlight = null;
+    following = null;
+  }
+
+  /**
+   * The idempotence is what lets a catalog poll adopt the server's active job
+   * every time without restarting the follower — and without the
+   * double-follow that would apply every event twice.
+   */
+  function start(jobId: string, cursor = 0): void {
+    if (following === jobId) return;
+    stop();
+    following = jobId;
+    void loop(jobId, cursor, generation);
+  }
+
+  async function loop(
+    jobId: string, startCursor: number, mine: number,
+  ): Promise<void> {
+    let cursor = startCursor;
+    let failures = 0;
+
+    while (mine === generation) {
+      const controller = new AbortController();
+      inFlight = controller;
+      let page: JobEventsPage;
+      try {
+        page = await fetchPage(jobId, cursor, controller.signal, waitS);
+      } catch (error) {
+        // A deliberate abort bumped the generation; anything else is the
+        // network, which a long install is entitled to survive — the work
+        // itself is happening server-side and does not care that we blinked.
+        if (mine !== generation) return;
+        failures += 1;
+        if (failures >= maxFailures) {
+          if (following === jobId) following = null;
+          const open = getOpenJob();
+          const held = open !== null && open.jobId === jobId ? open : null;
+          const handled = onGiveUp?.(jobId, error, held) === true;
+          if (!handled && held !== null) {
+            patchJob(jobId, { ...held, status: 'lost' });
+          }
+          return;
+        }
+        await sleep(retryMs);
+        continue;
+      }
+      if (mine !== generation) return;
+      failures = 0;
+
+      let folded: J | null = null;
+      const open = getOpenJob();
+      if (open !== null && open.jobId === jobId) {
+        folded = reduceJobEvents(open, page, onExtra);
+        patchJob(jobId, folded);
+      }
+
+      const advanced = page.cursor > cursor;
+      cursor = Math.max(cursor, page.cursor);
+      if (page.status !== 'running' && !advanced) {
+        if (following === jobId) following = null;
+        onSettled(jobId, page.status, folded);
+        return;
+      }
+      if (!advanced) await sleep(idleMs);
+    }
+  }
+
+  return { start, stop, followingJobId: () => following };
+}

--- a/frontend/src/store/jobFollower.ts
+++ b/frontend/src/store/jobFollower.ts
@@ -155,6 +155,12 @@ function sleep(ms: number): Promise<void> {
  * write. EVERY generic field is written back afterwards from this function's
  * own locals, so a careless callback cannot corrupt the log, the cursor, or
  * the identity the follower patches this job by.
+ *
+ * The other half of that: the generic fields a callback READS off the draft
+ * (`log`, `steps`, `items`, `cursor`, `status`, `error`) are the values as of
+ * ENTRY to this fold -- the draft is `{...job}`, captured before the loop --
+ * not the ones the events in this page are building. A callback that needs
+ * what an earlier event in the SAME page did has to track it itself.
  */
 export function reduceJobEvents<J extends Job>(
   job: J,
@@ -330,6 +336,10 @@ export interface JobFollowerOptions<J extends Job> {
    * bound — and passes it here, so the panel's exported reducer and the one
    * the follower runs are the same function rather than two wirings that can
    * drift.
+   *
+   * What the bound `onExtra` sees of the generic fields is `reduceJobEvents`'s
+   * to document: they are the values as of entry to the fold, not the ones
+   * the page being folded is building.
    */
   reduce?: (job: J, page: JobEventsPage) => J;
   waitS?: number;

--- a/frontend/src/store/packStore.ts
+++ b/frontend/src/store/packStore.ts
@@ -7,6 +7,7 @@ import {
   installPack,
   listPacks,
   removePackItem,
+  type JobEvent,
   type LaunchMode,
   type PackCatalog,
   type PackGpuInfo,
@@ -15,6 +16,21 @@ import {
   type PackJobStatus,
   type PackSummary,
 } from '../api/rest';
+import {
+  EVENT_WAIT_S,
+  FOLLOW_IDLE_MS,
+  FOLLOW_RETRY_MS,
+  MAX_FOLLOW_FAILURES,
+  MAX_LOG_LINES,
+  createJobFollower,
+  emptyJob,
+  reduceJobEvents,
+  type ItemProgress,
+  type Job,
+  type JobPhase,
+  type JobStep,
+  type LogLine,
+} from './jobFollower';
 import { confirm } from '../utils/dialog';
 import { localizedPackTitle } from '../utils/packAvailability';
 import { useToastStore, type ToastAction } from './toastStore';
@@ -53,35 +69,16 @@ import { useI18n, type TranslationKey } from '../i18n';
  * `sessionStorage` so the reloaded page can report how it went.
  */
 
-/** Long-poll parking time for the job follower, in SECONDS (server caps it). */
-export const EVENT_WAIT_S = 25;
-
 /**
- * Floor between follower turns that made no progress.
- *
- * The long poll is supposed to park server-side, so an unadvanced page
- * normally means its deadline passed and 500 ms of extra latency is noise. It
- * is also the thing standing between this loop and a busy-wait if a server
- * ever answers instantly without moving the cursor.
+ * The follower's own constants, re-exported under the names this panel and
+ * its tests have always used. `jobFollower` owns the values because the
+ * plugin center parks on the same endpoint shape with the same deadlines;
+ * a second copy here would be two numbers to keep in step.
  */
-export const FOLLOW_IDLE_MS = 500;
-
-/** Wait between retries after a failed events request. */
-export const FOLLOW_RETRY_MS = 2000;
-
-/**
- * Consecutive failures before the job is declared `lost` — or, for a
- * restart-mode job, settled as the `needs_restart` it was heading for.
- *
- * Five retries across ten seconds outlast a restarting dev server and a
- * flaky Wi-Fi hop, which are the two things that interrupt an install on a
- * developer's machine. Beyond that the honest thing to say is that we no
- * longer know what the download is doing.
- */
-export const MAX_FOLLOW_FAILURES = 5;
+export { EVENT_WAIT_S, FOLLOW_IDLE_MS, FOLLOW_RETRY_MS, MAX_FOLLOW_FAILURES };
 
 /** Ring-buffer bound on the rendered install log. */
-export const MAX_PACK_LOG_LINES = 400;
+export const MAX_PACK_LOG_LINES = MAX_LOG_LINES;
 
 /**
  * How much of a failed restart's `log_tail` a toast is allowed to carry.
@@ -138,48 +135,20 @@ const REFUSAL_TOASTS = new Map<string, TranslationKey>([
 ]);
 
 /**
- * One line of an install job's log.
+ * The generic job model under this panel's own names.
  *
- * `text` is the server's own message (English, and often a pip line), kept
- * verbatim rather than translated: it is a transcript of what ran, and the
- * step LABELS the UI translates come from `PackJobStep.step` ids instead.
+ * Aliases rather than copies: a pack job's log lines, per-item bars, steps
+ * and phases are the shared ones, and a second declaration would be a second
+ * thing to keep in step with the reducer that produces them. The names stay
+ * because the panel, the cards and their tests all read in packs.
  */
-export interface PackLogLine {
-  /** Unique, ascending, and stable — the React key for the line. */
-  seq: number;
-  ts: string | null;
-  kind: 'step' | 'log' | 'error';
-  text: string;
-}
+export type PackLogLine = LogLine;
+export type PackItemProgress = ItemProgress;
+export type PackJobStep = JobStep;
+export type PackJobPhase = JobPhase;
 
-/** How far one item has downloaded. */
-export interface PackItemProgress {
-  bytesDone: number;
-  /** null when the server never learned the size (a chunked response). */
-  bytesTotal: number | null;
-  /** 0..100, or null when there is no total to divide by. */
-  percent: number | null;
-}
-
-export interface PackJobStep {
-  /** The server's step id (`pip`, `download:<item>`, `verify`). */
-  step: string;
-  /** The server's English label — a fallback for a step the UI cannot name. */
-  label: string;
-  state: 'running' | 'done';
-}
-
-/**
- * A job's status as the UI knows it.
- *
- * `lost` is ours, not the server's: after enough failed polls we no longer
- * know what the job is doing, and saying "running" about a job nobody is
- * watching is the one answer that is definitely wrong.
- */
-export type PackJobPhase = PackJobStatus | 'lost';
-
-export interface PackJob {
-  jobId: string;
+/** A pack install job: the generic job plus what makes it a PACK's. */
+export interface PackJob extends Job {
   packId: string;
   /**
    * How this job was launched.
@@ -190,16 +159,6 @@ export interface PackJob {
    * the user to run a command. Only the first is a restart anybody asked for.
    */
   mode: PackInstallMode;
-  status: PackJobPhase;
-  steps: PackJobStep[];
-  /** Keyed by item id, so a replayed frame overwrites instead of appending. */
-  items: Record<string, PackItemProgress>;
-  log: PackLogLine[];
-  /** Highest event cursor applied — where the follower resumes. */
-  cursor: number;
-  error: { message: string; hint: string | null } | null;
-  /** Set by a `needs_restart` event: what to run when we cannot restart. */
-  restartCommand: string | null;
   /**
    * Set by a `needs_restart` event on a LIVE install the resolver stopped:
    * the mode that CAN finish it, when the server is able to offer one.
@@ -210,7 +169,6 @@ export interface PackJob {
    * build cannot follow.
    */
   retryMode: PackInstallMode | null;
-  startedAt: number;
 }
 
 export type RestartPhase = 'idle' | 'waiting' | 'notStarted' | 'timeout';
@@ -284,20 +242,7 @@ export function emptyPackJob(
   packId: string,
   mode: PackInstallMode = 'live',
 ): PackJob {
-  return {
-    jobId,
-    packId,
-    mode,
-    status: 'running',
-    steps: [],
-    items: {},
-    log: [],
-    cursor: 0,
-    error: null,
-    restartCommand: null,
-    retryMode: null,
-    startedAt: Date.now(),
-  };
+  return { ...emptyJob(jobId), packId, mode, retryMode: null };
 }
 
 function errorMessage(err: unknown): string {
@@ -327,14 +272,6 @@ function openCenterAction(packId: string): ToastAction {
 
 function str(value: unknown): string | null {
   return typeof value === 'string' ? value : null;
-}
-
-function num(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
-}
-
-function clampPercent(value: number): number {
-  return Math.min(100, Math.max(0, value));
 }
 
 function sleep(ms: number): Promise<void> {
@@ -389,148 +326,54 @@ function isTerminalPhase(status: PackJobPhase): boolean {
 }
 
 /**
- * Fold one page of events into a job.
+ * What a pack reads out of an event that the generic reducer does not.
+ *
+ * One key today, and it is genuinely pack-shaped: `retry_mode` is the
+ * server's offer to finish a LIVE install that its resolver stopped, and
+ * only this panel has a button that can take it up.
+ */
+function packExtras(event: JobEvent, draft: PackJob): void {
+  if (event.type !== 'needs_restart') return;
+  // Only the one mode this build knows how to post. The key is absent
+  // unless the server can actually restart itself, so reading anything
+  // else as a retry would offer a button whose request nothing here
+  // knows how to make.
+  draft.retryMode = str(event.retry_mode) === 'restart' ? 'restart' : null;
+}
+
+/**
+ * Fold one page of events into a pack job.
  *
  * Pure and exported so the interesting part — what each event type does to
  * the steps, the per-item bars and the log — is testable without a server, a
- * timer or a React tree.
- *
- * A `progress` event NEVER becomes a log line. A 2 GB download emits
- * thousands of them; one line each would bury every message that actually
- * says something, and the bytes already have a bar of their own.
+ * timer or a React tree. The fold itself is `jobFollower`'s, shared with the
+ * plugin center; only `retry_mode` is ours.
  */
 export function reducePackEvents(job: PackJob, page: PackJobEventsPage): PackJob {
-  let steps = job.steps;
-  let items = job.items;
-  let error = job.error;
-  let restartCommand = job.restartCommand;
-  let retryMode = job.retryMode;
-  const lines: PackLogLine[] = [];
-
-  // Log keys have to be unique for React and ascending for the reader. Event
-  // cursors are both, so they are used as-is; a frame that arrived without
-  // one (a hand-written double, an older backend) gets the next number after
-  // everything seen so far rather than a colliding zero.
-  let lastSeq = job.log.length > 0 ? job.log[job.log.length - 1].seq : 0;
-  if (job.cursor > lastSeq) lastSeq = job.cursor;
-
-  const line = (
-    seq: number, ts: string | null, kind: PackLogLine['kind'], text: string,
-  ) => lines.push({ seq, ts, kind, text });
-
-  const markStepDone = (predicate: (step: PackJobStep) => boolean) => {
-    if (!steps.some((step) => step.state === 'running' && predicate(step))) return;
-    steps = steps.map((step) => (
-      step.state === 'running' && predicate(step) ? { ...step, state: 'done' } : step
-    ));
-  };
-
-  for (const event of page.events) {
-    const cursor = num(event.cursor);
-    // Idempotent by cursor. `/events` returns events strictly AFTER the
-    // cursor we sent, so this only fires on a replay — but a replayed log
-    // line would be a duplicate React key as well as a duplicate line, and
-    // the reducer is cheaper to make safe than every caller is.
-    if (cursor !== null && cursor <= job.cursor) continue;
-    const seq = cursor !== null ? Math.max(cursor, lastSeq + 1) : lastSeq + 1;
-    lastSeq = seq;
-    const ts = str(event.ts);
-
-    switch (event.type) {
-      case 'step_started': {
-        const step = str(event.step);
-        if (step === null) break;
-        const label = str(event.label) ?? step;
-        // The server emits `step_done` for every step it finishes, but a step
-        // that ended by raising never gets one; closing the previous step
-        // here keeps the list from showing two spinners at once.
-        markStepDone(() => true);
-        steps = [...steps, { step, label, state: 'running' }];
-        line(seq, ts, 'step', label);
-        break;
-      }
-      case 'step_done': {
-        const step = str(event.step);
-        if (step === null) break;
-        markStepDone((entry) => entry.step === step);
-        break;
-      }
-      case 'log': {
-        const text = str(event.line);
-        // Blank lines are real in pip output and are nothing to render.
-        if (text === null || text.trim() === '') break;
-        line(seq, ts, 'log', text);
-        break;
-      }
-      case 'progress': {
-        const item = str(event.item);
-        if (item === null) break;
-        const bytesDone = num(event.bytes_done) ?? 0;
-        const bytesTotal = num(event.bytes_total);
-        const reported = num(event.percent);
-        const percent = reported !== null
-          ? clampPercent(reported)
-          : bytesTotal !== null && bytesTotal > 0
-            ? clampPercent((100 * bytesDone) / bytesTotal)
-            : null;
-        items = { ...items, [item]: { bytesDone, bytesTotal, percent } };
-        break;
-      }
-      case 'job_done':
-        markStepDone(() => true);
-        line(seq, ts, 'step', 'done');
-        break;
-      case 'job_failed': {
-        const message = str(event.message) ?? '';
-        error = { message, hint: str(event.hint) };
-        line(seq, ts, 'error', message);
-        break;
-      }
-      case 'needs_restart':
-        restartCommand = str(event.command);
-        // Only the one mode this build knows how to post. The key is absent
-        // unless the server can actually restart itself, so reading anything
-        // else as a retry would offer a button whose request nothing here
-        // knows how to make.
-        retryMode = str(event.retry_mode) === 'restart' ? 'restart' : null;
-        break;
-      default:
-        // An unknown type from a newer backend is skipped, never rendered as
-        // a mystery line — the log is a transcript, not a protocol dump.
-        break;
-    }
-  }
-
-  const log = lines.length > 0
-    ? [...job.log, ...lines].slice(-MAX_PACK_LOG_LINES)
-    : job.log;
-
-  return {
-    ...job,
-    status: page.status,
-    steps,
-    items,
-    log,
-    error,
-    restartCommand,
-    retryMode,
-    // Never moves backwards: an empty page returns the cursor we sent.
-    cursor: Math.max(job.cursor, page.cursor),
-  };
+  return reduceJobEvents(job, page, packExtras);
 }
 
 // ── module-scope schedulers ──────────────────────────────────────────────
 // In-flight requests and timers are process state, not store state: putting
 // them in the store would make every turn of the loop a re-render for
-// subscribers that only care about the data.
+// subscribers that only care about the data. The follower's half of that now
+// lives inside the closure `createJobFollower` returns; what is left here is
+// the restart handshake's.
 
-/** Bumped by every `stopFollowing`; a follower whose generation is stale exits. */
-let followGeneration = 0;
-let followAbort: AbortController | null = null;
-/** The job a follower is currently on, or null. Makes adoption idempotent. */
-let followingJobId: string | null = null;
 /** The last job `onJobSettled` fired for — its side effects run exactly once. */
 let settledJobId: string | null = null;
+
+/**
+ * The pack the running follower is installing.
+ *
+ * The follower is keyed by job id and knows nothing about packs, but every
+ * ending it reports is about one: which catalog row carries the fallback
+ * command, which name a toast says, which pack the reloaded page reports on.
+ * Set immediately before each `start`, and safe as a single slot because
+ * starting a different job replaces it and abandons the old loop in the same
+ * breath — a stale loop never gets to read it.
+ */
+let followingPackId: string | null = null;
 
 /** Bumped by every `restartFlow` and by the test reset; a stale loop exits. */
 let restartGeneration = 0;
@@ -547,131 +390,87 @@ let inProgressChecked = false;
  */
 let lastRestartRecord: Record<string, unknown> | null = null;
 
+/** Record on the open job — never on a job the user has moved on from. */
+function patchJob(jobId: string, next: PackJob): void {
+  usePackStore.setState((state) => (
+    state.job && state.job.jobId === jobId ? { job: next } : {}
+  ));
+}
+
 /**
- * Abandon the current follower, if any.
+ * The one follower this store runs.
  *
- * Two mechanisms, and both are needed. `abort()` releases the parked HTTP
- * request immediately — a 25 s long poll left dangling holds a connection
- * open on a server with a small pool. The generation bump is what stops the
- * LOOP: an abort only rejects the request in flight, and without it the
- * follower would simply issue the next one.
+ * Everything about HOW a job is tailed — the long poll, the generation
+ * guard, the retry budget, the "terminal AND the cursor did not move" stop
+ * condition — is `jobFollower`'s, and is shared with the plugin center.
+ * What is left here is the three things that are about PACKS: which endpoint
+ * to ask, what an ending means, and what to read into the endpoint going
+ * quiet.
  */
+const follower = createJobFollower<PackJob>({
+  fetchPage: (jobId, cursor, signal, wait) => (
+    getPackJobEvents(jobId, { cursor, wait, signal })
+  ),
+  getOpenJob: () => usePackStore.getState().job,
+  patchJob,
+  onExtra: packExtras,
+  onSettled: (jobId, status) => {
+    onJobSettled(jobId, followingPackId ?? '', status);
+  },
+  onGiveUp: (jobId, error, open) => {
+    // A RESTART-mode job is the one case where the endpoint going quiet is
+    // the expected ending rather than a lost connection: the server stops
+    // accepting half a second after the 202 and then exits, and a LAN client
+    // or a tab the browser had throttled can miss that half second entirely.
+    // `lost` would leave the user in front of a "we no longer know" banner
+    // while the wheel swap runs — no overlay, and worse, no breadcrumb, so
+    // the page that comes back could not report how the install went.
+    // Settling it as the ending it almost certainly reached runs the same
+    // handshake the last page would have started; if it turns out the server
+    // never went, the overlay's own thirty-second grace says so.
+    //
+    // Only for a connection that DROPPED, though. A `PackApiError` is the
+    // server answering — a 404 for a job that aged out, a 500 — and an
+    // answer is proof it is still there. Settling on those raised the
+    // blocking overlay over a live server, which is the bug the note in
+    // `onJobSettled` records as fixed. Every other ending declines here and
+    // takes the follower's own `lost`.
+    if (error instanceof PackApiError || open === null || open.mode !== 'restart') {
+      return false;
+    }
+    const packId = followingPackId ?? '';
+    // No `needs_restart` event ever arrived, so nothing carried the command
+    // — and both give-up screens name one ("Run this command, then
+    // reload:"). The catalog has it: `install_command` is what the panel's
+    // own button would have run for this pack.
+    const command = usePackStore.getState().byId[packId]?.install_command ?? null;
+    patchJob(jobId, {
+      ...open,
+      status: 'needs_restart',
+      restartCommand: open.restartCommand ?? command,
+    });
+    onJobSettled(jobId, packId, 'needs_restart');
+    return true;
+  },
+});
+
+/** Abandon the current follower, if any. */
 function stopFollowing(): void {
-  followGeneration += 1;
-  followAbort?.abort();
-  followAbort = null;
-  followingJobId = null;
+  follower.stop();
 }
 
 /**
  * Follow *jobId* from *cursor*, unless it is already being followed.
  *
  * The idempotence is what lets `refresh()` adopt `active_job` on every poll
- * without restarting the follower — and without the double-follow that would
- * apply every event twice.
+ * without restarting the follower — and without the double-follow that
+ * would apply every event twice. Asked here as well as inside `start` so the
+ * pack id is not rewritten under a loop already running on another job.
  */
 function startFollowing(jobId: string, packId: string, cursor: number): void {
-  if (followingJobId === jobId) return;
-  stopFollowing();
-  followingJobId = jobId;
-  void follow(jobId, packId, cursor, followGeneration);
-}
-
-/** Record on the open job — never on a job the user has moved on from. */
-function patchJob(jobId: string, patch: (job: PackJob) => PackJob): void {
-  usePackStore.setState((state) => (
-    state.job && state.job.jobId === jobId ? { job: patch(state.job) } : {}
-  ));
-}
-
-/**
- * Tail one install job until it can produce no more.
- *
- * The stop condition is "terminal AND the cursor did not move", which is the
- * only one that is actually true: a finished job with a backlog still has
- * pages to hand over, and a running job that returned nothing is simply
- * between events. Phrasing it in terms of the CURSOR rather than
- * `events.length` also makes a server that answers without making progress a
- * bounded loop instead of a busy-wait.
- */
-async function follow(
-  jobId: string, packId: string, startCursor: number, generation: number,
-): Promise<void> {
-  let cursor = startCursor;
-  let failures = 0;
-
-  while (generation === followGeneration) {
-    const controller = new AbortController();
-    followAbort = controller;
-    let page: PackJobEventsPage;
-    try {
-      page = await getPackJobEvents(jobId, {
-        cursor,
-        wait: EVENT_WAIT_S,
-        signal: controller.signal,
-      });
-    } catch (error) {
-      // A deliberate abort bumped the generation; anything else is the
-      // network, which an install is entitled to survive — the download
-      // itself is happening server-side and does not care that we blinked.
-      if (generation !== followGeneration) return;
-      failures += 1;
-      if (failures >= MAX_FOLLOW_FAILURES) {
-        if (followingJobId === jobId) followingJobId = null;
-        // A RESTART-mode job is the one case where the endpoint going quiet
-        // is the expected ending rather than a lost connection: the server
-        // stops accepting half a second after the 202 and then exits, and a
-        // LAN client or a tab the browser had throttled can miss that half
-        // second entirely. `lost` would leave the user in
-        // front of a "we no longer know" banner while the wheel swap runs —
-        // no overlay, and worse, no breadcrumb, so the page that comes back
-        // could not report how the install went. Settling it as the ending
-        // it almost certainly reached runs the same handshake the last page
-        // would have started; if it turns out the server never went, the
-        // overlay's own thirty-second grace says so.
-        //
-        // Only for a connection that DROPPED, though. A `PackApiError` is
-        // the server answering — a 404 for a job that aged out, a 500 — and
-        // an answer is proof it is still there. Settling on those raised the
-        // blocking overlay over a live server, which is the bug the note in
-        // `onJobSettled` records as fixed.
-        const store = usePackStore.getState();
-        const open = store.job;
-        if (!(error instanceof PackApiError)
-            && open?.jobId === jobId && open.mode === 'restart') {
-          // No `needs_restart` event ever arrived, so nothing carried the
-          // command — and both give-up screens name one ("Run this command,
-          // then reload:"). The catalog has it: `install_command` is what the
-          // panel's own button would have run for this pack.
-          const command = store.byId[packId]?.install_command ?? null;
-          patchJob(jobId, (job) => ({
-            ...job,
-            status: 'needs_restart',
-            restartCommand: job.restartCommand ?? command,
-          }));
-          onJobSettled(jobId, packId, 'needs_restart');
-        } else {
-          patchJob(jobId, (job) => ({ ...job, status: 'lost' }));
-        }
-        return;
-      }
-      await sleep(FOLLOW_RETRY_MS);
-      continue;
-    }
-    if (generation !== followGeneration) return;
-    failures = 0;
-
-    patchJob(jobId, (job) => reducePackEvents(job, page));
-
-    const advanced = page.cursor > cursor;
-    cursor = Math.max(cursor, page.cursor);
-    if (page.status !== 'running' && !advanced) {
-      if (followingJobId === jobId) followingJobId = null;
-      onJobSettled(jobId, packId, page.status);
-      return;
-    }
-    if (!advanced) await sleep(FOLLOW_IDLE_MS);
-  }
+  if (follower.followingJobId() === jobId) return;
+  followingPackId = packId;
+  follower.start(jobId, cursor);
 }
 
 /**
@@ -872,7 +671,7 @@ export const usePackStore = create<PackState>((set, get) => ({
       // follower's next page settles it as done/failed/cancelled. Marking it
       // `lost` from here is a race that turns a successful install into a
       // "lost contact with the server" banner.
-      && followingJobId !== job.jobId
+      && follower.followingJobId() !== job.jobId
     ) {
       // The server has no record of a job we think is running: it restarted,
       // or the job aged out. Saying "running" would be the one answer that
@@ -1143,7 +942,7 @@ export const usePackStore = create<PackState>((set, get) => ({
 
     // A download the user started before reloading is still going, and the
     // Package Center is closed. This toast is the only thing that says so.
-    if (followingJobId !== null) {
+    if (follower.followingJobId() !== null) {
       toast(t('packs.toast.inProgress'), 'info');
     }
 
@@ -1211,9 +1010,10 @@ function setPackStatus(packId: string, status: PackSummary['status']): void {
 
 /** Test-only: reset the module-scope schedulers and the store between cases. */
 export function _resetPackStoreForTesting(): void {
-  stopFollowing();
+  follower.stop();
   restartGeneration += 1;
   settledJobId = null;
+  followingPackId = null;
   inProgressChecked = false;
   lastRestartRecord = null;
   usePackStore.setState({

--- a/frontend/src/store/packStore.ts
+++ b/frontend/src/store/packStore.ts
@@ -369,7 +369,7 @@ export function reducePackEvents(job: PackJob, page: JobEventsPage): PackJob {
 let settledJobId: string | null = null;
 
 /**
- * The pack the running follower is installing.
+ * The pack the running follower is installing, and the job it was named for.
  *
  * The follower is keyed by job id and knows nothing about packs, but every
  * ending it reports is about one: which catalog row carries the fallback
@@ -377,8 +377,18 @@ let settledJobId: string | null = null;
  * Set immediately before each `start`, and safe as a single slot because
  * starting a different job replaces it and abandons the old loop in the same
  * breath — a stale loop never gets to read it.
+ *
+ * The job id travels with the pack id so that "the ending being reported is
+ * the job this slot was written for" is CHECKED rather than assumed. It costs
+ * a comparison, and it is what keeps an `await` slipped between the
+ * assignment and `follower.start` from naming the wrong row on the toast.
  */
-let followingPackId: string | null = null;
+let following: { jobId: string; packId: string } | null = null;
+
+/** The pack *jobId* is installing, or '' if it is not the one being followed. */
+function followedPack(jobId: string): string {
+  return following !== null && following.jobId === jobId ? following.packId : '';
+}
 
 /** Bumped by every `restartFlow` and by the test reset; a stale loop exits. */
 let restartGeneration = 0;
@@ -420,7 +430,7 @@ const follower = createJobFollower<PackJob>({
   patchJob,
   reduce: reducePackEvents,
   onSettled: (jobId, status) => {
-    onJobSettled(jobId, followingPackId ?? '', status);
+    onJobSettled(jobId, followedPack(jobId), status);
   },
   onGiveUp: (jobId, error, open) => {
     // A RESTART-mode job is the one case where the endpoint going quiet is
@@ -443,7 +453,7 @@ const follower = createJobFollower<PackJob>({
     if (error instanceof PackApiError || open === null || open.mode !== 'restart') {
       return false;
     }
-    const packId = followingPackId ?? '';
+    const packId = followedPack(jobId);
     // No `needs_restart` event ever arrived, so nothing carried the command
     // — and both give-up screens name one ("Run this command, then
     // reload:"). The catalog has it: `install_command` is what the panel's
@@ -474,7 +484,7 @@ function stopFollowing(): void {
  */
 function startFollowing(jobId: string, packId: string, cursor: number): void {
   if (follower.followingJobId() === jobId) return;
-  followingPackId = packId;
+  following = { jobId, packId };
   follower.start(jobId, cursor);
 }
 
@@ -1018,7 +1028,7 @@ export function _resetPackStoreForTesting(): void {
   follower.stop();
   restartGeneration += 1;
   settledJobId = null;
-  followingPackId = null;
+  following = null;
   inProgressChecked = false;
   lastRestartRecord = null;
   usePackStore.setState({

--- a/frontend/src/store/packStore.ts
+++ b/frontend/src/store/packStore.ts
@@ -8,11 +8,11 @@ import {
   listPacks,
   removePackItem,
   type JobEvent,
+  type JobEventsPage,
   type LaunchMode,
   type PackCatalog,
   type PackGpuInfo,
   type PackInstallMode,
-  type PackJobEventsPage,
   type PackJobStatus,
   type PackSummary,
 } from '../api/rest';
@@ -348,8 +348,13 @@ function packExtras(event: JobEvent, draft: PackJob): void {
  * the steps, the per-item bars and the log — is testable without a server, a
  * timer or a React tree. The fold itself is `jobFollower`'s, shared with the
  * plugin center; only `retry_mode` is ours.
+ *
+ * The follower below runs THIS function rather than being handed `packExtras`
+ * separately, so what the tests exercise and what a live install folds are one
+ * thing. Its page is the generic `JobEventsPage`: a `PackJobEventsPage` is one
+ * of those, and the extra keys are read off the index signature anyway.
  */
-export function reducePackEvents(job: PackJob, page: PackJobEventsPage): PackJob {
+export function reducePackEvents(job: PackJob, page: JobEventsPage): PackJob {
   return reduceJobEvents(job, page, packExtras);
 }
 
@@ -413,7 +418,7 @@ const follower = createJobFollower<PackJob>({
   ),
   getOpenJob: () => usePackStore.getState().job,
   patchJob,
-  onExtra: packExtras,
+  reduce: reducePackEvents,
   onSettled: (jobId, status) => {
     onJobSettled(jobId, followingPackId ?? '', status);
   },

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -1,0 +1,1064 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as rest from '../api/rest';
+import type {
+  JobEventsPage,
+  PluginCatalog,
+  PluginCatalogEntry,
+  PluginInspection,
+} from '../api/rest';
+import { ApiError } from '../api/rest';
+
+// Partial mock: `ApiError` is a real class the store narrows on with
+// `instanceof`, so only the network calls are stubbed.
+vi.mock('../api/rest', async (importOriginal) => {
+  const actual = await importOriginal<typeof rest>();
+  return {
+    ...actual,
+    listPluginCatalog: vi.fn(),
+    inspectPluginSource: vi.fn(),
+    installPlugin: vi.fn(),
+    updatePlugin: vi.fn(),
+    uninstallPlugin: vi.fn(),
+    setPluginEnabled: vi.fn(),
+    getPluginJobEvents: vi.fn(),
+    cancelPluginJob: vi.fn(),
+  };
+});
+
+// The uninstall confirmation is an in-app modal driven by a promise; mocking
+// the helper keeps these tests about the STORE's decisions.
+vi.mock('../utils/dialog', () => ({
+  confirm: vi.fn(async () => true),
+  prompt: vi.fn(async () => null),
+}));
+
+// The real one imports plugin bundles over the network and mounts widgets.
+// What matters here is only THAT it ran, and when.
+vi.mock('../plugins/PluginHost', () => ({
+  reloadPluginFrontends: vi.fn(),
+}));
+
+import {
+  _resetPluginStoreForTesting,
+  emptyPluginJob,
+  parseGitHubSource,
+  usePluginStore,
+} from './pluginStore';
+import { useNodeDefStore } from './nodeDefStore';
+import { useToastStore } from './toastStore';
+import { useUIStore } from './uiStore';
+import { useI18n } from '../i18n';
+import { confirm } from '../utils/dialog';
+import { reloadPluginFrontends } from '../plugins/PluginHost';
+
+const api = vi.mocked(rest);
+const confirmMock = vi.mocked(confirm);
+const reloadMock = vi.mocked(reloadPluginFrontends);
+
+/**
+ * What ran, in the order it ran.
+ *
+ * The three-step refresh is a promise of ORDER as much as of contents — the
+ * catalog before the definitions before the frontends — and three separate
+ * `toHaveBeenCalled` assertions cannot say that.
+ */
+const order: string[] = [];
+
+/** The most recent toast. `Array.prototype.at` is outside the project lib. */
+function lastToast() {
+  const { toasts } = useToastStore.getState();
+  return toasts[toasts.length - 1];
+}
+
+function entry(
+  partial: Partial<PluginCatalogEntry> & { id: string },
+): PluginCatalogEntry {
+  return {
+    name: partial.id,
+    description: '',
+    kind: 'builtin',
+    official: true,
+    status: 'available',
+    source_kind: null,
+    source: partial.id,
+    repo: null,
+    ref: null,
+    sha: null,
+    url: null,
+    homepage: '',
+    version: null,
+    installed_at: null,
+    enabled: false,
+    chapters: [],
+    lessons: [],
+    tags: [],
+    nodes: [],
+    node_count: 0,
+    capabilities: [],
+    trusted_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    consent_required: false,
+    frontend_entry: null,
+    job: null,
+    ...partial,
+  };
+}
+
+function catalog(partial: Partial<PluginCatalog> = {}): PluginCatalog {
+  return {
+    entries: [],
+    active_job: null,
+    remote_install_allowed: true,
+    generation: 1,
+    ...partial,
+  };
+}
+
+function inspection(partial: Partial<PluginInspection> = {}): PluginInspection {
+  return {
+    inspection_id: 'insp-1',
+    expires_at: '2026-01-01T00:00:00Z',
+    kind: 'github',
+    mode: 'install',
+    plugin_id: 'demo',
+    catalog_id: null,
+    official: false,
+    source: 'owner/demo',
+    url: 'https://github.com/owner/demo',
+    ref: null,
+    sha: 'a'.repeat(40),
+    name: 'Demo plugin',
+    version: '1.0.0',
+    description: '',
+    homepage: '',
+    manifest: {},
+    capabilities: [],
+    allowed_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    chapters: [],
+    lessons: [],
+    consent_required: false,
+    installed: null,
+    up_to_date: false,
+    capabilities_added: [],
+    allowed_modules_added: [],
+    warnings: [],
+    ...partial,
+  };
+}
+
+function eventsPage(partial: Partial<JobEventsPage> = {}): JobEventsPage {
+  return { job_id: 'j1', status: 'running', events: [], cursor: 0, ...partial };
+}
+
+/** A refusal shaped the way FastAPI sends one: the code lives under `detail`. */
+function refused(
+  status: number, code: string, extra: Record<string, unknown> = {},
+): ApiError {
+  return new ApiError(status, code, { detail: { code, ...extra } });
+}
+
+/** A parked long poll — the server holding the connection open. */
+function parked(): Promise<JobEventsPage> {
+  return new Promise<JobEventsPage>(() => {});
+}
+
+/**
+ * Answer every catalog read with *value*, recording the call in `order`.
+ *
+ * Always through this rather than `mockResolvedValue`, which would replace the
+ * recording implementation and quietly drop the catalog step out of the order
+ * the three-step refresh is asserted on.
+ */
+function serveCatalog(value: PluginCatalog = catalog()): void {
+  api.listPluginCatalog.mockImplementation(async () => {
+    order.push('catalog');
+    return value;
+  });
+}
+
+beforeEach(() => {
+  useI18n.setState({ locale: 'en' });
+  useToastStore.setState({ toasts: [] });
+  _resetPluginStoreForTesting();
+  order.length = 0;
+
+  serveCatalog();
+  api.inspectPluginSource.mockResolvedValue(inspection());
+  api.installPlugin.mockResolvedValue({ job_id: 'j1' });
+  api.updatePlugin.mockResolvedValue({ kind: 'job', job_id: 'j1' });
+  api.uninstallPlugin.mockResolvedValue({
+    id: 'demo',
+    removed: true,
+    tombstoned: false,
+    files_removed: true,
+    python_deps_left: [],
+    uninstall_command: null,
+    reinstall_hint: '',
+  });
+  api.setPluginEnabled.mockImplementation(async (id, enabled) => ({ id, enabled }));
+  // Running-and-idle by default: an accidental follower parks instead of
+  // settling and firing toasts into an unrelated test.
+  api.getPluginJobEvents.mockResolvedValue(eventsPage());
+  api.cancelPluginJob.mockResolvedValue({ job_id: 'j1', cancelled: true });
+  confirmMock.mockResolvedValue(true);
+  reloadMock.mockImplementation(async () => {
+    order.push('frontends');
+    return [];
+  });
+  // A fresh `vi.fn()` through `setState`, never `vi.spyOn` on an action read
+  // off `getState()`: the spy would keep a stale object and carry its call
+  // history into the next case.
+  useNodeDefStore.setState({
+    fetchDefinitions: vi.fn(async () => { order.push('definitions'); }),
+  });
+});
+
+afterEach(() => {
+  _resetPluginStoreForTesting();
+  // The panel is not this file's store, but a toast action opens it — and an
+  // open panel inherited by the next case is a state nothing here set.
+  useUIStore.setState({ pluginCenterOpen: false, pluginCenterFocusPluginId: null });
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+// ── source parsing ───────────────────────────────────────────────────────
+
+describe('parseGitHubSource', () => {
+  it('reads the three forms the CLI accepts', () => {
+    expect(parseGitHubSource('owner/repo')).toEqual({
+      kind: 'github', owner: 'owner', repo: 'repo', ref: null,
+    });
+    expect(parseGitHubSource('owner/repo@v1.2')).toEqual({
+      kind: 'github', owner: 'owner', repo: 'repo', ref: 'v1.2',
+    });
+    expect(parseGitHubSource('https://github.com/owner/repo')).toEqual({
+      kind: 'github', owner: 'owner', repo: 'repo', ref: null,
+    });
+  });
+
+  it('accepts the shapes a pasted URL actually has', () => {
+    // What comes off the GitHub UI's clone button and address bar.
+    expect(parseGitHubSource('https://github.com/owner/repo.git')).toMatchObject({
+      owner: 'owner', repo: 'repo',
+    });
+    expect(parseGitHubSource('https://www.github.com/owner/repo/')).toMatchObject({
+      owner: 'owner', repo: 'repo',
+    });
+    expect(parseGitHubSource('http://github.com/owner/repo@main')).toMatchObject({
+      repo: 'repo', ref: 'main',
+    });
+  });
+
+  it('reads a bare word as a catalog name and trims what was typed', () => {
+    expect(parseGitHubSource('  c1  ')).toEqual({ kind: 'catalog', id: 'c1' });
+  });
+
+  it('refuses anything that is neither', () => {
+    for (const bad of ['', '   ', 'Not A Source', 'https://gitlab.com/o/r', 'owner/']) {
+      expect(parseGitHubSource(bad), bad).toBeNull();
+    }
+  });
+});
+
+// ── the catalog ──────────────────────────────────────────────────────────
+
+describe('pluginStore — refresh', () => {
+  it('reads a 404 as a server without a Plugin Center', async () => {
+    api.listPluginCatalog.mockRejectedValue(new ApiError(404, 'Not Found'));
+
+    await usePluginStore.getState().refresh();
+
+    const state = usePluginStore.getState();
+    expect(state.unsupported).toBe(true);
+    expect(state.loaded).toBe(true);
+    expect(state.plugins).toEqual([]);
+    // Not an error the user did anything about, so nothing reports one.
+    expect(state.error).toBeNull();
+    expect(useToastStore.getState().toasts).toEqual([]);
+  });
+
+  it('keeps the rows it has when the network drops', async () => {
+    api.listPluginCatalog.mockResolvedValueOnce(
+      catalog({ entries: [entry({ id: 'demo', name: 'Demo plugin' })], generation: 7 }),
+    );
+    await usePluginStore.getState().refresh();
+
+    api.listPluginCatalog.mockRejectedValue(new Error('Failed to fetch'));
+    await usePluginStore.getState().refresh();
+
+    const state = usePluginStore.getState();
+    expect(state.plugins).toHaveLength(1);
+    expect(state.byId.demo.name).toBe('Demo plugin');
+    expect(state.generation).toBe(7);
+    expect(state.error).toBe('Failed to fetch');
+    // A dropped packet is not an answer: `unsupported` would blank the panel.
+    expect(state.unsupported).toBe(false);
+  });
+
+  it('adopts the server active job, and only follows it once', async () => {
+    serveCatalog(catalog({
+      active_job: { job_id: 'j9', plugin_id: 'demo', kind: 'update' },
+    }));
+    api.getPluginJobEvents.mockImplementation(parked);
+
+    await usePluginStore.getState().refresh();
+    await usePluginStore.getState().refresh();
+
+    expect(usePluginStore.getState().job).toMatchObject({
+      jobId: 'j9', pluginId: 'demo', kind: 'update', status: 'running',
+    });
+    // Adoption runs on every poll; restarting the follower each time would
+    // abort a long poll that was about to answer.
+    expect(api.getPluginJobEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks a running job lost when the server no longer knows it', async () => {
+    usePluginStore.setState({ job: emptyPluginJob('j1', 'demo') });
+
+    await usePluginStore.getState().refresh();
+
+    expect(usePluginStore.getState().job!.status).toBe('lost');
+  });
+
+  it('leaves a running job alone while a follower is still on it', async () => {
+    api.getPluginJobEvents.mockImplementation(parked);
+    usePluginStore.getState().followJob('j1', 'demo');
+
+    await usePluginStore.getState().refresh();
+
+    // `active_job` goes null the moment a job ends, and the follower's next
+    // page has the real answer; `lost` from here is a race.
+    expect(usePluginStore.getState().job!.status).toBe('running');
+  });
+});
+
+// ── inspecting and installing ────────────────────────────────────────────
+
+describe('pluginStore — install', () => {
+  it('installs straight away when the inspection asks for no consent', async () => {
+    api.inspectPluginSource.mockResolvedValue(inspection({
+      plugin_id: 'c1', consent_required: false, capabilities: [], mode: 'install',
+    }));
+
+    await usePluginStore.getState().install('c1');
+
+    expect(api.inspectPluginSource).toHaveBeenCalledWith('c1');
+    expect(api.installPlugin).toHaveBeenCalledWith({
+      inspection_id: 'insp-1', accept_capabilities: [],
+    });
+    expect(usePluginStore.getState().job).toMatchObject({
+      jobId: 'j1', pluginId: 'c1', kind: 'install',
+    });
+    // The review is spent: the card must not stay on screen behind the job.
+    expect(usePluginStore.getState().inspection).toEqual({ phase: 'idle' });
+    expect(usePluginStore.getState().busy.c1).toBeFalsy();
+  });
+
+  it('stops at the review when the plugin asks for something', async () => {
+    api.inspectPluginSource.mockResolvedValue(inspection({
+      plugin_id: 'demo', consent_required: true, capabilities: ['net'],
+    }));
+
+    await usePluginStore.getState().install('demo');
+
+    expect(api.installPlugin).not.toHaveBeenCalled();
+    expect(usePluginStore.getState().inspection).toMatchObject({
+      phase: 'ready',
+      source: 'demo',
+      // The row it came from, so the panel can show the review beside it.
+      forPluginId: 'demo',
+      kind: 'install',
+      error: null,
+    });
+  });
+
+  it('shows the row as installing the moment the job is accepted', async () => {
+    serveCatalog(
+      catalog({ entries: [entry({ id: 'demo', status: 'available' })] }),
+    );
+    await usePluginStore.getState().refresh();
+    api.inspectPluginSource.mockResolvedValue(inspection({ plugin_id: 'demo' }));
+
+    await usePluginStore.getState().install('demo');
+
+    expect(usePluginStore.getState().byId.demo.status).toBe('installing');
+    expect(usePluginStore.getState().plugins[0].status).toBe('installing');
+  });
+
+  it('refuses a second install while a job is running', async () => {
+    usePluginStore.setState({ job: emptyPluginJob('j1', 'other') });
+
+    await usePluginStore.getState().install('demo');
+
+    expect(api.inspectPluginSource).not.toHaveBeenCalled();
+    expect(lastToast().message).toBe('Another install is already running.');
+  });
+
+  it('ignores a second click while the first request is in flight', async () => {
+    let release: (value: PluginInspection) => void = () => {};
+    api.inspectPluginSource.mockReturnValue(
+      new Promise<PluginInspection>((resolve) => { release = resolve; }),
+    );
+
+    const first = usePluginStore.getState().install('demo');
+    expect(usePluginStore.getState().busy.demo).toBe(true);
+    await usePluginStore.getState().install('demo');
+    expect(api.inspectPluginSource).toHaveBeenCalledTimes(1);
+
+    release(inspection({ plugin_id: 'demo' }));
+    await first;
+    expect(usePluginStore.getState().busy.demo).toBeFalsy();
+  });
+});
+
+describe('pluginStore — inspect', () => {
+  it('refuses an unparseable source without asking the server', async () => {
+    await usePluginStore.getState().inspect('not a source!');
+
+    expect(api.inspectPluginSource).not.toHaveBeenCalled();
+    expect(usePluginStore.getState().inspection).toEqual({
+      phase: 'error',
+      source: 'not a source!',
+      message: 'Enter owner/repo[@ref] or a GitHub URL.',
+    });
+  });
+
+  it('records a typed source with no row of its own', async () => {
+    api.inspectPluginSource.mockResolvedValue(inspection({ mode: 'install' }));
+
+    await usePluginStore.getState().inspect('  owner/demo  ');
+
+    expect(api.inspectPluginSource).toHaveBeenCalledWith('owner/demo');
+    expect(usePluginStore.getState().inspection).toMatchObject({
+      phase: 'ready', source: 'owner/demo', forPluginId: null, kind: 'install',
+    });
+  });
+
+  it('keeps the server refusal as the review error', async () => {
+    api.inspectPluginSource.mockRejectedValue(
+      refused(400, 'unparseable_source'),
+    );
+
+    await usePluginStore.getState().inspect('owner/demo');
+
+    expect(usePluginStore.getState().inspection).toEqual({
+      phase: 'error', source: 'owner/demo', message: 'unparseable_source',
+    });
+  });
+
+  it('clears the review on request', async () => {
+    await usePluginStore.getState().inspect('owner/demo');
+    usePluginStore.getState().clearInspection();
+
+    expect(usePluginStore.getState().inspection).toEqual({ phase: 'idle' });
+  });
+});
+
+describe('pluginStore — installInspected', () => {
+  /** Put a ready review in front of the store, the way `inspect` would. */
+  async function ready(partial: Partial<PluginInspection> = {}): Promise<void> {
+    api.inspectPluginSource.mockResolvedValue(inspection({
+      plugin_id: 'demo', consent_required: true, capabilities: ['net', 'fs'],
+      allowed_modules: ['requests'], ...partial,
+    }));
+    await usePluginStore.getState().inspect('owner/demo');
+  }
+
+  it('sends the capabilities the manifest declared, never a blanket yes', async () => {
+    await ready();
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: true,
+    });
+
+    expect(api.installPlugin).toHaveBeenCalledWith({
+      inspection_id: 'insp-1',
+      accept_capabilities: ['net', 'fs'],
+      trust_author: true,
+    });
+    const body = api.installPlugin.mock.calls[0][0];
+    expect(Array.isArray(body.accept_capabilities)).toBe(true);
+    // Never sent unless a caller asks for it: the inspection's own mode is
+    // what makes an update an update.
+    expect(body.force).toBeUndefined();
+  });
+
+  it('omits what the user did not accept', async () => {
+    await ready();
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: false, trustAuthor: false,
+    });
+
+    expect(api.installPlugin).toHaveBeenCalledWith({ inspection_id: 'insp-1' });
+  });
+
+  it('sends force only when it is asked for', async () => {
+    await ready();
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: false, force: true,
+    });
+
+    expect(api.installPlugin.mock.calls[0][0].force).toBe(true);
+  });
+
+  it('seeds the job and starts following on a 202', async () => {
+    await ready();
+    api.getPluginJobEvents.mockImplementation(parked);
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: false,
+    });
+
+    expect(usePluginStore.getState().job).toMatchObject({
+      jobId: 'j1', pluginId: 'demo', kind: 'install', status: 'running', cursor: 0,
+    });
+    expect(api.getPluginJobEvents).toHaveBeenCalledWith(
+      'j1', expect.objectContaining({ cursor: 0 }),
+    );
+  });
+
+  it('keeps the review open when the consent was incomplete', async () => {
+    await ready();
+    api.installPlugin.mockRejectedValue(
+      refused(400, 'consent_required', { missing_capabilities: ['net'] }),
+    );
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: false, trustAuthor: false,
+    });
+
+    const state = usePluginStore.getState();
+    // The fix is a tick box on the card in front of the user, not a new
+    // inspection: the review stays, and grows a message.
+    expect(state.inspection).toMatchObject({
+      phase: 'ready', forPluginId: null, error: 'consent_required',
+    });
+    expect(state.job).toBeNull();
+  });
+
+  it('keeps the review open when the author was not trusted', async () => {
+    await ready();
+    api.installPlugin.mockRejectedValue(
+      refused(400, 'trust_author_required', { allowed_modules: ['requests'] }),
+    );
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: false,
+    });
+
+    expect(usePluginStore.getState().inspection).toMatchObject({
+      phase: 'ready', error: 'trust_author_required',
+    });
+  });
+
+  it('toasts and refreshes when the server is already busy', async () => {
+    await ready();
+    api.installPlugin.mockRejectedValue(refused(409, 'busy', { job_id: 'j2' }));
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: false,
+    });
+
+    expect(lastToast().message).toBe('Another install is already running.');
+    // Whatever the server IS running is more useful than the refusal.
+    expect(api.listPluginCatalog).toHaveBeenCalled();
+  });
+
+  it('says so when the server refuses a remote install', async () => {
+    await ready();
+    api.installPlugin.mockRejectedValue(new ApiError(403, 'Forbidden'));
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: false,
+    });
+
+    expect(lastToast().message).toBe(
+      'Installing is only allowed from the computer that runs the server.',
+    );
+    expect(lastToast().type).toBe('error');
+  });
+
+  it('reports anything else as a failed install', async () => {
+    await ready();
+    api.installPlugin.mockRejectedValue(new Error('Failed to fetch'));
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: false,
+    });
+
+    expect(lastToast().message).toBe('Install failed: Failed to fetch');
+  });
+
+  it('does nothing without a review to install', async () => {
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: false,
+    });
+
+    expect(api.installPlugin).not.toHaveBeenCalled();
+  });
+});
+
+// ── update ───────────────────────────────────────────────────────────────
+
+describe('pluginStore — update', () => {
+  beforeEach(async () => {
+    serveCatalog(catalog({
+      entries: [entry({ id: 'demo', name: 'Demo plugin', status: 'installed' })],
+    }));
+    await usePluginStore.getState().refresh();
+  });
+
+  it('says so when there was nothing to update', async () => {
+    api.updatePlugin.mockResolvedValue({ kind: 'up_to_date', sha: 'a'.repeat(40) });
+
+    await usePluginStore.getState().update('demo');
+
+    expect(lastToast().message).toBe('Demo plugin is up to date.');
+    expect(usePluginStore.getState().job).toBeNull();
+  });
+
+  it('opens the review when the new version asks for more', async () => {
+    api.updatePlugin.mockResolvedValue({
+      kind: 'needs_consent',
+      inspection: inspection({ plugin_id: 'demo', mode: 'update' }),
+      capabilities_added: ['net'],
+      allowed_modules_added: [],
+    });
+
+    await usePluginStore.getState().update('demo');
+
+    expect(usePluginStore.getState().inspection).toMatchObject({
+      phase: 'ready', forPluginId: 'demo', kind: 'update', source: 'demo',
+    });
+    expect(usePluginStore.getState().job).toBeNull();
+  });
+
+  it('follows the job an accepted update starts', async () => {
+    api.getPluginJobEvents.mockImplementation(parked);
+
+    await usePluginStore.getState().update('demo');
+
+    expect(usePluginStore.getState().job).toMatchObject({
+      jobId: 'j1', pluginId: 'demo', kind: 'update',
+    });
+    expect(usePluginStore.getState().byId.demo.status).toBe('installing');
+    expect(api.getPluginJobEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a refused update', async () => {
+    api.updatePlugin.mockRejectedValue(new ApiError(502, 'GitHub is down'));
+
+    await usePluginStore.getState().update('demo');
+
+    expect(lastToast().message).toBe('Update failed: GitHub is down');
+    expect(usePluginStore.getState().busy.demo).toBeFalsy();
+  });
+});
+
+// ── uninstall, enable, disable ───────────────────────────────────────────
+
+describe('pluginStore — uninstall', () => {
+  beforeEach(async () => {
+    serveCatalog(catalog({
+      entries: [entry({ id: 'demo', name: 'Demo plugin', status: 'installed' })],
+    }));
+    await usePluginStore.getState().refresh();
+    order.length = 0;
+  });
+
+  it('asks first, and does nothing when the answer is no', async () => {
+    confirmMock.mockResolvedValue(false);
+
+    await usePluginStore.getState().uninstall('demo');
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(api.uninstallPlugin).not.toHaveBeenCalled();
+  });
+
+  it('names the plugin in the question it asks', async () => {
+    await usePluginStore.getState().uninstall('demo');
+
+    expect(confirmMock.mock.calls[0][0]).toMatchObject({
+      message:
+        'Uninstall Demo plugin? Graphs that use its nodes will stop running. '
+        + 'Its Python packages stay installed.',
+      variant: 'danger',
+    });
+  });
+
+  it('removes it, then re-reads the catalog, the nodes and the frontends', async () => {
+    await usePluginStore.getState().uninstall('demo');
+
+    expect(api.uninstallPlugin).toHaveBeenCalledWith('demo');
+    expect(order).toEqual(['catalog', 'definitions', 'frontends']);
+    expect(lastToast().message).toBe('Demo plugin uninstalled.');
+    expect(lastToast().type).toBe('success');
+  });
+
+  it('carries the server hint when the files could not be deleted', async () => {
+    api.uninstallPlugin.mockRejectedValue(refused(409, 'files_locked', {
+      error: 'WinError 32', hint: 'Close the app that is holding the file.',
+    }));
+
+    await usePluginStore.getState().uninstall('demo');
+
+    expect(lastToast().message).toBe(
+      'Could not remove Demo plugin: Close the app that is holding the file.',
+    );
+    expect(lastToast().type).toBe('warning');
+  });
+
+  it('reports any other refusal against the plugin name', async () => {
+    api.uninstallPlugin.mockRejectedValue(new Error('Failed to fetch'));
+
+    await usePluginStore.getState().uninstall('demo');
+
+    expect(lastToast().message).toBe('Could not remove Demo plugin: Failed to fetch');
+    expect(usePluginStore.getState().busy.demo).toBeFalsy();
+  });
+});
+
+describe('pluginStore — setEnabled', () => {
+  beforeEach(async () => {
+    serveCatalog(catalog({
+      entries: [entry({ id: 'demo', name: 'Demo plugin', status: 'installed' })],
+    }));
+    await usePluginStore.getState().refresh();
+    order.length = 0;
+  });
+
+  it('enables, then re-reads everything the switch changed', async () => {
+    await usePluginStore.getState().setEnabled('demo', true);
+
+    expect(api.setPluginEnabled).toHaveBeenCalledWith('demo', true);
+    expect(order).toEqual(['catalog', 'definitions', 'frontends']);
+    expect(lastToast().message).toBe('Demo plugin enabled.');
+  });
+
+  it('disables the same way', async () => {
+    await usePluginStore.getState().setEnabled('demo', false);
+
+    expect(api.setPluginEnabled).toHaveBeenCalledWith('demo', false);
+    expect(order).toEqual(['catalog', 'definitions', 'frontends']);
+    expect(lastToast().message).toBe('Demo plugin disabled.');
+  });
+
+  it('reports a refused switch and clears the row', async () => {
+    api.setPluginEnabled.mockRejectedValue(new Error('nope'));
+
+    await usePluginStore.getState().setEnabled('demo', true);
+
+    expect(lastToast().message).toBe('Could not change Demo plugin: nope');
+    expect(usePluginStore.getState().busy.demo).toBeFalsy();
+  });
+
+  it('survives a step of the refresh failing, and still runs the rest', async () => {
+    reloadMock.mockRejectedValue(new Error('bundle gone'));
+
+    await usePluginStore.getState().setEnabled('demo', true);
+
+    // The definitions were still fetched, and the failure was reported.
+    expect(order).toEqual(['catalog', 'definitions']);
+    expect(useToastStore.getState().toasts.map((toast) => toast.message)).toContain(
+      'Install failed: bundle gone',
+    );
+  });
+});
+
+// ── the follower and its endings ─────────────────────────────────────────
+
+describe('pluginStore — the follower', () => {
+  /**
+   * Timers are faked throughout: the loop's only real waits are its idle and
+   * retry sleeps, and asserting "it did NOT poll again" by sleeping 10 ms of
+   * wall clock proves nothing when the next turn was 500 ms away regardless.
+   */
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  /** Let queued microtasks (a resolved fetch, a `set`) run to completion. */
+  const settle = () => vi.advanceTimersByTimeAsync(0);
+
+  /** Follow a job whose pages end in *pages*. */
+  function follow(kind: 'install' | 'update' = 'install'): void {
+    usePluginStore.getState().followJob('j1', 'demo', kind, 0);
+  }
+
+  it('folds pages into the job and settles it once', async () => {
+    api.getPluginJobEvents
+      .mockResolvedValueOnce(eventsPage({
+        cursor: 2,
+        events: [
+          { type: 'step_started', cursor: 1, ts: 't', step: 'download', label: 'Downloading' },
+          { type: 'log', cursor: 2, ts: 't', line: 'unpacking' },
+        ],
+      }))
+      .mockResolvedValue(eventsPage({
+        status: 'done', cursor: 3, events: [{ type: 'job_done', cursor: 3, ts: 't' }],
+      }));
+
+    follow();
+    await settle();
+
+    const job = usePluginStore.getState().job!;
+    expect(job.status).toBe('done');
+    expect(job.cursor).toBe(3);
+    expect(job.steps).toEqual([
+      { step: 'download', label: 'Downloading', state: 'done' },
+    ]);
+    expect(job.log.map((line) => line.text)).toEqual([
+      'Downloading', 'unpacking', 'done',
+    ]);
+  });
+
+  it('runs the catalog, the nodes and the frontends in that order when one lands', async () => {
+    api.getPluginJobEvents.mockResolvedValue(eventsPage({ status: 'done', cursor: 0 }));
+
+    follow();
+    await settle();
+
+    expect(order).toEqual(['catalog', 'definitions', 'frontends']);
+    expect(lastToast().message).toBe('demo installed.');
+    expect(lastToast().type).toBe('success');
+  });
+
+  it('says updated for an update job', async () => {
+    api.getPluginJobEvents.mockResolvedValue(eventsPage({ status: 'done', cursor: 0 }));
+
+    follow('update');
+    await settle();
+
+    expect(lastToast().message).toBe('demo updated.');
+  });
+
+  it('reports a failure with the message the job carried', async () => {
+    api.getPluginJobEvents.mockResolvedValue(eventsPage({
+      status: 'failed',
+      cursor: 1,
+      events: [{
+        type: 'job_failed', cursor: 1, ts: 't', message: 'pip exited 1', hint: null,
+      }],
+    }));
+
+    follow();
+    await settle();
+
+    expect(lastToast().message).toBe('Install failed: pip exited 1');
+    expect(lastToast().type).toBe('error');
+    // Nothing landed, so only the catalog is stale.
+    expect(order).toEqual(['catalog']);
+  });
+
+  it('puts an Open Plugin Center button on the failure, pointed at the row', async () => {
+    api.getPluginJobEvents.mockResolvedValue(eventsPage({ status: 'failed', cursor: 0 }));
+
+    follow();
+    await settle();
+
+    expect(lastToast().action!.label).toBe('Open Plugin Center');
+    lastToast().action!.onClick();
+    expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+    expect(useUIStore.getState().pluginCenterFocusPluginId).toBe('demo');
+  });
+
+  it('reports a cancelled job', async () => {
+    api.getPluginJobEvents.mockResolvedValue(eventsPage({ status: 'cancelled', cursor: 0 }));
+
+    follow();
+    await settle();
+
+    expect(lastToast().message).toBe('Install cancelled.');
+    expect(order).toEqual(['catalog']);
+  });
+
+  it('keeps a needs_restart job on screen and says what to do', async () => {
+    api.getPluginJobEvents.mockResolvedValue(eventsPage({
+      status: 'needs_restart',
+      cursor: 1,
+      events: [{
+        type: 'needs_restart', cursor: 1, ts: 't', command: 'cdui start',
+      }],
+    }));
+
+    follow();
+    await settle();
+
+    expect(lastToast().message).toBe('Restart the server to load demo.');
+    expect(lastToast().type).toBe('warning');
+    const job = usePluginStore.getState().job!;
+    expect(job.status).toBe('needs_restart');
+    expect(job.restartCommand).toBe('cdui start');
+  });
+
+  it('settles a job exactly once, however often it is adopted', async () => {
+    api.getPluginJobEvents.mockResolvedValue(eventsPage({ status: 'done', cursor: 0 }));
+
+    follow();
+    await settle();
+    follow();
+    await settle();
+
+    expect(
+      useToastStore.getState().toasts.filter((t) => t.message === 'demo installed.'),
+    ).toHaveLength(1);
+  });
+
+  it('marks the job lost after the retries run out', async () => {
+    api.getPluginJobEvents.mockRejectedValue(new Error('Failed to fetch'));
+
+    follow();
+    await settle();
+    await vi.advanceTimersByTimeAsync(2000 * 5);
+
+    // No restart handshake to read into the silence: `lost` is the honest
+    // answer, and nothing is toasted about it.
+    expect(usePluginStore.getState().job!.status).toBe('lost');
+    expect(useToastStore.getState().toasts).toEqual([]);
+  });
+
+  it('stops following on request', async () => {
+    api.getPluginJobEvents.mockImplementation(parked);
+
+    follow();
+    await settle();
+    usePluginStore.getState().stopFollowing();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(api.getPluginJobEvents).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── cancel and dismiss ───────────────────────────────────────────────────
+
+describe('pluginStore — cancel and dismiss', () => {
+  it('asks the server to cancel the open job', async () => {
+    usePluginStore.setState({ job: emptyPluginJob('j5', 'demo') });
+
+    await usePluginStore.getState().cancel();
+
+    expect(api.cancelPluginJob).toHaveBeenCalledWith('j5');
+    // Cooperative: the FOLLOWER records the outcome, not this call.
+    expect(usePluginStore.getState().job!.status).toBe('running');
+    expect(usePluginStore.getState().cancelling).toBe(false);
+  });
+
+  it('reports a cancel that did not go through', async () => {
+    usePluginStore.setState({ job: emptyPluginJob('j5', 'demo') });
+    api.cancelPluginJob.mockRejectedValue(new Error('gone'));
+
+    await usePluginStore.getState().cancel();
+
+    expect(lastToast().message).toBe('Could not cancel the install: gone');
+    expect(usePluginStore.getState().cancelling).toBe(false);
+  });
+
+  it('has nothing to cancel when no job is running', async () => {
+    await usePluginStore.getState().cancel();
+    usePluginStore.setState({
+      job: { ...emptyPluginJob('j5', 'demo'), status: 'done' },
+    });
+    await usePluginStore.getState().cancel();
+
+    expect(api.cancelPluginJob).not.toHaveBeenCalled();
+  });
+
+  it('refuses to dismiss a job that is still running', () => {
+    usePluginStore.setState({ job: emptyPluginJob('j5', 'demo') });
+
+    usePluginStore.getState().dismissJob();
+    expect(usePluginStore.getState().job).not.toBeNull();
+
+    usePluginStore.setState({
+      job: { ...emptyPluginJob('j5', 'demo'), status: 'failed' },
+    });
+    usePluginStore.getState().dismissJob();
+    expect(usePluginStore.getState().job).toBeNull();
+  });
+});
+
+// ── the boot read ────────────────────────────────────────────────────────
+
+describe('pluginStore — checkInProgress', () => {
+  it('adopts a job that outlived the page, and says so', async () => {
+    serveCatalog(catalog({
+      entries: [entry({ id: 'demo', name: 'Demo plugin' })],
+      active_job: { job_id: 'j9', plugin_id: 'demo', kind: 'install' },
+    }));
+    api.getPluginJobEvents.mockImplementation(parked);
+
+    await usePluginStore.getState().checkInProgress();
+
+    expect(lastToast().message).toBe(
+      'A plugin is still installing. Open the Plugin Center to watch it.',
+    );
+    expect(lastToast().action!.label).toBe('Open Plugin Center');
+    expect(usePluginStore.getState().job!.jobId).toBe('j9');
+  });
+
+  it('says nothing when there was no job to adopt', async () => {
+    await usePluginStore.getState().checkInProgress();
+
+    expect(useToastStore.getState().toasts).toEqual([]);
+    expect(usePluginStore.getState().loaded).toBe(true);
+  });
+
+  it('reads the catalog once per page load', async () => {
+    await usePluginStore.getState().checkInProgress();
+    await usePluginStore.getState().checkInProgress();
+
+    expect(api.listPluginCatalog).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a later mount try again when nothing answered', async () => {
+    api.listPluginCatalog.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+    await usePluginStore.getState().checkInProgress();
+    expect(usePluginStore.getState().loaded).toBe(false);
+
+    await usePluginStore.getState().checkInProgress();
+    expect(api.listPluginCatalog).toHaveBeenCalledTimes(2);
+    expect(usePluginStore.getState().loaded).toBe(true);
+  });
+
+  it('stays quiet on a server without the route', async () => {
+    api.listPluginCatalog.mockRejectedValue(new ApiError(404, 'Not Found'));
+
+    await usePluginStore.getState().checkInProgress();
+
+    expect(useToastStore.getState().toasts).toEqual([]);
+    expect(usePluginStore.getState().unsupported).toBe(true);
+  });
+});
+
+// ── the test hatch ───────────────────────────────────────────────────────
+
+describe('_resetPluginStoreForTesting', () => {
+  it('puts the store and its schedulers back to boot state', async () => {
+    api.getPluginJobEvents.mockImplementation(parked);
+    serveCatalog(catalog({
+      entries: [entry({ id: 'demo' })], generation: 4,
+    }));
+    await usePluginStore.getState().checkInProgress();
+    usePluginStore.getState().followJob('j1', 'demo');
+    usePluginStore.setState({ busy: { demo: true }, cancelling: true });
+
+    _resetPluginStoreForTesting();
+
+    expect(usePluginStore.getState()).toMatchObject({
+      plugins: [], byId: {}, loaded: false, unsupported: false, error: null,
+      generation: 0, job: null, busy: {}, cancelling: false,
+      inspection: { phase: 'idle' },
+    });
+    // The once-per-page guard is released too, or every case after the first
+    // would silently skip its boot read.
+    await usePluginStore.getState().checkInProgress();
+    expect(api.listPluginCatalog).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -1159,6 +1159,23 @@ describe('pluginStore — checkInProgress', () => {
     expect(usePluginStore.getState().job!.jobId).toBe('j9');
   });
 
+  it('opens the center unfocused when the adopted job names no plugin', async () => {
+    // A job adopted from another tab can settle before any catalog read has
+    // said whose it was. Scrolling the panel to a row called '' is worse
+    // than not scrolling at all, so the empty id has to reach
+    // `openPluginCenter` as undefined.
+    serveCatalog(catalog({
+      active_job: { job_id: 'j9', plugin_id: '', kind: 'install' },
+    }));
+    api.getPluginJobEvents.mockImplementation(parked);
+
+    await usePluginStore.getState().checkInProgress();
+    lastToast().action!.onClick();
+
+    expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+    expect(useUIStore.getState().pluginCenterFocusPluginId).toBeNull();
+  });
+
   it('says nothing when there was no job to adopt', async () => {
     await usePluginStore.getState().checkInProgress();
 

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -534,6 +534,20 @@ describe('pluginStore — inspect', () => {
     expect(state.inspection.failure.detail).toEqual({ code: 'reserved_id', id: 'edu' });
   });
 
+  it('says why a remote inspect was refused instead of showing Forbidden', async () => {
+    // The source box is where a LAN user first meets the gate, and the
+    // status text alone ("Forbidden") says nothing about where to install.
+    api.inspectPluginSource.mockRejectedValue(new ApiError(403, 'Forbidden'));
+
+    await usePluginStore.getState().inspect('owner/demo');
+
+    const state = usePluginStore.getState();
+    if (state.inspection.phase !== 'error') throw new Error('not an error phase');
+    expect(state.inspection.failure.message).toBe(
+      'Installing is only allowed from the computer that runs the server.',
+    );
+  });
+
   it('carries the names a catalog miss listed', async () => {
     // The hint the source box shows is `known`, and it only exists in the
     // body: the message is the bare code.
@@ -820,6 +834,19 @@ describe('pluginStore — uninstall', () => {
       'Could not remove Demo plugin: Close the app that is holding the file.',
     );
     expect(lastToast().type).toBe('warning');
+  });
+
+  it('says so when the server refuses a remote uninstall', async () => {
+    // The same gate as an install. Wrapped in "Could not remove Demo
+    // plugin", `Forbidden` tells a LAN user nothing about where to do it.
+    api.uninstallPlugin.mockRejectedValue(new ApiError(403, 'Forbidden'));
+
+    await usePluginStore.getState().uninstall('demo');
+
+    expect(lastToast().message).toBe(
+      'Installing is only allowed from the computer that runs the server.',
+    );
+    expect(lastToast().type).toBe('error');
   });
 
   it('reports any other refusal against the plugin name', async () => {

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -518,19 +518,22 @@ describe('pluginStore — inspect', () => {
   });
 
   it('keeps the code and the body a refused inspection carried', async () => {
-    // `{code: reserved_id, id: edu}` has no message at all: reduced to a
-    // string the card would show the raw token and could not name the id
-    // that is already taken.
-    api.inspectPluginSource.mockRejectedValue(
-      refused(400, 'reserved_id', { id: 'edu' }),
-    );
+    // Built by hand rather than through `refused`, whose message IS the
+    // code: the message and the code have to be told apart here, because
+    // the card switches on one and shows the other.
+    api.inspectPluginSource.mockRejectedValue(new ApiError(
+      400, 'that id is reserved', { detail: { code: 'reserved_id', id: 'edu' } },
+    ));
 
     await usePluginStore.getState().inspect('edu');
 
     const state = usePluginStore.getState();
     expect(state.inspection.phase).toBe('error');
     if (state.inspection.phase !== 'error') throw new Error('not an error phase');
+    expect(state.inspection.failure.message).toBe('that id is reserved');
     expect(state.inspection.failure.code).toBe('reserved_id');
+    // The id that is taken: nothing else carries it, and the card cannot
+    // name it without this.
     expect(state.inspection.failure.detail).toEqual({ code: 'reserved_id', id: 'edu' });
   });
 

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -257,8 +257,25 @@ describe('parseGitHubSource', () => {
     expect(parseGitHubSource('  c1  ')).toEqual({ kind: 'catalog', id: 'c1' });
   });
 
+  it('takes every catalog name the CLI takes, lower-cased', () => {
+    // The class is the CLI's (`scripts/plugins.py: _BARE_NAME`) because
+    // refusing here means refusing WITHOUT asking the server: `EDU` and `C1`
+    // are real packs, and an underscore is a legal name. The server looks
+    // them up in lower case, so the parse says what it will resolve to.
+    for (const [typed, id] of [
+      ['EDU', 'edu'],
+      ['C1', 'c1'],
+      ['Foundations', 'foundations'],
+      ['my_plugin', 'my_plugin'],
+    ] as const) {
+      expect(parseGitHubSource(typed), typed).toEqual({ kind: 'catalog', id });
+    }
+  });
+
   it('refuses anything that is neither', () => {
-    for (const bad of ['', '   ', 'Not A Source', 'https://gitlab.com/o/r', 'owner/']) {
+    for (const bad of [
+      '', '   ', 'Not A Source', 'https://gitlab.com/o/r', 'owner/', 'o/r/extra',
+    ]) {
       expect(parseGitHubSource(bad), bad).toBeNull();
     }
   });
@@ -454,7 +471,7 @@ describe('pluginStore — inspect', () => {
     expect(usePluginStore.getState().inspection).toEqual({
       phase: 'error',
       source: 'not a source!',
-      message: 'Enter owner/repo[@ref] or a GitHub URL.',
+      message: 'Enter a catalog name, owner/repo[@ref] or a GitHub URL.',
     });
   });
 
@@ -794,11 +811,33 @@ describe('pluginStore — setEnabled', () => {
 
     await usePluginStore.getState().setEnabled('demo', true);
 
-    // The definitions were still fetched, and the failure was reported.
+    // The definitions were still fetched, and the failure was reported — as a
+    // failed REFRESH. "Install failed" beside "demo enabled." would describe
+    // something that did not happen.
     expect(order).toEqual(['catalog', 'definitions']);
     expect(useToastStore.getState().toasts.map((toast) => toast.message)).toContain(
-      'Install failed: bundle gone',
+      'Could not refresh the editor after the change: bundle gone',
     );
+  });
+
+  it('runs the steps after one that threw, not just the ones before it', async () => {
+    // The middle step, so this can only pass if each step is guarded on its
+    // own: a single try around the three would lose the frontends here.
+    useNodeDefStore.setState({
+      fetchDefinitions: vi.fn(async () => {
+        order.push('definitions');
+        throw new Error('definitions gone');
+      }),
+    });
+
+    await usePluginStore.getState().setEnabled('demo', true);
+
+    expect(order).toEqual(['catalog', 'definitions', 'frontends']);
+    expect(useToastStore.getState().toasts.map((toast) => toast.message)).toContain(
+      'Could not refresh the editor after the change: definitions gone',
+    );
+    // And the change itself is still reported as the success it was.
+    expect(lastToast().message).toBe('Demo plugin enabled.');
   });
 });
 

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -433,7 +433,14 @@ describe('pluginStore — install', () => {
     // Ticking a box IS the fix here, so the card the user never asked for is
     // exactly what they now need.
     expect(usePluginStore.getState().inspection).toMatchObject({
-      phase: 'ready', forPluginId: 'c1', error: 'consent_required',
+      phase: 'ready',
+      forPluginId: 'c1',
+      error: {
+        code: 'consent_required',
+        // Which box is unticked: the card cannot ask for the right one
+        // without the list the refusal named.
+        detail: { missing_capabilities: ['net'] },
+      },
     });
   });
 
@@ -471,7 +478,13 @@ describe('pluginStore — inspect', () => {
     expect(usePluginStore.getState().inspection).toEqual({
       phase: 'error',
       source: 'not a source!',
-      message: 'Enter a catalog name, owner/repo[@ref] or a GitHub URL.',
+      // Nothing was refused, so there is no code to carry: this build knows
+      // on its own that the shape is not one the server could resolve.
+      failure: {
+        message: 'Enter a catalog name, owner/repo[@ref] or a GitHub URL.',
+        code: null,
+        detail: null,
+      },
     });
   });
 
@@ -494,8 +507,45 @@ describe('pluginStore — inspect', () => {
     await usePluginStore.getState().inspect('owner/demo');
 
     expect(usePluginStore.getState().inspection).toEqual({
-      phase: 'error', source: 'owner/demo', message: 'unparseable_source',
+      phase: 'error',
+      source: 'owner/demo',
+      failure: {
+        message: 'unparseable_source',
+        code: 'unparseable_source',
+        detail: { code: 'unparseable_source' },
+      },
     });
+  });
+
+  it('keeps the code and the body a refused inspection carried', async () => {
+    // `{code: reserved_id, id: edu}` has no message at all: reduced to a
+    // string the card would show the raw token and could not name the id
+    // that is already taken.
+    api.inspectPluginSource.mockRejectedValue(
+      refused(400, 'reserved_id', { id: 'edu' }),
+    );
+
+    await usePluginStore.getState().inspect('edu');
+
+    const state = usePluginStore.getState();
+    expect(state.inspection.phase).toBe('error');
+    if (state.inspection.phase !== 'error') throw new Error('not an error phase');
+    expect(state.inspection.failure.code).toBe('reserved_id');
+    expect(state.inspection.failure.detail).toEqual({ code: 'reserved_id', id: 'edu' });
+  });
+
+  it('carries the names a catalog miss listed', async () => {
+    // The hint the source box shows is `known`, and it only exists in the
+    // body: the message is the bare code.
+    api.inspectPluginSource.mockRejectedValue(
+      refused(400, 'unknown_catalog_name', { known: ['c1', 'c2'] }),
+    );
+
+    await usePluginStore.getState().inspect('c9');
+
+    const state = usePluginStore.getState();
+    if (state.inspection.phase !== 'error') throw new Error('not an error phase');
+    expect(state.inspection.failure.detail).toMatchObject({ known: ['c1', 'c2'] });
   });
 
   it('clears the review on request', async () => {
@@ -583,9 +633,15 @@ describe('pluginStore — installInspected', () => {
 
     const state = usePluginStore.getState();
     // The fix is a tick box on the card in front of the user, not a new
-    // inspection: the review stays, and grows a message.
+    // inspection: the review stays, and grows a failure.
     expect(state.inspection).toMatchObject({
-      phase: 'ready', forPluginId: null, error: 'consent_required',
+      phase: 'ready', forPluginId: null, error: { code: 'consent_required' },
+    });
+    // WHICH box: the capabilities the server said were missing, not just the
+    // fact that some were.
+    if (state.inspection.phase !== 'ready') throw new Error('not a ready review');
+    expect(state.inspection.error?.detail).toMatchObject({
+      missing_capabilities: ['net'],
     });
     expect(state.job).toBeNull();
   });
@@ -601,7 +657,11 @@ describe('pluginStore — installInspected', () => {
     });
 
     expect(usePluginStore.getState().inspection).toMatchObject({
-      phase: 'ready', error: 'trust_author_required',
+      phase: 'ready',
+      error: {
+        code: 'trust_author_required',
+        detail: { allowed_modules: ['requests'] },
+      },
     });
   });
 

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -1173,7 +1173,9 @@ describe('pluginStore — checkInProgress', () => {
     api.getPluginJobEvents.mockImplementation(parked);
 
     await usePluginStore.getState().checkInProgress();
-    lastToast().action!.onClick();
+    const openCenter = lastToast().action;
+    expect(openCenter).toBeDefined();
+    openCenter?.onClick();
 
     expect(useUIStore.getState().pluginCenterOpen).toBe(true);
     expect(useUIStore.getState().pluginCenterFocusPluginId).toBeNull();

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -389,6 +389,37 @@ describe('pluginStore — install', () => {
     expect(usePluginStore.getState().plugins[0].status).toBe('installing');
   });
 
+  it('leaves no review behind when an auto-install is refused', async () => {
+    api.inspectPluginSource.mockResolvedValue(inspection({
+      plugin_id: 'c1', consent_required: false,
+    }));
+    api.installPlugin.mockRejectedValue(refused(409, 'busy', { job_id: 'j2' }));
+
+    await usePluginStore.getState().install('c1');
+
+    // The user never saw a review; answering the failure toast with a form
+    // they did not ask for is not the fix for "another install is running".
+    expect(usePluginStore.getState().inspection).toEqual({ phase: 'idle' });
+    expect(lastToast().message).toBe('Another install is already running.');
+  });
+
+  it('keeps the review when an auto-install turns out to need consent', async () => {
+    api.inspectPluginSource.mockResolvedValue(inspection({
+      plugin_id: 'c1', consent_required: false, capabilities: ['net'],
+    }));
+    api.installPlugin.mockRejectedValue(
+      refused(400, 'consent_required', { missing_capabilities: ['net'] }),
+    );
+
+    await usePluginStore.getState().install('c1');
+
+    // Ticking a box IS the fix here, so the card the user never asked for is
+    // exactly what they now need.
+    expect(usePluginStore.getState().inspection).toMatchObject({
+      phase: 'ready', forPluginId: 'c1', error: 'consent_required',
+    });
+  });
+
   it('refuses a second install while a job is running', async () => {
     usePluginStore.setState({ job: emptyPluginJob('j1', 'other') });
 

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -63,6 +63,27 @@ export type PluginSourceRef =
   | { kind: 'catalog'; id: string };
 
 /**
+ * Why an inspection or an install was refused, in the three parts a review
+ * card needs.
+ *
+ * Not a string, because the backend's 400 bodies carry no message at all --
+ * `{code: reserved_id, id}`, `{code: unknown_catalog_name, known}`,
+ * `{code: consent_required, missing_capabilities}`, `{code:
+ * trust_author_required, allowed_modules}`. Reduced to `err.message` those
+ * become the raw token `consent_required` on screen, and the keys that say
+ * WHICH id is taken, which names exist, or which box is still unticked are
+ * gone by the time the card is rendered.
+ *
+ * `message` is what to show when nothing better is known, `code` is what a
+ * card switches on, and `detail` is the rest of that body.
+ */
+export interface InspectionFailure {
+  message: string;
+  code: string | null;
+  detail: Record<string, unknown> | null;
+}
+
+/**
  * The install review, as a little state machine.
  *
  * An inspection is not an install: it reads the manifest at a source and
@@ -86,9 +107,9 @@ export type InspectionState =
        * is a tick box on the card in front of the user rather than a new
        * inspection.
        */
-      error: string | null;
+      error: InspectionFailure | null;
     }
-  | { phase: 'error'; source: string; message: string };
+  | { phase: 'error'; source: string; failure: InspectionFailure };
 
 interface PluginState {
   plugins: PluginCatalogEntry[];
@@ -238,6 +259,25 @@ function openCenterAction(pluginId: string): ToastAction {
  */
 function refusalCode(err: unknown): string | null {
   return str(errorDetail(err)?.code);
+}
+
+/**
+ * Everything a thrown refusal carried, in the shape the review card reads.
+ *
+ * One builder rather than a shape assembled at each catch, so no caller can
+ * be the one that keeps only the message -- which is the state this replaces.
+ */
+function inspectionFailure(err: unknown): InspectionFailure {
+  return {
+    // 403 is the one status whose own message says nothing a user can act
+    // on ("Forbidden"): it is the server refusing to install from anywhere
+    // but the machine it runs on, which only this key explains.
+    message: err instanceof ApiError && err.status === 403
+      ? useI18n.getState().t('packs.remoteDisabled')
+      : errorMessage(err),
+    code: refusalCode(err),
+    detail: errorDetail(err),
+  };
 }
 
 /** A plugin's display name for a toast, falling back to its id. */
@@ -494,7 +534,13 @@ async function runInspect(
     // of on its own.
     usePluginStore.setState({
       inspection: {
-        phase: 'error', source: spec, message: t('pluginCenter.source.invalid'),
+        phase: 'error',
+        source: spec,
+        // No code: nothing was refused, this build simply knows the shape is
+        // not one the server could resolve.
+        failure: {
+          message: t('pluginCenter.source.invalid'), code: null, detail: null,
+        },
       },
     });
     return null;
@@ -511,7 +557,7 @@ async function runInspect(
     return data;
   } catch (err) {
     usePluginStore.setState({
-      inspection: { phase: 'error', source: spec, message: errorMessage(err) },
+      inspection: { phase: 'error', source: spec, failure: inspectionFailure(err) },
     });
     return null;
   }
@@ -553,11 +599,12 @@ async function startInstall(
     const code = refusalCode(err);
     if (code === 'consent_required' || code === 'trust_author_required') {
       // Recoverable, and recoverable on the card the user is already looking
-      // at: the inspection stays ready and grows a message, so the review can
-      // say which box is still unticked instead of starting over.
+      // at: the inspection stays ready and grows a failure, so the review can
+      // say which box is still unticked -- the refusal names the capabilities
+      // or the modules -- instead of starting over.
       usePluginStore.setState((state) => (
         state.inspection.phase === 'ready'
-          ? { inspection: { ...state.inspection, error: errorMessage(err) } }
+          ? { inspection: { ...state.inspection, error: inspectionFailure(err) } }
           : {}
       ));
     } else if (err instanceof ApiError && err.status === 409) {

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -1,0 +1,921 @@
+import { create } from 'zustand';
+import {
+  ApiError,
+  cancelPluginJob,
+  getPluginJobEvents,
+  inspectPluginSource,
+  installPlugin,
+  listPluginCatalog,
+  setPluginEnabled,
+  uninstallPlugin,
+  updatePlugin,
+  type JobStatus,
+  type PluginCatalog,
+  type PluginCatalogEntry,
+  type PluginInspection,
+  type PluginJobKind,
+} from '../api/rest';
+import { createJobFollower, emptyJob, type Job } from './jobFollower';
+import { confirm } from '../utils/dialog';
+import { reloadPluginFrontends } from '../plugins/PluginHost';
+import { useNodeDefStore } from './nodeDefStore';
+import { useToastStore, type ToastAction } from './toastStore';
+import { useUIStore } from './uiStore';
+import { useI18n } from '../i18n';
+
+/**
+ * App-level state for the Plugin Center.
+ *
+ * The same shape as `packStore`, and for the same reason: an install is a
+ * download, an unpack and a pip resolve that outlives the modal it was
+ * started from. The panel is a pure view of this store, so closing it, opening
+ * a second tab or reloading the page all leave the job running and pick it
+ * back up.
+ *
+ * ── What is different from a pack ──────────────────────────────────────
+ * A plugin install changes what the SERVER can do while it is still running:
+ * new node types, new frontend bundles, a changed registry generation. So
+ * every settled change ends in the same three steps -- the catalog, the node
+ * definitions, the plugin frontends -- rather than in a restart handshake.
+ * Nothing here swaps a wheel out from under the interpreter, which is why
+ * this store has no restart mode and its follower declines to read anything
+ * into an endpoint going quiet.
+ */
+
+/** A plugin install or update job: the generic job plus whose it is. */
+export interface PluginJob extends Job {
+  pluginId: string;
+  /** Decides which toast the ending gets: installed, or updated. */
+  kind: PluginJobKind;
+}
+
+export type { PluginJobKind };
+
+/**
+ * What `parseGitHubSource` made of what the user typed.
+ *
+ * `catalog` is a bare word, which can only have been meant as one of the
+ * built-in packs; the server is what decides whether that name exists.
+ */
+export type PluginSourceRef =
+  | { kind: 'github'; owner: string; repo: string; ref: string | null }
+  | { kind: 'catalog'; id: string };
+
+/**
+ * The install review, as a little state machine.
+ *
+ * An inspection is not an install: it reads the manifest at a source and
+ * reports what installing it WOULD cost, so the user consents to the exact
+ * version that was read. `forPluginId` is the catalog row the review was
+ * started from -- null when the user typed a source by hand, which is what
+ * lets the panel show the review beside that row or in the source box.
+ */
+export type InspectionState =
+  | { phase: 'idle' }
+  | { phase: 'inspecting'; source: string }
+  | {
+      phase: 'ready';
+      data: PluginInspection;
+      source: string;
+      forPluginId: string | null;
+      kind: PluginJobKind;
+      /**
+       * A refusal the review can still recover from: the server said the
+       * consent was incomplete. The inspection STAYS ready, because the fix
+       * is a tick box on the card in front of the user rather than a new
+       * inspection.
+       */
+      error: string | null;
+    }
+  | { phase: 'error'; source: string; message: string };
+
+interface PluginState {
+  plugins: PluginCatalogEntry[];
+  /** The same rows keyed by id, for the O(1) lookups a toast or a card does. */
+  byId: Record<string, PluginCatalogEntry>;
+  loading: boolean;
+  /** A first answer arrived — a catalog or a 404. A network error is neither. */
+  loaded: boolean;
+  /** The server predates the Plugin Center: the panel says so and stops. */
+  unsupported: boolean;
+  error: string | null;
+  remoteInstallAllowed: boolean;
+  /** The node registry's reload counter, as of the last catalog read. */
+  generation: number;
+  job: PluginJob | null;
+  /** Plugin ids with a request in flight — disables that row's buttons. */
+  busy: Record<string, boolean>;
+  cancelling: boolean;
+  inspection: InspectionState;
+
+  refresh: () => Promise<void>;
+  /** Inspect *pluginId* and install it straight away if nothing needs consent. */
+  install: (pluginId: string) => Promise<void>;
+  /** Inspect whatever the user typed: a catalog name, owner/repo, or a URL. */
+  inspect: (source: string) => Promise<void>;
+  installInspected: (opts: {
+    acceptCapabilities: boolean;
+    trustAuthor: boolean;
+    /**
+     * Reinstall over what is already there. Never needed for an update (the
+     * inspection's own `mode` carries that) and never sent unless a caller
+     * asks, so nothing here can overwrite an install by accident.
+     */
+    force?: boolean;
+  }) => Promise<void>;
+  clearInspection: () => void;
+  update: (pluginId: string) => Promise<void>;
+  uninstall: (pluginId: string) => Promise<void>;
+  setEnabled: (pluginId: string, enabled: boolean) => Promise<void>;
+  cancel: () => Promise<void>;
+  /** Adopt *jobId* and start (or keep) following it. Idempotent per job id. */
+  followJob: (
+    jobId: string, pluginId: string, kind?: PluginJobKind, cursor?: number,
+  ) => void;
+  stopFollowing: () => void;
+  /** Clear a finished job from the activity pane. Ignored while running. */
+  dismissJob: () => void;
+  /** Once per page load: adopt a job that outlived the last page. */
+  checkInProgress: () => Promise<void>;
+}
+
+/** A job with nothing in it yet — what an adopted or just-started job starts as. */
+export function emptyPluginJob(
+  jobId: string,
+  pluginId: string,
+  kind: PluginJobKind = 'install',
+): PluginJob {
+  return { ...emptyJob(jobId), pluginId, kind };
+}
+
+// ── source parsing ───────────────────────────────────────────────────────
+
+// The CLI's three forms, mirrored (`scripts/plugins.py: parse_source`): the
+// point is to refuse an unparseable source without a round trip, not to
+// resolve it -- the SERVER decides what a name or a repo actually is.
+const GITHUB_URL =
+  /^https?:\/\/(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?(?:@(.+))?$/;
+const GITHUB_SHORT = /^([\w.-]+)\/([\w.-]+?)(?:@([\w./-]+))?$/;
+/** One word, no slash and no scheme: it can only be a catalog name. */
+const CATALOG_NAME = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Read a plugin source the way the CLI reads one, or answer null.
+ *
+ * Exported because the panel wants it too: a source box that can say "that is
+ * not a repo" as you type is the difference between one wrong keystroke and a
+ * round trip that ends in a 400.
+ */
+export function parseGitHubSource(input: string): PluginSourceRef | null {
+  const spec = input.trim();
+
+  const url = GITHUB_URL.exec(spec);
+  if (url !== null) {
+    return { kind: 'github', owner: url[1], repo: url[2], ref: url[3] ?? null };
+  }
+  const short = GITHUB_SHORT.exec(spec);
+  if (short !== null) {
+    return { kind: 'github', owner: short[1], repo: short[2], ref: short[3] ?? null };
+  }
+  if (CATALOG_NAME.test(spec)) return { kind: 'catalog', id: spec };
+  return null;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+/**
+ * `action` is spread rather than always passed, so a toast without one is
+ * byte-for-byte the object every other caller produces.
+ */
+function toast(
+  message: string,
+  type: 'info' | 'error' | 'success' | 'warning',
+  action?: ToastAction,
+) {
+  useToastStore.getState().addToast(message, type, action ? { action } : undefined);
+}
+
+/**
+ * The button a toast about a plugin wears: it opens the panel on that plugin.
+ *
+ * An empty id opens the panel with no focus rather than scrolling to a row
+ * called "": a job adopted from another tab can settle before any catalog
+ * read has said whose it was.
+ */
+function openCenterAction(pluginId: string): ToastAction {
+  const { t } = useI18n.getState();
+  return {
+    label: t('pluginCenter.toast.openCenter'),
+    onClick: () => useUIStore.getState().openPluginCenter(pluginId || undefined),
+  };
+}
+
+/**
+ * The coded object out of a refusal, wherever the server put it.
+ *
+ * FastAPI nests it under `detail`; a plain `{code: ...}` body (or a proxy that
+ * unwrapped the detail) is the same information one level up. Reading only one
+ * of the two would silently lose the code that decides which toast this is.
+ */
+function refusal(err: unknown): Record<string, unknown> | null {
+  if (!(err instanceof ApiError) || err.body === null) return null;
+  const detail = err.body.detail;
+  if (detail !== null && typeof detail === 'object') {
+    return detail as Record<string, unknown>;
+  }
+  return err.body;
+}
+
+function refusalCode(err: unknown): string | null {
+  return str(refusal(err)?.code);
+}
+
+/** A plugin's display name for a toast, falling back to its id. */
+function pluginName(pluginId: string): string {
+  return usePluginStore.getState().byId[pluginId]?.name || pluginId;
+}
+
+/** Only `running` is live; everything else — `lost` included — is an ending. */
+function isRunning(job: PluginJob | null): boolean {
+  return job !== null && job.status === 'running';
+}
+
+/**
+ * A job kind off the wire, narrowed. Anything a newer backend invents reads
+ * as an install, which is the ending that says "installed" rather than one
+ * this build has no toast for.
+ */
+function jobKind(value: unknown): PluginJobKind {
+  return value === 'update' ? 'update' : 'install';
+}
+
+// ── module-scope schedulers ──────────────────────────────────────────────
+
+/** The last job `onJobSettled` fired for — its side effects run exactly once. */
+let settledJobId: string | null = null;
+
+/**
+ * Whose job the follower is on, and what it is doing.
+ *
+ * The follower is keyed by job id and knows nothing about plugins, but every
+ * ending it reports is about one: which name a toast says, which row the
+ * button on that toast opens. Set immediately before each `start`, and safe as
+ * a single slot because starting a different job replaces it and abandons the
+ * old loop in the same breath.
+ */
+let followingPluginId: string | null = null;
+let followingKind: PluginJobKind = 'install';
+
+/** Once per page load — StrictMode mounts effects twice in development. */
+let inProgressChecked = false;
+
+/** Record on the open job — never on a job the user has moved on from. */
+function patchJob(jobId: string, next: PluginJob): void {
+  usePluginStore.setState((state) => (
+    state.job && state.job.jobId === jobId ? { job: next } : {}
+  ));
+}
+
+/**
+ * The one follower this store runs. Everything about HOW a job is tailed is
+ * `jobFollower`'s, shared with the Package Center.
+ */
+const follower = createJobFollower<PluginJob>({
+  fetchPage: (jobId, cursor, signal, wait) => (
+    getPluginJobEvents(jobId, { cursor, wait, signal })
+  ),
+  getOpenJob: () => usePluginStore.getState().job,
+  patchJob,
+  onSettled: (jobId, status) => {
+    void onJobSettled(jobId, followingPluginId ?? '', followingKind, status);
+  },
+  // Nothing here restarts the server, so an events endpoint that stops
+  // answering is exactly what it looks like: we no longer know what the job is
+  // doing. Declining leaves the follower's own `lost`, which is the honest
+  // answer — the pack store's restart branch has no counterpart for plugins.
+  onGiveUp: () => false,
+});
+
+/** Abandon the current follower, if any. */
+function stopFollowing(): void {
+  follower.stop();
+}
+
+/**
+ * Follow *jobId* from *cursor*, unless it is already being followed.
+ *
+ * The idempotence is what lets `refresh()` adopt `active_job` on every poll
+ * without restarting the follower — and without the double-follow that would
+ * apply every event twice. Asked here as well as inside `start` so the plugin
+ * id is not rewritten under a loop already running on another job.
+ */
+function startFollowing(
+  jobId: string, pluginId: string, kind: PluginJobKind, cursor: number,
+): void {
+  if (follower.followingJobId() === jobId) return;
+  followingPluginId = pluginId;
+  followingKind = kind;
+  follower.start(jobId, cursor);
+}
+
+/**
+ * Everything that has to happen after a plugin's files changed on disk.
+ *
+ * Three steps, in this order and one at a time. The catalog first, because the
+ * rest of the UI reads statuses off it. Then the node definitions -- with
+ * `fetchDefinitions`, NOT `reload`: the server rediscovered its own nodes when
+ * the job finished, and asking it to do it again would throw away a warm
+ * registry for nothing. Then the plugin frontends, which have to come last
+ * because a bundle activates against the definitions that are now loaded.
+ *
+ * Every step is guarded on its own. A catalog that did not come back is no
+ * reason to leave a just-installed plugin's UI unloaded, and vice versa.
+ */
+async function refreshEverything(): Promise<void> {
+  const steps: (() => Promise<unknown>)[] = [
+    () => usePluginStore.getState().refresh(),
+    () => useNodeDefStore.getState().fetchDefinitions(),
+    () => reloadPluginFrontends(),
+  ];
+  for (const step of steps) {
+    try {
+      await step();
+    } catch (err) {
+      toast(
+        useI18n.getState().t('packs.toast.installFailed', { message: errorMessage(err) }),
+        'error',
+      );
+    }
+  }
+}
+
+/**
+ * Everything that happens once, when a job reaches its end.
+ *
+ * Guarded by job id rather than trusted to the caller: `refresh()` can adopt a
+ * job at any time, and a settled job announcing itself twice would toast twice
+ * and run the three-step refresh twice.
+ */
+async function onJobSettled(
+  jobId: string, pluginId: string, kind: PluginJobKind, status: JobStatus,
+): Promise<void> {
+  if (settledJobId === jobId) return;
+  settledJobId = jobId;
+
+  const { t } = useI18n.getState();
+  const store = usePluginStore.getState();
+  const name = pluginName(pluginId);
+  // The page that ended the job was applied to `job` a moment ago — but only
+  // if it is still the open one, so what is read back is checked rather than
+  // assumed. A dismissed job must not lend its message to this one.
+  const settled = store.job?.jobId === jobId ? store.job : null;
+
+  switch (status) {
+    case 'done':
+      toast(
+        t(kind === 'update'
+          ? 'pluginCenter.toast.updated'
+          : 'pluginCenter.toast.installed', { plugin: name }),
+        'success',
+      );
+      await refreshEverything();
+      break;
+    case 'failed':
+      // Only the catalog: nothing landed, so the node definitions and the
+      // frontends are exactly what they were.
+      toast(
+        t('packs.toast.installFailed', { message: settled?.error?.message ?? '' }),
+        'error',
+        openCenterAction(pluginId),
+      );
+      await store.refresh();
+      break;
+    case 'cancelled':
+      toast(t('packs.toast.cancelled'), 'info');
+      await store.refresh();
+      break;
+    case 'needs_restart':
+      // The files are in place and the registry could not pick them up from
+      // inside the running process. The JOB stays on screen — the panel's
+      // banner is what renders the command — and the catalog is refreshed
+      // because the row's status changed even though the nodes did not.
+      toast(
+        t('pluginCenter.toast.needsRestart', { plugin: name }),
+        'warning',
+        openCenterAction(pluginId),
+      );
+      await store.refresh();
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * Apply a whole catalog. The ONLY place `byId` is rebuilt.
+ */
+function setCatalog(catalog: PluginCatalog): void {
+  const byId: Record<string, PluginCatalogEntry> = {};
+  for (const entry of catalog.entries) byId[entry.id] = entry;
+  usePluginStore.setState({
+    plugins: catalog.entries,
+    byId,
+    remoteInstallAllowed: catalog.remote_install_allowed,
+    generation: catalog.generation,
+    loading: false,
+    loaded: true,
+    unsupported: false,
+    error: null,
+  });
+}
+
+/**
+ * Set one plugin's status without rebuilding the index.
+ *
+ * Used to show "Installing" the instant the 202 lands rather than at the next
+ * catalog poll. Both views are updated together: a row and its `byId` entry
+ * disagreeing is what puts a stale badge on a card.
+ */
+function setPluginStatus(pluginId: string, status: PluginCatalogEntry['status']): void {
+  usePluginStore.setState((state) => {
+    const current = state.byId[pluginId];
+    if (!current || current.status === status) return {};
+    const updated = { ...current, status };
+    return {
+      plugins: state.plugins.map((entry) => (entry.id === pluginId ? updated : entry)),
+      byId: { ...state.byId, [pluginId]: updated },
+    };
+  });
+}
+
+/**
+ * Inspect *source* and leave the review in whatever state it reached.
+ *
+ * Returns the inspection so `install` can act on it without re-reading the
+ * store. *forPluginId* is the catalog row this was started from, or null for
+ * a source the user typed.
+ */
+async function runInspect(
+  source: string, forPluginId: string | null,
+): Promise<PluginInspection | null> {
+  const { t } = useI18n.getState();
+  const spec = source.trim();
+
+  if (parseGitHubSource(spec) === null) {
+    // Refused without a round trip: the server would answer 400
+    // `unparseable_source`, and this is the one error the client can be sure
+    // of on its own.
+    usePluginStore.setState({
+      inspection: {
+        phase: 'error', source: spec, message: t('pluginCenter.source.invalid'),
+      },
+    });
+    return null;
+  }
+
+  usePluginStore.setState({ inspection: { phase: 'inspecting', source: spec } });
+  try {
+    const data = await inspectPluginSource(spec);
+    usePluginStore.setState({
+      inspection: {
+        phase: 'ready', data, source: spec, forPluginId, kind: data.mode, error: null,
+      },
+    });
+    return data;
+  } catch (err) {
+    usePluginStore.setState({
+      inspection: { phase: 'error', source: spec, message: errorMessage(err) },
+    });
+    return null;
+  }
+}
+
+/**
+ * Post an inspected install and adopt the job it starts.
+ *
+ * Shared by the auto-install path (`install` on a plugin that asks for
+ * nothing) and the review card's confirm (`installInspected`), so both send
+ * exactly the same body and read exactly the same refusals.
+ */
+async function startInstall(
+  data: PluginInspection,
+  opts: { acceptCapabilities: boolean; trustAuthor: boolean; force?: boolean },
+): Promise<void> {
+  const { t } = useI18n.getState();
+  const store = usePluginStore.getState();
+
+  try {
+    const { job_id } = await installPlugin({
+      inspection_id: data.inspection_id,
+      // The DECLARED list, never a blanket "yes". The server compares what
+      // comes back with what the manifest asks for and refuses a mismatch,
+      // which is the whole point: a client that echoed a boolean would be
+      // consenting on the user's behalf to whatever the source grows next.
+      ...(opts.acceptCapabilities ? { accept_capabilities: data.capabilities } : {}),
+      ...(opts.trustAuthor ? { trust_author: true } : {}),
+      ...(opts.force ? { force: true } : {}),
+    });
+
+    usePluginStore.setState({
+      job: emptyPluginJob(job_id, data.plugin_id, data.mode),
+      inspection: { phase: 'idle' },
+    });
+    setPluginStatus(data.plugin_id, 'installing');
+    startFollowing(job_id, data.plugin_id, data.mode, 0);
+  } catch (err) {
+    const code = refusalCode(err);
+    if (code === 'consent_required' || code === 'trust_author_required') {
+      // Recoverable, and recoverable on the card the user is already looking
+      // at: the inspection stays ready and grows a message, so the review can
+      // say which box is still unticked instead of starting over.
+      usePluginStore.setState((state) => (
+        state.inspection.phase === 'ready'
+          ? { inspection: { ...state.inspection, error: errorMessage(err) } }
+          : {}
+      ));
+    } else if (err instanceof ApiError && err.status === 409) {
+      // Somebody else got there first — this tab, another tab, or the CLI.
+      // The refresh adopts whatever the server IS running, which is more
+      // useful than the refusal.
+      toast(t('packs.toast.busy'), 'warning');
+      await store.refresh();
+    } else if (err instanceof ApiError && err.status === 403) {
+      toast(t('packs.remoteDisabled'), 'error');
+    } else {
+      toast(t('packs.toast.installFailed', { message: errorMessage(err) }), 'error');
+    }
+  }
+}
+
+export const usePluginStore = create<PluginState>((set, get) => ({
+  plugins: [],
+  byId: {},
+  loading: false,
+  loaded: false,
+  unsupported: false,
+  error: null,
+  remoteInstallAllowed: true,
+  generation: 0,
+  job: null,
+  busy: {},
+  cancelling: false,
+  inspection: { phase: 'idle' },
+
+  refresh: async () => {
+    set({ loading: true });
+    // Read BEFORE the request: a job that appears while this one is in flight
+    // is not described by the answer, and must not be declared lost on the
+    // strength of it.
+    const jobBefore = get().job;
+
+    let catalog: PluginCatalog;
+    try {
+      catalog = await listPluginCatalog();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        // A server older than the Plugin Center. Not an error the user did
+        // anything about, so the panel reports it silently and nothing else
+        // in the app changes.
+        set({
+          loading: false, loaded: true, unsupported: true,
+          plugins: [], byId: {}, error: null,
+        });
+        return;
+      }
+      // `loaded` stays as it was: no answer arrived, so a later mount is
+      // entitled to try again. The rows already on screen are kept — a
+      // dropped packet is no reason to blank the catalog.
+      set({ loading: false, error: errorMessage(err) });
+      return;
+    }
+
+    setCatalog(catalog);
+
+    const active = catalog.active_job;
+    if (active !== null) {
+      const current = get().job;
+      const kind = jobKind(active.kind);
+      if (!current || current.jobId !== active.job_id) {
+        set({ job: emptyPluginJob(active.job_id, active.plugin_id, kind) });
+      }
+      // Idempotent: this runs on every poll, and only the FIRST one starts a
+      // follower. This is how a job started in another tab is adopted.
+      startFollowing(active.job_id, active.plugin_id, kind, get().job?.cursor ?? 0);
+      return;
+    }
+
+    const job = get().job;
+    if (
+      job
+      && job.status === 'running'
+      && jobBefore?.jobId === job.jobId
+      // ...and nobody is watching it. A follower still parked on the events
+      // endpoint has a better answer coming than this catalog read does:
+      // `active_job` goes null the moment a job finishes, and the follower's
+      // next page settles it. Marking it `lost` from here is a race that turns
+      // a successful install into a "we lost contact" banner.
+      && follower.followingJobId() !== job.jobId
+    ) {
+      // The server has no record of a job we think is running: it restarted,
+      // or the job aged out. Saying "running" would be the one answer that is
+      // definitely wrong.
+      set({ job: { ...job, status: 'lost' } });
+    }
+  },
+
+  install: async (pluginId) => {
+    const state = get();
+    if (state.busy[pluginId]) return;
+    const { t } = useI18n.getState();
+
+    if (isRunning(state.job)) {
+      // One job at a time, server-side. Said here rather than after an
+      // inspection the user would then have to abandon.
+      toast(t('packs.toast.busy'), 'warning');
+      return;
+    }
+
+    set((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
+    try {
+      const data = await runInspect(pluginId, pluginId);
+      if (data === null) return;
+      if (data.consent_required) {
+        // Capabilities to grant, or an author to trust. The review card takes
+        // it from here; nothing is installed until the user says so.
+        return;
+      }
+      // Nothing to consent to, so asking would be a dialog whose only answer
+      // is yes. `trustAuthor` stays false for the same reason: an install
+      // with no `allowed_modules` has no author to trust.
+      await startInstall(data, { acceptCapabilities: true, trustAuthor: false });
+    } finally {
+      set((s) => {
+        const busy = { ...s.busy };
+        delete busy[pluginId];
+        return { busy };
+      });
+    }
+  },
+
+  inspect: async (source) => {
+    // No busy flag: a typed source names no row yet, so there is no button to
+    // disable. `inspection.phase` is what the source box reads instead.
+    await runInspect(source, null);
+  },
+
+  installInspected: async (opts) => {
+    const inspection = get().inspection;
+    if (inspection.phase !== 'ready') return;
+    const pluginId = inspection.data.plugin_id;
+    if (get().busy[pluginId]) return;
+
+    set((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
+    try {
+      await startInstall(inspection.data, opts);
+    } finally {
+      set((s) => {
+        const busy = { ...s.busy };
+        delete busy[pluginId];
+        return { busy };
+      });
+    }
+  },
+
+  clearInspection: () => set({ inspection: { phase: 'idle' } }),
+
+  update: async (pluginId) => {
+    const state = get();
+    if (state.busy[pluginId]) return;
+    const { t } = useI18n.getState();
+
+    if (isRunning(state.job)) {
+      toast(t('packs.toast.busy'), 'warning');
+      return;
+    }
+
+    set((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
+    try {
+      const result = await updatePlugin(pluginId);
+      if (result.kind === 'up_to_date') {
+        toast(t('pluginCenter.toast.upToDate', { plugin: pluginName(pluginId) }), 'info');
+        return;
+      }
+      if (result.kind === 'needs_consent') {
+        // The new version asks for something the installed one did not. Same
+        // review card as a fresh install, with `capabilities_added` the only
+        // part that is actually new.
+        set({
+          inspection: {
+            phase: 'ready',
+            data: result.inspection,
+            source: pluginId,
+            forPluginId: pluginId,
+            kind: 'update',
+            error: null,
+          },
+        });
+        return;
+      }
+      set({ job: emptyPluginJob(result.job_id, pluginId, 'update') });
+      setPluginStatus(pluginId, 'installing');
+      startFollowing(result.job_id, pluginId, 'update', 0);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        toast(t('packs.toast.busy'), 'warning');
+        await get().refresh();
+      } else if (err instanceof ApiError && err.status === 403) {
+        toast(t('packs.remoteDisabled'), 'error');
+      } else {
+        toast(t('pluginCenter.updateFailed', { message: errorMessage(err) }), 'error');
+      }
+    } finally {
+      set((s) => {
+        const busy = { ...s.busy };
+        delete busy[pluginId];
+        return { busy };
+      });
+    }
+  },
+
+  uninstall: async (pluginId) => {
+    const { t } = useI18n.getState();
+    if (get().busy[pluginId]) return;
+    // Read before the request: a github plugin's row is gone by the time the
+    // toast is written, and "uninstalled foo-plugin" reads better than the id
+    // the catalog no longer has a name for.
+    const name = pluginName(pluginId);
+
+    const ok = await confirm({
+      title: t('pluginCenter.uninstall'),
+      message: t('pluginCenter.uninstallConfirm', { plugin: name }),
+      confirmText: t('pluginCenter.uninstall'),
+      variant: 'danger',
+    });
+    if (!ok) return;
+
+    set((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
+    try {
+      await uninstallPlugin(pluginId);
+      // Its nodes are gone from the registry and its bundle is still
+      // activated in this page: all three steps, or the canvas keeps offering
+      // nodes the server will refuse to run.
+      await refreshEverything();
+      toast(t('pluginCenter.toast.removed', { plugin: name }), 'success');
+    } catch (err) {
+      const hint = str(refusal(err)?.hint);
+      if (refusalCode(err) === 'files_locked') {
+        // Windows keeps an open file: the plugin is deregistered but its
+        // directory is still there. The server's hint is the only thing that
+        // says what to do about it, so it is what the toast carries.
+        toast(
+          t('pluginCenter.toast.removeFailed', {
+            plugin: name, message: hint ?? errorMessage(err),
+          }),
+          'warning',
+        );
+        await refreshEverything();
+      } else if (err instanceof ApiError && err.status === 409) {
+        toast(t('packs.toast.busy'), 'warning');
+        await get().refresh();
+      } else {
+        toast(
+          t('pluginCenter.toast.removeFailed', {
+            plugin: name, message: errorMessage(err),
+          }),
+          'error',
+        );
+      }
+    } finally {
+      set((s) => {
+        const busy = { ...s.busy };
+        delete busy[pluginId];
+        return { busy };
+      });
+    }
+  },
+
+  setEnabled: async (pluginId, enabled) => {
+    const { t } = useI18n.getState();
+    if (get().busy[pluginId]) return;
+    const name = pluginName(pluginId);
+
+    set((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
+    try {
+      await setPluginEnabled(pluginId, enabled);
+      // Enabling registers nodes and activates a frontend; disabling takes
+      // both away. Either way the same three things are now stale.
+      await refreshEverything();
+      toast(
+        t(enabled ? 'pluginCenter.toast.enabled' : 'pluginCenter.toast.disabled',
+          { plugin: name }),
+        'success',
+      );
+    } catch (err) {
+      toast(
+        t('pluginCenter.toast.toggleFailed', {
+          plugin: name, message: errorMessage(err),
+        }),
+        'error',
+      );
+    } finally {
+      set((s) => {
+        const busy = { ...s.busy };
+        delete busy[pluginId];
+        return { busy };
+      });
+    }
+  },
+
+  cancel: async () => {
+    const job = get().job;
+    if (job === null || !isRunning(job) || get().cancelling) return;
+    set({ cancelling: true });
+    try {
+      // Cooperative: the flow notices between steps and inside a download, so
+      // the job may still say running when this returns. The FOLLOWER is what
+      // records the outcome — faking it here would show "cancelled" over an
+      // unpack that is still writing files.
+      await cancelPluginJob(job.jobId);
+    } catch (err) {
+      toast(
+        useI18n.getState().t('packs.toast.cancelFailed', { message: errorMessage(err) }),
+        'error',
+      );
+    } finally {
+      set({ cancelling: false });
+    }
+  },
+
+  followJob: (jobId, pluginId, kind = 'install', cursor = 0) => {
+    const current = get().job;
+    if (!current || current.jobId !== jobId) {
+      set({ job: emptyPluginJob(jobId, pluginId, kind) });
+    }
+    startFollowing(jobId, pluginId, kind, cursor);
+  },
+
+  stopFollowing: () => stopFollowing(),
+
+  dismissJob: () => {
+    const job = get().job;
+    if (job === null || isRunning(job)) return;
+    set({ job: null });
+  },
+
+  checkInProgress: async () => {
+    if (inProgressChecked) return;
+    inProgressChecked = true;
+
+    await get().refresh();
+    if (!get().loaded) {
+      // No answer arrived — `refresh` reports a network error and leaves
+      // `loaded` false precisely so a later mount can try again. The flag
+      // exists to keep two same-tick mounts from both fetching, NOT to make
+      // one dropped packet permanent, so it is released here.
+      inProgressChecked = false;
+      return;
+    }
+    if (get().unsupported) return;
+
+    // An install the user started before reloading is still going, and the
+    // Plugin Center is closed. This toast is the only thing that says so.
+    if (follower.followingJobId() !== null) {
+      toast(
+        useI18n.getState().t('pluginCenter.toast.inProgress'),
+        'info',
+        openCenterAction(get().job?.pluginId ?? ''),
+      );
+    }
+  },
+}));
+
+/** Test-only: reset the module-scope schedulers and the store between cases. */
+export function _resetPluginStoreForTesting(): void {
+  follower.stop();
+  settledJobId = null;
+  followingPluginId = null;
+  followingKind = 'install';
+  inProgressChecked = false;
+  usePluginStore.setState({
+    plugins: [],
+    byId: {},
+    loading: false,
+    loaded: false,
+    unsupported: false,
+    error: null,
+    remoteInstallAllowed: true,
+    generation: 0,
+    job: null,
+    busy: {},
+    cancelling: false,
+    inspection: { phase: 'idle' },
+  });
+}

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -156,8 +156,15 @@ export function emptyPluginJob(
 const GITHUB_URL =
   /^https?:\/\/(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?(?:@(.+))?$/;
 const GITHUB_SHORT = /^([\w.-]+)\/([\w.-]+?)(?:@([\w./-]+))?$/;
-/** One word, no slash and no scheme: it can only be a catalog name. */
-const CATALOG_NAME = /^[a-z0-9][a-z0-9-]*$/;
+/**
+ * One word, no slash and no scheme: it can only be a catalog name.
+ *
+ * The CLI's own class, character for character, because refusing here means
+ * refusing WITHOUT asking the server: a narrower rule would turn `EDU` or
+ * `C1` into "that is not a source" when the catalog has them. The lookup is
+ * case-insensitive there (`spec.lower()`), so the id is lower-cased to match.
+ */
+const CATALOG_NAME = /^[A-Za-z0-9][\w.-]*$/;
 
 /**
  * Read a plugin source the way the CLI reads one, or answer null.
@@ -177,7 +184,10 @@ export function parseGitHubSource(input: string): PluginSourceRef | null {
   if (short !== null) {
     return { kind: 'github', owner: short[1], repo: short[2], ref: short[3] ?? null };
   }
-  if (CATALOG_NAME.test(spec)) return { kind: 'catalog', id: spec };
+  // Lower-cased, not echoed: the server looks a catalog name up in lower
+  // case, so `EDU` and `edu` are the same pack and the panel should not show
+  // them as two.
+  if (CATALOG_NAME.test(spec)) return { kind: 'catalog', id: spec.toLowerCase() };
   return null;
 }
 
@@ -295,7 +305,18 @@ const follower = createJobFollower<PluginJob>({
   getOpenJob: () => usePluginStore.getState().job,
   patchJob,
   onSettled: (jobId, status) => {
-    void onJobSettled(jobId, followingPluginId ?? '', followingKind, status);
+    // Nothing awaits this, so a throw between its awaits would surface as an
+    // unhandled rejection in a console the user never opens. Every step of the
+    // refresh is already guarded; this is the net under the rest of it.
+    void onJobSettled(jobId, followingPluginId ?? '', followingKind, status)
+      .catch((err: unknown) => {
+        toast(
+          useI18n.getState().t(
+            'pluginCenter.toast.refreshFailed', { message: errorMessage(err) },
+          ),
+          'error',
+        );
+      });
   },
   // Nothing here restarts the server, so an events endpoint that stops
   // answering is exactly what it looks like: we no longer know what the job is
@@ -349,8 +370,14 @@ async function refreshEverything(): Promise<void> {
     try {
       await step();
     } catch (err) {
+      // Its own key, not `installFailed`: this runs after an uninstall and
+      // after a disable too, and "install failed" beside "demo uninstalled."
+      // describes something that did not happen. What DID happen is that the
+      // change landed and the editor could not be brought up to date.
       toast(
-        useI18n.getState().t('packs.toast.installFailed', { message: errorMessage(err) }),
+        useI18n.getState().t(
+          'pluginCenter.toast.refreshFailed', { message: errorMessage(err) },
+        ),
         'error',
       );
     }

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -656,6 +656,17 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       // is yes. `trustAuthor` stays false for the same reason: an install
       // with no `allowed_modules` has no author to trust.
       await startInstall(data, { acceptCapabilities: true, trustAuthor: false });
+
+      // The review this install passed through was never on screen. If the
+      // install failed for something a review cannot fix — busy, refused,
+      // offline — putting the card up now would answer a toast with a form
+      // nobody asked for. A consent refusal is the exception: it left a
+      // message on the review precisely because ticking a box is the fix.
+      const after = get().inspection;
+      if (after.phase === 'ready' && after.error === null
+          && after.forPluginId === pluginId) {
+        set({ inspection: { phase: 'idle' } });
+      }
     } finally {
       set((s) => {
         const busy = { ...s.busy };

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -367,8 +367,13 @@ function stopFollowing(): void {
  *
  * The idempotence is what lets `refresh()` adopt `active_job` on every poll
  * without restarting the follower — and without the double-follow that would
- * apply every event twice. Asked here as well as inside `start` so the plugin
- * id is not rewritten under a loop already running on another job.
+ * apply every event twice.
+ *
+ * Asked here as well as inside `start` because the two module slots below are
+ * not the follower's to guard: a second call for the job ALREADY being
+ * followed keeps the first call's plugin id and kind, and does not restart
+ * the loop. A call naming a different job replaces both, and the loop with
+ * them.
  */
 function startFollowing(
   jobId: string, pluginId: string, kind: PluginJobKind, cursor: number,

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -862,6 +862,12 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       } else if (err instanceof ApiError && err.status === 409) {
         toast(t('packs.toast.busy'), 'warning');
         await get().refresh();
+      } else if (err instanceof ApiError && err.status === 403) {
+        // Same gate as an install, and the same answer: the server only
+        // takes a change like this from the machine it runs on. Wrapping
+        // `Forbidden` in "Could not remove Demo plugin" would tell a LAN
+        // user that something went wrong rather than where to do it.
+        toast(t('packs.remoteDisabled'), 'error');
       } else {
         toast(
           t('pluginCenter.toast.removeFailed', {

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -280,6 +280,27 @@ function inspectionFailure(err: unknown): InspectionFailure {
   };
 }
 
+/**
+ * Run *fn* with *pluginId* marked busy, and unmark it however *fn* ends.
+ *
+ * Every action that acts on one plugin disables that row for the length of
+ * the request, and every one of them has to release it on a throw as well as
+ * on a return. Five copies of the same `finally` are five chances to leave a
+ * row disabled with nothing running behind it.
+ */
+async function withBusy<T>(pluginId: string, fn: () => Promise<T>): Promise<T> {
+  usePluginStore.setState((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
+  try {
+    return await fn();
+  } finally {
+    usePluginStore.setState((s) => {
+      const busy = { ...s.busy };
+      delete busy[pluginId];
+      return { busy };
+    });
+  }
+}
+
 /** A plugin's display name for a toast, falling back to its id. */
 function pluginName(pluginId: string): string {
   return usePluginStore.getState().byId[pluginId]?.name || pluginId;
@@ -714,8 +735,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       return;
     }
 
-    set((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
-    try {
+    await withBusy(pluginId, async () => {
       const data = await runInspect(pluginId, pluginId);
       if (data === null) return;
       if (data.consent_required) {
@@ -732,19 +752,13 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       // install failed for something a review cannot fix — busy, refused,
       // offline — putting the card up now would answer a toast with a form
       // nobody asked for. A consent refusal is the exception: it left a
-      // message on the review precisely because ticking a box is the fix.
+      // failure on the review precisely because ticking a box is the fix.
       const after = get().inspection;
       if (after.phase === 'ready' && after.error === null
           && after.forPluginId === pluginId) {
         set({ inspection: { phase: 'idle' } });
       }
-    } finally {
-      set((s) => {
-        const busy = { ...s.busy };
-        delete busy[pluginId];
-        return { busy };
-      });
-    }
+    });
   },
 
   inspect: async (source) => {
@@ -759,16 +773,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
     const pluginId = inspection.data.plugin_id;
     if (get().busy[pluginId]) return;
 
-    set((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
-    try {
-      await startInstall(inspection.data, opts);
-    } finally {
-      set((s) => {
-        const busy = { ...s.busy };
-        delete busy[pluginId];
-        return { busy };
-      });
-    }
+    await withBusy(pluginId, () => startInstall(inspection.data, opts));
   },
 
   clearInspection: () => set({ inspection: { phase: 'idle' } }),
@@ -783,48 +788,45 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       return;
     }
 
-    set((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
-    try {
-      const result = await updatePlugin(pluginId);
-      if (result.kind === 'up_to_date') {
-        toast(t('pluginCenter.toast.upToDate', { plugin: pluginName(pluginId) }), 'info');
-        return;
+    await withBusy(pluginId, async () => {
+      try {
+        const result = await updatePlugin(pluginId);
+        if (result.kind === 'up_to_date') {
+          toast(
+            t('pluginCenter.toast.upToDate', { plugin: pluginName(pluginId) }), 'info',
+          );
+          return;
+        }
+        if (result.kind === 'needs_consent') {
+          // The new version asks for something the installed one did not. Same
+          // review card as a fresh install, with `capabilities_added` the only
+          // part that is actually new.
+          set({
+            inspection: {
+              phase: 'ready',
+              data: result.inspection,
+              source: pluginId,
+              forPluginId: pluginId,
+              kind: 'update',
+              error: null,
+            },
+          });
+          return;
+        }
+        set({ job: emptyPluginJob(result.job_id, pluginId, 'update') });
+        setPluginStatus(pluginId, 'installing');
+        startFollowing(result.job_id, pluginId, 'update', 0);
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 409) {
+          toast(t('packs.toast.busy'), 'warning');
+          await get().refresh();
+        } else if (err instanceof ApiError && err.status === 403) {
+          toast(t('packs.remoteDisabled'), 'error');
+        } else {
+          toast(t('pluginCenter.updateFailed', { message: errorMessage(err) }), 'error');
+        }
       }
-      if (result.kind === 'needs_consent') {
-        // The new version asks for something the installed one did not. Same
-        // review card as a fresh install, with `capabilities_added` the only
-        // part that is actually new.
-        set({
-          inspection: {
-            phase: 'ready',
-            data: result.inspection,
-            source: pluginId,
-            forPluginId: pluginId,
-            kind: 'update',
-            error: null,
-          },
-        });
-        return;
-      }
-      set({ job: emptyPluginJob(result.job_id, pluginId, 'update') });
-      setPluginStatus(pluginId, 'installing');
-      startFollowing(result.job_id, pluginId, 'update', 0);
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 409) {
-        toast(t('packs.toast.busy'), 'warning');
-        await get().refresh();
-      } else if (err instanceof ApiError && err.status === 403) {
-        toast(t('packs.remoteDisabled'), 'error');
-      } else {
-        toast(t('pluginCenter.updateFailed', { message: errorMessage(err) }), 'error');
-      }
-    } finally {
-      set((s) => {
-        const busy = { ...s.busy };
-        delete busy[pluginId];
-        return { busy };
-      });
-    }
+    });
   },
 
   uninstall: async (pluginId) => {
@@ -843,51 +845,46 @@ export const usePluginStore = create<PluginState>((set, get) => ({
     });
     if (!ok) return;
 
-    set((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
-    try {
-      await uninstallPlugin(pluginId);
-      // Its nodes are gone from the registry and its bundle is still
-      // activated in this page: all three steps, or the canvas keeps offering
-      // nodes the server will refuse to run.
-      await refreshEverything();
-      toast(t('pluginCenter.toast.removed', { plugin: name }), 'success');
-    } catch (err) {
-      const hint = str(errorDetail(err)?.hint);
-      if (refusalCode(err) === 'files_locked') {
-        // Windows keeps an open file: the plugin is deregistered but its
-        // directory is still there. The server's hint is the only thing that
-        // says what to do about it, so it is what the toast carries.
-        toast(
-          t('pluginCenter.toast.removeFailed', {
-            plugin: name, message: hint ?? errorMessage(err),
-          }),
-          'warning',
-        );
+    await withBusy(pluginId, async () => {
+      try {
+        await uninstallPlugin(pluginId);
+        // Its nodes are gone from the registry and its bundle is still
+        // activated in this page: all three steps, or the canvas keeps
+        // offering nodes the server will refuse to run.
         await refreshEverything();
-      } else if (err instanceof ApiError && err.status === 409) {
-        toast(t('packs.toast.busy'), 'warning');
-        await get().refresh();
-      } else if (err instanceof ApiError && err.status === 403) {
-        // Same gate as an install, and the same answer: the server only
-        // takes a change like this from the machine it runs on. Wrapping
-        // `Forbidden` in "Could not remove Demo plugin" would tell a LAN
-        // user that something went wrong rather than where to do it.
-        toast(t('packs.remoteDisabled'), 'error');
-      } else {
-        toast(
-          t('pluginCenter.toast.removeFailed', {
-            plugin: name, message: errorMessage(err),
-          }),
-          'error',
-        );
+        toast(t('pluginCenter.toast.removed', { plugin: name }), 'success');
+      } catch (err) {
+        const hint = str(errorDetail(err)?.hint);
+        if (refusalCode(err) === 'files_locked') {
+          // Windows keeps an open file: the plugin is deregistered but its
+          // directory is still there. The server's hint is the only thing that
+          // says what to do about it, so it is what the toast carries.
+          toast(
+            t('pluginCenter.toast.removeFailed', {
+              plugin: name, message: hint ?? errorMessage(err),
+            }),
+            'warning',
+          );
+          await refreshEverything();
+        } else if (err instanceof ApiError && err.status === 409) {
+          toast(t('packs.toast.busy'), 'warning');
+          await get().refresh();
+        } else if (err instanceof ApiError && err.status === 403) {
+          // Same gate as an install, and the same answer: the server only
+          // takes a change like this from the machine it runs on. Wrapping
+          // `Forbidden` in "Could not remove Demo plugin" would tell a LAN
+          // user that something went wrong rather than where to do it.
+          toast(t('packs.remoteDisabled'), 'error');
+        } else {
+          toast(
+            t('pluginCenter.toast.removeFailed', {
+              plugin: name, message: errorMessage(err),
+            }),
+            'error',
+          );
+        }
       }
-    } finally {
-      set((s) => {
-        const busy = { ...s.busy };
-        delete busy[pluginId];
-        return { busy };
-      });
-    }
+    });
   },
 
   setEnabled: async (pluginId, enabled) => {
@@ -895,31 +892,26 @@ export const usePluginStore = create<PluginState>((set, get) => ({
     if (get().busy[pluginId]) return;
     const name = pluginName(pluginId);
 
-    set((s) => ({ busy: { ...s.busy, [pluginId]: true } }));
-    try {
-      await setPluginEnabled(pluginId, enabled);
-      // Enabling registers nodes and activates a frontend; disabling takes
-      // both away. Either way the same three things are now stale.
-      await refreshEverything();
-      toast(
-        t(enabled ? 'pluginCenter.toast.enabled' : 'pluginCenter.toast.disabled',
-          { plugin: name }),
-        'success',
-      );
-    } catch (err) {
-      toast(
-        t('pluginCenter.toast.toggleFailed', {
-          plugin: name, message: errorMessage(err),
-        }),
-        'error',
-      );
-    } finally {
-      set((s) => {
-        const busy = { ...s.busy };
-        delete busy[pluginId];
-        return { busy };
-      });
-    }
+    await withBusy(pluginId, async () => {
+      try {
+        await setPluginEnabled(pluginId, enabled);
+        // Enabling registers nodes and activates a frontend; disabling takes
+        // both away. Either way the same three things are now stale.
+        await refreshEverything();
+        toast(
+          t(enabled ? 'pluginCenter.toast.enabled' : 'pluginCenter.toast.disabled',
+            { plugin: name }),
+          'success',
+        );
+      } catch (err) {
+        toast(
+          t('pluginCenter.toast.toggleFailed', {
+            plugin: name, message: errorMessage(err),
+          }),
+          'error',
+        );
+      }
+    });
   },
 
   cancel: async () => {

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import {
   ApiError,
   cancelPluginJob,
+  errorDetail,
   getPluginJobEvents,
   inspectPluginSource,
   installPlugin,
@@ -229,23 +230,14 @@ function openCenterAction(pluginId: string): ToastAction {
 }
 
 /**
- * The coded object out of a refusal, wherever the server put it.
+ * The code a refusal was refused with, or null.
  *
- * FastAPI nests it under `detail`; a plain `{code: ...}` body (or a proxy that
- * unwrapped the detail) is the same information one level up. Reading only one
- * of the two would silently lose the code that decides which toast this is.
+ * `errorDetail` is the api client's, not a copy: every plugin route nests its
+ * keys under `detail`, and one unwrapper shared with the panel is what keeps a
+ * caller from reading `err.body.code` and finding nothing there.
  */
-function refusal(err: unknown): Record<string, unknown> | null {
-  if (!(err instanceof ApiError) || err.body === null) return null;
-  const detail = err.body.detail;
-  if (detail !== null && typeof detail === 'object') {
-    return detail as Record<string, unknown>;
-  }
-  return err.body;
-}
-
 function refusalCode(err: unknown): string | null {
-  return str(refusal(err)?.code);
+  return str(errorDetail(err)?.code);
 }
 
 /** A plugin's display name for a toast, falling back to its id. */
@@ -808,7 +800,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       await refreshEverything();
       toast(t('pluginCenter.toast.removed', { plugin: name }), 'success');
     } catch (err) {
-      const hint = str(refusal(err)?.hint);
+      const hint = str(errorDetail(err)?.hint);
       if (refusalCode(err) === 'files_locked') {
         // Windows keeps an open file: the plugin is deregistered but its
         // directory is still there. The server's hint is the only thing that

--- a/frontend/src/store/uiStore.test.ts
+++ b/frontend/src/store/uiStore.test.ts
@@ -31,6 +31,8 @@ describe('useUIStore', () => {
       shortcutsModalOpen: false,
       packCenterOpen: false,
       packCenterFocusPackId: null,
+      pluginCenterOpen: false,
+      pluginCenterFocusPluginId: null,
       draggingSourceType: null,
       reconnectingHandle: null,
       beginnerMode: false,
@@ -169,6 +171,62 @@ describe('useUIStore', () => {
       // render does not scroll the list out from under the reader again.
       useUIStore.getState().setPackCenterFocus(null);
       expect(useUIStore.getState().packCenterFocusPackId).toBeNull();
+      expect(useUIStore.getState().packCenterOpen).toBe(true);
+    });
+  });
+
+  describe('openPluginCenter / closePluginCenter', () => {
+    it('records the focus plugin and closePluginCenter clears it', () => {
+      expect(useUIStore.getState().pluginCenterOpen).toBe(false);
+      expect(useUIStore.getState().pluginCenterFocusPluginId).toBeNull();
+
+      // Opened from a toast about an install that failed: the panel scrolls
+      // to that plugin, where its log is.
+      useUIStore.getState().openPluginCenter('demo');
+      expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+      expect(useUIStore.getState().pluginCenterFocusPluginId).toBe('demo');
+
+      useUIStore.getState().closePluginCenter();
+      expect(useUIStore.getState().pluginCenterOpen).toBe(false);
+      expect(useUIStore.getState().pluginCenterFocusPluginId).toBeNull();
+    });
+
+    it('opens with no focus when reached from the menu', () => {
+      useUIStore.getState().openPluginCenter('demo');
+      useUIStore.getState().closePluginCenter();
+      useUIStore.getState().openPluginCenter();
+      expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+      expect(useUIStore.getState().pluginCenterFocusPluginId).toBeNull();
+    });
+
+    it('is transient — writes nothing to localStorage', () => {
+      useUIStore.getState().openPluginCenter('demo');
+      expect(localStorage.length).toBe(0);
+      useUIStore.getState().closePluginCenter();
+      expect(localStorage.length).toBe(0);
+    });
+
+    it('setPluginCenterFocus re-points the open panel without closing it', () => {
+      useUIStore.getState().openPluginCenter();
+
+      useUIStore.getState().setPluginCenterFocus('c1');
+      expect(useUIStore.getState().pluginCenterFocusPluginId).toBe('c1');
+      expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+
+      useUIStore.getState().setPluginCenterFocus(null);
+      expect(useUIStore.getState().pluginCenterFocusPluginId).toBeNull();
+      expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+    });
+
+    it('is a separate modal from the Package Center', () => {
+      // Two panels, two flags: opening one must not close or focus the other.
+      useUIStore.getState().openPackCenter('word-vectors');
+      useUIStore.getState().openPluginCenter('demo');
+
+      expect(useUIStore.getState().packCenterOpen).toBe(true);
+      expect(useUIStore.getState().packCenterFocusPackId).toBe('word-vectors');
+
+      useUIStore.getState().closePluginCenter();
       expect(useUIStore.getState().packCenterOpen).toBe(true);
     });
   });

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -53,6 +53,21 @@ interface UIState {
    */
   setPackCenterFocus: (packId: string | null) => void;
   closePackCenter: () => void;
+  /**
+   * Plugin Center modal. The Package Center's rules, one for one: workspace
+   * -global, never persisted, and `pluginCenterFocusPluginId` is the row the
+   * panel should scroll to when the modal was opened FROM something that
+   * needs a specific plugin (a toast about an install, a node whose plugin is
+   * disabled) rather than from the menu.
+   */
+  pluginCenterOpen: boolean;
+  pluginCenterFocusPluginId: string | null;
+  openPluginCenter: (pluginId?: string) => void;
+  /** Point the open panel at another plugin — or clear the request once it
+   * has been honoured, which is what keeps the highlight from firing again on
+   * every subsequent render. */
+  setPluginCenterFocus: (pluginId: string | null) => void;
+  closePluginCenter: () => void;
   draggingSourceType: string | null;
   setDraggingSourceType: (type: string | null) => void;
   /** Endpoint of the edge currently being detached during an edge-reconnect
@@ -182,6 +197,13 @@ export const useUIStore = create<UIState>((set) => ({
   setPackCenterFocus: (packId) => set({ packCenterFocusPackId: packId }),
   closePackCenter: () =>
     set({ packCenterOpen: false, packCenterFocusPackId: null }),
+  pluginCenterOpen: false,
+  pluginCenterFocusPluginId: null,
+  openPluginCenter: (pluginId) =>
+    set({ pluginCenterOpen: true, pluginCenterFocusPluginId: pluginId ?? null }),
+  setPluginCenterFocus: (pluginId) => set({ pluginCenterFocusPluginId: pluginId }),
+  closePluginCenter: () =>
+    set({ pluginCenterOpen: false, pluginCenterFocusPluginId: null }),
   draggingSourceType: null,
   setDraggingSourceType: (type) => set({ draggingSourceType: type }),
   reconnectingHandle: null,

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -63,9 +63,11 @@ interface UIState {
   pluginCenterOpen: boolean;
   pluginCenterFocusPluginId: string | null;
   openPluginCenter: (pluginId?: string) => void;
-  /** Point the open panel at another plugin — or clear the request once it
-   * has been honoured, which is what keeps the highlight from firing again on
-   * every subsequent render. */
+  /**
+   * Point the open panel at another plugin — or clear the request once it has
+   * been honoured, which is what keeps the highlight from firing again on
+   * every subsequent render.
+   */
   setPluginCenterFocus: (pluginId: string | null) => void;
   closePluginCenter: () => void;
   draggingSourceType: string | null;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -131,6 +131,16 @@ export interface NodeDefinition {
    * before the Package Center sends no such key.
    */
   requires_pack?: string | null;
+  /**
+   * Plugin Center. Who registered this node: the base install, a custom node
+   * dropped in by hand, or `plugin:<id>` for one a plugin brought.
+   *
+   * What lets the sidebar group a plugin's nodes and grey them out the moment
+   * the plugin is disabled, without asking the server which nodes were whose.
+   * Optional: a server built before the Plugin Center sends no such key, and
+   * the caller then knows only that the node exists.
+   */
+  provider?: 'builtin' | 'custom' | `plugin:${string}`;
 }
 
 export interface PresetDefinition {


### PR DESCRIPTION
> 中文摘要：外掛中心前端的第一個 PR，只有底層管線、沒有畫面。內容：對應外掛中心後端（#407）的 REST 客戶端與型別（錯誤類別 `ApiError` 通用化，套件中心的 `PackApiError` 變成它的子類別，行為不變）；把套件中心的背景工作追蹤器抽成不含領域邏輯的 `jobFollower`，套件中心的 store 改為委派（套件中心測試一個字都沒改仍全綠）；新的 `pluginStore`（目錄、檢視／同意狀態機、安裝／更新／解除安裝／啟用流程、安裝完成後依序重新讀目錄、節點定義、外掛前端，不用重新整理頁面）；`uiStore` 的開關狀態、開機時讀一次目錄的 hook；`PluginHost` 的啟用流程序列化並提供 `reloadPluginFrontends()`（伺服器連不上時保留現有畫面）；以及 store 用到的 i18n 文字（兩種語言）。伺服器沒有新路由時（#407 尚未合併）目錄讀取回 404 會視為「不支援」，所以這個 PR 可以獨立合併。外掛中心的對話框在下一個前端 PR。

## What / Why

Plumbing for the Plugin Center (P-F1 of the approved Plugin Center + Source Control wave). The modal, the Custom &
Plugins tab button and the Settings row come in the next frontend PR; this one lands everything they will call, so the
UI PR stays small and reviewable. No user-visible change except the two PluginHost toasts moving from hardcoded English
to i18n keys.

- `api/rest.ts`: `ApiError` (status + parsed body) with `PackApiError` as a subclass — every pack call still throws the
  subclass, so `packStore`'s `instanceof` narrowing means what it did; the plugin types mirror the backend contract
  field for field (`PluginCatalogEntry`, `PluginCatalog`, `PluginInspection`, `PluginUpdateResult`, `JobStatus`,
  `JobEvent`, `JobEventsPage`); eight endpoint functions (`listPluginCatalog`, `inspectPluginSource`, `installPlugin`,
  `updatePlugin`, `uninstallPlugin`, `setPluginEnabled`, `getPluginJobEvents`, `cancelPluginJob`) with per-field
  normalisation of sparse payloads. `NodeDefinition.provider` (optional; the backend already sends it).
- `store/jobFollower.ts`: the Package Center's event reducer and long-poll follower, extracted with no domain knowledge
  (instance-scoped state, a `reduce` option for domain extras, `onGiveUp` for the pack restart branch). `packStore.ts`
  delegates to it; `packStore.test.ts` and the PackCenter tests are byte-identical and green.
- `store/pluginStore.ts`: catalog (404 -> unsupported; failed refresh keeps rows), the inspection state machine (every
  install goes through inspect; a built-in pack auto-installs; a GitHub source stops at a review card the next PR
  renders; consent is sent as the declared capability list, never a boolean), install / update / uninstall / enable /
  disable, one follower instance, and after any settled change the sequential refresh catalog -> node definitions
  (`fetchDefinitions`, never `POST /api/nodes/reload`) -> plugin frontends. `uiStore` gains the plugin-center open/close/
  focus fields; `usePluginCatalogBootstrap` reads the catalog once at boot from the sidebar shell.
- `plugins/PluginHost.tsx`: all activations go through one promise chain (boot, reload, dev poll) so a reload can never
  race the boot; `reloadPluginFrontends()` fetches the plugin list first and keeps the current UI when the server is
  unreachable, otherwise tears down and re-imports with a cache-busted URL.

What I deliberately did not do: no UI; no changes to `plugins/contract.ts` (the SDK contract; `provider` is on the
app's `NodeDefinition` only — an apiVersion-6 note); the Chrome pass for this PR is a regression pass (Package Center
install + cancel, plugin frontends at boot, dev hot reload) because the plugin routes are not on this branch.

## Closes / relates to

Part of the Plugin Center + Source Control wave (no issue number; the wave plan is the authority). Stays open: the
Plugin Center UI (next PR), the install/inspect routes (#407, then the next backend PR).

## Test evidence

```
cd frontend && pnpm test          -> 159 files / 3980 tests passed   (main at 115b628: 156 files / 3811 tests)
cd frontend && pnpm build         -> green (contrast gate + tsc -b + vite; only the pre-existing chunk-size warning)
pack gate: pnpm test -- src/store/packStore.test.ts src/components/PackCenter -> 6 files / 219 tests green, files byte-identical to main
```

Chrome regression pass (Windows Chrome, the dist built from this head, served by this checkout's `cdui.cmd start` with
its dev sandbox user-data dir, the official template plugin linked):

- Boot: the plugin panel activates; `/api/plugins/catalog` answers 404 once, no retry, no toast; console clean.
- Package Center: `word-vectors` installs end to end through the extracted follower (cursors strictly increasing, one
  long-poll at a time, result banner, toast, row flips, catalog refreshed); `sentence-embeddings` started, page reloaded
  mid-job, the Settings row and the reopened pane pick the running job up and follow it to `done`; `rag` cancelled
  mid-download ends `cancelled` with the banner and toast, the row returns to partial, polling stops.
- Dev hot reload: after a reload-generation bump the host fetches `/api/plugins` exactly once, re-imports
  `.../frontend/index.js?v=5`, shows the zh-TW toast, and re-creates exactly one panel instance.

Every task was implemented by a fresh subagent, task-reviewed (spec + quality) with fix rounds, and the whole branch
got two area reviews plus one fix wave with a scoped re-review.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its zh-TW twin in the same PR (no docs page
      changed; both locale files changed together).
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do (above).
