### PR TITLE
fix(ui,packs,plugins): a tab keeps working after the server restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A tab kept working after the server restarts.** The server mints a new
+  session token every time its process starts, and the browser cached the
+  first one for the life of the page. A tab left open across a restart — a
+  `cdui` restart, or the Package Center restarting the server itself to finish
+  a pack that was already imported — held a token the server had never seen,
+  so every install, uninstall and Run answered `403`, and the execution
+  WebSocket was refused on every reconnect until it gave up. Mutating requests
+  now re-read the token once and retry; the WebSocket re-reads it before each
+  reconnect attempt, and a reconnect that fails before the socket exists no
+  longer ends the retry chain.
+- **A 403 says which of the two things it was.** Both the remote-install gate
+  and a refused session token answer `403`, and the Package and Plugin Centers
+  reported either as "Installing is only allowed from the computer that runs
+  the server" — pointing a user sitting at that very computer at nothing they
+  could do. The gate's sentence is now used only when the server actually said
+  installing is remote-disabled.
+
 ## [2.7.1] — 2026-09-08
 
 A smaller frontend build that no longer trips Vite's chunk-size warning. The

--- a/frontend/src/api/_auth.test.ts
+++ b/frontend/src/api/_auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   getSessionToken,
+  invalidateSessionToken,
   _setSessionTokenForTesting,
   apiFetch,
   wsUrlWithToken,
@@ -200,6 +201,102 @@ describe('apiFetch', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('/api/auth/bootstrap');
     const headers = new Headers(fetchMock.mock.calls[1][1].headers);
     expect(headers.get('X-CodefyUI-Token')).toBe('bootstrapped');
+  });
+});
+
+/**
+ * The server mints a new token every time its process starts, and a browser
+ * tab outlives a restart — the Package Center restarts the server itself to
+ * finish a pack that was already imported. Without a retry, every POST from
+ * that tab (install a plugin, install a pack, run a graph) answers 403 until
+ * the user reloads the page.
+ */
+describe('apiFetch after the server rotates its token', () => {
+  it('re-bootstraps and replays the request once on a 403', async () => {
+    _setSessionTokenForTesting('stale');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(403, 'Forbidden'))
+      .mockResolvedValueOnce(okResponse({ token: 'fresh' }))
+      .mockResolvedValueOnce(okResponse({ done: true }));
+    g.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await apiFetch('/api/plugins/install', {
+      method: 'POST',
+      body: '{"inspection_id":"i1"}',
+    });
+
+    expect(res.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(new Headers(fetchMock.mock.calls[0][1].headers).get('X-CodefyUI-Token'))
+      .toBe('stale');
+    expect(fetchMock.mock.calls[1][0]).toBe('/api/auth/bootstrap');
+    const replay = fetchMock.mock.calls[2];
+    expect(replay[0]).toBe('/api/plugins/install');
+    expect(new Headers(replay[1].headers).get('X-CodefyUI-Token')).toBe('fresh');
+    expect(replay[1].body).toBe('{"inspection_id":"i1"}');
+  });
+
+  it('keeps the 403 when the token has not changed', async () => {
+    // A refusal that is about the request, not the token: the server refuses
+    // a remote plugin or pack install with 403 as well. One request, not two.
+    _setSessionTokenForTesting('same');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(403, 'Forbidden'))
+      .mockResolvedValueOnce(okResponse({ token: 'same' }));
+    g.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await apiFetch('/api/plugins/install', { method: 'POST' });
+
+    expect(res.status).toBe(403);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the 403 when the bootstrap endpoint is unreachable', async () => {
+    _setSessionTokenForTesting('stale');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(errorResponse(403, 'Forbidden'))
+      .mockRejectedValueOnce(new Error('network down'));
+    g.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await apiFetch('/api/plugins/install', { method: 'POST' });
+    expect(res.status).toBe(403);
+  });
+
+  it('leaves other error statuses alone', async () => {
+    _setSessionTokenForTesting('tok');
+    const fetchMock = vi.fn().mockResolvedValue(errorResponse(500, 'Server Error'));
+    g.fetch = fetchMock as unknown as typeof fetch;
+
+    const res = await apiFetch('/api/plugins/install', { method: 'POST' });
+    expect(res.status).toBe(500);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not replay a request whose body is a stream', async () => {
+    // The first request consumed it; a second would throw instead of sending.
+    _setSessionTokenForTesting('stale');
+    const fetchMock = vi.fn().mockResolvedValue(errorResponse(403, 'Forbidden'));
+    g.fetch = fetchMock as unknown as typeof fetch;
+
+    const body = new ReadableStream();
+    const res = await apiFetch('/api/plugins/install', { method: 'POST', body });
+    expect(res.status).toBe(403);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('invalidateSessionToken', () => {
+  it('makes the next call re-read the bootstrap endpoint', async () => {
+    _setSessionTokenForTesting('old');
+    const fetchMock = vi.fn().mockResolvedValue(okResponse({ token: 'new' }));
+    g.fetch = fetchMock as unknown as typeof fetch;
+
+    invalidateSessionToken();
+    await expect(getSessionToken()).resolves.toBe('new');
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/bootstrap');
   });
 });
 

--- a/frontend/src/api/_auth.ts
+++ b/frontend/src/api/_auth.ts
@@ -52,6 +52,23 @@ export async function getSessionToken(): Promise<string> {
 }
 
 /**
+ * Drop the cached token so the next call re-reads /api/auth/bootstrap.
+ *
+ * The backend mints a new token every time its process starts (see
+ * `auth.py`), and a browser tab outlives a restart: the Package Center
+ * restarts the server itself to finish a pack that was already imported, and
+ * `cdui start` after a stop is the same event. From that moment the tab holds
+ * a token the server has never heard of, so every POST — install a plugin,
+ * install a pack, run a graph — comes back 403, and the WebSocket handshake
+ * is refused on every reconnect attempt. Re-reading the bootstrap endpoint is
+ * a local GET and gets the tab back in step.
+ */
+export function invalidateSessionToken(): void {
+  cachedToken = null;
+  inflight = null;
+}
+
+/**
  * Test-only escape hatch. Vitest setup pre-populates the token so we don't
  * have to mock the bootstrap endpoint in every test file.
  */
@@ -64,6 +81,13 @@ export function _setSessionTokenForTesting(token: string | null): void {
  * Drop-in replacement for ``fetch(url, init)`` that auto-attaches the session
  * token header on mutating requests. GET / HEAD / OPTIONS are passed through
  * unchanged.
+ *
+ * A 403 gets one retry with a freshly bootstrapped token, because the token
+ * this tab cached is refused verbatim after the server restarts — see
+ * {@link invalidateSessionToken}. The retry only goes out when the new token
+ * differs from the one just refused: 403 is also how the server refuses a
+ * remote plugin or pack install (`routes_plugins.py`, `routes_packs.py`), and
+ * that refusal must cost one request, not two.
  */
 export async function apiFetch(
   url: string,
@@ -74,9 +98,38 @@ export async function apiFetch(
     return fetch(url, init);
   }
   const token = await getSessionToken();
+  const res = await fetch(url, { ...init, headers: withToken(init, token) });
+  if (res.status !== 403 || !isReplayable(init.body)) return res;
+
+  invalidateSessionToken();
+  let fresh: string;
+  try {
+    fresh = await getSessionToken();
+  } catch {
+    // The server is unreachable now; the 403 we already have is the more
+    // useful answer to give the caller.
+    return res;
+  }
+  if (fresh === token) return res;
+  return fetch(url, { ...init, headers: withToken(init, fresh) });
+}
+
+/** *init*'s headers plus the session token. */
+function withToken(init: RequestInit, token: string): Headers {
   const headers = new Headers(init.headers);
   headers.set(TOKEN_HEADER, token);
-  return fetch(url, { ...init, headers });
+  return headers;
+}
+
+/**
+ * Whether this body can be sent a second time.
+ *
+ * Strings, `FormData` and blobs can. A `ReadableStream` cannot — the first
+ * request consumed it — so a request built from one keeps its 403 rather than
+ * being retried into a `TypeError`.
+ */
+function isReplayable(body: BodyInit | null | undefined): boolean {
+  return !(typeof ReadableStream !== 'undefined' && body instanceof ReadableStream);
 }
 
 /**

--- a/frontend/src/api/ws.test.ts
+++ b/frontend/src/api/ws.test.ts
@@ -47,9 +47,12 @@ class FakeWS {
   }
 }
 
-const g = globalThis as unknown as { WebSocket: unknown };
+const g = globalThis as unknown as { WebSocket: unknown; fetch: typeof fetch };
 let originalWebSocket: unknown;
+let originalFetch: typeof fetch;
 let addToastSpy: ReturnType<typeof vi.spyOn>;
+/** What the stubbed /api/auth/bootstrap hands back. Reassign per test. */
+let bootstrapToken: string;
 
 /**
  * Call connect() and wait for the awaited wsUrlWithToken() microtasks to
@@ -74,6 +77,19 @@ beforeEach(() => {
   FakeWS.instances = [];
   // Seed the token so wsUrlWithToken() resolves without hitting the network.
   _setSessionTokenForTesting('ws-test-token');
+  // Every reconnect drops the cached token first (the server may have
+  // restarted and minted a new one), so the bootstrap endpoint has to answer
+  // from the second attempt onwards. Same value by default: a reconnect in
+  // these tests is about the socket, not about the token.
+  originalFetch = g.fetch;
+  bootstrapToken = 'ws-test-token';
+  g.fetch = vi.fn(async (url: unknown) => {
+    if (String(url) === '/api/auth/bootstrap') {
+      return { ok: true, status: 200, json: async () => ({ token: bootstrapToken }) } as
+        unknown as Response;
+    }
+    throw new Error(`unexpected fetch: ${String(url)}`);
+  }) as unknown as typeof fetch;
   // Spy on the toast store so we can assert connection toasts without rendering.
   addToastSpy = vi.spyOn(useToastStore.getState(), 'addToast');
   vi.useFakeTimers();
@@ -83,6 +99,7 @@ afterEach(() => {
   vi.runOnlyPendingTimers();
   vi.useRealTimers();
   g.WebSocket = originalWebSocket;
+  g.fetch = originalFetch;
   _setSessionTokenForTesting(null);
   addToastSpy.mockRestore();
   vi.restoreAllMocks();
@@ -412,6 +429,69 @@ describe('onclose / reconnect', () => {
       (c: [string, ToastType?]) => c[1] === 'warning',
     );
     expect(warningToasts).toHaveLength(1);
+  });
+
+  it('handshakes with a freshly bootstrapped token on every retry', async () => {
+    // The commonest reason the socket drops is that the server restarted, and
+    // a restart rotates the session token. Reusing the cached one gets every
+    // handshake refused 403 until the tab is reloaded.
+    const ws = new ExecutionWebSocket();
+    const first = await startConnect(ws);
+    first.socket.fireOpen();
+    await first.promise;
+    expect(first.socket.url).toContain('token=ws-test-token');
+
+    bootstrapToken = 'rotated-token';
+    first.socket.fireClose();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(FakeWS.instances).toHaveLength(2);
+    expect(FakeWS.instances[1].url).toContain('token=rotated-token');
+    ws.disconnect();
+  });
+
+  it('keeps retrying when the bootstrap GET fails before a socket exists', async () => {
+    // The server is still down, so /api/auth/bootstrap throws and connect()
+    // rejects with no socket to fire onclose. Without a retry queued here the
+    // whole reconnect chain would stop on the first tick.
+    const ws = new ExecutionWebSocket();
+    const first = await startConnect(ws);
+    first.socket.fireOpen();
+    await first.promise;
+
+    g.fetch = vi.fn(async () => {
+      throw new Error('server down');
+    }) as unknown as typeof fetch;
+
+    first.socket.fireClose();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWS.instances).toHaveLength(1); // nothing opened
+
+    // The next backoff tick is still queued, and now the server answers.
+    g.fetch = vi.fn(async () => ({
+      ok: true, status: 200, json: async () => ({ token: 'back-up' }),
+    })) as unknown as typeof fetch;
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(FakeWS.instances).toHaveLength(2);
+    expect(FakeWS.instances[1].url).toContain('token=back-up');
+    ws.disconnect();
+  });
+
+  it('stops retrying after disconnect() even if the bootstrap GET was in flight', async () => {
+    const ws = new ExecutionWebSocket();
+    const first = await startConnect(ws);
+    first.socket.fireOpen();
+    await first.promise;
+
+    g.fetch = vi.fn(async () => {
+      throw new Error('server down');
+    }) as unknown as typeof fetch;
+
+    first.socket.fireClose();
+    ws.disconnect();
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(FakeWS.instances).toHaveLength(1);
   });
 
   it('gives up and shows a failure toast after MAX_RECONNECT_ATTEMPTS', async () => {

--- a/frontend/src/api/ws.ts
+++ b/frontend/src/api/ws.ts
@@ -1,6 +1,6 @@
 import { useToastStore } from '../store/toastStore';
 import { useI18n } from '../i18n';
-import { wsUrlWithToken } from './_auth';
+import { invalidateSessionToken, wsUrlWithToken } from './_auth';
 
 type MessageHandler = (data: any) => void;
 
@@ -65,6 +65,10 @@ export class ExecutionWebSocket {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+    // Cleared before the await so a caller that catches a rejection from here
+    // can tell "no socket was ever created" (the bootstrap GET failed) from
+    // "the socket opened and closed" (onclose runs and schedules the retry).
+    this.ws = null;
     // Token is appended as ?token=... because browsers cannot set custom
     // headers on WebSocket handshakes. wsUrlWithToken() awaits the bootstrap
     // exchange the first time it's called and caches the value afterwards.
@@ -172,11 +176,18 @@ export class ExecutionWebSocket {
     this.reconnectAttempt++;
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
+      // The commonest reason a socket drops is that the server restarted,
+      // and a restart mints a new session token. Reusing the cached one
+      // means every handshake from here on is refused 403 until the tab is
+      // reloaded, so re-read it before each attempt.
+      invalidateSessionToken();
       // connect() will reject if the server is still down; in that case
       // the WebSocket's onclose fires (because hasBeenConnected is true)
       // and queues the next attempt from there.
       this.connect().catch(() => {
-        /* handled via onclose → scheduleReconnect */
+        // Unless it failed at the bootstrap GET, before a socket existed:
+        // there is no onclose to carry the chain, so queue the retry here.
+        if (this.ws === null && !this.intentionalClose) this.scheduleReconnect();
       });
     }, delay);
   }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -940,6 +940,9 @@ const en = {
   'packs.cancel': 'Cancel install',
   'packs.cancelling': 'Cancelling...',
   'packs.remoteDisabled': 'Installing is only allowed from the computer that runs the server.',
+  // The server mints a new session token every time it starts, so a tab left
+  // open across a restart holds one the server will refuse.
+  'packs.sessionExpired': 'The server restarted. Reload the page and try again.',
 
   // Activity pane. `packs.activity.step.*` is keyed by the step id the job
   // sends, so an unknown step falls back to the server's own English label.

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -874,6 +874,7 @@ const zhTW: Record<TranslationKey, string> = {
   'packs.cancel': '取消安裝',
   'packs.cancelling': '正在取消...',
   'packs.remoteDisabled': '只能在執行伺服器的那台電腦上安裝。',
+  'packs.sessionExpired': '伺服器已重新啟動，請重新整理頁面後再試一次。',
 
   // Activity pane. `packs.activity.step.*` is keyed by the step id the job
   // sends, so an unknown step falls back to the server's own English label.

--- a/frontend/src/store/packStore.test.ts
+++ b/frontend/src/store/packStore.test.ts
@@ -737,6 +737,9 @@ describe('packStore — install', () => {
     });
 
   it('says installing is local-only on a 403', async () => {
+    // The gate is what the catalog's flag describes, so the state has to say
+    // so — the same fact the Install buttons are already disabled on.
+    usePackStore.setState({ remoteInstallAllowed: false });
     api.installPack.mockRejectedValue(new PackApiError(403, 'remote install refused'));
 
     await usePackStore.getState().install('word-vectors');
@@ -744,6 +747,19 @@ describe('packStore — install', () => {
     expect(lastToast()).toMatchObject({ type: 'error' });
     expect(lastToast().message).toBe(
       'Installing is only allowed from the computer that runs the server.',
+    );
+  });
+
+  it('blames the restarted server on a 403 with installing allowed', async () => {
+    // The other producer of a 403: the auth middleware refusing a session
+    // token the server rotated when it restarted.
+    api.installPack.mockRejectedValue(new PackApiError(403, 'Forbidden'));
+
+    await usePackStore.getState().install('word-vectors');
+
+    expect(lastToast()).toMatchObject({ type: 'error' });
+    expect(lastToast().message).toBe(
+      'The server restarted. Reload the page and try again.',
     );
   });
 

--- a/frontend/src/store/packStore.ts
+++ b/frontend/src/store/packStore.ts
@@ -755,7 +755,16 @@ export const usePackStore = create<PackState>((set, get) => ({
         toast(t('packs.toast.busy'), 'warning');
         await get().refresh();
       } else if (err instanceof PackApiError && err.status === 403) {
-        toast(t('packs.remoteDisabled'), 'error');
+        // Two things answer 403: the remote-install gate, and the auth
+        // middleware refusing this tab's session token — which the server
+        // rotates on every start, so a tab left open across a restart holds a
+        // dead one. `remote_install_allowed` is the flag the Install buttons
+        // are already disabled on, so a 403 while it says installing IS
+        // allowed can only be the second.
+        toast(
+          t(get().remoteInstallAllowed ? 'packs.sessionExpired' : 'packs.remoteDisabled'),
+          'error',
+        );
       } else if (err instanceof PackApiError && err.status === 400
                  && Array.isArray(err.body?.blocked_by)
                  && err.body.blocked_by.length > 0) {

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -612,6 +612,9 @@ describe('pluginStore — inspect', () => {
   it('says why a remote inspect was refused instead of showing Forbidden', async () => {
     // The source box is where a LAN user first meets the gate, and the
     // status text alone ("Forbidden") says nothing about where to install.
+    // The gate is what the catalog's flag describes, so the state has to say
+    // so — the same fact the panel disables the buttons on.
+    usePluginStore.setState({ remoteInstallAllowed: false });
     api.inspectPluginSource.mockRejectedValue(new ApiError(403, 'Forbidden'));
 
     await usePluginStore.getState().inspect('owner/demo');
@@ -620,6 +623,21 @@ describe('pluginStore — inspect', () => {
     if (state.inspection.phase !== 'error') throw new Error('not an error phase');
     expect(state.inspection.failure.message).toBe(
       'Installing is only allowed from the computer that runs the server.',
+    );
+  });
+
+  it('blames the restarted server when a 403 arrives with installing allowed', async () => {
+    // The other producer of a 403: the auth middleware refusing a session
+    // token the server rotated when it restarted. Telling a user sitting at
+    // the machine that they are on the wrong machine is a dead end.
+    api.inspectPluginSource.mockRejectedValue(new ApiError(403, 'Forbidden'));
+
+    await usePluginStore.getState().inspect('owner/demo');
+
+    const state = usePluginStore.getState();
+    if (state.inspection.phase !== 'error') throw new Error('not an error phase');
+    expect(state.inspection.failure.message).toBe(
+      'The server restarted. Reload the page and try again.',
     );
   });
 
@@ -892,6 +910,7 @@ describe('pluginStore — installInspected', () => {
 
   it('says so when the server refuses a remote install', async () => {
     await ready();
+    usePluginStore.setState({ remoteInstallAllowed: false });
     api.installPlugin.mockRejectedValue(new ApiError(403, 'Forbidden'));
 
     await usePluginStore.getState().installInspected({
@@ -900,6 +919,20 @@ describe('pluginStore — installInspected', () => {
 
     expect(lastToast().message).toBe(
       'Installing is only allowed from the computer that runs the server.',
+    );
+    expect(lastToast().type).toBe('error');
+  });
+
+  it('blames the restarted server when a 403 arrives with installing allowed', async () => {
+    await ready();
+    api.installPlugin.mockRejectedValue(new ApiError(403, 'Forbidden'));
+
+    await usePluginStore.getState().installInspected({
+      acceptCapabilities: true, trustAuthor: false,
+    });
+
+    expect(lastToast().message).toBe(
+      'The server restarted. Reload the page and try again.',
     );
     expect(lastToast().type).toBe('error');
   });
@@ -1189,12 +1222,24 @@ describe('pluginStore — uninstall', () => {
   it('says so when the server refuses a remote uninstall', async () => {
     // The same gate as an install. Wrapped in "Could not remove Demo
     // plugin", `Forbidden` tells a LAN user nothing about where to do it.
+    usePluginStore.setState({ remoteInstallAllowed: false });
     api.uninstallPlugin.mockRejectedValue(new ApiError(403, 'Forbidden'));
 
     await usePluginStore.getState().uninstall('demo');
 
     expect(lastToast().message).toBe(
       'Installing is only allowed from the computer that runs the server.',
+    );
+    expect(lastToast().type).toBe('error');
+  });
+
+  it('blames the restarted server when a 403 arrives with removing allowed', async () => {
+    api.uninstallPlugin.mockRejectedValue(new ApiError(403, 'Forbidden'));
+
+    await usePluginStore.getState().uninstall('demo');
+
+    expect(lastToast().message).toBe(
+      'The server restarted. Reload the page and try again.',
     );
     expect(lastToast().type).toBe('error');
   });

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -317,6 +317,25 @@ function refusalMessage(err: unknown): string {
   return key === undefined ? errorMessage(err) : useI18n.getState().t(key);
 }
 
+/** A 403 from any of these routes, whatever produced it. */
+function is403(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 403;
+}
+
+/**
+ * A 403 that is the remote-install gate (`_require_local_plugin_install`).
+ *
+ * Two things answer 403 here: that gate, and the auth middleware refusing
+ * this tab's session token — which the server rotates every time it starts,
+ * so a tab left open across a restart holds a dead one. Only the gate is
+ * described by `remote_install_allowed`, the same flag the Install buttons
+ * are already disabled on, so a 403 while the panel says installing IS
+ * allowed cannot be the gate and must not borrow its sentence.
+ */
+function isRemoteGate(err: unknown): boolean {
+  return is403(err) && !usePluginStore.getState().remoteInstallAllowed;
+}
+
 /**
  * Everything a thrown refusal carried, in the shape the review card reads.
  *
@@ -326,11 +345,14 @@ function refusalMessage(err: unknown): string {
 function inspectionFailure(err: unknown): InspectionFailure {
   return {
     // 403 is the one status whose own message says nothing a user can act
-    // on ("Forbidden"): it is the server refusing to install from anywhere
-    // but the machine it runs on, which only this key explains.
-    message: err instanceof ApiError && err.status === 403
+    // on ("Forbidden"): it is either the server refusing to install from
+    // anywhere but the machine it runs on, or this tab's session token being
+    // out of date. Only these keys explain either one.
+    message: isRemoteGate(err)
       ? useI18n.getState().t('packs.remoteDisabled')
-      : refusalMessage(err),
+      : is403(err)
+        ? useI18n.getState().t('packs.sessionExpired')
+        : refusalMessage(err),
     code: refusalCode(err),
     detail: errorDetail(err),
   };
@@ -727,8 +749,10 @@ async function startInstall(
       // useful than the refusal.
       toast(t('packs.toast.busy'), 'warning');
       await store.refresh();
-    } else if (err instanceof ApiError && err.status === 403) {
+    } else if (isRemoteGate(err)) {
       toast(t('packs.remoteDisabled'), 'error');
+    } else if (is403(err)) {
+      toast(t('packs.sessionExpired'), 'error');
     } else {
       toast(t('packs.toast.installFailed', { message: refusalMessage(err) }), 'error');
     }
@@ -940,8 +964,10 @@ export const usePluginStore = create<PluginState>((set, get) => ({
         } else if (err instanceof ApiError && err.status === 409) {
           toast(t('packs.toast.busy'), 'warning');
           await get().refresh();
-        } else if (err instanceof ApiError && err.status === 403) {
+        } else if (isRemoteGate(err)) {
           toast(t('packs.remoteDisabled'), 'error');
+        } else if (is403(err)) {
+          toast(t('packs.sessionExpired'), 'error');
         } else {
           toast(t('pluginCenter.updateFailed', { message: refusalMessage(err) }), 'error');
         }
@@ -1004,12 +1030,14 @@ export const usePluginStore = create<PluginState>((set, get) => ({
         } else if (err instanceof ApiError && err.status === 409) {
           toast(t('packs.toast.busy'), 'warning');
           await get().refresh();
-        } else if (err instanceof ApiError && err.status === 403) {
+        } else if (isRemoteGate(err)) {
           // Same gate as an install, and the same answer: the server only
           // takes a change like this from the machine it runs on. Wrapping
           // `Forbidden` in "Could not remove Demo plugin" would tell a LAN
           // user that something went wrong rather than where to do it.
           toast(t('packs.remoteDisabled'), 'error');
+        } else if (is403(err)) {
+          toast(t('packs.sessionExpired'), 'error');
         } else {
           toast(
             t('pluginCenter.toast.removeFailed', {


### PR DESCRIPTION
Reported as "the Package Center shows an error when installing a plugin". The install itself was not the
problem: the tab could no longer authenticate.

## What happens

`backend/app/core/auth.py:76` mints a fresh session token at every process start. `frontend/src/api/_auth.ts`
read it once and cached it for the life of the page. A tab left open across a restart — a `cdui` restart, or
the Package Center restarting the server itself to finish a pack that was already imported — then holds a
token the server has never seen. Every mutating request answers `403 Missing or invalid X-CodefyUI-Token
header`, and the execution WebSocket is refused on every reconnect attempt until it gives up after ten.
Nothing recovers short of reloading the page.

Captured on a live install, after a restart at 22:51 with the editor still open:

```
INFO:     127.0.0.1:58030 - "WebSocket /ws/execution?token=k_nOTR_uL6YU…" 403
INFO:     connection rejected (403 Forbidden)
```

repeated until the socket gave up. Clicking Install in either center in that state produced the error the
report describes.

## The fix

- `invalidateSessionToken()` drops the cache.
- `apiFetch` re-reads the token once on a 403 and replays the request — but only when the new token differs
  from the one just refused. 403 is also how the server refuses a remote plugin or pack install, and that
  refusal must cost one request rather than two. A body that cannot be sent twice (a `ReadableStream`) keeps
  its 403.
- The WebSocket re-reads the token before every reconnect attempt. `connect()` clears `this.ws` before
  awaiting the token, so a failure at the bootstrap GET (the server is still down) can be told apart from a
  socket that opened and closed. Without that the reconnect chain ended on the first tick: no `onclose`
  fires for a socket that was never created.
- Both centers reported either 403 as "Installing is only allowed from the computer that runs the server",
  which points a user sitting at that very computer at nothing they can do. The gate's sentence is now used
  only when the catalog says installing is remote-disabled — the same flag the Install buttons are already
  disabled on, so the toast cannot contradict the footer. The other 403 gets `packs.sessionExpired`.

## Tests

9 new cases: the 403 replay, the unchanged-token case, an unreachable bootstrap, a non-403, a stream body,
`invalidateSessionToken`, a reconnect handshaking with a rotated token, a reconnect surviving a failed
bootstrap GET, and `disconnect()` ending the chain. The four existing tests that describe the remote gate
now set the `remote_install_allowed: false` they were always describing, and each store gained a case for
the auth 403.

`pnpm vitest run`: 198 files, 5240 tests, all passing. `tsc -b` clean.

## Found alongside

A multi-agent sweep of both centers confirmed 18 further defects, four of them blockers (the
sentence-embeddings pack cannot resolve and its recoverable-conflict path never fires; the GPU PyTorch card
offers Apple Silicon eight builds that have no macOS wheel). Those land in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbCiuhnJvnwmR2A76HQseH
