### PR TITLE
feat(ui,plugins): the palette, the quick search and the gallery name the plugin a node came from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@ received — each links to the release it was published as.
   time, in git's own words. Reading any of these lists is an open read; every
   button that changes something carries the session token. History and the diff
   view are the part after this one.
+- **Every node says which plugin it came from.** Hovering a row in the node
+  library now ends its tooltip with the plugin that registered it, muted and
+  under everything that describes the node — and a plugin's node that ships no
+  description at all gets that one line rather than no tooltip at all, which is
+  what it used to get. The same name is a third thing the two searches match,
+  so typing part of a plugin's name into the library's search box, or into the
+  quick search you get by double-clicking the canvas, finds its nodes; before,
+  the only way to reach them was the `plugin:` prefix their type happens to
+  carry. The template gallery's detail pane names the plugin the same way
+  instead of printing its id. Until the Plugin Center's catalog has answered —
+  during boot, on a server too old to have one, or after the network dropped —
+  the id stands in, because **From plugin: edu** is already true and a line
+  that waits for the catalog is a line that flickers in on every page load.
 
 ## [2.6.0] — 2026-09-05
 

--- a/frontend/src/components/Canvas/QuickNodeSearch.test.tsx
+++ b/frontend/src/components/Canvas/QuickNodeSearch.test.tsx
@@ -468,13 +468,37 @@ describe('QuickNodeSearch', () => {
     expect(getByText('edu:FilterRows')).toBeInTheDocument();
   });
 
-  it('matches the id while the catalog has not answered', () => {
-    setStore([def('edu:FilterRows', { provider: 'plugin:edu' })], []);
-    const { getByPlaceholderText, getByText } = render(
+  it('matches the plugin id while the catalog has not answered', () => {
+    // The id here is deliberately NOT a substring of the node name or of the
+    // description: `edu:FilterRows` is contributed by the plugin `teach`, so
+    // the query below reaches this row through nothing but the third clause
+    // falling back to the id of a catalog that has not answered yet. (An id
+    // that also spells the node's prefix would pass with the clause deleted.)
+    setStore(
+      [
+        def('edu:FilterRows', {
+          description: 'drops rows a predicate rejects',
+          provider: 'plugin:teach',
+        }),
+        def('Conv2d'),
+      ],
+      [],
+    );
+    const { getByPlaceholderText, getByText, queryByText } = render(
       <QuickNodeSearch screenPos={SCREEN} flowPos={FLOW} onClose={() => {}} />,
     );
-    fireEvent.change(getByPlaceholderText('Search nodes...'), { target: { value: 'edu' } });
+    const input = getByPlaceholderText('Search nodes...');
+
+    fireEvent.change(input, { target: { value: 'teach' } });
     expect(getByText('edu:FilterRows')).toBeInTheDocument();
+    expect(queryByText('Conv2d')).toBeNull();
+
+    // The other half of "has not answered": the display name lives only in
+    // the catalog, so with an empty index a query that matches nothing but
+    // that name finds nothing. Seeded, it is the case above this one.
+    fireEvent.change(input, { target: { value: 'hands-on' } });
+    expect(getByText('No matching nodes')).toBeInTheDocument();
+    expect(queryByText('edu:FilterRows')).toBeNull();
   });
 
   it('leaves built-ins, custom nodes and presets unreachable by a plugin name', () => {

--- a/frontend/src/components/Canvas/QuickNodeSearch.test.tsx
+++ b/frontend/src/components/Canvas/QuickNodeSearch.test.tsx
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, fireEvent, waitFor, within } from '@testing-library/react';
 import { QuickNodeSearch } from './QuickNodeSearch';
 import { useNodeDefStore } from '../../store/nodeDefStore';
+import { _resetPluginStoreForTesting, usePluginStore } from '../../store/pluginStore';
 import { useTabStore } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
+import type { PluginCatalogEntry } from '../../api/rest';
 import type { NodeDefinition, PresetDefinition } from '../../types';
 
 function def(name: string, overrides: Partial<NodeDefinition> = {}): NodeDefinition {
@@ -33,6 +35,51 @@ function preset(name: string, overrides: Partial<PresetDefinition> = {}): Preset
   };
 }
 
+function pluginEntry(over: Partial<PluginCatalogEntry> & { id: string }): PluginCatalogEntry {
+  return {
+    name: over.id,
+    description: '',
+    kind: 'github',
+    official: false,
+    status: 'installed',
+    source_kind: 'github_url',
+    source: over.id,
+    repo: null,
+    ref: null,
+    sha: null,
+    url: null,
+    homepage: '',
+    version: null,
+    installed_at: null,
+    enabled: true,
+    chapters: [],
+    lessons: [],
+    tags: [],
+    nodes: [],
+    node_count: 0,
+    capabilities: [],
+    trusted_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    consent_required: false,
+    frontend_entry: null,
+    job: null,
+    ...over,
+  };
+}
+
+const eduEntry = () => pluginEntry({ id: 'edu', name: 'EDU - hands-on teaching nodes' });
+
+/** Put a catalog in the plugin store, the way a finished `refresh()` would. */
+function seedPlugins(...entries: PluginCatalogEntry[]) {
+  usePluginStore.setState({
+    loaded: true,
+    unsupported: false,
+    plugins: entries,
+    byId: Object.fromEntries(entries.map((entry) => [entry.id, entry])),
+  });
+}
+
 const SCREEN = { x: 50, y: 60 };
 const FLOW = { x: 11, y: 22 };
 
@@ -59,6 +106,9 @@ describe('QuickNodeSearch', () => {
   beforeEach(() => {
     useI18n.setState({ locale: 'en' });
     setStore([], []);
+    // Every case that does not seed one runs against an empty plugin catalog:
+    // the base install, where nothing in the library came from a plugin.
+    _resetPluginStoreForTesting();
     useTabStore.setState({ addNode: vi.fn(), addPresetNode: vi.fn() });
   });
 
@@ -391,5 +441,60 @@ describe('QuickNodeSearch', () => {
     const panel = container.firstElementChild as HTMLElement;
     expect(panel.style.left).toBe(`${window.innerWidth - 300}px`);
     expect(panel.style.top).toBe(`${window.innerHeight - 400}px`);
+  });
+
+  // ── Plugin provenance (P-F3) ────────────────────────────────────────────
+
+  it('finds a plugin node by the plugin display name', () => {
+    // The same third field the palette search gained: the plugin as the
+    // Plugin Center names it, which appears in no field of a definition.
+    seedPlugins(eduEntry());
+    setStore(
+      [def('edu:FilterRows', { description: 'drops rows a predicate rejects', provider: 'plugin:edu' }),
+        def('Conv2d')],
+      [],
+    );
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <QuickNodeSearch screenPos={SCREEN} flowPos={FLOW} onClose={() => {}} />,
+    );
+    const input = getByPlaceholderText('Search nodes...');
+
+    fireEvent.change(input, { target: { value: 'hands-on' } });
+    expect(getByText('edu:FilterRows')).toBeInTheDocument();
+    expect(queryByText('Conv2d')).toBeNull();
+
+    // Case-insensitive, like the two fields it joins.
+    fireEvent.change(input, { target: { value: 'TEACHING' } });
+    expect(getByText('edu:FilterRows')).toBeInTheDocument();
+  });
+
+  it('matches the id while the catalog has not answered', () => {
+    setStore([def('edu:FilterRows', { provider: 'plugin:edu' })], []);
+    const { getByPlaceholderText, getByText } = render(
+      <QuickNodeSearch screenPos={SCREEN} flowPos={FLOW} onClose={() => {}} />,
+    );
+    fireEvent.change(getByPlaceholderText('Search nodes...'), { target: { value: 'edu' } });
+    expect(getByText('edu:FilterRows')).toBeInTheDocument();
+  });
+
+  it('leaves built-ins, custom nodes and presets unreachable by a plugin name', () => {
+    seedPlugins(eduEntry());
+    setStore(
+      [def('Conv2d', { provider: 'builtin' }), def('MyLayer', { provider: 'custom' })],
+      [preset('MyBlock')],
+    );
+    const { getByPlaceholderText, getByText, queryByText } = render(
+      <QuickNodeSearch screenPos={SCREEN} flowPos={FLOW} onClose={() => {}} />,
+    );
+    const input = getByPlaceholderText('Search nodes...');
+
+    fireEvent.change(input, { target: { value: 'hands-on' } });
+    expect(getByText('No matching nodes')).toBeInTheDocument();
+
+    // Counterfactual: the same three are still found by their own fields.
+    fireEvent.change(input, { target: { value: 'my' } });
+    expect(getByText('MyLayer')).toBeInTheDocument();
+    expect(getByText('MyBlock')).toBeInTheDocument();
+    expect(queryByText('Conv2d')).toBeNull();
   });
 });

--- a/frontend/src/components/Canvas/QuickNodeSearch.tsx
+++ b/frontend/src/components/Canvas/QuickNodeSearch.tsx
@@ -1,10 +1,18 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNodeDefStore } from '../../store/nodeDefStore';
+import { usePluginStore } from '../../store/pluginStore';
 import { useTabStore } from '../../store/tabStore';
 import { useI18n } from '../../i18n';
 import { CATEGORY_COLORS } from '../../styles/theme';
+import { pluginNameOf, type PluginIndex } from '../../utils/provider';
 import type { NodeDefinition, PresetDefinition } from '../../types';
 import styles from './QuickNodeSearch.module.css';
+
+// Module-scope, so the subscription compares the same function's output frame
+// to frame; narrow, so an install running in the Plugin Center cannot re-render
+// the palette on every long-poll turn.
+type PluginStoreState = ReturnType<typeof usePluginStore.getState>;
+const selectPluginsById = (state: PluginStoreState): PluginIndex => state.byId;
 
 interface QuickNodeSearchProps {
   screenPos: { x: number; y: number };
@@ -24,6 +32,7 @@ export function QuickNodeSearch({ screenPos, flowPos, onClose }: QuickNodeSearch
 
   const definitions = useNodeDefStore((s) => s.definitions);
   const presets = useNodeDefStore((s) => s.presets);
+  const pluginsById = usePluginStore(selectPluginsById);
   const addNode = useTabStore((s) => s.addNode);
   const addPresetNode = useTabStore((s) => s.addPresetNode);
   const { t, tn } = useI18n();
@@ -34,7 +43,16 @@ export function QuickNodeSearch({ screenPos, flowPos, onClose }: QuickNodeSearch
     const items: SearchResult[] = [];
 
     for (const def of definitions) {
-      if (!q || def.node_name.toLowerCase().includes(q) || def.description.toLowerCase().includes(q)) {
+      // The same three fields the palette search matches. The plugin's id
+      // already matches through the qualified node name (`edu:FilterRows`);
+      // what the third one adds is its display name, which is how the Plugin
+      // Center names it and appears in no field of a definition.
+      if (
+        !q ||
+        def.node_name.toLowerCase().includes(q) ||
+        def.description.toLowerCase().includes(q) ||
+        (pluginNameOf(pluginsById, def.provider)?.toLowerCase().includes(q) ?? false)
+      ) {
         items.push({ kind: 'node', def });
       }
     }

--- a/frontend/src/components/Sidebar/NodePalette.module.css
+++ b/frontend/src/components/Sidebar/NodePalette.module.css
@@ -361,6 +361,17 @@
   word-break: break-word;
 }
 
+/* Which plugin registered the node — last, and muted rather than warning
+   coloured: it is where the node came from, not something to fix. */
+.nodeTooltipProvenance {
+  margin-top: var(--sp-2);
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  line-height: var(--lh-normal);
+  white-space: normal;
+  word-break: break-word;
+}
+
 /* ── Preset item ── */
 .presetItem {
   padding: var(--sp-3) var(--sp-4);

--- a/frontend/src/components/Sidebar/NodesTab.test.tsx
+++ b/frontend/src/components/Sidebar/NodesTab.test.tsx
@@ -3,9 +3,10 @@ import { render, screen, fireEvent, within, act } from '@testing-library/react';
 import { NodesTab } from './NodesTab';
 import { useNodeDefStore } from '../../store/nodeDefStore';
 import { _resetPackStoreForTesting, usePackStore } from '../../store/packStore';
+import { _resetPluginStoreForTesting, usePluginStore } from '../../store/pluginStore';
 import { useUIStore } from '../../store/uiStore';
 import { useI18n } from '../../i18n';
-import type { PackSummary } from '../../api/rest';
+import type { PackSummary, PluginCatalogEntry } from '../../api/rest';
 import type { NodeDefinition } from '../../types';
 
 /*
@@ -51,8 +52,10 @@ beforeEach(() => {
   useI18n.setState({ locale: 'en' });
   useUIStore.setState({ tooltipsEnabled: true, beginnerMode: false });
   // Every case that does not seed a catalog runs against an empty, unloaded
-  // one — the base install, where no palette row says anything about packs.
+  // one — the base install, where no palette row says anything about packs
+  // and nothing in the library came from a plugin.
   _resetPackStoreForTesting();
+  _resetPluginStoreForTesting();
   seedStore({ categorized: {} });
   // A fresh mock per test, set through the store rather than vi.spyOn: set()
   // clones the state object, so a spy would outlive restoreAllMocks() and carry
@@ -503,5 +506,203 @@ describe('NodesTab — needs-pack badge', () => {
     seedStore({ categorized: { CNN: [def('Conv2d', 'CNN')] } });
     render(<NodesTab />);
     expect(screen.queryByText('Needs pack')).toBeNull();
+  });
+});
+
+// ── Plugin provenance (P-F3) ──────────────────────────────────────────────
+
+function pluginEntry(over: Partial<PluginCatalogEntry> & { id: string }): PluginCatalogEntry {
+  return {
+    name: over.id,
+    description: '',
+    kind: 'github',
+    official: false,
+    status: 'installed',
+    source_kind: 'github_url',
+    source: over.id,
+    repo: null,
+    ref: null,
+    sha: null,
+    url: null,
+    homepage: '',
+    version: null,
+    installed_at: null,
+    enabled: true,
+    chapters: [],
+    lessons: [],
+    tags: [],
+    nodes: [],
+    node_count: 0,
+    capabilities: [],
+    trusted_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    consent_required: false,
+    frontend_entry: null,
+    job: null,
+    ...over,
+  };
+}
+
+const EDU_NAME = 'EDU - hands-on teaching nodes';
+const EDU_LINE = `From plugin: ${EDU_NAME}`;
+
+/** Put a catalog in the plugin store, the way a finished `refresh()` would. */
+function seedPlugins(...entries: PluginCatalogEntry[]) {
+  usePluginStore.setState({
+    loaded: true,
+    unsupported: false,
+    plugins: entries,
+    byId: Object.fromEntries(entries.map((entry) => [entry.id, entry])),
+  });
+}
+
+const eduEntry = () => pluginEntry({ id: 'edu', name: EDU_NAME });
+
+const eduDef = (description = 'drops rows a predicate rejects'): NodeDefinition => ({
+  ...def('edu:FilterRows', 'Data', description),
+  provider: 'plugin:edu',
+});
+
+/** The portal tooltip, found from a line inside it rather than by class. */
+const tooltipAround = (line: HTMLElement) => line.parentElement as HTMLElement;
+
+describe('NodesTab — plugin provenance', () => {
+  it('names the plugin on the last line of the tooltip, after the description', () => {
+    seedPlugins(eduEntry());
+    seedStore({ categorized: { Data: [eduDef()] } });
+    render(<NodesTab />);
+
+    const item = screen.getByText('edu:FilterRows').parentElement as HTMLElement;
+    fireEvent.mouseEnter(item);
+
+    const line = screen.getByText(EDU_LINE);
+    const tooltip = tooltipAround(line);
+    // Title, description, provenance — provenance last, because it is the
+    // least of the three things a reader wants before the drag.
+    expect(Array.from(tooltip.children).map((child) => child.textContent)).toEqual([
+      'edu:FilterRows',
+      'drops rows a predicate rejects',
+      EDU_LINE,
+    ]);
+  });
+
+  it('shows the id until the catalog answers', () => {
+    // Three ordinary states leave `byId` empty: before the boot fetch lands,
+    // on a server with no Plugin Center, and after a network error. The line
+    // still says something true, and sharpens when the catalog arrives.
+    seedStore({ categorized: { Data: [eduDef()] } });
+    render(<NodesTab />);
+
+    fireEvent.mouseEnter(screen.getByText('edu:FilterRows').parentElement as HTMLElement);
+    expect(screen.getByText('From plugin: edu')).toBeTruthy();
+
+    act(() => seedPlugins(eduEntry()));
+    expect(screen.getByText(EDU_LINE)).toBeTruthy();
+    expect(screen.queryByText('From plugin: edu')).toBeNull();
+  });
+
+  it('says nothing for a built-in, a custom node, or a server that sends no provider', () => {
+    seedPlugins(eduEntry());
+    seedStore({
+      categorized: {
+        CNN: [
+          { ...def('Conv2d', 'CNN'), provider: 'builtin' },
+          { ...def('MyLayer', 'CNN'), provider: 'custom' },
+          def('Dropout', 'CNN'),
+        ],
+      },
+    });
+    render(<NodesTab />);
+
+    for (const name of ['Conv2d', 'MyLayer', 'Dropout']) {
+      // Grabbed before the hover: once the tooltip is up the name is on screen
+      // twice, in the row and in the tooltip's title.
+      const item = screen.getByText(name).parentElement as HTMLElement;
+      fireEvent.mouseEnter(item);
+      expect(screen.queryByText(/^From plugin: /)).toBeNull();
+      fireEvent.mouseLeave(item);
+    }
+  });
+
+  it('earns a tooltip for a plugin node with no description and no pack sentence', () => {
+    // The old gate showed NO tooltip at all when a node had neither, so the
+    // one line worth reading about such a node could never appear.
+    seedPlugins(eduEntry());
+    seedStore({ categorized: { Data: [eduDef('')] } });
+    render(<NodesTab />);
+
+    const item = screen.getByText('edu:FilterRows').parentElement as HTMLElement;
+    fireEvent.mouseEnter(item);
+
+    const line = screen.getByText(EDU_LINE);
+    expect(Array.from(tooltipAround(line).children).map((c) => c.textContent)).toEqual([
+      'edu:FilterRows',
+      EDU_LINE,
+    ]);
+  });
+
+  it('puts the provenance under the pack sentence, not over it', () => {
+    seedPacks(wordVectors());
+    seedPlugins(eduEntry());
+    seedStore({
+      categorized: {
+        LLM: [{ ...packedDef(), node_name: 'edu:WordVectorLookup', provider: 'plugin:edu' }],
+      },
+    });
+    render(<NodesTab />);
+
+    fireEvent.mouseEnter(screen.getByText('edu:WordVectorLookup').parentElement as HTMLElement);
+    const line = screen.getByText(EDU_LINE);
+    // Muted, not the pack sentence's warning colour — its own class, or a
+    // reader is told where a node came from in the colour of a problem.
+    expect(line.className).not.toBe(screen.getByText(PALETTE_SENTENCE).className);
+    expect(Array.from(tooltipAround(line).children).map((c) => c.textContent)).toEqual([
+      'edu:WordVectorLookup',
+      'looks a word up in a vector table',
+      PALETTE_SENTENCE,
+      EDU_LINE,
+    ]);
+  });
+
+  it('finds a plugin node by the plugin display name', () => {
+    // Searching the id already worked — plugin node names are qualified, so
+    // `edu` matches `edu:FilterRows` through the name. What is new is the
+    // human name, which appears in no field of the definition.
+    seedPlugins(eduEntry());
+    seedStore({
+      categorized: {
+        Data: [eduDef()],
+        CNN: [def('Conv2d', 'CNN')],
+      },
+    });
+    render(<NodesTab />);
+
+    const search = screen.getByPlaceholderText('Search nodes...');
+    fireEvent.change(search, { target: { value: 'hands-on' } });
+    expect(screen.getByText('edu:FilterRows')).toBeTruthy();
+    expect(screen.queryByText('Conv2d')).toBeNull();
+
+    // Case-insensitive, like the two fields it joins.
+    fireEvent.change(search, { target: { value: 'TEACHING' } });
+    expect(screen.getByText('edu:FilterRows')).toBeTruthy();
+
+    // A built-in stays unreachable by a plugin name.
+    fireEvent.change(search, { target: { value: 'conv' } });
+    expect(screen.getByText('Conv2d')).toBeTruthy();
+    expect(screen.queryByText('edu:FilterRows')).toBeNull();
+  });
+
+  it('re-filters when the catalog lands mid-search', () => {
+    seedStore({ categorized: { Data: [eduDef()] } });
+    render(<NodesTab />);
+
+    fireEvent.change(screen.getByPlaceholderText('Search nodes...'), {
+      target: { value: 'hands-on' },
+    });
+    expect(screen.getByText('No matching nodes')).toBeTruthy();
+
+    act(() => seedPlugins(eduEntry()));
+    expect(screen.getByText('edu:FilterRows')).toBeTruthy();
   });
 });

--- a/frontend/src/components/Sidebar/NodesTab.tsx
+++ b/frontend/src/components/Sidebar/NodesTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { useNodeDefStore } from '../../store/nodeDefStore';
+import { usePluginStore } from '../../store/pluginStore';
 import { useUIStore } from '../../store/uiStore';
 import { useI18n } from '../../i18n';
 import {
@@ -8,10 +9,18 @@ import {
   nodeMissingPack,
   usePackAvailability,
 } from '../../utils/packAvailability';
+import { pluginNameOf, type PluginIndex } from '../../utils/provider';
 import type { NodeDefinition } from '../../types';
 import { orderCategories } from './categories';
 import { CategoryList, type CategoryGroup } from './CategoryList';
 import styles from './NodePalette.module.css';
+
+// A module-scope selector, so every row of a hundred-node library compares the
+// SAME function's output frame to frame. Narrow on purpose: an install running
+// in the Plugin Center writes `job`, `busy` and the log on every long-poll
+// turn, and none of that changes what a node is called.
+type PluginStoreState = ReturnType<typeof usePluginStore.getState>;
+const selectPluginsById = (state: PluginStoreState): PluginIndex => state.byId;
 
 // ── Operation Node Item ──
 
@@ -38,6 +47,14 @@ export function NodeItem({ definition }: NodeItemProps) {
           pack: localizedPackTitle(t, byId, missingPack.packId),
         });
 
+  // Who registered this node. Subscribed rather than read once, because the
+  // catalog lands after boot: the line says `edu` until it arrives and the
+  // plugin's own name from then on.
+  const pluginsById = usePluginStore(selectPluginsById);
+  const pluginName = pluginNameOf(pluginsById, definition.provider);
+  const provenance =
+    pluginName === null ? null : t('palette.fromPlugin', { plugin: pluginName });
+
   const desc = tn(definition.node_name, 'description', definition.description);
 
   const handleMouseEnter = useCallback(() => {
@@ -62,8 +79,10 @@ export function NodeItem({ definition }: NodeItemProps) {
   };
 
   // A pack-backed node with no description still earns a tooltip: the pack
-  // sentence is the thing worth reading before the drag.
-  const showTooltip = tooltipsEnabled && (desc || packSentence) && hovered && tooltipPos;
+  // sentence is the thing worth reading before the drag. So does a plugin's
+  // node, whose one line worth reading may be where it came from.
+  const showTooltip =
+    tooltipsEnabled && (desc || packSentence || provenance) && hovered && tooltipPos;
 
   return (
     <div
@@ -112,6 +131,10 @@ export function NodeItem({ definition }: NodeItemProps) {
           {packSentence !== null && (
             <div className={styles.nodeTooltipPack}>{packSentence}</div>
           )}
+          {/* Last: what the node is and whether it can run come first. */}
+          {provenance !== null && (
+            <div className={styles.nodeTooltipProvenance}>{provenance}</div>
+          )}
         </div>,
         document.body,
       )}
@@ -139,6 +162,7 @@ export function NodesTab() {
   const error = useNodeDefStore((s) => s.error);
   const refetch = useNodeDefStore((s) => s.fetchDefinitions);
   const beginnerMode = useUIStore((s) => s.beginnerMode);
+  const pluginsById = usePluginStore(selectPluginsById);
   const [searchQuery, setSearchQuery] = useState('');
   const { t } = useI18n();
 
@@ -150,16 +174,21 @@ export function NodesTab() {
     for (const category of orderCategories(Object.keys(categorized), beginnerMode)) {
       let items = categorized[category];
       if (q) {
+        // The third field is the plugin's DISPLAY name. Its id already
+        // matches through the qualified node name (`edu:FilterRows`), so what
+        // this adds is the plugin as a reader knows it from the Plugin Center
+        // — the only name for it that appears in no field of a definition.
         items = items.filter(
           (n) =>
             n.node_name.toLowerCase().includes(q) ||
-            n.description.toLowerCase().includes(q),
+            n.description.toLowerCase().includes(q) ||
+            (pluginNameOf(pluginsById, n.provider)?.toLowerCase().includes(q) ?? false),
         );
       }
       if (items.length > 0) out.push({ category, items });
     }
     return out;
-  }, [categorized, beginnerMode, searchQuery]);
+  }, [categorized, beginnerMode, pluginsById, searchQuery]);
 
   return (
     <>

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.test.tsx
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import { TemplateGalleryModal, exampleSourceLabel } from './TemplateGalleryModal';
+import { TemplateGalleryModal } from './TemplateGalleryModal';
 import { useDialogStore } from '../../store/dialogStore';
 import { useNodeDefStore } from '../../store/nodeDefStore';
 import { _resetPluginStoreForTesting, usePluginStore } from '../../store/pluginStore';
@@ -102,12 +102,10 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('exampleSourceLabel', () => {
-  it('names the plugin pack, and nothing for a builtin', () => {
-    expect(exampleSourceLabel(ex({ source: 'plugin:c2' }))).toBe('c2');
-    expect(exampleSourceLabel(ex({ source: 'builtin' }))).toBeNull();
-  });
-});
+// The pane's built-in/plugin gate is `utils/provider`'s `pluginNameOf`, and
+// the two unit cases the modal used to hold for a prefix test of its own live
+// in `utils/provider.test.ts` beside it. What stays here is what only a render
+// can answer: which sentence the detail pane shows.
 
 describe('TemplateGalleryModal', () => {
   it('renders nothing while closed', () => {
@@ -229,13 +227,22 @@ describe('TemplateGalleryModal', () => {
     // `plugin:` with nothing after it names nothing, and the pane said
     // "Built-in example" for it before the catalog was consulted at all.
     // Resolving a name must not turn that into an empty pair of quotes.
+    const older = ex({ name: 'Older', description: 'no source at all', path: 'o/2' });
+    // The wire type makes `source` optional: a frontend built from source can
+    // meet a backend that omits it, and that example is a built-in too.
+    delete older.source;
     mockedRest.listExamples.mockResolvedValue([
       ex({ name: 'Odd', description: 'a malformed source', path: 'o/1', source: 'plugin:' }),
+      older,
     ]);
     render(<TemplateGalleryModal />);
     await waitFor(() =>
       expect(within(detail()).getByText('a malformed source')).toBeInTheDocument(),
     );
+    expect(within(detail()).getByText('Built-in example')).toBeInTheDocument();
+
+    fireEvent.click(within(grid()).getByText('Older'));
+    expect(within(detail()).getByText('no source at all')).toBeInTheDocument();
     expect(within(detail()).getByText('Built-in example')).toBeInTheDocument();
   });
 

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.test.tsx
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.test.tsx
@@ -1,14 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { TemplateGalleryModal, exampleSourceLabel } from './TemplateGalleryModal';
 import { useDialogStore } from '../../store/dialogStore';
 import { useNodeDefStore } from '../../store/nodeDefStore';
+import { _resetPluginStoreForTesting, usePluginStore } from '../../store/pluginStore';
 import { useTabStore } from '../../store/tabStore';
 import { useToastStore } from '../../store/toastStore';
 import { useUIStore } from '../../store/uiStore';
 import { useI18n } from '../../i18n';
 import * as rest from '../../api/rest';
-import type { ExampleSummary } from '../../api/rest';
+import type { ExampleSummary, PluginCatalogEntry } from '../../api/rest';
 
 // Only the two network calls are stubbed. `openExampleInNewTab` and
 // `insertExample` run for real against the real tab store, so the two actions
@@ -39,6 +40,39 @@ function raw(id: string) {
   return { id, type: 'Dropout', position: { x: 0, y: 0 }, data: { params: {} } };
 }
 
+function pluginEntry(over: Partial<PluginCatalogEntry> & { id: string }): PluginCatalogEntry {
+  return {
+    name: over.id,
+    description: '',
+    kind: 'github',
+    official: false,
+    status: 'installed',
+    source_kind: 'github_url',
+    source: over.id,
+    repo: null,
+    ref: null,
+    sha: null,
+    url: null,
+    homepage: '',
+    version: null,
+    installed_at: null,
+    enabled: true,
+    chapters: [],
+    lessons: [],
+    tags: [],
+    nodes: [],
+    node_count: 0,
+    capabilities: [],
+    trusted_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    consent_required: false,
+    frontend_entry: null,
+    job: null,
+    ...over,
+  };
+}
+
 /** The card list. Scoped because the detail pane repeats the chosen name. */
 const grid = () => screen.getByRole('region', { name: 'Template list' });
 const detail = () => screen.getByRole('complementary', { name: 'Template details' });
@@ -46,6 +80,9 @@ const detail = () => screen.getByRole('complementary', { name: 'Template details
 beforeEach(() => {
   useI18n.setState({ locale: 'en' });
   useNodeDefStore.setState({ definitions: [], presets: [] });
+  // An empty plugin catalog unless a case seeds one: the state the modal
+  // renders in before the boot fetch lands, where the id stands in.
+  _resetPluginStoreForTesting();
   useToastStore.setState({ toasts: [] });
   useUIStore.setState({ templateGalleryOpen: true });
   useTabStore.setState({ tabs: [], activeTabId: null as unknown as string, clipboard: null });
@@ -160,6 +197,46 @@ describe('TemplateGalleryModal', () => {
     fireEvent.click(within(grid()).getByText('Second'));
     expect(within(detail()).getByText('the second one')).toBeInTheDocument();
     expect(within(detail()).getByText('From plugin pack "c2"')).toBeInTheDocument();
+  });
+
+  it('names the plugin the catalog knows, and the id until it answers', async () => {
+    mockedRest.listExamples.mockResolvedValue([
+      ex({ name: 'Lesson', description: 'a lesson graph', path: 'e/1', source: 'plugin:edu' }),
+    ]);
+    render(<TemplateGalleryModal />);
+    await waitFor(() =>
+      expect(within(detail()).getByText('a lesson graph')).toBeInTheDocument(),
+    );
+
+    // Before the catalog answers the id stands in — still a true sentence.
+    expect(within(detail()).getByText('From plugin pack "edu"')).toBeInTheDocument();
+
+    // The catalog lands: the same pane names the plugin as the Plugin Center
+    // does, without a reload and without the search behind it changing.
+    act(() => {
+      usePluginStore.setState({
+        loaded: true,
+        byId: { edu: pluginEntry({ id: 'edu', name: 'EDU - hands-on teaching nodes' }) },
+      });
+    });
+    expect(
+      within(detail()).getByText('From plugin pack "EDU - hands-on teaching nodes"'),
+    ).toBeInTheDocument();
+    expect(within(detail()).queryByText('From plugin pack "edu"')).toBeNull();
+  });
+
+  it('still calls a source that names no plugin a built-in', async () => {
+    // `plugin:` with nothing after it names nothing, and the pane said
+    // "Built-in example" for it before the catalog was consulted at all.
+    // Resolving a name must not turn that into an empty pair of quotes.
+    mockedRest.listExamples.mockResolvedValue([
+      ex({ name: 'Odd', description: 'a malformed source', path: 'o/1', source: 'plugin:' }),
+    ]);
+    render(<TemplateGalleryModal />);
+    await waitFor(() =>
+      expect(within(detail()).getByText('a malformed source')).toBeInTheDocument(),
+    );
+    expect(within(detail()).getByText('Built-in example')).toBeInTheDocument();
   });
 
   it('falls back to a placeholder for a template with no description', async () => {

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.tsx
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.tsx
@@ -3,8 +3,10 @@ import { createPortal } from 'react-dom';
 import { listExamples, type ExampleSummary } from '../../api/rest';
 import { insertExample, openExampleInNewTab } from '../../utils/openExample';
 import { useDialogStore } from '../../store/dialogStore';
+import { usePluginStore } from '../../store/pluginStore';
 import { useUIStore } from '../../store/uiStore';
 import { useI18n } from '../../i18n';
+import { pluginNameOf, type PluginIndex } from '../../utils/provider';
 import { EXAMPLE_CATEGORY_COLORS, EXAMPLE_CATEGORY_FALLBACK, mixColor, NODE_HEADER_TINT, SURFACE_RAISED } from '../../styles/theme';
 // The sidebar's Templates tab (#126) already owns the category order every
 // example surface is expected to share; importing it keeps the modal's grid
@@ -16,7 +18,21 @@ import {
 } from '../Sidebar/TemplatesTab';
 import styles from './TemplateGalleryModal.module.css';
 
-/** Human-readable origin: a built-in example, or the pack that ships it. */
+// Module-scope, so the subscription compares the same function's output frame
+// to frame, and narrow: an install running in the Plugin Center writes `job`
+// and its log on every long-poll turn, none of which renames a plugin.
+type PluginStoreState = ReturnType<typeof usePluginStore.getState>;
+const selectPluginsById = (state: PluginStoreState): PluginIndex => state.byId;
+
+/**
+ * Whether an example came from a plugin, and which one — as an id.
+ *
+ * Deliberately still the raw id and still pure: it is the GATE the detail pane
+ * asks (plugin, or built-in?), and the human name it prints comes from
+ * `pluginNameOf` at the render site, which needs the catalog and a live
+ * subscription to it. Keeping the two apart leaves this callable, and testable,
+ * without a store.
+ */
 export function exampleSourceLabel(example: ExampleSummary): string | null {
   const source = example.source ?? '';
   if (source.startsWith('plugin:')) return source.slice('plugin:'.length);
@@ -54,6 +70,7 @@ export function TemplateGalleryModal() {
 
 function TemplateGalleryBody() {
   const close = useUIStore((s) => s.closeTemplateGallery);
+  const pluginsById = usePluginStore(selectPluginsById);
   const { t } = useI18n();
 
   const [examples, setExamples] = useState<ExampleSummary[]>([]);
@@ -128,6 +145,7 @@ function TemplateGalleryBody() {
   // first remaining one rather than emptying the pane.
   const chosen =
     visible.find((e) => e.path === chosenPath) ?? visible[0] ?? null;
+  const chosenSourceId = chosen === null ? null : exampleSourceLabel(chosen);
 
   const take = useCallback(
     async (run: () => Promise<boolean>) => {
@@ -285,8 +303,13 @@ function TemplateGalleryBody() {
                     <span>{t('gallery.edgeCount', { count: chosen.edge_count })}</span>
                   </div>
                   <div className={styles.detailSource}>
-                    {exampleSourceLabel(chosen)
-                      ? t('gallery.sourcePlugin', { plugin: exampleSourceLabel(chosen)! })
+                    {/* The id is still the gate; the name is what a reader
+                        sees, and falls back to that same id for as long as the
+                        catalog has not answered. */}
+                    {chosenSourceId
+                      ? t('gallery.sourcePlugin', {
+                          plugin: pluginNameOf(pluginsById, chosen.source) ?? chosenSourceId,
+                        })
                       : t('gallery.sourceBuiltin')}
                   </div>
                   <p className={styles.detailDesc}>

--- a/frontend/src/components/TemplateGallery/TemplateGalleryModal.tsx
+++ b/frontend/src/components/TemplateGallery/TemplateGalleryModal.tsx
@@ -24,21 +24,6 @@ import styles from './TemplateGalleryModal.module.css';
 type PluginStoreState = ReturnType<typeof usePluginStore.getState>;
 const selectPluginsById = (state: PluginStoreState): PluginIndex => state.byId;
 
-/**
- * Whether an example came from a plugin, and which one — as an id.
- *
- * Deliberately still the raw id and still pure: it is the GATE the detail pane
- * asks (plugin, or built-in?), and the human name it prints comes from
- * `pluginNameOf` at the render site, which needs the catalog and a live
- * subscription to it. Keeping the two apart leaves this callable, and testable,
- * without a store.
- */
-export function exampleSourceLabel(example: ExampleSummary): string | null {
-  const source = example.source ?? '';
-  if (source.startsWith('plugin:')) return source.slice('plugin:'.length);
-  return null;
-}
-
 function matches(example: ExampleSummary, query: string): boolean {
   return (
     example.name.toLowerCase().includes(query) ||
@@ -145,7 +130,12 @@ function TemplateGalleryBody() {
   // first remaining one rather than emptying the pane.
   const chosen =
     visible.find((e) => e.path === chosenPath) ?? visible[0] ?? null;
-  const chosenSourceId = chosen === null ? null : exampleSourceLabel(chosen);
+  // One question, one answer: the NAME is both the gate (null means the
+  // example is a built-in, or names no plugin at all) and the word the pane
+  // prints. `pluginNameOf` already falls back to the bare id while the
+  // catalog has not answered, so there is no second fallback to keep in step.
+  const chosenPluginName =
+    chosen === null ? null : pluginNameOf(pluginsById, chosen.source);
 
   const take = useCallback(
     async (run: () => Promise<boolean>) => {
@@ -303,14 +293,9 @@ function TemplateGalleryBody() {
                     <span>{t('gallery.edgeCount', { count: chosen.edge_count })}</span>
                   </div>
                   <div className={styles.detailSource}>
-                    {/* The id is still the gate; the name is what a reader
-                        sees, and falls back to that same id for as long as the
-                        catalog has not answered. */}
-                    {chosenSourceId
-                      ? t('gallery.sourcePlugin', {
-                          plugin: pluginNameOf(pluginsById, chosen.source) ?? chosenSourceId,
-                        })
-                      : t('gallery.sourceBuiltin')}
+                    {chosenPluginName === null
+                      ? t('gallery.sourceBuiltin')
+                      : t('gallery.sourcePlugin', { plugin: chosenPluginName })}
                   </div>
                   <p className={styles.detailDesc}>
                     {chosen.description || t('gallery.noDescription')}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -92,6 +92,7 @@ const en = {
   'palette.noMatch': 'No matching nodes',
   'palette.empty': 'No nodes available',
   'palette.hint': 'Drag nodes onto the canvas',
+  'palette.fromPlugin': 'From plugin: {plugin}',
   'palette.searchPresets': 'Search presets...',
   'palette.presets.empty': 'No presets available',
   'palette.presets.noMatch': 'No matching presets',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -88,6 +88,7 @@ const zhTW: Record<TranslationKey, string> = {
   'palette.noMatch': '找不到符合的節點',
   'palette.empty': '沒有可用的節點',
   'palette.hint': '拖曳節點到畫布上',
+  'palette.fromPlugin': '來自外掛：{plugin}',
   'palette.searchPresets': '搜尋預設組合...',
   'palette.presets.empty': '沒有可用的預設組合',
   'palette.presets.noMatch': '找不到符合的預設組合',

--- a/frontend/src/utils/provider.test.ts
+++ b/frontend/src/utils/provider.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { pluginIdOf, pluginNameOf, type PluginIndex } from './provider';
+import type { PluginCatalogEntry } from '../api/rest';
+
+function entry(over: Partial<PluginCatalogEntry> & { id: string }): PluginCatalogEntry {
+  return {
+    name: over.id,
+    description: '',
+    kind: 'builtin',
+    official: true,
+    status: 'installed',
+    source_kind: null,
+    source: over.id,
+    repo: null,
+    ref: null,
+    sha: null,
+    url: null,
+    homepage: '',
+    version: null,
+    installed_at: null,
+    enabled: true,
+    chapters: [],
+    lessons: [],
+    tags: [],
+    nodes: [],
+    node_count: 0,
+    capabilities: [],
+    trusted_modules: [],
+    python_deps: {},
+    has_frontend: false,
+    consent_required: false,
+    frontend_entry: null,
+    job: null,
+    ...over,
+  };
+}
+
+const edu: PluginIndex = {
+  edu: entry({ id: 'edu', name: 'EDU - hands-on teaching nodes' }),
+};
+
+describe('pluginIdOf', () => {
+  it('strips the plugin: prefix off a plugin provider', () => {
+    expect(pluginIdOf('plugin:edu')).toBe('edu');
+    // Manifest ids keep their hyphens: the wire value is the registry key.
+    expect(pluginIdOf('plugin:official-template')).toBe('official-template');
+  });
+
+  it('answers null for everything that is not a plugin', () => {
+    expect(pluginIdOf('builtin')).toBeNull();
+    expect(pluginIdOf('custom')).toBeNull();
+    expect(pluginIdOf(undefined)).toBeNull();
+    expect(pluginIdOf(null)).toBeNull();
+    expect(pluginIdOf('')).toBeNull();
+    // A prefix with nothing after it names no plugin.
+    expect(pluginIdOf('plugin:')).toBeNull();
+  });
+});
+
+describe('pluginNameOf', () => {
+  it('answers the catalog name when the catalog knows the plugin', () => {
+    expect(pluginNameOf(edu, 'plugin:edu')).toBe('EDU - hands-on teaching nodes');
+  });
+
+  it('falls back to the id for a plugin the catalog has not answered for', () => {
+    // The three ordinary states with an empty index: before the boot fetch
+    // lands, on an unsupported server, and after a network error. "From
+    // plugin: edu" is still true, so the line stands rather than disappearing.
+    expect(pluginNameOf({}, 'plugin:edu')).toBe('edu');
+    // Same for an id this catalog does not list.
+    expect(pluginNameOf(edu, 'plugin:ghost')).toBe('ghost');
+  });
+
+  it('falls back to the id when the entry carries an empty name', () => {
+    expect(pluginNameOf({ edu: entry({ id: 'edu', name: '' }) }, 'plugin:edu')).toBe('edu');
+  });
+
+  it('answers null for a non-plugin provider', () => {
+    expect(pluginNameOf(edu, 'builtin')).toBeNull();
+    expect(pluginNameOf(edu, 'custom')).toBeNull();
+    expect(pluginNameOf(edu, undefined)).toBeNull();
+    expect(pluginNameOf(edu, null)).toBeNull();
+    expect(pluginNameOf(edu, '')).toBeNull();
+    expect(pluginNameOf(edu, 'plugin:')).toBeNull();
+  });
+
+  it('does not read a name off Object.prototype', () => {
+    // The index is built from parsed JSON, so a plain byId[id] answers with an
+    // inherited member for ids like `constructor` -- whose `.name` is the
+    // string "Object". The id is the honest answer.
+    expect(pluginNameOf({}, 'plugin:constructor')).toBe('constructor');
+    expect(pluginNameOf({}, 'plugin:toString')).toBe('toString');
+  });
+});

--- a/frontend/src/utils/provider.test.ts
+++ b/frontend/src/utils/provider.test.ts
@@ -84,6 +84,20 @@ describe('pluginNameOf', () => {
     expect(pluginNameOf(edu, 'plugin:')).toBeNull();
   });
 
+  it('names the plugin pack an example came from, and nothing for a builtin', () => {
+    // An example's `source` is the same vocabulary a definition's `provider`
+    // is (`builtin` / `plugin:<id>`), which is why the gallery asks these two
+    // functions rather than the prefix test it used to keep of its own. These
+    // are that helper's cases, against the one parser that survives.
+    expect(pluginIdOf('plugin:c2')).toBe('c2');
+    expect(pluginIdOf('builtin')).toBeNull();
+    expect(pluginNameOf({}, 'plugin:c2')).toBe('c2');
+    expect(pluginNameOf({}, 'builtin')).toBeNull();
+    // `source` is optional on the wire (an older backend omits it), and a
+    // missing one is a built-in.
+    expect(pluginNameOf({}, undefined)).toBeNull();
+  });
+
   it('does not read a name off Object.prototype', () => {
     // The index is built from parsed JSON, so a plain byId[id] answers with an
     // inherited member for ids like `constructor` -- whose `.name` is the

--- a/frontend/src/utils/provider.ts
+++ b/frontend/src/utils/provider.ts
@@ -1,0 +1,66 @@
+import type { PluginCatalogEntry } from '../api/rest';
+
+/**
+ * The one place that answers "which plugin did this come from?".
+ *
+ * A node definition carries `provider` (`builtin`, `custom`, or
+ * `plugin:<id>`; see `types/index.ts`) and an example carries the same shape
+ * in `source`. Four surfaces read it -- the palette tooltip, the palette
+ * search, the canvas quick search and the gallery's detail pane -- and every
+ * one of them wants the same two answers, so the parse lives here rather than
+ * four times over. `TemplateGalleryModal.exampleSourceLabel` predates this
+ * module and keeps its own copy of the prefix test, because it answers a
+ * narrower question (is this example a plugin's at all) for its own unit test.
+ *
+ * Both functions are PURE, and deliberately take the catalog index as an
+ * argument instead of reading `usePluginStore` themselves. A component that
+ * names a plugin has to re-render when the catalog lands -- `byId` is rebuilt
+ * asynchronously after boot -- and that only happens if the component itself
+ * subscribes with `usePluginStore((s) => s.byId)`. A helper reading
+ * `getState()` would render the id once and never correct itself.
+ *
+ * ── Why an unknown id still gets a line ────────────────────────────────
+ * `byId` is empty in three ordinary states: before the boot fetch resolves,
+ * on a server with no Plugin Center (a 404 clears the catalog), and after a
+ * network error. Suppressing the provenance until the catalog answers would
+ * make the line flicker in on every page load; showing the id instead is a
+ * sentence that is already true -- the node type is `edu:FilterRows` and the
+ * line says it came from `edu` -- and it improves by itself the moment the
+ * catalog arrives.
+ */
+
+/** Plugin catalog rows keyed by id -- `usePluginStore`'s `byId` slice. */
+export type PluginIndex = Record<string, PluginCatalogEntry>;
+
+const PLUGIN_PREFIX = 'plugin:';
+
+/**
+ * The plugin id inside a `provider` / `source` value, or null.
+ *
+ * `plugin:` with nothing after it is null rather than an empty string: it
+ * names no plugin, and an empty name in a sentence reads as a bug.
+ */
+export function pluginIdOf(provider: string | undefined | null): string | null {
+  if (typeof provider !== 'string' || !provider.startsWith(PLUGIN_PREFIX)) return null;
+  const id = provider.slice(PLUGIN_PREFIX.length);
+  return id === '' ? null : id;
+}
+
+/**
+ * What to call the plugin a node or an example came from, or null when it
+ * came from no plugin at all.
+ *
+ * Three answers in order: the catalog's human name, the bare id, null.
+ * `hasOwnProperty` rather than a plain index read because `byId` is built from
+ * parsed JSON -- a plugin id of `constructor` would otherwise resolve to
+ * `Object.prototype.constructor` and put the word "Object" in the sentence.
+ */
+export function pluginNameOf(
+  byId: PluginIndex,
+  provider: string | undefined | null,
+): string | null {
+  const id = pluginIdOf(provider);
+  if (id === null) return null;
+  const entry = Object.prototype.hasOwnProperty.call(byId, id) ? byId[id] : undefined;
+  return entry?.name || id;
+}

--- a/frontend/src/utils/provider.ts
+++ b/frontend/src/utils/provider.ts
@@ -8,9 +8,8 @@ import type { PluginCatalogEntry } from '../api/rest';
  * in `source`. Four surfaces read it -- the palette tooltip, the palette
  * search, the canvas quick search and the gallery's detail pane -- and every
  * one of them wants the same two answers, so the parse lives here rather than
- * four times over. `TemplateGalleryModal.exampleSourceLabel` predates this
- * module and keeps its own copy of the prefix test, because it answers a
- * narrower question (is this example a plugin's at all) for its own unit test.
+ * four times over -- the gallery's detail pane included, which used to keep a
+ * second copy of the prefix test for a gate this module now answers.
  *
  * Both functions are PURE, and deliberately take the catalog index as an
  * argument instead of reading `usePluginStore` themselves. A component that


### PR DESCRIPTION
## The palette, the quick search and the gallery name the plugin a node came from

Plugin Center frontend, part 3 (P-F3 of the Plugin Center + Source Control wave), frontend half.

### What

- `frontend/src/utils/provider.ts`: two pure helpers over `NodeDefinition.provider` (`builtin` | `custom` |
  `plugin:<id>`): `pluginIdOf` and `pluginNameOf(byId, provider)`, the latter answering the catalog name when
  the Plugin Center catalog has loaded and the id itself before it answers, on an `unsupported` server, or after
  a network error (the id is still true).
- Node palette tooltip: one last muted line, `From plugin: {plugin}` / 「來自外掛：{plugin}」, after the
  description and the pack sentence; a plugin node with no description still gets a tooltip carrying only
  that line.
- Palette search and the canvas quick search also match the plugin's display name (typing 動手 or EDU lists
  the eight `edu:` nodes); the id already matched through the qualified node name.
- Example gallery detail pane: the existing "From plugin pack" sentence now names the plugin instead of
  printing its id.
- One locale key (`palette.fromPlugin`, en + zh-TW); one CHANGELOG entry under Unreleased.

### Why

`/api/nodes` has carried `provider` since P-B1 and nothing in the editor read it; a student who installs a
pack from the Plugin Center could not tell which nodes it brought, and could not find them by the pack's name.

### What this PR deliberately leaves out

The plan's `docs/docs/usage/plugin-center.md` page and the edits to `advanced/plugins.md` and
`cli-commands.md`: the docs branch `docs/sync-code-2026-09` already ships the Plugin Center walkthrough, the
CLI pointer and the full REST table, so the usage page is written after that branch merges, against its text.
Nothing under `docs/` changes here.

### How it was verified

- `pnpm test` `188 files / 4903 tests`, `pnpm build` (tsc parity gate + contrast + vite), `pnpm contrast`
  (`461 colour relationships across 191 tokens`); every new test was red first.
- Chrome, zh-TW, dist from this branch with the `edu` pack installed: hovering `edu:ActivationLayer` shows
  「來自外掛：EDU — 動手做教學節點」 as the tooltip's last line; the palette search and the quick search list
  exactly the eight `edu:` nodes for 動手; console clean. The gallery line is covered by its render-site test
  (the `edu` pack ships no gallery examples to see it live).
- Review: spec + quality review (Opus), one Minors round with a scoped re-review. Ledger:
  `.superpowers/sdd/pcenter-pf3/progress.md` (git-ignored).

### Follow-up worth an issue

The 28-field `PluginCatalogEntry` test fixture now lives in nine test files and the `PluginState` type is
re-derived in three components; a shared factory under `src/test/` and an exported `PluginState` would make
the next catalog field a one-file change.
