### PR TITLE
fix(plugins,ui): the Plugin Center says what was refused, and to whom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,49 @@ received — each links to the release it was published as.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A plugin whose repository moved can be updated again.** GitHub keeps
+  answering at a repository's old address forever, through a 301, so an install
+  recorded before a rename or an org transfer kept fetching happily under a
+  name the catalog no longer lists — and every rule keyed on that name read it
+  as a fork of the pack it actually is. Update answered `reserved_id`
+  permanently, and the Official badge went out. The commit GitHub returns
+  already names the repository it was served from, so the canonical pair now
+  rides along on the resolve that was happening anyway, and the read that
+  notices a move corrects the lockfile. The rule that refuses a genuine fork is
+  unchanged: a fork is a real repository at its own address and redirects
+  nowhere.
+- **A refusal says who holds the id, in the reader's language.** `reserved_id`
+  reached the update toast as the bare wire token `reserved_id`, and the one
+  sentence the panel had said "reserved for a built-in pack" whichever of the
+  three things actually held the id. The server now sends which, plus the
+  repository when that is the answer, and the panel writes the sentence. A test
+  reads every coded refusal the routes can emit and fails when one is answered
+  neither by the panel's table nor at a named catch.
+- **A ref that does not resolve says so.** GitHub answers 422, not 404, for a
+  tag, branch or sha that does not exist, so a typo in a ref was reported as
+  "Cannot connect to GitHub" — a network failure on a working network.
+- **A row's refused Install reports itself on that row.** It appeared at the
+  top of the panel, under the "install from a repository" text field the user
+  never touched, worded as though they had typed it, while the row they did
+  press said nothing — and nothing at all when the list was scrolled.
+- **A refusal no longer outlives the panel.** One attached to a review that is
+  still usable survived a close, so reopening the Plugin Center hours later
+  answered a request that was long over.
+- **Installing a catalog row records it as one.** The row's Install button sent
+  `owner/repo` rather than the catalog id, so the install was recorded as
+  free-text third-party — no `catalog_id`, and the consent card reporting the
+  pack as unofficial. A row with files missing is still reinstalled from the
+  repository it recorded, which can be a fork.
+- **A plugin directory with no lockfile entry is no longer a dead end.** The
+  install was accepted, then failed with "already installed" and a hint about
+  `force` that the panel had no control for. It is refused up front, where the
+  panel's Reinstall button is.
+- **A plugin whose renderer names no node type says so.** Registering one for a
+  node that does not exist mounted nothing, silently; it now warns and, where
+  it can, names the type that was meant.
+
 ## [2.7.1] — 2026-09-08
 
 A smaller frontend build that no longer trips Vite's chunk-size warning. The

--- a/backend/app/api/routes_plugins.py
+++ b/backend/app/api/routes_plugins.py
@@ -70,7 +70,12 @@ from ..core.plugin_loader import (
 )
 from ..core.jobs import JobBusy
 from ..core.plugins import lifecycle
-from ..core.plugins.catalog import catalog_entries
+from ..core.plugins.catalog import (
+    RESERVED_BY_BUILTIN_PACK,
+    RESERVED_BY_ROUTE,
+    catalog_entries,
+    catalog_entry,
+)
 from ..core.plugins.errors import (
     AlreadyInstalled,
     ConsentRequired,
@@ -108,6 +113,13 @@ router = APIRouter(prefix="/api/plugins", tags=["plugins"])
 _REMOTE_REFUSAL = (
     "Installing plugins is only allowed from the computer that runs the "
     "server. Set CODEFYUI_ALLOW_REMOTE_PLUGIN_INSTALL=1 to override.")
+
+#: GitHub statuses that mean "that is not there". 404 is a typo in the owner
+#: or the repository; 422 is a typo in the REF -- ``GET /repos/{owner}/{repo}
+#: /commits/{ref}`` answers 422 ("No commit found for SHA: <ref>") for a tag,
+#: branch or sha that does not resolve, never 404 -- and both leave the user
+#: in the same place, checking what they typed.
+_MISSING = frozenset({404, 422})
 
 #: GitHub statuses that mean "ask again later" rather than "that is not
 #: there". 403 is how the API answers an exhausted rate limit -- its JSON
@@ -225,17 +237,28 @@ def _service(request: Request) -> PluginService:
 def _github_refusal(exc: GitHubError) -> HTTPException:
     """One GitHub failure, split three ways for three different next steps.
 
-    A 404 is the caller's -- a typo in the owner, the repository or the ref
-    -- so it travels as a 404 they can act on. Everything else happened
+    A 404 or a 422 is the caller's -- a typo in the owner, the repository or
+    the ref, GitHub answering 422 rather than 404 for a ref that does not
+    resolve -- so it travels as a 404 they can act on. Everything else happened
     between this server and GitHub, which is a 502 whether it was a rate
     limit, a 500 or a name that never resolved; the code says which, because
     "wait" and "check the network" are different waits.
     """
-    if exc.status == 404:
+    if exc.status in _MISSING:
         return _coded(404, "not_found")
     if exc.status in _RATE_LIMITED:
         return _coded(502, "github_rate_limited")
     return _coded(502, "github_unreachable")
+
+
+#: :attr:`~.errors.ReservedPluginId.taken_by` as something a client can
+#: switch on. Anything else is the third clause -- a catalog row belonging to
+#: a DIFFERENT repository -- which has no constant because the phrase names
+#: the repository it found.
+_RESERVED_HOLDER = {
+    RESERVED_BY_ROUTE: "route",
+    RESERVED_BY_BUILTIN_PACK: "builtin_pack",
+}
 
 
 def _inspect_refusal(exc: PluginInstallError) -> HTTPException:
@@ -254,7 +277,19 @@ def _inspect_refusal(exc: PluginInstallError) -> HTTPException:
     would have turned every reserved id into ``invalid_manifest``.
     """
     if isinstance(exc, ReservedPluginId):
-        return _coded(400, "reserved_id", id=exc.plugin_id)
+        # WHICH of the three clauses answered, as a code. ``taken_by`` is an
+        # English noun phrase, written for the sentence the CLI prints; a
+        # panel has to say this in the user's language, and the third holder
+        # -- another repository -- is a fact the panel can only name if it is
+        # given the repository. Compared against the constants themselves, so
+        # rewording one of them is still not a wire change.
+        holder = _RESERVED_HOLDER.get(exc.taken_by, "repository")
+        fields: dict[str, Any] = {"id": exc.plugin_id, "holder": holder}
+        if holder == "repository":
+            row = catalog_entry(exc.plugin_id)
+            if row is not None and row.repo:
+                fields["repo"] = row.repo
+        return _coded(400, "reserved_id", **fields)
     return _coded(400, "invalid_manifest")
 
 

--- a/backend/app/core/plugins/github.py
+++ b/backend/app/core/plugins/github.py
@@ -6,9 +6,10 @@ commit's tarball. They were three ad-hoc ``urlopen`` calls in the CLI, each
 translating ``HTTPError`` into its own sentence, and the sentences did not
 say the same thing about the same failure. A GUI cannot work from sentences
 at all, so the answer here is :class:`~.errors.GitHubError` with a
-``status``: 404 is a typo in the repo name, 403 is usually the rate limit,
-and ``None`` means the request never reached GitHub -- three different next
-steps for the user, and none of them recoverable from message text.
+``status``: 404 is a typo in the repo name and 422 a ref that does not
+resolve, 403 is usually the rate limit, and ``None`` means the request never
+reached GitHub -- three different next steps for the user, and none of them
+recoverable from message text.
 
 The message is GitHub's own when GitHub sent one. Its JSON bodies say
 "Not Found", "API rate limit exceeded for ...", "Bad credentials"; the HTTP
@@ -33,10 +34,12 @@ from __future__ import annotations
 import http.client
 import json
 import os
+import re
 import tarfile
 import time
 import urllib.request
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 
@@ -209,8 +212,38 @@ def _gh_get(
         raise _from_url_error(exc) from exc
 
 
-def resolve_sha(owner: str, repo: str, ref: str) -> str:
-    """Convert tag / branch / short-sha to a full 40-char SHA.
+#: The commit URL in GitHub's own answer, which names the repository it
+#: SERVED rather than the one that was asked for. Anchored on
+#: ``api.github.com`` and on the ``/repos/<owner>/<repo>/commits/`` shape
+#: because that host is the only one whose word is taken for this: the field
+#: is GitHub's, never repository content, and anything of another shape --
+#: a proxy that rewrote it, a stub with half a commit in it -- leaves the
+#: requested pair standing instead.
+_COMMIT_URL = re.compile(
+    r"^https://api\.github\.com/repos/([^/]+)/([^/]+)/commits/"
+)
+
+
+@dataclass(frozen=True)
+class ResolvedRef:
+    """One commit, and the repository GitHub answered from.
+
+    ``owner``/``repo`` are not always the pair that was asked for. A
+    repository that was renamed or moved to another org keeps answering at
+    its old address forever, through a 301 ``urlopen`` follows, so an
+    install recorded before the move asks under a name that no longer names
+    anything -- while every rule downstream (which catalog id this
+    repository may claim, whether the badge is earned) is about the
+    repository it actually IS.
+    """
+
+    sha: str
+    owner: str
+    repo: str
+
+
+def resolve_ref(owner: str, repo: str, ref: str) -> ResolvedRef:
+    """Resolve tag / branch / short-sha to a commit, and say whose it is.
 
     The failure is re-raised naming the repository and the ref, because
     GitHub's own "Not Found" answers a question the user never asked out
@@ -224,6 +257,10 @@ def resolve_sha(owner: str, repo: str, ref: str) -> str:
     that no caller of this function catches -- so it becomes a
     :class:`~.errors.GitHubError` with no status, because whatever answered
     was not GitHub.
+
+    The repository comes back beside the sha because GitHub has already said
+    it: the commit carries its own canonical ``url``, so following a rename
+    costs nothing here and a second request everywhere else.
     """
     target = ref or "HEAD"
     url = f"https://api.github.com/repos/{owner}/{repo}/commits/{target}"
@@ -251,7 +288,21 @@ def resolve_sha(owner: str, repo: str, ref: str) -> str:
         raise GitHubError(
             f"GitHub API response for {owner}/{repo}@{target} is missing 'sha'"
         )
-    return sha
+    served = data.get("url")
+    match = _COMMIT_URL.match(served) if isinstance(served, str) else None
+    if match is None:
+        return ResolvedRef(sha=sha, owner=owner, repo=repo)
+    return ResolvedRef(sha=sha, owner=match.group(1), repo=match.group(2))
+
+
+def resolve_sha(owner: str, repo: str, ref: str) -> str:
+    """The full 40-char SHA alone, for a caller that has the repository.
+
+    :func:`resolve_ref` with its second half dropped: ``cdui plugin info``
+    and ``cdui plugin update`` ask what a ref points at and already know
+    which repository they asked about.
+    """
+    return resolve_ref(owner, repo, ref).sha
 
 
 def fetch_manifest_text(owner: str, repo: str, sha: str) -> str:

--- a/backend/app/core/plugins/inspect.py
+++ b/backend/app/core/plugins/inspect.py
@@ -322,12 +322,30 @@ def inspect_github(
     because refusing it would make the official pack the one thing nobody can
     install, but a fork may not take its place.
 
+    That comparison is made against the repository GitHub ANSWERED as, which
+    is the pair asked for except when the repository has been renamed or
+    moved to another org: GitHub keeps the old address alive with a 301, so
+    an install recorded before the move asks under a name the catalog no
+    longer lists and reads, wrongly, as a fork of the pack it actually is.
+    The clause keeps its full force -- a fork is a real repository at its own
+    address and redirects nowhere, so it still resolves to itself, still
+    mismatches, and is still refused.
+
     Raises :class:`~.errors.GitHubError`, ``tomllib.TOMLDecodeError``,
     :class:`~.errors.ManifestError` or :class:`~.errors.ReservedPluginId`
     (a :class:`~.errors.PluginInstallError`, so every caller that already
     catches the base keeps catching this).
     """
-    sha = pinned_sha or github.resolve_sha(owner, repo, ref)
+    if not pinned_sha:
+        # The canonical pair rides along on the resolve that was happening
+        # anyway, so following a rename costs no extra request. A pinned sha
+        # skips the resolve, so it keeps the pair it was given -- a restore
+        # is replaying a recorded install, not re-deciding where it came
+        # from.
+        resolved = github.resolve_ref(owner, repo, ref)
+        sha, owner, repo = resolved.sha, resolved.owner, resolved.repo
+    else:
+        sha = pinned_sha
     manifest = tomllib.loads(github.fetch_manifest_text(owner, repo, sha))
     validate_manifest(manifest)
     plugin_id = manifest["plugin"]["id"]
@@ -444,6 +462,55 @@ def updatable_entry(plugin_id: str, *, lockfile: dict[str, Any]) -> dict[str, An
     return entry
 
 
+def _record_moved_repository(
+    plugin_id: str, recorded: str, found: Inspection
+) -> None:
+    """Correct a lockfile entry whose repository has since moved.
+
+    GitHub answers at a repository's old address forever, so an install made
+    before a rename or an org transfer keeps fetching happily and keeps
+    recording a name that names nothing any more. Everything keyed on that
+    name is then wrong permanently: the Official badge compares the recorded
+    repository against the catalog's (:func:`~.listing.is_official`), and an
+    update that finds nothing new answers ``up_to_date`` before any install
+    gets near the lockfile -- so the ordinary write never comes round to fix
+    it. Correcting the record on the read that noticed is what turns this
+    from a one-off migration into something that also handles the next move.
+
+    The entry is re-read from disk and re-checked against the address this
+    inspection actually followed: the file is one that the CLI and the server
+    both edit, and an install that landed while GitHub was being read owns
+    its own record.
+
+    Best effort and silent, because the caller is a READ. A lockfile that
+    could not be written is a stale badge; turning it into an exception would
+    mean a user cannot see the update they came for.
+    """
+    lockfile = plugin_loader.load_lockfile()
+    entry = _lockfile_entry(lockfile, plugin_id)
+    if entry is None:
+        return
+    match = _GITHUB_URL.match(_text(entry.get("url"))) or _GITHUB_SHORT.match(
+        _text(entry.get("source"))
+    )
+    if match is None or f"{match.group(1)}/{match.group(2)}".lower() != recorded:
+        return
+    entry["url"] = found.url
+    entry["source"] = found.source
+    row = catalog_module.catalog_entry(plugin_id)
+    if row is not None and row.repo and row.repo.lower() == (
+        f"{found.owner}/{found.repo}".lower()
+    ):
+        # GitHub says this IS the catalog's repository, which is exactly what
+        # ``catalog_id`` records -- and recording it keeps the badge lit if
+        # the catalog itself is later re-pointed somewhere else.
+        entry["catalog_id"] = row.id
+    try:
+        plugin_loader.save_lockfile(lockfile)
+    except OSError:
+        pass
+
+
 def inspect_installed(plugin_id: str, *, lockfile: dict[str, Any]) -> Inspection:
     """Describe the update available for an installed repository plugin.
 
@@ -486,6 +553,7 @@ def inspect_installed(plugin_id: str, *, lockfile: dict[str, Any]) -> Inspection
             hint=f"url={entry.get('url')!r} source={entry.get('source')!r}",
         )
     recorded_catalog_id = _text(entry.get("catalog_id")) or None
+    recorded_repo = f"{match.group(1)}/{match.group(2)}"
     found = inspect_github(
         match.group(1),
         match.group(2),
@@ -509,4 +577,8 @@ def inspect_installed(plugin_id: str, *, lockfile: dict[str, Any]) -> Inspection
                 f"want."
             ),
         )
+    if found.owner and found.repo and (
+        f"{found.owner}/{found.repo}".lower() != recorded_repo.lower()
+    ):
+        _record_moved_repository(plugin_id, recorded_repo.lower(), found)
     return found

--- a/backend/app/core/plugins/service.py
+++ b/backend/app/core/plugins/service.py
@@ -477,7 +477,9 @@ class PluginService:
         :raises AlreadyInstalled: the plugin is here and *force* was not
             given. Both kinds, and updates too: replacing what is on disk is
             an offer for the user to accept, not a default -- an inspection
-            stored by :meth:`update` carries that acceptance with it.
+            stored by :meth:`update` carries that acceptance with it. "Here"
+            means the lockfile records it OR the directory is on disk, so a
+            copy the lockfile never heard about is the same offer.
         :raises ConsentRequired: a capability the manifest asks for is not in
             *accept_capabilities* (nor already granted by a previous install).
         :raises TrustAuthorRequired: the manifest declares ``allowed_modules``
@@ -505,7 +507,20 @@ class PluginService:
         # "You already have this" is an OFFER -- Reinstall, --force -- and an
         # offer belongs in the response to the request, not in a job's event
         # log.
-        if inspection.installed is not None and not force:
+        #
+        # The disk half is the SAME question asked of the state the lockfile
+        # cannot see: a directory with no entry, left by a lockfile write that
+        # failed after the rename, by a hand-copied pack, or by an
+        # ``installed.json`` somebody edited. The flow refuses that one on
+        # ``plugin_dir.exists()``, and reached from in there the offer is
+        # unanswerable -- the job has already started, the inspection is
+        # spent, and the panel's Reinstall button exists only where this
+        # refusal does. Only the repository road: a built-in pack lives under
+        # the built-in root, and a stray user directory of the same name is
+        # not a copy of it.
+        on_disk = inspection.kind == "github" and (
+            plugin_loader.plugins_user_root() / inspection.plugin_id).exists()
+        if (inspection.installed is not None or on_disk) and not force:
             raise AlreadyInstalled(
                 f"Plugin {inspection.plugin_id!r} is already installed.",
                 plugin_id=inspection.plugin_id,

--- a/backend/tests/test_api_plugin_center.py
+++ b/backend/tests/test_api_plugin_center.py
@@ -903,12 +903,27 @@ class FakeGitHub:
         #: Every ``(owner, repo, ref)`` a resolve was asked for.
         self.resolved: list[tuple[str, str, str]] = []
 
-    def answers(self, manifest: str, *, sha: str = A_SHA) -> None:
-        def resolve(owner: str, repo: str, ref: str) -> str:
-            self.resolved.append((owner, repo, ref))
-            return sha
+    def answers(self, manifest: str, *, sha: str = A_SHA,
+                moved_to: str | None = None) -> None:
+        """Serve *manifest* at *sha*, as *moved_to* when it is given.
 
-        self._monkeypatch.setattr(github, "resolve_sha", resolve)
+        *moved_to* is the ``"owner/repo"`` GitHub ANSWERS as: a repository
+        that was renamed or transferred to another org keeps its old address
+        alive through a 301 forever, and the commit that comes back names the
+        repository it was served FROM. Left out, the repository answers as
+        itself -- every repository here that has not moved.
+        """
+        canonical = tuple(moved_to.split("/", 1)) if moved_to else None
+
+        def resolve(owner: str, repo: str, ref: str) -> github.ResolvedRef:
+            # Recorded as ASKED, because that is what the caller chose to
+            # fetch; the pair that comes back is what GitHub says it is.
+            self.resolved.append((owner, repo, ref))
+            served_owner, served_repo = canonical or (owner, repo)
+            return github.ResolvedRef(sha=sha, owner=served_owner,
+                                      repo=served_repo)
+
+        self._monkeypatch.setattr(github, "resolve_ref", resolve)
         self._monkeypatch.setattr(github, "fetch_manifest_text",
                                   lambda owner, repo, at: manifest)
 
@@ -921,8 +936,10 @@ class FakeGitHub:
         raises it. Faked at ``_gh_get``, which the module's own docstring
         names as the one place every request goes through.
         """
-        self._monkeypatch.setattr(github, "resolve_sha",
-                                  lambda owner, repo, ref: sha)
+        self._monkeypatch.setattr(
+            github, "resolve_ref",
+            lambda owner, repo, ref: github.ResolvedRef(
+                sha=sha, owner=owner, repo=repo))
         self._monkeypatch.setattr(github, "_gh_get",
                                   lambda url, *args, **kwargs: raw)
 
@@ -930,7 +947,7 @@ class FakeGitHub:
         def boom(*args, **kwargs):
             raise exc
 
-        self._monkeypatch.setattr(github, "resolve_sha", boom)
+        self._monkeypatch.setattr(github, "resolve_ref", boom)
         self._monkeypatch.setattr(github, "fetch_manifest_text", boom)
 
 
@@ -1269,8 +1286,36 @@ async def test_an_id_this_build_owns_is_refused_with_the_id(
     response = await client.post("/api/plugins/inspect",
                                  json={"source": "alice/extras"})
     assert response.status_code == 400, response.text
+    # `holder` says WHICH of the three clauses answered, so a panel can write
+    # the sentence itself: `taken_by` is English prose meant for the CLI.
     assert response.json()["detail"] == {"code": "reserved_id",
-                                         "id": "catalog"}
+                                         "id": "catalog",
+                                         "holder": "route"}
+
+
+async def test_an_id_another_repository_holds_names_that_repository(
+        client, fake_github):
+    """The third clause of the reserved-id rule, on the wire. ``holder``
+    tells the three apart -- a route, a pack that ships here, another
+    repository -- and only the third can be explained at all without the
+    repository that holds the id, which is why it travels beside it.
+
+    The other reserved-id tests all land on the route clause, so the sentence
+    a panel writes for this one was drawn from nothing: "reserved for a
+    built-in pack", about a plugin that is a GitHub repository."""
+    fake_github.answers(a_manifest("self-learning"))
+
+    response = await client.post(
+        "/api/plugins/inspect",
+        json={"source": "mallory/CodefyUI-Plugin-Self-Learning"})
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == {
+        "code": "reserved_id",
+        "id": "self-learning",
+        "holder": "repository",
+        "repo": "CodefyUI/CodefyUI-Plugin-Self-Learning",
+    }
 
 
 async def test_a_catalog_row_too_broken_to_install_is_not_a_500(
@@ -1290,6 +1335,9 @@ async def test_a_catalog_row_too_broken_to_install_is_not_a_500(
 
 @pytest.mark.parametrize("status, expected, code", [
     (404, 404, "not_found"),
+    # A ref that does not resolve: GitHub answers 422 for that, never 404,
+    # and it leaves the user in the same place -- checking what they typed.
+    (422, 404, "not_found"),
     (403, 502, "github_rate_limited"),
     (429, 502, "github_rate_limited"),
     (500, 502, "github_unreachable"),
@@ -2056,6 +2104,63 @@ async def test_the_commit_that_is_installed_leaves_nothing_to_do(
     assert not flow.started.is_set()
 
 
+#: The pack whose repository really did move, and the address an install
+#: made before the move still records. GitHub answers at both.
+GRAPH_COPILOT_REPO = "CodefyUI/CodefyUI-Plugin-Graph-Copilot"
+GRAPH_COPILOT_WAS = "a-previous-owner/CodefyUI-Plugin-Graph-Copilot"
+
+
+async def test_an_update_of_a_pack_whose_repository_moved_org_is_not_a_theft(
+        client, flow, fake_github, center_lockfile):
+    """A catalog pack installed before its repository was transferred.
+
+    The lockfile records the old owner, the catalog names the new one, and
+    the id is reserved AGAINST any repository but the catalog's -- so the
+    update read itself as a fork stealing the official pack's id and refused
+    every time, with a raw ``reserved_id``. GitHub is the one that knows the
+    two names are one repository, and it says so in the commit that was being
+    fetched anyway.
+
+    The record is corrected on the way through, which is the only chance
+    there is: the pack is already at the newest commit, so no install runs
+    and nothing else ever writes the lockfile.
+    """
+    data = lockfile_of(center_lockfile)
+    data["plugins"]["graph-copilot"] = {
+        "source_kind": "github_url",
+        "source": GRAPH_COPILOT_WAS,
+        "url": f"https://github.com/{GRAPH_COPILOT_WAS}",
+        "ref": "",
+        "sha": "4" * 40,
+        "installed_at": "2026-06-04T00:00:00Z",
+        "manifest": {"id": "graph-copilot", "version": "1.0.0"},
+        "trusted_modules": [],
+        "capabilities": [],
+        "catalog_id": None,
+        "enabled": True,
+    }
+    (center_lockfile / "installed.json").write_text(json.dumps(data),
+                                                    encoding="utf-8")
+    fake_github.answers(a_manifest("graph-copilot"), sha="4" * 40,
+                        moved_to=GRAPH_COPILOT_REPO)
+
+    response = await client.post("/api/plugins/graph-copilot/update")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"status": "up_to_date", "sha": "4" * 40}
+    # Fetched from the address the user installed from, which still works.
+    assert fake_github.resolved == [
+        ("a-previous-owner", "CodefyUI-Plugin-Graph-Copilot", "")]
+    assert not flow.started.is_set()
+    entry = lockfile_of(center_lockfile)["plugins"]["graph-copilot"]
+    assert entry["url"] == f"https://github.com/{GRAPH_COPILOT_REPO}"
+    assert entry["source"] == GRAPH_COPILOT_REPO
+    # And the badge, which reads the recorded repository: the row was drawn
+    # as third-party for as long as the record named nothing.
+    assert entry["catalog_id"] == "graph-copilot"
+    assert (await rows(client))["graph-copilot"]["official"] is True
+
+
 async def test_an_update_the_user_already_consented_to_starts_a_job(
         client, flow, fake_github):
     """One click, one job. The plan carries ``force`` because pressing Update
@@ -2245,6 +2350,9 @@ async def test_an_update_is_refused_while_another_source_is_being_read(
 
 @pytest.mark.parametrize("status, expected, code", [
     (404, 404, "not_found"),
+    # `/{id}/update` shares `_github_refusal`, and a pinned ref that stopped
+    # resolving lands here.
+    (422, 404, "not_found"),
     (403, 502, "github_rate_limited"),
     (500, 502, "github_unreachable"),
 ])
@@ -2372,8 +2480,11 @@ async def test_a_repository_that_now_declares_a_reserved_id_is_refused(
     response = await client.post("/api/plugins/demo-external/update")
 
     assert response.status_code == 400, response.text
+    # `holder` says WHICH of the three clauses answered, so a panel can write
+    # the sentence itself: `taken_by` is English prose meant for the CLI.
     assert response.json()["detail"] == {"code": "reserved_id",
-                                         "id": "catalog"}
+                                         "id": "catalog",
+                                         "holder": "route"}
 
 
 async def test_an_update_of_a_row_whose_manifest_is_not_one_is_a_400(
@@ -2613,5 +2724,8 @@ async def test_a_reserved_id_is_read_off_the_exception_not_its_message(
     response = await client.post("/api/plugins/inspect",
                                  json={"source": "alice/extras"})
     assert response.status_code == 400, response.text
+    # `holder` says WHICH of the three clauses answered, so a panel can write
+    # the sentence itself: `taken_by` is English prose meant for the CLI.
     assert response.json()["detail"] == {"code": "reserved_id",
-                                         "id": "catalog"}
+                                         "id": "catalog",
+                                         "holder": "route"}

--- a/backend/tests/test_plugin_capabilities.py
+++ b/backend/tests/test_plugin_capabilities.py
@@ -24,6 +24,7 @@ import pytest
 
 import plugins as plugin_cli
 from app.core import plugin_loader
+from app.core.plugins import github
 from app.core.plugins.errors import GitHubError, PluginInstallError
 
 
@@ -256,8 +257,12 @@ def fake_github(monkeypatch):
     ``progress`` keywords the flow passes.
     """
     def _make(files: dict[str, str]) -> None:
+        # `resolve_ref`, which `resolve_sha` delegates to: the inspection
+        # asks for the repository GitHub answered as, and a fake that stops
+        # one layer down would let the real request through.
         monkeypatch.setattr(
-            "app.core.plugins.github.resolve_sha", lambda o, r, ref: "0" * 40
+            "app.core.plugins.github.resolve_ref",
+            lambda o, r, ref: github.ResolvedRef(sha="0" * 40, owner=o, repo=r),
         )
         monkeypatch.setattr(
             "app.core.plugins.github.fetch_manifest_text",
@@ -517,7 +522,8 @@ def test_a_download_that_fails_is_reported_rather_than_raised(
     """
     monkeypatch.setenv("CODEFYUI_LANG", "en")
     monkeypatch.setattr(
-        "app.core.plugins.github.resolve_sha", lambda o, r, ref: "0" * 40
+        "app.core.plugins.github.resolve_ref",
+        lambda o, r, ref: github.ResolvedRef(sha="0" * 40, owner=o, repo=r),
     )
     monkeypatch.setattr(
         "app.core.plugins.github.fetch_manifest_text",

--- a/backend/tests/test_plugin_cli.py
+++ b/backend/tests/test_plugin_cli.py
@@ -20,6 +20,7 @@ import plugins as plugin_cli
 from app.core import plugin_loader
 from app.core.plugin_validator import PluginValidationError
 from app.core.plugins import catalog as core_catalog
+from app.core.plugins import github as core_github
 from app.core.plugins import lifecycle
 
 
@@ -1159,7 +1160,9 @@ def fake_github(monkeypatch):
     def _make(files: dict[str, str] | None = None) -> None:
         payload = {"cdui.plugin.toml": _TEMPLATE_MANIFEST} if files is None else files
         monkeypatch.setattr(
-            "app.core.plugins.github.resolve_sha", lambda o, r, ref: "0" * 40
+            "app.core.plugins.github.resolve_ref",
+            lambda o, r, ref: core_github.ResolvedRef(
+                sha="0" * 40, owner=o, repo=r),
         )
         monkeypatch.setattr(
             "app.core.plugins.github.fetch_manifest_text",

--- a/backend/tests/test_plugin_service.py
+++ b/backend/tests/test_plugin_service.py
@@ -576,6 +576,49 @@ async def test_a_plugin_that_is_already_here_is_an_offer_not_a_job(sources):
     assert not flow.started.is_set()
 
 
+async def test_a_directory_with_no_lockfile_entry_is_the_same_offer(
+        sources, isolated_user_root):
+    """The half of "already here" the lockfile cannot see.
+
+    A directory with no entry is what a lockfile write that failed after the
+    rename leaves behind, and what a hand-copied pack or an edited
+    ``installed.json`` looks like: the inspection reads ``installed=None,
+    mode="install"``, so only the disk knows. The flow refuses it too, but
+    reached from in there the offer is unanswerable -- the job has started,
+    the inspection is spent, and the panel draws its Reinstall button only
+    from THIS refusal.
+    """
+    flow = ScriptedFlow()
+    service = a_service(run_flow=flow)
+    (isolated_user_root / "extras").mkdir(parents=True)
+    inspection_id = await remembered(service, sources, an_inspection())
+
+    with pytest.raises(AlreadyInstalled) as excinfo:
+        await service.submit_install(inspection_id, accept_capabilities=None,
+                                     trust_author=False, force=False)
+
+    assert excinfo.value.plugin_id == "extras"
+    assert service.current_job() is None
+    assert not flow.started.is_set()
+
+
+async def test_a_user_directory_says_nothing_about_a_builtin(
+        sources, isolated_user_root):
+    """A built-in pack lives under the built-in root, so a user directory of
+    the same name is not a copy of it -- its lockfile entry is the only thing
+    that says it is here, and ``_install_builtin`` asks only that."""
+    flow = ScriptedFlow().script()
+    service = a_service(run_flow=flow)
+    (isolated_user_root / "stats").mkdir(parents=True)
+    inspection_id = await remembered(service, sources, a_builtin_inspection())
+
+    job = await service.submit_install(inspection_id, accept_capabilities=None,
+                                       trust_author=False, force=False)
+    _, status = await drain(service, job.job_id)
+
+    assert status == "done"
+
+
 async def test_a_builtin_that_is_already_here_is_refused_the_same_way(sources):
     flow = ScriptedFlow()
     service = a_service(run_flow=flow)

--- a/backend/tests/test_plugins_core_inspect.py
+++ b/backend/tests/test_plugins_core_inspect.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import http.client
 import io
+import json
 import tarfile
 import urllib.request
 from pathlib import Path
@@ -26,6 +27,7 @@ from urllib.error import HTTPError, URLError
 
 import pytest
 
+from app.core import plugin_loader
 from app.core.plugins import catalog as catalog_module
 from app.core.plugins import consent, github
 from app.core.plugins import inspect as plugin_inspect
@@ -68,9 +70,24 @@ def _tarball_of(files: dict[str, str], dest: Path) -> None:
 
 @pytest.fixture
 def fake_github(monkeypatch):
-    """Serve one commit -- a sha, a manifest and a tarball -- with no network."""
-    def _make(manifest_text: str, *, sha: str = "a" * 40, files=None):
-        monkeypatch.setattr(github, "resolve_sha", lambda o, r, ref: sha)
+    """Serve one commit -- a sha, a manifest and a tarball -- with no network.
+
+    *moved_to* is the ``"owner/repo"`` GitHub ANSWERS as, for a repository
+    that has been renamed or transferred: the old address keeps working
+    through a 301 forever, and the commit that comes back names the
+    repository it was served from rather than the one that was asked for.
+    Left out, the repository answers as itself -- every repository that has
+    not moved, which is all the others here.
+    """
+    def _make(manifest_text: str, *, sha: str = "a" * 40, files=None,
+              moved_to: str | None = None):
+        canonical = tuple(moved_to.split("/", 1)) if moved_to else None
+
+        def resolve(o, r, ref):
+            owner, repo = canonical or (o, r)
+            return github.ResolvedRef(sha=sha, owner=owner, repo=repo)
+
+        monkeypatch.setattr(github, "resolve_ref", resolve)
         monkeypatch.setattr(
             github, "fetch_manifest_text", lambda o, r, s: manifest_text
         )
@@ -218,7 +235,7 @@ def test_a_pinned_sha_is_never_re_resolved(monkeypatch, fake_github):
     def _explode(*_a):  # pragma: no cover - only runs on a bug
         raise AssertionError("a pinned install must not resolve the ref")
 
-    monkeypatch.setattr(github, "resolve_sha", _explode)
+    monkeypatch.setattr(github, "resolve_ref", _explode)
     found = plugin_inspect.inspect_github(
         "alice", "extras", "v1.2.0", lockfile={}, pinned_sha="c" * 40
     )
@@ -321,6 +338,54 @@ def test_the_repository_the_catalog_names_may_claim_its_own_id(fake_github):
     assert plugin_inspect.inspect_github(
         "codefyui", "codefyui-plugin-self-learning", "", lockfile={}
     ).plugin_id == "self-learning"
+
+
+def test_the_repository_the_catalog_names_may_have_moved_since(fake_github):
+    """The clause asks which repository this IS, and GitHub is the one that
+    knows. A pack transferred to another org keeps answering at its old
+    address through a 301, so an install recorded before the move asks under
+    a name the catalog no longer lists -- and reading that as a fork of the
+    pack it actually is refuses the official plugin its own update."""
+    fake_github(
+        '[plugin]\nid = "self-learning"\nversion = "1"\nschema_version = 1\n',
+        moved_to="CodefyUI/CodefyUI-Plugin-Self-Learning",
+    )
+
+    found = plugin_inspect.inspect_github(
+        "a-previous-owner", "CodefyUI-Plugin-Self-Learning", "", lockfile={}
+    )
+
+    assert found.plugin_id == "self-learning"
+    # And what comes back is the repository it turned out to be, not the one
+    # that was typed: everything downstream keys on this name.
+    assert found.owner == "CodefyUI"
+    assert found.repo == "CodefyUI-Plugin-Self-Learning"
+    assert found.source == "CodefyUI/CodefyUI-Plugin-Self-Learning"
+    assert found.url == "https://github.com/CodefyUI/CodefyUI-Plugin-Self-Learning"
+
+
+def test_a_fork_keeping_the_repository_name_is_still_refused(fake_github):
+    """The regression guard on the clause above, and the reason it had to be
+    GitHub's answer rather than a name comparison: a fork keeps the
+    repository name and changes only the owner, so anything that matched on
+    the name half alone would wave ``mallory`` straight through. A fork is a
+    real repository at its own address and redirects nowhere, so it resolves
+    to itself, mismatches, and is refused.
+
+    ``mallory/evil`` above cannot show this -- it would still be refused with
+    the protection gone, because its name does not match either."""
+    fake_github(
+        '[plugin]\nid = "self-learning"\nversion = "1"\nschema_version = 1\n'
+    )
+
+    with pytest.raises(ReservedPluginId) as excinfo:
+        plugin_inspect.inspect_github(
+            "mallory", "CodefyUI-Plugin-Self-Learning", "", lockfile={}
+        )
+
+    hint = excinfo.value.hint or ""
+    assert "mallory/CodefyUI-Plugin-Self-Learning" in hint
+    assert "CodefyUI/CodefyUI-Plugin-Self-Learning" in hint
 
 
 # ── an update compared against what was consented to ───────────────────────
@@ -464,6 +529,50 @@ def test_the_badge_is_re_derived_when_the_install_recorded_no_catalog_id(
     )
     assert found.catalog_id is None, "nothing was recorded, so nothing is claimed"
     assert found.official is True
+
+
+def test_a_moved_repository_is_corrected_in_the_lockfile(
+    fake_github, tmp_path, monkeypatch
+):
+    """The record is what everything else reads, so the read that noticed the
+    move is the one that has to fix it.
+
+    On the ``up_to_date`` path deliberately: the commit on disk is already
+    the newest one, so no install ever runs and the ordinary lockfile write
+    never comes round -- which is exactly the state a user is left in, with
+    the Official badge dark and the recorded repository naming nothing, for
+    as long as the pack stays current.
+    """
+    user_root = tmp_path / "plugins"
+    user_root.mkdir(parents=True)
+    monkeypatch.setattr(plugin_loader, "plugins_user_root", lambda: user_root)
+    lockfile = _installed_official(
+        source="a-previous-owner/CodefyUI-Plugin-Self-Learning",
+        url="https://github.com/a-previous-owner/CodefyUI-Plugin-Self-Learning",
+    )
+    (user_root / "installed.json").write_text(
+        json.dumps({"schema": 1, **lockfile}), encoding="utf-8"
+    )
+    fake_github(SELF_LEARNING_MANIFEST, sha="b" * 40, moved_to=SELF_LEARNING_REPO)
+
+    found = plugin_inspect.inspect_installed("self-learning", lockfile=lockfile)
+
+    assert found.up_to_date is True, "nothing to fetch, and still corrected"
+    corrected = json.loads(
+        (user_root / "installed.json").read_text(encoding="utf-8")
+    )
+    entry = corrected["plugins"]["self-learning"]
+    assert entry["url"] == f"https://github.com/{SELF_LEARNING_REPO}"
+    assert entry["source"] == SELF_LEARNING_REPO
+    # GitHub said this IS the catalog's repository, which is what the
+    # recorded catalog id means -- and it survives the catalog being
+    # re-pointed later.
+    assert entry["catalog_id"] == "self-learning"
+    # The badge this is all for: the next read compares a record that names
+    # the right repository, and lights it.
+    assert plugin_inspect.inspect_installed(
+        "self-learning", lockfile=corrected
+    ).official is True
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_plugins_flows.py
+++ b/backend/tests/test_plugins_flows.py
@@ -188,7 +188,10 @@ def fake_github(monkeypatch):
                 {f"{repo}-main/{rel}": text for rel, text in files.items()}, dest
             )
 
-        monkeypatch.setattr(github, "resolve_sha", lambda o, r, ref: sha)
+        monkeypatch.setattr(
+            github, "resolve_ref",
+            lambda o, r, ref: github.ResolvedRef(sha=sha, owner=o, repo=r),
+        )
         monkeypatch.setattr(
             github, "fetch_manifest_text",
             lambda o, r, s: files["cdui.plugin.toml"],
@@ -306,7 +309,7 @@ def test_a_repository_install_runs_every_step_in_order(
     def _never(*_a):  # pragma: no cover - only runs on a bug
         raise AssertionError("an install must not re-resolve the ref")
 
-    monkeypatch.setattr(github, "resolve_sha", _never)
+    monkeypatch.setattr(github, "resolve_ref", _never)
 
     events: list[dict] = []
     outcome = _install(plan, emit=events.append)

--- a/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.test.tsx
@@ -679,9 +679,133 @@ describe('PluginCenterModal — the source box', () => {
     expect(actions.clearInspection).not.toHaveBeenCalled();
   });
 
-  it('names the id a reserved-id refusal was about', () => {
-    // The refusal carries no sentence at all — only the id it is about, and
-    // that is the whole useful part.
+  it('closes over a card that is on screen only because the install was refused', () => {
+    // A row's Install button raised this review and the manifest asks for
+    // nothing, so the card exists because the server answered 409
+    // `already_installed` — an answer that is over the moment the panel is.
+    const clearInspection = vi.fn(() => {
+      usePluginStore.setState({ inspection: { phase: 'idle' } });
+    });
+    seed({
+      inspection: {
+        ...ready({ plugin_id: 'demo', consent_required: false }, 'demo'),
+        error: { message: 'already_installed', code: 'already_installed', detail: null },
+      },
+      clearInspection,
+    });
+    open();
+    render(<PluginCenterModal />);
+    expect(document.querySelector('[data-review-for="demo"]')).not.toBeNull();
+
+    act(() => {
+      useUIStore.setState({ pluginCenterOpen: false });
+    });
+    act(() => {
+      useUIStore.setState({ pluginCenterOpen: true });
+    });
+
+    expect(clearInspection).toHaveBeenCalled();
+    // Hours can pass between those two lines: the panel reopens over a
+    // request nobody is making any more, and must say nothing about it.
+    expect(document.querySelector('[data-review-for]')).toBeNull();
+  });
+
+  it('keeps the refusal that names the box a consent review is waiting on', () => {
+    seed({
+      inspection: {
+        ...ready(
+          { plugin_id: 'demo', consent_required: true, capabilities: ['network'] }, 'demo',
+        ),
+        error: {
+          message: 'consent_required',
+          code: 'consent_required',
+          detail: { code: 'consent_required', capabilities: ['network'] },
+        },
+      },
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    act(() => {
+      useUIStore.setState({ pluginCenterOpen: false });
+    });
+
+    // This card would be on screen without the refusal, and the refusal is
+    // what tells the user which capability is still unticked.
+    expect(actions.clearInspection).not.toHaveBeenCalled();
+  });
+
+  it('keeps a refused review of a source somebody typed', () => {
+    seed({
+      inspection: {
+        ...ready({ plugin_id: 'demo', consent_required: false }),
+        error: { message: 'already_installed', code: 'already_installed', detail: null },
+      },
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    act(() => {
+      useUIStore.setState({ pluginCenterOpen: false });
+    });
+
+    // The box the source was typed into keeps its answer: losing the code
+    // here would offer Install again for the 409 that just refused it.
+    expect(actions.clearInspection).not.toHaveBeenCalled();
+  });
+
+  it('names the id a reserved-id refusal was about, and who holds it', () => {
+    // The refusal carries no sentence at all — only the id and which of the
+    // three things holds it, which is the whole useful part.
+    seed({
+      inspection: {
+        phase: 'error',
+        source: 'owner/edu',
+        failure: {
+          message: 'reserved_id',
+          code: 'reserved_id',
+          detail: { code: 'reserved_id', id: 'edu', holder: 'builtin_pack' },
+        },
+      },
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(
+      screen.getByText('The id "edu" is reserved for a built-in pack.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/reserved_id/)).toBeNull();
+  });
+
+  it('names the repository that holds the id when another one does', () => {
+    seed({
+      inspection: {
+        phase: 'error',
+        source: 'mallory/CodefyUI-Plugin-Self-Learning',
+        failure: {
+          message: 'reserved_id',
+          code: 'reserved_id',
+          detail: {
+            code: 'reserved_id',
+            id: 'self-learning',
+            holder: 'repository',
+            repo: 'CodefyUI/CodefyUI-Plugin-Self-Learning',
+          },
+        },
+      },
+    });
+    open();
+    render(<PluginCenterModal />);
+
+    expect(screen.getByText(
+      'The id "self-learning" belongs to CodefyUI/CodefyUI-Plugin-Self-Learning,'
+      + ' so it cannot be installed or updated from this source.',
+    )).toBeInTheDocument();
+  });
+
+  it('stays holder-neutral when the server did not say who holds it', () => {
+    // A server older than the `holder` field. Guessing "a built-in pack"
+    // would name the wrong culprit for a repository clash.
     seed({
       inspection: {
         phase: 'error',
@@ -697,9 +821,8 @@ describe('PluginCenterModal — the source box', () => {
     render(<PluginCenterModal />);
 
     expect(
-      screen.getByText('The id "edu" is reserved for a built-in pack.'),
+      screen.getByText('The id "edu" already belongs to another plugin.'),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/reserved_id/)).toBeNull();
   });
 
   it('lists the names a catalog miss offered instead', () => {

--- a/frontend/src/components/PluginCenter/PluginCenterModal.tsx
+++ b/frontend/src/components/PluginCenter/PluginCenterModal.tsx
@@ -102,11 +102,28 @@ function PluginCenterBody() {
 
   // A refusal belongs to the box it was typed into, and does not outlive the
   // window that box was in: reopening the panel over "Could not fetch
-  // owner/demo: ..." would explain a request nobody here made. A REVIEW
-  // survives a close on purpose — it is a decision still waiting for an
-  // answer, and the store keeps the install job running behind it either way.
+  // owner/demo: ..." would explain a request nobody here made. A REVIEW still
+  // waiting for an answer survives a close on purpose — it is a decision, and
+  // the store keeps the install job running behind it either way.
   useEffect(() => () => {
-    if (usePluginStore.getState().inspection.phase === 'error') clearInspection();
+    const { inspection: left } = usePluginStore.getState();
+    if (left.phase === 'error') {
+      clearInspection();
+      return;
+    }
+    // The same rule for the card the render gate below draws over a refusal
+    // alone: a review a ROW's Install button raised asks nothing by itself,
+    // so it is on screen only because the install came back refused, and that
+    // refusal answers a request as finished as the box above. The two reviews
+    // that do survive are untouched — a source somebody typed, and a manifest
+    // still asking for consent — and each keeps its refusal, which is the
+    // detail naming the box that is still unticked.
+    if (
+      left.phase === 'ready' && left.error !== null
+      && left.forPluginId !== null && !left.data.consent_required
+    ) {
+      clearInspection();
+    }
   }, [clearInspection]);
 
   // Focus starts inside the panel and goes back where it came from. Not a

--- a/frontend/src/components/PluginCenter/PluginSourceForm.tsx
+++ b/frontend/src/components/PluginCenter/PluginSourceForm.tsx
@@ -1,7 +1,7 @@
 import { useId, useState, type FormEvent } from 'react';
 import type { InspectionFailure, InspectionState } from '../../store/pluginStore';
 import { useI18n } from '../../i18n';
-import { parseGitHubSource, type Translate } from './pluginStatus';
+import { parseGitHubSource, refusalSentence, type Translate } from './pluginStatus';
 import packStyles from '../PackCenter/PackCenterModal.module.css';
 import styles from './PluginCenterModal.module.css';
 
@@ -19,12 +19,6 @@ import styles from './PluginCenterModal.module.css';
  * printed under the row.
  */
 
-/** *detail*'s *key* when it is a non-empty string, else null. */
-function text(detail: Record<string, unknown> | null, key: string): string | null {
-  const value = detail?.[key];
-  return typeof value === 'string' && value !== '' ? value : null;
-}
-
 /** The string members of *detail*'s *key*, or nothing at all. */
 function list(detail: Record<string, unknown> | null, key: string): string[] {
   const value = detail?.[key];
@@ -36,36 +30,24 @@ function list(detail: Record<string, unknown> | null, key: string): string[] {
  * What a refused inspection should read as: the complaint, and the offer
  * under it when the refusal carried one.
  *
- * Two of these codes are answered here rather than by `REFUSAL_KEY`, because
- * the useful half of each is in the BODY and not in the code: which id is
- * taken, and which names would have worked. A sentence written server-side
- * could not have said either.
+ * Only the OFFER is written here. The complaint is `refusalSentence`, shared
+ * with the store because a refused Install on a ROW reports itself in a
+ * toast: two builders for one refusal is how the box's wording and the
+ * toast's drift apart. The offer stays because it is the box's alone -- a
+ * list of names to type is an answer to somebody typing.
  */
 function refusalLines(
   t: Translate, failure: InspectionFailure, source: string,
 ): { message: string; hint: string | null } {
-  if (failure.code === 'reserved_id') {
-    return {
-      message: t('pluginCenter.review.idConflict', {
-        id: text(failure.detail, 'id') ?? source,
-      }),
-      hint: null,
-    };
-  }
-  if (failure.code === 'unknown_catalog_name') {
-    const known = list(failure.detail, 'known');
-    return {
-      message: t('pluginCenter.source.unknownName', { source }),
-      hint: known.length === 0
-        ? null
-        : t('pluginCenter.source.knownNames', { known: known.join(', ') }),
-    };
-  }
-  // Everything else already has its sentence: the store maps a coded refusal
-  // to one before it ever reaches a component, so `message` is prose.
+  const message = refusalSentence(t, failure, source);
+  if (failure.code !== 'unknown_catalog_name') return { message, hint: null };
+
+  const known = list(failure.detail, 'known');
   return {
-    message: t('pluginCenter.source.fail', { source, message: failure.message }),
-    hint: null,
+    message,
+    hint: known.length === 0
+      ? null
+      : t('pluginCenter.source.knownNames', { known: known.join(', ') }),
   };
 }
 

--- a/frontend/src/components/PluginCenter/pluginStatus.test.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { PluginCatalogEntry, PluginStatus } from '../../api/rest';
 import { useI18n } from '../../i18n';
+import type { InspectionFailure } from '../../store/pluginStore';
 import {
   capabilityKey,
   cliInstallCommand,
@@ -13,6 +14,7 @@ import {
   originLabel,
   provenancePin,
   parseGitHubSource,
+  refusalSentence,
   statusKey,
   statusTone,
   stepLabel,
@@ -276,6 +278,80 @@ describe('originLabel', () => {
     // What is actually being loaded is the folder on disk, whoever wrote it.
     expect(originLabel(entry({ id: 'demo', official: true, source_kind: 'local' })))
       .toBe('pluginCenter.origin.local');
+  });
+});
+
+// ── what a refusal reads as ──────────────────────────────────────────────
+
+describe('refusalSentence', () => {
+  /** A refusal the way the store builds one: a code, a body, no prose. */
+  function coded(code: string, detail: Record<string, unknown>): InspectionFailure {
+    return { message: code, code, detail: { code, ...detail } };
+  }
+
+  it('names which of the three things holds a reserved id', () => {
+    // The server sends the holder as a discriminant precisely so this
+    // sentence can be written in the reader's language.
+    expect(refusalSentence(t, coded('reserved_id', { id: 'edu', holder: 'route' }), 'owner/edu'))
+      .toBe('The id "edu" is reserved by CodefyUI itself.');
+    expect(refusalSentence(
+      t, coded('reserved_id', { id: 'edu', holder: 'builtin_pack' }), 'owner/edu',
+    )).toBe('The id "edu" is reserved for a built-in pack.');
+    expect(refusalSentence(
+      t,
+      coded('reserved_id', {
+        id: 'graph-copilot',
+        holder: 'repository',
+        repo: 'CodefyUI/CodefyUI-Plugin-Graph-Copilot',
+      }),
+      'a-previous-owner/CodefyUI-Plugin-Graph-Copilot',
+    )).toBe(
+      'The id "graph-copilot" belongs to CodefyUI/CodefyUI-Plugin-Graph-Copilot, '
+      + 'so it cannot be installed or updated from this source.',
+    );
+  });
+
+  it('stays holder-neutral when the holder cannot be named', () => {
+    // A server older than the `holder` field, and one that says "repository"
+    // about a catalog row it can no longer describe. Guessing "a built-in
+    // pack" would name the wrong culprit, and the repo sentence without a
+    // repo would print the placeholder itself.
+    expect(refusalSentence(t, coded('reserved_id', { id: 'edu' }), 'owner/edu'))
+      .toBe('The id "edu" already belongs to another plugin.');
+    expect(refusalSentence(
+      t, coded('reserved_id', { id: 'edu', holder: 'repository' }), 'owner/edu',
+    )).toBe('The id "edu" already belongs to another plugin.');
+  });
+
+  it('falls back to the source when the refusal named no id', () => {
+    expect(refusalSentence(t, coded('reserved_id', { holder: 'route' }), 'edu'))
+      .toBe('The id "edu" is reserved by CodefyUI itself.');
+  });
+
+  it('says which name the catalog does not have', () => {
+    expect(refusalSentence(t, coded('unknown_catalog_name', { known: ['edu'] }), 'c9'))
+      .toBe('No plugin is called "c9".');
+  });
+
+  it('names what was being fetched for every refusal the store worded', () => {
+    // The code is already a sentence by the time it gets here; what is left
+    // is naming the source, because "Could not reach GitHub" says nothing
+    // about which repository was asked for.
+    expect(refusalSentence(
+      t,
+      { message: 'Could not reach GitHub.', code: 'github_unreachable', detail: null },
+      'owner/demo',
+    )).toBe('Could not fetch owner/demo: Could not reach GitHub.');
+  });
+
+  it('says the same thing in the language the reader is in', () => {
+    useI18n.setState({ locale: 'zh-TW' });
+
+    // The wire token as the whole explanation is what this replaces:
+    // 「更新失敗：reserved_id」.
+    expect(refusalSentence(
+      t, coded('reserved_id', { id: 'edu', holder: 'builtin_pack' }), 'owner/edu',
+    )).toBe('id「edu」是內建套件保留的名稱。');
   });
 });
 

--- a/frontend/src/components/PluginCenter/pluginStatus.ts
+++ b/frontend/src/components/PluginCenter/pluginStatus.ts
@@ -1,7 +1,7 @@
 import type { PluginCatalogEntry, PluginStatus } from '../../api/rest';
 import type { TranslationKey } from '../../i18n/locales/en';
 import type { ItemProgress, JobStep } from '../../store/jobFollower';
-import type { PluginJob } from '../../store/pluginStore';
+import type { InspectionFailure, PluginJob } from '../../store/pluginStore';
 import type { Translate } from '../PackCenter/packStatus';
 import type { PillTone } from '../shared/Pill';
 
@@ -289,6 +289,81 @@ const CAPABILITY_KEY: Record<string, TranslationKey | undefined> = {
 /** The sentence for *id*, or null when the card should print the raw id. */
 export function capabilityKey(id: string): TranslationKey | null {
   return CAPABILITY_KEY[id] ?? null;
+}
+
+// ── what a refusal reads as ──────────────────────────────────────────────
+
+/** *detail*'s *key* when it is a non-empty string, else null. */
+function text(detail: Record<string, unknown> | null, key: string): string | null {
+  const value = detail?.[key];
+  return typeof value === 'string' && value !== '' ? value : null;
+}
+
+/**
+ * Which of the three things holds a reserved id, as the sentence for it.
+ *
+ * The server sends this discriminant rather than the phrase itself: its
+ * `taken_by` is an English noun phrase written for the line the CLI prints,
+ * and a panel has to say the same thing in the reader's language.
+ */
+const HOLDER_KEY: Record<string, TranslationKey | undefined> = {
+  route: 'pluginCenter.error.idTakenByRoute',
+  builtin_pack: 'pluginCenter.error.idTakenByPack',
+  repository: 'pluginCenter.error.idTakenByRepo',
+};
+
+/**
+ * Who holds the id a `reserved_id` refusal was about.
+ *
+ * *fallbackId* is what to call the plugin when the body names no id -- the
+ * source that was refused, which is the closest thing to it on hand.
+ *
+ * A server that predates the `holder` field, and one that names a repository
+ * it can no longer describe, both land on the holder-neutral sentence: a
+ * refusal that guessed "a built-in pack" would name the wrong culprit, and
+ * `idTakenByRepo` without a `repo` would print the placeholder itself.
+ */
+function reservedIdSentence(
+  t: Translate, detail: Record<string, unknown> | null, fallbackId: string,
+): string {
+  const id = text(detail, 'id') ?? fallbackId;
+  const key = HOLDER_KEY[text(detail, 'holder') ?? ''];
+  if (key === 'pluginCenter.error.idTakenByRepo') {
+    const repo = text(detail, 'repo');
+    return repo === null
+      ? t('pluginCenter.error.idTaken', { id })
+      : t(key, { id, repo });
+  }
+  return key === undefined
+    ? t('pluginCenter.error.idTaken', { id })
+    : t(key, { id });
+}
+
+/**
+ * What a refused inspection reads as, in one sentence.
+ *
+ * Two of these codes are answered here rather than by the store's
+ * `REFUSAL_KEY`, because the useful half of each is in the BODY and not in
+ * the code: which id is taken and whose it is, and which name was asked for.
+ * A sentence written server-side could not have said either.
+ *
+ * Shared by the source box and by the toast a ROW's refused Install raises,
+ * so the two say the same thing about the same refusal. Everything else
+ * arrives as prose already -- the store maps a coded refusal to a sentence
+ * before it reaches a caller -- and only needs the frame that names what was
+ * being fetched, since "GitHub has no such repository" says nothing about
+ * which repository.
+ */
+export function refusalSentence(
+  t: Translate, failure: InspectionFailure, source: string,
+): string {
+  if (failure.code === 'reserved_id') {
+    return reservedIdSentence(t, failure.detail, source);
+  }
+  if (failure.code === 'unknown_catalog_name') {
+    return t('pluginCenter.source.unknownName', { source });
+  }
+  return t('pluginCenter.source.fail', { source, message: failure.message });
 }
 
 // ── provenance and contents ──────────────────────────────────────────────

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1188,7 +1188,15 @@ const en = {
   'pluginCenter.review.trust': 'I trust this author. Allows: {modules}',
   'pluginCenter.review.frontend':
     'Ships JavaScript that runs in this editor with full access.',
-  'pluginCenter.review.idConflict': 'The id "{id}" is reserved for a built-in pack.',
+  // Which of the three things holds the id. The server sends a `holder`
+  // discriminant plus the bare repository, because the sentence about a
+  // coded refusal belongs to whoever is talking to the user, in their
+  // language -- `taken_by` is an English noun phrase the CLI prints.
+  'pluginCenter.error.idTakenByRoute': 'The id "{id}" is reserved by CodefyUI itself.',
+  'pluginCenter.error.idTakenByPack': 'The id "{id}" is reserved for a built-in pack.',
+  'pluginCenter.error.idTakenByRepo':
+    'The id "{id}" belongs to {repo}, so it cannot be installed or updated from this source.',
+  'pluginCenter.error.idTaken': 'The id "{id}" already belongs to another plugin.',
   // The 409 the store treats as an OFFER, said out loud: without it the only
   // sign is the Install button coming back as Reinstall.
   'pluginCenter.review.alreadyInstalled':

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -1047,7 +1047,10 @@ const zhTW: Record<TranslationKey, string> = {
   'pluginCenter.review.grant': '同意授予這些能力',
   'pluginCenter.review.trust': '我信任這位作者。允許使用：{modules}',
   'pluginCenter.review.frontend': '包含會在編輯器中以完整權限執行的 JavaScript。',
-  'pluginCenter.review.idConflict': '「{id}」是內建套件保留的 id。',
+  'pluginCenter.error.idTakenByRoute': 'id「{id}」是 CodefyUI 本身保留的名稱。',
+  'pluginCenter.error.idTakenByPack': 'id「{id}」是內建套件保留的名稱。',
+  'pluginCenter.error.idTakenByRepo': 'id「{id}」屬於 {repo}，無法從這個來源安裝或更新。',
+  'pluginCenter.error.idTaken': 'id「{id}」已經屬於另一個外掛。',
   'pluginCenter.review.alreadyInstalled': '{plugin} 已安裝。重新安裝會以這個版本取代現有的安裝。',
 
   // One line per declared capability, each saying what granting it costs.

--- a/frontend/src/plugins/api.ts
+++ b/frontend/src/plugins/api.ts
@@ -675,6 +675,42 @@ function subscribeWorkspaceChanged(
   };
 }
 
+/**
+ * Warn when a plugin registers a renderer for a node type nothing will look up.
+ *
+ * `PluginNodeBridge` resolves a renderer by the node's namespaced type and
+ * falls back to the stock card body on a miss, so one wrong character costs a
+ * plugin its custom node body with no error and nothing in the console. The
+ * shipped `official-template` bundle hit exactly that, registering
+ * `official_template:MovingAverage` for a node the backend namespaces as
+ * `official-template:MovingAverage`.
+ *
+ * WARNS and never refuses. The definition list is what the host happens to
+ * know right now, a plugin may register for a builtin or for a node pack that
+ * arrives later, and a registration the host threw away would be a far worse
+ * failure than the one this catches. The guard's whole job is to say out loud
+ * what would otherwise go nowhere in silence.
+ */
+function warnIfUnknownNodeType(pluginId: string, nodeType: string): void {
+  const defs = useNodeDefStore.getState().definitions;
+  // An empty list means "not loaded", which is not "absent": PluginHost's
+  // waitForNodeDefinitions gives up after 15 s, and a slow /api/nodes must not
+  // make every installed plugin warn about types that do exist.
+  if (defs.length === 0) return;
+  if (defs.some((d) => d.node_name === nodeType)) return;
+  // The namespace is the one part a plugin author spells by hand, so an
+  // otherwise-known node under a different namespace is worth naming outright.
+  const corrected = nodeType.replace(/^[^:]+:/, `${pluginId}:`);
+  const hint = corrected !== nodeType && defs.some((d) => d.node_name === corrected)
+    ? ` Did you mean "${corrected}"? A plugin's node namespace is its manifest`
+      + ' id verbatim, hyphens included; only the Python import path is snake_cased.'
+    : '';
+  console.warn(
+    `[plugins] ${pluginId}: registerRenderer("${nodeType}") names no known node`
+    + ` type, so the renderer will never mount.${hint}`,
+  );
+}
+
 export function buildPluginAPI(
   pluginId: string,
   getWidgetContainer: (id: string) => HTMLElement,
@@ -748,6 +784,7 @@ export function buildPluginAPI(
     },
     nodes: {
       registerRenderer: (nodeType, renderer) => {
+        warnIfUnknownNodeType(pluginId, nodeType);
         const unregister = registerNodeRenderer(nodeType, renderer);
         trackCleanup?.(unregister);
         return unregister;

--- a/frontend/src/plugins/api.v3.test.ts
+++ b/frontend/src/plugins/api.v3.test.ts
@@ -270,6 +270,100 @@ describe('runs facade', () => {
 });
 
 /**
+ * A renderer registered for a type nothing will ever ask for.
+ *
+ * `PluginNodeBridge` falls back to the stock card body when no renderer
+ * matches a node's type, so a namespace the plugin author spelled by hand and
+ * got wrong costs the plugin its custom body with nothing anywhere saying so.
+ * The shipped `official-template` bundle registered
+ * `official_template:MovingAverage` for a node the backend namespaces as
+ * `official-template:MovingAverage`, and the only symptom was a stock body.
+ */
+describe('nodes.registerRenderer names an unknown node type', () => {
+  const MOVING_AVERAGE: NodeDefinition = {
+    node_name: 'official-template:MovingAverage', category: 'Layer',
+    description: '', inputs: [], outputs: [], params: [],
+  };
+
+  function templateApi() {
+    return buildPluginAPI('official-template', () => document.createElement('div'));
+  }
+
+  // Scoped to this block, and here rather than at the end of each test: a spy
+  // left installed by a FAILING assertion is handed straight back by the next
+  // `vi.spyOn(console, 'warn')`, carrying its call history with it, so one
+  // real failure would drag the test after it down as well.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns, and registers the renderer anyway', () => {
+    useNodeDefStore.setState({ definitions: [...DEFS, MOVING_AVERAGE] });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const renderer: PluginNodeRenderer = { mount: () => {} };
+
+    templateApi().nodes.registerRenderer('official_template:MovingAverage', renderer);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain(
+      'registerRenderer("official_template:MovingAverage")',
+    );
+    // Warned, never refused. The definition list is the host's snapshot of
+    // what exists right now, so treating a miss as an error would let a slow
+    // or partial /api/nodes throw away a renderer that is perfectly good.
+    expect(getNodeRenderer('official_template:MovingAverage')).toBe(renderer);
+  });
+
+  it('names the spelling that does exist when only the namespace is wrong', () => {
+    useNodeDefStore.setState({ definitions: [...DEFS, MOVING_AVERAGE] });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    templateApi().nodes.registerRenderer(
+      'official_template:MovingAverage', { mount: () => {} },
+    );
+
+    expect(warn.mock.calls[0][0]).toContain(
+      'Did you mean "official-template:MovingAverage"?',
+    );
+  });
+
+  it('leaves the hint off when the plugin\'s own namespace has no such node', () => {
+    useNodeDefStore.setState({ definitions: [...DEFS, MOVING_AVERAGE] });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // `official-template:Ema` does not exist either, so there is nothing to
+    // suggest and the warning stays a plain statement of the miss.
+    templateApi().nodes.registerRenderer('official_template:Ema', { mount: () => {} });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).not.toContain('Did you mean');
+  });
+
+  it('says nothing while the definition list is still empty', () => {
+    // `waitForNodeDefinitions` gives up after 15 s, so an empty list means
+    // "not loaded" and every type is unknown. Warning here would accuse every
+    // installed plugin of a typo whenever /api/nodes is slow.
+    useNodeDefStore.setState({ definitions: [] });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const renderer: PluginNodeRenderer = { mount: () => {} };
+
+    templateApi().nodes.registerRenderer('official_template:MovingAverage', renderer);
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(getNodeRenderer('official_template:MovingAverage')).toBe(renderer);
+  });
+
+  it('says nothing for a builtin type a plugin decorates', () => {
+    // The un-namespaced builtin the v2-compatibility plugin below registers.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    templateApi().nodes.registerRenderer('Source', { mount: () => {} });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+/**
  * apiVersion 3 was specified as purely additive, and Graph Copilot — which
  * declares `requires_codefyui = ">=1.3.0"` and was written against v2 — has to
  * keep working with no changes at all. `contract.v2.assert.ts` proves that at

--- a/frontend/src/store/pluginStore.test.ts
+++ b/frontend/src/store/pluginStore.test.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as rest from '../api/rest';
 import type {
@@ -42,6 +44,7 @@ import {
   _resetPluginStoreForTesting,
   emptyPluginJob,
   parseGitHubSource,
+  REFUSAL_KEY,
   usePluginStore,
 } from './pluginStore';
 import { useNodeDefStore } from './nodeDefStore';
@@ -435,6 +438,110 @@ describe('pluginStore — install', () => {
     await usePluginStore.getState().install('c1');
 
     expect(api.inspectPluginSource).toHaveBeenCalledWith('c1');
+  });
+
+  it('installs a catalog row by its id, not by the repository it names', async () => {
+    // The catalog serves `owner/repo` as an available row's source, and the
+    // installer will not take a provenance claim from free text: installed
+    // that way the lockfile entry gets no `catalog_id` and the plugin the
+    // panel just showed as Official is recorded as a third-party install.
+    serveCatalog(catalog({
+      entries: [entry({
+        id: 'self-learning',
+        kind: 'github',
+        official: true,
+        status: 'available',
+        source: 'CodefyUI/CodefyUI-Plugin-Self-Learning',
+        repo: 'CodefyUI/CodefyUI-Plugin-Self-Learning',
+      })],
+    }));
+    await usePluginStore.getState().refresh();
+
+    await usePluginStore.getState().install('self-learning');
+
+    expect(api.inspectPluginSource).toHaveBeenCalledWith('self-learning');
+  });
+
+  it('reinstalls a missing_files row from the repository IT recorded', async () => {
+    // The row has a lockfile entry and its directory is gone, so `source` is
+    // what the user actually installed -- here a FORK of the catalog's
+    // repository. Installing this one by its catalog id would fetch the
+    // official repo over the fork, silently, under a button that says
+    // Install.
+    serveCatalog(catalog({
+      entries: [entry({
+        id: 'graph-copilot',
+        kind: 'github',
+        status: 'missing_files',
+        source: 'a-previous-owner/CodefyUI-Plugin-Graph-Copilot',
+        repo: 'CodefyUI/CodefyUI-Plugin-Graph-Copilot',
+      })],
+    }));
+    await usePluginStore.getState().refresh();
+
+    await usePluginStore.getState().install('graph-copilot');
+
+    expect(api.inspectPluginSource).toHaveBeenCalledWith(
+      'a-previous-owner/CodefyUI-Plugin-Graph-Copilot',
+    );
+  });
+
+  it('toasts a row refusal instead of parking it under the source box', async () => {
+    serveCatalog(catalog({
+      entries: [entry({
+        id: 'self-learning', kind: 'github', status: 'available',
+        source: 'CodefyUI/CodefyUI-Plugin-Self-Learning',
+      })],
+    }));
+    await usePluginStore.getState().refresh();
+    api.inspectPluginSource.mockRejectedValue(refused(502, 'github_unreachable'));
+
+    await usePluginStore.getState().install('self-learning');
+
+    // Under the source box this read "Could not fetch ...", worded for a
+    // string the user never typed, while the row they pressed said nothing.
+    expect(usePluginStore.getState().inspection).toEqual({ phase: 'idle' });
+    expect(lastToast().message).toBe(
+      'Could not fetch self-learning: Could not reach GitHub.',
+    );
+    expect(lastToast().type).toBe('error');
+    // And a way back to the row it was about.
+    expect(lastToast().action!.label).toBe('Open Plugin Center');
+    lastToast().action!.onClick();
+    expect(useUIStore.getState().pluginCenterFocusPluginId).toBe('self-learning');
+  });
+
+  it('keeps the wire token out of a row refusal', async () => {
+    // `unknown_catalog_name` is mapped nowhere in `REFUSAL_KEY` -- the useful
+    // half is the name in the body -- so a toast built from the message
+    // alone would print the token itself.
+    serveCatalog(catalog({ entries: [entry({ id: 'c9', status: 'available' })] }));
+    await usePluginStore.getState().refresh();
+    api.inspectPluginSource.mockRejectedValue(
+      refused(400, 'unknown_catalog_name', { known: ['c1', 'c2'] }),
+    );
+
+    await usePluginStore.getState().install('c9');
+
+    expect(lastToast().message).toBe('No plugin is called "c9".');
+  });
+
+  it('says nothing in the source box while a row is being inspected', async () => {
+    let release: (value: PluginInspection) => void = () => {};
+    api.inspectPluginSource.mockReturnValue(
+      new Promise<PluginInspection>((resolve) => { release = resolve; }),
+    );
+
+    const first = usePluginStore.getState().install('demo');
+
+    // The box's Review button reads this phase and said "Downloading..."
+    // about a request it did not make. The row is not left silent: `busy`
+    // disables every control on it for the same span.
+    expect(usePluginStore.getState().inspection).toEqual({ phase: 'idle' });
+    expect(usePluginStore.getState().busy.demo).toBe(true);
+
+    release(inspection({ plugin_id: 'demo' }));
+    await first;
   });
 
   it('leaves no review behind when an auto-install is refused', async () => {
@@ -1014,6 +1121,38 @@ describe('pluginStore — update', () => {
 
     expect(lastToast().message).toBe(
       'Update failed: This plugin is not installed any more. Refresh the list.',
+    );
+  });
+
+  it('names who holds the id when a repository has claimed a reserved one', async () => {
+    // What an official repository that MOVED produces: the row was installed
+    // from the fork's address, and the id it declares belongs to the catalog
+    // row of the repository it moved from.
+    api.updatePlugin.mockRejectedValue(refused(400, 'reserved_id', {
+      id: 'graph-copilot',
+      holder: 'repository',
+      repo: 'CodefyUI/CodefyUI-Plugin-Graph-Copilot',
+    }));
+
+    await usePluginStore.getState().update('graph-copilot');
+
+    // "Update failed: reserved_id" — the wire token as the whole
+    // explanation — is the sentence this replaces.
+    expect(lastToast().message).toBe(
+      'Update failed: The id "graph-copilot" belongs to '
+      + 'CodefyUI/CodefyUI-Plugin-Graph-Copilot, so it cannot be installed or '
+      + 'updated from this source.',
+    );
+    expect(lastToast().type).toBe('error');
+  });
+
+  it('names the plugin when a reserved-id refusal carried no id', async () => {
+    api.updatePlugin.mockRejectedValue(refused(400, 'reserved_id'));
+
+    await usePluginStore.getState().update('demo');
+
+    expect(lastToast().message).toBe(
+      'Update failed: The id "demo" already belongs to another plugin.',
     );
   });
 });
@@ -1625,6 +1764,86 @@ describe('pluginStore — checkInProgress', () => {
 
     expect(useToastStore.getState().toasts).toEqual([]);
     expect(usePluginStore.getState().unsupported).toBe(true);
+  });
+});
+
+// ── the standing guard ───────────────────────────────────────────────────
+
+/**
+ * Every refusal code the plugin routes can send is answered by something.
+ *
+ * The routes answer `HTTPException(status, detail={"code": ...})` with no
+ * prose at all, so a code nothing here maps IS the sentence the user reads:
+ * `更新失敗：reserved_id`. That is not a hypothetical -- it is what shipped,
+ * because `reserved_id` grew a second producer (`POST /{id}/update`) years
+ * after the table that skips it was written, and nothing said so.
+ *
+ * Read out of the route module rather than listed here, so the next code
+ * added to it fails this file instead of reaching a toast as itself.
+ */
+describe('the refusal codes the routes can send', () => {
+  // From the working directory rather than from `import.meta.url`, which is
+  // an http: URL of the dev server here and not a path at all. Both roots are
+  // tried because this suite is run from the package and from the repository.
+  const RELATIVE = 'backend/app/api/routes_plugins.py';
+  const ROUTES = [
+    resolvePath(process.cwd(), '..', RELATIVE), resolvePath(process.cwd(), RELATIVE),
+  ].find((path) => existsSync(path)) ?? RELATIVE;
+
+  /**
+   * The codes NOT in `REFUSAL_KEY`, and what answers each instead.
+   *
+   * A note, not a proof: whether a catch still has its branch is what the
+   * cases above pin. What this list does is make ADDING a code a deliberate
+   * edit -- the author has to say where it is answered -- and make removing
+   * one show up as a stale entry.
+   */
+  const ANSWERED_ELSEWHERE: Record<string, string> = {
+    reserved_id: "update()'s catch and the source box, through refusalSentence",
+    unknown_catalog_name: 'the source box, and a row install through refusalSentence',
+    consent_required: 'the review card, which grows the tick box it names',
+    trust_author_required: 'the review card, which grows a second tick box',
+    already_installed: 'the review card, which grows a Reinstall button',
+    not_updatable: "update()'s catch, which prints the hint beside it",
+    files_locked: "uninstall()'s catch, which prints the hint beside it",
+    busy: 'every catch, in its 409 arm: another install is already running',
+    pack_install_running: 'the same 409 arm — the Package Center is installing',
+  };
+
+  /** The literal codes `_coded(status, "code", ...)` names in the module. */
+  function emittedCodes(): Set<string> {
+    const source = readFileSync(ROUTES, 'utf8');
+    return new Set(
+      [...source.matchAll(/_coded\(\s*\d+,\s*"([a-z_]+)"/g)].map((hit) => hit[1]),
+    );
+  }
+
+  it('answers each of them with a sentence, a control or a hint', () => {
+    // The regex is this guard's eyes: a `_coded` call it stops matching is a
+    // code nothing checks, and an empty answer would pass every assertion.
+    const emitted = emittedCodes();
+    expect(emitted.has('reserved_id')).toBe(true);
+    expect(emitted.has('unavailable')).toBe(true);
+    expect(emitted.size).toBeGreaterThan(10);
+
+    expect([...emitted].filter((code) => (
+      REFUSAL_KEY[code] === undefined && ANSWERED_ELSEWHERE[code] === undefined
+    ))).toEqual([]);
+  });
+
+  it('keeps the list of the ones answered elsewhere honest', () => {
+    const emitted = emittedCodes();
+    // `pack_install_running` travels as `exc.reason`, so it is the one code
+    // that is not a literal in the module that sends it.
+    emitted.add('pack_install_running');
+
+    expect(Object.keys(ANSWERED_ELSEWHERE).filter((code) => !emitted.has(code)))
+      .toEqual([]);
+    // Nothing is answered twice: a code with a sentence in `REFUSAL_KEY` is
+    // answered by that sentence wherever it lands.
+    expect(Object.keys(ANSWERED_ELSEWHERE).filter(
+      (code) => REFUSAL_KEY[code] !== undefined,
+    )).toEqual([]);
   });
 });
 

--- a/frontend/src/store/pluginStore.ts
+++ b/frontend/src/store/pluginStore.ts
@@ -17,6 +17,10 @@ import {
   type PluginJobKind,
 } from '../api/rest';
 import { createJobFollower, emptyJob, type Job } from './jobFollower';
+// The panel's own sentence for a refusal, because a ROW's refused Install is
+// answered in a toast from here rather than on the card. Imported rather than
+// copied: the box and the toast must not describe one refusal two ways.
+import { refusalSentence } from '../components/PluginCenter/pluginStatus';
 import { confirm } from '../utils/dialog';
 import { reloadPluginFrontends } from '../plugins/PluginHost';
 import { useNodeDefStore } from './nodeDefStore';
@@ -288,11 +292,17 @@ function refusalCode(err: unknown): string | null {
  * The three that are NOT are the three a control answers instead of a
  * sentence: `already_installed` grows a Reinstall button, `consent_required` a
  * tick box, `trust_author_required` a second one. `reserved_id` and
- * `unknown_catalog_name` are mapped nowhere either, because each has a line of
- * its own on the panel built from the body it carried (`id`, `known`) --
- * a sentence here would be the same refusal said twice.
+ * `unknown_catalog_name` are mapped nowhere either, because the useful half of
+ * each is in the BODY (`id` and `holder`, `known`) and this table maps a code
+ * to a sentence with nothing to interpolate into: both are written by
+ * `refusalSentence`, from wherever they are reported.
+ *
+ * Exported for the guard beside these tests, which reads every code the
+ * routes can emit and fails when one is answered neither here nor at a catch.
+ * That is what let `reserved_id` reach a toast as itself: it acquired a second
+ * producer -- `POST /{id}/update` -- long after this table was written.
  */
-const REFUSAL_KEY: Record<string, TranslationKey | undefined> = {
+export const REFUSAL_KEY: Record<string, TranslationKey | undefined> = {
   unavailable: 'pluginCenter.error.unavailable',
   inspection_expired: 'pluginCenter.error.inspectionExpired',
   unknown_job: 'pluginCenter.error.unknownJob',
@@ -622,6 +632,31 @@ function setPluginStatus(pluginId: string, status: PluginCatalogEntry['status'])
 }
 
 /**
+ * Say *failure* where the request it answers was made.
+ *
+ * A source the user TYPED is answered in the box they typed it into, which is
+ * the one surface that renders `phase: 'error'`.
+ *
+ * A ROW's Install button is not. The box never asked, so a refusal parked
+ * under a field nobody touched explains a request the user did not make --
+ * worded "Could not fetch {source}" as if they had -- while the row they DID
+ * press says nothing at all, and says nothing at all off screen if the list
+ * is scrolled. So it is toasted instead, naming the source it was about and
+ * carrying the button back to its row: the same shape `startInstall` gives
+ * the refusal of the POST that follows this one.
+ */
+function reportInspectFailure(
+  spec: string, forPluginId: string | null, failure: InspectionFailure,
+): void {
+  if (forPluginId === null) {
+    usePluginStore.setState({ inspection: { phase: 'error', source: spec, failure } });
+    return;
+  }
+  const { t } = useI18n.getState();
+  toast(refusalSentence(t, failure, spec), 'error', openCenterAction(forPluginId));
+}
+
+/**
  * Inspect *source* and leave the review in whatever state it reached.
  *
  * Returns the inspection so `install` can act on it without re-reading the
@@ -638,21 +673,21 @@ async function runInspect(
     // Refused without a round trip: the server would answer 400
     // `unparseable_source`, and this is the one error the client can be sure
     // of on its own.
-    usePluginStore.setState({
-      inspection: {
-        phase: 'error',
-        source: spec,
-        // No code: nothing was refused, this build simply knows the shape is
-        // not one the server could resolve.
-        failure: {
-          message: t('pluginCenter.source.invalid'), code: null, detail: null,
-        },
-      },
+    reportInspectFailure(spec, forPluginId, {
+      // No code: nothing was refused, this build simply knows the shape is
+      // not one the server could resolve.
+      message: t('pluginCenter.source.invalid'), code: null, detail: null,
     });
     return null;
   }
 
-  usePluginStore.setState({ inspection: { phase: 'inspecting', source: spec } });
+  // The transient phase belongs to the box too: it is what turns the Review
+  // button into "Downloading...", and a row's Install had that button
+  // reporting a request of its own. The row is not left silent by the
+  // omission -- `withBusy` disables every control on it for the same span.
+  if (forPluginId === null) {
+    usePluginStore.setState({ inspection: { phase: 'inspecting', source: spec } });
+  }
   try {
     const data = await inspectPluginSource(spec);
     usePluginStore.setState({
@@ -662,9 +697,7 @@ async function runInspect(
     });
     return data;
   } catch (err) {
-    usePluginStore.setState({
-      inspection: { phase: 'error', source: spec, failure: inspectionFailure(err) },
-    });
+    reportInspectFailure(spec, forPluginId, inspectionFailure(err));
     return null;
   }
 }
@@ -827,22 +860,35 @@ export const usePluginStore = create<PluginState>((set, get) => ({
       return;
     }
 
-    // What the row says it was installed FROM, not its id. The two are the
-    // same for every catalog row -- a builtin resolves by name -- but an
-    // EXTERNAL plugin, one installed from a repository this build's catalog
-    // does not list, has an id that resolves to no source at all: its Install
-    // button ended in a 400 `unknown_catalog_name` with nothing on screen to
-    // say so. `source` is documented as "what a user would type to install
-    // this", which is exactly what this button is typing on their behalf.
+    // What the row says it was installed FROM, for every row whose id is not
+    // itself a source. An EXTERNAL plugin, one installed from a repository
+    // this build's catalog does not list, has an id that resolves to no
+    // source at all: its Install button ended in a 400
+    // `unknown_catalog_name` with nothing on screen to say so. `source` is
+    // documented as "what a user would type to install this", which is
+    // exactly what this button is typing on their behalf.
     //
     // Own keys only: `byId` is built from parsed JSON, so a plugin called
     // `constructor` would otherwise hand back a function rather than a row.
     const row = Object.prototype.hasOwnProperty.call(state.byId, pluginId)
       ? state.byId[pluginId]
       : undefined;
+    // A CATALOG row that nothing is installed under is installed BY ITS ID:
+    // the id is what carries `catalog_id` and `official` into the lockfile,
+    // while `owner/repo` -- which is what such a row's `source` reads -- is
+    // free text the installer refuses to take a provenance claim from
+    // ("official is a claim only the catalog is entitled to make"), so the
+    // same install recorded through it is a third-party one.
+    //
+    // Rows with NO lockfile entry only (`available`, `removed`): a
+    // `missing_files` row is reinstalled from the repository IT recorded,
+    // which can be a FORK of the catalog's, and replacing that with the
+    // official repository behind the user's back is not a reinstall.
+    const fromCatalog = row !== undefined && row.kind !== 'external'
+      && (row.status === 'available' || row.status === 'removed');
     // `||`, not `??`: the catalog sends `''` for a row with no source, and an
     // empty source is not a source. The id is the better guess.
-    const source = row?.source || pluginId;
+    const source = fromCatalog ? pluginId : (row?.source || pluginId);
 
     await withBusy(pluginId, async () => {
       const data = await runInspect(source, pluginId);
@@ -934,9 +980,22 @@ export const usePluginStore = create<PluginState>((set, get) => ({
         // updates with `cdui update`, not from here. The same shape as
         // `uninstall`'s `files_locked` branch, and `warning` for the same
         // reason: nothing broke.
+        const code = refusalCode(err);
         const hint = str(errorDetail(err)?.hint);
-        if (refusalCode(err) === 'not_updatable' && hint !== null) {
+        if (code === 'not_updatable' && hint !== null) {
           toast(t('pluginCenter.updateFailed', { message: hint }), 'warning');
+        } else if (code === 'reserved_id') {
+          // The repository this row was installed from now declares an id
+          // this build owns -- a route, a pack that ships here, or another
+          // repository's catalog row, which is what an official repo that has
+          // MOVED produces. Answered here rather than in `REFUSAL_KEY` for
+          // the reason the source box answers it too: which id, and whose it
+          // is, are in the body, and a table of codes has nothing to
+          // interpolate. Without this arm the code IS the toast: a student
+          // was shown "更新失敗：reserved_id".
+          toast(t('pluginCenter.updateFailed', {
+            message: refusalSentence(t, inspectionFailure(err), pluginId),
+          }), 'error');
         } else if (err instanceof ApiError && err.status === 409) {
           toast(t('packs.toast.busy'), 'warning');
           await get().refresh();


### PR DESCRIPTION
Eight defects in how a refusal travels from the plugin routes to the panel. The first is live on any install
made before this repository was renamed.

## A moved repository can never be updated

GitHub answers at a repository's old address forever, through a 301 `urlopen` follows. So an install
recorded before a rename or an org transfer keeps fetching happily under a name the catalog no longer lists —
and every rule keyed on that name reads it as a *fork* of the pack it actually is. Update answers
`reserved_id` permanently, and the Official badge goes out.

Reproduced on a live install: `graph-copilot` is recorded at the pre-rename owner while the catalog says
`CodefyUI/CodefyUI-Plugin-Graph-Copilot`, so `POST /api/plugins/graph-copilot/update` returns
`400 {"code": "reserved_id", "id": "graph-copilot"}` on a plugin that is already at HEAD.

The commit GitHub returns already names the repository it was served from, so `resolve_ref()` takes the
canonical pair off the resolve that was happening anyway — no extra request, no extra rate limit — and the
read that notices a move corrects the lockfile. That last step is required, not tidying: an update with
nothing new answers `up_to_date` before any install writes the lockfile, so the ordinary write never comes
round to fix it.

**The fork protection is unchanged.** A fork is a real repository at its own address and redirects nowhere,
so it still resolves to itself, still mismatches, and is still refused. The obvious cheaper fix — matching on
the repository *name* half — would have let `mallory/CodefyUI-Plugin-Self-Learning` through, and the existing
test (`mallory/evil`, a different name) would have stayed green while the protection was gone. There is now a
test that uses a same-name fork, verified to fail when the clause is weakened that way.

## The rest

- **`reserved_id` reached the update toast as the bare wire token.** `REFUSAL_KEY` leaves it out because the
  review card writes a richer line from the body — true until `POST /{id}/update` became a second producer.
  A standing test now reads every `_coded(...)` the routes can emit (18 today) and fails unless each is in
  that table or at a named catch.
- **One sentence for three different holders.** "Reserved for a built-in pack" was shown whichever of the
  three things held the id. The route sends *which*, as a code, plus the repository when that is the answer;
  the sentence is written in the panel. `taken_by` stays out of the wire contract — it is an English noun
  phrase written for the line the CLI prints, and splicing it into a zh-TW sentence, or matching on it in
  TypeScript, would recreate the message-parsing this module was refactored to remove.
- **A 422 was reported as "Cannot connect to GitHub".** GitHub answers 422, never 404, for a ref that does
  not resolve, so a typo in a tag read as a network failure on a working network.
- **A row's refused Install appeared under the source box.** At the top of the panel, under a text field the
  user never typed into and worded as though they had, while the row they pressed said nothing — and nothing
  at all with the list scrolled. It is toasted against the row instead, from one builder shared with the box
  so the two cannot describe one refusal two ways.
- **A refusal outlived the panel.** One attached to a still-usable review survived a close, so reopening the
  Plugin Center hours later answered a request that was long over. Only the review that would not be on
  screen without its refusal is cleared — dropping the error outright loses what the consent card needs and
  flips Reinstall back to an Install the server refuses again.
- **A catalog row installed by `owner/repo` instead of its id**, so the install was recorded as free-text
  third-party: no `catalog_id`, and the consent card reporting an official pack as unofficial. Rows with
  files missing still reinstall from the repository *they* recorded, which can be a fork.
- **A plugin directory with no lockfile entry was a dead end**: accepted with a 202, then failed with
  "already installed" and a `force` hint the panel has no control for. It is refused up front, where the
  Reinstall button is.
- **A renderer naming a node type that does not exist mounted nothing, silently.** It now warns, and names
  the type that was meant where it can work it out. (The template plugin that trips this is in another
  repository — `official-template` registers `official_template:MovingAverage` when the namespace is the
  manifest id verbatim. That fix needs its own PR there.)

## Tests

Backend `pytest tests/`: 7806 passed, 57 skipped, 3 failed — all three pre-existing on `main`, confirmed by
running them from a clean `main` worktree (`test_tiered_policy`, `test_timestep_embedding_node`, and the
macOS GPU case that #441 fixes).

Frontend `pnpm vitest run`: 198 files, 5252 tests, all passing. `tsc -b` clean, `pnpm build` clean (the store
now imports the shared refusal builder from the panel's `pluginStatus`, so the chunk layout was checked for a
cycle). `ruff check` clean.

Ten test fakes stubbed `github.resolve_sha`, which `inspect_github` no longer calls; they were moved down to
`resolve_ref`, which `resolve_sha` now delegates to, so both layers stay covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbCiuhnJvnwmR2A76HQseH
