### PR TITLE
fix(ui,export): a viz viewer outlives its culled card, and the light card palette parts for colour-blind readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,6 +264,30 @@ received — each links to the release it was published as.
   atomically, so a reader sees the old file or the new one and never the
   write in progress.
 
+- **The full-size attention and embedding viewers survive the card that
+  opened them scrolling out of view** ([#324]). Since [#321] the canvas
+  renders only the cards inside the viewport, and each viz card kept its
+  "View full" heatmap or scatter viewer as its own local state — so a window
+  resize, a browser zoom, Shift+L or Ctrl+Z while the viewer was up unmounted
+  the card and took the viewer down with it. The viewer is now one component
+  at the app root, driven by the tab the way the node-detail, preset and
+  layers modals already are: a card only asks for its viewer, and the host
+  reads the node's output from the store and stays up until you close it.
+  Deleting the node, collapsing it into a block or opening another document
+  closes it, and Enter no longer opens the node-detail modal over it.
+
+- **Light-theme diagram exports: the card colours differ in lightness, so a
+  red-green colour-blind reader can tell the categories apart** ([#390]).
+  [#323] parted the wire ambers; the fourteen card hues still sat at one
+  lightness, so RNN and Tensor Operations were 0.01 L* apart and the closest
+  pair under a deuteranopia simulation measured 2.13 dE00 — one colour. Each
+  category now has its own lightness tier (LLM, Classical, Data Flow, Utility
+  and Tensor Operations sit darker; every hue stays its canvas hue), and the
+  closest pair is 6.7 dE00 under both deuteranopia and protanopia. The
+  contrast gate now simulates both deficiencies for every export palette and
+  holds the light cards to the same lightness-parting rule as the wires, so
+  the class cannot come back.
+
 ## [2.5.0] — 2026-09-01
 
 Twenty-four commits since 2.4.1, around three themes. The Package Center
@@ -3024,10 +3048,12 @@ Release candidates before 1.0.0 are on the
 [#380]: https://github.com/CodefyUI/CodefyUI/issues/380
 [#386]: https://github.com/CodefyUI/CodefyUI/issues/386
 [#387]: https://github.com/CodefyUI/CodefyUI/issues/387
+[#390]: https://github.com/CodefyUI/CodefyUI/issues/390
 [#371]: https://github.com/CodefyUI/CodefyUI/pull/371
 [#372]: https://github.com/CodefyUI/CodefyUI/issues/372
 [#305]: https://github.com/CodefyUI/CodefyUI/issues/305
 [#323]: https://github.com/CodefyUI/CodefyUI/issues/323
+[#324]: https://github.com/CodefyUI/CodefyUI/issues/324
 [#325]: https://github.com/CodefyUI/CodefyUI/issues/325
 [#337]: https://github.com/CodefyUI/CodefyUI/issues/337
 [#341]: https://github.com/CodefyUI/CodefyUI/issues/341

--- a/frontend/scripts/check-contrast.mjs
+++ b/frontend/scripts/check-contrast.mjs
@@ -131,6 +131,42 @@ const deltaE2000Lab = ([L1, a1, b1], [L2, a2, b2]) => {
 };
 const deltaE2000 = (a, b) => deltaE2000Lab(lab(a), lab(b));
 
+/** Linear-light sRGB, the space the dichromacy matrices below act in. */
+const linearRgb = (colour) =>
+  toRgb(colour).map((v) => {
+    const c = v / 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+const fromLinear = (lin) =>
+  `#${lin
+    .map((c) => {
+      const clamped = Math.min(1, Math.max(0, c));
+      const v = clamped <= 0.0031308 ? 12.92 * clamped : 1.055 * Math.pow(clamped, 1 / 2.4) - 0.055;
+      return Math.round(v * 255).toString(16).padStart(2, '0');
+    })
+    .join('')}`;
+
+/** Machado, Oliveira and Fernandes (2009), "A Physiologically-based Model
+ *  for Simulation of Color Vision Deficiency", at full severity. Rows act on
+ *  linear RGB and each sums to one, so a grey stays the same grey and only
+ *  hue is lost — which is the point: a palette that separates two hues on
+ *  the red-green axis alone measures fine in dE00 and collapses here. */
+const DEUTERANOPIA = [
+  [0.367322, 0.860646, -0.227968],
+  [0.280085, 0.672501, 0.047413],
+  [-0.01182, 0.04294, 0.968881],
+];
+const PROTANOPIA = [
+  [0.152286, 1.052583, -0.204868],
+  [0.114503, 0.786281, 0.099216],
+  [-0.003882, -0.048116, 1.051998],
+];
+/** The colour a dichromat with the given deficiency sees for `colour`. */
+const simulate = (colour, matrix) => {
+  const lin = linearRgb(colour);
+  return fromLinear(matrix.map((row) => row[0] * lin[0] + row[1] * lin[1] + row[2] * lin[2]));
+};
+
 /** Smallest CIEDE2000 distance between any two members of a palette, with the
  *  pair that produced it — that pair is the one a reader has to tell apart. */
 const closestPair = (entries) => {
@@ -186,6 +222,17 @@ const selfTests = [
     0.0001,
   ],
   ['dE00 of a colour with itself', deltaE2000('#4caf50', '#4caf50'), 0, 1e-9],
+  // The dichromacy matrices: a grey must come back as itself (rows sum to
+  // one), and a red beside a green — 86 dE00 apart to everyone else — must
+  // land within a few dE00 for a deuteranope, or the simulation is not one.
+  ['deuteranopia keeps white white', deltaE2000(simulate('#ffffff', DEUTERANOPIA), '#ffffff'), 0, 0.5],
+  ['protanopia keeps mid-grey grey', deltaE2000(simulate('#808080', PROTANOPIA), '#808080'), 0, 0.5],
+  [
+    'deuteranopia collapses red onto green',
+    deltaE2000(simulate('#ff0000', DEUTERANOPIA), simulate('#00a000', DEUTERANOPIA)),
+    0,
+    6,
+  ],
   // Lab of pure white is (100, 0, 0) — proves the sRGB -> Lab leg, which the
   // reference pairs above skip because they start in Lab.
   ['L* of #ffffff via lab()', lab('#ffffff')[0], 100, 0.001],
@@ -624,12 +671,16 @@ for (const [slugs, canvas, light] of LIGHT_TWINS) {
         reader calls "the ambers" — and the axis every viewer keeps is
         lightness, so a same-family pair has to be parted there.
 
-        Wires only. A wire is a bare coloured line with nothing written on it,
-        so its hue is the whole message; a category hue is drawn as a card's
-        border AND its title, in a box with the node's name inside it. (The
-        light card palette is iso-lightness by construction — fourteen hues all
-        at 4.7:1 on white — so holding it to this would be a repaint, not a
-        token edit.) */
+        Wires in both themes, and the light theme's cards too (core#390). The
+        light card palette used to be exempt — fourteen hues all at 4.7:1 on
+        white, iso-lightness by construction, so rnn and tensorops sat 0.01 L*
+        apart — and was repainted so that it no longer needs to be: each
+        category now has its own lightness, chosen so that two hues a
+        dichromat cannot tell apart differ in the one axis they can see (11d
+        below measures that directly). The dark theme's cards are the canvas
+        palette itself, whose classical/rl ambers are 1.5 L* apart; repainting
+        the app is a separate change, and `minSeparation` above records that
+        state. */
 const FAMILY_HUE_DEGREES = 20;
 const FAMILY_MIN_CHROMA = MIN_HUE_CHROMA;
 /* The floor, in L*, and where the number came from: optimizer/image is the
@@ -643,12 +694,11 @@ const FAMILY_MIN_CHROMA = MIN_HUE_CHROMA;
    buys separation the eye reads as "that colour again, dimmer". Move the hues
    apart instead and the pair leaves the 20-degree window on its own. */
 const FAMILY_MIN_LIGHTNESS = 4;
-for (const theme of DIAGRAM_THEMES) {
-  const wires = DIAGRAM_TYPES.map((slug) => [slug, t(theme.type(slug))]);
-  for (let i = 0; i < wires.length; i++) {
-    for (let j = i + 1; j < wires.length; j++) {
-      const [aSlug, a] = wires[i];
-      const [bSlug, b] = wires[j];
+const partedInLightness = (label, kind, entries) => {
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      const [aSlug, a] = entries[i];
+      const [bSlug, b] = entries[j];
       if (chroma(a) < FAMILY_MIN_CHROMA || chroma(b) < FAMILY_MIN_CHROMA) continue;
       const apart = hueGap(a, b);
       if (apart > FAMILY_HUE_DEGREES) continue;
@@ -656,12 +706,64 @@ for (const theme of DIAGRAM_THEMES) {
       const gap = Math.abs(lstar(a) - lstar(b));
       if (gap < FAMILY_MIN_LIGHTNESS) {
         failures.push(
-          `diagram/${theme.name}: wire types ${aSlug} and ${bSlug} are ${apart.toFixed(1)} degrees ` +
+          `${label}: ${kind} ${aSlug} and ${bSlug} are ${apart.toFixed(1)} degrees ` +
             `of hue apart — one colour family — and only ${gap.toFixed(2)} L* apart (needs ` +
             `${FAMILY_MIN_LIGHTNESS}); darken one of them past its contrast floor, the way ` +
             `--diagram-light-classical was parted from --diagram-light-rl`
         );
       }
+    }
+  }
+};
+for (const theme of DIAGRAM_THEMES) {
+  partedInLightness(
+    `diagram/${theme.name}`,
+    'wire types',
+    DIAGRAM_TYPES.map((slug) => [slug, t(theme.type(slug))]),
+  );
+  if (theme.name === 'light') {
+    partedInLightness(
+      `diagram/${theme.name}`,
+      'categories',
+      DIAGRAM_CATEGORIES.map((slug) => [slug, t(theme.category(slug))]),
+    );
+  }
+}
+
+/* 11d. The rule 11c approximates, measured directly: run each palette through
+        a dichromat and take its closest pair there. 11c only sees pairs inside
+        one hue family; a deuteranope also merges a blue with a violet and a
+        red with a green, so the light cards measured 2.13 dE00 at their
+        closest under deuteranopia (rnn/llm) while every normal-vision floor
+        above passed with room to spare (core#390).
+
+        One floor per palette. The light cards were repainted against this
+        rule and are held to a real floor: 6 dE00 is one notch under what the
+        repaint achieves under both deficiencies and about three times where
+        it started. The other three palettes were never designed for it, so
+        their floors record where they stand, which stops a token edit from
+        lowering them: the wire palettes' closest pairs (list/transform in both
+        themes) and the canvas cards' (classical/rl) are the same pairs 11 and
+        11c already name as the ones to part next. */
+const DICHROMACIES = [
+  ['deuteranopia', DEUTERANOPIA],
+  ['protanopia', PROTANOPIA],
+];
+const DICHROMAT_FLOORS = [
+  { label: 'diagram/light categories', theme: DIAGRAM_THEMES[0], palette: 'category', slugs: DIAGRAM_CATEGORIES, min: 6 },
+  { label: 'diagram/light wire types', theme: DIAGRAM_THEMES[0], palette: 'type', slugs: DIAGRAM_TYPES, min: 1.4 },
+  { label: 'diagram/dark categories', theme: DIAGRAM_THEMES[1], palette: 'category', slugs: DIAGRAM_CATEGORIES, min: 0.5 },
+  { label: 'diagram/dark wire types', theme: DIAGRAM_THEMES[1], palette: 'type', slugs: DIAGRAM_TYPES, min: 2.5 },
+];
+for (const { label, theme, palette, slugs, min } of DICHROMAT_FLOORS) {
+  for (const [deficiency, matrix] of DICHROMACIES) {
+    const seen = closestPair(slugs.map((slug) => [slug, simulate(t(theme[palette](slug)), matrix)]));
+    checked += 1;
+    if (seen.min < min) {
+      failures.push(
+        `${label}: under ${deficiency}, ${seen.pair.join(' and ')} are only ${seen.min.toFixed(2)} dE00 ` +
+          `apart (needs ${min}) — one colour to a red-green colour-blind reader; part them in lightness`
+      );
     }
   }
 }

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -47,6 +47,9 @@ vi.mock('./components/LayersEditor/LayersEditorModal', () => ({
 vi.mock('./components/NodeDetailModal/NodeDetailModal', () => ({
   NodeDetailModal: () => <div data-testid="node-detail-modal" />,
 }));
+vi.mock('./components/Nodes/VizViewerModal', () => ({
+  VizViewerModal: () => <div data-testid="viz-viewer-modal" />,
+}));
 vi.mock('./components/shared/Toast', () => ({
   ToastContainer: () => <div data-testid="toast-container" />,
 }));
@@ -124,6 +127,7 @@ describe('App', () => {
     expect(screen.getByTestId('preset-modal')).toBeTruthy();
     expect(screen.getByTestId('layers-editor-modal')).toBeTruthy();
     expect(screen.getByTestId('node-detail-modal')).toBeTruthy();
+    expect(screen.getByTestId('viz-viewer-modal')).toBeTruthy();
     expect(screen.getByTestId('toast-container')).toBeTruthy();
     expect(screen.getByTestId('shortcuts-modal')).toBeTruthy();
     expect(screen.getByTestId('dialog-container')).toBeTruthy();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { ResultsPanel } from './components/ResultsPanel/ResultsPanel';
 import { PresetConfigModal } from './components/PresetModal/PresetConfigModal';
 import { LayersEditorModal } from './components/LayersEditor/LayersEditorModal';
 import { NodeDetailModal } from './components/NodeDetailModal/NodeDetailModal';
+import { VizViewerModal } from './components/Nodes/VizViewerModal';
 import { TemplateGalleryModal } from './components/TemplateGallery/TemplateGalleryModal';
 import { PackCenterModal } from './components/PackCenter/PackCenterModal';
 import { RestartOverlay } from './components/PackCenter/RestartOverlay';
@@ -158,6 +159,7 @@ function App() {
       <PresetConfigModal />
       <LayersEditorModal />
       <NodeDetailModal />
+      <VizViewerModal />
       <TemplateGalleryModal />
       <PackCenterModal />
       <ToastContainer />

--- a/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
+++ b/frontend/src/components/NodeDetailModal/NodeDetailModal.test.tsx
@@ -280,6 +280,11 @@ describe('NodeDetailModal — open paths', () => {
     fireEvent.keyDown(document, { key: 'Enter' });
     expect(activeTab().nodeDetailNodeId).toBeNull();
 
+    // A viz card's full-size viewer is a modal too (core#324).
+    seedTab({ nodes: [node('n1')], selectedNodeId: 'n1', vizModalNodeId: 'n1' });
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(activeTab().nodeDetailNodeId).toBeNull();
+
     seedTab({ nodes: [node('n1')], selectedNodeId: 'n1', nodeDetailNodeId: 'n1' });
     const before = activeTab().nodes;
     fireEvent.keyDown(document, { key: 'Enter' });

--- a/frontend/src/components/Nodes/AttentionHeatmapVizNode.test.tsx
+++ b/frontend/src/components/Nodes/AttentionHeatmapVizNode.test.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../../i18n';
 import { useTabStore } from '../../store/tabStore';
 import type { NodeData, NodeDefinition, OutputSummary } from '../../types';
 import AttentionHeatmapVizNode from './AttentionHeatmapVizNode';
+import { VizViewerModal } from './VizViewerModal';
 
 const flowProps = {
   zIndex: 0,
@@ -52,6 +53,8 @@ function seed(summary: Record<string, OutputSummary> | undefined, runId: string 
         name: 'Tab',
         nodes: [],
         edges: [],
+        // A viewer left open by the previous test must not carry over.
+        vizModalNodeId: null,
         lastRunId: runId,
         outputSummaries: summary ? { [NODE_ID]: summary } : ({} as Record<string, Record<string, OutputSummary>>),
       },
@@ -60,8 +63,21 @@ function seed(summary: Record<string, OutputSummary> | undefined, runId: string 
 }
 
 function renderNode(d: NodeData = data()) {
+  // The "View full" viewer is the store-driven host at the app root
+  // (core#324), which reads the node off the tab -- so the tab has to hold
+  // the node the card is rendered for, and the host renders beside the card.
+  useTabStore.setState((s) => ({
+    tabs: s.tabs.map((t) =>
+      t.id === s.activeTabId
+        ? { ...t, nodes: [{ id: NODE_ID, type: 'attentionHeatmapNode', position: { x: 0, y: 0 }, data: d }] }
+        : t,
+    ),
+  }));
   return renderWithFlow(
-    <AttentionHeatmapVizNode id={NODE_ID} type="attentionHeatmapNode" data={d} selected={false} {...flowProps} />,
+    <>
+      <AttentionHeatmapVizNode id={NODE_ID} type="attentionHeatmapNode" data={d} selected={false} {...flowProps} />
+      <VizViewerModal />
+    </>,
   );
 }
 

--- a/frontend/src/components/Nodes/AttentionHeatmapVizNode.tsx
+++ b/frontend/src/components/Nodes/AttentionHeatmapVizNode.tsx
@@ -1,11 +1,11 @@
-import { memo, useMemo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import type { NodeProps } from '@xyflow/react';
 import type { AppNode } from '../../types';
 import { useTabStore } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
 import { HeatmapPlot, type HeatmapColormap } from '../shared/HeatmapPlot';
-import { HeatmapModal } from '../shared/HeatmapModal';
 import { BaseNodeBody } from './BaseNode';
+import { attentionWeights, labelList } from './vizViewers';
 import styles from './AttentionVizNode.module.css';
 
 /**
@@ -14,7 +14,8 @@ import styles from './AttentionVizNode.module.css';
  *
  * The "view full" path REST-fetches the tensor when WS values weren't
  * embedded inline (numel > 256), so this works for production-sized
- * attention matrices too.
+ * attention matrices too. The viewer itself is `VizViewerModal` at the app
+ * root (core#324); the card only asks the store to open it.
  */
 function AttentionHeatmapVizNode(props: NodeProps<AppNode>) {
   const { id, data } = props;
@@ -23,27 +24,10 @@ function AttentionHeatmapVizNode(props: NodeProps<AppNode>) {
     const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
     return tab?.outputSummaries?.[id];
   });
-  const runId = useTabStore((s) => {
-    const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
-    return tab?.lastRunId ?? null;
-  });
+  const openVizModal = useTabStore((s) => s.openVizModal);
 
-  const [expanded, setExpanded] = useState(false);
-
-  const matrix = useMemo<number[][] | number[][][] | null>(() => {
-    const v = summaries?.weights?.values;
-    if (!Array.isArray(v) || v.length === 0) return null;
-    if (Array.isArray(v[0]) && Array.isArray(v[0][0]) && Array.isArray((v[0][0] as unknown[])[0])) {
-      return (v as unknown as number[][][][])[0];
-    }
-    return v as number[][] | number[][][];
-  }, [summaries]);
-
-  const labels = useMemo<string[] | undefined>(() => {
-    const lv = summaries?.labels?.values;
-    if (!Array.isArray(lv) || lv.length === 0) return undefined;
-    return lv.map((s) => String(s));
-  }, [summaries]);
+  const matrix = useMemo(() => attentionWeights(summaries?.weights?.values), [summaries]);
+  const labels = useMemo(() => labelList(summaries?.labels?.values), [summaries]);
 
   const colormap = (data.params?.colormap as HeatmapColormap | undefined) ?? 'viridis';
   const hasShape = !!summaries?.weights;
@@ -60,7 +44,7 @@ function AttentionHeatmapVizNode(props: NodeProps<AppNode>) {
           <button
             type="button"
             className={styles.expandLink}
-            onClick={() => setExpanded(true)}
+            onClick={() => openVizModal(id)}
           >
             {t('attention.viewFull')} →
           </button>
@@ -73,23 +57,10 @@ function AttentionHeatmapVizNode(props: NodeProps<AppNode>) {
           colormap={colormap}
           panelWidth={is3D ? 140 : 220}
           panelHeight={is3D ? 140 : 220}
-          onExpand={() => setExpanded(true)}
+          onExpand={() => openVizModal(id)}
           normalizePerRow
         />
       )}
-      <HeatmapModal
-        isOpen={expanded}
-        onClose={() => setExpanded(false)}
-        title={`AttentionHeatmap · ${data.label ?? id}`}
-        inlineData={matrix}
-        rowLabels={labels}
-        colormap={colormap}
-        runId={runId}
-        nodeId={id}
-        port="weights"
-        detectCausalMask
-        normalizePerRow
-      />
     </div>
   );
 

--- a/frontend/src/components/Nodes/AttentionMaskVizNode.test.tsx
+++ b/frontend/src/components/Nodes/AttentionMaskVizNode.test.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../../i18n';
 import { useTabStore } from '../../store/tabStore';
 import type { NodeData, NodeDefinition, OutputSummary } from '../../types';
 import AttentionMaskVizNode from './AttentionMaskVizNode';
+import { VizViewerModal } from './VizViewerModal';
 
 const flowProps = {
   zIndex: 0,
@@ -52,6 +53,8 @@ function seed(summary: Record<string, OutputSummary> | undefined, runId: string 
         name: 'Tab',
         nodes: [],
         edges: [],
+        // A viewer left open by the previous test must not carry over.
+        vizModalNodeId: null,
         lastRunId: runId,
         outputSummaries: summary ? { [NODE_ID]: summary } : ({} as Record<string, Record<string, OutputSummary>>),
       },
@@ -60,8 +63,21 @@ function seed(summary: Record<string, OutputSummary> | undefined, runId: string 
 }
 
 function renderNode(d: NodeData = data()) {
+  // The "View full" viewer is the store-driven host at the app root
+  // (core#324), which reads the node off the tab -- so the tab has to hold
+  // the node the card is rendered for, and the host renders beside the card.
+  useTabStore.setState((s) => ({
+    tabs: s.tabs.map((t) =>
+      t.id === s.activeTabId
+        ? { ...t, nodes: [{ id: NODE_ID, type: 'attentionMaskNode', position: { x: 0, y: 0 }, data: d }] }
+        : t,
+    ),
+  }));
   return renderWithFlow(
-    <AttentionMaskVizNode id={NODE_ID} type="attentionMaskNode" data={d} selected={false} {...flowProps} />,
+    <>
+      <AttentionMaskVizNode id={NODE_ID} type="attentionMaskNode" data={d} selected={false} {...flowProps} />
+      <VizViewerModal />
+    </>,
   );
 }
 

--- a/frontend/src/components/Nodes/AttentionMaskVizNode.tsx
+++ b/frontend/src/components/Nodes/AttentionMaskVizNode.tsx
@@ -1,35 +1,23 @@
-import { memo, useMemo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import type { NodeProps } from '@xyflow/react';
 import type { AppNode } from '../../types';
 import { useTabStore } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
 import { HeatmapPlot } from '../shared/HeatmapPlot';
-import { HeatmapModal } from '../shared/HeatmapModal';
 import { BaseNodeBody } from './BaseNode';
+import { maskMatrix } from './vizViewers';
 import styles from './AttentionVizNode.module.css';
 
 function AttentionMaskVizNode(props: NodeProps<AppNode>) {
-  const { id, data } = props;
+  const { id } = props;
   const { t } = useI18n();
   const summaries = useTabStore((s) => {
     const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
     return tab?.outputSummaries?.[id];
   });
-  const runId = useTabStore((s) => {
-    const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
-    return tab?.lastRunId ?? null;
-  });
+  const openVizModal = useTabStore((s) => s.openVizModal);
 
-  const [expanded, setExpanded] = useState(false);
-
-  const matrix = useMemo<number[][] | null>(() => {
-    const v = summaries?.mask?.values;
-    if (!Array.isArray(v) || v.length === 0) return null;
-    const rows = v as unknown[];
-    return rows.map((row) =>
-      Array.isArray(row) ? row.map((x) => (x ? 1 : 0)) : [],
-    );
-  }, [summaries]);
+  const matrix = useMemo(() => maskMatrix(summaries?.mask?.values), [summaries]);
 
   const hasShape = !!summaries?.mask;
 
@@ -44,7 +32,7 @@ function AttentionMaskVizNode(props: NodeProps<AppNode>) {
           <button
             type="button"
             className={styles.expandLink}
-            onClick={() => setExpanded(true)}
+            onClick={() => openVizModal(id)}
           >
             {t('attention.viewFull')} →
           </button>
@@ -57,21 +45,9 @@ function AttentionMaskVizNode(props: NodeProps<AppNode>) {
           panelWidth={180}
           panelHeight={180}
           detectCausalMask={false}
-          onExpand={() => setExpanded(true)}
+          onExpand={() => openVizModal(id)}
         />
       )}
-      <HeatmapModal
-        isOpen={expanded}
-        onClose={() => setExpanded(false)}
-        title={`AttentionMask · ${data.label ?? id}`}
-        inlineData={matrix}
-        colormap="RdBu"
-        detectCausalMask={false}
-        runId={runId}
-        nodeId={id}
-        port="mask"
-        variant="mask"
-      />
     </div>
   );
 

--- a/frontend/src/components/Nodes/EduCrossAttentionVizNode.test.tsx
+++ b/frontend/src/components/Nodes/EduCrossAttentionVizNode.test.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../../i18n';
 import { useTabStore } from '../../store/tabStore';
 import type { NodeData, NodeDefinition, OutputSummary } from '../../types';
 import EduCrossAttentionVizNode from './EduCrossAttentionVizNode';
+import { VizViewerModal } from './VizViewerModal';
 
 const flowProps = {
   zIndex: 0,
@@ -52,6 +53,8 @@ function seed(summary: Record<string, OutputSummary> | undefined, runId: string 
         name: 'Tab',
         nodes: [],
         edges: [],
+        // A viewer left open by the previous test must not carry over.
+        vizModalNodeId: null,
         lastRunId: runId,
         outputSummaries: summary ? { [NODE_ID]: summary } : ({} as Record<string, Record<string, OutputSummary>>),
       },
@@ -60,8 +63,21 @@ function seed(summary: Record<string, OutputSummary> | undefined, runId: string 
 }
 
 function renderNode(d: NodeData = data()) {
+  // The "View full" viewer is the store-driven host at the app root
+  // (core#324), which reads the node off the tab -- so the tab has to hold
+  // the node the card is rendered for, and the host renders beside the card.
+  useTabStore.setState((s) => ({
+    tabs: s.tabs.map((t) =>
+      t.id === s.activeTabId
+        ? { ...t, nodes: [{ id: NODE_ID, type: 'eduCrossAttentionNode', position: { x: 0, y: 0 }, data: d }] }
+        : t,
+    ),
+  }));
   return renderWithFlow(
-    <EduCrossAttentionVizNode id={NODE_ID} type="eduCrossAttentionNode" data={d} selected={false} {...flowProps} />,
+    <>
+      <EduCrossAttentionVizNode id={NODE_ID} type="eduCrossAttentionNode" data={d} selected={false} {...flowProps} />
+      <VizViewerModal />
+    </>,
   );
 }
 

--- a/frontend/src/components/Nodes/EduCrossAttentionVizNode.tsx
+++ b/frontend/src/components/Nodes/EduCrossAttentionVizNode.tsx
@@ -1,11 +1,11 @@
-import { memo, useMemo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import type { NodeProps } from '@xyflow/react';
 import type { AppNode } from '../../types';
 import { useTabStore } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
 import { HeatmapPlot } from '../shared/HeatmapPlot';
-import { HeatmapModal } from '../shared/HeatmapModal';
 import { BaseNodeBody } from './BaseNode';
+import { attentionHeads, labelList } from './vizViewers';
 import styles from './AttentionVizNode.module.css';
 
 /**
@@ -21,34 +21,11 @@ function EduCrossAttentionVizNode(props: NodeProps<AppNode>) {
     const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
     return tab?.outputSummaries?.[id];
   });
-  const runId = useTabStore((s) => {
-    const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
-    return tab?.lastRunId ?? null;
-  });
+  const openVizModal = useTabStore((s) => s.openVizModal);
 
-  const [expanded, setExpanded] = useState(false);
-
-  const heads = useMemo<number[][][] | null>(() => {
-    const v = summaries?.weights?.values;
-    if (!Array.isArray(v) || v.length === 0) return null;
-    if (Array.isArray(v[0]) && Array.isArray(v[0][0]) && Array.isArray((v[0][0] as unknown[])[0])) {
-      // 4D — [B, H, Q_seq, K_seq] → take batch=0.
-      return (v as unknown as number[][][][])[0];
-    }
-    return v as unknown as number[][][];
-  }, [summaries]);
-
-  const qLabels = useMemo<string[] | undefined>(() => {
-    const lv = summaries?.q_labels?.values;
-    if (!Array.isArray(lv) || lv.length === 0) return undefined;
-    return lv.map((s) => String(s));
-  }, [summaries]);
-
-  const kLabels = useMemo<string[] | undefined>(() => {
-    const lv = summaries?.k_labels?.values;
-    if (!Array.isArray(lv) || lv.length === 0) return undefined;
-    return lv.map((s) => String(s));
-  }, [summaries]);
+  const heads = useMemo(() => attentionHeads(summaries?.weights?.values), [summaries]);
+  const qLabels = useMemo(() => labelList(summaries?.q_labels?.values), [summaries]);
+  const kLabels = useMemo(() => labelList(summaries?.k_labels?.values), [summaries]);
 
   const numHeads = heads?.length ?? Number(data.params?.num_heads ?? 0);
   const hasShape = !!summaries?.weights;
@@ -65,7 +42,7 @@ function EduCrossAttentionVizNode(props: NodeProps<AppNode>) {
           <button
             type="button"
             className={styles.expandLink}
-            onClick={() => setExpanded(true)}
+            onClick={() => openVizModal(id)}
           >
             {t('attention.viewFull')} →
           </button>
@@ -79,7 +56,7 @@ function EduCrossAttentionVizNode(props: NodeProps<AppNode>) {
             colLabels={kLabels}
             panelWidth={panelSize}
             panelHeight={panelSize}
-            onExpand={() => setExpanded(true)}
+            onExpand={() => openVizModal(id)}
             normalizePerRow
             // Cross-attention is always rectangular and lives outside the
             // causal regime — don't try to detect a causal pattern.
@@ -91,19 +68,6 @@ function EduCrossAttentionVizNode(props: NodeProps<AppNode>) {
           </div>
         </>
       )}
-      <HeatmapModal
-        isOpen={expanded}
-        onClose={() => setExpanded(false)}
-        title={`EduCrossAttention · ${data.label ?? id}`}
-        inlineData={heads}
-        rowLabels={qLabels}
-        colLabels={kLabels}
-        runId={runId}
-        nodeId={id}
-        port="weights"
-        detectCausalMask={false}
-        normalizePerRow
-      />
     </div>
   );
 

--- a/frontend/src/components/Nodes/EduMultiHeadAttentionVizNode.test.tsx
+++ b/frontend/src/components/Nodes/EduMultiHeadAttentionVizNode.test.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../../i18n';
 import { useTabStore } from '../../store/tabStore';
 import type { NodeData, NodeDefinition, OutputSummary } from '../../types';
 import EduMultiHeadAttentionVizNode from './EduMultiHeadAttentionVizNode';
+import { VizViewerModal } from './VizViewerModal';
 
 const flowProps = {
   zIndex: 0,
@@ -52,6 +53,8 @@ function seed(summary: Record<string, OutputSummary> | undefined, runId: string 
         name: 'Tab',
         nodes: [],
         edges: [],
+        // A viewer left open by the previous test must not carry over.
+        vizModalNodeId: null,
         lastRunId: runId,
         outputSummaries: summary ? { [NODE_ID]: summary } : ({} as Record<string, Record<string, OutputSummary>>),
       },
@@ -60,8 +63,21 @@ function seed(summary: Record<string, OutputSummary> | undefined, runId: string 
 }
 
 function renderNode(d: NodeData = data()) {
+  // The "View full" viewer is the store-driven host at the app root
+  // (core#324), which reads the node off the tab -- so the tab has to hold
+  // the node the card is rendered for, and the host renders beside the card.
+  useTabStore.setState((s) => ({
+    tabs: s.tabs.map((t) =>
+      t.id === s.activeTabId
+        ? { ...t, nodes: [{ id: NODE_ID, type: 'eduMultiHeadAttentionNode', position: { x: 0, y: 0 }, data: d }] }
+        : t,
+    ),
+  }));
   return renderWithFlow(
-    <EduMultiHeadAttentionVizNode id={NODE_ID} type="eduMultiHeadAttentionNode" data={d} selected={false} {...flowProps} />,
+    <>
+      <EduMultiHeadAttentionVizNode id={NODE_ID} type="eduMultiHeadAttentionNode" data={d} selected={false} {...flowProps} />
+      <VizViewerModal />
+    </>,
   );
 }
 

--- a/frontend/src/components/Nodes/EduMultiHeadAttentionVizNode.tsx
+++ b/frontend/src/components/Nodes/EduMultiHeadAttentionVizNode.tsx
@@ -1,11 +1,11 @@
-import { memo, useMemo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import type { NodeProps } from '@xyflow/react';
 import type { AppNode } from '../../types';
 import { useTabStore } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
 import { HeatmapPlot } from '../shared/HeatmapPlot';
-import { HeatmapModal } from '../shared/HeatmapModal';
 import { BaseNodeBody } from './BaseNode';
+import { attentionHeads, labelList } from './vizViewers';
 import styles from './AttentionVizNode.module.css';
 
 function EduMultiHeadAttentionVizNode(props: NodeProps<AppNode>) {
@@ -15,27 +15,10 @@ function EduMultiHeadAttentionVizNode(props: NodeProps<AppNode>) {
     const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
     return tab?.outputSummaries?.[id];
   });
-  const runId = useTabStore((s) => {
-    const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
-    return tab?.lastRunId ?? null;
-  });
+  const openVizModal = useTabStore((s) => s.openVizModal);
 
-  const [expanded, setExpanded] = useState(false);
-
-  const heads = useMemo<number[][][] | null>(() => {
-    const v = summaries?.weights?.values;
-    if (!Array.isArray(v) || v.length === 0) return null;
-    if (Array.isArray(v[0]) && Array.isArray(v[0][0]) && Array.isArray((v[0][0] as unknown[])[0])) {
-      return (v as unknown as number[][][][])[0];
-    }
-    return v as unknown as number[][][];
-  }, [summaries]);
-
-  const labels = useMemo<string[] | undefined>(() => {
-    const lv = summaries?.labels?.values;
-    if (!Array.isArray(lv) || lv.length === 0) return undefined;
-    return lv.map((s) => String(s));
-  }, [summaries]);
+  const heads = useMemo(() => attentionHeads(summaries?.weights?.values), [summaries]);
+  const labels = useMemo(() => labelList(summaries?.labels?.values), [summaries]);
 
   const numHeads = heads?.length ?? Number(data.params?.num_heads ?? 0);
   const causal = String(data.params?.causal) === 'true';
@@ -54,7 +37,7 @@ function EduMultiHeadAttentionVizNode(props: NodeProps<AppNode>) {
           <button
             type="button"
             className={styles.expandLink}
-            onClick={() => setExpanded(true)}
+            onClick={() => openVizModal(id)}
           >
             {t('attention.viewFull')} →
           </button>
@@ -67,7 +50,7 @@ function EduMultiHeadAttentionVizNode(props: NodeProps<AppNode>) {
             rowLabels={labels}
             panelWidth={panelSize}
             panelHeight={panelSize}
-            onExpand={() => setExpanded(true)}
+            onExpand={() => openVizModal(id)}
             normalizePerRow
           />
           <div className={styles.metaRow}>
@@ -79,18 +62,6 @@ function EduMultiHeadAttentionVizNode(props: NodeProps<AppNode>) {
           </div>
         </>
       )}
-      <HeatmapModal
-        isOpen={expanded}
-        onClose={() => setExpanded(false)}
-        title={`EduMultiHeadAttention · ${data.label ?? id}`}
-        inlineData={heads}
-        rowLabels={labels}
-        runId={runId}
-        nodeId={id}
-        port="weights"
-        detectCausalMask
-        normalizePerRow
-      />
     </div>
   );
 

--- a/frontend/src/components/Nodes/EduSelfAttentionVizNode.test.tsx
+++ b/frontend/src/components/Nodes/EduSelfAttentionVizNode.test.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../../i18n';
 import { useTabStore } from '../../store/tabStore';
 import type { NodeData, NodeDefinition, OutputSummary } from '../../types';
 import EduSelfAttentionVizNode from './EduSelfAttentionVizNode';
+import { VizViewerModal } from './VizViewerModal';
 
 const flowProps = {
   zIndex: 0,
@@ -52,6 +53,8 @@ function seed(summary: Record<string, OutputSummary> | undefined, runId: string 
         name: 'Tab',
         nodes: [],
         edges: [],
+        // A viewer left open by the previous test must not carry over.
+        vizModalNodeId: null,
         lastRunId: runId,
         outputSummaries: summary ? { [NODE_ID]: summary } : ({} as Record<string, Record<string, OutputSummary>>),
       },
@@ -60,8 +63,21 @@ function seed(summary: Record<string, OutputSummary> | undefined, runId: string 
 }
 
 function renderNode(d: NodeData = data()) {
+  // The "View full" viewer is the store-driven host at the app root
+  // (core#324), which reads the node off the tab -- so the tab has to hold
+  // the node the card is rendered for, and the host renders beside the card.
+  useTabStore.setState((s) => ({
+    tabs: s.tabs.map((t) =>
+      t.id === s.activeTabId
+        ? { ...t, nodes: [{ id: NODE_ID, type: 'eduSelfAttentionNode', position: { x: 0, y: 0 }, data: d }] }
+        : t,
+    ),
+  }));
   return renderWithFlow(
-    <EduSelfAttentionVizNode id={NODE_ID} type="eduSelfAttentionNode" data={d} selected={false} {...flowProps} />,
+    <>
+      <EduSelfAttentionVizNode id={NODE_ID} type="eduSelfAttentionNode" data={d} selected={false} {...flowProps} />
+      <VizViewerModal />
+    </>,
   );
 }
 

--- a/frontend/src/components/Nodes/EduSelfAttentionVizNode.tsx
+++ b/frontend/src/components/Nodes/EduSelfAttentionVizNode.tsx
@@ -1,11 +1,11 @@
-import { memo, useMemo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import type { NodeProps } from '@xyflow/react';
 import type { AppNode } from '../../types';
 import { useTabStore } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
 import { HeatmapPlot } from '../shared/HeatmapPlot';
-import { HeatmapModal } from '../shared/HeatmapModal';
 import { BaseNodeBody } from './BaseNode';
+import { labelList, selfAttentionWeights } from './vizViewers';
 import styles from './AttentionVizNode.module.css';
 
 /**
@@ -13,8 +13,9 @@ import styles from './AttentionVizNode.module.css';
  *
  * The backend's `_summarize_single` only embeds tensor values when
  * numel ≤ 256. For longer sequences we still get the shape summary, just
- * without the cell values — the modal then REST-fetches the full tensor
- * (max_elements=4096) so users can still see it at a larger size.
+ * without the cell values — the viewer (`VizViewerModal`, core#324) then
+ * REST-fetches the full tensor (max_elements=4096) so users can still see
+ * it at a larger size.
  */
 function EduSelfAttentionVizNode(props: NodeProps<AppNode>) {
   const { id, data } = props;
@@ -23,27 +24,10 @@ function EduSelfAttentionVizNode(props: NodeProps<AppNode>) {
     const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
     return tab?.outputSummaries?.[id];
   });
-  const runId = useTabStore((s) => {
-    const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
-    return tab?.lastRunId ?? null;
-  });
+  const openVizModal = useTabStore((s) => s.openVizModal);
 
-  const [expanded, setExpanded] = useState(false);
-
-  const matrix = useMemo<number[][] | null>(() => {
-    const v = summaries?.weights?.values;
-    if (!Array.isArray(v) || v.length === 0) return null;
-    if (Array.isArray(v[0]) && Array.isArray((v[0] as unknown[])[0])) {
-      return (v as unknown as number[][][])[0];
-    }
-    return v as number[][];
-  }, [summaries]);
-
-  const labels = useMemo<string[] | undefined>(() => {
-    const lv = summaries?.labels?.values;
-    if (!Array.isArray(lv) || lv.length === 0) return undefined;
-    return lv.map((s) => String(s));
-  }, [summaries]);
+  const matrix = useMemo(() => selfAttentionWeights(summaries?.weights?.values), [summaries]);
+  const labels = useMemo(() => labelList(summaries?.labels?.values), [summaries]);
 
   const causal = String(data.params?.causal) === 'true';
   const hasShape = !!summaries?.weights;
@@ -59,7 +43,7 @@ function EduSelfAttentionVizNode(props: NodeProps<AppNode>) {
           <button
             type="button"
             className={styles.expandLink}
-            onClick={() => setExpanded(true)}
+            onClick={() => openVizModal(id)}
           >
             {t('attention.viewFull')} →
           </button>
@@ -72,7 +56,7 @@ function EduSelfAttentionVizNode(props: NodeProps<AppNode>) {
             rowLabels={labels}
             panelWidth={220}
             panelHeight={220}
-            onExpand={() => setExpanded(true)}
+            onExpand={() => openVizModal(id)}
             normalizePerRow
           />
           {causal && (
@@ -83,18 +67,6 @@ function EduSelfAttentionVizNode(props: NodeProps<AppNode>) {
           )}
         </>
       )}
-      <HeatmapModal
-        isOpen={expanded}
-        onClose={() => setExpanded(false)}
-        title={`EduSelfAttention · ${data.label ?? id}`}
-        inlineData={matrix}
-        rowLabels={labels}
-        runId={runId}
-        nodeId={id}
-        port="weights"
-        detectCausalMask
-        normalizePerRow
-      />
     </div>
   );
 

--- a/frontend/src/components/Nodes/EmbeddingScatterVizNode.test.tsx
+++ b/frontend/src/components/Nodes/EmbeddingScatterVizNode.test.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../../i18n';
 import { useTabStore } from '../../store/tabStore';
 import type { NodeData, NodeDefinition, OutputSummary } from '../../types';
 import EmbeddingScatterVizNode from './EmbeddingScatterVizNode';
+import { VizViewerModal } from './VizViewerModal';
 
 const flowProps = {
   zIndex: 0,
@@ -45,15 +46,30 @@ function seed(summary: Record<string, OutputSummary> | undefined) {
         name: 'Tab',
         nodes: [],
         edges: [],
+        // A viewer left open by the previous test must not carry over.
+        vizModalNodeId: null,
         outputSummaries: summary ? { [NODE_ID]: summary } : ({} as Record<string, Record<string, OutputSummary>>),
       },
     ],
   }));
 }
 
-function renderNode() {
+function renderNode(d: NodeData = data()) {
+  // The "View full" viewer is the store-driven host at the app root
+  // (core#324), which reads the node off the tab -- so the tab has to hold
+  // the node the card is rendered for, and the host renders beside the card.
+  useTabStore.setState((s) => ({
+    tabs: s.tabs.map((t) =>
+      t.id === s.activeTabId
+        ? { ...t, nodes: [{ id: NODE_ID, type: 'embeddingScatterNode', position: { x: 0, y: 0 }, data: d }] }
+        : t,
+    ),
+  }));
   return renderWithFlow(
-    <EmbeddingScatterVizNode id={NODE_ID} type="embeddingScatterNode" data={data()} selected={false} {...flowProps} />,
+    <>
+      <EmbeddingScatterVizNode id={NODE_ID} type="embeddingScatterNode" data={d} selected={false} {...flowProps} />
+      <VizViewerModal />
+    </>,
   );
 }
 
@@ -164,15 +180,7 @@ describe('EmbeddingScatterVizNode', () => {
   it('titles the modal with the node id when the label is absent, and Esc closes it', () => {
     seed({ points_2d: { type: 'tensor', values: [[0, 0], [1, 1]] } });
     const noLabel = { ...data(), label: undefined as unknown as string };
-    const { container } = renderWithFlow(
-      <EmbeddingScatterVizNode
-        id={NODE_ID}
-        type="embeddingScatterNode"
-        data={noLabel}
-        selected={false}
-        {...flowProps}
-      />,
-    );
+    const { container } = renderNode(noLabel);
     fireEvent.click(container.querySelector('button') as HTMLButtonElement);
     expect(screen.getByText(new RegExp(`EmbeddingScatter · ${NODE_ID}`))).toBeTruthy();
     // Closing the modal flips the node's expanded state back off.

--- a/frontend/src/components/Nodes/EmbeddingScatterVizNode.tsx
+++ b/frontend/src/components/Nodes/EmbeddingScatterVizNode.tsx
@@ -1,43 +1,30 @@
-import { memo, useMemo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import type { NodeProps } from '@xyflow/react';
 import type { AppNode } from '../../types';
 import { useTabStore } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
-import { ScatterPlot, type ScatterPoint } from '../shared/ScatterPlot';
-import { ScatterModal } from '../shared/ScatterModal';
+import { ScatterPlot } from '../shared/ScatterPlot';
 import { BaseNodeBody } from './BaseNode';
+import { scatterPoints } from './vizViewers';
 import styles from './EmbeddingScatterVizNode.module.css';
 
 function EmbeddingScatterVizNode(props: NodeProps<AppNode>) {
-  const { id, data } = props;
+  const { id } = props;
   const { t } = useI18n();
   const summaries = useTabStore((s) => {
     const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
     return tab?.outputSummaries?.[id];
   });
-  const runId = useTabStore((s) => {
-    const tab = s.tabs.find((tt) => tt.id === s.activeTabId);
-    return tab?.lastRunId ?? null;
-  });
+  const openVizModal = useTabStore((s) => s.openVizModal);
 
-  const [expanded, setExpanded] = useState(false);
-
-  const points = useMemo<ScatterPoint[] | null>(() => {
-    const tensorVals = summaries?.points_2d?.values;
-    if (!Array.isArray(tensorVals) || tensorVals.length === 0) return null;
-    const labels = summaries?.labels?.values;
-    return tensorVals.map((row, i) => {
-      const r = Array.isArray(row) ? row : [];
-      const x = typeof r[0] === 'number' ? r[0] : 0;
-      const y = typeof r[1] === 'number' ? r[1] : 0;
-      const label = Array.isArray(labels) && typeof labels[i] === 'string' ? (labels[i] as string) : undefined;
-      return { x, y, label, cluster: i };
-    });
-  }, [summaries]);
+  const points = useMemo(
+    () => scatterPoints(summaries?.points_2d?.values, summaries?.labels?.values),
+    [summaries],
+  );
 
   // When N is large the backend skips the inline values (numel > 256), so
   // `points` is null even though the node ran. The shape still tells us how
-  // many points there are — offer the modal, which REST-fetches the full set.
+  // many points there are — offer the viewer, which REST-fetches the full set.
   const shape = summaries?.points_2d?.shape;
   const nPoints = Array.isArray(shape) && typeof shape[0] === 'number' ? shape[0] : 0;
   const tooLarge = points === null && nPoints > 0;
@@ -53,7 +40,7 @@ function EmbeddingScatterVizNode(props: NodeProps<AppNode>) {
           <button
             type="button"
             className={styles.expandLink}
-            onClick={() => setExpanded(true)}
+            onClick={() => openVizModal(id)}
           >
             {t('scatter.openDetail')} →
           </button>
@@ -65,19 +52,9 @@ function EmbeddingScatterVizNode(props: NodeProps<AppNode>) {
           width={300}
           height={207}
           showLabels
-          onExpand={() => setExpanded(true)}
+          onExpand={() => openVizModal(id)}
         />
       )}
-      <ScatterModal
-        isOpen={expanded}
-        onClose={() => setExpanded(false)}
-        title={`EmbeddingScatter · ${data.label ?? id}`}
-        inlinePoints={points}
-        runId={runId}
-        nodeId={id}
-        pointsPort="points_2d"
-        labelsPort="labels"
-      />
     </div>
   );
 

--- a/frontend/src/components/Nodes/VizViewerModal.test.tsx
+++ b/frontend/src/components/Nodes/VizViewerModal.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { FlowWrapper, renderWithFlow } from '../../test/utils';
+import { useI18n } from '../../i18n';
+import { useTabStore } from '../../store/tabStore';
+import type { NodeData, OutputSummary } from '../../types';
+import { VizViewerModal } from './VizViewerModal';
+import EduSelfAttentionVizNode from './EduSelfAttentionVizNode';
+
+const flowProps = {
+  zIndex: 0,
+  isConnectable: true,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  dragging: false,
+  draggable: false,
+  selectable: true,
+  deletable: true,
+} as const;
+
+const TAB = 'tab-viz-host';
+
+function tabNode(id: string, type: string, data: Partial<NodeData> = {}) {
+  return {
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: { label: `Card ${id}`, type: 'X', params: {}, ...data },
+  };
+}
+
+function seed(over: {
+  nodes?: ReturnType<typeof tabNode>[];
+  outputSummaries?: Record<string, Record<string, OutputSummary>>;
+  vizModalNodeId?: string | null;
+  lastRunId?: string | null;
+}) {
+  useTabStore.setState((s) => ({
+    activeTabId: TAB,
+    tabs: [
+      {
+        ...s.tabs[0],
+        id: TAB,
+        name: 'Tab',
+        nodes: [],
+        edges: [],
+        outputSummaries: {},
+        lastRunId: 'run-1',
+        vizModalNodeId: null,
+        ...over,
+      } as never,
+    ],
+  }));
+}
+
+const activeTab = () => useTabStore.getState().getActiveTab();
+const dialog = () => document.querySelector('[role="dialog"]');
+
+const g = globalThis as unknown as { fetch: typeof fetch };
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  useI18n.setState({ locale: 'en' });
+  seed({});
+  originalFetch = g.fetch;
+  // A viewer with no inline values REST-fetches; none of these tests care
+  // what comes back, only that the viewer is up.
+  g.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ type: 'tensor', shape: [2, 2], values: [[1, 0], [0, 1]] }),
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  g.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('VizViewerModal', () => {
+  it('renders nothing while no card has asked for its viewer', () => {
+    render(<VizViewerModal />);
+    expect(dialog()).toBeNull();
+  });
+
+  it('renders nothing for an id the tab does not hold, or a node type without a viewer', () => {
+    seed({ nodes: [], vizModalNodeId: 'ghost' });
+    const { rerender } = render(<VizViewerModal />);
+    expect(dialog()).toBeNull();
+
+    seed({ nodes: [tabNode('plain', 'baseNode')], vizModalNodeId: 'plain' });
+    rerender(<VizViewerModal />);
+    expect(dialog()).toBeNull();
+  });
+
+  it.each([
+    ['attentionHeatmapNode', 'AttentionHeatmap', { weights: { type: 'tensor', values: [[1, 0], [0, 1]] } }],
+    ['attentionMaskNode', 'AttentionMask', { mask: { type: 'tensor', values: [[1, 0], [0, 1]] } }],
+    ['eduCrossAttentionNode', 'EduCrossAttention', { weights: { type: 'tensor', values: [[[1, 0], [0, 1]]] } }],
+    ['eduMultiHeadAttentionNode', 'EduMultiHeadAttention', { weights: { type: 'tensor', values: [[[1, 0], [0, 1]]] } }],
+    ['eduSelfAttentionNode', 'EduSelfAttention', { weights: { type: 'tensor', values: [[1, 0], [0, 1]] } }],
+    ['embeddingScatterNode', 'EmbeddingScatter', { points_2d: { type: 'tensor', values: [[0, 0], [1, 1]] } }],
+  ] as [string, string, Record<string, OutputSummary>][])(
+    'shows the %s viewer titled after the card',
+    (type, kind, summary) => {
+    seed({
+      nodes: [tabNode('v1', type)],
+      outputSummaries: { v1: summary },
+      vizModalNodeId: 'v1',
+    });
+    render(<VizViewerModal />);
+    expect(dialog()).toBeTruthy();
+    expect(screen.getByText(`${kind} · Card v1`)).toBeTruthy();
+    },
+  );
+
+  it('Escape and a backdrop click both close through the store', () => {
+    seed({
+      nodes: [tabNode('v1', 'eduSelfAttentionNode')],
+      outputSummaries: { v1: { weights: { type: 'tensor', values: [[1, 0], [0, 1]] } } },
+      vizModalNodeId: 'v1',
+    });
+    render(<VizViewerModal />);
+    expect(dialog()).toBeTruthy();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(activeTab().vizModalNodeId).toBeNull();
+    expect(dialog()).toBeNull();
+
+    act(() => useTabStore.getState().openVizModal('v1'));
+    expect(dialog()).toBeTruthy();
+    fireEvent.click(dialog() as HTMLElement);
+    expect(activeTab().vizModalNodeId).toBeNull();
+    expect(dialog()).toBeNull();
+  });
+
+  it('survives the card that opened it being unmounted by viewport culling (core#324)', () => {
+    const data: NodeData = {
+      label: 'Attention',
+      type: 'Edu-SelfAttention',
+      params: {},
+      executionStatus: 'completed',
+    };
+    seed({
+      nodes: [tabNode('sa', 'eduSelfAttentionNode', data)],
+      outputSummaries: { sa: { weights: { type: 'tensor', values: [[1, 0], [0, 1]] } } },
+    });
+    const card = (
+      <EduSelfAttentionVizNode
+        id="sa"
+        type="eduSelfAttentionNode"
+        data={data}
+        selected={false}
+        {...flowProps}
+      />
+    );
+    const { rerender } = renderWithFlow(
+      <>
+        {card}
+        <VizViewerModal />
+      </>,
+    );
+    expect(dialog()).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Expand heatmap' }));
+    expect(activeTab().vizModalNodeId).toBe('sa');
+    expect(dialog()).toBeTruthy();
+
+    // `onlyRenderVisibleElements` unmounting the card is, to the card, just
+    // an unmount: the viewer it asked for must not go with it.
+    rerender(
+      <FlowWrapper>
+        <VizViewerModal />
+      </FlowWrapper>,
+    );
+    expect(dialog()).toBeTruthy();
+    expect(screen.getByText('EduSelfAttention · Attention')).toBeTruthy();
+
+    // And it is still the same viewer when the card comes back into view.
+    rerender(
+      <FlowWrapper>
+        {card}
+        <VizViewerModal />
+      </FlowWrapper>,
+    );
+    expect(dialog()).toBeTruthy();
+    expect(activeTab().vizModalNodeId).toBe('sa');
+  });
+
+  it('closes when the node it shows is deleted', () => {
+    seed({
+      nodes: [tabNode('v1', 'eduSelfAttentionNode')],
+      outputSummaries: { v1: { weights: { type: 'tensor', values: [[1, 0], [0, 1]] } } },
+      vizModalNodeId: 'v1',
+    });
+    render(<VizViewerModal />);
+    expect(dialog()).toBeTruthy();
+    act(() => useTabStore.getState().deleteNode('v1'));
+    expect(dialog()).toBeNull();
+  });
+
+  it('follows the run and the outputs it is handed, not a snapshot taken when it opened', () => {
+    seed({
+      nodes: [tabNode('v1', 'eduSelfAttentionNode')],
+      outputSummaries: { v1: { weights: { type: 'tensor', shape: [40, 40] } } },
+      vizModalNodeId: 'v1',
+      lastRunId: 'run-1',
+    });
+    render(<VizViewerModal />);
+    // No inline values: the viewer fetches the tensor for the run it was given.
+    expect(g.fetch).toHaveBeenCalledTimes(1);
+    expect(String((g.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0])).toContain('run-1');
+
+    // A later run replaces the summaries in place; the viewer re-reads them
+    // rather than keeping the first run's tensor.
+    act(() =>
+      useTabStore
+        .getState()
+        .setTabOutputSummary(TAB, 'v1', { weights: { type: 'tensor', values: [[1, 0], [0, 1]] } }),
+    );
+    expect(dialog()).toBeTruthy();
+    expect(g.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/Nodes/VizViewerModal.tsx
+++ b/frontend/src/components/Nodes/VizViewerModal.tsx
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { useTabStore } from '../../store/tabStore';
+import { HeatmapModal } from '../shared/HeatmapModal';
+import { ScatterModal } from '../shared/ScatterModal';
+import { VIZ_VIEWERS } from './vizViewers';
+
+/**
+ * The one host for every visualization card's "View full" viewer (core#324).
+ *
+ * Mounted once at the app root and driven by `tab.vizModalNodeId`, the way
+ * `NodeDetailModal` and the preset and layers editors are. The viewer used to
+ * be a `useState` flag inside each card, and `onlyRenderVisibleElements`
+ * (#162) unmounts a card the moment it leaves the viewport -- a window resize,
+ * a browser zoom, Shift+L or Ctrl+Z can all do that while the viewer is up --
+ * so the viewer closed under the user's cursor. Lifting the flag into the
+ * store alone would have been worse: a stored `true` reopens the dialog on
+ * remount with no gesture behind it. So a card only asks for its viewer, and
+ * this host, which nothing culls, reads the node's output from the store and
+ * renders it.
+ */
+export function VizViewerModal() {
+  const nodeId = useTabStore(
+    (s) => s.tabs.find((t) => t.id === s.activeTabId)?.vizModalNodeId ?? null,
+  );
+  if (nodeId === null) return null;
+  return <VizViewerModalBody nodeId={nodeId} />;
+}
+
+function VizViewerModalBody({ nodeId }: { nodeId: string }) {
+  // The whole active tab, the way `NodeDetailModalBody` reads it: the outer
+  // component mounts this one only while that tab names a node.
+  const tab = useTabStore((s) => s.tabs.find((t) => t.id === s.activeTabId)!);
+  const closeVizModal = useTabStore((s) => s.closeVizModal);
+  const node = tab.nodes.find((n) => n.id === nodeId);
+  const summaries = tab.outputSummaries[nodeId];
+  const runId = tab.lastRunId;
+
+  // Rebuilt only when the node, its outputs or the run change: the scatter
+  // viewer keys its fit-to-view and its wheel listener on the identity of the
+  // points it is handed, so a fresh array on every render would refit under
+  // the user's zoom.
+  const spec = useMemo(() => {
+    const build = node?.type ? VIZ_VIEWERS[node.type] : undefined;
+    return node && build ? build(node, summaries, runId) : null;
+  }, [node, summaries, runId]);
+
+  // The store nulls the id when the node is deleted, collapsed into a block
+  // or replaced with the document; what remains is a node the canvas is not
+  // showing right now (the user stepped into a block) or one with no viewer.
+  if (spec === null) return null;
+  if (spec.kind === 'scatter') {
+    return <ScatterModal isOpen onClose={closeVizModal} {...spec.props} />;
+  }
+  return <HeatmapModal isOpen onClose={closeVizModal} {...spec.props} />;
+}

--- a/frontend/src/components/Nodes/vizViewers.test.ts
+++ b/frontend/src/components/Nodes/vizViewers.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@xyflow/react';
+import type { NodeData } from '../../types';
+import {
+  VIZ_VIEWERS,
+  attentionHeads,
+  attentionWeights,
+  labelList,
+  maskMatrix,
+  scatterPoints,
+  selfAttentionWeights,
+} from './vizViewers';
+
+const m2 = [[1, 0], [0, 1]];
+const m3 = [m2, m2];
+const m4 = [m3];
+
+describe('tensor readers shared by the viz cards and their viewer', () => {
+  it('attentionWeights keeps 2-D and 3-D tensors and collapses a batched 4-D one to batch 0', () => {
+    expect(attentionWeights(m2)).toBe(m2);
+    expect(attentionWeights(m3)).toBe(m3);
+    expect(attentionWeights(m4)).toBe(m3);
+    expect(attentionWeights([])).toBeNull();
+    expect(attentionWeights(undefined)).toBeNull();
+  });
+
+  it('attentionHeads keeps [H, seq, seq] and collapses a batched tensor to batch 0', () => {
+    expect(attentionHeads(m3)).toBe(m3);
+    expect(attentionHeads(m4)).toBe(m3);
+    expect(attentionHeads('no')).toBeNull();
+  });
+
+  it('selfAttentionWeights keeps [seq, seq] and collapses a [1, seq, seq] tensor to its head', () => {
+    expect(selfAttentionWeights(m2)).toBe(m2);
+    expect(selfAttentionWeights([m2])).toBe(m2);
+    expect(selfAttentionWeights(null)).toBeNull();
+  });
+
+  it('maskMatrix coerces truthy cells to 1 and a malformed row to an empty one', () => {
+    expect(maskMatrix([[true, false], [0.5, 0], 'bad'])).toEqual([[1, 0], [1, 0], []]);
+    expect(maskMatrix([])).toBeNull();
+  });
+
+  it('labelList stringifies a list and is undefined for an empty or missing one', () => {
+    expect(labelList(['a', 1])).toEqual(['a', '1']);
+    expect(labelList([])).toBeUndefined();
+    expect(labelList(undefined)).toBeUndefined();
+  });
+
+  it('scatterPoints pairs coordinates with labels and tolerates malformed rows', () => {
+    expect(scatterPoints([[1, 2], [3], 'x'], ['a', 7])).toEqual([
+      { x: 1, y: 2, label: 'a', cluster: 0 },
+      { x: 3, y: 0, label: undefined, cluster: 1 },
+      { x: 0, y: 0, label: undefined, cluster: 2 },
+    ]);
+    expect(scatterPoints([[1, 2]], undefined)![0].label).toBeUndefined();
+    expect(scatterPoints([], [])).toBeNull();
+    expect(scatterPoints(undefined, [])).toBeNull();
+  });
+});
+
+describe('VIZ_VIEWERS', () => {
+  const node = (type: string, data: Partial<NodeData> = {}): Node<NodeData> => ({
+    id: 'n1',
+    type,
+    position: { x: 0, y: 0 },
+    data: { label: 'Card', type: 'X', params: {}, ...data },
+  });
+
+  it('covers exactly the six viz cards registered in FlowCanvas', () => {
+    expect(Object.keys(VIZ_VIEWERS).sort()).toEqual([
+      'attentionHeatmapNode',
+      'attentionMaskNode',
+      'eduCrossAttentionNode',
+      'eduMultiHeadAttentionNode',
+      'eduSelfAttentionNode',
+      'embeddingScatterNode',
+    ]);
+  });
+
+  it('titles the viewer with the node label, and with the id when the label is absent', () => {
+    const spec = VIZ_VIEWERS.eduSelfAttentionNode(node('eduSelfAttentionNode'), undefined, null);
+    expect(spec.kind).toBe('heatmap');
+    expect(spec.props.title).toBe('EduSelfAttention · Card');
+    const noLabel = node('eduSelfAttentionNode', { label: undefined as unknown as string });
+    expect(VIZ_VIEWERS.eduSelfAttentionNode(noLabel, undefined, null).props.title).toBe(
+      'EduSelfAttention · n1',
+    );
+  });
+
+  it('hands the heatmap viewer the port to fetch and the run to fetch it from', () => {
+    const spec = VIZ_VIEWERS.attentionHeatmapNode(
+      node('attentionHeatmapNode', { params: { colormap: 'magma' } }),
+      { weights: { type: 'tensor', shape: [40, 40] }, labels: { type: 'list', values: ['a'] } },
+      'run-9',
+    );
+    expect(spec.kind).toBe('heatmap');
+    expect(spec.props).toMatchObject({
+      inlineData: null,
+      rowLabels: ['a'],
+      colormap: 'magma',
+      runId: 'run-9',
+      nodeId: 'n1',
+      port: 'weights',
+    });
+    expect(
+      VIZ_VIEWERS.attentionHeatmapNode(node('attentionHeatmapNode'), undefined, null).props,
+    ).toMatchObject({ colormap: 'viridis', runId: null });
+  });
+
+  it('reads the mask, the cross-attention axes and the multi-head weights off their own ports', () => {
+    const mask = VIZ_VIEWERS.attentionMaskNode(
+      node('attentionMaskNode'),
+      { mask: { type: 'tensor', values: [[true, false]] } },
+      null,
+    );
+    expect(mask.props).toMatchObject({ inlineData: [[1, 0]], port: 'mask', variant: 'mask' });
+
+    const cross = VIZ_VIEWERS.eduCrossAttentionNode(
+      node('eduCrossAttentionNode'),
+      {
+        weights: { type: 'tensor', values: m3 },
+        q_labels: { type: 'list', values: ['q'] },
+        k_labels: { type: 'list', values: ['k1', 'k2'] },
+      },
+      null,
+    );
+    expect(cross.props).toMatchObject({
+      inlineData: m3,
+      rowLabels: ['q'],
+      colLabels: ['k1', 'k2'],
+      detectCausalMask: false,
+    });
+
+    const heads = VIZ_VIEWERS.eduMultiHeadAttentionNode(
+      node('eduMultiHeadAttentionNode'),
+      { weights: { type: 'tensor', values: m4 }, labels: { type: 'list', values: ['t'] } },
+      null,
+    );
+    expect(heads.props).toMatchObject({ inlineData: m3, rowLabels: ['t'], detectCausalMask: true });
+  });
+
+  it('builds the scatter viewer from the points and labels ports', () => {
+    const spec = VIZ_VIEWERS.embeddingScatterNode(
+      node('embeddingScatterNode'),
+      {
+        points_2d: { type: 'tensor', values: [[0, 1]] },
+        labels: { type: 'list', values: ['cat'] },
+      },
+      'run-1',
+    );
+    expect(spec.kind).toBe('scatter');
+    expect(spec.props).toMatchObject({
+      title: 'EmbeddingScatter · Card',
+      inlinePoints: [{ x: 0, y: 1, label: 'cat', cluster: 0 }],
+      runId: 'run-1',
+      nodeId: 'n1',
+      pointsPort: 'points_2d',
+      labelsPort: 'labels',
+    });
+  });
+});

--- a/frontend/src/components/Nodes/vizViewers.ts
+++ b/frontend/src/components/Nodes/vizViewers.ts
@@ -1,0 +1,188 @@
+import type { Node } from '@xyflow/react';
+import type { NodeData, OutputSummary } from '../../types';
+import type { HeatmapColormap } from '../shared/HeatmapPlot';
+import type { HeatmapModalProps } from '../shared/HeatmapModal';
+import type { ScatterModalProps } from '../shared/ScatterModal';
+import type { ScatterPoint } from '../shared/ScatterPlot';
+
+/**
+ * What each visualization card's "View full" viewer shows, and how to read it
+ * off the store (core#324).
+ *
+ * The six viz cards used to hold their viewer as a `useState` flag and render
+ * the modal themselves. `onlyRenderVisibleElements` (#162) unmounts a card the
+ * moment it leaves the viewport -- a window resize, a browser zoom, Shift+L or
+ * Ctrl+Z can all do that while the viewer is up -- and the flag went with it,
+ * so the viewer closed under the user's cursor. The viewer is now rendered
+ * once at the app root by `VizViewerModal`, which nothing culls, and driven by
+ * `tab.vizModalNodeId`. This module is what lets that one host stand in for
+ * six cards: keyed by the React Flow node type each card is registered under
+ * in `FlowCanvas`'s `nodeTypes`, it builds the modal's props from the node and
+ * its streamed output summaries. The cards read their inline plot through the
+ * same helpers, so the small plot and the full one cannot disagree about what
+ * a tensor means.
+ */
+
+/** The per-port output summaries the backend streamed for one node, if it has run. */
+export type NodeSummaries = Record<string, OutputSummary> | undefined;
+
+export type VizViewerSpec =
+  | { kind: 'heatmap'; props: Omit<HeatmapModalProps, 'isOpen' | 'onClose'> }
+  | { kind: 'scatter'; props: Omit<ScatterModalProps, 'isOpen' | 'onClose'> };
+
+export type VizViewerBuilder = (
+  node: Node<NodeData>,
+  summaries: NodeSummaries,
+  runId: string | null,
+) => VizViewerSpec;
+
+/** True when `values[0][0]...` is an array `depth` levels down (a tensor of that rank). */
+function rankAtLeast(values: unknown, depth: number): boolean {
+  let cur: unknown = values;
+  for (let d = 0; d < depth; d++) {
+    if (!Array.isArray(cur)) return false;
+    cur = cur[0];
+  }
+  return true;
+}
+
+/**
+ * Attention weights as the heatmap draws them: `[seq, seq]` or `[H, seq, seq]`.
+ * A batched `[B, H, seq, seq]` collapses to batch 0.
+ */
+export function attentionWeights(values: unknown): number[][] | number[][][] | null {
+  if (!Array.isArray(values) || values.length === 0) return null;
+  if (rankAtLeast(values, 4)) return (values as number[][][][])[0];
+  return values as number[][] | number[][][];
+}
+
+/** Per-head weights as `[H, seq, seq]`; a batched 4-D tensor collapses to batch 0. */
+export function attentionHeads(values: unknown): number[][][] | null {
+  if (!Array.isArray(values) || values.length === 0) return null;
+  if (rankAtLeast(values, 4)) return (values as number[][][][])[0];
+  return values as number[][][];
+}
+
+/** Single-head weights as `[seq, seq]`; a `[1, seq, seq]` tensor collapses to its one head. */
+export function selfAttentionWeights(values: unknown): number[][] | null {
+  if (!Array.isArray(values) || values.length === 0) return null;
+  if (rankAtLeast(values, 3)) return (values as number[][][])[0];
+  return values as number[][];
+}
+
+/** A boolean / 0-1 mask as 0/1 numbers, row by row. */
+export function maskMatrix(values: unknown): number[][] | null {
+  if (!Array.isArray(values) || values.length === 0) return null;
+  return (values as unknown[]).map((row) =>
+    Array.isArray(row) ? row.map((x) => (x ? 1 : 0)) : [],
+  );
+}
+
+/** A `LIST[str]` port's values as strings, or undefined when the port is empty. */
+export function labelList(values: unknown): string[] | undefined {
+  if (!Array.isArray(values) || values.length === 0) return undefined;
+  return values.map((s) => String(s));
+}
+
+/** `[N, 2]` coordinates plus an optional label list, as scatter points. */
+export function scatterPoints(coords: unknown, labels: unknown): ScatterPoint[] | null {
+  if (!Array.isArray(coords) || coords.length === 0) return null;
+  return coords.map((row, i) => {
+    const r = Array.isArray(row) ? row : [];
+    const x = typeof r[0] === 'number' ? r[0] : 0;
+    const y = typeof r[1] === 'number' ? r[1] : 0;
+    const label =
+      Array.isArray(labels) && typeof labels[i] === 'string' ? (labels[i] as string) : undefined;
+    return { x, y, label, cluster: i };
+  });
+}
+
+const titleOf = (kind: string, node: Node<NodeData>) => `${kind} · ${node.data.label ?? node.id}`;
+
+/**
+ * React Flow node type (the `nodeTypes` key in `FlowCanvas`) -> its viewer.
+ * A node type absent from this table has no full-size viewer, and
+ * `VizViewerModal` renders nothing for it.
+ */
+export const VIZ_VIEWERS: Record<string, VizViewerBuilder> = {
+  attentionHeatmapNode: (node, s, runId) => ({
+    kind: 'heatmap',
+    props: {
+      title: titleOf('AttentionHeatmap', node),
+      inlineData: attentionWeights(s?.weights?.values),
+      rowLabels: labelList(s?.labels?.values),
+      colormap: (node.data.params?.colormap as HeatmapColormap | undefined) ?? 'viridis',
+      runId,
+      nodeId: node.id,
+      port: 'weights',
+      detectCausalMask: true,
+      normalizePerRow: true,
+    },
+  }),
+  attentionMaskNode: (node, s, runId) => ({
+    kind: 'heatmap',
+    props: {
+      title: titleOf('AttentionMask', node),
+      inlineData: maskMatrix(s?.mask?.values),
+      colormap: 'RdBu',
+      detectCausalMask: false,
+      runId,
+      nodeId: node.id,
+      port: 'mask',
+      variant: 'mask',
+    },
+  }),
+  eduCrossAttentionNode: (node, s, runId) => ({
+    kind: 'heatmap',
+    props: {
+      title: titleOf('EduCrossAttention', node),
+      inlineData: attentionHeads(s?.weights?.values),
+      rowLabels: labelList(s?.q_labels?.values),
+      colLabels: labelList(s?.k_labels?.values),
+      runId,
+      nodeId: node.id,
+      port: 'weights',
+      // Cross-attention is always rectangular and lives outside the causal
+      // regime -- don't try to detect a causal pattern.
+      detectCausalMask: false,
+      normalizePerRow: true,
+    },
+  }),
+  eduMultiHeadAttentionNode: (node, s, runId) => ({
+    kind: 'heatmap',
+    props: {
+      title: titleOf('EduMultiHeadAttention', node),
+      inlineData: attentionHeads(s?.weights?.values),
+      rowLabels: labelList(s?.labels?.values),
+      runId,
+      nodeId: node.id,
+      port: 'weights',
+      detectCausalMask: true,
+      normalizePerRow: true,
+    },
+  }),
+  eduSelfAttentionNode: (node, s, runId) => ({
+    kind: 'heatmap',
+    props: {
+      title: titleOf('EduSelfAttention', node),
+      inlineData: selfAttentionWeights(s?.weights?.values),
+      rowLabels: labelList(s?.labels?.values),
+      runId,
+      nodeId: node.id,
+      port: 'weights',
+      detectCausalMask: true,
+      normalizePerRow: true,
+    },
+  }),
+  embeddingScatterNode: (node, s, runId) => ({
+    kind: 'scatter',
+    props: {
+      title: titleOf('EmbeddingScatter', node),
+      inlinePoints: scatterPoints(s?.points_2d?.values, s?.labels?.values),
+      runId,
+      nodeId: node.id,
+      pointsPort: 'points_2d',
+      labelsPort: 'labels',
+    },
+  }),
+};

--- a/frontend/src/components/shared/HeatmapModal.tsx
+++ b/frontend/src/components/shared/HeatmapModal.tsx
@@ -4,7 +4,7 @@ import { HeatmapPlot, type HeatmapColormap } from './HeatmapPlot';
 import { fetchOutput } from '../../api/executionOutputs';
 import styles from './HeatmapModal.module.css';
 
-interface HeatmapModalProps {
+export interface HeatmapModalProps {
   isOpen: boolean;
   onClose: () => void;
   title: string;

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -156,7 +156,8 @@ export function useKeyboardShortcuts() {
         if (
           activeTab.nodeDetailNodeId ||
           activeTab.presetModalNodeId ||
-          activeTab.layersModalNodeId
+          activeTab.layersModalNodeId ||
+          activeTab.vizModalNodeId
         ) {
           return;
         }

--- a/frontend/src/store/tabStore.loadDocument.test.ts
+++ b/frontend/src/store/tabStore.loadDocument.test.ts
@@ -345,6 +345,7 @@ describe('clear leaves the same per-document residue as opening a document', () 
     store().openPresetModal('same-id');
     store().openLayersModal('same-id');
     store().openNodeDetail('same-id', { tab: 'code', port: 'same-id::out' });
+    store().openVizModal('same-id');
     store().markDirty('same-id');
     store().setTabOutputSummary(tab().id, 'same-id', {
       out: { type: 'tensor', shape: [2, 2] },
@@ -363,6 +364,7 @@ describe('clear leaves the same per-document residue as opening a document', () 
       nodeDetailNodeId: t.nodeDetailNodeId,
       nodeDetailTab: t.nodeDetailTab,
       nodeDetailPort: t.nodeDetailPort,
+      vizModalNodeId: t.vizModalNodeId,
       dirtyNodeIds: [...t.dirtyNodeIds],
       outputSummaries: t.outputSummaries,
       lastRunId: t.lastRunId,
@@ -376,6 +378,7 @@ describe('clear leaves the same per-document residue as opening a document', () 
     nodeDetailNodeId: null,
     nodeDetailTab: null,
     nodeDetailPort: null,
+    vizModalNodeId: null,
     dirtyNodeIds: [],
     outputSummaries: {},
     lastRunId: null,

--- a/frontend/src/store/tabStore.subgraph.test.ts
+++ b/frontend/src/store/tabStore.subgraph.test.ts
@@ -1089,6 +1089,23 @@ describe('expandSubgraphInstance cleans up after the instance it removes', () =>
     expect(tab().nodes.find((n) => n.id === 'note')!.data.boundToNodeId).toBeNull();
     expect(tab().nodeDetailNodeId).toBeNull();
   });
+
+  it('closes a viz viewer that named the instance, and keeps one that named another node (core#324)', () => {
+    seedChain();
+    select('b', 'c');
+    store().collapseSelectionToSubgraph('Block');
+    const instanceId = tab().nodes.find((n) => subgraphIdOf(n.data.type))!.id;
+
+    store().openVizModal('a');
+    expect(store().expandSubgraphInstance(instanceId)).toBe(true);
+    expect(tab().vizModalNodeId).toBe('a');
+
+    store().undo();
+    const again = tab().nodes.find((n) => subgraphIdOf(n.data.type))!.id;
+    store().openVizModal(again);
+    expect(store().expandSubgraphInstance(again)).toBe(true);
+    expect(tab().vizModalNodeId).toBeNull();
+  });
 });
 
 describe('collapseSelectionToSubgraph closes a detail modal it swallowed', () => {
@@ -1099,6 +1116,20 @@ describe('collapseSelectionToSubgraph closes a detail modal it swallowed', () =>
     expect(store().collapseSelectionToSubgraph('Block').ok).toBe(true);
     expect(tab().nodes.some((n) => n.id === 'b')).toBe(false);
     expect(tab().nodeDetailNodeId).toBeNull();
+  });
+
+  it('clears vizModalNodeId when the node moved into the block, and keeps one that stayed outside (core#324)', () => {
+    seedChain();
+    store().openVizModal('a');
+    select('b', 'c');
+    expect(store().collapseSelectionToSubgraph('Block').ok).toBe(true);
+    expect(tab().vizModalNodeId).toBe('a');
+
+    store().undo();
+    store().openVizModal('b');
+    select('b', 'c');
+    expect(store().collapseSelectionToSubgraph('Block').ok).toBe(true);
+    expect(tab().vizModalNodeId).toBeNull();
   });
 });
 

--- a/frontend/src/store/tabStore.test.ts
+++ b/frontend/src/store/tabStore.test.ts
@@ -1281,6 +1281,43 @@ describe('onNodesChange', () => {
     expect(activeTab().nodeDetailNodeId).toBe('n1');
   });
 
+  // ── the viz viewer id (core#324) ──────────────────────────────────────────
+
+  it('openVizModal / closeVizModal set and clear the viewer id on the active tab', () => {
+    expect(activeTab().vizModalNodeId).toBeNull();
+    store().openVizModal('n1');
+    expect(activeTab().vizModalNodeId).toBe('n1');
+    store().closeVizModal();
+    expect(activeTab().vizModalNodeId).toBeNull();
+  });
+
+  it('closes the viz viewer when React Flow removes its node, and leaves it for another node', () => {
+    // Same reason as the detail modal above: the Delete key emits a `remove`
+    // change straight into the reducer, and a stale id would reopen the viewer
+    // on its own the moment an undo restores the node.
+    store().setNodes([
+      { id: 'n1', type: 'attentionHeatmapNode', position: { x: 0, y: 0 }, data: { label: 'A', type: 'A', params: {} } },
+      { id: 'n2', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'B', type: 'B', params: {} } },
+    ] as any);
+    store().openVizModal('n1');
+    store().onNodesChange([{ id: 'n2', type: 'remove' }]);
+    expect(activeTab().vizModalNodeId).toBe('n1');
+    store().onNodesChange([{ id: 'n1', type: 'remove' }]);
+    expect(activeTab().vizModalNodeId).toBeNull();
+  });
+
+  it('deleteNode closes the viz viewer showing that node', () => {
+    store().setNodes([
+      { id: 'n1', type: 'attentionHeatmapNode', position: { x: 0, y: 0 }, data: { label: 'A', type: 'A', params: {} } },
+      { id: 'n2', type: 'baseNode', position: { x: 0, y: 0 }, data: { label: 'B', type: 'B', params: {} } },
+    ] as any);
+    store().openVizModal('n1');
+    store().deleteNode('n2');
+    expect(activeTab().vizModalNodeId).toBe('n1');
+    store().deleteNode('n1');
+    expect(activeTab().vizModalNodeId).toBeNull();
+  });
+
   // ── deep-linking a tab and a port (#129) ──────────────────────────────────
 
   it('opens the detail modal with no tab or port requested by default', () => {

--- a/frontend/src/store/tabStore.ts
+++ b/frontend/src/store/tabStore.ts
@@ -316,6 +316,17 @@ export interface TabState {
    */
   nodeDetailNodeId: string | null;
   /**
+   * Node whose visualization viewer is open, or null (core#324) -- the
+   * heatmap or scatter modal an attention / embedding card opens from its
+   * "View full" affordance. Store-driven for the same reason the three modal
+   * ids above are: the viewer is rendered once at the app root by
+   * `VizViewerModal`, outside the canvas, so a card that
+   * `onlyRenderVisibleElements` (#162) unmounts while its viewer is up -- a
+   * window resize, a browser zoom, Shift+L, Ctrl+Z -- no longer takes the
+   * viewer down with it. Transient like the others.
+   */
+  vizModalNodeId: string | null;
+  /**
    * Tab id the detail modal should open on, or null for its default (#129).
    * Set by the edge tooltip's "View stats" link; every other entry point
    * writes null, so a deep link never becomes sticky.
@@ -395,6 +406,7 @@ function createTabState(id: string, name: string): TabState {
     nodeDetailNodeId: null,
     nodeDetailTab: null,
     nodeDetailPort: null,
+    vizModalNodeId: null,
     nodeDetailRequest: 0,
     undoStack: [],
     redoStack: [],
@@ -574,6 +586,9 @@ interface TabStoreState {
   closeLayersModal: () => void;
   openNodeDetail: (id: string, target?: { tab?: string; port?: string }) => void;
   closeNodeDetail: () => void;
+  /** One viz card's heatmap / scatter viewer (core#324); see `vizModalNodeId`. */
+  openVizModal: (id: string) => void;
+  closeVizModal: () => void;
   updateNodeLayers: (nodeId: string, layersJson: string) => void;
   setNodeExecutionStatus: (nodeId: string, status: NodeData['executionStatus'], error?: string) => void;
   clearExecutionStatus: () => void;
@@ -782,6 +797,7 @@ function clearedDocumentResidue(tab: TabState): Partial<TabState> {
     nodeDetailNodeId: null,
     nodeDetailTab: null,
     nodeDetailPort: null,
+    vizModalNodeId: null,
     dirtyNodeIds: new Set<string>(),
     outputSummaries: {},
     // A FINISHED run named the graph being replaced, and the Inspector, the
@@ -2066,6 +2082,7 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
           nodeDetailNodeId: stillThere(tab.nodeDetailNodeId)
             ? tab.nodeDetailNodeId
             : null,
+          vizModalNodeId: stillThere(tab.vizModalNodeId) ? tab.vizModalNodeId : null,
           selectedNodeId: stillThere(tab.selectedNodeId)
             ? tab.selectedNodeId
             : null,
@@ -2213,6 +2230,7 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
         // future callers) even though React Flow itself has no opinion left
         // — nothing is `.selected` once its node is gone.
         let nodeDetailNodeId = tab.nodeDetailNodeId;
+        let vizModalNodeId = tab.vizModalNodeId;
         let selectedNodeId = tab.selectedNodeId;
         // A segment whose head or tail is gone can never resolve a path, so
         // `deleteNode` drops it. React Flow's own Delete key never reaches
@@ -2235,6 +2253,9 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
           if (nodeDetailNodeId !== null && removedIds.has(nodeDetailNodeId)) {
             nodeDetailNodeId = null;
           }
+          if (vizModalNodeId !== null && removedIds.has(vizModalNodeId)) {
+            vizModalNodeId = null;
+          }
           if (selectedNodeId !== null && removedIds.has(selectedNodeId)) {
             selectedNodeId = null;
           }
@@ -2254,7 +2275,14 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
           }
         }
 
-        return { nodes: updatedNodes, nodeDetailNodeId, selectedNodeId, segmentGroups, activeSegment };
+        return {
+          nodes: updatedNodes,
+          nodeDetailNodeId,
+          vizModalNodeId,
+          selectedNodeId,
+          segmentGroups,
+          activeSegment,
+        };
       }),
     });
   },
@@ -2497,6 +2525,12 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
         nodeDetailPort: null,
       })),
     }),
+
+  openVizModal: (id) =>
+    set({ tabs: updateTab(get().tabs, get().activeTabId, () => ({ vizModalNodeId: id })) }),
+
+  closeVizModal: () =>
+    set({ tabs: updateTab(get().tabs, get().activeTabId, () => ({ vizModalNodeId: null })) }),
 
   updateNodeLayers: (nodeId, layersJson) =>
     set({
@@ -2942,6 +2976,8 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
           t.nodeDetailNodeId && swallowed.has(t.nodeDetailNodeId)
             ? null
             : t.nodeDetailNodeId,
+        vizModalNodeId:
+          t.vizModalNodeId && swallowed.has(t.vizModalNodeId) ? null : t.vizModalNodeId,
         // A collapsed block is one node again, so everything it contained
         // stops being a candidate for partial re-execution under its old id.
         dirtyNodeIds: new Set([result.instanceId]),
@@ -2993,6 +3029,7 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
             : t.activeSegment,
         nodeDetailNodeId:
           t.nodeDetailNodeId === nodeId ? null : t.nodeDetailNodeId,
+        vizModalNodeId: t.vizModalNodeId === nodeId ? null : t.vizModalNodeId,
         dirtyNodeIds: new Set(result.restoredIds),
       })),
     });
@@ -3174,6 +3211,7 @@ export const useTabStore = create<TabStoreState>((rawSet, get) => {
         // to render, so close it rather than leave an empty shell on screen.
         nodeDetailNodeId:
           tab.nodeDetailNodeId === nodeId ? null : tab.nodeDetailNodeId,
+        vizModalNodeId: tab.vizModalNodeId === nodeId ? null : tab.vizModalNodeId,
         // Drop any Teaching Inspector segment whose head/tail was this node —
         // it can never resolve a path once an endpoint is gone.
         segmentGroups: tab.segmentGroups.filter(

--- a/frontend/src/store/tabStore.workspace.test.ts
+++ b/frontend/src/store/tabStore.workspace.test.ts
@@ -209,6 +209,24 @@ describe('commitDocument + pushUndoSnapshotFor', () => {
     expect(activeTab().selectedNodeId).toBeNull();
   });
 
+  it('closes a viz viewer the commit removed the node for, and keeps one it kept (core#324)', () => {
+    const live = store().activeTabId;
+    store().loadGraphDocumentInto(live, {
+      nodes: [node('a'), node('b', 200)], edges: [], boundFile: null,
+    });
+    store().openVizModal('b');
+
+    store().commitDocument(live, {
+      nodes: [node('a'), node('b', 200)], edges: [], segmentGroups: [], dirtyIds: [],
+    });
+    expect(activeTab().vizModalNodeId).toBe('b');
+
+    store().commitDocument(live, {
+      nodes: [node('a')], edges: [], segmentGroups: [], dirtyIds: [],
+    });
+    expect(activeTab().vizModalNodeId).toBeNull();
+  });
+
   it('leaves both alone when the committed document still has the node', () => {
     const live = store().activeTabId;
     store().loadGraphDocumentInto(live, {

--- a/frontend/src/styles/theme.test.ts
+++ b/frontend/src/styles/theme.test.ts
@@ -281,6 +281,62 @@ describe('tokens.css / diagram export palette agreement', () => {
     return pairs;
   };
 
+  /**
+   * The light CARD palette under the same rule (core#390). It had been exempt
+   * — fourteen hues lowered to one lightness — which left RNN and Tensor
+   * Operations 0.01 L* apart and Transformer/LLM at 0.16. The palette now
+   * carries its own lightness tiers; this restates gate rule 11c over the
+   * categories so that flattening any one of them back fails a unit test as
+   * well as `pnpm build`. The dichromat simulation itself (gate rule 11d)
+   * stays in the gate: it needs a colour-vision model this file has no
+   * business duplicating.
+   */
+  const lightCategoryFamilyPairs = (): [string, string][] => {
+    const names = Object.keys(CATEGORY_COLORS_ON_LIGHT).sort();
+    const pairs: [string, string][] = [];
+    for (let i = 0; i < names.length; i++) {
+      for (let j = i + 1; j < names.length; j++) {
+        const [a, b] = [CATEGORY_COLORS_ON_LIGHT[names[i]], CATEGORY_COLORS_ON_LIGHT[names[j]]];
+        if (chroma(a) < FAMILY_MIN_CHROMA || chroma(b) < FAMILY_MIN_CHROMA) continue;
+        if (hueGap(a, b) > FAMILY_HUE_DEGREES) continue;
+        pairs.push([names[i], names[j]]);
+      }
+    }
+    return pairs;
+  };
+
+  it('has same-family light card pairs to hold apart at all', () => {
+    // The blue-violet run (RNN, Tensor Operations, LLM, Transformer) and the
+    // amber run (Classical, RL, Data Flow) both sit inside the window.
+    expect(lightCategoryFamilyPairs().length).toBeGreaterThan(0);
+  });
+
+  it.each(lightCategoryFamilyPairs())(
+    'parts the light card colours %s and %s in lightness, not only in hue',
+    (first, second) => {
+      const gap = Math.abs(
+        lstar(CATEGORY_COLORS_ON_LIGHT[first]) - lstar(CATEGORY_COLORS_ON_LIGHT[second]),
+      );
+      expect(gap).toBeGreaterThanOrEqual(FAMILY_MIN_LIGHTNESS);
+    },
+  );
+
+  it('keeps the exported RNN and Tensor Operations blues apart in lightness', () => {
+    // The reported pair (core#390): 0.01 L* apart before the repaint. Tensor
+    // Operations is the half that moved, to the middle of the blue tier.
+    const gap =
+      lstar(CATEGORY_COLORS_ON_LIGHT.RNN) - lstar(CATEGORY_COLORS_ON_LIGHT['Tensor Operations']);
+    expect(gap).toBeGreaterThan(FAMILY_MIN_LIGHTNESS);
+  });
+
+  it('keeps every light card colour darker than its canvas twin', () => {
+    // Every floor the palette is held to is a contrast against a white page,
+    // which only a darker colour can clear; gate rule 11b measures the same.
+    for (const name of Object.keys(CATEGORY_COLORS_ON_LIGHT)) {
+      expect(lstar(CATEGORY_COLORS_ON_LIGHT[name]), name).toBeLessThan(lstar(CATEGORY_COLORS[name]));
+    }
+  });
+
   it('has same-family light wire pairs to hold apart at all', () => {
     // A sweep that matches nothing passes for the wrong reason. Four pairs
     // sit inside the window today (dataset/transform, image/optimizer,

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -52,29 +52,37 @@ export const CATEGORY_VARS: Record<string, string> = {
  * card the SVG exporter draws by default, those hues measured 2.15:1 to
  * 3.09:1 as a border and every one of them failed the 4.5:1 the exporter also
  * needs from them as the card's title text (core#227). Each value below is its
- * counterpart above converted to OKLCH, hue held, chroma pushed to the gamut
- * edge and lightness lowered until it clears the bar — so the hue a reader
- * knows from the app survives while the measurement changes. Drift is at most
- * 1.8 degrees of CIE Lab hue angle, which is what the contrast gate measures.
+ * counterpart above converted to OKLCH, hue held within 8 degrees of CIE Lab
+ * hue angle and chroma held near the canvas value — so the hue a reader knows
+ * from the app survives while the measurement changes.
+ *
+ * Lightness is set per category (core#390). Lowering every hue just until it
+ * cleared 4.5:1 had put all fourteen at one lightness, and a red-green
+ * colour-blind reader keeps little besides lightness: RNN and Tensor
+ * Operations sat 0.01 L* apart, and the palette's closest pair under a
+ * deuteranopia simulation was 2.13 dE00. Five categories now sit darker (LLM,
+ * Classical, Data Flow, Utility, Tensor Operations) so that every pair a
+ * dichromat cannot part by hue is parted by lightness; the closest pair is
+ * 6.7 dE00 under both deuteranopia and protanopia.
  *
  * Mirrors the `--diagram-light-*` tokens; `theme.test.ts` asserts the match,
  * and `scripts/check-contrast.mjs` re-derives every measurement above.
  */
 export const CATEGORY_COLORS_ON_LIGHT: Record<string, string> = {
-  CNN: '#1a8626',
-  RNN: '#0077c8',
-  Transformer: '#9f58ab',
-  LLM: '#7f61cc',
-  Diffusion: '#c93d86',
-  Classical: '#7e4e00',
-  RL: '#a96300',
-  Data: '#018091',
-  Training: '#d14039',
-  IO: '#866f66',
-  'Data Flow': '#ad4900',
-  Utility: '#617782',
+  CNN: '#298340',
+  RNN: '#0075d6',
+  Transformer: '#a458b0',
+  LLM: '#5327b0',
+  Diffusion: '#de1181',
+  Classical: '#693e00',
+  RL: '#a56100',
+  Data: '#007d8d',
+  Training: '#d83a41',
+  IO: '#877065',
+  'Data Flow': '#995020',
+  Utility: '#476370',
   Normalization: '#008278',
-  'Tensor Operations': '#6570ad',
+  'Tensor Operations': '#4b549f',
 };
 
 /** `--diagram-light-*` variable name for each category. */

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -381,12 +381,21 @@
    rather than borrowing the dark one (core#227).
 
    The light hues are not hand-picked. Each is its dark counterpart converted
-   to OKLCH, hue held fixed, chroma pushed to the sRGB gamut edge, and
-   lightness lowered until it clears the bar on a white card. Hue drift is at
-   most 1.8 degrees of CIE Lab hue angle, so a green category stays the same
-   green a reader knows from the app. Two are marked: Classical and RL are 3.71
-   CIEDE2000 apart in the dark palette — its closest pair by a wide margin —
-   and splitting them on lightness costs nothing on paper.
+   to OKLCH, hue held (within 8 degrees of CIE Lab hue angle, so a green
+   category stays the same green a reader knows from the app), chroma held
+   near the canvas value, and lightness set per category. The first cut put
+   all fourteen at the same lightness — each lowered just until it cleared
+   4.5:1 — which left rnn and tensorops 0.01 L* apart and the palette's
+   closest pair under a deuteranopia simulation at 2.13 dE00 (core#390): a
+   red-green colour-blind reader keeps lightness and the blue-yellow axis and
+   little else, so fourteen hues at one lightness collapse into a handful.
+   The lightness of each category is now chosen so that every pair a
+   dichromat cannot part by hue is parted by lightness instead: the closest
+   pair is 6.7 dE00 under both deuteranopia and protanopia, 9.9 with normal
+   vision, and every same-family pair is at least 4 L* apart — the rule the
+   wire palette below already obeys. Five categories sit darker than the
+   rest to make that room (LLM, Classical, Data Flow, Utility and Tensor
+   Operations); each is still its canvas hue, darkened.
 
    Nothing in CSS references these; they are consumed by the SVG exporter
    through the `styles/theme.ts` mirror, because an exported file is
@@ -420,21 +429,28 @@
 
   /* Light category hues. Each clears 4.5:1 on the white card, which covers
      both roles the hue plays there: the card border (1.4.11, 3:1) and the
-     card title, which is drawn in the same colour (1.4.3, 4.5:1). */
-  --diagram-light-cnn: #1a8626; /* 4.69 */
-  --diagram-light-rnn: #0077c8; /* 4.70 */
-  --diagram-light-transformer: #9f58ab; /* 4.71 */
-  --diagram-light-llm: #7f61cc; /* 4.68 */
-  --diagram-light-diffusion: #c93d86; /* 4.67 */
-  --diagram-light-classical: #7e4e00; /* 7.05 — darkened past the bar to part it from RL */
-  --diagram-light-rl: #a96300; /* 4.70 */
-  --diagram-light-data: #018091; /* 4.67 */
-  --diagram-light-training: #d14039; /* 4.66 */
-  --diagram-light-io: #866f66; /* 4.69 */
-  --diagram-light-dataflow: #ad4900; /* 5.63 — likewise parted from RL */
-  --diagram-light-utility: #617782; /* 4.70 */
-  --diagram-light-normalization: #008278; /* 4.70 */
-  --diagram-light-tensorops: #6570ad; /* 4.69 */
+     card title, which is drawn in the same colour (1.4.3, 4.5:1). The second
+     number is CIE L*: the lightness tiers are the design (see above), and
+     `check-contrast.mjs` rules 11c and 11d are what hold them. */
+  --diagram-light-cnn: #298340; /* 4.76, L* 48 */
+  --diagram-light-rnn: #0075d6; /* 4.65, L* 49 */
+  --diagram-light-transformer: #a458b0; /* 4.56, L* 49 */
+  /* 9.19, L* 31 — the blue tier's dark member. At one lightness with RNN it
+     was 2.13 dE00 from it under deuteranopia, the palette's worst pair. */
+  --diagram-light-llm: #5327b0;
+  --diagram-light-diffusion: #de1181; /* 4.66, L* 49 */
+  /* 9.17, L* 31 — the amber tier's dark member, parted from RL and Data Flow
+     (2.61 dE00 from Data Flow under protanopia before). */
+  --diagram-light-classical: #693e00;
+  --diagram-light-rl: #a56100; /* 4.87, L* 48 */
+  --diagram-light-data: #007d8d; /* 4.86, L* 48 */
+  --diagram-light-training: #d83a41; /* 4.56, L* 49 */
+  --diagram-light-io: #877065; /* 4.63, L* 49 */
+  --diagram-light-dataflow: #995020; /* 5.96, L* 42 — the amber tier's middle */
+  --diagram-light-utility: #476370; /* 6.39, L* 40 — parted from Normalization and Data */
+  --diagram-light-normalization: #008278; /* 4.70, L* 49 */
+  /* 6.84, L* 38 — the blue tier's middle: was 0.01 L* from RNN. */
+  --diagram-light-tensorops: #4b549f;
 
   /* Light data-type hues. These paint the wires, and a wire has to be visible
      as a line before its colour can mean anything — LIST measured 1.51:1 and


### PR DESCRIPTION
> 中文摘要：兩個 3.0.0 前的使用者可見修正。(1) #324：六張視覺化卡片（注意力熱圖、embedding 散點）原本各自用 `useState` 持有「查看完整」檢視器並自行渲染 modal；#162 的視窗裁切會在卡片離開可視範圍時卸載它，視窗縮放、瀏覽器縮放、Shift+L、Ctrl+Z 都會讓開著的檢視器自己關掉。現在檢視器改為 App root 上的單一 host `VizViewerModal`，由 `tab.vizModalNodeId` 驅動（與 node detail、preset、layers 三個 modal 同一模式），卡片只負責要求開啟；刪除節點、收合成 block、換文件等都會清掉該 id。(2) #390：淺色匯出的 14 個卡片色全部壓在同一亮度，rnn/tensorops 只差 0.01 L*，紅綠色弱模擬下最近一對只有 2.13 dE00。重繪為分層亮度（LLM、Classical、Data Flow、Utility、Tensor Operations 較深），色相維持畫布色相，紅綠色弱模擬下最近一對 6.69/6.70 dE00；contrast gate 新增規則 11c 擴及卡片與 11d 二色覺模擬，讓這類缺陷不會回來。

## What / Why

**#324 — the "View full" viewer closed by itself.** Each of the six visualization cards (`AttentionHeatmap`, `AttentionMask`, `Edu-SelfAttention`, `Edu-MultiHeadAttention`, `Edu-CrossAttention`, `EmbeddingScatter`) held its viewer as a local `useState` flag and rendered `HeatmapModal` / `ScatterModal` inside the card. `onlyRenderVisibleElements` (#162) unmounts a card the moment it leaves the viewport, and a window resize, a browser zoom, Shift+L or Ctrl+Z can all do that while the viewer is up — so the viewer vanished under the user's cursor. Lifting the flag into the store was tried and reverted in #391: a stored `true` reopens the dialog on remount with no gesture behind it.

The viewer is now one component at the app root, `VizViewerModal`, driven by a new per-tab `vizModalNodeId` the way `NodeDetailModal`, the preset editor and the layers editor already are. A card only calls `openVizModal(id)`; the host reads the node, its streamed output summaries and the run id off the store and renders the right modal. `vizViewers.ts` is the single table both halves read: keyed by the React Flow node type, it builds the modal props, and the cards derive their inline plots through the same tensor helpers, so the small plot and the full one cannot disagree about what a tensor means. The id is cleared everywhere the other modal ids are — `deleteNode`, React Flow's own Delete key (`onNodesChange`), collapse into and expansion of a block, a plugin's `commitDocument`, and `clearedDocumentResidue` (#337). Enter no longer opens the node-detail modal over an open viewer.

**#390 — the light export's card colours were one colour to a colour-blind reader.** The fourteen light card hues were each lowered just until they cleared 4.5:1 on white, which put them all at one lightness: RNN and Tensor Operations sat 0.01 L* apart, and the palette's closest pair under a deuteranopia simulation measured 2.13 dE00, in the theme a student hands in. #323 had parted the wire ambers the same way one palette over.

Each category now has its own lightness tier. LLM, Classical, Data Flow, Utility and Tensor Operations sit darker; every hue stays its canvas hue (Lab hue drift at most 8 degrees), every colour still clears 4.5:1 as the card's border and title, and every same-family pair is at least 4 L* apart. Measured: closest pair 9.89 dE00 with normal vision, 6.69 under deuteranopia, 6.70 under protanopia (was 9.85 / 2.13 / 2.61).

The palette was found by a search over per-category lightness, chroma and hue offset that maximised the dichromat closest pair under those constraints, then read against swatches under both simulations. Alternatives with a higher floor (up to 9.75 dE00) existed and were rejected: they pushed RNN to a navy or RL to a brown, and a category hue that no longer reads as the app's hue costs more than the extra separation buys.

The gate learns the class. `check-contrast.mjs` rule 11c (same-family pairs must part in lightness) now covers the light cards as well as the wires, and a new rule 11d runs every export palette through the Machado (2009) deuteranopia and protanopia matrices and takes the closest pair there, with three self-tests on the matrices. The light cards are held to 6 dE00. The wire palettes and the canvas cards were never designed for this rule, so their floors record where they stand (1.4, 2.5 and 0.5 dE00) rather than a target; the message names list/transform and classical/rl as the pairs a later repaint has to part. `theme.test.ts` restates the lightness rule over the categories, so flattening one of them back fails a unit test as well as `pnpm build`.

## Closes / relates to

Closes #324
Closes #390

## Test evidence

```
cd frontend && pnpm build            -> contrast gate passed (460 relationships), tsc, vite build ok
cd frontend && npx vitest run        -> 158 files, 3849 tests passed
cd frontend && npx vitest run --coverage
                                     -> VizViewerModal.tsx, vizViewers.ts and the six cards at 100% (statements, branches, functions, lines)
```

In Chrome against the Vite dev server (backend 2.5.0): opened the `deep` plugin example Self-Attention 101, ran it, opened the heatmap viewer from the card, then zoomed the canvas until the card was unmounted (`.react-flow__node[data-id="attn"]` gone from the DOM). The dialog stayed up and `tab.vizModalNodeId` stayed `attn`; Escape closed it and nulled the id. The light-theme `graphToSvg` output of the same graph was rendered in-page with the new palette.

## What I deliberately did not do

- The dark-theme cards (the canvas palette) and both wire palettes still measure under 3 dE00 at their closest pair under the simulation. They are recorded floors in rule 11d, not repainted here: the canvas palette is the app's own colour coding and repainting it is a separate change (the gate's `minSeparation` comment already says so), and the wire pairs are the same list/transform and classical/rl pairs rules 11 and 11c name.
- No docs page changed: nothing in `docs/` names the light card values or the viewer's implementation.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] No docs page or node-param description changed, so no zh-TW twin to update.
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do (above).

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJYwm7kmzNrsSD8ujeVmmH
