### PR TITLE
build(frontend): lazy KaTeX and a five-chunk layout, no more 500 kB warning

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -65,7 +65,18 @@ jobs:
 
       - name: Build
         working-directory: frontend
-        run: pnpm build
+        run: |
+          set -o pipefail
+          pnpm build 2>&1 | tee "$RUNNER_TEMP/vite-build.log"
+          # vite.config.ts keeps build.chunkSizeWarningLimit at its default so
+          # the 500 kB warning stays the tripwire for the chunk layout. A chunk
+          # past the limit fails here, where the output is read, instead of
+          # scrolling by in a green job. A `!`-negated command is exempt from
+          # errexit, hence the explicit exit.
+          if grep -Eq 'Some chunks are larger than|Circular chunk' "$RUNNER_TEMP/vite-build.log"; then
+            echo 'vite build printed a chunk warning; see the chunk layout in vite.config.ts' >&2
+            exit 1
+          fi
 
       - name: Verify dist contents
         working-directory: frontend

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -109,7 +109,18 @@ jobs:
 
       - name: Build frontend
         working-directory: frontend
-        run: pnpm build
+        run: |
+          set -o pipefail
+          pnpm build 2>&1 | tee "$RUNNER_TEMP/vite-build.log"
+          # vite.config.ts keeps build.chunkSizeWarningLimit at its default so
+          # the 500 kB warning stays the tripwire for the chunk layout. A chunk
+          # past the limit fails here, where the output is read, instead of
+          # scrolling by in a green job. A `!`-negated command is exempt from
+          # errexit, hence the explicit exit.
+          if grep -Eq 'Some chunks are larger than|Circular chunk' "$RUNNER_TEMP/vite-build.log"; then
+            echo 'vite build printed a chunk warning; see the chunk layout in vite.config.ts' >&2
+            exit 1
+          fi
 
       - name: Verify dist contents
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+### Changed
+
+- **A smaller, warning-free frontend build.** The single 1.48 MB entry script
+  is now five eager chunks cut along what changes together (React, React Flow
+  with dagre and d3, the translations, the stores and API layer, the
+  components), so after `cdui update` a browser re-downloads only what
+  changed, and KaTeX is fetched on the first description that contains a
+  formula, the way the code editor already fetches CodeMirror. `pnpm build` no
+  longer warns about a chunk over 500 kB. The build fails if a static import
+  ever undoes one of the two lazy boundaries or if the chunk layout forms a
+  cycle, and CI fails if a chunk grows past the limit.
+
 ## [2.7.0] — 2026-09-07
 
 The Source Control tab is complete. 2.6.0 shipped the working tree and the

--- a/frontend/src/components/shared/MathText.chunkFailure.test.tsx
+++ b/frontend/src/components/shared/MathText.chunkFailure.test.tsx
@@ -1,0 +1,33 @@
+import { it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { MathText } from './MathText';
+
+// Own file on purpose: the module-level promise cache in MathText starts
+// empty here, so the first mount is the one whose chunk fails. A factory that
+// throws makes the dynamic import() reject, and vitest calls it again on the
+// next import, which is what lets one test cover the loader's catch (reset and
+// rethrow), the effect's catch, and the retry on a later mount.
+//
+// Vitest wraps the factory's error ("[vitest] There was an error when mocking
+// a module..."), so nothing below asserts on the message: the contract under
+// test is the fallback and the retry, never the error text.
+let attempts = 0;
+vi.mock('./katexRenderer', () => {
+  attempts += 1;
+  throw new Error('chunk unavailable');
+});
+
+it('keeps the raw source when the chunk fails and lets a later mount retry', async () => {
+  const first = render(<MathText text="value $x$ end" />);
+  await waitFor(() => expect(attempts).toBe(1));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(first.container.querySelector('.katex')).toBeNull();
+  expect(first.container.textContent).toBe('value $x$ end');
+  first.unmount();
+
+  const second = render(<MathText text="$$y$$" />);
+  await waitFor(() => expect(attempts).toBe(2));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(second.container.querySelector('.katex')).toBeNull();
+  expect(second.container.textContent).toBe('$$y$$');
+});

--- a/frontend/src/components/shared/MathText.module.css
+++ b/frontend/src/components/shared/MathText.module.css
@@ -12,18 +12,3 @@
      own sizing does. */
   font-size: 0.85em;
 }
-
-/* KaTeX inherits parent text color rather than its hardcoded black so
-   the formulas blend into the dark theme. */
-:global(.katex) {
-  color: inherit;
-}
-
-/* Block math should scroll horizontally inside the narrow Inspector /
-   ConfigPanel without forcing the parent panel to grow. */
-:global(.katex-display) {
-  margin: 0.4em 0;
-  overflow-x: auto;
-  overflow-y: hidden;
-  padding: 0 var(--sp-2);
-}

--- a/frontend/src/components/shared/MathText.test.tsx
+++ b/frontend/src/components/shared/MathText.test.tsx
@@ -1,6 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
 import { parseMathSegments, MathText } from './MathText';
+
+// KaTeX is loaded through a dynamic import so it never reaches the entry
+// bundle. This pass-through mock keeps the real renderer (the assertions
+// below look for KaTeX markup) and counts how often the chunk is requested,
+// which is what proves a text-only description never asks for it and that
+// mounts share one load.
+let chunkLoads = 0;
+vi.mock('./katexRenderer', async (importOriginal) => {
+  chunkLoads += 1;
+  return importOriginal();
+});
 
 describe('parseMathSegments', () => {
   it('returns plain text as a single segment', () => {
@@ -102,46 +113,71 @@ describe('MathText component', () => {
     expect(container.querySelector('div.d1')).toBeTruthy();
   });
 
-  it('renders plain text segments inside the chosen tag', () => {
+  it('renders plain text segments without requesting the KaTeX chunk', async () => {
     const { container } = render(<MathText text="hello world" as="div" className="wrap" />);
     const div = container.querySelector('div.wrap');
     expect(div?.textContent).toContain('hello world');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(chunkLoads).toBe(0);
   });
 
-  it('renders inline math via KaTeX (katex markup present)', () => {
+  // Must stay the FIRST formula rendered in this file: the module-level
+  // cache in MathText is empty only once per file, and this is the test that
+  // exercises the load itself. Tests run in declaration order.
+  it('shares one in-flight load between mounts and ignores it after unmount', async () => {
+    expect(chunkLoads).toBe(0);
+    const a = render(<MathText text="$a$" />);
+    const b = render(<MathText text="value $b$ end" />);
+    // Until the chunk resolves the raw source stands in; nothing goes blank.
+    expect(b.container.querySelector('.katex')).toBeNull();
+    expect(b.container.textContent).toBe('value $b$ end');
+    a.unmount();
+    await waitFor(() => expect(b.container.querySelector('.katex')).toBeTruthy());
+    expect(chunkLoads).toBe(1);
+  });
+
+  it('typesets synchronously once the chunk is cached', () => {
+    const { container } = render(<MathText text="$$\\frac{1}{2}$$" />);
+    expect(container.querySelector('.katex')).toBeTruthy();
+    expect(chunkLoads).toBe(1);
+  });
+
+  it('renders inline math via KaTeX (katex markup present)', async () => {
     const { container } = render(<MathText text="value $x+1$ end" />);
     // react-katex injects elements carrying the "katex" class on success.
-    expect(container.querySelector('.katex')).toBeTruthy();
+    await waitFor(() => expect(container.querySelector('.katex')).toBeTruthy());
     expect(container.textContent).toContain('value ');
     expect(container.textContent).toContain(' end');
   });
 
-  it('renders block math via KaTeX', () => {
+  it('renders block math via KaTeX', async () => {
     const { container } = render(<MathText text="$$\\frac{1}{2}$$" />);
-    expect(container.querySelector('.katex')).toBeTruthy();
+    await waitFor(() => expect(container.querySelector('.katex')).toBeTruthy());
   });
 
-  it('renders a mixed string with text, inline, and block segments', () => {
+  it('renders a mixed string with text, inline, and block segments', async () => {
     const { container } = render(<MathText text={'A $$y$$ B $z$ C'} />);
     expect(container.textContent).toContain('A ');
     expect(container.textContent).toContain(' B ');
     expect(container.textContent).toContain(' C');
-    expect(container.querySelectorAll('.katex').length).toBeGreaterThanOrEqual(1);
+    await waitFor(() =>
+      expect(container.querySelectorAll('.katex').length).toBeGreaterThanOrEqual(1)
+    );
   });
 
-  it('falls back to a monospace literal when an inline formula is malformed', () => {
+  it('falls back to a monospace literal when an inline formula is malformed', async () => {
     // Unclosed group "\frac{" is a KaTeX parse error → renderError fires and
     // emits the styled fallback span containing the raw source and error name.
     const { container } = render(<MathText text={'bad $\\frac{$ ok'} />);
+    await waitFor(() => expect(container.querySelector('[class*="fallback"]')).toBeTruthy());
     const fallback = container.querySelector('[class*="fallback"]');
-    expect(fallback).toBeTruthy();
     expect(fallback?.textContent).toContain('\\frac{');
   });
 
-  it('falls back to a monospace literal when a block formula is malformed', () => {
+  it('falls back to a monospace literal when a block formula is malformed', async () => {
     const { container } = render(<MathText text={'$$\\frac{$$'} />);
+    await waitFor(() => expect(container.querySelector('[class*="fallback"]')).toBeTruthy());
     const fallback = container.querySelector('[class*="fallback"]');
-    expect(fallback).toBeTruthy();
     expect(fallback?.textContent).toContain('\\frac{');
   });
 });

--- a/frontend/src/components/shared/MathText.tsx
+++ b/frontend/src/components/shared/MathText.tsx
@@ -1,5 +1,4 @@
-import { Fragment, type ReactNode } from 'react';
-import { InlineMath, BlockMath } from 'react-katex';
+import { Fragment, useEffect, useMemo, useState, type ReactNode } from 'react';
 import styles from './MathText.module.css';
 
 interface Props {
@@ -78,30 +77,64 @@ export function parseMathSegments(input: string): Segment[] {
   return segments;
 }
 
-function renderSegment(seg: Segment, key: number): ReactNode {
+type KatexModule = typeof import('./katexRenderer');
+
+/**
+ * Module-level cache of the dynamic import (the shape CodeEditor.tsx uses
+ * for CodeMirror).
+ *
+ * KaTeX is about 260 kB and only a handful of node descriptions contain a
+ * formula, so it is fetched the first time one is rendered rather than at
+ * startup. Keeping the promise means the chunk is requested once per
+ * session, and `katexModule` seeds later mounts so every description after
+ * the first one typesets synchronously, with no source-to-math swap.
+ */
+let katexPromise: Promise<KatexModule> | null = null;
+let katexModule: KatexModule | null = null;
+
+function loadKatex(): Promise<KatexModule> {
+  if (!katexPromise) {
+    katexPromise = import('./katexRenderer')
+      .then((mod) => {
+        katexModule = mod;
+        return mod;
+      })
+      .catch((error) => {
+        // Drop the rejected promise so the next mount asks again instead of
+        // inheriting this failure; this mount keeps the raw source. A chunk
+        // can fail on a flaky network, or 404 once `cdui update` has replaced
+        // dist/ under an open page. Browsers remember a failed module fetch
+        // for the life of the page, so in practice the formula typesets
+        // again after a reload; nothing here is lost by asking sooner.
+        katexPromise = null;
+        throw error;
+      });
+  }
+  return katexPromise;
+}
+
+function renderSegment(seg: Segment, key: number, katex: KatexModule | null): ReactNode {
   if (seg.kind === 'text') {
     return <Fragment key={key}>{seg.value}</Fragment>;
+  }
+  const source = seg.kind === 'block' ? `$$${seg.value}$$` : `$${seg.value}$`;
+  // Until the chunk resolves the raw source stands in, so a description is
+  // never blank and stays readable if the chunk never arrives.
+  if (!katex) {
+    return <Fragment key={key}>{source}</Fragment>;
   }
   // Wrap KaTeX in an error-tolerant boundary by relying on react-katex's
   // built-in errorColor / renderError. We render plain monospace fallback
   // when the formula is malformed, instead of crashing the parent.
-  if (seg.kind === 'block') {
-    return (
-      <BlockMath
-        key={key}
-        math={seg.value}
-        renderError={(err) => (
-          <span className={styles.fallback}>${`$${seg.value}$$`} ({err.name})</span>
-        )}
-      />
-    );
-  }
+  const MathComponent = seg.kind === 'block' ? katex.BlockMath : katex.InlineMath;
   return (
-    <InlineMath
+    <MathComponent
       key={key}
       math={seg.value}
       renderError={(err) => (
-        <span className={styles.fallback}>${seg.value}$ ({err.name})</span>
+        <span className={styles.fallback}>
+          {source} ({err.name})
+        </span>
       )}
     />
   );
@@ -111,14 +144,31 @@ function renderSegment(seg: Segment, key: number): ReactNode {
  * Render text containing inline `$x$` and block `$$x$$` LaTeX via KaTeX.
  * Falls back to monospace text on parse errors so a single bad formula
  * never crashes the surrounding panel.
+ *
+ * KaTeX itself is loaded lazily, and only when the text contains a formula:
+ * a text-only description never requests the chunk.
  */
 export function MathText({ text, className, as = 'span' }: Props) {
   const Tag = as as 'span' | 'div';
+  const segments = useMemo(() => (text ? parseMathSegments(text) : []), [text]);
+  const needsKatex = segments.some((seg) => seg.kind !== 'text');
+  const [katex, setKatex] = useState<KatexModule | null>(katexModule);
+
+  useEffect(() => {
+    if (!needsKatex || katex) return;
+    let cancelled = false;
+    loadKatex()
+      .then((mod) => {
+        if (!cancelled) setKatex(mod);
+      })
+      .catch(() => {
+        // The raw source is already on screen; nothing else to do here.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [needsKatex, katex]);
+
   if (!text) return <Tag className={className} />;
-  const segments = parseMathSegments(text);
-  return (
-    <Tag className={className}>
-      {segments.map(renderSegment)}
-    </Tag>
-  );
+  return <Tag className={className}>{segments.map((seg, i) => renderSegment(seg, i, katex))}</Tag>;
 }

--- a/frontend/src/components/shared/katexOverrides.css
+++ b/frontend/src/components/shared/katexOverrides.css
@@ -1,0 +1,18 @@
+/* Overrides of katex.min.css. This sheet is part of the lazy KaTeX chunk and
+   is imported after katex.min.css (see katexRenderer.tsx), which is what lets
+   these rules win at equal specificity. */
+
+/* KaTeX inherits parent text color rather than its hardcoded black so
+   the formulas blend into the dark theme. */
+.katex {
+  color: inherit;
+}
+
+/* Block math should scroll horizontally inside the narrow Inspector /
+   ConfigPanel without forcing the parent panel to grow. */
+.katex-display {
+  margin: 0.4em 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0 var(--sp-2);
+}

--- a/frontend/src/components/shared/katexRenderer.tsx
+++ b/frontend/src/components/shared/katexRenderer.tsx
@@ -1,0 +1,18 @@
+/**
+ * The KaTeX half of {@link MathText}.
+ *
+ * Deliberately a SEPARATE module: `MathText` reaches it through a dynamic
+ * `import()`, and that import is the chunk boundary. Nothing here may be
+ * imported statically from anywhere else, or KaTeX (about 260 kB) lands in
+ * an eager chunk and the lazy loading is undone silently. vite.config.ts
+ * fails the build if a static import ever reaches the katex package, and
+ * lazyBoundaries.test.ts fails `pnpm test` if one names this module.
+ *
+ * The stylesheet travels with the chunk for the same reason. Vite appends it
+ * to <head> AFTER index.css when the chunk loads, so the overrides are
+ * imported after katex.min.css here: that is the order that lets them win
+ * the cascade at equal specificity.
+ */
+import 'katex/dist/katex.min.css';
+import './katexOverrides.css';
+export { InlineMath, BlockMath } from 'react-katex';

--- a/frontend/src/components/shared/lazyBoundaries.test.ts
+++ b/frontend/src/components/shared/lazyBoundaries.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The two lazy chunk boundaries (codemirrorSetup.ts, katexRenderer.tsx) are
+ * undone silently by a single static import: the code keeps working, the
+ * chunk just moves into the first paint. vite.config.ts catches the package
+ * side of that at build time; this test catches the module side in
+ * `pnpm test`, by reading the sources from disk the way
+ * SourceControl.integration.test.tsx reads its stylesheets.
+ */
+const BOUNDARIES = ['codemirrorSetup', 'katexRenderer'];
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name !== 'test') sourceFiles(full, out);
+    } else if (/\.tsx?$/.test(entry.name) && !/\.(test|d)\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// `import x from '...'`, `import '...'` and `export ... from '...'`; a
+// `typeof import('...')` type or an `import()` expression is not matched.
+const STATIC_IMPORT = /^\s*(?:import|export)\b[^;]*?\bfrom\s+['"]([^'"]+)['"]|^\s*import\s+['"]([^'"]+)['"]/gm;
+
+describe('lazy chunk boundaries', () => {
+  const files = sourceFiles(SRC);
+
+  it('sees both boundary modules', () => {
+    for (const name of BOUNDARIES) {
+      expect(files.some((file) => new RegExp(`/${name}\\.tsx?$`).test(file))).toBe(true);
+    }
+  });
+
+  it('are never imported statically', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      for (const match of readFileSync(file, 'utf8').matchAll(STATIC_IMPORT)) {
+        if (/^\s*import\s+type\b/.test(match[0])) continue;
+        const specifier = match[1] ?? match[2];
+        if (BOUNDARIES.some((name) => specifier.endsWith(`/${name}`))) {
+          offenders.push(`${relative(SRC, file)} imports ${specifier}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import 'katex/dist/katex.min.css';
 import './App.css';
 import App from './App';
 import { getSessionToken } from './api/_auth';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,115 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Rollup } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+
+/**
+ * Chunk layout.
+ *
+ * The entry bundle used to be one 1.48 MB file, past Rollup's 500 kB warning.
+ * It is cut along lines that change at different rates, so a release only
+ * re-downloads what changed and no single chunk can drift past the warning
+ * unnoticed:
+ *   react     react, react-dom, scheduler, zustand (moves on a React bump)
+ *   flow      React Flow, dagre and d3 (moves on a React Flow bump)
+ *   vendor    any other package the entry reaches statically (none today)
+ *   i18n      the string tables
+ *   app-core  stores, API clients, utils, hooks, plugin host: the non-visual
+ *             layer every component imports
+ *   index     the components, App and main
+ * Chunk edges are all one-way, so chunks evaluate in a fixed order:
+ *   index    -> react, flow, i18n, app-core  (dynamic: katexRenderer, codemirrorSetup)
+ *   app-core -> react, flow, i18n
+ *   i18n     -> react
+ *   flow     -> react
+ * `onLog` below fails the build if an import ever closes a cycle.
+ *
+ * CodeMirror (shared/codemirrorSetup.ts) and KaTeX (shared/katexRenderer.tsx)
+ * are reached only through a dynamic import() and are deliberately NOT named
+ * here: a manual chunk is loaded eagerly, so naming them would undo the lazy
+ * loading. `eagerIds` keeps any module that is reachable only through an
+ * import() out of the eager chunks without a hand-maintained list, and
+ * LAZY_ONLY turns a static import of one of those packages into a build
+ * error instead of a silent 260 kB regression.
+ *
+ * Rollup pulls every UNASSIGNED static dependency into the first manual chunk
+ * that walks it. That is why the packages are assigned explicitly: left open,
+ * zustand was walked into app-core, and since every store imports useI18n
+ * while i18n imports zustand, Rollup reported a circular chunk.
+ */
+type ChunkMeta = Parameters<Rollup.GetManualChunk>[1];
+
+/** Packages that exist only behind a dynamic import(). */
+const LAZY_ONLY = /\/node_modules\/(katex|react-katex|@codemirror|@lezer)\//;
+const REACT_RUNTIME = /\/node_modules\/(react|react-dom|scheduler|zustand|use-sync-external-store)\//;
+const FLOW_RUNTIME = /\/node_modules\/(@xyflow\/[^/]+|@dagrejs\/[^/]+|d3-[^/]+|classcat)\//;
+const APP_CORE = /\/src\/(store|utils|api|hooks|plugins)\//;
+const STYLESHEET = /\.css(\?|$)/;
+
+const eagerCache = new WeakMap<ChunkMeta, Set<string>>();
+
+/** Module ids reachable from the entry through static imports alone. */
+function eagerIds(meta: ChunkMeta): Set<string> {
+  const cached = eagerCache.get(meta);
+  if (cached) return cached;
+  const ids = new Set<string>();
+  const queue = [...meta.getModuleIds()].filter((id) => meta.getModuleInfo(id)?.isEntry);
+  if (queue.length === 0) throw new Error('manualChunks: no entry module found');
+  for (const id of queue) {
+    if (ids.has(id)) continue;
+    ids.add(id);
+    queue.push(...(meta.getModuleInfo(id)?.importedIds ?? []));
+  }
+  eagerCache.set(meta, ids);
+  return ids;
+}
+
+function manualChunks(id: string, meta: ChunkMeta): string | undefined {
+  if (id.includes('/node_modules/')) {
+    if (!eagerIds(meta).has(id)) return undefined;
+    // Loud, at build time, when a static import undoes one of the two lazy
+    // boundaries. Checked before the stylesheet rule so that re-adding
+    // `import 'katex/dist/katex.min.css'` to main.tsx is caught as well.
+    if (LAZY_ONLY.test(id)) {
+      throw new Error(`${id} is reached through a static import; it must stay behind its dynamic import()`);
+    }
+    // A stylesheet stays with the module that imports it (Rollup's default).
+    // App.css and @xyflow/react/dist/style.css set the same properties on the
+    // same selectors at equal specificity (edge stroke, selection, minimap,
+    // controls), so their order inside index.css is part of the rendered
+    // result; a flow.css linked ahead of index.css would flip those rules.
+    if (STYLESHEET.test(id)) return undefined;
+    if (REACT_RUNTIME.test(id)) return 'react';
+    if (FLOW_RUNTIME.test(id)) return 'flow';
+    return 'vendor';
+  }
+  if (STYLESHEET.test(id)) return undefined;
+  if (id.includes('/src/i18n/')) return 'i18n';
+  // Only the statically reachable part of the layer: a store or API client
+  // that later moves behind a lazy tab must not be dragged back by this rule.
+  if (APP_CORE.test(id) && eagerIds(meta).has(id)) return 'app-core';
+  return undefined;
+}
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      output: { manualChunks },
+      // A chunk cycle lets a module read an import before its chunk has
+      // evaluated, and Rollup only warns about it. Fail the build instead, so
+      // an import that closes a cycle is caught by `pnpm build` rather than
+      // by a blank page after `cdui update`.
+      onLog(level, log, handler) {
+        if (log.code === 'CIRCULAR_CHUNK') {
+          throw new Error(`manualChunks produced a chunk cycle: ${log.message}`);
+        }
+        handler(level, log);
+      },
     },
   },
   server: {


### PR DESCRIPTION
## Why

`pnpm build` printed `(!) Some chunks are larger than 500 kB after minification`: the entry script was one 1,479.84 kB file. `cdui install` (when pnpm is present), `cdui update`, `frontend-build.yml` and `release-build.yml` all run that build, so the warning showed up in every one of them.

## What

Two changes that land together (the config tripwire fails the build if `MathText.tsx` alone were reverted):

1. **KaTeX is a lazy boundary** behind `MathText`, modelled on `CodeEditor.tsx` / `codemirrorSetup.ts`. `katexRenderer.tsx` re-exports react-katex and owns the stylesheet; `MathText` reaches it through a cached dynamic `import()` only when a description contains a formula, and the raw `$...$` source stands in until the chunk resolves. Text-only descriptions never request it. The two `:global` overrides move into `katexOverrides.css` inside the chunk, imported after `katex.min.css`, because the lazy stylesheet is appended after `index.css` and would otherwise lose the cascade.
2. **A five-chunk eager layout** in `vite.config.ts` (`manualChunks` function): packages are placed only when they are statically reachable from the entry, so the CodeMirror and KaTeX families can never be swallowed into an eager chunk; the same reachability test guards the `app-core` rule, so a later lazy Source Control tab is not dragged back.

Tripwires so this does not regress silently:

- `LAZY_ONLY` fails the build when a static import reaches `katex`, `react-katex`, `@codemirror` or `@lezer`, checked before the stylesheet rule so re-adding `import 'katex/dist/katex.min.css'` to `main.tsx` is caught too.
- `onLog` turns Rollup's `CIRCULAR_CHUNK` warning into a build error.
- `lazyBoundaries.test.ts` fails `pnpm test` if any non-test module statically imports `codemirrorSetup` or `katexRenderer` (the build tripwire does not see an unused import, the test does).
- Both CI build steps fail on the chunk warning instead of letting it scroll by. `chunkSizeWarningLimit` stays at the default 500 so the warning remains the signal.

## Asset table

| chunk | before | after |
|---|---|---|
| index-*.js | 1,479.84 kB | 399.12 kB |
| flow-*.js (React Flow, dagre, d3) | in index | 217.85 kB |
| react-*.js (react, react-dom, scheduler, zustand) | in index | 198.35 kB |
| app-core-*.js (store, utils, api, hooks, plugins) | in index | 197.99 kB |
| i18n-*.js | in index | 195.60 kB |
| katexRenderer-*.js + .css (lazy, on the first formula) | in index | 263.88 kB + 29.37 kB |
| codemirrorSetup-B_OIItkv.js (lazy, unchanged hash) | 359.89 kB | 359.89 kB |
| index-*.css | 238.15 kB | 208.56 kB |

Eager JavaScript on a cold load drops from 1,479.84 kB to 1,208.91 kB and KaTeX's 29 kB of CSS leaves the eager stylesheet. Chunk edges are one-way (index -> react, flow, i18n, app-core; app-core -> react, flow, i18n; i18n, flow -> react), verified acyclic.

Headroom, honestly: index sits at 80 percent of the limit. Component source grew about 180 kB per minor during the Source Control build-out, which puts the limit roughly two minors away at that pace; the CI gate makes that loud when it happens, and the next cut (App-level `React.lazy` on the six modals, about 106 kB, then the Source Control tab plus diff window, about 76 kB) is measured and leaves this config untouched.

Load-bearing invariant for the layout: nothing under `src/store`, `src/utils`, `src/api`, `src/hooks` or `src/plugins` may statically import a non-leaf component module. The one existing edge (`store/gitStore.ts` -> `components/SourceControl/scm.ts`) is a leaf and is absorbed into `app-core`; a new edge that closes a cycle fails the build.

## Verification

- `pnpm build`: warning-free, the table above, `codemirrorSetup-B_OIItkv.js` byte-identical to the previous dist, 59 KaTeX font assets unchanged, zero `.katex` rules left in `index.css`.
- Tripwires reproduced and reverted: katex CSS re-import in `main.tsx`, `import 'katex'`, node_modules left unassigned (`Circular chunk: i18n -> app-core -> i18n`), a used static import of `katexRenderer` in `App.tsx` (build error plus the guard test naming `App.tsx`).
- `pnpm vitest run --coverage` from `frontend/`: 198 files / 5227 tests green (was 196 / 5222). `MathText.tsx` and `katexRenderer.tsx` at 100 percent in all four columns; suite totals rise by exactly the new statements (13528/13901 statements, 9721/10353 branches). The coverage note in the repo memory ("100 percent") was stale: HEAD is at 97.31 percent statements; this PR neither claims nor lowers that.
- Backend: `test_spa_cache_headers.py` and `test_spa_fallback_routing.py` pass (22 tests); every new file lands under `dist/assets` with the immutable cache header.
- Chromium against this checkout's backend serving the built dist: cold load requests exactly the five eager chunks and two stylesheets (no `katexRenderer`, no `codemirrorSetup`), console clean, minimap and controls present; selecting a LayerNorm node fetches `katexRenderer` JS and CSS once and the formula typesets with the theme colour (computed colour equals the parent's); a second formula fetches nothing; with the chunk blocked the description shows the raw `$...$` source, no `.katex`, the app stays up; a reload recovers. Browsers remember a failed module fetch for the life of the page, so the in-page retry in `loadKatex` is a cheap reset rather than a guarantee; the comment says so.

Not exercised here: a Windows `cdui install` with pnpm present (no CI job runs `pnpm build` on Windows; the config matches forward-slash ids, which Rollup normalises on every platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Di52VUzHXjTmXqQ4fihqrs
