### PR TITLE
fix(cli,packs): cdui start no longer opens a console window that kills the server when closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,29 @@ received — each links to the release it was published as.
 
 ### Fixed
 
+- **`cdui start` on Windows no longer puts an empty black window on the
+  desktop that kills the server when you close it** ([#420]). The window was
+  the server's own console, not the launcher's, and it appeared because of a
+  flag that reads as exactly right: the background server was started with
+  `DETACHED_PROCESS`, meaning no console to inherit and no console to be
+  Ctrl-C'd through. That holds for a program. It does not hold for
+  `backend/.venv/Scripts/uvicorn.exe`, which in a uv-built venv is a launcher
+  shim rather than a program — it spawns the real interpreter as a child of
+  itself, and Windows answers a detached parent's console-less child by
+  creating a brand-new *visible* console for it. So every `cdui start` left
+  an empty window titled with the shim's path sitting over the desktop, and
+  closing a window nobody asked for sent `CTRL_CLOSE_EVENT` to the server
+  behind it. The server is now started with `CREATE_NO_WINDOW`, which gives
+  the same chain one console with no window at all: nothing to see, and
+  nothing to close. It is still just as detached — its own console means the
+  launching terminal's close cannot reach it, and its own process group keeps
+  Ctrl-C away — and closing the terminal you started it from still leaves it
+  running. The same flag was wrong in two more places for the same reason,
+  and both are fixed with it: the relaunch that brings the server back after
+  a restart-mode install from the Package Center, and the spawn of the
+  restart helper itself, where the window a user closed would have sent that
+  same event into `uv` midway through rewriting their virtual environment.
+
 - **A plugin's `assets/` were served from a mount built at startup — and in a
   released build, never served at all.** Every installed plugin's `assets/`
   directory was attached to the server once, while the startup lifespan ran,
@@ -3129,6 +3152,7 @@ Release candidates before 1.0.0 are on the
 [#396]: https://github.com/CodefyUI/CodefyUI/issues/396
 [#398]: https://github.com/CodefyUI/CodefyUI/issues/398
 [#140]: https://github.com/CodefyUI/CodefyUI/issues/140
+[#420]: https://github.com/CodefyUI/CodefyUI/issues/420
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
 [Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.5.0...main

--- a/backend/app/core/packs/restart.py
+++ b/backend/app/core/packs/restart.py
@@ -111,11 +111,6 @@ HELPER_START_GRACE_S = 60
 #: exited.
 HELPER_COMMAND = "packs-run-pending"
 
-#: No console at all, which is what a process outliving its parent needs.
-#: Not exposed by ``subprocess`` off Windows, so it is spelled out here --
-#: ``dev.py``'s ``start`` does the same for the server it daemonises.
-DETACHED_PROCESS = 0x00000008
-
 #: Mirror of ``scripts/dev.py``'s ``TORCH_INDEX_URLS`` (see the module
 #: docstring for why it is a copy). ``None`` means "let PyPI resolve it";
 #: ``"__skip__"`` means "do not touch torch at all".
@@ -970,9 +965,16 @@ def spawn_helper(pending_path: Path) -> int:
     Detached in whichever way the OS understands. POSIX gets
     ``start_new_session``: its own session and process group, so neither the
     terminal's Ctrl-C nor the SIGHUP of a closing shell reaches it. Windows
-    gets ``DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP``: no console to
-    inherit, and no console to be Ctrl-C'd through -- the same pair
-    ``cdui start`` uses to daemonise the server this will replace.
+    gets ``CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP`` -- the same pair
+    ``cdui start`` uses to daemonise the server this will replace, and the
+    same pair :func:`runner.creation_flags` passes to every live install.
+    A console of its own means no Ctrl-C and no closing terminal can reach
+    it; no WINDOW on that console means the helper cannot be closed by a
+    user who does not know what it is, mid-rewrite of their venv. Not
+    ``DETACHED_PROCESS``, which is what this was until core#420: a launcher
+    that is one of uv's ``Scripts\\*.exe`` shims spawns the real interpreter
+    as a child, and Windows gives a console-less parent's child a brand-new
+    VISIBLE console -- exactly the window this pair exists to avoid.
 
     Output goes to a FILE, never a pipe. The parent is seconds from exiting,
     and a pipe with nobody left to read it fills up and blocks the helper
@@ -1018,8 +1020,7 @@ def spawn_helper(pending_path: Path) -> int:
 
     detach: dict = {}
     if sys.platform == "win32":
-        detach["creationflags"] = (DETACHED_PROCESS
-                                   | runner.CREATE_NEW_PROCESS_GROUP)
+        detach["creationflags"] = runner.creation_flags()
     else:
         detach["start_new_session"] = True
 

--- a/backend/tests/test_dev_packs_cli.py
+++ b/backend/tests/test_dev_packs_cli.py
@@ -1574,14 +1574,44 @@ def test_terminating_a_process_does_not_flash_a_console_window(monkeypatch,
 # ── the relaunch ──────────────────────────────────────────────────────────
 
 
-def test_the_relaunch_is_detached_and_logged(helper):
+@pytest.mark.parametrize("platform", ["win32", "linux"])
+def test_the_relaunch_is_detached_and_logged(helper, monkeypatch, platform):
+    """The server comes back the way `cdui start` daemonises one, and on
+    Windows that means a console with no WINDOW on it -- never
+    `DETACHED_PROCESS`.
+
+    A relaunch is the one start nobody is watching: it happens after the
+    Package Center swapped the venv's torch out, with the user looking at an
+    editor that has lost its server. Handing it `DETACHED_PROCESS` puts an
+    empty black window on their desktop instead (core#420) -- uv's
+    `Scripts\\*.exe` launcher shims spawn the real interpreter as a child,
+    and Windows gives a console-less parent's child a visible console of its
+    own. Closing that window kills the server that just came back.
+
+    Both platforms are faked rather than branched on, so Linux CI checks the
+    Windows answer too. The constants are dropped first and then declared:
+    nothing on this path may be inherited from the machine running the suite.
+    """
+    monkeypatch.setattr(sys, "platform", platform)
+    for name in ("CREATE_NO_WINDOW", "CREATE_NEW_PROCESS_GROUP"):
+        monkeypatch.delattr(dev.subprocess, name, raising=False)
+    monkeypatch.setattr(dev.subprocess, "CREATE_NO_WINDOW", 0x08000000,
+                        raising=False)
+    monkeypatch.setattr(dev.subprocess, "CREATE_NEW_PROCESS_GROUP",
+                        0x00000200, raising=False)
+
     dev._run_pending_job(_pending(helper))
     kwargs = helper["relaunch_kwargs"]
-    if sys.platform == "win32":
-        assert kwargs["creationflags"] & 0x00000008          # DETACHED_PROCESS
+    if platform == "win32":
+        assert kwargs["creationflags"] & dev.subprocess.CREATE_NO_WINDOW
         assert kwargs["creationflags"] & dev.subprocess.CREATE_NEW_PROCESS_GROUP
+        assert not kwargs["creationflags"] & 0x00000008   # DETACHED_PROCESS
+        assert "start_new_session" not in kwargs, (
+            "start_new_session is a POSIX-only kwarg")
     else:
         assert kwargs["start_new_session"] is True
+        assert "creationflags" not in kwargs, (
+            "a Windows creation flag would be rejected off Windows")
     # Never a pipe: this process is about to exit, and a pipe with nobody
     # left to read it fills up and blocks the server mid-start.
     assert kwargs["stdout"] is not dev.subprocess.PIPE

--- a/backend/tests/test_dev_start_command.py
+++ b/backend/tests/test_dev_start_command.py
@@ -260,6 +260,68 @@ def test_daemon_path_appends_the_forwarded_args(started, monkeypatch):
     assert dev.SERVER_ADDRFILE.read_text() == "127.0.0.1:8000"
 
 
+@pytest.mark.parametrize("platform", ["win32", "linux"])
+def test_the_daemon_gets_no_console_window_of_its_own(started, monkeypatch,
+                                                      platform):
+    """`cdui start` must put NO window on the user's desktop (core#420).
+
+    It used to put one there, and the window killed the server. The flags
+    were `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`, which reads as
+    exactly right -- no console to inherit, no console to be Ctrl-C'd
+    through -- and is wrong for one reason nothing in the call says: the
+    thing being spawned is `backend/.venv/Scripts/uvicorn.exe`, and in a
+    uv-built venv that is a launcher shim, not a program. It spawns the real
+    interpreter as a CHILD of itself. A detached parent has no console to
+    hand that child, so Windows creates a brand-new VISIBLE one for it: an
+    empty black window, titled with the shim's own path, sitting over the
+    desktop for as long as the server runs.
+
+    Users close windows they did not ask for. Closing that one sends
+    CTRL_CLOSE_EVENT to everything attached to it, and the server they had
+    just started went away -- which is how this was reported.
+
+    `CREATE_NO_WINDOW` gives the whole shim chain one console that has no
+    window at all. The isolation the daemon actually needs is unchanged: the
+    server is on its own console, so the CTRL_CLOSE_EVENT of the terminal
+    that launched it never reaches it, and its own process group keeps
+    Ctrl-C away.
+
+    Both platforms are faked rather than branched on, so Linux CI checks the
+    Windows answer too.
+    """
+    monkeypatch.setattr(sys, "platform", platform)
+    # POSIX has neither constant, and a `win32` fake sends this whole call
+    # down the branch that reaches for both. Dropped first and then declared,
+    # so nothing here is inherited from the machine running the suite.
+    for name in ("CREATE_NO_WINDOW", "CREATE_NEW_PROCESS_GROUP"):
+        monkeypatch.delattr(dev.subprocess, name, raising=False)
+    monkeypatch.setattr(dev.subprocess, "CREATE_NO_WINDOW", 0x08000000,
+                        raising=False)
+    monkeypatch.setattr(dev.subprocess, "CREATE_NEW_PROCESS_GROUP",
+                        0x00000200, raising=False)
+    _argv(monkeypatch)
+
+    dev.start()
+
+    kwargs = started["popen_kwargs"]
+    if platform == "win32":
+        flags = kwargs["creationflags"]
+        assert flags & dev.subprocess.CREATE_NO_WINDOW, (
+            "the server would get a console window a user can close")
+        assert flags & dev.subprocess.CREATE_NEW_PROCESS_GROUP, (
+            "Ctrl-C in the launching terminal would reach the server")
+        assert not flags & 0x00000008, (
+            "DETACHED_PROCESS is what put the window there: a console-less "
+            "parent's child gets a VISIBLE console of its own")
+        assert "start_new_session" not in kwargs, (
+            "start_new_session is a POSIX-only kwarg")
+    else:
+        assert kwargs["start_new_session"] is True, (
+            "SIGHUP on terminal close would reach the server")
+        assert "creationflags" not in kwargs, (
+            "a Windows creation flag would be rejected off Windows")
+
+
 def test_foreground_path_appends_the_forwarded_args(started, monkeypatch):
     _argv(monkeypatch, "-f", "--", "--root-path", "/codefyui")
     dev.start()

--- a/backend/tests/test_packs_restart.py
+++ b/backend/tests/test_packs_restart.py
@@ -852,8 +852,15 @@ def test_spawn_helper_argv_flags_and_log_file(monkeypatch, tmp_path, launcher,
     kwargs = seen["kwargs"]
     assert kwargs["stderr"] is subprocess.STDOUT
     assert kwargs["stdin"] is subprocess.DEVNULL
-    assert kwargs["creationflags"] & restart.DETACHED_PROCESS
+    assert kwargs["creationflags"] & runner.CREATE_NO_WINDOW
     assert kwargs["creationflags"] & runner.CREATE_NEW_PROCESS_GROUP
+    # NOT `DETACHED_PROCESS` (0x8), which is what this was until core#420.
+    # A launcher that is one of uv's `Scripts\*.exe` shims spawns the real
+    # interpreter as a child of itself, and Windows hands a console-less
+    # parent's child a brand-new VISIBLE console: a window over the editor
+    # for the length of the install, and a CTRL_CLOSE_EVENT into `uv`
+    # mid-rewrite the moment anyone closes it.
+    assert not kwargs["creationflags"] & 0x00000008
     assert "start_new_session" not in kwargs, (
         "start_new_session is a POSIX-only kwarg")
     assert "shell" not in kwargs

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -300,9 +300,11 @@ RELEASE_ASSET = "frontend-dist.tar.gz"
 def _has_console_window() -> bool:
     """Windows: does this process own a console window?
 
-    A `cdui` run typed at a terminal does. The restart helper does not: it is
-    spawned DETACHED by a server that is about to exit, precisely so that
-    closing the console it came from cannot take it with it.
+    A `cdui` run typed at a terminal does. A run with no window on its
+    console does not, and neither does one with no console at all -- both
+    are launched by something that wanted no window on the user's desktop,
+    and the answer this returns is what keeps the hop in `_reexec` from
+    putting one there.
 
     Never raises, and an unanswerable probe reads as "there is one" -- that
     is the behaviour every `cdui` run had before this question was asked, and
@@ -1728,9 +1730,10 @@ def _pid_alive(pid: int) -> bool:
             ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
             capture_output=True, **_CONSOLE_TEXT_KW,
             # `packs-run-pending` polls this every half second for up to two
-            # minutes, from a DETACHED process with no console of its own --
-            # without this each poll pops a console window over whatever the
-            # user is looking at while their server is away.
+            # minutes, from a process started for a user who is looking at an
+            # editor, not a terminal -- without this each poll can pop a
+            # console window over whatever they are looking at while their
+            # server is away.
             creationflags=subprocess.CREATE_NO_WINDOW,
         )
         # `or ""`: a dead pid makes tasklist print a translated "no tasks
@@ -1884,9 +1887,25 @@ def start() -> None:
     logf = open(SERVER_LOG, "a", buffering=1)  # noqa: SIM115 — handed to child
     popen_kw: dict = {}
     if sys.platform == "win32":
-        # New process group + detached so closing the console doesn't kill it.
-        DETACHED_PROCESS = 0x00000008
-        popen_kw["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
+        # A console of its own, with no window on it, plus its own process
+        # group: the launching terminal's Ctrl-C cannot reach the server, and
+        # closing that terminal cannot either, because the CTRL_CLOSE_EVENT a
+        # closing console sends only reaches processes attached to THAT
+        # console.
+        #
+        # NOT `DETACHED_PROCESS`, which is what this was until core#420 and
+        # is the one thing that looks right and is not. A uv-built venv's
+        # `Scripts\*.exe` are launcher shims: `uvicorn.exe` does not run
+        # Python, it SPAWNS the interpreter as a child of itself. A detached
+        # parent has no console to hand that child, and Windows answers by
+        # giving it a brand-new VISIBLE one -- an empty black window, titled
+        # after the shim, sitting over the desktop for as long as the server
+        # runs. Users close it, because nobody asked for it; closing it sends
+        # CTRL_CLOSE_EVENT to everything on that console, and the server they
+        # just started dies. `CREATE_NO_WINDOW` gives the same chain one
+        # console with no window at all: nothing to see, and nothing to close.
+        popen_kw["creationflags"] = (subprocess.CREATE_NO_WINDOW
+                                     | subprocess.CREATE_NEW_PROCESS_GROUP)
     else:
         # New session → no controlling terminal, so SIGHUP on terminal close
         # doesn't reach the server.
@@ -2679,11 +2698,13 @@ def _run_pending_install(cmd: list, on_started=None) -> "tuple[int, list]":
     spawned this process -- so echoing is what makes an install nobody watched
     reviewable afterwards.
 
-    `CREATE_NO_WINDOW` because this helper was spawned DETACHED and has no
-    console to lend: Windows gives such a child a console of its OWN, so a
-    window sits over whatever the user is looking at for the length of the
-    install -- and closing it sends CTRL_CLOSE_EVENT to `uv` mid-rewrite,
-    which is the corruption the whole mechanism exists to prevent.
+    `CREATE_NO_WINDOW` because a window over the user's editor for the length
+    of the install is a window they will close, and closing it sends
+    CTRL_CLOSE_EVENT to `uv` mid-rewrite -- the corruption this whole
+    mechanism exists to prevent. Stated here rather than inherited from the
+    helper's own flags: `uv` is a program, but the launcher that started this
+    helper may be one of uv's `Scripts\\*.exe` shims, and a shim's child is a
+    second chance for Windows to hand out a console nobody asked for.
     `runner.creation_flags()` passes the same flag for live installs.
 
     *on_started* is called with the process the moment it exists, and before
@@ -2808,11 +2829,13 @@ def _relaunch_server(launcher: list, relaunch_argv: list, log_path: Path) -> "in
     and the page they were looking at. Whatever went wrong is in the outcome
     record, which the server that comes back reads and shows.
 
-    Detached the same two ways `start()` daemonises: no console to inherit and
-    no console to be Ctrl-C'd through on Windows, its own session on POSIX. Its
-    output goes to the job log FILE and never a pipe -- this process exits
-    seconds later, and a pipe with nobody left to read it fills up and blocks
-    the server mid-start.
+    Detached the same two ways `start()` daemonises: on Windows a console of
+    its own with no window on it, and its own process group, so neither a
+    Ctrl-C nor a closing terminal reaches it (and no window appears over the
+    editor -- see the flags in `start()` for why it is `CREATE_NO_WINDOW` and
+    not `DETACHED_PROCESS`); on POSIX its own session. Its output goes to the
+    job log FILE and never a pipe -- this process exits seconds later, and a
+    pipe with nobody left to read it fills up and blocks the server mid-start.
 
     The environment is this process's, minus the stdlib pointers -- see
     `_restart_child_env`. Nearly all of it is carried over on purpose: it is
@@ -2826,9 +2849,8 @@ def _relaunch_server(launcher: list, relaunch_argv: list, log_path: Path) -> "in
     cmd = [*launcher, "start", *relaunch_argv]
     detach: dict = {}
     if sys.platform == "win32":
-        DETACHED_PROCESS = 0x00000008
-        detach["creationflags"] = (subprocess.CREATE_NEW_PROCESS_GROUP
-                                   | DETACHED_PROCESS)
+        detach["creationflags"] = (subprocess.CREATE_NO_WINDOW
+                                   | subprocess.CREATE_NEW_PROCESS_GROUP)
     else:
         detach["start_new_session"] = True
 
@@ -3810,11 +3832,12 @@ def _terminate_pid(pid: int) -> None:
     if sys.platform == "win32":
         subprocess.run(["taskkill", "/F", "/T", "/PID", str(pid)],
                        capture_output=True,
-                       # The restart helper calls this from a DETACHED
-                       # process with no console of its own, and without
-                       # this Windows opens one for `taskkill` -- a window
-                       # over the user's screen at the one moment they are
-                       # already waiting on a server that went away.
+                       # The restart helper calls this while the user is
+                       # looking at an editor whose server has gone away.
+                       # Without this, `taskkill` -- a console program -- can
+                       # be handed a console of its own, which is a window
+                       # over their screen at the one moment they are already
+                       # waiting.
                        creationflags=subprocess.CREATE_NO_WINDOW)
         return
     import signal  # noqa: PLC0415 — only needed here, POSIX only


### PR DESCRIPTION
> 中文摘要：Windows 上 `cdui start` 會在桌面留下一個空的黑色主控台視窗，那是伺服器自己的視窗，關掉它 CodefyUI 就停了。原因是背景啟動用了 `DETACHED_PROCESS`，而 uv 建出來的 venv 裡 `uvicorn.exe` 是啟動殼不是程式，它會再開一個子行程；detached 的父行程沒有主控台可以給，Windows 就替那個子行程開一個全新且可見的主控台。改用 `CREATE_NO_WINDOW`，整條鏈共用一個沒有視窗的主控台：沒有東西可看，也沒有東西可關，而 daemon 該有的隔離一項都沒少。同一組旗標還有兩處用錯，一併改掉。

## What / Why

From the issue: on Windows, `cdui start` leaves an empty black console window
on the desktop titled `...\backend\.venv\Scripts\uvicorn.exe`. It is not the
launcher's window — that one closes by itself — it is the server's. Nobody
keeps a window they cannot identify, and closing it stops CodefyUI.

The flag was `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`, which reads as
exactly right and is the one thing here that is wrong. It holds for a
program. `backend/.venv/Scripts/uvicorn.exe` in a uv-built venv is not a
program: it is a launcher shim that spawns the real interpreter as a child of
itself. A detached parent has no console to hand that child, and Windows
answers by creating a brand-new **visible** console for it. Closing that
window sends `CTRL_CLOSE_EVENT` to everything attached to it, server included.

`CREATE_NO_WINDOW` gives the same shim chain one console with no window at
all. Every isolation property the daemon actually needs is unchanged: a
console of its own means the launching terminal's close cannot reach it, and
its own process group keeps Ctrl-C away.

Three call sites shared the flag, and the two beyond the reported one fail
the same way for the same reason:

1. `start()`'s background path — the reported symptom.
2. `_relaunch_server()` — the server coming back after a restart-mode install
   from the Package Center, for a user already looking at an editor with no
   server behind it.
3. `spawn_helper()` — the restart helper. The window a user closes there
   sends that same event into `uv` midway through rewriting their virtual
   environment, which is the corruption the restart mechanism exists to
   prevent. It now takes `runner.creation_flags()`, the pair live installs
   already use, so the two cannot drift apart again.

Several comments explained the old mechanism by saying the helper has no
console of its own. That stopped being true, so they now say what is.

## Closes / relates to

Closes #420

## Test evidence

Unit, in this branch:

```
python scripts/check_control_bytes.py                  -> OK, 1391 tracked files
uvx ruff@0.14.4 check .                                -> All checks passed
pytest -q tests/test_dev_start_command.py \
         tests/test_packs_restart.py \
         tests/test_dev_packs_cli.py                   -> 240 passed
pytest -q  (full backend suite)                        -> 7439 passed, 20 failed
```

Those 20 are pre-existing and unrelated: the identical set fails on `main` in
the same local environment (19 in `test_codegen.py`, where an exported
script's subprocess cannot `import app`, plus one `huggingface_hub` version
probe). `git diff main --stat` touches no file any of them import.

Mutation-tested — each site reverted to `DETACHED_PROCESS` one at a time, and
each one turns its own test red:

```
RED (good)  start() daemon      test_the_daemon_gets_no_console_window_of_its_own
RED (good)  _relaunch_server    test_the_relaunch_is_detached_and_logged
RED (good)  spawn_helper        test_spawn_helper_argv_flags_and_log_file
```

Both new/changed tests fake `win32` and `linux` rather than branching on the
host, so Linux CI checks the Windows answer too.

Live on Windows 11 Pro, uv 0.11.1, driving the real launcher in this branch:

| | before | after |
| --- | --- | --- |
| extra console windows after `cdui start` | 1, titled `uvicorn.exe`, visible | 0 |
| closing that window | server dead in < 5 s | no such window exists |
| closing the launcher's own window (2 console hosts x 3 timings) | server survives | server survives |
| `cdui status` / `cdui stop` against the daemon | ok | ok |

The flag itself, measured through the venv shim: `DETACHED_PROCESS` gives the
child a `GetConsoleWindow()` that is non-zero and visible; `CREATE_NO_WINDOW`
gives it zero.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its
      zh-TW twin in the same PR — no docs page changed; CHANGELOG.md is
      English-only by convention.
- [x] No pictographic emoji in code, logs, UI strings, or this PR body
