### PR TITLE
feat(ui,plugins): the Plugin Center in the editor - browse, review and install plugins from the sidebar and Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,31 @@ received — each links to the release it was published as.
   is "whoever is sitting at this machine" unless a deliberate classroom or
   lab server opts back in with `CODEFYUI_ALLOW_REMOTE_PLUGIN_INSTALL=1`.
 
+- **The Plugin Center: teaching packs and GitHub plugins, installed from the
+  editor.** Until now the only way to add a chapter's nodes was a terminal and
+  `cdui plugin install`, which is a different window, a different skill and,
+  in a classroom, a different person. The panel opens from the sidebar's
+  Custom & Plugins tab and from Settings, and lists what this server has
+  alongside what it can fetch: every built-in teaching pack, every plugin
+  already on disk, and anything on GitHub you name as `owner/repo`, with an
+  optional `@tag`. Naming a repository does not install it — it downloads the
+  manifest and shows you what you would be agreeing to: who wrote it, which
+  nodes it brings, which Python packages it wants, whether it ships a UI that
+  will run inside the editor, and each capability it asks for spelled out as
+  the sentence it actually means rather than as a word like `filesystem`.
+  Install stays disabled until you say you have read it. From then on the row
+  is the whole lifecycle: enable, disable, update to the latest commit on its
+  ref, and uninstall, which asks first and says the two things that follow —
+  graphs using its nodes stop running, and the Python packages it pulled in
+  stay. An install reports itself while it runs, step by step, and its nodes
+  appear in the palette when it lands, without a page reload; disabling takes
+  them straight back out. Nothing here is a second implementation of the CLI:
+  the panel and `cdui plugin install` run the same flow on the server, an
+  install started in one is visible in the other, and when a job cannot
+  finish, the panel hands you the exact command to finish it in a terminal.
+  Installing is gated to whoever is at the machine, like the Package Center;
+  on a shared server the buttons say so instead of failing when pressed.
+
 ### Changed
 
 - **A plugin cannot be switched on, off or removed while its own install is
@@ -313,6 +338,14 @@ received — each links to the release it was published as.
   contrast gate now simulates both deficiencies for every export palette and
   holds the light cards to the same lightness-parting rule as the wires, so
   the class cannot come back.
+
+- **The Custom & Plugins tab's enabled/disabled chip follows the theme
+  again.** Its green and grey washes were written as literal `rgba()` values
+  rather than taken from the token layer, so they were mixed for one theme and
+  carried unchanged into the other, and the same "Enabled" that the Package
+  Center draws from tokens was a slightly different colour one panel away. The
+  chip is now the shared pill both centers use, which leaves no hard-coded
+  colour anywhere in that tab.
 
 ## [2.5.0] — 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,21 +196,23 @@ received — each links to the release it was published as.
   already on disk, and anything on GitHub you name as `owner/repo`, with an
   optional `@tag`. Naming a repository does not install it — it downloads the
   manifest and shows you what you would be agreeing to: who wrote it, which
-  nodes it brings, which Python packages it wants, whether it ships a UI that
-  will run inside the editor, and each capability it asks for spelled out as
-  the sentence it actually means rather than as a word like `filesystem`.
-  Install stays disabled until you say you have read it. From then on the row
+  Python packages it wants, whether it ships a UI that will run inside the
+  editor, and each capability it asks for spelled out as the sentence it
+  actually means rather than as a word like `filesystem`. When it asks for a
+  capability, or to have the import scan turned off for a module, Install
+  stays disabled until you accept that in as many words. From then on the row
   is the whole lifecycle: enable, disable, update to the latest commit on its
   ref, and uninstall, which asks first and says the two things that follow —
   graphs using its nodes stop running, and the Python packages it pulled in
   stay. An install reports itself while it runs, step by step, and its nodes
   appear in the palette when it lands, without a page reload; disabling takes
   them straight back out. Nothing here is a second implementation of the CLI:
-  the panel and `cdui plugin install` run the same flow on the server, an
-  install started in one is visible in the other, and when a job cannot
-  finish, the panel hands you the exact command to finish it in a terminal.
-  Installing is gated to whoever is at the machine, like the Package Center;
-  on a shared server the buttons say so instead of failing when pressed.
+  the panel and `cdui plugin install` are two front ends over one install
+  function, so a plugin installed by either is the same plugin to the other,
+  and when a job cannot finish, the panel hands you the exact command to
+  finish it in a terminal. Installing is gated to whoever is at the machine,
+  like the Package Center; on a shared server the buttons say so instead of
+  failing when pressed.
 
 ### Changed
 
@@ -339,13 +341,13 @@ received — each links to the release it was published as.
   holds the light cards to the same lightness-parting rule as the wires, so
   the class cannot come back.
 
-- **The Custom & Plugins tab's enabled/disabled chip follows the theme
-  again.** Its green and grey washes were written as literal `rgba()` values
-  rather than taken from the token layer, so they were mixed for one theme and
-  carried unchanged into the other, and the same "Enabled" that the Package
-  Center draws from tokens was a slightly different colour one panel away. The
-  chip is now the shared pill both centers use, which leaves no hard-coded
-  colour anywhere in that tab.
+- **The Custom & Plugins tab's enabled/disabled chip comes from the token
+  layer.** Its green and grey washes were written as literal `rgba()` values,
+  which nothing checks: the contrast gate reads `tokens.css`, so a colour
+  spelled out inside a component stylesheet is invisible to it. That is how
+  the same "Enabled" that the Package Center draws from tokens ended up a
+  slightly different colour one panel away. The chip is now the shared pill
+  both centers use, which leaves no hard-coded colour anywhere in that tab.
 
 ## [2.5.0] — 2026-09-01
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { NodeDetailModal } from './components/NodeDetailModal/NodeDetailModal';
 import { VizViewerModal } from './components/Nodes/VizViewerModal';
 import { TemplateGalleryModal } from './components/TemplateGallery/TemplateGalleryModal';
 import { PackCenterModal } from './components/PackCenter/PackCenterModal';
+import { PluginCenterModal } from './components/PluginCenter/PluginCenterModal';
 import { RestartOverlay } from './components/PackCenter/RestartOverlay';
 import { ToastContainer } from './components/shared/Toast';
 import { ShortcutsModal } from './components/shared/ShortcutsModal';
@@ -162,6 +163,7 @@ function App() {
       <VizViewerModal />
       <TemplateGalleryModal />
       <PackCenterModal />
+      <PluginCenterModal />
       <ToastContainer />
       <ShortcutsModal />
       <DialogContainer />

--- a/frontend/src/api/rest.test.ts
+++ b/frontend/src/api/rest.test.ts
@@ -1564,6 +1564,88 @@ describe('plugin center endpoints', () => {
       expect(err.message).toBe('unknown_catalog_name');
       expect(err.body).toEqual(body);
     });
+
+    // The review card maps over four of these arrays on every repaint and
+    // slices `installed.sha` down to seven characters. An absent key has to
+    // arrive as an empty list, or the consent screen crashes halfway through
+    // rendering the thing it is asking the user to agree to.
+    it('normalizes a sparse inspection', async () => {
+      mockFetch(200, { inspection_id: 'insp-1', plugin_id: 'c1-tokenizer' });
+      expect(await inspectPluginSource('c1-tokenizer')).toEqual({
+        inspection_id: 'insp-1',
+        expires_at: '',
+        // Not said is not `builtin`: that is the narrower claim.
+        kind: 'github',
+        mode: 'install',
+        plugin_id: 'c1-tokenizer',
+        catalog_id: null,
+        official: false,
+        source: '',
+        url: null,
+        ref: null,
+        sha: null,
+        name: '',
+        version: '',
+        description: '',
+        homepage: '',
+        manifest: {},
+        capabilities: [],
+        allowed_modules: [],
+        python_deps: {},
+        has_frontend: false,
+        chapters: [],
+        lessons: [],
+        consent_required: false,
+        installed: null,
+        up_to_date: false,
+        capabilities_added: [],
+        allowed_modules_added: [],
+        warnings: [],
+      });
+    });
+
+    it("folds a builtin's absent sha and a legacy source_kind to null", async () => {
+      // What the lockfile actually holds for an installed built-in pack: no
+      // commit, because nothing was fetched from a repository, and a
+      // `source_kind` written before that field had a vocabulary. The server
+      // passes the dict through untouched, so this is the only place either
+      // can be made safe to read.
+      mockFetch(200, inspection({
+        installed: {
+          sha: null, version: '1.0.0', source_kind: '',
+        } as unknown as PluginInspection['installed'],
+      }));
+      const out = await inspectPluginSource('c1-tokenizer');
+      expect(out.installed).toEqual({
+        sha: null,
+        version: '1.0.0',
+        capabilities: [],
+        trusted_modules: [],
+        // A record with no switch in it predates disabling: it is on.
+        enabled: true,
+        source_kind: null,
+      });
+    });
+
+    it('reads a kind, a mode or a source_kind outside its union', async () => {
+      mockFetch(200, inspection({
+        kind: 'local' as PluginInspection['kind'],
+        mode: 'repair' as PluginInspection['mode'],
+        installed: {
+          sha: 'abc123', version: '1.0.0', capabilities: [], trusted_modules: [],
+          enabled: false, source_kind: 'ftp',
+        } as unknown as PluginInspection['installed'],
+      }));
+      const out = await inspectPluginSource('c1-tokenizer');
+      // A source this build cannot name is still one it can install from a
+      // repository, and a mode it cannot name is a fresh install rather than
+      // an update of nothing.
+      expect(out.kind).toBe('github');
+      expect(out.mode).toBe('install');
+      expect(out.installed?.source_kind).toBeNull();
+      // An explicit false survives: only an ABSENT switch is derived.
+      expect(out.installed?.enabled).toBe(false);
+    });
   });
 
   describe('installPlugin', () => {
@@ -1639,6 +1721,25 @@ describe('plugin center endpoints', () => {
         capabilities_added: ['network'],
         allowed_modules_added: ['requests'],
       });
+    });
+
+    it('normalizes the inspection a needs_consent carries', async () => {
+      // The same review card renders this as renders a fresh install's, so it
+      // gets the same defaults rather than being trusted because it arrived
+      // on a different route.
+      mockFetch(200, {
+        status: 'needs_consent',
+        inspection: { inspection_id: 'insp-2', plugin_id: 'c1-tokenizer' },
+      });
+      const out = await updatePlugin('c1-tokenizer');
+      if (out.kind !== 'needs_consent') throw new Error('not a consent answer');
+      expect(out.inspection.capabilities).toEqual([]);
+      expect(out.inspection.python_deps).toEqual({});
+      expect(out.inspection.installed).toBeNull();
+      expect(out.inspection.mode).toBe('install');
+      // The two lists beside it default too, so the card can read either.
+      expect(out.capabilities_added).toEqual([]);
+      expect(out.allowed_modules_added).toEqual([]);
     });
 
     it('throws rather than guessing at a 200 that is neither shape', async () => {

--- a/frontend/src/api/rest.ts
+++ b/frontend/src/api/rest.ts
@@ -1422,12 +1422,18 @@ export interface PluginInspection {
   consent_required: boolean;
   /** What is on disk today, for an update; null for a fresh install. */
   installed: {
-    sha: string;
+    /**
+     * null for a builtin: the lockfile records a commit only for what came
+     * from a repository, so a card that reads `sha.slice(0, 7)` unguarded
+     * crashes on the first installed built-in pack.
+     */
+    sha: string | null;
     version: string;
     capabilities: string[];
     trusted_modules: string[];
     enabled: boolean;
-    source_kind: PluginSourceKind;
+    /** null for a legacy lockfile entry, which recorded `''`. */
+    source_kind: PluginSourceKind | null;
   } | null;
   up_to_date: boolean;
   /** What this version asks for that the installed one did not: the ONLY
@@ -1591,6 +1597,91 @@ export async function listPluginCatalog(): Promise<PluginCatalog> {
 }
 
 /**
+ * The `installed` block as it arrives: the lockfile's own dict, which the
+ * server passes through unmodified. Every field can be absent, `sha` is null
+ * for a builtin, and `source_kind` is `''` in an entry written before that
+ * field had a vocabulary.
+ */
+type RawInstalled = Omit<
+  Partial<NonNullable<PluginInspection['installed']>>,
+  'source_kind'
+> & { source_kind?: string | null };
+
+/** An inspection as it arrives, with the enum-ish fields widened. */
+type RawInspection = Omit<
+  Partial<PluginInspection>,
+  'kind' | 'mode' | 'installed'
+> & {
+  kind?: string;
+  mode?: string;
+  installed?: RawInstalled | null;
+};
+
+function normalizeInstalled(raw: RawInstalled | null | undefined) {
+  if (raw === null || raw === undefined) return null;
+  return {
+    // '' is not a commit. Folded to null so the review card's "is there a sha
+    // to show" question has one answer instead of two.
+    sha: raw.sha ? raw.sha : null,
+    version: raw.version ?? '',
+    capabilities: raw.capabilities ?? [],
+    trusted_modules: raw.trusted_modules ?? [],
+    // A record with no switch in it predates disabling: it is on.
+    enabled: raw.enabled ?? true,
+    source_kind: PLUGIN_SOURCE_KINDS.includes(raw.source_kind ?? '')
+      ? (raw.source_kind as PluginSourceKind)
+      : null,
+  };
+}
+
+/**
+ * One inspection, field by field -- the review card's whole input.
+ *
+ * Normalised for the reason the catalog rows are: the card maps over
+ * `capabilities`, `allowed_modules`, `python_deps` and `chapters` on every
+ * repaint, and it slices `installed.sha` down to seven characters. An absent
+ * key has to arrive as an empty list and a missing commit as `null`, or a
+ * consent screen crashes halfway through rendering the thing it is asking the
+ * user to agree to.
+ */
+function normalizePluginInspection(raw: RawInspection): PluginInspection {
+  return {
+    inspection_id: raw.inspection_id ?? '',
+    expires_at: raw.expires_at ?? '',
+    // A source this build cannot name is still one it can install from a
+    // repository; `builtin` is the narrower claim, so it has to be said.
+    kind: raw.kind === 'builtin' ? 'builtin' : 'github',
+    // Same narrowing as the store's `jobKind`: anything a newer backend
+    // invents reads as a fresh install rather than as an update of nothing.
+    mode: raw.mode === 'update' ? 'update' : 'install',
+    plugin_id: raw.plugin_id ?? '',
+    catalog_id: raw.catalog_id ?? null,
+    official: raw.official ?? false,
+    source: raw.source ?? '',
+    url: raw.url ?? null,
+    ref: raw.ref ?? null,
+    sha: raw.sha ?? null,
+    name: raw.name ?? '',
+    version: raw.version ?? '',
+    description: raw.description ?? '',
+    homepage: raw.homepage ?? '',
+    manifest: raw.manifest ?? {},
+    capabilities: raw.capabilities ?? [],
+    allowed_modules: raw.allowed_modules ?? [],
+    python_deps: raw.python_deps ?? {},
+    has_frontend: raw.has_frontend ?? false,
+    chapters: raw.chapters ?? [],
+    lessons: raw.lessons ?? [],
+    consent_required: raw.consent_required ?? false,
+    installed: normalizeInstalled(raw.installed),
+    up_to_date: raw.up_to_date ?? false,
+    capabilities_added: raw.capabilities_added ?? [],
+    allowed_modules_added: raw.allowed_modules_added ?? [],
+    warnings: raw.warnings ?? [],
+  };
+}
+
+/**
  * Resolve a source -- a builtin name, a GitHub URL, a local path -- and
  * report what installing it would mean, WITHOUT installing anything.
  *
@@ -1605,7 +1696,7 @@ export async function inspectPluginSource(source: string): Promise<PluginInspect
     body: JSON.stringify({ source }),
   });
   if (!res.ok) throw await apiError(res);
-  return res.json();
+  return normalizePluginInspection((await res.json()) as RawInspection);
 }
 
 /**
@@ -1633,7 +1724,7 @@ type RawUpdateResponse = {
   job_id?: string;
   status?: string;
   sha?: string;
-  inspection?: PluginInspection;
+  inspection?: RawInspection;
   capabilities_added?: string[];
   allowed_modules_added?: string[];
 };
@@ -1676,7 +1767,10 @@ export async function updatePlugin(pluginId: string): Promise<PluginUpdateResult
   if (data.status === 'needs_consent' && data.inspection !== undefined) {
     return {
       kind: 'needs_consent',
-      inspection: data.inspection,
+      // The same review card renders this as renders a fresh install's, so it
+      // is normalised the same way rather than trusted because it arrived on
+      // a different route.
+      inspection: normalizePluginInspection(data.inspection),
       capabilities_added: data.capabilities_added ?? [],
       allowed_modules_added: data.allowed_modules_added ?? [],
     };

--- a/frontend/src/components/PackCenter/PackCard.tsx
+++ b/frontend/src/components/PackCenter/PackCard.tsx
@@ -9,6 +9,7 @@ import type {
 import type { PackItemProgress, PackJob } from '../../store/packStore';
 import { useI18n } from '../../i18n';
 import { localizedPackTitle, type PackIndex } from '../../utils/packAvailability';
+import { Pill } from '../shared/Pill';
 import { GpuPackDetails } from './GpuPackDetails';
 import { PackItemRow } from './PackItemRow';
 import {
@@ -23,16 +24,12 @@ import styles from './PackCenterModal.module.css';
 
 export function StatusPill({ status }: { status: PackStatus }) {
   const { t } = useI18n();
-  const tone = statusTone(status);
+  // The chip itself is shared with the Plugin Center; what is a pack's here is
+  // only which tone a pack status wears and what it is called.
   return (
-    <span className={styles.pill} data-tone={tone}>
-      {status === 'installing' && (
-        // A pulsing dot rather than a spinner: it says "still going" without
-        // claiming to know how far, and it stops dead under reduced motion.
-        <span className={styles.pillDot} data-role="pulse" aria-hidden="true" />
-      )}
+    <Pill tone={statusTone(status)} pulse={status === 'installing'}>
       {t(statusKey(status))}
-    </span>
+    </Pill>
   );
 }
 

--- a/frontend/src/components/PackCenter/PackCenterModal.module.css
+++ b/frontend/src/components/PackCenter/PackCenterModal.module.css
@@ -265,65 +265,8 @@
   color: var(--text-primary);
 }
 
-/* ── Status pill ────────────────────────────────────────────────────────── */
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--sp-2);
-  font-size: var(--fs-2xs);
-  font-weight: var(--fw-semibold);
-  padding: var(--sp-1) var(--sp-3);
-  border-radius: var(--radius-pill);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.pill[data-tone='success'] {
-  background: var(--success-wash);
-  color: var(--status-success);
-}
-
-.pill[data-tone='warning'] {
-  background: var(--warning-wash);
-  color: var(--status-warning);
-}
-
-.pill[data-tone='info'] {
-  background: var(--info-wash);
-  color: var(--status-info);
-}
-
-.pill[data-tone='neutral'] {
-  background: var(--surface-input);
-  color: var(--text-muted);
-}
-
-.pillDot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentcolor;
-  flex-shrink: 0;
-  animation: packPulse 1.6s ease-in-out infinite;
-}
-
-@keyframes packPulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0.25;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .pillDot {
-    animation: none;
-  }
-}
+/* The status pill moved to `components/shared/Pill.module.css`: the Plugin
+   Center wears the same chip, and two copies of a wash scale drift. */
 
 /* ── Item rows ──────────────────────────────────────────────────────────── */
 

--- a/frontend/src/components/PackCenter/PackCenterModal.tsx
+++ b/frontend/src/components/PackCenter/PackCenterModal.tsx
@@ -95,6 +95,12 @@ function PackCenterBody() {
       // shortcuts window nobody can see.
       if (useDialogStore.getState().active !== null) return;
       if (useUIStore.getState().shortcutsModalOpen) return;
+      // The Plugin Center is a second window with a second Escape handler on
+      // the same key, and it defers to this one for exactly the same reason.
+      // Both can be open at once — a toast from either store offers to open
+      // the other — and without this, one press would close the window the
+      // user is NOT looking at and leave the one they are.
+      if (useUIStore.getState().pluginCenterOpen) return;
       if (!closable()) return;
       e.preventDefault();
       close();

--- a/frontend/src/components/PackCenter/PackCenterModal.tsx
+++ b/frontend/src/components/PackCenter/PackCenterModal.tsx
@@ -96,9 +96,11 @@ function PackCenterBody() {
       if (useDialogStore.getState().active !== null) return;
       if (useUIStore.getState().shortcutsModalOpen) return;
       // The Plugin Center is a second window with a second Escape handler on
-      // the same key, and it defers to this one for exactly the same reason.
-      // Both can be open at once — a toast from either store offers to open
-      // the other — and without this, one press would close the window the
+      // the same key, and it is the one on top: it renders one z-index rung
+      // above this panel (`PluginCenter/PluginCenterModal.module.css:
+      // .topBackdrop`), so a press belongs to it. Both can be open at once —
+      // each is reachable from Settings and from the sidebar's Custom &
+      // Plugins tab — and without this, one press would close the window the
       // user is NOT looking at and leave the one they are.
       if (useUIStore.getState().pluginCenterOpen) return;
       if (!closable()) return;

--- a/frontend/src/components/PackCenter/RestartOverlay.module.css
+++ b/frontend/src/components/PackCenter/RestartOverlay.module.css
@@ -5,10 +5,10 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  /* Above the modals (10000) and the toast stack (10001): while the server is
-     going away, nothing on the page is still true, so nothing may sit on top
-     of this. */
-  z-index: 10002;
+  /* Above the modals (10000), the Plugin Center (10001), the confirm dialog
+     (10002) and the toast stack (10003): while the server is going away,
+     nothing on the page is still true, so nothing may sit on top of this. */
+  z-index: 10004;
   background: var(--surface-scrim);
   backdrop-filter: blur(2px);
   display: flex;

--- a/frontend/src/components/PackCenter/packStatus.ts
+++ b/frontend/src/components/PackCenter/packStatus.ts
@@ -1,6 +1,7 @@
 import type { PackItem, PackStatus, PackSummary } from '../../api/rest';
 import type { PackJob } from '../../store/packStore';
 import type { TranslationKey } from '../../i18n/locales/en';
+import type { PillTone } from '../shared/Pill';
 
 /**
  * The pure half of the Package Center: everything the panel needs to decide
@@ -29,8 +30,14 @@ export type Translate = (
   vars?: Record<string, string | number>,
 ) => string;
 
-/** Which wash a status pill wears. Names a ROLE, not a colour. */
-export type StatusTone = 'success' | 'warning' | 'info' | 'neutral';
+/**
+ * Which wash a status pill wears. Names a ROLE, not a colour.
+ *
+ * An alias, not a second list: the tone is `Pill`'s vocabulary, and the two
+ * spellings of it drifted apart the moment the chip was extracted. A tone
+ * added there has to reach every `statusTone` that feeds a pill.
+ */
+export type StatusTone = PillTone;
 
 /**
  * A pack status as a tone.

--- a/frontend/src/components/PluginCenter/PluginActivityPane.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginActivityPane.test.tsx
@@ -363,10 +363,12 @@ describe('PluginActivityPane — how a job ended', () => {
     expect(within(banner()).getByText('Install cancelled.')).toBeInTheDocument();
   });
 
-  it('asks for a restart, and prints the command the server cannot run itself', () => {
+  it('says nothing was installed, and prints the command the server cannot run', () => {
     // The shape the backend really sends: a plugin reaches this status only
     // when its Python packages would replace one the running interpreter has
-    // loaded, and the command is the install to run with the server stopped.
+    // loaded, which the resolver refuses BEFORE anything is written -- so the
+    // command is the install to run with the server stopped, and the panel
+    // install has to be repeated afterwards.
     paint({
       job: job({
         status: 'needs_restart',
@@ -377,9 +379,22 @@ describe('PluginActivityPane — how a job ended', () => {
 
     expect(banner()).toHaveAttribute('data-tone', 'warning');
     expect(
-      within(banner()).getByText('Installed. Restart the server to load Demo plugin:'),
+      within(banner()).getByText(
+        "The install stopped before changing anything: Demo plugin's Python packages "
+        + 'would replace one the server has loaded. With the server stopped, run this, '
+        + 'then install again:',
+      ),
     ).toBeInTheDocument();
     expect(within(banner()).getByText('uv pip install "torch==2.4.0"')).toBeInTheDocument();
+  });
+
+  it('leaves the banner alone when a stopped install carried no command', () => {
+    paint({ job: job({ status: 'needs_restart', restartCommand: null }), entry: demo });
+
+    expect(banner()).toHaveAttribute('data-tone', 'warning');
+    expect(within(banner()).getByText(/^The install stopped/)).toBeInTheDocument();
+    // `CommandBlock` is the only thing in the pane with a copy button.
+    expect(screen.queryByRole('button', { name: 'Copy command' })).toBeNull();
   });
 
   it('offers to re-read the catalog when the follower lost contact', () => {

--- a/frontend/src/components/PluginCenter/PluginActivityPane.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginActivityPane.test.tsx
@@ -3,7 +3,8 @@ import { render, screen, fireEvent, within } from '@testing-library/react';
 import type { PluginCatalogEntry } from '../../api/rest';
 import { emptyPluginJob, type PluginJob } from '../../store/pluginStore';
 import { useI18n } from '../../i18n';
-import { PluginActivityPane, jobOverallPercent } from './PluginActivityPane';
+import { PluginActivityPane } from './PluginActivityPane';
+import { jobOverallPercent } from './pluginStatus';
 
 function entry(over: Partial<PluginCatalogEntry> & { id: string }): PluginCatalogEntry {
   return {
@@ -219,17 +220,37 @@ describe('PluginActivityPane — a running job', () => {
 // ── The overall bar ─────────────────────────────────────────────────────────
 
 describe('PluginActivityPane — the overall bar', () => {
-  it('weights the bar by the tarball bytes when the server sent a size', () => {
+  it('lets the tarball bytes refine the step that is downloading', () => {
+    // A quarter of the download, which is one step of eight: a quarter of
+    // that step, on top of the one that is done.
     const bytes = downloading({
       items: { tarball: { bytesDone: 300, bytesTotal: 1200, percent: 25 } },
     });
-    expect(jobOverallPercent(bytes)).toBe(25);
+    expect(jobOverallPercent(bytes, demo)).toBe(15.625);
 
     paint({ job: bytes, entry: demo });
-    expect(progressBar()).toHaveAttribute('aria-valuenow', '25');
+    expect(progressBar()).toHaveAttribute('aria-valuenow', '15.625');
   });
 
-  it('counts finished steps out of the eight an install has, when no size came', () => {
+  it('stops reading full through the steps after the download', () => {
+    // The bytes are ONE step's worth. Counted as the whole job, a finished
+    // download parked the bar at 100 % through `deps` -- minutes of uv --
+    // and everything after it.
+    const unpacking = job({
+      steps: [
+        { step: 'resolve', label: 'Resolving owner/demo', state: 'done' },
+        { step: 'download', label: 'Downloading', state: 'done' },
+        { step: 'extract', label: 'Unpacking demo', state: 'done' },
+        { step: 'verify', label: 'Scanning demo for unsafe code', state: 'done' },
+        { step: 'deps', label: 'Installing packages', state: 'running' },
+      ],
+      items: { tarball: { bytesDone: 1000, bytesTotal: 1000, percent: 100 } },
+    });
+
+    expect(jobOverallPercent(unpacking, demo)).toBe(50);
+  });
+
+  it('counts finished steps out of the eight a GitHub install has', () => {
     // Out of EIGHT and not out of the steps announced so far: the server
     // announces a step as it starts, so "one of the two we know about" would
     // read as half a bar during the second step of eight.
@@ -241,11 +262,28 @@ describe('PluginActivityPane — the overall bar', () => {
         { step: 'verify', label: 'Scanning demo for unsafe code', state: 'running' },
       ],
     });
-    expect(jobOverallPercent(steps)).toBe(37.5);
+    expect(jobOverallPercent(steps, demo)).toBe(37.5);
 
     paint({ job: steps, entry: demo });
     expect(progressBar()).toHaveAttribute('aria-valuenow', '37.5');
     expect(screen.getByText('Step 4: Checking the code')).toBeInTheDocument();
+  });
+
+  it('lets a built-in pack reach the end of its own four steps', () => {
+    // A built-in has nothing to download: `resolve [deps] lock reload`. Out
+    // of eight it topped out at half a bar and was replaced by the banner
+    // there, which reads as an install that stopped halfway.
+    const builtin = job({
+      pluginId: 'stats',
+      steps: [
+        { step: 'resolve', label: 'Resolving stats', state: 'done' },
+        { step: 'deps', label: 'Installing packages', state: 'done' },
+        { step: 'lock', label: 'Recording the install', state: 'done' },
+        { step: 'reload', label: 'Loading the nodes', state: 'done' },
+      ],
+    });
+
+    expect(jobOverallPercent(builtin, stats)).toBe(100);
   });
 
   it('falls back to the steps when the download never learned its size', () => {
@@ -256,23 +294,31 @@ describe('PluginActivityPane — the overall bar', () => {
         downloading({
           items: { tarball: { bytesDone: 4096, bytesTotal: null, percent: null } },
         }),
+        demo,
       ),
     ).toBe(12.5);
   });
 
-  it('never reads past full, whatever the server says it downloaded', () => {
+  it('counts no more than one step of bytes, whatever the server says', () => {
     expect(
       jobOverallPercent(
         downloading({
           items: { tarball: { bytesDone: 1500, bytesTotal: 1000, percent: 100 } },
         }),
+        demo,
       ),
-    ).toBe(100);
+    ).toBe(25);
+  });
+
+  it('counts a row the catalog has not got as the longer install', () => {
+    // A first install from a typed repository has no row at all, and eight
+    // steps is both the likely truth and the understated guess.
+    expect(jobOverallPercent(downloading(), undefined)).toBe(12.5);
   });
 
   it('has no answer at all for no job and no steps', () => {
-    expect(jobOverallPercent(null)).toBeNull();
-    expect(jobOverallPercent(job())).toBeNull();
+    expect(jobOverallPercent(null, demo)).toBeNull();
+    expect(jobOverallPercent(job(), demo)).toBeNull();
   });
 });
 
@@ -407,8 +453,15 @@ describe('PluginActivityPane — how a job ended', () => {
       ),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh plugin status' }));
+    // "Refresh", not the header icon's "Refresh plugin status": the sentence
+    // above it already says what refreshing is for, and the dialog would
+    // otherwise offer two controls with one name.
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
     expect(handlers.onRefresh).toHaveBeenCalledTimes(1);
+
+    // A job nobody can report is still a job to put away.
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(handlers.onDismiss).toHaveBeenCalledTimes(1);
   });
 
   it('hands Dismiss to the store, and offers no cancel', () => {
@@ -437,5 +490,18 @@ describe('PluginActivityPane — how a job ended', () => {
       />,
     );
     expect(live()).toHaveTextContent('Install cancelled.');
+  });
+
+  it('announces the job by its id while the catalog has no row for it', () => {
+    // Before the first step event there is no step sentence and no
+    // percentage, so the headline is all the region has -- and a job adopted
+    // from another tab is named by its plugin id until the catalog answers.
+    const { container } = paint({
+      job: job({ pluginId: 'owner-demo' }), entry: undefined,
+    });
+
+    expect(container.querySelector('[aria-atomic="true"]')).toHaveTextContent(
+      'Installing owner-demo',
+    );
   });
 });

--- a/frontend/src/components/PluginCenter/PluginActivityPane.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginActivityPane.test.tsx
@@ -1,0 +1,426 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import type { PluginCatalogEntry } from '../../api/rest';
+import { emptyPluginJob, type PluginJob } from '../../store/pluginStore';
+import { useI18n } from '../../i18n';
+import { PluginActivityPane, jobOverallPercent } from './PluginActivityPane';
+
+function entry(over: Partial<PluginCatalogEntry> & { id: string }): PluginCatalogEntry {
+  return {
+    name: over.id,
+    description: '',
+    kind: 'builtin',
+    official: true,
+    status: 'available',
+    source_kind: null,
+    source: over.id,
+    repo: null,
+    ref: null,
+    sha: null,
+    url: null,
+    homepage: '',
+    version: null,
+    installed_at: null,
+    enabled: false,
+    chapters: [],
+    lessons: [],
+    tags: [],
+    nodes: [],
+    node_count: 0,
+    capabilities: [],
+    trusted_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    consent_required: false,
+    frontend_entry: null,
+    job: null,
+    ...over,
+  };
+}
+
+/** A third-party plugin off GitHub, installed and pinned to a tag. */
+const demo = entry({
+  id: 'demo',
+  name: 'Demo plugin',
+  kind: 'github',
+  official: false,
+  status: 'installed',
+  source_kind: 'github_url',
+  repo: 'owner/demo',
+  ref: 'v1.2.0',
+  version: '1.2.0',
+});
+
+/** A built-in teaching pack: a catalog NAME is what installs it. */
+const stats = entry({ id: 'stats', name: 'Stats nodes', source_kind: 'builtin' });
+
+/** A folder somebody linked from disk. `cdui plugin install` cannot take it. */
+const linked = entry({
+  id: 'lab',
+  name: 'Lab nodes',
+  kind: 'external',
+  official: false,
+  status: 'installed',
+  source_kind: 'local',
+  source: 'D:/work/lab-nodes',
+});
+
+function job(over: Partial<PluginJob> = {}): PluginJob {
+  return { ...emptyPluginJob('j1', 'demo'), ...over };
+}
+
+/** A job that has got as far as its second step, with nothing downloaded. */
+function downloading(over: Partial<PluginJob> = {}): PluginJob {
+  return job({
+    steps: [
+      { step: 'resolve', label: 'Resolving owner/demo', state: 'done' },
+      { step: 'download', label: 'Downloading owner/demo@4f0a1c9', state: 'running' },
+    ],
+    ...over,
+  });
+}
+
+/** Fresh mocks for every handler the pane is allowed to call. */
+function makeHandlers() {
+  return { onCancel: vi.fn(), onDismiss: vi.fn(), onRefresh: vi.fn() };
+}
+
+let handlers: ReturnType<typeof makeHandlers>;
+
+/**
+ * Mount the pane over one job. Fresh `vi.fn()` handlers every time, so no
+ * case can read another's calls.
+ */
+function paint(over: {
+  job?: PluginJob | null;
+  entry?: PluginCatalogEntry | undefined;
+  cancelling?: boolean;
+} = {}) {
+  handlers = makeHandlers();
+  return render(
+    <PluginActivityPane
+      job={over.job ?? null}
+      entry={over.entry}
+      cancelling={over.cancelling ?? false}
+      {...handlers}
+    />,
+  );
+}
+
+/** The result banner, the only `status` element the pane renders. */
+const banner = () => screen.getByRole('status');
+
+const progressBar = () => screen.getByRole('progressbar', { name: 'Install progress' });
+
+beforeEach(() => {
+  useI18n.setState({ locale: 'en' });
+});
+
+// ── Idle ────────────────────────────────────────────────────────────────────
+
+describe('PluginActivityPane — idle', () => {
+  it('says nothing is installing, and offers no controls', () => {
+    paint();
+
+    expect(screen.getByText('Nothing is installing right now.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Downloads keep going if you close this window.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).toBeNull();
+    expect(screen.queryByRole('log')).toBeNull();
+    expect(screen.queryAllByRole('button')).toEqual([]);
+  });
+});
+
+// ── A job in flight ─────────────────────────────────────────────────────────
+
+describe('PluginActivityPane — a running job', () => {
+  it('names the plugin it is installing, the step it is on and how far it has got', () => {
+    paint({ job: downloading(), entry: demo });
+
+    expect(screen.getByText('Installing Demo plugin')).toBeInTheDocument();
+    // The step id is what is translated; the server's English label is only
+    // the fallback for an id this build has never heard of.
+    expect(screen.getByText('Step 2: Downloading')).toBeInTheDocument();
+    expect(screen.getByText('Overall progress')).toBeInTheDocument();
+    expect(progressBar()).toHaveAttribute('aria-valuenow', '12.5');
+    // Nothing has ended, so there is no banner to say otherwise.
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('says it is UPDATING when that is what the job is', () => {
+    paint({ job: downloading({ kind: 'update' }), entry: demo });
+
+    expect(screen.getByText('Updating Demo plugin')).toBeInTheDocument();
+    expect(screen.queryByText('Installing Demo plugin')).toBeNull();
+  });
+
+  it('names a plugin the catalog has no row for by its id', () => {
+    // A job adopted from another tab, or a plugin installed from a URL this
+    // registry does not list: the pane still has a name to print.
+    paint({ job: downloading({ pluginId: 'owner-demo' }), entry: undefined });
+
+    expect(screen.getByText('Installing owner-demo')).toBeInTheDocument();
+  });
+
+  it('shows the transcript, and says so while it is still empty', () => {
+    paint({ job: downloading(), entry: demo });
+    expect(
+      within(screen.getByRole('log', { name: 'Install log' })).getByText(
+        'Waiting for the first message...',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('prints the server log verbatim, in the server language', () => {
+    paint({
+      job: downloading({
+        log: [
+          { seq: 1, ts: null, kind: 'step', text: 'Resolving owner/demo' },
+          { seq: 2, ts: null, kind: 'log', text: 'Collecting model2vec>=0.8.0' },
+        ],
+      }),
+      entry: demo,
+    });
+
+    const log = within(screen.getByRole('log', { name: 'Install log' }));
+    expect(log.getByText('Resolving owner/demo')).toBeInTheDocument();
+    expect(log.getByText('Collecting model2vec>=0.8.0')).toBeInTheDocument();
+  });
+
+  it('is indeterminate until the first step is announced', () => {
+    // 0 % about a job that is clearly working is a wrong number rather than
+    // no number: ARIA spells "unknown" as a missing `aria-valuenow`.
+    paint({ job: job(), entry: demo });
+
+    expect(progressBar()).not.toHaveAttribute('aria-valuenow');
+    expect(screen.queryByText(/^Step /)).toBeNull();
+  });
+
+  it('hands Cancel to the store', () => {
+    paint({ job: downloading(), entry: demo });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel install' }));
+    expect(handlers.onCancel).toHaveBeenCalledTimes(1);
+    // Nothing to dismiss while it runs.
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull();
+  });
+
+  it('says it is cancelling, and takes no second press', () => {
+    paint({ job: downloading(), entry: demo, cancelling: true });
+
+    const button = screen.getByRole('button', { name: 'Cancelling...' });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(handlers.onCancel).not.toHaveBeenCalled();
+  });
+});
+
+// ── The overall bar ─────────────────────────────────────────────────────────
+
+describe('PluginActivityPane — the overall bar', () => {
+  it('weights the bar by the tarball bytes when the server sent a size', () => {
+    const bytes = downloading({
+      items: { tarball: { bytesDone: 300, bytesTotal: 1200, percent: 25 } },
+    });
+    expect(jobOverallPercent(bytes)).toBe(25);
+
+    paint({ job: bytes, entry: demo });
+    expect(progressBar()).toHaveAttribute('aria-valuenow', '25');
+  });
+
+  it('counts finished steps out of the eight an install has, when no size came', () => {
+    // Out of EIGHT and not out of the steps announced so far: the server
+    // announces a step as it starts, so "one of the two we know about" would
+    // read as half a bar during the second step of eight.
+    const steps = job({
+      steps: [
+        { step: 'resolve', label: 'Resolving owner/demo', state: 'done' },
+        { step: 'download', label: 'Downloading', state: 'done' },
+        { step: 'extract', label: 'Unpacking demo', state: 'done' },
+        { step: 'verify', label: 'Scanning demo for unsafe code', state: 'running' },
+      ],
+    });
+    expect(jobOverallPercent(steps)).toBe(37.5);
+
+    paint({ job: steps, entry: demo });
+    expect(progressBar()).toHaveAttribute('aria-valuenow', '37.5');
+    expect(screen.getByText('Step 4: Checking the code')).toBeInTheDocument();
+  });
+
+  it('falls back to the steps when the download never learned its size', () => {
+    // `codeload` generates a tarball on demand and often sends no
+    // Content-Length at all, which is a null total rather than a zero one.
+    expect(
+      jobOverallPercent(
+        downloading({
+          items: { tarball: { bytesDone: 4096, bytesTotal: null, percent: null } },
+        }),
+      ),
+    ).toBe(12.5);
+  });
+
+  it('never reads past full, whatever the server says it downloaded', () => {
+    expect(
+      jobOverallPercent(
+        downloading({
+          items: { tarball: { bytesDone: 1500, bytesTotal: 1000, percent: 100 } },
+        }),
+      ),
+    ).toBe(100);
+  });
+
+  it('has no answer at all for no job and no steps', () => {
+    expect(jobOverallPercent(null)).toBeNull();
+    expect(jobOverallPercent(job())).toBeNull();
+  });
+});
+
+// ── How a job ended ─────────────────────────────────────────────────────────
+
+describe('PluginActivityPane — how a job ended', () => {
+  it('reports an install that finished, and titles it by its plugin', () => {
+    paint({ job: job({ status: 'done' }), entry: demo });
+
+    expect(banner()).toHaveAttribute('data-tone', 'success');
+    expect(within(banner()).getByText('Installed Demo plugin.')).toBeInTheDocument();
+    // "Installing X" over "Installed X." would be the panel saying both.
+    expect(screen.queryByText('Installing Demo plugin')).toBeNull();
+    expect(screen.getByText('Demo plugin')).toBeInTheDocument();
+    // The bar belongs to a job that is still going.
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+
+  it('reports an update that finished', () => {
+    paint({ job: job({ status: 'done', kind: 'update' }), entry: demo });
+    expect(within(banner()).getByText('Updated Demo plugin.')).toBeInTheDocument();
+  });
+
+  it('reports a failure with the server hint, and the same install in a terminal', () => {
+    paint({
+      job: job({
+        status: 'failed',
+        error: { message: 'HTTP 404', hint: 'Check the repository name.' },
+      }),
+      entry: demo,
+    });
+
+    expect(banner()).toHaveAttribute('data-tone', 'error');
+    expect(within(banner()).getByText('Install failed: HTTP 404')).toBeInTheDocument();
+    expect(within(banner()).getByText('Check the repository name.')).toBeInTheDocument();
+    expect(within(banner()).getByText('Or install from a terminal:')).toBeInTheDocument();
+    // The repository and the ref this row is pinned to, so what the user
+    // pastes reproduces THIS row rather than whatever the branch holds now.
+    expect(
+      within(banner()).getByText('cdui plugin install owner/demo@v1.2.0'),
+    ).toBeInTheDocument();
+  });
+
+  it('offers a built-in pack its catalog name', () => {
+    paint({
+      job: job({ status: 'failed', pluginId: 'stats', error: { message: 'boom', hint: null } }),
+      entry: stats,
+    });
+    expect(within(banner()).getByText('cdui plugin install stats')).toBeInTheDocument();
+  });
+
+  it('offers a linked folder no command at all', () => {
+    // `cdui plugin install` takes a name or a repository. A linked row's
+    // source is a path on this machine, so the command would be one the CLI
+    // refuses; a folder is put back with `cdui plugin link`.
+    paint({
+      job: job({ status: 'failed', pluginId: 'lab', error: { message: 'boom', hint: null } }),
+      entry: linked,
+    });
+
+    expect(within(banner()).getByText('Install failed: boom')).toBeInTheDocument();
+    expect(screen.queryByText('Or install from a terminal:')).toBeNull();
+    expect(screen.queryByText(/^cdui plugin/)).toBeNull();
+  });
+
+  it('offers no command for a job whose row the catalog has not got', () => {
+    paint({
+      job: job({ status: 'failed', error: { message: 'boom', hint: null } }),
+      entry: undefined,
+    });
+
+    expect(within(banner()).getByText('Install failed: boom')).toBeInTheDocument();
+    expect(screen.queryByText('Or install from a terminal:')).toBeNull();
+  });
+
+  it('says an UPDATE failed in the words an update gets', () => {
+    paint({
+      job: job({ status: 'failed', kind: 'update', error: { message: 'HTTP 500', hint: null } }),
+      entry: demo,
+    });
+    expect(within(banner()).getByText('Update failed: HTTP 500')).toBeInTheDocument();
+  });
+
+  it('reports an install the user stopped', () => {
+    paint({ job: job({ status: 'cancelled' }), entry: demo });
+
+    expect(banner()).toHaveAttribute('data-tone', 'neutral');
+    expect(within(banner()).getByText('Install cancelled.')).toBeInTheDocument();
+  });
+
+  it('asks for a restart, and prints the command the server cannot run itself', () => {
+    // The shape the backend really sends: a plugin reaches this status only
+    // when its Python packages would replace one the running interpreter has
+    // loaded, and the command is the install to run with the server stopped.
+    paint({
+      job: job({
+        status: 'needs_restart',
+        restartCommand: 'uv pip install "torch==2.4.0"',
+      }),
+      entry: demo,
+    });
+
+    expect(banner()).toHaveAttribute('data-tone', 'warning');
+    expect(
+      within(banner()).getByText('Installed. Restart the server to load Demo plugin:'),
+    ).toBeInTheDocument();
+    expect(within(banner()).getByText('uv pip install "torch==2.4.0"')).toBeInTheDocument();
+  });
+
+  it('offers to re-read the catalog when the follower lost contact', () => {
+    paint({ job: job({ status: 'lost' }), entry: demo });
+
+    expect(banner()).toHaveAttribute('data-tone', 'warning');
+    expect(
+      within(banner()).getByText(
+        'Lost contact with the server. Refresh to check the plugin status.',
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh plugin status' }));
+    expect(handlers.onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('hands Dismiss to the store, and offers no cancel', () => {
+    paint({ job: job({ status: 'done' }), entry: demo });
+
+    expect(screen.queryByRole('button', { name: 'Cancel install' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(handlers.onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('announces the ending in the live region that was there all along', () => {
+    // A `role="status"` element that MOUNTS with its text already in it is
+    // not reliably announced, which is what made `cancelled` and `lost`
+    // silent: one region for the job's whole life, and the sentence lands in
+    // it as a change.
+    const { container, rerender } = paint({ job: downloading(), entry: demo });
+    const live = () => container.querySelector('[aria-atomic="true"]');
+    expect(live()).toHaveTextContent('Step 2: Downloading 13%');
+
+    rerender(
+      <PluginActivityPane
+        job={job({ status: 'cancelled' })}
+        entry={demo}
+        cancelling={false}
+        {...handlers}
+      />,
+    );
+    expect(live()).toHaveTextContent('Install cancelled.');
+  });
+});

--- a/frontend/src/components/PluginCenter/PluginActivityPane.tsx
+++ b/frontend/src/components/PluginCenter/PluginActivityPane.tsx
@@ -1,0 +1,364 @@
+import { useMemo } from 'react';
+import type { PluginCatalogEntry } from '../../api/rest';
+import type { ItemProgress, JobPhase, JobStep } from '../../store/jobFollower';
+import type { PluginJob } from '../../store/pluginStore';
+import { useI18n } from '../../i18n';
+import { ProgressBar } from '../shared/ProgressBar';
+// The pack panel's own pieces rather than copies of them: an install
+// transcript and a command with a copy button are the same objects in both
+// windows, and two of each would drift the day one is fixed.
+import { CommandBlock } from '../PackCenter/CommandBlock';
+import { PackLogTail } from '../PackCenter/PackLogTail';
+import { cliInstallCommand, stepLabel, type Translate } from './pluginStatus';
+import styles from '../PackCenter/PackCenterModal.module.css';
+
+/**
+ * The one item a plugin job reports bytes for: the repository tarball
+ * (`backend/app/core/plugins/flows.py: _tarball_progress`).
+ *
+ * A plugin install has exactly one download, so this is a NAME rather than a
+ * set to sum -- which is the difference between this pane's bar and the pack
+ * panel's, where a job fetches several models of very different sizes.
+ */
+export const TARBALL_ITEM = 'tarball';
+
+/**
+ * How many steps a full install has: `resolve download extract verify deps
+ * stage lock reload`.
+ *
+ * The denominator is this constant and NOT `job.steps.length`, because the
+ * server announces a step as it starts: the array holds the steps so far, so
+ * "one of the two we have heard of is done" would read as 50 % during the
+ * second step of eight. A catalog install, which skips the four steps a
+ * download needs, therefore tops out around half a bar before it ends -- an
+ * understated bar, which is the honest way round for a job whose remaining
+ * steps are unknowable from here.
+ */
+export const PLUGIN_STEP_COUNT = 8;
+
+function clamp(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+/**
+ * How far the whole job has got, 0..100, or null when nobody can say yet.
+ *
+ * The tarball's bytes when the server sent a size, and the step count
+ * otherwise. `codeload` streams a tarball it generates on demand and usually
+ * sends no `Content-Length` at all, so the step count is the ordinary case
+ * and the bytes are the refinement a server that DOES state a size buys.
+ *
+ * Null (indeterminate) rather than 0 for a job with no steps yet: 0 % about a
+ * job that is clearly working is a wrong number rather than no number, and
+ * the seconds between "the install was accepted" and the first step event are
+ * exactly that job.
+ */
+export function jobOverallPercent(job: PluginJob | null): number | null {
+  if (job === null) return null;
+
+  const tarball: ItemProgress | undefined = job.items[TARBALL_ITEM];
+  const total = tarball?.bytesTotal ?? null;
+  if (tarball && total !== null && Number.isFinite(total) && total > 0) {
+    // A server that reports more bytes than it promised must not push the bar
+    // past full.
+    return clamp((Math.max(0, tarball.bytesDone) / total) * 100);
+  }
+
+  if (job.steps.length === 0) return null;
+  const finished = job.steps.filter((step) => step.state === 'done').length;
+  return clamp((finished / PLUGIN_STEP_COUNT) * 100);
+}
+
+/**
+ * The step the pane should be showing: the one still running, or the last one
+ * to have finished while the next has not been announced yet.
+ *
+ * Takes the STEPS rather than the job, so it says what it needs and stays
+ * usable for any job shape. (The pack panel's equivalent takes a `PackJob`,
+ * which a `PluginJob` is not; widening it there is a change to the Package
+ * Center, and this task changes none.)
+ */
+function currentStep(steps: JobStep[]): { index: number; step: JobStep } | null {
+  if (steps.length === 0) return null;
+  const running = steps.findIndex((step) => step.state === 'running');
+  const index = running === -1 ? steps.length - 1 : running;
+  return { index: index + 1, step: steps[index] };
+}
+
+type BannerTone = 'success' | 'warning' | 'error' | 'neutral';
+
+const BANNER_TONE: Record<JobPhase, BannerTone> = {
+  running: 'neutral',
+  done: 'success',
+  failed: 'error',
+  cancelled: 'neutral',
+  needs_restart: 'warning',
+  lost: 'warning',
+};
+
+export interface PluginActivityPaneProps {
+  job: PluginJob | null;
+  /**
+   * The catalog row for `job.pluginId`: its name, and the source the terminal
+   * fallback would install from.
+   *
+   * Undefined when the catalog has no row for this job -- a plugin installed
+   * from a URL this registry does not list, or a job adopted before the first
+   * catalog read answers. The pane then names the job by its plugin id and
+   * offers no command, rather than guessing at either.
+   */
+  entry: PluginCatalogEntry | undefined;
+  /** A cancel request is in flight: the button says so and takes no second press. */
+  cancelling: boolean;
+  onCancel: () => void;
+  onDismiss: () => void;
+  /** Re-read the catalog, for the one banner that cannot say what happened. */
+  onRefresh: () => void;
+}
+
+/**
+ * The right-hand column of the Plugin Center: what is installing, how far it
+ * has got, and what it left behind when it stopped.
+ *
+ * A pure VIEW of `pluginStore.job`, exactly like the Package Center's pane and
+ * for the same reason: an install has to survive this window being closed, a
+ * second tab and a page reload, so the job's whole lifecycle lives in the
+ * store and this component only renders it.
+ *
+ * Its markup and roles ARE the pack pane's -- the same title, the same live
+ * region, the same bar, the same log and the same two buttons -- so the two
+ * panes read identically to a screen reader and neither has to be learned
+ * twice. What differs is only what a plugin job is: install or update, one
+ * tarball rather than several models, and no restart-mode retry (this store
+ * has no restart mode; a plugin never swaps a wheel out from under the
+ * running interpreter).
+ */
+export function PluginActivityPane({
+  job,
+  entry,
+  cancelling,
+  onCancel,
+  onDismiss,
+  onRefresh,
+}: PluginActivityPaneProps) {
+  const { t, locale } = useI18n();
+
+  const percent = jobOverallPercent(job);
+  const current = job === null ? null : currentStep(job.steps);
+  // The catalog row's name, falling back to the id -- the store's own rule
+  // (`pluginStore.ts: pluginName`), so a toast and this pane call a plugin
+  // the same thing.
+  const title = job === null ? '' : (entry?.name || job.pluginId);
+  const headline = job === null
+    ? ''
+    : t(job.kind === 'update'
+      ? 'pluginCenter.activity.updating'
+      : 'pluginCenter.activity.installing', { plugin: title });
+  const stepText = current === null
+    ? null
+    : t('packs.activity.step', {
+      index: current.index,
+      label: stepLabel(t, current.step.step, current.step.label),
+    });
+
+  // How a job that has stopped is reported, or null while it is running.
+  const result = job === null ? null : resultSentence(t, job, title);
+
+  // Announced on a STEP change and every ten percent, never on every byte: a
+  // polite live region re-read on each progress frame would talk over itself
+  // for the whole install.
+  //
+  // Falls back to the job's own headline for the second or two between "the
+  // install was accepted" and the first step event, so a screen reader hears
+  // that something started rather than a bare "0%".
+  const bucket = percent === null ? -1 : Math.floor(percent / 10);
+  const announcement = useMemo(
+    () =>
+      result ?? [
+        stepText ?? headline,
+        percent === null ? null : `${Math.round(percent)}%`,
+      ]
+        .filter(Boolean)
+        .join(' '),
+    // Intentionally narrow: `stepText`, `headline` and `percent` are read at
+    // the moment one of these changes, which IS the throttle. `result` is a
+    // string, so it compares by value and the ending announces itself even
+    // when the step and the bucket both stayed put.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [job?.jobId, current?.step.step, bucket, locale, result],
+  );
+
+  if (job === null) {
+    return (
+      <>
+        <div className={styles.activityTitle}>{t('packs.activity.idle')}</div>
+        <div className={styles.activityHint}>{t('packs.activity.idleHint')}</div>
+      </>
+    );
+  }
+
+  const running = job.status === 'running';
+
+  return (
+    <>
+      {/* "Installing X" only while it IS installing: a stopped job is titled
+          by its plugin, and the banner underneath is what happened to it. */}
+      <div className={styles.activityTitle}>{running ? headline : title}</div>
+
+      {/* Mounted for the job's whole life, not just while it runs: a live
+          region that appears WITH its text already in it is not reliably
+          announced, and that is what makes `cancelled` and `lost` silent. One
+          region, from "installing" to the sentence that ends it. */}
+      <div className={styles.srOnly} aria-live="polite" aria-atomic="true">
+        {announcement}
+      </div>
+
+      {running ? (
+        <>
+          {stepText !== null && <div className={styles.stepLine}>{stepText}</div>}
+          <div className={styles.overallLabel}>{t('packs.activity.overall')}</div>
+          <ProgressBar
+            tone="info"
+            showValue
+            label={t('packs.activity.progressAria')}
+            value={percent}
+          />
+        </>
+      ) : (
+        <ResultBanner job={job} title={title} entry={entry} onRefresh={onRefresh} />
+      )}
+
+      <PackLogTail lines={job.log} ariaLabel={t('packs.activity.log')} />
+
+      <div className={styles.cardActions}>
+        {running ? (
+          <button
+            type="button"
+            className={styles.secondaryBtn}
+            disabled={cancelling}
+            onClick={onCancel}
+          >
+            {cancelling ? t('packs.cancelling') : t('packs.cancel')}
+          </button>
+        ) : (
+          <button type="button" className={styles.secondaryBtn} onClick={onDismiss}>
+            {t('packs.activity.dismiss')}
+          </button>
+        )}
+      </div>
+    </>
+  );
+}
+
+/** How a finished job is reported: one toned banner, and what to do next. */
+function ResultBanner({
+  job,
+  title,
+  entry,
+  onRefresh,
+}: {
+  job: PluginJob;
+  title: string;
+  entry: PluginCatalogEntry | undefined;
+  onRefresh: () => void;
+}) {
+  const { t } = useI18n();
+  const tone = BANNER_TONE[job.status] ?? 'neutral';
+
+  // The same sentence the live region announces, by construction rather than
+  // by two copies of the same five `t()` calls.
+  const sentence = resultSentence(t, job, title);
+
+  // The same install in a terminal, for a job the panel could not finish.
+  //
+  // NOT offered for a LINKED FOLDER: `cdui plugin install` takes a name or a
+  // repository, and a linked row's source is a path on this machine, so the
+  // command would be one the CLI refuses. A folder is put back with `cdui
+  // plugin link`, which is a different sentence and outside this panel.
+  //
+  // Nor for a job whose row the catalog does not have: what to install is
+  // exactly what is missing, and `cdui plugin install <id>` on a plugin that
+  // is not in the registry is a command that fails.
+  const fallback = job.status === 'failed'
+    && entry !== undefined
+    && entry.source_kind !== 'local'
+    ? cliInstallCommand(entry)
+    : null;
+
+  return (
+    <div className={styles.resultBanner} role="status" data-tone={tone}>
+      {sentence !== null && <span>{sentence}</span>}
+
+      {/* The server's hint is the actionable half -- "check the repository
+          name", "the tarball is larger than this build will download" -- and
+          it is written by the step that failed. */}
+      {job.status === 'failed' && job.error?.hint && (
+        <span className={styles.resultHint}>{job.error.hint}</span>
+      )}
+
+      {/* The command the server cannot run for itself, which the sentence
+          above ends in a colon for. A plugin job reaches this status from one
+          place only -- `deps.install_deps_step` refusing to replace a package
+          the running interpreter has already loaded -- so what it carries is
+          the `uv pip install` line to run with the server stopped. */}
+      {job.status === 'needs_restart' && job.restartCommand !== null && (
+        <CommandBlock command={job.restartCommand} />
+      )}
+
+      {fallback !== null && (
+        <>
+          <span className={styles.resultHint}>{t('pluginCenter.activity.cliFallback')}</span>
+          <CommandBlock command={fallback} />
+        </>
+      )}
+
+      {/* The one ending nobody can report: the follower gave up, so what the
+          job did is a question only the catalog can answer. */}
+      {job.status === 'lost' && (
+        <div className={styles.cardActions}>
+          <button type="button" className={styles.primaryBtn} onClick={onRefresh}>
+            {t('pluginCenter.refresh')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The one sentence a finished job is reported with.
+ *
+ * Shared by the banner and the live region on purpose: the banner is what a
+ * sighted reader sees, and a `role="status"` element that MOUNTS with its text
+ * already in it is not reliably announced. The announcer stays mounted for the
+ * whole job and this sentence lands in it as a change, which is the thing
+ * screen readers do read.
+ *
+ * A failure is worded by KIND, out of the two keys that already exist for it
+ * -- the same pair the store's toast uses -- rather than printing the server's
+ * message bare: `error.message` is often a fragment ("HTTP 404"), and a red
+ * box containing only that does not say what failed.
+ */
+function resultSentence(t: Translate, job: PluginJob, title: string): string | null {
+  const update = job.kind === 'update';
+  switch (job.status) {
+    case 'done':
+      return t(
+        update ? 'pluginCenter.activity.updated' : 'pluginCenter.activity.installed',
+        { plugin: title },
+      );
+    case 'failed':
+      return t(
+        update ? 'pluginCenter.updateFailed' : 'packs.toast.installFailed',
+        { message: job.error?.message ?? '' },
+      );
+    case 'cancelled':
+      return t('packs.activity.cancelled');
+    case 'needs_restart':
+      return t('pluginCenter.activity.needsRestart', { plugin: title });
+    case 'lost':
+      return t('pluginCenter.activity.lost');
+    default:
+      return null;
+  }
+}

--- a/frontend/src/components/PluginCenter/PluginActivityPane.tsx
+++ b/frontend/src/components/PluginCenter/PluginActivityPane.tsx
@@ -32,13 +32,15 @@ const BANNER_TONE: Record<JobPhase, BannerTone> = {
 export interface PluginActivityPaneProps {
   job: PluginJob | null;
   /**
-   * The catalog row for `job.pluginId`: its name, and the source the terminal
-   * fallback would install from.
+   * The catalog row for `job.pluginId`: its name, the source the terminal
+   * fallback would install from, and how long an install of it should take
+   * (a built-in pack has no download and four steps; a repository has eight).
    *
    * Undefined when the catalog has no row for this job -- a plugin installed
    * from a URL this registry does not list, or a job adopted before the first
-   * catalog read answers. The pane then names the job by its plugin id and
-   * offers no command, rather than guessing at either.
+   * catalog read answers. The pane then names the job by its plugin id,
+   * offers no command, and counts it as the longer install, rather than
+   * guessing at any of the three.
    */
   entry: PluginCatalogEntry | undefined;
   /** A cancel request is in flight: the button says so and takes no second press. */

--- a/frontend/src/components/PluginCenter/PluginActivityPane.tsx
+++ b/frontend/src/components/PluginCenter/PluginActivityPane.tsx
@@ -348,8 +348,12 @@ function resultSentence(t: Translate, job: PluginJob, title: string): string | n
         { plugin: title },
       );
     case 'failed':
+      // The PANE's key, not the toast's twin of it: the two are the same
+      // string in both locales today, and keeping this one on the pane's
+      // namespace is what stops a later edit to the toast rewording a banner.
+      // There is no pane-side key for an update, so that arm keeps its own.
       return t(
-        update ? 'pluginCenter.updateFailed' : 'packs.toast.installFailed',
+        update ? 'pluginCenter.updateFailed' : 'packs.activity.failed',
         { message: job.error?.message ?? '' },
       );
     case 'cancelled':

--- a/frontend/src/components/PluginCenter/PluginActivityPane.tsx
+++ b/frontend/src/components/PluginCenter/PluginActivityPane.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { PluginCatalogEntry } from '../../api/rest';
-import type { ItemProgress, JobPhase, JobStep } from '../../store/jobFollower';
+import type { JobPhase } from '../../store/jobFollower';
 import type { PluginJob } from '../../store/pluginStore';
 import { useI18n } from '../../i18n';
 import { ProgressBar } from '../shared/ProgressBar';
@@ -9,81 +9,14 @@ import { ProgressBar } from '../shared/ProgressBar';
 // windows, and two of each would drift the day one is fixed.
 import { CommandBlock } from '../PackCenter/CommandBlock';
 import { PackLogTail } from '../PackCenter/PackLogTail';
-import { cliInstallCommand, stepLabel, type Translate } from './pluginStatus';
+import {
+  cliInstallCommand,
+  currentStep,
+  jobOverallPercent,
+  stepLabel,
+  type Translate,
+} from './pluginStatus';
 import styles from '../PackCenter/PackCenterModal.module.css';
-
-/**
- * The one item a plugin job reports bytes for: the repository tarball
- * (`backend/app/core/plugins/flows.py: _tarball_progress`).
- *
- * A plugin install has exactly one download, so this is a NAME rather than a
- * set to sum -- which is the difference between this pane's bar and the pack
- * panel's, where a job fetches several models of very different sizes.
- */
-export const TARBALL_ITEM = 'tarball';
-
-/**
- * How many steps a full install has: `resolve download extract verify deps
- * stage lock reload`.
- *
- * The denominator is this constant and NOT `job.steps.length`, because the
- * server announces a step as it starts: the array holds the steps so far, so
- * "one of the two we have heard of is done" would read as 50 % during the
- * second step of eight. A catalog install, which skips the four steps a
- * download needs, therefore tops out around half a bar before it ends -- an
- * understated bar, which is the honest way round for a job whose remaining
- * steps are unknowable from here.
- */
-export const PLUGIN_STEP_COUNT = 8;
-
-function clamp(value: number): number {
-  return Math.min(100, Math.max(0, value));
-}
-
-/**
- * How far the whole job has got, 0..100, or null when nobody can say yet.
- *
- * The tarball's bytes when the server sent a size, and the step count
- * otherwise. `codeload` streams a tarball it generates on demand and usually
- * sends no `Content-Length` at all, so the step count is the ordinary case
- * and the bytes are the refinement a server that DOES state a size buys.
- *
- * Null (indeterminate) rather than 0 for a job with no steps yet: 0 % about a
- * job that is clearly working is a wrong number rather than no number, and
- * the seconds between "the install was accepted" and the first step event are
- * exactly that job.
- */
-export function jobOverallPercent(job: PluginJob | null): number | null {
-  if (job === null) return null;
-
-  const tarball: ItemProgress | undefined = job.items[TARBALL_ITEM];
-  const total = tarball?.bytesTotal ?? null;
-  if (tarball && total !== null && Number.isFinite(total) && total > 0) {
-    // A server that reports more bytes than it promised must not push the bar
-    // past full.
-    return clamp((Math.max(0, tarball.bytesDone) / total) * 100);
-  }
-
-  if (job.steps.length === 0) return null;
-  const finished = job.steps.filter((step) => step.state === 'done').length;
-  return clamp((finished / PLUGIN_STEP_COUNT) * 100);
-}
-
-/**
- * The step the pane should be showing: the one still running, or the last one
- * to have finished while the next has not been announced yet.
- *
- * Takes the STEPS rather than the job, so it says what it needs and stays
- * usable for any job shape. (The pack panel's equivalent takes a `PackJob`,
- * which a `PluginJob` is not; widening it there is a change to the Package
- * Center, and this task changes none.)
- */
-function currentStep(steps: JobStep[]): { index: number; step: JobStep } | null {
-  if (steps.length === 0) return null;
-  const running = steps.findIndex((step) => step.state === 'running');
-  const index = running === -1 ? steps.length - 1 : running;
-  return { index: index + 1, step: steps[index] };
-}
 
 type BannerTone = 'success' | 'warning' | 'error' | 'neutral';
 
@@ -143,7 +76,9 @@ export function PluginActivityPane({
 }: PluginActivityPaneProps) {
   const { t, locale } = useI18n();
 
-  const percent = jobOverallPercent(job);
+  // The row as well as the job: how many steps an install takes depends on
+  // where it comes from, and a built-in pack has no download at all.
+  const percent = jobOverallPercent(job, entry);
   const current = job === null ? null : currentStep(job.steps);
   // The catalog row's name, falling back to the id -- the store's own rule
   // (`pluginStore.ts: pluginName`), so a toast and this pane call a plugin
@@ -316,8 +251,12 @@ function ResultBanner({
           job did is a question only the catalog can answer. */}
       {job.status === 'lost' && (
         <div className={styles.cardActions}>
+          {/* "Refresh", not `pluginCenter.refresh`: the sentence above the
+              button already ends in "Refresh to check the plugin status", and
+              that key is also the header icon's name -- two controls with one
+              name, one of them repeating the line it sits under. */}
           <button type="button" className={styles.primaryBtn} onClick={onRefresh}>
-            {t('pluginCenter.refresh')}
+            {t('sidebar.refresh')}
           </button>
         </div>
       )}

--- a/frontend/src/components/PluginCenter/PluginCard.tsx
+++ b/frontend/src/components/PluginCenter/PluginCard.tsx
@@ -1,0 +1,262 @@
+import { Fragment, type ReactNode } from 'react';
+import type { PluginCatalogEntry } from '../../api/rest';
+import type { PluginJob } from '../../store/pluginStore';
+import { useI18n } from '../../i18n';
+import { Pill } from '../shared/Pill';
+import { originLabel, statusKey, statusTone } from './pluginStatus';
+import styles from '../PackCenter/PackCenterModal.module.css';
+
+/**
+ * What separates two facts on one meta line.
+ *
+ * The node docs' own separator (`NodeDetailModal/DocsTab.tsx`), so a meta line
+ * reads the same wherever the editor prints one. Punctuation, not information:
+ * it is `aria-hidden`, and each fact keeps its own element so a reader — and a
+ * query — gets one phrase at a time rather than a run-on.
+ */
+const FACT_SEPARATOR = '  ·  ';
+
+interface Fact {
+  key: string;
+  node: ReactNode;
+}
+
+/** One line of small facts, or nothing at all when there are none. */
+function MetaLine({ facts }: { facts: Fact[] }) {
+  if (facts.length === 0) return null;
+  return (
+    <div className={styles.cardMeta}>
+      {facts.map((fact, index) => (
+        <Fragment key={fact.key}>
+          {index > 0 && <span aria-hidden="true">{FACT_SEPARATOR}</span>}
+          {fact.node}
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One `name>=version` the way the installer would write it.
+ *
+ * Mirrors `backend/app/core/plugins/deps.py: _build_dep_spec`: a constraint
+ * that starts with an operator is used as written, a bare version is pinned.
+ * What the card prints is then what `uv pip install` would be given, rather
+ * than a prettier string that means something slightly different.
+ */
+function depSpec(name: string, constraint: string): string {
+  if (constraint === '') return name;
+  return /^[<>=~!]/.test(constraint) ? `${name}${constraint}` : `${name}==${constraint}`;
+}
+
+export interface PluginCardProps {
+  entry: PluginCatalogEntry;
+  /** The job in flight anywhere, or null. May be another plugin's. */
+  job: PluginJob | null;
+  /** This plugin has a request in flight — an enable, an uninstall, an install. */
+  busy: boolean;
+  highlighted: boolean;
+  /** False when the server refuses installs from this browser (remote). */
+  canInstall: boolean;
+  onInstall: () => void;
+  onUpdate: () => void;
+  onUninstall: () => void;
+  onSetEnabled: (enabled: boolean) => void;
+}
+
+/**
+ * One plugin: what it is, where it came from, what it brings, and the buttons
+ * that change that.
+ *
+ * A pure view — every button hands straight back to the store, which owns the
+ * confirm dialog, the job and the three-step refresh that follows a change.
+ * Nothing here is scratch state, which is why this card has none.
+ */
+export function PluginCard({
+  entry,
+  job,
+  busy,
+  highlighted,
+  canInstall,
+  onInstall,
+  onUpdate,
+  onUninstall,
+  onSetEnabled,
+}: PluginCardProps) {
+  const { t } = useI18n();
+
+  const running = job !== null && job.pluginId === entry.id && job.status === 'running';
+  // A job the catalog has not caught up with still says so on the row: the
+  // server calls any row carrying a job `installing`, and the store sets it
+  // the moment a 202 lands, but a job adopted from another tab arrives first.
+  const status = running ? 'installing' : entry.status;
+  // Every button this row has, off for as long as something is happening to
+  // it. One flag rather than a check per button: five ways to leave a row
+  // half-live are five ways to send a second request into the first one.
+  const locked = busy || running;
+
+  // A linked folder is a directory on this machine that the CLI pointed at.
+  // Nothing here installs, updates or removes one — `cdui plugin link` owns
+  // it — so the row offers the one thing the server CAN do: switch it off.
+  const local = entry.source_kind === 'local';
+  // Said in `title` only. The footer already carries this sentence once; a
+  // copy beside every button it disables would be the same fact three times
+  // down one card.
+  const remoteReason = canInstall ? undefined : t('packs.remoteDisabled');
+
+  const showInstall =
+    !local && (status === 'available' || status === 'removed' || status === 'missing_files');
+  const showEnable = status === 'disabled';
+  const showDisable = status === 'installed';
+  // Only a plugin fetched from a repository has anything to update FROM: a
+  // built-in ships with the server, and a linked folder is already whatever
+  // the folder says.
+  const showUpdate = status === 'installed' && entry.source_kind === 'github_url';
+  // `missing_files` is in the lockfile with its directory gone, so removing
+  // the record is a real answer to it. `removed` is the opposite — already a
+  // tombstone, with nothing left to remove.
+  const showUninstall =
+    !local && (status === 'installed' || status === 'disabled' || status === 'missing_files');
+  const hasActions = showInstall || showEnable || showDisable || showUpdate || showUninstall;
+
+  const origin = originLabel(entry);
+  const repo = entry.repo ?? '';
+  const sha7 = entry.sha === null ? null : entry.sha.slice(0, 7);
+  // `ref` is `''` for a default-branch install — an answer, not a miss — so a
+  // row pinned to no branch says the commit alone rather than a bare `@`.
+  const pin = sha7 === null ? null : entry.ref ? `${entry.ref} @ ${sha7}` : sha7;
+
+  const provenance: Fact[] = [];
+  if (origin !== null) provenance.push({ key: 'origin', node: <span>{t(origin)}</span> });
+  if (repo !== '') {
+    provenance.push({
+      key: 'repo',
+      node:
+        entry.url === null || entry.url === '' ? (
+          <span>{repo}</span>
+        ) : (
+          <a
+            className={styles.linkBtn}
+            href={entry.url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {repo}
+          </a>
+        ),
+    });
+  }
+  if (pin !== null) provenance.push({ key: 'pin', node: <span>{pin}</span> });
+
+  // Chapters when the row has them, lesson ids when it has only those: both
+  // answer "which part of the book is this", and a plugin that declares the
+  // finer list has still answered it. One line, under the one label.
+  const taught = entry.chapters.length > 0 ? entry.chapters : entry.lessons;
+  const deps = Object.entries(entry.python_deps).map(([name, spec]) => depSpec(name, spec));
+
+  const contents: Fact[] = [];
+  if (taught.length > 0) {
+    contents.push({
+      key: 'chapters',
+      node: <span>{t('pluginCenter.chapters', { chapters: taught.join(', ') })}</span>,
+    });
+  }
+  // The count, not the list: a pack of a dozen node types would be a paragraph
+  // here, and the palette is where they are read one by one.
+  if (entry.node_count > 0) {
+    contents.push({
+      key: 'nodes',
+      node: <span>{t('empty.nodeCount', { count: entry.node_count })}</span>,
+    });
+  }
+  if (deps.length > 0) {
+    contents.push({
+      key: 'deps',
+      node: <span>{t('packs.pip', { specs: deps.join(', ') })}</span>,
+    });
+  }
+
+  return (
+    <div
+      className={`${styles.card} ${highlighted ? styles.cardHighlighted : ''}`}
+      data-status={status}
+      data-plugin-id={entry.id}
+    >
+      <div className={styles.cardHeader}>
+        <span className={styles.cardTitle}>{entry.name || entry.id}</span>
+        <Pill tone={statusTone(status)} pulse={status === 'installing'}>
+          {t(statusKey(status))}
+        </Pill>
+        {/* The right-hand metadata slot the pack card puts a download size in:
+            same place, same monospace, and a version is the one number a
+            plugin row has. */}
+        {entry.version !== null && entry.version !== '' && (
+          <span className={styles.cardSize}>v{entry.version}</span>
+        )}
+      </div>
+
+      {entry.description !== '' && <p className={styles.cardDesc}>{entry.description}</p>}
+
+      <MetaLine facts={provenance} />
+      <MetaLine facts={contents} />
+
+      {hasActions && (
+        <div className={styles.cardActions}>
+          {showInstall && (
+            <button
+              type="button"
+              className={styles.primaryBtn}
+              disabled={locked || !canInstall}
+              title={remoteReason}
+              onClick={onInstall}
+            >
+              {t('pluginCenter.install')}
+            </button>
+          )}
+          {showEnable && (
+            <button
+              type="button"
+              className={styles.primaryBtn}
+              disabled={locked}
+              onClick={() => onSetEnabled(true)}
+            >
+              {t('pluginCenter.enable')}
+            </button>
+          )}
+          {showDisable && (
+            <button
+              type="button"
+              className={styles.secondaryBtn}
+              disabled={locked}
+              onClick={() => onSetEnabled(false)}
+            >
+              {t('pluginCenter.disable')}
+            </button>
+          )}
+          {showUpdate && (
+            <button
+              type="button"
+              className={styles.secondaryBtn}
+              disabled={locked || !canInstall}
+              title={remoteReason}
+              onClick={onUpdate}
+            >
+              {t('pluginCenter.update')}
+            </button>
+          )}
+          {showUninstall && (
+            <button
+              type="button"
+              className={styles.secondaryBtn}
+              disabled={locked || !canInstall}
+              title={remoteReason}
+              onClick={onUninstall}
+            >
+              {t('pluginCenter.uninstall')}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PluginCenter/PluginCard.tsx
+++ b/frontend/src/components/PluginCenter/PluginCard.tsx
@@ -3,7 +3,7 @@ import type { PluginCatalogEntry } from '../../api/rest';
 import type { PluginJob } from '../../store/pluginStore';
 import { useI18n } from '../../i18n';
 import { Pill } from '../shared/Pill';
-import { originLabel, statusKey, statusTone } from './pluginStatus';
+import { depSpec, originLabel, provenancePin, statusKey, statusTone } from './pluginStatus';
 import styles from '../PackCenter/PackCenterModal.module.css';
 
 /**
@@ -34,19 +34,6 @@ function MetaLine({ facts }: { facts: Fact[] }) {
       ))}
     </div>
   );
-}
-
-/**
- * One `name>=version` the way the installer would write it.
- *
- * Mirrors `backend/app/core/plugins/deps.py: _build_dep_spec`: a constraint
- * that starts with an operator is used as written, a bare version is pinned.
- * What the card prints is then what `uv pip install` would be given, rather
- * than a prettier string that means something slightly different.
- */
-function depSpec(name: string, constraint: string): string {
-  if (constraint === '') return name;
-  return /^[<>=~!]/.test(constraint) ? `${name}${constraint}` : `${name}==${constraint}`;
 }
 
 export interface PluginCardProps {
@@ -121,10 +108,9 @@ export function PluginCard({
 
   const origin = originLabel(entry);
   const repo = entry.repo ?? '';
-  const sha7 = entry.sha === null ? null : entry.sha.slice(0, 7);
-  // `ref` is `''` for a default-branch install — an answer, not a miss — so a
-  // row pinned to no branch says the commit alone rather than a bare `@`.
-  const pin = sha7 === null ? null : entry.ref ? `${entry.ref} @ ${sha7}` : sha7;
+  // The version is passed in because the header prints it: a pin that repeats
+  // it is the same release named twice down one card.
+  const pin = provenancePin(entry.ref, entry.sha, entry.version);
 
   const provenance: Fact[] = [];
   if (origin !== null) provenance.push({ key: 'origin', node: <span>{t(origin)}</span> });

--- a/frontend/src/components/PluginCenter/PluginCenterModal.module.css
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.module.css
@@ -1,0 +1,86 @@
+/* PluginCenterModal.module.css — the two things the Plugin Center has that the
+   Package Center has not: the box you type a repository into, and the filter
+   over the list.
+
+   Everything else — the backdrop, the modal, the header, the list, the cards,
+   the activity pane, the 860 px stack — comes from
+   `../PackCenter/PackCenterModal.module.css`, imported by the components
+   themselves. Two panels that are the same object cannot drift; two panels
+   that merely look alike do. Colour, type and spacing are tokens only. */
+
+/* ── The source box ─────────────────────────────────────────────────────── */
+
+/* Installing something the catalog does not list: a label, a field and the
+   Review button on one row, wrapping rather than shrinking the field into
+   uselessness. Rendered by `PluginSourceForm`. */
+.sourceForm {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface-panel);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+}
+
+.sourceForm input {
+  flex: 1;
+  /* Below this the field no longer shows a whole `owner/repo@ref`, which is
+     the one thing it exists to show; the row wraps instead. */
+  min-width: 220px;
+  height: var(--h-control);
+  padding: 0 var(--sp-3);
+  background: var(--surface-input);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: var(--fs-sm);
+}
+
+.sourceForm input::placeholder {
+  color: var(--text-disabled);
+}
+
+.sourceForm input:focus {
+  outline: none;
+  border-color: var(--accent-deep);
+}
+
+/* ── The filter ─────────────────────────────────────────────────────────── */
+
+/* All | Installed | Available. The pressed one is styled through
+   `aria-pressed` rather than a second class, so what a screen reader is told
+   and what the eye is shown cannot disagree. */
+.filterBar {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  flex-wrap: wrap;
+}
+
+.filterBar button {
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-tight);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.filterBar button:hover {
+  border-color: var(--accent-deep);
+  color: var(--accent);
+}
+
+.filterBar button[aria-pressed='true'] {
+  background: var(--accent-wash);
+  border-color: var(--accent-deep);
+  color: var(--accent);
+}

--- a/frontend/src/components/PluginCenter/PluginCenterModal.module.css
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.module.css
@@ -49,6 +49,50 @@
   border-color: var(--accent-deep);
 }
 
+/* Why the last Review was refused. `flex-basis: 100%` puts it on its own row
+   of the wrapping form rather than squeezing the field it is about. */
+.sourceError {
+  flex-basis: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  color: var(--status-error);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-normal);
+  /* A refused source is whatever the user typed: a pasted URL has no break
+     opportunity of its own, and the panel's only overflow is `hidden`. */
+  overflow-wrap: anywhere;
+}
+
+/* The half of a refusal that offers something — the catalog names that WOULD
+   have worked. An offer is not a complaint, so it keeps the block and drops
+   the alarm colour. */
+.sourceHint {
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+}
+
+/* ── The review card ────────────────────────────────────────────────────── */
+
+/* One thing the user has to agree to, beside its box. Everything else on the
+   card is the Package Center's stylesheet; only this pairing is new. */
+.consentCheck {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-3);
+  color: var(--text-primary);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-normal);
+  cursor: pointer;
+}
+
+/* A 14 px box against a 13 px line at 1.55: aligned to the top of the line
+   box it sits a hair above the text it labels, which is what this token is
+   for. */
+.consentCheck input {
+  margin-top: var(--sp-1);
+}
+
 /* ── The filter ─────────────────────────────────────────────────────────── */
 
 /* All | Installed | Available. The pressed one is styled through

--- a/frontend/src/components/PluginCenter/PluginCenterModal.module.css
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.module.css
@@ -8,6 +8,33 @@
    themselves. Two panels that are the same object cannot drift; two panels
    that merely look alike do. Colour, type and spacing are tokens only. */
 
+/* ── Stacking ───────────────────────────────────────────────────────────── */
+
+/* The Package Center's backdrop, one rung higher.
+
+   Both centers portal into <body> and both render nothing at all while they
+   are closed, so at an equal z-index the one on top is simply whichever was
+   opened last -- and the Escape rule the two panels share ("the top-most one
+   closes, the one underneath stands down") would then mean something
+   different every time. A rule that depends on open order is not a rule, so
+   the Plugin Center takes a rung of its own.
+
+   The three layers that sit above the modal rung moved up with it, keeping
+   their order and the reasons written beside them: the confirm dialog
+   (10002), which this panel itself raises to ask about an uninstall; the
+   toast stack (10003), which reports what this panel's buttons did; and the
+   restart overlay (10004). tokens.css has no z-index scale to take the next
+   value from -- every z-index in this app is a literal with the rung it
+   belongs to written next to it, and these are four more of the same.
+
+   `composes` rather than a second class in the markup: two single-class
+   rules have the same specificity, so which one won would come down to the
+   order the bundler happened to emit the two stylesheets in. */
+.topBackdrop {
+  composes: backdrop from '../PackCenter/PackCenterModal.module.css';
+  z-index: 10001;
+}
+
 /* ── The source box ─────────────────────────────────────────────────────── */
 
 /* Installing something the catalog does not list: a label, a field and the

--- a/frontend/src/components/PluginCenter/PluginCenterModal.module.css
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.module.css
@@ -88,8 +88,14 @@
 
 /* A 14 px box against a 13 px line at 1.55: aligned to the top of the line
    box it sits a hair above the text it labels, which is what this token is
-   for. */
+   for.
+
+   `flex-shrink: 0` because the sentence beside it is interpolated — a trust
+   line names every module the manifest asked for — and this is the first
+   FLEX use of that box: the pack panel's rows are a grid with an `auto`
+   track, so the box has never had to defend its own width before. */
 .consentCheck input {
+  flex-shrink: 0;
   margin-top: var(--sp-1);
 }
 

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -57,7 +57,9 @@ const edu = entry({
   version: '0.1.0',
   chapters: ['I1', 'I2'],
   node_count: 8,
-  python_deps: { model2vec: '>=0.8.0' },
+  // Both shapes a manifest writes: a constraint that leads with an operator,
+  // and a bare version the installer has to pin with `==`.
+  python_deps: { model2vec: '>=0.8.0', torch: '2.1.0' },
 });
 
 /** A third-party plugin off GitHub, installed and pinned. */
@@ -213,9 +215,11 @@ describe('PluginCenterModal — the plugin list', () => {
     expect(card.getByText('Built-in')).toBeInTheDocument();
     expect(card.getByText('Lessons: I1, I2')).toBeInTheDocument();
     expect(card.getByText('8 nodes')).toBeInTheDocument();
-    // The spec as the installer would write it, not a prettier string that
+    // The specs as the installer would write them, not prettier strings that
     // would install something else.
-    expect(card.getByText('Python packages: model2vec>=0.8.0')).toBeInTheDocument();
+    expect(
+      card.getByText('Python packages: model2vec>=0.8.0, torch==2.1.0'),
+    ).toBeInTheDocument();
   });
 
   it('links a GitHub plugin to its repository and says which commit is here', () => {
@@ -226,12 +230,23 @@ describe('PluginCenterModal — the plugin list', () => {
     const card = within(cardFor('demo'));
     const link = card.getByRole('link', { name: 'owner/demo' });
     expect(link).toHaveAttribute('href', 'https://github.com/owner/demo');
-    // Seven characters of the sha, and the ref it was taken from: enough to
-    // check against a repository, short enough to sit on a meta line.
-    expect(card.getByText('v1.2.0 @ abcdef1')).toBeInTheDocument();
+    // Seven characters of the sha: enough to check against a repository,
+    // short enough to sit on a meta line. The ref is `v1.2.0` and the header
+    // already says `v1.2.0`, so the pin drops it rather than printing one
+    // release twice down one card.
+    expect(card.getByText('abcdef1')).toBeInTheDocument();
+    expect(card.getAllByText('v1.2.0')).toHaveLength(1);
     // A plain third-party repository wears no origin chip — the row already
     // prints owner/repo, and "GitHub" over a GitHub link says it twice.
     expect(card.queryByText('Official')).toBeNull();
+  });
+
+  it('keeps the ref on a plugin pinned to something other than its version', () => {
+    seed({ plugins: [entry({ ...demo, ref: 'main' })] });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(cardFor('demo')).getByText('main @ abcdef1')).toBeInTheDocument();
   });
 
   it('says it is loading before the first answer', () => {

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -145,6 +145,8 @@ function makeActions() {
     update: vi.fn(async () => {}),
     uninstall: vi.fn(async () => {}),
     setEnabled: vi.fn(async () => {}),
+    cancel: vi.fn(async () => {}),
+    dismissJob: vi.fn(() => {}),
   };
 }
 
@@ -993,6 +995,90 @@ describe('PluginCenterModal — the review', () => {
     expect(within(card()).getByRole('button', { name: 'Install' })).toBeDisabled();
     // Putting the review away is not an install, and never was refused.
     expect(within(card()).getByRole('button', { name: 'Cancel' })).toBeEnabled();
+  });
+});
+
+// ── The activity pane ───────────────────────────────────────────────────────
+
+describe('PluginCenterModal — the activity pane', () => {
+  /** The pane, scoped: the header has a Refresh button of its own. */
+  const pane = () =>
+    within(screen.getByRole('complementary', { name: 'Install activity' }));
+
+  it('says nothing is installing when no job is', () => {
+    seed({ plugins: [demo] });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(pane().getByText('Nothing is installing right now.')).toBeInTheDocument();
+  });
+
+  it('follows the running job, named from its catalog row', () => {
+    seed({
+      plugins: [demo],
+      job: job({
+        pluginId: 'demo',
+        steps: [{ step: 'download', label: 'Downloading owner/demo', state: 'running' }],
+      }),
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(pane().getByText('Installing Demo plugin')).toBeInTheDocument();
+    expect(pane().getByText('Step 1: Downloading')).toBeInTheDocument();
+  });
+
+  it('hands Cancel to the store', () => {
+    seed({ plugins: [demo], job: job({ pluginId: 'demo' }) });
+    open();
+    render(<PluginCenterModal />);
+
+    fireEvent.click(pane().getByRole('button', { name: 'Cancel install' }));
+    expect(actions.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('says so while a cancel is in flight', () => {
+    seed({ plugins: [demo], job: job({ pluginId: 'demo' }), cancelling: true });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(pane().getByRole('button', { name: 'Cancelling...' })).toBeDisabled();
+  });
+
+  it('hands Dismiss to the store once the job has stopped', () => {
+    seed({ plugins: [demo], job: job({ pluginId: 'demo', status: 'done' }) });
+    open();
+    render(<PluginCenterModal />);
+
+    fireEvent.click(pane().getByRole('button', { name: 'Dismiss' }));
+    expect(actions.dismissJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers a failed install the terminal command for its own row', () => {
+    // The pane is handed the catalog row for the JOB's plugin, which is where
+    // the repository and the ref in that command come from.
+    seed({
+      plugins: [demo],
+      job: job({
+        pluginId: 'demo',
+        status: 'failed',
+        error: { message: 'HTTP 404', hint: null },
+      }),
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(pane().getByText('cdui plugin install owner/demo@v1.2.0')).toBeInTheDocument();
+  });
+
+  it('re-reads the catalog from the banner that lost contact', () => {
+    seed({ plugins: [demo], job: job({ pluginId: 'demo', status: 'lost' }) });
+    open();
+    render(<PluginCenterModal />);
+
+    fireEvent.click(pane().getByRole('button', { name: 'Refresh plugin status' }));
+    // Once on open, once for this button.
+    expect(actions.refresh).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -1223,24 +1223,43 @@ describe('PluginCenterModal — closing', () => {
     expect(useUIStore.getState().pluginCenterOpen).toBe(true);
     useDialogStore.setState({ active: null });
 
-    // The Package Center answers the same key. One press, one window.
-    useUIStore.setState({ packCenterOpen: true });
-    fireEvent.keyDown(window, { key: 'Escape' });
-    expect(useUIStore.getState().pluginCenterOpen).toBe(true);
-    useUIStore.setState({ packCenterOpen: false });
-
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(useUIStore.getState().pluginCenterOpen).toBe(false);
   });
 
+  it('closes over an open Package Center, which is underneath it', () => {
+    // This panel renders a z-index rung above the pack one, so it is the
+    // window the press belongs to. The pack side of the same rule, in both
+    // open orders, is `escapeStacking.test.tsx`.
+    useUIStore.setState({ packCenterOpen: true });
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(useUIStore.getState().pluginCenterOpen).toBe(false);
+    expect(useUIStore.getState().packCenterOpen).toBe(true);
+  });
+});
+
+describe('PluginCenterModal — focus', () => {
   it('hands focus back to whatever had it', () => {
-    // The modal took focus on open; closing it must not leave focus on <body>.
-    const dialog = screen.getByRole('dialog');
-    expect(dialog).toHaveFocus();
+    // Focused BEFORE the panel opens, and a real element: with nothing
+    // focused, `activeElement` is <body> before and after, and the assertion
+    // holds whether or not the panel restores anything.
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+    expect(opener).toHaveFocus();
+
+    seed({ plugins: [edu] });
+    open();
+    render(<PluginCenterModal />);
+    expect(screen.getByRole('dialog')).toHaveFocus();
 
     act(() => {
       useUIStore.getState().closePluginCenter();
     });
-    expect(document.activeElement).not.toBe(dialog);
+
+    expect(opener).toHaveFocus();
+    opener.remove();
   });
 });

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -937,6 +937,14 @@ describe('PluginCenterModal — the review', () => {
     open();
     render(<PluginCenterModal />);
 
+    // Said out loud, not just implied by a button changing its word.
+    expect(
+      within(card()).getByText(
+        'Demo plugin is already installed. Reinstall replaces the installed copy '
+        + 'with this one.',
+      ),
+    ).toBeInTheDocument();
+
     // The 409 was an offer, not a failure: the review is still spendable and
     // the button is what accepts it.
     fireEvent.click(within(card()).getByRole('button', { name: 'Reinstall' }));

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -125,10 +125,12 @@ function inspection(over: Partial<PluginInspection> = {}): PluginInspection {
  */
 function ready(
   over: Partial<PluginInspection> = {},
+  /** The row whose button raised it; null for a source somebody typed. */
+  forPluginId: string | null = null,
 ): Extract<InspectionState, { phase: 'ready' }> {
   const data = inspection(over);
   return {
-    phase: 'ready', data, source: data.source, forPluginId: null, kind: data.mode, error: null,
+    phase: 'ready', data, source: data.source, forPluginId, kind: data.mode, error: null,
   };
 }
 
@@ -586,6 +588,24 @@ describe('PluginCenterModal — the source box', () => {
     expect(screen.getByRole('button', { name: 'Downloading...' })).toBeDisabled();
   });
 
+  it('withdraws the inline refusal as soon as the box changes', () => {
+    seed();
+    open();
+    render(<PluginCenterModal />);
+
+    review('not a repo!');
+    const input = screen.getByLabelText('Install from GitHub');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+
+    // The refusal was earned by the STRING, so it is withdrawn by the
+    // keystroke that changes it rather than by another press of Review.
+    fireEvent.change(input, { target: { value: 'owner/demo' } });
+    expect(
+      screen.queryByText('Enter a catalog name, owner/repo[@ref] or a GitHub URL.'),
+    ).toBeNull();
+    expect(input).not.toHaveAttribute('aria-invalid');
+  });
+
   it('reports a source the server could not read', () => {
     // The store has already turned the code into a sentence; what is left is
     // naming the source it was about.
@@ -602,6 +622,45 @@ describe('PluginCenterModal — the source box', () => {
     expect(
       screen.getByText('Could not fetch owner/demo: Could not reach GitHub.'),
     ).toBeInTheDocument();
+    // `role="alert"` says it once when it arrives; this is what says it again
+    // to somebody who tabs back into the field.
+    expect(screen.getByLabelText('Install from GitHub')).toHaveAttribute(
+      'aria-describedby', screen.getByRole('alert').id,
+    );
+  });
+
+  it('does not carry a refusal over into the next time the panel is opened', () => {
+    seed({
+      inspection: {
+        phase: 'error',
+        source: 'owner/demo',
+        failure: { message: 'Could not reach GitHub.', code: 'github_unreachable', detail: null },
+      },
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    act(() => {
+      useUIStore.setState({ pluginCenterOpen: false });
+    });
+
+    // A refusal belongs to the box it was typed into; reopening the panel
+    // over it would explain a request nobody made.
+    expect(actions.clearInspection).toHaveBeenCalled();
+  });
+
+  it('keeps a review that is still waiting for an answer', () => {
+    seed({ inspection: ready() });
+    open();
+    render(<PluginCenterModal />);
+
+    act(() => {
+      useUIStore.setState({ pluginCenterOpen: false });
+    });
+
+    // A decision, not a complaint: the install it leads to outlives the
+    // window, so the card that offers it does too.
+    expect(actions.clearInspection).not.toHaveBeenCalled();
   });
 
   it('names the id a reserved-id refusal was about', () => {
@@ -681,6 +740,54 @@ describe('PluginCenterModal — the review', () => {
     // Nothing has been read yet, and the button already says so: an empty
     // card here would be the same fact twice and a second layout jump.
     expect(screen.queryByRole('region', { name: 'Review before installing' })).toBeNull();
+  });
+
+  it('stays away from an install a row started that asks for nothing', () => {
+    // `install()` inspects before it installs, and the review is READY
+    // between those two round trips. Without this, pressing Install on a
+    // built-in pack — the commonest thing in this panel — would flash a
+    // consent card at the top of the list and scroll away from the row that
+    // was clicked, for as long as the install request takes.
+    seed({
+      plugins: [edu],
+      inspection: ready({ plugin_id: 'edu', consent_required: false }, 'edu'),
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(screen.queryByRole('region', { name: 'Review before installing' })).toBeNull();
+  });
+
+  it('answers a row whose plugin does ask for something', () => {
+    seed({
+      plugins: [demo],
+      inspection: ready(
+        { plugin_id: 'demo', consent_required: true, capabilities: ['network'] }, 'demo',
+      ),
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    // Which row it is about: the store's `forPluginId` never reaches the
+    // card, so this attribute is the only thing tying the two together.
+    expect(card()).toHaveAttribute('data-review-for', 'demo');
+  });
+
+  it('comes back for a row when the server refused the install', () => {
+    // `already_installed` leaves `consent_required` false — the refusal is
+    // the whole reason there is a card, and Reinstall is what answers it.
+    seed({
+      inspection: {
+        ...ready({ plugin_id: 'demo', consent_required: false }, 'demo'),
+        error: {
+          message: 'already_installed', code: 'already_installed', detail: null,
+        },
+      },
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(card()).getByRole('button', { name: 'Reinstall' })).toBeInTheDocument();
   });
 
   it('brings itself into view, however far down the row that asked was', () => {
@@ -842,6 +949,20 @@ describe('PluginCenterModal — the review', () => {
     render(<PluginCenterModal />);
 
     expect(within(card()).getByRole('button', { name: 'Update' })).toBeInTheDocument();
+  });
+
+  it('will not state the installed nodes on a card about the next version', () => {
+    // The catalog knows what is registered TODAY, which on an update is the
+    // version being replaced — and this is the one screen whose whole job is
+    // saying what is about to arrive.
+    seed({
+      plugins: [entry({ id: 'demo', nodes: ['demo:Split', 'demo:Join'] })],
+      inspection: ready({ plugin_id: 'demo', mode: 'update' }),
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(card()).queryByText(/^Nodes:/)).toBeNull();
   });
 
   it('puts the review away when it is cancelled', () => {

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -1,0 +1,618 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, render, screen, fireEvent, within } from '@testing-library/react';
+import type { PluginCatalogEntry } from '../../api/rest';
+import { useDialogStore } from '../../store/dialogStore';
+import {
+  emptyPluginJob,
+  usePluginStore,
+  _resetPluginStoreForTesting,
+  type PluginJob,
+} from '../../store/pluginStore';
+import { useUIStore } from '../../store/uiStore';
+import { useI18n } from '../../i18n';
+import { HIGHLIGHT_MS } from '../PackCenter/PackCenterModal';
+import { PluginCenterModal } from './PluginCenterModal';
+
+function entry(over: Partial<PluginCatalogEntry> & { id: string }): PluginCatalogEntry {
+  return {
+    name: over.id,
+    description: '',
+    kind: 'builtin',
+    official: true,
+    status: 'available',
+    source_kind: null,
+    source: over.id,
+    repo: null,
+    ref: null,
+    sha: null,
+    url: null,
+    homepage: '',
+    version: null,
+    installed_at: null,
+    enabled: false,
+    chapters: [],
+    lessons: [],
+    tags: [],
+    nodes: [],
+    node_count: 0,
+    capabilities: [],
+    trusted_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    consent_required: false,
+    frontend_entry: null,
+    job: null,
+    ...over,
+  };
+}
+
+/** A built-in teaching pack, installed: the common row. */
+const edu = entry({
+  id: 'edu',
+  name: 'EDU teaching nodes',
+  description: 'Hands-on teaching nodes for the labs.',
+  status: 'installed',
+  source_kind: 'builtin',
+  enabled: true,
+  version: '0.1.0',
+  chapters: ['I1', 'I2'],
+  node_count: 8,
+  python_deps: { model2vec: '>=0.8.0' },
+});
+
+/** A third-party plugin off GitHub, installed and pinned. */
+const demo = entry({
+  id: 'demo',
+  name: 'Demo plugin',
+  kind: 'github',
+  official: false,
+  status: 'installed',
+  source_kind: 'github_url',
+  enabled: true,
+  version: '1.2.0',
+  repo: 'owner/demo',
+  url: 'https://github.com/owner/demo',
+  ref: 'v1.2.0',
+  sha: 'abcdef1234567890abcdef1234567890abcdef12',
+});
+
+/** A built-in pack nobody has installed. */
+const stats = entry({ id: 'stats', name: 'Stats nodes' });
+
+/** Fresh mocks for every action the panel is allowed to call. */
+function makeActions() {
+  return {
+    refresh: vi.fn(async () => {}),
+    install: vi.fn(async () => {}),
+    update: vi.fn(async () => {}),
+    uninstall: vi.fn(async () => {}),
+    setEnabled: vi.fn(async () => {}),
+  };
+}
+
+let actions: ReturnType<typeof makeActions>;
+
+/**
+ * Seed the store the panel reads, with fresh mock actions installed through
+ * `setState`. Never `vi.spyOn(usePluginStore.getState(), ...)`: that spies on a
+ * snapshot object, and the history leaks between cases.
+ */
+function seed(state: Partial<ReturnType<typeof usePluginStore.getState>> = {}) {
+  actions = makeActions();
+  const plugins = state.plugins ?? [];
+  usePluginStore.setState({
+    plugins,
+    byId: Object.fromEntries(plugins.map((p) => [p.id, p])),
+    loading: false,
+    loaded: true,
+    unsupported: false,
+    error: null,
+    remoteInstallAllowed: true,
+    job: null,
+    busy: {},
+    cancelling: false,
+    inspection: { phase: 'idle' },
+    ...actions,
+    ...state,
+  });
+}
+
+function job(over: Partial<PluginJob> = {}): PluginJob {
+  return { ...emptyPluginJob('j1', 'demo'), ...over };
+}
+
+function open(pluginId?: string) {
+  useUIStore.getState().openPluginCenter(pluginId);
+}
+
+const cardFor = (pluginId: string) =>
+  document.querySelector(`[data-plugin-id="${pluginId}"]`) as HTMLElement;
+
+/** Every button on one row, by its label. */
+const buttonsOn = (pluginId: string) =>
+  within(cardFor(pluginId))
+    .queryAllByRole('button')
+    .map((button) => button.textContent);
+
+beforeEach(() => {
+  useI18n.setState({ locale: 'en' });
+  useDialogStore.setState({ active: null });
+  useUIStore.setState({
+    pluginCenterOpen: false,
+    pluginCenterFocusPluginId: null,
+    packCenterOpen: false,
+    shortcutsModalOpen: false,
+  });
+  _resetPluginStoreForTesting();
+  seed();
+});
+
+afterEach(() => {
+  // Inside act(): this hook runs BEFORE Testing Library's own cleanup, so the
+  // panel is still mounted and subscribed when `pluginCenterOpen` goes false —
+  // closing it here is a real React update, and unwrapped it printed an
+  // "update was not wrapped in act(...)" line for every case in this file.
+  act(() => {
+    useUIStore.setState({
+      pluginCenterOpen: false,
+      pluginCenterFocusPluginId: null,
+      packCenterOpen: false,
+      shortcutsModalOpen: false,
+    });
+    useDialogStore.setState({ active: null });
+  });
+  vi.restoreAllMocks();
+});
+
+// ── Mounting ────────────────────────────────────────────────────────────────
+
+describe('PluginCenterModal — mounting', () => {
+  it('renders nothing, and asks the server nothing, while it is closed', () => {
+    render(<PluginCenterModal />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(actions.refresh).not.toHaveBeenCalled();
+  });
+
+  it('reads the catalog once when it opens', () => {
+    seed({ plugins: [edu] });
+    open();
+    render(<PluginCenterModal />);
+    expect(screen.getByRole('dialog', { name: 'Plugin Center' })).toBeInTheDocument();
+    expect(actions.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads on the refresh button', () => {
+    seed({ plugins: [edu] });
+    open();
+    render(<PluginCenterModal />);
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh plugin status' }));
+    expect(actions.refresh).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── The list ────────────────────────────────────────────────────────────────
+
+describe('PluginCenterModal — the plugin list', () => {
+  it('names a plugin, where it came from and what it brings', () => {
+    seed({ plugins: [edu] });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(screen.getByRole('region', { name: 'Plugin list' })).toBeInTheDocument();
+    // The activity pane's own element exists from the start, so the pane can
+    // move in later without the list reflowing around a new column.
+    expect(
+      screen.getByRole('complementary', { name: 'Install activity' }),
+    ).toBeInTheDocument();
+
+    const card = within(cardFor('edu'));
+    expect(card.getByText('EDU teaching nodes')).toBeInTheDocument();
+    // Scoped to the card: "Installed" is also the middle filter button.
+    expect(card.getByText('Installed')).toBeInTheDocument();
+    expect(card.getByText('v0.1.0')).toBeInTheDocument();
+    expect(card.getByText('Built-in')).toBeInTheDocument();
+    expect(card.getByText('Lessons: I1, I2')).toBeInTheDocument();
+    expect(card.getByText('8 nodes')).toBeInTheDocument();
+    // The spec as the installer would write it, not a prettier string that
+    // would install something else.
+    expect(card.getByText('Python packages: model2vec>=0.8.0')).toBeInTheDocument();
+  });
+
+  it('links a GitHub plugin to its repository and says which commit is here', () => {
+    seed({ plugins: [demo] });
+    open();
+    render(<PluginCenterModal />);
+
+    const card = within(cardFor('demo'));
+    const link = card.getByRole('link', { name: 'owner/demo' });
+    expect(link).toHaveAttribute('href', 'https://github.com/owner/demo');
+    // Seven characters of the sha, and the ref it was taken from: enough to
+    // check against a repository, short enough to sit on a meta line.
+    expect(card.getByText('v1.2.0 @ abcdef1')).toBeInTheDocument();
+    // A plain third-party repository wears no origin chip — the row already
+    // prints owner/repo, and "GitHub" over a GitHub link says it twice.
+    expect(card.queryByText('Official')).toBeNull();
+  });
+
+  it('says it is loading before the first answer', () => {
+    seed({ loading: true, loaded: false, plugins: [] });
+    open();
+    render(<PluginCenterModal />);
+    expect(screen.getByText('Loading plugins...')).toBeInTheDocument();
+  });
+
+  it('reports a failed read and offers to try again', () => {
+    seed({ loaded: false, error: 'connection refused', plugins: [] });
+    open();
+    render(<PluginCenterModal />);
+    expect(
+      screen.getByText('Failed to load plugins: connection refused'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(actions.refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the rows it has when a refresh fails, and still says it failed', () => {
+    seed({ plugins: [edu], error: 'connection refused' });
+    open();
+    render(<PluginCenterModal />);
+    // One dropped packet must not empty the Plugin Center.
+    expect(cardFor('edu')).not.toBeNull();
+    expect(
+      screen.getByText('Failed to load plugins: connection refused'),
+    ).toBeInTheDocument();
+  });
+
+  it('explains a server that predates the Plugin Center, and offers it nothing', () => {
+    seed({ unsupported: true, plugins: [] });
+    open();
+    render(<PluginCenterModal />);
+    expect(
+      screen.getByText('This server has no Plugin Center. Update CodefyUI and restart it.'),
+    ).toBeInTheDocument();
+    // No filter and no source box over a server that cannot answer either.
+    expect(screen.queryByRole('button', { name: 'All' })).toBeNull();
+  });
+
+  it('says so when the server lists no plugins at all', () => {
+    seed({ plugins: [] });
+    open();
+    render(<PluginCenterModal />);
+    expect(screen.getByText('No plugins are available')).toBeInTheDocument();
+  });
+});
+
+// ── A row per state ─────────────────────────────────────────────────────────
+
+describe('PluginCenterModal — what a row offers', () => {
+  it('offers Install, and nothing else, on a plugin that is not here', () => {
+    seed({ plugins: [stats] });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(cardFor('stats')).getByText('Not installed')).toBeInTheDocument();
+    expect(buttonsOn('stats')).toEqual(['Install']);
+  });
+
+  it('switches off, updates or removes an installed GitHub plugin', () => {
+    seed({ plugins: [demo] });
+    open();
+    render(<PluginCenterModal />);
+    expect(buttonsOn('demo')).toEqual(['Disable', 'Update', 'Uninstall']);
+  });
+
+  it('has nothing to update a built-in from', () => {
+    seed({ plugins: [edu] });
+    open();
+    render(<PluginCenterModal />);
+    // It ships with the server: the update route would have no source to read.
+    expect(buttonsOn('edu')).toEqual(['Disable', 'Uninstall']);
+  });
+
+  it('offers Enable and Uninstall on a plugin that is switched off', () => {
+    seed({ plugins: [entry({ id: 'demo', status: 'disabled', source_kind: 'github_url' })] });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(cardFor('demo')).getByText('Disabled')).toBeInTheDocument();
+    expect(buttonsOn('demo')).toEqual(['Enable', 'Uninstall']);
+  });
+
+  it('only switches a linked folder, never installs or removes one', () => {
+    seed({
+      plugins: [
+        entry({
+          id: 'wip',
+          name: 'Work in progress',
+          kind: 'external',
+          official: false,
+          status: 'installed',
+          source_kind: 'local',
+        }),
+      ],
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    // `cdui plugin link` owns the directory; the panel would be removing
+    // somebody's working copy.
+    expect(within(cardFor('wip')).getByText('Linked folder')).toBeInTheDocument();
+    expect(buttonsOn('wip')).toEqual(['Disable']);
+  });
+
+  it('offers to put a removed plugin back', () => {
+    seed({ plugins: [entry({ id: 'stats', status: 'removed' })] });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(cardFor('stats')).getByText('Removed')).toBeInTheDocument();
+    // A tombstone has nothing left to uninstall.
+    expect(buttonsOn('stats')).toEqual(['Install']);
+  });
+
+  it('offers to repair or clear a plugin whose files are gone', () => {
+    seed({ plugins: [entry({ id: 'demo', status: 'missing_files', source_kind: 'github_url' })] });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(cardFor('demo')).getByText('Files missing')).toBeInTheDocument();
+    // The lockfile still has it, so clearing the record is a real answer.
+    expect(buttonsOn('demo')).toEqual(['Install', 'Uninstall']);
+  });
+
+  it('says a row is installing, and offers no button while it is', () => {
+    seed({ plugins: [entry({ id: 'demo', status: 'installing' })] });
+    open();
+    render(<PluginCenterModal />);
+
+    const card = cardFor('demo');
+    expect(within(card).getByText('Installing')).toBeInTheDocument();
+    expect(card.querySelector('[data-role="pulse"]')).not.toBeNull();
+    expect(buttonsOn('demo')).toEqual([]);
+  });
+
+  it('says so from the job alone, before the catalog has caught up', () => {
+    // A job adopted from another tab lands before the poll that would have
+    // set the row's status: the row this job names is installing either way.
+    seed({ plugins: [demo], job: job({ pluginId: 'demo' }) });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(cardFor('demo')).getByText('Installing')).toBeInTheDocument();
+    expect(buttonsOn('demo')).toEqual([]);
+  });
+
+  it('leaves a row alone while one of its own requests is in flight', () => {
+    seed({ plugins: [demo], busy: { demo: true } });
+    open();
+    render(<PluginCenterModal />);
+
+    // The buttons stay — this is a request, not an install job — but every
+    // one of them is dead until it answers.
+    for (const button of within(cardFor('demo')).getAllByRole('button')) {
+      expect(button).toBeDisabled();
+    }
+  });
+});
+
+// ── The actions ─────────────────────────────────────────────────────────────
+
+describe('PluginCenterModal — the actions', () => {
+  it('hands every change to the store, which owns the confirm and the job', () => {
+    seed({ plugins: [stats, demo] });
+    open();
+    render(<PluginCenterModal />);
+
+    fireEvent.click(within(cardFor('stats')).getByRole('button', { name: 'Install' }));
+    expect(actions.install).toHaveBeenCalledWith('stats');
+
+    fireEvent.click(within(cardFor('demo')).getByRole('button', { name: 'Update' }));
+    expect(actions.update).toHaveBeenCalledWith('demo');
+
+    // No second confirm here: `pluginStore.uninstall` asks first, with the
+    // danger dialog and the sentence about the Python packages that stay.
+    fireEvent.click(within(cardFor('demo')).getByRole('button', { name: 'Uninstall' }));
+    expect(actions.uninstall).toHaveBeenCalledWith('demo');
+
+    fireEvent.click(within(cardFor('demo')).getByRole('button', { name: 'Disable' }));
+    expect(actions.setEnabled).toHaveBeenCalledWith('demo', false);
+  });
+
+  it('switches a disabled plugin back on', () => {
+    seed({ plugins: [entry({ id: 'demo', status: 'disabled' })] });
+    open();
+    render(<PluginCenterModal />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Enable' }));
+    expect(actions.setEnabled).toHaveBeenCalledWith('demo', true);
+  });
+});
+
+// ── A server that only installs locally ─────────────────────────────────────
+
+describe('PluginCenterModal — remote installs refused', () => {
+  it('says why once, and disables exactly what the server would refuse', () => {
+    seed({ plugins: [stats, demo], remoteInstallAllowed: false });
+    open();
+    render(<PluginCenterModal />);
+
+    const sentence = 'Installing is only allowed from the computer that runs the server.';
+    // Once, in the footer. On the buttons it is a `title`, not a fourth copy
+    // of the same sentence down the card.
+    expect(screen.getAllByText(sentence)).toHaveLength(1);
+
+    const install = within(cardFor('stats')).getByRole('button', { name: 'Install' });
+    expect(install).toBeDisabled();
+    expect(install).toHaveAttribute('title', sentence);
+
+    const update = within(cardFor('demo')).getByRole('button', { name: 'Update' });
+    expect(update).toBeDisabled();
+    expect(within(cardFor('demo')).getByRole('button', { name: 'Uninstall' })).toBeDisabled();
+
+    // Switching a plugin off changes nothing on disk, so the token-only gate
+    // does not cover it and neither does this.
+    expect(within(cardFor('demo')).getByRole('button', { name: 'Disable' })).toBeEnabled();
+  });
+});
+
+// ── The filter ──────────────────────────────────────────────────────────────
+
+describe('PluginCenterModal — the filter', () => {
+  it('shows one half of the catalog at a time', () => {
+    seed({ plugins: [edu, stats] });
+    open();
+    render(<PluginCenterModal />);
+
+    const all = screen.getByRole('button', { name: 'All' });
+    const installed = screen.getByRole('button', { name: 'Installed' });
+    const available = screen.getByRole('button', { name: 'Available' });
+    expect(all).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(installed);
+    expect(installed).toHaveAttribute('aria-pressed', 'true');
+    expect(all).toHaveAttribute('aria-pressed', 'false');
+    expect(cardFor('edu')).not.toBeNull();
+    expect(cardFor('stats')).toBeNull();
+
+    fireEvent.click(available);
+    expect(cardFor('edu')).toBeNull();
+    expect(cardFor('stats')).not.toBeNull();
+
+    fireEvent.click(all);
+    expect(cardFor('edu')).not.toBeNull();
+    expect(cardFor('stats')).not.toBeNull();
+  });
+
+  it('offers no filter over a catalog with nothing in it', () => {
+    seed({ plugins: [] });
+    open();
+    render(<PluginCenterModal />);
+    expect(screen.queryByRole('button', { name: 'All' })).toBeNull();
+  });
+});
+
+// ── The deep link ───────────────────────────────────────────────────────────
+
+describe('PluginCenterModal — the deep link', () => {
+  it('scrolls to the plugin it was opened for, and consumes the request', () => {
+    seed({ plugins: [edu, stats] });
+    const scroll = vi.spyOn(HTMLElement.prototype, 'scrollIntoView');
+    open('stats');
+    render(<PluginCenterModal />);
+
+    expect(scroll).toHaveBeenCalledWith({ block: 'nearest' });
+    expect(cardFor('stats').className).toContain('cardHighlighted');
+    expect(cardFor('edu').className).not.toContain('cardHighlighted');
+    // Consumed, so a later unrelated render does not re-fire the jump.
+    expect(useUIStore.getState().pluginCenterFocusPluginId).toBeNull();
+  });
+
+  it('widens the filter rather than sending a jump to a hidden row', () => {
+    seed({ plugins: [edu, stats] });
+    vi.spyOn(HTMLElement.prototype, 'scrollIntoView');
+    open();
+    render(<PluginCenterModal />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Available' }));
+    expect(cardFor('edu')).toBeNull();
+
+    // A toast about an installed plugin, arriving while the list is narrowed
+    // to what is not installed.
+    act(() => {
+      useUIStore.getState().openPluginCenter('edu');
+    });
+
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(cardFor('edu').className).toContain('cardHighlighted');
+    expect(useUIStore.getState().pluginCenterFocusPluginId).toBeNull();
+  });
+
+  it('drops the ring after HIGHLIGHT_MS so it reads as a pointer, not a state', () => {
+    seed({ plugins: [edu, stats] });
+    vi.useFakeTimers();
+    try {
+      open('stats');
+      render(<PluginCenterModal />);
+      expect(cardFor('stats').className).toContain('cardHighlighted');
+
+      // The constant, not a copy of it: a ring that outlived its exported
+      // duration would still pass a hard-coded 2000.
+      act(() => {
+        vi.advanceTimersByTime(HIGHLIGHT_MS - 1);
+      });
+      expect(cardFor('stats').className).toContain('cardHighlighted');
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(cardFor('stats').className).not.toContain('cardHighlighted');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ── Closing ─────────────────────────────────────────────────────────────────
+
+describe('PluginCenterModal — closing', () => {
+  beforeEach(() => {
+    seed({ plugins: [edu] });
+    open();
+    render(<PluginCenterModal />);
+  });
+
+  it('closes on Escape', () => {
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useUIStore.getState().pluginCenterOpen).toBe(false);
+  });
+
+  it('closes on the backdrop but not on a press inside the surface', () => {
+    const dialog = screen.getByRole('dialog');
+    fireEvent.mouseDown(dialog);
+    expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+
+    fireEvent.mouseDown(dialog.parentElement!);
+    expect(useUIStore.getState().pluginCenterOpen).toBe(false);
+  });
+
+  it('closes on the close button', () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Close Plugin Center' }));
+    expect(useUIStore.getState().pluginCenterOpen).toBe(false);
+  });
+
+  it('leaves Escape alone while something is stacked above it', () => {
+    useUIStore.setState({ shortcutsModalOpen: true });
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+    useUIStore.setState({ shortcutsModalOpen: false });
+
+    useDialogStore.setState({ active: { kind: 'confirm', title: 'x' } as never });
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+    useDialogStore.setState({ active: null });
+
+    // The Package Center answers the same key. One press, one window.
+    useUIStore.setState({ packCenterOpen: true });
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+    useUIStore.setState({ packCenterOpen: false });
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(useUIStore.getState().pluginCenterOpen).toBe(false);
+  });
+
+  it('hands focus back to whatever had it', () => {
+    // The modal took focus on open; closing it must not leave focus on <body>.
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveFocus();
+
+    act(() => {
+      useUIStore.getState().closePluginCenter();
+    });
+    expect(document.activeElement).not.toBe(dialog);
+  });
+});

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -683,6 +683,18 @@ describe('PluginCenterModal — the review', () => {
     expect(screen.queryByRole('region', { name: 'Review before installing' })).toBeNull();
   });
 
+  it('brings itself into view, however far down the row that asked was', () => {
+    // A row's own Install button raises a review, and this card renders at
+    // the top of the list: without the scroll, clicking Install on the eighth
+    // plugin would look like nothing happened.
+    const scroll = vi.spyOn(HTMLElement.prototype, 'scrollIntoView');
+    seed({ inspection: ready() });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(scroll).toHaveBeenCalledWith({ block: 'nearest' });
+  });
+
   it('shows what was found at the source, and what installing it would cost', () => {
     seed({
       plugins: [entry({ id: 'demo', nodes: ['demo:Split', 'demo:Join'] })],

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -314,6 +314,19 @@ describe('PluginCenterModal — the plugin list', () => {
     expect(screen.getByText('Loading plugins...')).toBeInTheDocument();
   });
 
+  it('says nothing about loading while a refresh runs over rows it has', () => {
+    // The direction that matters: the rule is `loading && plugins.length ===
+    // 0`, and a case seeded with an empty list passes with the second half
+    // deleted. A re-read must not put "Loading plugins..." over a catalog
+    // that is already on screen.
+    seed({ plugins: [edu], loading: true });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(screen.queryByText('Loading plugins...')).toBeNull();
+    expect(cardFor('edu')).not.toBeNull();
+  });
+
   it('reports a failed read and offers to try again', () => {
     seed({ loaded: false, error: 'connection refused', plugins: [] });
     open();

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, render, screen, fireEvent, within } from '@testing-library/react';
-import type { PluginCatalogEntry } from '../../api/rest';
+import type { PluginCatalogEntry, PluginInspection } from '../../api/rest';
 import { useDialogStore } from '../../store/dialogStore';
 import {
   emptyPluginJob,
   usePluginStore,
   _resetPluginStoreForTesting,
+  type InspectionState,
   type PluginJob,
 } from '../../store/pluginStore';
 import { useUIStore } from '../../store/uiStore';
@@ -81,11 +82,64 @@ const demo = entry({
 /** A built-in pack nobody has installed. */
 const stats = entry({ id: 'stats', name: 'Stats nodes' });
 
+/** An inspection as the server would answer one. */
+function inspection(over: Partial<PluginInspection> = {}): PluginInspection {
+  return {
+    inspection_id: 'insp-1',
+    expires_at: '2026-01-01T00:00:00Z',
+    kind: 'github',
+    mode: 'install',
+    plugin_id: 'demo',
+    catalog_id: null,
+    official: false,
+    source: 'owner/demo',
+    url: 'https://github.com/owner/demo',
+    ref: null,
+    sha: null,
+    name: 'Demo plugin',
+    version: '1.2.0',
+    description: '',
+    homepage: '',
+    manifest: {},
+    capabilities: [],
+    allowed_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    chapters: [],
+    lessons: [],
+    consent_required: false,
+    installed: null,
+    up_to_date: false,
+    capabilities_added: [],
+    allowed_modules_added: [],
+    warnings: [],
+    ...over,
+  };
+}
+
+/**
+ * A review the server has answered, in the shape the store keeps it.
+ *
+ * The narrow variant rather than `InspectionState`, so a case that adds an
+ * `error` to it can spread this instead of casting the union back down.
+ */
+function ready(
+  over: Partial<PluginInspection> = {},
+): Extract<InspectionState, { phase: 'ready' }> {
+  const data = inspection(over);
+  return {
+    phase: 'ready', data, source: data.source, forPluginId: null, kind: data.mode, error: null,
+  };
+}
+
 /** Fresh mocks for every action the panel is allowed to call. */
 function makeActions() {
   return {
     refresh: vi.fn(async () => {}),
     install: vi.fn(async () => {}),
+    inspect: vi.fn(async () => {}),
+    installInspected: vi.fn(async () => {}),
+    clearInspection: vi.fn(() => {}),
     update: vi.fn(async () => {}),
     uninstall: vi.fn(async () => {}),
     setEnabled: vi.fn(async () => {}),
@@ -288,6 +342,8 @@ describe('PluginCenterModal — the plugin list', () => {
     ).toBeInTheDocument();
     // No filter and no source box over a server that cannot answer either.
     expect(screen.queryByRole('button', { name: 'All' })).toBeNull();
+    expect(screen.queryByLabelText('Install from GitHub')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Review' })).toBeNull();
   });
 
   it('says so when the server lists no plugins at all', () => {
@@ -468,6 +524,342 @@ describe('PluginCenterModal — remote installs refused', () => {
     // Switching a plugin off changes nothing on disk, so the token-only gate
     // does not cover it and neither does this.
     expect(within(cardFor('demo')).getByRole('button', { name: 'Disable' })).toBeEnabled();
+  });
+});
+
+// ── The source box ──────────────────────────────────────────────────────────
+
+describe('PluginCenterModal — the source box', () => {
+  /** Type *value* into the box and press Review. */
+  function review(value: string) {
+    fireEvent.change(screen.getByLabelText('Install from GitHub'), {
+      target: { value },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Review' }));
+  }
+
+  it('offers a box for a plugin the catalog does not list', () => {
+    seed({ plugins: [edu] });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(screen.getByLabelText('Install from GitHub')).toHaveAttribute(
+      'placeholder', 'owner/repo[@ref] or GitHub URL',
+    );
+    // Nothing to review until something is typed.
+    expect(screen.getByRole('button', { name: 'Review' })).toBeDisabled();
+  });
+
+  it('refuses a source that is not one without asking the server', () => {
+    seed();
+    open();
+    render(<PluginCenterModal />);
+
+    review('not a repo!');
+
+    expect(
+      screen.getByText('Enter a catalog name, owner/repo[@ref] or a GitHub URL.'),
+    ).toBeInTheDocument();
+    // The server would answer 400 to the same string; this build knows that
+    // without the round trip, so it does not make one.
+    expect(actions.inspect).not.toHaveBeenCalled();
+  });
+
+  it('asks the server to read a source it can parse, trimmed', () => {
+    seed();
+    open();
+    render(<PluginCenterModal />);
+
+    review('  owner/demo@v1  ');
+
+    expect(actions.inspect).toHaveBeenCalledWith('owner/demo@v1');
+    expect(
+      screen.queryByText('Enter a catalog name, owner/repo[@ref] or a GitHub URL.'),
+    ).toBeNull();
+  });
+
+  it('says it is reading the source while it waits', () => {
+    seed({ inspection: { phase: 'inspecting', source: 'owner/demo' } });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(screen.getByRole('button', { name: 'Downloading...' })).toBeDisabled();
+  });
+
+  it('reports a source the server could not read', () => {
+    // The store has already turned the code into a sentence; what is left is
+    // naming the source it was about.
+    seed({
+      inspection: {
+        phase: 'error',
+        source: 'owner/demo',
+        failure: { message: 'Could not reach GitHub.', code: 'github_unreachable', detail: null },
+      },
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(
+      screen.getByText('Could not fetch owner/demo: Could not reach GitHub.'),
+    ).toBeInTheDocument();
+  });
+
+  it('names the id a reserved-id refusal was about', () => {
+    // The refusal carries no sentence at all — only the id it is about, and
+    // that is the whole useful part.
+    seed({
+      inspection: {
+        phase: 'error',
+        source: 'owner/edu',
+        failure: {
+          message: 'reserved_id',
+          code: 'reserved_id',
+          detail: { code: 'reserved_id', id: 'edu' },
+        },
+      },
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(
+      screen.getByText('The id "edu" is reserved for a built-in pack.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/reserved_id/)).toBeNull();
+  });
+
+  it('lists the names a catalog miss offered instead', () => {
+    seed({
+      inspection: {
+        phase: 'error',
+        source: 'c9',
+        failure: {
+          message: 'unknown_catalog_name',
+          code: 'unknown_catalog_name',
+          detail: { code: 'unknown_catalog_name', known: ['edu', 'stats'] },
+        },
+      },
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(screen.getByText('No plugin is called "c9".')).toBeInTheDocument();
+    // The list only exists in the refusal's body: no sentence written on the
+    // server could have said which names would have worked.
+    expect(screen.getByText('This server can install: edu, stats')).toBeInTheDocument();
+  });
+
+  it('will not review from a browser the server refuses installs from', () => {
+    seed({ remoteInstallAllowed: false });
+    open();
+    render(<PluginCenterModal />);
+
+    fireEvent.change(screen.getByLabelText('Install from GitHub'), {
+      target: { value: 'owner/demo' },
+    });
+    const button = screen.getByRole('button', { name: 'Review' });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title', 'Installing is only allowed from the computer that runs the server.',
+    );
+  });
+});
+
+// ── The review ──────────────────────────────────────────────────────────────
+
+describe('PluginCenterModal — the review', () => {
+  const card = () => screen.getByRole('region', { name: 'Review before installing' });
+
+  it('stays out of the way until the server has answered', () => {
+    seed({ plugins: [edu] });
+    open();
+    render(<PluginCenterModal />);
+    expect(screen.queryByRole('region', { name: 'Review before installing' })).toBeNull();
+
+    act(() => {
+      usePluginStore.setState({ inspection: { phase: 'inspecting', source: 'owner/demo' } });
+    });
+    // Nothing has been read yet, and the button already says so: an empty
+    // card here would be the same fact twice and a second layout jump.
+    expect(screen.queryByRole('region', { name: 'Review before installing' })).toBeNull();
+  });
+
+  it('shows what was found at the source, and what installing it would cost', () => {
+    seed({
+      plugins: [entry({ id: 'demo', nodes: ['demo:Split', 'demo:Join'] })],
+      inspection: ready({
+        name: 'Demo plugin',
+        version: '1.2.0',
+        description: 'Two nodes and a panel.',
+        manifest: { plugin: { authors: ['Ada', 'Grace'] } },
+        homepage: 'https://example.com/demo',
+        python_deps: { torch: '2.1.0' },
+        ref: 'main',
+        sha: 'abcdef1234567890',
+        capabilities: ['network', 'gpu'],
+        allowed_modules: ['subprocess'],
+        has_frontend: true,
+        consent_required: true,
+      }),
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    const review = within(card());
+    expect(review.getByText('Demo plugin')).toBeInTheDocument();
+    expect(review.getByText('v1.2.0')).toBeInTheDocument();
+    expect(review.getByText('Two nodes and a panel.')).toBeInTheDocument();
+    expect(review.getByText('Author: Ada, Grace')).toBeInTheDocument();
+    // The catalog's row is where node names come from: an inspection cannot
+    // say without importing the code it is asking about.
+    expect(review.getByText('Nodes: demo:Split, demo:Join')).toBeInTheDocument();
+    expect(review.getByText('Python packages: torch==2.1.0')).toBeInTheDocument();
+    expect(review.getByText('main @ abcdef1')).toBeInTheDocument();
+    expect(review.getByRole('link', { name: 'Homepage' }))
+      .toHaveAttribute('href', 'https://example.com/demo');
+
+    // One line per capability, saying what granting it costs — and the raw
+    // id for one this build has no line for, rather than a silent gap.
+    expect(review.getByText(/^network: reach any host/)).toBeInTheDocument();
+    expect(review.getByText('gpu')).toBeInTheDocument();
+    expect(review.getByText(/Granting is a declaration, not a sandbox/))
+      .toBeInTheDocument();
+    expect(review.getByText('I trust this author. Allows: subprocess'))
+      .toBeInTheDocument();
+    expect(
+      review.getByText('Ships JavaScript that runs in this editor with full access.'),
+    ).toBeInTheDocument();
+  });
+
+  it('asks nothing of a manifest that declares nothing', () => {
+    seed({ inspection: ready() });
+    open();
+    render(<PluginCenterModal />);
+
+    const review = within(card());
+    expect(review.queryByRole('checkbox')).toBeNull();
+    expect(review.queryByText('This plugin asks for:')).toBeNull();
+    // Nothing to agree to, so nothing to wait for.
+    expect(review.getByRole('button', { name: 'Install' })).toBeEnabled();
+  });
+
+  it('keeps Install dead until every box the manifest asks for is ticked', () => {
+    seed({
+      inspection: ready({
+        capabilities: ['network'], allowed_modules: ['subprocess'], consent_required: true,
+      }),
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    const review = within(card());
+    const install = review.getByRole('button', { name: 'Install' });
+    expect(install).toBeDisabled();
+
+    fireEvent.click(review.getByRole('checkbox', { name: 'Grant these capabilities' }));
+    // One of two is not consent.
+    expect(install).toBeDisabled();
+
+    fireEvent.click(
+      review.getByRole('checkbox', { name: 'I trust this author. Allows: subprocess' }),
+    );
+    expect(install).toBeEnabled();
+  });
+
+  it('sends the capabilities and the trust the user actually ticked', () => {
+    seed({
+      inspection: ready({
+        capabilities: ['network'], allowed_modules: ['subprocess'], consent_required: true,
+      }),
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    const review = within(card());
+    fireEvent.click(review.getByRole('checkbox', { name: 'Grant these capabilities' }));
+    fireEvent.click(
+      review.getByRole('checkbox', { name: 'I trust this author. Allows: subprocess' }),
+    );
+    fireEvent.click(review.getByRole('button', { name: 'Install' }));
+
+    // The store turns the tick into the DECLARED list on the wire; what the
+    // card promises is that it never sends a trust nobody gave.
+    expect(actions.installInspected).toHaveBeenCalledWith({
+      acceptCapabilities: true, trustAuthor: true,
+    });
+  });
+
+  it('trusts no author when there was none to trust', () => {
+    seed({ inspection: ready({ capabilities: ['network'], consent_required: true }) });
+    open();
+    render(<PluginCenterModal />);
+
+    const review = within(card());
+    fireEvent.click(review.getByRole('checkbox', { name: 'Grant these capabilities' }));
+    fireEvent.click(review.getByRole('button', { name: 'Install' }));
+
+    expect(actions.installInspected).toHaveBeenCalledWith({
+      acceptCapabilities: true, trustAuthor: false,
+    });
+  });
+
+  it('offers to reinstall a plugin the server says is already here', () => {
+    seed({
+      inspection: {
+        ...ready(),
+        error: {
+          message: 'already_installed',
+          code: 'already_installed',
+          detail: { code: 'already_installed', plugin_id: 'demo' },
+        },
+      },
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    // The 409 was an offer, not a failure: the review is still spendable and
+    // the button is what accepts it.
+    fireEvent.click(within(card()).getByRole('button', { name: 'Reinstall' }));
+    expect(actions.installInspected).toHaveBeenCalledWith({
+      acceptCapabilities: true, trustAuthor: false, force: true,
+    });
+  });
+
+  it('says Update when the review is of a version over one already installed', () => {
+    seed({ inspection: ready({ mode: 'update' }) });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(card()).getByRole('button', { name: 'Update' })).toBeInTheDocument();
+  });
+
+  it('puts the review away when it is cancelled', () => {
+    seed({ inspection: ready() });
+    open();
+    render(<PluginCenterModal />);
+
+    fireEvent.click(within(card()).getByRole('button', { name: 'Cancel' }));
+    expect(actions.clearInspection).toHaveBeenCalled();
+  });
+
+  it('will not link a homepage that is not a web address', () => {
+    // A manifest at a source nobody has installed yet is untrusted text, and
+    // `javascript:` in the one link on a consent screen is a script that
+    // runs in this editor.
+    seed({ inspection: ready({ homepage: 'javascript:alert(1)' }) });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(card()).queryByRole('link')).toBeNull();
+  });
+
+  it('will not install from a browser the server refuses installs from', () => {
+    seed({ inspection: ready(), remoteInstallAllowed: false });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(within(card()).getByRole('button', { name: 'Install' })).toBeDisabled();
+    // Putting the review away is not an install, and never was refused.
+    expect(within(card()).getByRole('button', { name: 'Cancel' })).toBeEnabled();
   });
 });
 

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -1076,7 +1076,9 @@ describe('PluginCenterModal — the activity pane', () => {
     open();
     render(<PluginCenterModal />);
 
-    fireEvent.click(pane().getByRole('button', { name: 'Refresh plugin status' }));
+    // Scoped to the pane: the header's icon button is the one still called
+    // "Refresh plugin status", and this banner's says only "Refresh".
+    fireEvent.click(pane().getByRole('button', { name: 'Refresh' }));
     // Once on open, once for this button.
     expect(actions.refresh).toHaveBeenCalledTimes(2);
   });

--- a/frontend/src/components/PluginCenter/PluginCenterModal.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.tsx
@@ -9,7 +9,8 @@ import { RefreshIcon } from '../shared/Icons';
 // for" across both windows, and one place to change it.
 import { HIGHLIGHT_MS } from '../PackCenter/PackCenterModal';
 import { PluginCard } from './PluginCard';
-import { PluginFilterBar, matchesFilter, type PluginFilter } from './PluginFilterBar';
+import { PluginFilterBar } from './PluginFilterBar';
+import { matchesFilter, type PluginFilter } from './pluginStatus';
 import styles from '../PackCenter/PackCenterModal.module.css';
 
 /**

--- a/frontend/src/components/PluginCenter/PluginCenterModal.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.tsx
@@ -16,6 +16,10 @@ import { PluginReviewCard } from './PluginReviewCard';
 import { PluginSourceForm } from './PluginSourceForm';
 import { matchesFilter, type PluginFilter } from './pluginStatus';
 import styles from '../PackCenter/PackCenterModal.module.css';
+// Everything this panel wears is `styles` (the pack sheet); `ownStyles` is
+// the handful of rules that are only true of this one — here, the backdrop's
+// rung above the Package Center's.
+import ownStyles from './PluginCenterModal.module.css';
 
 /**
  * The Plugin Center (core#…): every plugin this server knows about, what of it
@@ -128,12 +132,18 @@ function PluginCenterBody() {
       // this panel and leaving a shortcuts window nobody can see.
       if (useDialogStore.getState().active !== null) return;
       if (useUIStore.getState().shortcutsModalOpen) return;
-      // The Package Center is a second window with a second Escape handler on
-      // the same key. Both can be open at once — a node badge opens one, the
-      // sidebar the other — and without this, one press would close both.
-      if (useUIStore.getState().packCenterOpen) return;
       e.preventDefault();
       close();
+      // The Package Center is a second window with a second handler on this
+      // same key, and it stands down while this panel is open — but it reads
+      // `pluginCenterOpen` from the store, which `close()` has just set to
+      // false. Without this, one press would close both whenever the Package
+      // Center registered its listener FIRST (both can be open at once: each
+      // is reachable from Settings and from the sidebar's Custom & Plugins
+      // tab). This panel is the one on top by stylesheet
+      // (`PluginCenterModal.module.css: .topBackdrop`), so it is the one the
+      // press belongs to, and nothing underneath sees it.
+      e.stopImmediatePropagation();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
@@ -186,7 +196,10 @@ function PluginCenterBody() {
 
   return createPortal(
     <div
-      className={styles.backdrop}
+      // The pack panel's backdrop, one rung up: with both centers open this
+      // one is on top whichever was opened first, which is what makes "the
+      // top-most closes on Escape" a fact rather than an assumption.
+      className={ownStyles.topBackdrop}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) close();
       }}

--- a/frontend/src/components/PluginCenter/PluginCenterModal.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.tsx
@@ -84,6 +84,15 @@ function PluginCenterBody() {
     void refresh();
   }, [refresh]);
 
+  // A refusal belongs to the box it was typed into, and does not outlive the
+  // window that box was in: reopening the panel over "Could not fetch
+  // owner/demo: ..." would explain a request nobody here made. A REVIEW
+  // survives a close on purpose — it is a decision still waiting for an
+  // answer, and the store keeps the install job running behind it either way.
+  useEffect(() => () => {
+    if (usePluginStore.getState().inspection.phase === 'error') clearInspection();
+  }, [clearInspection]);
+
   // Focus starts inside the panel and goes back where it came from. Not a
   // focus trap — Tab still walks out into the page underneath, exactly as it
   // does in the Package Center and the template gallery. Trapping is worth
@@ -214,10 +223,26 @@ function PluginCenterBody() {
               />
             )}
 
-            {/* Keyed on the inspection: a second Review answers a different
+            {/* Not on the phase alone. `install()` inspects before it
+                installs, and `runInspect` leaves the review READY between
+                those two round trips — so a built-in pack, which asks for
+                nothing and is installed straight from that inspection, would
+                flash a consent card at the top of the list and scroll to it
+                for as long as the install request takes.
+
+                The card is rendered for the question it answers instead: a
+                source somebody typed (`forPluginId === null`), a plugin that
+                asks for something, or a refusal a control on this card is the
+                fix for. The window the store passes through on its way to an
+                automatic install is the only thing this drops.
+
+                Keyed on the inspection: a second Review answers a different
                 manifest, and the boxes ticked for the first one must not
                 carry over to it. */}
-            {!unsupported && inspection.phase === 'ready' && (
+            {!unsupported && inspection.phase === 'ready'
+              && (inspection.forPluginId === null
+                || inspection.data.consent_required
+                || inspection.error !== null) && (
               <PluginReviewCard
                 key={inspection.data.inspection_id}
                 inspection={inspection}

--- a/frontend/src/components/PluginCenter/PluginCenterModal.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import type { PluginCatalogEntry } from '../../api/rest';
 import { useDialogStore } from '../../store/dialogStore';
 import { usePluginStore } from '../../store/pluginStore';
 import { useUIStore } from '../../store/uiStore';
@@ -10,6 +11,8 @@ import { RefreshIcon } from '../shared/Icons';
 import { HIGHLIGHT_MS } from '../PackCenter/PackCenterModal';
 import { PluginCard } from './PluginCard';
 import { PluginFilterBar } from './PluginFilterBar';
+import { PluginReviewCard } from './PluginReviewCard';
+import { PluginSourceForm } from './PluginSourceForm';
 import { matchesFilter, type PluginFilter } from './pluginStatus';
 import styles from '../PackCenter/PackCenterModal.module.css';
 
@@ -32,6 +35,19 @@ export function PluginCenterModal() {
   return <PluginCenterBody />;
 }
 
+/**
+ * The node types *pluginId* registers, as the catalog last said.
+ *
+ * Own keys only: `byId` is a bare object built from parsed JSON, so a plugin
+ * called `constructor` would otherwise hand back a function and `.nodes`
+ * would be undefined on it.
+ */
+function ownNodes(byId: Record<string, PluginCatalogEntry>, pluginId: string): string[] {
+  return Object.prototype.hasOwnProperty.call(byId, pluginId)
+    ? byId[pluginId].nodes
+    : [];
+}
+
 function PluginCenterBody() {
   const { t } = useI18n();
   const close = useUIStore((s) => s.closePluginCenter);
@@ -46,8 +62,12 @@ function PluginCenterBody() {
   const remoteInstallAllowed = usePluginStore((s) => s.remoteInstallAllowed);
   const job = usePluginStore((s) => s.job);
   const busy = usePluginStore((s) => s.busy);
+  const inspection = usePluginStore((s) => s.inspection);
   const refresh = usePluginStore((s) => s.refresh);
   const install = usePluginStore((s) => s.install);
+  const inspect = usePluginStore((s) => s.inspect);
+  const installInspected = usePluginStore((s) => s.installInspected);
+  const clearInspection = usePluginStore((s) => s.clearInspection);
   const update = usePluginStore((s) => s.update);
   const uninstall = usePluginStore((s) => s.uninstall);
   const setEnabled = usePluginStore((s) => s.setEnabled);
@@ -183,8 +203,31 @@ function PluginCenterBody() {
 
         <div className={styles.body}>
           <section className={styles.list} aria-label={t('pluginCenter.list')}>
-            {/* The source box and the install review go here, above the
-                filter: they are about a plugin that is not in the list yet. */}
+            {/* Above the filter, because both are about a plugin that is not
+                in the list yet. A server with no Plugin Center is offered
+                neither. */}
+            {!unsupported && (
+              <PluginSourceForm
+                inspection={inspection}
+                canInstall={remoteInstallAllowed}
+                onReview={(source) => void inspect(source)}
+              />
+            )}
+
+            {/* Keyed on the inspection: a second Review answers a different
+                manifest, and the boxes ticked for the first one must not
+                carry over to it. */}
+            {!unsupported && inspection.phase === 'ready' && (
+              <PluginReviewCard
+                key={inspection.data.inspection_id}
+                inspection={inspection}
+                nodes={ownNodes(byId, inspection.data.plugin_id)}
+                busy={busy[inspection.data.plugin_id] === true}
+                canInstall={remoteInstallAllowed}
+                onInstall={(opts) => void installInspected(opts)}
+                onCancel={clearInspection}
+              />
+            )}
 
             {/* No filter over a list nobody can act on: a server with no
                 Plugin Center has no rows, and neither has one whose catalog

--- a/frontend/src/components/PluginCenter/PluginCenterModal.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useDialogStore } from '../../store/dialogStore';
+import { usePluginStore } from '../../store/pluginStore';
+import { useUIStore } from '../../store/uiStore';
+import { useI18n } from '../../i18n';
+import { RefreshIcon } from '../shared/Icons';
+// The pack panel's, not a copy: one duration for "this is the row you asked
+// for" across both windows, and one place to change it.
+import { HIGHLIGHT_MS } from '../PackCenter/PackCenterModal';
+import { PluginCard } from './PluginCard';
+import { PluginFilterBar, matchesFilter, type PluginFilter } from './PluginFilterBar';
+import styles from '../PackCenter/PackCenterModal.module.css';
+
+/**
+ * The Plugin Center (core#…): every plugin this server knows about, what of it
+ * is installed, and one place to change that.
+ *
+ * Mounted once at the app root and driven by `uiStore.pluginCenterOpen`, like
+ * the Package Center — and, like it, a pure VIEW: the catalog, the install
+ * job, the long-poll follower and the confirm dialogs all live in
+ * `pluginStore`, so closing this window cannot interrupt an install.
+ *
+ * The chrome is the Package Center's, imported rather than reimplemented: the
+ * backdrop, the modal, the header, the list, the pane and the 860 px stack are
+ * one stylesheet, so the two surfaces cannot drift apart.
+ */
+export function PluginCenterModal() {
+  const open = useUIStore((s) => s.pluginCenterOpen);
+  if (!open) return null;
+  return <PluginCenterBody />;
+}
+
+function PluginCenterBody() {
+  const { t } = useI18n();
+  const close = useUIStore((s) => s.closePluginCenter);
+  const focusPluginId = useUIStore((s) => s.pluginCenterFocusPluginId);
+  const setFocus = useUIStore((s) => s.setPluginCenterFocus);
+
+  const plugins = usePluginStore((s) => s.plugins);
+  const byId = usePluginStore((s) => s.byId);
+  const loading = usePluginStore((s) => s.loading);
+  const error = usePluginStore((s) => s.error);
+  const unsupported = usePluginStore((s) => s.unsupported);
+  const remoteInstallAllowed = usePluginStore((s) => s.remoteInstallAllowed);
+  const job = usePluginStore((s) => s.job);
+  const busy = usePluginStore((s) => s.busy);
+  const refresh = usePluginStore((s) => s.refresh);
+  const install = usePluginStore((s) => s.install);
+  const update = usePluginStore((s) => s.update);
+  const uninstall = usePluginStore((s) => s.uninstall);
+  const setEnabled = usePluginStore((s) => s.setEnabled);
+
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
+  const cardRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [highlighted, setHighlighted] = useState<string | null>(null);
+  const [filter, setFilter] = useState<PluginFilter>('all');
+
+  // One read on open. The catalog is cheap, this panel is the one surface
+  // where "is it installed yet" has to be current, and `refresh` adopts a job
+  // started in another tab while it is at it.
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Focus starts inside the panel and goes back where it came from. Not a
+  // focus trap — Tab still walks out into the page underneath, exactly as it
+  // does in the Package Center and the template gallery. Trapping is worth
+  // doing, but as one change to all of them rather than a divergence here.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    surfaceRef.current?.focus();
+    return () => {
+      if (previouslyFocused && previouslyFocused.isConnected) {
+        previouslyFocused.focus();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      // Something can sit ON TOP of this panel: a confirm dialog (uninstall
+      // asks first), or the shortcuts modal, which renders at `z-index: 9000`
+      // — behind this panel rather than over it — and has no Escape handler of
+      // its own, so swallowing the key is what keeps one press from closing
+      // this panel and leaving a shortcuts window nobody can see.
+      if (useDialogStore.getState().active !== null) return;
+      if (useUIStore.getState().shortcutsModalOpen) return;
+      // The Package Center is a second window with a second Escape handler on
+      // the same key. Both can be open at once — a node badge opens one, the
+      // sidebar the other — and without this, one press would close both.
+      if (useUIStore.getState().packCenterOpen) return;
+      e.preventDefault();
+      close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [close]);
+
+  // Jump to the plugin somebody asked for — from a toast, the sidebar, or the
+  // settings popover. Deliberately waits for the card to EXIST: the request
+  // usually arrives with the panel, before the catalog has answered, and
+  // clearing it early would lose the jump.
+  useEffect(() => {
+    if (focusPluginId === null) return;
+    // Own keys only. The map is a bare object keyed by plugin id, so a plugin
+    // called `constructor` or `toString` would otherwise hand back a FUNCTION
+    // — truthy, and `scrollIntoView` is not one of its methods, so the panel
+    // would die of a TypeError instead of quietly not finding the card.
+    const card = Object.prototype.hasOwnProperty.call(cardRefs.current, focusPluginId)
+      ? cardRefs.current[focusPluginId]
+      : null;
+    if (!card) {
+      // The catalog HAS this plugin and the filter is what is hiding it. A
+      // toast that says "open the Plugin Center on demo" must not land on a
+      // list without demo in it, so the filter gives way to the request.
+      if (
+        filter !== 'all'
+        && Object.prototype.hasOwnProperty.call(byId, focusPluginId)
+      ) {
+        setFilter('all');
+      }
+      return;
+    }
+    card.scrollIntoView({ block: 'nearest' });
+    setHighlighted(focusPluginId);
+    setFocus(null);
+  }, [focusPluginId, plugins, filter, byId, setFocus]);
+
+  // Its own effect, keyed on the highlight rather than on the request: the
+  // request is cleared immediately above, and a timer hung off THAT effect
+  // would be torn down by the very change that cleared it.
+  useEffect(() => {
+    if (highlighted === null) return;
+    const timer = setTimeout(() => setHighlighted(null), HIGHLIGHT_MS);
+    return () => clearTimeout(timer);
+  }, [highlighted]);
+
+  const visible = plugins.filter((entry) => matchesFilter(filter, entry.status));
+
+  return createPortal(
+    <div
+      className={styles.backdrop}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) close();
+      }}
+    >
+      <div
+        ref={surfaceRef}
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('pluginCenter.title')}
+        tabIndex={-1}
+      >
+        <div className={styles.header}>
+          <div className={styles.titleBlock}>
+            <div className={styles.title}>{t('pluginCenter.title')}</div>
+            <div className={styles.subtitle}>{t('pluginCenter.subtitle')}</div>
+          </div>
+          <button
+            type="button"
+            className={styles.iconBtn}
+            onClick={() => void refresh()}
+            disabled={loading}
+            title={t('pluginCenter.refresh')}
+            aria-label={t('pluginCenter.refresh')}
+          >
+            <RefreshIcon />
+          </button>
+          <button
+            type="button"
+            className={styles.closeBtn}
+            onClick={close}
+            title={t('pluginCenter.close')}
+            aria-label={t('pluginCenter.close')}
+          >
+            &#215;
+          </button>
+        </div>
+
+        <div className={styles.body}>
+          <section className={styles.list} aria-label={t('pluginCenter.list')}>
+            {/* The source box and the install review go here, above the
+                filter: they are about a plugin that is not in the list yet. */}
+
+            {/* No filter over a list nobody can act on: a server with no
+                Plugin Center has no rows, and neither has one whose catalog
+                has not answered yet. */}
+            {!unsupported && plugins.length > 0 && (
+              <PluginFilterBar value={filter} onChange={setFilter} />
+            )}
+
+            {/* A refresh over rows that are already on screen must not blank
+                them: only a FIRST read with nothing to show says "loading". */}
+            {loading && plugins.length === 0 && (
+              <div className={styles.stateMessage}>{t('pluginCenter.loading')}</div>
+            )}
+
+            {/* Shown ABOVE the rows rather than instead of them: the store
+                keeps the last good catalog through a failed refresh, and
+                blanking it would turn one dropped packet into an empty Plugin
+                Center. */}
+            {!loading && error !== null && (
+              <div className={styles.stateMessage}>
+                <div className={styles.errorText}>{t('pluginCenter.loadFail', { error })}</div>
+                <button type="button" className={styles.retryBtn} onClick={() => void refresh()}>
+                  {t('palette.retry')}
+                </button>
+              </div>
+            )}
+
+            {unsupported && (
+              <div className={styles.stateMessage}>{t('pluginCenter.unsupported')}</div>
+            )}
+
+            {/* About the CATALOG, not about the filter: "no plugins" over a
+                list the user has just narrowed to Available would be the panel
+                answering its own question wrongly. A filter that matches
+                nothing shows the pressed button and an empty list, which says
+                the same thing without claiming the server has nothing. */}
+            {!loading && !unsupported && error === null && plugins.length === 0 && (
+              <div className={styles.stateMessage}>{t('pluginCenter.empty')}</div>
+            )}
+
+            {visible.map((entry) => (
+              <div
+                key={entry.id}
+                ref={(node) => {
+                  cardRefs.current[entry.id] = node;
+                }}
+              >
+                <PluginCard
+                  entry={entry}
+                  job={job}
+                  busy={busy[entry.id] === true}
+                  highlighted={highlighted === entry.id}
+                  canInstall={remoteInstallAllowed}
+                  onInstall={() => void install(entry.id)}
+                  onUpdate={() => void update(entry.id)}
+                  onUninstall={() => void uninstall(entry.id)}
+                  onSetEnabled={(enabled) => void setEnabled(entry.id, enabled)}
+                />
+              </div>
+            ))}
+          </section>
+
+          {/* The activity pane lands here: what is installing, how far it has
+              got, and how it ended. Its own element already, so that arrival
+              is a swap rather than a second aside. */}
+          <aside className={styles.activity} aria-label={t('packs.activity')} />
+        </div>
+
+        {!remoteInstallAllowed && (
+          <div className={styles.footer}>{t('packs.remoteDisabled')}</div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/PluginCenter/PluginCenterModal.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.tsx
@@ -9,6 +9,7 @@ import { RefreshIcon } from '../shared/Icons';
 // The pack panel's, not a copy: one duration for "this is the row you asked
 // for" across both windows, and one place to change it.
 import { HIGHLIGHT_MS } from '../PackCenter/PackCenterModal';
+import { PluginActivityPane } from './PluginActivityPane';
 import { PluginCard } from './PluginCard';
 import { PluginFilterBar } from './PluginFilterBar';
 import { PluginReviewCard } from './PluginReviewCard';
@@ -36,16 +37,23 @@ export function PluginCenterModal() {
 }
 
 /**
- * The node types *pluginId* registers, as the catalog last said.
+ * The catalog row for *pluginId*, or undefined.
  *
  * Own keys only: `byId` is a bare object built from parsed JSON, so a plugin
- * called `constructor` would otherwise hand back a function and `.nodes`
- * would be undefined on it.
+ * called `constructor` would otherwise hand back a FUNCTION — truthy, with no
+ * `nodes` and no `name` on it.
  */
-function ownNodes(byId: Record<string, PluginCatalogEntry>, pluginId: string): string[] {
+function ownEntry(
+  byId: Record<string, PluginCatalogEntry>, pluginId: string,
+): PluginCatalogEntry | undefined {
   return Object.prototype.hasOwnProperty.call(byId, pluginId)
-    ? byId[pluginId].nodes
-    : [];
+    ? byId[pluginId]
+    : undefined;
+}
+
+/** The node types *pluginId* registers, as the catalog last said. */
+function ownNodes(byId: Record<string, PluginCatalogEntry>, pluginId: string): string[] {
+  return ownEntry(byId, pluginId)?.nodes ?? [];
 }
 
 function PluginCenterBody() {
@@ -62,8 +70,11 @@ function PluginCenterBody() {
   const remoteInstallAllowed = usePluginStore((s) => s.remoteInstallAllowed);
   const job = usePluginStore((s) => s.job);
   const busy = usePluginStore((s) => s.busy);
+  const cancelling = usePluginStore((s) => s.cancelling);
   const inspection = usePluginStore((s) => s.inspection);
   const refresh = usePluginStore((s) => s.refresh);
+  const cancel = usePluginStore((s) => s.cancel);
+  const dismissJob = usePluginStore((s) => s.dismissJob);
   const install = usePluginStore((s) => s.install);
   const inspect = usePluginStore((s) => s.inspect);
   const installInspected = usePluginStore((s) => s.installInspected);
@@ -168,6 +179,10 @@ function PluginCenterBody() {
   }, [highlighted]);
 
   const visible = plugins.filter((entry) => matchesFilter(filter, entry.status));
+  // The row the job is about, for the name it is titled with and the terminal
+  // command a failure offers. Undefined for a plugin the catalog does not
+  // list, which the pane is written to expect.
+  const jobEntry = job === null ? undefined : ownEntry(byId, job.pluginId);
 
   return createPortal(
     <div
@@ -315,10 +330,19 @@ function PluginCenterBody() {
             ))}
           </section>
 
-          {/* The activity pane lands here: what is installing, how far it has
-              got, and how it ended. Its own element already, so that arrival
-              is a swap rather than a second aside. */}
-          <aside className={styles.activity} aria-label={t('packs.activity')} />
+          {/* What is installing, how far it has got, and how it ended. A pure
+              view of the store's job: closing this window cannot interrupt an
+              install, and reopening it picks the same job back up. */}
+          <aside className={styles.activity} aria-label={t('packs.activity')}>
+            <PluginActivityPane
+              job={job}
+              entry={jobEntry}
+              cancelling={cancelling}
+              onCancel={() => void cancel()}
+              onDismiss={dismissJob}
+              onRefresh={() => void refresh()}
+            />
+          </aside>
         </div>
 
         {!remoteInstallAllowed && (

--- a/frontend/src/components/PluginCenter/PluginFilterBar.tsx
+++ b/frontend/src/components/PluginCenter/PluginFilterBar.tsx
@@ -1,0 +1,66 @@
+import type { PluginStatus } from '../../api/rest';
+import { useI18n, type TranslationKey } from '../../i18n';
+import styles from './PluginCenterModal.module.css';
+
+/** Which half of the catalog the list is showing. */
+export type PluginFilter = 'all' | 'installed' | 'available';
+
+/**
+ * Whether a row belongs to the "Available" half.
+ *
+ * Written as the narrow half and negated for the other, so the two halves are
+ * exhaustive by construction: a status this build has never heard of lands
+ * under "Installed" rather than under neither, and no filter can make a row
+ * disappear from both tabs. `removed` is available — a tombstone is a plugin
+ * that is not here and can be put back — while `missing_files` and
+ * `installing` are not: the lockfile has them.
+ */
+export function isAvailableStatus(status: PluginStatus): boolean {
+  return status === 'available' || status === 'removed';
+}
+
+/** Whether *status* passes *filter*. */
+export function matchesFilter(filter: PluginFilter, status: PluginStatus): boolean {
+  if (filter === 'all') return true;
+  return isAvailableStatus(status) === (filter === 'available');
+}
+
+const OPTIONS: { value: PluginFilter; key: TranslationKey }[] = [
+  { value: 'all', key: 'pluginCenter.filter.all' },
+  { value: 'installed', key: 'pluginCenter.filter.installed' },
+  { value: 'available', key: 'pluginCenter.filter.available' },
+];
+
+export interface PluginFilterBarProps {
+  value: PluginFilter;
+  onChange: (value: PluginFilter) => void;
+}
+
+/**
+ * All | Installed | Available.
+ *
+ * Buttons rather than tabs, and `aria-pressed` rather than a class: this
+ * filters a list that is already on screen, so nothing here is a navigation.
+ *
+ * Deliberately three and not five. Official and GitHub are facts the card
+ * states about itself; a filter for each would be two more controls over a
+ * catalog that is a dozen rows long.
+ */
+export function PluginFilterBar({ value, onChange }: PluginFilterBarProps) {
+  const { t } = useI18n();
+
+  return (
+    <div className={styles.filterBar}>
+      {OPTIONS.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          aria-pressed={value === option.value}
+          onClick={() => onChange(option.value)}
+        >
+          {t(option.key)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/PluginCenter/PluginFilterBar.tsx
+++ b/frontend/src/components/PluginCenter/PluginFilterBar.tsx
@@ -1,29 +1,9 @@
-import type { PluginStatus } from '../../api/rest';
 import { useI18n, type TranslationKey } from '../../i18n';
+// The partition itself is a rule, not a control: it lives with the other pure
+// rules, where a test can pin which half `installing` falls in without
+// mounting a bar to press.
+import type { PluginFilter } from './pluginStatus';
 import styles from './PluginCenterModal.module.css';
-
-/** Which half of the catalog the list is showing. */
-export type PluginFilter = 'all' | 'installed' | 'available';
-
-/**
- * Whether a row belongs to the "Available" half.
- *
- * Written as the narrow half and negated for the other, so the two halves are
- * exhaustive by construction: a status this build has never heard of lands
- * under "Installed" rather than under neither, and no filter can make a row
- * disappear from both tabs. `removed` is available — a tombstone is a plugin
- * that is not here and can be put back — while `missing_files` and
- * `installing` are not: the lockfile has them.
- */
-export function isAvailableStatus(status: PluginStatus): boolean {
-  return status === 'available' || status === 'removed';
-}
-
-/** Whether *status* passes *filter*. */
-export function matchesFilter(filter: PluginFilter, status: PluginStatus): boolean {
-  if (filter === 'all') return true;
-  return isAvailableStatus(status) === (filter === 'available');
-}
 
 const OPTIONS: { value: PluginFilter; key: TranslationKey }[] = [
   { value: 'all', key: 'pluginCenter.filter.all' },

--- a/frontend/src/components/PluginCenter/PluginReviewCard.tsx
+++ b/frontend/src/components/PluginCenter/PluginReviewCard.tsx
@@ -1,0 +1,216 @@
+import { useState, type ReactNode } from 'react';
+import type { InspectionState } from '../../store/pluginStore';
+import { useI18n, type TranslationKey } from '../../i18n';
+import {
+  capabilityKey,
+  depSpec,
+  httpUrl,
+  manifestAuthor,
+  provenancePin,
+} from './pluginStatus';
+import packStyles from '../PackCenter/PackCenterModal.module.css';
+import styles from './PluginCenterModal.module.css';
+
+/**
+ * The consent screen: what was found at a source, and what installing it
+ * would cost.
+ *
+ * An inspection is not an install. The server has read a manifest at one
+ * exact commit and is holding it under an `inspection_id`; this card is what
+ * turns that into a yes about THAT version rather than about whatever the
+ * branch holds a minute later. Nothing is sent until every box the manifest
+ * asks for is ticked.
+ *
+ * Rendered only while the review is `ready`. A built-in pack that asks for
+ * nothing never gets here at all -- the store installs it straight from the
+ * inspection, because a dialog whose only answer is yes is not a question.
+ */
+
+/** The review, once the server has answered. */
+type ReadyInspection = Extract<InspectionState, { phase: 'ready' }>;
+
+interface Fact {
+  key: string;
+  node: ReactNode;
+}
+
+export interface PluginReviewCardProps {
+  inspection: ReadyInspection;
+  /**
+   * The node types this plugin already registers, when the catalog knows it.
+   *
+   * An inspection cannot say: naming a plugin's nodes means importing it, and
+   * nothing here runs a line of the code under review. So the line appears
+   * for an update -- where the catalog has the installed row -- and is left
+   * off a first install, where nobody can honestly answer it yet.
+   */
+  nodes: string[];
+  /** This plugin has a request in flight. */
+  busy: boolean;
+  /** False when the server refuses installs from this browser (remote). */
+  canInstall: boolean;
+  onInstall: (opts: {
+    acceptCapabilities: boolean;
+    trustAuthor: boolean;
+    force?: boolean;
+  }) => void;
+  onCancel: () => void;
+}
+
+export function PluginReviewCard({
+  inspection, nodes, busy, canInstall, onInstall, onCancel,
+}: PluginReviewCardProps) {
+  const { t } = useI18n();
+  const { data, error } = inspection;
+
+  const [granted, setGranted] = useState(false);
+  const [trusted, setTrusted] = useState(false);
+
+  const needsGrant = data.capabilities.length > 0;
+  const needsTrust = data.allowed_modules.length > 0;
+  // Every question this manifest asks has an answer. The button is dead
+  // until then, rather than sending an install the server would refuse.
+  const answered = (!needsGrant || granted) && (!needsTrust || trusted);
+
+  // A 409 the server sends as an OFFER: the plugin is already here, and the
+  // review it refused is still spendable. The card keeps everything it was
+  // showing and changes what the button does.
+  const reinstall = error !== null && error.code === 'already_installed';
+  const actionKey: TranslationKey = reinstall
+    ? 'pluginCenter.reinstall'
+    : inspection.kind === 'update'
+      ? 'pluginCenter.update'
+      : 'pluginCenter.install';
+
+  const author = manifestAuthor(data.manifest);
+  const homepage = httpUrl(data.homepage);
+  const deps = Object.entries(data.python_deps).map(([name, spec]) => depSpec(name, spec));
+  // The version is in the header, so a ref that only repeats it is dropped.
+  const pin = provenancePin(data.ref, data.sha, data.version);
+
+  const facts: Fact[] = [];
+  if (author !== null) {
+    facts.push({ key: 'author', node: t('pluginCenter.review.author', { author }) });
+  }
+  if (nodes.length > 0) {
+    facts.push({
+      key: 'nodes', node: t('pluginCenter.review.nodes', { nodes: nodes.join(', ') }),
+    });
+  }
+  if (deps.length > 0) {
+    facts.push({ key: 'deps', node: t('packs.pip', { specs: deps.join(', ') }) });
+  }
+  if (pin !== null) facts.push({ key: 'pin', node: pin });
+  if (homepage !== null) {
+    facts.push({
+      key: 'homepage',
+      node: (
+        <a className={packStyles.linkBtn} href={homepage} target="_blank" rel="noreferrer">
+          {t('pluginCenter.homepage')}
+        </a>
+      ),
+    });
+  }
+
+  return (
+    <section
+      // The accent ring the panel puts on a row somebody asked for: this is
+      // the one card on screen that is waiting for an answer.
+      className={`${packStyles.card} ${packStyles.cardHighlighted}`}
+      aria-label={t('pluginCenter.review.title')}
+      data-review-for={data.plugin_id}
+    >
+      <div className={packStyles.cardMeta}>{t('pluginCenter.review.title')}</div>
+
+      <div className={packStyles.cardHeader}>
+        <span className={packStyles.cardTitle}>{data.name || data.plugin_id}</span>
+        {data.version !== '' && (
+          <span className={packStyles.cardSize}>v{data.version}</span>
+        )}
+      </div>
+
+      {data.description !== '' && (
+        <p className={packStyles.cardDesc}>{data.description}</p>
+      )}
+
+      {facts.length > 0 && (
+        <ul className={packStyles.facts}>
+          {facts.map((fact) => <li key={fact.key}>{fact.node}</li>)}
+        </ul>
+      )}
+
+      {needsGrant && (
+        <>
+          <div className={packStyles.note}>{t('pluginCenter.review.capabilities')}</div>
+          <ul className={packStyles.facts}>
+            {data.capabilities.map((id) => {
+              // An id from a newer server has no line here, and a consent
+              // screen must not silently drop what it is consenting to.
+              const key = capabilityKey(id);
+              return <li key={id}>{key === null ? id : t(key)}</li>;
+            })}
+          </ul>
+          <div className={packStyles.caption}>{t('pluginCenter.review.capNote')}</div>
+          <label className={styles.consentCheck}>
+            <input
+              type="checkbox"
+              className={packStyles.itemCheck}
+              checked={granted}
+              disabled={busy}
+              onChange={(event) => setGranted(event.target.checked)}
+            />
+            {t('pluginCenter.review.grant')}
+          </label>
+        </>
+      )}
+
+      {needsTrust && (
+        <label className={styles.consentCheck}>
+          <input
+            type="checkbox"
+            className={packStyles.itemCheck}
+            checked={trusted}
+            disabled={busy}
+            onChange={(event) => setTrusted(event.target.checked)}
+          />
+          {t('pluginCenter.review.trust', { modules: data.allowed_modules.join(', ') })}
+        </label>
+      )}
+
+      {/* Browser code is a different trust decision from anything the import
+          gate covers: it runs in this editor, with everything the editor has. */}
+      {data.has_frontend && (
+        <div className={packStyles.resultBanner} data-tone="warning">
+          {t('pluginCenter.review.frontend')}
+        </div>
+      )}
+
+      <div className={packStyles.cardActions}>
+        <button
+          type="button"
+          className={packStyles.primaryBtn}
+          disabled={!answered || busy || !canInstall}
+          title={canInstall ? undefined : t('packs.remoteDisabled')}
+          onClick={() => onInstall({
+            // Nothing declared is nothing to withhold, and the store's own
+            // auto-install path sends the (empty) list too: this way every
+            // install body is built the same way.
+            acceptCapabilities: needsGrant ? granted : true,
+            trustAuthor: trusted,
+            ...(reinstall ? { force: true } : {}),
+          })}
+        >
+          {t(actionKey)}
+        </button>
+        <button
+          type="button"
+          className={packStyles.secondaryBtn}
+          disabled={busy}
+          onClick={onCancel}
+        >
+          {t('dialog.cancel')}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/PluginCenter/PluginReviewCard.tsx
+++ b/frontend/src/components/PluginCenter/PluginReviewCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react';
 import type { InspectionState } from '../../store/pluginStore';
 import { useI18n, type TranslationKey } from '../../i18n';
 import {
@@ -37,12 +37,16 @@ interface Fact {
 export interface PluginReviewCardProps {
   inspection: ReadyInspection;
   /**
-   * The node types this plugin already registers, when the catalog knows it.
+   * The node types the catalog says are registered under this plugin id.
    *
-   * An inspection cannot say: naming a plugin's nodes means importing it, and
-   * nothing here runs a line of the code under review. So the line appears
-   * for an update -- where the catalog has the installed row -- and is left
-   * off a first install, where nobody can honestly answer it yet.
+   * An inspection cannot say what a source WOULD register: naming a plugin's
+   * nodes means importing it, and nothing on this path runs a line of the
+   * code under review. So this is what is here now, from a different source
+   * of truth -- and the card prints it only for a fresh install, where the
+   * two cannot disagree. On an update, "what is registered today" is the
+   * version being REPLACED, and this is the one screen whose whole job is
+   * saying what is about to arrive: a plugin that adds a node in the version
+   * under review would have its old set stated as fact.
    */
   nodes: string[];
   /** This plugin has a request in flight. */
@@ -65,6 +69,7 @@ export function PluginReviewCard({
 
   const [granted, setGranted] = useState(false);
   const [trusted, setTrusted] = useState(false);
+  const titleId = useId();
   const cardRef = useRef<HTMLElement | null>(null);
 
   // A review can be raised by the Install button on a row far down the list,
@@ -103,7 +108,9 @@ export function PluginReviewCard({
   if (author !== null) {
     facts.push({ key: 'author', node: t('pluginCenter.review.author', { author }) });
   }
-  if (nodes.length > 0) {
+  // Only for a fresh install: see the prop's docblock. On an update this
+  // would state the outgoing version's nodes as a fact about the incoming one.
+  if (inspection.kind === 'install' && nodes.length > 0) {
     facts.push({
       key: 'nodes', node: t('pluginCenter.review.nodes', { nodes: nodes.join(', ') }),
     });
@@ -129,10 +136,17 @@ export function PluginReviewCard({
       // The accent ring the panel puts on a row somebody asked for: this is
       // the one card on screen that is waiting for an answer.
       className={`${packStyles.card} ${packStyles.cardHighlighted}`}
-      aria-label={t('pluginCenter.review.title')}
+      // Labelled BY the eyebrow rather than with a copy of it: an `aria-label`
+      // saying what the next line already says is the region announced twice.
+      aria-labelledby={titleId}
+      // Which plugin this review is about, for a caller that has to find it:
+      // `forPluginId` never reaches this component, so on a card raised by a
+      // row's button this is the only thing tying the two together.
       data-review-for={data.plugin_id}
     >
-      <div className={packStyles.cardMeta}>{t('pluginCenter.review.title')}</div>
+      <div id={titleId} className={packStyles.cardMeta}>
+        {t('pluginCenter.review.title')}
+      </div>
 
       <div className={packStyles.cardHeader}>
         <span className={packStyles.cardTitle}>{data.name || data.plugin_id}</span>

--- a/frontend/src/components/PluginCenter/PluginReviewCard.tsx
+++ b/frontend/src/components/PluginCenter/PluginReviewCard.tsx
@@ -21,9 +21,14 @@ import styles from './PluginCenterModal.module.css';
  * branch holds a minute later. Nothing is sent until every box the manifest
  * asks for is ticked.
  *
- * Rendered only while the review is `ready`. A built-in pack that asks for
- * nothing never gets here at all -- the store installs it straight from the
- * inspection, because a dialog whose only answer is yes is not a question.
+ * The PANEL decides when this is on screen, and it is not the phase alone:
+ * `PluginCenterModal` renders it while a review is ready AND it is a source
+ * somebody typed (`forPluginId === null`), or the manifest asks for
+ * something, or a refusal a control here can answer came back. That gate is
+ * what keeps a built-in pack -- which asks for nothing and is installed
+ * straight from its own inspection -- from flashing a consent card between
+ * the two round trips; the STORE deliberately leaves the review ready
+ * through that window, so nothing here may be deleted as redundant.
  */
 
 /** The review, once the server has answered. */
@@ -208,6 +213,19 @@ export function PluginReviewCard({
       {data.has_frontend && (
         <div className={packStyles.resultBanner} data-tone="warning">
           {t('pluginCenter.review.frontend')}
+        </div>
+      )}
+
+      {/* The offer said out loud. Without it, pressing Install greys the
+          buttons for a moment and the primary one comes back reading
+          "Reinstall" -- one word changing, as the entire account of what the
+          server answered. The code itself is not showable: it arrives as the
+          bare token `already_installed`. */}
+      {reinstall && (
+        <div className={packStyles.resultBanner} data-tone="warning">
+          {t('pluginCenter.review.alreadyInstalled', {
+            plugin: data.name || data.plugin_id,
+          })}
         </div>
       )}
 

--- a/frontend/src/components/PluginCenter/PluginReviewCard.tsx
+++ b/frontend/src/components/PluginCenter/PluginReviewCard.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import type { InspectionState } from '../../store/pluginStore';
 import { useI18n, type TranslationKey } from '../../i18n';
 import {
@@ -65,6 +65,17 @@ export function PluginReviewCard({
 
   const [granted, setGranted] = useState(false);
   const [trusted, setTrusted] = useState(false);
+  const cardRef = useRef<HTMLElement | null>(null);
+
+  // A review can be raised by the Install button on a row far down the list,
+  // and this card renders at the TOP of it. Without this, clicking Install on
+  // the eighth plugin looks like nothing happened at all.
+  //
+  // Once per review: the panel keys this component on the inspection id, so a
+  // second Review remounts rather than re-runs.
+  useEffect(() => {
+    cardRef.current?.scrollIntoView({ block: 'nearest' });
+  }, []);
 
   const needsGrant = data.capabilities.length > 0;
   const needsTrust = data.allowed_modules.length > 0;
@@ -114,6 +125,7 @@ export function PluginReviewCard({
 
   return (
     <section
+      ref={cardRef}
       // The accent ring the panel puts on a row somebody asked for: this is
       // the one card on screen that is waiting for an answer.
       className={`${packStyles.card} ${packStyles.cardHighlighted}`}

--- a/frontend/src/components/PluginCenter/PluginSourceForm.tsx
+++ b/frontend/src/components/PluginCenter/PluginSourceForm.tsx
@@ -1,0 +1,152 @@
+import { useId, useState, type FormEvent } from 'react';
+import type { InspectionFailure, InspectionState } from '../../store/pluginStore';
+import { useI18n } from '../../i18n';
+import { parseGitHubSource, type Translate } from './pluginStatus';
+import packStyles from '../PackCenter/PackCenterModal.module.css';
+import styles from './PluginCenterModal.module.css';
+
+/**
+ * The box you type a repository into.
+ *
+ * Installing something the catalog does not list is the one thing the Plugin
+ * Center does that the Package Center has no equivalent for, and it is a
+ * two-step conversation: this box asks the server to READ a source, and the
+ * review card that follows is what accepts what it found. Nothing here
+ * installs anything.
+ *
+ * A pure view of `pluginStore.inspection` apart from what has been typed:
+ * the phase decides what the button says, and a refusal that phase carries is
+ * printed under the row.
+ */
+
+/** *detail*'s *key* when it is a non-empty string, else null. */
+function text(detail: Record<string, unknown> | null, key: string): string | null {
+  const value = detail?.[key];
+  return typeof value === 'string' && value !== '' ? value : null;
+}
+
+/** The string members of *detail*'s *key*, or nothing at all. */
+function list(detail: Record<string, unknown> | null, key: string): string[] {
+  const value = detail?.[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+/**
+ * What a refused inspection should read as: the complaint, and the offer
+ * under it when the refusal carried one.
+ *
+ * Two of these codes are answered here rather than by `REFUSAL_KEY`, because
+ * the useful half of each is in the BODY and not in the code: which id is
+ * taken, and which names would have worked. A sentence written server-side
+ * could not have said either.
+ */
+function refusalLines(
+  t: Translate, failure: InspectionFailure, source: string,
+): { message: string; hint: string | null } {
+  if (failure.code === 'reserved_id') {
+    return {
+      message: t('pluginCenter.review.idConflict', {
+        id: text(failure.detail, 'id') ?? source,
+      }),
+      hint: null,
+    };
+  }
+  if (failure.code === 'unknown_catalog_name') {
+    const known = list(failure.detail, 'known');
+    return {
+      message: t('pluginCenter.source.unknownName', { source }),
+      hint: known.length === 0
+        ? null
+        : t('pluginCenter.source.knownNames', { known: known.join(', ') }),
+    };
+  }
+  // Everything else already has its sentence: the store maps a coded refusal
+  // to one before it ever reaches a component, so `message` is prose.
+  return {
+    message: t('pluginCenter.source.fail', { source, message: failure.message }),
+    hint: null,
+  };
+}
+
+export interface PluginSourceFormProps {
+  inspection: InspectionState;
+  /** False when the server refuses installs from this browser (remote). */
+  canInstall: boolean;
+  onReview: (source: string) => void;
+}
+
+export function PluginSourceForm({
+  inspection, canInstall, onReview,
+}: PluginSourceFormProps) {
+  const { t } = useI18n();
+  const inputId = useId();
+  const [source, setSource] = useState('');
+  // Typed something that is not a source. Local, because nothing was sent:
+  // the store has no state for a request that was never made.
+  const [invalid, setInvalid] = useState(false);
+
+  const inspecting = inspection.phase === 'inspecting';
+  const typed = source.trim();
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    if (typed === '') return;
+    if (parseGitHubSource(typed) === null) {
+      // Refused without a round trip. The server would answer 400
+      // `unparseable_source` to the same string, and this is the one refusal
+      // a client can be sure of on its own — so the sentence appears as fast
+      // as the keystroke that earned it.
+      setInvalid(true);
+      return;
+    }
+    setInvalid(false);
+    onReview(typed);
+  };
+
+  // The newest fact wins: a source that never left this browser is what the
+  // user just did, and a stale failure from the last request under it would
+  // be two complaints about one box.
+  const refusal = invalid
+    ? { message: t('pluginCenter.source.invalid'), hint: null }
+    : inspection.phase === 'error'
+      ? refusalLines(t, inspection.failure, inspection.source)
+      : null;
+
+  return (
+    <form className={styles.sourceForm} onSubmit={submit}>
+      <label htmlFor={inputId}>{t('pluginCenter.source.label')}</label>
+      <input
+        id={inputId}
+        type="text"
+        value={source}
+        placeholder={t('pluginCenter.source.placeholder')}
+        onChange={(event) => setSource(event.target.value)}
+        aria-invalid={invalid || undefined}
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <button
+        type="submit"
+        className={packStyles.primaryBtn}
+        disabled={inspecting || typed === '' || !canInstall}
+        // The footer prints this sentence once; a button that is off because
+        // of it says so where the pointer already is.
+        title={canInstall ? undefined : t('packs.remoteDisabled')}
+      >
+        {inspecting ? t('pluginCenter.source.reviewing') : t('pluginCenter.source.review')}
+      </button>
+
+      {refusal !== null && (
+        <div className={styles.sourceError} role="alert">
+          <div>{refusal.message}</div>
+          {/* The names that WOULD have worked are an offer, not part of the
+              complaint, so they keep the block and drop its colour. */}
+          {refusal.hint !== null && (
+            <div className={styles.sourceHint}>{refusal.hint}</div>
+          )}
+        </div>
+      )}
+    </form>
+  );
+}

--- a/frontend/src/components/PluginCenter/PluginSourceForm.tsx
+++ b/frontend/src/components/PluginCenter/PluginSourceForm.tsx
@@ -81,6 +81,7 @@ export function PluginSourceForm({
 }: PluginSourceFormProps) {
   const { t } = useI18n();
   const inputId = useId();
+  const errorId = useId();
   const [source, setSource] = useState('');
   // Typed something that is not a source. Local, because nothing was sent:
   // the store has no state for a request that was never made.
@@ -121,8 +122,17 @@ export function PluginSourceForm({
         type="text"
         value={source}
         placeholder={t('pluginCenter.source.placeholder')}
-        onChange={(event) => setSource(event.target.value)}
+        onChange={(event) => {
+          setSource(event.target.value);
+          // Withdrawn on the keystroke, because it was earned on one: this
+          // build judged the STRING, so the moment the string changes the
+          // judgement is about something that is no longer in the box.
+          setInvalid(false);
+        }}
         aria-invalid={invalid || undefined}
+        // `role="alert"` announces a refusal when it arrives; this is what
+        // says it again to somebody who tabs back into the field.
+        aria-describedby={refusal === null ? undefined : errorId}
         autoComplete="off"
         spellCheck={false}
       />
@@ -138,7 +148,7 @@ export function PluginSourceForm({
       </button>
 
       {refusal !== null && (
-        <div className={styles.sourceError} role="alert">
+        <div id={errorId} className={styles.sourceError} role="alert">
           <div>{refusal.message}</div>
           {/* The names that WOULD have worked are an offer, not part of the
               complaint, so they keep the block and drop its colour. */}

--- a/frontend/src/components/PluginCenter/escapeStacking.test.tsx
+++ b/frontend/src/components/PluginCenter/escapeStacking.test.tsx
@@ -2,30 +2,41 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, render } from '@testing-library/react';
 import { useDialogStore } from '../../store/dialogStore';
 import { usePackStore, _resetPackStoreForTesting } from '../../store/packStore';
+import { usePluginStore, _resetPluginStoreForTesting } from '../../store/pluginStore';
 import { useUIStore } from '../../store/uiStore';
 import { useI18n } from '../../i18n';
 import { PackCenterModal } from '../PackCenter/PackCenterModal';
+import { PluginCenterModal } from './PluginCenterModal';
 
 /**
  * One Escape key, two centers.
  *
  * The Package Center and the Plugin Center are separate windows with separate
- * Escape handlers, and both can be on screen at once -- a toast from either
- * store offers to open the other, and toasts sit above a modal. Each one
- * therefore stands down while the other is open, the same way both already
- * stand down for a confirm dialog and for the shortcuts modal.
+ * Escape handlers, and both can be on screen at once: each is reachable from
+ * Settings and from the sidebar's Custom & Plugins tab, so one can be opened
+ * over the other in either order.
  *
- * This case is the PACK side of that pair, and it lives here rather than in
- * `PackCenter/PackCenterModal.test.tsx` because that file is a frozen gate
- * for this branch: the Plugin Center reuses the pack panel's stylesheet, its
- * pill and its job follower, and the pack tests staying byte-identical is
- * what proves none of that reuse changed the panel it came from. The
- * PLUGIN side of the same rule is in `PluginCenterModal.test.tsx`, under
- * "leaves Escape alone while something is stacked above it".
+ * The rule is that the top-most window closes and the one underneath stands
+ * down -- and "top-most" is a fact rather than an assumption about who opened
+ * first: the Plugin Center's backdrop renders one z-index rung above the pack
+ * one. Both handlers are on `window`, registered in OPEN order (each panel
+ * renders null while closed, so its listener does not exist until it opens),
+ * which is why the pack guard alone is not enough: with the Package Center
+ * opened first its handler runs first, reads a `pluginCenterOpen` the plugin
+ * handler has not cleared yet, and stands down; with the Plugin Center opened
+ * first, the plugin handler runs first, closes, and `stopImmediatePropagation`
+ * is what keeps the pack handler from acting on a store the same press has
+ * already changed.
+ *
+ * Both orders live here rather than in `PackCenter/PackCenterModal.test.tsx`
+ * because that file is a frozen gate for this branch: the Plugin Center reuses
+ * the pack panel's stylesheet, its pill and its job follower, and the pack
+ * tests staying byte-identical is what proves none of that reuse changed the
+ * panel it came from.
  */
 
 /** Fresh mocks for every action the pack panel calls on mount. */
-function makeActions() {
+function makePackActions() {
   return {
     refresh: vi.fn(async () => {}),
     install: vi.fn(async () => {}),
@@ -35,6 +46,29 @@ function makeActions() {
     stopFollowing: vi.fn(() => {}),
   };
 }
+
+/** The same for the plugin panel, whose body reads the catalog on mount. */
+function makePluginActions() {
+  return {
+    refresh: vi.fn(async () => {}),
+    cancel: vi.fn(async () => {}),
+    dismissJob: vi.fn(() => {}),
+  };
+}
+
+/** Both panels mounted and closed, so opening one is what registers its key. */
+function renderBoth() {
+  return render(
+    <>
+      <PackCenterModal />
+      <PluginCenterModal />
+    </>,
+  );
+}
+
+const escape = () => act(() => {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+});
 
 beforeEach(() => {
   useI18n.setState({ locale: 'en' });
@@ -47,15 +81,17 @@ beforeEach(() => {
     shortcutsModalOpen: false,
   });
   _resetPackStoreForTesting();
+  _resetPluginStoreForTesting();
   // Actions installed through setState, never `vi.spyOn` on a getState()
-  // snapshot: the panel reads `refresh` on mount, and a spy taken off a
+  // snapshot: both panels read `refresh` on mount, and a spy taken off a
   // snapshot outlives the store it was taken from.
-  usePackStore.setState({ loaded: true, ...makeActions() });
+  usePackStore.setState({ loaded: true, ...makePackActions() });
+  usePluginStore.setState({ loaded: true, ...makePluginActions() });
 });
 
 afterEach(() => {
-  // Inside act(): this runs BEFORE Testing Library's cleanup, so the panel is
-  // still mounted and subscribed when `packCenterOpen` goes false.
+  // Inside act(): this runs BEFORE Testing Library's cleanup, so both panels
+  // are still mounted and subscribed when their flags go false.
   act(() => {
     useUIStore.setState({
       packCenterOpen: false,
@@ -68,24 +104,44 @@ afterEach(() => {
 });
 
 describe('the Package Center and the Plugin Center on one Escape key', () => {
-  it('leaves Escape to the Plugin Center while both are open', () => {
+  it('closes the Plugin Center first when the Package Center opened first', () => {
+    renderBoth();
     act(() => {
       useUIStore.getState().openPackCenter();
+    });
+    act(() => {
       useUIStore.getState().openPluginCenter();
     });
-    render(<PackCenterModal />);
 
-    act(() => {
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-    });
-    // The window underneath must not be the one that closes: the Plugin
-    // Center is the later portal and the one the user is looking at.
+    escape();
+
+    // The window underneath must not be the one that closes.
+    expect(useUIStore.getState().pluginCenterOpen).toBe(false);
     expect(useUIStore.getState().packCenterOpen).toBe(true);
 
+    escape();
+    expect(useUIStore.getState().packCenterOpen).toBe(false);
+  });
+
+  it('closes the Plugin Center first when it opened first', () => {
+    // The order the pack guard alone gets wrong: the pack handler is
+    // registered first, so it runs after the plugin handler has already
+    // written `pluginCenterOpen: false` -- and would close a second window on
+    // one press.
+    renderBoth();
     act(() => {
-      useUIStore.getState().closePluginCenter();
-      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      useUIStore.getState().openPluginCenter();
     });
+    act(() => {
+      useUIStore.getState().openPackCenter();
+    });
+
+    escape();
+
+    expect(useUIStore.getState().pluginCenterOpen).toBe(false);
+    expect(useUIStore.getState().packCenterOpen).toBe(true);
+
+    escape();
     expect(useUIStore.getState().packCenterOpen).toBe(false);
   });
 });

--- a/frontend/src/components/PluginCenter/escapeStacking.test.tsx
+++ b/frontend/src/components/PluginCenter/escapeStacking.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { useDialogStore } from '../../store/dialogStore';
+import { usePackStore, _resetPackStoreForTesting } from '../../store/packStore';
+import { useUIStore } from '../../store/uiStore';
+import { useI18n } from '../../i18n';
+import { PackCenterModal } from '../PackCenter/PackCenterModal';
+
+/**
+ * One Escape key, two centers.
+ *
+ * The Package Center and the Plugin Center are separate windows with separate
+ * Escape handlers, and both can be on screen at once -- a toast from either
+ * store offers to open the other, and toasts sit above a modal. Each one
+ * therefore stands down while the other is open, the same way both already
+ * stand down for a confirm dialog and for the shortcuts modal.
+ *
+ * This case is the PACK side of that pair, and it lives here rather than in
+ * `PackCenter/PackCenterModal.test.tsx` because that file is a frozen gate
+ * for this branch: the Plugin Center reuses the pack panel's stylesheet, its
+ * pill and its job follower, and the pack tests staying byte-identical is
+ * what proves none of that reuse changed the panel it came from. The
+ * PLUGIN side of the same rule is in `PluginCenterModal.test.tsx`, under
+ * "leaves Escape alone while something is stacked above it".
+ */
+
+/** Fresh mocks for every action the pack panel calls on mount. */
+function makeActions() {
+  return {
+    refresh: vi.fn(async () => {}),
+    install: vi.fn(async () => {}),
+    cancel: vi.fn(async () => {}),
+    removeItem: vi.fn(async () => {}),
+    dismissJob: vi.fn(() => {}),
+    stopFollowing: vi.fn(() => {}),
+  };
+}
+
+beforeEach(() => {
+  useI18n.setState({ locale: 'en' });
+  useDialogStore.setState({ active: null });
+  useUIStore.setState({
+    packCenterOpen: false,
+    packCenterFocusPackId: null,
+    pluginCenterOpen: false,
+    pluginCenterFocusPluginId: null,
+    shortcutsModalOpen: false,
+  });
+  _resetPackStoreForTesting();
+  // Actions installed through setState, never `vi.spyOn` on a getState()
+  // snapshot: the panel reads `refresh` on mount, and a spy taken off a
+  // snapshot outlives the store it was taken from.
+  usePackStore.setState({ loaded: true, ...makeActions() });
+});
+
+afterEach(() => {
+  // Inside act(): this runs BEFORE Testing Library's cleanup, so the panel is
+  // still mounted and subscribed when `packCenterOpen` goes false.
+  act(() => {
+    useUIStore.setState({
+      packCenterOpen: false,
+      packCenterFocusPackId: null,
+      pluginCenterOpen: false,
+      pluginCenterFocusPluginId: null,
+    });
+  });
+  vi.restoreAllMocks();
+});
+
+describe('the Package Center and the Plugin Center on one Escape key', () => {
+  it('leaves Escape to the Plugin Center while both are open', () => {
+    act(() => {
+      useUIStore.getState().openPackCenter();
+      useUIStore.getState().openPluginCenter();
+    });
+    render(<PackCenterModal />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    // The window underneath must not be the one that closes: the Plugin
+    // Center is the later portal and the one the user is looking at.
+    expect(useUIStore.getState().packCenterOpen).toBe(true);
+
+    act(() => {
+      useUIStore.getState().closePluginCenter();
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(useUIStore.getState().packCenterOpen).toBe(false);
+  });
+});

--- a/frontend/src/components/PluginCenter/pluginStatus.test.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.test.ts
@@ -7,6 +7,7 @@ import {
   depSpec,
   httpUrl,
   isAvailableStatus,
+  isInstalledStatus,
   manifestAuthor,
   matchesFilter,
   originLabel,
@@ -135,6 +136,32 @@ describe('isAvailableStatus', () => {
   it('puts a status this build has never heard of on the installed side', () => {
     // Written as the narrow half and negated for the other, so no filter can
     // make a row disappear from both tabs.
+    expect(isAvailableStatus('quarantined' as PluginStatus)).toBe(false);
+  });
+});
+
+describe('isInstalledStatus', () => {
+  it('calls a plugin installed when its files are here, switched on or not', () => {
+    expect(isInstalledStatus('installed')).toBe(true);
+    expect(isInstalledStatus('disabled')).toBe(true);
+    expect(isInstalledStatus('available')).toBe(false);
+    expect(isInstalledStatus('removed')).toBe(false);
+  });
+
+  it('is NOT the filter negated: two statuses are in neither count', () => {
+    // The sidebar list and the settings summary answer "what have I got" and
+    // "what can I get". A download in flight is neither, and a lockfile entry
+    // with no directory is neither -- while the FILTER has to put both
+    // somewhere, so that no row vanishes from both of its tabs.
+    for (const status of ['installing', 'missing_files'] as PluginStatus[]) {
+      expect(isInstalledStatus(status)).toBe(false);
+      expect(isAvailableStatus(status)).toBe(false);
+      expect(isInstalledStatus(status)).not.toBe(!isAvailableStatus(status));
+    }
+  });
+
+  it('leaves a status this build has never heard of out of both counts', () => {
+    expect(isInstalledStatus('quarantined' as PluginStatus)).toBe(false);
     expect(isAvailableStatus('quarantined' as PluginStatus)).toBe(false);
   });
 });

--- a/frontend/src/components/PluginCenter/pluginStatus.test.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.test.ts
@@ -4,9 +4,11 @@ import { useI18n } from '../../i18n';
 import {
   capabilityKey,
   cliInstallCommand,
+  depSpec,
   isAvailableStatus,
   matchesFilter,
   originLabel,
+  provenancePin,
   parseGitHubSource,
   statusKey,
   statusTone,
@@ -245,6 +247,53 @@ describe('originLabel', () => {
     // What is actually being loaded is the folder on disk, whoever wrote it.
     expect(originLabel(entry({ id: 'demo', official: true, source_kind: 'local' })))
       .toBe('pluginCenter.origin.local');
+  });
+});
+
+describe('provenancePin', () => {
+  it('names the ref and the seven characters of the commit', () => {
+    expect(provenancePin('main', 'abcdef1234567890', '1.2.0')).toBe('main @ abcdef1');
+  });
+
+  it('says the commit alone for a default-branch install', () => {
+    // '' is the server saying "the default branch", not a missing value: a
+    // bare `@` would read as a pin that lost half of itself.
+    expect(provenancePin('', 'abcdef1234567890', '1.2.0')).toBe('abcdef1');
+    expect(provenancePin(null, 'abcdef1234567890', null)).toBe('abcdef1');
+  });
+
+  it('drops a ref that only repeats the version the header prints', () => {
+    // A card's header says `v1.2.0`. `v1.2.0 @ abcdef1` under it is one
+    // release wearing two rows -- and the tag and the bare number are the
+    // same release named two ways.
+    expect(provenancePin('v1.2.0', 'abcdef1234567890', '1.2.0')).toBe('abcdef1');
+    expect(provenancePin('1.2.0', 'abcdef1234567890', '1.2.0')).toBe('abcdef1');
+    // A ref that says something else keeps its half.
+    expect(provenancePin('v1.3.0', 'abcdef1234567890', '1.2.0')).toBe('v1.3.0 @ abcdef1');
+  });
+
+  it('has nothing to pin without a commit', () => {
+    expect(provenancePin('main', null, '1.2.0')).toBeNull();
+    // A lockfile entry for a built-in records `''` rather than null, and
+    // `''.slice(0, 7)` is an empty phrase on the meta line.
+    expect(provenancePin('main', '', '1.2.0')).toBeNull();
+  });
+});
+
+describe('depSpec', () => {
+  it('uses an operator-led constraint exactly as the manifest wrote it', () => {
+    expect(depSpec('model2vec', '>=0.8.0')).toBe('model2vec>=0.8.0');
+    expect(depSpec('numpy', '~=1.24')).toBe('numpy~=1.24');
+  });
+
+  it('pins a bare version, the way the installer would', () => {
+    // `torch = "2.1.0"` in a manifest means that version, and `uv pip install
+    // torch2.1.0` is not a spec. `_build_dep_spec` adds the `==`; so does this.
+    expect(depSpec('torch', '2.1.0')).toBe('torch==2.1.0');
+  });
+
+  it('leaves a name alone when nothing is constrained', () => {
+    expect(depSpec('requests', '')).toBe('requests');
   });
 });
 

--- a/frontend/src/components/PluginCenter/pluginStatus.test.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { PluginCatalogEntry, PluginStatus } from '../../api/rest';
+import { useI18n } from '../../i18n';
+import {
+  capabilityKey,
+  cliInstallCommand,
+  originLabel,
+  parseGitHubSource,
+  statusKey,
+  statusTone,
+  stepLabel,
+} from './pluginStatus';
+
+/**
+ * The Plugin Center's pure rules.
+ *
+ * Every case here is a value that arrives from a SERVER: a status, a step id,
+ * a capability name, a row with half its fields null. What is pinned is what
+ * this build does with one it has never seen, because that is the answer the
+ * panel cannot be tested for once it is on screen.
+ */
+
+function entry(
+  partial: Partial<PluginCatalogEntry> & { id: string },
+): PluginCatalogEntry {
+  return {
+    name: partial.id,
+    description: '',
+    kind: 'github',
+    official: false,
+    status: 'available',
+    source_kind: null,
+    source: '',
+    repo: null,
+    ref: null,
+    sha: null,
+    url: null,
+    homepage: '',
+    version: null,
+    installed_at: null,
+    enabled: false,
+    chapters: [],
+    lessons: [],
+    tags: [],
+    nodes: [],
+    node_count: 0,
+    capabilities: [],
+    trusted_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    consent_required: false,
+    frontend_entry: null,
+    job: null,
+    ...partial,
+  };
+}
+
+const t = useI18n.getState().t;
+
+beforeEach(() => {
+  useI18n.setState({ locale: 'en' });
+});
+
+// ── status ───────────────────────────────────────────────────────────────
+
+describe('statusTone', () => {
+  it('greens what is here and blues what is arriving', () => {
+    expect(statusTone('installed')).toBe('success');
+    expect(statusTone('installing')).toBe('info');
+  });
+
+  it('warns only about the status that is actually wrong', () => {
+    // The registry has the plugin and its directory is gone. Everything else
+    // below is a state the user chose, and dressing a deliberate switch-off
+    // as a warning would say something went wrong.
+    expect(statusTone('missing_files')).toBe('warning');
+    expect(statusTone('disabled')).toBe('neutral');
+    expect(statusTone('removed')).toBe('neutral');
+    expect(statusTone('available')).toBe('neutral');
+  });
+
+  it('reads a status this build has never heard of as neutral', () => {
+    expect(statusTone('quarantined' as PluginStatus)).toBe('neutral');
+  });
+});
+
+describe('statusKey', () => {
+  it('labels every status the catalog can send', () => {
+    expect(t(statusKey('installed'))).toBe('Installed');
+    expect(t(statusKey('disabled'))).toBe('Disabled');
+    expect(t(statusKey('available'))).toBe('Not installed');
+    expect(t(statusKey('installing'))).toBe('Installing');
+    expect(t(statusKey('removed'))).toBe('Removed');
+    expect(t(statusKey('missing_files'))).toBe('Files missing');
+  });
+
+  it('falls back to "not installed" for a status off a newer server', () => {
+    // The safe reading: it offers an Install button rather than claiming
+    // something is in place. `undefined` would render as the raw key.
+    expect(t(statusKey('quarantined' as PluginStatus))).toBe('Not installed');
+  });
+
+  it('translates with the locale, not with the call site', () => {
+    useI18n.setState({ locale: 'zh-TW' });
+    expect(t(statusKey('missing_files'))).toBe('檔案遺失');
+  });
+});
+
+// ── steps ────────────────────────────────────────────────────────────────
+
+describe('stepLabel', () => {
+  it('has a sentence for all eight steps a plugin job emits', () => {
+    // The server's own label is a log line ("Scanning demo for unsafe code");
+    // it is passed in here to prove the id wins over it.
+    expect(stepLabel(t, 'resolve', 'Resolving owner/demo')).toBe('Resolving the source');
+    expect(stepLabel(t, 'download', 'Downloading owner/demo@abc')).toBe('Downloading');
+    expect(stepLabel(t, 'extract', 'Unpacking demo')).toBe('Unpacking');
+    expect(stepLabel(t, 'verify', 'Scanning demo')).toBe('Checking the code');
+    expect(stepLabel(t, 'stage', 'Installing demo')).toBe('Copying files');
+    expect(stepLabel(t, 'lock', 'Recording demo')).toBe('Recording the install');
+    expect(stepLabel(t, 'reload', 'Loading demo')).toBe('Loading the nodes');
+  });
+
+  it('says pip the way the Package Center says it', () => {
+    // One sentence for one job: `deps` has no key of its own on purpose.
+    expect(stepLabel(t, 'deps', 'Installing requests')).toBe(
+      'Installing Python packages',
+    );
+  });
+
+  it('reads the kind half of an id that carries an item', () => {
+    // No plugin step is shaped this way today; the job protocol allows it,
+    // and a newer backend's `download:tarball` still has to find its
+    // sentence rather than fall through to a log line.
+    expect(stepLabel(t, 'download:tarball', 'Downloading the tarball')).toBe(
+      'Downloading',
+    );
+  });
+
+  it('falls back to the server label, and to the id when there is none', () => {
+    expect(stepLabel(t, 'quarantine', 'Checking the quarantine')).toBe(
+      'Checking the quarantine',
+    );
+    expect(stepLabel(t, 'quarantine', '')).toBe('quarantine');
+  });
+});
+
+// ── capabilities ─────────────────────────────────────────────────────────
+
+describe('capabilityKey', () => {
+  /** The line a card would print for *id*. Throws rather than falling back. */
+  function line(id: string): string {
+    const key = capabilityKey(id);
+    if (key === null) throw new Error(`no capability line for "${id}"`);
+    return t(key);
+  }
+
+  it('says what granting each of the three costs', () => {
+    expect(line('network')).toBe(
+      'network: reach any host, and write what it downloads to disk',
+    );
+    expect(line('filesystem')).toBe(
+      'filesystem: use the file libraries (pathlib, shutil, zip/tar, sqlite3)',
+    );
+    expect(line('process-env')).toContain('the whole os module');
+    // The hyphenated id keeps its wire spelling; only the KEY is camelCase.
+    expect(capabilityKey('process-env')).toBe('pluginCenter.cap.processEnv');
+  });
+
+  it('answers null for an id this build has no line for', () => {
+    // The card prints the raw id then: an unknown capability must still be
+    // visible on a consent screen, not silently dropped.
+    expect(capabilityKey('gpu')).toBeNull();
+    expect(capabilityKey('')).toBeNull();
+  });
+});
+
+// ── origin and the CLI line ──────────────────────────────────────────────
+
+describe('originLabel', () => {
+  it('names the origins that are not obvious from the row', () => {
+    expect(originLabel(entry({ id: 'edu', kind: 'builtin', official: true })))
+      .toBe('pluginCenter.origin.builtin');
+    expect(originLabel(entry({ id: 'demo', official: true })))
+      .toBe('pluginCenter.origin.official');
+    expect(originLabel(entry({ id: 'demo', kind: 'external', source_kind: 'local' })))
+      .toBe('pluginCenter.origin.local');
+  });
+
+  it('says nothing about a plain third-party repository', () => {
+    // The card prints owner/repo beside this; a "GitHub" chip over a GitHub
+    // link is the same fact twice.
+    expect(originLabel(entry({ id: 'demo', repo: 'owner/demo' }))).toBeNull();
+  });
+
+  it('prefers the linked folder to who published it', () => {
+    // What is actually being loaded is the folder on disk, whoever wrote it.
+    expect(originLabel(entry({ id: 'demo', official: true, source_kind: 'local' })))
+      .toBe('pluginCenter.origin.local');
+  });
+});
+
+describe('cliInstallCommand', () => {
+  it('installs a built-in pack by name', () => {
+    expect(cliInstallCommand(entry({ id: 'edu', kind: 'builtin', source: 'edu' })))
+      .toBe('cdui plugin install edu');
+  });
+
+  it('pins the ref a github row was installed at', () => {
+    expect(cliInstallCommand(entry({
+      id: 'demo', repo: 'owner/demo', ref: 'v1.2', source: 'owner/demo',
+    }))).toBe('cdui plugin install owner/demo@v1.2');
+  });
+
+  it('leaves the ref off a default-branch install', () => {
+    // '' is the server's way of saying "the default branch", not a missing
+    // value: `owner/demo@` would be a command that does not run.
+    expect(cliInstallCommand(entry({ id: 'demo', repo: 'owner/demo', ref: '' })))
+      .toBe('cdui plugin install owner/demo');
+  });
+
+  it('falls back to the source, and then to the id', () => {
+    expect(cliInstallCommand(entry({ id: 'demo', source: 'owner/demo' })))
+      .toBe('cdui plugin install owner/demo');
+    expect(cliInstallCommand(entry({ id: 'demo' }))).toBe('cdui plugin install demo');
+  });
+});
+
+// ── the re-export ────────────────────────────────────────────────────────
+
+describe('parseGitHubSource', () => {
+  it('is the store parser, so the form and the store agree on a source', () => {
+    expect(parseGitHubSource('owner/demo@v1')).toEqual({
+      kind: 'github', owner: 'owner', repo: 'demo', ref: 'v1',
+    });
+    expect(parseGitHubSource('not a repo!')).toBeNull();
+  });
+});

--- a/frontend/src/components/PluginCenter/pluginStatus.test.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.test.ts
@@ -5,7 +5,9 @@ import {
   capabilityKey,
   cliInstallCommand,
   depSpec,
+  httpUrl,
   isAvailableStatus,
+  manifestAuthor,
   matchesFilter,
   originLabel,
   provenancePin,
@@ -294,6 +296,46 @@ describe('depSpec', () => {
 
   it('leaves a name alone when nothing is constrained', () => {
     expect(depSpec('requests', '')).toBe('requests');
+  });
+});
+
+describe('manifestAuthor', () => {
+  it('reads the list the scaffolded manifest writes', () => {
+    expect(manifestAuthor({ plugin: { authors: ['Ada', 'Grace'] } })).toBe('Ada, Grace');
+  });
+
+  it('takes the singular a hand-written manifest as often has', () => {
+    expect(manifestAuthor({ plugin: { author: '  Ada  ' } })).toBe('Ada');
+  });
+
+  it('says nothing rather than something it cannot read', () => {
+    // A manifest is hand-written, and an inspection echoes it whole and
+    // unvalidated: `[object Object]` on a consent screen is worse than no
+    // line at all.
+    expect(manifestAuthor({})).toBeNull();
+    expect(manifestAuthor({ plugin: {} })).toBeNull();
+    expect(manifestAuthor({ plugin: { authors: [] } })).toBeNull();
+    expect(manifestAuthor({ plugin: { authors: [{ name: 'Ada' }] } })).toBeNull();
+    expect(manifestAuthor({ plugin: { author: '   ' } })).toBeNull();
+    expect(manifestAuthor({ plugin: 'Ada' })).toBeNull();
+  });
+});
+
+describe('httpUrl', () => {
+  it('passes a web address through', () => {
+    expect(httpUrl('https://example.com/demo')).toBe('https://example.com/demo');
+    expect(httpUrl('  http://example.com  ')).toBe('http://example.com');
+  });
+
+  it('refuses a scheme that would run rather than navigate', () => {
+    // The homepage comes out of a manifest at a source NOBODY has installed
+    // yet, and the review card is the one screen that asks the user to trust
+    // it: a `javascript:` href there runs inside the editor on a click.
+    expect(httpUrl('javascript:alert(1)')).toBeNull();
+    expect(httpUrl('data:text/html,<script>alert(1)</script>')).toBeNull();
+    expect(httpUrl('file:///etc/passwd')).toBeNull();
+    expect(httpUrl('example.com')).toBeNull();
+    expect(httpUrl('')).toBeNull();
   });
 });
 

--- a/frontend/src/components/PluginCenter/pluginStatus.test.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.test.ts
@@ -4,6 +4,8 @@ import { useI18n } from '../../i18n';
 import {
   capabilityKey,
   cliInstallCommand,
+  isAvailableStatus,
+  matchesFilter,
   originLabel,
   parseGitHubSource,
   statusKey,
@@ -106,10 +108,56 @@ describe('statusKey', () => {
   });
 });
 
+// ── the filter ───────────────────────────────────────────────────────────
+
+describe('isAvailableStatus', () => {
+  it('calls a plugin available when it is not here and could be', () => {
+    expect(isAvailableStatus('available')).toBe(true);
+    // A tombstone is a plugin that is not here and can be put back.
+    expect(isAvailableStatus('removed')).toBe(true);
+    expect(isAvailableStatus('installed')).toBe(false);
+    expect(isAvailableStatus('disabled')).toBe(false);
+  });
+
+  it('reads a row the lockfile has as installed, however wrong it is', () => {
+    // The two statuses that are neither "here" nor "not here": one is being
+    // written and one lost its directory. Both are IN the lockfile, so both
+    // belong to the Installed half -- under Available they would offer to
+    // install what is already being installed.
+    expect(isAvailableStatus('installing')).toBe(false);
+    expect(isAvailableStatus('missing_files')).toBe(false);
+  });
+
+  it('puts a status this build has never heard of on the installed side', () => {
+    // Written as the narrow half and negated for the other, so no filter can
+    // make a row disappear from both tabs.
+    expect(isAvailableStatus('quarantined' as PluginStatus)).toBe(false);
+  });
+});
+
+describe('matchesFilter', () => {
+  it('lets everything past the All tab', () => {
+    expect(matchesFilter('all', 'available')).toBe(true);
+    expect(matchesFilter('all', 'installed')).toBe(true);
+  });
+
+  it('splits the catalog into two halves with nothing in neither', () => {
+    const statuses: PluginStatus[] = [
+      'installed', 'disabled', 'available', 'removed', 'installing', 'missing_files',
+    ];
+    for (const status of statuses) {
+      expect(matchesFilter('installed', status)).toBe(!matchesFilter('available', status));
+    }
+  });
+});
+
 // ── steps ────────────────────────────────────────────────────────────────
 
 describe('stepLabel', () => {
-  it('has a sentence for all eight steps a plugin job emits', () => {
+  it('has a sentence of its own for seven of the eight steps', () => {
+    // The eighth is `deps`, which shares the Package Center's pip sentence
+    // and is pinned in the case below rather than counted here.
+    //
     // The server's own label is a log line ("Scanning demo for unsafe code");
     // it is passed in here to prove the id wins over it.
     expect(stepLabel(t, 'resolve', 'Resolving owner/demo')).toBe('Resolving the source');

--- a/frontend/src/components/PluginCenter/pluginStatus.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.ts
@@ -1,5 +1,7 @@
 import type { PluginCatalogEntry, PluginStatus } from '../../api/rest';
 import type { TranslationKey } from '../../i18n/locales/en';
+import type { ItemProgress, JobStep } from '../../store/jobFollower';
+import type { PluginJob } from '../../store/pluginStore';
 import type { Translate } from '../PackCenter/packStatus';
 import type { PillTone } from '../shared/Pill';
 
@@ -154,6 +156,104 @@ export function stepLabel(t: Translate, step: string, label: string): string {
   const kind = separator === -1 ? step : step.slice(0, separator);
   const key = STEP_KEY[kind];
   return key === undefined ? label || step : t(key);
+}
+
+// ── how far a job has got ────────────────────────────────────────────────
+
+/**
+ * The one item a plugin job reports bytes for: the repository tarball
+ * (`backend/app/core/plugins/flows.py: _tarball_progress`).
+ *
+ * A plugin install has exactly one download, so this is a NAME rather than a
+ * set to sum -- which is the difference between this pane's bar and the pack
+ * panel's, where a job fetches several models of very different sizes.
+ */
+const TARBALL_ITEM = 'tarball';
+
+/**
+ * How many steps a job of each shape has.
+ *
+ * A GitHub install emits `resolve download extract verify deps stage lock`
+ * plus the `reload` the service adds; a built-in pack has nothing to
+ * download and emits `resolve [deps] lock reload`, where `deps` depends on
+ * its manifest. A denominator, not a promise: the server announces a step as
+ * it STARTS, so `job.steps.length` is the steps heard of so far and dividing
+ * by it would read as 50 % during the second step of eight.
+ */
+const GITHUB_STEP_COUNT = 8;
+const BUILTIN_STEP_COUNT = 4;
+
+/**
+ * How many steps *entry*'s install is expected to take.
+ *
+ * A row the catalog does not have is counted as a GitHub install, which is
+ * both the likely truth (a first install from a typed repository has no row
+ * yet) and the safe guess: the longer shape understates the bar rather than
+ * parking it at full.
+ */
+function expectedSteps(entry: PluginCatalogEntry | undefined): number {
+  return entry?.kind === 'builtin' ? BUILTIN_STEP_COUNT : GITHUB_STEP_COUNT;
+}
+
+function clamp(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+/**
+ * How far the whole job has got, 0..100, or null when nobody can say yet.
+ *
+ * Finished steps out of the steps this shape of install takes -- and never
+ * fewer than the steps already announced, so a server that adds one cannot
+ * push the bar past full. The tarball's bytes refine the step that is
+ * downloading and nothing else: they are ONE step's worth, and the bar that
+ * read 100 % the moment a download ended then sat there through `deps`
+ * (minutes of uv), `stage`, `lock` and `reload` was saying the install was
+ * over at the point where the slow part starts.
+ *
+ * Null (indeterminate) rather than 0 for a job with no steps yet: 0 % about a
+ * job that is clearly working is a wrong number rather than no number, and
+ * the seconds between "the install was accepted" and the first step event are
+ * exactly that job.
+ */
+export function jobOverallPercent(
+  job: PluginJob | null, entry: PluginCatalogEntry | undefined,
+): number | null {
+  if (job === null || job.steps.length === 0) return null;
+
+  const denominator = Math.max(expectedSteps(entry), job.steps.length);
+  const finished = job.steps.filter((step) => step.state === 'done').length;
+
+  const tarball: ItemProgress | undefined = job.items[TARBALL_ITEM];
+  const total = tarball?.bytesTotal ?? null;
+  const downloading = job.steps.some(
+    (step) => step.step === 'download' && step.state === 'running',
+  );
+  // `codeload` streams a tarball it generates on demand and usually sends no
+  // `Content-Length` at all, so no fraction is the ordinary case and the
+  // bytes are the refinement a server that DOES state a size buys. A server
+  // that reports more bytes than it promised is worth no more than one step.
+  const partial = downloading && tarball !== undefined
+    && total !== null && Number.isFinite(total) && total > 0
+    ? Math.min(1, Math.max(0, tarball.bytesDone) / total)
+    : 0;
+
+  return clamp(((finished + partial) / denominator) * 100);
+}
+
+/**
+ * The step the pane should be showing: the one still running, or the last one
+ * to have finished while the next has not been announced yet.
+ *
+ * Takes the STEPS rather than the job, so it says what it needs and stays
+ * usable for any job shape. (The pack panel's equivalent takes a `PackJob`,
+ * which a `PluginJob` is not; widening it there is a change to the Package
+ * Center, which this panel makes none of.)
+ */
+export function currentStep(steps: JobStep[]): { index: number; step: JobStep } | null {
+  if (steps.length === 0) return null;
+  const running = steps.findIndex((step) => step.state === 'running');
+  const index = running === -1 ? steps.length - 1 : running;
+  return { index: index + 1, step: steps[index] };
 }
 
 /**

--- a/frontend/src/components/PluginCenter/pluginStatus.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.ts
@@ -101,6 +101,26 @@ export function matchesFilter(filter: PluginFilter, status: PluginStatus): boole
 }
 
 /**
+ * Whether a plugin is INSTALLED: its files are on disk and the lockfile has
+ * it, whether or not the user has it switched on.
+ *
+ * Deliberately NOT `!isAvailableStatus`, and the two must not be folded
+ * together. The filter above partitions the catalog so that every row lands
+ * in exactly one half; this answers a different question -- "is this plugin
+ * here" -- for the two places that COUNT and LIST plugins outside the panel:
+ * the sidebar's Plugins section and the settings row. `installing` is a
+ * download in progress and `missing_files` is a lockfile entry whose
+ * directory is gone; neither is something to list as installed, and neither
+ * is something the user can install either, so both sit outside both counts.
+ *
+ * This is also exactly what `GET /api/plugins` used to answer, which is what
+ * the sidebar listed before the catalog replaced that call.
+ */
+export function isInstalledStatus(status: PluginStatus): boolean {
+  return status === 'installed' || status === 'disabled';
+}
+
+/**
  * The eight step ids a plugin job emits, as sentences.
  *
  * `deps` is pip, which the pack panel already has a sentence for -- the same

--- a/frontend/src/components/PluginCenter/pluginStatus.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.ts
@@ -214,6 +214,43 @@ export function depSpec(name: string, constraint: string): string {
 }
 
 /**
+ * Who wrote a plugin, out of the manifest it says so in -- or null.
+ *
+ * An inspection has no author field: `[plugin].authors` is optional metadata
+ * nothing installs against, so the wire contract echoes the manifest whole
+ * and leaves reading it to whoever wants to show it. The scaffold writes a
+ * LIST (`authors = []`); a hand-written manifest as often has the singular
+ * string, and both are answers to the same question. Anything else -- a
+ * table, a number, a list of tables -- is dropped rather than stringified,
+ * because `[object Object]` on a consent screen is worse than no line.
+ */
+export function manifestAuthor(manifest: Record<string, unknown>): string | null {
+  const plugin = manifest.plugin;
+  if (typeof plugin !== 'object' || plugin === null) return null;
+  const table = plugin as Record<string, unknown>;
+
+  const names = (Array.isArray(table.authors) ? table.authors : [table.author])
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim())
+    .filter((value) => value !== '');
+  return names.length === 0 ? null : names.join(', ');
+}
+
+/**
+ * *value* when it is a link a browser may follow, else null.
+ *
+ * A homepage is a hand-written field in a manifest at a source NOBODY has
+ * installed yet, and the review card is where it is first shown: a
+ * `javascript:` URL there is a script that runs inside the editor the moment
+ * a reviewer clicks the one link on the screen that asks them to trust this
+ * plugin. Only http(s) survives, which is all a homepage ever is.
+ */
+export function httpUrl(value: string): string | null {
+  const url = value.trim();
+  return /^https?:\/\//i.test(url) ? url : null;
+}
+
+/**
  * The `cdui plugin install ...` line for *entry*, for the terminal fallback
  * the activity pane offers when a job fails.
  *

--- a/frontend/src/components/PluginCenter/pluginStatus.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.ts
@@ -1,0 +1,163 @@
+import type { PluginCatalogEntry, PluginStatus } from '../../api/rest';
+import type { TranslationKey } from '../../i18n/locales/en';
+import type { Translate } from '../PackCenter/packStatus';
+import type { PillTone } from '../shared/Pill';
+
+/**
+ * The pure half of the Plugin Center: everything the panel needs to decide
+ * that does not need a DOM, a store or a clock.
+ *
+ * The same split as `PackCenter/packStatus.ts`, and for the same reason: each
+ * of these is a rule with an edge case worth pinning in a test -- a status
+ * this build has no word for, a step id from a newer backend, a plugin with
+ * no repository to name -- and none of them are worth mounting a modal to
+ * exercise.
+ */
+
+/**
+ * `Translate` is the pack panel's, not a copy: both panels format the same
+ * way, and one signature is what keeps a helper callable from outside React.
+ */
+export type { Translate };
+
+/**
+ * Re-exported from the store because this is where the panel looks for it.
+ *
+ * The source box needs the CLI's grammar to refuse `not a repo!` without a
+ * round trip, and the store needs it to refuse the same string before it
+ * inspects. One exported parser, so the two can never disagree about what a
+ * source is.
+ */
+export { parseGitHubSource } from '../../store/pluginStore';
+
+/**
+ * A plugin status as a tone.
+ *
+ * `disabled` and `removed` are neutral on purpose: both are states the user
+ * chose, and dressing a deliberate switch-off as a warning would say
+ * something went wrong. `missing_files` is the only status that IS wrong --
+ * the registry has the plugin and its directory is gone.
+ */
+export function statusTone(status: PluginStatus): PillTone {
+  switch (status) {
+    case 'installed':
+      return 'success';
+    case 'installing':
+      return 'info';
+    case 'missing_files':
+      return 'warning';
+    default:
+      return 'neutral';
+  }
+}
+
+/**
+ * The label for one plugin status.
+ *
+ * Three of the six reuse the pack panel's words, because "Installed" is
+ * "Installed" and a second translation of it is a second thing to keep in
+ * step; `disabled` reuses the sidebar's. Only the two states packs have no
+ * equivalent for get keys of their own.
+ */
+const STATUS_KEY: Record<PluginStatus, TranslationKey> = {
+  installed: 'packs.status.installed',
+  disabled: 'customNodes.disabled',
+  available: 'packs.status.not_installed',
+  removed: 'pluginCenter.status.removed',
+  installing: 'packs.status.installing',
+  missing_files: 'pluginCenter.status.missingFiles',
+};
+
+export function statusKey(status: PluginStatus): TranslationKey {
+  // A status off a newer server must not render as `undefined`. "Not
+  // installed" is the safe reading: it offers an Install button rather than
+  // claiming something is in place.
+  return STATUS_KEY[status] ?? STATUS_KEY.available;
+}
+
+/**
+ * The eight step ids a plugin job emits, as sentences.
+ *
+ * `deps` is pip, which the pack panel already has a sentence for -- the same
+ * work, said the same way, rather than a second string that has to stay in
+ * step with it.
+ */
+const STEP_KEY: Record<string, TranslationKey | undefined> = {
+  resolve: 'pluginCenter.step.resolve',
+  download: 'pluginCenter.step.download',
+  extract: 'pluginCenter.step.extract',
+  verify: 'pluginCenter.step.verify',
+  deps: 'packs.activity.step.pip',
+  stage: 'pluginCenter.step.stage',
+  lock: 'pluginCenter.step.lock',
+  reload: 'pluginCenter.step.reload',
+};
+
+/**
+ * A job step as a sentence, keyed off the step ID rather than its text.
+ *
+ * The server's `label` is English and written for a log ("Scanning
+ * c1-tokenizer for unsafe code"); the step id is a stable vocabulary this can
+ * translate. An id from a newer backend falls back to that label, which is at
+ * least true, and to the raw id when even the label is empty.
+ */
+export function stepLabel(t: Translate, step: string, label: string): string {
+  // No plugin step carries a `:item` half today, but the job protocol allows
+  // one and the pack panel already splits on it: a `download:tarball` from a
+  // newer backend still has to find the download sentence.
+  const separator = step.indexOf(':');
+  const kind = separator === -1 ? step : step.slice(0, separator);
+  const key = STEP_KEY[kind];
+  return key === undefined ? label || step : t(key);
+}
+
+/**
+ * Where a plugin came from, as a key -- or null when the row says it better
+ * itself.
+ *
+ * A plain third-party repository gets no chip: the card already prints
+ * `owner/repo` beside it, and "GitHub" over a GitHub link is the same fact
+ * twice. `local` outranks `official` because a linked folder is what is
+ * actually being loaded, whoever published it.
+ */
+export function originLabel(entry: PluginCatalogEntry): TranslationKey | null {
+  if (entry.kind === 'builtin') return 'pluginCenter.origin.builtin';
+  if (entry.source_kind === 'local') return 'pluginCenter.origin.local';
+  if (entry.official) return 'pluginCenter.origin.official';
+  return null;
+}
+
+/**
+ * The three capabilities a manifest may declare, each as the sentence that
+ * says what granting it costs.
+ *
+ * A fixed map rather than a templated key, because `t()` takes a
+ * `TranslationKey` and a capability id is a value off the wire: an id a newer
+ * server invents must reach the card as itself, not as a missing key.
+ */
+const CAPABILITY_KEY: Record<string, TranslationKey | undefined> = {
+  network: 'pluginCenter.cap.network',
+  filesystem: 'pluginCenter.cap.filesystem',
+  'process-env': 'pluginCenter.cap.processEnv',
+};
+
+/** The sentence for *id*, or null when the card should print the raw id. */
+export function capabilityKey(id: string): TranslationKey | null {
+  return CAPABILITY_KEY[id] ?? null;
+}
+
+/**
+ * The `cdui plugin install ...` line for *entry*, for the terminal fallback
+ * the activity pane offers when a job fails.
+ *
+ * `repo` before `source`, and the ref pinned when there is one: what the user
+ * copies should reproduce THIS row rather than whatever the default branch
+ * holds by the time they paste it. `ref` is `''` for a default-branch install
+ * -- a real answer, not a miss -- so it is appended only when set.
+ */
+export function cliInstallCommand(entry: PluginCatalogEntry): string {
+  const repo = entry.repo ?? '';
+  const spec = repo || entry.source || entry.id;
+  const ref = repo && entry.ref ? `@${entry.ref}` : '';
+  return `cdui plugin install ${spec}${ref}`;
+}

--- a/frontend/src/components/PluginCenter/pluginStatus.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.ts
@@ -171,6 +171,48 @@ export function capabilityKey(id: string): TranslationKey | null {
   return CAPABILITY_KEY[id] ?? null;
 }
 
+// ── provenance and contents ──────────────────────────────────────────────
+
+/**
+ * The commit a row is pinned to, as one phrase -- or null when it has none.
+ *
+ * `{ref} @ {sha7}` when both halves say something, and the commit alone when
+ * the ref does not:
+ *
+ * - `''` is the server's way of saying "the default branch", an answer rather
+ *   than a miss, so a bare `@` is never printed;
+ * - a ref that IS the version reads as the version twice, because a card
+ *   prints `v{version}` in its header -- `v1.2.0 @ 4f0a1c9` under a heading
+ *   that already says `v1.2.0`. The tag and the bare number are both matched:
+ *   `v1.2.0` and `1.2.0` are the same release named two ways.
+ *
+ * `sha` is `''` for a built-in in some lockfiles, which is not a commit
+ * either: `''.slice(0, 7)` would put an empty phrase on the meta line.
+ */
+export function provenancePin(
+  ref: string | null, sha: string | null, version: string | null,
+): string | null {
+  if (sha === null || sha === '') return null;
+  const sha7 = sha.slice(0, 7);
+  if (ref === null || ref === '') return sha7;
+  const named = version !== null && version !== ''
+    && (ref === version || ref === `v${version}`);
+  return named ? sha7 : `${ref} @ ${sha7}`;
+}
+
+/**
+ * One `name>=version` the way the installer would write it.
+ *
+ * Mirrors `backend/app/core/plugins/deps.py: _build_dep_spec`: a constraint
+ * that starts with an operator is used as written, a bare version is pinned.
+ * What a card prints is then what `uv pip install` would be given, rather
+ * than a prettier string that means something slightly different.
+ */
+export function depSpec(name: string, constraint: string): string {
+  if (constraint === '') return name;
+  return /^[<>=~!]/.test(constraint) ? `${name}${constraint}` : `${name}==${constraint}`;
+}
+
 /**
  * The `cdui plugin install ...` line for *entry*, for the terminal fallback
  * the activity pane offers when a job fails.

--- a/frontend/src/components/PluginCenter/pluginStatus.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.ts
@@ -75,6 +75,31 @@ export function statusKey(status: PluginStatus): TranslationKey {
   return STATUS_KEY[status] ?? STATUS_KEY.available;
 }
 
+// ── the filter ───────────────────────────────────────────────────────────
+
+/** Which half of the catalog the list is showing. */
+export type PluginFilter = 'all' | 'installed' | 'available';
+
+/**
+ * Whether a row belongs to the "Available" half.
+ *
+ * Written as the narrow half and negated for the other, so the two halves are
+ * exhaustive by construction: a status this build has never heard of lands
+ * under "Installed" rather than under neither, and no filter can make a row
+ * disappear from both tabs. `removed` is available -- a tombstone is a plugin
+ * that is not here and can be put back -- while `missing_files` and
+ * `installing` are not: the lockfile has them.
+ */
+export function isAvailableStatus(status: PluginStatus): boolean {
+  return status === 'available' || status === 'removed';
+}
+
+/** Whether *status* passes *filter*. */
+export function matchesFilter(filter: PluginFilter, status: PluginStatus): boolean {
+  if (filter === 'all') return true;
+  return isAvailableStatus(status) === (filter === 'available');
+}
+
 /**
  * The eight step ids a plugin job emits, as sentences.
  *

--- a/frontend/src/components/Sidebar/CustomTab.module.css
+++ b/frontend/src/components/Sidebar/CustomTab.module.css
@@ -109,21 +109,7 @@
   margin-top: var(--sp-2);
 }
 
-.chipOn,
-.chipOff {
-  font-size: var(--fs-2xs);
-  padding: var(--sp-1) var(--sp-2);
-  border-radius: var(--radius-sm);
-  font-weight: var(--fw-semibold);
-  flex-shrink: 0;
-}
-
-.chipOn {
-  background: rgba(94, 194, 105, 0.13);
-  color: var(--status-success);
-}
-
-.chipOff {
-  background: rgba(158, 158, 158, 0.13);
-  color: var(--status-skipped);
-}
+/* The enabled/disabled chip on a custom-node or plugin row is the shared
+   `Pill` (`components/shared/Pill.tsx`), not a stylesheet of its own: the
+   washes it used to hard-code were the only literal rgba left in this tab,
+   and a status has to read the same here as it does in either center. */

--- a/frontend/src/components/Sidebar/CustomTab.test.tsx
+++ b/frontend/src/components/Sidebar/CustomTab.test.tsx
@@ -188,13 +188,20 @@ describe('CustomTab', () => {
     expect(screen.getByText('Plugins')).toBeTruthy();
   });
 
-  it('shows an empty state per section, with the install hint for plugins', async () => {
+  it('shows an empty state per section, and no hint that repeats a button', async () => {
     render(<CustomTab />);
     await screen.findByText('No custom nodes yet');
     expect(screen.getByText('No plugins installed')).toBeTruthy();
-    // Re-worded with the Plugin Center: the CLI still works, but it is no
-    // longer the only way in, and this hint is beside the button that is.
-    expect(screen.getByText('Install plugins from the Plugin Center')).toBeTruthy();
+    // The button one line above the empty state IS the Plugin Center, so the
+    // hint that named it as a destination is gone. The packs one stays: it
+    // says what a pack is, which no button can.
+    expect(screen.getByRole('button', { name: 'Plugin Center...' })).toBeTruthy();
+    expect(screen.queryByText('Install plugins from the Plugin Center')).toBeNull();
+    expect(
+      screen.getByText(
+        'Models and libraries for LLM nodes are installed from the Package Center',
+      ),
+    ).toBeTruthy();
   });
 
   it('lists custom node files with their node names and enabled chip', async () => {
@@ -332,6 +339,18 @@ describe('CustomTab', () => {
     });
     fireEvent.click(screen.getByText('Retry'));
     await screen.findByText('Recovered');
+  });
+
+  it('keeps the tab when a catalog it already has fails to refresh', async () => {
+    // The plugin store is SHARED, and its error is sticky until the next
+    // catalog lands: a refresh the Plugin Center asked for, over rows this
+    // tab is already showing, must not replace the custom nodes and the packs
+    // with somebody else's dropped packet.
+    seedPlugins([plugin({ name: 'Chapter 1' })], { error: 'connection refused' });
+    render(<CustomTab />);
+    await screen.findByText('Chapter 1');
+
+    expect(screen.queryByText('Failed to load: connection refused')).toBeNull();
   });
 
   it('re-fetches from the refresh button', async () => {

--- a/frontend/src/components/Sidebar/CustomTab.test.tsx
+++ b/frontend/src/components/Sidebar/CustomTab.test.tsx
@@ -4,12 +4,14 @@ import { CustomTab } from './CustomTab';
 import { useI18n } from '../../i18n';
 import { useUIStore } from '../../store/uiStore';
 import { _resetPackStoreForTesting, usePackStore } from '../../store/packStore';
+import { _resetPluginStoreForTesting, usePluginStore } from '../../store/pluginStore';
 import * as rest from '../../api/rest';
 import type {
   CustomNodeInfo,
   PackCatalog,
   PackSummary,
-  PluginSummary,
+  PluginCatalog,
+  PluginCatalogEntry,
 } from '../../api/rest';
 
 vi.mock('../../api/rest', async (importOriginal) => {
@@ -17,10 +19,10 @@ vi.mock('../../api/rest', async (importOriginal) => {
   return {
     ...actual,
     listCustomNodes: vi.fn(),
-    listPlugins: vi.fn(),
-    // The packs section is a view of `packStore`; the tab's Refresh button
-    // asks it to re-read the catalog through this call.
+    // Both catalogs are read through the stores, and both stores read them
+    // through these calls; the tab's Refresh button asks for a re-read.
     listPacks: vi.fn(),
+    listPluginCatalog: vi.fn(),
   };
 });
 
@@ -40,14 +42,37 @@ function customNode(overrides: Partial<CustomNodeInfo> = {}): CustomNodeInfo {
   return { filename: 'my_node.py', enabled: true, nodes: ['MyNode'], ...overrides };
 }
 
-function plugin(overrides: Partial<PluginSummary> = {}): PluginSummary {
+/** One installed, enabled plugin, as the catalog answers with it. */
+function plugin(overrides: Partial<PluginCatalogEntry> = {}): PluginCatalogEntry {
   return {
     id: 'c1',
     name: 'Chapter 1',
-    version: '1.0.0',
     description: 'Intro nodes',
+    kind: 'builtin',
+    official: true,
+    status: 'installed',
+    source_kind: 'builtin',
+    source: 'c1',
+    repo: null,
+    ref: null,
+    sha: null,
+    url: null,
+    homepage: '',
+    version: '1.0.0',
+    installed_at: null,
     enabled: true,
+    chapters: [],
+    lessons: [],
+    tags: [],
     nodes: ['EduAdd', 'EduMul'],
+    node_count: 2,
+    capabilities: [],
+    trusted_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    consent_required: false,
+    frontend_entry: null,
+    job: null,
     ...overrides,
   };
 }
@@ -81,10 +106,18 @@ const EMPTY_CATALOG: PackCatalog = {
   gpu: null,
 };
 
-// `_resetPackStoreForTesting` restores the store's DATA, not its actions, so
-// the one case that installs a fake `refresh` would otherwise leave it in
-// place for every case after it.
+const EMPTY_PLUGIN_CATALOG: PluginCatalog = {
+  entries: [],
+  active_job: null,
+  remote_install_allowed: true,
+  generation: 0,
+};
+
+// `_reset*ForTesting` restores a store's DATA, not its actions, so the cases
+// that install a fake `refresh` would otherwise leave it in place for every
+// case after them.
 const realPackRefresh = usePackStore.getState().refresh;
+const realPluginRefresh = usePluginStore.getState().refresh;
 
 /** Put a catalog in the store, the way a finished `refresh()` would. */
 function seedPacks(packs: PackSummary[], unsupported = false) {
@@ -96,24 +129,52 @@ function seedPacks(packs: PackSummary[], unsupported = false) {
   });
 }
 
+/**
+ * The same for plugins. The section is a pure VIEW of this store now — the
+ * tab has no `listPlugins` call of its own — so every case that wants a
+ * plugin row puts one here.
+ */
+function seedPlugins(
+  plugins: PluginCatalogEntry[],
+  extra: Partial<ReturnType<typeof usePluginStore.getState>> = {},
+) {
+  usePluginStore.setState({
+    loaded: true,
+    loading: false,
+    unsupported: false,
+    error: null,
+    plugins,
+    byId: Object.fromEntries(plugins.map((entry) => [entry.id, entry])),
+    ...extra,
+  });
+}
+
 beforeEach(() => {
   useI18n.setState({ locale: 'en' });
-  useUIStore.setState({ packCenterOpen: false, packCenterFocusPackId: null });
+  useUIStore.setState({
+    packCenterOpen: false,
+    packCenterFocusPackId: null,
+    pluginCenterOpen: false,
+    pluginCenterFocusPluginId: null,
+  });
   _resetPackStoreForTesting();
+  _resetPluginStoreForTesting();
   usePackStore.setState({ refresh: realPackRefresh });
+  usePluginStore.setState({ refresh: realPluginRefresh });
   mockedRest.listCustomNodes.mockReset();
-  mockedRest.listPlugins.mockReset();
   mockedRest.listPacks.mockReset();
+  mockedRest.listPluginCatalog.mockReset();
   mockedRest.listCustomNodes.mockResolvedValue([]);
-  mockedRest.listPlugins.mockResolvedValue([]);
   mockedRest.listPacks.mockResolvedValue(EMPTY_CATALOG);
+  mockedRest.listPluginCatalog.mockResolvedValue(EMPTY_PLUGIN_CATALOG);
   seedPacks([]);
+  seedPlugins([]);
 });
 
 afterEach(() => {
-  // The pack store is reset in `beforeEach`, NOT here: the tab is still
-  // mounted at this point, and writing to a store it subscribes to would
-  // re-render it outside `act`.
+  // Both stores are reset in `beforeEach`, NOT here: the tab is still mounted
+  // at this point, and writing to a store it subscribes to would re-render it
+  // outside `act`.
   vi.restoreAllMocks();
 });
 
@@ -131,7 +192,9 @@ describe('CustomTab', () => {
     render(<CustomTab />);
     await screen.findByText('No custom nodes yet');
     expect(screen.getByText('No plugins installed')).toBeTruthy();
-    expect(screen.getByText('Install packs with the cdui plugin CLI')).toBeTruthy();
+    // Re-worded with the Plugin Center: the CLI still works, but it is no
+    // longer the only way in, and this hint is beside the button that is.
+    expect(screen.getByText('Install plugins from the Plugin Center')).toBeTruthy();
   });
 
   it('lists custom node files with their node names and enabled chip', async () => {
@@ -149,7 +212,7 @@ describe('CustomTab', () => {
   });
 
   it('lists plugin packs with version, description and node count', async () => {
-    mockedRest.listPlugins.mockResolvedValue([plugin()]);
+    seedPlugins([plugin()]);
     render(<CustomTab />);
     await screen.findByText('Chapter 1');
     expect(screen.getByText('v1.0.0')).toBeTruthy();
@@ -159,8 +222,16 @@ describe('CustomTab', () => {
   });
 
   it('greys out a disabled plugin and omits absent optional fields', async () => {
-    mockedRest.listPlugins.mockResolvedValue([
-      plugin({ id: 'c2', name: 'Chapter 2', version: '', description: '', enabled: false, nodes: [] }),
+    seedPlugins([
+      plugin({
+        id: 'c2',
+        name: 'Chapter 2',
+        status: 'disabled',
+        version: null,
+        description: '',
+        enabled: false,
+        nodes: [],
+      }),
     ]);
     const { container } = render(<CustomTab />);
     await screen.findByText('Chapter 2');
@@ -171,9 +242,56 @@ describe('CustomTab', () => {
     expect(container.querySelectorAll('[class*="rowMeta"]')).toHaveLength(0);
   });
 
+  it('lists what is installed, and leaves the rest of the catalog to the panel', async () => {
+    // The catalog is everything a server COULD have; this section has always
+    // answered "what have I got". An install still running and a lockfile
+    // entry whose files are gone are in neither half.
+    seedPlugins([
+      plugin({ id: 'c1', name: 'Chapter 1', status: 'installed' }),
+      plugin({ id: 'c2', name: 'Chapter 2', status: 'disabled', enabled: false }),
+      plugin({ id: 'c3', name: 'Chapter 3', status: 'available', enabled: false }),
+      plugin({ id: 'c4', name: 'Chapter 4', status: 'removed', enabled: false }),
+      plugin({ id: 'c5', name: 'Chapter 5', status: 'installing', enabled: false }),
+      plugin({ id: 'c6', name: 'Chapter 6', status: 'missing_files', enabled: false }),
+    ]);
+    const { container } = render(<CustomTab />);
+
+    await screen.findByText('Chapter 1');
+    expect(screen.getByText('Chapter 2')).toBeTruthy();
+    for (const absent of ['Chapter 3', 'Chapter 4', 'Chapter 5', 'Chapter 6']) {
+      expect(screen.queryByText(absent)).toBeNull();
+    }
+    // ...and the header count agrees with the rows it is counting.
+    const counts = Array.from(container.querySelectorAll('[class*="sectionCount"]')).map(
+      (el) => el.textContent,
+    );
+    expect(counts).toEqual(['0', '0', '2']);
+  });
+
+  it('shows the empty state on a server with no Plugin Center at all', async () => {
+    // `unsupported` and a stale catalog can be true together; the server's
+    // verdict wins, and no row claims a plugin this server cannot report on.
+    seedPlugins([plugin()], { unsupported: true });
+    render(<CustomTab />);
+
+    expect(await screen.findByText('No plugins installed')).toBeTruthy();
+    expect(screen.queryByText('Chapter 1')).toBeNull();
+  });
+
+  it('opens the Plugin Center from the section header', async () => {
+    render(<CustomTab />);
+    await screen.findByText('No plugins installed');
+
+    fireEvent.click(screen.getByText('Plugin Center...'));
+    expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+    // No plugin is focused: the handler must not pass its click event
+    // through as a plugin id.
+    expect(useUIStore.getState().pluginCenterFocusPluginId).toBeNull();
+  });
+
   it('shows the section counts', async () => {
     mockedRest.listCustomNodes.mockResolvedValue([customNode({ filename: 'a.py' })]);
-    mockedRest.listPlugins.mockResolvedValue([plugin(), plugin({ id: 'c2', name: 'Chapter 2' })]);
+    seedPlugins([plugin(), plugin({ id: 'c2', name: 'Chapter 2' })]);
     const { container } = render(<CustomTab />);
     await screen.findByText('a.py');
     const counts = Array.from(container.querySelectorAll('[class*="sectionCount"]')).map(
@@ -198,11 +316,20 @@ describe('CustomTab', () => {
   });
 
   it('shows the error state and retries on click', async () => {
-    mockedRest.listPlugins.mockRejectedValueOnce(new Error('backend gone'));
+    // A catalog read that failed is still the tab's error to report: the
+    // Plugins section is one of the two lists this tab is about, and half a
+    // tab behind an error the other half is not in reads as a broken list.
+    seedPlugins([], { error: 'backend gone', loaded: false });
     render(<CustomTab />);
     await screen.findByText('Failed to load: backend gone');
 
-    mockedRest.listPlugins.mockResolvedValue([plugin({ name: 'Recovered' })]);
+    // A fresh action installed through setState, never a spy on the live one:
+    // a spy taken from getState() outlives the store it was taken from.
+    usePluginStore.setState({
+      refresh: vi.fn(async () => {
+        seedPlugins([plugin({ name: 'Recovered' })]);
+      }),
+    });
     fireEvent.click(screen.getByText('Retry'));
     await screen.findByText('Recovered');
   });
@@ -210,7 +337,11 @@ describe('CustomTab', () => {
   it('re-fetches from the refresh button', async () => {
     render(<CustomTab />);
     await screen.findByText('No plugins installed');
-    mockedRest.listPlugins.mockResolvedValue([plugin({ name: 'Just installed' })]);
+    usePluginStore.setState({
+      refresh: vi.fn(async () => {
+        seedPlugins([plugin({ name: 'Just installed' })]);
+      }),
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
     await screen.findByText('Just installed');
   });
@@ -302,12 +433,24 @@ describe('CustomTab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
 
     expect(refresh).toHaveBeenCalledTimes(1);
-    await waitFor(() => expect(mockedRest.listPlugins).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockedRest.listCustomNodes).toHaveBeenCalledTimes(2));
   });
 
-  it('does not read the catalog on mount — the sidebar shell already has', async () => {
+  it('the refresh button re-reads the plugin catalog too', async () => {
+    render(<CustomTab />);
+    await screen.findByText('No plugins installed');
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    usePluginStore.setState({ refresh });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not read either catalog on mount — the sidebar shell already has', async () => {
     render(<CustomTab />);
     await screen.findByText('No optional packs available');
     expect(mockedRest.listPacks).not.toHaveBeenCalled();
+    expect(mockedRest.listPluginCatalog).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/Sidebar/CustomTab.tsx
+++ b/frontend/src/components/Sidebar/CustomTab.tsx
@@ -133,7 +133,12 @@ export function CustomTab() {
   // over a catalog already on screen is not a load, hence `!pluginsLoaded` —
   // only a first read blanks the tab.
   const busy = loading || (pluginsLoading && !pluginsLoaded);
-  const failed = error ?? pluginsError;
+  // The plugin store's `error` is sticky until the next catalog lands, and it
+  // belongs to a SHARED store: a refresh that fails inside the Plugin Center
+  // would otherwise replace this whole tab -- custom nodes and packs included
+  // -- with "Failed to load". Only a catalog that has never arrived is this
+  // tab's business, which is the store's own rule for the rows it keeps.
+  const failed = error ?? (pluginsLoaded ? null : pluginsError);
 
   return (
     <>
@@ -252,10 +257,14 @@ export function CustomTab() {
               </button>
             </div>
 
+            {/* No hint under this one, unlike the packs section above it: the
+                header button one line up IS the Plugin Center, so a sentence
+                whose only content is that destination says the same thing
+                twice in sixty pixels of column. The packs hint earns its line
+                by saying what a pack is. */}
             {visiblePlugins.length === 0 ? (
               <div className={tabStyles.sectionEmpty}>
                 <div>{t('customTab.plugins.empty')}</div>
-                <div className={tabStyles.sectionHint}>{t('customTab.plugins.hint')}</div>
               </div>
             ) : (
               visiblePlugins.map((plugin) => (

--- a/frontend/src/components/Sidebar/CustomTab.tsx
+++ b/frontend/src/components/Sidebar/CustomTab.tsx
@@ -1,52 +1,59 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
   listCustomNodes,
-  listPlugins,
   type CustomNodeInfo,
   type PackSummary,
-  type PluginSummary,
+  type PluginCatalogEntry,
 } from '../../api/rest';
 import { useI18n } from '../../i18n';
 import { usePackStore } from '../../store/packStore';
+import { usePluginStore } from '../../store/pluginStore';
 import { useUIStore } from '../../store/uiStore';
 import { CustomNodeManager } from '../CustomNodeManager/CustomNodeManager';
 import { StatusPill } from '../PackCenter/PackCard';
+import { isInstalledStatus } from '../PluginCenter/pluginStatus';
 import { catalogKey, localizedPackTitle } from '../../utils/packAvailability';
+import { Pill } from '../shared/Pill';
 import { RefreshIcon } from '../shared/Icons';
 import styles from './NodePalette.module.css';
 import tabStyles from './CustomTab.module.css';
 
 type PackStoreState = ReturnType<typeof usePackStore.getState>;
+type PluginStoreState = ReturnType<typeof usePluginStore.getState>;
 
 // Module-scope selectors, so each subscription compares the SAME function's
-// output frame to frame. Only two, and neither moves while a download runs:
-// `packs` is replaced when the catalog is re-read or a status changes, which
-// is exactly when these rows have something new to say.
+// output frame to frame, and one slice per selector so an install writing its
+// log and its per-step bytes on every long-poll turn cannot re-render this
+// list. `packs` and `plugins` are replaced when a catalog is re-read or a
+// status changes, which is exactly when these rows have something new to say.
 const selectPacks = (state: PackStoreState): PackSummary[] => state.packs;
 const selectPacksUnsupported = (state: PackStoreState): boolean => state.unsupported;
+const selectPlugins = (state: PluginStoreState): PluginCatalogEntry[] => state.plugins;
+const selectPluginsLoading = (state: PluginStoreState): boolean => state.loading;
+const selectPluginsLoaded = (state: PluginStoreState): boolean => state.loaded;
+const selectPluginsError = (state: PluginStoreState): string | null => state.error;
+const selectPluginsUnsupported = (state: PluginStoreState): boolean => state.unsupported;
 
 /**
  * Everything the user has added to this install: uploaded custom-node files
- * and installed plugin packs (#126).
+ * and installed plugins (#126).
  *
  * The custom-node rows are a read-only summary; enable/disable/upload/delete
  * stay in the existing `CustomNodeManager` modal, opened from here rather than
- * duplicated into a 250px column. Plugin packs are read-only by design — they
- * are installed and removed through the `cdui plugin` CLI, which writes the
- * lockfile on disk.
+ * duplicated into a 250px column. Custom nodes are the one thing this tab
+ * still fetches for itself, on mount and again when that modal closes (an
+ * upload or a toggle changes what belongs here).
  *
- * Both lists are fetched together on mount, and re-fetched when the manager
- * modal closes (an upload or a toggle changes what belongs here).
- *
- * Optional packs sit between the two, and are the one section that owns no
- * fetch: the catalog is read once by the sidebar shell this tab lives in
- * (`usePackCatalogBootstrap`) and kept in `packStore`, because an install
- * outlives the tab that started it. The rows are a pure view of it, and the
- * only way to change anything is the Package Center itself.
+ * The other two sections own no fetch at all. Both catalogs are read once by
+ * the sidebar shell this tab lives in (`usePackCatalogBootstrap`,
+ * `usePluginCatalogBootstrap`) and kept in `packStore` / `pluginStore`,
+ * because an install is a download that outlives the tab that started it.
+ * These rows are a pure view of that state, and the only way to change
+ * anything is the Package Center or the Plugin Center — which is why all
+ * three section headers now offer the same shape of button.
  */
 export function CustomTab() {
   const [customNodes, setCustomNodes] = useState<CustomNodeInfo[]>([]);
-  const [plugins, setPlugins] = useState<PluginSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [managerOpen, setManagerOpen] = useState(false);
@@ -56,17 +63,20 @@ export function CustomTab() {
   const packsUnsupported = usePackStore(selectPacksUnsupported);
   const openPackCenter = useUIStore((s) => s.openPackCenter);
 
+  const plugins = usePluginStore(selectPlugins);
+  const pluginsLoading = usePluginStore(selectPluginsLoading);
+  const pluginsLoaded = usePluginStore(selectPluginsLoaded);
+  const pluginsError = usePluginStore(selectPluginsError);
+  const pluginsUnsupported = usePluginStore(selectPluginsUnsupported);
+  const openPluginCenter = useUIStore((s) => s.openPluginCenter);
+
   const load = useCallback(() => {
     setLoading(true);
     setError(null);
-    Promise.all([listCustomNodes(), listPlugins()])
-      .then(([nodes, packs]) => {
-        setCustomNodes(nodes);
-        setPlugins(packs);
-      })
+    listCustomNodes()
+      .then(setCustomNodes)
       .catch((e: Error) => {
         setCustomNodes([]);
-        setPlugins([]);
         setError(e.message);
       })
       .finally(() => setLoading(false));
@@ -81,13 +91,14 @@ export function CustomTab() {
     load();
   }, [load]);
 
-  // The Refresh button means "re-read everything this tab shows", and the
-  // pack catalog is now part of that — it is also the retry for a boot read
-  // that never arrived. Mount does NOT go through here: the shell has already
-  // read the catalog by the time this tab can be selected.
+  // "Re-read everything this tab shows", which is both catalogs as well as
+  // the files — and the retry for a boot read that never arrived. Mount does
+  // NOT go through here: the shell has already read both catalogs by the time
+  // this tab can be selected.
   const refreshAll = useCallback(() => {
     load();
     void usePackStore.getState().refresh();
+    void usePluginStore.getState().refresh();
   }, [load]);
 
   /** A pack's name and one-line description, preferring this build's copy. */
@@ -107,6 +118,23 @@ export function CustomTab() {
   // over from a previous server cannot make the header disagree with them.
   const visiblePacks = packsUnsupported ? [] : packs;
 
+  // The same rule for plugins, over the half of the catalog that is actually
+  // HERE. The full catalog also lists what could be installed, and this
+  // section has always answered "what have I got" — with a chip that says
+  // enabled or disabled, which is not a sentence about a plugin nobody has
+  // downloaded. The rest of the catalog is the Plugin Center's to show.
+  const visiblePlugins = pluginsUnsupported
+    ? []
+    : plugins.filter((plugin) => isInstalledStatus(plugin.status));
+
+  // One spinner and one error line for the tab, as before: the plugin catalog
+  // was fetched here until the store took it over, and hiding half a tab
+  // behind a state the other half is not in reads as a broken list. A REFRESH
+  // over a catalog already on screen is not a load, hence `!pluginsLoaded` —
+  // only a first read blanks the tab.
+  const busy = loading || (pluginsLoading && !pluginsLoaded);
+  const failed = error ?? pluginsError;
+
   return (
     <>
       <div className={styles.header}>
@@ -125,18 +153,20 @@ export function CustomTab() {
       </div>
 
       <div className={styles.panelBody}>
-        {loading && <div className={styles.stateMessage}>{t('customNodes.loading')}</div>}
+        {busy && <div className={styles.stateMessage}>{t('customNodes.loading')}</div>}
 
-        {!loading && error && (
+        {!busy && failed && (
           <div className={styles.errorWrapper}>
-            <div className={styles.errorText}>{t('customTab.loadFail', { error })}</div>
-            <button type="button" onClick={load} className={styles.retryButton}>
+            <div className={styles.errorText}>
+              {t('customTab.loadFail', { error: failed })}
+            </div>
+            <button type="button" onClick={refreshAll} className={styles.retryButton}>
               {t('palette.retry')}
             </button>
           </div>
         )}
 
-        {!loading && !error && (
+        {!busy && !failed && (
           <div className={styles.content}>
             {/* ── Custom nodes ── */}
             <div className={tabStyles.sectionHeader}>
@@ -162,11 +192,9 @@ export function CustomTab() {
                 >
                   <div className={tabStyles.rowTitle}>
                     <span className={tabStyles.rowName}>{file.filename}</span>
-                    <span
-                      className={file.enabled ? tabStyles.chipOn : tabStyles.chipOff}
-                    >
+                    <Pill tone={file.enabled ? 'success' : 'neutral'}>
                       {file.enabled ? t('customNodes.enabled') : t('customNodes.disabled')}
-                    </span>
+                    </Pill>
                   </div>
                   {file.nodes.length > 0 && (
                     <div className={tabStyles.rowDesc}>{file.nodes.join(', ')}</div>
@@ -211,28 +239,38 @@ export function CustomTab() {
               })
             )}
 
-            {/* ── Plugin packs ── */}
+            {/* ── Plugins ── */}
             <div className={tabStyles.sectionHeader}>
               <span className={tabStyles.sectionTitle}>{t('customTab.section.plugins')}</span>
-              <span className={tabStyles.sectionCount}>{plugins.length}</span>
+              <span className={tabStyles.sectionCount}>{visiblePlugins.length}</span>
+              <button
+                type="button"
+                className={tabStyles.manageButton}
+                onClick={() => openPluginCenter()}
+              >
+                {t('customTab.plugins.open')}
+              </button>
             </div>
 
-            {plugins.length === 0 ? (
+            {visiblePlugins.length === 0 ? (
               <div className={tabStyles.sectionEmpty}>
                 <div>{t('customTab.plugins.empty')}</div>
                 <div className={tabStyles.sectionHint}>{t('customTab.plugins.hint')}</div>
               </div>
             ) : (
-              plugins.map((plugin) => (
+              visiblePlugins.map((plugin) => (
                 <div key={plugin.id} className={tabStyles.row} data-disabled={!plugin.enabled}>
                   <div className={tabStyles.rowTitle}>
                     <span className={tabStyles.rowName}>{plugin.name}</span>
                     {plugin.version && (
                       <span className={tabStyles.rowVersion}>v{plugin.version}</span>
                     )}
-                    <span className={plugin.enabled ? tabStyles.chipOn : tabStyles.chipOff}>
+                    {/* Enabled or not, rather than the panel's six-state
+                        status: everything listed here is installed, so the
+                        one thing left to say is whether it is switched on. */}
+                    <Pill tone={plugin.enabled ? 'success' : 'neutral'}>
                       {plugin.enabled ? t('customNodes.enabled') : t('customNodes.disabled')}
-                    </span>
+                    </Pill>
                   </div>
                   {plugin.description && (
                     <div className={tabStyles.rowDesc}>{plugin.description}</div>

--- a/frontend/src/components/Sidebar/NodePalette.test.tsx
+++ b/frontend/src/components/Sidebar/NodePalette.test.tsx
@@ -27,7 +27,6 @@ vi.mock('../../api/rest', async (importOriginal) => {
     ...actual,
     listExamples: vi.fn(),
     listCustomNodes: vi.fn(),
-    listPlugins: vi.fn(),
     // The shell bootstraps the plugin catalog on mount (`usePluginCatalogBootstrap`),
     // which every case in this file therefore triggers. Stubbed so it reaches
     // a promise rather than the real module's `fetch`.
@@ -116,7 +115,6 @@ beforeEach(() => {
   // reset them so "was this tab fetched?" means "in THIS test".
   mockedRest.listExamples.mockReset().mockResolvedValue([]);
   mockedRest.listCustomNodes.mockReset().mockResolvedValue([]);
-  mockedRest.listPlugins.mockReset().mockResolvedValue([]);
   mockedRest.listPluginCatalog.mockReset().mockResolvedValue({
     entries: [],
     active_job: null,

--- a/frontend/src/components/Sidebar/NodePalette.test.tsx
+++ b/frontend/src/components/Sidebar/NodePalette.test.tsx
@@ -28,6 +28,10 @@ vi.mock('../../api/rest', async (importOriginal) => {
     listExamples: vi.fn(),
     listCustomNodes: vi.fn(),
     listPlugins: vi.fn(),
+    // The shell bootstraps the plugin catalog on mount (`usePluginCatalogBootstrap`),
+    // which every case in this file therefore triggers. Stubbed so it reaches
+    // a promise rather than the real module's `fetch`.
+    listPluginCatalog: vi.fn(),
   };
 });
 
@@ -113,6 +117,12 @@ beforeEach(() => {
   mockedRest.listExamples.mockReset().mockResolvedValue([]);
   mockedRest.listCustomNodes.mockReset().mockResolvedValue([]);
   mockedRest.listPlugins.mockReset().mockResolvedValue([]);
+  mockedRest.listPluginCatalog.mockReset().mockResolvedValue({
+    entries: [],
+    active_job: null,
+    remote_install_allowed: true,
+    generation: 0,
+  });
 });
 
 afterEach(() => {

--- a/frontend/src/components/Toolbar/SettingsPopover.test.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.test.tsx
@@ -15,15 +15,23 @@ import {
   logoutCodex,
   fetchHealth,
   listPacks,
+  listPluginCatalog,
   PackApiError,
   type PackCatalog,
   type PackSummary,
+  type PluginCatalog,
+  type PluginCatalogEntry,
 } from '../../api/rest';
 import {
   _resetPackStoreForTesting,
   emptyPackJob,
   usePackStore,
 } from '../../store/packStore';
+import {
+  _resetPluginStoreForTesting,
+  emptyPluginJob,
+  usePluginStore,
+} from '../../store/pluginStore';
 import { computeSegmentNodes } from '../../utils/segmentPath';
 
 vi.mock('../../api/rest', async (importOriginal) => ({
@@ -32,6 +40,8 @@ vi.mock('../../api/rest', async (importOriginal) => ({
   // makes that line throw a TypeError instead of reporting the 404 an older
   // server answers with.
   PackApiError: (await importOriginal<typeof import('../../api/rest')>()).PackApiError,
+  // `pluginStore.refresh()` narrows the same way, on the shared class.
+  ApiError: (await importOriginal<typeof import('../../api/rest')>()).ApiError,
   resetWeights: vi.fn(),
   // The "This Server" section reads /api/health when the popover opens
   // (#193 item 2); its own behaviour is covered in HealthSection.test.tsx.
@@ -58,6 +68,8 @@ vi.mock('../../api/rest', async (importOriginal) => ({
   // this call. Stubbed so the one case that lets the popover bootstrap it
   // has something to resolve with, and so the rest never touch the network.
   listPacks: vi.fn(),
+  // The plugins row, and its store, the same way.
+  listPluginCatalog: vi.fn(),
 }));
 
 vi.mock('../../utils/segmentPath', () => ({
@@ -70,6 +82,7 @@ const mockedStartCodexLogin = vi.mocked(startCodexLogin);
 const mockedLogoutCodex = vi.mocked(logoutCodex);
 const mockedComputeSegment = vi.mocked(computeSegmentNodes);
 const mockedListPacks = vi.mocked(listPacks);
+const mockedListPluginCatalog = vi.mocked(listPluginCatalog);
 
 const EMPTY_CATALOG: PackCatalog = {
   packs: [],
@@ -79,6 +92,13 @@ const EMPTY_CATALOG: PackCatalog = {
   launch_mode: 'start',
   restart_available: false,
   gpu: null,
+};
+
+const EMPTY_PLUGIN_CATALOG: PluginCatalog = {
+  entries: [],
+  active_job: null,
+  remote_install_allowed: true,
+  generation: 0,
 };
 
 function packSummary(overrides: Partial<PackSummary> = {}): PackSummary {
@@ -109,6 +129,53 @@ function seedPacks(
     loaded: true,
     packs,
     byId: Object.fromEntries(packs.map((pack) => [pack.id, pack])),
+    ...extra,
+  });
+}
+
+/** One catalog row. Only the fields the settings row reads are interesting. */
+function pluginEntry(over: Partial<PluginCatalogEntry> & { id: string }): PluginCatalogEntry {
+  return {
+    name: over.id,
+    description: '',
+    kind: 'builtin',
+    official: true,
+    status: 'available',
+    source_kind: null,
+    source: over.id,
+    repo: null,
+    ref: null,
+    sha: null,
+    url: null,
+    homepage: '',
+    version: null,
+    installed_at: null,
+    enabled: false,
+    chapters: [],
+    lessons: [],
+    tags: [],
+    nodes: [],
+    node_count: 0,
+    capabilities: [],
+    trusted_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    consent_required: false,
+    frontend_entry: null,
+    job: null,
+    ...over,
+  };
+}
+
+/** The same for the plugin catalog. */
+function seedPlugins(
+  plugins: PluginCatalogEntry[],
+  extra: Partial<ReturnType<typeof usePluginStore.getState>> = {},
+) {
+  usePluginStore.setState({
+    loaded: true,
+    plugins,
+    byId: Object.fromEntries(plugins.map((entry) => [entry.id, entry])),
     ...extra,
   });
 }
@@ -167,13 +234,19 @@ describe('SettingsPopover', () => {
       edgeStyle: 'circuit',
       packCenterOpen: false,
       packCenterFocusPackId: null,
+      pluginCenterOpen: false,
+      pluginCenterFocusPluginId: null,
     });
     _resetPackStoreForTesting();
+    _resetPluginStoreForTesting();
     mockedListPacks.mockReset();
     mockedListPacks.mockResolvedValue(EMPTY_CATALOG);
+    mockedListPluginCatalog.mockReset();
+    mockedListPluginCatalog.mockResolvedValue(EMPTY_PLUGIN_CATALOG);
     // An empty catalog that has already ARRIVED: the popover only bootstraps
     // one nobody has read yet, so every case but that one stays offline.
     seedPacks([]);
+    seedPlugins([]);
     vi.mocked(fetchHealth).mockReset();
     vi.mocked(fetchHealth).mockResolvedValue({
       status: 'ok', version: '2.2.0', nodes_loaded: 137, presets_loaded: 12,
@@ -381,6 +454,104 @@ describe('SettingsPopover', () => {
     usePackStore.setState({ loading: true });
     render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
     expect(mockedListPacks).not.toHaveBeenCalled();
+  });
+
+  // ── Plugins (the Plugin Center entry point) ───────────────────────
+
+  it('counts what is installed and what is installable, and opens the Plugin Center', () => {
+    seedPlugins([
+      pluginEntry({ id: 'edu', status: 'installed', enabled: true }),
+      pluginEntry({ id: 'c1', status: 'disabled' }),
+      pluginEntry({ id: 'stats', status: 'available' }),
+      pluginEntry({ id: 'gone', status: 'removed' }),
+      // Neither half: an install in flight is not something the reader has,
+      // and a lockfile entry with no files is not something they can install.
+      pluginEntry({ id: 'busy', status: 'installing' }),
+      pluginEntry({ id: 'broken', status: 'missing_files' }),
+    ]);
+    const onClose = vi.fn();
+    render(<SettingsPopover open onClose={onClose} triggerRef={makeTriggerRef()} />);
+
+    expect(screen.getByText('Plugins')).toBeInTheDocument();
+    expect(screen.getByText('Plugin Center')).toBeInTheDocument();
+    expect(screen.getByText('2 installed, 2 available')).toBeInTheDocument();
+    // A view of the store: a catalog already here is never re-read.
+    expect(mockedListPluginCatalog).not.toHaveBeenCalled();
+
+    // Named for what it opens, because "Open" is now the visible word on two
+    // buttons in this panel and says nothing on its own in a list of controls.
+    fireEvent.click(screen.getByRole('button', { name: 'Plugin Center' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(useUIStore.getState().pluginCenterOpen).toBe(true);
+    // No plugin is focused: this is the "show me everything" entry point, and
+    // the click handler must not pass its event through as a plugin id.
+    expect(useUIStore.getState().pluginCenterFocusPluginId).toBeNull();
+  });
+
+  it('leaves the Package Center button findable by its own visible word', () => {
+    // Two rows, two buttons, one visible label between them. The pack button
+    // keeps the plain accessible name it has always had.
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+    expect(screen.getByRole('button', { name: 'Open' })).toBeInTheDocument();
+    expect(screen.getAllByText('Open')).toHaveLength(2);
+  });
+
+  it('says unsupported on a server with no Plugin Center', () => {
+    seedPlugins([], { unsupported: true });
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+
+    // Scoped to the row: the packs row reuses this same sentence about its
+    // own server, and the two verdicts are independent.
+    const row = screen.getByText('Plugin Center').parentElement!;
+    expect(within(row).getByText('Not available on this server')).toBeInTheDocument();
+    expect(screen.queryByText('0 installed, 0 available')).toBeNull();
+  });
+
+  it('shows the installing summary while a job runs, naming the row', () => {
+    seedPlugins([pluginEntry({ id: 'edu', name: 'EDU teaching nodes', status: 'installing' })], {
+      job: emptyPluginJob('job-1', 'edu'),
+    });
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+
+    expect(screen.getByText('Installing EDU teaching nodes...')).toBeInTheDocument();
+  });
+
+  it('falls back to the plugin id when the catalog in hand does not list it', () => {
+    // A job adopted from another tab can name a plugin this catalog read
+    // missed; the id is still a usable sentence.
+    seedPlugins([], { job: emptyPluginJob('job-2', 'mystery-plugin') });
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+
+    expect(screen.getByText('Installing mystery-plugin...')).toBeInTheDocument();
+  });
+
+  it('ignores a plugin job that is no longer running', () => {
+    seedPlugins([pluginEntry({ id: 'edu', status: 'installed', enabled: true })], {
+      job: { ...emptyPluginJob('job-3', 'edu'), status: 'done' },
+    });
+    render(<SettingsPopover open onClose={vi.fn()} triggerRef={makeTriggerRef()} />);
+
+    expect(screen.getByText('1 installed, 0 available')).toBeInTheDocument();
+  });
+
+  it('reads the plugin catalog when the popover opens, and not while it is closed', async () => {
+    _resetPluginStoreForTesting();
+    const triggerRef = makeTriggerRef();
+    const { rerender } = render(
+      <SettingsPopover open={false} onClose={vi.fn()} triggerRef={triggerRef} />,
+    );
+    expect(mockedListPluginCatalog).not.toHaveBeenCalled();
+    // Nothing has answered yet, so the row explains itself instead of
+    // claiming "0 installed, 0 available".
+    rerender(<SettingsPopover open onClose={vi.fn()} triggerRef={triggerRef} />);
+    expect(
+      screen.getByText('Install teaching node packs and plugins from GitHub.'),
+    ).toBeInTheDocument();
+
+    await waitFor(() => expect(usePluginStore.getState().loaded).toBe(true));
+    expect(mockedListPluginCatalog).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('0 installed, 0 available')).toBeInTheDocument();
   });
 
   // ── Execution: global device selector ─────────────────────────────

--- a/frontend/src/components/Toolbar/SettingsPopover.test.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.test.tsx
@@ -479,8 +479,10 @@ describe('SettingsPopover', () => {
     expect(mockedListPluginCatalog).not.toHaveBeenCalled();
 
     // Named for what it opens, because "Open" is now the visible word on two
-    // buttons in this panel and says nothing on its own in a list of controls.
-    fireEvent.click(screen.getByRole('button', { name: 'Plugin Center' }));
+    // buttons in this panel and says nothing on its own in a list of
+    // controls. The name CONTAINS the visible word, so "click Open" still
+    // reaches it (WCAG 2.5.3) rather than only the pack row's button.
+    fireEvent.click(screen.getByRole('button', { name: 'Open Plugin Center' }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(useUIStore.getState().pluginCenterOpen).toBe(true);

--- a/frontend/src/components/Toolbar/SettingsPopover.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.tsx
@@ -3,6 +3,7 @@ import { useTabStore } from '../../store/tabStore';
 import { useUIStore } from '../../store/uiStore';
 import { useToastStore } from '../../store/toastStore';
 import { usePackStore } from '../../store/packStore';
+import { usePluginStore } from '../../store/pluginStore';
 import { useI18n } from '../../i18n';
 import {
   resetWeights,
@@ -13,11 +14,13 @@ import {
   type CodexAuthStatus,
   type DeviceInfo,
   type PackSummary,
+  type PluginCatalogEntry,
 } from '../../api/rest';
 import { computeSegmentNodes } from '../../utils/segmentPath';
 import { generateId } from '../../utils';
 import { confirm } from '../../utils/dialog';
 import { localizedPackTitle, type PackIndex } from '../../utils/packAvailability';
+import { isAvailableStatus, isInstalledStatus } from '../PluginCenter/pluginStatus';
 import { HealthSection } from './HealthSection';
 import { SettingsRow as Row } from './SettingsRow';
 import styles from './SettingsPopover.module.css';
@@ -29,6 +32,8 @@ interface Props {
 }
 
 type PackStoreState = ReturnType<typeof usePackStore.getState>;
+type PluginStoreState = ReturnType<typeof usePluginStore.getState>;
+type PluginIndex = Record<string, PluginCatalogEntry>;
 
 // Module-scope selectors, so each subscription compares the SAME function's
 // output frame to frame. The job is narrowed to the one thing this row says
@@ -43,6 +48,15 @@ const selectPacksLoaded = (state: PackStoreState): boolean => state.loaded;
 const selectPacksUnsupported = (state: PackStoreState): boolean => state.unsupported;
 const selectInstallingPackId = (state: PackStoreState): string | null =>
   state.job !== null && state.job.status === 'running' ? state.job.packId : null;
+
+// The plugin row reads the same five things about its own store, for the same
+// reasons. A plugin install streams its steps too.
+const selectPlugins = (state: PluginStoreState): PluginCatalogEntry[] => state.plugins;
+const selectPluginsById = (state: PluginStoreState): PluginIndex => state.byId;
+const selectPluginsLoaded = (state: PluginStoreState): boolean => state.loaded;
+const selectPluginsUnsupported = (state: PluginStoreState): boolean => state.unsupported;
+const selectInstallingPluginId = (state: PluginStoreState): string | null =>
+  state.job !== null && state.job.status === 'running' ? state.job.pluginId : null;
 
 export function SettingsPopover({ open, onClose, triggerRef }: Props) {
   const ref = useRef<HTMLDivElement>(null);
@@ -122,6 +136,22 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
   useEffect(() => {
     if (!open) return;
     const state = usePackStore.getState();
+    if (!state.loaded && !state.loading) void state.refresh();
+  }, [open]);
+
+  // Plugins, read the same way and bootstrapped under the same guard: the
+  // sidebar shell reads this catalog at boot, and this is the retry for a
+  // read that never arrived.
+  const openPluginCenter = useUIStore((s) => s.openPluginCenter);
+  const plugins = usePluginStore(selectPlugins);
+  const pluginsById = usePluginStore(selectPluginsById);
+  const pluginsLoaded = usePluginStore(selectPluginsLoaded);
+  const pluginsUnsupported = usePluginStore(selectPluginsUnsupported);
+  const installingPluginId = usePluginStore(selectInstallingPluginId);
+
+  useEffect(() => {
+    if (!open) return;
+    const state = usePluginStore.getState();
     if (!state.loaded && !state.loading) void state.refresh();
   }, [open]);
 
@@ -292,6 +322,39 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
           // Package Center is for instead.
           t('settings.packs.desc');
 
+  /**
+   * What to call a plugin: the catalog's own name, and the id when the
+   * catalog in hand does not list it. Unlike a pack, a plugin has no shipped
+   * copy in this build to prefer — a plugin off GitHub is named by its own
+   * manifest, and that name arrives with the row.
+   *
+   * `hasOwnProperty` rather than a bare index: `byId` is built from parsed
+   * JSON, so a plugin id of `constructor` would otherwise answer with a
+   * function and print `Object` as its name.
+   */
+  const pluginName = (pluginId: string): string => {
+    const entry = Object.prototype.hasOwnProperty.call(pluginsById, pluginId)
+      ? pluginsById[pluginId]
+      : undefined;
+    return entry?.name || pluginId;
+  };
+
+  // Deliberately two counts rather than "n of m": a plugin catalog lists what
+  // could be installed as well as what is, and most of it will never be. The
+  // two halves are also not each other's complement — an install in flight
+  // and a lockfile entry whose files are gone are in neither, because neither
+  // is a plugin the reader has, and neither is one they can install.
+  const pluginsDesc = pluginsUnsupported
+    ? t('settings.packs.unsupported')
+    : installingPluginId !== null
+      ? t('settings.plugins.summaryInstalling', { plugin: pluginName(installingPluginId) })
+      : pluginsLoaded
+        ? t('settings.plugins.summary', {
+            installed: plugins.filter((plugin) => isInstalledStatus(plugin.status)).length,
+            available: plugins.filter((plugin) => isAvailableStatus(plugin.status)).length,
+          })
+        : t('settings.plugins.desc');
+
   const compareLabel = canCreateSegment
     ? t('settings.compare.actionCreate')
     : canClearSegment
@@ -409,6 +472,38 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
                   // named after a React synthetic event.
                   openPackCenter();
                 }}
+                className={styles.action}
+              >
+                {t('settings.packs.action')}
+              </button>
+            }
+          />
+        </section>
+
+        {/* ── Plugins ────────────────────────────────────────────── */}
+        <section className={styles.section}>
+          <div className={styles.sectionTitle}>
+            {t('toolbar.settings.section.plugins')}
+          </div>
+
+          <Row
+            name={t('settings.plugins.name')}
+            desc={pluginsDesc}
+            ctrl={
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClose();
+                  // No argument, for the same reason the pack button passes
+                  // none: this entry point opens the whole catalog.
+                  openPluginCenter();
+                }}
+                // "Open" reads fine beside its own row and says nothing at
+                // all in a list of controls, where it is now the second one
+                // with that label. The visible word stays; the accessible
+                // name says which center it opens.
+                aria-label={t('settings.plugins.name')}
                 className={styles.action}
               >
                 {t('settings.packs.action')}

--- a/frontend/src/components/Toolbar/SettingsPopover.tsx
+++ b/frontend/src/components/Toolbar/SettingsPopover.tsx
@@ -502,8 +502,10 @@ export function SettingsPopover({ open, onClose, triggerRef }: Props) {
                 // "Open" reads fine beside its own row and says nothing at
                 // all in a list of controls, where it is now the second one
                 // with that label. The visible word stays; the accessible
-                // name says which center it opens.
-                aria-label={t('settings.plugins.name')}
+                // name CONTAINS it and says which center it opens, so speech
+                // input ("click Open") still reaches this button and the pack
+                // row keeps the bare word to itself.
+                aria-label={t('settings.plugins.action')}
                 className={styles.action}
               >
                 {t('settings.packs.action')}

--- a/frontend/src/components/Toolbar/Toolbar.test.tsx
+++ b/frontend/src/components/Toolbar/Toolbar.test.tsx
@@ -9,6 +9,7 @@ import { useToastStore } from '../../store/toastStore';
 import { useDialogStore } from '../../store/dialogStore';
 import { useProjectStore } from '../../store/projectStore';
 import { usePackStore } from '../../store/packStore';
+import { usePluginStore } from '../../store/pluginStore';
 import { useI18n } from '../../i18n';
 import * as rest from '../../api/rest';
 import * as exportDiagram from '../../utils/exportDiagram';
@@ -27,6 +28,8 @@ vi.mock('../../api/rest', async (importOriginal) => ({
   // makes that line throw a TypeError instead of reporting the 404 an older
   // server answers with.
   PackApiError: (await importOriginal<typeof import('../../api/rest')>()).PackApiError,
+  // `pluginStore.refresh()` narrows the same way, on the shared class.
+  ApiError: (await importOriginal<typeof import('../../api/rest')>()).ApiError,
   // Used directly by Toolbar
   saveGraph: vi.fn(),
   loadGraph: vi.fn(),
@@ -66,6 +69,16 @@ vi.mock('../../api/rest', async (importOriginal) => ({
       launch_mode: 'start',
       restart_available: false,
       gpu: null,
+    }),
+  ),
+  // ...and the Plugins row beside it, which reads its own catalog the same
+  // way and under the same guard.
+  listPluginCatalog: vi.fn(() =>
+    Promise.resolve({
+      entries: [],
+      active_job: null,
+      remote_install_allowed: true,
+      generation: 0,
     }),
   ),
 }));
@@ -156,9 +169,10 @@ describe('Toolbar', () => {
     });
     useNodeDefStore.setState({ definitions: [], presets: [], categorized: {}, presetCategorized: {} });
     useProjectStore.setState({ projectDir: null, projectName: null, loaded: false });
-    // An empty catalog that has already ARRIVED: the settings popover only
+    // Empty catalogs that have already ARRIVED: the settings popover only
     // asks for one nobody has read yet, so opening it here stays offline.
     usePackStore.setState({ packs: [], byId: {}, loaded: true, loading: false, job: null });
+    usePluginStore.setState({ plugins: [], byId: {}, loaded: true, loading: false, job: null });
     setActiveTab();
 
     // Stub blob-download plumbing (jsdom lacks createObjectURL).

--- a/frontend/src/components/shared/DialogContainer.module.css
+++ b/frontend/src/components/shared/DialogContainer.module.css
@@ -6,7 +6,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 10000;
+  /* Above every panel that can raise one: the modal rung (10000) and the
+     Plugin Center on 10001, which asks this dialog before an uninstall. It
+     used to share the modal rung and win on DOM order alone -- this portal
+     mounts when the question is asked, so it was always the later sibling --
+     which stopped being true the moment one panel took a rung of its own. */
+  z-index: 10002;
   padding: var(--sp-7);
 }
 

--- a/frontend/src/components/shared/Pill.module.css
+++ b/frontend/src/components/shared/Pill.module.css
@@ -1,0 +1,61 @@
+/* Shared status pill. Colours, type and spacing come from tokens.css only. */
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--fs-2xs);
+  font-weight: var(--fw-semibold);
+  /* Density comes from the padding: the label stays legible at any size. */
+  padding: var(--sp-1) var(--sp-3);
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.pill[data-tone='success'] {
+  background: var(--success-wash);
+  color: var(--status-success);
+}
+
+.pill[data-tone='warning'] {
+  background: var(--warning-wash);
+  color: var(--status-warning);
+}
+
+.pill[data-tone='info'] {
+  background: var(--info-wash);
+  color: var(--status-info);
+}
+
+.pill[data-tone='neutral'] {
+  background: var(--surface-input);
+  color: var(--text-muted);
+}
+
+.pillDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  /* The pill's own colour, so one rule per tone dresses the dot as well. */
+  background: currentcolor;
+  flex-shrink: 0;
+  animation: pillPulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pillPulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.25;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pillDot {
+    animation: none;
+  }
+}

--- a/frontend/src/components/shared/Pill.test.tsx
+++ b/frontend/src/components/shared/Pill.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Pill } from './Pill';
+
+/**
+ * The chip both centers wear.
+ *
+ * What is worth pinning is the contract its callers and their tests read:
+ * the tone lands on `data-tone`, the pulse dot is marked and hidden from
+ * assistive tech, and the label is the pill's whole accessible text.
+ */
+
+describe('Pill', () => {
+  it('renders the label and reports its tone as an attribute', () => {
+    render(<Pill tone="success">Installed</Pill>);
+
+    const pill = screen.getByText('Installed');
+    expect(pill.getAttribute('data-tone')).toBe('success');
+    expect(pill.className).toMatch(/pill/);
+  });
+
+  it('wears every tone the scale defines', () => {
+    const { rerender } = render(<Pill tone="warning">Files missing</Pill>);
+    expect(screen.getByText('Files missing').getAttribute('data-tone')).toBe('warning');
+
+    rerender(<Pill tone="info">Installing</Pill>);
+    expect(screen.getByText('Installing').getAttribute('data-tone')).toBe('info');
+
+    rerender(<Pill tone="neutral">Not installed</Pill>);
+    expect(screen.getByText('Not installed').getAttribute('data-tone')).toBe('neutral');
+  });
+
+  it('shows no dot by default', () => {
+    const { container } = render(<Pill tone="neutral">Disabled</Pill>);
+
+    expect(container.querySelector('[data-role="pulse"]')).toBeNull();
+  });
+
+  it('marks a pulsing pill as live without announcing the dot', () => {
+    const { container } = render(<Pill tone="info" pulse>Installing</Pill>);
+
+    const dot = container.querySelector('[data-role="pulse"]');
+    expect(dot).not.toBeNull();
+    // Decoration: the label beside it already says the state, and a screen
+    // reader that stopped on an empty span would be reading punctuation.
+    expect(dot?.getAttribute('aria-hidden')).toBe('true');
+    // Still the pill's only text, so `getByText('Installing')` in a caller's
+    // test keeps matching the pill rather than splitting across two nodes.
+    expect(screen.getByText('Installing').textContent).toBe('Installing');
+  });
+});

--- a/frontend/src/components/shared/Pill.tsx
+++ b/frontend/src/components/shared/Pill.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+import styles from './Pill.module.css';
+
+/** Which wash a pill wears. Names a ROLE, not a colour. */
+export type PillTone = 'success' | 'warning' | 'info' | 'neutral';
+
+export interface PillProps {
+  tone: PillTone;
+  /**
+   * Prefix the label with a pulsing dot: something is still happening.
+   *
+   * A dot rather than a spinner, because it says "still going" without
+   * claiming to know how far, and it stops dead under reduced motion.
+   */
+  pulse?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * One status chip for the whole app: a pack's state, a plugin's state, the
+ * chip on a plugin row in the sidebar.
+ *
+ * The tone is an attribute rather than a class so the stylesheet reads as one
+ * table of washes, and so a test can assert the ROLE a pill is claiming
+ * ("this is a warning") instead of a hashed CSS-module name.
+ *
+ * Deliberately not a button and not focusable: it reports a state the
+ * controls beside it change. A pill that wants a click is a button.
+ */
+export function Pill({ tone, pulse = false, children }: PillProps) {
+  return (
+    <span className={styles.pill} data-tone={tone}>
+      {pulse && (
+        <span className={styles.pillDot} data-role="pulse" aria-hidden="true" />
+      )}
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/shared/Toast.module.css
+++ b/frontend/src/components/shared/Toast.module.css
@@ -2,12 +2,12 @@
   position: fixed;
   bottom: var(--sp-6);
   right: var(--sp-6);
-  /* Above the modal backdrops (10000). Both are portalled into <body> and
-     neither ancestor makes a stacking context, so a tie is broken by tree
-     order and the Package Center — a later sibling — painted its scrim over
-     every toast its own buttons fire. A click then hit the backdrop and
-     closed the panel. */
-  z-index: 10001;
+  /* Above every modal backdrop (10000), the Plugin Center on its own rung
+     (10001) and the confirm dialog (10002). Neither ancestor makes a
+     stacking context, so a tie is broken by tree order and the Package
+     Center — a later sibling — painted its scrim over every toast its own
+     buttons fire. A click then hit the backdrop and closed the panel. */
+  z-index: 10003;
   display: flex;
   flex-direction: column-reverse;
   gap: var(--sp-3);

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1087,6 +1087,110 @@ const en = {
   'pluginCenter.source.invalid':
     'Enter a catalog name, owner/repo[@ref] or a GitHub URL.',
 
+  // The panel: its chrome, what the list can be saying instead of rows, and
+  // the filter over them.
+  'pluginCenter.title': 'Plugin Center',
+  'pluginCenter.subtitle': 'Install packs of teaching nodes, and plugins from GitHub',
+  'pluginCenter.close': 'Close Plugin Center',
+  'pluginCenter.refresh': 'Refresh plugin status',
+  'pluginCenter.list': 'Plugin list',
+  'pluginCenter.loading': 'Loading plugins...',
+  'pluginCenter.loadFail': 'Failed to load plugins: {error}',
+  // A server older than the Plugin Center. `pluginCenter.error.unavailable`
+  // says the same sentence about a server whose plugin service is not up:
+  // the cause differs, what the user does about it does not.
+  'pluginCenter.unsupported':
+    'This server has no Plugin Center. Update CodefyUI and restart it.',
+  'pluginCenter.empty': 'No plugins are available',
+  'pluginCenter.filter.all': 'All',
+  'pluginCenter.filter.installed': 'Installed',
+  'pluginCenter.filter.available': 'Available',
+
+  // Where a plugin came from. A plain third-party repository gets no chip --
+  // the card prints owner/repo, and "GitHub" over a GitHub link says it twice.
+  'pluginCenter.origin.builtin': 'Built-in',
+  'pluginCenter.origin.official': 'Official',
+  'pluginCenter.origin.local': 'Linked folder',
+  'pluginCenter.homepage': 'Homepage',
+  'pluginCenter.chapters': 'Lessons: {chapters}',
+
+  // The two states a pack has no word for. The other four statuses reuse
+  // `packs.status.*` and `customNodes.disabled`.
+  'pluginCenter.status.removed': 'Removed',
+  'pluginCenter.status.missingFiles': 'Files missing',
+
+  // The row's buttons (`pluginCenter.uninstall` is up with its confirm).
+  'pluginCenter.install': 'Install',
+  'pluginCenter.enable': 'Enable',
+  'pluginCenter.disable': 'Disable',
+  'pluginCenter.update': 'Update',
+  // The server refused an install because the plugin is already there. That
+  // refusal is an offer rather than a failure, and this button accepts it.
+  'pluginCenter.reinstall': 'Reinstall',
+
+  // Installing something the catalog does not list.
+  'pluginCenter.source.label': 'Install from GitHub',
+  'pluginCenter.source.placeholder': 'owner/repo[@ref] or GitHub URL',
+  'pluginCenter.source.review': 'Review',
+  'pluginCenter.source.reviewing': 'Downloading...',
+  'pluginCenter.source.fail': 'Could not fetch {source}: {message}',
+
+  // The consent screen. Nothing is installed until this has been read and
+  // what it asks for has been ticked.
+  'pluginCenter.review.title': 'Review before installing',
+  'pluginCenter.review.author': 'Author: {author}',
+  'pluginCenter.review.nodes': 'Nodes: {nodes}',
+  'pluginCenter.review.capabilities': 'This plugin asks for:',
+  // Says what granting is and is not: "capabilities" reads like a sandbox,
+  // and this is a declaration -- nothing here is enforced at runtime.
+  'pluginCenter.review.capNote':
+    'Granting is a declaration, not a sandbox: the plugin may use these '
+    + 'modules and will not be asked again.',
+  'pluginCenter.review.grant': 'Grant these capabilities',
+  'pluginCenter.review.trust': 'I trust this author. Allows: {modules}',
+  'pluginCenter.review.frontend':
+    'Ships JavaScript that runs in this editor with full access.',
+  'pluginCenter.review.idConflict': 'The id "{id}" is reserved for a built-in pack.',
+
+  // One line per declared capability, each saying what granting it COSTS
+  // rather than what it is called. An id this build has no line for is
+  // printed as itself.
+  'pluginCenter.cap.network':
+    'network: reach any host, and write what it downloads to disk',
+  'pluginCenter.cap.filesystem':
+    'filesystem: use the file libraries (pathlib, shutil, zip/tar, sqlite3)',
+  'pluginCenter.cap.processEnv':
+    "process-env: the whole os module, including this process's environment "
+    + 'and API keys, starting programs, deleting files',
+
+  // The activity pane: what is running, and how it ended.
+  'pluginCenter.activity.installing': 'Installing {plugin}',
+  'pluginCenter.activity.updating': 'Updating {plugin}',
+  'pluginCenter.activity.installed': 'Installed {plugin}.',
+  'pluginCenter.activity.updated': 'Updated {plugin}.',
+  'pluginCenter.activity.lost':
+    'Lost contact with the server. Refresh to check the plugin status.',
+  'pluginCenter.activity.needsRestart': 'Installed. Restart the server to load {plugin}:',
+  'pluginCenter.activity.cliFallback': 'Or install from a terminal:',
+
+  // The steps of an install, in the order they run. There is no `step.deps`
+  // on purpose: pip is pip, and it reuses `packs.activity.step.pip`.
+  'pluginCenter.step.resolve': 'Resolving the source',
+  'pluginCenter.step.download': 'Downloading',
+  'pluginCenter.step.extract': 'Unpacking',
+  'pluginCenter.step.verify': 'Checking the code',
+  'pluginCenter.step.stage': 'Copying files',
+  'pluginCenter.step.lock': 'Recording the install',
+  'pluginCenter.step.reload': 'Loading the nodes',
+
+  // The refusals whose entire body is a code: these routes answer
+  // `{detail: {code: ...}}` with no message at all, so without a sentence
+  // here the panel shows the raw token -- "inspection_expired".
+  'pluginCenter.error.unavailable':
+    'This server has no Plugin Center. Update CodefyUI and restart it.',
+  'pluginCenter.error.inspectionExpired': 'The review expired. Review the source again.',
+  'pluginCenter.error.unknownJob': 'That install is no longer tracked. Refresh.',
+
   // Source Control (the sidebar's fifth tab). Part 2 of the track: status,
   // stage / unstage / discard, commit, init and the commit identity. Branches,
   // remotes, history and the diff view arrive with their own strings later, so

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1072,8 +1072,13 @@ const en = {
   // wrong.
   'pluginCenter.toast.refreshFailed':
     'Could not refresh the editor after the change: {message}',
-  // The files are in place; the running server could not pick them up.
-  'pluginCenter.toast.needsRestart': 'Restart the server to load {plugin}.',
+  // NOTHING was installed. A plugin job reaches this status from one place
+  // only -- the resolver refusing to replace a package the running server has
+  // already loaded -- and that happens before a single file is written, so
+  // the install has to be run again after the packages are in place.
+  'pluginCenter.toast.needsRestart':
+    'The install of {plugin} stopped: its Python packages need the server '
+    + 'stopped first. The command is in the Plugin Center.',
   'pluginCenter.toast.inProgress':
     'A plugin is still installing. Open the Plugin Center to watch it.',
   'pluginCenter.toast.openCenter': 'Open Plugin Center',
@@ -1177,7 +1182,12 @@ const en = {
   'pluginCenter.activity.updated': 'Updated {plugin}.',
   'pluginCenter.activity.lost':
     'Lost contact with the server. Refresh to check the plugin status.',
-  'pluginCenter.activity.needsRestart': 'Installed. Restart the server to load {plugin}:',
+  // Ends in a colon because a `CommandBlock` follows it, and the command is a
+  // `uv pip install` line to run with the server STOPPED -- not a restart.
+  'pluginCenter.activity.needsRestart':
+    "The install stopped before changing anything: {plugin}'s Python packages "
+    + 'would replace one the server has loaded. With the server stopped, run this, '
+    + 'then install again:',
   'pluginCenter.activity.cliFallback': 'Or install from a terminal:',
 
   // The steps of an install, in the order they run. There is no `step.deps`

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1184,6 +1184,11 @@ const en = {
   'pluginCenter.review.frontend':
     'Ships JavaScript that runs in this editor with full access.',
   'pluginCenter.review.idConflict': 'The id "{id}" is reserved for a built-in pack.',
+  // The 409 the store treats as an OFFER, said out loud: without it the only
+  // sign is the Install button coming back as Reinstall.
+  'pluginCenter.review.alreadyInstalled':
+    '{plugin} is already installed. Reinstall replaces the installed copy '
+    + 'with this one.',
 
   // One line per declared capability, each saying what granting it COSTS
   // rather than what it is called. An id this build has no line for is

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -146,9 +146,10 @@ const en = {
   'customTab.section.nodes': 'Custom Nodes',
   'customTab.section.plugins': 'Plugins',
   'customTab.manage': 'Manage...',
+  'customTab.plugins.open': 'Plugin Center...',
   'customTab.nodes.empty': 'No custom nodes yet',
   'customTab.plugins.empty': 'No plugins installed',
-  'customTab.plugins.hint': 'Install packs with the cdui plugin CLI',
+  'customTab.plugins.hint': 'Install plugins from the Plugin Center',
   'customTab.loadFail': 'Failed to load: {error}',
 
   // Config Panel
@@ -1208,6 +1209,18 @@ const en = {
     "GitHub's request limit was reached. Try again later, or set "
     + 'CODEFYUI_GITHUB_TOKEN on the server.',
   'pluginCenter.error.githubUnreachable': 'Could not reach GitHub.',
+
+  // Where the Plugin Center is opened from: the settings popover's own row.
+  // The sidebar's entry point is up with the rest of the Custom & Plugins
+  // tab. `settings.packs.unsupported` and `settings.packs.action` are reused
+  // as they are -- "Not available on this server" and "Open" say the same
+  // thing about either center, and a second translation of each is a second
+  // string to keep in step.
+  'toolbar.settings.section.plugins': 'Plugins',
+  'settings.plugins.name': 'Plugin Center',
+  'settings.plugins.desc': 'Install teaching node packs and plugins from GitHub.',
+  'settings.plugins.summary': '{installed} installed, {available} available',
+  'settings.plugins.summaryInstalling': 'Installing {plugin}...',
 
   // Source Control (the sidebar's fifth tab). Part 2 of the track: status,
   // stage / unstage / discard, commit, init and the commit identity. Branches,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -148,8 +148,11 @@ const en = {
   'customTab.manage': 'Manage...',
   'customTab.plugins.open': 'Plugin Center...',
   'customTab.nodes.empty': 'No custom nodes yet',
+  // No hint under the empty plugins section: the header button one line above
+  // it IS the Plugin Center, so a sentence naming that destination is the
+  // same fact twice. The packs hint stays because it carries another one --
+  // what a pack is.
   'customTab.plugins.empty': 'No plugins installed',
-  'customTab.plugins.hint': 'Install plugins from the Plugin Center',
   'customTab.loadFail': 'Failed to load: {error}',
 
   // Config Panel
@@ -1026,6 +1029,24 @@ const en = {
   'customTab.packs.hint':
     'Models and libraries for LLM nodes are installed from the Package Center',
 
+  // Where the Plugin Center is opened from: the settings popover's own row,
+  // beside the pack one it is modelled on. The sidebar's entry point is up
+  // with the rest of the Custom & Plugins tab. `settings.packs.unsupported`
+  // is reused as it is -- "Not available on this server" says the same thing
+  // about either center, and a second translation of it is a second string to
+  // keep in step.
+  'toolbar.settings.section.plugins': 'Plugins',
+  'settings.plugins.name': 'Plugin Center',
+  'settings.plugins.desc': 'Install teaching node packs and plugins from GitHub.',
+  'settings.plugins.summary': '{installed} installed, {available} available',
+  'settings.plugins.summaryInstalling': 'Installing {plugin}...',
+  // The button's visible word is `settings.packs.action` ("Open"), the same
+  // as the pack row's. This is its accessible name: two buttons reading
+  // "Open" say nothing in a list of controls, and speech input ("click Open")
+  // has to reach one of them -- so the pack row keeps the bare word and this
+  // one contains it, the way `paramField.installPackFor` does.
+  'settings.plugins.action': 'Open Plugin Center',
+
   // "This needs a pack" — said on a select option, a node, a palette entry
   // and a refused run. Every one of them names the pack, because "needs a
   // pack" without a name is not something a user can act on.
@@ -1222,18 +1243,6 @@ const en = {
     "GitHub's request limit was reached. Try again later, or set "
     + 'CODEFYUI_GITHUB_TOKEN on the server.',
   'pluginCenter.error.githubUnreachable': 'Could not reach GitHub.',
-
-  // Where the Plugin Center is opened from: the settings popover's own row.
-  // The sidebar's entry point is up with the rest of the Custom & Plugins
-  // tab. `settings.packs.unsupported` and `settings.packs.action` are reused
-  // as they are -- "Not available on this server" and "Open" say the same
-  // thing about either center, and a second translation of each is a second
-  // string to keep in step.
-  'toolbar.settings.section.plugins': 'Plugins',
-  'settings.plugins.name': 'Plugin Center',
-  'settings.plugins.desc': 'Install teaching node packs and plugins from GitHub.',
-  'settings.plugins.summary': '{installed} installed, {available} available',
-  'settings.plugins.summaryInstalling': 'Installing {plugin}...',
 
   // Source Control (the sidebar's fifth tab). Part 2 of the track: status,
   // stage / unstage / discard, commit, init and the commit identity. Branches,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1190,6 +1190,18 @@ const en = {
     'This server has no Plugin Center. Update CodefyUI and restart it.',
   'pluginCenter.error.inspectionExpired': 'The review expired. Review the source again.',
   'pluginCenter.error.unknownJob': 'That install is no longer tracked. Refresh.',
+  // One review at a time, server-side: this one is not about the source at
+  // all, which is why it says "again" rather than anything about the repo.
+  'pluginCenter.error.inspectBusy': 'Another review is still running. Try again in a moment.',
+  // The three ways a source can turn out not to be a plugin this build
+  // installs: the manifest, a repository or ref that is not there, and
+  // GitHub itself.
+  'pluginCenter.error.invalidManifest': "The plugin's manifest is invalid.",
+  'pluginCenter.error.notFound': 'GitHub has no such repository or ref.',
+  'pluginCenter.error.githubRateLimited':
+    "GitHub's request limit was reached. Try again later, or set "
+    + 'CODEFYUI_GITHUB_TOKEN on the server.',
+  'pluginCenter.error.githubUnreachable': 'Could not reach GitHub.',
 
   // Source Control (the sidebar's fifth tab). Part 2 of the track: status,
   // stage / unstage / discard, commit, init and the commit identity. Branches,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1134,6 +1134,12 @@ const en = {
   'pluginCenter.source.review': 'Review',
   'pluginCenter.source.reviewing': 'Downloading...',
   'pluginCenter.source.fail': 'Could not fetch {source}: {message}',
+  // A bare word that is not one of this build's packs. The refusal is a code
+  // with no sentence in it, and no sentence written on the server could have
+  // said the useful part: which names WOULD work. That list only exists in
+  // the body, so the panel is what puts the two together.
+  'pluginCenter.source.unknownName': 'No plugin is called "{source}".',
+  'pluginCenter.source.knownNames': 'This server can install: {known}',
 
   // The consent screen. Nothing is installed until this has been read and
   // what it asks for has been ticked.

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1197,6 +1197,9 @@ const en = {
     'This server has no Plugin Center. Update CodefyUI and restart it.',
   'pluginCenter.error.inspectionExpired': 'The review expired. Review the source again.',
   'pluginCenter.error.unknownJob': 'That install is no longer tracked. Refresh.',
+  // A row for a plugin that has since been removed somewhere else: the button
+  // was pressed against a catalog this tab read a while ago.
+  'pluginCenter.error.notInstalled': 'This plugin is not installed any more. Refresh the list.',
   // One review at a time, server-side: this one is not about the source at
   // all, which is why it says "again" rather than anything about the repo.
   'pluginCenter.error.inspectBusy': 'Another review is still running. Try again in a moment.',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -1063,6 +1063,7 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.error.unavailable': '這台伺服器不支援外掛中心。請更新 CodefyUI 後重新啟動。',
   'pluginCenter.error.inspectionExpired': '檢視已過期，請重新檢視來源。',
   'pluginCenter.error.unknownJob': '找不到這個安裝，請重新整理。',
+  'pluginCenter.error.notInstalled': '這個外掛已不在安裝清單中，請重新整理。',
   'pluginCenter.error.inspectBusy': '另一個檢視仍在進行，請稍後再試。',
   'pluginCenter.error.invalidManifest': '外掛的 manifest 無效。',
   'pluginCenter.error.notFound': 'GitHub 上找不到這個 repository 或 ref。',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -1060,6 +1060,12 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.error.unavailable': '這台伺服器不支援外掛中心。請更新 CodefyUI 後重新啟動。',
   'pluginCenter.error.inspectionExpired': '檢視已過期，請重新檢視來源。',
   'pluginCenter.error.unknownJob': '找不到這個安裝，請重新整理。',
+  'pluginCenter.error.inspectBusy': '另一個檢視仍在進行，請稍後再試。',
+  'pluginCenter.error.invalidManifest': '外掛的 manifest 無效。',
+  'pluginCenter.error.notFound': 'GitHub 上找不到這個 repository 或 ref。',
+  'pluginCenter.error.githubRateLimited':
+    '已達 GitHub 請求上限，請稍後再試，或在伺服器設定 CODEFYUI_GITHUB_TOKEN。',
+  'pluginCenter.error.githubUnreachable': '無法連線到 GitHub。',
 
   // Source Control (the sidebar's fifth tab).
   'git.action.more': '更多動作',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -139,9 +139,10 @@ const zhTW: Record<TranslationKey, string> = {
   'customTab.section.nodes': '自訂節點',
   'customTab.section.plugins': '外掛',
   'customTab.manage': '管理...',
+  'customTab.plugins.open': '外掛中心...',
   'customTab.nodes.empty': '尚未有自訂節點',
   'customTab.plugins.empty': '尚未安裝外掛',
-  'customTab.plugins.hint': '使用 cdui plugin 指令安裝外掛套件',
+  'customTab.plugins.hint': '外掛可在外掛中心安裝',
   'customTab.loadFail': '載入失敗：{error}',
 
   // Config Panel
@@ -1068,6 +1069,13 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.error.githubRateLimited':
     '已達 GitHub 請求上限，請稍後再試，或在伺服器設定 CODEFYUI_GITHUB_TOKEN。',
   'pluginCenter.error.githubUnreachable': '無法連線到 GitHub。',
+
+  // Where the Plugin Center is opened from: the settings popover's own row.
+  'toolbar.settings.section.plugins': '外掛',
+  'settings.plugins.name': '外掛中心',
+  'settings.plugins.desc': '安裝教學節點套件與 GitHub 上的外掛。',
+  'settings.plugins.summary': '已安裝 {installed} 個，可安裝 {available} 個',
+  'settings.plugins.summaryInstalling': '正在安裝 {plugin}...',
 
   // Source Control (the sidebar's fifth tab).
   'git.action.more': '更多動作',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -142,7 +142,6 @@ const zhTW: Record<TranslationKey, string> = {
   'customTab.plugins.open': '外掛中心...',
   'customTab.nodes.empty': '尚未有自訂節點',
   'customTab.plugins.empty': '尚未安裝外掛',
-  'customTab.plugins.hint': '外掛可在外掛中心安裝',
   'customTab.loadFail': '載入失敗：{error}',
 
   // Config Panel
@@ -941,6 +940,16 @@ const zhTW: Record<TranslationKey, string> = {
   'customTab.packs.empty': '沒有可安裝的套件',
   'customTab.packs.hint': 'LLM 節點的模型與函式庫可在套件中心安裝',
 
+  // Where the Plugin Center is opened from: the settings popover's own row,
+  // beside the pack one it is modelled on.
+  'toolbar.settings.section.plugins': '外掛',
+  'settings.plugins.name': '外掛中心',
+  'settings.plugins.desc': '安裝教學節點套件與 GitHub 上的外掛。',
+  'settings.plugins.summary': '已安裝 {installed} 個，可安裝 {available} 個',
+  'settings.plugins.summaryInstalling': '正在安裝 {plugin}...',
+  // The accessible name only; the visible word stays `settings.packs.action`.
+  'settings.plugins.action': '開啟外掛中心',
+
   // "This needs a pack" — said on a select option, a node, a palette entry
   // and a refused run. Every one of them names the pack, because "needs a
   // pack" without a name is not something a user can act on.
@@ -1073,13 +1082,6 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.error.githubRateLimited':
     '已達 GitHub 請求上限，請稍後再試，或在伺服器設定 CODEFYUI_GITHUB_TOKEN。',
   'pluginCenter.error.githubUnreachable': '無法連線到 GitHub。',
-
-  // Where the Plugin Center is opened from: the settings popover's own row.
-  'toolbar.settings.section.plugins': '外掛',
-  'settings.plugins.name': '外掛中心',
-  'settings.plugins.desc': '安裝教學節點套件與 GitHub 上的外掛。',
-  'settings.plugins.summary': '已安裝 {installed} 個，可安裝 {available} 個',
-  'settings.plugins.summaryInstalling': '正在安裝 {plugin}...',
 
   // Source Control (the sidebar's fifth tab).
   'git.action.more': '更多動作',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -1018,6 +1018,8 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.source.review': '檢視',
   'pluginCenter.source.reviewing': '正在下載...',
   'pluginCenter.source.fail': '無法取得 {source}：{message}',
+  'pluginCenter.source.unknownName': '沒有名為「{source}」的外掛。',
+  'pluginCenter.source.knownNames': '這台伺服器可安裝：{known}',
 
   // The consent screen.
   'pluginCenter.review.title': '安裝前請確認',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -972,7 +972,8 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.toast.toggleFailed': '無法變更 {plugin}：{message}',
   'pluginCenter.toast.refreshFailed':
     '變更後無法重新整理編輯器：{message}',
-  'pluginCenter.toast.needsRestart': '請重新啟動伺服器以載入 {plugin}。',
+  'pluginCenter.toast.needsRestart':
+    '{plugin} 的安裝停住了：它的 Python 套件需要先停止伺服器才能安裝，指令在外掛中心。',
   'pluginCenter.toast.inProgress': '有外掛仍在安裝中，可在外掛中心查看進度。',
   'pluginCenter.toast.openCenter': '開啟外掛中心',
   'pluginCenter.updateFailed': '更新失敗：{message}',
@@ -1047,7 +1048,9 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.activity.installed': '已安裝 {plugin}。',
   'pluginCenter.activity.updated': '已更新 {plugin}。',
   'pluginCenter.activity.lost': '與伺服器失去聯繫。請重新整理以確認外掛狀態。',
-  'pluginCenter.activity.needsRestart': '已安裝，請重新啟動伺服器以載入 {plugin}：',
+  'pluginCenter.activity.needsRestart':
+    '安裝在改動任何東西前停住了：{plugin} 的 Python 套件會替換伺服器已載入的套件。'
+    + '先停止伺服器並執行這行指令，再重新安裝：',
   'pluginCenter.activity.cliFallback': '或在終端機安裝：',
 
   // The steps of an install; `deps` reuses `packs.activity.step.pip`.

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -980,6 +980,87 @@ const zhTW: Record<TranslationKey, string> = {
     '要解除安裝「{plugin}」嗎？使用它節點的圖將無法執行；它安裝的 Python 套件會保留。',
   'pluginCenter.source.invalid': '請輸入內建套件名稱、owner/repo[@ref] 或 GitHub URL。',
 
+  // The panel: chrome, list states, filter.
+  'pluginCenter.title': '外掛中心',
+  'pluginCenter.subtitle': '安裝教學節點套件與 GitHub 上的外掛',
+  'pluginCenter.close': '關閉外掛中心',
+  'pluginCenter.refresh': '重新整理外掛狀態',
+  'pluginCenter.list': '外掛清單',
+  'pluginCenter.loading': '正在載入外掛...',
+  'pluginCenter.loadFail': '無法載入外掛：{error}',
+  'pluginCenter.unsupported': '這台伺服器不支援外掛中心。請更新 CodefyUI 後重新啟動。',
+  'pluginCenter.empty': '目前沒有可安裝的外掛',
+  'pluginCenter.filter.all': '全部',
+  'pluginCenter.filter.installed': '已安裝',
+  'pluginCenter.filter.available': '可安裝',
+
+  // Where a plugin came from.
+  'pluginCenter.origin.builtin': '內建',
+  'pluginCenter.origin.official': '官方',
+  'pluginCenter.origin.local': '本機連結',
+  'pluginCenter.homepage': '首頁',
+  'pluginCenter.chapters': '章節：{chapters}',
+
+  // The two states a pack has no word for.
+  'pluginCenter.status.removed': '已移除',
+  'pluginCenter.status.missingFiles': '檔案遺失',
+
+  // The row's buttons.
+  'pluginCenter.install': '安裝',
+  'pluginCenter.enable': '啟用',
+  'pluginCenter.disable': '停用',
+  'pluginCenter.update': '更新',
+  'pluginCenter.reinstall': '重新安裝',
+
+  // Installing something the catalog does not list.
+  'pluginCenter.source.label': '從 GitHub 安裝',
+  'pluginCenter.source.placeholder': 'owner/repo[@ref] 或 GitHub URL',
+  'pluginCenter.source.review': '檢視',
+  'pluginCenter.source.reviewing': '正在下載...',
+  'pluginCenter.source.fail': '無法取得 {source}：{message}',
+
+  // The consent screen.
+  'pluginCenter.review.title': '安裝前請確認',
+  'pluginCenter.review.author': '作者：{author}',
+  'pluginCenter.review.nodes': '節點：{nodes}',
+  'pluginCenter.review.capabilities': '這個外掛要求：',
+  'pluginCenter.review.capNote':
+    '授予是一種聲明，不是沙箱：外掛可使用這些模組，之後不會再詢問。',
+  'pluginCenter.review.grant': '同意授予這些能力',
+  'pluginCenter.review.trust': '我信任這位作者。允許使用：{modules}',
+  'pluginCenter.review.frontend': '包含會在編輯器中以完整權限執行的 JavaScript。',
+  'pluginCenter.review.idConflict': '「{id}」是內建套件保留的 id。',
+
+  // One line per declared capability, each saying what granting it costs.
+  'pluginCenter.cap.network': 'network：可連線任何主機，並把下載內容寫入磁碟',
+  'pluginCenter.cap.filesystem':
+    'filesystem：使用檔案函式庫（pathlib、shutil、zip/tar、sqlite3）',
+  'pluginCenter.cap.processEnv':
+    'process-env：整個 os 模組，包含此行程的環境變數與 API 金鑰、啟動程式、刪除檔案',
+
+  // The activity pane.
+  'pluginCenter.activity.installing': '正在安裝 {plugin}',
+  'pluginCenter.activity.updating': '正在更新 {plugin}',
+  'pluginCenter.activity.installed': '已安裝 {plugin}。',
+  'pluginCenter.activity.updated': '已更新 {plugin}。',
+  'pluginCenter.activity.lost': '與伺服器失去聯繫。請重新整理以確認外掛狀態。',
+  'pluginCenter.activity.needsRestart': '已安裝，請重新啟動伺服器以載入 {plugin}：',
+  'pluginCenter.activity.cliFallback': '或在終端機安裝：',
+
+  // The steps of an install; `deps` reuses `packs.activity.step.pip`.
+  'pluginCenter.step.resolve': '正在解析來源',
+  'pluginCenter.step.download': '正在下載',
+  'pluginCenter.step.extract': '正在解壓縮',
+  'pluginCenter.step.verify': '正在檢查程式碼',
+  'pluginCenter.step.stage': '正在複製檔案',
+  'pluginCenter.step.lock': '正在寫入安裝紀錄',
+  'pluginCenter.step.reload': '正在載入節點',
+
+  // The refusals whose entire body is a code.
+  'pluginCenter.error.unavailable': '這台伺服器不支援外掛中心。請更新 CodefyUI 後重新啟動。',
+  'pluginCenter.error.inspectionExpired': '檢視已過期，請重新檢視來源。',
+  'pluginCenter.error.unknownJob': '找不到這個安裝，請重新整理。',
+
   // Source Control (the sidebar's fifth tab).
   'git.action.more': '更多動作',
   'git.action.identity': '提交身分...',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -1043,6 +1043,7 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.review.trust': '我信任這位作者。允許使用：{modules}',
   'pluginCenter.review.frontend': '包含會在編輯器中以完整權限執行的 JavaScript。',
   'pluginCenter.review.idConflict': '「{id}」是內建套件保留的 id。',
+  'pluginCenter.review.alreadyInstalled': '{plugin} 已安裝。重新安裝會以這個版本取代現有的安裝。',
 
   // One line per declared capability, each saying what granting it costs.
   'pluginCenter.cap.network': 'network：可連線任何主機，並把下載內容寫入磁碟',

--- a/frontend/src/store/packStore.ts
+++ b/frontend/src/store/packStore.ts
@@ -33,7 +33,8 @@ import {
 } from './jobFollower';
 import { confirm } from '../utils/dialog';
 import { localizedPackTitle } from '../utils/packAvailability';
-import { useToastStore, type ToastAction } from './toastStore';
+import { errorMessage, str, toast } from './storeText';
+import type { ToastAction } from './toastStore';
 import { useUIStore } from './uiStore';
 import { useI18n, type TranslationKey } from '../i18n';
 
@@ -245,33 +246,20 @@ export function emptyPackJob(
   return { ...emptyJob(jobId), packId, mode, retryMode: null };
 }
 
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
 /**
- * `action` is spread rather than always passed, so a toast without one is
- * byte-for-byte the object every existing caller was already producing.
+ * The button a toast about a pack wears: it opens the panel on that pack.
+ *
+ * Stays here rather than joining `errorMessage`, `str` and `toast` in
+ * `storeText`: the plugin store's copy looks identical and names a different
+ * panel and a different key, so one shared version would need both of them
+ * passed in to say nothing extra.
  */
-function toast(
-  message: string,
-  type: 'info' | 'error' | 'success' | 'warning',
-  action?: ToastAction,
-) {
-  useToastStore.getState().addToast(message, type, action ? { action } : undefined);
-}
-
-/** The button a toast about a pack wears: it opens the panel on that pack. */
 function openCenterAction(packId: string): ToastAction {
   const { t } = useI18n.getState();
   return {
     label: t('packs.toast.openCenter'),
     onClick: () => useUIStore.getState().openPackCenter(packId),
   };
-}
-
-function str(value: unknown): string | null {
-  return typeof value === 'string' ? value : null;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -444,6 +444,27 @@ describe('pluginStore — install', () => {
     });
   });
 
+  it('turns an already-installed refusal into an offer rather than a toast', async () => {
+    api.inspectPluginSource.mockResolvedValue(inspection({
+      plugin_id: 'c1', consent_required: false,
+    }));
+    api.installPlugin.mockRejectedValue(
+      refused(409, 'already_installed', { plugin_id: 'c1' }),
+    );
+
+    await usePluginStore.getState().install('c1');
+
+    // A 409, but not a busy one. The review stays up carrying the code, and
+    // the card turns it into a Reinstall button; read as "another install is
+    // running" this would have toasted and refreshed the offer away.
+    expect(usePluginStore.getState().inspection).toMatchObject({
+      phase: 'ready',
+      forPluginId: 'c1',
+      error: { code: 'already_installed', detail: { plugin_id: 'c1' } },
+    });
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
   it('refuses a second install while a job is running', async () => {
     usePluginStore.setState({ job: emptyPluginJob('j1', 'other') });
 
@@ -549,6 +570,24 @@ describe('pluginStore — inspect', () => {
     expect(state.inspection.failure.message).toBe(
       'Installing is only allowed from the computer that runs the server.',
     );
+  });
+
+  it('says the server has no plugin service instead of showing the code', async () => {
+    // 503 `{code: unavailable}`: the service failed to start, or this build
+    // predates it. The catalog route answers without the service, so this is
+    // where a user meets that refusal first.
+    api.inspectPluginSource.mockRejectedValue(refused(503, 'unavailable'));
+
+    await usePluginStore.getState().inspect('owner/demo');
+
+    const state = usePluginStore.getState();
+    if (state.inspection.phase !== 'error') throw new Error('not an error phase');
+    expect(state.inspection.failure.message).toBe(
+      'This server has no Plugin Center. Update CodefyUI and restart it.',
+    );
+    // The code survives the rewrite: the card switches on one and shows the
+    // other.
+    expect(state.inspection.failure.code).toBe('unavailable');
   });
 
   it('carries the names a catalog miss listed', async () => {
@@ -682,6 +721,76 @@ describe('pluginStore — installInspected', () => {
     });
   });
 
+  it('keeps the review spendable when the plugin is already installed', async () => {
+    await ready();
+    api.installPlugin.mockRejectedValue(
+      refused(409, 'already_installed', { plugin_id: 'demo' }),
+    );
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: true,
+    });
+
+    expect(usePluginStore.getState().inspection).toMatchObject({
+      phase: 'ready',
+      error: { code: 'already_installed', detail: { plugin_id: 'demo' } },
+    });
+    // No busy toast and no refresh: both would answer an offer as if it were
+    // a failure, and the refresh is what takes the card away.
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+    expect(api.listPluginCatalog).not.toHaveBeenCalled();
+  });
+
+  it('reinstalls over what is there without inspecting again', async () => {
+    await ready();
+    // Refused once; the beforeEach default answers the retry with a job.
+    api.installPlugin.mockRejectedValueOnce(
+      refused(409, 'already_installed', { plugin_id: 'demo' }),
+    );
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: true,
+    });
+    api.getPluginJobEvents.mockImplementation(parked);
+
+    // What the card's Reinstall button does.
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: true, force: true,
+    });
+
+    // The same inspection id: the user agreed to a manifest that was read
+    // once, and nothing went back to the source to read it again.
+    expect(api.installPlugin).toHaveBeenCalledTimes(2);
+    expect(api.installPlugin.mock.calls[1][0]).toEqual({
+      inspection_id: 'insp-1',
+      accept_capabilities: ['net', 'fs'],
+      trust_author: true,
+      force: true,
+    });
+    expect(api.inspectPluginSource).toHaveBeenCalledTimes(1);
+    expect(usePluginStore.getState().job).toMatchObject({
+      jobId: 'j1', pluginId: 'demo',
+    });
+    // Spent: the card comes down once the install it offered is running.
+    expect(usePluginStore.getState().inspection).toEqual({ phase: 'idle' });
+  });
+
+  it('says the review expired instead of showing the raw code', async () => {
+    await ready();
+    // `{detail: {code}}` with no message at all, so `err.message` IS
+    // "inspection_expired" -- which is what a student would otherwise read.
+    api.installPlugin.mockRejectedValue(
+      refused(404, 'inspection_expired', { inspection_id: 'insp-1' }),
+    );
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: false,
+    });
+
+    expect(lastToast().message).toBe(
+      'Install failed: The review expired. Review the source again.',
+    );
+  });
+
   it('toasts and refreshes when the server is already busy', async () => {
     await ready();
     api.installPlugin.mockRejectedValue(refused(409, 'busy', { job_id: 'j2' }));
@@ -783,6 +892,17 @@ describe('pluginStore — update', () => {
 
     expect(lastToast().message).toBe('Update failed: GitHub is down');
     expect(usePluginStore.getState().busy.demo).toBeFalsy();
+  });
+
+  it('spells out a refusal whose whole body was a code', async () => {
+    api.updatePlugin.mockRejectedValue(refused(503, 'unavailable'));
+
+    await usePluginStore.getState().update('demo');
+
+    // "Update failed: unavailable" is the sentence this replaces.
+    expect(lastToast().message).toBe(
+      'Update failed: This server has no Plugin Center. Update CodefyUI and restart it.',
+    );
   });
 });
 
@@ -1117,6 +1237,20 @@ describe('pluginStore — cancel and dismiss', () => {
 
     expect(lastToast().message).toBe('Could not cancel the install: gone');
     expect(usePluginStore.getState().cancelling).toBe(false);
+  });
+
+  it('says a forgotten job is untracked instead of showing the code', async () => {
+    // The refusal a cancel actually meets: the server restarted, or the job
+    // aged out. "Could not cancel the install: unknown_job" is what this
+    // replaces.
+    usePluginStore.setState({ job: emptyPluginJob('j5', 'demo') });
+    api.cancelPluginJob.mockRejectedValue(refused(404, 'unknown_job', { job_id: 'j5' }));
+
+    await usePluginStore.getState().cancel();
+
+    expect(lastToast().message).toBe(
+      'Could not cancel the install: That install is no longer tracked. Refresh.',
+    );
   });
 
   it('has nothing to cancel when no job is running', async () => {

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -990,6 +990,32 @@ describe('pluginStore — update', () => {
       'Update failed: This server has no Plugin Center. Update CodefyUI and restart it.',
     );
   });
+
+  it('carries the hint when this is not a plugin the panel updates', async () => {
+    // The code says nothing and the hint says everything: a built-in pack
+    // comes with the release, so it updates with the release.
+    api.updatePlugin.mockRejectedValue(refused(400, 'not_updatable', {
+      hint: 'A built-in pack updates with cdui update.',
+    }));
+
+    await usePluginStore.getState().update('demo');
+
+    expect(lastToast().message).toBe(
+      'Update failed: A built-in pack updates with cdui update.',
+    );
+    // Nothing broke, so the same tone `files_locked` gets.
+    expect(lastToast().type).toBe('warning');
+  });
+
+  it('says a plugin has gone rather than showing not_installed', async () => {
+    api.updatePlugin.mockRejectedValue(refused(404, 'not_installed'));
+
+    await usePluginStore.getState().update('demo');
+
+    expect(lastToast().message).toBe(
+      'Update failed: This plugin is not installed any more. Refresh the list.',
+    );
+  });
 });
 
 // ── uninstall, enable, disable ───────────────────────────────────────────
@@ -1066,6 +1092,20 @@ describe('pluginStore — uninstall', () => {
     expect(lastToast().message).toBe('Could not remove Demo plugin: Failed to fetch');
     expect(usePluginStore.getState().busy.demo).toBeFalsy();
   });
+
+  it('says a plugin has gone rather than showing not_installed', async () => {
+    // Removed from the CLI or another tab a moment ago: this row is stale,
+    // and "Could not remove Demo plugin: not_installed" is the token this
+    // replaces.
+    api.uninstallPlugin.mockRejectedValue(refused(404, 'not_installed'));
+
+    await usePluginStore.getState().uninstall('demo');
+
+    expect(lastToast().message).toBe(
+      'Could not remove Demo plugin: This plugin is not installed any more. '
+      + 'Refresh the list.',
+    );
+  });
 });
 
 describe('pluginStore — setEnabled', () => {
@@ -1100,6 +1140,18 @@ describe('pluginStore — setEnabled', () => {
 
     expect(lastToast().message).toBe('Could not change Demo plugin: nope');
     expect(usePluginStore.getState().busy.demo).toBeFalsy();
+  });
+
+  it('re-reads the catalog when the plugin turns out to be busy', async () => {
+    // The switch is only still on screen because this tab's catalog is old:
+    // "Could not change Demo plugin: busy" is the token this replaces.
+    api.setPluginEnabled.mockRejectedValue(refused(409, 'busy', { job_id: 'j1' }));
+
+    await usePluginStore.getState().setEnabled('demo', true);
+
+    expect(lastToast().message).toBe('Another install is already running.');
+    expect(lastToast().type).toBe('warning');
+    expect(order).toEqual(['catalog']);
   });
 
   it('survives a step of the refresh failing, and still runs the rest', async () => {

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -1274,6 +1274,25 @@ describe('pluginStore — the follower', () => {
     expect(order).toEqual(['catalog']);
   });
 
+  it('says an UPDATE failed in the words the panel uses beside it', async () => {
+    // The pane's banner words a failure by kind, and the toast fires at the
+    // same instant: "Install failed: X" beside "Update failed: X" is one fact
+    // said twice.
+    api.getPluginJobEvents.mockResolvedValue(eventsPage({
+      status: 'failed',
+      cursor: 1,
+      events: [{
+        type: 'job_failed', cursor: 1, ts: 't', message: 'HTTP 500', hint: null,
+      }],
+    }));
+
+    follow('update');
+    await settle();
+
+    expect(lastToast().message).toBe('Update failed: HTTP 500');
+    expect(lastToast().type).toBe('error');
+  });
+
   it('puts an Open Plugin Center button on the failure, pointed at the row', async () => {
     api.getPluginJobEvents.mockResolvedValue(eventsPage({ status: 'failed', cursor: 0 }));
 
@@ -1297,22 +1316,28 @@ describe('pluginStore — the follower', () => {
   });
 
   it('keeps a needs_restart job on screen and says what to do', async () => {
+    // The command the backend really sends: the packages to put in place with
+    // the server stopped, which is what this status IS -- the resolve refused
+    // before anything was written, so nothing was installed.
     api.getPluginJobEvents.mockResolvedValue(eventsPage({
       status: 'needs_restart',
       cursor: 1,
       events: [{
-        type: 'needs_restart', cursor: 1, ts: 't', command: 'cdui start',
+        type: 'needs_restart', cursor: 1, ts: 't', command: 'uv pip install "torch==2.4.0"',
       }],
     }));
 
     follow();
     await settle();
 
-    expect(lastToast().message).toBe('Restart the server to load demo.');
+    expect(lastToast().message).toBe(
+      'The install of demo stopped: its Python packages need the server stopped '
+      + 'first. The command is in the Plugin Center.',
+    );
     expect(lastToast().type).toBe('warning');
     const job = usePluginStore.getState().job!;
     expect(job.status).toBe('needs_restart');
-    expect(job.restartCommand).toBe('cdui start');
+    expect(job.restartCommand).toBe('uv pip install "torch==2.4.0"');
   });
 
   it('settles a job exactly once, however often it is adopted', async () => {

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -406,6 +406,37 @@ describe('pluginStore — install', () => {
     expect(usePluginStore.getState().plugins[0].status).toBe('installing');
   });
 
+  it('installs an external plugin from the source its own row records', async () => {
+    // The row is in the lockfile and its directory is gone, so the card
+    // offers Install. Its id is not a catalog name and never was -- it came
+    // from a repository this build does not list -- so inspecting the ID
+    // would be a 400 `unknown_catalog_name` under a button that looks fine.
+    serveCatalog(catalog({
+      entries: [entry({
+        id: 'demo', kind: 'external', status: 'missing_files', source: 'owner/demo',
+      })],
+    }));
+    await usePluginStore.getState().refresh();
+
+    await usePluginStore.getState().install('demo');
+
+    expect(api.inspectPluginSource).toHaveBeenCalledWith('owner/demo');
+    // The review is still the ROW's, whatever string was inspected: it is
+    // what puts the card beside that row and what clears it afterwards.
+    expect(api.installPlugin).toHaveBeenCalled();
+  });
+
+  it('falls back to the id when the row records no source', async () => {
+    // A builtin resolves by name, and the catalog sends `''` rather than null
+    // for a row that has nothing to record.
+    serveCatalog(catalog({ entries: [entry({ id: 'c1', source: '' })] }));
+    await usePluginStore.getState().refresh();
+
+    await usePluginStore.getState().install('c1');
+
+    expect(api.inspectPluginSource).toHaveBeenCalledWith('c1');
+  });
+
   it('leaves no review behind when an auto-install is refused', async () => {
     api.inspectPluginSource.mockResolvedValue(inspection({
       plugin_id: 'c1', consent_required: false,
@@ -492,6 +523,21 @@ describe('pluginStore — install', () => {
 });
 
 describe('pluginStore — inspect', () => {
+  /**
+   * The sentence a refused inspect leaves on the review.
+   *
+   * Every refusal below is a bare `{code}` with no message, so what this
+   * returns is exactly what the panel would print: the mapped sentence, or
+   * the raw token when nothing maps it.
+   */
+  async function failureMessage(err: unknown, source = 'owner/demo'): Promise<string> {
+    api.inspectPluginSource.mockRejectedValue(err);
+    await usePluginStore.getState().inspect(source);
+    const state = usePluginStore.getState();
+    if (state.inspection.phase !== 'error') throw new Error('not an error phase');
+    return state.inspection.failure.message;
+  }
+
   it('refuses an unparseable source without asking the server', async () => {
     await usePluginStore.getState().inspect('not a source!');
 
@@ -520,18 +566,23 @@ describe('pluginStore — inspect', () => {
     });
   });
 
-  it('keeps the server refusal as the review error', async () => {
+  it('keeps the server refusal as the review error, in words', async () => {
+    // `owner/demo@..` passes this build's parser and is refused by the
+    // server's, which will not walk a ref up the URL path. One sentence for
+    // the two refusals, because the fix is the same: type a source that is
+    // one. The code and the body survive the rewrite -- the panel switches on
+    // one and prints the other.
     api.inspectPluginSource.mockRejectedValue(
       refused(400, 'unparseable_source'),
     );
 
-    await usePluginStore.getState().inspect('owner/demo');
+    await usePluginStore.getState().inspect('owner/demo@..');
 
     expect(usePluginStore.getState().inspection).toEqual({
       phase: 'error',
-      source: 'owner/demo',
+      source: 'owner/demo@..',
       failure: {
-        message: 'unparseable_source',
+        message: 'Enter a catalog name, owner/repo[@ref] or a GitHub URL.',
         code: 'unparseable_source',
         detail: { code: 'unparseable_source' },
       },
@@ -588,6 +639,41 @@ describe('pluginStore — inspect', () => {
     // The code survives the rewrite: the card switches on one and shows the
     // other.
     expect(state.inspection.failure.code).toBe('unavailable');
+  });
+
+  it('says another review is running instead of showing inspect_busy', async () => {
+    // One inspection at a time, server-side. Not about the source at all,
+    // which is why the sentence says "again" and nothing about the repo.
+    expect(await failureMessage(refused(409, 'inspect_busy'))).toBe(
+      'Another review is still running. Try again in a moment.',
+    );
+  });
+
+  it('says the manifest is invalid instead of showing invalid_manifest', async () => {
+    expect(await failureMessage(refused(400, 'invalid_manifest'))).toBe(
+      "The plugin's manifest is invalid.",
+    );
+  });
+
+  it('says GitHub has no such repository instead of showing not_found', async () => {
+    expect(await failureMessage(refused(404, 'not_found'))).toBe(
+      'GitHub has no such repository or ref.',
+    );
+  });
+
+  it('names the token to set instead of showing github_rate_limited', async () => {
+    // The one refusal here with a server-side fix, so the sentence carries
+    // the variable rather than leaving "try later" as the only advice.
+    expect(await failureMessage(refused(502, 'github_rate_limited'))).toBe(
+      "GitHub's request limit was reached. Try again later, or set "
+      + 'CODEFYUI_GITHUB_TOKEN on the server.',
+    );
+  });
+
+  it('says it could not reach GitHub instead of showing github_unreachable', async () => {
+    expect(await failureMessage(refused(502, 'github_unreachable'))).toBe(
+      'Could not reach GitHub.',
+    );
   });
 
   it('carries the names a catalog miss listed', async () => {

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -246,16 +246,32 @@ function refusalCode(err: unknown): string | null {
  * The refusals whose code IS the whole message, and what to say instead.
  *
  * Every route here answers `HTTPException(status, detail={"code": ...})` with
- * deliberately no `message`, so `readApiError` falls back to the code and
- * `err.message` is the raw token: a student is shown `inspection_expired`.
- * These three are the ones with a fix worth naming; `already_installed` is
- * not here because it is answered with a button rather than a sentence, and
- * everything else keeps the server's own message, which is at least true.
+ * deliberately no `message` -- "prose about a coded refusal belongs to whoever
+ * is talking to the user, in their language" -- so `readApiError` falls back to
+ * the code and `err.message` is the raw token: a student is shown
+ * `inspection_expired`. Every code that can reach a sentence is therefore
+ * mapped here.
+ *
+ * The three that are NOT are the three a control answers instead of a
+ * sentence: `already_installed` grows a Reinstall button, `consent_required` a
+ * tick box, `trust_author_required` a second one. `reserved_id` and
+ * `unknown_catalog_name` are mapped nowhere either, because each has a line of
+ * its own on the panel built from the body it carried (`id`, `known`) --
+ * a sentence here would be the same refusal said twice.
  */
 const REFUSAL_KEY: Record<string, TranslationKey | undefined> = {
   unavailable: 'pluginCenter.error.unavailable',
   inspection_expired: 'pluginCenter.error.inspectionExpired',
   unknown_job: 'pluginCenter.error.unknownJob',
+  inspect_busy: 'pluginCenter.error.inspectBusy',
+  // The same sentence the source box shows before it asks at all: the server
+  // and this build read a source by the same grammar, so a string that got
+  // past the client parser and was still refused is answered the same way.
+  unparseable_source: 'pluginCenter.source.invalid',
+  invalid_manifest: 'pluginCenter.error.invalidManifest',
+  not_found: 'pluginCenter.error.notFound',
+  github_rate_limited: 'pluginCenter.error.githubRateLimited',
+  github_unreachable: 'pluginCenter.error.githubUnreachable',
 };
 
 /** What a refusal should read as, once its code has had its say. */
@@ -761,8 +777,25 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       return;
     }
 
+    // What the row says it was installed FROM, not its id. The two are the
+    // same for every catalog row -- a builtin resolves by name -- but an
+    // EXTERNAL plugin, one installed from a repository this build's catalog
+    // does not list, has an id that resolves to no source at all: its Install
+    // button ended in a 400 `unknown_catalog_name` with nothing on screen to
+    // say so. `source` is documented as "what a user would type to install
+    // this", which is exactly what this button is typing on their behalf.
+    //
+    // Own keys only: `byId` is built from parsed JSON, so a plugin called
+    // `constructor` would otherwise hand back a function rather than a row.
+    const row = Object.prototype.hasOwnProperty.call(state.byId, pluginId)
+      ? state.byId[pluginId]
+      : undefined;
+    // `||`, not `??`: the catalog sends `''` for a row with no source, and an
+    // empty source is not a source. The id is the better guess.
+    const source = row?.source || pluginId;
+
     await withBusy(pluginId, async () => {
-      const data = await runInspect(pluginId, pluginId);
+      const data = await runInspect(source, pluginId);
       if (data === null) return;
       if (data.consent_required) {
         // Capabilities to grant, or an author to trust. The review card takes
@@ -777,8 +810,11 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       // The review this install passed through was never on screen. If the
       // install failed for something a review cannot fix — busy, refused,
       // offline — putting the card up now would answer a toast with a form
-      // nobody asked for. A consent refusal is the exception: it left a
-      // failure on the review precisely because ticking a box is the fix.
+      // nobody asked for. The three refusals a control CAN answer are the
+      // exceptions: an unticked capability, an untrusted author and a plugin
+      // that is already here all leave a failure on the review, precisely
+      // because a box or a button on that card is the fix. The clause below
+      // spares them by looking for `error === null`.
       const after = get().inspection;
       if (after.phase === 'ready' && after.error === null
           && after.forPluginId === pluginId) {

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -249,8 +249,9 @@ function refusalCode(err: unknown): string | null {
  * deliberately no `message` -- "prose about a coded refusal belongs to whoever
  * is talking to the user, in their language" -- so `readApiError` falls back to
  * the code and `err.message` is the raw token: a student is shown
- * `inspection_expired`. Every code that can reach a sentence is therefore
- * mapped here.
+ * `inspection_expired`. Every code that reaches a toast or the review card is
+ * therefore mapped here; the ones a branch answers with a better sentence of
+ * its own (`busy`, `not_updatable`) are handled at their catch instead.
  *
  * The three that are NOT are the three a control answers instead of a
  * sentence: `already_installed` grows a Reinstall button, `consent_required` a
@@ -264,6 +265,10 @@ const REFUSAL_KEY: Record<string, TranslationKey | undefined> = {
   inspection_expired: 'pluginCenter.error.inspectionExpired',
   unknown_job: 'pluginCenter.error.unknownJob',
   inspect_busy: 'pluginCenter.error.inspectBusy',
+  // A row this tab is still showing for a plugin that is gone -- removed from
+  // the CLI or another tab. Both `DELETE /{id}` and `POST /{id}/update`
+  // answer it, and neither carries a word of prose.
+  not_installed: 'pluginCenter.error.notInstalled',
   // The same sentence the source box shows before it asks at all: the server
   // and this build read a source by the same grammar, so a string that got
   // past the client parser and was still refused is answered the same way.
@@ -879,7 +884,15 @@ export const usePluginStore = create<PluginState>((set, get) => ({
         setPluginStatus(pluginId, 'installing');
         startFollowing(result.job_id, pluginId, 'update', 0);
       } catch (err) {
-        if (err instanceof ApiError && err.status === 409) {
+        // 400 `not_updatable` is a code with a `hint` beside it, and the hint
+        // is the only half that says what to do instead -- a built-in pack
+        // updates with `cdui update`, not from here. The same shape as
+        // `uninstall`'s `files_locked` branch, and `warning` for the same
+        // reason: nothing broke.
+        const hint = str(errorDetail(err)?.hint);
+        if (refusalCode(err) === 'not_updatable' && hint !== null) {
+          toast(t('pluginCenter.updateFailed', { message: hint }), 'warning');
+        } else if (err instanceof ApiError && err.status === 409) {
           toast(t('packs.toast.busy'), 'warning');
           await get().refresh();
         } else if (err instanceof ApiError && err.status === 403) {
@@ -966,12 +979,20 @@ export const usePluginStore = create<PluginState>((set, get) => ({
           'success',
         );
       } catch (err) {
-        toast(
-          t('pluginCenter.toast.toggleFailed', {
-            plugin: name, message: refusalMessage(err),
-          }),
-          'error',
-        );
+        if (err instanceof ApiError && err.status === 409) {
+          // That plugin's own install is running, and this row is what is out
+          // of date -- the button is still on screen because the catalog has
+          // not been re-read. Same branch, and the same refresh, as uninstall.
+          toast(t('packs.toast.busy'), 'warning');
+          await get().refresh();
+        } else {
+          toast(
+            t('pluginCenter.toast.toggleFailed', {
+              plugin: name, message: refusalMessage(err),
+            }),
+            'error',
+          );
+        }
       }
     });
   },

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -518,8 +518,13 @@ async function onJobSettled(
     case 'failed':
       // Only the catalog: nothing landed, so the node definitions and the
       // frontends are exactly what they were.
+      //
+      // Worded by KIND, like the pane's banner: the two are on screen
+      // together, and "Install failed" in a toast beside "Update failed" in
+      // the panel is one fact said two ways.
       toast(
-        t('packs.toast.installFailed', { message: settled?.error?.message ?? '' }),
+        t(kind === 'update' ? 'pluginCenter.updateFailed' : 'packs.toast.installFailed',
+          { message: settled?.error?.message ?? '' }),
         'error',
         openCenterAction(pluginId),
       );
@@ -530,10 +535,11 @@ async function onJobSettled(
       await store.refresh();
       break;
     case 'needs_restart':
-      // The files are in place and the registry could not pick them up from
-      // inside the running process. The JOB stays on screen — the panel's
-      // banner is what renders the command — and the catalog is refreshed
-      // because the row's status changed even though the nodes did not.
+      // NOTHING was installed: the only step that can end a job this way is
+      // the dependency resolve, which runs before a file is written, so the
+      // row is exactly what it was. The JOB stays on screen — the panel's
+      // banner is what renders the command to run with the server stopped —
+      // and the catalog is re-read because the job that held it is over.
       toast(
         t('pluginCenter.toast.needsRestart', { plugin: name }),
         'warning',

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -20,9 +20,10 @@ import { createJobFollower, emptyJob, type Job } from './jobFollower';
 import { confirm } from '../utils/dialog';
 import { reloadPluginFrontends } from '../plugins/PluginHost';
 import { useNodeDefStore } from './nodeDefStore';
-import { useToastStore, type ToastAction } from './toastStore';
+import { errorMessage, str, toast } from './storeText';
+import type { ToastAction } from './toastStore';
 import { useUIStore } from './uiStore';
-import { useI18n } from '../i18n';
+import { useI18n, type TranslationKey } from '../i18n';
 
 /**
  * App-level state for the Plugin Center.
@@ -215,26 +216,6 @@ export function parseGitHubSource(input: string): PluginSourceRef | null {
 
 // ── helpers ──────────────────────────────────────────────────────────────
 
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
-function str(value: unknown): string | null {
-  return typeof value === 'string' ? value : null;
-}
-
-/**
- * `action` is spread rather than always passed, so a toast without one is
- * byte-for-byte the object every other caller produces.
- */
-function toast(
-  message: string,
-  type: 'info' | 'error' | 'success' | 'warning',
-  action?: ToastAction,
-) {
-  useToastStore.getState().addToast(message, type, action ? { action } : undefined);
-}
-
 /**
  * The button a toast about a plugin wears: it opens the panel on that plugin.
  *
@@ -262,6 +243,28 @@ function refusalCode(err: unknown): string | null {
 }
 
 /**
+ * The refusals whose code IS the whole message, and what to say instead.
+ *
+ * Every route here answers `HTTPException(status, detail={"code": ...})` with
+ * deliberately no `message`, so `readApiError` falls back to the code and
+ * `err.message` is the raw token: a student is shown `inspection_expired`.
+ * These three are the ones with a fix worth naming; `already_installed` is
+ * not here because it is answered with a button rather than a sentence, and
+ * everything else keeps the server's own message, which is at least true.
+ */
+const REFUSAL_KEY: Record<string, TranslationKey | undefined> = {
+  unavailable: 'pluginCenter.error.unavailable',
+  inspection_expired: 'pluginCenter.error.inspectionExpired',
+  unknown_job: 'pluginCenter.error.unknownJob',
+};
+
+/** What a refusal should read as, once its code has had its say. */
+function refusalMessage(err: unknown): string {
+  const key = REFUSAL_KEY[refusalCode(err) ?? ''];
+  return key === undefined ? errorMessage(err) : useI18n.getState().t(key);
+}
+
+/**
  * Everything a thrown refusal carried, in the shape the review card reads.
  *
  * One builder rather than a shape assembled at each catch, so no caller can
@@ -274,10 +277,28 @@ function inspectionFailure(err: unknown): InspectionFailure {
     // but the machine it runs on, which only this key explains.
     message: err instanceof ApiError && err.status === 403
       ? useI18n.getState().t('packs.remoteDisabled')
-      : errorMessage(err),
+      : refusalMessage(err),
     code: refusalCode(err),
     detail: errorDetail(err),
   };
+}
+
+/**
+ * Leave *err* on the review the user is looking at, if there still is one.
+ *
+ * The refusals answered ON the card -- an unticked capability, an untrusted
+ * author, a plugin that turned out to be installed already -- keep the
+ * inspection ready and grow an error, because the fix is a control on that
+ * card rather than a new inspection. A review that is no longer ready (a
+ * second tab cleared it) drops the refusal rather than resurrecting a card
+ * for a decision nobody is making.
+ */
+function attachInspectionFailure(err: unknown): void {
+  usePluginStore.setState((state) => (
+    state.inspection.phase === 'ready'
+      ? { inspection: { ...state.inspection, error: inspectionFailure(err) } }
+      : {}
+  ));
 }
 
 /**
@@ -628,11 +649,16 @@ async function startInstall(
       // at: the inspection stays ready and grows a failure, so the review can
       // say which box is still unticked -- the refusal names the capabilities
       // or the modules -- instead of starting over.
-      usePluginStore.setState((state) => (
-        state.inspection.phase === 'ready'
-          ? { inspection: { ...state.inspection, error: inspectionFailure(err) } }
-          : {}
-      ));
+      attachInspectionFailure(err);
+    } else if (code === 'already_installed') {
+      // Not a failure of anything: an OFFER, and the backend says so in as
+      // many words. The install this refused is the one the user asked for,
+      // so the review stays up carrying the code and the card grows a
+      // Reinstall button -- `installInspected({force: true})`, which spends
+      // this same inspection rather than reading the source again. Checked
+      // before the 409 below, which would otherwise swallow it as "another
+      // install is already running" and refresh the offer away.
+      attachInspectionFailure(err);
     } else if (err instanceof ApiError && err.status === 409) {
       // Somebody else got there first — this tab, another tab, or the CLI.
       // The refresh adopts whatever the server IS running, which is more
@@ -642,7 +668,7 @@ async function startInstall(
     } else if (err instanceof ApiError && err.status === 403) {
       toast(t('packs.remoteDisabled'), 'error');
     } else {
-      toast(t('packs.toast.installFailed', { message: errorMessage(err) }), 'error');
+      toast(t('packs.toast.installFailed', { message: refusalMessage(err) }), 'error');
     }
   }
 }
@@ -823,7 +849,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
         } else if (err instanceof ApiError && err.status === 403) {
           toast(t('packs.remoteDisabled'), 'error');
         } else {
-          toast(t('pluginCenter.updateFailed', { message: errorMessage(err) }), 'error');
+          toast(t('pluginCenter.updateFailed', { message: refusalMessage(err) }), 'error');
         }
       }
     });
@@ -861,7 +887,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
           // says what to do about it, so it is what the toast carries.
           toast(
             t('pluginCenter.toast.removeFailed', {
-              plugin: name, message: hint ?? errorMessage(err),
+              plugin: name, message: hint ?? refusalMessage(err),
             }),
             'warning',
           );
@@ -878,7 +904,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
         } else {
           toast(
             t('pluginCenter.toast.removeFailed', {
-              plugin: name, message: errorMessage(err),
+              plugin: name, message: refusalMessage(err),
             }),
             'error',
           );
@@ -906,7 +932,7 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       } catch (err) {
         toast(
           t('pluginCenter.toast.toggleFailed', {
-            plugin: name, message: errorMessage(err),
+            plugin: name, message: refusalMessage(err),
           }),
           'error',
         );
@@ -925,10 +951,10 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       // unpack that is still writing files.
       await cancelPluginJob(job.jobId);
     } catch (err) {
-      toast(
-        useI18n.getState().t('packs.toast.cancelFailed', { message: errorMessage(err) }),
-        'error',
-      );
+      // A job the server has already forgotten is the common refusal here,
+      // and `unknown_job` on a toast is not a sentence.
+      const { t } = useI18n.getState();
+      toast(t('packs.toast.cancelFailed', { message: refusalMessage(err) }), 'error');
     } finally {
       set({ cancelling: false });
     }

--- a/frontend/src/store/storeText.test.ts
+++ b/frontend/src/store/storeText.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { errorMessage, str, toast } from './storeText';
+import { useToastStore } from './toastStore';
+
+/**
+ * The helpers `packStore` and `pluginStore` both call.
+ *
+ * Each one exists for a value that arrives from outside TypeScript's reach --
+ * a thrown non-Error, a field off a JSON refusal body -- so the cases worth
+ * pinning are the ones a `catch` or a `detail` actually produces.
+ */
+
+beforeEach(() => {
+  useToastStore.setState({ toasts: [] });
+});
+
+// ── errorMessage ─────────────────────────────────────────────────────────
+
+describe('errorMessage', () => {
+  it('reads an Error, however it was subclassed', () => {
+    expect(errorMessage(new Error('Failed to fetch'))).toBe('Failed to fetch');
+    expect(errorMessage(new TypeError('bad json'))).toBe('bad json');
+  });
+
+  it('stringifies what was thrown when it was not an Error', () => {
+    // `throw 'boom'` and a rejected promise carrying a plain object both reach
+    // a store's catch, and "[object Object]" beats an empty toast.
+    expect(errorMessage('boom')).toBe('boom');
+    expect(errorMessage(null)).toBe('null');
+    expect(errorMessage(undefined)).toBe('undefined');
+    expect(errorMessage({ code: 'busy' })).toBe('[object Object]');
+  });
+});
+
+// ── str ──────────────────────────────────────────────────────────────────
+
+describe('str', () => {
+  it('passes a string through, empty one included', () => {
+    expect(str('files_locked')).toBe('files_locked');
+    // '' is a string the server sent, not a missing key: the caller decides
+    // what an empty answer means.
+    expect(str('')).toBe('');
+  });
+
+  it('answers null for everything that is not a string', () => {
+    expect(str(7)).toBeNull();
+    expect(str(null)).toBeNull();
+    expect(str(undefined)).toBeNull();
+    expect(str({ code: 'busy' })).toBeNull();
+    expect(str(['busy'])).toBeNull();
+  });
+});
+
+// ── toast ────────────────────────────────────────────────────────────────
+
+describe('toast', () => {
+  it('puts the message and the type on screen', () => {
+    toast('Install failed: offline', 'error');
+
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+    expect(useToastStore.getState().toasts[0]).toMatchObject({
+      message: 'Install failed: offline', type: 'error',
+    });
+  });
+
+  it('leaves out the action key entirely when there is no action', () => {
+    // Spread, not `action: undefined`: a toast without a button must be the
+    // same object it was before actions existed, or every equality assertion
+    // written against one breaks.
+    toast('Plugin UI reloaded.', 'success');
+
+    expect('action' in useToastStore.getState().toasts[0]).toBe(false);
+  });
+
+  it('carries an action when one is passed', () => {
+    const onClick = () => {};
+    toast('A plugin is still installing.', 'info', {
+      label: 'Open Plugin Center', onClick,
+    });
+
+    expect(useToastStore.getState().toasts[0].action).toEqual({
+      label: 'Open Plugin Center', onClick,
+    });
+  });
+});

--- a/frontend/src/store/storeText.ts
+++ b/frontend/src/store/storeText.ts
@@ -1,0 +1,45 @@
+import { useToastStore, type ToastAction } from './toastStore';
+
+/**
+ * The three text helpers every center's store needs, in one place.
+ *
+ * `packStore` and `pluginStore` grew the same three private functions --
+ * "what does this thrown thing say", "is this JSON value a string", "put a
+ * toast up" -- character for character, because both of them read coded
+ * refusals off the wire and both of them answer in toasts. A third store
+ * would have copied them again.
+ *
+ * Deliberately NOT a place for everything two stores share: `openCenterAction`
+ * looks identical and is not, because each store names its own panel and its
+ * own key. Only what is genuinely the same is here.
+ */
+
+/** What a thrown value says, whether or not it was an Error. */
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * A JSON value as a string, or null.
+ *
+ * The refusal bodies both stores read are `Record<string, unknown>`: every
+ * field off one is `unknown`, and this is the narrowing that keeps a number or
+ * a nested object from reaching a toast as "[object Object]".
+ */
+export function str(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+/**
+ * Put one toast up.
+ *
+ * `action` is spread rather than always passed, so a toast without one is
+ * byte-for-byte the object every caller was already producing.
+ */
+export function toast(
+  message: string,
+  type: 'info' | 'error' | 'success' | 'warning',
+  action?: ToastAction,
+) {
+  useToastStore.getState().addToast(message, type, action ? { action } : undefined);
+}


### PR DESCRIPTION
> 中文摘要：外掛中心（外掛安裝視窗）的前端。在「自訂與外掛」分頁與設定選單都能開啟「外掛中心」：列出可安裝的內建教學節點套件與官方外掛，一鍵安裝內建套件；輸入 owner/repo[@ref] 或 GitHub 網址可先檢視外掛要求的能力與是否包含前端程式碼，勾選同意後才安裝；安裝過程在右側顯示步驗、進度、日誌與取消；安裝完成後節點直接出現在節點面板，不必重新載入頁面；也可以停用、啟用、更新（GitHub 外掛）與解除安裝。伺服器拒絕遠端安裝時，視窗底部說明一次並停用安裝按鈕。所有字串兩種語言。複審後補了幾件事：每一種後端只回代碼的拒絕都有對應的句子；「已安裝」的情況會說明並提供重新安裝；依賴衝突時不再說「已安裝」而是說明要先停伺服器再執行指令；兩個視窗同時開啟時 Escape 只關最上面那個；設定列按鈕的無障礙名稱與可見文字一致；空的外掛區塊不再重複一句話。

## What / Why

P-F2 of the approved Plugin Center + Source Control wave: the modal on top of the client and store that P-F1 (#409)
added and the backend routes that P-B2 (#410) and P-B3 (#411) added.

- `components/PluginCenter/`: `PluginCenterModal` (chrome shared with the Package Center by importing its stylesheet;
  the four state-message rules; focus-in/restore; Escape closes the top-most center), `PluginFilterBar` (All / Installed /
  Available), `PluginCard` (status pill, version, origin line, lessons / node count / Python packages, actions per
  status, danger confirm before uninstall), `PluginSourceForm` (client-side validation, no request on garbage; every
  coded refusal the routes can answer rendered as a sentence), `PluginReviewCard` (facts, capability lines, the grant
  and trust checkboxes, the frontend-JS banner, the Reinstall offer when already installed), `PluginActivityPane` (steps,
  a bytes-then-steps progress bar, log tail, Cancel, result banners, the CLI fallback command on failure).
- Store and client: the `already_installed` 409 is an offer (Reinstall with `force`); every coded refusal maps to a
  sentence before it is toasted; `install(id)` uses the row's own source; the inspection is normalised (`installed.sha`
  nullable, legacy `source_kind`); the three helpers both stores shared now live in `store/storeText.ts`; the status
  chip is one shared `Pill`.
- Entry points: the 自訂與外掛 tab's Plugins section is a view of the store with a `Plugin Center...` button; the
  Settings popover gets a Plugins row with the installed / available counts.
- i18n: the wave plan's `pluginCenter.*` table plus the refusal sentences the review found missing, both locales.

What I deliberately did not do: provenance in the palette and the docs page (P-F3); plugin restart-mode installs
(the backend has no such path; a resolver conflict tells you to stop the server and run the command); a structured
banner for the Python packages an uninstall leaves behind (the confirm already says they stay).

## Closes / relates to

Part of the Plugin Center + Source Control wave (no issue number; the wave plan is the authority). Stays open: P-F3
(palette provenance, docs page), the follow-ups filed as #412-#416.

## Test evidence

```
cd frontend && pnpm test      -> 180 files / 4508 tests   (main at 267b25e: 174 files / 4319 tests)
cd frontend && pnpm build     -> green (contrast gate + tsc -b + vite)
cd frontend && pnpm contrast  -> passed
```

Chrome pass (zh-TW, a dist built from this branch served by this checkout's launcher on :8770 with a fresh sandbox
user-data dir; the GitHub source was the template's `fix/tests-pass-the-install-scan` branch because the template's
default branch is still refused by the install-time scan until CodefyUI-Plugin-Official#4 merges): the 自訂與外掛 tab
shows three symmetric section headers and the Plugins section as a view of the store; the Settings row reads
「已安裝 0 個，可安裝 8 個」 and opens the modal; the modal lists the 8 catalog entries with pills, filter, source form and
the idle pane; installing `edu` from its card shows the steps, the bar, the log and ends with the banner + toast, and
the `edu:*` nodes appear in the palette without a page reload; disable drops them and enable brings them back;
uninstall shows the danger confirm with the two consequences and the row returns to the catalog; the source form
refuses garbage inline without a request, lists the eight known names for an unknown one, and says GitHub has no such
repository for a missing repo; the template's review card shows the facts, the ref @ sha, the homepage link and the
frontend-JS banner, installs through download / extract / verify / stage / lock / reload, the template's tool panel
appears without a reload and its two nodes show in the palette; Update answers 「已是最新」; cancelling during the download
leaves no plugin, no staging directory and a clean lockfile (verified with `cdui plugin list`); from a LAN address with
`--host 0.0.0.0` the footer sentence appears once, Install / Uninstall / Review are disabled with the sentence as their
tooltip and Disable still works; console clean throughout. Not reproducible by automation on this machine: the
< 860 px stacking (maximized window; the media query is inherited unchanged from the Package Center stylesheet) and
whether Chrome shows a tooltip on a disabled button.

Every task was implemented by a fresh subagent, task-reviewed (spec + quality) with fix rounds where needed, and the
whole branch got a two-area final review plus one fix wave with a scoped re-review.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its zh-TW twin in the same PR. (No docs page in this PR; the usage page is P-F3.)
- [x] No pictographic emoji in code, logs, UI strings, or this PR body.
- [x] I explained what I deliberately did not do (above).
