### PR TITLE
chore(release): 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+## [2.6.0] — 2026-09-05
+
+Two things that used to need a terminal now happen in the editor: putting a
+project under version control, and installing a plugin. Neither is a button
+that shells out — the first is a git service that runs the host's own git
+against the open project directory and nothing else, the second a Plugin
+Center that reads a plugin's manifest and shows you what it asks for before a
+byte of the repository moves. The plugin rules the CLI privately owned moved
+into the backend to make the second one possible, which is why `cdui plugin`
+and the panel are now two front ends over one implementation rather than two
+implementations that would have drifted. Also here: the Windows fix for a
+black window that appeared beside every `cdui start` and stopped the server
+when it was closed.
+
 ### Added
 
 - **Source control from the editor, part 1 — the git service and the read and
@@ -3155,7 +3169,8 @@ Release candidates before 1.0.0 are on the
 [#420]: https://github.com/CodefyUI/CodefyUI/issues/420
 [@oyea0801]: https://github.com/oyea0801
 [@latteine1217]: https://github.com/latteine1217
-[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.5.0...main
+[Unreleased]: https://github.com/CodefyUI/CodefyUI/compare/2.6.0...main
+[2.6.0]: https://github.com/CodefyUI/CodefyUI/compare/2.5.0...2.6.0
 [2.5.0]: https://github.com/CodefyUI/CodefyUI/compare/2.4.1...2.5.0
 [2.4.1]: https://github.com/CodefyUI/CodefyUI/compare/2.4.0...2.4.1
 [2.4.0]: https://github.com/CodefyUI/CodefyUI/compare/2.3.0...2.4.0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codefyui-backend"
-version = "2.5.0"
+version = "2.6.0"
 description = "Visual Node-Based ML Pipeline Builder - Backend"
 # Names the copyright holder in distribution metadata. Until this landed, no
 # file in the repository said who owns CodefyUI, which left the commercial

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "codefyui-backend"
-version = "2.5.0"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "datasets" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codefyui-frontend",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "AGPL-3.0-only",
   "author": "CodefyUI (https://github.com/CodefyUI)",
   "packageManager": "pnpm@9.15.0",


### PR DESCRIPTION
> 中文摘要：把 CHANGELOG 的 `[Unreleased]` 升格成 `2.6.0`，並把三個版號欄位（`backend/pyproject.toml`、`backend/uv.lock`、`frontend/package.json`）從 2.5.0 改成 2.6.0。用 2.6.0 而不是 2.5.1，是因為 2.5.0 之後累積的內容包含新功能——編輯器內的版本控制、外掛中心——依 SemVer 屬於 minor。沒有程式碼變更。

## What / Why

Release commit for 2.6.0. Nothing but the changelog promotion and the version
fields.

**Why a minor and not a patch.** Everything that landed after 2.5.0 is in the
`[Unreleased]` section, and it is not only fixes: source control from the
editor (parts 1 and 2), the Plugin Center in full, three official plugins
installable by name, and two new environment variables. SemVer, which this
changelog declares in its own preamble, makes that a minor.

`git log 2.5.0..main` is eight commits (#407, #408, #409, #410, #411, #417,
#418, #419) plus #421, and every one of them already has an entry — the
reconciliation pass found nothing missing.

## Closes / relates to

Release-only. Closes nothing; the issues in this release were closed by their
own PRs.

## Test evidence

```
git grep -n "stamp-on-release" docs/     -> empty, no docs placeholder pending
python scripts/check_control_bytes.py    -> OK, 1391 tracked files
uvx ruff@0.14.4 check .                  -> All checks passed
cd backend && uv lock --check            -> resolved, no change beyond the bump
pytest -q tests/test_version_surfacing.py -> 14 passed
```

`test_all_version_fields_agree` is the one that matters here — it is what
fails on a half-done bump. The `uv.lock` diff is a single line
(`version = "2.5.0"` to `"2.6.0"`), so no dependency moved.

The `2.6.0` heading uses U+2014 EM DASH with a space either side, matching
every released section above it, so the `#260--2026-09-05` anchor the tag
annotation links to resolves.

## Checklist

- [x] Commits are signed off (`git commit -s`) per CONTRIBUTING.md's DCO section.
- [x] If I changed a docs page or a node-param description, I updated its
      zh-TW twin in the same PR — no docs page changed.
- [x] No pictographic emoji in code, logs, UI strings, or this PR body
